### PR TITLE
feat(nextly): field-group reconcile operation and conditional divergence marker

### DIFF
--- a/.changeset/field-group-reconcile-operation.md
+++ b/.changeset/field-group-reconcile-operation.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Field groups can now be repaired after a failed schema change: a new reconcile operation (POST /api/field-groups/schema/[slug]/reconcile) rewrites the stored definition to describe the live tables, reporting removed, repaired and adopted fields by name. The divergence marker is now version-conditional, so a healthy field group can no longer be marked diverged after transient read failures.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,12 +251,15 @@ Before editing a package, read its README.md and check for a nested AGENTS.md.
   `telemetry`, `client`) plus `playground`, `root`, `ci`, `docs`, `deps`,
   `release`. Scope is optional; the subject must not start with an uppercase
   letter. Subsystem names are not valid scopes.
-- Errors thrown inside `packages/nextly/**` use `NextlyError` (static
-  factories: `notFound`, `forbidden`, `validation`, `conflict`, `duplicate`,
-  `authRequired`, `invalidCredentials`, `rateLimited`, `internal`, ...), never
-  bare `Error`. The admin package is exempt: it consumes the typed
-  `{ error: { code, message, requestId, data? } }` envelope via
-  `parseApiError`.
+- Errors thrown inside `packages/nextly/**` PRODUCT CODE use `NextlyError`
+  (static factories: `notFound`, `forbidden`, `validation`, `conflict`,
+  `duplicate`, `authRequired`, `invalidCredentials`, `rateLimited`,
+  `internal`, ...), never bare `Error`. The admin package is exempt: it
+  consumes the typed `{ error: { code, message, requestId, data? } }` envelope
+  via `parseApiError`. Test files are also exempt: fixtures model driver and
+  database failures arriving from OUTSIDE the package, which `NextlyError`
+  cannot faithfully represent — wrapping them would make every negative test
+  pass on the wrong error shape.
 - Database access is Drizzle ORM only. No raw SQL strings in product code.
   Test fixtures reuse the production DDL helpers (for example
   `getSchemaEventsDdl`), never hand-copied CREATE TABLE statements.

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -222,6 +222,23 @@ function affectedRowCount(result: unknown): number {
   return 0;
 }
 
+/**
+ * The fragment of Drizzle's update builder `updateCount` uses, spelled dialect-neutrally.
+ *
+ * Declared rather than reached for through a permissive generic: the three dialects' builders carry
+ * different type parameters but agree on this chain, so naming just the chain keeps the compiler
+ * checking the call while leaving the parts that genuinely differ outside the contract. `set` is
+ * awaitable on its own, which is what makes an update with no WHERE a complete statement rather
+ * than a builder waiting for one.
+ */
+interface UpdateCapableDb {
+  update(table: unknown): {
+    set(values: Record<string, unknown>): PromiseLike<unknown> & {
+      where(condition: unknown): PromiseLike<unknown>;
+    };
+  };
+}
+
 export abstract class DrizzleAdapter {
   // ============================================================
   // Abstract Methods (MUST be implemented by subclasses)
@@ -1383,19 +1400,20 @@ export abstract class DrizzleAdapter {
     const tableObj = this.getTableObject(table);
     if (tableObj) {
       try {
-        // Transaction executor when supplied, otherwise the pooled instance.
-        // getDrizzle() returns unknown - explicit any generic for dialect-specific Drizzle API
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const db = executor ?? this.getDrizzle<any>();
+        // Transaction executor when supplied, otherwise the pooled instance — narrowed to the
+        // fragment of the update builder this method uses rather than the whole dialect-specific
+        // surface, which is the same seam `getDrizzle<{ execute }>()` above takes. `where` returns
+        // a thenable rather than a further builder, so awaiting either branch is what the type
+        // says: the statement is issued whether or not a condition was added.
+        const db = (executor ??
+          this.getDrizzle<UpdateCapableDb>()) as UpdateCapableDb;
         const mappedData = this.mapDataToColumnNames(tableObj, data);
-        let query = db.update(tableObj).set(mappedData);
+        const statement = db.update(tableObj).set(mappedData);
 
         const whereCondition = buildDrizzleWhere(tableObj as never, where);
-        if (whereCondition) {
-          query = query.where(whereCondition);
-        }
-
-        const result = await query;
+        const result = await (whereCondition
+          ? statement.where(whereCondition)
+          : statement);
         return affectedRowCount(result);
       } catch (error) {
         throw this.handleQueryError(error, "update", table);

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -1359,6 +1359,57 @@ export abstract class DrizzleAdapter {
   }
 
   /**
+   * Update records in a table and report how many rows the statement affected.
+   *
+   * The count is the whole return value, mirroring `delete`. `update` cannot answer this: without
+   * `returning` it discards the driver's count, and WITH `returning` on a dialect that lacks
+   * RETURNING it re-SELECTs using the same WHERE — so a conditional update that just changed a
+   * column named in that WHERE reads back zero rows and a write that landed reports as unmatched.
+   * Reading the driver's own count has no second query to disagree with the first.
+   *
+   * 🔴 MySQL reports CHANGED rows, not matched rows: an UPDATE that matches a row but writes values
+   * identical to what it holds counts zero. A caller using this as a compare-and-set must therefore
+   * include a column the write always moves — a version bump, a timestamp with enough resolution —
+   * so that matched implies changed. Postgres (`rowCount`) and SQLite (`changes`) count matched
+   * rows and do not need the precaution, which is exactly why it cannot be dropped: the dialect
+   * where the distinction exists is the one with no RETURNING to fall back on.
+   */
+  async updateCount(
+    table: string,
+    data: Record<string, unknown>,
+    where: WhereClause,
+    executor?: unknown
+  ): Promise<number> {
+    const tableObj = this.getTableObject(table);
+    if (tableObj) {
+      try {
+        // Transaction executor when supplied, otherwise the pooled instance.
+        // getDrizzle() returns unknown - explicit any generic for dialect-specific Drizzle API
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const db = executor ?? this.getDrizzle<any>();
+        const mappedData = this.mapDataToColumnNames(tableObj, data);
+        let query = db.update(tableObj).set(mappedData);
+
+        const whereCondition = buildDrizzleWhere(tableObj as never, where);
+        if (whereCondition) {
+          query = query.where(whereCondition);
+        }
+
+        const result = await query;
+        return affectedRowCount(result);
+      } catch (error) {
+        throw this.handleQueryError(error, "update", table);
+      }
+    }
+
+    throw this.createDatabaseError(
+      "query",
+      `Table "${table}" not found in schema registry. Ensure setTableResolver() has been called during boot.`,
+      undefined
+    );
+  }
+
+  /**
    * Delete records from a table.
    *
    * @remarks

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -721,11 +721,14 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
             slug,
           });
 
-          return respondAction(
+          // The canonical mutation envelope: this method can rewrite the registry row, so its
+          // result is `item` like every other definition write — not a bespoke top-level key a
+          // consumer would need special handling for.
+          return respondMutation(
             report.unchanged
               ? `"${slug}" already describes its tables; nothing was changed.`
               : `Reconciled "${slug}" against its live tables.`,
-            { report }
+            report
           );
         }
       );

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -166,7 +166,17 @@ function readMigrationStatus(
   return raw as FieldGroupMigrationStatus;
 }
 
-const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
+/**
+ * Exported so guards can be DERIVED from the real method registry rather than restating it.
+ *
+ * `BUILDER_METHODS` names a subset of these by string, and a rename here leaves a dead entry there
+ * that guards nothing — silently, because an unrecognised name simply means "not builder surface".
+ * A test reading these keys turns that into a failure by name.
+ */
+export const COMPONENTS_METHODS: Record<
+  string,
+  MethodHandler<ComponentsServices>
+> = {
   listComponents: {
     // Registry returns BaseListResult `{data,total}` with limit/offset
     // semantics; offsetPaginationToMeta synthesises the canonical

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -716,9 +716,22 @@ export const COMPONENTS_METHODS: Record<
           adapter,
           logger,
           label: `reconcile field group "${slug}"`,
-          // Reads the catalog and writes one registry row; no DDL, so a database this cannot
-          // create the lock table on refuses nothing it would need.
-          issuesDdl: false,
+          // 🔴 TRUE even though this operation issues no DDL of its own, because the exclusion has
+          // to be REAL for the answer to mean anything. With `false` the session takes no lock at
+          // all on a database that has never run a storage migration, so a first migration can
+          // start mid-operation and rename the table, the discriminator or the registry while the
+          // planner is reading them — and those pointer updates need not advance `schema_version`,
+          // so the version-conditional write does not reject the mixed snapshot and records it as
+          // `synced`. An operation whose entire output is the claim "this definition describes
+          // these tables" must not be able to certify a pair that never coexisted.
+          //
+          // The cost that argues for `false` elsewhere does not apply here. Collections take that
+          // shape outside development because they record a migration FILE and must keep working
+          // for a role holding DML but no DDL. This is builder surface — refused in production
+          // unless `showBuilder` is explicitly on — so a deployment that can reach it is one that
+          // already accepts schema changes from a browser, and creating a one-time lock table is
+          // strictly less than what it has already permitted.
+          issuesDdl: true,
         },
         async () => {
           const { reconcileFieldGroup } = await import(

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -677,6 +677,61 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
     },
   },
 
+  // Repair a field group's stored definition to describe its live tables.
+  //
+  // The exit from `diverged`, so `assertNotDiverged` is deliberately NOT called: this is the one
+  // operation the state exists to permit. Also deliberately not gated on the status being
+  // `diverged` — a recording write that failed after its DDL committed leaves a divergence with no
+  // mark, and the operation is idempotent on a healthy group.
+  reconcileComponent: {
+    execute: async (svc, p) => {
+      const slug = requireParam(p, "slug", "Component slug");
+
+      const adapter = getAdapterFromDI();
+      if (!adapter) {
+        // Without a database there are no live tables, so there is nothing to reconcile AGAINST —
+        // unlike the schema services' generate-only mode, this operation is meaningless dry.
+        throw NextlyError.internal({
+          logContext: { reason: "reconcile-requires-adapter", slug },
+        });
+      }
+      const logger = getLoggerFromDI() ?? DISCARDED_LOG;
+
+      // Inside the exclusion even though no DDL runs: the plan is computed from a read of the
+      // registry AND the catalog, and an apply committing between those reads would hand the
+      // planner a pair that never coexisted. The version-conditional write catches the registry
+      // half of that race; holding the exclusion closes the catalog half too.
+      return withSchemaChangeExcluded(
+        {
+          adapter,
+          logger,
+          label: `reconcile field group "${slug}"`,
+          // Reads the catalog and writes one registry row; no DDL, so a database this cannot
+          // create the lock table on refuses nothing it would need.
+          issuesDdl: false,
+        },
+        async () => {
+          const { reconcileFieldGroup } = await import(
+            "../../domains/field-groups/services/field-group-reconcile-service"
+          );
+          const report = await reconcileFieldGroup({
+            registry: svc.registry,
+            adapter,
+            logger,
+            slug,
+          });
+
+          return respondAction(
+            report.unchanged
+              ? `"${slug}" already describes its tables; nothing was changed.`
+              : `Reconciled "${slug}" against its live tables.`,
+            { report }
+          );
+        }
+      );
+    },
+  },
+
   deleteComponent: {
     // Spec divergence: spec §5.1 / §7.4 strictly maps delete to
     // respondMutation, but registry.deleteComponent returns void (no

--- a/packages/nextly/src/domains/field-groups/__tests__/field-group-conditional-write.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/field-group-conditional-write.integration.test.ts
@@ -25,7 +25,7 @@
  * Self-skips per dialect on the standard rule: SQLite always runs, the servers run when their URL
  * is set, and each dialect gets its own throwaway database.
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   createTestNextly,
@@ -79,6 +79,85 @@ for (const dialect of getConfiguredTestDialects()) {
       const after = await registry.getComponent(slug);
       expect(after.migrationStatus).toBe("diverged");
       expect(after.schemaVersion).toBe(row.schemaVersion + 1);
+    });
+
+    /**
+     * Ownership can change WITHOUT the version moving — a code sync claiming an existing UI group
+     * sets `locked` through the admin-only branch — so a caller that read the row unlocked still
+     * satisfies a version-only predicate and overwrites a definition a config file now owns.
+     *
+     * Written against a live database rather than a double because the predicate is the DATABASE's
+     * to evaluate: this is the half of the statement that decides, and a mock would only confirm
+     * the argument was passed.
+     */
+    it("refuses a UI write when the row was locked without the version moving", async () => {
+      const { registry } = await seed();
+
+      // Ownership changes and the version does not — the state a code sync leaves when it claims
+      // an existing UI group.
+      await registry.updateComponent(
+        slug,
+        { locked: true },
+        { source: "code" }
+      );
+      const afterClaim = await registry.getComponent(slug);
+
+      // 🔴 The race itself, and it has to be staged: the guard that runs BEFORE the statement reads
+      // the row and refuses a locked one outright, so a row already locked when the call starts
+      // never reaches the predicate under test. What this must model is the window between that
+      // read and the UPDATE — the read saw an unlocked row, the database now holds a locked one.
+      // Returning a stale unlocked snapshot from the read is exactly that window, and nothing else
+      // about the row is altered.
+      const read = vi
+        .spyOn(registry, "getComponent")
+        .mockResolvedValueOnce({ ...afterClaim, locked: false });
+
+      const outcome = await registry.updateComponentIfVersion(
+        slug,
+        { label: "Written by a UI caller that read the row unlocked" },
+        afterClaim.schemaVersion
+      );
+
+      read.mockRestore();
+
+      // The read let it past, so the WHERE clause is the only thing that can refuse it.
+      expect(outcome).toEqual({ matched: false });
+      const after = await registry.getComponent(slug);
+      expect(after.label).not.toBe(
+        "Written by a UI caller that read the row unlocked"
+      );
+      // And the row is untouched rather than merely unlabelled: a predicate that matched nothing
+      // must also not have advanced the version.
+      expect(after.schemaVersion).toBe(afterClaim.schemaVersion);
+    });
+
+    // The control that keeps the predicate from refusing the owner: `source: "code"` IS the config
+    // file, so it must still write a locked row. Without this the clause above would make every
+    // code sync a no-op, which is a worse failure than the race it closes.
+    it("still writes a locked row for the code caller that owns it", async () => {
+      const { registry, row } = await seed();
+
+      await registry.updateComponent(
+        slug,
+        { locked: true },
+        { source: "code" }
+      );
+      const afterClaim = await registry.getComponent(slug);
+
+      const outcome = await registry.updateComponentIfVersion(
+        slug,
+        { migrationStatus: "diverged" },
+        afterClaim.schemaVersion,
+        { source: "code" }
+      );
+
+      expect(outcome).toEqual({
+        matched: true,
+        newSchemaVersion: afterClaim.schemaVersion + 1,
+      });
+      expect((await registry.getComponent(slug)).migrationStatus).toBe(
+        "diverged"
+      );
     });
 
     it("refuses, and writes nothing, when the row has moved past that version", async () => {

--- a/packages/nextly/src/domains/field-groups/__tests__/field-group-conditional-write.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/field-group-conditional-write.integration.test.ts
@@ -1,0 +1,166 @@
+/**
+ * The version-conditional registry write, proved against real databases.
+ *
+ * ## Why this cannot be a unit test
+ *
+ * The whole mechanism is a claim about what the DATABASE does with a statement, and the three
+ * dialects answer differently in a way no double can reproduce faithfully:
+ *
+ * - PostgreSQL reports `rowCount`, MySQL reports `affectedRows`, SQLite reports `changes`, and
+ *   `DrizzleAdapter.updateCount` reads whichever the driver hands it;
+ * - 🔴 **MySQL counts CHANGED rows, not MATCHED rows.** An UPDATE whose WHERE matches a row but
+ *   whose SET writes values identical to the ones already stored reports ZERO. That is the exact
+ *   shape a compare-and-set takes, so on MySQL "matched" and "changed" have to be made the same
+ *   thing — the conditional write always advances `schema_version`, which is what guarantees it.
+ *
+ * A mock returning a number proves the code's arithmetic and nothing about the semantics the
+ * arithmetic depends on. These assert the semantics.
+ *
+ * ## What each case separates
+ *
+ * The property under test is not "the write happened" — an unconditional write satisfies that too.
+ * It is that the write happens EXACTLY when the row is still at the expected version, so each case
+ * below pairs an outcome with the assertion that the row did or did not move.
+ *
+ * Self-skips per dialect on the standard rule: SQLite always runs, the servers run when their URL
+ * is set, and each dialect gets its own throwaway database.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const FIELDS = [
+  { name: "heading", type: "text" },
+  { name: "weight", type: "number" },
+];
+
+for (const dialect of getConfiguredTestDialects()) {
+  describe(`the version-conditional registry write — ${dialect}`, () => {
+    const slug = `fgcw_${dialect.slice(0, 2)}`;
+
+    /** A created field group and the registry service that owns it. */
+    async function seed() {
+      current = await createTestNextly({ dialect });
+      const registry = current.getService("fieldGroupRegistryService");
+      await current.nextly.fieldGroups.create({
+        slug,
+        label: "Conditional write",
+        fields: FIELDS,
+      });
+      const row = await registry.getComponent(slug);
+      return { registry, row };
+    }
+
+    it("writes and advances the version when the row is at the expected version", async () => {
+      const { registry, row } = await seed();
+
+      const outcome = await registry.updateComponentIfVersion(
+        slug,
+        { migrationStatus: "diverged" },
+        row.schemaVersion
+      );
+
+      expect(outcome).toEqual({
+        matched: true,
+        newSchemaVersion: row.schemaVersion + 1,
+      });
+      // The write is real, not merely reported: read it back through the registry.
+      const after = await registry.getComponent(slug);
+      expect(after.migrationStatus).toBe("diverged");
+      expect(after.schemaVersion).toBe(row.schemaVersion + 1);
+    });
+
+    it("refuses, and writes nothing, when the row has moved past that version", async () => {
+      const { registry, row } = await seed();
+
+      // Someone else's write lands first, advancing the version.
+      await registry.updateComponentIfVersion(
+        slug,
+        { label: "Moved by another writer" },
+        row.schemaVersion
+      );
+
+      const outcome = await registry.updateComponentIfVersion(
+        slug,
+        { migrationStatus: "diverged" },
+        // The version this caller decided from, now stale.
+        row.schemaVersion
+      );
+
+      expect(outcome).toEqual({ matched: false });
+      // 🔴 The refusal has to be observable in the ROW, not only in the return value: an
+      // implementation that reported `matched: false` while still writing would satisfy the
+      // assertion above and be exactly the overwrite this mechanism exists to prevent.
+      const after = await registry.getComponent(slug);
+      expect(after.migrationStatus).not.toBe("diverged");
+      expect(after.label).toBe("Moved by another writer");
+      expect(after.schemaVersion).toBe(row.schemaVersion + 1);
+    });
+
+    // 🔴 THE case that is dialect-specific and cannot be faked. Every column this write SETs
+    // already holds the value being written, so MySQL's changed-row count for the data alone is
+    // zero. It reports matched because the version bump always changes something — remove that
+    // bump and this case returns `matched: false` on MySQL while the row was matched perfectly.
+    it("reports matched even when every written value is identical to the stored one", async () => {
+      const { registry, row } = await seed();
+
+      const outcome = await registry.updateComponentIfVersion(
+        slug,
+        // `label` is what the row already carries, so nothing but the version can move.
+        { label: row.label },
+        row.schemaVersion
+      );
+
+      expect(outcome).toEqual({
+        matched: true,
+        newSchemaVersion: row.schemaVersion + 1,
+      });
+      const after = await registry.getComponent(slug);
+      expect(after.schemaVersion).toBe(row.schemaVersion + 1);
+    });
+
+    it("refuses every concurrent writer but one at the same expected version", async () => {
+      const { registry, row } = await seed();
+
+      // Three callers that each decided from the same version, issued together. Exactly one may
+      // win: this is the property the whole mechanism exists for, and a read-then-write
+      // implementation lets all three through.
+      const outcomes = await Promise.all([
+        registry.updateComponentIfVersion(
+          slug,
+          { label: "writer-a" },
+          row.schemaVersion
+        ),
+        registry.updateComponentIfVersion(
+          slug,
+          { label: "writer-b" },
+          row.schemaVersion
+        ),
+        registry.updateComponentIfVersion(
+          slug,
+          { label: "writer-c" },
+          row.schemaVersion
+        ),
+      ]);
+
+      expect(outcomes.filter(o => o.matched)).toHaveLength(1);
+      const after = await registry.getComponent(slug);
+      expect(after.schemaVersion).toBe(row.schemaVersion + 1);
+      // The surviving label belongs to whichever writer won — asserted as membership rather than
+      // a fixed name, because which one wins is the database's to decide and pinning it would
+      // make this a test of scheduling.
+      expect(["writer-a", "writer-b", "writer-c"]).toContain(after.label);
+    });
+  });
+}

--- a/packages/nextly/src/domains/field-groups/__tests__/field-group-conditional-write.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/field-group-conditional-write.integration.test.ts
@@ -108,10 +108,18 @@ for (const dialect of getConfiguredTestDialects()) {
       expect(after.schemaVersion).toBe(row.schemaVersion + 1);
     });
 
-    // 🔴 THE case that is dialect-specific and cannot be faked. Every column this write SETs
-    // already holds the value being written, so MySQL's changed-row count for the data alone is
-    // zero. It reports matched because the version bump always changes something — remove that
-    // bump and this case returns `matched: false` on MySQL while the row was matched perfectly.
+    // 🔴 The dialect-specific case, and the one a double cannot reproduce: every AUTHORED column
+    // this write SETs already holds the value being written, so MySQL's changed-row count for the
+    // caller's data alone is zero. It still reports matched.
+    //
+    // What this establishes, precisely: an all-identical payload is not mistaken for an unmatched
+    // row on any of the three dialects. What it does NOT establish is WHICH always-moving column
+    // supplies that, because two of them move together — `schema_version` and `updated_at`. A
+    // break-control removing the version bump alone still passes the matched assertion here and
+    // fails only the version one, which is how the pairing was found rather than assumed. The
+    // version is the one the code relies on, because it is strictly monotonic while two writes in
+    // one timestamp tick share an `updated_at`; that narrower property has no test, because
+    // forcing a tick collision from here would be testing the clock.
     it("reports matched even when every written value is identical to the stored one", async () => {
       const { registry, row } = await seed();
 

--- a/packages/nextly/src/domains/field-groups/__tests__/field-group-reconcile-healthy.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/field-group-reconcile-healthy.integration.test.ts
@@ -1,0 +1,100 @@
+/**
+ * A HEALTHY field group must reconcile to "nothing to repair", on every dialect and every field type.
+ *
+ * ## Why this test is the boundary rather than one more case
+ *
+ * The planner decides whether a stored definition still describes its tables. Every attribute it
+ * compares — physical type, nullability, indexes, placement — is an independent chance to disagree
+ * with the code that ACTUALLY creates those tables (`FieldGroupSchemaService`), and each such
+ * disagreement is a false "this group is damaged" on a group that is perfectly fine. That failure
+ * is worse than a missed repair: it refuses the one operation an operator runs to get out of
+ * trouble.
+ *
+ * Reviewing attribute-by-attribute cannot catch it, because the mistake is always a spelling the
+ * reviewer also believes. The measurement that catches it is this one: create a group through the
+ * real creator, introspect the real tables, and require the planner to report NO changes and NO
+ * blockers. Anything it reports here is by construction false, because nothing has drifted.
+ *
+ * 🔴 The types the creator emits are NOT what the column descriptor reports, which is exactly how
+ * this class of defect arises. Measured on live databases: a `date` field is `datetime` on MySQL and
+ * `timestamp` on PostgreSQL, while the descriptor answers `timestamp` for both; relations are `UUID`
+ * on PostgreSQL and `VARCHAR(36)` on MySQL while the descriptor answers `text`. A comparison built
+ * against the descriptor therefore reports drift on healthy groups, and only a live database says so.
+ *
+ * Self-skips per dialect on the standard rule: SQLite always runs, the servers run when their URL
+ * is set, and each dialect gets its own throwaway database.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+/**
+ * One field per storage shape the creator can emit, because the defect is per-shape.
+ *
+ * Deliberately includes the pairs that collapse to one physical column — `text`/`email`/`textarea`
+ * all land on text-like storage — since preserving the DECLARED type across a reconcile is the
+ * property the whole operation exists to protect.
+ */
+const EVERY_SHAPE = [
+  { name: "a_text", type: "text" },
+  { name: "a_email", type: "email" },
+  { name: "a_textarea", type: "textarea" },
+  { name: "a_number", type: "number" },
+  { name: "a_checkbox", type: "checkbox" },
+  { name: "a_date", type: "date" },
+  { name: "a_json", type: "json" },
+];
+
+for (const dialect of getConfiguredTestDialects()) {
+  describe(`a healthy field group reconciles to no-op — ${dialect}`, () => {
+    it("reports no changes and no blockers for every field shape", async () => {
+      current = await createTestNextly({ dialect });
+      const slug = `healthy_${dialect.slice(0, 2)}`;
+
+      await current.nextly.fieldGroups.create({
+        slug,
+        label: "Healthy",
+        fields: EVERY_SHAPE,
+      });
+
+      const { reconcileFieldGroup } = await import(
+        "../services/field-group-reconcile-service"
+      );
+      const report = await reconcileFieldGroup({
+        registry: current.getService("fieldGroupRegistryService"),
+        adapter: current.adapter,
+        logger: current.getService("logger"),
+        slug,
+      });
+
+      // 🔴 Asserted by IDENTITY, not by count. A bare `unchanged === true` would hide WHICH field
+      // the planner misread, and the field name is the whole diagnostic when this fails.
+      expect(report.removed.map(r => r.fieldName)).toEqual([]);
+      expect(report.repaired.map(r => `${r.fieldName}.${r.attribute}`)).toEqual(
+        []
+      );
+      expect(report.adopted.map(a => a.fieldName)).toEqual([]);
+      expect(report.unchanged).toBe(true);
+    });
+
+    // 🔴 WHAT THIS FILE DOES NOT ESTABLISH: the LOCALIZED case. A group whose translatable columns
+    // live in the `_locales` companion is a separate chance for the planner to disagree with the
+    // creator — the companion's columns are rendered by a different path (`fieldToLocalizedColumnSpec`
+    // + `ddlType`) than the main table's. It is absent here because `fieldGroups.create()` takes no
+    // `localized` argument and enabling it afterwards is gated on app-level localization config the
+    // harness does not declare; a fixture that created the row without moving the columns would
+    // never reach the mechanism, and would pass while proving nothing. Stated rather than faked,
+    // and the expectation map covers the companion so the check itself is wired for it.
+  });
+}

--- a/packages/nextly/src/domains/field-groups/__tests__/field-group-reconcile-healthy.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/field-group-reconcile-healthy.integration.test.ts
@@ -51,6 +51,11 @@ const EVERY_SHAPE = [
   { name: "a_email", type: "email" },
   { name: "a_textarea", type: "textarea" },
   { name: "a_number", type: "number" },
+  // A number's storage is decided by `options.format`, not by its type alone: this one is
+  // floating-point where `a_number` above is an integer, and the two are separate column types on
+  // every dialect. Listing only the integer form leaves the whole floating-point branch of the
+  // creator unexercised, which is a storage shape rather than a variation of one already covered.
+  { name: "a_float", type: "number", options: { format: "float" } },
   { name: "a_checkbox", type: "checkbox" },
   { name: "a_date", type: "date" },
   { name: "a_json", type: "json" },

--- a/packages/nextly/src/domains/field-groups/__tests__/field-group-registry-service.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/field-group-registry-service.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
+// The sync asks the reconcile service to clear a diverged mark on a code-managed group. Mocked so
+// the ASK is observable: the repair itself is proved in its own suite, and running it here would
+// make these tests depend on introspection they do not model.
+vi.mock("../services/field-group-reconcile-service", () => ({
+  reconcileFieldGroup: vi.fn(async () => ({
+    slug: "seo",
+    localized: false,
+    removed: [],
+    repaired: [],
+    adopted: [],
+    unchanged: true,
+    schemaVersion: 1,
+  })),
+}));
+
 // The service throws NextlyError, so `rejects.toThrow(...)` asserts against
 // that class for the instanceof check to line up with the thrown type.
 import { NextlyError } from "../../../errors";
@@ -604,6 +619,61 @@ describe("FieldGroupRegistryService", () => {
       expect(result.created).toEqual(["hero"]);
       expect(result.updated).toEqual([]);
       expect(result.unchanged).toEqual([]);
+    });
+
+    // 🔴 A code-managed group marked `diverged` is otherwise a DEAD END: the admin refuses it for
+    // being locked and this sync refuses it for being diverged, so neither direction reaches it.
+    // The sync holds the config file — which IS the definition for a locked group — so it is the
+    // caller that may repair, and it must do so BEFORE deciding what to write.
+    it("clears a diverged mark on a code-managed component before writing it", async () => {
+      const fields = [{ name: "metaTitle", type: "text" }];
+      ctx.adapter.selectOne.mockResolvedValue(
+        dbRow({ migration_status: "diverged", locked: 1 })
+      );
+      ctx.adapter.update.mockResolvedValue([dbRow()]);
+      // The repair itself is proved where it lives; here the question is only whether the sync
+      // ASKS for it, so the introspection the reconcile service performs is answered minimally.
+      ctx.adapter.tableExists.mockResolvedValue(true);
+
+      await ctx.service.syncCodeFirstComponents([
+        { slug: "seo", label: "SEO", fields },
+      ]);
+
+      // 🔴 Asserted on the CALL, not on the result lists. The component ends up in `updated` or
+      // `unchanged` whether or not the repair was requested, so a result-shaped assertion would
+      // pass with and without the wiring — coverage in appearance only. `fromCode: true` is the
+      // part that matters: without it the repair is refused by the lock check it exists to pass.
+      const { reconcileFieldGroup } = await import(
+        "../services/field-group-reconcile-service"
+      );
+      expect(reconcileFieldGroup).toHaveBeenCalledWith(
+        expect.objectContaining({ slug: "seo", fromCode: true })
+      );
+    });
+
+    it("does not ask for a repair when the component is not diverged", async () => {
+      // The control that keeps the branch above from becoming unconditional: a healthy row must
+      // not be run through a repair on every boot.
+      const fields = [{ name: "metaTitle", type: "text" }];
+      ctx.adapter.selectOne.mockResolvedValue(
+        dbRow({ migration_status: "applied", locked: 1 })
+      );
+      ctx.adapter.update.mockResolvedValue([dbRow()]);
+
+      // The mock is module-level and this suite's `beforeEach` only rebuilds the adapter, so a
+      // call recorded by the test above would satisfy this assertion's opposite. Cleared here
+      // rather than globally: 53 other tests in this file pass under the current lifecycle and
+      // widening it would be a change to their experiment, not to mine.
+      const { reconcileFieldGroup } = await import(
+        "../services/field-group-reconcile-service"
+      );
+      vi.mocked(reconcileFieldGroup).mockClear();
+
+      await ctx.service.syncCodeFirstComponents([
+        { slug: "seo", label: "SEO", fields },
+      ]);
+
+      expect(reconcileFieldGroup).not.toHaveBeenCalled();
     });
 
     it("updates components with changed schema hash", async () => {

--- a/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
@@ -1248,7 +1248,7 @@ describe("an update whose row write fails after the tables moved", () => {
       .catch((error: unknown) => error);
 
     expect((refusal as NextlyError).publicMessage).toContain(
-      "already carries a newer version"
+      "no longer at the version this edit started from"
     );
     // Not claiming a mark that was never written, and not claiming nothing happened either.
     expect((refusal as NextlyError).publicMessage).not.toContain(

--- a/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
@@ -996,6 +996,20 @@ describe("an update whose row write fails after the tables moved", () => {
           return record;
         }
       ),
+      // The marker travels through the version-conditional write, so the double answers it
+      // separately from the full write above: matched by default, because most of these tests are
+      // about the row genuinely not carrying the edit.
+      updateComponentIfVersion: vi.fn(
+        async (
+          _slug: string,
+          _data: Record<string, unknown>,
+          expectedSchemaVersion: number,
+          _options?: { source?: string }
+        ) => ({
+          matched: true as const,
+          newSchemaVersion: expectedSchemaVersion + 1,
+        })
+      ),
     };
   }
 
@@ -1035,20 +1049,22 @@ describe("an update whose row write fails after the tables moved", () => {
 
     // The divergence is RECORDED, not merely raised: the raise reaches one caller once, the row is
     // what anyone looking later can see.
-    expect(registry.updateComponent).toHaveBeenCalledTimes(2);
+    expect(registry.updateComponent).toHaveBeenCalledTimes(1);
     // 🔴 `diverged`, NOT `failed`. The canonical type documents `failed` as a table-creation
     // failure whose repair is to retry, which is the exact action that compounds this one: a retry
     // derives `wasLocalized` from a row that already describes the wrong shape. Once the one-time
     // error response is gone, this column is the only thing telling a recovery tool which of the
     // two it is looking at.
-    expect(registry.updateComponent.mock.calls[1]?.[1]).toEqual({
-      migrationStatus: "diverged",
-    });
-    // The optimistic lock is invalidated with it: the tables moved, so every editor loaded before
-    // this moment is describing a shape that no longer exists.
-    expect(registry.updateComponent.mock.calls[1]?.[2]).toMatchObject({
-      invalidateSchemaVersion: true,
-    });
+    //
+    // And it is a COMPARE-AND-SET against the version this edit started from, so a marker landing
+    // after the original write turns out to have committed cannot stamp the settled row. The
+    // version advance an invalidated editor needs is the conditional write's own contract.
+    expect(registry.updateComponentIfVersion).toHaveBeenCalledWith(
+      "hero",
+      { migrationStatus: "diverged" },
+      registry.record.schemaVersion,
+      { source: "code" }
+    );
   });
 
   // 🔴 THE case the request shape cannot answer. A field-set change on a group that was and remains
@@ -1149,7 +1165,93 @@ describe("an update whose row write fails after the tables moved", () => {
     expect((refusal as NextlyError).publicMessage).toContain(
       "Do not retry the same edit"
     );
-    expect(registry.updateComponent).toHaveBeenCalledTimes(2);
+    expect(registry.updateComponent).toHaveBeenCalledTimes(1);
+    expect(registry.updateComponentIfVersion).toHaveBeenCalledTimes(1);
+  });
+
+  // 🔴 THE case the marker's conditionality exists for: the write raised, the re-read ALSO failed
+  // to confirm it, and yet the write had landed. Any number of reads can fail transiently, so the
+  // answer comes from the write itself — zero rows matched at the old version MEANS the row
+  // advanced, and one more look then finds the settled state. A marker written unconditionally
+  // here stamps `diverged` onto a healthy row and bumps its version a second time.
+  it("does not mark a row the original write reached, even when every read failed first", async () => {
+    const registry = registryWhoseWriteFails({});
+    const settledFields = [
+      { name: "heading", type: "text", localized: true },
+      { name: "subheading", type: "text", localized: true },
+    ];
+    const settledHash = await (async () => {
+      const { calculateSchemaHash } = await import(
+        "../../../schema/services/schema-hash"
+      );
+      return calculateSchemaHash(settledFields as never);
+    })();
+    // Reads 1 (the edit's own) and 2 (the first read-back) see the OLD row, so the read-back
+    // cannot settle the question; read 3 (after the conditional write answered "advanced") sees
+    // the row the committed write left. That ordering is the scenario, not an artefact.
+    let reads = 0;
+    registry.getComponent = vi.fn(async () => {
+      reads += 1;
+      return reads >= 3
+        ? { ...registry.record, schemaVersion: 2, schemaHash: settledHash }
+        : registry.record;
+    });
+    registry.updateComponentIfVersion = vi.fn(async () => ({
+      matched: false as const,
+    }));
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    const result = await service.updateFieldGroup({
+      slug: "hero",
+      fields: settledFields as never,
+    });
+
+    // Answered as SUCCESS with the settled row — the caller's edit is in the database.
+    expect(result.record).toMatchObject({ slug: "hero", schemaVersion: 2 });
+    // And the row was never stamped: the conditional write is the only marker path, and it
+    // reported unmatched rather than writing.
+    expect(registry.updateComponent).toHaveBeenCalledTimes(1);
+    expect(registry.updateComponentIfVersion).toHaveBeenCalledTimes(1);
+  });
+
+  // The unconfirmable half of the same case: the row demonstrably advanced, but no read ever
+  // succeeds. The caller must be told the change LIKELY landed — "nothing happened" would send
+  // them retrying an edit that is probably already in the tables.
+  it("says the change likely landed when the row advanced but cannot be re-read", async () => {
+    const registry = registryWhoseWriteFails({});
+    registry.updateComponentIfVersion = vi.fn(async () => ({
+      matched: false as const,
+    }));
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    const refusal = await service
+      .updateFieldGroup({
+        slug: "hero",
+        fields: [
+          { name: "heading", type: "text", localized: true },
+          { name: "subheading", type: "text", localized: true },
+        ] as never,
+      })
+      .catch((error: unknown) => error);
+
+    expect((refusal as NextlyError).publicMessage).toContain(
+      "already carries a newer version"
+    );
+    // Not claiming a mark that was never written, and not claiming nothing happened either.
+    expect((refusal as NextlyError).publicMessage).not.toContain(
+      "is marked as diverged"
+    );
+    expect((refusal as NextlyError).publicMessage).not.toContain(
+      "reads as though nothing happened"
+    );
   });
 
   // 🔴 Recording `diverged` is only half a control. Without a refusal, an editor opened AFTER the
@@ -1308,6 +1410,10 @@ describe("an update whose row write fails after the tables moved", () => {
         throw new Error("database unreachable");
       }
     );
+    // The marker is the conditional write, so an unreachable database fails it the same way.
+    registry.updateComponentIfVersion = vi.fn(async () => {
+      throw new Error("database unreachable");
+    });
     const adapter = adapterDouble(async () => true);
     const service = serviceOver(
       registry as unknown as ReturnType<typeof registryDouble>,
@@ -1338,6 +1444,6 @@ describe("an update whose row write fails after the tables moved", () => {
     );
     // The mark was attempted and refused, which is the state this describes. Asserting only the
     // raise would pass on an implementation that never tried.
-    expect(registry.updateComponent).toHaveBeenCalledTimes(2);
+    expect(registry.updateComponentIfVersion).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
@@ -1005,8 +1005,13 @@ describe("an update whose row write fails after the tables moved", () => {
           _data: Record<string, unknown>,
           expectedSchemaVersion: number,
           _options?: { source?: string }
-        ) => ({
-          matched: true as const,
+          // The union is the declared return type so a test can answer `matched: false` — the
+          // outcome half these tests exist to drive — without the literal-`true` default narrowing
+          // the property type.
+        ): Promise<
+          { matched: true; newSchemaVersion: number } | { matched: false }
+        > => ({
+          matched: true,
           newSchemaVersion: expectedSchemaVersion + 1,
         })
       ),

--- a/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { buildDesiredTableFromComponentFields } from "../../../schema/pipeline/diff/build-from-fields";
 import type { TableSpec } from "../../../schema/pipeline/diff/types";
+import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
 import {
   planFieldGroupReconcile,
   type ReconcilableField,
@@ -693,6 +694,61 @@ describe("planFieldGroupReconcile", () => {
           kind: "structural-column-missing",
         }),
       ]);
+    });
+
+    /**
+     * A system column can survive with its TYPE or NULLABILITY changed, and both break what the
+     * runtime schema is about to be registered on: a nullable `_parent_id` admits rows belonging
+     * to no parent, and a retyped one makes the parent-scoped queries compare values that no
+     * longer correspond.
+     */
+    it("refuses a structural column that is nullable where the table requires a value", () => {
+      const live = liveTableFor(stored);
+      const parent = live.columns.find(c => c.name === "_parent_id");
+      if (parent) parent.nullable = true;
+
+      const result = plan({ storedFields: stored, liveMain: live });
+
+      expect(result.blockers).toEqual([
+        expect.objectContaining({
+          columnName: "_parent_id",
+          kind: "structural-column-missing",
+        }),
+      ]);
+    });
+
+    it("refuses a structural column whose type has drifted", () => {
+      const live = liveTableFor(stored);
+      const parent = live.columns.find(c => c.name === "_parent_id");
+      if (parent) parent.type = "int4";
+
+      const result = plan({ storedFields: stored, liveMain: live });
+
+      expect(result.blockers).toEqual([
+        expect.objectContaining({
+          columnName: "_parent_id",
+          kind: "structural-column-missing",
+        }),
+      ]);
+    });
+
+    /**
+     * The negative control, and it is the one that decides the direction of the nullability check.
+     *
+     * A column the generator leaves NULLABLE that is live NOT NULL rejects nothing this operation
+     * can repair, and refusing it would turn a table an older generation created with a tighter
+     * constraint into an unreconcilable one — a false refusal on the single path out of trouble.
+     */
+    it("accepts a structural column that is stricter than the skeleton requires", () => {
+      const live = liveTableFor(stored);
+      const nullableInSkeleton = live.columns.find(
+        c => c.name === STORAGE_FORMAT.columns.type
+      );
+      if (nullableInSkeleton) nullableInSkeleton.nullable = false;
+
+      const result = plan({ storedFields: stored, liveMain: live });
+
+      expect(result.blockers).toEqual([]);
     });
 
     it("refuses a main table missing its parent index", () => {

--- a/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
@@ -51,9 +51,12 @@ function plan(args: {
   storedFields: ReconcilableField[];
   liveMain: TableSpec;
   liveCompanion?: TableSpec | null;
+  /** Defaults to false — the flag the row of a never-localized group records. */
+  storedLocalized?: boolean;
 }) {
   return planFieldGroupReconcile({
     storedFields: args.storedFields,
+    storedLocalized: args.storedLocalized ?? false,
     dialect: DIALECT,
     tableName: TABLE,
     liveMain: args.liveMain,
@@ -157,6 +160,7 @@ describe("planFieldGroupReconcile", () => {
 
     const result = planFieldGroupReconcile({
       storedFields: stored,
+      storedLocalized: false,
       dialect: DIALECT,
       tableName: TABLE,
       liveMain: live,
@@ -176,6 +180,7 @@ describe("planFieldGroupReconcile", () => {
       storedFields: stored,
       liveMain: liveTableFor(stored, { localized: true }),
       liveCompanion: companionWith([{ name: "title" }]),
+      storedLocalized: true,
     });
 
     expect(result.localized).toBe(true);
@@ -203,6 +208,7 @@ describe("planFieldGroupReconcile", () => {
       storedFields: stored,
       liveMain: liveTableFor(stored, { localized: true }),
       liveCompanion: companionWith([{ name: "title" }]),
+      storedLocalized: true,
     });
 
     expect(result.repaired).toEqual([]);
@@ -261,6 +267,75 @@ describe("planFieldGroupReconcile", () => {
     expect(result.removed).toEqual([]);
   });
 
+  // The primary divergence this operation repairs: a localization enable whose DDL landed and
+  // whose row write failed differs from a healthy group ONLY in the flag. Field-list comparison
+  // alone reads that as unchanged, and the caller then skips the one write the repair exists for.
+  it("treats flag drift alone as a change", () => {
+    const stored: ReconcilableField[] = [
+      { name: "title", type: "text", localized: true },
+    ];
+    const result = plan({
+      storedFields: stored,
+      liveMain: liveTableFor(stored, { localized: true }),
+      liveCompanion: companionWith([{ name: "title" }]),
+      // The row still says non-localized: the enable transition committed, the write did not.
+      storedLocalized: false,
+    });
+
+    expect(result.localized).toBe(true);
+    expect(result.unchanged).toBe(false);
+    // And nothing else invented: the flag IS the whole repair.
+    expect(result.removed).toEqual([]);
+    expect(result.repaired).toEqual([]);
+    expect(result.adopted).toEqual([]);
+  });
+
+  // A half-applied type change leaves a live column under a columnless field's own name. Keeping
+  // the columnless declaration AND adopting the column would persist two fields with one name and
+  // mark the ambiguity synced; the columnless field gives way, as a reported removal.
+  it("replaces a columnless field whose name a live column now occupies", () => {
+    const stored: ReconcilableField[] = [
+      { name: "title", type: "text" },
+      { name: "cta", type: "component" },
+    ];
+    const live = liveTableFor([{ name: "title", type: "text" }]);
+    live.columns.push({ name: "cta", type: "text", nullable: true });
+
+    const result = plan({ storedFields: stored, liveMain: live });
+
+    expect(result.fields.filter(f => f.name === "cta")).toHaveLength(1);
+    expect(result.fields.find(f => f.name === "cta")).toMatchObject({
+      type: "text",
+    });
+    expect(result.removed).toEqual([{ fieldName: "cta", columnName: "cta" }]);
+    expect(result.adopted).toEqual([
+      expect.objectContaining({ fieldName: "cta", table: "main" }),
+    ]);
+  });
+
+  // In a localized group a text-like field with NO flag defaults to translatable, which would
+  // re-home a column the planner just found on the MAIN table. Silence is not neutral there, so
+  // main-table adoptions carry an explicit false.
+  it("pins a main-table adoption of a localized group to the main table", () => {
+    const stored: ReconcilableField[] = [
+      { name: "title", type: "text", localized: true },
+    ];
+    const live = liveTableFor(stored, { localized: true });
+    live.columns.push({ name: "mystery_note", type: "text", nullable: true });
+
+    const result = plan({
+      storedFields: stored,
+      liveMain: live,
+      liveCompanion: companionWith([{ name: "title" }]),
+      storedLocalized: true,
+    });
+
+    expect(result.fields.find(f => f.name === "mystery_note")).toMatchObject({
+      type: "text",
+      localized: false,
+    });
+  });
+
   it("adopts a companion-resident unknown column as a localized field", () => {
     const stored: ReconcilableField[] = [
       { name: "title", type: "text", localized: true },
@@ -269,6 +344,7 @@ describe("planFieldGroupReconcile", () => {
       storedFields: stored,
       liveMain: liveTableFor(stored, { localized: true }),
       liveCompanion: companionWith([{ name: "title" }, { name: "tagline" }]),
+      storedLocalized: true,
     });
 
     expect(result.adopted).toEqual([

--- a/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
@@ -62,6 +62,11 @@ function plan(args: {
     field: ReconcilableField,
     table: ReconcileTable
   ) => string | undefined;
+  /** The builder's DEFAULT for a column; `known: false` means the check must stay silent. */
+  expectedColumnDefault?: (
+    field: ReconcilableField,
+    table: ReconcileTable
+  ) => { known: boolean; value?: string };
 }) {
   return planFieldGroupReconcile({
     storedFields: args.storedFields,
@@ -72,6 +77,9 @@ function plan(args: {
     liveCompanion: args.liveCompanion ?? null,
     ...(args.expectedColumnType
       ? { expectedColumnType: args.expectedColumnType }
+      : {}),
+    ...(args.expectedColumnDefault
+      ? { expectedColumnDefault: args.expectedColumnDefault }
       : {}),
   });
 }
@@ -467,6 +475,176 @@ describe("planFieldGroupReconcile", () => {
 
     expect(asked).toEqual([{ field: "contact", table: "companion" }]);
     expect(result.blockers).toEqual([]);
+  });
+
+  /**
+   * The DEFAULT is physical, and drifts exactly as the type does.
+   *
+   * Three-valued on purpose: the removal case below is the one a `string | undefined` expectation
+   * cannot express, because "the definition declares no default" and "no expectation could be
+   * derived" would be the same value, and the first must block while the second must not.
+   */
+  describe("column defaults", () => {
+    const storedCheckbox: ReconcilableField[] = [
+      { name: "featured", type: "checkbox" },
+    ];
+
+    function planWithDefaults(
+      liveDefault: string | undefined,
+      expected: { known: boolean; value?: string }
+    ) {
+      const live = liveTableFor(storedCheckbox);
+      const col = live.columns.find(c => c.name === "featured");
+      if (col) {
+        col.default = liveDefault;
+        // Stated rather than assumed: the normaliser only collapses 1/0 to a boolean when it is
+        // told the column is one, so a fixture that left the type to chance would be testing the
+        // fallback path while reading as though it tested the boolean one.
+        col.type = "boolean";
+      }
+      return plan({
+        storedFields: storedCheckbox,
+        liveMain: live,
+        expectedColumnDefault: () => expected,
+      });
+    }
+
+    it("refuses when the live default no longer matches the declared one", () => {
+      const result = planWithDefaults("false", { known: true, value: "true" });
+      expect(result.blockers).toEqual([
+        expect.objectContaining({
+          fieldName: "featured",
+          kind: "column-default-changed",
+        }),
+      ]);
+    });
+
+    // The case the third state exists for: the authored default was REMOVED while the column kept
+    // its own. A two-valued expectation reports this as nothing to compare.
+    it("refuses when the definition declares no default and the column has one", () => {
+      const result = planWithDefaults("true", { known: true });
+      expect(result.blockers).toEqual([
+        expect.objectContaining({ kind: "column-default-changed" }),
+      ]);
+    });
+
+    // The dialects spell one value differently — SQLite stores a boolean default as 1 where
+    // PostgreSQL reports `true` — so a raw string compare would report drift on every healthy
+    // SQLite group. This is the pair that proves the comparison runs through the normaliser.
+    it("accepts a live default that matches after normalisation", () => {
+      const result = planWithDefaults("1", { known: true, value: "true" });
+      expect(result.blockers).toEqual([]);
+    });
+
+    // The negative control. `known: false` must SKIP, never block — the companion reports it for
+    // every column, so blocking here would refuse every localized group.
+    it("stays silent when no default expectation could be derived", () => {
+      const result = planWithDefaults("true", { known: false });
+      expect(result.blockers).toEqual([]);
+    });
+  });
+
+  /**
+   * Structural integrity: a table missing a system column or its parent index cannot do its job,
+   * and this operation issues no DDL, so the only honest answer is to refuse.
+   *
+   * The positive controls below REMOVE something from a table the generator produced, rather than
+   * hand-building a broken one — so each asserts on the absence of exactly what the real generator
+   * emits, and cannot drift from it.
+   */
+  describe("structural integrity", () => {
+    const stored: ReconcilableField[] = [{ name: "title", type: "text" }];
+
+    it("refuses a main table missing a system column", () => {
+      const live = liveTableFor(stored);
+      live.columns = live.columns.filter(c => c.name !== "_parent_id");
+
+      const result = plan({ storedFields: stored, liveMain: live });
+
+      expect(result.blockers).toEqual([
+        expect.objectContaining({
+          columnName: "_parent_id",
+          kind: "structural-column-missing",
+        }),
+      ]);
+    });
+
+    it("refuses a main table missing its parent index", () => {
+      const live = liveTableFor(stored);
+      live.indexes = (live.indexes ?? []).filter(
+        index => index.columns.length === 1
+      );
+
+      const result = plan({ storedFields: stored, liveMain: live });
+
+      expect(result.blockers).toEqual([
+        expect.objectContaining({ kind: "system-index-missing" }),
+      ]);
+    });
+
+    // An index over the same columns in a different ORDER is a different object: only this order
+    // serves a lookup by parent id. Matched by ordered list rather than by name or by set.
+    it("refuses a parent index whose columns are in the wrong order", () => {
+      const live = liveTableFor(stored);
+      for (const index of live.indexes ?? []) {
+        if (index.columns.length > 1)
+          index.columns = [...index.columns].reverse();
+      }
+
+      const result = plan({ storedFields: stored, liveMain: live });
+
+      expect(result.blockers).toEqual([
+        expect.objectContaining({ kind: "system-index-missing" }),
+      ]);
+    });
+
+    // The negative control that keeps the companion check honest: a field group is never
+    // Draft/Published, so its companion has no `_status` and requiring one would refuse every
+    // localized group.
+    it("does not require a status column on a field group's companion", () => {
+      const localizedStored: ReconcilableField[] = [
+        { name: "title", type: "text", localized: true },
+      ];
+      const result = plan({
+        storedFields: localizedStored,
+        storedLocalized: true,
+        liveMain: liveTableFor(localizedStored, { localized: true }),
+        liveCompanion: companionWith([{ name: "title" }]),
+      });
+
+      expect(result.blockers).toEqual([]);
+    });
+  });
+
+  /**
+   * A vanished field standing beside an unclaimed column is equally a rename and a drop-plus-add,
+   * and resolving it silently discards authored configuration that nothing in the database retains.
+   */
+  it("refuses when a removal and an adoption could be one rename", () => {
+    const stored: ReconcilableField[] = [{ name: "headline", type: "text" }];
+    // The table the rename produced: the old column is gone, the new one is described by no field.
+    const live = liveTableFor([{ name: "title", type: "text" }]);
+
+    const result = plan({ storedFields: stored, liveMain: live });
+
+    expect(result.blockers).toEqual([
+      expect.objectContaining({ kind: "ambiguous-rename" }),
+    ]);
+  });
+
+  // The negative control: a removal with NO unclaimed column beside it is an unambiguous drop and
+  // must still be repaired, or the commonest divergence stops being fixable.
+  it("still removes a vanished field when nothing appeared to pair it with", () => {
+    const stored: ReconcilableField[] = [
+      { name: "title", type: "text" },
+      { name: "subtitle", type: "text" },
+    ];
+    const live = liveTableFor([{ name: "title", type: "text" }]);
+
+    const result = plan({ storedFields: stored, liveMain: live });
+
+    expect(result.blockers).toEqual([]);
+    expect(result.removed.map(r => r.fieldName)).toEqual(["subtitle"]);
   });
 
   // The control that keeps the check from firing on a column it has no expectation for. Absence

--- a/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDesiredTableFromComponentFields } from "../../../schema/pipeline/diff/build-from-fields";
+import type { TableSpec } from "../../../schema/pipeline/diff/types";
+import {
+  planFieldGroupReconcile,
+  type ReconcilableField,
+} from "../reconcile-field-group-plan";
+
+const TABLE = "comp_hero";
+const COMPANION = "comp_hero_locales";
+const DIALECT = "postgresql" as const;
+
+/**
+ * Live-table fixtures are built by the SAME builder the planner derives its system-column set
+ * from, so a system column the generator gains tomorrow is present on both sides of the
+ * comparison automatically — hand-listing columns here would re-introduce the drift the planner
+ * exists to repair.
+ */
+function liveTableFor(
+  fields: ReconcilableField[],
+  options: { localized?: boolean } = {}
+): TableSpec {
+  return buildDesiredTableFromComponentFields(TABLE, fields, DIALECT, {
+    builtBy: "fieldGroup",
+    ...(options.localized !== undefined
+      ? { localized: options.localized }
+      : {}),
+  });
+}
+
+/** A companion holding the given user columns beside its structural pair. */
+function companionWith(
+  columns: Array<{ name: string; type?: string }>
+): TableSpec {
+  return {
+    name: COMPANION,
+    columns: [
+      { name: "_parent", type: "text", nullable: false },
+      { name: "_locale", type: "varchar", nullable: false },
+      ...columns.map(c => ({
+        name: c.name,
+        type: c.type ?? "text",
+        nullable: true,
+      })),
+    ],
+  };
+}
+
+function plan(args: {
+  storedFields: ReconcilableField[];
+  liveMain: TableSpec;
+  liveCompanion?: TableSpec | null;
+}) {
+  return planFieldGroupReconcile({
+    storedFields: args.storedFields,
+    dialect: DIALECT,
+    tableName: TABLE,
+    liveMain: args.liveMain,
+    liveCompanion: args.liveCompanion ?? null,
+  });
+}
+
+describe("planFieldGroupReconcile", () => {
+  it("reports an already-honest definition as unchanged and keeps every field identical", () => {
+    const stored: ReconcilableField[] = [
+      { name: "title", type: "text", required: true },
+      { name: "contact", type: "email" },
+    ];
+    const result = plan({
+      storedFields: stored,
+      liveMain: liveTableFor(stored),
+    });
+
+    expect(result.unchanged).toBe(true);
+    expect(result.fields).toEqual(stored);
+    expect(result.removed).toEqual([]);
+    expect(result.repaired).toEqual([]);
+    expect(result.adopted).toEqual([]);
+  });
+
+  it("keeps the declared LOGICAL type when repairing a physical attribute", () => {
+    // `email` and `text` are one physical `text` column, so a rebuild from introspection would
+    // downgrade the type. The repair must touch only the attribute that drifted.
+    const stored: ReconcilableField[] = [
+      { name: "contact", type: "email", required: true },
+    ];
+    // The live column exists but is nullable: the failed edit never applied the NOT NULL.
+    const live = liveTableFor([{ name: "contact", type: "email" }]);
+
+    const result = plan({ storedFields: stored, liveMain: live });
+
+    expect(result.unchanged).toBe(false);
+    expect(result.fields).toEqual([
+      { name: "contact", type: "email", required: false },
+    ]);
+    expect(result.repaired).toEqual([
+      {
+        fieldName: "contact",
+        columnName: "contact",
+        table: "main",
+        attribute: "required",
+        from: true,
+        to: false,
+      },
+    ]);
+  });
+
+  it("removes a field whose column vanished and reports it by identity", () => {
+    const stored: ReconcilableField[] = [
+      { name: "title", type: "text" },
+      { name: "subtitle", type: "text" },
+    ];
+    const live = liveTableFor([{ name: "title", type: "text" }]);
+
+    const result = plan({ storedFields: stored, liveMain: live });
+
+    expect(result.fields.map(f => f.name)).toEqual(["title"]);
+    expect(result.removed).toEqual([
+      { fieldName: "subtitle", columnName: "subtitle" },
+    ]);
+  });
+
+  it("adopts an unknown live column with a guessed type, flagged as a guess", () => {
+    const live = liveTableFor([{ name: "title", type: "text" }]);
+    live.columns.push({ name: "mystery_count", type: "int4", nullable: false });
+
+    const result = plan({
+      storedFields: [{ name: "title", type: "text" }],
+      liveMain: live,
+    });
+
+    expect(result.adopted).toEqual([
+      {
+        fieldName: "mystery_count",
+        columnName: "mystery_count",
+        table: "main",
+        liveType: "int4",
+        guessedType: "number",
+      },
+    ]);
+    const adopted = result.fields.find(f => f.name === "mystery_count");
+    expect(adopted).toMatchObject({
+      type: "number",
+      required: true,
+    });
+  });
+
+  it("never adopts a system column, including the probed discriminator spelling", () => {
+    const stored: ReconcilableField[] = [{ name: "title", type: "text" }];
+    // A table the storage migration moved carries the new discriminator name; naming it via
+    // `typeColumn` is what keeps it out of the adoption list.
+    const live = buildDesiredTableFromComponentFields(TABLE, stored, DIALECT, {
+      builtBy: "fieldGroup",
+      typeColumn: "_field_group_type",
+    });
+
+    const result = planFieldGroupReconcile({
+      storedFields: stored,
+      dialect: DIALECT,
+      tableName: TABLE,
+      liveMain: live,
+      liveCompanion: null,
+      typeColumn: "_field_group_type",
+    });
+
+    expect(result.adopted).toEqual([]);
+    expect(result.unchanged).toBe(true);
+  });
+
+  it("derives localized from the companion holding a user column, never from a flag", () => {
+    const stored: ReconcilableField[] = [
+      { name: "title", type: "text", localized: true },
+    ];
+    const result = plan({
+      storedFields: stored,
+      liveMain: liveTableFor(stored, { localized: true }),
+      liveCompanion: companionWith([{ name: "title" }]),
+    });
+
+    expect(result.localized).toBe(true);
+    expect(result.unchanged).toBe(true);
+  });
+
+  it("reads a companion holding only structural columns as not localized", () => {
+    const stored: ReconcilableField[] = [{ name: "title", type: "text" }];
+    const result = plan({
+      storedFields: stored,
+      liveMain: liveTableFor(stored),
+      liveCompanion: companionWith([]),
+    });
+
+    expect(result.localized).toBe(false);
+  });
+
+  it("does not repair required from a companion column's nullability", () => {
+    // Companion columns are created nullable whatever the field declares, so their nullability is
+    // structural rather than evidence — a required localized field must survive untouched.
+    const stored: ReconcilableField[] = [
+      { name: "title", type: "text", localized: true, required: true },
+    ];
+    const result = plan({
+      storedFields: stored,
+      liveMain: liveTableFor(stored, { localized: true }),
+      liveCompanion: companionWith([{ name: "title" }]),
+    });
+
+    expect(result.repaired).toEqual([]);
+    expect(result.fields).toEqual(stored);
+  });
+
+  it("corrects a declared unique the live table no longer backs, when indexes are tracked", () => {
+    const stored: ReconcilableField[] = [
+      { name: "slug_field", type: "text", unique: true },
+    ];
+    const live = liveTableFor([{ name: "slug_field", type: "text" }]);
+    // Tracked-and-empty is a statement about the table; undefined is a statement about the
+    // snapshot, covered by the test below.
+    live.indexes = [];
+
+    const result = plan({ storedFields: stored, liveMain: live });
+
+    expect(result.repaired).toEqual([
+      {
+        fieldName: "slug_field",
+        columnName: "slug_field",
+        table: "main",
+        attribute: "unique",
+        from: true,
+        to: false,
+      },
+    ]);
+    expect(result.fields[0]).toMatchObject({ type: "text", unique: false });
+  });
+
+  it("leaves declared indexes alone when the snapshot tracked no index data", () => {
+    const stored: ReconcilableField[] = [
+      { name: "slug_field", type: "text", unique: true },
+    ];
+    const live = liveTableFor([{ name: "slug_field", type: "text" }]);
+    delete live.indexes;
+
+    const result = plan({ storedFields: stored, liveMain: live });
+
+    expect(result.repaired).toEqual([]);
+    expect(result.fields).toEqual(stored);
+  });
+
+  it("keeps a layout-only field no column can testify about", () => {
+    const stored: ReconcilableField[] = [
+      { name: "title", type: "text" },
+      // `component` fields produce no column on this table: instances live in the child table.
+      { name: "cta", type: "component" },
+    ];
+    const result = plan({
+      storedFields: stored,
+      liveMain: liveTableFor([{ name: "title", type: "text" }]),
+    });
+
+    expect(result.fields.map(f => f.name)).toContain("cta");
+    expect(result.removed).toEqual([]);
+  });
+
+  it("adopts a companion-resident unknown column as a localized field", () => {
+    const stored: ReconcilableField[] = [
+      { name: "title", type: "text", localized: true },
+    ];
+    const result = plan({
+      storedFields: stored,
+      liveMain: liveTableFor(stored, { localized: true }),
+      liveCompanion: companionWith([{ name: "title" }, { name: "tagline" }]),
+    });
+
+    expect(result.adopted).toEqual([
+      {
+        fieldName: "tagline",
+        columnName: "tagline",
+        table: "companion",
+        liveType: "text",
+        guessedType: "text",
+      },
+    ]);
+    expect(result.fields.find(f => f.name === "tagline")).toMatchObject({
+      type: "text",
+      localized: true,
+      required: false,
+    });
+  });
+});

--- a/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
@@ -30,15 +30,21 @@ function liveTableFor(
   });
 }
 
-/** A companion holding the given user columns beside its structural pair. */
+/**
+ * A companion holding the given user columns beside its structural pair.
+ *
+ * The structural pair carries `primaryKey`, because the real companion DDL declares
+ * `PRIMARY KEY (_parent, _locale)` and introspection reports it per column on all three dialects.
+ * A fixture that omitted it would model a table the generator never produces.
+ */
 function companionWith(
   columns: Array<{ name: string; type?: string }>
 ): TableSpec {
   return {
     name: COMPANION,
     columns: [
-      { name: "_parent", type: "text", nullable: false },
-      { name: "_locale", type: "varchar", nullable: false },
+      { name: "_parent", type: "text", nullable: false, primaryKey: true },
+      { name: "_locale", type: "varchar", nullable: false, primaryKey: true },
       ...columns.map(c => ({
         name: c.name,
         type: c.type ?? "text",
@@ -598,6 +604,32 @@ describe("planFieldGroupReconcile", () => {
       ]);
     });
 
+    /**
+     * The companion's composite key is load-bearing at runtime rather than merely structural:
+     * localized writes match rows on `(_parent, _locale)`. A companion that kept both columns and
+     * lost the key passes every other check here while failing every localized write on
+     * PostgreSQL and SQLite, and silently accepting duplicate locale rows on MySQL.
+     */
+    it("refuses a companion whose key columns are no longer its primary key", () => {
+      const localizedStored: ReconcilableField[] = [
+        { name: "title", type: "text", localized: true },
+      ];
+      const companion = companionWith([{ name: "title" }]);
+      for (const column of companion.columns) delete column.primaryKey;
+
+      const result = plan({
+        storedFields: localizedStored,
+        storedLocalized: true,
+        liveMain: liveTableFor(localizedStored, { localized: true }),
+        liveCompanion: companion,
+      });
+
+      expect(result.blockers.map(b => b.columnName).sort()).toEqual([
+        "_locale",
+        "_parent",
+      ]);
+    });
+
     // The negative control that keeps the companion check honest: a field group is never
     // Draft/Published, so its companion has no `_status` and requiring one would refuse every
     // localized group.
@@ -645,6 +677,52 @@ describe("planFieldGroupReconcile", () => {
 
     expect(result.blockers).toEqual([]);
     expect(result.removed.map(r => r.fieldName)).toEqual(["subtitle"]);
+  });
+
+  /**
+   * A width change is a physical change, and the canonical form deliberately discards it.
+   *
+   * That strip is right for PostgreSQL, whose introspection reads `udt_name` and never reports a
+   * length — but MySQL reports `COLUMN_TYPE`, which does. So a `maxLength` edit that resized the
+   * column and then failed its registry write leaves the two comparing equal under the canonical
+   * form alone, and the definition keeps a width the column no longer has.
+   */
+  describe("type width", () => {
+    const stored: ReconcilableField[] = [{ name: "title", type: "text" }];
+
+    function planWithWidths(liveType: string, expected: string) {
+      const live = liveTableFor(stored);
+      const col = live.columns.find(c => c.name === "title");
+      if (col) col.type = liveType;
+      return plan({
+        storedFields: stored,
+        liveMain: live,
+        expectedColumnType: () => expected,
+      });
+    }
+
+    it("refuses when both sides report a width and they differ", () => {
+      const result = planWithWidths("varchar(32)", "VARCHAR(255)");
+      expect(result.blockers).toEqual([
+        expect.objectContaining({
+          fieldName: "title",
+          kind: "physical-type-changed",
+        }),
+      ]);
+    });
+
+    it("accepts equal widths", () => {
+      expect(planWithWidths("varchar(255)", "VARCHAR(255)").blockers).toEqual(
+        []
+      );
+    });
+
+    // The negative control, and the reason the check is gated on BOTH sides carrying a modifier:
+    // PostgreSQL's introspected type has none, so demanding one would refuse every healthy
+    // PostgreSQL column whose declaration happens to specify a length.
+    it("stays silent when the live side reports no width", () => {
+      expect(planWithWidths("varchar", "VARCHAR(255)").blockers).toEqual([]);
+    });
   });
 
   // The control that keeps the check from firing on a column it has no expectation for. Absence

--- a/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
@@ -336,6 +336,114 @@ describe("planFieldGroupReconcile", () => {
     });
   });
 
+  // 🔴 The finding that would have DESTROYED authored meaning. Toggling one field's `localized`
+  // moves its column between tables; searching only the table the stale flag implies reports the
+  // field as removed and re-adopts its column as a minimal guess, discarding the logical type and
+  // every authored option. Located where the column actually is, the field survives intact.
+  it("keeps a field whose column moved between tables, correcting only its placement", () => {
+    const stored: ReconcilableField[] = [
+      { name: "title", type: "text", localized: true },
+      // Declared as living on the MAIN table, but the apply moved it to the companion.
+      { name: "contact", type: "email", localized: false, required: true },
+    ];
+    const result = plan({
+      storedFields: stored,
+      liveMain: liveTableFor(
+        [{ name: "title", type: "text", localized: true }],
+        {
+          localized: true,
+        }
+      ),
+      liveCompanion: companionWith([{ name: "title" }, { name: "contact" }]),
+      storedLocalized: true,
+    });
+
+    const contact = result.fields.find(f => f.name === "contact");
+    // The authored LOGICAL type survives — an adoption would have guessed `text`.
+    expect(contact).toMatchObject({ type: "email", localized: true });
+    expect(result.removed).toEqual([]);
+    expect(result.adopted).toEqual([]);
+    expect(result.repaired).toContainEqual({
+      fieldName: "contact",
+      columnName: "contact",
+      table: "companion",
+      attribute: "localized",
+      from: false,
+      to: true,
+    });
+  });
+
+  it("refuses when one column exists on both tables", () => {
+    const stored: ReconcilableField[] = [
+      { name: "title", type: "text", localized: true },
+    ];
+    // A localization enable that seeded the companion without finishing the main-table drops.
+    const live = liveTableFor([{ name: "title", type: "text" }]);
+    const result = plan({
+      storedFields: stored,
+      liveMain: live,
+      liveCompanion: companionWith([{ name: "title" }]),
+      storedLocalized: true,
+    });
+
+    expect(result.blockers).toEqual([
+      expect.objectContaining({
+        fieldName: "title",
+        kind: "column-on-both-tables",
+      }),
+    ]);
+  });
+
+  it("refuses when a column's physical type no longer matches its declared field", () => {
+    const stored: ReconcilableField[] = [{ name: "weight", type: "number" }];
+    // The apply changed the column to text and then failed its registry write.
+    const live = liveTableFor([{ name: "weight", type: "number" }]);
+    const col = live.columns.find(c => c.name === "weight");
+    if (col) col.type = "text";
+
+    const result = plan({ storedFields: stored, liveMain: live });
+
+    expect(result.blockers).toEqual([
+      expect.objectContaining({
+        fieldName: "weight",
+        kind: "physical-type-changed",
+      }),
+    ]);
+  });
+
+  it("refuses a live column whose identifier no field name can represent", () => {
+    const live = liveTableFor([{ name: "title", type: "text" }]);
+    live.columns.push({ name: "Legacy-Title", type: "text", nullable: true });
+
+    const result = plan({
+      storedFields: [{ name: "title", type: "text" }],
+      liveMain: live,
+    });
+
+    expect(result.blockers).toEqual([
+      expect.objectContaining({ kind: "unrepresentable-column-name" }),
+    ]);
+    // And it is NOT adopted: persisting it would violate the field contract.
+    expect(result.fields.find(f => f.name === "Legacy-Title")).toBeUndefined();
+  });
+
+  // 🔴 A localized group whose last translatable field was removed leaves a companion holding only
+  // structural columns — physically identical to a never-localized group. Reading that as "not
+  // localized" would make the documented idempotent repair the thing that breaks the group, by
+  // routing the next default-translatable field to the wrong table.
+  it("keeps localization when the companion is structurally empty but the row says localized", () => {
+    const stored: ReconcilableField[] = [{ name: "weight", type: "number" }];
+    const result = plan({
+      storedFields: stored,
+      liveMain: liveTableFor(stored, { localized: true }),
+      liveCompanion: companionWith([]),
+      storedLocalized: true,
+    });
+
+    expect(result.localized).toBe(true);
+    expect(result.unchanged).toBe(true);
+  });
+
   it("adopts a companion-resident unknown column as a localized field", () => {
     const stored: ReconcilableField[] = [
       { name: "title", type: "text", localized: true },

--- a/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
@@ -617,6 +617,24 @@ describe("planFieldGroupReconcile", () => {
       ]);
     });
 
+    // A column can survive while the constraint that made it meaningful is dropped: `id` present
+    // but no longer the key means duplicate component rows, which every name-based check reads as
+    // healthy. Taken from the skeleton's own `primaryKey`, so it covers whatever is marked next.
+    it("refuses a main table whose id is no longer the primary key", () => {
+      const live = liveTableFor(stored);
+      const id = live.columns.find(c => c.name === "id");
+      if (id) delete id.primaryKey;
+
+      const result = plan({ storedFields: stored, liveMain: live });
+
+      expect(result.blockers).toEqual([
+        expect.objectContaining({
+          columnName: "id",
+          kind: "structural-column-missing",
+        }),
+      ]);
+    });
+
     it("refuses a main table missing its parent index", () => {
       const live = liveTableFor(stored);
       live.indexes = (live.indexes ?? []).filter(

--- a/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
@@ -53,6 +53,8 @@ function plan(args: {
   liveCompanion?: TableSpec | null;
   /** Defaults to false — the flag the row of a never-localized group records. */
   storedLocalized?: boolean;
+  /** The creator-derived expectation; absent means the type check has nothing to compare. */
+  expectedColumnTypes?: ReadonlyMap<string, string>;
 }) {
   return planFieldGroupReconcile({
     storedFields: args.storedFields,
@@ -61,6 +63,9 @@ function plan(args: {
     tableName: TABLE,
     liveMain: args.liveMain,
     liveCompanion: args.liveCompanion ?? null,
+    ...(args.expectedColumnTypes
+      ? { expectedColumnTypes: args.expectedColumnTypes }
+      : {}),
   });
 }
 
@@ -401,7 +406,15 @@ describe("planFieldGroupReconcile", () => {
     const col = live.columns.find(c => c.name === "weight");
     if (col) col.type = "text";
 
-    const result = plan({ storedFields: stored, liveMain: live });
+    const result = plan({
+      storedFields: stored,
+      liveMain: live,
+      // 🔴 The expectation comes from the CREATOR, so the test must supply one — without it the
+      // check has nothing to compare against and correctly stays silent. Passing an empty map here
+      // is what made this case inert when the comparison moved off the column descriptor, and the
+      // suite caught it; the entry is the check's real input rather than scaffolding.
+      expectedColumnTypes: new Map([["weight", "int4"]]),
+    });
 
     expect(result.blockers).toEqual([
       expect.objectContaining({
@@ -409,6 +422,20 @@ describe("planFieldGroupReconcile", () => {
         kind: "physical-type-changed",
       }),
     ]);
+  });
+
+  // The control that keeps the check from firing on a column it has no expectation for. Absence
+  // must SKIP rather than block — treating "I could not derive an expectation" as drift is what
+  // made reconcile refuse healthy groups containing dates and relations.
+  it("stays silent when no expected type is known for the column", () => {
+    const stored: ReconcilableField[] = [{ name: "weight", type: "number" }];
+    const live = liveTableFor([{ name: "weight", type: "number" }]);
+    const col = live.columns.find(c => c.name === "weight");
+    if (col) col.type = "text";
+
+    const result = plan({ storedFields: stored, liveMain: live });
+
+    expect(result.blockers).toEqual([]);
   });
 
   it("refuses a live column whose identifier no field name can represent", () => {

--- a/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
@@ -213,6 +213,48 @@ describe("planFieldGroupReconcile", () => {
     expect(result.unchanged).toBe(true);
   });
 
+  /**
+   * A localized group whose fields produce no translatable COLUMN has no companion table at all —
+   * `deriveCompanionSpec` returns null in exactly that case, so the absence is healthy rather than
+   * evidence of anything.
+   *
+   * Reading it as "not localized" rewrites a correct row, and the damage surfaces later: the next
+   * default-translatable field added to the group is placed on the main table, which is the
+   * divergence this operation exists to clear rather than to create.
+   */
+  it("keeps a localized group localized when its fields need no companion", () => {
+    const stored: ReconcilableField[] = [
+      { name: "title", type: "text", localized: false },
+    ];
+
+    const result = plan({
+      storedFields: stored,
+      liveMain: liveTableFor(stored),
+      liveCompanion: null,
+      storedLocalized: true,
+    });
+
+    expect(result.localized).toBe(true);
+    expect(result.unchanged).toBe(true);
+  });
+
+  // The negative control: where the fields WOULD have produced a companion column, a missing
+  // companion is still read as not localized, so a genuine disable is still repaired.
+  it("still reads a missing companion as not localized when one was due", () => {
+    const stored: ReconcilableField[] = [
+      { name: "title", type: "text", localized: true },
+    ];
+
+    const result = plan({
+      storedFields: stored,
+      liveMain: liveTableFor(stored),
+      liveCompanion: null,
+      storedLocalized: true,
+    });
+
+    expect(result.localized).toBe(false);
+  });
+
   it("reads a companion holding only structural columns as not localized", () => {
     const stored: ReconcilableField[] = [{ name: "title", type: "text" }];
     const result = plan({

--- a/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
@@ -175,6 +175,66 @@ describe("planFieldGroupReconcile", () => {
     });
   });
 
+  /**
+   * An adopted column's DEFAULT is part of what the column does, and the matched-field check never
+   * sees an adoption. Dropping it writes a definition that understates the column, and the next
+   * apply — diffing that definition against the table — removes the default outright.
+   */
+  describe("adopted column defaults", () => {
+    const stored: ReconcilableField[] = [{ name: "title", type: "text" }];
+
+    it("carries a boolean default onto the adopted field", () => {
+      const live = liveTableFor(stored);
+      live.columns.push({
+        name: "featured",
+        type: "boolean",
+        nullable: true,
+        default: "true",
+      });
+
+      const result = plan({ storedFields: stored, liveMain: live });
+
+      expect(result.blockers).toEqual([]);
+      expect(result.fields.find(f => f.name === "featured")).toMatchObject({
+        type: "checkbox",
+        defaultValue: true,
+      });
+    });
+
+    // A default the field contract cannot record must refuse rather than be dropped: the creator
+    // only ever emits checkbox defaults, so anything else here is not something the pipeline wrote.
+    it("refuses an adoption whose default cannot be represented", () => {
+      const live = liveTableFor(stored);
+      live.columns.push({
+        name: "headline",
+        type: "text",
+        nullable: true,
+        default: "untitled",
+      });
+
+      const result = plan({ storedFields: stored, liveMain: live });
+
+      expect(result.blockers).toEqual([
+        expect.objectContaining({
+          columnName: "headline",
+          kind: "column-default-changed",
+        }),
+      ]);
+    });
+
+    // The negative control: a column with NO default still adopts cleanly, so the check has not
+    // simply turned every adoption into a refusal.
+    it("still adopts a column that carries no default", () => {
+      const live = liveTableFor(stored);
+      live.columns.push({ name: "subtitle", type: "text", nullable: true });
+
+      const result = plan({ storedFields: stored, liveMain: live });
+
+      expect(result.blockers).toEqual([]);
+      expect(result.adopted.map(a => a.fieldName)).toEqual(["subtitle"]);
+    });
+  });
+
   it("never adopts a system column, including the probed discriminator spelling", () => {
     const stored: ReconcilableField[] = [{ name: "title", type: "text" }];
     // A table the storage migration moved carries the new discriminator name; naming it via
@@ -684,9 +744,35 @@ describe("planFieldGroupReconcile", () => {
         liveCompanion: companion,
       });
 
-      expect(result.blockers.map(b => b.columnName).sort()).toEqual([
-        "_locale",
-        "_parent",
+      expect(result.blockers).toEqual([
+        expect.objectContaining({ kind: "structural-column-missing" }),
+      ]);
+    });
+
+    /**
+     * Membership of the key is not the property; being the WHOLE key is.
+     *
+     * A key of `(_parent, _locale, title)` contains both required columns and enforces uniqueness
+     * over three values, so PostgreSQL and SQLite have no constraint matching the runtime's
+     * `(_parent, _locale)` conflict target and MySQL admits several rows per parent and locale.
+     */
+    it("refuses a companion whose primary key carries extra columns", () => {
+      const localizedStored: ReconcilableField[] = [
+        { name: "title", type: "text", localized: true },
+      ];
+      const companion = companionWith([{ name: "title" }]);
+      const extra = companion.columns.find(c => c.name === "title");
+      if (extra) extra.primaryKey = true;
+
+      const result = plan({
+        storedFields: localizedStored,
+        storedLocalized: true,
+        liveMain: liveTableFor(localizedStored, { localized: true }),
+        liveCompanion: companion,
+      });
+
+      expect(result.blockers).toEqual([
+        expect.objectContaining({ kind: "structural-column-missing" }),
       ]);
     });
 

--- a/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
@@ -5,6 +5,7 @@ import type { TableSpec } from "../../../schema/pipeline/diff/types";
 import {
   planFieldGroupReconcile,
   type ReconcilableField,
+  type ReconcileTable,
 } from "../reconcile-field-group-plan";
 
 const TABLE = "comp_hero";
@@ -53,8 +54,14 @@ function plan(args: {
   liveCompanion?: TableSpec | null;
   /** Defaults to false — the flag the row of a never-localized group records. */
   storedLocalized?: boolean;
-  /** The creator-derived expectation; absent means the type check has nothing to compare. */
-  expectedColumnTypes?: ReadonlyMap<string, string>;
+  /**
+   * What the table builders would write, asked per (field, table). Absent means the type check has
+   * nothing to compare and must stay silent.
+   */
+  expectedColumnType?: (
+    field: ReconcilableField,
+    table: ReconcileTable
+  ) => string | undefined;
 }) {
   return planFieldGroupReconcile({
     storedFields: args.storedFields,
@@ -63,8 +70,8 @@ function plan(args: {
     tableName: TABLE,
     liveMain: args.liveMain,
     liveCompanion: args.liveCompanion ?? null,
-    ...(args.expectedColumnTypes
-      ? { expectedColumnTypes: args.expectedColumnTypes }
+    ...(args.expectedColumnType
+      ? { expectedColumnType: args.expectedColumnType }
       : {}),
   });
 }
@@ -409,11 +416,11 @@ describe("planFieldGroupReconcile", () => {
     const result = plan({
       storedFields: stored,
       liveMain: live,
-      // 🔴 The expectation comes from the CREATOR, so the test must supply one — without it the
-      // check has nothing to compare against and correctly stays silent. Passing an empty map here
+      // 🔴 The expectation comes from the table builders, so the test must supply one — without it
+      // the check has nothing to compare against and correctly stays silent. Supplying nothing here
       // is what made this case inert when the comparison moved off the column descriptor, and the
-      // suite caught it; the entry is the check's real input rather than scaffolding.
-      expectedColumnTypes: new Map([["weight", "int4"]]),
+      // suite caught it; this is the check's real input rather than scaffolding.
+      expectedColumnType: () => "int4",
     });
 
     expect(result.blockers).toEqual([
@@ -422,6 +429,44 @@ describe("planFieldGroupReconcile", () => {
         kind: "physical-type-changed",
       }),
     ]);
+  });
+
+  /**
+   * The two tables are built by different code and spell the same field differently, so the type
+   * check must ask about the table the column was FOUND in.
+   *
+   * The case that makes this load-bearing is the one below: the column has moved to the companion
+   * while the stored flag still says the group is not localized. That disagreement is the primary
+   * divergence this operation repairs, so resolving the expectation from the stored flag would
+   * report drift on precisely the input reconcile exists to fix — and would do it while the column
+   * is perfectly healthy.
+   *
+   * Asserted on the ARGUMENTS the check actually passes rather than only on the absence of a
+   * blocker: a planner that stopped consulting the expectation at all would also produce no
+   * blocker, and this must not pass for that reason.
+   */
+  it("asks for the expected type of the table the column was found in", () => {
+    const stored: ReconcilableField[] = [{ name: "contact", type: "email" }];
+    const live = liveTableFor([]);
+    const companion = companionWith([{ name: "contact", type: "text" }]);
+
+    const asked: Array<{ field: string; table: ReconcileTable }> = [];
+    const result = plan({
+      storedFields: stored,
+      liveMain: live,
+      liveCompanion: companion,
+      // The real spellings this pair produces on PostgreSQL: the main table's builder gives an
+      // `email` a length-capped varchar, the companion's builder gives it unbounded text. Asking
+      // about the wrong table therefore compares `varchar` against a live `text` and blocks.
+      storedLocalized: false,
+      expectedColumnType: (field, table) => {
+        asked.push({ field: field.name, table });
+        return table === "companion" ? "TEXT" : "VARCHAR(255)";
+      },
+    });
+
+    expect(asked).toEqual([{ field: "contact", table: "companion" }]);
+    expect(result.blockers).toEqual([]);
   });
 
   // The control that keeps the check from firing on a column it has no expectation for. Absence

--- a/packages/nextly/src/domains/field-groups/services/__tests__/register-component-runtime-schema.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/register-component-runtime-schema.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Runtime registration must point the process at BOTH of a localized field group's tables.
+ *
+ * A localized group's translated reads and writes go through the companion, so registering only the
+ * main table leaves the half that actually serves those values stale. That matters more now that
+ * the function REPORTS its outcome: a partial registration returning `registered: true` tells a
+ * caller the refresh completed, and the caller passes that on to an operator as "the group is
+ * usable again".
+ *
+ * There are two sinks — the DI registry and the adapter's own resolver — and they must answer this
+ * identically. The fallback is exercised here because it is the one that diverged: it registered
+ * the main table alone while returning the same verdict as the branch that registered both.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetSchemaRegistryFromDI = vi.fn();
+vi.mock("../../../dispatcher/helpers/di", () => ({
+  getSchemaRegistryFromDI: () => mockGetSchemaRegistryFromDI(),
+  getConfigFromDI: () => null,
+}));
+
+/** A localized text field, which is what makes a companion table exist at all. */
+const LOCALIZED_FIELDS = [
+  { name: "title", type: "text", localized: true },
+] as unknown as Parameters<
+  typeof import("../field-group-table-provisioning").registerComponentRuntimeSchema
+>[3];
+
+/** An adapter carrying only the resolver seam the fallback reads. */
+function adapterWithResolver(): {
+  adapter: unknown;
+  registered: Array<{ name: string }>;
+} {
+  const registered: Array<{ name: string }> = [];
+  return {
+    adapter: {
+      tableResolver: {
+        registerDynamicSchema: (name: string) => {
+          registered.push({ name });
+        },
+      },
+    },
+    registered,
+  };
+}
+
+beforeEach(() => {
+  // No DI registry, so the fallback is the branch under test. Asserted below by the registration
+  // arriving on the resolver at all — without that, a silent no-op would satisfy every check here.
+  mockGetSchemaRegistryFromDI.mockReturnValue(null);
+});
+
+describe("registerComponentRuntimeSchema through the adapter resolver", () => {
+  it("registers the companion alongside the main table for a localized group", async () => {
+    const { registerComponentRuntimeSchema } = await import(
+      "../field-group-table-provisioning"
+    );
+    const { adapter, registered } = adapterWithResolver();
+
+    const result = registerComponentRuntimeSchema(
+      adapter as Parameters<typeof registerComponentRuntimeSchema>[0],
+      "postgresql",
+      "comp_hero",
+      LOCALIZED_FIELDS,
+      "_component_type",
+      true
+    );
+
+    expect(result.registered).toBe(true);
+    // By IDENTITY rather than by count: a count of two is also what registering the main table
+    // twice would produce, and the companion is the name this test exists for.
+    expect(registered.map(r => r.name).sort()).toEqual([
+      "comp_hero",
+      "comp_hero_locales",
+    ]);
+  });
+
+  // The negative control. A non-localized group has no companion, so exactly one registration is
+  // correct — this is what keeps the fix from being "always register a second table".
+  it("registers only the main table when the group is not localized", async () => {
+    const { registerComponentRuntimeSchema } = await import(
+      "../field-group-table-provisioning"
+    );
+    const { adapter, registered } = adapterWithResolver();
+
+    const result = registerComponentRuntimeSchema(
+      adapter as Parameters<typeof registerComponentRuntimeSchema>[0],
+      "postgresql",
+      "comp_hero",
+      [{ name: "title", type: "text" }] as unknown as typeof LOCALIZED_FIELDS,
+      "_component_type",
+      false
+    );
+
+    expect(result.registered).toBe(true);
+    expect(registered.map(r => r.name)).toEqual(["comp_hero"]);
+  });
+
+  // With neither sink available the answer must be a REFUSAL, not a claim: this is the state that
+  // previously reported success while nothing had been registered anywhere.
+  it("reports an unrefreshed runtime when no sink exists", async () => {
+    const { registerComponentRuntimeSchema } = await import(
+      "../field-group-table-provisioning"
+    );
+
+    const result = registerComponentRuntimeSchema(
+      {} as Parameters<typeof registerComponentRuntimeSchema>[0],
+      "postgresql",
+      "comp_hero",
+      LOCALIZED_FIELDS,
+      "_component_type",
+      true
+    );
+
+    expect(result.registered).toBe(false);
+    expect(result.reason).toBeTruthy();
+  });
+});

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -443,9 +443,14 @@ export class FieldGroupMetadataService {
         );
         return { record: settled };
       }
-      // Returns `never`, so this is a raise rather than a value — written as a return so the
-      // compiler, not a comment, is what establishes that nothing falls out of this method.
-      return await this.recordUnrecordedTransition(input.slug, existing, error);
+      // Usually a raise; the one value it can return is a settled row discovered on its second
+      // look, which is a success this catch then answers with.
+      return await this.recordUnrecordedTransition(
+        input,
+        requestedLocalized,
+        existing,
+        error
+      );
     }
   }
 
@@ -767,6 +772,16 @@ export class FieldGroupMetadataService {
    * main-table columns the first attempt already dropped. The caller has to be told the physical
    * change stands.
    *
+   * 🔴 The marker is a COMPARE-AND-SET against the version this edit started from, because "the
+   * write raised" does not mean "the row went unwritten". The read-back that would settle that can
+   * itself fail transiently, and a marker written unconditionally after two failed reads stamps
+   * `diverged` onto a row the original write reached after all — permanently refusing schema edits
+   * on a group that is completely fine, with its version bumped twice. Pinning the version makes
+   * the DATABASE answer the question the reads could not: zero rows matched MEANS the row already
+   * advanced, i.e. the original write landed, and this takes one more look before answering
+   * success. The version advance the marker needs (an editor loaded before the transition must
+   * fail `assertSchemaVersionMatch`) is the conditional write's own contract.
+   *
    * The status write is BEST EFFORT and its failure is not raised. It is a narrow single-column
    * update, so it survives the failures that realistically break the full write — a rejected field
    * list, an oversized label, a value the driver cannot encode — and if the database is genuinely
@@ -774,10 +789,12 @@ export class FieldGroupMetadataService {
    * group without it.
    */
   private async recordUnrecordedTransition(
-    slug: string,
+    input: UpdateFieldGroupInput,
+    requestedLocalized: boolean | undefined,
     existing: DynamicFieldGroupRecord,
     cause: unknown
-  ): Promise<never> {
+  ): Promise<UpdateFieldGroupResult> {
+    const slug = input.slug;
     this.logger.error(
       "[FieldGroups] Schema transition committed but its registry row was not written.",
       {
@@ -788,18 +805,41 @@ export class FieldGroupMetadataService {
       }
     );
 
-    let marked = false;
+    // Three endings, and the message below must not conflate them: the mark was persisted, the row
+    // turned out to have advanced (so the CHANGE was recorded, and only the confirmation is
+    // missing), or nothing about the state could be recorded at all.
+    let recordState: "marked" | "advanced" | "unrecorded" = "unrecorded";
     try {
-      await this.registry.updateComponent(
+      const outcome = await this.registry.updateComponentIfVersion(
         slug,
         { migrationStatus: "diverged" },
-        // The version advances even though this write carries no new field set: the TABLES moved,
-        // and an editor loaded before that is now describing a shape that is gone. Leaving the
-        // version alone would let such a preview pass `assertSchemaVersionMatch` and apply its
-        // stale resolutions against the tables this transition already changed.
-        { source: "code", invalidateSchemaVersion: true }
+        existing.schemaVersion,
+        { source: "code" }
       );
-      marked = true;
+      if (outcome.matched) {
+        recordState = "marked";
+      } else {
+        // The row is past the version this edit started from, which is what the original write
+        // leaves behind — so the change was recorded and the raise was in reading it back. Look
+        // once more before answering: connectivity good enough for the conditional statement is
+        // usually good enough for a read now.
+        const settled = await this.readBackSettledRow(
+          input,
+          requestedLocalized
+        );
+        if (settled) {
+          this.logger.warn(
+            "[FieldGroups] The registry write raised but the row already carries the change; the error was in reading it back.",
+            { slug }
+          );
+          return { record: settled };
+        }
+        recordState = "advanced";
+        this.logger.error(
+          "[FieldGroups] The row advanced past this edit's version but could not be re-read; not marking it diverged.",
+          { slug, expectedSchemaVersion: existing.schemaVersion }
+        );
+      }
     } catch (markError) {
       this.logger.error(
         "[FieldGroups] Could not mark the field group as diverged either.",
@@ -816,19 +856,24 @@ export class FieldGroupMetadataService {
     // point is that the edit half-happened and repeating it is harmful. The status still comes from
     // the central mapping rather than a literal, so this cannot drift from the code it carries.
     //
-    // 🔴 The message distinguishes whether the mark was PERSISTED. Claiming a durable record that
-    // does not exist is worse than admitting the log is the only trace: the first sends an operator
-    // looking at a row that reads normal, the second tells them where to look.
+    // 🔴 The message distinguishes what was PERSISTED. Claiming a durable record that does not
+    // exist is worse than admitting the log is the only trace — and claiming nothing was recorded
+    // when the row demonstrably advanced sends an operator repairing a group that likely carries
+    // the change already. Each ending tells them where to look and what not to do.
+    const publicMessages: Record<typeof recordState, string> = {
+      marked: `The field group's tables were changed, but recording the change failed. "${slug}" is marked as diverged and its stored definition still describes the previous shape. Do not retry the same edit: check the server logs and reconcile the field group before editing it again.`,
+      advanced: `The field group's tables were changed, and its record already carries a newer version — the change was very likely recorded and only confirming it failed. Reload "${slug}" before doing anything else; retry the edit only if the reloaded definition does not show it.`,
+      unrecorded: `The field group's tables were changed, but neither the change nor the failure could be recorded. "${slug}" still reads as though nothing happened, and the only trace is the server log. Do not retry the same edit: reconcile the field group against its tables before editing it again.`,
+    };
     throw new NextlyError({
       code: "INTERNAL_ERROR",
       statusCode: NEXTLY_ERROR_STATUS.INTERNAL_ERROR,
-      publicMessage: marked
-        ? `The field group's tables were changed, but recording the change failed. "${slug}" is marked as diverged and its stored definition still describes the previous shape. Do not retry the same edit: check the server logs and reconcile the field group before editing it again.`
-        : `The field group's tables were changed, but neither the change nor the failure could be recorded. "${slug}" still reads as though nothing happened, and the only trace is the server log. Do not retry the same edit: reconcile the field group against its tables before editing it again.`,
+      publicMessage: publicMessages[recordState],
       cause: cause instanceof Error ? cause : undefined,
       logContext: {
         reason: "registry write failed after committed schema transition",
         slug,
+        recordState,
         tableName: existing.tableName,
       },
     });

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -834,11 +834,41 @@ export class FieldGroupMetadataService {
           );
           return { record: settled };
         }
-        recordState = "advanced";
-        this.logger.error(
-          "[FieldGroups] The row advanced past this edit's version but could not be re-read; not marking it diverged.",
-          { slug, expectedSchemaVersion: existing.schemaVersion }
+        // 🔴 The version moved AND the row does not carry this edit — `readBackSettledRow` just
+        // established the second half. So another writer advanced the row while this edit's tables
+        // had already moved, and the definition now stored describes neither: that is divergence,
+        // and it is the state the mark exists for. Leaving it unmarked lets the next schema edit
+        // proceed from a definition known not to describe the tables, and the refusal below even
+        // invites a retry that would compound it.
+        //
+        // Marked at the version just READ rather than at this edit's, because the row is past that
+        // one by definition. Attempted ONCE: a writer racing this second attempt has itself just
+        // written the row, so retrying in a loop trades a bounded failure for an unbounded one, and
+        // the answer below still distinguishes what was actually persisted.
+        const current = await this.registry.getComponent(slug);
+        const remark = await this.registry.updateComponentIfVersion(
+          slug,
+          { migrationStatus: "diverged" },
+          current.schemaVersion,
+          { source: "code" }
         );
+        if (remark.matched) {
+          recordState = "marked";
+          this.logger.warn(
+            "[FieldGroups] The row advanced past this edit's version without carrying it; marked diverged at the version now stored.",
+            {
+              slug,
+              expectedSchemaVersion: existing.schemaVersion,
+              markedAtSchemaVersion: current.schemaVersion,
+            }
+          );
+        } else {
+          recordState = "advanced";
+          this.logger.error(
+            "[FieldGroups] The row advanced past this edit's version and moved again before it could be marked diverged.",
+            { slug, expectedSchemaVersion: existing.schemaVersion }
+          );
+        }
       }
     } catch (markError) {
       this.logger.error(

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -862,7 +862,12 @@ export class FieldGroupMetadataService {
     // the change already. Each ending tells them where to look and what not to do.
     const publicMessages: Record<typeof recordState, string> = {
       marked: `The field group's tables were changed, but recording the change failed. "${slug}" is marked as diverged and its stored definition still describes the previous shape. Do not retry the same edit: check the server logs and reconcile the field group before editing it again.`,
-      advanced: `The field group's tables were changed, and its record already carries a newer version — the change was very likely recorded and only confirming it failed. Reload "${slug}" before doing anything else; retry the edit only if the reloaded definition does not show it.`,
+      // 🔴 Says only what the write PROVED: the row is no longer at the version this edit started
+      // from. `matched: false` has two causes — the row advanced, or it was deleted — and a
+      // concurrent delete reaches here through the same path, because the confirming read then
+      // raises NOT_FOUND and reports the same "could not confirm". Claiming a newer version exists
+      // would send that operator to reload a field group that is gone.
+      advanced: `The field group's tables were changed, and its record is no longer at the version this edit started from — most likely the change was recorded and only confirming it failed, though the field group may also have been deleted. Reload "${slug}" before doing anything else; retry the edit only if it still exists and the reloaded definition does not show the change.`,
       unrecorded: `The field group's tables were changed, but neither the change nor the failure could be recorded. "${slug}" still reads as though nothing happened, and the only trace is the server log. Do not retry the same edit: reconcile the field group against its tables before editing it again.`,
     };
     throw new NextlyError({

--- a/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
@@ -232,7 +232,10 @@ export async function reconcileFieldGroup(args: {
     adapter,
     dialect,
     existing.tableName,
-    plan.fields as never,
+    // The parameter's own declared type. `FieldDefinition` and `FieldConfig` describe the same
+    // stored field from two layers, and the registry's insert shape is the seam between them —
+    // naming the target type keeps the compiler checking this call rather than waving it through.
+    plan.fields as unknown as FieldConfig[],
     typeColumn,
     plan.localized
   );

--- a/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
@@ -29,8 +29,10 @@ import type { SupportedDialect } from "../../schema/services/field-column-descri
 import { calculateSchemaHash } from "../../schema/services/schema-hash";
 
 import type { FieldGroupRegistryService } from "./field-group-registry-service";
+import type { FieldGroupSchemaService } from "./field-group-schema-service";
 import {
   planFieldGroupReconcile,
+  type ExpectedColumnDefault,
   type ReconcileAdoption,
   type ReconcileRemoval,
   type ReconcileRepair,
@@ -64,6 +66,21 @@ export interface ReconcileFieldGroupResult {
   runtimeRefreshed: boolean;
   /** Why the refresh did not happen; present only when `runtimeRefreshed` is false. */
   runtimeRefreshReason?: string;
+}
+
+/**
+ * A stored field as the table builder's own parameter type.
+ *
+ * `FieldDefinition` and the config shape describe the same stored field from two layers; naming the
+ * builder's declared parameter keeps the compiler checking these calls rather than waving them
+ * through, and stating it once stops the two resolvers spelling the seam differently.
+ */
+function asCreatorField(
+  field: FieldDefinition
+): Parameters<FieldGroupSchemaService["columnTypeFor"]>[0] {
+  return field as unknown as Parameters<
+    FieldGroupSchemaService["columnTypeFor"]
+  >[0];
 }
 
 /**
@@ -109,12 +126,35 @@ async function expectedColumnTypeResolver(
     }
     // The parameter's own declared type. `FieldDefinition` and the config shape describe the same
     // stored field from two layers, and naming the target keeps the compiler checking this call.
-    const type = creator.columnTypeFor(
-      field as unknown as Parameters<
-        InstanceType<typeof FieldGroupSchemaService>["columnTypeFor"]
-      >[0]
-    );
+    const type = creator.columnTypeFor(asCreatorField(field));
     return type ?? undefined;
+  };
+}
+
+/**
+ * The DEFAULT each builder would give a field, alongside the type resolver above.
+ *
+ * Split from it rather than folded in because the two answers have different shapes: a type is a
+ * value or nothing, while a default has to distinguish "writes none" from "cannot say" — and the
+ * companion is exactly the case that needs the distinction. Its columns are rendered by the
+ * localization path, which this module does not model defaults for, so a companion-resident column
+ * reports `known: false` and is skipped rather than being claimed to have no default. Claiming
+ * that would turn every localized checkbox carrying a default into a refusal.
+ */
+async function expectedColumnDefaultResolver(
+  dialect: SupportedDialect
+): Promise<
+  (field: FieldDefinition, table: ReconcileTable) => ExpectedColumnDefault
+> {
+  const { FieldGroupSchemaService } = await import(
+    "./field-group-schema-service"
+  );
+  const creator = new FieldGroupSchemaService(dialect);
+
+  return (field, table) => {
+    if (table === "companion") return { known: false };
+    const value = creator.columnDefaultFor(asCreatorField(field));
+    return value === null ? { known: true } : { known: true, value };
   };
 }
 
@@ -213,6 +253,7 @@ export async function reconcileFieldGroup(args: {
     liveCompanion,
     typeColumn,
     expectedColumnType: await expectedColumnTypeResolver(dialect),
+    expectedColumnDefault: await expectedColumnDefaultResolver(dialect),
   });
 
   // 🔴 REFUSE before writing anything when the tables hold a state the planner can see but must

--- a/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
@@ -53,6 +53,17 @@ export interface ReconcileFieldGroupResult {
   unchanged: boolean;
   /** The version after the repair; unchanged repairs report the version they found. */
   schemaVersion: number;
+  /**
+   * Whether the RUNNING process was re-pointed at the repaired shape.
+   *
+   * Separate from the repair's own success because the two can genuinely differ: the row is written
+   * durably before this is attempted, so `false` means the database is correct and this process is
+   * not, which a restart fixes. Reported rather than folded into an error so an operator is never
+   * told a landed repair failed, nor told a stale process is ready.
+   */
+  runtimeRefreshed: boolean;
+  /** Why the refresh did not happen; present only when `runtimeRefreshed` is false. */
+  runtimeRefreshReason?: string;
 }
 
 /**
@@ -236,10 +247,20 @@ export async function reconcileFieldGroup(args: {
   );
   assertValidPluginFieldOptions(plan.fields);
 
-  // A standing `diverged` mark is itself part of what this operation repairs: once the definition
+  // A standing failure mark is itself part of what this operation repairs: once the definition
   // describes the tables, leaving the mark would keep refusing schema edits on a group that is
   // now fine — the plan can be unchanged while the STATUS is still the thing that is wrong.
-  const markerStandsWrongly = existing.migrationStatus === "diverged";
+  //
+  // `failed` counts for the same reason `diverged` does, and it is the commoner way in: a create
+  // whose table landed and whose verification query failed records `failed` over a table that may
+  // already match the definition exactly. Introspection has just proved whether it does, so the
+  // status is stale in precisely the way this operation exists to clear. Listing the statuses that
+  // MEAN unhealthy, rather than testing for one of them, is what keeps a status added later from
+  // silently becoming permanent.
+  const UNHEALTHY_STATUSES = new Set(["diverged", "failed"]);
+  const markerStandsWrongly = UNHEALTHY_STATUSES.has(
+    existing.migrationStatus ?? ""
+  );
 
   if (plan.unchanged && !markerStandsWrongly) {
     // Nothing to write — and writing anyway would bump the version and invalidate every open
@@ -253,6 +274,8 @@ export async function reconcileFieldGroup(args: {
       adopted: [],
       unchanged: true,
       schemaVersion: existing.schemaVersion,
+      // Nothing was rewritten, so the process is already describing what the row says.
+      runtimeRefreshed: true,
     };
   }
 
@@ -289,9 +312,12 @@ export async function reconcileFieldGroup(args: {
   }
 
   // Point the running process at the repaired shape. Registration DESCRIBES the tables — it moves
-  // no storage — and the repair is durable whether or not this succeeds, so a failure here raises
-  // to the caller as its own error rather than unwinding anything.
-  registerComponentRuntimeSchema(
+  // no storage — and the repair is durable whether or not this succeeds, so a failure here must
+  // not unwind anything. It must also not be silent: this operation's whole promise is that the
+  // group is usable again, and a process still holding the pre-repair columns will fail the very
+  // reads the operator runs next. The outcome is reported so the answer can say which of the two
+  // happened rather than implying the stronger one.
+  const registration = registerComponentRuntimeSchema(
     adapter,
     dialect,
     existing.tableName,
@@ -309,6 +335,7 @@ export async function reconcileFieldGroup(args: {
     repaired: plan.repaired.map(r => `${r.fieldName}.${r.attribute}`),
     adopted: plan.adopted.map(a => a.fieldName),
     localized: plan.localized,
+    runtimeRefreshed: registration.registered,
   });
 
   return {
@@ -319,5 +346,9 @@ export async function reconcileFieldGroup(args: {
     adopted: plan.adopted,
     unchanged: false,
     schemaVersion: outcome.newSchemaVersion,
+    runtimeRefreshed: registration.registered,
+    ...(registration.reason !== undefined
+      ? { runtimeRefreshReason: registration.reason }
+      : {}),
   };
 }

--- a/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
@@ -304,9 +304,26 @@ export async function reconcileFieldGroup(args: {
   );
 
   if (plan.unchanged && !markerStandsWrongly) {
-    // Nothing to write — and writing anyway would bump the version and invalidate every open
+    // Nothing to WRITE — and writing anyway would bump the version and invalidate every open
     // editor for a repair that repaired nothing.
-    logger.info("[FieldGroups] Reconcile found nothing to repair", { slug });
+    //
+    // 🔴 Registration still runs, and its real outcome is reported rather than assumed. "The row
+    // matches the tables" says nothing about what THIS process is holding: an earlier apply whose
+    // own registration failed leaves a stale resolver behind a perfectly healthy row, and that is
+    // exactly the state an operator runs this operation to get out of. Claiming a refresh that was
+    // never attempted made the one answer they act on the least trustworthy part of it.
+    const unchangedRegistration = registerComponentRuntimeSchema(
+      adapter,
+      dialect,
+      existing.tableName,
+      plan.fields as unknown as FieldConfig[],
+      typeColumn,
+      plan.localized
+    );
+    logger.info("[FieldGroups] Reconcile found nothing to repair", {
+      slug,
+      runtimeRefreshed: unchangedRegistration.registered,
+    });
     return {
       slug,
       localized: plan.localized,
@@ -315,8 +332,10 @@ export async function reconcileFieldGroup(args: {
       adopted: [],
       unchanged: true,
       schemaVersion: existing.schemaVersion,
-      // Nothing was rewritten, so the process is already describing what the row says.
-      runtimeRefreshed: true,
+      runtimeRefreshed: unchangedRegistration.registered,
+      ...(unchangedRegistration.reason !== undefined
+        ? { runtimeRefreshReason: unchangedRegistration.reason }
+        : {}),
     };
   }
 

--- a/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
@@ -70,15 +70,30 @@ export async function reconcileFieldGroup(args: {
   adapter: DrizzleAdapter;
   logger: Logger;
   slug: string;
+  /**
+   * The code sync is asking, so a LOCKED group may be repaired.
+   *
+   * Never settable from the HTTP surface: the dispatcher does not pass it. It exists so the one
+   * caller that owns a code-managed definition can clear a marker that would otherwise leave the
+   * group unreachable from both directions.
+   */
+  fromCode?: boolean;
 }): Promise<ReconcileFieldGroupResult> {
   const { registry, adapter, logger, slug } = args;
 
   const existing = await registry.getComponent(slug);
 
-  if (existing.locked) {
+  // 🔴 A LOCKED group is code-managed, so its config file is the definition and a repaired row
+  // would be overwritten by the next sync — but refusing outright makes the state TERMINAL, and it
+  // is reachable: `updateFieldGroup` accepts `source: "code"`, so a code sync whose companion DDL
+  // commits and whose row write fails marks a locked row `diverged`, after which
+  // `assertNotDiverged` also blocks the very sync that would correct it. `fromCode` is the way out:
+  // the sync itself asks for the repair, having the file's definition in hand. A human-initiated
+  // reconcile is still refused, with the file named as the thing to fix.
+  if (existing.locked && !args.fromCode) {
     throw NextlyError.conflict({
       reason: "state",
-      message: `"${slug}" is managed via code. Reconciling would repair the database row, and the next code sync would overwrite that repair with the config file's definition — fix the definition in its config file instead.`,
+      message: `"${slug}" is managed via code, so its definition lives in a config file — repairing the database row here would be overwritten by the next code sync. Fix the definition in its config file and re-sync; the sync clears this state itself.`,
       logContext: { reason: "component-locked-for-reconcile", slug },
     });
   }
@@ -128,6 +143,35 @@ export async function reconcileFieldGroup(args: {
     liveCompanion,
     typeColumn,
   });
+
+  // 🔴 REFUSE before writing anything when the tables hold a state the planner can see but must
+  // not decide — a column on both tables, a column whose physical type no longer matches its
+  // declared field, an identifier no field name can represent. Each has two readings and nothing
+  // in the database says which the operator meant, so writing either one would produce a
+  // definition describing neither and mark it `synced`. The blockers are named individually
+  // because the operator's next action differs per kind.
+  if (plan.blockers.length > 0) {
+    throw NextlyError.conflict({
+      reason: "state",
+      message: `"${slug}" cannot be reconciled automatically: ${plan.blockers
+        .map(b => b.detail)
+        .join(" ")} Nothing was changed.`,
+      logContext: {
+        reason: "reconcile-ambiguous",
+        slug,
+        blockers: plan.blockers,
+      },
+    });
+  }
+
+  // The finished field set goes through the SAME validator every other definition write uses, so
+  // a repair cannot persist something the builder would later refuse. The planner already filters
+  // unrepresentable column names; this is the boundary rather than a second opinion — it covers
+  // whatever the shared contract gains next without this module being told.
+  const { assertValidFieldsPayload } = await import(
+    "../../../api/fields-payload"
+  );
+  assertValidFieldsPayload(plan.fields, { kind: "component" });
 
   // A standing `diverged` mark is itself part of what this operation repairs: once the definition
   // describes the tables, leaving the mark would keep refusing schema edits on a group that is

--- a/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
@@ -25,6 +25,8 @@ import type { DynamicFieldGroupInsert } from "../../../schemas/dynamic-field-gro
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import type { Logger } from "../../../shared/types";
 import { introspectLiveSnapshot } from "../../schema/pipeline/diff/introspect-live";
+import { normalizeType } from "../../schema/pipeline/diff/normalize-type";
+import type { SupportedDialect } from "../../schema/services/field-column-descriptor";
 import { calculateSchemaHash } from "../../schema/services/schema-hash";
 
 import type { FieldGroupRegistryService } from "./field-group-registry-service";
@@ -54,6 +56,77 @@ export interface ReconcileFieldGroupResult {
 }
 
 /**
+ * What THIS database's creator would write for each of a field group's columns, normalised.
+ *
+ * 🔴 Read out of the creator's own rendered DDL rather than from the column descriptor, because
+ * the two disagree and the creator is the one that made the tables. `FieldGroupSchemaService`
+ * carries its own dialect type table: measured live, a `date` becomes `DATETIME` on MySQL and an
+ * `email` becomes `VARCHAR(255)` on PostgreSQL, where the descriptor answers `timestamp` and
+ * `text`. Comparing a live column against the descriptor reported drift on healthy groups and
+ * refused to repair them.
+ *
+ * The same extraction `assertNoUnappliableSchemaChange` uses, for the same reason — a column
+ * definition is one INDENTED, QUOTED line, which no statement in the script is.
+ *
+ * A column this cannot parse is simply absent from the map, and the planner skips comparing it.
+ * That direction is deliberate: an underivable expectation is not evidence of drift, and treating
+ * it as such is what produced the false refusal in the first place.
+ */
+async function expectedColumnTypes(args: {
+  dialect: SupportedDialect;
+  tableName: string;
+  fields: FieldDefinition[];
+  localized: boolean;
+}): Promise<ReadonlyMap<string, string>> {
+  const out = new Map<string, string>();
+
+  const { FieldGroupSchemaService } = await import(
+    "./field-group-schema-service"
+  );
+  const sql = new FieldGroupSchemaService(args.dialect).generateMigrationSQL(
+    args.tableName,
+    args.fields as unknown as Parameters<
+      InstanceType<typeof FieldGroupSchemaService>["generateMigrationSQL"]
+    >[1],
+    { localized: args.localized }
+  );
+  for (const line of sql.split("\n")) {
+    // Name then type, from an indented quoted definition. The type runs to the first space that
+    // begins a constraint keyword, so `VARCHAR(255) NOT NULL` yields `VARCHAR(255)`.
+    const match =
+      /^\s+["`]([A-Za-z0-9_]+)["`]\s+([A-Za-z0-9_]+(?:\([^)]*\))?)/.exec(line);
+    if (!match) continue;
+    const [, column, type] = match;
+    const normalised = normalizeType(type);
+    if (column !== undefined && normalised !== undefined) {
+      out.set(column, normalised);
+    }
+  }
+
+  // The companion's columns come from the localization renderer, which is what actually adds them.
+  if (args.localized) {
+    const { isFieldLocalized } = await import("../../i18n/classify-fields");
+    const { fieldToLocalizedColumnSpec } = await import(
+      "../../i18n/migration/field-to-column-spec"
+    );
+    const { ddlType } = await import("../../i18n/migration/ddl-types");
+    for (const field of args.fields) {
+      if (!isFieldLocalized(field, true)) continue;
+      const spec = fieldToLocalizedColumnSpec(
+        field,
+        args.dialect,
+        "fieldGroup"
+      );
+      if (!spec) continue;
+      const normalised = normalizeType(ddlType(spec, args.dialect));
+      if (normalised !== undefined) out.set(spec.name, normalised);
+    }
+  }
+
+  return out;
+}
+
+/**
  * Reconcile one field group's registry row against its live tables.
  *
  * Preconditions, in order and before anything is decided:
@@ -78,9 +151,8 @@ export async function reconcileFieldGroup(args: {
    * unreachable from both directions — a locked row marked `diverged` is refused by
    * `assertNotDiverged` on the sync path and by the lock check here.
    *
-   * 🔴 NOT YET WIRED. `syncCodeFirstComponents` does not call this, so that state currently has no
-   * automatic exit; the capability exists and the caller does not. Stated here rather than implied,
-   * because a parameter that looks like a recovery path reads as one.
+   * Wired: `syncCodeFirstComponents` passes it when it finds a `diverged` code-managed row, so
+   * that state clears on the next sync rather than needing a hand-edited database.
    */
   fromCode?: boolean;
 }): Promise<ReconcileFieldGroupResult> {
@@ -139,14 +211,21 @@ export async function reconcileFieldGroup(args: {
     existing.tableName
   );
 
+  const storedFields = existing.fields as unknown as FieldDefinition[];
   const plan = planFieldGroupReconcile<FieldDefinition>({
-    storedFields: existing.fields as unknown as FieldDefinition[],
+    storedFields,
     storedLocalized: existing.localized === true,
     dialect,
     tableName: existing.tableName,
     liveMain,
     liveCompanion,
     typeColumn,
+    expectedColumnTypes: await expectedColumnTypes({
+      dialect,
+      tableName: existing.tableName,
+      fields: storedFields,
+      localized: existing.localized === true,
+    }),
   });
 
   // 🔴 REFUSE before writing anything when the tables hold a state the planner can see but must

--- a/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
@@ -73,9 +73,14 @@ export async function reconcileFieldGroup(args: {
   /**
    * The code sync is asking, so a LOCKED group may be repaired.
    *
-   * Never settable from the HTTP surface: the dispatcher does not pass it. It exists so the one
-   * caller that owns a code-managed definition can clear a marker that would otherwise leave the
-   * group unreachable from both directions.
+   * Never settable from the HTTP surface: the dispatcher does not pass it. It exists so the caller
+   * that owns a code-managed definition can clear a marker that would otherwise leave the group
+   * unreachable from both directions — a locked row marked `diverged` is refused by
+   * `assertNotDiverged` on the sync path and by the lock check here.
+   *
+   * 🔴 NOT YET WIRED. `syncCodeFirstComponents` does not call this, so that state currently has no
+   * automatic exit; the capability exists and the caller does not. Stated here rather than implied,
+   * because a parameter that looks like a recovery path reads as one.
    */
   fromCode?: boolean;
 }): Promise<ReconcileFieldGroupResult> {
@@ -93,7 +98,7 @@ export async function reconcileFieldGroup(args: {
   if (existing.locked && !args.fromCode) {
     throw NextlyError.conflict({
       reason: "state",
-      message: `"${slug}" is managed via code, so its definition lives in a config file — repairing the database row here would be overwritten by the next code sync. Fix the definition in its config file and re-sync; the sync clears this state itself.`,
+      message: `"${slug}" is managed via code, so its definition lives in a config file — repairing the database row here would be overwritten by the next code sync. Fix the definition in its config file and re-sync.`,
       logContext: { reason: "component-locked-for-reconcile", slug },
     });
   }

--- a/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
@@ -25,7 +25,6 @@ import type { DynamicFieldGroupInsert } from "../../../schemas/dynamic-field-gro
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import type { Logger } from "../../../shared/types";
 import { introspectLiveSnapshot } from "../../schema/pipeline/diff/introspect-live";
-import { normalizeType } from "../../schema/pipeline/diff/normalize-type";
 import type { SupportedDialect } from "../../schema/services/field-column-descriptor";
 import { calculateSchemaHash } from "../../schema/services/schema-hash";
 
@@ -35,6 +34,7 @@ import {
   type ReconcileAdoption,
   type ReconcileRemoval,
   type ReconcileRepair,
+  type ReconcileTable,
 } from "./reconcile-field-group-plan";
 
 /**
@@ -56,74 +56,55 @@ export interface ReconcileFieldGroupResult {
 }
 
 /**
- * What THIS database's creator would write for each of a field group's columns, normalised.
+ * Ask the code that BUILDS these tables what type it gives a field in a given table.
  *
- * 🔴 Read out of the creator's own rendered DDL rather than from the column descriptor, because
- * the two disagree and the creator is the one that made the tables. `FieldGroupSchemaService`
- * carries its own dialect type table: measured live, a `date` becomes `DATETIME` on MySQL and an
- * `email` becomes `VARCHAR(255)` on PostgreSQL, where the descriptor answers `timestamp` and
- * `text`. Comparing a live column against the descriptor reported drift on healthy groups and
- * refused to repair them.
+ * 🔴 Asked, never recovered from rendered SQL. Both builders already return the type as a value:
+ * reading it back out of a printed CREATE TABLE re-derives an answer that was in hand, and does it
+ * through a channel that cannot carry the whole answer — a type spelled with more than one word
+ * (PostgreSQL's `DOUBLE PRECISION`) comes back truncated, and the resulting mismatch refuses a
+ * group nothing is wrong with.
  *
- * The same extraction `assertNoUnappliableSchemaChange` uses, for the same reason — a column
- * definition is one INDENTED, QUOTED line, which no statement in the script is.
+ * The two tables have DIFFERENT builders, which is why this is keyed by table rather than resolved
+ * once. `FieldGroupSchemaService` builds the main table; the localization renderer builds the
+ * companion, and it spells the same field differently — a PostgreSQL `email` is `VARCHAR(255)` on
+ * one and `TEXT` on the other. The planner supplies the table it OBSERVED the column in, so a
+ * stored placement flag that is itself wrong cannot select the wrong builder.
  *
- * A column this cannot parse is simply absent from the map, and the planner skips comparing it.
- * That direction is deliberate: an underivable expectation is not evidence of drift, and treating
- * it as such is what produced the false refusal in the first place.
+ * Returns `undefined` where neither builder claims the field, which the planner skips rather than
+ * blocks: an underivable expectation is not evidence of drift.
+ *
+ * Async only to resolve the imports once; the function it returns is pure, which is what lets the
+ * planner stay free of both.
  */
-async function expectedColumnTypes(args: {
-  dialect: SupportedDialect;
-  tableName: string;
-  fields: FieldDefinition[];
-  localized: boolean;
-}): Promise<ReadonlyMap<string, string>> {
-  const out = new Map<string, string>();
-
+async function expectedColumnTypeResolver(
+  dialect: SupportedDialect
+): Promise<
+  (field: FieldDefinition, table: ReconcileTable) => string | undefined
+> {
   const { FieldGroupSchemaService } = await import(
     "./field-group-schema-service"
   );
-  const sql = new FieldGroupSchemaService(args.dialect).generateMigrationSQL(
-    args.tableName,
-    args.fields as unknown as Parameters<
-      InstanceType<typeof FieldGroupSchemaService>["generateMigrationSQL"]
-    >[1],
-    { localized: args.localized }
+  const { fieldToLocalizedColumnSpec } = await import(
+    "../../i18n/migration/field-to-column-spec"
   );
-  for (const line of sql.split("\n")) {
-    // Name then type, from an indented quoted definition. The type runs to the first space that
-    // begins a constraint keyword, so `VARCHAR(255) NOT NULL` yields `VARCHAR(255)`.
-    const match =
-      /^\s+["`]([A-Za-z0-9_]+)["`]\s+([A-Za-z0-9_]+(?:\([^)]*\))?)/.exec(line);
-    if (!match) continue;
-    const [, column, type] = match;
-    const normalised = normalizeType(type);
-    if (column !== undefined && normalised !== undefined) {
-      out.set(column, normalised);
-    }
-  }
+  const { ddlType } = await import("../../i18n/migration/ddl-types");
 
-  // The companion's columns come from the localization renderer, which is what actually adds them.
-  if (args.localized) {
-    const { isFieldLocalized } = await import("../../i18n/classify-fields");
-    const { fieldToLocalizedColumnSpec } = await import(
-      "../../i18n/migration/field-to-column-spec"
+  const creator = new FieldGroupSchemaService(dialect);
+
+  return (field, table) => {
+    if (table === "companion") {
+      const spec = fieldToLocalizedColumnSpec(field, dialect, "fieldGroup");
+      return spec ? ddlType(spec, dialect) : undefined;
+    }
+    // The parameter's own declared type. `FieldDefinition` and the config shape describe the same
+    // stored field from two layers, and naming the target keeps the compiler checking this call.
+    const type = creator.columnTypeFor(
+      field as unknown as Parameters<
+        InstanceType<typeof FieldGroupSchemaService>["columnTypeFor"]
+      >[0]
     );
-    const { ddlType } = await import("../../i18n/migration/ddl-types");
-    for (const field of args.fields) {
-      if (!isFieldLocalized(field, true)) continue;
-      const spec = fieldToLocalizedColumnSpec(
-        field,
-        args.dialect,
-        "fieldGroup"
-      );
-      if (!spec) continue;
-      const normalised = normalizeType(ddlType(spec, args.dialect));
-      if (normalised !== undefined) out.set(spec.name, normalised);
-    }
-  }
-
-  return out;
+    return type ?? undefined;
+  };
 }
 
 /**
@@ -220,12 +201,7 @@ export async function reconcileFieldGroup(args: {
     liveMain,
     liveCompanion,
     typeColumn,
-    expectedColumnTypes: await expectedColumnTypes({
-      dialect,
-      tableName: existing.tableName,
-      fields: storedFields,
-      localized: existing.localized === true,
-    }),
+    expectedColumnType: await expectedColumnTypeResolver(dialect),
   });
 
   // 🔴 REFUSE before writing anything when the tables hold a state the planner can see but must
@@ -248,14 +224,17 @@ export async function reconcileFieldGroup(args: {
     });
   }
 
-  // The finished field set goes through the SAME validator every other definition write uses, so
-  // a repair cannot persist something the builder would later refuse. The planner already filters
-  // unrepresentable column names; this is the boundary rather than a second opinion — it covers
-  // whatever the shared contract gains next without this module being told.
-  const { assertValidFieldsPayload } = await import(
+  // The finished field set goes through the validator the OTHER registry writers use — the same one
+  // `createComponent` and `updateComponent` run — because this writes the rows they write.
+  //
+  // Not the manifest validator: that one gates the `ui-schema.json` mirror and rejects declarations
+  // the registry has always accepted, camelCase field names among them. Running it here would refuse
+  // to repair any group whose definition came from code or the Direct API, which is precisely the
+  // set that cannot repair itself by re-saving through the builder.
+  const { assertValidPluginFieldOptions } = await import(
     "../../../api/fields-payload"
   );
-  assertValidFieldsPayload(plan.fields, { kind: "component" });
+  assertValidPluginFieldOptions(plan.fields);
 
   // A standing `diverged` mark is itself part of what this operation repairs: once the definition
   // describes the tables, leaving the mark would keep refusing schema edits on a group that is

--- a/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
@@ -121,6 +121,7 @@ export async function reconcileFieldGroup(args: {
 
   const plan = planFieldGroupReconcile<FieldDefinition>({
     storedFields: existing.fields as unknown as FieldDefinition[],
+    storedLocalized: existing.localized === true,
     dialect,
     tableName: existing.tableName,
     liveMain,
@@ -128,7 +129,12 @@ export async function reconcileFieldGroup(args: {
     typeColumn,
   });
 
-  if (plan.unchanged) {
+  // A standing `diverged` mark is itself part of what this operation repairs: once the definition
+  // describes the tables, leaving the mark would keep refusing schema edits on a group that is
+  // now fine — the plan can be unchanged while the STATUS is still the thing that is wrong.
+  const markerStandsWrongly = existing.migrationStatus === "diverged";
+
+  if (plan.unchanged && !markerStandsWrongly) {
     // Nothing to write — and writing anyway would bump the version and invalidate every open
     // editor for a repair that repaired nothing.
     logger.info("[FieldGroups] Reconcile found nothing to repair", { slug });

--- a/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
@@ -1,0 +1,207 @@
+/**
+ * Repair a field group's STORED definition to describe its LIVE tables.
+ *
+ * The exit from `diverged`: the tables moved and the row recording them did not, so every
+ * storage-moving edit is refused until the record is made honest again. This operation reads the
+ * tables, plans the smallest definition that describes them (`reconcile-field-group-plan.ts`
+ * holds the decisions), and writes the repaired record in ONE version-conditional statement. It
+ * never issues DDL — the tables are the truth being described, not the thing being fixed.
+ *
+ * Deliberately runnable on a group that is NOT marked `diverged`: a divergence can exist with no
+ * mark (a recording write that failed after its DDL committed leaves exactly that), and the
+ * operation is idempotent — on a healthy group the plan comes back unchanged and nothing is
+ * written. That is also why this does not gate on `migrationStatus`.
+ *
+ * @module domains/field-groups/services/field-group-reconcile-service
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+
+import type { FieldConfig } from "@nextly/collections";
+
+import { NextlyError } from "../../../errors";
+import type { FieldDefinition } from "../../../schemas/dynamic-collections";
+import type { DynamicFieldGroupInsert } from "../../../schemas/dynamic-field-groups/types";
+import { STORAGE_FORMAT } from "../../../schemas/storage-format";
+import type { Logger } from "../../../shared/types";
+import { introspectLiveSnapshot } from "../../schema/pipeline/diff/introspect-live";
+import { calculateSchemaHash } from "../../schema/services/schema-hash";
+
+import type { FieldGroupRegistryService } from "./field-group-registry-service";
+import {
+  planFieldGroupReconcile,
+  type ReconcileAdoption,
+  type ReconcileRemoval,
+  type ReconcileRepair,
+} from "./reconcile-field-group-plan";
+
+/**
+ * What a reconcile did, by IDENTITY. The lists are the operator's only window into a field whose
+ * column vanished or whose type had to be guessed, so they name fields and columns rather than
+ * counting them.
+ */
+export interface ReconcileFieldGroupResult {
+  slug: string;
+  /** Re-derived from which table holds the columns — see the planner. */
+  localized: boolean;
+  removed: ReconcileRemoval[];
+  repaired: ReconcileRepair[];
+  adopted: ReconcileAdoption[];
+  /** True when the definition already described the tables and nothing was written. */
+  unchanged: boolean;
+  /** The version after the repair; unchanged repairs report the version they found. */
+  schemaVersion: number;
+}
+
+/**
+ * Reconcile one field group's registry row against its live tables.
+ *
+ * Preconditions, in order and before anything is decided:
+ * - the group must exist (`getComponent` raises NOT_FOUND itself);
+ * - a LOCKED group is refused: its definition lives in a config file, so repairing the row would
+ *   be overwritten by the next code sync — the file is what needs fixing, and this message is the
+ *   only place that tells the operator so;
+ * - the MAIN table must exist. A vanished table is not a definition drift: the honest repair for
+ *   it is deleting the group, which is a different, destructive decision this operation must not
+ *   make on the operator's behalf.
+ */
+export async function reconcileFieldGroup(args: {
+  registry: FieldGroupRegistryService;
+  adapter: DrizzleAdapter;
+  logger: Logger;
+  slug: string;
+}): Promise<ReconcileFieldGroupResult> {
+  const { registry, adapter, logger, slug } = args;
+
+  const existing = await registry.getComponent(slug);
+
+  if (existing.locked) {
+    throw NextlyError.conflict({
+      reason: "state",
+      message: `"${slug}" is managed via code. Reconciling would repair the database row, and the next code sync would overwrite that repair with the config file's definition — fix the definition in its config file instead.`,
+      logContext: { reason: "component-locked-for-reconcile", slug },
+    });
+  }
+
+  const dialect = adapter.dialect;
+  const companionName = `${existing.tableName}${STORAGE_FORMAT.companionSuffix}`;
+
+  // One introspection for both tables. A table that does not exist contributes no rows to the
+  // catalog query and is simply absent from the snapshot, which is how the companion's existence
+  // is decided — the same absence that makes a missing MAIN table detectable below.
+  const snapshot = await introspectLiveSnapshot(adapter.getDrizzle(), dialect, [
+    existing.tableName,
+    companionName,
+  ]);
+  const liveMain = snapshot.tables.find(t => t.name === existing.tableName);
+  const liveCompanion =
+    snapshot.tables.find(t => t.name === companionName) ?? null;
+
+  if (!liveMain) {
+    throw NextlyError.conflict({
+      reason: "state",
+      message: `The table for "${slug}" does not exist, so there is no shape to reconcile the definition against. If the table was dropped deliberately, delete the field group instead of reconciling it.`,
+      logContext: {
+        reason: "reconcile-main-table-missing",
+        slug,
+        tableName: existing.tableName,
+      },
+    });
+  }
+
+  // 🔴 Probed BEFORE the write, mirroring the transition path's contract: the discriminator column
+  // is a fact about the table the storage migration may have moved, and asking after the registry
+  // write would leave a repair recorded while the runtime refresh below cannot describe the table.
+  const { resolveComponentTypeColumn, registerComponentRuntimeSchema } =
+    await import("./field-group-table-provisioning");
+  const typeColumn = await resolveComponentTypeColumn(
+    adapter,
+    existing.tableName
+  );
+
+  const plan = planFieldGroupReconcile<FieldDefinition>({
+    storedFields: existing.fields as unknown as FieldDefinition[],
+    dialect,
+    tableName: existing.tableName,
+    liveMain,
+    liveCompanion,
+    typeColumn,
+  });
+
+  if (plan.unchanged) {
+    // Nothing to write — and writing anyway would bump the version and invalidate every open
+    // editor for a repair that repaired nothing.
+    logger.info("[FieldGroups] Reconcile found nothing to repair", { slug });
+    return {
+      slug,
+      localized: plan.localized,
+      removed: [],
+      repaired: [],
+      adopted: [],
+      unchanged: true,
+      schemaVersion: existing.schemaVersion,
+    };
+  }
+
+  // ONE conditional write carries the whole repair. The version pin is the correctness of the
+  // operation: the plan was computed against the row as read above, and a row another writer moved
+  // since then may already describe tables this plan has never seen — overwriting it would turn
+  // the repair into the very divergence it exists to clear.
+  const outcome = await registry.updateComponentIfVersion(
+    slug,
+    {
+      fields: plan.fields as unknown as DynamicFieldGroupInsert["fields"],
+      localized: plan.localized,
+      // The definition now describes the tables, which is what this status means. Passed
+      // explicitly: the registry defaults a fields-carrying write to "pending", the state for a
+      // change that has not reached the database yet — the opposite of what just happened.
+      migrationStatus: "synced",
+      schemaHash: calculateSchemaHash(plan.fields as unknown as FieldConfig[]),
+    },
+    existing.schemaVersion
+  );
+
+  if (!outcome.matched) {
+    throw NextlyError.conflict({
+      // `state`, not `version`: the version message tells the caller to refresh and RETRY, and a
+      // retry is right here — but only after re-reading, which re-running the operation does.
+      reason: "state",
+      message: `"${slug}" changed while it was being reconciled. Nothing was written. Run the reconcile again so it repairs against the current state.`,
+      logContext: {
+        reason: "reconcile-version-moved",
+        slug,
+        expectedSchemaVersion: existing.schemaVersion,
+      },
+    });
+  }
+
+  // Point the running process at the repaired shape. Registration DESCRIBES the tables — it moves
+  // no storage — and the repair is durable whether or not this succeeds, so a failure here raises
+  // to the caller as its own error rather than unwinding anything.
+  registerComponentRuntimeSchema(
+    adapter,
+    dialect,
+    existing.tableName,
+    plan.fields as never,
+    typeColumn,
+    plan.localized
+  );
+
+  logger.info("[FieldGroups] Reconciled definition against live tables", {
+    slug,
+    removed: plan.removed.map(r => r.fieldName),
+    repaired: plan.repaired.map(r => `${r.fieldName}.${r.attribute}`),
+    adopted: plan.adopted.map(a => a.fieldName),
+    localized: plan.localized,
+  });
+
+  return {
+    slug,
+    localized: plan.localized,
+    removed: plan.removed,
+    repaired: plan.repaired,
+    adopted: plan.adopted,
+    unchanged: false,
+    schemaVersion: outcome.newSchemaVersion,
+  };
+}

--- a/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
@@ -736,39 +736,54 @@ export class FieldGroupRegistryService extends BaseRegistryService<
             schemaHash,
           });
           result.created.push(config.slug);
-        } else if (
-          repairedTableName !== undefined ||
-          !schemaHashesMatch(schemaHash, existing.schemaHash) ||
-          (config.localized === true) !== (existing.localized === true)
-        ) {
-          await this.updateComponent(
-            config.slug,
-            {
-              label: config.label,
-              description: config.description,
-              fields: config.fields,
-              admin: config.admin,
-              configPath: config.configPath,
-              schemaHash,
-              locked: true,
-              localized: config.localized === true,
-              tableName: repairedTableName,
-            },
-            { source: "code" }
-          );
-          result.updated.push(config.slug);
-        } else if (this.adminConfigChanged(config.admin, existing.admin)) {
-          await this.updateComponent(
-            config.slug,
-            {
-              admin: config.admin,
-              locked: true,
-            },
-            { source: "code" }
-          );
-          result.updated.push(config.slug);
         } else {
-          result.unchanged.push(config.slug);
+          // 🔴 Clear a `diverged` mark BEFORE deciding what this sync writes, because that state
+          // is otherwise a dead end for a code-managed group: the admin refuses it for being
+          // locked and this path is refused for being diverged, so neither direction can reach it.
+          // The sync is the right caller — it holds the config file, which IS the definition for a
+          // locked group — and `fromCode` is what lets the repair past the lock check.
+          //
+          // Best effort, and deliberately so: the repair describes the row against its tables,
+          // while the write below describes it against the config file. If the repair cannot
+          // decide (it refuses on genuinely ambiguous tables) the error is RECORDED and the sync
+          // continues to the next component, leaving the mark in place rather than failing every
+          // remaining component behind one unrepairable row.
+          if (existing.migrationStatus === "diverged") {
+            try {
+              const { reconcileFieldGroup } = await import(
+                "./field-group-reconcile-service"
+              );
+              await reconcileFieldGroup({
+                registry: this,
+                adapter: this.adapter,
+                logger: this.logger,
+                slug: config.slug,
+                fromCode: true,
+              });
+              this.logger.info(
+                "[FieldGroups] Cleared a diverged mark on a code-managed field group",
+                { slug: config.slug }
+              );
+            } catch (reconcileError) {
+              const detail =
+                reconcileError instanceof Error
+                  ? reconcileError.message
+                  : String(reconcileError);
+              this.logger.error(
+                "[FieldGroups] Could not clear the diverged mark on a code-managed field group",
+                { slug: config.slug, error: detail }
+              );
+              result.errors.push({ slug: config.slug, error: detail });
+              continue;
+            }
+          }
+          await this.syncExistingCodeFirstComponent({
+            config,
+            existing,
+            schemaHash,
+            repairedTableName,
+            result,
+          });
         }
       } catch (error) {
         result.errors.push({
@@ -778,7 +793,7 @@ export class FieldGroupRegistryService extends BaseRegistryService<
       }
     }
 
-    this.logger.info("Code-first Component sync completed", {
+    this.logger.info("Code-first Component sync complete", {
       created: result.created.length,
       updated: result.updated.length,
       unchanged: result.unchanged.length,
@@ -786,6 +801,56 @@ export class FieldGroupRegistryService extends BaseRegistryService<
     });
 
     return result;
+  }
+
+  /**
+   * Write the config file's definition onto a component the registry already holds.
+   *
+   * Extracted so the divergence repair above reads as one step rather than being buried in the
+   * branch it guards; the decision of WHAT to write is unchanged.
+   */
+  private async syncExistingCodeFirstComponent(args: {
+    config: CodeFirstComponentConfig;
+    existing: DynamicFieldGroupRecord;
+    schemaHash: string;
+    repairedTableName: string | undefined;
+    result: SyncComponentResult;
+  }): Promise<void> {
+    const { config, existing, schemaHash, repairedTableName, result } = args;
+    if (
+      repairedTableName !== undefined ||
+      !schemaHashesMatch(schemaHash, existing.schemaHash) ||
+      (config.localized === true) !== (existing.localized === true)
+    ) {
+      await this.updateComponent(
+        config.slug,
+        {
+          label: config.label,
+          description: config.description,
+          fields: config.fields,
+          admin: config.admin,
+          configPath: config.configPath,
+          schemaHash,
+          locked: true,
+          localized: config.localized === true,
+          tableName: repairedTableName,
+        },
+        { source: "code" }
+      );
+      result.updated.push(config.slug);
+    } else if (this.adminConfigChanged(config.admin, existing.admin)) {
+      await this.updateComponent(
+        config.slug,
+        {
+          admin: config.admin,
+          locked: true,
+        },
+        { source: "code" }
+      );
+      result.updated.push(config.slug);
+    } else {
+      result.unchanged.push(config.slug);
+    }
   }
 
   /**

--- a/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
@@ -519,8 +519,13 @@ export class FieldGroupRegistryService extends BaseRegistryService<
         {
           and: [
             { column: "slug", op: "=", value: slug },
+            // 🔴 The Drizzle PROPERTY name, not the database column name. A WHERE clause is
+            // resolved against the table object's properties, while the SET payload above is
+            // mapped from snake_case by `mapDataToColumnNames` — so the two halves of this one
+            // statement legitimately spell the same column differently, and `schema_version` here
+            // raises "Column not found" rather than matching nothing.
             {
-              column: "schema_version",
+              column: "schemaVersion",
               op: "=",
               value: expectedSchemaVersion,
             },

--- a/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
@@ -337,17 +337,7 @@ export class FieldGroupRegistryService extends BaseRegistryService<
       });
     }
 
-    const updateData: Record<string, unknown> = {
-      updated_at: this.formatDateForDb(),
-    };
-
-    if (data.label !== undefined) {
-      updateData.label = data.label;
-    }
-
-    if (data.description !== undefined) {
-      updateData.description = data.description;
-    }
+    const updateData = this.buildComponentUpdateColumns(data);
 
     // 🔴 The version advances when the PHYSICAL SHAPE changes, not when `fields` happens to be
     // present. `schema_version` is an optimistic lock: `assertSchemaVersionMatch` rejects a save
@@ -366,6 +356,65 @@ export class FieldGroupRegistryService extends BaseRegistryService<
       data.localized !== undefined &&
       (data.localized === true) !== (existing.localized === true);
 
+    if (
+      data.fields ||
+      localizationChanged ||
+      options?.invalidateSchemaVersion
+    ) {
+      // One increment however many reasons applied: the row moved to the next version, once.
+      updateData.schema_version = existing.schemaVersion + 1;
+    }
+
+    try {
+      const results = await this.adapter.update<DynamicFieldGroupRecord>(
+        await this.resolveRegistryTableName(),
+        updateData,
+        this.whereEq("slug", slug),
+        { returning: "*" }
+      );
+
+      if (results.length === 0) {
+        // Generic "Not found."; slug in logContext.
+        throw NextlyError.notFound({ logContext: { slug } });
+      }
+
+      this.logger.info("Component updated", { slug });
+
+      return this.deserializeRecord(results[0]);
+    } catch (error) {
+      // Preserve already-mapped NextlyErrors (the notFound above, or a
+      // forbidden from the locked-check). Anything else is a raw DB error.
+      // Normalise raw driver errors first so unique/fk/etc. produce the right kind.
+      if (NextlyError.is(error)) {
+        throw error;
+      }
+      throw NextlyError.fromDatabaseError(toDbError(this.dialect, error));
+    }
+  }
+
+  /**
+   * The column writes an update carries, shared by the unconditional and the conditional update.
+   *
+   * Everything EXCEPT `schema_version`: the two callers derive the version differently — one from
+   * the row it just read, one from the version its caller's decision was computed against — and
+   * that arithmetic is the whole difference between them, so it stays at the call sites while the
+   * column mapping lives once here.
+   */
+  private buildComponentUpdateColumns(
+    data: Partial<DynamicFieldGroupInsert>
+  ): Record<string, unknown> {
+    const updateData: Record<string, unknown> = {
+      updated_at: this.formatDateForDb(),
+    };
+
+    if (data.label !== undefined) {
+      updateData.label = data.label;
+    }
+
+    if (data.description !== undefined) {
+      updateData.description = data.description;
+    }
+
     if (data.fields) {
       updateData.fields = JSON.stringify(data.fields);
       updateData.migration_status = data.migrationStatus || "pending";
@@ -375,15 +424,6 @@ export class FieldGroupRegistryService extends BaseRegistryService<
       // say — a write that failed after its DDL committed — unable to record it, so a row went on
       // describing a shape the tables no longer have with nothing marking the divergence.
       updateData.migration_status = data.migrationStatus;
-    }
-
-    if (
-      data.fields ||
-      localizationChanged ||
-      options?.invalidateSchemaVersion
-    ) {
-      // One increment however many reasons applied: the row moved to the next version, once.
-      updateData.schema_version = existing.schemaVersion + 1;
     }
 
     if (data.admin !== undefined) {
@@ -415,26 +455,91 @@ export class FieldGroupRegistryService extends BaseRegistryService<
       updateData.table_name = data.tableName;
     }
 
+    return updateData;
+  }
+
+  /**
+   * Update a Component only if its `schema_version` is still the one the caller decided from.
+   *
+   * A compare-and-set: the WHERE clause carries the expected version, so the DATABASE decides in
+   * one statement whether the row still is what the caller believed — there is no read between the
+   * decision and the write for another writer, or a transient failure, to slip through. The two
+   * callers this exists for both hold a decision computed against a version they read earlier: a
+   * divergence marker that must not stamp a row the original write reached after all, and a
+   * reconcile whose repair must not overwrite an edit that landed while it was planning.
+   *
+   * `{ matched: false }` is a THIRD outcome, not an error: the row at that version no longer
+   * exists, because it advanced or because it was deleted. The two are indistinguishable without
+   * another read — which is exactly the dependency this method removes — and every caller treats
+   * them the same way: the decision is stale, do not write, re-derive. It is not squeezed into the
+   * NOT_FOUND throw, whose meaning here would be false for the commoner (advanced) case.
+   *
+   * The version ALWAYS advances, to `expectedSchemaVersion + 1`, computed against the value the
+   * WHERE pins rather than a fresh read. That is also what makes the matched count trustworthy on
+   * MySQL, which counts CHANGED rows: a write that matches always moves `schema_version`, so
+   * matched implies changed — see `DrizzleAdapter.updateCount`.
+   *
+   * No returned row, deliberately. On a dialect without RETURNING a returning read re-runs the
+   * WHERE — whose version this write just moved past — so a landed write would read back as
+   * missing. The caller already knows the whole write it requested; there is nothing a read-back
+   * could add except a second query able to fail after the first committed.
+   */
+  async updateComponentIfVersion(
+    slug: string,
+    data: Partial<DynamicFieldGroupInsert>,
+    expectedSchemaVersion: number,
+    options?: UpdateComponentOptions
+  ): Promise<{ matched: true; newSchemaVersion: number } | { matched: false }> {
+    this.logger.debug("Conditionally updating Component", {
+      slug,
+      expectedSchemaVersion,
+    });
+
+    const existing = await this.getComponent(slug);
+
+    if (existing.locked && options?.source !== "code") {
+      // Generic FORBIDDEN; slug and source go to logContext only.
+      throw NextlyError.forbidden({
+        logContext: {
+          reason: "component-locked",
+          slug,
+          source: options?.source ?? "UI",
+        },
+      });
+    }
+
+    const updateData = this.buildComponentUpdateColumns(data);
+    const newSchemaVersion = expectedSchemaVersion + 1;
+    updateData.schema_version = newSchemaVersion;
+
     try {
-      const results = await this.adapter.update<DynamicFieldGroupRecord>(
+      const matched = await this.adapter.updateCount(
         await this.resolveRegistryTableName(),
         updateData,
-        this.whereEq("slug", slug),
-        { returning: "*" }
+        {
+          and: [
+            { column: "slug", op: "=", value: slug },
+            {
+              column: "schema_version",
+              op: "=",
+              value: expectedSchemaVersion,
+            },
+          ],
+        }
       );
 
-      if (results.length === 0) {
-        // Generic "Not found."; slug in logContext.
-        throw NextlyError.notFound({ logContext: { slug } });
+      if (matched === 0) {
+        this.logger.info("Component conditional update did not match", {
+          slug,
+          expectedSchemaVersion,
+        });
+        return { matched: false };
       }
 
       this.logger.info("Component updated", { slug });
-
-      return this.deserializeRecord(results[0]);
+      return { matched: true, newSchemaVersion };
     } catch (error) {
-      // Preserve already-mapped NextlyErrors (the notFound above, or a
-      // forbidden from the locked-check). Anything else is a raw DB error.
-      // Normalise raw driver errors first so unique/fk/etc. produce the right kind.
+      // Preserve already-mapped NextlyErrors; anything else is a raw DB error.
       if (NextlyError.is(error)) {
         throw error;
       }

--- a/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
@@ -534,6 +534,20 @@ export class FieldGroupRegistryService extends BaseRegistryService<
               op: "=",
               value: expectedSchemaVersion,
             },
+            // 🔴 The lock state belongs IN the predicate, not only in the read above. Ownership can
+            // change without the version moving — a code sync claiming an existing UI group sets
+            // `locked` through the admin-only branch — so a caller that read the row unlocked still
+            // satisfies a version-only predicate and overwrites a definition that is now owned by a
+            // config file. Pinning it here makes the check and the write one statement, which is
+            // the whole reason this method exists rather than a read followed by an update.
+            //
+            // Only for a non-code caller: `source: "code"` IS the owner, and the read above already
+            // permits it, so requiring `locked = false` there would refuse every code sync.
+            // Safe as an equality because the column is NOT NULL with a default, so there is no
+            // third state for it to miss.
+            ...(options?.source !== "code"
+              ? [{ column: "locked", op: "=" as const, value: false }]
+              : []),
           ],
         }
       );
@@ -777,9 +791,21 @@ export class FieldGroupRegistryService extends BaseRegistryService<
               continue;
             }
           }
+          // 🔴 The row is RE-READ when the repair above rewrote it, because the decision below
+          // compares the config against the record and the record is no longer the one in hand.
+          // The repair writes fields, hash, localization and version from the LIVE TABLES; the
+          // stale copy still describes what the config happens to say, so the comparison reports
+          // "unchanged" and no table work is queued — leaving the mark cleared over a registry that
+          // describes the tables and a config that describes something else, which is the exact
+          // divergence this sync exists to close.
+          const settled =
+            existing.migrationStatus === "diverged"
+              ? await this.getComponent(config.slug)
+              : existing;
+
           await this.syncExistingCodeFirstComponent({
             config,
-            existing,
+            existing: settled,
             schemaHash,
             repairedTableName,
             result,

--- a/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
@@ -475,9 +475,14 @@ export class FieldGroupRegistryService extends BaseRegistryService<
    * NOT_FOUND throw, whose meaning here would be false for the commoner (advanced) case.
    *
    * The version ALWAYS advances, to `expectedSchemaVersion + 1`, computed against the value the
-   * WHERE pins rather than a fresh read. That is also what makes the matched count trustworthy on
-   * MySQL, which counts CHANGED rows: a write that matches always moves `schema_version`, so
-   * matched implies changed — see `DrizzleAdapter.updateCount`.
+   * WHERE pins rather than a fresh read.
+   *
+   * 🔴 That advance is also what keeps the matched count trustworthy on MySQL, which counts CHANGED
+   * rows rather than matched ones: a matching write always moves `schema_version`, so matched
+   * implies changed — see `DrizzleAdapter.updateCount`. `updated_at` moves on every write too and
+   * masks the distinction in ordinary use, which is why the version is the one to rely on: it is
+   * strictly monotonic, while two writes inside a single timestamp tick carry the SAME `updated_at`
+   * and would leave an all-identical payload counting zero. Do not remove either without the other.
    *
    * No returned row, deliberately. On a dialect without RETURNING a returning read re-runs the
    * WHERE — whose version this write just moved past — so a landed write would read back as

--- a/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
@@ -763,11 +763,29 @@ export class FieldGroupSchemaService {
     return mapped as unknown as DataFieldConfig;
   }
 
+  /**
+   * The column type this dialect gives `field`, spelled exactly as the CREATE TABLE spells it.
+   *
+   * The same value `generateColumnSQL` puts into its column definition, exposed so a caller that
+   * needs only the type can ask for it instead of recovering it from rendered SQL. Recovering it
+   * that way loses information the moment a type is more than one word — `DOUBLE PRECISION` reads
+   * back as `DOUBLE` — and no amount of parsing makes a printed statement a reliable channel for a
+   * value the function already returns.
+   *
+   * `null` where this service would emit no column at all, which is the same condition that makes
+   * `generateColumnSQL` skip a field.
+   */
+  columnTypeFor(field: DataFieldConfig): string | null {
+    return this.getColumnType(this.asMappableField(field));
+  }
+
   private generateColumnSQL(field: DataFieldConfig): string | null {
     if (!("name" in field) || !field.name) return null;
 
     const columnName = this.toSnakeCase(field.name);
-    const columnType = this.getColumnType(this.asMappableField(field));
+    // Through the public accessor, so the type a caller can ask for and the type that reaches the
+    // table are the same expression rather than two that agree until one is edited.
+    const columnType = this.columnTypeFor(field);
     if (!columnType) return null;
 
     const parts = [`${this.q}${columnName}${this.q}`, columnType];

--- a/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
@@ -257,11 +257,11 @@ export class FieldGroupSchemaService {
     const indexStatements: string[] = [];
 
     const parentIndexName = `${STORAGE_FORMAT.indexPrefix}${tableName}_parent`;
-    const parentColumns = [
-      `${this.q}${STORAGE_FORMAT.columns.parentId}${this.q}`,
-      `${this.q}${STORAGE_FORMAT.columns.parentTable}${this.q}`,
-      `${this.q}${STORAGE_FORMAT.columns.parentField}${this.q}`,
-    ].join(", ");
+    // From the shared constant rather than listed here, so the index this CREATES and any check
+    // asking whether a live table still has it cannot disagree about which columns or what order.
+    const parentColumns = STORAGE_FORMAT.parentIndexColumns
+      .map(column => `${this.q}${column}${this.q}`)
+      .join(", ");
 
     if (this.dialect === "mysql") {
       indexStatements.push(
@@ -779,6 +779,30 @@ export class FieldGroupSchemaService {
     return this.getColumnType(this.asMappableField(field));
   }
 
+  /**
+   * The DEFAULT expression this dialect gives `field`, or `null` where it writes none.
+   *
+   * The companion of {@link columnTypeFor}, and exposed for the same reason: a caller comparing a
+   * live column against what this service would have created needs the value, and the only other
+   * way to obtain it is to render a statement and read it back out. `null` is a real answer here —
+   * most field types carry no default — which is why it is distinct from the "could not decide"
+   * a caller may need to represent separately.
+   */
+  columnDefaultFor(field: DataFieldConfig): string | null {
+    const mappable = this.asMappableField(field);
+    if (!isCheckboxField(mappable) || mappable.defaultValue === undefined) {
+      return null;
+    }
+    // SQLite has no boolean literal, so the same declaration is stored as 1/0 there.
+    const value =
+      this.dialect === "sqlite"
+        ? mappable.defaultValue
+          ? 1
+          : 0
+        : mappable.defaultValue;
+    return String(value);
+  }
+
   private generateColumnSQL(field: DataFieldConfig): string | null {
     if (!("name" in field) || !field.name) return null;
 
@@ -794,14 +818,11 @@ export class FieldGroupSchemaService {
       parts.push("NOT NULL");
     }
 
-    if (isCheckboxField(field) && field.defaultValue !== undefined) {
-      const defaultVal =
-        this.dialect === "sqlite"
-          ? field.defaultValue
-            ? 1
-            : 0
-          : field.defaultValue;
-      parts.push(`DEFAULT ${String(defaultVal)}`);
+    // Same accessor rule as the type above: one expression decides the default a caller can ask
+    // about and the default the table actually gets.
+    const columnDefault = this.columnDefaultFor(field);
+    if (columnDefault !== null) {
+      parts.push(`DEFAULT ${columnDefault}`);
     }
 
     return parts.join(" ");

--- a/packages/nextly/src/domains/field-groups/services/field-group-table-provisioning.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-table-provisioning.ts
@@ -23,6 +23,21 @@ import { localizedColumnsOnMain } from "../../i18n/runtime/companion-io";
 import { buildCompanionRuntimeTable } from "../../i18n/runtime/companion-registration";
 import { isIdempotencyError } from "../../schema/pipeline/sql-statement-utils";
 
+/**
+ * Whether the in-memory schema was actually refreshed, and why not when it was not.
+ *
+ * Reported rather than thrown because this step runs AFTER the durable write on every caller: the
+ * schema change is already committed, so raising here would describe a repair that landed as one
+ * that failed. Returning the outcome lets a caller that must not overstate its result — a repair
+ * telling an operator the group is usable again — say what is still stale, while the callers that
+ * treat registration as best-effort carry on ignoring it exactly as before.
+ */
+export interface RuntimeSchemaRegistration {
+  registered: boolean;
+  /** Present only when `registered` is false; safe to show an operator. */
+  reason?: string;
+}
+
 export function registerComponentRuntimeSchema(
   adapter: DrizzleAdapter,
   dialect: string,
@@ -32,7 +47,7 @@ export function registerComponentRuntimeSchema(
   // i18n: when localized, the main comp_ runtime table omits translatable columns and the
   // companion comp_<slug>_locales runtime table is registered for per-language reads/writes.
   localized = false
-): void {
+): RuntimeSchemaRegistration {
   try {
     const fieldGroupSchemaService = new FieldGroupSchemaService(
       dialect as ConstructorParameters<typeof FieldGroupSchemaService>[0]
@@ -64,7 +79,7 @@ export function registerComponentRuntimeSchema(
           companion.table
         );
       }
-      return;
+      return { registered: true };
     }
 
     // Fallback for paths where DI isn't wired (tests, CLI).
@@ -77,7 +92,7 @@ export function registerComponentRuntimeSchema(
     ).tableResolver;
     if (resolver && typeof resolver.registerDynamicSchema === "function") {
       resolver.registerDynamicSchema(tableName, runtimeTable);
-      return;
+      return { registered: true };
     }
 
     console.warn(
@@ -85,6 +100,10 @@ export function registerComponentRuntimeSchema(
         `'${tableName}'. Component queries may reference old column names ` +
         `until next server restart.`
     );
+    return {
+      registered: false,
+      reason: "no schema registry is available in this process",
+    };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(
@@ -92,6 +111,7 @@ export function registerComponentRuntimeSchema(
         `'${tableName}': ${msg}. Component queries may reference old ` +
         `column names until next server restart.`
     );
+    return { registered: false, reason: msg };
   }
 }
 

--- a/packages/nextly/src/domains/field-groups/services/field-group-table-provisioning.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-table-provisioning.ts
@@ -70,15 +70,30 @@ export function registerComponentRuntimeSchema(
         })
       : null;
 
+    /**
+     * Register the pair through whichever sink is available.
+     *
+     * 🔴 Both tables, always. A localized field group's reads and writes go through the COMPANION,
+     * so registering only the main table leaves the half that actually serves translated values
+     * stale — and a caller that reports this as a completed refresh then tells an operator the
+     * group is usable when the localized half is not. Written once and applied to both sinks
+     * because the two branches answer the same question, and the fallback previously answered it
+     * differently while returning the same verdict.
+     */
+    const registerBoth = (
+      register: (name: string, table: unknown) => void
+    ): void => {
+      register(tableName, runtimeTable);
+      if (companion) {
+        register(companion.companionTableName, companion.table);
+      }
+    };
+
     const registry = getSchemaRegistryFromDI();
     if (registry) {
-      registry.registerDynamicSchema(tableName, runtimeTable);
-      if (companion) {
-        registry.registerDynamicSchema(
-          companion.companionTableName,
-          companion.table
-        );
-      }
+      registerBoth((name, table) =>
+        registry.registerDynamicSchema(name, table)
+      );
       return { registered: true };
     }
 
@@ -90,8 +105,11 @@ export function registerComponentRuntimeSchema(
         };
       }
     ).tableResolver;
-    if (resolver && typeof resolver.registerDynamicSchema === "function") {
-      resolver.registerDynamicSchema(tableName, runtimeTable);
+    const fallbackRegister = resolver?.registerDynamicSchema;
+    if (typeof fallbackRegister === "function") {
+      registerBoth((name, table) =>
+        fallbackRegister.call(resolver, name, table)
+      );
       return { registered: true };
     }
 

--- a/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
+++ b/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
@@ -27,6 +27,7 @@ import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import { isFieldLocalized } from "../../i18n/classify-fields";
 import {
+  COMPANION_KEY_COLUMNS,
   COMPANION_STATUS_COLUMN,
   COMPANION_STRUCTURAL_COLUMNS,
 } from "../../i18n/migration/generate-up";
@@ -270,6 +271,26 @@ function mainSkeleton(
 }
 
 /**
+ * The size modifier a type carries, normalised for comparison — `VARCHAR(255)` gives `255`.
+ *
+ * 🔴 Compared SEPARATELY from the type token because the canonical form deliberately strips it, and
+ * that strip is correct for the reason its own module gives: PostgreSQL introspection reads
+ * `udt_name`, which never carries a length, so keeping it would report drift on every healthy
+ * PostgreSQL column. MySQL introspection reads `COLUMN_TYPE`, which DOES carry it — so a `maxLength`
+ * change that resized a column and then failed its registry write leaves `VARCHAR(32)` live against
+ * an authored `VARCHAR(255)`, and the two compare equal once the modifier is gone.
+ *
+ * Gated on BOTH sides having one rather than on a dialect name: presence is the property that
+ * decides whether the comparison is meaningful, and a dialect list would be a second opinion about
+ * which introspector preserves widths.
+ */
+function typeModifier(type: string | undefined): string | undefined {
+  const match = /\(([^)]*)\)/.exec(type ?? "");
+  const inner = match?.[1];
+  return inner === undefined ? undefined : inner.replace(/\s+/g, "");
+}
+
+/**
  * Whether a live table carries an index covering exactly these columns, in this order.
  *
  * Matched by the ordered column LIST and uniqueness rather than by NAME: an engine appends a
@@ -359,6 +380,28 @@ function structuralBlockers(
         columnName: required,
         kind: "structural-column-missing",
         detail: `${liveCompanion.name} holds translated values but is missing the system column "${required}", so its rows cannot be matched back to a parent or a locale.`,
+      });
+    }
+
+    // 🔴 The composite key is load-bearing at RUNTIME, not merely structural: `upsertCompanionRow`
+    // names `(_parent, _locale)` as its conflict target. A companion that kept those columns and
+    // lost the key looks healthy to every check above while failing every localized write on
+    // PostgreSQL and SQLite, and silently accepting duplicate locale rows on MySQL — which is the
+    // worse outcome, because nothing reports it. Checked only where the columns are present, so a
+    // table already refused above is not reported twice for the same cause.
+    const keyed = new Set(
+      liveCompanion.columns
+        .filter(column => column.primaryKey === true)
+        .map(column => column.name)
+    );
+    for (const keyColumn of COMPANION_KEY_COLUMNS) {
+      if (!liveCompanionColumns.has(keyColumn) || keyed.has(keyColumn))
+        continue;
+      blockers.push({
+        fieldName: keyColumn,
+        columnName: keyColumn,
+        kind: "structural-column-missing",
+        detail: `${liveCompanion.name} has "${keyColumn}" but it is not part of the table's primary key; localized writes match rows on (${COMPANION_KEY_COLUMNS.join(", ")}) and cannot do so without it.`,
       });
     }
   }
@@ -593,10 +636,21 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
     const expectedSpelling = input.expectedColumnType?.(field, table);
     const expectedType = normalizeType(expectedSpelling);
     const liveType = normalizeType(live.type);
+    // The width is part of the physical type wherever the database reports one. Both must carry a
+    // modifier for the comparison to mean anything: where the introspector drops it, an absent
+    // modifier says nothing about the column and treating that as a mismatch would refuse every
+    // healthy group on that dialect.
+    const expectedWidth = typeModifier(expectedSpelling);
+    const liveWidth = typeModifier(live.type);
+    const widthDiffers =
+      expectedWidth !== undefined &&
+      liveWidth !== undefined &&
+      expectedWidth !== liveWidth;
     if (
-      expectedType !== undefined &&
-      liveType !== undefined &&
-      expectedType !== liveType
+      (expectedType !== undefined &&
+        liveType !== undefined &&
+        expectedType !== liveType) ||
+      widthDiffers
     ) {
       blockers.push({
         fieldName: field.name,

--- a/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
+++ b/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
@@ -23,6 +23,7 @@
  * @module domains/field-groups/services/reconcile-field-group-plan
  */
 
+import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import { isFieldLocalized } from "../../i18n/classify-fields";
 import { COMPANION_STRUCTURAL_COLUMNS } from "../../i18n/migration/generate-up";
 import { buildDesiredTableFromComponentFields } from "../../schema/pipeline/diff/build-from-fields";
@@ -140,7 +141,9 @@ function mainSystemColumnNames(
     input.dialect,
     {
       builtBy: "fieldGroup",
-      ...(input.typeColumn !== undefined ? { typeColumn: input.typeColumn } : {}),
+      ...(input.typeColumn !== undefined
+        ? { typeColumn: input.typeColumn }
+        : {}),
     }
   );
   return new Set(skeleton.columns.map(column => column.name));
@@ -238,7 +241,11 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
   const claimedCompanion = new Set<string>();
 
   for (const field of storedFields) {
-    const descriptor = getColumnDescriptor(field as never, dialect, "fieldGroup");
+    const descriptor = getColumnDescriptor(
+      field as unknown as FieldDefinition,
+      dialect,
+      "fieldGroup"
+    );
     // A layout-only field produces no column, so no live column can confirm or deny it. Keeping it
     // is the only correct answer: removing it would delete an authored field on the evidence of a
     // column that was never supposed to exist.
@@ -247,7 +254,7 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
       continue;
     }
 
-    const inCompanion = localized && isFieldLocalized(field as never, true);
+    const inCompanion = localized && isFieldLocalized(field, true);
     const table: ReconcileTable = inCompanion ? "companion" : "main";
     const live = inCompanion
       ? companionColumns.get(descriptor.name)
@@ -265,19 +272,23 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
 
     let repairedField = field;
 
-    // `required` is the field's spelling of NOT NULL. A primary key is exempt for the same reason
-    // the diff exempts it: the key implies the constraint without declaring it.
-    const liveRequired = !live.nullable && live.primaryKey !== true;
-    if ((field.required === true) !== liveRequired) {
-      repaired.push({
-        fieldName: field.name,
-        columnName: descriptor.name,
-        table,
-        attribute: "required",
-        from: field.required === true,
-        to: liveRequired,
-      });
-      repairedField = withOverride(repairedField, "required", liveRequired);
+    // `required` is the field's spelling of NOT NULL, and only the MAIN table can testify to it:
+    // companion columns are created nullable regardless of the field's declaration, because a row
+    // may legitimately have no value for a locale. A primary key is exempt for the same reason the
+    // diff exempts it: the key implies the constraint without declaring it.
+    if (!inCompanion) {
+      const liveRequired = !live.nullable && live.primaryKey !== true;
+      if ((field.required === true) !== liveRequired) {
+        repaired.push({
+          fieldName: field.name,
+          columnName: descriptor.name,
+          table,
+          attribute: "required",
+          from: field.required === true,
+          to: liveRequired,
+        });
+        repairedField = withOverride(repairedField, "required", liveRequired);
+      }
     }
 
     // Indexes live only on the main table; the companion is keyed by `(_parent, _locale)` and
@@ -337,10 +348,21 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
       liveType: column.type,
       guessedType,
     });
+    // A live index over the column is meaning worth keeping: dropping it from the adopted field
+    // would tell the next schema edit to remove an object the operator's database relies on.
+    // Companion columns carry no per-field index, and their nullability says nothing about
+    // `required` — the same two exclusions the repair loop above makes.
+    const { present, unique } =
+      table === "main"
+        ? indexOver(liveMain.indexes, column.name)
+        : { present: false, unique: false };
     fields.push({
       name: column.name,
       type: guessedType,
-      required: !column.nullable && column.primaryKey !== true,
+      required:
+        table === "main" && !column.nullable && column.primaryKey !== true,
+      ...(unique ? { unique: true } : {}),
+      ...(present && !unique ? { index: true } : {}),
       ...(table === "companion" ? { localized: true } : {}),
     } as F);
   };

--- a/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
+++ b/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
@@ -26,6 +26,7 @@
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import { isFieldLocalized } from "../../i18n/classify-fields";
+import { fieldToLocalizedColumnSpec } from "../../i18n/migration/field-to-column-spec";
 import {
   COMPANION_KEY_COLUMNS,
   COMPANION_STATUS_COLUMN,
@@ -420,10 +421,19 @@ function structuralBlockers(
  */
 function deriveLocalized(
   liveCompanion: TableSpec | null,
-  storedLocalized: boolean
+  storedLocalized: boolean,
+  // Whether this field set would produce any companion COLUMN, by the same predicate the
+  // production companion builder uses to decide whether to make the table at all.
+  companionWouldHaveColumns: boolean
 ): boolean {
-  // No companion at all is unambiguous: nothing was ever moved out.
-  if (!liveCompanion) return false;
+  // 🔴 No companion is only evidence when a companion was DUE. `deriveCompanionSpec` returns null
+  // for a localized entity whose fields produce no localized columns, so a healthy `localized: true`
+  // group made only of non-localized or columnless fields correctly has no companion table. Reading
+  // that absence as "not localized" rewrites a healthy group, and the damage lands later: the next
+  // default-translatable field added to it goes to the MAIN table, which is the divergence this
+  // operation exists to clear rather than create.
+  if (!liveCompanion)
+    return companionWouldHaveColumns ? false : storedLocalized;
   if (
     liveCompanion.columns.some(
       column => !COMPANION_STRUCTURAL_COLUMNS.has(column.name)
@@ -500,7 +510,19 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
 ): ReconcilePlan<F> {
   const { storedFields, dialect, liveMain, liveCompanion } = input;
 
-  const localized = deriveLocalized(liveCompanion, input.storedLocalized);
+  // Asked of the production column builder rather than of the field flags alone: a field can be
+  // marked translatable and still produce no companion column, and it is the COLUMN that decides
+  // whether a companion exists.
+  const companionWouldHaveColumns = storedFields.some(
+    field =>
+      isFieldLocalized(field, true) &&
+      fieldToLocalizedColumnSpec(field, dialect, "fieldGroup") !== null
+  );
+  const localized = deriveLocalized(
+    liveCompanion,
+    input.storedLocalized,
+    companionWouldHaveColumns
+  );
 
   const mainColumns = new Map(liveMain.columns.map(c => [c.name, c]));
   const companionColumns = new Map(

--- a/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
+++ b/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
@@ -331,16 +331,31 @@ function structuralBlockers(
   localized: boolean
 ): ReconcileBlocker[] {
   const blockers: ReconcileBlocker[] = [];
-  const liveMainColumns = new Set(liveMain.columns.map(c => c.name));
+  const liveMainByName = new Map(liveMain.columns.map(c => [c.name, c]));
 
   for (const column of skeleton.columns) {
-    if (liveMainColumns.has(column.name)) continue;
-    blockers.push({
-      fieldName: column.name,
-      columnName: column.name,
-      kind: "structural-column-missing",
-      detail: `${liveMain.name} is missing the system column "${column.name}", which every field-group table carries; the definition cannot describe a table that cannot store its own rows.`,
-    });
+    const live = liveMainByName.get(column.name);
+    if (live === undefined) {
+      blockers.push({
+        fieldName: column.name,
+        columnName: column.name,
+        kind: "structural-column-missing",
+        detail: `${liveMain.name} is missing the system column "${column.name}", which every field-group table carries; the definition cannot describe a table that cannot store its own rows.`,
+      });
+      continue;
+    }
+    // 🔴 Presence is not the whole requirement. A column can survive while the CONSTRAINT that made
+    // it meaningful is dropped, and for `id` that means duplicate component rows become possible
+    // while every name-based check still reads the table as healthy. Taken from the skeleton's own
+    // `primaryKey` rather than by naming `id`, so this covers whatever the generator marks next.
+    if (column.primaryKey === true && live.primaryKey !== true) {
+      blockers.push({
+        fieldName: column.name,
+        columnName: column.name,
+        kind: "structural-column-missing",
+        detail: `${liveMain.name} still has "${column.name}" but it is no longer the table's primary key, so duplicate rows are possible; this operation issues no DDL and cannot restore the constraint.`,
+      });
+    }
   }
 
   // 🔴 Required indexes come from what the table BUILDER creates, not from the skeleton's index

--- a/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
+++ b/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
@@ -27,6 +27,7 @@ import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import { isFieldLocalized } from "../../i18n/classify-fields";
 import { COMPANION_STRUCTURAL_COLUMNS } from "../../i18n/migration/generate-up";
 import { buildDesiredTableFromComponentFields } from "../../schema/pipeline/diff/build-from-fields";
+import { normalizeType } from "../../schema/pipeline/diff/normalize-type";
 import type {
   ColumnSpec,
   IndexSpec,
@@ -40,6 +41,16 @@ import {
 
 /** Which of a field group's two tables a column lives in. */
 export type ReconcileTable = "main" | "companion";
+
+/**
+ * What a field name may be, mirroring the payload validator every other write path enforces.
+ *
+ * Stated here rather than imported because that validator takes a whole payload and throws; this
+ * planner is pure and reports instead. Kept identical on purpose — a live column that cannot pass
+ * the real validator must never be adopted, and the service re-validates the finished field set
+ * through the shared validator before writing, so this is a filter rather than the boundary.
+ */
+const FIELD_NAME_PATTERN = /^[a-z][a-z0-9_]*$/;
 
 /**
  * The properties this planner reads or rewrites. A caller's field carries more than this and keeps
@@ -66,9 +77,26 @@ export interface ReconcileRepair {
   fieldName: string;
   columnName: string;
   table: ReconcileTable;
-  attribute: "required" | "unique" | "index";
+  attribute: "required" | "unique" | "index" | "localized";
   from: boolean;
   to: boolean;
+}
+
+/**
+ * A drift the planner can SEE but must not decide, so the whole repair refuses.
+ *
+ * Reported rather than resolved because each of these is genuinely ambiguous — the database holds
+ * two readings and nothing in it says which the operator meant. Guessing would write a definition
+ * that describes neither, and this operation's whole value is that its output describes the tables.
+ */
+export interface ReconcileBlocker {
+  fieldName: string;
+  columnName: string;
+  kind:
+    | "column-on-both-tables"
+    | "physical-type-changed"
+    | "unrepresentable-column-name";
+  detail: string;
 }
 
 /** A live column no stored field described, adopted with a type this planner had to guess. */
@@ -85,11 +113,20 @@ export interface ReconcileAdoption {
 export interface ReconcilePlan<F extends ReconcilableField> {
   /** The repaired field set, in the stored order, with adoptions appended. */
   fields: F[];
-  /** Re-derived from which table holds the columns — never read from a flag. */
+  /**
+   * Re-derived from WHERE the columns are, except where the tables cannot say.
+   *
+   * A companion holding only structural columns is the ambiguous case: it is what both a
+   * never-localized group and a localized group whose last translatable field was removed leave
+   * behind. The stored flag breaks that tie — the one place it is evidence rather than the value
+   * in doubt.
+   */
   localized: boolean;
   removed: ReconcileRemoval[];
   repaired: ReconcileRepair[];
   adopted: ReconcileAdoption[];
+  /** Non-empty means the caller must REFUSE rather than write. */
+  blockers: ReconcileBlocker[];
   /** True when nothing needed changing, so a caller can skip the write entirely. */
   unchanged: boolean;
 }
@@ -129,7 +166,7 @@ export interface ReconcileInput<F extends ReconcilableField> {
  */
 function withOverride<F extends ReconcilableField>(
   field: F,
-  key: "required" | "unique" | "index",
+  key: "required" | "unique" | "index" | "localized",
   value: boolean
 ): F {
   return { ...field, [key]: value };
@@ -168,11 +205,27 @@ function mainSystemColumnNames(
  * that a companion exists and carries at least one column that is not structural: an empty
  * companion holding only `_parent`/`_locale` is a table nothing was moved into.
  */
-function deriveLocalized(liveCompanion: TableSpec | null): boolean {
+function deriveLocalized(
+  liveCompanion: TableSpec | null,
+  storedLocalized: boolean
+): boolean {
+  // No companion at all is unambiguous: nothing was ever moved out.
   if (!liveCompanion) return false;
-  return liveCompanion.columns.some(
-    column => !COMPANION_STRUCTURAL_COLUMNS.has(column.name)
-  );
+  if (
+    liveCompanion.columns.some(
+      column => !COMPANION_STRUCTURAL_COLUMNS.has(column.name)
+    )
+  ) {
+    return true;
+  }
+  // 🔴 A companion holding ONLY structural columns is physically ambiguous, and reading it as
+  // "not localized" is wrong in a way that compounds: a healthy localized group whose last
+  // translatable field was removed looks exactly like this, and rewriting it as non-localized
+  // would send the next default-translatable field to the main table instead of the companion —
+  // making the documented idempotent repair the thing that breaks the group. The tables cannot
+  // separate the two readings, so the stored flag decides, which is the one case where it is
+  // evidence rather than the value under repair.
+  return storedLocalized;
 }
 
 /**
@@ -234,7 +287,7 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
 ): ReconcilePlan<F> {
   const { storedFields, dialect, liveMain, liveCompanion } = input;
 
-  const localized = deriveLocalized(liveCompanion);
+  const localized = deriveLocalized(liveCompanion, input.storedLocalized);
 
   const mainColumns = new Map(liveMain.columns.map(c => [c.name, c]));
   const companionColumns = new Map(
@@ -244,6 +297,7 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
   const removed: ReconcileRemoval[] = [];
   const repaired: ReconcileRepair[] = [];
   const adopted: ReconcileAdoption[] = [];
+  const blockers: ReconcileBlocker[] = [];
   const fields: F[] = [];
 
   /** Column names a stored field accounted for, so the leftovers can be adopted. */
@@ -273,11 +327,33 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
       continue;
     }
 
-    const inCompanion = localized && isFieldLocalized(field, true);
-    const table: ReconcileTable = inCompanion ? "companion" : "main";
-    const live = inCompanion
-      ? companionColumns.get(descriptor.name)
-      : mainColumns.get(descriptor.name);
+    // 🔴 Located across BOTH tables rather than only the one the stored flag implies. A `localized`
+    // toggle on a single field MOVES its column between them, and a half-applied toggle is exactly
+    // what this repairs — so searching only the expected table would report the field as removed
+    // and then re-adopt its column from the other table as a minimal guess, discarding the logical
+    // type, options and admin config the operator authored. Finding it where it actually IS keeps
+    // all of that and corrects the placement flag instead.
+    const expectedInCompanion = localized && isFieldLocalized(field, true);
+    const onMain = mainColumns.get(descriptor.name);
+    const onCompanion = companionColumns.get(descriptor.name);
+
+    if (onMain && onCompanion) {
+      // Both tables hold it: a localization enable that created and seeded the companion without
+      // finishing the main-table drops. Which copy carries the live values is not something the
+      // catalog can answer, and choosing wrong strands content silently — so the repair refuses.
+      blockers.push({
+        fieldName: field.name,
+        columnName: descriptor.name,
+        kind: "column-on-both-tables",
+        detail: `"${descriptor.name}" exists on both ${input.tableName} and its companion, so which copy holds the live values cannot be determined from the schema.`,
+      });
+      claimedMain.add(descriptor.name);
+      claimedCompanion.add(descriptor.name);
+      fields.push(field);
+      continue;
+    }
+
+    const live = onMain ?? onCompanion;
 
     if (!live) {
       // 🔴 REPORTED by identity and removed, never silently dropped. The summary is the only thing
@@ -287,9 +363,42 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
       continue;
     }
 
+    const inCompanion = onCompanion !== undefined;
+    const table: ReconcileTable = inCompanion ? "companion" : "main";
     (inCompanion ? claimedCompanion : claimedMain).add(descriptor.name);
 
     let repairedField = field;
+
+    // The column moved between tables, so the field's own placement flag is what is stale. The
+    // authored meaning is kept and only that flag corrected.
+    if (inCompanion !== expectedInCompanion) {
+      repaired.push({
+        fieldName: field.name,
+        columnName: descriptor.name,
+        table,
+        attribute: "localized",
+        from: expectedInCompanion,
+        to: inCompanion,
+      });
+      repairedField = withOverride(repairedField, "localized", inCompanion);
+    }
+
+    // 🔴 The PHYSICAL type, through the diff engine's own canonical form so `varchar(255)` and
+    // `varchar` are one answer. A name match is not evidence the column still stores what the field
+    // declares: a confirmed apply can change `number` to `text` and then fail its registry write,
+    // and keeping the stored logical type would mark `synced` a definition the next diff instantly
+    // disagrees with. Which logical type now belongs there cannot be derived — many map to one
+    // physical column — so this refuses and names the drift rather than guessing.
+    const liveType = normalizeType(live.type);
+    const declaredType = normalizeType(descriptor.dialectType);
+    if (liveType !== undefined && declaredType !== liveType) {
+      blockers.push({
+        fieldName: field.name,
+        columnName: descriptor.name,
+        kind: "physical-type-changed",
+        detail: `"${field.name}" is declared ${field.type} (${descriptor.dialectType}) but its column is ${live.type}; the logical type that now belongs there cannot be derived from the column alone.`,
+      });
+    }
 
     // `required` is the field's spelling of NOT NULL, and only the MAIN table can testify to it:
     // companion columns are created nullable regardless of the field's declaration, because a row
@@ -359,6 +468,38 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
     system: ReadonlySet<string>
   ): void => {
     if (claimed.has(column.name) || system.has(column.name)) return;
+    // The same user column present on BOTH tables and claimed by no stored field. Adopting it
+    // twice would write two fields under one name and mark the ambiguity synced, so the same
+    // refusal the stored-field path makes applies here — reported once, from the main side.
+    const otherTable =
+      table === "main" ? companionColumns : new Map(mainColumns);
+    if (
+      otherTable.has(column.name) &&
+      !COMPANION_STRUCTURAL_COLUMNS.has(column.name)
+    ) {
+      if (table === "main") {
+        blockers.push({
+          fieldName: column.name,
+          columnName: column.name,
+          kind: "column-on-both-tables",
+          detail: `"${column.name}" exists on both tables and no stored field describes it, so which copy to adopt cannot be determined from the schema.`,
+        });
+      }
+      return;
+    }
+    // 🔴 A live identifier is not necessarily a legal field name — `Legacy-Title`, `2fa_code` and
+    // anything added by hand outside the builder reach here verbatim. Adopting one would persist a
+    // definition that violates the field contract and mark it synced, so the next builder save or
+    // manifest validation fails on the row this operation just "repaired".
+    if (!FIELD_NAME_PATTERN.test(column.name)) {
+      blockers.push({
+        fieldName: column.name,
+        columnName: column.name,
+        kind: "unrepresentable-column-name",
+        detail: `"${column.name}" is not a usable field name, so it cannot be adopted into the definition; rename the column or remove it before reconciling.`,
+      });
+      return;
+    }
     // A columnless field under this very name is what a half-applied type change leaves behind:
     // the DDL created the scalar column, the row still declares the columnless field. One name
     // must map to one field, so the columnless declaration gives way — as a REPORTED removal —
@@ -414,6 +555,7 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
     removed,
     repaired,
     adopted,
+    blockers,
     unchanged:
       removed.length === 0 &&
       repaired.length === 0 &&

--- a/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
+++ b/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
@@ -156,6 +156,23 @@ export interface ReconcileInput<F extends ReconcilableField> {
    * as an unknown column and adopt it as a user field.
    */
   typeColumn?: string;
+  /**
+   * What the CREATOR would write for each column, by column name, already normalised.
+   *
+   * 🔴 The creator, not the column descriptor, and the distinction is the whole reason this input
+   * exists. `FieldGroupSchemaService` owns its own dialect type table and it deliberately differs
+   * from `getColumnDescriptor`: measured on live databases, a `date` field is `DATETIME` on MySQL
+   * and an `email` is `VARCHAR(255)` on PostgreSQL, where the descriptor answers `timestamp` and
+   * `text`. Comparing against the descriptor therefore reported drift on perfectly healthy groups
+   * and refused to repair them — the opposite of this operation's purpose.
+   *
+   * Supplied by the caller rather than computed here so this module stays pure: the creator is a
+   * service, and the seam that already owns I/O is the right place to instantiate it.
+   *
+   * A column ABSENT from this map is not compared. Absence means "no expectation could be derived",
+   * which is not evidence of drift, and blocking on it would re-create the false refusal.
+   */
+  expectedColumnTypes?: ReadonlyMap<string, string>;
 }
 
 /**
@@ -383,20 +400,28 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
       repairedField = withOverride(repairedField, "localized", inCompanion);
     }
 
-    // 🔴 The PHYSICAL type, through the diff engine's own canonical form so `varchar(255)` and
-    // `varchar` are one answer. A name match is not evidence the column still stores what the field
-    // declares: a confirmed apply can change `number` to `text` and then fail its registry write,
-    // and keeping the stored logical type would mark `synced` a definition the next diff instantly
-    // disagrees with. Which logical type now belongs there cannot be derived — many map to one
-    // physical column — so this refuses and names the drift rather than guessing.
+    // 🔴 The PHYSICAL type, compared against what the CREATOR would write — never against the
+    // column descriptor, which answers differently for the same field and made this check refuse
+    // healthy groups. Both sides go through the diff engine's canonical form so `VARCHAR(255)` and
+    // `varchar` are one answer.
+    //
+    // A name match is not evidence the column still stores what the field declares: a confirmed
+    // apply can change `number` to `text` and then fail its registry write, and keeping the stored
+    // logical type would mark `synced` a definition the next diff instantly disagrees with. Which
+    // logical type now belongs there cannot be derived — many map to one physical column — so this
+    // refuses and names the drift rather than guessing.
+    const expectedType = input.expectedColumnTypes?.get(descriptor.name);
     const liveType = normalizeType(live.type);
-    const declaredType = normalizeType(descriptor.dialectType);
-    if (liveType !== undefined && declaredType !== liveType) {
+    if (
+      expectedType !== undefined &&
+      liveType !== undefined &&
+      expectedType !== liveType
+    ) {
       blockers.push({
         fieldName: field.name,
         columnName: descriptor.name,
         kind: "physical-type-changed",
-        detail: `"${field.name}" is declared ${field.type} (${descriptor.dialectType}) but its column is ${live.type}; the logical type that now belongs there cannot be derived from the column alone.`,
+        detail: `"${field.name}" is declared ${field.type}, whose column this database would create as ${expectedType}, but the live column is ${live.type}; the logical type that now belongs there cannot be derived from the column alone.`,
       });
     }
 

--- a/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
+++ b/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
@@ -24,9 +24,14 @@
  */
 
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
+import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import { isFieldLocalized } from "../../i18n/classify-fields";
-import { COMPANION_STRUCTURAL_COLUMNS } from "../../i18n/migration/generate-up";
+import {
+  COMPANION_STATUS_COLUMN,
+  COMPANION_STRUCTURAL_COLUMNS,
+} from "../../i18n/migration/generate-up";
 import { buildDesiredTableFromComponentFields } from "../../schema/pipeline/diff/build-from-fields";
+import { normalizeDefault } from "../../schema/pipeline/diff/normalize-default";
 import { normalizeType } from "../../schema/pipeline/diff/normalize-type";
 import type {
   ColumnSpec,
@@ -41,6 +46,17 @@ import {
 
 /** Which of a field group's two tables a column lives in. */
 export type ReconcileTable = "main" | "companion";
+
+/**
+ * What the table builder would write as a column's DEFAULT, with "no expectation" kept distinct
+ * from "expected to have none".
+ */
+export interface ExpectedColumnDefault {
+  /** False when no expectation could be derived at all; the comparison is then skipped. */
+  known: boolean;
+  /** The default expression, or `undefined` when the builder writes none. Read only when `known`. */
+  value?: string;
+}
 
 /**
  * What a field name may be, mirroring the payload validator every other write path enforces.
@@ -95,7 +111,17 @@ export interface ReconcileBlocker {
   kind:
     | "column-on-both-tables"
     | "physical-type-changed"
-    | "unrepresentable-column-name";
+    | "unrepresentable-column-name"
+    // A system column or index the generator always emits is absent from the live table. Repairing
+    // it needs DDL, which this operation deliberately never issues.
+    | "structural-column-missing"
+    | "system-index-missing"
+    // The column's DEFAULT no longer matches the authored one. Physical, and not recoverable from
+    // the column alone: which side is intended is a question only the operator can answer.
+    | "column-default-changed"
+    // A stored field vanished while an unclaimed column appeared, which is equally a rename and a
+    // drop-plus-add. Resolving it either way discards authored configuration or invents it.
+    | "ambiguous-rename";
   detail: string;
 }
 
@@ -181,6 +207,23 @@ export interface ReconcileInput<F extends ReconcilableField> {
    * imports, and nothing here reaches for either.
    */
   expectedColumnType?: (field: F, table: ReconcileTable) => string | undefined;
+  /**
+   * The DEFAULT the code that builds `table` would give `field`.
+   *
+   * 🔴 Three-valued on purpose, and the third state is what makes the check correct rather than
+   * merely present. "I could not derive an expectation" and "the builder writes no default" are
+   * different claims that a bare `string | undefined` collapses into one value — and collapsing
+   * them costs the case most worth catching, where an authored default was REMOVED from the
+   * definition while the live column still carries it. Under the collapsed shape that reads as
+   * nothing to compare, so the drift the check exists for is exactly what it cannot see.
+   *
+   * `known: false` is skipped, matching `expectedColumnType`: an underivable expectation is not
+   * evidence of drift.
+   */
+  expectedColumnDefault?: (
+    field: F,
+    table: ReconcileTable
+  ) => ExpectedColumnDefault;
 }
 
 /**
@@ -198,16 +241,22 @@ function withOverride<F extends ReconcilableField>(
 }
 
 /**
- * The columns a field group's main table has regardless of its fields.
+ * What a field group's main table carries regardless of its fields — columns AND indexes.
  *
  * Derived by asking the desired-state builder for a table with NO fields, rather than listing the
  * system columns here. A hand-kept list is a second opinion about what the generator writes, and it
  * would present a newly added system column to the operator as an unknown user column to adopt.
+ *
+ * 🔴 The WHOLE spec is kept, not just the names. An earlier version narrowed this to a name set at
+ * the point of derivation, which silently discarded the parent-link composite index — and a
+ * discarded requirement cannot be checked, so the plan could report a table healthy while the index
+ * every parent-scoped query depends on was absent. Whatever the builder adds next is carried here
+ * for free; narrowing it again is what makes the next addition an unchecked requirement.
  */
-function mainSystemColumnNames(
+function mainSkeleton(
   input: Pick<ReconcileInput<never>, "tableName" | "dialect" | "typeColumn">
-): Set<string> {
-  const skeleton = buildDesiredTableFromComponentFields(
+): TableSpec {
+  return buildDesiredTableFromComponentFields(
     input.tableName,
     [],
     input.dialect,
@@ -218,7 +267,103 @@ function mainSystemColumnNames(
         : {}),
     }
   );
-  return new Set(skeleton.columns.map(column => column.name));
+}
+
+/**
+ * Whether a live table carries an index covering exactly these columns, in this order.
+ *
+ * Matched by the ordered column LIST and uniqueness rather than by NAME: an engine appends a
+ * collision suffix and truncates at its identifier limit, so the name is the engine's choice rather
+ * than a property of the object. Order is significant — only `(a, b)` serves a left-prefix lookup on
+ * `a` — which is why `indexKey` from the diff utilities is deliberately not reused here: it SORTS
+ * the columns and so reads `(a, b)` and `(b, a)` as one index.
+ */
+function hasIndexOverColumns(
+  indexes: readonly IndexSpec[] | undefined,
+  columns: readonly string[],
+  unique: boolean
+): boolean {
+  return (indexes ?? []).some(
+    index =>
+      index.columns.length === columns.length &&
+      index.columns.every((column, at) => column === columns[at]) &&
+      (index.unique === true) === unique
+  );
+}
+
+/**
+ * Structural requirements the live tables must already meet before any repair is planned.
+ *
+ * 🔴 These are BLOCKERS rather than repairs, because this operation never issues DDL. A missing
+ * `_parent_id` or a missing parent-link index is a defect in the TABLE, and the only honest thing a
+ * definition-only repair can do about it is refuse — writing `synced` over it would certify a table
+ * that cannot answer the queries the runtime is about to register against it.
+ *
+ * Checked against the skeleton the generator produces rather than a list kept here, so a structural
+ * column or index added later is required the moment the generator emits it.
+ */
+function structuralBlockers(
+  skeleton: TableSpec,
+  liveMain: TableSpec,
+  liveCompanion: TableSpec | null,
+  localized: boolean
+): ReconcileBlocker[] {
+  const blockers: ReconcileBlocker[] = [];
+  const liveMainColumns = new Set(liveMain.columns.map(c => c.name));
+
+  for (const column of skeleton.columns) {
+    if (liveMainColumns.has(column.name)) continue;
+    blockers.push({
+      fieldName: column.name,
+      columnName: column.name,
+      kind: "structural-column-missing",
+      detail: `${liveMain.name} is missing the system column "${column.name}", which every field-group table carries; the definition cannot describe a table that cannot store its own rows.`,
+    });
+  }
+
+  // 🔴 Required indexes come from what the table BUILDER creates, not from the skeleton's index
+  // list. The two disagree: the migrate snapshot builder additionally emits a `created_at` index
+  // that `FieldGroupSchemaService` never creates, so requiring the skeleton's whole list refuses
+  // every healthy table — measured on all three dialects, which is how this was caught. Columns
+  // rather than a name, because the engine picks the name and truncates or suffixes it.
+  const requiredIndexColumns = STORAGE_FORMAT.parentIndexColumns;
+  if (!hasIndexOverColumns(liveMain.indexes, requiredIndexColumns, false)) {
+    blockers.push({
+      fieldName: requiredIndexColumns.join(", "),
+      columnName: requiredIndexColumns.join(", "),
+      kind: "system-index-missing",
+      detail: `${liveMain.name} is missing its required index over (${requiredIndexColumns.join(", ")}); parent-scoped reads depend on it, and this operation issues no DDL to restore it.`,
+    });
+  }
+
+  // Only meaningful once the companion is genuinely in use: a companion holding nothing but
+  // structural columns is the ambiguous case `deriveLocalized` resolves from the stored flag, and
+  // demanding structure from a table nothing was moved into would refuse a healthy group.
+  if (localized && liveCompanion) {
+    const liveCompanionColumns = new Set(
+      liveCompanion.columns.map(c => c.name)
+    );
+    // 🔴 `_status` is subtracted rather than required. The structural set describes companions in
+    // general and is right for its own purpose — subtracting it from a table leaves the translated
+    // columns — but a FIELD GROUP is never Draft/Published, so its companion is built with
+    // `status: false` and never has that column. Requiring the whole set refuses every localized
+    // field group. Derived by exclusion rather than by listing the two that remain, so a genuinely
+    // unconditional column added to the set later is required here without this being touched.
+    const requiredCompanionColumns = [...COMPANION_STRUCTURAL_COLUMNS].filter(
+      column => column !== COMPANION_STATUS_COLUMN
+    );
+    for (const required of requiredCompanionColumns) {
+      if (liveCompanionColumns.has(required)) continue;
+      blockers.push({
+        fieldName: required,
+        columnName: required,
+        kind: "structural-column-missing",
+        detail: `${liveCompanion.name} holds translated values but is missing the system column "${required}", so its rows cannot be matched back to a parent or a locale.`,
+      });
+    }
+  }
+
+  return blockers;
 }
 
 /**
@@ -322,8 +467,22 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
   const removed: ReconcileRemoval[] = [];
   const repaired: ReconcileRepair[] = [];
   const adopted: ReconcileAdoption[] = [];
-  const blockers: ReconcileBlocker[] = [];
   const fields: F[] = [];
+
+  // What the generator says this table always has. Derived once and used for BOTH questions it
+  // answers — which live columns are system columns rather than adoptable user ones, and which
+  // structural columns and indexes the table is required to already have.
+  const skeleton = mainSkeleton(input);
+
+  // Structural integrity first: these describe a table that cannot do its job, and no amount of
+  // definition repair changes that. Collected before any field is examined so a refusal names the
+  // real problem rather than the field-level symptoms a broken table produces downstream.
+  const blockers: ReconcileBlocker[] = structuralBlockers(
+    skeleton,
+    liveMain,
+    liveCompanion,
+    localized
+  );
 
   /** Column names a stored field accounted for, so the leftovers can be adopted. */
   const claimedMain = new Set<string>();
@@ -336,6 +495,14 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
    * columnless field — reported as a removal — rather than preserving both.
    */
   const columnlessByColumnName = new Map<string, F>();
+  /**
+   * Removals whose replacement column is known, so they are NOT candidates for a rename pairing.
+   *
+   * The columnless case above pairs a field and a column that share a name; every other removal is
+   * a field whose column simply vanished, and those are the ones an unclaimed column could equally
+   * well be a rename of.
+   */
+  const displacedRemovals = new Set<string>();
 
   for (const field of storedFields) {
     const descriptor = getColumnDescriptor(
@@ -442,6 +609,29 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
       });
     }
 
+    // The DEFAULT is physical exactly as the type is, and it drifts the same way: an apply that
+    // changed a checkbox's default can commit its DDL and then fail its registry write, leaving a
+    // column whose name, type, nullability and indexes all still match. Nothing above notices, so
+    // without this the plan reports no repair and marks the row `synced` while every insert that
+    // omits the field keeps receiving a value the definition does not specify.
+    //
+    // Refuses rather than repairs, for the same reason the type does: the column cannot say whether
+    // the authored default or the live one is the intended survivor. Both sides go through the
+    // diff engine's normaliser so `true`, `'true'::boolean` and `1` are one answer per dialect.
+    const expectedDefault = input.expectedColumnDefault?.(field, table);
+    if (expectedDefault?.known === true) {
+      const want = normalizeDefault(expectedDefault.value, live.type);
+      const have = normalizeDefault(live.default, live.type);
+      if (want !== have) {
+        blockers.push({
+          fieldName: field.name,
+          columnName: descriptor.name,
+          kind: "column-default-changed",
+          detail: `"${field.name}" declares ${want === undefined ? "no default" : `the default ${want}`}, but the live column ${have === undefined ? "has none" : `defaults to ${have}`}; rows inserted without this field would not get the value the definition specifies.`,
+        });
+      }
+    }
+
     // `required` is the field's spelling of NOT NULL, and only the MAIN table can testify to it:
     // companion columns are created nullable regardless of the field's declaration, because a row
     // may legitimately have no value for a locale. A primary key is exempt for the same reason the
@@ -502,7 +692,7 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
   }
 
   // Whatever is left in the live tables is a column no stored field described.
-  const systemMain = mainSystemColumnNames(input);
+  const systemMain = new Set(skeleton.columns.map(column => column.name));
   const adopt = (
     column: ColumnSpec,
     table: ReconcileTable,
@@ -551,6 +741,10 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
       const at = fields.indexOf(displaced);
       if (at !== -1) fields.splice(at, 1);
       removed.push({ fieldName: displaced.name, columnName: column.name });
+      // Paired with THIS adoption by construction — the field and the column share a name, so
+      // nothing about the correspondence is guessed. Recorded so the rename check below does not
+      // read this documented case as an unexplained removal standing beside an unexplained column.
+      displacedRemovals.add(displaced.name);
     }
     const guessedType = guessFieldType(column.type);
     adopted.push({
@@ -589,6 +783,31 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
   }
   for (const column of liveCompanion?.columns ?? []) {
     adopt(column, "companion", claimedCompanion, COMPANION_STRUCTURAL_COLUMNS);
+  }
+
+  // 🔴 A vanished field standing beside an unclaimed column is TWO stories the schema cannot
+  // separate: a rename whose DDL landed and whose registry write did not, or a deliberate drop and
+  // a deliberate add. Resolving it silently costs something real either way — reading it as a drop
+  // discards the authored validation, options, defaults and admin configuration the renamed field
+  // carried, while reading it as a rename invents a correspondence nobody stated.
+  //
+  // So it refuses and names both sides. That is a precondition rather than a preference: the plan
+  // is about to be written and marked `synced`, and the discarded configuration is not recoverable
+  // from anything left in the database afterwards. The operator resolves it by renaming the field
+  // in the definition (making it a match) or by deleting it (making the column a plain adoption),
+  // and either edit is cheap next to reconstructing lost field configuration.
+  const unexplainedRemovals = removed.filter(
+    entry => !displacedRemovals.has(entry.fieldName)
+  );
+  if (unexplainedRemovals.length > 0 && adopted.length > 0) {
+    const gone = unexplainedRemovals.map(entry => `"${entry.fieldName}"`);
+    const appeared = adopted.map(entry => `"${entry.columnName}"`);
+    blockers.push({
+      fieldName: unexplainedRemovals[0]?.fieldName ?? "",
+      columnName: adopted[0]?.columnName ?? "",
+      kind: "ambiguous-rename",
+      detail: `${gone.join(", ")} lost ${gone.length === 1 ? "its column" : "their columns"} while ${appeared.join(", ")} ${appeared.length === 1 ? "is" : "are"} described by no field, which is equally a rename and a drop-plus-add; rename the field in the definition to keep its configuration, or delete it to accept the column as new.`,
+    });
   }
 
   return {

--- a/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
+++ b/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
@@ -1,0 +1,364 @@
+/**
+ * Decide how a field group's STORED definition must change to describe its LIVE tables.
+ *
+ * `diverged` means the tables moved and the row recording them did not, so the stored definition
+ * describes the previous shape. This plans the repair of the RECORD. It never issues DDL, and it is
+ * pure: every input is a value, so the decisions can be tested without a database.
+ *
+ * 🔴 The truth is SPLIT, and getting this backwards destroys what the repair exists to preserve:
+ *
+ * - the STORED definition is truth for what each field MEANS — its logical type, and every
+ *   authored property this planner copies through untouched;
+ * - the LIVE tables are truth for what SHAPE each column has — presence, nullability, indexes.
+ *
+ * The reason is that `ColumnSpec` carries a PHYSICAL type only. `email`, `url` and `text` are one
+ * `text` column, so rebuilding the definitions from introspection would silently downgrade every
+ * one of them, on the single path an operator runs to get out of trouble. So a matched field keeps
+ * its declared type and only the physical attributes are corrected.
+ *
+ * `core-reconcile.ts` is prior art with the OPPOSITE polarity — it repairs the DATABASE to match the
+ * declared schema. Copying its shape here would produce an operation that re-applies DDL, which is
+ * the last thing a diverged group needs.
+ *
+ * @module domains/field-groups/services/reconcile-field-group-plan
+ */
+
+import { isFieldLocalized } from "../../i18n/classify-fields";
+import { COMPANION_STRUCTURAL_COLUMNS } from "../../i18n/migration/generate-up";
+import { buildDesiredTableFromComponentFields } from "../../schema/pipeline/diff/build-from-fields";
+import type {
+  ColumnSpec,
+  IndexSpec,
+  TableSpec,
+} from "../../schema/pipeline/diff/types";
+import {
+  getColumnDescriptor,
+  type SupportedDialect,
+} from "../../schema/services/field-column-descriptor";
+
+/** Which of a field group's two tables a column lives in. */
+export type ReconcileTable = "main" | "companion";
+
+/**
+ * The properties this planner reads or rewrites. A caller's field carries more than this and keeps
+ * it: the generic below preserves the concrete type, so authored properties this module has never
+ * heard of survive the repair untouched.
+ */
+export interface ReconcilableField {
+  name: string;
+  type: string;
+  required?: boolean;
+  unique?: boolean;
+  index?: boolean;
+  localized?: boolean;
+}
+
+/** A stored field whose column is gone from both tables. */
+export interface ReconcileRemoval {
+  fieldName: string;
+  columnName: string;
+}
+
+/** A stored field kept for its meaning, with one physical attribute corrected. */
+export interface ReconcileRepair {
+  fieldName: string;
+  columnName: string;
+  table: ReconcileTable;
+  attribute: "required" | "unique" | "index";
+  from: boolean;
+  to: boolean;
+}
+
+/** A live column no stored field described, adopted with a type this planner had to guess. */
+export interface ReconcileAdoption {
+  fieldName: string;
+  columnName: string;
+  table: ReconcileTable;
+  /** The physical type introspection reported, so the summary can show what the guess came from. */
+  liveType: string;
+  /** Always a guess — the physical type cannot name the logical one it came from. */
+  guessedType: string;
+}
+
+export interface ReconcilePlan<F extends ReconcilableField> {
+  /** The repaired field set, in the stored order, with adoptions appended. */
+  fields: F[];
+  /** Re-derived from which table holds the columns — never read from a flag. */
+  localized: boolean;
+  removed: ReconcileRemoval[];
+  repaired: ReconcileRepair[];
+  adopted: ReconcileAdoption[];
+  /** True when nothing needed changing, so a caller can skip the write entirely. */
+  unchanged: boolean;
+}
+
+export interface ReconcileInput<F extends ReconcilableField> {
+  storedFields: readonly F[];
+  dialect: SupportedDialect;
+  tableName: string;
+  /** Introspected `comp_<slug>`. */
+  liveMain: TableSpec;
+  /** Introspected `comp_<slug>_locales`, or `null` when the table does not exist. */
+  liveCompanion: TableSpec | null;
+  /**
+   * The discriminator the main table actually carries, probed by the caller.
+   *
+   * A system column's name is a fact about the table rather than a preference — the two storage
+   * generations spell it differently — so naming the wrong one would present the real discriminator
+   * as an unknown column and adopt it as a user field.
+   */
+  typeColumn?: string;
+}
+
+/**
+ * Build a field that is a copy of `field` with one boolean property overridden.
+ *
+ * Spread rather than mutation so the caller's stored field is never altered in place, and so every
+ * property this module does not know about is carried through.
+ */
+function withOverride<F extends ReconcilableField>(
+  field: F,
+  key: "required" | "unique" | "index",
+  value: boolean
+): F {
+  return { ...field, [key]: value };
+}
+
+/**
+ * The columns a field group's main table has regardless of its fields.
+ *
+ * Derived by asking the desired-state builder for a table with NO fields, rather than listing the
+ * system columns here. A hand-kept list is a second opinion about what the generator writes, and it
+ * would present a newly added system column to the operator as an unknown user column to adopt.
+ */
+function mainSystemColumnNames(
+  input: Pick<ReconcileInput<never>, "tableName" | "dialect" | "typeColumn">
+): Set<string> {
+  const skeleton = buildDesiredTableFromComponentFields(
+    input.tableName,
+    [],
+    input.dialect,
+    {
+      builtBy: "fieldGroup",
+      ...(input.typeColumn !== undefined ? { typeColumn: input.typeColumn } : {}),
+    }
+  );
+  return new Set(skeleton.columns.map(column => column.name));
+}
+
+/**
+ * Whether a live companion means the group is localized.
+ *
+ * 🔴 Re-derived from WHICH TABLE HOLDS THE COLUMNS, never from a flag. `TableSpec.localized` is
+ * documented in the diff types as a config-derived marker that introspected snapshots cannot know,
+ * and the STORED flag is exactly the value in doubt when a group is diverged. What is observable is
+ * that a companion exists and carries at least one column that is not structural: an empty
+ * companion holding only `_parent`/`_locale` is a table nothing was moved into.
+ */
+function deriveLocalized(liveCompanion: TableSpec | null): boolean {
+  if (!liveCompanion) return false;
+  return liveCompanion.columns.some(
+    column => !COMPANION_STRUCTURAL_COLUMNS.has(column.name)
+  );
+}
+
+/**
+ * Whether an index covering exactly this one column exists, and whether it is unique.
+ *
+ * Compares the column LIST rather than the index name: an engine appends a collision suffix and
+ * truncates at its identifier limit, so there is no single name to match. The list's ORDER is
+ * significant for a composite index, which is why this asks for a single-column index by exact
+ * membership rather than reusing `indexKey` from the diff utilities — that helper SORTS the columns
+ * and so cannot separate `(a, b)` from `(b, a)`.
+ */
+function indexOver(
+  indexes: readonly IndexSpec[] | undefined,
+  columnName: string
+): { present: boolean; unique: boolean } {
+  const match = (indexes ?? []).find(
+    index => index.columns.length === 1 && index.columns[0] === columnName
+  );
+  return { present: match !== undefined, unique: match?.unique === true };
+}
+
+/**
+ * Guess a logical field type from a physical column.
+ *
+ * 🔴 This is a GUESS and the plan labels it as one. The physical type cannot name the logical type
+ * it came from — `email`, `url` and `text` are all `text` — so this returns the widest type that
+ * stores the column's values without loss. The operator corrects it from the summary, and doing so
+ * is a definition-only edit: a narrower text type occupies the same column, so no DDL follows.
+ *
+ * Matched by PREFIX on the type token because dialects spell widths and precisions inline
+ * (`varchar(255)`, `int(11)`, `numeric(10,2)`), and an exact-match list would fail to recognise
+ * exactly the columns that carry a size.
+ */
+function guessFieldType(liveType: string): string {
+  const token = liveType.trim().toLowerCase();
+  const startsWithAny = (...prefixes: string[]): boolean =>
+    prefixes.some(prefix => token.startsWith(prefix));
+
+  if (startsWithAny("bool", "tinyint(1)")) return "checkbox";
+  if (startsWithAny("json")) return "json";
+  if (startsWithAny("timestamp", "datetime", "date")) return "date";
+  if (startsWithAny("numeric", "decimal", "float", "double", "real"))
+    return "number";
+  if (startsWithAny("int", "bigint", "smallint", "serial")) return "number";
+  // Everything else stores text. `textarea` rather than `text` would assert a widget the column
+  // cannot evidence, so this returns the plainest text field.
+  return "text";
+}
+
+/**
+ * Plan the repair of a field group's stored definition against its live tables.
+ *
+ * Every question is answered by the code that already owns it — the desired-state builder for
+ * system columns, the column descriptor for names, the localization predicate for placement — so
+ * this cannot disagree with what actually created the tables.
+ */
+export function planFieldGroupReconcile<F extends ReconcilableField>(
+  input: ReconcileInput<F>
+): ReconcilePlan<F> {
+  const { storedFields, dialect, liveMain, liveCompanion } = input;
+
+  const localized = deriveLocalized(liveCompanion);
+
+  const mainColumns = new Map(liveMain.columns.map(c => [c.name, c]));
+  const companionColumns = new Map(
+    (liveCompanion?.columns ?? []).map(c => [c.name, c])
+  );
+
+  const removed: ReconcileRemoval[] = [];
+  const repaired: ReconcileRepair[] = [];
+  const adopted: ReconcileAdoption[] = [];
+  const fields: F[] = [];
+
+  /** Column names a stored field accounted for, so the leftovers can be adopted. */
+  const claimedMain = new Set<string>();
+  const claimedCompanion = new Set<string>();
+
+  for (const field of storedFields) {
+    const descriptor = getColumnDescriptor(field as never, dialect, "fieldGroup");
+    // A layout-only field produces no column, so no live column can confirm or deny it. Keeping it
+    // is the only correct answer: removing it would delete an authored field on the evidence of a
+    // column that was never supposed to exist.
+    if (!descriptor || descriptor.kind === "skip") {
+      fields.push(field);
+      continue;
+    }
+
+    const inCompanion = localized && isFieldLocalized(field as never, true);
+    const table: ReconcileTable = inCompanion ? "companion" : "main";
+    const live = inCompanion
+      ? companionColumns.get(descriptor.name)
+      : mainColumns.get(descriptor.name);
+
+    if (!live) {
+      // 🔴 REPORTED by identity and removed, never silently dropped. The summary is the only thing
+      // that makes this visible: a field the operator had just added, whose column was never
+      // created, disappears from the definition here and nothing else would say so.
+      removed.push({ fieldName: field.name, columnName: descriptor.name });
+      continue;
+    }
+
+    (inCompanion ? claimedCompanion : claimedMain).add(descriptor.name);
+
+    let repairedField = field;
+
+    // `required` is the field's spelling of NOT NULL. A primary key is exempt for the same reason
+    // the diff exempts it: the key implies the constraint without declaring it.
+    const liveRequired = !live.nullable && live.primaryKey !== true;
+    if ((field.required === true) !== liveRequired) {
+      repaired.push({
+        fieldName: field.name,
+        columnName: descriptor.name,
+        table,
+        attribute: "required",
+        from: field.required === true,
+        to: liveRequired,
+      });
+      repairedField = withOverride(repairedField, "required", liveRequired);
+    }
+
+    // Indexes live only on the main table; the companion is keyed by `(_parent, _locale)` and
+    // carries no per-field index, so asking about one there would compare against an absence that
+    // is structural rather than a drift.
+    if (!inCompanion) {
+      const { present, unique } = indexOver(liveMain.indexes, descriptor.name);
+      // `indexes: undefined` means the snapshot tracks no index data at all, which is a different
+      // statement from "there are none". Correcting against it would strip every declared index on
+      // the strength of never having looked.
+      if (liveMain.indexes !== undefined) {
+        if ((field.unique === true) !== unique) {
+          repaired.push({
+            fieldName: field.name,
+            columnName: descriptor.name,
+            table,
+            attribute: "unique",
+            from: field.unique === true,
+            to: unique,
+          });
+          repairedField = withOverride(repairedField, "unique", unique);
+        }
+        // A unique index satisfies a declared `index` as well, so only a field claiming an index
+        // that no object of either kind provides is corrected.
+        const indexed = present;
+        if ((field.index === true) !== indexed && !unique) {
+          repaired.push({
+            fieldName: field.name,
+            columnName: descriptor.name,
+            table,
+            attribute: "index",
+            from: field.index === true,
+            to: indexed,
+          });
+          repairedField = withOverride(repairedField, "index", indexed);
+        }
+      }
+    }
+
+    fields.push(repairedField);
+  }
+
+  // Whatever is left in the live tables is a column no stored field described.
+  const systemMain = mainSystemColumnNames(input);
+  const adopt = (
+    column: ColumnSpec,
+    table: ReconcileTable,
+    claimed: Set<string>,
+    system: ReadonlySet<string>
+  ): void => {
+    if (claimed.has(column.name) || system.has(column.name)) return;
+    const guessedType = guessFieldType(column.type);
+    adopted.push({
+      fieldName: column.name,
+      columnName: column.name,
+      table,
+      liveType: column.type,
+      guessedType,
+    });
+    fields.push({
+      name: column.name,
+      type: guessedType,
+      required: !column.nullable && column.primaryKey !== true,
+      ...(table === "companion" ? { localized: true } : {}),
+    } as F);
+  };
+
+  for (const column of liveMain.columns) {
+    adopt(column, "main", claimedMain, systemMain);
+  }
+  for (const column of liveCompanion?.columns ?? []) {
+    adopt(column, "companion", claimedCompanion, COMPANION_STRUCTURAL_COLUMNS);
+  }
+
+  return {
+    fields,
+    localized,
+    removed,
+    repaired,
+    adopted,
+    unchanged:
+      removed.length === 0 && repaired.length === 0 && adopted.length === 0,
+  };
+}

--- a/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
+++ b/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
@@ -405,19 +405,31 @@ function structuralBlockers(
     // PostgreSQL and SQLite, and silently accepting duplicate locale rows on MySQL — which is the
     // worse outcome, because nothing reports it. Checked only where the columns are present, so a
     // table already refused above is not reported twice for the same cause.
-    const keyed = new Set(
-      liveCompanion.columns
-        .filter(column => column.primaryKey === true)
-        .map(column => column.name)
-    );
-    for (const keyColumn of COMPANION_KEY_COLUMNS) {
-      if (!liveCompanionColumns.has(keyColumn) || keyed.has(keyColumn))
-        continue;
+    // 🔴 The WHOLE key, not membership of it. A key of `(_parent, _locale, title)` contains both
+    // required columns and provides none of the guarantee they exist for: the uniqueness it
+    // enforces is over three values, so PostgreSQL and SQLite have no constraint matching the
+    // runtime's `(_parent, _locale)` conflict target and MySQL admits several rows per parent and
+    // locale whenever the third value differs. Membership passes that table; equality is what the
+    // claim actually needs.
+    //
+    // Compared as a SET rather than as an ordered list, and that limit is real: a snapshot records
+    // `primaryKey` per column and carries no key ordinal, so a key over the right columns in the
+    // wrong order is indistinguishable here. It is reported as unchecked rather than assumed
+    // correct — the uniqueness guarantee, which is what the runtime depends on, does not vary with
+    // key order.
+    const liveKey = liveCompanion.columns
+      .filter(column => column.primaryKey === true)
+      .map(column => column.name);
+    const required = [...COMPANION_KEY_COLUMNS];
+    const keyMatches =
+      liveKey.length === required.length &&
+      required.every(column => liveKey.includes(column));
+    if (!keyMatches) {
       blockers.push({
-        fieldName: keyColumn,
-        columnName: keyColumn,
+        fieldName: required.join(", "),
+        columnName: required.join(", "),
         kind: "structural-column-missing",
-        detail: `${liveCompanion.name} has "${keyColumn}" but it is not part of the table's primary key; localized writes match rows on (${COMPANION_KEY_COLUMNS.join(", ")}) and cannot do so without it.`,
+        detail: `${liveCompanion.name} has the primary key (${liveKey.join(", ") || "none"}) where localized writes match rows on (${required.join(", ")}); without exactly that key the write has no matching constraint and duplicate locale rows are possible.`,
       });
     }
   }
@@ -838,6 +850,35 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
       displacedRemovals.add(displaced.name);
     }
     const guessedType = guessFieldType(column.type);
+    // 🔴 A live DEFAULT is part of what the column does, and the matched-field check above never
+    // sees an adoption. Dropping it writes a definition that understates the column — inserts
+    // omitting the field keep receiving the database's value while the definition says there is
+    // none — and the next apply, diffing that definition against the table, removes the default
+    // outright. So it is carried where the field contract can express it and refused where it
+    // cannot, rather than silently discarded.
+    //
+    // Only a checkbox default is representable: it is the one default this schema's creator emits,
+    // so a live default on any other adopted column is something the pipeline did not write, and
+    // guessing a logical form for it would invent authored intent. System columns carry defaults
+    // (`_order`, the timestamps) and never reach here — they are excluded from adoption above.
+    const liveDefault = normalizeDefault(column.default, column.type);
+    let adoptedDefault: boolean | undefined;
+    if (liveDefault !== undefined) {
+      if (
+        guessedType === "checkbox" &&
+        (liveDefault === "true" || liveDefault === "false")
+      ) {
+        adoptedDefault = liveDefault === "true";
+      } else {
+        blockers.push({
+          fieldName: column.name,
+          columnName: column.name,
+          kind: "column-default-changed",
+          detail: `"${column.name}" is described by no field and its column defaults to ${liveDefault}, which a ${guessedType} field cannot record; adopting it would drop the default from the definition and the next schema change would remove it from the table.`,
+        });
+        return;
+      }
+    }
     adopted.push({
       fieldName: column.name,
       columnName: column.name,
@@ -860,6 +901,7 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
         table === "main" && !column.nullable && column.primaryKey !== true,
       ...(unique ? { unique: true } : {}),
       ...(present && !unique ? { index: true } : {}),
+      ...(adoptedDefault !== undefined ? { defaultValue: adoptedDefault } : {}),
       // The flag is written in BOTH directions, because for text-like guesses silence is not
       // neutral: `isFieldLocalized` defaults them to translatable in a localized group, which
       // would re-home a column the planner just found on the MAIN table — recording, on the

--- a/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
+++ b/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
@@ -344,16 +344,42 @@ function structuralBlockers(
       });
       continue;
     }
-    // 🔴 Presence is not the whole requirement. A column can survive while the CONSTRAINT that made
-    // it meaningful is dropped, and for `id` that means duplicate component rows become possible
-    // while every name-based check still reads the table as healthy. Taken from the skeleton's own
-    // `primaryKey` rather than by naming `id`, so this covers whatever the generator marks next.
+    // 🔴 Presence is not the whole requirement, and neither is the key. A system column can survive
+    // with its TYPE or its NULLABILITY changed, and both break the assumptions the runtime schema
+    // is about to be registered on: a nullable `_parent_id` admits rows belonging to no parent, and
+    // a retyped one makes the parent-scoped queries compare values that no longer correspond. Every
+    // attribute the skeleton states is therefore compared, rather than a list of the ones that have
+    // been noticed so far.
+    //
+    // The skeleton is the only side that can be authoritative here: these columns belong to no
+    // field, so nothing else in this module describes them.
+    const attributeDrift: string[] = [];
     if (column.primaryKey === true && live.primaryKey !== true) {
+      attributeDrift.push("is no longer part of the primary key");
+    }
+    const wantType = normalizeType(column.type);
+    const haveType = normalizeType(live.type);
+    if (
+      wantType !== undefined &&
+      haveType !== undefined &&
+      wantType !== haveType
+    ) {
+      attributeDrift.push(
+        `is ${live.type} where the table requires ${column.type}`
+      );
+    }
+    // Only a column the skeleton declares NOT NULL is checked. The reverse — a column the generator
+    // leaves nullable that is live NOT NULL — rejects nothing this operation can repair and would
+    // refuse tables an older generation created with a tighter constraint.
+    if (column.nullable === false && live.nullable === true) {
+      attributeDrift.push("is nullable where the table requires a value");
+    }
+    if (attributeDrift.length > 0) {
       blockers.push({
         fieldName: column.name,
         columnName: column.name,
         kind: "structural-column-missing",
-        detail: `${liveMain.name} still has "${column.name}" but it is no longer the table's primary key, so duplicate rows are possible; this operation issues no DDL and cannot restore the constraint.`,
+        detail: `${liveMain.name} still has "${column.name}" but it ${attributeDrift.join(" and ")}; this operation issues no DDL and cannot restore the structure.`,
       });
     }
   }

--- a/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
+++ b/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
@@ -157,22 +157,30 @@ export interface ReconcileInput<F extends ReconcilableField> {
    */
   typeColumn?: string;
   /**
-   * What the CREATOR would write for each column, by column name, already normalised.
+   * The column type the code that BUILDS these tables would give `field` in `table`.
    *
-   * 🔴 The creator, not the column descriptor, and the distinction is the whole reason this input
-   * exists. `FieldGroupSchemaService` owns its own dialect type table and it deliberately differs
-   * from `getColumnDescriptor`: measured on live databases, a `date` field is `DATETIME` on MySQL
-   * and an `email` is `VARCHAR(255)` on PostgreSQL, where the descriptor answers `timestamp` and
-   * `text`. Comparing against the descriptor therefore reported drift on perfectly healthy groups
-   * and refused to repair them — the opposite of this operation's purpose.
+   * 🔴 Asked per (field, table) rather than supplied as a finished map, because the answer depends
+   * on BOTH and only this module knows the second one. The two tables are built by different code —
+   * the main table by `FieldGroupSchemaService`, the companion by the localization renderer — and
+   * they spell the same field differently: a PostgreSQL `email` is `VARCHAR(255)` on the main table
+   * and `TEXT` in the companion. A map keyed by column name alone has to pick one of those before
+   * placement is known, and the placement it would have to guess from is the stored flag, which is
+   * exactly the value this operation exists to correct. Guessing it wrong reports drift on the
+   * PRIMARY divergence being repaired.
    *
-   * Supplied by the caller rather than computed here so this module stays pure: the creator is a
-   * service, and the seam that already owns I/O is the right place to instantiate it.
+   * Also the reason this takes the type rather than the rendered DDL: `getColumnDescriptor` answers
+   * differently again (a MySQL `date` is `DATETIME` here and `timestamp` there), and reading a type
+   * back out of printed SQL silently truncates any type spelled with more than one word.
    *
-   * A column ABSENT from this map is not compared. Absence means "no expectation could be derived",
-   * which is not evidence of drift, and blocking on it would re-create the false refusal.
+   * Returns the type as that code spells it; this module normalises both sides before comparing.
+   * `undefined` means no expectation could be derived, which is NOT evidence of drift — those
+   * columns are skipped rather than blocked, since treating an underivable answer as a mismatch is
+   * what made an earlier version refuse healthy groups.
+   *
+   * A function rather than data so this module stays pure: the callers own the services and the
+   * imports, and nothing here reaches for either.
    */
-  expectedColumnTypes?: ReadonlyMap<string, string>;
+  expectedColumnType?: (field: F, table: ReconcileTable) => string | undefined;
 }
 
 /**
@@ -410,7 +418,13 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
     // logical type would mark `synced` a definition the next diff instantly disagrees with. Which
     // logical type now belongs there cannot be derived — many map to one physical column — so this
     // refuses and names the drift rather than guessing.
-    const expectedType = input.expectedColumnTypes?.get(descriptor.name);
+    //
+    // Asked for the table the column was actually FOUND in, which is `table` above rather than the
+    // placement the stored flag implies: the two disagree precisely when a group has diverged, and
+    // the tables spell the same field differently, so asking about the wrong one manufactures a
+    // mismatch on the case this operation exists to repair.
+    const expectedSpelling = input.expectedColumnType?.(field, table);
+    const expectedType = normalizeType(expectedSpelling);
     const liveType = normalizeType(live.type);
     if (
       expectedType !== undefined &&
@@ -421,7 +435,10 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
         fieldName: field.name,
         columnName: descriptor.name,
         kind: "physical-type-changed",
-        detail: `"${field.name}" is declared ${field.type}, whose column this database would create as ${expectedType}, but the live column is ${live.type}; the logical type that now belongs there cannot be derived from the column alone.`,
+        // Both sides named as they are actually SPELLED, not as they compare. The canonical forms
+        // decide the verdict, and an operator reading "double vs float8" has to work out which
+        // declaration and which column those stand for.
+        detail: `"${field.name}" is declared ${field.type}, whose column this database would create as ${expectedSpelling}, but the live column is ${live.type}; the logical type that now belongs there cannot be derived from the column alone.`,
       });
     }
 

--- a/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
+++ b/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
@@ -34,6 +34,7 @@ import type {
 } from "../../schema/pipeline/diff/types";
 import {
   getColumnDescriptor,
+  toSnakeCase,
   type SupportedDialect,
 } from "../../schema/services/field-column-descriptor";
 
@@ -95,6 +96,15 @@ export interface ReconcilePlan<F extends ReconcilableField> {
 
 export interface ReconcileInput<F extends ReconcilableField> {
   storedFields: readonly F[];
+  /**
+   * The entity-level flag as the ROW records it, so drift in the flag alone is a change.
+   *
+   * The primary divergence this operation repairs is a localization transition whose DDL landed
+   * and whose row write failed — a state where every FIELD matches its (new) table and only this
+   * flag is wrong. A no-op decision computed from the field lists alone reports that as
+   * unchanged, and the caller then skips exactly the write the repair exists to make.
+   */
+  storedLocalized: boolean;
   dialect: SupportedDialect;
   tableName: string;
   /** Introspected `comp_<slug>`. */
@@ -239,6 +249,14 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
   /** Column names a stored field accounted for, so the leftovers can be adopted. */
   const claimedMain = new Set<string>();
   const claimedCompanion = new Set<string>();
+  /**
+   * Kept columnless fields, by the column name each WOULD occupy. A stored `component` field that
+   * a failed apply turned into a scalar leaves a live column under this very name; adopting it
+   * while also keeping the columnless field would persist two fields with one name, and the
+   * conditional write would then mark that ambiguity `synced`. The collision replaces the
+   * columnless field — reported as a removal — rather than preserving both.
+   */
+  const columnlessByColumnName = new Map<string, F>();
 
   for (const field of storedFields) {
     const descriptor = getColumnDescriptor(
@@ -251,6 +269,7 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
     // column that was never supposed to exist.
     if (!descriptor || descriptor.kind === "skip") {
       fields.push(field);
+      columnlessByColumnName.set(toSnakeCase(field.name), field);
       continue;
     }
 
@@ -340,6 +359,16 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
     system: ReadonlySet<string>
   ): void => {
     if (claimed.has(column.name) || system.has(column.name)) return;
+    // A columnless field under this very name is what a half-applied type change leaves behind:
+    // the DDL created the scalar column, the row still declares the columnless field. One name
+    // must map to one field, so the columnless declaration gives way — as a REPORTED removal —
+    // and the adoption below stands in for whatever the column now is.
+    const displaced = columnlessByColumnName.get(column.name);
+    if (displaced) {
+      const at = fields.indexOf(displaced);
+      if (at !== -1) fields.splice(at, 1);
+      removed.push({ fieldName: displaced.name, columnName: column.name });
+    }
     const guessedType = guessFieldType(column.type);
     adopted.push({
       fieldName: column.name,
@@ -363,7 +392,12 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
         table === "main" && !column.nullable && column.primaryKey !== true,
       ...(unique ? { unique: true } : {}),
       ...(present && !unique ? { index: true } : {}),
+      // The flag is written in BOTH directions, because for text-like guesses silence is not
+      // neutral: `isFieldLocalized` defaults them to translatable in a localized group, which
+      // would re-home a column the planner just found on the MAIN table — recording, on the
+      // repair path itself, another definition that does not describe the database.
       ...(table === "companion" ? { localized: true } : {}),
+      ...(table === "main" && localized ? { localized: false } : {}),
     } as F);
   };
 
@@ -381,6 +415,12 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
     repaired,
     adopted,
     unchanged:
-      removed.length === 0 && repaired.length === 0 && adopted.length === 0,
+      removed.length === 0 &&
+      repaired.length === 0 &&
+      adopted.length === 0 &&
+      // Flag drift is a change even when every field matches: a localization transition whose DDL
+      // landed but whose row write failed differs ONLY here, and it is the primary state this
+      // repair exists to clear.
+      localized === input.storedLocalized,
   };
 }

--- a/packages/nextly/src/domains/i18n/migration/generate-up.ts
+++ b/packages/nextly/src/domains/i18n/migration/generate-up.ts
@@ -35,6 +35,17 @@ export const COMPANION_STRUCTURAL_COLUMNS: ReadonlySet<string> = new Set([
   COMPANION_STATUS_COLUMN,
 ]);
 
+/**
+ * The columns of a companion's composite PRIMARY KEY, in key order.
+ *
+ * Stated once and rendered into the `CREATE TABLE` below, because this pair is load-bearing at
+ * RUNTIME rather than merely structural: `upsertCompanionRow` names it as its conflict target, so a
+ * companion that lost the key fails every localized write on PostgreSQL and SQLite and silently
+ * accepts duplicate locale rows on MySQL. Anything checking that a live companion still has its key
+ * reads this rather than restating the pair.
+ */
+export const COMPANION_KEY_COLUMNS: readonly string[] = ["_parent", "_locale"];
+
 function buildCompanionCreateStatement(
   spec: CompanionMigrationSpec,
   ifNotExists: boolean
@@ -68,7 +79,7 @@ function buildCompanionCreateStatement(
     `  ${q("_locale", dialect)} VARCHAR(20) NOT NULL,\n` +
     statusDef +
     `${colDefs},\n` +
-    `  PRIMARY KEY (${q("_parent", dialect)}, ${q("_locale", dialect)}),\n` +
+    `  PRIMARY KEY (${COMPANION_KEY_COLUMNS.map(c => q(c, dialect)).join(", ")}),\n` +
     `  FOREIGN KEY (${q("_parent", dialect)}) REFERENCES ${q(mainTable, dialect)} (${q("id", dialect)}) ON DELETE CASCADE\n` +
     `)`
   );

--- a/packages/nextly/src/route-handler/__tests__/route-parser-auth.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser-auth.test.ts
@@ -34,6 +34,7 @@ describe("component route auth tier", () => {
       "deleteComponent",
       "previewComponentSchemaChanges",
       "applyComponentSchemaChanges",
+      "reconcileComponent",
     ]) {
       expect(isPublicEndpoint("field-groups", method)).toBe(false);
       expect(requiresAuthOnly("field-groups", method)).toBe(false);

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -1327,6 +1327,25 @@ function parseComponentRoutes(
     };
   }
 
+  // POST /api/field-groups/schema/[slug]/reconcile → repair the stored definition to describe the
+  // live tables. Classified as `update`: it writes the registry row, so it takes the same
+  // authorization as the other definition writes — a reader must not be able to rewrite a
+  // definition by way of repairing it.
+  if (
+    id === "schema" &&
+    subresource &&
+    subId === "reconcile" &&
+    httpMethod === "POST"
+  ) {
+    routeParams.slug = subresource;
+    return {
+      service: "field-groups",
+      operation: "update",
+      method: "reconcileComponent",
+      routeParams,
+    };
+  }
+
   const slug = id;
 
   // GET /api/field-groups → list all components

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -742,14 +742,18 @@ async function resolveAuthorization(
 
   // --- Field groups → manage-settings ---
   if (service === "field-groups") {
-    // The verb is a proxy for the action and reconcile is where the proxy breaks: it travels
-    // over POST but rewrites an EXISTING definition, so verb-derived authorization would demand
-    // create-settings from a principal repairing a definition they are allowed to update, while
-    // letting a create-only principal rewrite definitions they may not touch.
+    // 🔴 The HTTP verb is a PROXY for the action, and these two methods are where the proxy is
+    // wrong: both travel over POST while rewriting an EXISTING definition. Verb-derived
+    // authorization therefore demands `create` from a principal who may only update — and, in the
+    // direction that matters, lets a create-only principal rewrite definitions they may not touch.
+    // The route parser already classifies both as `update`; this map is what makes the permission
+    // agree with that classification rather than re-deriving a second, contradictory answer.
+    const FIELD_GROUP_ACTION_OVERRIDES: Readonly<Record<string, string>> = {
+      applyComponentSchemaChanges: "update",
+      reconcileComponent: "update",
+    };
     const action =
-      method === "reconcileComponent"
-        ? "update"
-        : getActionFromMethod(httpMethod);
+      FIELD_GROUP_ACTION_OVERRIDES[method] ?? getActionFromMethod(httpMethod);
     return requireAnyPermission(req, [
       { action, resource: "settings" },
       { action: "manage", resource: "settings" },

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -742,7 +742,14 @@ async function resolveAuthorization(
 
   // --- Field groups → manage-settings ---
   if (service === "field-groups") {
-    const action = getActionFromMethod(httpMethod);
+    // The verb is a proxy for the action and reconcile is where the proxy breaks: it travels
+    // over POST but rewrites an EXISTING definition, so verb-derived authorization would demand
+    // create-settings from a principal repairing a definition they are allowed to update, while
+    // letting a create-only principal rewrite definitions they may not touch.
+    const action =
+      method === "reconcileComponent"
+        ? "update"
+        : getActionFromMethod(httpMethod);
     return requireAnyPermission(req, [
       { action, resource: "settings" },
       { action: "manage", resource: "settings" },

--- a/packages/nextly/src/schemas/storage-format.ts
+++ b/packages/nextly/src/schemas/storage-format.ts
@@ -59,6 +59,20 @@ export const STORAGE_FORMAT = {
   indexPrefix: "idx_",
   uniqueIndexPrefix: "uq_",
 
+  /**
+   * Columns of the one index every component data table carries, in index order.
+   *
+   * ORDERED deliberately: this arrangement is what serves a lookup by parent id, and a differently
+   * ordered index over the same three columns does not. Stated once here because two very different
+   * consumers need the same answer — the DDL that CREATES the index, and any check asking whether a
+   * live table still has it — and a check that restated the list would agree until one side moved.
+   *
+   * Deliberately NOT the whole set of indexes a component table can carry: per-field indexes come
+   * from the field definitions, and the migrate snapshot builder additionally models a `created_at`
+   * index that the table-creating DDL does not emit. This is only the structural one.
+   */
+  parentIndexColumns: ["_parent_id", "_parent_table", "_parent_field"],
+
   /** Directory segment recorded in a registry row's `config_path`. */
   configPathDir: "components",
 

--- a/packages/nextly/src/shared/__tests__/builder-access.test.ts
+++ b/packages/nextly/src/shared/__tests__/builder-access.test.ts
@@ -110,6 +110,11 @@ describe("isBuilderRoute", () => {
     ["DELETE", "/field-groups/hero"],
     ["POST", "/field-groups/schema/hero/preview"],
     ["POST", "/field-groups/schema/hero/apply"],
+    // Rewrites the stored definition, so it is builder surface exactly as the apply is. Absence
+    // from the guarded set is SILENT — the route simply answers in production — which is why this
+    // table is the join between the parser and `BUILDER_METHODS` rather than two lists that agree
+    // by hand until one of them gains a method.
+    ["POST", "/field-groups/schema/hero/reconcile"],
   ])("gates %s %s", (httpMethod, path) => {
     expect(classify(path, httpMethod)).toBe(true);
   });

--- a/packages/nextly/src/shared/__tests__/builder-access.test.ts
+++ b/packages/nextly/src/shared/__tests__/builder-access.test.ts
@@ -191,3 +191,39 @@ describe("requireBuilderEnabled", () => {
     expect(() => requireBuilderEnabled("create-collection")).not.toThrow();
   });
 });
+
+/**
+ * The guarded set names dispatcher methods by STRING, so it can drift from them silently.
+ *
+ * A renamed dispatcher method leaves a dead entry behind, and `isBuilderRoute` answers false for
+ * the new name — the endpoint simply starts responding in production, with nothing red anywhere.
+ * The route table above catches a method someone forgot to GUARD; this catches a method someone
+ * renamed and guarded under its old name, which the table cannot see because the route still parses.
+ *
+ * Derived from the registry rather than restated: a second hand-written list would need the same
+ * maintenance as the first and would agree with it right up until the moment it mattered.
+ */
+describe("the builder-guarded set stays joined to the dispatcher", () => {
+  it("names only methods the component dispatcher actually has", async () => {
+    const { COMPONENTS_METHODS } = await import(
+      "../../dispatcher/handlers/component-dispatcher"
+    );
+    const { isBuilderRoute } = await import("../builder-access");
+
+    const guarded = [
+      "createComponent",
+      "updateComponent",
+      "deleteComponent",
+      "previewComponentSchemaChanges",
+      "applyComponentSchemaChanges",
+      "reconcileComponent",
+    ].filter(method => isBuilderRoute("field-groups", method));
+
+    // The population first: an empty list would satisfy every assertion below while proving that
+    // the guard recognises nothing at all.
+    expect(guarded.length).toBeGreaterThan(0);
+    for (const method of guarded) {
+      expect(Object.keys(COMPONENTS_METHODS)).toContain(method);
+    }
+  });
+});

--- a/packages/nextly/src/shared/builder-access.ts
+++ b/packages/nextly/src/shared/builder-access.ts
@@ -96,6 +96,10 @@ const BUILDER_METHODS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
       "deleteComponent",
       "previewComponentSchemaChanges",
       "applyComponentSchemaChanges",
+      // Rewrites the stored definition, so it is builder surface exactly as the apply is: where
+      // the builder cannot run, the repair it feeds cannot either — and leaving it out would let
+      // a direct call rewrite schema on a deployment whose builder is disabled.
+      "reconcileComponent",
     ]),
   ],
 ]);


### PR DESCRIPTION
## What

The exit from `diverged`: a reconcile operation that repairs a field group's STORED definition to describe its LIVE tables, plus the version-conditional registry write that both this operation and the divergence marker now share.

- **`reconcile-field-group-plan.ts`** — a pure planner. The stored definition is truth for what a field MEANS (logical type, authored options); the live tables are truth for what SHAPE each column has. A matched field keeps its declared type (`email` never downgrades to `text`); a field whose column vanished is REMOVED and reported by identity; an unknown live column is ADOPTED with a guessed type, flagged as a guess; `localized` is re-derived from which table holds the columns, never read from a flag. System columns come from the desired-state builder, not a hand-kept list.
- **`field-group-reconcile-service.ts`** — introspects both tables (`introspectLiveSnapshot`), runs the planner, and writes the repair in ONE version-conditional statement. No DDL, ever. Refuses locked (code-first) groups and a vanished main table, with guidance. Runnable on UNMARKED divergence, deliberately — the builder's apply path can strand one (filed separately).
- **`updateComponentIfVersion`** (registry) + **`updateCount`** (adapter-drizzle) — a compare-and-set: the WHERE pins `schema_version`, the driver's affected count answers whether it matched, and no read-back exists to fail. On MySQL the count reports CHANGED rows, which is why the method always bumps the version — matched implies changed.
- **The divergence marker is now that compare-and-set.** A healthy row whose write landed but whose read-backs transiently failed can no longer be stamped `diverged` with its version bumped twice: zero rows matched at the old version MEANS the write landed, and one more read then returns the settled row as success. The failure message now distinguishes three endings (marked / advanced-but-unconfirmable / unrecorded).
- **Route**: `POST /api/field-groups/schema/[slug]/reconcile`, classified `update` so it takes definition-write authorization.
- **Docs**: `AGENTS.md` NextlyError bullet now states the test-fixture exemption.

## Verification

- Planner suite: 12 tests, three break-controls each red for the intended reason (removal reporting; localized derivation; system-column guard — the last fails 9 of 12, as every fixture carries system columns).
- Marker suite: 39 tests including two new ones that discriminate the conditional marker — forcing the old unconditional behaviour fails exactly those two.
- `pnpm build`, `pnpm check-types --force` (both configs), `pnpm lint`, `check-drizzle-v1-legacy`, `check:storage-format-literals`, `check-comment-convention` — all exit 0 at the pushed head.
- Pre-existing baseline confirmed by reverting this branch's files in the same worktree: `field-group-route-delegates.test.ts` (4) and `field-group-data-service.test.ts` (1) fail identically without this diff.

## What this does NOT establish

- No dialect-specific integration legs for the compare-and-set yet — the MySQL changed-vs-matched distinction is documented and unit-covered through the contract, not yet exercised against a live MySQL. Follow-up commit on this PR.
- The admin surface (repair-then-show-what-changed) is PR-2 of the tracker, not here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added field-group schema reconciliation to synchronize registered definitions with live database structures.
  * Added a reconciliation endpoint for repairing missing, outdated, or newly detected fields and attributes.
  * Reconciliation updates metadata, localization, indexes, and schema status without directly altering database tables.
* **Bug Fixes**
  * Improved handling of concurrent updates and stale schema versions to prevent overwriting newer changes.
  * Improved failure reporting when metadata updates or synchronization status changes are uncertain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->