### PR TITLE
fix(root): size the settle allowance to a frame, and check the specs nothing read

### DIFF
--- a/e2e/tests/canvas/driver.ts
+++ b/e2e/tests/canvas/driver.ts
@@ -715,18 +715,24 @@ const INSET_APPROACH_PX = 4;
 const EDGE_SETTLE_ATTEMPTS = 3;
 
 /**
- * The longest a zone edge may still be moving after the pointer enters it.
+ * The longest a zone edge may still be moving after the pointer enters it, for a driver that
+ * declares nothing.
  *
- * The canvas animates a drop zone's height and margin over 100ms when it becomes
- * the active target, and an animation is CONTINUOUS: two brackets taken back to
- * back can quantize to the same whole pixel while the edge is still travelling
- * inside it. Agreement between adjacent samples is therefore necessary and not
- * sufficient, and no purely positional method can close that — "has an animation
- * finished" is a question about an interval.
+ * An animation is CONTINUOUS: two brackets taken back to back can quantize to the same whole pixel
+ * while the edge is still travelling inside it. Agreement between adjacent samples is therefore
+ * necessary and not sufficient, and no purely positional method can close that — "has an animation
+ * finished" is a question about an interval. So this is a clock, deliberately, paired with the
+ * agreement check: the wait covers the animation, the agreement confirms it is over.
  *
- * So this is a clock, deliberately, and it is the canvas's own transition
- * duration rather than a guess. Paired with the agreement check: the wait covers
- * the animation, the agreement confirms it is over.
+ * It is a FALLBACK and it is generous on purpose. A driver that declares its own allowance has
+ * measured its canvas; one that declares nothing has not, and this is the only thing standing
+ * between an unmeasured canvas and a bracket taken mid-animation. It is therefore tuned to no
+ * canvas in particular — an earlier version of this comment justified the number with the page
+ * builder's 100ms zone transition, which made a shared default read as a fact about one caller and
+ * invited lowering it when that caller's animation went away.
+ *
+ * Understating it is self-punishing rather than self-serving: measurements come back stale and the
+ * assertions built on them fail. That asymmetry is what makes it safe to leave high.
  */
 const DEFAULT_GEOMETRY_SETTLE_MS = 120;
 

--- a/e2e/tests/canvas/poc-driver.ts
+++ b/e2e/tests/canvas/poc-driver.ts
@@ -52,8 +52,26 @@ const DROP_ZONES = ".nx-pb-dropzone, .nx-pb-dropzone-empty";
  * Exported so the guard that checks it against the canvas's MEASURED spans reads the SAME value
  * the driver uses. A guard restating the number checks a constant against itself and passes while
  * the driver carries something else entirely.
+ *
+ * ## Why it is a frame and not an animation
+ *
+ * This was the canvas's own transition duration, from when a zone grew its height and margin on
+ * becoming the active target. It does not do that any more: a zone is `position:absolute` at a
+ * fixed `height:6px`, and `[data-drag]` / `[data-active]` change only `pointer-events`,
+ * `background` and `box-shadow`. The guard beside it measures every one of those states through
+ * the browser and pins the geometry span at 0ms, so an allowance sized for an animation is sized
+ * for something that does not happen.
+ *
+ * What the wait still has to do is separate two brackets into DIFFERENT animation frames: adjacent
+ * samples can quantize to the same whole pixel inside one frame, so agreement between them is
+ * necessary and not sufficient however static the edge is. A frame is ~16ms, and this carries a
+ * comfortable multiple of it.
+ *
+ * Not a speed change, and it must not be sold as one. `dragToInsetInZone` is the only consumer of
+ * this value; no browser test reaches it, and the one suite that does drives a test double which
+ * declares no allowance and therefore spends the shared default instead.
  */
-export const POC_GEOMETRY_SETTLE_MS = 120;
+export const POC_GEOMETRY_SETTLE_MS = 32;
 
 /**
  * Block-level insertion targets. A grid registers insert-before and append

--- a/packages/plugin-page-builder/e2e/rendered-blocks.spec.ts
+++ b/packages/plugin-page-builder/e2e/rendered-blocks.spec.ts
@@ -21,9 +21,21 @@ import { renderToStaticMarkup } from "react-dom/server";
 // Built output (plain JS) — avoids TSX transpilation in the Playwright runner.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import { PageRenderer } from "../dist/render/index.js";
+// Types from source, values from `dist`. The built entry re-exports the renderer but not the
+// document types, and a type-only import is erased anyway — so this couples the fixture to the
+// shape the package actually declares rather than to whatever the bundler happened to surface.
+import type { BlockDocument, BlockNode } from "../src/core/types";
 
 let n = 0;
-const h = (type: string, props: object = {}, slots?: object) => ({
+// `Record<string, unknown>` rather than `object`: a block node's props are an index-signature type,
+// and `object` is not assignable to one — `{}` has no index signature, so a document built from
+// this helper is rejected by `PageRenderer` at the type level while being perfectly valid at
+// runtime.
+const h = (
+  type: string,
+  props: Record<string, unknown> = {},
+  slots?: Record<string, BlockNode[]>
+): BlockNode => ({
   id: `e2e-${type.replace(/\W/g, "")}-${n++}`,
   type,
   props,
@@ -31,8 +43,8 @@ const h = (type: string, props: object = {}, slots?: object) => ({
 });
 
 function buildHtml(): string {
-  const doc = {
-    version: 1 as const,
+  const doc: BlockDocument = {
+    version: 1,
     root: h(
       "core/container",
       {},
@@ -55,10 +67,18 @@ function buildHtml(): string {
       }
     ),
   };
-  // Entrance motion on the heading to assert the compiled animation.
-  (
-    doc.root as { slots: { default: { motion?: unknown }[] } }
-  ).slots.default[0].motion = { entrance: "slide-up", duration: "400ms" };
+  // Entrance motion on the heading, which is what the animation assertion below reads.
+  //
+  // Reached through the real type rather than a cast. The cast this replaces asserted a shape the
+  // document does not have, so it would have kept compiling after the fixture stopped putting a
+  // heading first — and the browser assertion would then fail naming the renderer.
+  const heading = doc.root.slots?.default?.[0];
+  if (!heading) {
+    throw new Error(
+      "the fixture must put a heading first for motion to be applied to"
+    );
+  }
+  heading.motion = { entrance: "slide-up", duration: "400ms" };
   const body = renderToStaticMarkup(
     React.createElement(PageRenderer, { document: doc })
   );

--- a/packages/plugin-page-builder/package.json
+++ b/packages/plugin-page-builder/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p tsconfig.tests.json",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "test": "vitest run",
@@ -79,6 +79,7 @@
     "@nextlyhq/plugin-sdk": "workspace:*",
     "@nextlyhq/tsconfig": "workspace:*",
     "@nextlyhq/ui": "workspace:*",
+    "@playwright/test": "^1.58.2",
     "@tanstack/react-query": "^5.62.0",
     "@types/css-tree": "^2.3.4",
     "@types/node": "^20.19.17",

--- a/packages/plugin-page-builder/tsconfig.tests.json
+++ b/packages/plugin-page-builder/tsconfig.tests.json
@@ -1,0 +1,32 @@
+// Type-checks what `tsconfig.json` leaves out: this package's test files, and the two Playwright
+// specs under `e2e/`.
+//
+// The shipping config sets `include: ["src/**/*"]` and excludes `**/*.test.ts(x)`, so neither tree
+// was in any TypeScript program at all — measured with `tsc --listFiles`, zero files from `e2e/`.
+// Vitest does not close that either, because esbuild strips annotations rather than checking them.
+//
+// `rootDir` is cleared because it is `src` in the shipping config and `e2e/` sits beside it, not
+// under it. With `noEmit` there is no output layout for it to describe, so the constraint only
+// serves to reject the files this config exists to read.
+//
+// `types` is re-widened for the same reason the other packages' test configs do it: the shipping
+// config sets it to `[]` so nothing published can reach `process` or `node:fs`, and test code
+// legitimately can. Both halves are needed — the empty list alone breaks these files, and node
+// types alone would put `process` in reach of every module this package publishes.
+//
+// `**/*.test.ts(x)` STAYS EXCLUDED here, and that is a deliberate boundary rather than a copy of
+// the parent's list. Admitting this package's unit tests reports 38 errors across ten files —
+// measured, not estimated — because they have never been in any program either. That is a real
+// gap and a bigger one than this config was opened to close; carrying it here would either block
+// this change behind ten unrelated repairs or force the gate to land red, and a gate that lands
+// red is one somebody turns off. It is filed separately with the count.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "e2e/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1353,6 +1353,9 @@ importers:
       '@nextlyhq/ui':
         specifier: workspace:*
         version: link:../ui
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.61.1
       '@tanstack/react-query':
         specifier: ^5.62.0
         version: 5.90.7(react@19.2.0)


### PR DESCRIPTION
Three canvas test-harness gaps, measured before and after.

## 1. The settle allowance documented an animation that no longer exists

`POC_GEOMETRY_SETTLE_MS` was the canvas's own transition duration, from when a drop zone grew its height and margin on becoming the active target. It stopped doing that: a zone is `position:absolute` at a fixed `height:6px`, and `[data-drag]` / `[data-active]` change only `pointer-events`, `background` and `box-shadow`.

`geometry-settle-matches-the-canvas.test.ts` measures every one of those states through the browser and **pins the geometry span at 0ms**. All 24 of its cases pass on this branch.

What the wait still has to do is separate two brackets into different animation frames, since adjacent samples can quantize to the same whole pixel inside one frame however static the edge is. A frame is ~16ms; 32ms carries a comfortable multiple.

### This is NOT a speedup and is deliberately not sold as one

`dragToInsetInZone` is the only consumer of the value. It is called from exactly one file — `zone-inset.test.ts` — which drives a pure test double that declares no allowance and therefore spends the **shared default** instead. So **no browser test spends this constant at all.**

Wall clock on the full canvas suite, two runs each:

| | run 1 | run 2 |
|---|---|---|
| before (120ms) | 118s | 85s |
| after (32ms) | 89s | 85s |

A **33-second spread between two runs at the same value**, against a predicted saving of ~1.4s. The measurement cannot see this change, which is the finding rather than a limitation of it. 93 passed on every run, same expected-failure set.

The shared `DEFAULT_GEOMETRY_SETTLE_MS` keeps its value and loses the justification naming one caller's animation — which is what made a fallback look tunable.

## 2. `plugin-page-builder/e2e/` was in no TypeScript program

Measured with `tsc --listFiles`: zero files from that directory. The root cause is that the package never declared the `@playwright/test` those specs import, so nothing could have compiled them.

A `tsconfig.tests.json` now reads them, wired into `check-types` the way the other packages do it. It immediately found a cast asserting a shape the document does not have — `doc.root as { slots: { default: { motion?: unknown }[] } }` — which would have kept compiling after the fixture stopped putting a heading first, and failed in the browser naming the renderer. Replaced with the real types and a guard.

**Positive control:** injecting `const CONTROL: number = "not a number";` into `page-builder.spec.ts` — the file this PR does not otherwise touch — produces `error TS2322` and names that file. Removing it returns to zero. The config demonstrably reads both specs rather than neither.

### One boundary stated rather than crossed

`**/*.test.ts(x)` stays excluded. Admitting this package's unit tests reports **38 errors across ten files**, measured — they have never been in any program either. That is a real gap and a bigger one; carrying it here would either block this behind ten unrelated repairs or land the gate red, and a gate that lands red is one somebody turns off. Filed separately with the count.

## 3. The wide-viewport requirement needed no fix

Checked every canvas spec: all four that drive a browser already set `test.use({ viewport: { width: 2560, height: 1400 } })`, and the rest use no browser. Nothing to change, so nothing was changed. Recorded because the filed task implied exposure that no longer exists.

## Verification

- `check-types` and `lint` green for `@nextlyhq/e2e` and `@nextlyhq/plugin-page-builder`, turbo `--force` so nothing replayed.
- Full canvas suite twice at the new value: 93 passed, 0 failed.
- The geometry guard's own 24 cases pass, which is what makes the 0ms pin evidence rather than assertion.

No changeset: test and build-config only, nothing shipped changes.