### PR TITLE
test(root): graduate the autoscroll acceptance point

### DIFF
--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -763,40 +763,62 @@ test.describe("a canvas any Nextly editor could ship", () => {
       "the fixture must overflow the canvas, or autoscroll is unobservable"
     ).toBeGreaterThan(1400);
 
-    await dragFromPanel(driver);
+    // A second precondition, and it is about the CANVAS rather than the fixture: a document that
+    // renders tall enough still gives autoscroll nothing to do if the element that holds it does
+    // not overflow. The two are different failures and only this one is invisible in the boxes.
+    const range = await chrome.canvasScroll();
+    expect(
+      range.max,
+      "the canvas must have somewhere to scroll TO, or nothing here can move"
+    ).toBeGreaterThan(0);
+    expect(range.top, "the canvas must start at the top").toBe(0);
 
-    // The canvas cannot answer this at all, and that refusal IS the
-    // shortfall. Asserted as the reader's OWN error type BEFORE the
-    // expectation is marked, so a broken selector, a missing iframe or a
-    // failed seed stays a real failure instead of becoming another
-    // expected one. It also fires the day the capability arrives: this
-    // line goes red first and forces the target below to be rewritten.
-    //
-    // Wrapped in an async thunk because these readers throw SYNCHRONOUSLY:
-    // `expect(reader())` never receives a promise, so `.rejects` cannot see
-    // the refusal and the raw error escapes the assertion entirely.
-    await expect(async () => chrome.canvasScrollTop()).rejects.toThrow(
-      CanvasCapabilityError
-    );
+    // To the EDGE, then dwell. Autoscroll answers a pointer resting near a boundary, not a single
+    // move — and walking down in fixed steps runs the pointer off the viewport before it has
+    // dwelled anywhere, which reads as the canvas ignoring the gesture.
+    const source = await driver.dragSourceCentre();
+    await driver.startDragAt(source);
+    await dragPointerTo(driver, await driver.canvasBottomEdge());
 
-    // Marked only now. Everything above ran unprotected.
-    test.fail(true, "this canvas does not autoscroll toward an edge");
+    // Moving by a pixel each tick rather than holding still. dnd-kit recomputes the scroll intent
+    // from the drag position, and a pointer that never moves again produces no further signal —
+    // so a perfectly still hold can measure a canvas that simply stopped being told anything.
+    const dwell = async (ticks: number) => {
+      for (let tick = 0; tick < ticks; tick += 1) {
+        await driver.moveBy(0, tick % 2 === 0 ? 1 : -1);
+      }
+    };
 
-    const start = await chrome.canvasScrollTop();
-    // Autoscroll answers dwelling near an edge, not a single move.
-    for (let tick = 0; tick < 12; tick += 1) await driver.moveBy(0, 40);
-    const engaged = await chrome.canvasScrollTop();
-    for (let tick = 0; tick < 40; tick += 1) await driver.moveBy(0, 40);
-    const settled = await chrome.canvasScrollTop();
-    const stillSettled = await chrome.canvasScrollTop();
+    await dwell(20);
+    const engaged = await chrome.canvasScroll();
+    // Long enough to reach the end of a 6000px document at any plausible rate. The bound is what
+    // this half is about, so the dwell has to be generous enough to actually arrive at it.
+    await dwell(200);
+    const settled = await chrome.canvasScroll();
+    await dwell(40);
+    const stillSettled = await chrome.canvasScroll();
     await driver.cancel();
 
-    expect(engaged, "autoscroll must engage near an edge").toBeGreaterThan(
-      start
-    );
-    // And stop. A scroll that runs past the end leaves the author looking at
-    // blank space with no way back except releasing the drag.
-    expect(settled, "autoscroll must stop at the bounds").toBe(stillSettled);
+    expect(
+      engaged.top,
+      "autoscroll must engage while the pointer rests near an edge"
+    ).toBeGreaterThan(range.top);
+    // And STOP, at the end rather than merely somewhere. Two equal readings alone are satisfied by
+    // a scroll that stalled for any reason, including one that never started — so the bound is
+    // asserted as well. A scroll that runs past the end leaves the author looking at blank space
+    // with no way back except releasing the drag.
+    expect(
+      settled.top,
+      "autoscroll must not scroll past the end of the document"
+    ).toBeLessThanOrEqual(settled.max);
+    expect(
+      settled.top,
+      "autoscroll must actually reach the bound it is asked to stop at"
+    ).toBe(settled.max);
+    expect(
+      stillSettled.top,
+      "autoscroll must stay stopped once it is at the bound"
+    ).toBe(settled.top);
   });
 
   test("stays responsive dragging over a large tree", async ({ request }) => {

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -76,6 +76,20 @@ const PLAN_POINT = {
   escapeCancelsWithoutNavigating: 12,
 } as const;
 
+/**
+ * Time budgets for the autoscroll case, in milliseconds.
+ *
+ * Durations rather than move counts. The scroll advances on the canvas's own timer, so a number of
+ * synthesised pointer events says nothing about how far it has travelled — a faster runner sends
+ * them sooner and arrives at the same place later in wall-clock terms, which is exactly backwards.
+ *
+ * Each is a CEILING that the wait stops early on. Reaching the bound in 200ms costs 200ms; the
+ * budget is only spent when the canvas never arrives, which is the failure being reported.
+ */
+const ENGAGE_WINDOW_MS = 2_000;
+const REACH_BOUND_WINDOW_MS = 15_000;
+const HOLD_AT_BOUND_MS = 500;
+
 /** Record which property a test covers, and why it cannot pass yet. */
 function note(point: number, becomes: string, shortfall?: string): void {
   test.info().annotations.push({
@@ -779,23 +793,52 @@ test.describe("a canvas any Nextly editor could ship", () => {
     const source = await driver.dragSourceCentre();
     await driver.startDragAt(source);
     await dragPointerTo(driver, await driver.canvasBottomEdge());
+    let pointerUp = false;
 
     // Moving by a pixel each tick rather than holding still. dnd-kit recomputes the scroll intent
     // from the drag position, and a pointer that never moves again produces no further signal —
     // so a perfectly still hold can measure a canvas that simply stopped being told anything.
-    const dwell = async (ticks: number) => {
-      for (let tick = 0; tick < ticks; tick += 1) {
-        await driver.moveBy(0, tick % 2 === 0 ? 1 : -1);
+    const nudge = async () => {
+      pointerUp = !pointerUp;
+      await driver.moveBy(0, pointerUp ? 1 : -1);
+    };
+
+    /**
+     * Keep the pointer alive until `done`, or until the deadline passes.
+     *
+     * By ELAPSED TIME, not by a count of moves. The scroll advances on dnd-kit's own timer, so a
+     * number of Playwright commands is not a duration: on a fast runner the loop can finish before
+     * a correct autoscroller has crossed a 5000px range, and the bound assertion then fails on a
+     * canvas doing exactly the right thing. Counting events measures the harness.
+     */
+    const keepDragging = async (
+      untilMs: number,
+      done?: () => Promise<boolean>
+    ) => {
+      const deadline = Date.now() + untilMs;
+      while (Date.now() < deadline) {
+        await nudge();
+        if (done && (await done())) return;
       }
     };
 
-    await dwell(20);
+    // Engagement is a change, so it needs only enough time for the first tick to land.
+    await keepDragging(
+      ENGAGE_WINDOW_MS,
+      async () => (await chrome.canvasScroll()).top > range.top
+    );
     const engaged = await chrome.canvasScroll();
-    // Long enough to reach the end of a 6000px document at any plausible rate. The bound is what
-    // this half is about, so the dwell has to be generous enough to actually arrive at it.
-    await dwell(200);
+
+    // The bound is an ARRIVAL, so this waits for it rather than for a number of moves, and stops
+    // as soon as it is reached. A timeout here means autoscroll never got there, which the
+    // assertions below report as the failure it is rather than hiding in a longer wait.
+    await keepDragging(REACH_BOUND_WINDOW_MS, async () => {
+      const now = await chrome.canvasScroll();
+      return now.top >= now.max;
+    });
     const settled = await chrome.canvasScroll();
-    await dwell(40);
+    // And STAYS there while the pointer is still at the edge, which is the "stops" half.
+    await keepDragging(HOLD_AT_BOUND_MS);
     const stillSettled = await chrome.canvasScroll();
     await driver.cancel();
 

--- a/e2e/tests/canvas/driver.ts
+++ b/e2e/tests/canvas/driver.ts
@@ -92,6 +92,15 @@ export interface CanvasDriver {
   canvasCentre(): Promise<Point>;
 
   /**
+   * A point just inside the canvas's BOTTOM edge, in host coordinates.
+   *
+   * Autoscroll is a response to the pointer approaching an edge, so a test of it has to be able
+   * to name that edge. Asking the driver rather than measuring an iframe in the suite keeps the
+   * question engine-agnostic: a replacement canvas that is not an iframe still has a bottom.
+   */
+  canvasBottomEdge(): Promise<Point>;
+
+  /**
    * Insert a block without dragging: the non-drag path WCAG 2.2 §2.5.7 requires
    * for every drag gesture. On the driver because how it is offered is a canvas
    * decision, while "it must exist" is a requirement of every canvas.
@@ -339,8 +348,15 @@ export interface CanvasChromeReader {
    */
   readsInvalidTarget(): Promise<boolean>;
 
-  /** Scroll offset inside the canvas frame, for autoscroll assertions. */
-  canvasScrollTop(): Promise<number>;
+  /**
+   * How far the canvas has scrolled, and how far it CAN.
+   *
+   * Both from one reader because "autoscroll stopped" and "autoscroll stopped AT THE BOUND" are
+   * different claims, and only the second is the requirement. Two consecutive equal offsets are
+   * satisfied by a scroll that stalled anywhere — including one that never started — so the bound
+   * is what separates stopping correctly from merely stopping.
+   */
+  canvasScroll(): Promise<{ top: number; max: number }>;
 
   /** Begin dragging a block that is already in the canvas, by its id. */
   startDragOfBlock(id: string): Promise<void>;

--- a/e2e/tests/canvas/poc-driver.ts
+++ b/e2e/tests/canvas/poc-driver.ts
@@ -129,6 +129,15 @@ const REFUSAL_RENDER_MS = 2_000;
 /** Past dnd-kit's activation distance in one move, so a drag actually starts. */
 const DRAG_THRESHOLD_PX = 12;
 
+/**
+ * How far inside the canvas's bottom edge {@link CanvasDriver.canvasBottomEdge} stands.
+ *
+ * Comfortably inside dnd-kit's own autoscroll threshold, which is a fraction of the scroller's
+ * size rather than a fixed distance, so a point a few pixels in is within it for any canvas large
+ * enough to scroll at all.
+ */
+const EDGE_INSET_PX = 8;
+
 export function createPocDriver(page: Page): CanvasDriver {
   /** The canvas iframe, from the one place that decides which frame that is. */
   function canvasFrame(): Frame {
@@ -290,6 +299,18 @@ export function createPocDriver(page: Page): CanvasDriver {
       // Near the top rather than the middle: the drag then travels downward
       // through the tree, which is what the sweep scenarios need.
       return { x: box.x + box.width / 2, y: box.y + 40 };
+    },
+
+    async canvasBottomEdge() {
+      const box = await page.locator("iframe").boundingBox();
+      if (!box) throw new Error("canvas iframe has no box");
+      // INSIDE the edge, not on it. A pointer on the boundary is as likely to resolve to whatever
+      // sits below the canvas, and a drag that has left the canvas is not a test of what the
+      // canvas does near its edge.
+      return {
+        x: box.x + box.width / 2,
+        y: box.y + box.height - EDGE_INSET_PX,
+      };
     },
 
     async clickToInsert() {
@@ -835,11 +856,26 @@ export function createPocChromeReader(page: Page): CanvasChromeReader {
       return said.trim().length > 0;
     },
 
-    canvasScrollTop(): Promise<number> {
-      throw new CanvasCapabilityError(
-        "this canvas does not autoscroll, so its scroll offset during a drag " +
-          "reports nothing about a behaviour it does not have"
-      );
+    async canvasScroll(): Promise<{ top: number; max: number }> {
+      // The FRAME's own document. The host wrapper around the iframe has `overflow: auto` and is
+      // the obvious thing to watch, and it never moves: the iframe is sized to the wrapper, so
+      // the document that overflows is the one inside it. Measured — during a drag held at the
+      // edge the frame document travelled 3192px while the wrapper stayed at 0 — and a reader
+      // pointed at the wrapper would report "no autoscroll" about a canvas that is scrolling.
+      return canvasFrameOf(page).evaluate(() => {
+        const el = document.scrollingElement;
+        if (!el) {
+          throw new Error(
+            "the canvas frame has no scrolling element, so its scroll offset cannot be read"
+          );
+        }
+        return {
+          top: el.scrollTop,
+          // The bound the requirement is about. `scrollTop` alone cannot distinguish autoscroll
+          // stopping because it reached the end from autoscroll stopping for any other reason.
+          max: Math.max(0, el.scrollHeight - el.clientHeight),
+        };
+      });
     },
 
     startDragOfBlock(id: string): Promise<void> {


### PR DESCRIPTION
**The canvas autoscrolls. It has all along.** Plan 04's B-8 is recorded as "not built" and that is wrong.

## How it was hiding

`createPocChromeReader.canvasScrollTop()` **threw** `CanvasCapabilityError` rather than measuring, and the acceptance case asserted that throw *before* marking itself `test.fail`. A refusal cannot become a red, so the case would have passed forever whether or not the capability existed.

This is the second acceptance point with that exact shape — the first was B-7's invalid-target reader, graduated in #847. Both were recorded as product shortfalls when the evidence was a reader declining to look.

## Measured, before any code was changed

A throwaway probe held a drag at the canvas's bottom edge and read every candidate scroller:

```
BEFORE  frameDoc {scrollTop: 0,    scrollHeight: 6003, clientHeight: 1041}
        host     {wrapScrollTop: 0, wrapScrollHeight: 1041, wrapClientHeight: 1041}
AFTER   frameDoc {scrollTop: 3192, ...}
DELTA   frameDoc: 3192   wrap: 0
```

dnd-kit ships `AutoScroller` in `defaultPreset`, and `getElementFromPoint` explicitly recurses into an iframe's `contentDocument` with adjusted coordinates — so the cross-document canvas never defeated it.

**Note which element moves.** The host wrapper around the iframe has `overflow: auto` and is the obvious thing to watch; it stays at 0, because the iframe is sized to it and the document that overflows is the one *inside*. A reader pointed at the wrapper reports "no autoscroll" about a canvas that is scrolling.

## What the reader returns now

`canvasScroll(): Promise<{ top, max }>` replaces `canvasScrollTop()`. The bound is not decoration:

> Two equal offsets are satisfied by a scroll that stalled for **any** reason, including one that never started.

"Stops at the bounds" is the requirement, so the case now asserts the scroll **reaches** `max`, does not exceed it, and stays there. Without `max`, the stopping half was satisfied by a canvas that never moved.

## Two mechanics the old case got wrong

- **It walked the pointer down in fixed 40px steps.** That runs off the viewport before dwelling anywhere, which reads as the canvas ignoring the gesture. It now goes to the edge via the shared stepped transport and dwells there.
- **A perfectly still hold produces no further signal.** dnd-kit recomputes scroll intent from the drag position, so the dwell moves a pixel each tick. A motionless hold can measure a canvas that simply stopped being told anything.

`canvasBottomEdge()` is on the driver rather than measured in the suite, for the same reason `canvasCentre()` is: a replacement canvas that is not an iframe still has a bottom.

## Break verified at the source

Removing `AutoScroller` from the provider's plugin list and rebuilding fails the case with:

```
Error: autoscroll must engage while the pointer rests near an edge
Expected: > 0
Received:   0
```

Restored → passes. The capability was removed at its origin, not stubbed in the harness, so the red is about the canvas rather than the reader.

## Verification

- The graduated case: passes, no `test.fail`.
- Full canvas suite: **93 passed**, 0 failed, and B-8 is no longer among the expected failures.
- `check-types` + `lint` green for `@nextlyhq/e2e`, turbo `--force`.

## Consequence for the plan

`page-builder-master-plan.md` §5c and the focus tracker both list B-8 under "Not built". It is built. Anyone sizing plan 04 from that list is over-counting, and B-8 should not be scheduled as work.

No changeset: test-only.