### PR TITLE
refactor(plugin-page-builder): ask the engine whether a block may nest

### DIFF
--- a/.changeset/drop-rules-call-can-nest.md
+++ b/.changeset/drop-rules-call-can-nest.md
@@ -1,5 +1,30 @@
 ---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
 "@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
 ---
 
-The editor now asks the block engine whether a block may nest under a container, rather than deciding it again. One rule, three callers.
+The editor now asks the block engine whether a block may nest under a container, rather than
+deciding it a second time. One rule, three callers: the drag, the keyboard insert, and the
+engine's own validation of a stored document.

--- a/.changeset/drop-rules-call-can-nest.md
+++ b/.changeset/drop-rules-call-can-nest.md
@@ -1,0 +1,5 @@
+---
+"@nextlyhq/plugin-page-builder": patch
+---
+
+The editor now asks the block engine whether a block may nest under a container, rather than deciding it again. One rule, three callers.

--- a/packages/plugin-page-builder/src/admin/logic/dropRules.ts
+++ b/packages/plugin-page-builder/src/admin/logic/dropRules.ts
@@ -7,6 +7,8 @@
  * independent — neither is derivable from the other — and a block is only placeable where both
  * agree.
  */
+import { canNest, type NestingRefusal } from "@nextlyhq/blocks-engine";
+
 import {
   isContainerType,
   isDeclaredHere,
@@ -45,6 +47,25 @@ export type DropCheck =
   | { ok: true; reason?: undefined }
   | { ok: false; reason: DropReason };
 
+/**
+ * The editor's word for each refusal the nesting rule can produce.
+ *
+ * A total `Record` rather than a narrowing check, because the two vocabularies are allowed to
+ * diverge and only this table may decide how. Narrowing on the one reason `canNest` produces today
+ * would fail OPEN the moment the engine adds another — the drop would simply be permitted — while
+ * an exhaustive map stops compiling until somebody chooses the editor's word for it.
+ *
+ * `restricted-at-root` maps to the same reason rather than gaining one of its own, and that is a
+ * judgement about the SENTENCE rather than about the rule. "This block can only go inside certain
+ * containers" is exactly what an author needs to hear about a block that restricts its parents and
+ * is sitting where there are none. `canNest` cannot return it — only `canBeRoot` can, and nothing
+ * here calls that — so this arm is unreachable today and costs nothing while it stays so.
+ */
+const NESTING_REASONS: Record<NestingRefusal, DropReason> = {
+  "wrong-parent": "wrong-parent",
+  "restricted-at-root": "wrong-parent",
+};
+
 export function canDrop(
   parentType: string,
   slotName: string,
@@ -76,11 +97,19 @@ export function canDrop(
     return { ok: false, reason: "not-allowed-in-slot" };
   }
   // The child's own restriction, which the parent's allowlist cannot express. A slot that takes
-  // anything still may not be a home for a block that only means something under one parent, and
-  // asking here rather than at each caller is what makes drag, Insert, paste and reorder agree.
-  const parents = parentsOf(childType, registry);
-  if (parents && !parents.includes(parentType)) {
-    return { ok: false, reason: "wrong-parent" };
+  // anything still may not be a home for a block that only means something under one parent.
+  //
+  // ASKED of the engine rather than answered here. The same rule decides whether a stored document
+  // is valid and whether a drag may land, and two implementations of it agree on the day they are
+  // written — so this calls `canNest` rather than re-reading `parentsOf` itself. What stays here is
+  // the editor's own concern: which RESOLVER the rule reads through, since this package resolves a
+  // definition first and falls back to declared structure so a plugin-contributed block is not
+  // reported as unrestricted.
+  const verdict = canNest(childType, parentType, {
+    parentsOf: type => parentsOf(type, registry),
+  });
+  if (!verdict.allowed) {
+    return { ok: false, reason: NESTING_REASONS[verdict.reason] };
   }
   return { ok: true };
 }


### PR DESCRIPTION
Three places enforced a child's `parent` restriction: this editor rule, the plugin's legacy document validator, and — since **#866** — the engine. Three implementations of one question, agreeing on the day they were written.

## What changed

`canDrop`'s parent branch now calls `canNest` instead of re-reading `parentsOf` and comparing itself.

What stays here is the part that genuinely belongs to the editor: **which resolver the rule reads through**. This package resolves a definition first and falls back to declared structure, so a block a plugin contributed is not reported as unrestricted. That resolution is what the `NestingSource` adapter supplies — three lines — while the *rule* moves to the one place that owns it.

## Why a total map rather than a narrowing check

`canNest` can only return `wrong-parent` today. Its **type** is the full `NestingRefusal` union, so the obvious code is a narrow:

```ts
if (!verdict.allowed && verdict.reason === "wrong-parent") return { ok: false, reason: "wrong-parent" };
```

That **fails open**. The moment the engine adds a refusal, an unmatched reason falls through and the drop is simply permitted — a rule silently stopping being enforced, which is the failure direction that costs most. An exhaustive `Record<NestingRefusal, DropReason>` stops compiling until somebody chooses the editor's word for the new member.

`restricted-at-root` maps to the same reason rather than gaining one, and that is a judgement about the **sentence**, not the rule: *"This block can only go inside certain containers"* is exactly what an author needs to hear about a block that restricts its parents and is sitting where there are none. `canNest` cannot return it — only `canBeRoot` can, and nothing here calls that.

## The control: is the delegation real, or agreement by coincidence?

A refactor like this passes its tests whether or not the call actually reaches the engine, because both implementations agree. So the engine's rule was **broken at its source** and its `dist` rebuilt — `canNest` made to always allow:

```
FAIL  dropRules.test.ts > refuses a block whose parent list does not name this container
FAIL  dropRules.test.ts > refuses the plugin block outside the parent its DEFINITION names
FAIL  insertPlan.test.ts > walks past a container that would accept it, to the one it belongs in
FAIL  insertPlan.test.ts > reports nowhere when no ancestor is a permitted parent
FAIL  contributed-nesting.test.ts > refuses a block the child's own parent list excludes
Tests  5 failed | 801 passed (806)
```

Five failures across three files, including `insertPlan`, which reaches the rule through `canDrop`. Restored and rebuilt: **806 passed**.

The rebuild is not incidental — this package resolves `@nextlyhq/blocks-engine` through its built output, so a source edit with no rebuild would have proved nothing and reported a clean pass.

## Not in this change

The plugin's legacy `core/validate.ts` copy is the canvas lane's to delete as A-0 step 4, and they are holding that step until the engine enforcement they depend on has landed. This PR removes the editor's duplicate; that one removes the validator's.

## Verification

- `@nextlyhq/plugin-page-builder`: **806 passed**, 85 files.
- `check-types` + `lint` green, turbo `--force`.
- Break verified at the engine, with the `dist` rebuilt so the control could reach the code under test.

`main` is currently red on `create-nextly-app`'s `scaffold-ships-an-agent-guide.test.ts` — inherited from `6b154cd3a`, fix in **#869**, unrelated to this change.