### PR TITLE
test(root): recover the clock-bound commit stranded by #867

### DIFF
--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -1551,7 +1551,12 @@ test.describe("the drop-zone geometry the probe waits on", () => {
     });
     expect(applied).not.toBeNull();
     expect(applied?.rate).toBe(1);
-    expect(applied?.currentTime).toBe(-30000);
+    // A BOUND, not an equality. The clock keeps running between the assignment and the read, so
+    // an exact comparison measures how long that round trip took — it held locally and lost a
+    // frame (16.7ms) on CI. What makes this the case it claims to be is that the effect is rewound
+    // far into the past, which is stable; the exact value is not, and asserting it tests the
+    // runner rather than the rewind.
+    expect(applied?.currentTime).toBeLessThan(-29000);
     // The two readings a naive live span would use, both still describing the stylesheet.
     expect(applied?.activeDuration).toBe(20000);
     expect(applied?.delay).toBe(0);


### PR DESCRIPTION
**#867 merged without its final commit, and `main` carries an assertion that already failed CI.**

## What happened

`git log <headRefOid>..<ls-remote tip>` names one commit absent from the merge:

```
be8a0a0ba test(root): bound the rewound clock rather than pinning it
```

Confirmed by CONTENT, with a control proving the search works: `toBeLessThan(-29000)` is present on the branch head and **absent** from merge commit `88b44fce8`. `main` still reads:

```ts
expect(applied?.currentTime).toBe(-30000);
```

## Why that matters rather than being cosmetic

That exact-equality assertion is the one that **failed `Browser tests` on #867's own CI**:

```
Expected: -30000
Received: -29983.334
```

The animation's clock advances between the assignment and the read — one frame, 16.7ms. It held locally and lost that frame on the runner. So `main` currently carries a canvas test that fails whenever the round trip costs a frame, which is most of the time on a loaded machine.

The recovered commit replaces it with a bound. What makes the fixture the case it claims to be is that the effect is rewound **far into the past** — stable. The exact value is not, and asserting it measures how long the round trip took rather than the rewind.

## Verification

- Cherry-picked onto `main`, one file, +6/-1.
- Guard suite: **32 passed**.
- The same stranded-tail check that found this reports the recovered branch clean.

This is the second tail this lane has stranded — #825 did it too, recovered as #854 — and both times the cause was the same: pushing a fix while a merge was being computed. Worth noting on the merge procedure rather than only in a PR body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved animation rewind test reliability by allowing for minor timing differences when validating the current playback position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->