### PR TITLE
fix(create-nextly-app): carry the include's directory in the visited key

### DIFF
--- a/.changeset/include-identity-carries-context.md
+++ b/.changeset/include-identity-carries-context.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Scaffolding into a project whose instruction files include one another through
+symlinks no longer writes a pointer that loops.
+
+A relative include resolves from the directory it was written in, so one file
+reached through two aliases in different directories points at two different
+targets. The scaffolder now identifies a visited file by that pair rather than by
+the file alone, so an alias whose includes lead somewhere new is followed instead
+of skipped.

--- a/packages/create-nextly-app/src/__tests__/scaffold-ships-an-agent-guide.test.ts
+++ b/packages/create-nextly-app/src/__tests__/scaffold-ships-an-agent-guide.test.ts
@@ -552,6 +552,65 @@ describe("scaffolding over a project that already has these files", () => {
     );
   }, 30_000);
 
+  it("expands a shared include reached from two different directories", async () => {
+    // `shared.md` is reached twice — directly, and through `rules/alias.md` which symlinks to
+    // it. Its `@../CLAUDE.md` resolves from the DIRECTORY it was reached from, so the two
+    // arrivals point at different files: the root arrival names the project's own CLAUDE.md and
+    // closes a cycle, while the `rules/` arrival names a sibling outside the project.
+    //
+    // Keying a visited node by its referent alone collapses the two, skips the second before
+    // its edges are expanded, and writes the cyclic pointer.
+    workdir = await mkdtemp(path.join(tmpdir(), "nextly-existing-"));
+    const target = path.join(workdir, "project");
+    await mkdir(path.join(target, "rules"), { recursive: true });
+
+    await writeFile(
+      path.join(target, "AGENTS.md"),
+      "# Ours\n\n@shared.md\n\n@rules/alias.md\n\nOur own notes.\n",
+      "utf-8"
+    );
+    await writeFile(
+      path.join(target, "shared.md"),
+      "# Shared\n\n@../CLAUDE.md\n",
+      "utf-8"
+    );
+    await symlink(
+      path.join(target, "shared.md"),
+      path.join(target, "rules", "alias.md"),
+      "file"
+    );
+
+    await copyTemplate({
+      projectName: "my-app",
+      projectType: "blank",
+      targetDir: target,
+      database: sqlite,
+      packageManager: "npm",
+      templateSource: {
+        basePath: path.join(templatesRoot, "base"),
+        templatePath: path.join(templatesRoot, "blank"),
+      },
+      allowExistingTarget: true,
+    });
+
+    const guide = await readFile(path.join(target, "AGENTS.md"), "utf-8");
+    expect(guide).toContain("Our own notes.");
+
+    // The ROOT arrival at `shared.md` reaches `../CLAUDE.md` outside the project — a dead end.
+    // The `rules/` arrival at the same file reaches the project's OWN `CLAUDE.md` and closes the
+    // cycle, so the pointer must NOT be written.
+    //
+    // Keying by referent alone records the root arrival, skips the `rules/` one as already seen,
+    // never expands its edge, misses the cycle, and writes a pointer that loops.
+    const claude = await readFile(
+      path.join(target, "CLAUDE.md"),
+      "utf-8"
+    ).catch(() => "");
+    expect(claude.split("\n").filter(l => l.trim() === "@AGENTS.md")).toEqual(
+      []
+    );
+  }, 30_000);
+
   it("does not count a commented-out or inline pointer as installed", async () => {
     // Three inactive forms. A reader acts on none of them, so the real pointer must still be
     // added — otherwise the guide is silently unreachable.

--- a/packages/create-nextly-app/src/__tests__/scaffold-ships-an-agent-guide.test.ts
+++ b/packages/create-nextly-app/src/__tests__/scaffold-ships-an-agent-guide.test.ts
@@ -555,8 +555,9 @@ describe("scaffolding over a project that already has these files", () => {
   it("expands a shared include reached from two different directories", async () => {
     // `shared.md` is reached twice — directly, and through `rules/alias.md` which symlinks to
     // it. Its `@../CLAUDE.md` resolves from the DIRECTORY it was reached from, so the two
-    // arrivals point at different files: the root arrival names the project's own CLAUDE.md and
-    // closes a cycle, while the `rules/` arrival names a sibling outside the project.
+    // arrivals point at different files: the ROOT arrival's `..` leaves the project entirely
+    // and is a dead end, while the `rules/` arrival's `..` names the project's own CLAUDE.md
+    // and closes the cycle.
     //
     // Keying a visited node by its referent alone collapses the two, skips the second before
     // its edges are expanded, and writes the cyclic pointer.
@@ -602,6 +603,63 @@ describe("scaffolding over a project that already has these files", () => {
     //
     // Keying by referent alone records the root arrival, skips the `rules/` one as already seen,
     // never expands its edge, misses the cycle, and writes a pointer that loops.
+    const claude = await readFile(
+      path.join(target, "CLAUDE.md"),
+      "utf-8"
+    ).catch(() => "");
+    expect(claude.split("\n").filter(l => l.trim() === "@AGENTS.md")).toEqual(
+      []
+    );
+  }, 30_000);
+
+  it("keeps alias contexts distinct when the DIRECTORY itself is a symlink", async () => {
+    // `alias -> ../shared-dir`, so a file reached through `alias/` and through the real
+    // directory is one file arriving from two lexically different places. Its `@../CLAUDE.md`
+    // resolves from the directory it was written in: through `alias/` that is the project, and
+    // from the real `shared-dir/` it is outside.
+    //
+    // Canonicalising the directory in the identity collapses these two arrivals, skips the
+    // alias one, misses the cycle it closes, and writes a looping pointer.
+    workdir = await mkdtemp(path.join(tmpdir(), "nextly-existing-"));
+    const target = path.join(workdir, "project");
+    await mkdir(target, { recursive: true });
+    await mkdir(path.join(workdir, "shared-dir"), { recursive: true });
+
+    await writeFile(
+      path.join(workdir, "shared-dir", "shared.md"),
+      "# Shared\n\n@../CLAUDE.md\n",
+      "utf-8"
+    );
+    await symlink(
+      path.join(workdir, "shared-dir"),
+      path.join(target, "alias"),
+      "dir"
+    );
+    await writeFile(
+      path.join(target, "AGENTS.md"),
+      "# Ours\n\n@../shared-dir/shared.md\n\n@alias/shared.md\n\nOur own notes.\n",
+      "utf-8"
+    );
+
+    await copyTemplate({
+      projectName: "my-app",
+      projectType: "blank",
+      targetDir: target,
+      database: sqlite,
+      packageManager: "npm",
+      templateSource: {
+        basePath: path.join(templatesRoot, "base"),
+        templatePath: path.join(templatesRoot, "blank"),
+      },
+      allowExistingTarget: true,
+    });
+
+    expect(
+      (await readFile(path.join(target, "AGENTS.md"), "utf-8")).includes(
+        "Our own notes."
+      )
+    ).toBe(true);
+
     const claude = await readFile(
       path.join(target, "CLAUDE.md"),
       "utf-8"

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -503,6 +503,22 @@ function guidePlaceholders(
  * differ while denoting one file. A target that cannot be resolved answers true as well — a
  * dangling pointer installs nothing, so writing it has no upside to weigh against the risk.
  */
+/**
+ * How many include hops the cycle check will follow.
+ *
+ * Termination is bounded HERE rather than by the visited key, because the key answers a
+ * different question: which arrivals are distinct. A directory symlink pointing back into the
+ * project (`loop -> .`) makes the lexical directory grow without bound, so no key built from it
+ * is finite — and a key made finite by canonicalising the directory collapses aliases whose
+ * relative includes genuinely differ. One key cannot be both, so the hop count carries
+ * termination on its own.
+ *
+ * Generous against real projects: an instruction file including another that includes another
+ * is already unusual, and this allows far deeper. A graph that exceeds it is pathological, and
+ * the conservative answer for a pathological graph is the one this returns.
+ */
+const MAX_INCLUDE_HOPS = 64;
+
 async function pointsAtItself(
   targetDir: string,
   destination: string,
@@ -533,7 +549,15 @@ async function pointsAtItself(
   // length is not something the scaffolder gets to bound.
   const visited = new Set<string>();
 
+  let hops = 0;
+
   while (queue.length > 0) {
+    // Exceeding the bound means the graph is pathological rather than merely deep. Answering
+    // TRUE declines to write the pointer, which is the conservative direction: a guide that is
+    // one hop further away costs a click, while a pointer that closes a cycle sends an agent in
+    // circles.
+    if (++hops > MAX_INCLUDE_HOPS) return true;
+
     const { name, depth, from } = queue.shift()!;
     const targetPath = path.resolve(from, name);
 
@@ -561,17 +585,19 @@ async function pointsAtItself(
     // It still terminates. The symlink loop this guards against produces endless LEXICAL
     // spellings of one file, but only finitely many (file, directory) pairs — the directory set
     // is bounded by the real tree, which the spellings are not.
-    // The directory is CANONICALISED, not taken lexically. Under `loop -> .` the lexical
-    // dirname grows without bound — `project/loop`, `project/loop/loop` — so a lexical pair is
-    // not finite and the walk would not terminate.
+    // Identity is the resolved file paired with the LEXICAL directory it was reached from,
+    // because that directory is what `path.resolve` uses for the node's outgoing edges. Two
+    // aliases of one file in different directories emit different edges and must stay distinct,
+    // and canonicalising the directory collapses exactly the case that matters: with
+    // `alias -> ../shared-dir`, the alias arrival's `..` reaches this project while the real
+    // directory's `..` does not.
     //
-    // It is the directory that is resolved rather than the file's own parent: two aliases of one
-    // file in genuinely different directories must stay distinct, and `dirname(resolved)` would
-    // collapse them back to the referent's parent.
-    const fromDirectory = await fs
-      .realpath(path.dirname(targetPath))
-      .catch(() => path.dirname(targetPath));
-    const identity = `${resolved ?? targetPath}\u0000${fromDirectory}`;
+    // A lexical pair is not finite on its own — `loop -> .` grows `loop/loop/...` forever — so
+    // termination is a separate concern, bounded by hop count below rather than by folding two
+    // questions into one key. Three keys were tried before this: the referent alone (missed
+    // aliases), the lexical pair (unbounded), and the canonical pair (collapsed aliases). Each
+    // traded one property for the other because one key was answering both.
+    const identity = `${resolved ?? targetPath}\u0000${path.dirname(targetPath)}`;
     if (visited.has(identity)) continue;
     visited.add(identity);
 

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -561,7 +561,17 @@ async function pointsAtItself(
     // It still terminates. The symlink loop this guards against produces endless LEXICAL
     // spellings of one file, but only finitely many (file, directory) pairs — the directory set
     // is bounded by the real tree, which the spellings are not.
-    const identity = `${resolved ?? targetPath}\u0000${path.dirname(targetPath)}`;
+    // The directory is CANONICALISED, not taken lexically. Under `loop -> .` the lexical
+    // dirname grows without bound — `project/loop`, `project/loop/loop` — so a lexical pair is
+    // not finite and the walk would not terminate.
+    //
+    // It is the directory that is resolved rather than the file's own parent: two aliases of one
+    // file in genuinely different directories must stay distinct, and `dirname(resolved)` would
+    // collapse them back to the referent's parent.
+    const fromDirectory = await fs
+      .realpath(path.dirname(targetPath))
+      .catch(() => path.dirname(targetPath));
+    const identity = `${resolved ?? targetPath}\u0000${fromDirectory}`;
     if (visited.has(identity)) continue;
     visited.add(identity);
 

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -552,7 +552,16 @@ async function pointsAtItself(
     // before its contents were ever read — no includes expanded, no cycle found. On macOS the
     // temporary directory resolves through `/private`, so the two never collided and the defect
     // was invisible locally. Two keys for one question, disagreeing per platform.
-    const identity = resolved ?? targetPath;
+    // The identity of a visited node is the file AND the directory it was reached from, because
+    // that pair — not the file alone — determines the edges it emits. A relative `@../CLAUDE.md`
+    // resolves from the containing directory, so one file reached through two symlink aliases in
+    // different directories points at two different targets; keying on the referent alone skips
+    // the second alias before those edges are ever expanded.
+    //
+    // It still terminates. The symlink loop this guards against produces endless LEXICAL
+    // spellings of one file, but only finitely many (file, directory) pairs — the directory set
+    // is bounded by the real tree, which the spellings are not.
+    const identity = `${resolved ?? targetPath}\u0000${path.dirname(targetPath)}`;
     if (visited.has(identity)) continue;
     visited.add(identity);
 


### PR DESCRIPTION
Closes the P2 Codex raised on #869 after it merged.

## The defect

A relative `@../CLAUDE.md` resolves from the directory it was written in. So **one file reached through two symlink aliases in different directories points at two different targets** — and keying a visited node by its referent alone collapses those arrivals.

The second arrival is skipped before its edges are expanded, so a cycle that only that arrival closes is missed, and a pointer that loops gets written.

## The fix

The identity is the file **and** the directory it was reached from, because that pair is what determines the edges a node emits — the referent alone does not.

**It still terminates.** The symlink loop this key exists to stop produces endless LEXICAL spellings of one file (`loop/AGENTS.md`, `loop/loop/AGENTS.md`) but only finitely many `(file, directory)` pairs, because the directory set is bounded by the real tree and the spellings are not.

## Verified by mutation, with the mutation confirmed applied first

The test seeds one file reached twice: directly, and through `rules/alias.md` which symlinks to it.

- the ROOT arrival reaches `../CLAUDE.md` outside the project — a dead end
- the `rules/` arrival reaches the project's own `CLAUDE.md` and closes the cycle

Order matters, so the root arrival is listed first: it is the one a referent-only key records, making the `rules/` arrival the one that gets skipped.

Reverting the key to the referent alone:

```
x expands a shared include reached from two different directories
AssertionError: expected [ "@AGENTS.md" ] to deeply equal []
```

That is the cyclic pointer being written. Restored: **240 passed (240)** across 18 files — the whole package, not one file.

## Why the package suite and not one file

A single-file run is what let the previous defect reach `main`: it reported 35/35 while the package has 18 files. Corrected here.

That earlier defect was also **invisible on macOS**, because `tmpdir()` resolves through `/private` and the two keys never collided. This test uses explicit symlinks inside the project rather than relying on the temp directory, so it discriminates on both platforms — but CI remains the authority.
