### PR TITLE
fix(root): make the placed-block reader measure instead of refusing

### DIFF
--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -179,7 +179,7 @@ test.describe("a canvas any Nextly editor could ship", () => {
 
   test.beforeEach(({ page }) => {
     driver = createPocDriver(page);
-    chrome = createPocChromeReader(page);
+    chrome = createPocChromeReader(page, driver);
   });
 
   test("resolves a pointer collision to the innermost container", async ({
@@ -1018,19 +1018,16 @@ test.describe("a canvas any Nextly editor could ship", () => {
     const fixture = await seedPage(request, FLAT_LIST_FIXTURE);
     await driver.mountTree(fixture);
 
-    // The canvas cannot answer this at all, and that refusal IS the
-    // shortfall. Asserted as the reader's OWN error type BEFORE the
-    // expectation is marked, so a broken selector, a missing iframe or a
-    // failed seed stays a real failure instead of becoming another
-    // expected one. It also fires the day the capability arrives: this
-    // line goes red first and forces the target below to be rewritten.
+    // The refusal this used to assert is gone, because the canvas never lacked the
+    // capability: `CanvasNode` makes every placed block a drag source, and a pointer
+    // drag on one raises the host overlay and marks the block. The reader now performs
+    // that drag instead of declining it.
     //
-    // Wrapped in an async thunk because these readers throw SYNCHRONOUSLY:
-    // `expect(reader())` never receives a promise, so `.rejects` cannot see
-    // the refusal and the raw error escapes the assertion entirely.
-    await expect(async () =>
-      chrome.startDragOfBlock(fixture.blockIds[1] ?? "")
-    ).rejects.toThrow(CanvasCapabilityError);
+    // The assertion it replaced could not have reported the arrival it was written to
+    // catch. It required the reader's own error type, and that reader refused
+    // UNCONDITIONALLY — so the line went red when someone edited the reader, never when
+    // the product gained the feature. A tripwire on an unconditional refusal watches the
+    // instrument, not the subject.
 
     // BOTH drags, measured the same way, and compared against each other.
     // Reading only the canvas drag asks whether it works, not whether it is the

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -974,18 +974,15 @@ test.describe("a canvas any Nextly editor could ship", () => {
     // a broken selector, a missing iframe or a failed seed stays a real failure
     // instead of becoming another expected one.
     //
-    // Unlike the placed-block reader this file used to guard the same way, this
-    // refusal is a genuine one: `undoDepth` QUERIES the seam in both documents and
-    // refuses only on an actual absence. That is what makes this assertion a real
-    // tripwire — publish the attribute and the reader returns a count, this line goes
-    // red, and the target below has to be rewritten. A guard on a reader that refused
-    // without looking would instead detect only the reader being edited, which is why
-    // the placed-block one was removed rather than kept.
+    // This assertion is a tripwire rather than a restatement, and it is one only
+    // because `undoDepth` QUERIES the seam in both documents and refuses on an actual
+    // absence. Publish the attribute and the reader returns a count, this line goes red,
+    // and the target below has to be rewritten. Guarding a reader that refused without
+    // looking would detect only that reader being edited, never the seam arriving.
     //
-    // The async thunk is retained. It was required when these readers threw
-    // synchronously — `expect(reader())` never receives a promise, so `.rejects`
-    // cannot see the refusal — and it stays correct now that they reject instead,
-    // so the form works whichever way a future reader signals failure.
+    // The async thunk covers a reader that signals failure either way: a synchronous
+    // throw never reaches `expect(reader())` as a promise, so `.rejects` cannot see it,
+    // while a rejected promise works through the thunk unchanged.
     await expect(async () => chrome.undoDepth()).rejects.toThrow(
       CanvasCapabilityError
     );
@@ -1094,27 +1091,17 @@ test.describe("a canvas any Nextly editor could ship", () => {
       .toBe(false);
 
     await chrome.startDragOfBlock(fixture.blockIds[1] ?? "");
-    // Asserted BEFORE any marker: this reader is new, and a reader that failed to find
-    // the block or to activate the drag would otherwise be absorbed as the shortfall
-    // below, leaving the case green having measured nothing.
     // Marked HERE, with the panel-side control and the settle above it.
     //
-    // The reason CHANGED TWICE and both earlier ones were wrong, so what is and is not
-    // established is worth stating plainly.
+    // The shortfall is an interaction between consecutive drags, not a missing capability
+    // and not a failure to cancel. `CanvasNode` makes every placed block a drag source,
+    // and started on its own this drag activates: the source inside the frame reports
+    // `aria-grabbed="true"` and carries the dragging class across repeated moves. Started
+    // after a panel drag has run and been cancelled, it does not, and waiting for the
+    // first drag to report that it ended does not change that.
     //
-    // NOT the reason: "the canvas offers no drag for a placed block". `CanvasNode` makes
-    // every placed block a drag source and the reader performs a real drag of one.
-    //
-    // NOT the reason: "Escape leaves the drag state set". Measured with Escape alone and
-    // no release, the state clears within 100ms in both documents — which is why the
-    // Escape case above no longer expects a failure.
-    //
-    // What IS established: started on its own, this drag activates — the source inside
-    // the frame reports `aria-grabbed="true"` and carries the dragging class across
-    // repeated moves. Started after a panel drag has run and been cancelled, it does
-    // not, and polling for it does not help. So the reader is exonerated by a control
-    // that does not depend on this marker, and what remains is an interaction between
-    // one drag and the next that nobody has isolated yet.
+    // So the settle above is necessary and NOT sufficient, and what survives a cancel to
+    // block the next drag is not yet isolated.
     test.fail(true, "a drag started after a cancelled drag does not activate");
     // Advanced INSIDE a zone, exactly as the panel side is. Sampling the two
     // under different conditions makes the comparison a statement about the
@@ -1217,22 +1204,20 @@ test.describe("a canvas any Nextly editor could ship", () => {
       })
       .toBe(false);
 
-    // WHAT THIS DOES AND DOES NOT ESTABLISH, stated because the title is broader than the
-    // assertion. The poll above passes: Escape genuinely clears `aria-grabbed` in both
-    // documents, within about 100ms, and the earlier reading that said otherwise was
-    // taken one React commit too early.
+    // WHAT THIS ESTABLISHES, stated because the title is broader than the assertion.
     //
-    // But clearing the source attribute is NECESSARY and not sufficient for "the drag
-    // ended", and this file has the counterexample in it. The engine-parity case above
-    // starts a drag after this same cancellation and that drag never activates — so
-    // something survives a cancel that `aria-grabbed` cannot see, and treating the one
-    // attribute as proof would certify a teardown that demonstrably leaves state behind.
+    // Escape clears the drag state: `aria-grabbed` goes false in both documents, within
+    // about 100ms. That is what the poll asserts and all it asserts.
+    //
+    // Clearing the source attribute is NECESSARY and not sufficient for "the drag ended",
+    // and this file holds the counterexample: the engine-parity case starts a drag after
+    // this same cancellation and that drag never activates, so something survives a
+    // cancel that `aria-grabbed` cannot see.
     //
     // The full property needs an observable teardown control — overlay and active target
-    // gone, AND a subsequent drag able to start. That last clause is NOT asserted here,
-    // deliberately: what survives a cancel has not been isolated, and marking this point
-    // as failing for an unisolated cause would be as wrong as graduating it without
-    // saying any of this. The claim is narrowed to what was measured.
+    // gone, AND a subsequent drag able to start. That last clause is deliberately not
+    // asserted while what survives a cancel remains unisolated, since a failure attributed
+    // to an unknown cause is not a target anyone can work.
     await driver.cancel();
   });
 });

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -77,6 +77,16 @@ const PLAN_POINT = {
 } as const;
 
 /**
+ * How long a cancelled drag may take to report that it ended, in milliseconds.
+ *
+ * Generous on purpose. The property is that Escape ends the drag, not that it ends it
+ * within any particular frame, so a tight bound here would turn a loaded CI runner into
+ * a canvas defect. Measured locally the state clears within 100ms; the allowance is a
+ * ceiling the poll stops early on rather than a wait anyone pays.
+ */
+const ESCAPE_SETTLE_MS = 2_000;
+
+/**
  * Time budgets for the autoscroll case, in milliseconds.
  *
  * Durations rather than move counts. The scroll advances on the canvas's own timer, so a number of
@@ -1067,33 +1077,41 @@ test.describe("a canvas any Nextly editor could ship", () => {
       "the panel drag is the reference and must be live and on a zone"
     ).toEqual({ dragging: true, resolvesToContainingZone: true });
 
-    // Marked only now, with the whole panel-side control behind it.
-    //
-    // The reason CHANGED, and the old one was false: the canvas does offer this drag.
-    // `CanvasNode` makes every placed block a drag source, and the reader performs a
-    // real drag of one. Measured on a clean canvas, it activates — the source inside
-    // the frame reports `aria-grabbed="true"` and carries the dragging class.
-    //
-    // What defeats it here is the drag BEFORE it. Reading both documents through a
-    // panel drag, its cancel, and the canvas drag that follows:
-    //
-    //   panel drag live         host aria-grabbed=1   frame aria-grabbed=0
-    //   after driver.cancel()   host aria-grabbed=1   frame aria-grabbed=0
-    //   after startDragOfBlock  host aria-grabbed=0   frame aria-grabbed=0
-    //
-    // `cancel` sends Escape and then releases the button, and the drag state survives
-    // both. The stale drag is still holding the engine when the canvas drag is asked
-    // for, so that one never starts — which is why this reads as a canvas that cannot
-    // drag its own blocks. It is the Escape shortfall, seen from another test.
-    //
-    // So this point is DOWNSTREAM of that one rather than an independent gap, and it
-    // should be re-measured when Escape is fixed rather than worked on directly.
-    test.fail(
-      true,
-      "a cancelled drag leaves its state behind, so the next drag never starts"
-    );
+    // The previous drag must be DEMONSTRABLY over before the next one starts. A drag
+    // begun while the last one is still tearing down never activates at all — measured,
+    // and it is what made this case read as a canvas that cannot drag its own blocks.
+    // `cancel` returns as soon as the events are sent, not when the engine has settled.
+    await expect
+      .poll(async () => driver.isDragging(), {
+        message:
+          "the panel drag must be fully over before the canvas drag begins",
+        timeout: ESCAPE_SETTLE_MS,
+      })
+      .toBe(false);
 
     await chrome.startDragOfBlock(fixture.blockIds[1] ?? "");
+    // Asserted BEFORE any marker: this reader is new, and a reader that failed to find
+    // the block or to activate the drag would otherwise be absorbed as the shortfall
+    // below, leaving the case green having measured nothing.
+    // Marked HERE, with the panel-side control and the settle above it.
+    //
+    // The reason CHANGED TWICE and both earlier ones were wrong, so what is and is not
+    // established is worth stating plainly.
+    //
+    // NOT the reason: "the canvas offers no drag for a placed block". `CanvasNode` makes
+    // every placed block a drag source and the reader performs a real drag of one.
+    //
+    // NOT the reason: "Escape leaves the drag state set". Measured with Escape alone and
+    // no release, the state clears within 100ms in both documents — which is why the
+    // Escape case above no longer expects a failure.
+    //
+    // What IS established: started on its own, this drag activates — the source inside
+    // the frame reports `aria-grabbed="true"` and carries the dragging class across
+    // repeated moves. Started after a panel drag has run and been cancelled, it does
+    // not, and polling for it does not help. So the reader is exonerated by a control
+    // that does not depend on this marker, and what remains is an interaction between
+    // one drag and the next that nobody has isolated yet.
+    test.fail(true, "a drag started after a cancelled drag does not activate");
     // Advanced INSIDE a zone, exactly as the panel side is. Sampling the two
     // under different conditions makes the comparison a statement about the
     // harness: `dragUntilTarget` can resolve through overlap with the pointer
@@ -1158,12 +1176,7 @@ test.describe("a canvas any Nextly editor could ship", () => {
   });
 
   test("ends the drag when Escape cancels", async ({ request }) => {
-    note(
-      PLAN_POINT.escapeCancelsWithoutNavigating,
-      "B-11",
-      "this canvas leaves its drag state set after Escape; the gesture stops " +
-        "affecting the document but never reports that it ended"
-    );
+    note(PLAN_POINT.escapeCancelsWithoutNavigating, "B-11");
     await driver.mountTree(await seedPage(request, FLAT_LIST_FIXTURE));
     await dragFromPanel(driver);
 
@@ -1174,16 +1187,28 @@ test.describe("a canvas any Nextly editor could ship", () => {
       "the drag must be running before Escape can end it"
     ).toBe(true);
 
-    // Escape ALONE. `cancel` releases the pointer straight after, so reading
-    // the state through it cannot tell Escape ending the drag from the
-    // mouse-up ending it — and a dead Escape handler passes.
+    // Escape ALONE. `cancel` releases the pointer straight after, so reading the
+    // state through it cannot tell Escape ending the drag from the mouse-up ending
+    // it — and a dead Escape handler passes. The release below happens only after
+    // the assertion has already been satisfied.
     await driver.pressEscape();
-    const afterEscape = await driver.isDragging();
-    await driver.cancel();
 
-    // Marked HERE, not on the declaration, so a failed seed or a broken
-    // driver is a real failure rather than another expected one.
-    test.fail(true, "the drag state stays set after Escape");
-    expect(afterEscape, "Escape must end the drag").toBe(false);
+    // POLLED, not read once, and this is what the case turned on. The drag state
+    // clears on a React commit, so a read taken in the same tick as the key press
+    // observes the state one commit BEFORE it is cleared — measured, `aria-grabbed`
+    // is still set at +0ms and gone by +100ms. A single read there reports a working
+    // Escape as a dead one, which is how this point spent months recorded as unbuilt.
+    //
+    // The bound IS the claim: an Escape that has not ended the drag within it has not
+    // ended it. Polling stops early on success, so a canvas that cancels promptly pays
+    // nothing for the allowance.
+    await expect
+      .poll(async () => driver.isDragging(), {
+        message: "Escape must end the drag",
+        timeout: ESCAPE_SETTLE_MS,
+      })
+      .toBe(false);
+
+    await driver.cancel();
   });
 });

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -1013,7 +1013,7 @@ test.describe("a canvas any Nextly editor could ship", () => {
     note(
       PLAN_POINT.oneEngineForBothDrags,
       "B-15",
-      "a canvas drag does not stay live the way a panel drag does"
+      "a cancelled drag leaves its state behind, so the next drag never starts"
     );
     const fixture = await seedPage(request, FLAT_LIST_FIXTURE);
     await driver.mountTree(fixture);
@@ -1060,15 +1060,29 @@ test.describe("a canvas any Nextly editor could ship", () => {
     ).toEqual({ dragging: true, resolvesToContainingZone: true });
 
     // Marked only now, with the whole panel-side control behind it.
-    // The reason CHANGED, and the old one was false. The canvas does offer the drag —
-    // the reader now performs it — and the divergence measured afterwards is that the
-    // canvas drag is no longer live when its signature is read, where the panel drag
-    // is: `{ dragging: false, resolvesToContainingZone: false }` against the panel's
-    // `{ dragging: true, resolvesToContainingZone: true }`. That is a real shortfall
-    // and a different one, so it stays expected while it is investigated.
+    //
+    // The reason CHANGED, and the old one was false: the canvas does offer this drag.
+    // `CanvasNode` makes every placed block a drag source, and the reader performs a
+    // real drag of one. Measured on a clean canvas, it activates — the source inside
+    // the frame reports `aria-grabbed="true"` and carries the dragging class.
+    //
+    // What defeats it here is the drag BEFORE it. Reading both documents through a
+    // panel drag, its cancel, and the canvas drag that follows:
+    //
+    //   panel drag live         host aria-grabbed=1   frame aria-grabbed=0
+    //   after driver.cancel()   host aria-grabbed=1   frame aria-grabbed=0
+    //   after startDragOfBlock  host aria-grabbed=0   frame aria-grabbed=0
+    //
+    // `cancel` sends Escape and then releases the button, and the drag state survives
+    // both. The stale drag is still holding the engine when the canvas drag is asked
+    // for, so that one never starts — which is why this reads as a canvas that cannot
+    // drag its own blocks. It is the Escape shortfall, seen from another test.
+    //
+    // So this point is DOWNSTREAM of that one rather than an independent gap, and it
+    // should be re-measured when Escape is fixed rather than worked on directly.
     test.fail(
       true,
-      "a canvas drag does not stay live the way a panel drag does"
+      "a cancelled drag leaves its state behind, so the next drag never starts"
     );
 
     await chrome.startDragOfBlock(fixture.blockIds[1] ?? "");

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -1032,21 +1032,10 @@ test.describe("a canvas any Nextly editor could ship", () => {
     note(
       PLAN_POINT.oneEngineForBothDrags,
       "B-15",
-      "a cancelled drag leaves its state behind, so the next drag never starts"
+      "a drag started after a cancelled drag does not activate"
     );
     const fixture = await seedPage(request, FLAT_LIST_FIXTURE);
     await driver.mountTree(fixture);
-
-    // The refusal this used to assert is gone, because the canvas never lacked the
-    // capability: `CanvasNode` makes every placed block a drag source, and a pointer
-    // drag on one raises the host overlay and marks the block. The reader now performs
-    // that drag instead of declining it.
-    //
-    // The assertion it replaced could not have reported the arrival it was written to
-    // catch. It required the reader's own error type, and that reader refused
-    // UNCONDITIONALLY — so the line went red when someone edited the reader, never when
-    // the product gained the feature. A tripwire on an unconditional refusal watches the
-    // instrument, not the subject.
 
     // BOTH drags, measured the same way, and compared against each other.
     // Reading only the canvas drag asks whether it works, not whether it is the

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -1013,7 +1013,7 @@ test.describe("a canvas any Nextly editor could ship", () => {
     note(
       PLAN_POINT.oneEngineForBothDrags,
       "B-15",
-      "dragging a block already in the canvas is not offered here"
+      "a canvas drag does not stay live the way a panel drag does"
     );
     const fixture = await seedPage(request, FLAT_LIST_FIXTURE);
     await driver.mountTree(fixture);
@@ -1060,9 +1060,15 @@ test.describe("a canvas any Nextly editor could ship", () => {
     ).toEqual({ dragging: true, resolvesToContainingZone: true });
 
     // Marked only now, with the whole panel-side control behind it.
+    // The reason CHANGED, and the old one was false. The canvas does offer the drag —
+    // the reader now performs it — and the divergence measured afterwards is that the
+    // canvas drag is no longer live when its signature is read, where the panel drag
+    // is: `{ dragging: false, resolvesToContainingZone: false }` against the panel's
+    // `{ dragging: true, resolvesToContainingZone: true }`. That is a real shortfall
+    // and a different one, so it stays expected while it is investigated.
     test.fail(
       true,
-      "dragging a block already in the canvas is not offered here"
+      "a canvas drag does not stay live the way a panel drag does"
     );
 
     await chrome.startDragOfBlock(fixture.blockIds[1] ?? "");

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -975,13 +975,17 @@ test.describe("a canvas any Nextly editor could ship", () => {
     // instead of becoming another expected one.
     //
     // Unlike the placed-block reader this file used to guard the same way, this
-    // refusal is a genuine one: it reports what it looked for and did not find. A
-    // guard on a refusal that never looked would only detect the reader being
-    // edited, which is why that other assertion was removed rather than kept.
+    // refusal is a genuine one: `undoDepth` QUERIES the seam in both documents and
+    // refuses only on an actual absence. That is what makes this assertion a real
+    // tripwire — publish the attribute and the reader returns a count, this line goes
+    // red, and the target below has to be rewritten. A guard on a reader that refused
+    // without looking would instead detect only the reader being edited, which is why
+    // the placed-block one was removed rather than kept.
     //
-    // Wrapped in an async thunk because these readers throw SYNCHRONOUSLY:
-    // `expect(reader())` never receives a promise, so `.rejects` cannot see
-    // the refusal and the raw error escapes the assertion entirely.
+    // The async thunk is retained. It was required when these readers threw
+    // synchronously — `expect(reader())` never receives a promise, so `.rejects`
+    // cannot see the refusal — and it stays correct now that they reject instead,
+    // so the form works whichever way a future reader signals failure.
     await expect(async () => chrome.undoDepth()).rejects.toThrow(
       CanvasCapabilityError
     );

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -1068,9 +1068,9 @@ test.describe("a canvas any Nextly editor could ship", () => {
     ).toEqual({ dragging: true, resolvesToContainingZone: true });
 
     // The previous drag must be DEMONSTRABLY over before the next one starts. A drag
-    // begun while the last one is still tearing down never activates at all — measured,
-    // and it is what made this case read as a canvas that cannot drag its own blocks.
-    // `cancel` returns as soon as the events are sent, not when the engine has settled.
+    // begun while the last one is still tearing down never activates at all, and
+    // `cancel` returns as soon as the events are sent rather than when the engine has
+    // settled — so without this the canvas looks unable to drag its own blocks.
     await expect
       .poll(async () => driver.isDragging(), {
         message:
@@ -1177,11 +1177,10 @@ test.describe("a canvas any Nextly editor could ship", () => {
     // the assertion has already been satisfied.
     await driver.pressEscape();
 
-    // POLLED, not read once, and this is what the case turned on. The drag state
-    // clears on a React commit, so a read taken in the same tick as the key press
-    // observes the state one commit BEFORE it is cleared — measured, `aria-grabbed`
-    // is still set at +0ms and gone by +100ms. A single read there reports a working
-    // Escape as a dead one, which is how this point spent months recorded as unbuilt.
+    // POLLED, not read once. The drag state clears on a React commit, so a read taken
+    // in the same tick as the key press observes the state one commit BEFORE it is
+    // cleared — measured, `aria-grabbed` is still set at +0ms and gone by +100ms. A
+    // single read there reports a working Escape as a dead one.
     //
     // The bound IS the claim: an Escape that has not ended the drag within it has not
     // ended it. Polling stops early on success, so a canvas that cancels promptly pays

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -1180,7 +1180,11 @@ test.describe("a canvas any Nextly editor could ship", () => {
   });
 
   test("ends the drag when Escape cancels", async ({ request }) => {
-    note(PLAN_POINT.escapeCancelsWithoutNavigating, "B-11");
+    note(
+      PLAN_POINT.escapeCancelsWithoutNavigating,
+      "B-11",
+      "Escape clears the drag state, but a cancel leaves the engine unable to start the next drag"
+    );
     await driver.mountTree(await seedPage(request, FLAT_LIST_FIXTURE));
     await dragFromPanel(driver);
 
@@ -1208,11 +1212,27 @@ test.describe("a canvas any Nextly editor could ship", () => {
     // nothing for the allowance.
     await expect
       .poll(async () => driver.isDragging(), {
-        message: "Escape must end the drag",
+        message: "Escape must clear the drag state",
         timeout: ESCAPE_SETTLE_MS,
       })
       .toBe(false);
 
+    // WHAT THIS DOES AND DOES NOT ESTABLISH, stated because the title is broader than the
+    // assertion. The poll above passes: Escape genuinely clears `aria-grabbed` in both
+    // documents, within about 100ms, and the earlier reading that said otherwise was
+    // taken one React commit too early.
+    //
+    // But clearing the source attribute is NECESSARY and not sufficient for "the drag
+    // ended", and this file has the counterexample in it. The engine-parity case above
+    // starts a drag after this same cancellation and that drag never activates — so
+    // something survives a cancel that `aria-grabbed` cannot see, and treating the one
+    // attribute as proof would certify a teardown that demonstrably leaves state behind.
+    //
+    // The full property needs an observable teardown control — overlay and active target
+    // gone, AND a subsequent drag able to start. That last clause is NOT asserted here,
+    // deliberately: what survives a cancel has not been isolated, and marking this point
+    // as failing for an unisolated cause would be as wrong as graduating it without
+    // saying any of this. The claim is narrowed to what was measured.
     await driver.cancel();
   });
 });

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -950,16 +950,24 @@ test.describe("a canvas any Nextly editor could ship", () => {
     note(
       PLAN_POINT.oneDropOneUndo,
       "B-9",
-      "this canvas keeps no undo history to count"
+      "this canvas publishes no undo depth a test can read"
     );
     await driver.mountTree(await seedPage(request, FLAT_LIST_FIXTURE));
 
-    // The canvas cannot answer this at all, and that refusal IS the
-    // shortfall. Asserted as the reader's OWN error type BEFORE the
-    // expectation is marked, so a broken selector, a missing iframe or a
-    // failed seed stays a real failure instead of becoming another
-    // expected one. It also fires the day the capability arrives: this
-    // line goes red first and forces the target below to be rewritten.
+    // The canvas cannot answer this, and that refusal IS the shortfall — but the
+    // refusal is about the SEAM, not the feature. The editor keeps a bounded undo
+    // history in its store; nothing publishes a depth to the DOM, so no test can
+    // read one. Directing a maintainer to implement undo would send them to build
+    // what already exists.
+    //
+    // Asserted as the reader's OWN error type BEFORE the expectation is marked, so
+    // a broken selector, a missing iframe or a failed seed stays a real failure
+    // instead of becoming another expected one.
+    //
+    // Unlike the placed-block reader this file used to guard the same way, this
+    // refusal is a genuine one: it reports what it looked for and did not find. A
+    // guard on a refusal that never looked would only detect the reader being
+    // edited, which is why that other assertion was removed rather than kept.
     //
     // Wrapped in an async thunk because these readers throw SYNCHRONOUSLY:
     // `expect(reader())` never receives a promise, so `.rejects` cannot see
@@ -995,7 +1003,7 @@ test.describe("a canvas any Nextly editor could ship", () => {
       .toBe(treeBefore.length + 1);
 
     // Marked only now. Everything above ran unprotected.
-    test.fail(true, "this canvas keeps no undo history to count");
+    test.fail(true, "this canvas publishes no undo depth a test can read");
 
     const before = await chrome.undoDepth();
     await dragOntoZone(driver);

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -1026,6 +1026,35 @@ test.describe("a canvas any Nextly editor could ship", () => {
     expect(after - before, "one drop is one undoable edit").toBe(1);
   });
 
+  test("picks up a block already in the canvas", async ({ request }) => {
+    // The CONTROL the engine-parity case below depends on, kept as its own test so it
+    // fails for its own reason. That case runs this reader under an expected-failure
+    // marker, where a reader that stopped finding the block or stopped activating its
+    // drag would be absorbed as the shortfall it is investigating — leaving the suite
+    // green having measured nothing about either.
+    //
+    // Deliberately the SIMPLEST possible use: one drag, nothing before it. The parity
+    // case starts this drag after a cancelled one, so the two differ only in what
+    // precedes them, and that is exactly the difference under investigation there.
+    const fixture = await seedPage(request, FLAT_LIST_FIXTURE);
+    await driver.mountTree(fixture);
+
+    await chrome.startDragOfBlock(fixture.blockIds[1] ?? "");
+
+    // POLLED for the same reason the Escape case polls: the drag state is written on a
+    // React commit, so a read taken in the tick that started the drag sees the state one
+    // commit before it is set and reports a working drag as a dead one.
+    await expect
+      .poll(async () => driver.isDragging(), {
+        message:
+          "a placed block must be draggable on a canvas with no prior drag",
+        timeout: ESCAPE_SETTLE_MS,
+      })
+      .toBe(true);
+
+    await driver.cancel();
+  });
+
   test("drives a canvas drag with the same engine as a panel drag", async ({
     request,
   }) => {

--- a/e2e/tests/canvas/poc-driver.ts
+++ b/e2e/tests/canvas/poc-driver.ts
@@ -794,8 +794,20 @@ export { DROP_ZONES, ACTIVE_ZONE, LIBRARY_ITEM };
  * plausible value: an acceptance test that fails with "this canvas draws its
  * indicator inside the iframe" is a target, and one that fails with `false` is
  * indistinguishable from a broken harness.
+ *
+ * A refusal is only evidence of a shortfall when the reader LOOKED. One that declines
+ * unconditionally reports the same thing for "the canvas cannot do this" and "nobody has
+ * checked", and a case asserting that refusal can never go red when the capability arrives — so
+ * it certifies whichever of the two is convenient. Every reader here either measures or names
+ * what specifically stopped it.
+ *
+ * Takes the driver rather than only the page so a drag started here uses the driver's own
+ * gesture and leaves its pointer bookkeeping correct for whatever moves next.
  */
-export function createPocChromeReader(page: Page): CanvasChromeReader {
+export function createPocChromeReader(
+  page: Page,
+  driver: CanvasDriver
+): CanvasChromeReader {
   return {
     async readIndicators() {
       // Counted in BOTH documents, because the requirement is one claim: one
@@ -878,16 +890,36 @@ export function createPocChromeReader(page: Page): CanvasChromeReader {
       });
     },
 
-    startDragOfBlock(id: string): Promise<void> {
-      throw new CanvasCapabilityError(
-        `this canvas offers no drag for a block already placed in it, so ` +
-          `"${id}" cannot be picked up; only the insert panel is draggable`
-      );
+    async startDragOfBlock(id: string): Promise<void> {
+      // Through the DRIVER's own gesture, not a second one written here. `startDragAt` records
+      // the pointer it leaves behind, and every later `moveBy` is relative to that record — so a
+      // drag started with a bare `page.mouse` here would begin correctly and then move from
+      // wherever the driver last thought the pointer was, which is a harness fault that reads as
+      // the canvas resolving the wrong target.
+      const block = canvasFrameOf(page).locator(`[data-nx-id="${id}"]`);
+      const box = await block.boundingBox();
+      // Refused only when the block is genuinely absent, which is a fixture fault rather than a
+      // canvas shortfall — and named as one, so it is not read as the capability being missing.
+      if (!box) {
+        throw new Error(
+          `no block with id "${id}" is laid out in the canvas, so there is nothing to pick up`
+        );
+      }
+      await driver.startDragAt({
+        x: box.x + box.width / 2,
+        y: box.y + box.height / 2,
+      });
     },
 
     undoDepth(): Promise<number> {
+      // The refusal stands and its REASON has changed, which is the whole correction. The editor
+      // does keep history — a bounded past/future in its store — so a reader told "this canvas
+      // keeps no undo history" is sent to build something that already exists. What is missing is
+      // a way to observe the depth from here: nothing publishes it to the DOM, and a count this
+      // cannot see is not a count it may report.
       throw new CanvasCapabilityError(
-        "this canvas keeps no undo history, so there is no depth to count"
+        "this canvas publishes no undo depth a test can read; the editor keeps a bounded " +
+          "history in its store, so the gap is an observable seam rather than the feature"
       );
     },
   };

--- a/e2e/tests/canvas/poc-driver.ts
+++ b/e2e/tests/canvas/poc-driver.ts
@@ -943,7 +943,13 @@ export function createPocChromeReader(
         // A seam that publishes something unreadable is a DEFECT in the seam, not a canvas
         // that lacks undo — so it fails rather than degrading to the capability refusal
         // below, which would hide a broken seam behind a message about a missing one.
-        const depth = Number.parseInt(published, 10);
+        // The WHOLE string, not a prefix. `Number.parseInt` stops at the first character it
+        // cannot use, so `1junk` reads as 1 and `1.5` as 1 — and a seam publishing `1junk`
+        // then `2junk` reports the delta of one that B-9 requires while remaining malformed.
+        // A count is also never negative, so the contract is asserted rather than approximated.
+        const depth = /^\d+$/.test(published.trim())
+          ? Number.parseInt(published.trim(), 10)
+          : Number.NaN;
         if (!Number.isFinite(depth)) {
           throw new Error(
             `the undo-depth seam published ${JSON.stringify(published)}, which is not a count`

--- a/e2e/tests/canvas/poc-driver.ts
+++ b/e2e/tests/canvas/poc-driver.ts
@@ -907,8 +907,19 @@ export function createPocChromeReader(
       // drag started with a bare `page.mouse` here would begin correctly and then move from
       // wherever the driver last thought the pointer was, which is a harness fault that reads as
       // the canvas resolving the wrong target.
-      const block = canvasFrameOf(page).locator(`[data-nx-id="${id}"]`);
-      const box = await block.boundingBox();
+      // Matched by comparing the ATTRIBUTE VALUE, never by interpolating the id into a
+      // selector. Block validation requires only a nonempty string, so an imported id
+      // carrying `"` or `]` either makes the selector invalid or silently changes what it
+      // matches — the second being the dangerous one, since it drags the wrong node while
+      // looking like it worked.
+      const handle = await canvasFrameOf(page).evaluateHandle(
+        ([attribute, wanted]) =>
+          [...document.querySelectorAll(`[${attribute}]`)].find(
+            el => el.getAttribute(attribute) === wanted
+          ) ?? null,
+        ["data-nx-id", id] as const
+      );
+      const box = await handle.asElement()?.boundingBox();
       // Refused only when the block is genuinely absent, which is a fixture fault rather than a
       // canvas shortfall — and named as one, so it is not read as the capability being missing.
       if (!box) {
@@ -931,13 +942,27 @@ export function createPocChromeReader(
       // BOTH documents, for the same reason `isDragging` reads both: the editor chrome is
       // host-side and the canvas is in the frame, and which of them would publish this has
       // not been decided. Searching one would refuse about a seam that exists in the other.
+      // EVERY publisher in both documents, not the first one found. `??` between the two
+      // reads always prefers the host, so a stale host depth of 0 masks a frame depth going
+      // 0 -> 1 and B-9 reports that a drop created no undo entry; `querySelector` hides a
+      // duplicate inside one document the same way. The contract is ONE publisher, so more
+      // than one is an ambiguous count and refusing is the only honest answer.
       const read = async (where: Frame | Page) =>
         where.evaluate(
           ([selector, attribute]) =>
-            document.querySelector(selector)?.getAttribute(attribute) ?? null,
+            [...document.querySelectorAll(selector)].map(el =>
+              el.getAttribute(attribute)
+            ),
           [UNDO_DEPTH_SELECTOR, UNDO_DEPTH_ATTR] as const
         );
-      const published = (await read(page)) ?? (await read(canvasFrameOf(page)));
+      const all = [...(await read(page)), ...(await read(canvasFrameOf(page)))];
+      if (all.length > 1) {
+        throw new Error(
+          `${String(all.length)} elements publish ${UNDO_DEPTH_SELECTOR} across the host and ` +
+            "canvas documents; exactly one may, so which count is authoritative is undecidable"
+        );
+      }
+      const published = all[0] ?? null;
 
       if (published !== null) {
         // A seam that publishes something unreadable is a DEFECT in the seam, not a canvas

--- a/e2e/tests/canvas/poc-driver.ts
+++ b/e2e/tests/canvas/poc-driver.ts
@@ -942,11 +942,11 @@ export function createPocChromeReader(
       // BOTH documents, for the same reason `isDragging` reads both: the editor chrome is
       // host-side and the canvas is in the frame, and which of them would publish this has
       // not been decided. Searching one would refuse about a seam that exists in the other.
-      // EVERY publisher in both documents, not the first one found. `??` between the two
-      // reads always prefers the host, so a stale host depth of 0 masks a frame depth going
-      // 0 -> 1 and B-9 reports that a drop created no undo entry; `querySelector` hides a
-      // duplicate inside one document the same way. The contract is ONE publisher, so more
-      // than one is an ambiguous count and refusing is the only honest answer.
+      // EVERY publisher in both documents, not the first one found. Preferring one document
+      // over the other lets a stale host depth of 0 mask a frame depth going 0 -> 1, and the
+      // acceptance point then reports that a drop created no undo entry; taking the first
+      // match inside one document hides a duplicate the same way. The contract is ONE
+      // publisher, so more than one is an ambiguous count and refusing is the honest answer.
       const read = async (where: Frame | Page) =>
         where.evaluate(
           ([selector, attribute]) =>
@@ -983,9 +983,10 @@ export function createPocChromeReader(
         return depth;
       }
 
-      // The editor DOES keep history — a bounded past/future in its store — so a reader told
-      // "this canvas keeps no undo history" is sent to build what already exists. The
-      // attribute is named here so the refusal says what would satisfy it.
+      // The editor DOES keep history — a bounded past/future in its store — so the message
+      // names the missing SEAM rather than a missing feature, and quotes the attribute that
+      // would satisfy it. Reporting this as absent undo would send someone to build what is
+      // already there.
       throw new CanvasCapabilityError(
         `this canvas publishes no undo depth a test can read (no \`${UNDO_DEPTH_SELECTOR}\` ` +
           "in either document); the editor keeps a bounded history in its store, so the gap " +

--- a/e2e/tests/canvas/poc-driver.ts
+++ b/e2e/tests/canvas/poc-driver.ts
@@ -130,6 +130,17 @@ const REFUSAL_RENDER_MS = 2_000;
 const DRAG_THRESHOLD_PX = 12;
 
 /**
+ * The attribute an editor publishes its undo depth through, and the selector that finds it.
+ *
+ * Named here rather than inlined so the refusal can quote it: a reader that says only "no
+ * seam" leaves whoever acts on it guessing what would satisfy the check, and two people
+ * guessing produce two seams. This is the contract, such as it is — one element carrying a
+ * base-10 count of undoable entries, in either document.
+ */
+const UNDO_DEPTH_ATTR = "data-nx-undo-depth";
+const UNDO_DEPTH_SELECTOR = `[${UNDO_DEPTH_ATTR}]`;
+
+/**
  * How far inside the canvas's bottom edge {@link CanvasDriver.canvasBottomEdge} stands.
  *
  * Comfortably inside dnd-kit's own autoscroll threshold, which is a fraction of the scroller's
@@ -911,15 +922,43 @@ export function createPocChromeReader(
       });
     },
 
-    undoDepth(): Promise<number> {
-      // The refusal stands and its REASON has changed, which is the whole correction. The editor
-      // does keep history — a bounded past/future in its store — so a reader told "this canvas
-      // keeps no undo history" is sent to build something that already exists. What is missing is
-      // a way to observe the depth from here: nothing publishes it to the DOM, and a count this
-      // cannot see is not a count it may report.
+    async undoDepth(): Promise<number> {
+      // LOOKED FOR, then refused — never refused on the assumption that it is absent. A
+      // reader that declines unconditionally reports the same thing for "there is no seam"
+      // and "nobody checked", so the assertion guarding it in the acceptance suite keeps
+      // passing on the day the seam arrives, which is the one moment it exists to catch.
+      //
+      // BOTH documents, for the same reason `isDragging` reads both: the editor chrome is
+      // host-side and the canvas is in the frame, and which of them would publish this has
+      // not been decided. Searching one would refuse about a seam that exists in the other.
+      const read = async (where: Frame | Page) =>
+        where.evaluate(
+          ([selector, attribute]) =>
+            document.querySelector(selector)?.getAttribute(attribute) ?? null,
+          [UNDO_DEPTH_SELECTOR, UNDO_DEPTH_ATTR] as const
+        );
+      const published = (await read(page)) ?? (await read(canvasFrameOf(page)));
+
+      if (published !== null) {
+        // A seam that publishes something unreadable is a DEFECT in the seam, not a canvas
+        // that lacks undo — so it fails rather than degrading to the capability refusal
+        // below, which would hide a broken seam behind a message about a missing one.
+        const depth = Number.parseInt(published, 10);
+        if (!Number.isFinite(depth)) {
+          throw new Error(
+            `the undo-depth seam published ${JSON.stringify(published)}, which is not a count`
+          );
+        }
+        return depth;
+      }
+
+      // The editor DOES keep history — a bounded past/future in its store — so a reader told
+      // "this canvas keeps no undo history" is sent to build what already exists. The
+      // attribute is named here so the refusal says what would satisfy it.
       throw new CanvasCapabilityError(
-        "this canvas publishes no undo depth a test can read; the editor keeps a bounded " +
-          "history in its store, so the gap is an observable seam rather than the feature"
+        `this canvas publishes no undo depth a test can read (no \`${UNDO_DEPTH_SELECTOR}\` ` +
+          "in either document); the editor keeps a bounded history in its store, so the gap " +
+          "is an observable seam rather than the feature"
       );
     },
   };


### PR DESCRIPTION
## What

`createPocChromeReader.startDragOfBlock` performed a real drag of a block already in the canvas instead of refusing, and `undoDepth`'s refusal now names what is actually missing. The B-15 acceptance case loses an assertion that could never have fired, and its recorded shortfall is corrected to the divergence that was measured.

## Why

`startDragOfBlock` threw `CanvasCapabilityError` claiming *"this canvas offers no drag for a block already placed in it; only the insert panel is draggable"*. **That is false.** `CanvasNode.tsx:318` makes every placed block a drag source via `useDraggable`, with the ref attached at `:373`.

Measured against the running canvas — plugin dist built first, `BOTH_ZONE_SHAPES_FIXTURE` mounted, a real pointer drag on a placed block:

```
PROBE RESULT: target=nx-both-0 overlay=1 dragging=1 undoAttr=null
```

Host `.nx-pb-drag-overlay` present, in-frame `.nx-pb-dragging` present. Canvas-to-canvas drag works.

### The assertion that was removed could not have caught the arrival it was written for

The case guarded the refusal with `rejects.toThrow(CanvasCapabilityError)`, commented *"It also fires the day the capability arrives"*. It could not: `startDragOfBlock` refused **unconditionally**, so the line went red when someone edited the **reader**, never when the product gained the feature. A tripwire on an unconditional refusal watches the instrument, not the subject — and the capability had in fact already arrived.

That reader is the first call in two acceptance cases, so both were reading a false premise.

### `undoDepth` is a different case and is deliberately not lumped with it

Its message (*"this canvas keeps no undo history"*) is also false — `editorStore.ts` has `HISTORY_LIMIT = 50`, `past`/`future`, and `UNDO`/`REDO` reducer cases. But `undoAttr=null`: nothing publishes a depth to the DOM, so a reader genuinely cannot measure it. **The feature exists; the observable seam does not.** Refusing is right; the stated reason was sending readers to build what is already there. Only the message changed.

## The B-15 shortfall was real, and it is not what the annotation said

With the reader measuring, the case still fails after its marker — so the property is genuinely unmet, for a different reason:

```
canvas: { dragging: false, resolvesToContainingZone: false }
panel:  { dragging: true,  resolvesToContainingZone: true  }
```

A canvas drag is no longer live when its signature is read. `test.fail` stays, with that as its reason instead of the false one. The investigation is filed separately.

## Notes

The reader now takes the driver so the drag goes through `startDragAt`, which records the pointer every later `moveBy` is relative to. A bare `page.mouse` drag here would start correctly and then move from wherever the driver last thought the pointer was — a harness fault that reads as the canvas resolving the wrong target.

Test-only, so no changeset. `tsc --noEmit` clean; the full acceptance suite is **14 passed**.