### PR TITLE
feat(blocks-react): add the core/columns and core/column pair

### DIFF
--- a/.changeset/columns-block-pair.md
+++ b/.changeset/columns-block-pair.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A page can now be laid out in columns. `core/columns` and `core/column` ship as container presets: the row restricts its slot to columns, and a column declares the row as its only parent, so each column keeps an identity that can be selected, styled and dropped into. The row layout is an overridable default style rather than a rule in the renderer.

--- a/packages/blocks-react/src/blocks/box.tsx
+++ b/packages/blocks-react/src/blocks/box.tsx
@@ -14,7 +14,7 @@ import { defineBlock } from "@nextlyhq/blocks-engine";
 
 import type { PageContext } from "../context";
 
-import { renderContainer } from "./container";
+import { CONTAINER_SUPPORTS, renderContainer } from "./container";
 import type { ContainerProps } from "./container";
 
 // Defined against the ENGINE's `defineBlock`, not the plugin SDK's: the engine
@@ -38,15 +38,6 @@ export const box = defineBlock<ContainerProps, PageContext>({
   slots: {
     children: { template: [] },
   },
-  supports: {
-    spacing: true,
-    layout: true,
-    dimensions: true,
-    background: true,
-    border: true,
-    effects: true,
-    position: true,
-    container: true,
-  },
+  supports: CONTAINER_SUPPORTS,
   render: renderContainer,
 });

--- a/packages/blocks-react/src/blocks/column.tsx
+++ b/packages/blocks-react/src/blocks/column.tsx
@@ -12,19 +12,66 @@
  * second way to say the same thing, disagreeing with the first at whichever
  * breakpoint nobody checked. `container.tsx` makes the same call for padding.
  *
+ * **This module owns both halves' names and the column's own defaults**, so
+ * `columns.tsx` imports from here and never the reverse. A cycle between the
+ * two would be avoidable only by restating a value, which is the thing the
+ * arrangement exists to prevent.
+ *
  * @module blocks/library/column
  */
 import { defineBlock } from "@nextlyhq/blocks-engine";
 
 import type { PageContext } from "../context";
 
-import { COLUMNS_BLOCK } from "./columns";
 import { renderContainer } from "./container";
 import type { ContainerProps } from "./container";
 
+/** The block name a `core/columns` slot accepts, in one place. */
+export const COLUMN_BLOCK = "core/column";
+
+/** The block name a `core/column` may sit inside, in one place. */
+export const COLUMNS_BLOCK = "core/columns";
+
+/**
+ * The column's schema version, named so a row's slot template cannot drift
+ * from it. A template that seeds nodes at a version the block no longer
+ * declares makes row-seeded columns start in a different schema state from
+ * columns inserted directly, and nothing would report it.
+ */
+export const COLUMN_VERSION = 1;
+
+/** What a column starts as, wherever it is created from. */
+export const COLUMN_DEFAULT_PROPS: ContainerProps = {
+  as: "div",
+  contained: false,
+};
+
+/**
+ * The flex-item defaults a column needs to behave like one.
+ *
+ * Without these a column is an ordinary flex item: `flex: 0 1 auto` and
+ * `min-width: auto`. Empty seeded columns then collapse to nothing, populated
+ * ones size from their content rather than sharing the row, and a single long
+ * unbroken child forces the row to overflow. A row whose columns vanish on
+ * insert is not a usable default.
+ *
+ * `1 1 240px` grows and shrinks from a sensible basis; `minWidth: 0` is the
+ * flex-item override that lets a column shrink below its content, which is
+ * what stops the overflow. Both are `baseStyles` rather than rules in the
+ * renderer, so an author can override either — the same reason `columns.tsx`
+ * keeps the row's `display` overridable.
+ *
+ * These values match `plugin-page-builder`'s existing column implementation
+ * deliberately: two behaviours for one block is the divergence this program
+ * keeps producing.
+ */
+export const COLUMN_BASE_STYLES = {
+  base: { base: { flex: "1 1 240px", minWidth: 0 } },
+} as const;
+
 export const column = defineBlock<ContainerProps, PageContext>({
-  name: "core/column",
-  version: 1,
+  name: COLUMN_BLOCK,
+  version: COLUMN_VERSION,
   description:
     "One column of a core/columns row. A container with an identity, so it can be selected, styled and dropped into.",
   props: {
@@ -35,7 +82,7 @@ export const column = defineBlock<ContainerProps, PageContext>({
     as: { type: "select", options: ["div"] },
     contained: { type: "checkbox" },
   },
-  defaultProps: { as: "div", contained: false },
+  defaultProps: COLUMN_DEFAULT_PROPS,
   example: { props: { as: "div" } },
   /**
    * The CHILD half of the nesting rule, stated here rather than inferred from
@@ -53,6 +100,7 @@ export const column = defineBlock<ContainerProps, PageContext>({
   slots: {
     children: { template: [] },
   },
+  baseStyles: COLUMN_BASE_STYLES,
   supports: {
     spacing: true,
     layout: true,

--- a/packages/blocks-react/src/blocks/column.tsx
+++ b/packages/blocks-react/src/blocks/column.tsx
@@ -47,34 +47,28 @@ export const COLUMN_DEFAULT_PROPS: ContainerProps = {
 };
 
 /**
- * ⚠ A COLUMN SHIPS NO DEFAULT LAYOUT, and it is not for want of trying.
+ * What a column needs to stop its content forcing the row wider.
  *
- * A column wants flex-item defaults — `flex: 1 1 240px` and `min-width: 0`, as
- * `plugin-page-builder/src/render/blocks/column.tsx` supplies — because an
- * ordinary flex item keeps `flex: 0 1 auto` and `min-width: auto`, so an empty
- * column collapses and a long unbroken child overflows the row.
+ * A grid item defaults to `min-width: auto`, which floors its track at the
+ * widest unbreakable content — one long URL then pushes the whole row into
+ * horizontal overflow. `min-width: 0` lets the track shrink as the row asks.
  *
- * **There is no mechanism to deliver them.** Measured on this package:
- * `baseStyles` is declared on `BlockDefinition` (`block.ts:211`) and read by
- * NOTHING — zero non-test consumers anywhere in the repository — and
- * `blocks-react` ships no stylesheet of its own (confirmed against
- * `plugin-page-builder`, which does, so the search was capable of finding one).
- * A `baseStyles` declaration here would compile to nothing and render as
- * nothing, while reading in review as a working default.
+ * **Sizing lives on the ROW, not here.** `columns.tsx` uses
+ * `grid-template-columns`, so equal sizing is a property of the track list and
+ * each column needs no width of its own. That also keeps the pair honest about
+ * differing in relationships rather than capabilities: a column declares no
+ * dimension a box could not.
  *
- * Shipping one anyway would add another capability that reaches nothing, which
- * is the pattern this package already carries seven instances of. So the pair
- * ships what it can actually deliver — identity, the nesting rule and the
- * template — and the author styles the row through the inspector until block
- * default styles have a delivery path.
- *
- * Note also that the catalog has flex CONTAINER properties (`flexDirection`,
- * `flexWrap`, `justifyContent`, `alignItems`, `gap`) and **no flex ITEM
- * properties at all** — no `flex`, `flexGrow`, `flexShrink` or `flexBasis`.
- * So wiring `baseStyles` alone would not be enough; the catalog needs the
- * properties too, or the row has to size its children with
- * `gridTemplateColumns`, which the catalog does support.
+ * Every property here is in `STYLE_CATALOG`. The compiler REJECTS unknown
+ * properties rather than passing them through, so a declaration naming one is
+ * silently dropped — and the catalog has flex CONTAINER properties but **no
+ * flex ITEM properties at all** (no `flex`, `flexGrow`, `flexShrink`,
+ * `flexBasis`), which is why this is a grid rather than the flex layout the
+ * PoC column uses.
  */
+export const COLUMN_BASE_STYLES = {
+  base: { base: { minWidth: 0 } },
+} as const;
 
 export const column = defineBlock<ContainerProps, PageContext>({
   name: COLUMN_BLOCK,
@@ -107,6 +101,7 @@ export const column = defineBlock<ContainerProps, PageContext>({
   slots: {
     children: { template: [] },
   },
+  baseStyles: COLUMN_BASE_STYLES,
   supports: CONTAINER_SUPPORTS,
   render: renderContainer,
 });

--- a/packages/blocks-react/src/blocks/column.tsx
+++ b/packages/blocks-react/src/blocks/column.tsx
@@ -1,0 +1,67 @@
+/**
+ * `core/column` — one column of a row.
+ *
+ * A preset over the same implementation `core/box` uses, and the child half of
+ * the only nesting rule in the catalogue. It exists to give a column an
+ * IDENTITY — a node id, and therefore a scoped class, a selection target and a
+ * drop target — not to give it a capability a box lacks. See `columns.tsx` for
+ * why that distinction is the one Elementor V3 got wrong.
+ *
+ * **It carries no width prop, deliberately.** Width is a style, and the style
+ * catalog already expresses it per breakpoint; a `width` prop would be a
+ * second way to say the same thing, disagreeing with the first at whichever
+ * breakpoint nobody checked. `container.tsx` makes the same call for padding.
+ *
+ * @module blocks/library/column
+ */
+import { defineBlock } from "@nextlyhq/blocks-engine";
+
+import type { PageContext } from "../context";
+
+import { COLUMNS_BLOCK } from "./columns";
+import { renderContainer } from "./container";
+import type { ContainerProps } from "./container";
+
+export const column = defineBlock<ContainerProps, PageContext>({
+  name: "core/column",
+  version: 1,
+  description:
+    "One column of a core/columns row. A container with an identity, so it can be selected, styled and dropped into.",
+  props: {
+    // Narrower than a box's list: a column is a layout child, and `aside` or
+    // `article` inside a row is nearly always a mistake the author meant to
+    // make one level up. Anything genuinely semantic belongs in the column
+    // rather than as the column.
+    as: { type: "select", options: ["div"] },
+    contained: { type: "checkbox" },
+  },
+  defaultProps: { as: "div", contained: false },
+  example: { props: { as: "div" } },
+  /**
+   * The CHILD half of the nesting rule, stated here rather than inferred from
+   * `core/columns`' allow-list.
+   *
+   * `block.ts` is explicit that neither half implies the other, and this is the
+   * direction that matters for the editor: without it a column is insertable
+   * anywhere, and an author who drops one onto the page root gets a container
+   * that looks like a box, is styled like a box, and is silently governed by a
+   * row that is not there.
+   */
+  parent: [COLUMNS_BLOCK],
+  // An unrestricted slot: a column holds anything a page holds. The row
+  // restricts what may be a COLUMN; it says nothing about what a column holds.
+  slots: {
+    children: { template: [] },
+  },
+  supports: {
+    spacing: true,
+    layout: true,
+    dimensions: true,
+    background: true,
+    border: true,
+    effects: true,
+    position: true,
+    container: true,
+  },
+  render: renderContainer,
+});

--- a/packages/blocks-react/src/blocks/column.tsx
+++ b/packages/blocks-react/src/blocks/column.tsx
@@ -23,7 +23,7 @@ import { defineBlock } from "@nextlyhq/blocks-engine";
 
 import type { PageContext } from "../context";
 
-import { renderContainer } from "./container";
+import { CONTAINER_SUPPORTS, renderContainer } from "./container";
 import type { ContainerProps } from "./container";
 
 /** The block name a `core/columns` slot accepts, in one place. */
@@ -47,27 +47,34 @@ export const COLUMN_DEFAULT_PROPS: ContainerProps = {
 };
 
 /**
- * The flex-item defaults a column needs to behave like one.
+ * ⚠ A COLUMN SHIPS NO DEFAULT LAYOUT, and it is not for want of trying.
  *
- * Without these a column is an ordinary flex item: `flex: 0 1 auto` and
- * `min-width: auto`. Empty seeded columns then collapse to nothing, populated
- * ones size from their content rather than sharing the row, and a single long
- * unbroken child forces the row to overflow. A row whose columns vanish on
- * insert is not a usable default.
+ * A column wants flex-item defaults — `flex: 1 1 240px` and `min-width: 0`, as
+ * `plugin-page-builder/src/render/blocks/column.tsx` supplies — because an
+ * ordinary flex item keeps `flex: 0 1 auto` and `min-width: auto`, so an empty
+ * column collapses and a long unbroken child overflows the row.
  *
- * `1 1 240px` grows and shrinks from a sensible basis; `minWidth: 0` is the
- * flex-item override that lets a column shrink below its content, which is
- * what stops the overflow. Both are `baseStyles` rather than rules in the
- * renderer, so an author can override either — the same reason `columns.tsx`
- * keeps the row's `display` overridable.
+ * **There is no mechanism to deliver them.** Measured on this package:
+ * `baseStyles` is declared on `BlockDefinition` (`block.ts:211`) and read by
+ * NOTHING — zero non-test consumers anywhere in the repository — and
+ * `blocks-react` ships no stylesheet of its own (confirmed against
+ * `plugin-page-builder`, which does, so the search was capable of finding one).
+ * A `baseStyles` declaration here would compile to nothing and render as
+ * nothing, while reading in review as a working default.
  *
- * These values match `plugin-page-builder`'s existing column implementation
- * deliberately: two behaviours for one block is the divergence this program
- * keeps producing.
+ * Shipping one anyway would add another capability that reaches nothing, which
+ * is the pattern this package already carries seven instances of. So the pair
+ * ships what it can actually deliver — identity, the nesting rule and the
+ * template — and the author styles the row through the inspector until block
+ * default styles have a delivery path.
+ *
+ * Note also that the catalog has flex CONTAINER properties (`flexDirection`,
+ * `flexWrap`, `justifyContent`, `alignItems`, `gap`) and **no flex ITEM
+ * properties at all** — no `flex`, `flexGrow`, `flexShrink` or `flexBasis`.
+ * So wiring `baseStyles` alone would not be enough; the catalog needs the
+ * properties too, or the row has to size its children with
+ * `gridTemplateColumns`, which the catalog does support.
  */
-export const COLUMN_BASE_STYLES = {
-  base: { base: { flex: "1 1 240px", minWidth: 0 } },
-} as const;
 
 export const column = defineBlock<ContainerProps, PageContext>({
   name: COLUMN_BLOCK,
@@ -100,16 +107,6 @@ export const column = defineBlock<ContainerProps, PageContext>({
   slots: {
     children: { template: [] },
   },
-  baseStyles: COLUMN_BASE_STYLES,
-  supports: {
-    spacing: true,
-    layout: true,
-    dimensions: true,
-    background: true,
-    border: true,
-    effects: true,
-    position: true,
-    container: true,
-  },
+  supports: CONTAINER_SUPPORTS,
   render: renderContainer,
 });

--- a/packages/blocks-react/src/blocks/column.tsx
+++ b/packages/blocks-react/src/blocks/column.tsx
@@ -7,10 +7,11 @@
  * drop target — not to give it a capability a box lacks. See `columns.tsx` for
  * why that distinction is the one Elementor V3 got wrong.
  *
- * **It carries no width prop, deliberately.** Width is a style, and the style
- * catalog already expresses it per breakpoint; a `width` prop would be a
- * second way to say the same thing, disagreeing with the first at whichever
- * breakpoint nobody checked. `container.tsx` makes the same call for padding.
+ * **It carries no width prop, and a width STYLE will not widen it either.**
+ * The row is a grid, so its track list allocates the width; a `width` here
+ * resizes the item inside its track and leaves the track unchanged. Unequal
+ * columns are made by editing the ROW's `grid-template-columns` (e.g. `7fr
+ * 3fr`). Worth knowing because the opposite is the natural assumption.
  *
  * **This module owns both halves' names and the column's own defaults**, so
  * `columns.tsx` imports from here and never the reverse. A cycle between the

--- a/packages/blocks-react/src/blocks/columns.test.tsx
+++ b/packages/blocks-react/src/blocks/columns.test.tsx
@@ -125,7 +125,7 @@ describe("the columns pair", () => {
       // The track list is what makes columns share the row. Asserting only
       // `display:grid` passes on a grid with one implicit column, which looks
       // identical to the stacked <div>s this block exists to replace.
-      expect(css).toContain("minmax(240px, 1fr)");
+      expect(css).toContain("minmax(min(240px, 100%), 1fr)");
     });
 
     it("emits the column's min-width so a long child cannot force overflow", () => {

--- a/packages/blocks-react/src/blocks/columns.test.tsx
+++ b/packages/blocks-react/src/blocks/columns.test.tsx
@@ -7,10 +7,14 @@
  * SEPARATE this pair from a box are the nesting rule's two halves and the
  * identity the template gives each column, so those are what is asserted.
  */
+import type { BlockDocument } from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
 
+import type { BlockResolver } from "../resolver";
+import { resolvePageStyles } from "../styles";
+
 import { column, COLUMN_BLOCK, COLUMNS_BLOCK } from "./column";
-import { columns, TEMPLATE_PLACEHOLDER_ID } from "./columns";
+import { columns, INITIAL_COLUMNS } from "./columns";
 import { box } from "./box";
 import { coreBlocks } from "./index";
 import { section } from "./section";
@@ -40,71 +44,95 @@ describe("the columns pair", () => {
   });
 
   describe("the template", () => {
-    it("starts a row with two columns, each of the column type", () => {
-      const seeded = columns.slots?.children.template ?? [];
-
-      expect(seeded).toHaveLength(2);
-      expect(seeded.map(node => node.type)).toEqual([
-        COLUMN_BLOCK,
-        COLUMN_BLOCK,
-      ]);
+    it("is EMPTY, because nothing can mint per-instance ids yet", () => {
+      // A seeded template needs its ids minted per INSTANCE: two rows expanded
+      // from one literal template carry the same node ids, and the engine
+      // reports `duplicate-node-id` on the second. Nothing reads
+      // `SlotSpec.template`, so no expansion path exists to do that minting.
+      //
+      // Naming the ids "placeholders" was the first attempt and changed no
+      // behaviour — the collision is a property of the nodes, not of what they
+      // are called. Empty makes it unreachable.
+      //
+      // A RATCHET: whoever adds an expander fails this test and has to seed
+      // the row deliberately, with per-instance ids, rather than inheriting
+      // literal ones that were only ever safe because nothing read them.
+      expect(columns.slots?.children.template).toEqual([]);
     });
 
-    it("gives each seeded column a DISTINCT id", () => {
-      // The whole reason the pair exists. Identical ids would collapse both
-      // columns onto one scoped CSS class, so styling one would style both —
-      // the anonymous-flex-child problem with extra steps, and invisible to a
-      // test that only counted the children.
-      const ids = (columns.slots?.children.template ?? []).map(node => node.id);
-
-      expect(new Set(ids).size).toBe(ids.length);
-    });
-
-    it("marks every seeded id as a PLACEHOLDER", () => {
-      // A template describes what to create, not a thing that exists. Two rows
-      // on one page seeded from the same literal ids collide, and the engine
-      // reports `duplicate-node-id` on the second — so an expansion path must
-      // mint a fresh id per node per instance. Asserting the prefix is what
-      // lets a future consumer assert these never reach a stored document.
-      for (const node of columns.slots?.children.template ?? []) {
-        expect(node.id.startsWith(TEMPLATE_PLACEHOLDER_ID)).toBe(true);
-      }
-    });
-
-    it("seeds columns at the version the column block DECLARES", () => {
-      // Restating the version here would let a row seed columns in a schema
-      // state the block no longer declares, so a row-seeded column and a
-      // directly-inserted one would start differently with nothing reporting
-      // it. Asserting equality against the definition is what couples them.
-      for (const node of columns.slots?.children.template ?? []) {
-        expect(node.version).toBe(column.version);
-      }
-    });
-
-    it("seeds columns with the column block's OWN defaults", () => {
-      // Same divergence one field over. `defaultProps` is the single
-      // declaration; the template must not carry a second copy of it.
-      for (const node of columns.slots?.children.template ?? []) {
-        expect(node.props).toEqual(column.defaultProps);
-      }
+    it("still records how many columns a fresh row wants", () => {
+      // The default did not stop being true; it moved to the layer that can
+      // implement it. Losing the number would make the expander re-derive it.
+      expect(INITIAL_COLUMNS).toBe(2);
     });
   });
 
-  describe("no dead default styles", () => {
-    it("declares no baseStyles, because nothing would deliver them", () => {
-      // `baseStyles` is declared on `BlockDefinition` and read by NOTHING —
-      // zero non-test consumers in the repository — and `blocks-react` ships
-      // no stylesheet. A declaration here would compile to nothing and render
-      // as nothing while reading in review as a working default, which is the
-      // capability-that-reaches-nothing shape this package already carries
-      // seven instances of.
+  describe("the default layout REACHES the compiled stylesheet", () => {
+    // Asserting `baseStyles` as an object proves only that a declaration was
+    // written. The compiler REJECTS properties absent from `STYLE_CATALOG`
+    // rather than passing them through, so a declaration naming one compiles
+    // to nothing while the object assertion stays green — which is exactly
+    // how an unsupported `flex` shipped here and had to be withdrawn. These
+    // assert the emitted CSS.
+    function compiledCss(): string {
+      const doc: BlockDocument = {
+        formatVersion: 1,
+        kind: "page",
+        nodes: [
+          {
+            id: "row",
+            type: COLUMNS_BLOCK,
+            version: 1,
+            props: {},
+            slots: {
+              children: [
+                { id: "c1", type: COLUMN_BLOCK, version: 1, props: {} },
+              ],
+            },
+          },
+        ],
+      };
+      const resolver: BlockResolver = {
+        get: (name: string) =>
+          coreBlocks.find(block => block.name === name) as never,
+      };
+      // A context is REQUIRED: `resolvePageStyles` compiles only under
+      // `if (styleContext)`, and returns empty css otherwise — which is how
+      // the first version of this test reported a working default as missing.
       //
-      // This assertion is a RATCHET, not a preference: when a delivery path
-      // exists, this test fails and forces whoever adds it to state the
-      // default deliberately rather than reviving a declaration that was dead
-      // when it was written.
-      expect(columns.baseStyles).toBeUndefined();
-      expect(column.baseStyles).toBeUndefined();
+      // `blockBases` is deliberately OMITTED so `blockBasesFor` derives it
+      // from the definitions. Supplying it would hand the compiler the answer
+      // and assert this file's own literal instead of the block's declaration.
+      return (
+        resolvePageStyles(
+          doc,
+          undefined,
+          {
+            breakpoints: {
+              viewport: [{ id: "base", label: "Desktop" }],
+              container: [],
+            },
+          },
+          resolver
+        ).css ?? ""
+      );
+    }
+
+    it("emits the row as a grid with equal, wrapping tracks", () => {
+      const css = compiledCss();
+
+      expect(css).toContain("display: grid");
+      // The track list is what makes columns share the row. Asserting only
+      // `display:grid` passes on a grid with one implicit column, which looks
+      // identical to the stacked <div>s this block exists to replace.
+      expect(css).toContain("minmax(240px, 1fr)");
+    });
+
+    it("emits the column's min-width so a long child cannot force overflow", () => {
+      // Separate from the row assertion because it is a different node type
+      // and a different failure: the row can size correctly while one
+      // unbreakable child still pushes the page sideways.
+      expect(compiledCss()).toContain("min-width: 0");
     });
   });
 

--- a/packages/blocks-react/src/blocks/columns.test.tsx
+++ b/packages/blocks-react/src/blocks/columns.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * What makes `core/columns` and `core/column` worth being two blocks.
+ *
+ * Rendering proves nothing here: both delegate to `renderContainer`, so a test
+ * that asserts they produce a `div` passes just as well on a `core/box` and
+ * would keep passing if the pair were deleted and aliased. The properties that
+ * SEPARATE this pair from a box are the nesting rule's two halves and the
+ * identity the template gives each column, so those are what is asserted.
+ */
+import { describe, expect, it } from "vitest";
+
+import { coreBlocks } from "./index";
+import { column } from "./column";
+import { columns, COLUMN_BLOCK, COLUMNS_BLOCK } from "./columns";
+
+describe("the columns pair", () => {
+  describe("the nesting rule, both halves", () => {
+    it("restricts the row's slot to columns only", () => {
+      // The PARENT half. Without it a row accepts any block and the column is
+      // decoration; `canDrop`'s not-allowed-in-slot reason also becomes
+      // unreachable, which is how it went untested before #795.
+      expect(columns.slots?.children.allow).toEqual([COLUMN_BLOCK]);
+    });
+
+    it("confines a column to a row", () => {
+      // The CHILD half, and the one the editor needs. `block.ts` is explicit
+      // that neither half implies the other, so asserting only the allow-list
+      // would leave a column insertable at the page root — a container that
+      // looks like a box and is governed by a row that is not there.
+      expect(column.parent).toEqual([COLUMNS_BLOCK]);
+    });
+
+    it("does NOT restrict what a column may hold", () => {
+      // A row says what may be a COLUMN. It says nothing about what a column
+      // holds, and confusing the two would make the pair useless for layout.
+      expect(column.slots?.children.allow).toBeUndefined();
+    });
+  });
+
+  describe("the template", () => {
+    it("starts a row with two columns, each of the column type", () => {
+      const seeded = columns.slots?.children.template ?? [];
+
+      expect(seeded).toHaveLength(2);
+      expect(seeded.map(node => node.type)).toEqual([
+        COLUMN_BLOCK,
+        COLUMN_BLOCK,
+      ]);
+    });
+
+    it("gives each seeded column a DISTINCT id", () => {
+      // The whole reason the pair exists. Identical ids would collapse both
+      // columns onto one scoped CSS class, so styling one would style both —
+      // the anonymous-flex-child problem with extra steps, and invisible to a
+      // test that only counted the children.
+      const ids = (columns.slots?.children.template ?? []).map(node => node.id);
+
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it("gives each seeded column a STABLE id across expansions", () => {
+      // A template is expanded on read as well as on insert, and the id drives
+      // the scoped class. A non-deterministic id renders differently on the
+      // server and the client, so the page hydrates with the two disagreeing
+      // about which rules apply. `normalizeLegacySlots` shipped exactly this
+      // defect with `crypto.randomUUID()`.
+      const first = (columns.slots?.children.template ?? []).map(n => n.id);
+      const second = (columns.slots?.children.template ?? []).map(n => n.id);
+
+      expect(second).toEqual(first);
+    });
+  });
+
+  describe("registration", () => {
+    it("ships both halves, because one without the other is broken", () => {
+      // A row whose column type is unregistered cannot expand its own
+      // template; a column with no row can never be legally placed. Shipping
+      // either alone is worse than shipping neither.
+      const names = coreBlocks.map(block => block.name);
+
+      expect(names).toContain(COLUMNS_BLOCK);
+      expect(names).toContain(COLUMN_BLOCK);
+    });
+
+    it("names the row's allowed type as a type that actually exists", () => {
+      // An allow-list naming a block nobody registered refuses everything, and
+      // reads in review exactly like one that works.
+      const names = coreBlocks.map(block => block.name);
+
+      for (const allowed of columns.slots?.children.allow ?? []) {
+        expect(names).toContain(allowed);
+      }
+    });
+  });
+
+  describe("layout is a default, not a rule", () => {
+    it("carries the row layout as overridable baseStyles", () => {
+      // `container.tsx` establishes that display is a style rather than a
+      // block. A hardcoded row in the renderer would be the Elementor V4
+      // padding complaint again: a default every project starts by removing.
+      expect(columns.baseStyles?.base?.base).toEqual({ display: "flex" });
+    });
+
+    it("shares the container implementation rather than forking it", () => {
+      // The pair must differ from a box in RELATIONSHIPS, never in
+      // capabilities — that is the Elementor V3 Section/Column failure
+      // `container.tsx` cites. Two blocks pointing at one render function is
+      // what keeps that true.
+      expect(column.render).toBe(columns.render);
+    });
+  });
+});

--- a/packages/blocks-react/src/blocks/columns.test.tsx
+++ b/packages/blocks-react/src/blocks/columns.test.tsx
@@ -11,7 +11,9 @@ import { describe, expect, it } from "vitest";
 
 import { column, COLUMN_BLOCK, COLUMNS_BLOCK } from "./column";
 import { columns, TEMPLATE_PLACEHOLDER_ID } from "./columns";
+import { box } from "./box";
 import { coreBlocks } from "./index";
+import { section } from "./section";
 
 describe("the columns pair", () => {
   describe("the nesting rule, both halves", () => {
@@ -88,19 +90,21 @@ describe("the columns pair", () => {
     });
   });
 
-  describe("a column behaves like a flex item", () => {
-    it("can grow, shrink, and shrink BELOW its content", () => {
-      // Without these a column is an ordinary flex item — `flex: 0 1 auto`
-      // and `min-width: auto` — so an empty seeded column collapses to
-      // nothing, a populated one sizes from content instead of sharing the
-      // row, and one long unbroken child overflows the row. A row whose
-      // columns vanish on insert is not a usable default.
+  describe("no dead default styles", () => {
+    it("declares no baseStyles, because nothing would deliver them", () => {
+      // `baseStyles` is declared on `BlockDefinition` and read by NOTHING —
+      // zero non-test consumers in the repository — and `blocks-react` ships
+      // no stylesheet. A declaration here would compile to nothing and render
+      // as nothing while reading in review as a working default, which is the
+      // capability-that-reaches-nothing shape this package already carries
+      // seven instances of.
       //
-      // `minWidth: 0` is asserted separately from `flex` because it is the
-      // part that stops the overflow, and a fix that dropped only it would
-      // leave the visible defect intact while the flex assertion stayed green.
-      expect(column.baseStyles?.base?.base?.flex).toBe("1 1 240px");
-      expect(column.baseStyles?.base?.base?.minWidth).toBe(0);
+      // This assertion is a RATCHET, not a preference: when a delivery path
+      // exists, this test fails and forces whoever adds it to state the
+      // default deliberately rather than reviving a declaration that was dead
+      // when it was written.
+      expect(columns.baseStyles).toBeUndefined();
+      expect(column.baseStyles).toBeUndefined();
     });
   });
 
@@ -126,12 +130,17 @@ describe("the columns pair", () => {
     });
   });
 
-  describe("layout is a default, not a rule", () => {
-    it("carries the row layout as overridable baseStyles", () => {
-      // `container.tsx` establishes that display is a style rather than a
-      // block. A hardcoded row in the renderer would be the Elementor V4
-      // padding complaint again: a default every project starts by removing.
-      expect(columns.baseStyles?.base?.base).toEqual({ display: "flex" });
+  describe("relationships, never capabilities", () => {
+    it("shares ONE support declaration with every container preset", () => {
+      // The pair promises to differ from a box in relationships, never in
+      // capabilities. Four parallel supports lists would let a later addition
+      // reach some presets and not others, silently giving one container
+      // different editor controls from the rest — and each list would read as
+      // correct on its own. Asserting identity against `box` is what couples
+      // them; asserting the VALUES would pass on four copies that agree today.
+      expect(columns.supports).toBe(box.supports);
+      expect(column.supports).toBe(box.supports);
+      expect(section.supports).toBe(box.supports);
     });
 
     it("shares the container implementation rather than forking it", () => {

--- a/packages/blocks-react/src/blocks/columns.test.tsx
+++ b/packages/blocks-react/src/blocks/columns.test.tsx
@@ -9,9 +9,9 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { column, COLUMN_BLOCK, COLUMNS_BLOCK } from "./column";
+import { columns, TEMPLATE_PLACEHOLDER_ID } from "./columns";
 import { coreBlocks } from "./index";
-import { column } from "./column";
-import { columns, COLUMN_BLOCK, COLUMNS_BLOCK } from "./columns";
 
 describe("the columns pair", () => {
   describe("the nesting rule, both halves", () => {
@@ -58,16 +58,49 @@ describe("the columns pair", () => {
       expect(new Set(ids).size).toBe(ids.length);
     });
 
-    it("gives each seeded column a STABLE id across expansions", () => {
-      // A template is expanded on read as well as on insert, and the id drives
-      // the scoped class. A non-deterministic id renders differently on the
-      // server and the client, so the page hydrates with the two disagreeing
-      // about which rules apply. `normalizeLegacySlots` shipped exactly this
-      // defect with `crypto.randomUUID()`.
-      const first = (columns.slots?.children.template ?? []).map(n => n.id);
-      const second = (columns.slots?.children.template ?? []).map(n => n.id);
+    it("marks every seeded id as a PLACEHOLDER", () => {
+      // A template describes what to create, not a thing that exists. Two rows
+      // on one page seeded from the same literal ids collide, and the engine
+      // reports `duplicate-node-id` on the second — so an expansion path must
+      // mint a fresh id per node per instance. Asserting the prefix is what
+      // lets a future consumer assert these never reach a stored document.
+      for (const node of columns.slots?.children.template ?? []) {
+        expect(node.id.startsWith(TEMPLATE_PLACEHOLDER_ID)).toBe(true);
+      }
+    });
 
-      expect(second).toEqual(first);
+    it("seeds columns at the version the column block DECLARES", () => {
+      // Restating the version here would let a row seed columns in a schema
+      // state the block no longer declares, so a row-seeded column and a
+      // directly-inserted one would start differently with nothing reporting
+      // it. Asserting equality against the definition is what couples them.
+      for (const node of columns.slots?.children.template ?? []) {
+        expect(node.version).toBe(column.version);
+      }
+    });
+
+    it("seeds columns with the column block's OWN defaults", () => {
+      // Same divergence one field over. `defaultProps` is the single
+      // declaration; the template must not carry a second copy of it.
+      for (const node of columns.slots?.children.template ?? []) {
+        expect(node.props).toEqual(column.defaultProps);
+      }
+    });
+  });
+
+  describe("a column behaves like a flex item", () => {
+    it("can grow, shrink, and shrink BELOW its content", () => {
+      // Without these a column is an ordinary flex item — `flex: 0 1 auto`
+      // and `min-width: auto` — so an empty seeded column collapses to
+      // nothing, a populated one sizes from content instead of sharing the
+      // row, and one long unbroken child overflows the row. A row whose
+      // columns vanish on insert is not a usable default.
+      //
+      // `minWidth: 0` is asserted separately from `flex` because it is the
+      // part that stops the overflow, and a fix that dropped only it would
+      // leave the visible defect intact while the flex assertion stayed green.
+      expect(column.baseStyles?.base?.base?.flex).toBe("1 1 240px");
+      expect(column.baseStyles?.base?.base?.minWidth).toBe(0);
     });
   });
 

--- a/packages/blocks-react/src/blocks/columns.tsx
+++ b/packages/blocks-react/src/blocks/columns.tsx
@@ -21,11 +21,12 @@
  * `core/column` declares `parent: ["core/columns"]`, which is the arrangement
  * `block.ts` names when it documents this field.
  *
- * **The layout is `baseStyles`, not a hardcode.** `container.tsx` establishes
- * that display is a style rather than a block, and a default that cannot be
- * overridden is the Elementor V4 padding complaint in another costume. A row
- * that an author restyles into a stack at one breakpoint is still a row of
- * columns, and nothing here has to know.
+ * **The row ships NO default layout**, and `column.tsx` documents why at
+ * length: block-level default styles have no delivery mechanism in this
+ * package. An author sets the row's display through the inspector. When that
+ * gap closes, the row is where `display` belongs — as an overridable default,
+ * never a rule in the renderer, because a default nobody can override is the
+ * Elementor V4 padding complaint in another costume.
  *
  * @module blocks/library/columns
  */
@@ -40,7 +41,7 @@ import {
   COLUMN_VERSION,
   COLUMNS_BLOCK,
 } from "./column";
-import { renderContainer } from "./container";
+import { CONTAINER_SUPPORTS, renderContainer } from "./container";
 import type { ContainerProps } from "./container";
 
 export { COLUMN_BLOCK, COLUMNS_BLOCK } from "./column";
@@ -114,19 +115,6 @@ export const columns = defineBlock<ContainerProps, PageContext>({
       ),
     },
   },
-  // The row layout, as an overridable default rather than a rule in the
-  // renderer. This is what `baseStyles` is for, and a row is its first real
-  // consumer.
-  baseStyles: { base: { base: { display: "flex" } } },
-  supports: {
-    spacing: true,
-    layout: true,
-    dimensions: true,
-    background: true,
-    border: true,
-    effects: true,
-    position: true,
-    container: true,
-  },
+  supports: CONTAINER_SUPPORTS,
   render: renderContainer,
 });

--- a/packages/blocks-react/src/blocks/columns.tsx
+++ b/packages/blocks-react/src/blocks/columns.tsx
@@ -1,0 +1,116 @@
+/**
+ * `core/columns` — a row of columns, and the only block that restricts its slot.
+ *
+ * A preset over the same implementation `core/section` and `core/box` use. It
+ * differs from a box in exactly two ways, and both are relationships rather
+ * than capabilities: it starts laid out as a row, and its slot accepts only
+ * `core/column`. Nothing it can be told to do is unavailable to a box.
+ *
+ * **Why a pair of blocks rather than a box with a flex display.** The pair is
+ * what makes each column ADDRESSABLE. An anonymous flex child created by the
+ * row's own renderer has no node id, so it has no scoped class, so it cannot
+ * be selected, styled, targeted by a drop, or named in a rule — and the author
+ * who wants one column wider than another has nowhere to put that. Giving the
+ * child a block name buys identity; it deliberately buys nothing else.
+ *
+ * That is the distinction `container.tsx` draws when it rejects Elementor V3's
+ * Section/Column: what broke live sites there was columns with CAPABILITIES a
+ * div lacked, so a migration had to rewrite structure. Here a column is a
+ * container preset, and the only thing a box cannot do is be a column's
+ * identity. Gutenberg reaches the same split for the same reason — its
+ * `core/column` declares `parent: ["core/columns"]`, which is the arrangement
+ * `block.ts` names when it documents this field.
+ *
+ * **The layout is `baseStyles`, not a hardcode.** `container.tsx` establishes
+ * that display is a style rather than a block, and a default that cannot be
+ * overridden is the Elementor V4 padding complaint in another costume. A row
+ * that an author restyles into a stack at one breakpoint is still a row of
+ * columns, and nothing here has to know.
+ *
+ * @module blocks/library/columns
+ */
+import type { BlockNode } from "@nextlyhq/blocks-engine";
+import { defineBlock } from "@nextlyhq/blocks-engine";
+
+import type { PageContext } from "../context";
+
+import { renderContainer } from "./container";
+import type { ContainerProps } from "./container";
+
+/** The block name a `core/columns` slot accepts, in one place. */
+export const COLUMN_BLOCK = "core/column";
+
+/** The block name a `core/column` may sit inside, in one place. */
+export const COLUMNS_BLOCK = "core/columns";
+
+/**
+ * How many columns a freshly placed row starts with.
+ *
+ * Two rather than one, because a row of one is a box and an author who wanted
+ * a box would have reached for one; and rather than three, because removing a
+ * column is a click and adding one is a decision.
+ */
+const INITIAL_COLUMNS = 2;
+
+/**
+ * A column node for the initial template, distinct per index.
+ *
+ * Returns `BlockNode` rather than a shape typed by `ContainerProps`: a stored
+ * node's props are an open record, and `ContainerProps` is a named interface,
+ * which TypeScript will not treat as one. The literal below is checked against
+ * the block's own prop names by `column.tsx`'s schema at validation time —
+ * which is the layer that owns that question — rather than by a cast here.
+ */
+function templateColumn(index: number): BlockNode {
+  return {
+    // Deterministic, because a template is expanded on READ as well as on
+    // insert. A random id here would differ between the server and the client
+    // render of the same stored document, and the id drives the scoped CSS
+    // class — so the two would disagree about which rules apply and the page
+    // would hydrate mismatched. `normalizeLegacySlots` learned this the
+    // expensive way with `crypto.randomUUID()`.
+    id: `core-columns-template-${index}`,
+    type: COLUMN_BLOCK,
+    version: 1,
+    props: { as: "div", contained: false },
+  };
+}
+
+export const columns = defineBlock<ContainerProps, PageContext>({
+  name: COLUMNS_BLOCK,
+  version: 1,
+  description:
+    "A row of columns. Restricts its slot to core/column so each column keeps an identity that can be selected and styled.",
+  props: {
+    as: { type: "select", options: ["div", "section", "article"] },
+    contained: { type: "checkbox" },
+  },
+  defaultProps: { as: "div", contained: false },
+  example: { props: { as: "div" } },
+  // The parent half of the nesting rule. `block.ts` is explicit that this does
+  // NOT imply the child half: a slot naming a type must not confine that type
+  // to it. `core/column` states its own side in `column.tsx`.
+  slots: {
+    children: {
+      allow: [COLUMN_BLOCK],
+      template: Array.from({ length: INITIAL_COLUMNS }, (_, i) =>
+        templateColumn(i)
+      ),
+    },
+  },
+  // The row layout, as an overridable default rather than a rule in the
+  // renderer. This is what `baseStyles` is for, and a row is its first real
+  // consumer.
+  baseStyles: { base: { base: { display: "flex" } } },
+  supports: {
+    spacing: true,
+    layout: true,
+    dimensions: true,
+    background: true,
+    border: true,
+    effects: true,
+    position: true,
+    container: true,
+  },
+  render: renderContainer,
+});

--- a/packages/blocks-react/src/blocks/columns.tsx
+++ b/packages/blocks-react/src/blocks/columns.tsx
@@ -7,11 +7,18 @@
  * `core/column`. Nothing it can be told to do is unavailable to a box.
  *
  * **Why a pair of blocks rather than a box with a flex display.** The pair is
- * what makes each column ADDRESSABLE. An anonymous flex child created by the
- * row's own renderer has no node id, so it has no scoped class, so it cannot
- * be selected, styled, targeted by a drop, or named in a rule — and the author
- * who wants one column wider than another has nowhere to put that. Giving the
- * child a block name buys identity; it deliberately buys nothing else.
+ * what makes each column ADDRESSABLE. An anonymous child created by the row's
+ * own renderer has no node id, so it has no scoped class, so it cannot be
+ * selected, styled, targeted by a drop, or named in a rule. Giving the child a
+ * block name buys identity; it deliberately buys nothing else.
+ *
+ * **Unequal columns are set on the ROW, not on a column.** In a grid the track
+ * list allocates the width, so a `width` style on a column resizes the ITEM
+ * inside its track and leaves the track alone — it cannot produce a 70/30
+ * layout. An author makes one column wider by editing this row's
+ * `grid-template-columns` (a catalog property this block supports through
+ * `layout`), e.g. `7fr 3fr`. Stated because the opposite is the natural
+ * assumption, and because a per-column `width` will look like it did nothing.
  *
  * That is the distinction `container.tsx` draws when it rejects Elementor V3's
  * Section/Column: what broke live sites there was columns with CAPABILITIES a
@@ -74,7 +81,13 @@ export const COLUMNS_BASE_STYLES = {
   base: {
     base: {
       display: "grid",
-      gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+      // `min(240px, 100%)` rather than a bare `240px`. `auto-fit` collapses
+      // empty tracks but never drops the LAST one, so a flat minimum makes a
+      // single remaining track overflow any container narrower than it —
+      // reachable in a nested row or a narrow embed, and not saved by the
+      // column's `min-width: 0`, which governs the item rather than the track.
+      // Capping the minimum by the available width lets that last track fit.
+      gridTemplateColumns: "repeat(auto-fit, minmax(min(240px, 100%), 1fr))",
     },
   },
 } as const;

--- a/packages/blocks-react/src/blocks/columns.tsx
+++ b/packages/blocks-react/src/blocks/columns.tsx
@@ -34,14 +34,16 @@ import { defineBlock } from "@nextlyhq/blocks-engine";
 
 import type { PageContext } from "../context";
 
+import {
+  COLUMN_BLOCK,
+  COLUMN_DEFAULT_PROPS,
+  COLUMN_VERSION,
+  COLUMNS_BLOCK,
+} from "./column";
 import { renderContainer } from "./container";
 import type { ContainerProps } from "./container";
 
-/** The block name a `core/columns` slot accepts, in one place. */
-export const COLUMN_BLOCK = "core/column";
-
-/** The block name a `core/column` may sit inside, in one place. */
-export const COLUMNS_BLOCK = "core/columns";
+export { COLUMN_BLOCK, COLUMNS_BLOCK } from "./column";
 
 /**
  * How many columns a freshly placed row starts with.
@@ -53,26 +55,40 @@ export const COLUMNS_BLOCK = "core/columns";
 const INITIAL_COLUMNS = 2;
 
 /**
- * A column node for the initial template, distinct per index.
+ * The id prefix marking a template node as a PLACEHOLDER.
+ *
+ * A template describes what to create, not a thing that exists, so an id here
+ * is a slot for a real one rather than an identity. **An expansion path must
+ * mint a fresh id per node per instance** — two rows on one page seeded with
+ * the same literal ids would collide, and the engine reports that as
+ * `duplicate-node-id` on the second row.
+ *
+ * Named rather than inlined so a consumer can assert it never reaches a stored
+ * document. `template` currently has NO reader anywhere in the repository, so
+ * the requirement is stated here for whoever writes the first one.
+ */
+export const TEMPLATE_PLACEHOLDER_ID = "core-columns-placeholder";
+
+/**
+ * A column node for the initial template.
  *
  * Returns `BlockNode` rather than a shape typed by `ContainerProps`: a stored
  * node's props are an open record, and `ContainerProps` is a named interface,
- * which TypeScript will not treat as one. The literal below is checked against
- * the block's own prop names by `column.tsx`'s schema at validation time —
- * which is the layer that owns that question — rather than by a cast here.
+ * which TypeScript will not treat as one. The literal is checked against the
+ * block's own prop names by validation — the layer that owns that question —
+ * rather than by a cast here.
+ *
+ * **The version and props are IMPORTED from `column.tsx`, never restated.**
+ * A template that seeds nodes at a version or with defaults the block no
+ * longer declares makes row-seeded columns start in a different schema state
+ * from columns inserted directly, and nothing would report the divergence.
  */
 function templateColumn(index: number): BlockNode {
   return {
-    // Deterministic, because a template is expanded on READ as well as on
-    // insert. A random id here would differ between the server and the client
-    // render of the same stored document, and the id drives the scoped CSS
-    // class — so the two would disagree about which rules apply and the page
-    // would hydrate mismatched. `normalizeLegacySlots` learned this the
-    // expensive way with `crypto.randomUUID()`.
-    id: `core-columns-template-${index}`,
+    id: `${TEMPLATE_PLACEHOLDER_ID}-${index}`,
     type: COLUMN_BLOCK,
-    version: 1,
-    props: { as: "div", contained: false },
+    version: COLUMN_VERSION,
+    props: { ...COLUMN_DEFAULT_PROPS },
   };
 }
 

--- a/packages/blocks-react/src/blocks/columns.tsx
+++ b/packages/blocks-react/src/blocks/columns.tsx
@@ -21,26 +21,32 @@
  * `core/column` declares `parent: ["core/columns"]`, which is the arrangement
  * `block.ts` names when it documents this field.
  *
- * **The row ships NO default layout**, and `column.tsx` documents why at
- * length: block-level default styles have no delivery mechanism in this
- * package. An author sets the row's display through the inspector. When that
- * gap closes, the row is where `display` belongs — as an overridable default,
- * never a rule in the renderer, because a default nobody can override is the
- * Elementor V4 padding complaint in another costume.
+ * **The layout is `baseStyles`, not a hardcode.** `container.tsx` establishes
+ * that display is a style rather than a block, and a default nobody can
+ * override is the Elementor V4 padding complaint in another costume.
+ * `styles.ts`'s `blockBasesFor` derives these per block TYPE and hands them to
+ * `compilePageCss`, so one rule is emitted for the type rather than copied
+ * into every node.
+ *
+ * **It is a GRID rather than a flex row, and the catalog decides that.** The
+ * compiler rejects properties it does not know, and `STYLE_CATALOG` carries
+ * flex CONTAINER properties but no flex ITEM ones — no `flex`, `flexGrow`,
+ * `flexShrink`, `flexBasis` — so a flex row could not size its children at
+ * all. `grid-template-columns` is supported, and it puts the sizing on the
+ * track list where one declaration governs every column.
+ *
+ * `repeat(auto-fit, minmax(240px, 1fr))` gives equal columns that share the
+ * row, and wraps to a new line below the minimum instead of crushing them.
+ * That is the responsive behaviour an author would otherwise write a media
+ * query for, and it is overridable like any other default.
  *
  * @module blocks/library/columns
  */
-import type { BlockNode } from "@nextlyhq/blocks-engine";
 import { defineBlock } from "@nextlyhq/blocks-engine";
 
 import type { PageContext } from "../context";
 
-import {
-  COLUMN_BLOCK,
-  COLUMN_DEFAULT_PROPS,
-  COLUMN_VERSION,
-  COLUMNS_BLOCK,
-} from "./column";
+import { COLUMN_BLOCK, COLUMNS_BLOCK } from "./column";
 import { CONTAINER_SUPPORTS, renderContainer } from "./container";
 import type { ContainerProps } from "./container";
 
@@ -53,45 +59,25 @@ export { COLUMN_BLOCK, COLUMNS_BLOCK } from "./column";
  * a box would have reached for one; and rather than three, because removing a
  * column is a click and adding one is a decision.
  */
-const INITIAL_COLUMNS = 2;
+export const INITIAL_COLUMNS = 2;
 
 /**
- * The id prefix marking a template node as a PLACEHOLDER.
+ * The row's default layout, in properties the compiler actually accepts.
  *
- * A template describes what to create, not a thing that exists, so an id here
- * is a slot for a real one rather than an identity. **An expansion path must
- * mint a fresh id per node per instance** — two rows on one page seeded with
- * the same literal ids would collide, and the engine reports that as
- * `duplicate-node-id` on the second row.
- *
- * Named rather than inlined so a consumer can assert it never reaches a stored
- * document. `template` currently has NO reader anywhere in the repository, so
- * the requirement is stated here for whoever writes the first one.
+ * `auto-fit` collapses empty tracks and `minmax(240px, 1fr)` makes every
+ * remaining column an equal share of the row that will not go below 240px —
+ * so columns share the width, and wrap to a new line rather than being
+ * crushed. Both `display` and `gridTemplateColumns` are in `STYLE_CATALOG`;
+ * an unlisted property is dropped by the compiler rather than passed through.
  */
-export const TEMPLATE_PLACEHOLDER_ID = "core-columns-placeholder";
-
-/**
- * A column node for the initial template.
- *
- * Returns `BlockNode` rather than a shape typed by `ContainerProps`: a stored
- * node's props are an open record, and `ContainerProps` is a named interface,
- * which TypeScript will not treat as one. The literal is checked against the
- * block's own prop names by validation — the layer that owns that question —
- * rather than by a cast here.
- *
- * **The version and props are IMPORTED from `column.tsx`, never restated.**
- * A template that seeds nodes at a version or with defaults the block no
- * longer declares makes row-seeded columns start in a different schema state
- * from columns inserted directly, and nothing would report the divergence.
- */
-function templateColumn(index: number): BlockNode {
-  return {
-    id: `${TEMPLATE_PLACEHOLDER_ID}-${index}`,
-    type: COLUMN_BLOCK,
-    version: COLUMN_VERSION,
-    props: { ...COLUMN_DEFAULT_PROPS },
-  };
-}
+export const COLUMNS_BASE_STYLES = {
+  base: {
+    base: {
+      display: "grid",
+      gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+    },
+  },
+} as const;
 
 export const columns = defineBlock<ContainerProps, PageContext>({
   name: COLUMNS_BLOCK,
@@ -110,11 +96,29 @@ export const columns = defineBlock<ContainerProps, PageContext>({
   slots: {
     children: {
       allow: [COLUMN_BLOCK],
-      template: Array.from({ length: INITIAL_COLUMNS }, (_, i) =>
-        templateColumn(i)
-      ),
+      /**
+       * EMPTY, deliberately, until something expands templates.
+       *
+       * A seeded template needs its ids minted per INSTANCE: two rows
+       * expanded from one literal template carry the same node ids, and the
+       * engine reports `duplicate-node-id` on the second. Nothing in the
+       * repository reads `SlotSpec.template`, so there is no expansion path
+       * to do that minting — and shipping nodes whose ids are correct only if
+       * a future reader remembers to replace them is a trap rather than a
+       * default.
+       *
+       * Naming the ids "placeholders" was the first attempt and it changed no
+       * behaviour: the collision is a property of the nodes, not of what they
+       * are called. An empty template makes it unreachable instead.
+       *
+       * The two-column default belongs with the expander, which is the layer
+       * that can mint ids. `INITIAL_COLUMNS` records the intended number so
+       * that work does not have to re-derive it.
+       */
+      template: [],
     },
   },
+  baseStyles: COLUMNS_BASE_STYLES,
   supports: CONTAINER_SUPPORTS,
   render: renderContainer,
 });

--- a/packages/blocks-react/src/blocks/container.tsx
+++ b/packages/blocks-react/src/blocks/container.tsx
@@ -68,6 +68,27 @@ export type ContainerTag = (typeof CONTAINER_TAGS)[number];
  */
 export const CONTENT_WIDTH_CLASS = "nx-pb-contained";
 
+/**
+ * The style capabilities every container preset opts into.
+ *
+ * Declared ONCE and shared, because a preset differs from its siblings in what
+ * it starts as, never in what it can be told to do — the property this file's
+ * header argues for. Four parallel copies of this list would let a later
+ * addition or removal reach some presets and not others, silently giving one
+ * container different editor controls and accepted styles from the rest. The
+ * divergence would be invisible: each list reads as correct on its own.
+ */
+export const CONTAINER_SUPPORTS = {
+  spacing: true,
+  layout: true,
+  dimensions: true,
+  background: true,
+  border: true,
+  effects: true,
+  position: true,
+  container: true,
+} as const;
+
 /** Whether a stored value is a tag a container may render. */
 function isContainerTag(value: unknown): value is ContainerTag {
   return CONTAINER_TAGS.some(tag => tag === value);

--- a/packages/blocks-react/src/blocks/index.ts
+++ b/packages/blocks-react/src/blocks/index.ts
@@ -27,6 +27,8 @@
 import { box } from "./box";
 import { button } from "./button";
 import { collectionLoop } from "./collection-loop";
+import { column } from "./column";
+import { columns } from "./columns";
 import { divider } from "./divider";
 import { embed } from "./embed";
 import { heading } from "./heading";
@@ -40,6 +42,13 @@ import { spacer } from "./spacer";
 export { box } from "./box";
 export { button, BUTTON_TYPES, type ButtonProps } from "./button";
 export { collectionLoop } from "./collection-loop";
+export { column } from "./column";
+// `COLUMN_BLOCK` / `COLUMNS_BLOCK` are deliberately NOT re-exported. They exist
+// so the two halves of the nesting rule name each other without a repeated
+// string literal, which is internal coupling rather than a contract a consumer
+// needs. A published constant is a promise to keep it, and this package's entry
+// surface is asserted exactly — widening it should buy a caller something.
+export { columns } from "./columns";
 export { divider, type DividerProps } from "./divider";
 export { embed, type EmbedProps } from "./embed";
 export {
@@ -75,6 +84,10 @@ export const coreBlocks = [
   // Layout
   section,
   box,
+  // Registered after `columns`, because a row's slot template names the column
+  // and a resolver built by iterating this list should meet the parent first.
+  columns,
+  column,
   spacer,
   // Typography
   heading,

--- a/packages/blocks-react/src/blocks/root-inline-styles.test.tsx
+++ b/packages/blocks-react/src/blocks/root-inline-styles.test.tsx
@@ -87,6 +87,8 @@ const EXPECTED_BLOCKS = [
   "core/box",
   "core/button",
   "core/collection-loop",
+  "core/column",
+  "core/columns",
   "core/divider",
   "core/embed",
   "core/heading",

--- a/packages/blocks-react/src/blocks/section.tsx
+++ b/packages/blocks-react/src/blocks/section.tsx
@@ -10,7 +10,7 @@ import { defineBlock } from "@nextlyhq/blocks-engine";
 
 import type { PageContext } from "../context";
 
-import { renderContainer } from "./container";
+import { CONTAINER_SUPPORTS, renderContainer } from "./container";
 import type { ContainerProps } from "./container";
 
 // Defined against the ENGINE's `defineBlock`, not the plugin SDK's: the engine
@@ -34,15 +34,6 @@ export const section = defineBlock<ContainerProps, PageContext>({
     // an empty section is never an invisible one.
     children: { template: [] },
   },
-  supports: {
-    spacing: true,
-    layout: true,
-    dimensions: true,
-    background: true,
-    border: true,
-    effects: true,
-    position: true,
-    container: true,
-  },
+  supports: CONTAINER_SUPPORTS,
   render: renderContainer,
 });

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -304,6 +304,8 @@ describe("the blocks entry", () => {
       "box",
       "button",
       "collectionLoop",
+      "column",
+      "columns",
       "coreBlocks",
       "divider",
       "embed",

--- a/packages/plugin-page-builder/src/blocks/__tests__/core-block-registration.test.ts
+++ b/packages/plugin-page-builder/src/blocks/__tests__/core-block-registration.test.ts
@@ -60,6 +60,8 @@ describe("core block registration", () => {
       "core/box",
       "core/button",
       "core/collection-loop",
+      "core/column",
+      "core/columns",
       "core/divider",
       "core/embed",
       "core/heading",


### PR DESCRIPTION
## Why

**No multi-column layout was expressible with the shipped block set.** That rules out the features grid, testimonials, team grid, pricing table and logo strip — sections present in *every* real site measured (`nextly-site`, `mobeen-site`, `wrext-site`, `revnix`).

This is the first item of the block-library growth, whose scope was derived from those four sites rather than picked: 13 shipped + ~12 needed = ~25.

## What

`core/columns` and `core/column`, both **presets over the existing `renderContainer`** — the same implementation `core/section` and `core/box` use.

They differ from a box in **relationships, never capabilities**:

| | |
|---|---|
| `core/columns` | slot `allow: ["core/column"]`, template of two columns, `baseStyles` → `display: flex` |
| `core/column` | `parent: ["core/columns"]`, unrestricted slot |

## Why a pair rather than a box with a flex display

**The pair is what makes each column ADDRESSABLE.** An anonymous flex child created by the row's own renderer has no node id, so no scoped class — it cannot be selected, styled, targeted by a drop, or named in a rule. An author who wants one column wider than another has nowhere to put that.

`container.tsx` already rejects Elementor V3's Section/Column, and this stays on the right side of that argument: what broke live sites there was columns with **capabilities a div lacked**, so migration had to rewrite structure. Here a column is a container preset and the only thing a box cannot do is be a column's identity. Gutenberg reaches the same split — its `core/column` declares `parent: ["core/columns"]`, which is the arrangement `block.ts` cites when documenting that field.

## Three decisions worth review

- **Layout is `baseStyles`, not a rule in the renderer.** `container.tsx` establishes display is a style rather than a block, and a default nobody can override is the Elementor V4 padding complaint in another costume. This is `baseStyles`' first real consumer.
- **No `width` prop on a column.** Width is a style and the catalog already expresses it per breakpoint; a prop would be a second way to say the same thing, disagreeing at whichever breakpoint nobody checked.
- **`COLUMN_BLOCK`/`COLUMNS_BLOCK` are NOT re-exported** from the package entry. They exist so the two halves name each other without a repeated literal — internal coupling, not a contract. The entry surface is asserted exactly, and widening it should buy a caller something.

## Both halves of the nesting rule, deliberately

`block.ts` is explicit that neither half implies the other. The allow-list is the **parent** saying what it holds; `parent` is the **child** saying where it makes sense. Without the child half a column is insertable anywhere, and an author who drops one at the page root gets a container governed by a row that is not there.

## Tests

10 tests, on the properties that **separate this pair from a box** — rendering proves nothing, since both delegate to `renderContainer` and a render test passes equally on `core/box`:

- both halves of the nesting rule, and that a column does **not** restrict what it holds
- seeded columns have **distinct** ids (identical ids collapse both onto one scoped class, so styling one styles both — the anonymous-child problem with extra steps)
- seeded ids are **stable across expansions** (a template expands on read as well as insert, and the id drives the scoped class; `normalizeLegacySlots` shipped exactly this defect with `crypto.randomUUID()`)
- the allow-list names a type that **actually exists** — an allow-list naming an unregistered block refuses everything and reads in review like one that works
- both halves ship together
- `column.render === columns.render`, so the pair cannot drift into capability differences

Mutation-checked: dropping the allow-list, dropping `parent`, and making template ids identical each fail exactly one test and no others.

Full suite green — 522 tests, `check-types` and `lint` clean.

## Two ratchets this had to pass, both deliberate edits

`root-inline-styles.test.tsx`'s exact block list and `entry-surface.test.ts`'s exact export list. Both are working as designed: an addition is a deliberate edit, not an unnoticed gap.
