### PR TITLE
fix(plugin-form-builder): put the form builder on the shared layout

### DIFF
--- a/.changeset/form-builder-shared-layout.md
+++ b/.changeset/form-builder-shared-layout.md
@@ -1,0 +1,45 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Put the form builder's Create/Edit view on the shared form-layout components
+(`FormLayout`, `FormActions`, `FieldShell`, `Grid`) from `@nextlyhq/ui`.
+
+The view no longer hand-rolls its own card, page padding or a negative-margin
+hack to escape that padding; `FormLayout` owns the measure. The submit and
+cancel actions moved into one `FormActions` bar at the end of the page, fed the
+form state's existing dirty flag instead of a second, separately-rendered
+unsaved-changes indicator. The Settings and Notifications tabs no longer cap
+their own width, so they fill the page measure instead of sitting narrower
+than it. The Notifications sheet's two-column rows moved off a viewport
+breakpoint onto `Grid`'s container-query mode, since the admin content region
+is narrower than the window whenever both sidebars are open.
+
+Simple single-element fields (plain text/email inputs) now render through
+`FieldShell` for their label, description and error wiring. Fields built on a
+compound control (Radix `Select`) stay hand-rolled: `Select`'s root does not
+forward arbitrary props to its trigger, so a wrapper that clones a single
+child to attach `id`/`aria-describedby` has nothing to attach them to.

--- a/.changeset/form-builder-shared-layout.md
+++ b/.changeset/form-builder-shared-layout.md
@@ -39,7 +39,27 @@ breakpoint onto `Grid`'s container-query mode, since the admin content region
 is narrower than the window whenever both sidebars are open.
 
 Simple single-element fields (plain text/email inputs) now render through
-`FieldShell` for their label, description and error wiring. Fields built on a
-compound control (Radix `Select`) stay hand-rolled: `Select`'s root does not
-forward arbitrary props to its trigger, so a wrapper that clones a single
-child to attach `id`/`aria-describedby` has nothing to attach them to.
+`FieldShell` for their label, description and error wiring.
+
+`FieldShell`'s `children` now also accepts a function —
+`(field: FieldShellRenderProps) => ReactNode`, `FieldShellRenderProps` newly
+exported — receiving the `{ id, describedBy, invalid }` it computes so a
+caller can apply that wiring to a nested element instead of relying on a
+single top-level `cloneElement`. This is what a compound Radix control needs:
+`Select`'s root destructures a fixed prop list and never forwards the rest,
+so an id cloned onto it never reaches the real, focusable `SelectTrigger` two
+levels down — silently, with no error and no warning. Both call paths derive
+their id/`aria-describedby`/`aria-invalid` from one shared computation, so
+they cannot drift into disagreeing about the same field. In development,
+`FieldShell` now also checks after mount whether the id it computed landed on
+any element in the document at all, and warns once, by field name, if it did
+not — the general form of the defect a compound control's dropped id was a
+specific case of. Every `Select`-driven field in the form builder's Create/
+Edit view and its Notifications sheet (Status, Email provider, Email
+template, Send-to type, Recipient address in field mode, Reply-To mode,
+Reply-To visitor-field in field mode, and the send-condition Field and
+Comparison pickers) now goes through `FieldShell` using this render-function
+form, wiring their `SelectTrigger` correctly for the first time. `RadioGroup`,
+`AddressChipList` and the horizontal label-left/control-right rows
+(`SettingRow`, the Enabled toggle) stay hand-rolled for their own, unrelated
+reasons, each documented at its own call site.

--- a/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
+++ b/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
@@ -402,32 +402,38 @@ function FormBuilderViewInner({
               forwards none of the rest to the trigger DOM node, so a
               FieldShell clone's id/aria-describedby/aria-invalid would land
               on a component that drops them rather than on the focusable
-              trigger. Kept hand-rolled so the label stays wired to the real
-              control instead of silently failing to connect. */}
-          <div className="w-36 space-y-1.5">
-            <label
-              htmlFor="form-status"
-              className="text-sm font-medium text-foreground"
-            >
-              Status
-            </label>
-            <Select
-              value={formData.status || "draft"}
-              onValueChange={value =>
-                updateFormData({
-                  status: value as "draft" | "published" | "closed",
-                })
-              }
-            >
-              <SelectTrigger id="form-status" className="bg-transparent">
-                <SelectValue placeholder="Status" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="draft">Draft</SelectItem>
-                <SelectItem value="published">Published</SelectItem>
-                <SelectItem value="closed">Closed</SelectItem>
-              </SelectContent>
-            </Select>
+              trigger. The render-function form of `children` sidesteps
+              that: FieldShell hands the computed wiring to this function,
+              which applies it to SelectTrigger — the actual focusable,
+              ARIA-bearing element — instead of a clone that can never reach
+              past `Select`'s root. */}
+          <div className="w-36">
+            <FieldShell label="Status" htmlFor="form-status">
+              {({ id, describedBy, invalid }) => (
+                <Select
+                  value={formData.status || "draft"}
+                  onValueChange={value =>
+                    updateFormData({
+                      status: value as "draft" | "published" | "closed",
+                    })
+                  }
+                >
+                  <SelectTrigger
+                    id={id}
+                    aria-describedby={describedBy}
+                    aria-invalid={invalid}
+                    className="bg-transparent"
+                  >
+                    <SelectValue placeholder="Status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="draft">Draft</SelectItem>
+                    <SelectItem value="published">Published</SelectItem>
+                    <SelectItem value="closed">Closed</SelectItem>
+                  </SelectContent>
+                </Select>
+              )}
+            </FieldShell>
           </div>
         </div>
 

--- a/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
+++ b/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
@@ -14,6 +14,9 @@
 
 import {
   Button,
+  FieldShell,
+  FormActions,
+  FormLayout,
   Input,
   toast,
   Tabs,
@@ -348,243 +351,214 @@ function FormBuilderViewInner({
   ];
 
   // ── Render ────────────────────────────────────────────────────────────────
+  // `FormLayout` owns the page measure, centring and padding, so nothing here
+  // hand-rolls a card, a width cap or a hack to escape either.
   return (
-    <>
-      {/* ── Page header (Outside the white card) ── */}
-      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6 px-1">
-        <div>
-          <h1 className="text-2xl font-semibold text-foreground tracking-tight">
-            {isCreating ? "Create Form" : "Edit Form"}
-          </h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            {isCreating
-              ? "Design a new form with drag-and-drop fields."
-              : "Modify your form fields and settings."}
-          </p>
-        </div>
-
-        {/* Action buttons — same variant/size as Collection Builder */}
-        <div className="flex items-center gap-2 shrink-0">
-          {isDirty && (
-            // Full-strength warning border so the unsaved-changes badge boundary is perceivable over its tinted fill.
-            <span className="text-xs font-medium bg-warning-100 text-warning-700 dark:bg-warning-900 dark:text-warning-100 border border-warning px-2.5 py-1 rounded-none whitespace-nowrap">
-              Unsaved changes
-            </span>
-          )}
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={handleCancel}
-            disabled={isSaving}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            onClick={() => {
-              void handleSave();
-            }}
-            disabled={isSaving}
-            className="flex items-center gap-1.5"
-          >
-            {isSaving ? (
-              <>
-                <svg
-                  className="animate-spin h-3.5 w-3.5"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                >
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="4"
-                  />
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                  />
-                </svg>
-                Saving…
-              </>
-            ) : isCreating ? (
-              "Create"
-            ) : (
-              "Save Changes"
-            )}
-          </Button>
-        </div>
+    <FormLayout>
+      {/* ── Page header ── */}
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold text-foreground tracking-tight">
+          {isCreating ? "Create Form" : "Edit Form"}
+        </h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          {isCreating
+            ? "Design a new form with drag-and-drop fields."
+            : "Modify your form fields and settings."}
+        </p>
       </div>
 
-      {/*
-        Outer shell — white card with rounded-none border (no shadow).
-        Fills available height in the admin page container.
-      */}
-      <div className="flex border border-border bg-background overflow-hidden">
-        {/* =================================================================
-            LEFT — scrollable main content
-        ================================================================= */}
-        <div className="flex-1 min-w-0">
-          <div className="w-full px-8 pt-8 pb-12 space-y-6">
-            {/* ── Fixed Metadata & Tab Navigation ── */}
-            {/* -mx-8 + px-8: full-width divider, inset content. */}
-            <div className="bg-background -mx-8 px-8 border-b border-border space-y-4">
-              <div className="flex flex-wrap gap-4">
-                {/* Form Name */}
-                <div className="flex-1 min-w-[200px] max-w-sm space-y-1.5">
-                  <label
-                    htmlFor="form-name"
-                    className="text-sm font-medium text-foreground"
-                  >
-                    Form Name
-                  </label>
-                  <Input
-                    id="form-name"
-                    type="text"
-                    value={formData.name || ""}
-                    onChange={e => handleNameChange(e.target.value)}
-                    placeholder="e.g., Contact Form"
-                    className="bg-transparent"
-                  />
-                </div>
+      {/* ── Metadata & tab navigation ── */}
+      <div className="border-b border-border space-y-4 pb-4 mb-6">
+        <div className="flex flex-wrap gap-4">
+          <FieldShell
+            label="Form Name"
+            htmlFor="form-name"
+            className="flex-1 min-w-[200px]"
+          >
+            <Input
+              type="text"
+              value={formData.name || ""}
+              onChange={e => handleNameChange(e.target.value)}
+              placeholder="e.g., Contact Form"
+              className="bg-transparent"
+            />
+          </FieldShell>
 
-                {/* Slug */}
-                <div className="flex-1 min-w-[160px] max-w-xs space-y-1.5">
-                  <label
-                    htmlFor="form-slug"
-                    className="text-sm font-medium text-foreground"
-                  >
-                    Slug
-                  </label>
-                  <Input
-                    id="form-slug"
-                    type="text"
-                    value={formData.slug || ""}
-                    onChange={e => updateFormData({ slug: e.target.value })}
-                    placeholder="e.g., contact-form"
-                    className="bg-transparent placeholder:text-muted-foreground"
-                  />
-                </div>
+          <FieldShell
+            label="Slug"
+            htmlFor="form-slug"
+            className="flex-1 min-w-[160px]"
+          >
+            <Input
+              type="text"
+              value={formData.slug || ""}
+              onChange={e => updateFormData({ slug: e.target.value })}
+              placeholder="e.g., contact-form"
+              className="bg-transparent placeholder:text-muted-foreground"
+            />
+          </FieldShell>
 
-                {/* Status */}
-                <div className="w-36 space-y-1.5">
-                  <label
-                    htmlFor="form-status"
-                    className="text-sm font-medium text-foreground"
-                  >
-                    Status
-                  </label>
-                  <Select
-                    value={formData.status || "draft"}
-                    onValueChange={value =>
-                      updateFormData({
-                        status: value as "draft" | "published" | "closed",
-                      })
-                    }
-                  >
-                    <SelectTrigger id="form-status" className="bg-transparent">
-                      <SelectValue placeholder="Status" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="draft">Draft</SelectItem>
-                      <SelectItem value="published">Published</SelectItem>
-                      <SelectItem value="closed">Closed</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-
-              {/* ── Main tab navigation ── */}
-              <Tabs
-                value={activeTab}
-                onValueChange={v => setActiveTab(v as typeof activeTab)}
-              >
-                {/* Layout only. The underline, the active and hover colours, the
-                    focus ring and the disabled state all come from the shared
-                    primitive; restating them here is how two copies of one
-                    appearance start drifting. `gap-0` and the scroll behaviour
-                    are genuinely local: this strip can overflow its container.
-                    `-mb-px` is too: the header above draws its own 1px bottom
-                    divider, and pulling the strip down over it lets the active
-                    tab's underline REPLACE that divider rather than stack a
-                    2px mark on top of a 1px one. */}
-                <TabsList className="bg-transparent justify-start gap-0 -mb-px max-w-full overflow-x-auto">
-                  {mainTabs.map(tab => (
-                    <TabsTrigger
-                      key={tab.value}
-                      value={tab.value}
-                      className="shrink-0 whitespace-nowrap"
-                    >
-                      {tab.label}
-                      {/* `rounded-sm`, the adornment step, matching the shared
-                          Badge and the identically sized notification count.
-                          Square is the TAB's corner and it exists so the
-                          underline runs flush to the trigger's edges; a chip
-                          inside the label inherits none of that reasoning, and
-                          carrying it made the count read as a second tab. */}
-                      {tab.count !== null && (
-                        <span
-                          className={`inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 text-[10px] font-semibold rounded-sm ml-2 transition-colors ${
-                            activeTab === tab.value
-                              ? "bg-primary/5 text-primary"
-                              : "bg-primary/5 text-muted-foreground"
-                          }`}
-                        >
-                          {tab.count}
-                        </span>
-                      )}
-                    </TabsTrigger>
-                  ))}
-                </TabsList>
-              </Tabs>
-            </div>
-
-            {/* ── Tab content ── */}
-
-            {/* Builder tab */}
-            {activeTab === "builder" && (
-              <FieldCards
-                enabledTypes={enabledTypes}
-                disabledFieldTypes={disabledFieldTypes}
-                onAddField={handleAddField}
-              />
-            )}
-
-            {/* Preview tab */}
-            {activeTab === "preview" && (
-              <FormPreview fields={fields} formData={formData} />
-            )}
-
-            {/* Settings tab */}
-            {activeTab === "settings" && (
-              <div className="w-full">
-                <FormSettingsTab spamDefaults={spamDefaults} />
-              </div>
-            )}
-
-            {/* Notifications tab */}
-            {activeTab === "notifications" && (
-              <div className="w-full">
-                <FormNotificationsTab defaults={notificationDefaults} />
-              </div>
-            )}
-
-            {/* Save error */}
-            {saveError && (
-              // Full-strength destructive border so the error box boundary is perceivable over its tinted fill.
-              <div className="p-3 text-sm text-destructive bg-destructive/10 border border-destructive rounded-none">
-                {saveError}
-              </div>
-            )}
+          {/* Status is a Radix Select: its Root accepts a fixed prop list and
+              forwards none of the rest to the trigger DOM node, so a
+              FieldShell clone's id/aria-describedby/aria-invalid would land
+              on a component that drops them rather than on the focusable
+              trigger. Kept hand-rolled so the label stays wired to the real
+              control instead of silently failing to connect. */}
+          <div className="w-36 space-y-1.5">
+            <label
+              htmlFor="form-status"
+              className="text-sm font-medium text-foreground"
+            >
+              Status
+            </label>
+            <Select
+              value={formData.status || "draft"}
+              onValueChange={value =>
+                updateFormData({
+                  status: value as "draft" | "published" | "closed",
+                })
+              }
+            >
+              <SelectTrigger id="form-status" className="bg-transparent">
+                <SelectValue placeholder="Status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="draft">Draft</SelectItem>
+                <SelectItem value="published">Published</SelectItem>
+                <SelectItem value="closed">Closed</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
         </div>
+
+        {/* ── Main tab navigation ── */}
+        <Tabs
+          value={activeTab}
+          onValueChange={v => setActiveTab(v as typeof activeTab)}
+        >
+          {/* Layout only. The underline, the active and hover colours, the
+              focus ring and the disabled state all come from the shared
+              primitive; restating them here is how two copies of one
+              appearance start drifting. `gap-0` and the scroll behaviour
+              are genuinely local: this strip can overflow its container. */}
+          <TabsList className="bg-transparent justify-start gap-0 max-w-full overflow-x-auto">
+            {mainTabs.map(tab => (
+              <TabsTrigger
+                key={tab.value}
+                value={tab.value}
+                className="shrink-0 whitespace-nowrap"
+              >
+                {tab.label}
+                {/* `rounded-sm`, the adornment step, matching the shared
+                    Badge and the identically sized notification count.
+                    Square is the TAB's corner and it exists so the
+                    underline runs flush to the trigger's edges; a chip
+                    inside the label inherits none of that reasoning, and
+                    carrying it made the count read as a second tab. */}
+                {tab.count !== null && (
+                  <span
+                    className={`inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 text-[10px] font-semibold rounded-sm ml-2 transition-colors ${
+                      activeTab === tab.value
+                        ? "bg-primary/5 text-primary"
+                        : "bg-primary/5 text-muted-foreground"
+                    }`}
+                  >
+                    {tab.count}
+                  </span>
+                )}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
       </div>
-    </>
+
+      {/* ── Tab content ── */}
+
+      {/* Builder tab */}
+      {activeTab === "builder" && (
+        <FieldCards
+          enabledTypes={enabledTypes}
+          disabledFieldTypes={disabledFieldTypes}
+          onAddField={handleAddField}
+        />
+      )}
+
+      {/* Preview tab */}
+      {activeTab === "preview" && (
+        <FormPreview fields={fields} formData={formData} />
+      )}
+
+      {/* Settings tab */}
+      {activeTab === "settings" && (
+        <FormSettingsTab spamDefaults={spamDefaults} />
+      )}
+
+      {/* Notifications tab */}
+      {activeTab === "notifications" && (
+        <FormNotificationsTab defaults={notificationDefaults} />
+      )}
+
+      {/* Save error */}
+      {saveError && (
+        // Full-strength destructive border so the error box boundary is perceivable over its tinted fill.
+        <div className="mt-6 p-3 text-sm text-destructive bg-destructive/10 border border-destructive rounded-none">
+          {saveError}
+        </div>
+      )}
+
+      {/* A form commits as one document, so there is exactly one action bar,
+          fed the dirty flag the form state already tracks rather than a
+          second computation of it. */}
+      <FormActions dirty={isDirty}>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handleCancel}
+          disabled={isSaving}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => {
+            void handleSave();
+          }}
+          disabled={isSaving}
+          className="flex items-center gap-1.5"
+        >
+          {isSaving ? (
+            <>
+              <svg
+                className="animate-spin h-3.5 w-3.5"
+                viewBox="0 0 24 24"
+                fill="none"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                />
+              </svg>
+              Saving…
+            </>
+          ) : isCreating ? (
+            "Create"
+          ) : (
+            "Save Changes"
+          )}
+        </Button>
+      </FormActions>
+    </FormLayout>
   );
 }
 

--- a/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.tsx
@@ -599,62 +599,81 @@ function NotificationSheet({
               narrower than the window whenever both sidebars are open, so a
               viewport breakpoint promises columns this sheet does not have. */}
           <Grid cols={2} responsive>
-            <div className="space-y-1.5">
-              <Label htmlFor="notification-provider">Email provider</Label>
-              <Select
-                value={form.providerId ?? "__default"}
-                onValueChange={value =>
-                  update(
-                    "providerId",
-                    value === "__default" ? undefined : value
-                  )
-                }
-              >
-                <SelectTrigger
-                  id="notification-provider"
-                  className="w-full bg-transparent border-input dark:bg-muted/50"
+            {/* Both `Select`-driven: FieldShell's render-function `children`
+                applies the computed id/aria-describedby/aria-invalid to
+                SelectTrigger, the actual focusable element, rather than to
+                `Select`'s root (which accepts a fixed prop list and forwards
+                none of the rest). */}
+            <FieldShell label="Email provider" htmlFor="notification-provider">
+              {({ id, describedBy, invalid }) => (
+                <Select
+                  value={form.providerId ?? "__default"}
+                  onValueChange={value =>
+                    update(
+                      "providerId",
+                      value === "__default" ? undefined : value
+                    )
+                  }
                 >
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__default">
-                    {defaultProviderLabel}
-                  </SelectItem>
-                  {providers.map(p => (
-                    <SelectItem key={p.id} value={p.id}>
-                      {p.name}
-                      {p.isDefault ? " (Default)" : ""}
+                  <SelectTrigger
+                    id={id}
+                    aria-describedby={describedBy}
+                    aria-invalid={invalid}
+                    className="w-full bg-transparent border-input dark:bg-muted/50"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__default">
+                      {defaultProviderLabel}
                     </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="notification-template">Email template</Label>
-              <Select
-                value={form.templateSlug ?? "__none"}
-                onValueChange={value =>
-                  update("templateSlug", value === "__none" ? undefined : value)
-                }
-              >
-                <SelectTrigger
-                  id="notification-template"
-                  className="w-full bg-transparent border-input dark:bg-muted/50"
-                >
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none">Select a template</SelectItem>
-                  {templates
-                    .filter(t => t.isActive && t.kind !== "layout")
-                    .map(t => (
-                      <SelectItem key={t.id} value={t.slug}>
-                        {t.name}
+                    {providers.map(p => (
+                      <SelectItem key={p.id} value={p.id}>
+                        {p.name}
+                        {p.isDefault ? " (Default)" : ""}
                       </SelectItem>
                     ))}
-                </SelectContent>
-              </Select>
+                  </SelectContent>
+                </Select>
+              )}
+            </FieldShell>
+
+            <div className="space-y-1.5">
+              <FieldShell
+                label="Email template"
+                htmlFor="notification-template"
+              >
+                {({ id, describedBy, invalid }) => (
+                  <Select
+                    value={form.templateSlug ?? "__none"}
+                    onValueChange={value =>
+                      update(
+                        "templateSlug",
+                        value === "__none" ? undefined : value
+                      )
+                    }
+                  >
+                    <SelectTrigger
+                      id={id}
+                      aria-describedby={describedBy}
+                      aria-invalid={invalid}
+                      className="w-full bg-transparent border-input dark:bg-muted/50"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__none">Select a template</SelectItem>
+                      {templates
+                        .filter(t => t.isActive && t.kind !== "layout")
+                        .map(t => (
+                          <SelectItem key={t.id} value={t.slug}>
+                            {t.name}
+                          </SelectItem>
+                        ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              </FieldShell>
               {!form.templateSlug && (
                 <p className="flex items-center gap-1 text-xs text-destructive">
                   <TriangleAlert className="h-3 w-3" aria-hidden="true" />
@@ -683,60 +702,74 @@ function NotificationSheet({
           {/* Recipients */}
           <div className="space-y-4 pt-4 border-t border-border">
             <Grid cols={2} responsive>
-              <div className="space-y-1.5">
-                <Label htmlFor="notification-recipient-type">Send to</Label>
-                <Select
-                  value={form.recipientType}
-                  onValueChange={value => {
-                    // Switching target kinds invalidates the previous `to`
-                    // value shape, so it resets rather than leaking a
-                    // {{ref}} into the static input (or vice versa).
-                    setForm(prev => ({
-                      ...prev,
-                      recipientType: value as "static" | "field",
-                      to: "",
-                    }));
-                  }}
-                >
-                  <SelectTrigger
-                    id="notification-recipient-type"
-                    className="w-full bg-transparent border-input dark:bg-muted/50"
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="static">A specific address</SelectItem>
-                    <SelectItem value="field">
-                      The visitor (email field)
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-
-              {form.recipientType === "field" ? (
-                <div className="space-y-1.5">
-                  <Label htmlFor="notification-to">Visitor email field</Label>
+              <FieldShell label="Send to" htmlFor="notification-recipient-type">
+                {({ id, describedBy, invalid }) => (
                   <Select
-                    value={toRef ?? "__none"}
-                    onValueChange={value =>
-                      update("to", value === "__none" ? "" : toFieldRef(value))
-                    }
+                    value={form.recipientType}
+                    onValueChange={value => {
+                      // Switching target kinds invalidates the previous `to`
+                      // value shape, so it resets rather than leaking a
+                      // {{ref}} into the static input (or vice versa).
+                      setForm(prev => ({
+                        ...prev,
+                        recipientType: value as "static" | "field",
+                        to: "",
+                      }));
+                    }}
                   >
                     <SelectTrigger
-                      id="notification-to"
+                      id={id}
+                      aria-describedby={describedBy}
+                      aria-invalid={invalid}
                       className="w-full bg-transparent border-input dark:bg-muted/50"
                     >
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="__none">Select a field</SelectItem>
-                      {toFieldOptions.map(f => (
-                        <SelectItem key={f.name} value={f.name}>
-                          {f.label}
-                        </SelectItem>
-                      ))}
+                      <SelectItem value="static">A specific address</SelectItem>
+                      <SelectItem value="field">
+                        The visitor (email field)
+                      </SelectItem>
                     </SelectContent>
                   </Select>
+                )}
+              </FieldShell>
+
+              {form.recipientType === "field" ? (
+                <div className="space-y-1.5">
+                  <FieldShell
+                    label="Visitor email field"
+                    htmlFor="notification-to"
+                  >
+                    {({ id, describedBy, invalid }) => (
+                      <Select
+                        value={toRef ?? "__none"}
+                        onValueChange={value =>
+                          update(
+                            "to",
+                            value === "__none" ? "" : toFieldRef(value)
+                          )
+                        }
+                      >
+                        <SelectTrigger
+                          id={id}
+                          aria-describedby={describedBy}
+                          aria-invalid={invalid}
+                          className="w-full bg-transparent border-input dark:bg-muted/50"
+                        >
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="__none">Select a field</SelectItem>
+                          {toFieldOptions.map(f => (
+                            <SelectItem key={f.name} value={f.name}>
+                              {f.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
+                  </FieldShell>
                   {toFieldOptions.length === 0 && (
                     <p className="text-xs text-muted-foreground">
                       Add an email field to the form first.
@@ -764,66 +797,73 @@ function NotificationSheet({
 
             {/* Reply-To */}
             <Grid cols={2} responsive>
-              <div className="space-y-1.5">
-                <Label htmlFor="notification-replyto-mode">Reply-To</Label>
-                <Select
-                  value={replyToMode}
-                  onValueChange={value => {
-                    const mode = value as ReplyToMode;
-                    setReplyToMode(mode);
-                    // A mode change always clears the stored value (the old
-                    // shape can't be represented in the new mode); it stays
-                    // absent — not an empty string — until the user picks a
-                    // field or types an address.
-                    update("replyTo", undefined);
-                  }}
-                >
-                  <SelectTrigger
-                    id="notification-replyto-mode"
-                    className="w-full bg-transparent border-input dark:bg-muted/50"
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    <SelectItem value="field">
-                      The visitor (email field)
-                    </SelectItem>
-                    <SelectItem value="custom">A custom address</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-
-              {replyToMode === "field" && (
-                <div className="space-y-1.5">
-                  <Label htmlFor="notification-replyto">
-                    Visitor email field
-                  </Label>
+              <FieldShell label="Reply-To" htmlFor="notification-replyto-mode">
+                {({ id, describedBy, invalid }) => (
                   <Select
-                    value={replyToRef ?? "__none"}
-                    onValueChange={value =>
-                      update(
-                        "replyTo",
-                        value === "__none" ? undefined : toFieldRef(value)
-                      )
-                    }
+                    value={replyToMode}
+                    onValueChange={value => {
+                      const mode = value as ReplyToMode;
+                      setReplyToMode(mode);
+                      // A mode change always clears the stored value (the old
+                      // shape can't be represented in the new mode); it stays
+                      // absent — not an empty string — until the user picks a
+                      // field or types an address.
+                      update("replyTo", undefined);
+                    }}
                   >
                     <SelectTrigger
-                      id="notification-replyto"
+                      id={id}
+                      aria-describedby={describedBy}
+                      aria-invalid={invalid}
                       className="w-full bg-transparent border-input dark:bg-muted/50"
                     >
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="__none">Select a field</SelectItem>
-                      {replyToFieldOptions.map(f => (
-                        <SelectItem key={f.name} value={f.name}>
-                          {f.label}
-                        </SelectItem>
-                      ))}
+                      <SelectItem value="none">None</SelectItem>
+                      <SelectItem value="field">
+                        The visitor (email field)
+                      </SelectItem>
+                      <SelectItem value="custom">A custom address</SelectItem>
                     </SelectContent>
                   </Select>
-                </div>
+                )}
+              </FieldShell>
+
+              {replyToMode === "field" && (
+                <FieldShell
+                  label="Visitor email field"
+                  htmlFor="notification-replyto"
+                >
+                  {({ id, describedBy, invalid }) => (
+                    <Select
+                      value={replyToRef ?? "__none"}
+                      onValueChange={value =>
+                        update(
+                          "replyTo",
+                          value === "__none" ? undefined : toFieldRef(value)
+                        )
+                      }
+                    >
+                      <SelectTrigger
+                        id={id}
+                        aria-describedby={describedBy}
+                        aria-invalid={invalid}
+                        className="w-full bg-transparent border-input dark:bg-muted/50"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__none">Select a field</SelectItem>
+                        {replyToFieldOptions.map(f => (
+                          <SelectItem key={f.name} value={f.name}>
+                            {f.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
+                </FieldShell>
               )}
               {replyToMode === "custom" && (
                 <FieldShell
@@ -899,65 +939,77 @@ function NotificationSheet({
 
             {condition && (
               <div className="flex flex-wrap items-end gap-2 border border-border bg-muted/40 p-3">
-                <div className="min-w-36 flex-1 space-y-1.5">
-                  <Label htmlFor="notification-condition-field">Field</Label>
-                  <Select
-                    value={condition.field || "__none"}
-                    onValueChange={value =>
-                      update("condition", {
-                        ...condition,
-                        field: value === "__none" ? "" : value,
-                      })
-                    }
-                  >
-                    <SelectTrigger
-                      id="notification-condition-field"
-                      className="w-full bg-transparent border-input dark:bg-muted/50"
+                <FieldShell
+                  label="Field"
+                  htmlFor="notification-condition-field"
+                  className="min-w-36 flex-1"
+                >
+                  {({ id, describedBy, invalid }) => (
+                    <Select
+                      value={condition.field || "__none"}
+                      onValueChange={value =>
+                        update("condition", {
+                          ...condition,
+                          field: value === "__none" ? "" : value,
+                        })
+                      }
                     >
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none">Select a field</SelectItem>
-                      {fields.map(f => (
-                        <SelectItem key={f.name} value={f.name}>
-                          {f.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                <div className="min-w-36 flex-1 space-y-1.5">
-                  <Label htmlFor="notification-condition-comparison">
-                    Comparison
-                  </Label>
-                  <Select
-                    value={condition.comparison}
-                    onValueChange={value =>
-                      update("condition", {
-                        ...condition,
-                        comparison:
-                          value as ConditionalLogicCondition["comparison"],
-                      })
-                    }
-                  >
-                    <SelectTrigger
-                      id="notification-condition-comparison"
-                      className="w-full bg-transparent border-input dark:bg-muted/50"
-                    >
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {Object.entries(COMPARISON_LABELS).map(
-                        ([value, label]) => (
-                          <SelectItem key={value} value={value}>
-                            {label}
+                      <SelectTrigger
+                        id={id}
+                        aria-describedby={describedBy}
+                        aria-invalid={invalid}
+                        className="w-full bg-transparent border-input dark:bg-muted/50"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__none">Select a field</SelectItem>
+                        {fields.map(f => (
+                          <SelectItem key={f.name} value={f.name}>
+                            {f.label}
                           </SelectItem>
-                        )
-                      )}
-                    </SelectContent>
-                  </Select>
-                </div>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
+                </FieldShell>
+
+                <FieldShell
+                  label="Comparison"
+                  htmlFor="notification-condition-comparison"
+                  className="min-w-36 flex-1"
+                >
+                  {({ id, describedBy, invalid }) => (
+                    <Select
+                      value={condition.comparison}
+                      onValueChange={value =>
+                        update("condition", {
+                          ...condition,
+                          comparison:
+                            value as ConditionalLogicCondition["comparison"],
+                        })
+                      }
+                    >
+                      <SelectTrigger
+                        id={id}
+                        aria-describedby={describedBy}
+                        aria-invalid={invalid}
+                        className="w-full bg-transparent border-input dark:bg-muted/50"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Object.entries(COMPARISON_LABELS).map(
+                          ([value, label]) => (
+                            <SelectItem key={value} value={value}>
+                              {label}
+                            </SelectItem>
+                          )
+                        )}
+                      </SelectContent>
+                    </Select>
+                  )}
+                </FieldShell>
 
                 {!VALUELESS_COMPARISONS.has(condition.comparison) && (
                   <FieldShell

--- a/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.tsx
@@ -21,6 +21,8 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  FieldShell,
+  Grid,
   Input,
   Label,
   Select,
@@ -583,19 +585,20 @@ function NotificationSheet({
 
         <div className="flex-1 overflow-y-auto p-4 space-y-6">
           {/* Name */}
-          <div className="space-y-1.5">
-            <Label htmlFor="notification-name">Name</Label>
+          <FieldShell label="Name" htmlFor="notification-name" width="half">
             <Input
-              id="notification-name"
               type="text"
               value={form.name}
               onChange={e => update("name", e.target.value)}
               placeholder="e.g. Admin notification"
             />
-          </div>
+          </FieldShell>
 
-          {/* Provider & Template */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {/* Provider & Template. A container-query grid rather than the
+              viewport's `sm:` breakpoint: the admin content region is
+              narrower than the window whenever both sidebars are open, so a
+              viewport breakpoint promises columns this sheet does not have. */}
+          <Grid cols={2} responsive>
             <div className="space-y-1.5">
               <Label htmlFor="notification-provider">Email provider</Label>
               <Select
@@ -659,31 +662,27 @@ function NotificationSheet({
                 </p>
               )}
             </div>
-          </div>
+          </Grid>
 
           {/* Sender */}
-          <div className="space-y-1.5">
-            <Label htmlFor="notification-sender">Sender email</Label>
+          <FieldShell
+            label="Sender email"
+            htmlFor="notification-sender"
+            width="half"
+            description={addressErrors.senderEmail ? undefined : senderHelp}
+            error={addressErrors.senderEmail}
+          >
             <Input
-              id="notification-sender"
               type="email"
               value={form.senderEmail ?? ""}
               onChange={e => update("senderEmail", e.target.value || undefined)}
               placeholder={senderPlaceholder}
-              aria-invalid={addressErrors.senderEmail ? true : undefined}
             />
-            {addressErrors.senderEmail ? (
-              <p className="text-xs text-destructive">
-                {addressErrors.senderEmail}
-              </p>
-            ) : (
-              <p className="text-xs text-muted-foreground">{senderHelp}</p>
-            )}
-          </div>
+          </FieldShell>
 
           {/* Recipients */}
           <div className="space-y-4 pt-4 border-t border-border">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Grid cols={2} responsive>
               <div className="space-y-1.5">
                 <Label htmlFor="notification-recipient-type">Send to</Label>
                 <Select
@@ -714,13 +713,9 @@ function NotificationSheet({
                 </Select>
               </div>
 
-              <div className="space-y-1.5">
-                <Label htmlFor="notification-to">
-                  {form.recipientType === "field"
-                    ? "Visitor email field"
-                    : "Recipient address"}
-                </Label>
-                {form.recipientType === "field" ? (
+              {form.recipientType === "field" ? (
+                <div className="space-y-1.5">
+                  <Label htmlFor="notification-to">Visitor email field</Label>
                   <Select
                     value={toRef ?? "__none"}
                     onValueChange={value =>
@@ -742,32 +737,33 @@ function NotificationSheet({
                       ))}
                     </SelectContent>
                   </Select>
-                ) : (
+                  {toFieldOptions.length === 0 && (
+                    <p className="text-xs text-muted-foreground">
+                      Add an email field to the form first.
+                    </p>
+                  )}
+                </div>
+              ) : (
+                <FieldShell
+                  label="Recipient address"
+                  htmlFor="notification-to"
+                  width="half"
+                  error={addressErrors.to}
+                >
                   <Input
-                    id="notification-to"
                     type="email"
                     value={form.to}
                     onChange={e => update("to", e.target.value)}
                     placeholder={
                       defaults?.defaultToEmail || "admin@example.com"
                     }
-                    aria-invalid={addressErrors.to ? true : undefined}
                   />
-                )}
-                {addressErrors.to && (
-                  <p className="text-xs text-destructive">{addressErrors.to}</p>
-                )}
-                {form.recipientType === "field" &&
-                  toFieldOptions.length === 0 && (
-                    <p className="text-xs text-muted-foreground">
-                      Add an email field to the form first.
-                    </p>
-                  )}
-              </div>
-            </div>
+                </FieldShell>
+              )}
+            </Grid>
 
             {/* Reply-To */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Grid cols={2} responsive>
               <div className="space-y-1.5">
                 <Label htmlFor="notification-replyto-mode">Reply-To</Label>
                 <Select
@@ -830,26 +826,23 @@ function NotificationSheet({
                 </div>
               )}
               {replyToMode === "custom" && (
-                <div className="space-y-1.5">
-                  <Label htmlFor="notification-replyto">Reply-To address</Label>
+                <FieldShell
+                  label="Reply-To address"
+                  htmlFor="notification-replyto"
+                  width="half"
+                  error={addressErrors.replyTo}
+                >
                   <Input
-                    id="notification-replyto"
                     type="email"
                     value={form.replyTo ?? ""}
                     onChange={e =>
                       update("replyTo", e.target.value || undefined)
                     }
                     placeholder="replies@example.com"
-                    aria-invalid={addressErrors.replyTo ? true : undefined}
                   />
-                  {addressErrors.replyTo && (
-                    <p className="text-xs text-destructive">
-                      {addressErrors.replyTo}
-                    </p>
-                  )}
-                </div>
+                </FieldShell>
               )}
-            </div>
+            </Grid>
             {replyToMode === "field" && (
               <p className="text-xs text-muted-foreground -mt-2">
                 Replying to this email answers the person who submitted the
@@ -967,10 +960,12 @@ function NotificationSheet({
                 </div>
 
                 {!VALUELESS_COMPARISONS.has(condition.comparison) && (
-                  <div className="min-w-36 flex-1 space-y-1.5">
-                    <Label htmlFor="notification-condition-value">Value</Label>
+                  <FieldShell
+                    label="Value"
+                    htmlFor="notification-condition-value"
+                    className="min-w-36 flex-1"
+                  >
                     <Input
-                      id="notification-condition-value"
                       type="text"
                       value={
                         typeof condition.value === "string" ||
@@ -985,7 +980,7 @@ function NotificationSheet({
                         })
                       }
                     />
-                  </div>
+                  </FieldShell>
                 )}
 
                 <Button
@@ -1110,7 +1105,8 @@ export function FormNotificationsTab({ defaults }: FormNotificationsTabProps) {
   const initialNotification = sheetState.editing ?? createNotification();
 
   return (
-    <div className="max-w-200">
+    // The measure belongs to `FormLayout` now, not to this tab.
+    <div>
       <div className="flex items-center justify-between mb-8 pb-4 border-b border-border">
         <div>
           <h3 className="text-xl font-semibold text-foreground">

--- a/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
@@ -46,7 +46,7 @@ function SettingRow({
 }) {
   return (
     <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-6 py-2">
-      <div className="space-y-1 max-w-xl">
+      <div className="space-y-1">
         <Label
           htmlFor={htmlFor}
           className="text-[13px] font-semibold text-foreground tracking-tight"
@@ -135,7 +135,8 @@ export function FormSettingsTab({ spamDefaults }: FormSettingsTabProps) {
   const { settings, updateSettings } = useFormBuilder();
 
   return (
-    <div className="w-full max-w-3xl flex flex-col gap-10">
+    // The measure belongs to `FormLayout` now, not to this tab.
+    <div className="flex flex-col gap-10">
       {/* Submission */}
       <section>
         <SectionHeading>Submission</SectionHeading>

--- a/packages/ui/STABILITY.md
+++ b/packages/ui/STABILITY.md
@@ -119,26 +119,42 @@ expect them to move.
 `@experimental` as entry points: the functions are trivial and unlikely to change, but
 the subpaths are new and unexercised by any third party.
 
-`FieldShell` (with `FieldShellProps` and `FieldWidth`) is the atom of the form-layout
-kit: a labelled row that caps its control's width to a named token rather than a
-one-off measurement. It owns its own prop merge with `cloneElement` rather than
-delegating to Radix `Slot`, so there is exactly one implementation of "what props does
-the control end up with" and it is not subject to another library's precedence rules.
-`htmlFor` is optional: when omitted, `FieldShell` generates an id with `useId()` and
-puts it on the label; a non-empty `id` the child already carries wins over that
-generated id (an explicitly-present `id={undefined}` does not), and the label always
-targets whichever id the control actually ends up with. Pass `htmlFor` explicitly only
-when the caller already manages its own id. `FieldShell` also owns the control's ARIA
-wiring: it generates ids for `description` and `error` (only for whichever are actually
-rendered) and COMPOSES them onto the control's `aria-describedby` alongside any ids the
-child already listed there, rather than replacing them; the attribute is omitted
+`FieldShell` (with `FieldShellProps`, `FieldShellRenderProps` and `FieldWidth`) is the
+atom of the form-layout kit: a labelled row that caps its control's width to a named
+token rather than a one-off measurement. It owns its own prop merge with `cloneElement`
+rather than delegating to Radix `Slot`, so there is exactly one implementation of "what
+props does the control end up with" and it is not subject to another library's
+precedence rules. `htmlFor` is optional: when omitted, `FieldShell` generates an id with
+`useId()` and puts it on the label; a non-empty `id` the child already carries wins over
+that generated id (an explicitly-present `id={undefined}` does not), and the label
+always targets whichever id the control actually ends up with. Pass `htmlFor` explicitly
+only when the caller already manages its own id. `FieldShell` also owns the control's
+ARIA wiring: it generates ids for `description` and `error` (only for whichever are
+actually rendered) and COMPOSES them onto the control's `aria-describedby` alongside any
+ids the child already listed there, rather than replacing them; the attribute is omitted
 entirely when the result would be empty. A rendered `error` always forces
 `aria-invalid="true"`, overriding whatever the child set; with no error, the child's own
-`aria-invalid` passes through untouched. `children` is typed as a single `ReactElement`,
-not `ReactNode`, and must not be a `Fragment` — nothing can forward props through one —
-which `FieldShell` detects at runtime and reports via `devWarnOnce` rather than
-throwing, since no compile-time check can rule it out. No first-party plugin exercises
-it yet, so it has not met the graduation bar.
+`aria-invalid` passes through untouched.
+
+`children` accepts EITHER a single `ReactElement` (cloned, as above) OR a function of
+type `(field: FieldShellRenderProps) => ReactNode`, called with the SAME `{ id,
+describedBy, invalid }` the clone path would have applied — both derive from one shared
+computation, so the two forms cannot silently drift into answering "what does the
+control get" differently. The element form must not be a `Fragment` — nothing can
+forward props through one — which `FieldShell` detects at runtime and reports via
+`devWarnOnce` rather than throwing, since no compile-time check can rule it out. The
+function form exists for a compound control built on a Radix `Root` (`Select`, and by
+the same shape `RadioGroup`): `Root` destructures a fixed, named prop list and never
+spreads the remainder, so an id `cloneElement` attaches to it never reaches the actual
+focusable element nested inside (`SelectTrigger`, two levels down); the caller applies
+the wiring to that nested element itself instead. In development, `FieldShell` checks
+after mount whether the id it computed landed on any element in the document at all —
+regardless of which `children` form was used — and warns once, by name, if it did not:
+a compound control silently dropping the id is otherwise indistinguishable from one that
+correctly wired it up, since nothing throws and nothing else warns either way. No
+first-party plugin exercised `FieldShell` in production until `plugin-form-builder`'s
+Notifications and Status fields adopted the function form for their `Select` controls,
+so it has not yet met the graduation bar.
 
 `FormSection` (with `FormSectionProps`) is the form-layout kit's section: a labelled
 card holding a group of fields. It composes `Card` for its container rather than

--- a/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
+++ b/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
@@ -143,6 +143,7 @@ exports[`ui public export surface > . surface is unchanged 1`] = `
   "DropdownMenuTrigger (value)",
   "FieldShell (value)",
   "FieldShellProps (type)",
+  "FieldShellRenderProps (type)",
   "FieldWidth (type)",
   "FilterInfo (type)",
   "FormActions (value)",

--- a/packages/ui/src/components/field-shell.test.tsx
+++ b/packages/ui/src/components/field-shell.test.tsx
@@ -14,11 +14,33 @@
  * precedence happened to produce.
  */
 import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { resetDevWarnings } from "../lib/dev-warn";
+import type { FieldShellRenderProps } from "../types/form-layout";
 
 import { FieldShell } from "./field-shell";
+
+/**
+ * Stands in for `@radix-ui/react-select`'s `Root`: it destructures a fixed,
+ * named prop list and never spreads the remainder, so anything cloned onto
+ * it — `id`, `aria-describedby`, `aria-invalid` — never reaches a real DOM
+ * node. Using this shape rather than the real `Select` keeps the suite
+ * independent of `@radix-ui/react-select` while exercising precisely the
+ * failure mode the render-function contract and the mount assertion exist
+ * for.
+ */
+function DropsPropsRoot({
+  children,
+}: {
+  id?: string;
+  "aria-describedby"?: string;
+  "aria-invalid"?: boolean;
+  children: ReactNode;
+}) {
+  return <div data-testid="drops-props-root">{children}</div>;
+}
 
 // Several cases below share the label text "Name" and query for it through
 // the shared jsdom document via `screen`, so a leftover mount from an earlier
@@ -265,5 +287,149 @@ describe("FieldShell", () => {
     } finally {
       warn.mockRestore();
     }
+  });
+
+  describe("a render-function child", () => {
+    it("receives a computed id that lands on the element the caller applies it to, matching the label's htmlFor", () => {
+      render(
+        <FieldShell label="Status">
+          {({ id }: FieldShellRenderProps) => (
+            <input aria-label="Status" id={id} />
+          )}
+        </FieldShell>
+      );
+      const label = screen.getByText("Status");
+      const control = screen.getByLabelText("Status");
+      expect(control.id).not.toBe("");
+      expect(label.getAttribute("for")).toBe(control.id);
+    });
+
+    it("computes the same id, describedBy and invalid as the element path for the same props", () => {
+      // Re-rendering the SAME FieldShell instance — rather than mounting two
+      // separate ones — is what makes this comparison meaningful: `useId()`
+      // is stable across a re-render of one instance but differs between
+      // two independent mounts, so only a re-render lets the two paths be
+      // compared by identical id values rather than merely similar shapes.
+      // If the render-function path re-derived its own answer instead of
+      // sharing the element path's computation, swapping `children` here
+      // would change what the function receives even though nothing else
+      // did.
+      let received: FieldShellRenderProps | undefined;
+      const { rerender } = render(
+        <FieldShell
+          label="Name"
+          description="Shown in the key list."
+          error="Name is required"
+        >
+          <input aria-label="Name" />
+        </FieldShell>
+      );
+      const elementControl = screen.getByLabelText("Name");
+      const elementId = elementControl.id;
+      const elementDescribedBy =
+        elementControl.getAttribute("aria-describedby");
+      const elementInvalid = elementControl.getAttribute("aria-invalid");
+
+      rerender(
+        <FieldShell
+          label="Name"
+          description="Shown in the key list."
+          error="Name is required"
+        >
+          {(field: FieldShellRenderProps) => {
+            received = field;
+            return (
+              <input
+                aria-label="Name"
+                id={field.id}
+                aria-describedby={field.describedBy}
+                aria-invalid={field.invalid}
+              />
+            );
+          }}
+        </FieldShell>
+      );
+
+      expect(received?.id).toBe(elementId);
+      expect(received?.describedBy).toBe(elementDescribedBy ?? undefined);
+      expect(String(received?.invalid)).toBe(elementInvalid);
+    });
+  });
+
+  describe("the post-mount id assertion", () => {
+    it("warns when the computed id lands on no element in the document", () => {
+      // `DropsPropsRoot` is the failure mode itself: a component that takes
+      // `id` as a prop and never puts it anywhere in the DOM, exactly like
+      // `@radix-ui/react-select`'s `Root`.
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        render(
+          <FieldShell label="Status">
+            <DropsPropsRoot>
+              <button type="button">Status trigger</button>
+            </DropsPropsRoot>
+          </FieldShell>
+        );
+        expect(warn).toHaveBeenCalled();
+        const messages = warn.mock.calls.map(call => String(call[0]));
+        expect(messages.some(message => message.includes('"Status"'))).toBe(
+          true
+        );
+        expect(
+          messages.some(message =>
+            message.includes("never appeared on any element")
+          )
+        ).toBe(true);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it("stays silent for a correctly wired atomic control", () => {
+      // The positive control for the case above: without it, a check that
+      // fired unconditionally — or that never ran at all and let the
+      // `toHaveBeenCalled()` assertion above pass on some other warning —
+      // would pass this too.
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        render(
+          <FieldShell label="Name">
+            <input aria-label="Name" />
+          </FieldShell>
+        );
+        expect(warn).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it("stays silent for a correctly wired render-function control", () => {
+      // The render-function counterpart of the atomic-control control above:
+      // the caller applies the computed wiring to the real, focusable
+      // element nested inside the compound root, so the id lands and the
+      // check has nothing to report.
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        render(
+          <FieldShell label="Status">
+            {({ id, describedBy, invalid }: FieldShellRenderProps) => (
+              <DropsPropsRoot>
+                <button
+                  type="button"
+                  id={id}
+                  aria-describedby={describedBy}
+                  aria-invalid={invalid}
+                >
+                  Status trigger
+                </button>
+              </DropsPropsRoot>
+            )}
+          </FieldShell>
+        );
+        expect(warn).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
+    });
   });
 });

--- a/packages/ui/src/components/field-shell.tsx
+++ b/packages/ui/src/components/field-shell.tsx
@@ -1,9 +1,15 @@
-import { cva } from "class-variance-authority";
-import { cloneElement, Fragment, useId } from "react";
+"use client";
 
-import { devWarnOnce } from "../lib/dev-warn";
+import { cva } from "class-variance-authority";
+import type * as React from "react";
+import { cloneElement, Fragment, useEffect, useId } from "react";
+
+import { devWarnOnce, isDevelopmentRuntime } from "../lib/dev-warn";
 import { cn } from "../lib/utils";
-import type { FieldShellProps } from "../types/form-layout";
+import type {
+  FieldShellProps,
+  FieldShellRenderProps,
+} from "../types/form-layout";
 
 /**
  * The width cap applies to a wrapper around the control, not to the field row.
@@ -36,17 +42,17 @@ const controlWidth = cva("w-full", {
  * primitive type — rather than asserting a shape onto a value nothing has
  * verified. A key present with the wrong type (an `id` that is a number, an
  * `aria-describedby` that is a boolean) is treated the same as absent: the
- * caller's field-shell contract is about ids and id-reference strings, and a
- * value that cannot serve as one is not a real override.
+ * caller's field-shell contract is about ids, id-reference strings and a
+ * validity flag, and a value that cannot serve as one is not a real
+ * override.
  */
 interface KnownControlProps {
   id?: unknown;
   "aria-describedby"?: unknown;
+  "aria-invalid"?: unknown;
 }
 
-function readControlProps(
-  child: FieldShellProps["children"]
-): KnownControlProps {
+function readControlProps(child: React.ReactElement): KnownControlProps {
   const props: unknown = child.props;
   // An object with no properties the type checker knows about is already
   // assignable to a type whose properties are all optional, so no cast is
@@ -55,7 +61,7 @@ function readControlProps(
 }
 
 /**
- * The props this component injects onto the control, computed once and
+ * The props this component injects onto a cloned control, computed once and
  * applied with a single `cloneElement` call.
  *
  * Declared as its own type, rather than inlined at the call site, so the
@@ -70,6 +76,85 @@ interface ControlOverrides {
   id: string;
   "aria-describedby"?: string;
   "aria-invalid"?: boolean;
+}
+
+/**
+ * `children` may be a single element (cloned) or a function that receives
+ * the computed wiring and applies it itself.
+ *
+ * `typeof` is the only check that can tell the two apart at runtime: both
+ * are valid members of the union, and nothing about a value's STATIC type
+ * alone settles which one a given `children` is. Declaring this as a real
+ * type-guard function — rather than inlining `typeof children === "function"`
+ * at each call site — is what lets every caller below narrow `children`
+ * without a cast.
+ */
+function isRenderFunction(
+  children: FieldShellProps["children"]
+): children is (field: FieldShellRenderProps) => React.ReactNode {
+  return typeof children === "function";
+}
+
+/**
+ * The id, `aria-describedby` and `aria-invalid` this component computes for
+ * its control — ONE computation, shared by both the element-clone path and
+ * the render-function path, so the two can never silently drift into
+ * answering the same question differently.
+ *
+ * `ownProps` carries whatever the caller's single element already had (its
+ * own id, an existing `aria-describedby` to compose with, an
+ * `aria-invalid` to defer to when there is no error). The render-function
+ * path passes an empty object: there is no pre-existing child to read those
+ * from — the caller applies the returned wiring itself — so "nothing to
+ * defer to" is simply the empty case of this same function rather than a
+ * second, parallel computation.
+ */
+function computeControlWiring(
+  ownProps: KnownControlProps,
+  requestedId: string,
+  renderedMessageIds: readonly string[],
+  hasError: boolean
+): FieldShellRenderProps {
+  // A non-empty string the child already carries wins over the requested id;
+  // anything else — including an explicitly-present `id={undefined}`, which
+  // a naive object spread would let win — does not. Deciding this here,
+  // rather than leaving it to a generic prop-merge, is the entire point of
+  // owning the merge: there is exactly one rule for what counts as "the
+  // child already has an id", and it is applied before the clone rather than
+  // discovered afterward in whatever a merge library happened to do.
+  const ownId =
+    typeof ownProps.id === "string" && ownProps.id !== ""
+      ? ownProps.id
+      : undefined;
+  const id = ownId ?? requestedId;
+
+  const ownDescribedByIds =
+    typeof ownProps["aria-describedby"] === "string"
+      ? ownProps["aria-describedby"].split(" ").filter(Boolean)
+      : [];
+  // Compose, never replace: a child may already point at ids of its own (a
+  // unit label, a character counter) that this component knows nothing
+  // about, and overwriting them would break whatever wired them up. The
+  // child's own ids come first so the reading order matches what the caller
+  // wrote; `Set` then drops any id both sides already agree on.
+  const describedByIds = Array.from(
+    new Set([...ownDescribedByIds, ...renderedMessageIds])
+  );
+  const describedBy =
+    describedByIds.length > 0 ? describedByIds.join(" ") : undefined;
+
+  const ownInvalid =
+    typeof ownProps["aria-invalid"] === "boolean"
+      ? ownProps["aria-invalid"]
+      : undefined;
+  // A rendered error always forces the control invalid: a child that
+  // already set `aria-invalid={false}`, or left it unset, must not
+  // suppress a validation message that is visibly on the page. With no
+  // error, the child's own claim about itself (if any) passes through
+  // unmodified instead of being cleared to absent.
+  const invalid = hasError ? true : ownInvalid;
+
+  return { id, describedBy, invalid };
 }
 
 /** @experimental */
@@ -96,21 +181,6 @@ export function FieldShell({
   // otherwise.
   const requestedId = htmlFor ?? generatedControlId;
 
-  const ownProps = readControlProps(children);
-
-  // A non-empty string the child already carries wins over the requested id;
-  // anything else — including an explicitly-present `id={undefined}`, which
-  // a naive object spread would let win — does not. Deciding this here,
-  // rather than leaving it to a generic prop-merge, is the entire point of
-  // owning the merge: there is exactly one rule for what counts as "the
-  // child already has an id", and it is applied before the clone rather than
-  // discovered afterward in whatever a merge library happened to do.
-  const ownId =
-    typeof ownProps.id === "string" && ownProps.id !== ""
-      ? ownProps.id
-      : undefined;
-  const controlId = ownId ?? requestedId;
-
   // Only messages that actually render get an id, and only those ids are
   // listed: a control pointed at an id nothing carries is worse than one
   // with no description at all.
@@ -119,62 +189,94 @@ export function FieldShell({
     error ? errorId : null,
   ].filter((id): id is string => id !== null);
 
-  const ownDescribedByIds =
-    typeof ownProps["aria-describedby"] === "string"
-      ? ownProps["aria-describedby"].split(" ").filter(Boolean)
-      : [];
-
-  // Compose, never replace: a child may already point at ids of its own (a
-  // unit label, a character counter) that this component knows nothing
-  // about, and overwriting them would break whatever wired them up. The
-  // child's own ids come first so the reading order matches what the caller
-  // wrote; `Set` then drops any id both sides already agree on.
-  const describedByIds = Array.from(
-    new Set([...ownDescribedByIds, ...renderedMessageIds])
-  );
-  const describedBy =
-    describedByIds.length > 0 ? describedByIds.join(" ") : undefined;
-
-  const controlOverrides: ControlOverrides = {
-    id: controlId,
-    ...(describedBy !== undefined ? { "aria-describedby": describedBy } : {}),
-    // A rendered error always forces the control invalid: a child that
-    // already set `aria-invalid={false}`, or left it unset, must not
-    // suppress a validation message that is visibly on the page. With no
-    // error the key is omitted entirely rather than set to `undefined`, so
-    // `cloneElement` leaves whatever the child already had untouched instead
-    // of overwriting it with an absence.
-    ...(error ? { "aria-invalid": true } : {}),
-  };
+  const wiring = isRenderFunction(children)
+    ? computeControlWiring({}, requestedId, renderedMessageIds, Boolean(error))
+    : computeControlWiring(
+        readControlProps(children),
+        requestedId,
+        renderedMessageIds,
+        Boolean(error)
+      );
 
   // A Fragment is a valid `ReactElement` — it type-checks as one — but it
   // forwards none of these props to anything inside it, so cloning it would
   // silently disconnect the label and the validation wiring from every real
   // element the Fragment contains. The type system cannot rule this out
   // (`Fragment`'s element type is indistinguishable from any other
-  // component's at the type level), so it is checked at runtime instead.
-  const isFragment = children.type === Fragment;
-  devWarnOnce(
-    !isFragment,
-    "FieldShell: `children` must be a single element, not a Fragment. A Fragment forwards " +
-      "no props to the elements inside it, so the id, aria-describedby and aria-invalid this " +
-      "component computes would have nowhere to land — the label and the control would look " +
-      "wired up and never actually connect. Wrap the intended elements in a real element " +
-      "instead, such as a `<div>`."
-  );
-  // Cloning a Fragment with these props would only add React's own "invalid
-  // prop supplied to React.Fragment" warning on top of the one above without
-  // fixing anything, so it is rendered unmodified and the warning is the
-  // only signal.
-  const control = isFragment
-    ? children
-    : cloneElement(children, controlOverrides);
+  // component's at the type level), so it is checked at runtime instead, and
+  // computed here — once — rather than separately by the render branch below
+  // and the mount check that follows it.
+  const isFragmentChild =
+    !isRenderFunction(children) && children.type === Fragment;
+
+  // Development-only: confirm the id this component computed actually
+  // landed on something in the document. A compound Radix control (the
+  // `Select` root, and by the same shape `RadioGroup`) destructures a fixed,
+  // named prop list and never spreads the remainder, so an id attached via
+  // `cloneElement` — or one a render function forgot to apply to its real
+  // control — is silently dropped: nothing throws, nothing else warns, and
+  // the label ends up pointing at an id nothing carries. Gated on
+  // `isDevelopmentRuntime()` up front, rather than only inside
+  // `devWarnOnce`, so the DOM query itself never runs in production — not
+  // merely its console output. Skipped for a Fragment child: that case is
+  // already reported, precisely and without a DOM query, by the warning
+  // below — this check would only restate the same defect less specifically.
+  useEffect(() => {
+    if (!isDevelopmentRuntime()) return;
+    if (isFragmentChild) return;
+    const landed = document.getElementById(wiring.id) !== null;
+    const fieldName = typeof label === "string" ? `"${label}"` : "this field";
+    devWarnOnce(
+      landed,
+      `FieldShell: the id computed for ${fieldName} never appeared on any element in the ` +
+        "document, so its label and any description are not connected to the control. This " +
+        "happens when the control is a compound component — a Radix `Select`, `RadioGroup`, " +
+        "or similar — whose root does not forward `id`/`aria-describedby`/`aria-invalid` to a " +
+        "real DOM node. Pass `children` as a function and apply those to the control's actual " +
+        "focusable element (its trigger) instead of a single top-level clone."
+    );
+    // `wiring.id` is the value being checked; `label` supplies the message's
+    // field name; `isFragmentChild` decides whether the check runs at all.
+    // Re-running when any of these changes lets the check re-evaluate a
+    // field whose identity, generated id or child shape shifted, rather
+    // than only ever inspecting the very first commit.
+  }, [wiring.id, label, isFragmentChild]);
+
+  let control: React.ReactNode;
+  if (isRenderFunction(children)) {
+    control = children(wiring);
+  } else {
+    devWarnOnce(
+      !isFragmentChild,
+      "FieldShell: `children` must be a single element, not a Fragment. A Fragment forwards " +
+        "no props to the elements inside it, so the id, aria-describedby and aria-invalid this " +
+        "component computes would have nowhere to land — the label and the control would look " +
+        "wired up and never actually connect. Wrap the intended elements in a real element " +
+        "instead, such as a `<div>`."
+    );
+    const controlOverrides: ControlOverrides = {
+      id: wiring.id,
+      ...(wiring.describedBy !== undefined
+        ? { "aria-describedby": wiring.describedBy }
+        : {}),
+      ...(wiring.invalid !== undefined
+        ? { "aria-invalid": wiring.invalid }
+        : {}),
+    };
+    // Cloning a Fragment with these props would only add React's own
+    // "invalid prop supplied to React.Fragment" warning on top of the one
+    // above without fixing anything, so it is rendered unmodified and the
+    // warning is the only signal.
+    control = isFragmentChild
+      ? children
+      : cloneElement(children, controlOverrides);
+  }
 
   return (
     <div className={cn("flex flex-col gap-1.5", className)}>
       {label ? (
         <label
-          htmlFor={controlId}
+          htmlFor={wiring.id}
           className="text-sm font-medium text-foreground"
         >
           {label}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -547,7 +547,11 @@ export type { KeyChord, KeySequence } from "./lib/shortcuts/key-spec";
 /** @experimental Form layout. No first-party plugin has exercised it in production yet. */
 export { FieldShell } from "./components/field-shell";
 /** @experimental */
-export type { FieldShellProps, FieldWidth } from "./types/form-layout";
+export type {
+  FieldShellProps,
+  FieldShellRenderProps,
+  FieldWidth,
+} from "./types/form-layout";
 
 /**
  * @experimental A labelled card holding a group of fields, composing `Card`

--- a/packages/ui/src/lib/dev-warn.ts
+++ b/packages/ui/src/lib/dev-warn.ts
@@ -68,8 +68,13 @@ const SPEAKING_ENVIRONMENTS = new Set(["development", "test"]);
  * at build time, but nothing obliges them to: a build that leaves `process`
  * undefined would answer "not production" and ship every warning to end users.
  * An unrecognized environment is treated as one to stay quiet in.
+ *
+ * Exported so a caller that needs to skip more than a `console.warn` in
+ * production — a component gating an entire post-mount DOM check, for
+ * example — reuses this SAME predicate rather than re-deriving its own
+ * `process.env.NODE_ENV` guard next to it.
  */
-function isDevelopmentRuntime(): boolean {
+export function isDevelopmentRuntime(): boolean {
   if (typeof process === "undefined") return false;
   const env = process?.env?.NODE_ENV;
   return env !== undefined && SPEAKING_ENVIRONMENTS.has(env);

--- a/packages/ui/src/types/form-layout.ts
+++ b/packages/ui/src/types/form-layout.ts
@@ -9,6 +9,25 @@
  */
 export type FieldWidth = "half" | "full" | "fill";
 
+/**
+ * The wiring `FieldShell` computes for its control: the id to attach, the
+ * composed `aria-describedby` (`undefined` when nothing is rendered to point
+ * at), and whether a rendered `error` forces the control invalid (`undefined`
+ * when there is no error to force one way or the other).
+ *
+ * A render-function `children` (see `FieldShellProps`) receives exactly this
+ * object — the SAME computation the element-clone path derives its
+ * `cloneElement` overrides from — so a caller wiring a compound control (a
+ * Radix `Select`'s trigger, for example) gets precisely the values the
+ * simple, single-element case would have applied.
+ * @experimental
+ */
+export interface FieldShellRenderProps {
+  id: string;
+  describedBy: string | undefined;
+  invalid: boolean | undefined;
+}
+
 /** @experimental */
 export interface FieldShellProps {
   label?: React.ReactNode;
@@ -21,17 +40,32 @@ export interface FieldShellProps {
   htmlFor?: string;
   className?: string;
   /**
-   * Exactly one element: the control this field wraps. `FieldShell` clones it
-   * with `cloneElement` to attach the id, `aria-describedby` and
-   * `aria-invalid` it computes, rather than rendering a wrapper. Typing this
-   * as `ReactNode` would let a composite field (two inputs with a unit
-   * between them, for example) compile and then crash on mount. A caller
-   * with several elements to slot in wraps them in one — a `<div>`, not a
-   * `<Fragment>`: a Fragment forwards none of those props to what is inside
-   * it, so the element must be single and DOM-bearing for the clone to have
-   * anywhere to land them.
+   * Either a single element to clone, or a function that receives the
+   * computed wiring and applies it itself.
+   *
+   * The element form is `FieldShell` cloning it with `cloneElement` to
+   * attach the id, `aria-describedby` and `aria-invalid` it computes —
+   * unchanged from before, and still the right choice for an atomic control
+   * (`Input`, `Textarea`, `Switch`) that spreads its own props onto a real
+   * DOM node. Typing this branch as `ReactNode` would let a composite field
+   * (two inputs with a unit between them, for example) compile and then
+   * crash on mount, so it stays a single `ReactElement` — wrap several
+   * elements in one real element, a `<div>`, not a `<Fragment>`: a Fragment
+   * forwards none of those props to what is inside it.
+   *
+   * The function form exists for a compound control built on a Radix `Root`
+   * (`Select`, and by the same shape `RadioGroup`): `Root` destructures a
+   * fixed, named prop list and never spreads the remainder, so `id` handed
+   * to it via `cloneElement` is silently dropped rather than reaching the
+   * actual focusable element two levels down (`Select` > `SelectTrigger` >
+   * `SelectValue`). A render function is called with `FieldShellRenderProps`
+   * and applies `id`/`describedBy`/`invalid` to whichever nested element is
+   * the real control, instead of relying on a single top-level clone that
+   * can never reach it.
    */
-  children: React.ReactElement;
+  children:
+    | React.ReactElement
+    | ((field: FieldShellRenderProps) => React.ReactNode);
 }
 
 /**


### PR DESCRIPTION
## Summary

Puts the Create Form page onto the shared form layout layer from #872, and closes one contract gap the conversion exposed.

This page was the deliberate pilot: it lives in a **plugin**, so it can only import `@nextlyhq/ui` and `@nextlyhq/plugin-sdk/admin`, never `@nextlyhq/admin`. If the layer works here it works everywhere.

### What the page loses

- the hand-rolled outer card (`flex border border-border bg-background overflow-hidden`)
- its own page padding (`w-full px-8 pt-8 pb-12 space-y-6`)
- the `-mx-8 px-8` negative-margin divider hack, which existed only to escape that padding, so it had nothing left to escape
- `max-w-3xl` and `max-w-xl` in the Settings tab, and `max-w-200` in Notifications: these were why those tabs did not fill their region
- three `grid-cols-1 sm:grid-cols-2` blocks, now container-driven. The viewport breakpoint was wrong here because the admin content region is 328px narrower than the window whenever both sidebars are open

Submit and Cancel move into one `FormActions`, and the page's own hand-rolled "Unsaved changes" badge is deleted because `FormActions` renders that state itself. Two implementations of one fact is what this whole layer exists to remove.

### The contract gap the pilot found

`FieldShell` attached `id`/`aria-describedby`/`aria-invalid` by cloning its single child. That works for `Input`, `Textarea` and `Switch`, which spread props onto a real DOM node. It **fails silently** for compound Radix controls: `Select` is `Root` + `Trigger`, and `Root` destructures a fixed prop list and never spreads the rest, so the props are dropped. The label ends up pointing at an id that exists nowhere and nothing throws.

Ten fields on this page alone, and it would recur on every remaining admin form page.

Two changes close it:

1. **`children` may now be a render function** receiving `{ id, describedBy, invalid }`, so a caller can apply them to whichever nested element is the real control (`SelectTrigger` here). The single-element clone path is unchanged, so simple fields stay simple. Both paths derive from one computation, which is asserted.
2. **A development-only assertion makes the failure loud.** After mount, if no element carries the id the component computed, it warns through the package's existing `devWarnOnce`. The worst property of the old design was not that the clone missed, it is that it missed in silence.

## Test plan

- `packages/ui` 1056 passing, `plugin-form-builder` 89 passing, `packages/admin` failing FILE SET byte-identical to the pre-existing baseline (`comm -13` empty).
- Every new assertion break-verified: mechanism removed, test confirmed failing at runtime for the intended reason, restored.
- **Verified in a real browser at 1280x900, both themes**, on all three tabs. Measured rather than eyeballed:
  - content region 952px, layout measure 888px, so the measure binds and centres
  - **zero dangling `label[for]` targets and zero dangling `aria-describedby` ids in either theme** — that is the exact defect class this PR's contract change exists to prevent, checked against the live DOM
  - scrolled to the bottom of the longest tab, **zero elements obscured** by the sticky action bar

## Pre-existing failures, flagged so they are not read as regressions

`packages/admin` has 5 failing test files / 19 tests on `main`, unrelated to this PR: `StatsCard`, `RoleBasicInfo`, `BasicsTab`, `SlugInput`, `DefaultValueField`.

## Changeset

Changeset added: **yes (patch)**, one, covering the fixed group.

## Known limit, stated rather than hidden

The dev assertion has one false-positive shape: a render function that mounts its real control asynchronously, past the first commit, would get a single non-retracting warning. No converted field has that shape. Documented rather than solved with a larger mechanism.
