### PR TITLE
fix(nextly): let the code sync's repair reach the write

### DIFF
--- a/.changeset/field-group-code-sync-repair-writes.md
+++ b/.changeset/field-group-code-sync-repair-writes.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Field-group repair for a code-managed group now writes its fix instead of being refused for the lock the caller was already cleared past.

--- a/packages/nextly/src/domains/field-groups/__tests__/field-group-reconcile-from-code.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/field-group-reconcile-from-code.integration.test.ts
@@ -1,0 +1,117 @@
+/**
+ * The code-sync recovery path must actually WRITE its repair.
+ *
+ * A code-managed field group is LOCKED, and a locked row marked `diverged` is refused from both
+ * directions — `assertNotDiverged` blocks the sync that would correct it, and the lock check blocks
+ * a human-initiated reconcile. `fromCode` is the single way out: the sync itself asks for the
+ * repair, holding the config file that IS the definition.
+ *
+ * 🔴 What makes this file necessary rather than redundant: every other test of that path asserts
+ * the CALL — that the sync invokes reconcile — and a call that reaches the database and writes
+ * nothing satisfies all of them. The write is the whole point of the recovery, and it crosses two
+ * guards that read the same row for different reasons (the lock check before the plan, the
+ * conditional predicate inside the write). A change to either can strand this path while every
+ * existing assertion stays green, which is exactly what happened once: adding `locked` to the
+ * conditional predicate left the lock check passing and the write matching zero rows, so the
+ * recovery raised "run the reconcile again" on a row that could never satisfy it.
+ *
+ * Self-skips per dialect on the standard rule.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const FIELDS = [
+  { name: "heading", type: "text" },
+  { name: "weight", type: "number" },
+];
+
+for (const dialect of getConfiguredTestDialects()) {
+  describe(`the code-sync reconcile recovery — ${dialect}`, () => {
+    const slug = `fgfc_${dialect.slice(0, 2)}`;
+
+    /** A LOCKED, `diverged` group — the state the recovery exists to clear. */
+    async function seedLockedDiverged() {
+      current = await createTestNextly({ dialect });
+      const registry = current.getService("fieldGroupRegistryService");
+      await current.nextly.fieldGroups.create({
+        slug,
+        label: "Code managed",
+        fields: FIELDS,
+      });
+      // Claimed by code and marked, exactly as a sync whose companion DDL committed and whose row
+      // write failed leaves it. `source: "code"` because a UI caller cannot set either.
+      await registry.updateComponent(
+        slug,
+        { locked: true, migrationStatus: "diverged" },
+        { source: "code" }
+      );
+      return { registry, row: await registry.getComponent(slug) };
+    }
+
+    it("clears the mark on a locked group and persists the repair", async () => {
+      const { registry, row } = await seedLockedDiverged();
+      expect(row.locked).toBe(true);
+      expect(row.migrationStatus).toBe("diverged");
+
+      const { reconcileFieldGroup } = await import(
+        "../services/field-group-reconcile-service"
+      );
+      const report = await reconcileFieldGroup({
+        registry,
+        adapter: current!.adapter,
+        logger: current!.getService("logger"),
+        slug,
+        fromCode: true,
+      });
+
+      // The tables are healthy, so nothing about the FIELDS needed repairing — the standing mark
+      // is the thing that was wrong, and clearing it is a write.
+      expect(report.slug).toBe(slug);
+
+      // 🔴 Asserted on the ROW, not on the report. A path that returned a plausible report while
+      // writing nothing is precisely the failure this file exists to catch, and the report alone
+      // cannot separate the two.
+      const after = await registry.getComponent(slug);
+      expect(after.migrationStatus).toBe("synced");
+      expect(after.schemaVersion).toBe(row.schemaVersion + 1);
+      // Still code-managed: the recovery repairs the record, it does not release ownership.
+      expect(after.locked).toBe(true);
+    });
+
+    // The control that keeps `fromCode` from becoming a general bypass: without it the same call
+    // must still be refused, because a human-initiated repair of a code-managed row would be
+    // overwritten by the next sync and the config file is what needs fixing.
+    it("still refuses a locked group when the caller is not the code sync", async () => {
+      const { registry } = await seedLockedDiverged();
+
+      const { reconcileFieldGroup } = await import(
+        "../services/field-group-reconcile-service"
+      );
+
+      await expect(
+        reconcileFieldGroup({
+          registry,
+          adapter: current!.adapter,
+          logger: current!.getService("logger"),
+          slug,
+        })
+      ).rejects.toMatchObject({ code: "CONFLICT" });
+
+      // And the refusal wrote nothing.
+      const after = await registry.getComponent(slug);
+      expect(after.migrationStatus).toBe("diverged");
+    });
+  });
+}

--- a/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
@@ -354,7 +354,15 @@ export async function reconcileFieldGroup(args: {
       migrationStatus: "synced",
       schemaHash: calculateSchemaHash(plan.fields as unknown as FieldConfig[]),
     },
-    existing.schemaVersion
+    existing.schemaVersion,
+    // 🔴 The caller's identity has to reach the WRITE, not stop at the precondition above. A
+    // code-managed group is LOCKED, and the registry refuses a locked row to any writer that is not
+    // the config file — first with a permission refusal, then with the lock clause in the
+    // conditional predicate. `fromCode` means the code sync is asking, holding the file that IS the
+    // definition, so it is the owner here exactly as it is for the lock check at the top of this
+    // function. Omitting it left the recovery path reaching the database and being refused every
+    // time, on the one route out of a locked row marked `diverged`.
+    args.fromCode ? { source: "code" } : undefined
   );
 
   if (!outcome.matched) {


### PR DESCRIPTION
## What this fixes

The code-sync recovery for a **locked** field group marked `diverged` never worked. It reached the database and was refused every time.

`reconcileFieldGroup` clears a `fromCode` caller past its own lock check, then called `updateComponentIfVersion` **without saying who was asking**. That method refuses a locked row to any writer that is not the config file — so the repair was rejected at the write, on the one route out of a locked `diverged` row.

That state is reachable and is a dead end without this: `assertNotDiverged` blocks the sync that would correct it, and the lock check blocks a human-initiated reconcile. `fromCode` is the way out, and it did not reach the part that writes.

## Why nothing caught it

Every existing test asserted that the sync **calls** reconcile. A call that reaches the database and writes nothing satisfies all of them.

The new integration file asserts the **row** afterwards, on all three dialects, plus the control that a non-code caller is still refused and writes nothing.

## Verification

- `field-group-reconcile-from-code.integration.test.ts` — 6/6 across postgres, mysql, sqlite
- field-group integration **121/121** (was 115; +6 new)
- field-group unit 742 passed, 1 pre-existing failure unchanged (`field-group-data-service.test.ts > deleteComponentDataInTransaction`)
- build, check-types, lint, drizzle-v1, storage-format-literals, comment-convention all green by exit code
- Break control: removing the argument fails `clears the mark on a locked group and persists the repair` on every dialect and nothing else

## Note

Found while auditing the final commit of #863, which merged without a review verdict on either endpoint. This defect predates that commit — it shipped with the `fromCode` path itself.