### PR TITLE
test(root): assert which block the canvas reports dragging

### DIFF
--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -1039,18 +1039,24 @@ test.describe("a canvas any Nextly editor could ship", () => {
     const fixture = await seedPage(request, FLAT_LIST_FIXTURE);
     await driver.mountTree(fixture);
 
-    await chrome.startDragOfBlock(fixture.blockIds[1] ?? "");
+    const wanted = fixture.blockIds[1] ?? "";
+    await chrome.startDragOfBlock(wanted);
 
+    // The block BY NAME, not merely that a drag is running. `isDragging` answers for any
+    // grabbed element in either document, so a coordinate offset that pressed a sibling
+    // would satisfy it while the reader picked up the wrong block — and the case below
+    // would then rest on an instrument that had quietly stopped doing what it claims.
+    //
     // POLLED for the same reason the Escape case polls: the drag state is written on a
     // React commit, so a read taken in the tick that started the drag sees the state one
     // commit before it is set and reports a working drag as a dead one.
     await expect
-      .poll(async () => driver.isDragging(), {
+      .poll(async () => chrome.draggingBlockId(), {
         message:
-          "a placed block must be draggable on a canvas with no prior drag",
+          "the block asked for must be the one the canvas reports dragging",
         timeout: ESCAPE_SETTLE_MS,
       })
-      .toBe(true);
+      .toBe(wanted);
 
     await driver.cancel();
   });

--- a/e2e/tests/canvas/driver.ts
+++ b/e2e/tests/canvas/driver.ts
@@ -361,6 +361,16 @@ export interface CanvasChromeReader {
   /** Begin dragging a block that is already in the canvas, by its id. */
   startDragOfBlock(id: string): Promise<void>;
 
+  /**
+   * Which block the canvas currently reports as the drag source, or `null` when none is.
+   *
+   * Named rather than counted, because "some element is being dragged" and "THIS block is
+   * being dragged" are different claims and only the second separates a working
+   * {@link startDragOfBlock} from one whose coordinates drifted onto a sibling. A control
+   * asserting the first stays green while the reader picks up the wrong block.
+   */
+  draggingBlockId(): Promise<string | null>;
+
   /** How many entries the editor's undo history holds. */
   undoDepth(): Promise<number>;
 }

--- a/e2e/tests/canvas/poc-driver.ts
+++ b/e2e/tests/canvas/poc-driver.ts
@@ -933,6 +933,28 @@ export function createPocChromeReader(
       });
     },
 
+    async draggingBlockId(): Promise<string | null> {
+      // The block's OWN id, read from the element the canvas marks as grabbed, so a caller
+      // can assert WHICH block moved rather than that something did. Matched by comparing
+      // attribute values rather than by building a selector from an id, for the same reason
+      // the drag itself is: an id is data, and one carrying selector syntax would otherwise
+      // change what is matched.
+      //
+      // Both documents, because a panel drag's source is host chrome while a placed block's
+      // is inside the frame.
+      const read = async (where: Frame | Page) =>
+        where.evaluate(attribute => {
+          const grabbed = document.querySelector('[aria-grabbed="true"]');
+          if (!grabbed) return null;
+          // The marked element may be the block itself or a wrapper inside it, so the id is
+          // taken from the nearest enclosing node that carries one.
+          return (
+            grabbed.closest(`[${attribute}]`)?.getAttribute(attribute) ?? null
+          );
+        }, "data-nx-id");
+      return (await read(page)) ?? (await read(canvasFrameOf(page)));
+    },
+
     async undoDepth(): Promise<number> {
       // LOOKED FOR, then refused — never refused on the assumption that it is absent. A
       // reader that declines unconditionally reports the same thing for "there is no seam"


### PR DESCRIPTION
## What

The fresh-drag control added in #877 polled `isDragging()`, which answers for **any** grabbed element in either document. It never checked that the block it asked for is the one being dragged. `CanvasChromeReader` gains `draggingBlockId()`, and the control asserts the name.

## Why

`startDragOfBlock` presses at a computed point. A coordinate offset that lands on a sibling still starts a drag, so `isDragging()` stays true while the reader picks up the wrong block — and the B-15 expected-failure case then rests on an instrument that has quietly stopped doing what it claims.

"Some element is being dragged" and "THIS block is being dragged" are different claims, and only the second separates a working reader from a drifted one.

## Evidence

Seen failing for the intended reason. With the press point shifted a block height down so it lands on the neighbour:

```
Error: the block asked for must be the one the canvas reports dragging
Expected: "nx-flat-0"
Received: "nx-flat-1"
```

**A drag was genuinely running throughout that break** — the reader returned a real id — so the previous `isDragging()` assertion would have passed. That is the separating property demonstrated rather than argued.

Restored, full suite **15 passed**.

## Notes

`draggingBlockId()` reads both documents, because a panel drag's source is host chrome while a placed block's is inside the frame. It matches by comparing attribute values rather than building a selector from an id, for the same reason the drag itself does: an id is data, and one carrying selector syntax would change what is matched. It walks to the nearest enclosing `[data-nx-id]`, since the marked element may be a wrapper inside the block.

Test-only, so no changeset.