### PR TITLE
fix(nextly): require the exact main key and the system column defaults

### DIFF
--- a/.changeset/field-group-structural-key-and-defaults.md
+++ b/.changeset/field-group-structural-key-and-defaults.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Field-group repair now refuses a table whose primary key is not exactly the expected one, and one whose system columns have lost their database defaults.

--- a/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
@@ -678,6 +678,25 @@ describe("planFieldGroupReconcile", () => {
       ]);
     });
 
+    /**
+     * The key must BE the skeleton's key, not merely contain it.
+     *
+     * A composite `(id, some_column)` leaves `id` marked as part of a key while enforcing
+     * uniqueness over the pair — so the same component id can repeat whenever the other value
+     * differs, which is precisely the guarantee `id` exists to provide.
+     */
+    it("refuses a main table whose primary key carries extra columns", () => {
+      const live = liveTableFor(stored);
+      const extra = live.columns.find(c => c.name === "title");
+      if (extra) extra.primaryKey = true;
+
+      const result = plan({ storedFields: stored, liveMain: live });
+
+      expect(result.blockers).toEqual([
+        expect.objectContaining({ kind: "structural-column-missing" }),
+      ]);
+    });
+
     // A column can survive while the constraint that made it meaningful is dropped: `id` present
     // but no longer the key means duplicate component rows, which every name-based check reads as
     // healthy. Taken from the skeleton's own `primaryKey`, so it covers whatever is marked next.
@@ -747,6 +766,67 @@ describe("planFieldGroupReconcile", () => {
       if (nullableInSkeleton) nullableInSkeleton.nullable = false;
 
       const result = plan({ storedFields: stored, liveMain: live });
+
+      expect(result.blockers).toEqual([]);
+    });
+
+    /**
+     * The system columns' DEFAULTS are load-bearing rather than cosmetic: the generated runtime
+     * schema declares them as DATABASE defaults, so Drizzle omits those columns from an INSERT and
+     * the database supplies the value. A dropped default fails a NOT NULL insert outright, or
+     * silently stores NULL where a zero was intended.
+     *
+     * The skeleton records no default for any system column, so the expectation has to come from
+     * the creator — supplied here the way the service supplies it.
+     */
+    it("refuses a system column whose database default was dropped", () => {
+      const live = liveTableFor(stored);
+      const order = live.columns.find(
+        c => c.name === STORAGE_FORMAT.columns.order
+      );
+      if (order) order.default = undefined;
+
+      const result = planFieldGroupReconcile({
+        storedFields: stored,
+        storedLocalized: false,
+        dialect: DIALECT,
+        tableName: TABLE,
+        liveMain: live,
+        liveCompanion: null,
+        structuralColumnDefaults: new Map([
+          [STORAGE_FORMAT.columns.order, "0"],
+        ]),
+      });
+
+      expect(result.blockers).toEqual([
+        expect.objectContaining({
+          columnName: STORAGE_FORMAT.columns.order,
+          kind: "structural-column-missing",
+        }),
+      ]);
+    });
+
+    // The negative control, and the one that matters most here: the dialects spell the same default
+    // differently from the DDL that wrote it, so a raw string compare would refuse every healthy
+    // table. This is the pair that proves the comparison runs through the normaliser.
+    it("accepts a system default that matches after normalisation", () => {
+      const live = liveTableFor(stored);
+      const order = live.columns.find(
+        c => c.name === STORAGE_FORMAT.columns.order
+      );
+      if (order) order.default = "0";
+
+      const result = planFieldGroupReconcile({
+        storedFields: stored,
+        storedLocalized: false,
+        dialect: DIALECT,
+        tableName: TABLE,
+        liveMain: live,
+        liveCompanion: null,
+        structuralColumnDefaults: new Map([
+          [STORAGE_FORMAT.columns.order, "0"],
+        ]),
+      });
 
       expect(result.blockers).toEqual([]);
     });

--- a/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
@@ -141,6 +141,22 @@ async function expectedColumnTypeResolver(
  * reports `known: false` and is skipped rather than being claimed to have no default. Claiming
  * that would turn every localized checkbox carrying a default into a refusal.
  */
+/**
+ * The DEFAULT each system column is created with, asked of the code that creates them.
+ *
+ * The desired-state skeleton records no default for any system column, so it cannot answer this —
+ * and a comparison built on its silence would report drift on every healthy table. The creator is
+ * the only side that knows, and it renders its own CREATE TABLE from this same map.
+ */
+async function structuralColumnDefaults(
+  dialect: SupportedDialect
+): Promise<ReadonlyMap<string, string>> {
+  const { FieldGroupSchemaService } = await import(
+    "./field-group-schema-service"
+  );
+  return new FieldGroupSchemaService(dialect).structuralColumnDefaults();
+}
+
 async function expectedColumnDefaultResolver(
   dialect: SupportedDialect
 ): Promise<
@@ -254,6 +270,7 @@ export async function reconcileFieldGroup(args: {
     typeColumn,
     expectedColumnType: await expectedColumnTypeResolver(dialect),
     expectedColumnDefault: await expectedColumnDefaultResolver(dialect),
+    structuralColumnDefaults: await structuralColumnDefaults(dialect),
   });
 
   // 🔴 REFUSE before writing anything when the tables hold a state the planner can see but must

--- a/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
@@ -182,7 +182,7 @@ export class FieldGroupSchemaService {
     options: { localized?: boolean } = {}
   ): string {
     const types = SQL_COLUMN_TYPES[this.dialect];
-    const tsDefault = TIMESTAMP_DEFAULT[this.dialect];
+    const structuralDefaults = this.structuralColumnDefaults();
     // i18n: a localized component omits its translatable columns from the main comp_ CREATE
     // (they live in the companion `comp_<slug>_locales` table, provisioned out-of-band).
     const localizedNames = options.localized
@@ -222,7 +222,7 @@ export class FieldGroupSchemaService {
       `  ${this.q}${STORAGE_FORMAT.columns.parentField}${this.q} ${types.varchar(255)} NOT NULL,`
     );
     lines.push(
-      `  ${this.q}${STORAGE_FORMAT.columns.order}${this.q} ${types.integer} DEFAULT 0,`
+      `  ${this.q}${STORAGE_FORMAT.columns.order}${this.q} ${types.integer} DEFAULT ${structuralDefaults.get(STORAGE_FORMAT.columns.order)},`
     );
     lines.push(
       `  ${this.q}${STORAGE_FORMAT.columns.type}${this.q} ${types.varchar(255)},`
@@ -244,10 +244,10 @@ export class FieldGroupSchemaService {
     }
 
     lines.push(
-      `  ${this.q}created_at${this.q} ${types.timestamp} NOT NULL ${tsDefault},`
+      `  ${this.q}created_at${this.q} ${types.timestamp} NOT NULL DEFAULT ${structuralDefaults.get("created_at")},`
     );
     lines.push(
-      `  ${this.q}updated_at${this.q} ${types.timestamp} NOT NULL ${tsDefault}`
+      `  ${this.q}updated_at${this.q} ${types.timestamp} NOT NULL DEFAULT ${structuralDefaults.get("updated_at")}`
     );
 
     lines.push(");");
@@ -777,6 +777,32 @@ export class FieldGroupSchemaService {
    */
   columnTypeFor(field: DataFieldConfig): string | null {
     return this.getColumnType(this.asMappableField(field));
+  }
+
+  /**
+   * The DEFAULT expression each SYSTEM column is created with, by column name.
+   *
+   * These belong to no field, so nothing derived from the field list can describe them — and they
+   * are not decoration: the generated runtime schema declares `_order` and the timestamps as
+   * DATABASE defaults, so Drizzle OMITS those columns from an INSERT and the database supplies the
+   * value. A dropped default therefore fails a NOT NULL insert outright, or silently stores NULL
+   * where a zero was intended.
+   *
+   * Rendered into the CREATE TABLE below rather than restated there, so the defaults a caller can
+   * ask about and the ones the table actually gets are one expression.
+   */
+  structuralColumnDefaults(): ReadonlyMap<string, string> {
+    // The timestamp keyword carries its own `DEFAULT ` prefix in the DDL table; the VALUE is what a
+    // comparison needs, so the prefix is stripped once, here.
+    const timestamp = TIMESTAMP_DEFAULT[this.dialect].replace(
+      /^DEFAULT\s+/,
+      ""
+    );
+    return new Map([
+      [STORAGE_FORMAT.columns.order, "0"],
+      ["created_at", timestamp],
+      ["updated_at", timestamp],
+    ]);
   }
 
   /**

--- a/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
+++ b/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
@@ -226,6 +226,19 @@ export interface ReconcileInput<F extends ReconcilableField> {
     field: F,
     table: ReconcileTable
   ) => ExpectedColumnDefault;
+  /**
+   * The DEFAULT each SYSTEM column is created with, by column name.
+   *
+   * Separate from `expectedColumnDefault` because these belong to no FIELD: nothing derived from
+   * the field list describes `_order` or the timestamps, and the desired-state skeleton records
+   * `undefined` for every one of them — so comparing the skeleton against a live table would report
+   * drift on every healthy database. The creator is the only side that knows.
+   *
+   * Load-bearing rather than cosmetic: the generated runtime schema declares these as DATABASE
+   * defaults, so Drizzle omits the columns from an INSERT and the database supplies the value. A
+   * dropped default fails a NOT NULL insert, or silently stores NULL where a zero was intended.
+   */
+  structuralColumnDefaults?: ReadonlyMap<string, string>;
 }
 
 /**
@@ -328,10 +341,34 @@ function structuralBlockers(
   skeleton: TableSpec,
   liveMain: TableSpec,
   liveCompanion: TableSpec | null,
-  localized: boolean
+  localized: boolean,
+  structuralDefaults: ReadonlyMap<string, string> | undefined
 ): ReconcileBlocker[] {
   const blockers: ReconcileBlocker[] = [];
   const liveMainByName = new Map(liveMain.columns.map(c => [c.name, c]));
+
+  // 🔴 The main table's key compared as a WHOLE, for the reason the companion's is. Asking only
+  // whether `id` participates in a key accepts a composite `(id, user_column)`, which enforces
+  // uniqueness over the pair and so lets one component id repeat whenever the other value differs —
+  // the guarantee `id` exists for, absent, behind a check that passes. Membership is the wrong
+  // question on either table; equality is the property both keys actually need.
+  const skeletonKey = skeleton.columns
+    .filter(column => column.primaryKey === true)
+    .map(column => column.name);
+  const liveMainKey = liveMain.columns
+    .filter(column => column.primaryKey === true)
+    .map(column => column.name);
+  const mainKeyMatches =
+    skeletonKey.length === liveMainKey.length &&
+    skeletonKey.every(name => liveMainKey.includes(name));
+  if (skeletonKey.length > 0 && !mainKeyMatches) {
+    blockers.push({
+      fieldName: skeletonKey.join(", "),
+      columnName: skeletonKey.join(", "),
+      kind: "structural-column-missing",
+      detail: `${liveMain.name} has the primary key (${liveMainKey.join(", ") || "none"}) where every field-group table is keyed on (${skeletonKey.join(", ")}); any other key lets one row's identity repeat, and this operation issues no DDL to restore it.`,
+    });
+  }
 
   for (const column of skeleton.columns) {
     const live = liveMainByName.get(column.name);
@@ -354,9 +391,6 @@ function structuralBlockers(
     // The skeleton is the only side that can be authoritative here: these columns belong to no
     // field, so nothing else in this module describes them.
     const attributeDrift: string[] = [];
-    if (column.primaryKey === true && live.primaryKey !== true) {
-      attributeDrift.push("is no longer part of the primary key");
-    }
     const wantType = normalizeType(column.type);
     const haveType = normalizeType(live.type);
     if (
@@ -373,6 +407,19 @@ function structuralBlockers(
     // refuse tables an older generation created with a tighter constraint.
     if (column.nullable === false && live.nullable === true) {
       attributeDrift.push("is nullable where the table requires a value");
+    }
+    // The system column's DEFAULT, taken from the creator rather than the skeleton, which records
+    // none for any of them. Compared through the diff engine's normaliser so a dialect reporting
+    // `now()` where the DDL wrote `NOW()` is not drift.
+    const wantDefault = structuralDefaults?.get(column.name);
+    if (wantDefault !== undefined) {
+      const want = normalizeDefault(wantDefault, column.type);
+      const have = normalizeDefault(live.default, live.type);
+      if (want !== have) {
+        attributeDrift.push(
+          `defaults to ${have ?? "nothing"} where the table requires ${want ?? "nothing"}`
+        );
+      }
     }
     if (attributeDrift.length > 0) {
       blockers.push({
@@ -599,7 +646,8 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
     skeleton,
     liveMain,
     liveCompanion,
-    localized
+    localized,
+    input.structuralColumnDefaults
   );
 
   /** Column names a stored field accounted for, so the leftovers can be adopted. */


### PR DESCRIPTION
## Why this exists separately

**These two fixes were stranded by #880's merge.** That PR merged from `37fa697065`, but its final commit `5f683c31b` had been pushed after GitHub computed the merge, so it never landed.

Confirmed by content against `origin/main`, with a positive control so the search is trustworthy:

- `fromCode ? { source: "code" }` (the FIRST commit) — **present** in main, so the path resolves and the search works
- `structuralColumnDefaults` — **absent**
- `mainKeyMatches` — **absent**

`node scripts/verify-merge.mjs 880` exits **2** and names `5f683c31b` as a candidate absent from the merge. This PR lands it.

## The two fixes

Both were P1 findings Codex raised on #863 **five minutes after that PR merged**, so they were never actionable before the merge.

**1 — The main table's primary key is compared as a whole, not by membership.** A composite `(id, user_column)` left `id` marked as part of a key while enforcing uniqueness over the pair, so the same component `id` could repeat whenever the other value differed. The guarantee `id` exists for, absent, behind a check that passed.

I had already made this correction on the *companion* key in an earlier round and did not carry it across — membership was the wrong question on both tables.

**2 — System column defaults are compared, taken from the creator.** Verified the mechanism before building it: the generated runtime schema declares `_order` and both timestamps with Drizzle `.default(0)` / `.defaultNow()`, which are **database** defaults — Drizzle omits those columns from the INSERT and the database supplies the value. A dropped default fails a NOT NULL insert outright, or silently stores NULL where a zero was intended.

The desired-state skeleton records `default: undefined` for every system column, so it could not be the authority — comparing against it would have refused every healthy table. `FieldGroupSchemaService.structuralColumnDefaults()` now owns them and its own `CREATE TABLE` renders from that same map, so the defaults a caller can ask about and the ones the table gets are one expression. Compared through `normalizeDefault`, so `NOW()` in the DDL against `now()` from introspection is not drift.

## Verification

Re-run against **current** main, not the state at the original push:

- field-group integration **121/121** across postgres, mysql, sqlite
- field-group unit 745 passed, 1 pre-existing failure unchanged (`field-group-data-service.test.ts > deleteComponentDataInTransaction`)
- build, check-types, lint, drizzle-v1, storage-format-literals, comment-convention — all green by exit code
- Break controls, each with the pattern asserted found before trusting the result: reverting the key comparison to membership fails only `refuses a main table whose primary key carries extra columns`; forcing the default expectation to `undefined` fails only `refuses a system column whose database default was dropped`
- Both a positive and a negative control on the defaults check, because a green healthy-group suite would equally mean the check never ran

Brought up to current main by **merge, not rebase** — a force-push would permanently disqualify the stranded-tail check on this branch, which is the check that caught this.