### PR TITLE
fix(nextly): record a column's declared type modifier in the snapshot

### DIFF
--- a/.changeset/schema-snapshot-records-type-modifiers.md
+++ b/.changeset/schema-snapshot-records-type-modifiers.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Schema snapshots now record a column's declared size or precision, so field-group repair can tell a resized column from an unchanged one on PostgreSQL.

--- a/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/reconcile-field-group-plan.test.ts
@@ -892,10 +892,20 @@ describe("planFieldGroupReconcile", () => {
   describe("type width", () => {
     const stored: ReconcilableField[] = [{ name: "title", type: "text" }];
 
-    function planWithWidths(liveType: string, expected: string) {
+    function planWithWidths(
+      liveType: string,
+      expected: string,
+      liveModifier?: string
+    ) {
       const live = liveTableFor(stored);
       const col = live.columns.find(c => c.name === "title");
-      if (col) col.type = liveType;
+      if (col) {
+        col.type = liveType;
+        // The modifier is carried in its OWN field, because the live type string cannot always hold
+        // it: PostgreSQL introspection reports `udt_name`, which never does. A fixture that only
+        // set the type would be modelling a snapshot no PostgreSQL database produces.
+        if (liveModifier !== undefined) col.typeModifier = liveModifier;
+      }
       return plan({
         storedFields: stored,
         liveMain: live,
@@ -904,7 +914,7 @@ describe("planFieldGroupReconcile", () => {
     }
 
     it("refuses when both sides report a width and they differ", () => {
-      const result = planWithWidths("varchar(32)", "VARCHAR(255)");
+      const result = planWithWidths("varchar", "VARCHAR(255)", "32");
       expect(result.blockers).toEqual([
         expect.objectContaining({
           fieldName: "title",
@@ -914,7 +924,7 @@ describe("planFieldGroupReconcile", () => {
     });
 
     it("accepts equal widths", () => {
-      expect(planWithWidths("varchar(255)", "VARCHAR(255)").blockers).toEqual(
+      expect(planWithWidths("varchar", "VARCHAR(255)", "255").blockers).toEqual(
         []
       );
     });

--- a/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
+++ b/packages/nextly/src/domains/field-groups/services/reconcile-field-group-plan.ts
@@ -716,7 +716,12 @@ export function planFieldGroupReconcile<F extends ReconcilableField>(
     // modifier says nothing about the column and treating that as a mismatch would refuse every
     // healthy group on that dialect.
     const expectedWidth = typeModifier(expectedSpelling);
-    const liveWidth = typeModifier(live.type);
+    // 🔴 From what introspection REPORTED, not from the live type string. On PostgreSQL that
+    // string is `udt_name`, which never carries a modifier — so parsing it made this comparison
+    // permanently inert on the dialect where a varchar length or numeric precision change is most
+    // likely to be the whole edit. The snapshot records the modifier separately, gated per dialect
+    // to what was actually declared.
+    const liveWidth = live.typeModifier;
     const widthDiffers =
       expectedWidth !== undefined &&
       liveWidth !== undefined &&

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/introspect-live.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/introspect-live.test.ts
@@ -143,6 +143,11 @@ describe("introspectLiveSnapshot - mysql", () => {
       nullable: false,
       default: undefined,
       primaryKey: true,
+      // MySQL reports the DECLARATION in `COLUMN_TYPE`, so a display width declared on the column
+      // is part of what it says. Recorded as reported rather than judged here: whether a modifier
+      // is meaningful for a given type is the consumer's question, and inventing an absence would
+      // be the same error as inventing a width.
+      typeModifier: "11",
     });
     expect(snapshot.tables[0].indexes).toEqual([
       { name: "idx_dc_posts_views", columns: ["views"], unique: false },

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/type-modifier.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/type-modifier.integration.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Which type MODIFIER the snapshot records, read from real servers.
+ *
+ * A declared width is part of what a column does — `varchar(32)` rejects what `varchar(255)`
+ * accepts — and `type` cannot carry it: `normalizeType` strips modifiers so the live and desired
+ * sides compare equal, and PostgreSQL's `udt_name` never reports one in the first place. So the
+ * modifier is recorded separately, and this suite is what proves the reading is right.
+ *
+ * 🔴 The cases that matter are the NEGATIVE ones, and they are why this must run against servers.
+ * Both report a precision for types that were never declared with one, and reading those as
+ * modifiers would compare a fabricated width against a generator that emits none:
+ *
+ * - PostgreSQL 17: `integer` reports numeric_precision 32, `double precision` reports 53.
+ * - MySQL 8: a `TEXT` column reports CHARACTER_MAXIMUM_LENGTH 65535, while its `COLUMN_TYPE` is a
+ *   bare `text`.
+ *
+ * No fixture would have shown either. Each dialect is therefore read from the source that reports
+ * the DECLARATION — `COLUMN_TYPE` and `PRAGMA table_info.type` carry it already; PostgreSQL has no
+ * equivalent, so it is reconstructed from the two families that genuinely take a modifier.
+ *
+ * Self-skips per dialect on the standard rule.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestNextly,
+} from "../../../../../plugins/test-nextly";
+import { introspectLiveSnapshot } from "../introspect-live";
+import type { ColumnSpec } from "../types";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const TABLE = "nextly_typemod_probe";
+
+/**
+ * The column list per dialect, spelled as each one declares these types, with what the snapshot
+ * must report. `undefined` means "no modifier" — those are the negative controls.
+ */
+const PER_DIALECT: Record<
+  string,
+  { ddl: string; expected: ReadonlyArray<[string, string | undefined]> }
+> = {
+  postgresql: {
+    ddl: `CREATE TABLE "${TABLE}" (a_varchar VARCHAR(255), a_decimal NUMERIC(10,2), a_text TEXT, a_double DOUBLE PRECISION, a_int INTEGER)`,
+    expected: [
+      ["a_varchar", "255"],
+      ["a_decimal", "10,2"],
+      ["a_text", undefined],
+      ["a_double", undefined],
+      ["a_int", undefined],
+    ],
+  },
+  mysql: {
+    ddl: `CREATE TABLE \`${TABLE}\` (a_varchar VARCHAR(255), a_decimal DECIMAL(10,2), a_text TEXT, a_double DOUBLE, a_int INT)`,
+    expected: [
+      ["a_varchar", "255"],
+      ["a_decimal", "10,2"],
+      ["a_text", undefined],
+      ["a_double", undefined],
+      ["a_int", undefined],
+    ],
+  },
+  sqlite: {
+    // SQLite stores the declaration verbatim, so a modifier survives even where the type has no
+    // meaning attached to it. Nothing this codebase generates carries one on SQLite — the creator
+    // maps varchar() to TEXT — so the modifier is reported when declared and absent otherwise.
+    ddl: `CREATE TABLE "${TABLE}" (a_varchar VARCHAR(255), a_decimal NUMERIC(10,2), a_text TEXT, a_double REAL, a_int INTEGER)`,
+    expected: [
+      ["a_varchar", "255"],
+      ["a_decimal", "10,2"],
+      ["a_text", undefined],
+      ["a_double", undefined],
+      ["a_int", undefined],
+    ],
+  },
+};
+
+for (const dialect of getConfiguredTestDialects()) {
+  const spec = PER_DIALECT[dialect];
+  if (!spec) continue;
+
+  describe(`type modifiers — ${dialect}`, () => {
+    it("records a declared modifier and invents none for types without one", async () => {
+      current = await createTestNextly({ dialect });
+      await current.adapter.executeQuery(spec.ddl);
+
+      const snapshot = await introspectLiveSnapshot(
+        current.adapter.getDrizzle(),
+        dialect,
+        [TABLE]
+      );
+      const table = snapshot.tables.find(t => t.name === TABLE);
+
+      // The POPULATION first: an empty column list satisfies every per-column assertion below,
+      // and an introspection that silently read nothing is exactly the failure that would hide.
+      expect(table?.columns.map(c => c.name).sort()).toEqual(
+        spec.expected.map(([name]) => name).sort()
+      );
+
+      const byName = new Map<string, ColumnSpec>(
+        (table?.columns ?? []).map(c => [c.name, c])
+      );
+      // Asserted as a whole map rather than per column, so a reader sees which one drifted.
+      expect(
+        spec.expected.map(([name]) => [name, byName.get(name)?.typeModifier])
+      ).toEqual(spec.expected.map(([name, modifier]) => [name, modifier]));
+    });
+  });
+}

--- a/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
@@ -120,12 +120,17 @@ function modifierFromDeclaredType(type: string): string | undefined {
  * carry a length, exact-numeric types carry precision and scale.
  */
 function pgTypeModifier(row: PgRow): string | undefined {
-  if (row.character_maximum_length !== null) {
+  // 🔴 Tested for a NUMBER rather than against null. `information_schema` yields null for a type
+  // with no modifier, but a row that simply lacks the key — an older snapshot, a driver that omits
+  // nulls, a hand-built row — is `undefined`, and `undefined !== null` is true. That branch then
+  // stringifies to the literal "undefined" and records it as a width, which is a fabricated
+  // modifier of exactly the kind the gating below exists to prevent.
+  if (typeof row.character_maximum_length === "number") {
     return String(row.character_maximum_length);
   }
   const exactNumeric = row.udt_name === "numeric" || row.udt_name === "decimal";
-  if (exactNumeric && row.numeric_precision !== null) {
-    return row.numeric_scale !== null
+  if (exactNumeric && typeof row.numeric_precision === "number") {
+    return typeof row.numeric_scale === "number"
       ? `${row.numeric_precision},${row.numeric_scale}`
       : String(row.numeric_precision);
   }

--- a/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
@@ -90,6 +90,48 @@ function normalizeIndexOrder(snapshot: NextlySchemaSnapshot): void {
   }
 }
 
+/**
+ * The modifier a DECLARED type string already carries — `varchar(255)` gives `255`.
+ *
+ * Right for MySQL and SQLite, whose introspection reports the declaration itself
+ * (`COLUMN_TYPE`, `PRAGMA table_info.type`). Reading their information_schema
+ * width columns instead would INVENT modifiers: measured on MySQL 8, a `TEXT`
+ * column reports `CHARACTER_MAXIMUM_LENGTH` 65535 while its `COLUMN_TYPE` is a
+ * bare `text`, and an `INT` reports precision 10.
+ */
+function modifierFromDeclaredType(type: string): string | undefined {
+  const match = /\(([^)]*)\)/.exec(type);
+  const inner = match?.[1];
+  return inner === undefined ? undefined : inner.replace(/\s+/g, "");
+}
+
+/**
+ * PostgreSQL's modifier, reconstructed — it has no `COLUMN_TYPE` equivalent, and
+ * `udt_name` never carries one.
+ *
+ * 🔴 GATED BY TYPE, because `information_schema` reports a precision for types
+ * that were never declared with one. Measured on PostgreSQL 17: `integer` reports
+ * numeric_precision 32, `double precision` reports 53. Those are properties of the
+ * storage, not of the declaration — nobody writes `INTEGER(32)` — so copying them
+ * would compare a fabricated modifier against a generator that emits none, and
+ * refuse healthy tables.
+ *
+ * Only the two families that genuinely take a modifier are read: character types
+ * carry a length, exact-numeric types carry precision and scale.
+ */
+function pgTypeModifier(row: PgRow): string | undefined {
+  if (row.character_maximum_length !== null) {
+    return String(row.character_maximum_length);
+  }
+  const exactNumeric = row.udt_name === "numeric" || row.udt_name === "decimal";
+  if (exactNumeric && row.numeric_precision !== null) {
+    return row.numeric_scale !== null
+      ? `${row.numeric_precision},${row.numeric_scale}`
+      : String(row.numeric_precision);
+  }
+  return undefined;
+}
+
 interface PgRow {
   table_name: string;
   column_name: string;
@@ -98,6 +140,9 @@ interface PgRow {
   column_default: string | null;
   owned_sequence_default: boolean;
   is_primary_key: boolean;
+  character_maximum_length: number | null;
+  numeric_precision: number | null;
+  numeric_scale: number | null;
 }
 
 interface MysqlRow {
@@ -191,6 +236,7 @@ export async function introspectLiveSnapshot(
     const result = (await dbTyped.execute(
       sql`SELECT c.table_name, c.column_name, c.udt_name, c.is_nullable,
                  c.column_default,
+                 c.character_maximum_length, c.numeric_precision, c.numeric_scale,
                  EXISTS (
                    SELECT 1
                    FROM pg_index i
@@ -393,6 +439,10 @@ export async function introspectLiveSnapshot(
           // Coerce primitives to string; treat anything non-primitive as
           // missing (defensive - SQLite never returns object defaults).
           default: sqliteDefaultExpression(r.dflt_value),
+          // PRAGMA reports the DECLARED type, so any modifier is already in it.
+          ...(modifierFromDeclaredType(r.type) !== undefined
+            ? { typeModifier: modifierFromDeclaredType(r.type) }
+            : {}),
         })
       ),
     });
@@ -477,6 +527,8 @@ function buildSnapshotFromPgRows(rows: PgRow[]): NextlySchemaSnapshot {
     // so a snapshot taken before this reads the same as one where the column
     // is genuinely not part of the key.
     if (r.is_primary_key === true) column.primaryKey = true;
+    const pgModifier = pgTypeModifier(r);
+    if (pgModifier !== undefined) column.typeModifier = pgModifier;
     cols.push(column);
   }
   return {
@@ -554,6 +606,8 @@ function buildSnapshotFromMysqlRows(
     if (primaryKeyColumns.has(`${r.TABLE_NAME}.${r.COLUMN_NAME}`)) {
       column.primaryKey = true;
     }
+    const myModifier = modifierFromDeclaredType(r.COLUMN_TYPE);
+    if (myModifier !== undefined) column.typeModifier = myModifier;
     cols.push(column);
   }
   return {

--- a/packages/nextly/src/domains/schema/pipeline/diff/types.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/types.ts
@@ -49,6 +49,20 @@ export interface ColumnSpec {
   // the two apart, which is why this is carried in the snapshot rather than
   // re-derived in the diff.
   ownedSequenceDefault?: boolean;
+  // The size or precision the column was DECLARED with, when it has one:
+  // "255" for varchar(255), "10,2" for numeric(10,2). Absent when the type
+  // carries no modifier.
+  //
+  // Separate from `type` deliberately, and the diff must never read it.
+  // `normalizeType` strips modifiers precisely so the live side (which on
+  // PostgreSQL reads `udt_name` and cannot report one) and the desired side
+  // (which authors lengths) compare equal — folding the modifier into `type`
+  // would emit a `change_column_type` for every core column of every existing
+  // PostgreSQL database, which is the whole failure that strip prevents.
+  //
+  // Recorded so a consumer that legitimately needs the width can ask for it
+  // without re-deriving it from a string the strip has already flattened.
+  typeModifier?: string;
 }
 
 export interface IndexSpec {


### PR DESCRIPTION
Closes the last open finding from #863's post-merge review.

## The problem

Field-group repair compares a column's declared width, and that comparison was **permanently inert on PostgreSQL** — the dialect where a `varchar` length or `numeric` precision change is most likely to be the entire edit.

`introspect-live.ts` reads `udt_name`, which never carries a modifier, so the live side always reported none and the comparison skipped. A resized column read as unchanged, and repair could clear `diverged` while the definition kept a stale `maxLength`.

## Why the modifier is its own field, not part of `type`

`normalizeType` strips modifiers **on purpose**, and its own header says why: the live side reads `udt_name` while the desired side authors lengths, so a raw compare emits `change_column_type` for every core column and `nextly migrate` refuses the whole apply as destructive.

Folding the modifier into `type` would reintroduce exactly that, on every existing PostgreSQL database. So `ColumnSpec` gains a separate `typeModifier` that **the diff never reads**.

## What the measurements changed

I probed live servers before writing the implementation, and it changed the design twice.

| dialect | honest source | trap avoided |
|---|---|---|
| PostgreSQL | reconstructed, **gated by type** | `integer` reports precision **32**, `double precision` reports **53** — storage artifacts, not declarations |
| MySQL | `COLUMN_TYPE` | `CHARACTER_MAXIMUM_LENGTH` says **65535 for `TEXT`** while `COLUMN_TYPE` is a bare `text` |
| SQLite | PRAGMA declared type | none — nothing here emits a modifier on SQLite |

Nobody writes `INTEGER(32)`. A naive implementation would have compared a fabricated width against a generator that emits none and refused healthy tables on both servers.

## A bug the integration test could not have caught

The first implementation guarded with `!== null`. A row where the field is simply **absent** is `undefined`, which passes that check and stringifies — recording the literal string `"undefined"` as a width.

Live drivers return `null`, so every dialect leg passed. Only the unit test with a hand-built row exposed it. It now tests for a `number`.

## Verification

- New `type-modifier.integration.test.ts` — all three dialects, and the cases that matter are the **negative** ones (`text`, `double`, `int` must report no modifier). Asserts the column population before the per-column values, so an introspection that read nothing cannot pass.
- Schema integration 101 passed / 7 skipped; field-group integration **121/121**
- Schema unit failures compared to `main` **by membership**: 6 on main, 6 on this branch, **zero new** (the toggle/float8/layout failures are pre-existing)
- Break controls, pattern asserted found before trusting each: removing the PostgreSQL type gate fails on `a_double`/`a_int`; restoring `!== null` reproduces the `"undefined"` string