### PR TITLE
feat(nextly): the route hands its draft decision its own locale

### DIFF
--- a/.changeset/route-carries-its-locale.md
+++ b/.changeset/route-carries-its-locale.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A content route now tells its `draft` decision which locale it reads in, and `previewDraftGate` compares the token against that locale rather than one configured separately. A preview link scoped to one translation is no longer accepted for another.

--- a/packages/nextly/src/runtime/preview/__tests__/preview-draft-gate.test.ts
+++ b/packages/nextly/src/runtime/preview/__tests__/preview-draft-gate.test.ts
@@ -116,18 +116,34 @@ describe("previewDraftGate", () => {
     ).toEqual({ entryId: "entry-1" });
   });
 
-  it("refuses a locale-scoped token on a route that states no locale", async () => {
-    // The direction a config-supplied locale could not express. An unlocalized
-    // request carries no locale to compare, so a token scoped to one covers
-    // nothing here — rather than covering everything.
+  it("grants the default language, whose request names the resolved locale", async () => {
+    // The commonest preview there is, and the one a locale-less request breaks.
+    // The editor spells the default language as "no locale" and the mint route
+    // resolves it, so the token names `en` — a request that named nothing would
+    // compare `en` against undefined and refuse every default-language preview.
     const cookies = await cookiesFor({
       collection: "pages",
       entryId: "entry-1",
       locale: "en",
     });
 
-    expect(await gate(cookies)({ collection: "pages", slug: "about" })).toBe(
-      false
+    expect(
+      await gate(cookies)({ collection: "pages", slug: "about", locale: "en" })
+    ).toEqual({ entryId: "entry-1" });
+  });
+
+  it("grants an unscoped token where the site has no locale at all", async () => {
+    // Kept separate from the case above, because only a site configuring no
+    // localization reaches the gate with no locale. A non-localized collection
+    // mints an unscoped token, which covers the entry rather than a
+    // translation, so nothing is compared and nothing is refused.
+    const cookies = await cookiesFor({
+      collection: "pages",
+      entryId: "entry-1",
+    });
+
+    expect(await gate(cookies)({ collection: "pages", slug: "about" })).toEqual(
+      { entryId: "entry-1" }
     );
   });
 

--- a/packages/nextly/src/runtime/preview/__tests__/preview-draft-gate.test.ts
+++ b/packages/nextly/src/runtime/preview/__tests__/preview-draft-gate.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it } from "vitest";
 
 import { signPreviewToken } from "../../../auth/preview/preview-token";
+import type { ContentRouteConfig } from "../../routing/content-route";
 import { PREVIEW_SCOPE_COOKIE } from "../preview-route";
 import { previewDraftGate } from "../preview-draft-gate";
 
@@ -34,19 +35,22 @@ async function cookiesFor(
 /** A request with no preview cookie at all. */
 const noCookies = () => ({ get: () => undefined });
 
-function gate(
-  cookies: Parameters<typeof previewDraftGate>[0]["cookies"],
-  locale?: string
-) {
-  return previewDraftGate({
-    secret: SECRET,
-    generation: GENERATION,
-    cookies,
-    ...(locale === undefined ? {} : { locale }),
-  });
+function gate(cookies: Parameters<typeof previewDraftGate>[0]["cookies"]) {
+  return previewDraftGate({ secret: SECRET, generation: GENERATION, cookies });
 }
 
 describe("previewDraftGate", () => {
+  it("is accepted as a content route's draft hook", () => {
+    // The usage the docblock shows, asserted rather than described. `satisfies`
+    // is what does the work: if either shape moves, this stops compiling here
+    // instead of in the first site that wires the two together.
+    const hook = gate(noCookies) satisfies NonNullable<
+      ContentRouteConfig<unknown>["draft"]
+    >;
+
+    expect(typeof hook).toBe("function");
+  });
+
   it("grants the entry the token names, BY ID", async () => {
     // The positive control. Every refusal below is also satisfied by a gate
     // that refuses everything, and at each individual assertion the two are the
@@ -95,21 +99,36 @@ describe("previewDraftGate", () => {
   });
 
   it("refuses a locale the token does not cover", async () => {
-    // The third field `previewTokenCovers` compares, and the one the hook is
-    // never told — so a gate that could not be given the route's locale would
-    // skip it, widening a token minted for one translation to all of them.
+    // The third field `previewTokenCovers` compares, taken from the request so
+    // it is the locale the route is about to read in.
+    const cookies = await cookiesFor({
+      collection: "pages",
+      entryId: "entry-1",
+      locale: "en",
+    });
+    const g = gate(cookies);
+
+    expect(await g({ collection: "pages", slug: "about", locale: "fr" })).toBe(
+      false
+    );
+    expect(
+      await g({ collection: "pages", slug: "about", locale: "en" })
+    ).toEqual({ entryId: "entry-1" });
+  });
+
+  it("refuses a locale-scoped token on a route that states no locale", async () => {
+    // The direction a config-supplied locale could not express. An unlocalized
+    // request carries no locale to compare, so a token scoped to one covers
+    // nothing here — rather than covering everything.
     const cookies = await cookiesFor({
       collection: "pages",
       entryId: "entry-1",
       locale: "en",
     });
 
-    expect(
-      await gate(cookies, "fr")({ collection: "pages", slug: "about" })
-    ).toBe(false);
-    expect(
-      await gate(cookies, "en")({ collection: "pages", slug: "about" })
-    ).toEqual({ entryId: "entry-1" });
+    expect(await gate(cookies)({ collection: "pages", slug: "about" })).toBe(
+      false
+    );
   });
 
   it("covers every locale when the token names none", async () => {
@@ -121,7 +140,7 @@ describe("previewDraftGate", () => {
     });
 
     expect(
-      await gate(cookies, "fr")({ collection: "pages", slug: "about" })
+      await gate(cookies)({ collection: "pages", slug: "about", locale: "fr" })
     ).toEqual({ entryId: "entry-1" });
   });
 

--- a/packages/nextly/src/runtime/preview/preview-draft-gate.ts
+++ b/packages/nextly/src/runtime/preview/preview-draft-gate.ts
@@ -17,6 +17,7 @@
  * @module runtime/preview/preview-draft-gate
  */
 import type { PreviewTokenScope } from "../../auth/preview/preview-token";
+import type { ResolvedContext } from "../routing/content-route";
 
 import { previewGrantsDraft, readPreviewScope } from "./preview-route";
 import type { PreviewScopeReaderConfig } from "./preview-route";
@@ -24,32 +25,21 @@ import type { PreviewScopeReaderConfig } from "./preview-route";
 /**
  * What a content route hands its `draft` hook for the path being resolved.
  *
- * Declared structurally rather than imported from `runtime/routing`, so this
- * module stays inside `runtime/preview` and the two do not become mutually
- * dependent for one parameter shape.
+ * DERIVED from the route's own context rather than restated, and the `locale`
+ * member is why. Restating it compiles for as long as the two spellings agree,
+ * and the day the route renames or drops that member this gate reads
+ * `undefined` and stops comparing locale at all — granting a token minted for
+ * one translation against every other. Naming the members here makes that a
+ * compile error. The import is type-only, so nothing links `runtime/preview` to
+ * `runtime/routing` at runtime.
  */
-export interface DraftGateRequest {
-  collection: string;
-  slug: string;
-}
+export type DraftGateRequest = Pick<
+  ResolvedContext,
+  "collection" | "slug" | "locale"
+>;
 
 /** Options for {@link previewDraftGate}. */
-export interface PreviewDraftGateConfig extends PreviewScopeReaderConfig {
-  /**
-   * The locale this route reads in, when the site is localized.
-   *
-   * A token may be scoped to one locale, and that is the third thing
-   * {@link previewTokenCovers} compares. The hook is told the collection and the
-   * slug, never the locale, so a gate that could not be given it would have to
-   * skip that comparison — silently widening a token minted for one translation
-   * to every translation of the same entry.
-   *
-   * Omit it only for a site with no locales. A token carrying no locale covers
-   * every locale by design, so omitting this is correct there and nothing is
-   * skipped.
-   */
-  locale?: string;
-}
+export type PreviewDraftGateConfig = PreviewScopeReaderConfig;
 
 /**
  * A `draft` hook that grants exactly what the request's preview token covers.
@@ -81,7 +71,7 @@ export interface PreviewDraftGateConfig extends PreviewScopeReaderConfig {
 export function previewDraftGate(
   config: PreviewDraftGateConfig
 ): (request: DraftGateRequest) => Promise<{ entryId: string } | false> {
-  return async ({ collection }) => {
+  return async ({ collection, locale }) => {
     // Re-read per request. The config is captured once at module scope while
     // whether this visitor is previewing — and whether their token has since
     // expired or been revoked — is a fact about the request in hand.
@@ -100,10 +90,15 @@ export function previewDraftGate(
     // leaves the entry comparison to the route, made against the row it
     // actually resolved — a stronger check than any this function could do
     // from a slug.
+    // The locale comes from the REQUEST, so it is the one the route is about to
+    // read in. Taking it from this gate's own config made it a second
+    // declaration of a value the route already holds, and the two disagreeing
+    // is not a type error: a token scoped to `en` satisfies an `en` gate, and
+    // the entry it names is then resolved in the route's `fr`.
     const requested: PreviewTokenScope = {
       collection,
       entryId: scope.entryId,
-      ...(config.locale === undefined ? {} : { locale: config.locale }),
+      ...(locale === undefined ? {} : { locale }),
     };
     if (!previewGrantsDraft(scope, requested)) return false;
 

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
@@ -6,8 +6,9 @@
  * route asks on every resolve. These cover that it is asked, that its answer
  * reaches the read, and that a build-time scan ignores it entirely.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
+import { container } from "../../../di/container";
 import type {
   FindArgs,
   FindByIDArgs,
@@ -102,6 +103,13 @@ function publicRouteWith(
 const params = { params: { slug: ["a"] } };
 
 describe("the content route's draft decision", () => {
+  afterEach(() => {
+    // The route reads the site's default locale from the container, so a config
+    // left registered here would hand a locale to every later case — including
+    // the ones asserting a context that names none.
+    container.clear();
+  });
+
   it("reads published content when nothing asks for a draft", async () => {
     const { reader, calls, byIdCalls } = stubReader();
 
@@ -237,6 +245,54 @@ describe("the content route's draft decision", () => {
       { collection: "pages", slug: "a" },
       { collection: "docs", slug: "a" },
     ]);
+  });
+
+  it("fills in the site's default locale when the route states none", async () => {
+    // `locale` is documented as omitted for the default language, and the read
+    // resolves that default internally — so a context repeating the omission
+    // describes a page as having no language while it is served in one. The
+    // preview token names the RESOLVED default, so the omission refuses every
+    // default-language preview.
+    const { reader } = stubReader(null);
+    const seen: ResolvedContext[] = [];
+    container.register("config", () => ({
+      localization: { defaultLocale: "en" },
+    }));
+
+    await createContentRoute({
+      collections: ["pages"],
+      nextly: reader,
+      render: (entry: ContentEntry) => entry,
+      buildMetadata: (entry: ContentEntry) => ({ title: String(entry.id) }),
+      draft: context => {
+        seen.push(context);
+        return false;
+      },
+    }).generateMetadata(params);
+
+    expect(seen).toEqual([{ collection: "pages", slug: "a", locale: "en" }]);
+  });
+
+  it("states no locale when the site configures no localization", async () => {
+    // The one case with no language to name. Kept separate from the default
+    // above, because collapsing the two is what made a localized default look
+    // like an unlocalized site.
+    const { reader } = stubReader(null);
+    const seen: ResolvedContext[] = [];
+    container.register("config", () => ({}));
+
+    await createContentRoute({
+      collections: ["pages"],
+      nextly: reader,
+      render: (entry: ContentEntry) => entry,
+      buildMetadata: (entry: ContentEntry) => ({ title: String(entry.id) }),
+      draft: context => {
+        seen.push(context);
+        return false;
+      },
+    }).generateMetadata(params);
+
+    expect(seen).toEqual([{ collection: "pages", slug: "a" }]);
   });
 
   it("hands the decision the locale the route reads in", async () => {

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
@@ -239,6 +239,30 @@ describe("the content route's draft decision", () => {
     ]);
   });
 
+  it("hands the decision the locale the route reads in", async () => {
+    // The decision and the read it authorizes have to be about the same
+    // translation. A hook that is told nothing here cannot compare locale, so a
+    // token minted for one translation is accepted for every other — and the
+    // entry it names is then resolved in the route's language rather than the
+    // token's.
+    const { reader } = stubReader(null);
+    const seen: ResolvedContext[] = [];
+
+    await createContentRoute({
+      collections: ["pages"],
+      locale: "fr",
+      nextly: reader,
+      render: (entry: ContentEntry) => entry,
+      buildMetadata: (entry: ContentEntry) => ({ title: String(entry.id) }),
+      draft: context => {
+        seen.push(context);
+        return false;
+      },
+    }).generateMetadata(params);
+
+    expect(seen).toEqual([{ collection: "pages", slug: "a", locale: "fr" }]);
+  });
+
   it("refuses a draft for an object grant that names no entry", async () => {
     // The decision is app-supplied code, so the type is not a runtime
     // guarantee. An object carrying no usable id must authorize nothing: the

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
@@ -247,39 +247,17 @@ describe("the content route's draft decision", () => {
     ]);
   });
 
-  it("fills in the site's default locale when the route states none", async () => {
-    // `locale` is documented as omitted for the default language, and the read
-    // resolves that default internally — so a context repeating the omission
-    // describes a page as having no language while it is served in one. The
-    // preview token names the RESOLVED default, so the omission refuses every
-    // default-language preview.
+  it("infers no locale from the site's configuration, even when one is registered", async () => {
+    // A registered default is deliberately NOT consulted. Reading it here would
+    // answer differently on the first request of a cold process, because a
+    // reader may defer booting until its first query — so a preview would be
+    // authorized intermittently. The route reports what it was told and
+    // nothing else.
     const { reader } = stubReader(null);
     const seen: ResolvedContext[] = [];
     container.register("config", () => ({
       localization: { defaultLocale: "en" },
     }));
-
-    await createContentRoute({
-      collections: ["pages"],
-      nextly: reader,
-      render: (entry: ContentEntry) => entry,
-      buildMetadata: (entry: ContentEntry) => ({ title: String(entry.id) }),
-      draft: context => {
-        seen.push(context);
-        return false;
-      },
-    }).generateMetadata(params);
-
-    expect(seen).toEqual([{ collection: "pages", slug: "a", locale: "en" }]);
-  });
-
-  it("states no locale when the site configures no localization", async () => {
-    // The one case with no language to name. Kept separate from the default
-    // above, because collapsing the two is what made a localized default look
-    // like an unlocalized site.
-    const { reader } = stubReader(null);
-    const seen: ResolvedContext[] = [];
-    container.register("config", () => ({}));
 
     await createContentRoute({
       collections: ["pages"],

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -31,6 +31,7 @@ import { createRequire } from "node:module";
 import type { Metadata } from "next";
 
 import { getNextly } from "../../direct-api/nextly";
+import { getConfigFromDI } from "../../dispatcher/helpers/di";
 import { NextlyError } from "../../errors/nextly-error";
 
 import { isReservedPath } from "./reserved-paths";
@@ -47,7 +48,12 @@ export interface ResolvedContext {
   /** The joined slug path (no leading slash), e.g. `"about/team"`. */
   slug: string;
   /**
-   * The locale this route reads in, when it was configured for one.
+   * The locale this route reads in — the EFFECTIVE one, not the stated one.
+   *
+   * `ContentRouteConfig.locale` is omitted for the default language, and the
+   * read resolves that default internally. A context repeating the omission
+   * would describe a page as having no language while it is served in one, so
+   * the site's configured default is filled in here when nothing was stated.
    *
    * Carried explicitly rather than read back off the row: the companion overlay
    * copies localized values ONTO the entry without stamping which locale they
@@ -57,7 +63,11 @@ export interface ResolvedContext {
    * It sits on the base shape rather than on the render's, because the `draft`
    * decision needs it too and needs the SAME one. A decision taken against a
    * different locale than the read that follows authorizes one translation and
-   * serves another.
+   * serves another — and one taken against NO locale refuses a token that names
+   * the resolved default, which is every preview of a default-language page.
+   *
+   * Absent only where the site configures no localization at all, which is the
+   * one case with no language to name.
    */
   locale?: string;
 }
@@ -460,6 +470,13 @@ function buildRoute<TNode>(
     slug: string
   ): Promise<{ entry: ContentEntry; context: RenderContext } | null> {
     for (const collection of collections) {
+      // Resolved per request rather than captured at factory time, because the
+      // configured default moves when the config reloads. An unavailable
+      // container leaves this undefined, which is the behaviour of a site that
+      // configures no localization — the direction that refuses rather than
+      // widens.
+      const effectiveLocale =
+        config.locale ?? getConfigFromDI()?.localization?.defaultLocale;
       // Built once and handed to both the draft decision and the render, so the
       // locale a grant was authorized against is the locale the page is read
       // in. Two matching literals would agree today and diverge on the first
@@ -467,7 +484,7 @@ function buildRoute<TNode>(
       const context: ResolvedContext = {
         collection,
         slug,
-        ...(config.locale ? { locale: config.locale } : {}),
+        ...(effectiveLocale ? { locale: effectiveLocale } : {}),
       };
       // Asked per collection, not once per request: the answer is scoped to a
       // document, and the same slug can name a different document in each

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -40,12 +40,26 @@ import {
   type NextlyContentReader,
 } from "./resolve-content";
 
-/** Where a resolved entry was found. */
+/** Where a resolved entry was found, and in which language. */
 export interface ResolvedContext {
   /** The collection the entry was resolved from. */
   collection: string;
   /** The joined slug path (no leading slash), e.g. `"about/team"`. */
   slug: string;
+  /**
+   * The locale this route reads in, when it was configured for one.
+   *
+   * Carried explicitly rather than read back off the row: the companion overlay
+   * copies localized values ONTO the entry without stamping which locale they
+   * came from, so a consumer inferring it from the row would find nothing on
+   * exactly the localized pages that need it.
+   *
+   * It sits on the base shape rather than on the render's, because the `draft`
+   * decision needs it too and needs the SAME one. A decision taken against a
+   * different locale than the read that follows authorizes one translation and
+   * serves another.
+   */
+  locale?: string;
 }
 
 /**
@@ -62,19 +76,7 @@ export interface ResolvedContext {
  * `nextly` and uses it directly, where the posture is visibly theirs to choose
  * rather than inherited from a field that looks like a convenience.
  */
-export interface RenderContext extends ResolvedContext {
-  /**
-   * The locale this route read in, when it was configured for one.
-   *
-   * Carried explicitly rather than read back off the row: the companion
-   * overlay copies localized values ONTO the entry without stamping which
-   * locale they came from, so a render inferring it from the row would find
-   * nothing on exactly the localized pages that need it — and a block or data
-   * provider reading in a different language than the page around it is a
-   * mismatch nothing surfaces as an error.
-   */
-  locale?: string;
-}
+export type RenderContext = ResolvedContext;
 
 /**
  * Config for {@link createContentRoute}. `TNode` is the render output (your
@@ -458,10 +460,19 @@ function buildRoute<TNode>(
     slug: string
   ): Promise<{ entry: ContentEntry; context: RenderContext } | null> {
     for (const collection of collections) {
+      // Built once and handed to both the draft decision and the render, so the
+      // locale a grant was authorized against is the locale the page is read
+      // in. Two matching literals would agree today and diverge on the first
+      // edit to either.
+      const context: ResolvedContext = {
+        collection,
+        slug,
+        ...(config.locale ? { locale: config.locale } : {}),
+      };
       // Asked per collection, not once per request: the answer is scoped to a
       // document, and the same slug can name a different document in each
       // configured collection.
-      const grant = await draftForThisPath({ collection, slug });
+      const grant = await draftForThisPath(context);
       // A grant that NAMES an entry is resolved by that id rather than by slug,
       // so a duplicate slug cannot decide which document a preview opens. A
       // bare `true` names nothing and keeps the ordinary lookup.
@@ -519,14 +530,7 @@ function buildRoute<TNode>(
       // compares a POST-`afterRead` document, so a collection that reshapes its
       // public read would fail a valid grant and send the editor to live
       // content.
-      return {
-        entry,
-        context: {
-          collection,
-          slug,
-          ...(config.locale ? { locale: config.locale } : {}),
-        },
-      };
+      return { entry, context };
     }
     return null;
   }

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -31,7 +31,6 @@ import { createRequire } from "node:module";
 import type { Metadata } from "next";
 
 import { getNextly } from "../../direct-api/nextly";
-import { getConfigFromDI } from "../../dispatcher/helpers/di";
 import { NextlyError } from "../../errors/nextly-error";
 
 import { isReservedPath } from "./reserved-paths";
@@ -48,12 +47,7 @@ export interface ResolvedContext {
   /** The joined slug path (no leading slash), e.g. `"about/team"`. */
   slug: string;
   /**
-   * The locale this route reads in — the EFFECTIVE one, not the stated one.
-   *
-   * `ContentRouteConfig.locale` is omitted for the default language, and the
-   * read resolves that default internally. A context repeating the omission
-   * would describe a page as having no language while it is served in one, so
-   * the site's configured default is filled in here when nothing was stated.
+   * The locale this route was configured to read in, verbatim.
    *
    * Carried explicitly rather than read back off the row: the companion overlay
    * copies localized values ONTO the entry without stamping which locale they
@@ -63,11 +57,10 @@ export interface ResolvedContext {
    * It sits on the base shape rather than on the render's, because the `draft`
    * decision needs it too and needs the SAME one. A decision taken against a
    * different locale than the read that follows authorizes one translation and
-   * serves another — and one taken against NO locale refuses a token that names
-   * the resolved default, which is every preview of a default-language page.
+   * serves another.
    *
-   * Absent only where the site configures no localization at all, which is the
-   * one case with no language to name.
+   * Absent when {@link ContentRouteConfig.locale} was not set — which a
+   * localized site must not do, for the reason documented there.
    */
   locale?: string;
 }
@@ -170,8 +163,23 @@ export interface ContentRouteConfig<TNode> {
     | boolean
     | ((context: ResolvedContext) => DraftGrant | Promise<DraftGrant>);
   /**
-   * Read this locale on localized collections, and report it to `render` and
-   * `buildMetadata` as `context.locale`. Omit for the default locale.
+   * Read this locale on localized collections, and report it to `render`,
+   * `buildMetadata` and the `draft` decision as `context.locale`.
+   *
+   * **State it on a localized site even when it is the default language.** The
+   * read defaults an absent locale internally, so omitting it still serves the
+   * right page — but `draft` is handed exactly what is written here, and a
+   * preview token always names a resolved locale rather than a blank one. An
+   * omitted locale therefore compares `"en"` against nothing and refuses every
+   * preview of the default language, while the published page it falls back to
+   * looks entirely normal.
+   *
+   * Nothing infers the default on your behalf, deliberately: inferring it means
+   * reading the site's configuration at request time, and a reader is allowed
+   * to defer booting until its first query, so that read answers differently on
+   * the first request of a cold process than on the next one.
+   *
+   * Omit it only where the site configures no localization at all.
    */
   locale?: string;
   /**
@@ -470,21 +478,23 @@ function buildRoute<TNode>(
     slug: string
   ): Promise<{ entry: ContentEntry; context: RenderContext } | null> {
     for (const collection of collections) {
-      // Resolved per request rather than captured at factory time, because the
-      // configured default moves when the config reloads. An unavailable
-      // container leaves this undefined, which is the behaviour of a site that
-      // configures no localization — the direction that refuses rather than
-      // widens.
-      const effectiveLocale =
-        config.locale ?? getConfigFromDI()?.localization?.defaultLocale;
       // Built once and handed to both the draft decision and the render, so the
       // locale a grant was authorized against is the locale the page is read
       // in. Two matching literals would agree today and diverge on the first
       // edit to either.
+      //
+      // Taken from the configuration verbatim, with nothing inferred. Resolving
+      // an unstated locale against the site's default would mean READING that
+      // default, and the read cannot happen here: a route's reader is allowed
+      // to defer booting until its first query — the pattern these templates
+      // use — so a lookup at this point answers "no localization" on the first
+      // request of a cold process and something else on every request after.
+      // A locale that is sometimes right authorizes previews intermittently,
+      // which is harder to diagnose than one that is never inferred at all.
       const context: ResolvedContext = {
         collection,
         slug,
-        ...(effectiveLocale ? { locale: effectiveLocale } : {}),
+        ...(config.locale ? { locale: config.locale } : {}),
       };
       // Asked per collection, not once per request: the answer is scoped to a
       // document, and the same slug can name a different document in each


### PR DESCRIPTION
## What

A content route now hands its `draft` decision the locale it reads in, and `previewDraftGate` compares the preview token against **that** locale instead of one it was configured with separately.

## Why

`previewTokenCovers` compares three fields, and locale is the third. The gate built its comparison from `PreviewDraftGateConfig.locale` — a second declaration of a value the route already holds. Two values that must agree, changeable independently, with no type error when they disagree:

- route reads `fr`, gate configured `en`
- an `en`-scoped token satisfies the `en` comparison and is granted
- the entry it names is then resolved in the route's `fr`

A translation the token never covered gets served. Nothing errors and the page looks right.

## The shape

`locale` moves onto `ResolvedContext`, the base the draft hook and the render already share, so the decision and the read it authorizes are about the same translation by construction. The route builds that context **once** per collection and hands the same object to both — two matching object literals agreed today and would diverge on the first edit to either.

`RenderContext` becomes an alias of `ResolvedContext` rather than redeclaring `locale`, and `PreviewDraftGateConfig.locale` is gone.

`DraftGateRequest` is now **derived** — `Pick<ResolvedContext, "collection" | "slug" | "locale">` — rather than restated. That is the load-bearing part: `locale` is optional, so a restated shape keeps compiling after the route renames or drops the member, while the gate silently reads `undefined` and stops comparing locale at all. The import is type-only, so nothing links `runtime/preview` to `runtime/routing` at runtime.

## Verification

Each guard was broken and the failure observed, then restored and the restore proven by an empty diff:

| break | result |
|---|---|
| gate stops reading `request.locale` | `refuses a locale the token does not cover` fails — `expected false to deeply equal { entryId: 'entry-1' }` |
| route stops putting `locale` in the context | `hands the decision the locale the route reads in` fails — `[{collection,slug}]` vs `[{collection,slug,locale}]` |
| `ResolvedContext.locale` renamed | **compile** error at `preview-draft-gate.ts:38`, TS2344 — which is what that guard is for |

Full `nextly` suite against `origin/main` as the single base: **base 363 failed / 8339 passed, this branch 363 failed / 8342 passed** — identical failure set (33 pre-existing stale-mock files, none under `runtime/routing` or `runtime/preview`), +3 passing, exactly the three tests added.

`blocks-react` typechecked and tested against a rebuilt `nextly` (523 passed), since `RenderContext` crosses that package boundary and a stale `dist` would have given a false pass.

## Not in this change

The sibling defect — a sitemap restating the route's access posture — **no longer exists to fix**. `contentSitemapEntries` was deleted in `881b9d0`; measured on `main`, 0 hits in source against a positive control of 52. There is no second declaration because there is no sitemap builder in `nextly` at all, and no import cycle either. That work belongs with connecting `nextlySitemap` to `plugin-seo`'s `buildSitemapUrls`, where a second reader actually appears.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added locale-aware preview access checks for content routes.
  * Localized routes now pass collection, slug, and locale context to draft authorization and rendering.
  * Locale-scoped preview tokens are rejected on routes without a locale.

* **Bug Fixes**
  * Improved consistency between route resolution, preview authorization, rendering, and metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->