### PR TITLE
fix(nextly): keep declared column widths when rebuilding from a snapshot

### DIFF
--- a/.changeset/rebuild-preserves-column-width.md
+++ b/.changeset/rebuild-preserves-column-width.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A table rebuilt from a live PostgreSQL snapshot keeps its declared column widths instead of widening them to unbounded.

--- a/packages/nextly/src/domains/schema/pipeline/sql-templates/create-table-body.ts
+++ b/packages/nextly/src/domains/schema/pipeline/sql-templates/create-table-body.ts
@@ -17,6 +17,25 @@
  */
 import type { ColumnSpec, TableSpec } from "../diff/types";
 
+/**
+ * The column's type as it must be WRITTEN, with any declared size restored.
+ *
+ * 🔴 A snapshot does not always spell the modifier inside `type`. PostgreSQL introspection reads
+ * `udt_name`, which reports a bare `varchar` however the column was declared, and records the
+ * length separately. Rendering `type` alone therefore recreates `varchar(20)` as an UNBOUNDED
+ * `varchar` — a real widening of the column, silent because both the source and the rebuilt table
+ * then describe themselves the same way.
+ *
+ * MySQL and SQLite report the declaration itself, so their `type` already carries the modifier and
+ * must not have a second one appended.
+ */
+function renderedType(c: ColumnSpec): string {
+  if (c.typeModifier === undefined) return c.type;
+  // Already spelled inside the type — the MySQL and SQLite case.
+  if (c.type.includes("(")) return c.type;
+  return `${c.type}(${c.typeModifier})`;
+}
+
 /** Quotes an identifier the way one dialect spells it. */
 export type QuoteIdentifier = (name: string) => string;
 
@@ -29,7 +48,7 @@ export type QuoteIdentifier = (name: string) => string;
 export function columnDefinition(c: ColumnSpec, q: QuoteIdentifier): string {
   const nullable = c.nullable ? "" : " NOT NULL";
   const def = c.default !== undefined ? ` DEFAULT ${c.default}` : "";
-  return `${q(c.name)} ${c.type}${nullable}${def}`;
+  return `${q(c.name)} ${renderedType(c)}${nullable}${def}`;
 }
 
 /**
@@ -44,7 +63,7 @@ function createTableColumn(c: ColumnSpec, q: QuoteIdentifier): string {
   if (c.primaryKey !== true) return columnDefinition(c, q);
   const nullable = c.nullable ? "" : " NOT NULL";
   const def = c.default !== undefined ? ` DEFAULT ${c.default}` : "";
-  return `${q(c.name)} ${c.type} PRIMARY KEY${nullable}${def}`;
+  return `${q(c.name)} ${renderedType(c)} PRIMARY KEY${nullable}${def}`;
 }
 
 /**


### PR DESCRIPTION
## 🔴 `main` is red — this fixes it

`Integration (postgres)` is `completed/failure` on merge commit `631792293` (my #883). Confirmed a genuine failure via the jobs API, not a cancellation. mysql and sqlite pass; postgres alone fails.

```
migrate-baseline.transition.integration.test.ts:641
  expect(rebuilt.tables).toEqual(source.tables)
  -  "typeModifier": "20"     <- source has it, rebuilt does not
```

## What actually broke, and what did not

**#883 did not introduce this defect — it made an existing one visible.**

`createTableBody` renders a `CREATE TABLE` from a snapshot using `ColumnSpec.type` alone. PostgreSQL introspection reads `udt_name`, which reports a bare `varchar` however the column was declared and carries the length separately. So **a table rebuilt from a live PostgreSQL snapshot has always widened `varchar(20)` to unbounded `varchar`.**

That loss was invisible while the snapshot recorded no modifier: source and rebuilt both described themselves as `varchar`, and the round-trip comparison agreed. Recording the modifier made them disagree — the test is reporting a real widening, not a spurious mismatch.

This is the rebuild path used by `--adopt-unknown` and by `buildCompanionCreateFromLive`, so the consequence is a real column being recreated wider than it was.

## The fix

`renderedType` composes the declared size back when the snapshot carries one, and leaves the type alone when it already spells it — MySQL and SQLite report the declaration itself and must not receive a second modifier.

## Verification

- The failing test passes: `migrate-baseline.transition` 18/18 on postgres
- CLI integration 52/52, schema integration 101 passed / 7 skipped, field-group integration 121/121 — postgres, mysql and sqlite
- build, check-types, lint, drizzle-v1, storage-format-literals, comment-convention all green by exit code
- Break control, pattern asserted found first: returning `c.type` unconditionally reproduces the exact failure now on `main` — `--adopt-unknown rebuilds the companion from the database, undescribed column and all` — and nothing else