### PR TITLE
fix(builder): say the editor needs more width, not a wider screen

### DIFF
--- a/.changeset/shell-measures-its-container.md
+++ b/.changeset/shell-measures-its-container.md
@@ -25,6 +25,6 @@
 "nextly": patch
 ---
 
-The page editor now decides whether it fits by measuring the space it was actually given, rather than the size of the browser window. Embedded as a field inside a form on a wide screen, it used to conclude it had room and squeeze the rail, panel and canvas below the widths they need; it now shows the "needs a wider screen" message in that case, and goes back to the full layout as soon as the space grows again.
+The page editor now decides whether it fits by measuring the space it was actually given, rather than the size of the browser window. Embedded as a field inside a form on a wide screen, it used to conclude it had room and squeeze the rail, panel and canvas below the widths they need; it now says it needs more width in that case, and goes back to the full layout as soon as the space grows again.
 
 The media picker also no longer floats over that message. It opens in a layer outside the editor, so hiding the editor left an open picker visible and clickable on top of the notice saying the editor was unavailable.

--- a/.changeset/shell-width-copy.md
+++ b/.changeset/shell-width-copy.md
@@ -1,0 +1,28 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+The page editor now says it needs more width, rather than a wider screen, when it cannot fit. It measures the space it was given, so an editor placed in a narrow column on a large display was telling authors their screen was too small — which was both untrue and impossible to act on.

--- a/.changeset/shell-width-copy.md
+++ b/.changeset/shell-width-copy.md
@@ -25,4 +25,4 @@
 "nextly": patch
 ---
 
-The page editor now says it needs more width, rather than a wider screen, when it cannot fit. It measures the space it was given, so an editor placed in a narrow column on a large display was telling authors their screen was too small — which was both untrue and impossible to act on.
+The page editor now says it needs more width, rather than a wider screen, when it cannot fit. It measures the space it was given, so an editor placed in a narrow column on a large display was telling authors their screen was too small, which was both untrue and impossible to act on.

--- a/e2e/tests/shell/shell.spec.ts
+++ b/e2e/tests/shell/shell.spec.ts
@@ -219,7 +219,7 @@ test.describe("a viewport below the supported width", () => {
     const shell = createShellDriver(page);
     await page.goto("/builder-shell");
 
-    await expect(page.getByText(/needs a wider screen/i)).toBeVisible();
+    await expect(page.getByText(/needs more width/i)).toBeVisible();
     await expect(page.getByRole("region", { name: "Canvas" })).toHaveCount(0);
     // The way out has to survive every degraded state.
     await expect(
@@ -246,7 +246,7 @@ test.describe("a narrow CONTAINER inside a wide window", () => {
     // what makes this the separating case rather than a second narrow test.
     await page.goto(`/builder-shell?container=${MIN_SHELL_WIDTH - 100}`);
 
-    await expect(page.getByText(/needs a wider screen/i)).toBeVisible();
+    await expect(page.getByText(/needs more width/i)).toBeVisible();
     await expect(page.getByRole("region", { name: "Canvas" })).toHaveCount(0);
   });
 
@@ -259,26 +259,23 @@ test.describe("a narrow CONTAINER inside a wide window", () => {
     await page.goto(`/builder-shell?container=${MIN_SHELL_WIDTH + 200}`);
 
     await expect(page.getByRole("region", { name: "Canvas" })).toBeVisible();
-    await expect(page.getByText(/needs a wider screen/i)).toHaveCount(0);
+    await expect(page.getByText(/needs more width/i)).toHaveCount(0);
   });
 
   test("recovers when the container grows back", async ({ page }) => {
-    // THE DEADLOCK, and the reason the observer follows the VISIBLE root.
+    // The decision has to be REVERSIBLE, which is what the always-rendered
+    // measuring wrapper buys. Anything measured only in one state reports
+    // nothing useful in the other: the editor's subtree is `display: contents`
+    // when visible and `hidden` when narrow, so a shell that measured it would
+    // read 0 for the whole narrow state and never rise above the threshold
+    // again.
     //
-    // The editor stays mounted behind the notice so unsaved slot state
-    // survives, and its wrapper is `display: contents` when visible and
-    // `hidden` when narrow. Observing THAT element reports width 0 while the
-    // notice is up, so `0 >= MIN_SHELL_WIDTH` stays false and the shell can
-    // never measure its way back — narrowing once would disable the editor for
-    // the rest of the session.
-    //
-    // This has to run in a browser. The unit suite's ResizeObserver is a fake
-    // that reports the width the test sets regardless of which element is
-    // observed, so it answers identically for the hidden wrapper and the
-    // visible root — verified by writing the deadlock deliberately, which left
-    // the unit file green.
+    // It has to run in a BROWSER. The unit suite's `ResizeObserver` is a fake
+    // reporting the width the test sets, so it cannot distinguish one element's
+    // box from another's; which element carries the observer, and whether that
+    // element has a box at all, are only decidable where layout is real.
     await page.goto(`/builder-shell?container=${MIN_SHELL_WIDTH - 100}`);
-    await expect(page.getByText(/needs a wider screen/i)).toBeVisible();
+    await expect(page.getByText(/needs more width/i)).toBeVisible();
 
     // Grow the CONTAINER, not the window: the window never changed.
     //
@@ -294,7 +291,7 @@ test.describe("a narrow CONTAINER inside a wide window", () => {
     }, MIN_SHELL_WIDTH + 20);
 
     await expect(page.getByRole("region", { name: "Canvas" })).toBeVisible();
-    await expect(page.getByText(/needs a wider screen/i)).toHaveCount(0);
+    await expect(page.getByText(/needs more width/i)).toHaveCount(0);
   });
 });
 

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -607,7 +607,7 @@ describe("which shell F6 belongs to", () => {
     );
 
     // Exactly one shell is usable.
-    expect(screen.queryAllByText(/wider screen/i)).toHaveLength(1);
+    expect(screen.queryAllByText(/needs more width/i)).toHaveLength(1);
     const rails = screen.getAllByRole("navigation", { name: "Editor panels" });
     expect(rails).toHaveLength(1);
 
@@ -666,12 +666,12 @@ describe("an embedded host with nowhere to exit to", () => {
 
 describe("a viewport too narrow for the shell", () => {
   it("says where to edit instead of compressing", () => {
-    // An editor that merely gets cramped is worse than one that says it needs a
-    // wider screen: the author otherwise discovers the limit by failing a task.
+    // An editor that merely gets cramped is worse than one that says it needs
+    // more width: the author otherwise discovers the limit by failing a task.
     stubContainerFits(false);
     render(<BuilderShell onExit={vi.fn()} store={memoryStore()} />);
 
-    expect(screen.getByText(/needs a wider screen/i)).toBeTruthy();
+    expect(screen.getByText(/needs more width/i)).toBeTruthy();
     expect(screen.queryByRole("region", { name: "Canvas" })).toBeNull();
   });
 
@@ -695,7 +695,7 @@ describe("a viewport too narrow for the shell", () => {
     stubContainerFits(false);
     render(<BuilderShell store={memoryStore()} />);
 
-    expect(screen.getByText(/needs a wider screen/i)).toBeTruthy();
+    expect(screen.getByText(/needs more width/i)).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Exit editor" })).toBeNull();
     expect(screen.queryByText(/from the admin/i)).toBeNull();
   });
@@ -717,7 +717,7 @@ describe("a viewport too narrow for the shell", () => {
       </BuilderShell>
     );
 
-    expect(screen.getByText(/needs a wider screen/i)).toBeTruthy();
+    expect(screen.getByText(/needs more width/i)).toBeTruthy();
     expect(screen.queryByTestId("canvas-slot")).not.toBeNull();
   });
 
@@ -759,7 +759,7 @@ describe("a viewport too narrow for the shell", () => {
     );
 
     expect(screen.queryByRole("region", { name: "Canvas" })).not.toBeNull();
-    expect(screen.queryByText(/wider screen/i)).toBeNull();
+    expect(screen.queryByText(/needs more width/i)).toBeNull();
   });
 
   it("refuses one pixel below that boundary", () => {
@@ -773,7 +773,7 @@ describe("a viewport too narrow for the shell", () => {
       </BuilderShell>
     );
 
-    expect(screen.queryByText(/wider screen/i)).not.toBeNull();
+    expect(screen.queryByText(/needs more width/i)).not.toBeNull();
     expect(screen.queryByRole("region", { name: "Canvas" })).toBeNull();
   });
 
@@ -790,7 +790,7 @@ describe("a viewport too narrow for the shell", () => {
       </BuilderShell>
     );
 
-    expect(screen.queryByText(/wider screen/i)).not.toBeNull();
+    expect(screen.queryByText(/needs more width/i)).not.toBeNull();
     expect(screen.queryByRole("region", { name: "Canvas" })).toBeNull();
   });
 
@@ -807,7 +807,7 @@ describe("a viewport too narrow for the shell", () => {
     );
 
     expect(screen.queryByRole("region", { name: "Canvas" })).not.toBeNull();
-    expect(screen.queryByText(/wider screen/i)).toBeNull();
+    expect(screen.queryByText(/needs more width/i)).toBeNull();
   });
 
   it("recovers into the band where the notice's own padding would hide it", () => {
@@ -834,7 +834,7 @@ describe("a viewport too narrow for the shell", () => {
         <p>canvas</p>
       </BuilderShell>
     );
-    expect(screen.queryByText(/wider screen/i)).not.toBeNull();
+    expect(screen.queryByText(/needs more width/i)).not.toBeNull();
 
     act(() => {
       observedWidth = inBand;
@@ -842,7 +842,7 @@ describe("a viewport too narrow for the shell", () => {
     });
 
     expect(screen.queryByRole("region", { name: "Canvas" })).not.toBeNull();
-    expect(screen.queryByText(/wider screen/i)).toBeNull();
+    expect(screen.queryByText(/needs more width/i)).toBeNull();
   });
 
   it("re-renders the editor when the measured width comes back up", () => {
@@ -868,7 +868,7 @@ describe("a viewport too narrow for the shell", () => {
         <p data-testid="canvas-slot">the caller&apos;s canvas</p>
       </BuilderShell>
     );
-    expect(screen.queryByText(/wider screen/i)).not.toBeNull();
+    expect(screen.queryByText(/needs more width/i)).not.toBeNull();
     expect(screen.queryByRole("region", { name: "Canvas" })).toBeNull();
 
     act(() => {
@@ -876,7 +876,7 @@ describe("a viewport too narrow for the shell", () => {
     });
 
     expect(screen.queryByRole("region", { name: "Canvas" })).not.toBeNull();
-    expect(screen.queryByText(/wider screen/i)).toBeNull();
+    expect(screen.queryByText(/needs more width/i)).toBeNull();
   });
 
   it("keeps a portalling slot child from opening over the notice", () => {
@@ -960,7 +960,7 @@ describe("a viewport too narrow for the shell", () => {
 
     const notice = container.querySelector(".host-placed-me");
     expect(notice).not.toBeNull();
-    expect(notice?.textContent).toMatch(/needs a wider screen/i);
+    expect(notice?.textContent).toMatch(/needs more width/i);
   });
 });
 

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -213,33 +213,24 @@ function useFitsFullShell(): [(node: HTMLElement | null) => void, boolean] {
       const entry = entries[entries.length - 1];
       if (entry === undefined) return;
       // The CONTENT box of the measuring wrapper, which is by construction the
-      // space the regions will be laid out in.
+      // space the regions are laid out in.
       //
-      // Getting this right took two wrong answers, and both were wrong for the
-      // same underlying reason — the observed element kept being something
-      // other than the box the regions actually get.
+      // Two properties make that the right quantity, and both are easy to lose:
       //
-      // Observing whichever ROOT was visible made the answer depend on that
-      // root's own padding: the notice is `p-6` and the shell root is not, so
-      // the content box reported the same container 48px narrower while the
-      // notice was up, and a container growing back into that band could never
-      // recover. Switching to the border box fixed the asymmetry and introduced
-      // the opposite error, because a border box INCLUDES whatever padding or
-      // border the caller put on `className` — decoration the regions never
-      // receive — so a 1280px root with `p-6` reported that it fitted while
-      // leaving 1232px to lay out in.
+      // The wrapper carries the caller's `className` and nothing else, so its
+      // content box is the space INSIDE whatever padding or border the host
+      // applied — decoration the regions never receive. A border box would
+      // report a 1280px root with `p-6` as fitting while leaving 1232px to lay
+      // out in.
       //
-      // Both disappear once the measured element is a single always-rendered
-      // wrapper that carries the caller's `className` and nothing else. Its
-      // content box is the space inside the caller's decoration, which is
-      // exactly what its children are given, and it is the same element in both
-      // states so no branch's padding can move the threshold. The notice's own
-      // `p-6` is inside it and cannot be seen from here.
+      // It is also the SAME element whichever branch renders, so no branch's
+      // own padding can move the threshold. The notice is `p-6` and sits inside
+      // this box, where it is invisible to the measurement; measuring a branch
+      // instead would make the answer depend on which one happened to be up.
       //
-      // `contentRect` rather than `getBoundingClientRect` for the reason it
-      // always was: both are layout sizes, so a transformed ancestor — this
-      // editor has canvas zoom — does not scale the number against a minimum
-      // expressed in CSS pixels.
+      // `contentRect` rather than `getBoundingClientRect`: both are layout
+      // sizes, so a transformed ancestor — this editor has canvas zoom — does
+      // not scale the number against a minimum expressed in CSS pixels.
 
       // The comparison itself comes from `shell-state`, which exports and tests
       // it. Repeating `>= MIN_SHELL_WIDTH` here would be a second answer to one
@@ -961,8 +952,8 @@ function ShellRegions({
  *
  * Below the supported width the shell does not try to compress: the rail, both
  * panels and a usable canvas do not fit at their minimums, and an editor that
- * merely gets cramped is worse than one that says it needs a wider screen —
- * the author otherwise discovers the limit by failing at a task.
+ * merely gets cramped is worse than one that says it needs more width — the
+ * author otherwise discovers the limit by failing at a task.
  *
  * @experimental
  */
@@ -1015,8 +1006,15 @@ export function BuilderShell({ store, ...props }: BuilderShellProps) {
                 "nx-builder-chrome flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center"
               )}
             >
+              {/*
+               * Worded as WIDTH rather than as a screen, because the shell
+               * measures the space it was given. An editor embedded in a narrow
+               * column on a large display is the case that named the wrong
+               * cause: the author's screen is fine and widening it changes
+               * nothing.
+               */}
               <p className="text-sm font-medium">
-                The page editor needs a wider screen
+                The page editor needs more width
               </p>
               {/*
                * The escape sentence and the button below it are ONE UNIT with the
@@ -1032,9 +1030,9 @@ export function BuilderShell({ store, ...props }: BuilderShellProps) {
               {props.onExit ? (
                 <>
                   <p className="text-[color:var(--nx-builder-text-muted)] max-w-sm text-sm">
-                    Editing a layout needs at least {MIN_SHELL_WIDTH}px. On a
-                    smaller screen you can still edit this page&apos;s content
-                    from the admin.
+                    Editing a layout needs at least {MIN_SHELL_WIDTH}px of
+                    width. In a narrower space you can still edit this
+                    page&apos;s content from the admin.
                   </p>
                   <button
                     type="button"
@@ -1046,7 +1044,7 @@ export function BuilderShell({ store, ...props }: BuilderShellProps) {
                 </>
               ) : (
                 <p className="text-[color:var(--nx-builder-text-muted)] max-w-sm text-sm">
-                  Editing a layout needs at least {MIN_SHELL_WIDTH}px.
+                  Editing a layout needs at least {MIN_SHELL_WIDTH}px of width.
                 </p>
               )}
             </div>

--- a/packages/builder/src/shell-state.ts
+++ b/packages/builder/src/shell-state.ts
@@ -90,8 +90,8 @@ export const MIN_CANVAS_WIDTH = 480;
  * Below this the rail, both panels and a usable canvas do not fit at their
  * minimum widths, so the shell does not try: it shows the canvas and says where
  * to edit instead. A builder that merely gets cramped is worse than one that
- * says it needs a wider screen, because the author discovers the limit by
- * failing at a task.
+ * says it needs more width, because the author discovers the limit by failing
+ * at a task.
  */
 export const MIN_SHELL_WIDTH = 1280;
 

--- a/packages/plugin-page-builder/src/admin/controls/MediaControl.tsx
+++ b/packages/plugin-page-builder/src/admin/controls/MediaControl.tsx
@@ -30,14 +30,14 @@ export function MediaControl({ value, onChange, label }: ControlProps) {
   /*
    * The picker renders through a portal, so the shell cannot contain it.
    *
-   * When the viewport is too narrow the shell hides and inerts the inspector
-   * while deliberately keeping it MOUNTED, which preserves half-finished work.
-   * Both of those reach the subtree only; this dialog's content is portalled to
-   * `document.body`, outside it, so it stayed visible and clickable on top of
-   * the "needs a wider screen" notice.
+   * When the space the shell was given is too narrow it hides and inerts the
+   * inspector while deliberately keeping it MOUNTED, which preserves
+   * half-finished work. Both of those reach the subtree only; this dialog's
+   * content is portalled to `document.body`, outside it, so it stayed visible
+   * and clickable on top of the notice the shell shows instead.
    *
    * DERIVED rather than closed by an effect. An effect would write `open`
-   * false, which discards the author's intent: widening the window again
+   * false, which discards the author's intent: giving the editor room again
    * should bring back the picker they had opened, exactly as it brings back
    * everything else the shell kept mounted. Deriving also means there is no
    * second source of truth to fall out of step with the shell.


### PR DESCRIPTION
Restores a commit that #884 lost, and it is user-facing.

## Why this exists

`47951929d` was pushed while GitHub was computing #884's merge, so it never landed. Verified by content rather than by ancestry: the marker `The page editor needs more width` is present at the branch tip and absent from merge commit `737f6c87a`, with zero history-rewrite events on the timeline. This is the second stranded tail on this lane today and, per another lane, the fifth in the repository.

## What `main` currently does

Measured on `origin/main` just now:

- `setFits(fitsFullShell(entry.contentRect.width))` — present. The shell measures its CONTAINER.
- `The page editor needs a wider screen` — present. The notice still names the WINDOW.

Those two together are the defect. An editor embedded in a narrow column on a large display now correctly refuses to compress, and then tells the author their screen is too small — which is untrue, and widening the window does nothing because the column is what constrains it. The body carried the same wrong cause: "On a smaller screen you can still edit this page's content from the admin."

## The change

- heading: "The page editor needs more width"
- body: "Editing a layout needs at least 1280px of width. In a narrower space you can still edit this page's content from the admin."
- the no-exit body: "Editing a layout needs at least 1280px of width."

Matchers in `packages/builder/src/builder-shell.test.tsx` and `e2e/tests/shell/shell.spec.ts` move with it, along with three prose comments in `shell-state.ts` and `builder-shell.tsx` that explained the refuse-rather-than-compress decision in terms of a screen.

It also carries a comment repair that #884 lost. `e2e/tests/shell/shell.spec.ts` opened with "THE DEADLOCK, and the reason the observer follows the VISIBLE root" — a design replaced before #884 merged, so `main` currently documents an implementation that does not exist. It now states the property the test pins: the decision has to be reversible, which is what an always-rendered measured element buys.

## Verification

Stub-verified rather than asserted: restoring the old heading fails four notice tests in the unit suite, so the matchers are bound to the rendered text rather than passing vacuously.

- `packages/builder`: 370/370, typecheck, lint clean
- `packages/plugin-page-builder`: 828/828
- `e2e/tests/shell/shell.spec.ts`: 20/20 in Chromium
- `npx sherif`: 0 errors
- changeset generated from the workspace and checked with `scripts/release/check-changesets.mjs` (all 24 lockstep packages)
