### PR TITLE
fix(playground): state the site's locale on the blocks route

### DIFF
--- a/apps/playground/src/app/blocks/[[...slug]]/page.tsx
+++ b/apps/playground/src/app/blocks/[[...slug]]/page.tsx
@@ -136,6 +136,14 @@ const { ContentPage, generateMetadata } = createBlocksPage({
   collections: ["block-pages"],
   field: "content",
   nextly: reader,
+  // Stated even though it is this site's default language, because the read is
+  // not the only thing it feeds. An omitted locale still serves the right page
+  // — the read defaults it internally — but it is also what a `draft` decision
+  // compares a preview token against, and a token always names a resolved
+  // locale rather than a blank one. Omitting it here would leave the next route
+  // that adds a preview gate refusing every default-language preview, behind a
+  // published page that looks entirely correct.
+  locale: "en",
   // An explicit set, not the process registry. `registeredBlocks()` reads the
   // engine's global registry, which is populated by whatever booted the
   // editor — so a public route depending on it renders the unknown-block


### PR DESCRIPTION
## What

The playground's blocks route now states `locale: "en"`.

## Why

The site is localized — `apps/playground/nextly.config.ts:70-79` configures `en`, `es`, `ar` with `defaultLocale: "en"` — and the route said nothing about locale.

That is currently harmless: this route wires no `draft` decision, so nothing compares a locale. It matters because the file is the reference someone copies. #885 made `ContentRouteConfig.locale` the value a `draft` decision is handed, and a preview token always names a *resolved* locale rather than a blank one — so the first person to add `previewDraftGate` here, following the docs, would get every default-language preview refused behind a published page that looks entirely correct.

An example that contradicts the documentation is worse than no example.

## Scope

One option and its comment. No behaviour change: the read already defaulted an absent locale to `en` internally, so the same page is served either way.

**No changeset** — `apps/playground` is not a published package.

## Verification

- `locale: "en"` matches the configured `defaultLocale: "en"` (checked, not assumed)
- `pnpm --filter playground check-types` → exit 0, zero errors
- comment-convention gate → exit 0
