### PR TITLE
feat(blocks-react): add core/accordion and core/accordion-item

### DIFF
--- a/.changeset/core-accordion-blocks.md
+++ b/.changeset/core-accordion-blocks.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Adds `core/accordion` and `core/accordion-item` to the block library. A section holds ordinary blocks rather than a string of Markdown, so an image or a button can live inside one, and the disclosure itself is a native `<details>` — no client JavaScript.

--- a/packages/blocks-react/src/blocks/accordion-item.tsx
+++ b/packages/blocks-react/src/blocks/accordion-item.tsx
@@ -1,0 +1,146 @@
+/**
+ * `core/accordion-item` — one disclosure section, open and closed by the browser.
+ *
+ * A native `<details>` with a `<summary>`, which is the whole implementation:
+ * the open/closed state, the keyboard behaviour, the focus handling and the
+ * screen-reader announcement are the platform's, and none of them is JavaScript
+ * this package would have to ship. `blocks-react` renders on the server and
+ * carries no client boundary — there is no `"use client"` anywhere in it — so a
+ * disclosure built any other way would be the first thing to need one.
+ *
+ * **The content is a SLOT, not a prop, and that is the substance of the port.**
+ * The older page-builder's accordion stored its sections as a repeater of
+ * `{ title, content }` strings and rendered the content through a Markdown
+ * pass. That makes an accordion the only place in a document where you cannot
+ * put an image, a button, or anything else the library can draw. Here the body
+ * is ordinary children, so a section holds whatever a section holds and every
+ * block inside it is selectable and stylable in its own right.
+ *
+ * **What this deliberately does NOT do: close its siblings.** `<details name>`
+ * makes a group mutually exclusive with no script, and it needs one shared name
+ * across the group. A child cannot derive that: `BlockRenderArgs` carries the
+ * node being rendered and never its ancestors, so this block can see its own id
+ * and not the accordion's. Three ways to supply it were considered and each
+ * costs more than the behaviour is worth:
+ *
+ * - seeding a group id through `SlotSpec.template` — the templates are empty by
+ *   a ratchet test, because literal ids collide across instances;
+ * - passing it through the slot context — `renderSlot(name, ctx)` REPLACES the
+ *   subtree's context, and `PageContext` says in as many words that widening it
+ *   is "a deliberate act rather than a side effect of a new block";
+ * - moving the whole group into one block that renders every `<details>`
+ *   itself — which is the repeater design above, and loses the slot.
+ *
+ * Independent sections are also the safer default rather than merely the
+ * cheaper one: an exclusive group collapses a section while someone is reading
+ * it, which is why several design systems do not offer exclusivity at all.
+ * Should it be wanted, the honest route is a group id on the context, decided
+ * for the renderer as a whole rather than smuggled in with this block.
+ *
+ * **`<summary>` takes the title as text, and cannot yet be styled separately.**
+ * Styles compile onto a block's own root element, so a rule for a descendant
+ * has nowhere to live in the catalog. The summary therefore keeps the browser's
+ * own disclosure affordance — a real marker, a real focus ring, both already
+ * accessible — and the block does not fake one with an inline style the engine
+ * would not compile. Everything a site can express today is available on the
+ * `<details>` root through {@link ACCORDION_ITEM_SUPPORTS}.
+ *
+ * @module blocks/library/accordion-item
+ */
+import { defineBlock } from "@nextlyhq/blocks-engine";
+import type { ReactElement } from "react";
+
+// This package's own render args, not the engine's. The engine leaves
+// `renderSlot`'s return renderer-agnostic; `context.ts` narrows it to
+// `ReactNode` so a slot's output can be placed straight into JSX.
+import type { BlockRenderArgs, PageContext } from "../context";
+
+/** This block's registered name, so the tests and its parent name it once. */
+export const ACCORDION_ITEM_BLOCK = "core/accordion-item";
+
+/** Its parent's name, declared here so the pair agrees on one string. */
+export const ACCORDION_BLOCK = "core/accordion";
+
+/** What an author writes on a section. */
+export interface AccordionItemProps {
+  /** The always-visible label in the `<summary>`. */
+  title: string;
+  /** Whether this section starts open. */
+  open: boolean;
+}
+
+/**
+ * What a section may be styled with.
+ *
+ * A `<details>` is a block-level box, so spacing, borders, background, colour
+ * and typography apply to it exactly as they would to a box, and typography
+ * inherits to the summary — which is the only way to reach that element, since
+ * styles compile onto a block's own root and the catalog expresses no
+ * descendant selector.
+ *
+ * **`layout` is withheld deliberately.** A `<details>` is not a flex or grid
+ * container in any useful sense: its children are a `<summary>` and the flow
+ * content the browser reveals, so `display: flex` there sets the title beside
+ * the body, which is never what was wanted. The engine would accept it — every
+ * key here must be a registered support, and `layout` is one — so withholding
+ * it is this block's decision rather than a limitation.
+ *
+ * Every key is a STYLE CATALOG group. The older page-builder's accordion also
+ * declared `visibility` and `customAttributes`, which are not groups in this
+ * engine at all; node visibility is its own field on `BlockNode`, not a style
+ * support. Copying that list is what the registry's unknown-support check
+ * caught, and it is why the list is derived from the catalog rather than from
+ * the block it replaces.
+ */
+export const ACCORDION_ITEM_SUPPORTS = {
+  spacing: true,
+  border: true,
+  background: true,
+  color: true,
+  typography: true,
+  dimensions: true,
+  effects: true,
+} as const;
+
+/** A section: its title always visible, its children revealed when open. */
+function renderAccordionItem({
+  props,
+  className,
+  renderSlot,
+}: BlockRenderArgs<AccordionItemProps>): ReactElement {
+  // Read defensively rather than trusted. The type states what an author may
+  // write; the document states what is stored, and validation asks only that
+  // props be an object. A stored non-string title would otherwise reach React
+  // as a child object and throw, taking the page down with it.
+  const title = typeof props.title === "string" ? props.title : "";
+  return (
+    <details className={className} open={props.open === true}>
+      <summary>{title}</summary>
+      {renderSlot("children")}
+    </details>
+  );
+}
+
+export const accordionItem = defineBlock<AccordionItemProps, PageContext>({
+  name: ACCORDION_ITEM_BLOCK,
+  version: 1,
+  description:
+    "One section of an accordion: a title that is always visible and children the browser reveals when it is open.",
+  props: {
+    title: { type: "text" },
+    open: { type: "checkbox" },
+  },
+  defaultProps: { title: "Section", open: false },
+  example: { props: { title: "What is included?", open: false } },
+  // The child half of the nesting rule. The parent states the other half in
+  // `accordion.tsx`; `block.ts` is explicit that neither implies the other.
+  parent: [ACCORDION_BLOCK],
+  slots: {
+    // Empty for the same reason every slot template in this library is: a
+    // literal template carries literal ids, and two sections expanded from one
+    // template collide on `duplicate-node-id`. Nothing reads templates yet.
+    children: { template: [] },
+  },
+  supports: ACCORDION_ITEM_SUPPORTS,
+  render: renderAccordionItem,
+});

--- a/packages/blocks-react/src/blocks/accordion.test.tsx
+++ b/packages/blocks-react/src/blocks/accordion.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * What makes `core/accordion` and `core/accordion-item` worth being two blocks.
+ *
+ * The group delegates to `renderContainer`, so asserting that it draws a `div`
+ * would pass equally on a `core/box` and would keep passing if the pair were
+ * deleted and aliased. What SEPARATES this pair is the nesting rule's two
+ * halves, the native disclosure element the item renders, and the fact that a
+ * section's body is a SLOT rather than a string — that last one being the whole
+ * reason this is a port rather than a copy of the older repeater block.
+ */
+import { describe, expect, it } from "vitest";
+
+import { accordion, ACCORDION_BASE_STYLES } from "./accordion";
+import {
+  accordionItem,
+  ACCORDION_BLOCK,
+  ACCORDION_ITEM_BLOCK,
+  ACCORDION_ITEM_SUPPORTS,
+} from "./accordion-item";
+import { coreBlocks } from "./index";
+
+/** Render args with only what these blocks read, so a test states its inputs. */
+function args(props: Record<string, unknown>, slot = "BODY") {
+  return {
+    props,
+    node: { id: "n1", type: ACCORDION_ITEM_BLOCK, version: 1, props },
+    className: "cls",
+    renderSlot: (name: string) => (name === "children" ? slot : null),
+  } as never;
+}
+
+describe("the accordion pair", () => {
+  it("states BOTH halves of the nesting rule", () => {
+    // Neither half implies the other: `block.ts` is explicit that a slot naming
+    // a type does not confine that type to it, so a group that only declared
+    // `allow` would still let a section be dropped at the document root.
+    expect(accordion.slots?.children?.allow).toEqual([ACCORDION_ITEM_BLOCK]);
+    expect(accordionItem.parent).toEqual([ACCORDION_BLOCK]);
+  });
+
+  it("is registered, parent before child", () => {
+    // A resolver built by iterating `coreBlocks` should meet the group first,
+    // which is the ordering the columns pair records and this one follows.
+    const names = coreBlocks.map(block => block.name);
+    expect(names).toContain(ACCORDION_BLOCK);
+    expect(names).toContain(ACCORDION_ITEM_BLOCK);
+    expect(names.indexOf(ACCORDION_BLOCK)).toBeLessThan(
+      names.indexOf(ACCORDION_ITEM_BLOCK)
+    );
+  });
+
+  it("renders a native <details> whose body comes from the SLOT", () => {
+    // The property that separates this from the block it replaces. The older
+    // page-builder stored section bodies as strings and ran them through a
+    // Markdown pass, so no block could live inside one.
+    const out = accordionItem.render?.(args({ title: "T", open: false }));
+    const el = out as { type: string; props: Record<string, unknown> };
+
+    expect(el.type).toBe("details");
+    expect(el.props.className).toBe("cls");
+    // The slot's output is placed as a child, not a prop-derived string.
+    expect(JSON.stringify(el.props.children)).toContain("BODY");
+  });
+
+  it("honours `open`, so a section can start expanded", () => {
+    const closed = accordionItem.render?.(args({ title: "T", open: false }));
+    const open = accordionItem.render?.(args({ title: "T", open: true }));
+
+    expect((closed as { props: { open: boolean } }).props.open).toBe(false);
+    expect((open as { props: { open: boolean } }).props.open).toBe(true);
+  });
+
+  it("survives a stored title that is not a string", () => {
+    // Validation asks only that props be an object, so the type states what an
+    // author may write and the document states what is stored. A stored object
+    // reaching React as a child throws and takes the page with it.
+    const out = accordionItem.render?.(args({ title: { a: 1 }, open: false }));
+
+    expect(() => JSON.stringify(out)).not.toThrow();
+    expect(JSON.stringify(out)).not.toContain('"a":1');
+  });
+
+  it("separates sections with spacing, never a hardcoded divider colour", () => {
+    // `defaultSiteTokens()` guarantees no border colour, and the older block
+    // drew its dividers with `var(--nx-color-border)` — the ADMIN namespace,
+    // which this renderer never emits, so that rule resolves to nothing on a
+    // published page while looking right in an admin preview.
+    const declared = JSON.stringify(ACCORDION_BASE_STYLES);
+
+    expect(declared).toContain("space.4");
+    expect(declared).not.toContain("--nx-");
+    expect(declared).not.toContain("border");
+  });
+
+  it("offers no `layout` support, since a <details> is not a flex container", () => {
+    // Withheld by this block rather than by the engine: `layout` is a real
+    // registered support, and granting it here sets the title beside the body.
+    expect(ACCORDION_ITEM_SUPPORTS).not.toHaveProperty("layout");
+    // Every key must be a STYLE CATALOG group — the registry refuses unknown
+    // ones, which is what caught `visibility` copied from the older block.
+    expect(ACCORDION_ITEM_SUPPORTS).not.toHaveProperty("visibility");
+  });
+});

--- a/packages/blocks-react/src/blocks/accordion.tsx
+++ b/packages/blocks-react/src/blocks/accordion.tsx
@@ -1,0 +1,103 @@
+/**
+ * `core/accordion` — the group a set of disclosure sections belongs to.
+ *
+ * A preset over the same implementation `core/box`, `core/section`, `core/card`
+ * and the columns pair use, restricted to `core/accordion-item` children. It
+ * differs from a box in relationships and defaults, never in capabilities,
+ * which is the property `container.tsx` argues for: display is a style, so a
+ * stack of sections is a box that starts stacked rather than a second kind of
+ * container.
+ *
+ * **Why the group exists at all, given the sections work alone.** A bare
+ * `<details>` is already a working disclosure, so a library could ship only the
+ * item and let authors drop them anywhere. The group earns its place by holding
+ * the things that belong to the SET rather than to a section: the spacing
+ * between sections, the shared border treatment, and — the load-bearing one —
+ * an identity the editor can select, so "the FAQ" is one thing to move,
+ * duplicate or hide rather than six things that happen to be adjacent.
+ *
+ * It is also what makes the slot restriction expressible. `core/accordion`
+ * accepts only `core/accordion-item`, so the editor can refuse a paragraph
+ * dropped between two sections — which would render outside every `<details>`
+ * and be permanently visible, looking like a bug in the accordion rather than a
+ * misplaced block.
+ *
+ * **The gap between sections is `baseStyles`, not a rule in the renderer.**
+ * `blocks-react/src/styles.ts` feeds `baseStyles` to `compilePageCss`, so a
+ * default declared here is a real stylesheet rule an author can override on the
+ * node like any other. A value hardcoded in the render function could not be
+ * overridden at all.
+ *
+ * **No default border, and no default background.** `defaultSiteTokens()`
+ * guarantees `color.text`, `color.background`, `color.primary`, `font.body`,
+ * `content.width` and `space.4` — there is no surface colour and no border
+ * colour among them. The older page-builder drew its dividers with
+ * `var(--nx-color-border)`, which is the ADMIN token namespace: this renderer
+ * emits `--site-*`, so that declaration validates, compiles, ships, and then
+ * resolves to nothing on the visitor's page while looking correct inside an
+ * admin preview. Separation between sections is therefore spacing, which every
+ * theme can express, and the divider is left to the author until a surface
+ * token exists to carry it.
+ *
+ * @module blocks/library/accordion
+ */
+import { defineBlock } from "@nextlyhq/blocks-engine";
+
+import type { PageContext } from "../context";
+
+import { ACCORDION_BLOCK, ACCORDION_ITEM_BLOCK } from "./accordion-item";
+import { CONTAINER_SUPPORTS, renderContainer } from "./container";
+import type { ContainerProps } from "./container";
+
+export { ACCORDION_BLOCK, ACCORDION_ITEM_BLOCK } from "./accordion-item";
+
+/**
+ * Sections stacked, with a gap between them.
+ *
+ * `display: grid` rather than `flex` because a single-column grid gives `gap`
+ * its meaning with no other declaration — no direction to set, no wrapping to
+ * disable, and no flex-item properties needed on the children. The catalog has
+ * no flex ITEM properties at all (`flex`, `flexGrow`, `flexShrink`, `flexBasis`
+ * are absent), so a flex layout here would leave the sections unable to express
+ * how they take space; a grid puts that on the track list, which the group owns.
+ *
+ * `space.4` is one of the six tokens `defaultSiteTokens()` guarantees, so this
+ * default resolves under every theme rather than only where a site happens to
+ * define a spacing scale.
+ */
+export const ACCORDION_BASE_STYLES = {
+  base: {
+    base: {
+      display: "grid",
+      gap: { $token: "space.4" },
+    },
+  },
+} as const;
+
+export const accordion = defineBlock<ContainerProps, PageContext>({
+  name: ACCORDION_BLOCK,
+  version: 1,
+  description:
+    "A group of disclosure sections. Restricts its slot to core/accordion-item so a stray block cannot render outside every section and stay permanently visible.",
+  props: {
+    as: { type: "select", options: ["div", "section", "article"] },
+    contained: { type: "checkbox" },
+  },
+  defaultProps: { as: "div", contained: false },
+  example: { props: { as: "div" } },
+  // The parent half of the nesting rule. `block.ts` is explicit that a slot
+  // naming a type does NOT confine that type to this slot; the item states its
+  // own side in `accordion-item.tsx`.
+  slots: {
+    children: {
+      allow: [ACCORDION_ITEM_BLOCK],
+      // Empty, as everywhere in this library: a literal template carries
+      // literal ids and two groups expanded from one collide on
+      // `duplicate-node-id`. Nothing reads `SlotSpec.template` yet.
+      template: [],
+    },
+  },
+  baseStyles: ACCORDION_BASE_STYLES,
+  supports: CONTAINER_SUPPORTS,
+  render: renderContainer,
+});

--- a/packages/blocks-react/src/blocks/base-styles.test.tsx
+++ b/packages/blocks-react/src/blocks/base-styles.test.tsx
@@ -175,6 +175,7 @@ describe("every default the core library declares", () => {
     // so a filter that matched nothing would run zero cases and the file would
     // pass having inspected nothing at all.
     expect(DECLARING.map(block => block.name).sort()).toEqual([
+      "core/accordion",
       "core/card",
       "core/column",
       "core/columns",

--- a/packages/blocks-react/src/blocks/index.ts
+++ b/packages/blocks-react/src/blocks/index.ts
@@ -24,6 +24,8 @@
  * @module blocks
  */
 
+import { accordion } from "./accordion";
+import { accordionItem } from "./accordion-item";
 import { box } from "./box";
 import { button } from "./button";
 import { card } from "./card";
@@ -41,6 +43,11 @@ import { quote } from "./quote";
 import { section } from "./section";
 import { spacer } from "./spacer";
 
+// `ACCORDION_BLOCK` / `ACCORDION_ITEM_BLOCK` are deliberately NOT re-exported,
+// for the reason recorded below for the columns pair: they exist so the two
+// halves of the nesting rule name each other without a repeated string literal.
+export { accordion } from "./accordion";
+export { accordionItem, type AccordionItemProps } from "./accordion-item";
 export { box } from "./box";
 export { button, BUTTON_TYPES, type ButtonProps } from "./button";
 // `CARD_BLOCK` is deliberately NOT re-exported, for the reason recorded below
@@ -104,6 +111,10 @@ export const coreBlocks = [
   columns,
   column,
   card,
+  // Parent before child, for the reason recorded on the columns pair: a
+  // resolver built by iterating this list should meet the group first.
+  accordion,
+  accordionItem,
   spacer,
   // Typography
   heading,

--- a/packages/blocks-react/src/blocks/root-inline-styles.test.tsx
+++ b/packages/blocks-react/src/blocks/root-inline-styles.test.tsx
@@ -86,6 +86,8 @@ const ALLOWED: ReadonlyMap<string, ReadonlySet<string>> = new Map();
 const EXPECTED_BLOCKS = [
   "core/box",
   "core/button",
+  "core/accordion",
+  "core/accordion-item",
   "core/card",
   "core/collection-loop",
   "core/column",

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -303,6 +303,8 @@ describe("the blocks entry", () => {
       "HEADING_LEVELS",
       "IMAGE_LOADING",
       "LIST_KINDS",
+      "accordion",
+      "accordionItem",
       "box",
       "button",
       "card",

--- a/packages/plugin-page-builder/src/blocks/__tests__/core-block-registration.test.ts
+++ b/packages/plugin-page-builder/src/blocks/__tests__/core-block-registration.test.ts
@@ -57,6 +57,8 @@ describe("core block registration", () => {
     // forever, so the list itself is pinned.
     expect(coreBlocks.length).toBeGreaterThanOrEqual(3);
     expect(coreBlocks.map(block => block.name).sort()).toEqual([
+      "core/accordion",
+      "core/accordion-item",
       "core/box",
       "core/button",
       "core/card",


### PR DESCRIPTION
## What

`core/accordion` and `core/accordion-item` — the disclosure pair from the derived block list (`left-tasks/2026-08-16-r3b-block-library-derived.md`, FAQ, "not composable — needs disclosure state").

## The design, and what it is NOT

**A pair, following `core/columns` + `core/column`.** The group owns what belongs to the set — the spacing between sections, and an identity the editor can select so "the FAQ" is one thing to move rather than six adjacent things. The slot restriction is what lets the editor refuse a paragraph dropped between two sections, which would render outside every `<details>` and be permanently visible.

**The body is a SLOT, not a prop — that is the substance of the port.** The older page-builder stored sections as a repeater of `{ title, content }` strings run through a Markdown pass, which made an accordion the only place in a document where you cannot put an image or a button.

**Native `<details>`, so no client JavaScript.** Measured: `blocks-react` has zero `"use client"` anywhere (the single grep hit is inside a docblock; positive control — `builder` 6 files, `admin` 296). Open/closed state, keyboard handling, focus and screen-reader announcement are all the platform's.

**It deliberately does not close its siblings.** `<details name>` gives exclusivity with no script but needs one shared name, and a child cannot derive it: `BlockRenderArgs` carries its own node, never its ancestors. Three routes were considered and each costs more than the behaviour: `SlotSpec.template` is empty by ratchet (literal ids collide); `renderSlot(name, ctx)` REPLACES the subtree context and `PageContext` says widening it is "a deliberate act rather than a side effect of a new block"; and folding the group into one block is the repeater design that loses the slot. Independent sections are also the safer default — an exclusive group collapses a section while someone is reading it.

## Two things measured rather than copied

**The PoC's supports list is not portable.** It declares `visibility` and `customAttributes`, which are not style-catalog groups in this engine — node visibility is its own field on `BlockNode`. The registry's unknown-support check caught it; the list here is derived from the catalog's own groups.

**No default divider colour.** The PoC draws section dividers with `var(--nx-color-border)` — the ADMIN token namespace. This renderer emits `--site-*`, so that declaration validates, compiles, ships, and resolves to nothing on a visitor's page while looking correct in an admin preview. Separation is spacing (`space.4`, one of the six tokens `defaultSiteTokens()` guarantees); the divider is left to the author until a surface token exists.

That is the **third** independent instance of PoC styling escaping the engine's compiler (after `badge` and `tabs`), which makes it a property of the PoC rather than of any one block.

## Verification

Ratchets updated as deliberate edits, never to go green: `root-inline-styles.test.tsx`, `base-styles.test.tsx`, `entry-surface.test.ts`, and `plugin-page-builder`'s `core-block-registration.test.ts`. The consumer suite was run **after** `pnpm --filter @nextlyhq/blocks-react... build`, since it resolves `dist`.

Stub-verified, each restore proven by an empty diff:

| break | result |
|---|---|
| defensive title read removed | `survives a stored title that is not a string` fails |
| `parent: [ACCORDION_BLOCK]` removed | `states BOTH halves of the nesting rule` fails |

`blocks-react`: 561 + 7 new, all passing. `check-types` (both configs) and `lint` exit 0. Comment-convention gate exit 0.

**Unrelated, found on the way:** the pre-push hook failed on `@nextlyhq/builder/shell` being unresolvable from `plugin-page-builder` — a stale install in my worktree (`@nextlyhq/builder` declared but not linked), not a code defect. `pnpm install` relinked it; no `--no-verify` was used.
