### PR TITLE
fix(root): judge the document after the drag ends, not in the same tick

### DIFF
--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -1173,6 +1173,25 @@ test.describe("a canvas any Nextly editor could ship", () => {
     await dragFromPanel(driver);
     await driver.cancel();
 
+    // The drag must be OVER before the document is judged, and this is the whole
+    // difficulty of asserting that nothing changed. A read taken in the same tick as
+    // the cancel is satisfied by the document not having been mutated YET — so a
+    // canvas that corrupts the tree one commit later passes, and the assertion that
+    // exists to catch exactly that reports success.
+    //
+    // `expect.poll` cannot fix it: polling retries until a condition becomes TRUE, and
+    // "unchanged" is already true at t=0, so it returns immediately having waited for
+    // nothing. What is needed is a BARRIER, and the drag ending is the right one —
+    // a drag that has finished cannot mutate the document afterwards, which is a
+    // property of the system rather than a duration someone guessed.
+    await expect
+      .poll(async () => driver.isDragging(), {
+        message:
+          "the drag must be over before the document is judged unchanged",
+        timeout: ESCAPE_SETTLE_MS,
+      })
+      .toBe(false);
+
     // Two of the three claims. Split from the third because a canvas can
     // satisfy any two, and folding them into one assertion would let this
     // canvas's shortfall on the third hide the regression cover the first two

--- a/e2e/tests/canvas/scenarios.spec.ts
+++ b/e2e/tests/canvas/scenarios.spec.ts
@@ -456,6 +456,38 @@ test("scenario 4b: a 2px jitter at a zone edge keeps the indicator stable", asyn
 });
 
 /**
+ * How long a keyboard move may take to reach the tree, in milliseconds.
+ *
+ * A ceiling the wait stops early on, not a delay anyone pays: a canvas that reorders
+ * returns as soon as it has, and only a canvas that never does spends the allowance.
+ */
+const KEYBOARD_MOVE_SETTLE_MS = 2_000;
+
+/**
+ * The tree once it has stopped being the one the gesture started from, or the
+ * unchanged tree if it never moves.
+ *
+ * Returns a SHAPE either way rather than throwing, because "it did not move" is the
+ * result the caller is measuring rather than an error — the assertion about whether
+ * that is acceptable belongs to the caller, and a helper that threw would make the
+ * absence of a move indistinguishable from a broken harness.
+ */
+async function settledTreeShape(
+  driver: CanvasDriver,
+  before: readonly string[]
+): Promise<string[]> {
+  const deadline = Date.now() + KEYBOARD_MOVE_SETTLE_MS;
+  let latest = await driver.readTreeShape();
+  while (
+    Date.now() < deadline &&
+    JSON.stringify(latest) === JSON.stringify(before)
+  ) {
+    latest = await driver.readTreeShape();
+  }
+  return latest;
+}
+
+/**
  * Marked failing, not passing, because it CANNOT fail here.
  *
  * Probed directly: a block takes focus (`document.activeElement` is the right
@@ -476,7 +508,15 @@ test("scenario 5: a keyboard move actually moves a block", async ({
 
   const before = await driver.readTreeShape();
   await driver.keyboardInsert("down");
-  const moved = await driver.readTreeShape();
+  // WAITED for, not read once. A reorder lands on a React commit after the drop
+  // resolves, so a read taken in the same tick sees the tree the gesture started
+  // from — which reports a working keyboard move as an absent one, and would go on
+  // doing so after the capability arrived. Elsewhere in this suite `readTreeShape`
+  // is polled after an asynchronous mutation for exactly this reason.
+  //
+  // The wait ends early the moment the tree differs, so a canvas that reorders pays
+  // nothing; only the canvas that never does spends the allowance.
+  const moved = await settledTreeShape(driver, before);
 
   test.info().annotations.push({
     type: "keyboard-shape",


### PR DESCRIPTION
## What

Two canvas assertions read state in the same tick as the action they observe. One is a **false green** and is the reason for this PR; the other is a false red that would survive the feature arriving.

## The false green — `acceptance.spec.ts`, "leaves the document and the editor intact when Escape cancels"

```ts
await driver.cancel();
expect(await driver.readTreeShape(), "Escape changes nothing").toEqual(before);
```

An unpolled read asserting the **absence** of change. Reading early *guarantees* the assertion passes, whether or not a mutation lands a commit later — so **a canvas that corrupts the document on Escape passes this test**. It carries no `test.fail`, so it is an active, passing test nobody is looking at, and it is the guard for the exact property its own title claims.

Measured: it is the only read-and-assert-in-one-tick site in the suite — `grep -c "expect(await driver\.\|expect(await chrome\."` gives `acceptance.spec.ts:1` and `0` in `scenarios`. An outlier, not a house style.

**`expect.poll` cannot fix it**, which is the trap: polling retries until a condition becomes TRUE, and "unchanged" is already true at t=0, so a poll returns immediately having waited for nothing. What is needed is a **barrier**, and the drag ending is the right one — a property of the system rather than a duration someone guessed.

The barrier is load-bearing rather than decorative. Measured on this canvas: immediately after `cancel()` the source still reports `aria-grabbed="true"`, and it clears by +100ms. So the assertion now waits out a window the old code read straight through.

**What it does not close, stated rather than implied:** a mutation arriving well after the drag has ended is still outside this barrier. It closes the window where a commit from the drag itself is in flight, which is the case that produced the false green.

## The false red — `scenarios.spec.ts`, scenario 5 (keyboard move)

```ts
await driver.keyboardInsert("down");
const moved = await driver.readTreeShape();   // same tick
```

A reorder lands on a React commit after the drop resolves. `readTreeShape` is already polled after an asynchronous mutation in three other places in this suite, one of them spelling out the reason. Now waits, ending early the moment the tree differs.

**Measured before changing it, and the marker is honest:** with focus asserted on the target first (`nx-flat-0`, `tabindex=0`, `role=button`), the tree is byte-identical at 0, 100, 300, 1000 and 2000ms. **B-14 is genuinely unbuilt.** The change is so the case reports the arrival — as written it would keep saying "no keyboard move path at all" after keyboard dragging landed.

## Notes

Test-only, so no changeset. `tsc --noEmit` clean; both suites **21 passed**.

Local canvas e2e on current `main` needs `pnpm --filter @nextlyhq/builder... build` first — `plugin-page-builder`'s dist imports `@nextlyhq/builder/shell` since #865, and a stale builder dist throws at `dist/admin/index.js:1134` with every case timing out on `mountTree`. It reads exactly like a broken canvas.