### PR TITLE
feat(blocks-react): add core/gallery

### DIFF
--- a/.changeset/core-gallery-block.md
+++ b/.changeset/core-gallery-block.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Adds `core/gallery`, a reflowing grid of pictures restricted to `core/image` so every item carries alt text and an intrinsic size. It sizes to its container rather than to a viewport breakpoint, so it reflows correctly inside a column or a card.

--- a/packages/blocks-react/src/blocks/base-styles.test.tsx
+++ b/packages/blocks-react/src/blocks/base-styles.test.tsx
@@ -180,6 +180,7 @@ describe("every default the core library declares", () => {
       "core/column",
       "core/columns",
       "core/form",
+      "core/gallery",
     ]);
   });
 

--- a/packages/blocks-react/src/blocks/gallery.test.tsx
+++ b/packages/blocks-react/src/blocks/gallery.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * What makes `core/gallery` worth being a block rather than a styled box.
+ *
+ * It delegates to `renderContainer`, so asserting that it draws a `div` passes
+ * equally on a `core/box` and would keep passing if the block were deleted and
+ * aliased. What separates it is the slot restriction, the ASYMMETRY of that
+ * restriction, and a track list that survives compilation — the last one
+ * because a property the catalog does not know is dropped in silence, which is
+ * how `core/columns` once shipped a layout that did nothing.
+ */
+import { describe, expect, it } from "vitest";
+
+import { gallery, GALLERY_BASE_STYLES, GALLERY_ITEM_BLOCK } from "./gallery";
+import { image } from "./image";
+import { coreBlocks } from "./index";
+
+describe("core/gallery", () => {
+  it("lays out pictures and refuses anything else", () => {
+    // A paragraph in a gallery is laid out as though it were a photograph,
+    // which reads as a broken gallery rather than a misplaced block.
+    expect(gallery.slots?.children?.allow).toEqual([GALLERY_ITEM_BLOCK]);
+    expect(GALLERY_ITEM_BLOCK).toBe(image.name);
+  });
+
+  it("does NOT confine core/image to itself", () => {
+    // The asymmetry that separates this from the columns pair. A column has no
+    // meaning outside its row, so it declares `parent`. An image belongs
+    // anywhere, so a gallery naming it must not confine it — `block.ts` is
+    // explicit that the two halves are independent, and this is the case that
+    // relies on it.
+    expect(image.parent).toBeUndefined();
+  });
+
+  it("is registered after the block its slot allows", () => {
+    const names = coreBlocks.map(block => block.name);
+    expect(names).toContain(gallery.name);
+    expect(names.indexOf(image.name)).toBeLessThan(names.indexOf(gallery.name));
+  });
+
+  it("declares a track list the catalog can actually compile", () => {
+    // The property this block would most naturally have reached for is `flex`,
+    // and the catalog has NO flex item properties at all — an absent property
+    // is dropped by the compiler without a word, so the layout would be silence
+    // rather than an error. Grid is what survives.
+    const declared = JSON.stringify(GALLERY_BASE_STYLES);
+
+    expect(declared).toContain("gridTemplateColumns");
+    expect(declared).not.toContain("flexBasis");
+    expect(declared).not.toContain('"flex"');
+  });
+
+  it("reflows on the container rather than on a breakpoint", () => {
+    // A gallery holds however many pictures were uploaded, and it can sit
+    // inside a column or a card where a viewport breakpoint measures the wrong
+    // box. `auto-fit` is what makes the count the container's business.
+    const tracks = JSON.stringify(GALLERY_BASE_STYLES);
+
+    expect(tracks).toContain("auto-fit");
+    // Capped by the available width: at a container narrower than the floor a
+    // bare `minmax(180px, 1fr)` makes one track wider than its parent.
+    expect(tracks).toContain("min(180px, 100%)");
+  });
+
+  it("imposes no aspect ratio, so the library is not cropped to one shape", () => {
+    // A default here is invisible in the editor's own preview, because the same
+    // rule applies there. Uniform tiles stay available on the image itself.
+    expect(JSON.stringify(GALLERY_BASE_STYLES)).not.toContain("aspectRatio");
+  });
+
+  it("uses only guaranteed tokens, so it resolves under every theme", () => {
+    // `defaultSiteTokens()` guarantees space.4 but no surface or border colour,
+    // and the older page-builder's grids reached for `--nx-*` — the ADMIN
+    // namespace, which this renderer never emits.
+    const declared = JSON.stringify(GALLERY_BASE_STYLES);
+
+    expect(declared).toContain("space.4");
+    expect(declared).not.toContain("--nx-");
+  });
+});

--- a/packages/blocks-react/src/blocks/gallery.tsx
+++ b/packages/blocks-react/src/blocks/gallery.tsx
@@ -1,0 +1,115 @@
+/**
+ * `core/gallery` — a grid of pictures.
+ *
+ * A preset over the same implementation `core/box`, `core/section`, `core/card`
+ * and the columns pair use, restricted to `core/image` children. It differs
+ * from a box in relationships and defaults, never in capabilities, which is the
+ * property `container.tsx` argues for: display is a style, so a gallery is a
+ * box that starts as a picture grid rather than a second kind of container.
+ *
+ * **Why this is not `core/columns` with images in it.** A row of columns gives
+ * every child an identity to be selected and styled, which is what a layout
+ * wants and what a gallery does not: twelve photographs would need twelve
+ * column blocks around them, and every one is a node an author has to create,
+ * name and keep in step. The pictures ARE the items here, so they sit in the
+ * slot directly and the track list is the group's business.
+ *
+ * The restriction is what makes that safe. `core/image` resolves its picture
+ * through the host's media library, so a gallery item carries alt text, an
+ * intrinsic size and a caption without the group knowing anything about media.
+ * A paragraph dropped into a gallery would be laid out as though it were a
+ * photograph, which reads as a broken gallery rather than a misplaced block —
+ * so the slot refuses it and the editor can say why.
+ *
+ * **The track list is `baseStyles`, not a rule in the renderer.**
+ * `blocks-react/src/styles.ts` feeds `baseStyles` to `compilePageCss`, so this
+ * default is a real stylesheet rule an author overrides on the node like any
+ * other. A value hardcoded in the render function could not be overridden at
+ * all, which is what makes the difference between a default and a constraint.
+ *
+ * **`auto-fit` rather than a fixed column count, and the reason is the
+ * content.** A gallery holds however many pictures were uploaded, and that
+ * number changes without anyone revisiting the layout. A fixed
+ * `repeat(3, 1fr)` leaves a row of one on the wrong count and needs a
+ * breakpoint for every size; `auto-fit` with a minimum fits as many as the
+ * container allows and reflows on its own — including inside a column or a
+ * card, where a viewport breakpoint would be measuring the wrong box.
+ *
+ * The minimum is capped by the available width for the same reason
+ * `core/columns` caps its own: at a container narrower than the floor, a bare
+ * `minmax(180px, 1fr)` makes a single track wider than its parent and the
+ * pictures overflow. `min(180px, 100%)` lets the last one fit.
+ *
+ * **No default gap of its own beyond the guaranteed token, and no aspect
+ * ratio.** `defaultSiteTokens()` guarantees `space.4`, so the gap resolves
+ * under every theme. A default `aspect-ratio` was considered and refused: it
+ * would crop every picture in the library to one shape, and the crop is
+ * invisible in the editor's own preview because the same rule applies there.
+ * Uniform tiles are a real want, so `aspectRatio` stays available on the image
+ * through its own supports rather than being imposed by the group.
+ *
+ * @module blocks/library/gallery
+ */
+import { defineBlock } from "@nextlyhq/blocks-engine";
+
+import type { PageContext } from "../context";
+
+import { CONTAINER_SUPPORTS, renderContainer } from "./container";
+import type { ContainerProps } from "./container";
+
+/** This block's registered name, so its tests name it once. */
+export const GALLERY_BLOCK = "core/gallery";
+
+/** The only child a gallery lays out. */
+export const GALLERY_ITEM_BLOCK = "core/image";
+
+/**
+ * Pictures in a reflowing grid.
+ *
+ * `display: grid` rather than flex because the catalog has NO flex item
+ * properties at all — `flex`, `flexGrow`, `flexShrink` and `flexBasis` are
+ * absent, and an absent property is dropped by the compiler without a word. A
+ * flex gallery would therefore leave every picture unable to say how it takes
+ * space. A grid puts that on the track list, which the group owns and can
+ * express.
+ */
+export const GALLERY_BASE_STYLES = {
+  base: {
+    base: {
+      display: "grid",
+      gridTemplateColumns: "repeat(auto-fit, minmax(min(180px, 100%), 1fr))",
+      gap: { $token: "space.4" },
+    },
+  },
+} as const;
+
+export const gallery = defineBlock<ContainerProps, PageContext>({
+  name: GALLERY_BLOCK,
+  version: 1,
+  description:
+    "A reflowing grid of pictures. Restricts its slot to core/image so every item carries alt text and an intrinsic size, and a stray block cannot be laid out as though it were a photograph.",
+  props: {
+    as: { type: "select", options: ["div", "section", "article"] },
+    contained: { type: "checkbox" },
+  },
+  defaultProps: { as: "div", contained: false },
+  example: { props: { as: "div" } },
+  // The parent half of the nesting rule, and the ONLY half this pair has.
+  // `block.ts` is explicit that a slot naming a type does not confine that type
+  // to it — which is exactly right here: `core/image` is a general-purpose
+  // block that belongs anywhere, so it must NOT declare `parent: [gallery]`.
+  // That asymmetry is the difference between this and the columns pair, where
+  // a column has no meaning outside its row.
+  slots: {
+    children: {
+      allow: [GALLERY_ITEM_BLOCK],
+      // Empty, as everywhere in this library: a literal template carries
+      // literal ids, and two galleries expanded from one collide on
+      // `duplicate-node-id`. Nothing reads `SlotSpec.template` yet.
+      template: [],
+    },
+  },
+  baseStyles: GALLERY_BASE_STYLES,
+  supports: CONTAINER_SUPPORTS,
+  render: renderContainer,
+});

--- a/packages/blocks-react/src/blocks/index.ts
+++ b/packages/blocks-react/src/blocks/index.ts
@@ -35,6 +35,7 @@ import { columns } from "./columns";
 import { divider } from "./divider";
 import { embed } from "./embed";
 import { form } from "./form";
+import { gallery } from "./gallery";
 import { heading } from "./heading";
 import { image } from "./image";
 import { list } from "./list";
@@ -73,6 +74,10 @@ export {
   type FormMethod,
   type FormProps,
 } from "./form";
+// `GALLERY_BLOCK` / `GALLERY_ITEM_BLOCK` are deliberately NOT re-exported, for
+// the reason recorded on the columns pair: they exist so this block names its
+// own type and its allowed child once.
+export { gallery } from "./gallery";
 export {
   heading,
   HEADING_LEVELS,
@@ -124,6 +129,8 @@ export const coreBlocks = [
   image,
   button,
   form,
+  // Registered after `image`, the only block its slot allows.
+  gallery,
   // Structure
   divider,
   quote,

--- a/packages/blocks-react/src/blocks/root-inline-styles.test.tsx
+++ b/packages/blocks-react/src/blocks/root-inline-styles.test.tsx
@@ -95,6 +95,7 @@ const EXPECTED_BLOCKS = [
   "core/divider",
   "core/embed",
   "core/form",
+  "core/gallery",
   "core/heading",
   "core/image",
   "core/list",

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -315,6 +315,7 @@ describe("the blocks entry", () => {
       "divider",
       "embed",
       "form",
+      "gallery",
       "heading",
       "image",
       "list",

--- a/packages/plugin-page-builder/src/blocks/__tests__/core-block-registration.test.ts
+++ b/packages/plugin-page-builder/src/blocks/__tests__/core-block-registration.test.ts
@@ -68,6 +68,7 @@ describe("core block registration", () => {
       "core/divider",
       "core/embed",
       "core/form",
+      "core/gallery",
       "core/heading",
       "core/image",
       "core/list",


### PR DESCRIPTION
## What

`core/gallery` — a reflowing grid of pictures, restricted to `core/image`.

**Branch name says `table`; the block is `gallery`. That is deliberate — see below.**

## Why `table` is not in this PR

I set out to build `table` and measured three engine gaps that make it an engine decision rather than a block:

```
borderCollapse   ABSENT from STYLE_CATALOG
borderSpacing    ABSENT
tableLayout      ABSENT
captionSide      ABSENT
verticalAlign    ABSENT
```

An absent property is **dropped by the compiler in silence** — the defect that made `core/columns` ship a `flex: 1 1 240px` that did nothing. So a table could not express `border-collapse: collapse` and would render with doubled borders and gaps, with nothing reporting it.

Two more on top: `defaultSiteTokens()` guarantees no border colour (the wall `core/card` hit), and WCAG 2.2 wants a wide table in a focusable scroll region (`tabindex="0"`, `role="region"`), which sits awkwardly against `block.ts`'s "blocks render a single element and never wrap it" — styles would then target the scroller rather than the table.

Filed rather than forced. `gallery` has none of these problems.

## The design

A preset over the same implementation as `box`/`section`/`card`/`columns`, differing in relationships and defaults, never capabilities.

**Not `core/columns` with images inside.** A row gives every child an identity to select and style, which a layout wants and a gallery does not: twelve photographs would need twelve column blocks, each a node to create and keep in step. The pictures ARE the items, so they sit in the slot directly.

**The restriction is asymmetric, and that is the point.** `core/gallery` allows only `core/image`, but `core/image` does **not** declare `parent`. A column has no meaning outside its row; an image belongs anywhere. `block.ts` states the two halves are independent, and this is the case that relies on it — there is a test asserting `image.parent` stays undefined.

**Grid, not flex, and not by taste.** The catalog has no flex ITEM properties at all — `flex`, `flexGrow`, `flexShrink`, `flexBasis` are absent — so a flex gallery leaves every picture unable to say how it takes space, silently. A grid puts that on the track list.

**`auto-fit` sized to the CONTAINER.** A gallery holds however many pictures were uploaded, and it can sit inside a column or a card where a viewport breakpoint measures the wrong box. The floor is capped at `min(180px, 100%)` for the same reason `core/columns` caps its own: below the floor, a bare `minmax` makes one track wider than its parent.

**No default `aspect-ratio`**, considered and refused: it would crop the whole library to one shape, and the crop is invisible in the editor's preview because the same rule applies there. Uniform tiles stay available on the image.

## Verification

Ratchets updated as deliberate edits: `root-inline-styles.test.tsx`, `base-styles.test.tsx`, `entry-surface.test.ts`, and `plugin-page-builder`'s `core-block-registration.test.ts` — the last run **after** `pnpm --filter @nextlyhq/blocks-react... build`, since it resolves `dist`.

Stub-verified, restores proven by empty diff:

| break | result |
|---|---|
| slot `allow` removed | `lays out pictures and refuses anything else` fails |
| grid swapped for `flex`/`flexBasis` | `declares a track list the catalog can actually compile` + the reflow test fail |

571 tests green in `blocks-react`, consumer suite 5/5, `check-types` (both configs) and `lint` exit 0, comment-convention exit 0.

## Reviewer note

There is currently no working automated reviewer: Codex returns its usage-limit message, and `@nextly-bot` has produced zero comments and zero reviews on #888, #889 and #890. Treat silence on this PR as unreviewed, not as approval.
