### PR TITLE
feat(nextly): add a concurrency token to the autosave compare-and-set

### DIFF
--- a/.changeset/versions-autosave-concurrency-token.md
+++ b/.changeset/versions-autosave-concurrency-token.md
@@ -1,0 +1,44 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+feat(nextly): add a concurrency token to the autosave compare-and-set
+
+The rolling autosave row is rewritten in place, guarded by a compare-and-set so
+that two tabs belonging to one author cannot overwrite each other. That guard
+compared `updated_at` against the value the write had observed, and the stored
+resolution of a timestamp differs per dialect: SQLite keeps whole epoch seconds
+and MySQL milliseconds. Two rewrites close enough together serialize
+identically, so the second writer observes exactly what the first wrote, its
+predicate matches, and it overwrites newer work believing the row untouched.
+
+`nextly_versions` gains a monotonic `revision` counter. The compare-and-set
+reads it, applies only while the row still holds it, and writes its successor.
+A counter has no resolution to exhaust, so the guard holds however close
+together two writes fall.
+
+The column is additive and carries a default, so `nextly migrate` adds it to
+databases that already exist rather than refusing the migration.

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -208,7 +208,8 @@ export function generateSqliteCoreTableStatements(): string[] {
       "source_version_no" INTEGER,
       "created_by" TEXT,
       "created_at" INTEGER NOT NULL,
-      "updated_at" INTEGER NOT NULL
+      "updated_at" INTEGER NOT NULL,
+      "revision" INTEGER NOT NULL DEFAULT 0
     )`,
     `CREATE UNIQUE INDEX IF NOT EXISTS "nextly_versions_seq_uidx"
       ON "nextly_versions" ("scope_kind", "scope_slug", "entry_id", "version_no")`,

--- a/packages/nextly/src/domains/versions/__tests__/autosave-upsert.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/autosave-upsert.test.ts
@@ -25,7 +25,7 @@ const REF = {
  * Records every insert and update so a test can assert which was issued, and
  * the `where` of each so the addressing can be checked rather than assumed.
  */
-function stubDb(existing: Array<{ id: string }> = []) {
+function stubDb(existing: Array<{ id: string; revision: number }> = []) {
   const inserts: Array<Record<string, unknown>> = [];
   const updates: Array<{
     values: Record<string, unknown>;
@@ -74,6 +74,10 @@ describe("VersionsRepository.upsertAutosave", () => {
       // and surface in history.
       versionNo: null,
       createdBy: "user-1",
+      // The compare-and-set token starts at a known value rather than being
+      // left to the column default, so the first rewrite of this row compares
+      // against something this insert decided.
+      revision: 0,
     });
   });
 
@@ -84,7 +88,9 @@ describe("VersionsRepository.upsertAutosave", () => {
    * and on MySQL and SQLite nothing would stop it.
    */
   it("updates in place when a row already exists, and inserts nothing", async () => {
-    const { db, inserts, updates } = stubDb([{ id: "existing-row" }]);
+    const { db, inserts, updates } = stubDb([
+      { id: "existing-row", revision: 7 },
+    ]);
 
     await new VersionsRepository(db).upsertAutosave({
       ...input,
@@ -101,7 +107,7 @@ describe("VersionsRepository.upsertAutosave", () => {
    * other's, and the loser would recover somebody else's work.
    */
   it("addresses the row by author as well as document", async () => {
-    const { db, updates } = stubDb([{ id: "existing-row" }]);
+    const { db, updates } = stubDb([{ id: "existing-row", revision: 7 }]);
 
     await new VersionsRepository(db).upsertAutosave(input);
 
@@ -128,12 +134,38 @@ describe("VersionsRepository.upsertAutosave", () => {
     // Inverting it to `!=` makes every uncontended write match nothing and
     // silently do nothing, so the operator is pinned here rather than left to
     // read correctly at a glance.
-    expect(conditions).toContainEqual(
-      expect.objectContaining({ column: "updatedAt", op: "=" })
-    );
+    //
+    // The VALUE is pinned too. A predicate naming the right column and
+    // comparing against a fresh read, or against the value being written,
+    // matches unconditionally and blocks nothing, which the operator alone
+    // cannot separate from a working compare-and-set.
+    expect(conditions).toContainEqual({
+      column: "revision",
+      op: "=",
+      value: 7,
+    });
     // And nothing else: an extra condition would narrow the lookup in a way
     // this test would otherwise not notice.
     expect(conditions).toHaveLength(6);
+  });
+
+  /**
+   * The other half of compare-and-set, and the half a predicate test cannot
+   * see. Comparing against the observed token only excludes a racing writer if
+   * the winning write ADVANCES that token: a rewrite leaving it unchanged
+   * satisfies every assertion about the predicate while both racers succeed and
+   * the older snapshot lands last.
+   *
+   * Pinned as the exact successor rather than merely "greater". A write that
+   * jumped ahead would leave the values a second writer can hold unbounded, and
+   * a timestamp is precisely the unbounded version this column replaced.
+   */
+  it("advances the token to the successor of the value it compared against", async () => {
+    const { db, updates } = stubDb([{ id: "existing-row", revision: 7 }]);
+
+    await new VersionsRepository(db).upsertAutosave(input);
+
+    expect(updates[0]?.values.revision).toBe(8);
   });
 
   /**
@@ -142,7 +174,7 @@ describe("VersionsRepository.upsertAutosave", () => {
    * to find the existing row and insert a second one on every save.
    */
   it("matches a null author with IS NULL rather than equality", async () => {
-    const { db, updates } = stubDb([{ id: "existing-row" }]);
+    const { db, updates } = stubDb([{ id: "existing-row", revision: 7 }]);
 
     await new VersionsRepository(db).upsertAutosave({
       ...input,

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -585,12 +585,12 @@ export class VersionsRepository {
     const where = this.autosaveWhere(input.ref, createdBy);
     // Project only the id: the existence check must not transfer the (possibly
     // large) snapshot of the row it is about to overwrite.
-    const existing = await this.db.select<{ id: string; updatedAt: Date }>(
+    const existing = await this.db.select<{ id: string; revision: number }>(
       TABLE,
       {
-        // `updatedAt` rides along so the update can compare against the value
+        // `revision` rides along so the update can compare against the value
         // this read OBSERVED rather than against a clock.
-        columns: ["id", "updatedAt"],
+        columns: ["id", "revision"],
         where,
         limit: 1,
       }
@@ -612,6 +612,10 @@ export class VersionsRepository {
           status: input.status,
           locale: input.locale ?? null,
           updatedAt: now,
+          // Advancing the token is what makes the next writer's predicate fail.
+          // Computed from the OBSERVED value rather than read again, so the
+          // value written is the successor of the one being compared against.
+          revision: existing[0].revision + 1,
         },
         // Flattened into the same conjunction rather than nested, so the
         // predicate stays one readable list of conditions.
@@ -620,18 +624,21 @@ export class VersionsRepository {
             ...(where.and ?? []),
             // EQUALITY against the value this read observed: apply only while
             // the row still holds it, which is what compare-and-set means. A
-            // concurrent writer changes the value, this matches nothing, and
-            // the slower write is dropped rather than overwriting newer work.
+            // concurrent writer advances it, this matches nothing, and the
+            // slower write is dropped rather than overwriting newer work.
             //
-            // Not `<` against a clock: SQLite stores this column as integer
-            // epoch SECONDS, so a rewrite inside the same second serializes
-            // identically and an ordering comparison would match nothing even
-            // with no contention, silently dropping every autosave after the
-            // first.
+            // The token is `revision` rather than `updatedAt` because a
+            // timestamp's stored resolution differs per dialect and can run
+            // out: SQLite keeps whole epoch SECONDS, so two rewrites inside one
+            // second are indistinguishable, and the second writer's read
+            // observes exactly what the first wrote. Its predicate then matches
+            // and it overwrites newer work believing the row untouched. A
+            // counter advances on every write regardless of how close together
+            // they fall.
             {
-              column: "updatedAt",
+              column: "revision",
               op: "=" as const,
-              value: existing[0].updatedAt,
+              value: existing[0].revision,
             },
           ],
         }
@@ -662,6 +669,9 @@ export class VersionsRepository {
           createdBy,
           createdAt: now,
           updatedAt: now,
+          // Stated rather than left to the column default, so the first value
+          // the compare-and-set will read is fixed by this insert.
+          revision: 0,
         },
         { returning: [] }
       );

--- a/packages/nextly/src/schemas/versions/__tests__/revision-reaches-existing-databases.test.ts
+++ b/packages/nextly/src/schemas/versions/__tests__/revision-reaches-existing-databases.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Whether the autosave concurrency token can reach a database that already
+ * exists.
+ *
+ * The token is only worth having if every installation gets it. A database
+ * created before this column existed is upgraded by `nextly migrate` Phase 1,
+ * which introspects the live core tables, diffs them against `getCoreSchema`
+ * and classifies the result under `production-strict`. Two properties decide
+ * whether that path applies the column or refuses the whole migration, and
+ * neither is visible from the schema file:
+ *
+ *   - the table must be part of the core snapshot at all, since the diff only
+ *     considers tables it finds there;
+ *   - the column must carry a DEFAULT, because `production-strict` refuses an
+ *     `add_column` that is NOT NULL with none. Refusing is the safe behaviour
+ *     for a column that would fail at apply time, and here it would mean every
+ *     existing installation's migration stops rather than the column being
+ *     silently skipped.
+ *
+ * Both are asserted against the real snapshot and the real classifier rather
+ * than restated, so dropping `.default(0)` fails here instead of at a user's
+ * `migrate`.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import { classifyForMode } from "../../../domains/schema/pipeline/classifier/modes";
+import type { AddColumnOp } from "../../../domains/schema/pipeline/diff/types";
+import { getCoreSchema } from "../../index";
+
+const DIALECTS: SupportedDialect[] = ["postgresql", "mysql", "sqlite"];
+
+describe.each(DIALECTS)("nextly_versions.revision on %s", dialect => {
+  const table = getCoreSchema(dialect).tables.find(
+    t => t.name === "nextly_versions"
+  );
+  const column = table?.columns.find(c => c.name === "revision");
+
+  it("is part of the core snapshot the reconcile diffs against", () => {
+    // The positive control for everything below: a column the snapshot does not
+    // contain produces no operation at all, and a test that only asserted "no
+    // refusal" would pass on exactly that.
+    expect(table).toBeDefined();
+    expect(column).toBeDefined();
+  });
+
+  it("declares a default, so adding it to an existing table is not refused", () => {
+    expect(column?.nullable).toBe(false);
+    // The value itself, not merely that one is present. A default the diff
+    // cannot render lands as `undefined` here, which is the refusing case.
+    expect(column?.default).toBe("0");
+  });
+
+  it("classifies as applicable under production-strict", () => {
+    // Narrowed by a throw rather than a non-null assertion: an absent column
+    // would otherwise reach the classifier as `undefined` and fail there with
+    // a message about a property access, naming neither this table nor why it
+    // matters.
+    if (!column) {
+      throw new Error("nextly_versions.revision is absent from the snapshot");
+    }
+
+    const op: AddColumnOp = {
+      type: "add_column",
+      tableName: "nextly_versions",
+      // The column as the snapshot actually describes it. Constructing one by
+      // hand would assert the classifier's rule against a value this schema
+      // may not produce, which is the agreement being tested.
+      column,
+    };
+
+    const result = classifyForMode([op], dialect, "production-strict");
+
+    expect(result.verdict).toBe("apply");
+  });
+});

--- a/packages/nextly/src/schemas/versions/mysql.ts
+++ b/packages/nextly/src/schemas/versions/mysql.ts
@@ -53,6 +53,10 @@ export const nextlyVersionsMysql = mysqlTable(
     updatedAt: datetime("updated_at", { fsp: 3 })
       .$defaultFn(() => new Date())
       .notNull(),
+    // Compare-and-set token for the in-place autosave rewrite. `updated_at`
+    // resolves to milliseconds here, which is finer than SQLite but still a
+    // resolution two rewrites can share; a counter cannot collide.
+    revision: int("revision").default(0).notNull(),
   },
   table => [
     // Durable version_no uniqueness per document. A FULL (non-partial) unique

--- a/packages/nextly/src/schemas/versions/postgres.ts
+++ b/packages/nextly/src/schemas/versions/postgres.ts
@@ -58,6 +58,19 @@ export const nextlyVersionsPg = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true })
       .$defaultFn(() => new Date())
       .notNull(),
+    // Monotonic per-row counter, bumped on every in-place rewrite of the
+    // coalesced autosave row. This is the compare-and-set token: a writer reads
+    // the value, then applies its update only while the row still holds it.
+    //
+    // `updated_at` cannot serve that purpose across dialects. Its stored
+    // resolution varies (SQLite keeps whole seconds, MySQL milliseconds), so
+    // two rewrites close enough together serialize to the SAME value and become
+    // indistinguishable: the second writer's read observes what the first
+    // wrote, its predicate matches, and it overwrites newer work believing the
+    // row untouched. A counter has no resolution to run out of.
+    //
+    // Insert-only rows (durable versions are never rewritten) stay at 0.
+    revision: integer("revision").default(0).notNull(),
   },
   table => [
     // Durable versions get a unique, monotonic sequence per document.

--- a/packages/nextly/src/schemas/versions/sqlite.ts
+++ b/packages/nextly/src/schemas/versions/sqlite.ts
@@ -54,6 +54,10 @@ export const nextlyVersionsSqlite = sqliteTable(
     updatedAt: integer("updated_at", { mode: "timestamp" })
       .$defaultFn(() => new Date())
       .notNull(),
+    // Compare-and-set token for the in-place autosave rewrite. Carries the
+    // ordering that `updated_at` cannot here: `mode: "timestamp"` stores whole
+    // epoch SECONDS, so two rewrites inside one second are stored identically.
+    revision: integer("revision").default(0).notNull(),
   },
   table => [
     // Durable version_no uniqueness per document. A FULL (non-partial) unique


### PR DESCRIPTION
## What

`nextly_versions` gains a monotonic `revision` counter, and the autosave
compare-and-set moves onto it.

## Why

The rolling autosave row is rewritten in place, guarded by a compare-and-set so
two tabs belonging to one author cannot overwrite each other. That guard
compared `updated_at` against the value the write had observed.

The stored resolution of a timestamp differs per dialect:

| dialect | column | resolution |
| --- | --- | --- |
| SQLite | `integer(mode: "timestamp")` | whole epoch **seconds** |
| MySQL | `datetime(fsp: 3)` | milliseconds |
| Postgres | `timestamptz` | microseconds |

Two rewrites close enough together serialize to the same value. The second
writer then observes exactly what the first wrote, its predicate matches, and it
overwrites newer work believing the row untouched. A counter has no resolution
to exhaust.

## Reaching databases that already exist

A token only helps if every installation gets it, and that is decided outside
the schema file.

`nextly migrate` Phase 1 (`reconcileCore`) introspects the live core tables,
diffs against `getCoreSchema`, and classifies under `production-strict`.
`nextly_versions` is in that snapshot, and `production-strict` refuses an
`add_column` that is NOT NULL with no default. The column carries
`.default(0)`, so it applies rather than refusing the migration.

That is asserted against the real snapshot and the real classifier
(`revision-reaches-existing-databases.test.ts`, all three dialects) rather than
reasoned about, so dropping the default fails in CI instead of at a user's
`migrate`.

## Scope

Deliberately **not** in this PR:

- **Locale keying on the autosave unique index.** Blocked on a pipeline
  capability, not on this table. `isManagedIndexName` permits dropping only
  `idx_*`/`uq_*` names, and the live index is `nextly_versions_autosave_uidx`,
  so replacing it emits the add and silently omits the drop. Both indexes would
  then coexist on an existing database and the old one would keep enforcing the
  old rule, giving different behaviour on fresh and existing installs with no
  error either way.
- **`upsertWorkingDraft`.** It has no compare-and-set at all: it selects only
  `id` and updates unconditionally. A pre-existing race, and a silent
  drop-the-loser is the wrong remedy for a shared working draft, which wants a
  conflict signal instead.

## Verification

Every assertion added here was break-verified, each failing only its intended
test:

| break | result |
| --- | --- |
| compare against `updatedAt` instead of `revision` | predicate test fails |
| write the token without advancing it | successor test fails |
| leave the insert token to the column default | insert test fails |
| bootstrap DDL omits the column | DDL agreement test fails |
| drop `.default(0)` from the Postgres schema | 2 Postgres reachability assertions fail, MySQL and SQLite legs stay green |

Gates run locally: `check-types` + `lint` (8/8), `check:comments`,
`check:storage-format-literals`, `lint:workspace`, and
`check-changesets.mjs` against the new changeset, with a control that drops one
package and correctly exits 1.

Two failures in `versions-methods.test.ts` are **pre-existing**, controlled at
`b06706e79` without this change: same two tests, same names.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autosave reliability by using revision tracking to prevent conflicting updates.
  * Autosaved changes now advance their revision token, while new records start at revision 0.
  * Added consistent revision support across PostgreSQL, MySQL, and SQLite databases.
  * Existing databases can safely recognize and apply the new revision field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->