### PR TITLE
test(nextly): pin that no route is claimed deeper than autosave

### DIFF
--- a/packages/nextly/src/route-handler/__tests__/route-parser.versions.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.versions.test.ts
@@ -387,6 +387,34 @@ describe("version label routes", () => {
     ).toBeUndefined();
   });
 
+  /**
+   * A path deeper than the autosave sub-resource belongs to no route, and the
+   * parser must say so rather than truncate it to the nearest one it does own.
+   *
+   * The failure this guards is quiet in a way a 404 is not: the segments after
+   * `autosave` would simply be dropped, and the request would answer 200 from
+   * the caller's recovery point while naming a resource that does not exist.
+   * Nothing downstream can detect that, because by then the route looks like an
+   * ordinary autosave read.
+   *
+   * Asserted for both scopes. The two parsers reach this through different
+   * guards, so one can lose it while the other keeps it.
+   */
+  it("claims no route deeper than the autosave sub-resource", () => {
+    expect(
+      parseRestRoute(
+        ["collections", "posts", "entries", "e1", "versions", "autosave", "x"],
+        "GET"
+      ).method
+    ).toBeUndefined();
+    expect(
+      parseRestRoute(
+        ["singles", "settings", "versions", "autosave", "x"],
+        "GET"
+      ).method
+    ).toBeUndefined();
+  });
+
   it("leaves other methods on a version alone", () => {
     expect(
       parseRestRoute(


### PR DESCRIPTION
## What

One test, pinning that the versions parser claims no route deeper than the
`autosave` sub-resource, for collections and Singles alike.

No changeset: test-only.

## Why

The behaviour is already correct. Both parsers return `null` for a path deeper
than the sub-route they own, and nothing here changes that. What was missing is
anything holding it in place.

The regression this guards is quiet in a way a 404 is not. Losing the depth
guard does not error: the segments after `autosave` are dropped and the request
answers **200 from the caller's own recovery point**, for a resource that does
not exist. By the time the request reaches a handler it looks like an ordinary
autosave read, so nothing downstream can tell the difference.

That this is a live class rather than a hypothetical was established next door:
on the field-groups branch of the same parser, disabling a route guard did not
404. The URL fell through and resolved to `getComponent`. The versions branch
does not share that shape, and this test is what keeps it that way after someone
edits the branch above it.

## Verification

Both scopes are asserted separately because the two parsers reach the guard
through different conditions (`additionalParams.length > 2` for collections,
`> 0` for Singles), so one can be lost while the other holds.

Break-verified independently, which is what justifies asserting both rather than
one:

| break | result |
| --- | --- |
| remove the collection depth guard | this test fails (plus 2 adjacent depth tests) |
| remove the Single depth guard | this test fails (plus 1 adjacent depth test) |

Suite green at 43 tests with the guards in place.
