### PR TITLE
fix(blocks-react): stop three blocks depending on token CSS nothing emits

### DIFF
--- a/.changeset/form-accordion-gallery-token-gap.md
+++ b/.changeset/form-accordion-gallery-token-gap.md
@@ -1,0 +1,53 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(blocks-react): stop three blocks depending on token CSS nothing emits
+
+`core/form`, `core/accordion` and `core/gallery` each declared
+`gap: { $token: "space.4" }`. A token reference compiles to
+`var(--site-space-4)`, and nothing in this repository ever emits that variable,
+so the declaration was invalid at computed-value time and `gap` fell back to
+`normal` — zero for a grid. Three blocks rendered with their children touching.
+
+Measured three ways that agree: `compileSiteSheet`, the only thing that turns a
+token set into CSS, has zero consumers outside `blocks-engine`;
+`emitTokenBlocks` is called only by that function, its own tests and a
+benchmark; and the string `--site-` appears in no source file outside the engine
+at all, against a positive control of `--nx-` appearing in four. So
+`defaultSiteTokens()` guarantees nothing today — it is a default nobody applies.
+
+Every existing check passed while this was broken: the property is in
+`STYLE_CATALOG`, and the declaration did reach the compiled stylesheet. Whether
+the `var()` inside the value RESOLVES is a third question, and nothing asked it.
+
+The blocks now use the length `space.4` itself declares, so the value does not
+change when this becomes a token again. `base-styles.test.tsx` gains the check
+that asks the third question, walking to the leaf so a token nested inside an
+object-shaped declaration is caught too, with a positive control for both
+shapes. It is a ratchet with an expiry: when the site stylesheet is wired into
+the render path it should be deleted by the change that wires it, rather than
+weakened or exempted per block.

--- a/packages/blocks-react/src/blocks/accordion.test.tsx
+++ b/packages/blocks-react/src/blocks/accordion.test.tsx
@@ -81,13 +81,22 @@ describe("the accordion pair", () => {
   });
 
   it("separates sections with spacing, never a hardcoded divider colour", () => {
-    // `defaultSiteTokens()` guarantees no border colour, and the older block
-    // drew its dividers with `var(--nx-color-border)` — the ADMIN namespace,
-    // which this renderer never emits, so that rule resolves to nothing on a
-    // published page while looking right in an admin preview.
+    // The divider reasoning below is unchanged and was right. What changed is
+    // the SPACING: this required `space.4`, and a token resolves to nothing.
+    //
+    // `defaultSiteTokens()` guarantees nothing today — `compileSiteSheet` has
+    // zero consumers outside `blocks-engine` and `--site-` appears in no source
+    // file outside it, so `gap: { $token: "space.4" }` compiled to
+    // `var(--site-space-4)`, nothing defined it, and the gap fell back to
+    // `normal`: zero for a grid. The sections touched, which is precisely the
+    // separation this test exists to guarantee.
     const declared = JSON.stringify(ACCORDION_BASE_STYLES);
 
-    expect(declared).toContain("space.4");
+    expect(declared).toContain("1rem");
+    expect(declared).not.toContain("$token");
+    // The older block drew its dividers with `var(--nx-color-border)` — the
+    // ADMIN namespace, which this renderer never emits, so that rule resolves
+    // to nothing on a published page while looking right in an admin preview.
     expect(declared).not.toContain("--nx-");
     expect(declared).not.toContain("border");
   });

--- a/packages/blocks-react/src/blocks/accordion.tsx
+++ b/packages/blocks-react/src/blocks/accordion.tsx
@@ -69,7 +69,11 @@ export const ACCORDION_BASE_STYLES = {
   base: {
     base: {
       display: "grid",
-      gap: { $token: "space.4" },
+      // A LENGTH, not a token: nothing emits token CSS yet, so a `{ $token }`
+      // reference compiles to a `var()` with nothing behind it and the gap
+      // silently falls back to `normal`, which for a grid is zero. `1rem` is
+      // what `space.4` itself declares, so the value survives the change back.
+      gap: "1rem",
     },
   },
 } as const;

--- a/packages/blocks-react/src/blocks/base-styles.test.tsx
+++ b/packages/blocks-react/src/blocks/base-styles.test.tsx
@@ -244,3 +244,72 @@ describe("every default the core library declares", () => {
     }
   );
 });
+
+/**
+ * Every token reference a `NodeStyles` makes, at any depth.
+ *
+ * Walked to the leaf rather than read one level down: a token may sit inside an
+ * object-shaped declaration — a per-corner radius, a per-side border colour —
+ * and a check that only inspected top-level values would report those clean.
+ */
+function tokenNamesIn(value: unknown): string[] {
+  if (typeof value !== "object" || value === null) return [];
+  const record = value as Record<string, unknown>;
+  if (typeof record.$token === "string") return [record.$token];
+  return Object.values(record).flatMap(tokenNamesIn);
+}
+
+describe("a default may not depend on a design token yet", () => {
+  /**
+   * **A token reference compiles to a `var()` that NOTHING DEFINES.**
+   *
+   * `compileSiteSheet` is the only thing that turns a token set into CSS, and it
+   * has zero consumers outside `blocks-engine` — so `--site-*` is emitted by no
+   * product path, and `defaultSiteTokens()` is a default nobody applies. An
+   * undefined custom property makes the whole declaration invalid at
+   * computed-value time, so the property falls back to its initial value.
+   *
+   * `core/form` shipped that way: `gap: { $token: "space.4" }` became
+   * `gap: var(--site-space-4)`, which resolved to nothing, so a grid whose
+   * fields were supposed to be spaced rendered with them touching.
+   *
+   * **Neither check above can see it.** The property is in the catalog, and the
+   * declaration DOES reach the compiled stylesheet — it is the `var()` inside
+   * the value that dangles. Whether a reference resolves is a third question,
+   * and this is the one that asks it.
+   *
+   * **This is a ratchet with an expiry.** When the site stylesheet is wired into
+   * the render path, tokens become the RIGHT way to express a default and this
+   * case should be deleted in the change that wires it — not weakened, and not
+   * exempted per block.
+   */
+  it.each(DECLARING.map(block => [block.name, block] as const))(
+    "%s uses no token reference",
+    (name, block) => {
+      expect(
+        tokenNamesIn(block.baseStyles),
+        `${name} declares a { $token } default. Nothing emits token CSS yet ` +
+          `(compileSiteSheet has no consumers outside blocks-engine), so the ` +
+          `reference compiles to a var() with nothing behind it and the ` +
+          `property silently falls back to its initial value. Use a literal ` +
+          `until the site stylesheet is wired, then delete this case.`
+      ).toEqual([]);
+    }
+  );
+
+  it("detects a token reference at any depth, including inside an object", () => {
+    // The positive control. Every assertion above passes by finding NOTHING, so
+    // a walker that returned nothing under all circumstances would leave the
+    // whole case green — and the nested form is the one a shallow reader misses.
+    expect(
+      tokenNamesIn({ base: { base: { gap: { $token: "space.4" } } } })
+    ).toEqual(["space.4"]);
+    expect(
+      tokenNamesIn({
+        base: {
+          base: { borderRadius: { startStart: { $token: "radius.sm" } } },
+        },
+      })
+    ).toEqual(["radius.sm"]);
+  });
+});

--- a/packages/blocks-react/src/blocks/card.tsx
+++ b/packages/blocks-react/src/blocks/card.tsx
@@ -30,12 +30,20 @@
  * author adds padding to the card when there is no image, or to a box inside it
  * when there is, and both stay available. A default would remove the second.
  *
- * **No default background or border, because no token can express one.**
- * `defaultSiteTokens()` guarantees `color.text`, `color.background`,
- * `color.primary`, `font.body`, `content.width` and `space.4` — there is no
- * surface colour and no border colour among them. A `{ $token }` reference to a
- * name a site never defines compiles to a `var()` with nothing behind it, and a
- * hardcoded hex is wrong in whichever of light and dark it was not chosen for.
+ * **No default background or border, and the reason is stronger than first
+ * recorded.** This docblock used to say `defaultSiteTokens()` "guarantees"
+ * `color.text`, `color.background`, `color.primary`, `font.body`,
+ * `content.width` and `space.4`, and that a surface colour was merely absent
+ * from that set. **It guarantees none of them.** `compileSiteSheet` — the only
+ * thing that turns a token set into CSS — has ZERO consumers outside
+ * `blocks-engine`, and the string `--site-` appears in no source file outside
+ * the engine (positive control: `--nx-` appears in four). The default token set
+ * is a default nobody applies.
+ *
+ * So a `{ $token }` reference here would compile to a `var()` with nothing
+ * behind it — not because the name is unlisted, but because **no token name
+ * resolves at all yet.** A hardcoded hex is wrong in whichever of light and
+ * dark it was not chosen for.
  *
  * The obvious way around that is to DERIVE a surface from the two colours that
  * are guaranteed, which is what the older page-builder blocks do:

--- a/packages/blocks-react/src/blocks/form.tsx
+++ b/packages/blocks-react/src/blocks/form.tsx
@@ -105,11 +105,31 @@ const MAX_FIELDS = 100;
 /**
  * The grid that stacks the labels and controls.
  *
- * `gap` takes a `{ $token }` rather than a length because `space.4` is in the
- * guaranteed default token set, and `container.tsx` is explicit that spacing
- * comes from the document or from a token and never from a block file. Where no
- * token is guaranteed — corner radius, a surface colour — a block has to either
- * use a literal or leave the property alone; here one exists, so it is used.
+ * **`gap` is a LENGTH rather than a `{ $token }`, and the reason is a defect
+ * this block shipped with.** It first read `{ $token: "space.4" }`, on the
+ * argument that `container.tsx` wants spacing from a token and that `space.4`
+ * is in `defaultSiteTokens()`. Both halves are true and the conclusion was
+ * still wrong: a token reference compiles to `var(--site-space-4)`, and
+ * **nothing in this repository ever emits that variable.**
+ *
+ * Measured, three ways that agree: `compileSiteSheet` — the only thing that
+ * writes token CSS — has ZERO consumers outside `blocks-engine`;
+ * `emitTokenBlocks` is called only by that function, its own tests and a
+ * benchmark; and the string `--site-` appears in no source file outside the
+ * engine at all (positive control: `--nx-` appears in four). So
+ * `defaultSiteTokens()` guarantees nothing today — it is a default nobody
+ * applies.
+ *
+ * An undefined custom property makes the declaration invalid at computed-value
+ * time, so `gap` fell back to `normal`, which for a grid is zero. The form
+ * rendered with its fields touching, and every check passed: the property is in
+ * `STYLE_CATALOG`, the declaration reached the compiled stylesheet, and the
+ * test asserted exactly that. **Whether the `var()` RESOLVES is a third
+ * question, and nothing asks it.**
+ *
+ * A length is correct until the site stylesheet is wired into the render path.
+ * `1rem` because that is what `space.4` itself declares, so the value does not
+ * change when this becomes a token again.
  *
  * Both `display` and `gap` are in `STYLE_CATALOG`. A property that is not is
  * dropped by the compiler rather than passed through, so the test asserts the
@@ -120,7 +140,7 @@ export const FORM_BASE_STYLES = {
   base: {
     base: {
       display: "grid",
-      gap: { $token: "space.4" },
+      gap: "1rem",
     },
   },
 } as const;

--- a/packages/blocks-react/src/blocks/gallery.test.tsx
+++ b/packages/blocks-react/src/blocks/gallery.test.tsx
@@ -67,13 +67,28 @@ describe("core/gallery", () => {
     expect(JSON.stringify(GALLERY_BASE_STYLES)).not.toContain("aspectRatio");
   });
 
-  it("uses only guaranteed tokens, so it resolves under every theme", () => {
-    // `defaultSiteTokens()` guarantees space.4 but no surface or border colour,
-    // and the older page-builder's grids reached for `--nx-*` — the ADMIN
-    // namespace, which this renderer never emits.
+  it("spaces its tiles with a value that actually resolves", () => {
+    // This test used to require `space.4` and was named "uses only guaranteed
+    // tokens, so it resolves under every theme". The `--nx-` half was right and
+    // is kept; the token half asserted a premise that does not hold.
+    //
+    // `defaultSiteTokens()` guarantees NOTHING today: `compileSiteSheet` — the
+    // only thing that turns a token set into CSS — has zero consumers outside
+    // `blocks-engine`, and `--site-` appears in no source file outside the
+    // engine (positive control: `--nx-` appears in four). So a `{ $token }`
+    // compiled to `var(--site-space-4)`, nothing defined it, the declaration
+    // was invalid at computed-value time, and `gap` fell back to `normal` —
+    // zero for a grid. The tiles touched.
+    //
+    // The ratchet that catches this class for every block lives in
+    // `base-styles.test.tsx`; this asserts the value this block settled on.
     const declared = JSON.stringify(GALLERY_BASE_STYLES);
 
-    expect(declared).toContain("space.4");
+    expect(declared).toContain("1rem");
+    expect(declared).not.toContain("$token");
+    // The ADMIN namespace, which this renderer never emits — so a rule using it
+    // resolves to nothing on a published page while looking right in an admin
+    // preview. Three separate blocks reached for it independently.
     expect(declared).not.toContain("--nx-");
   });
 });

--- a/packages/blocks-react/src/blocks/gallery.tsx
+++ b/packages/blocks-react/src/blocks/gallery.tsx
@@ -78,7 +78,11 @@ export const GALLERY_BASE_STYLES = {
     base: {
       display: "grid",
       gridTemplateColumns: "repeat(auto-fit, minmax(min(180px, 100%), 1fr))",
-      gap: { $token: "space.4" },
+      // A LENGTH, not a token: nothing emits token CSS yet, so a `{ $token }`
+      // reference compiles to a `var()` with nothing behind it and the gap
+      // silently falls back to `normal`, which for a grid is zero. `1rem` is
+      // what `space.4` itself declares, so the value survives the change back.
+      gap: "1rem",
     },
   },
 } as const;


### PR DESCRIPTION
Three blocks — `core/form`, `core/accordion`, `core/gallery` — each declared `gap: { $token: "space.4" }`. **That compiles to `var(--site-space-4)`, and nothing in this repository ever emits that variable.**

An undefined custom property makes the whole declaration invalid at computed-value time, so `gap` fell back to `normal` — **zero for a grid**. All three rendered with their children touching.

## The measurement

Three independent ways, all agreeing:

| probe | result |
| --- | --- |
| `compileSiteSheet` (the only thing that turns a token set into CSS) | **0 consumers outside `blocks-engine`** |
| `emitTokenBlocks` | called only by that function, its own tests, and a benchmark |
| the string `--site-` in any source file outside the engine | **0 files** (positive control: `--nx-` → 4 files) |

So **`defaultSiteTokens()` guarantees nothing today.** It is a default nobody applies. The whole token pipeline is built, tested, and unreachable — a fourth member of the built-but-unreachable set alongside `style-trace.ts` and the breakpoint dialog.

## Why every existing check passed

This is the part worth keeping. The `baseStyles` ratchet added in #888 asks two questions:

1. is the property in `STYLE_CATALOG`? — **yes**, `gap` is
2. does the declaration reach the compiled stylesheet? — **yes**, as `gap: var(--site-space-4)`

**Whether the `var()` inside the value RESOLVES is a third question, and nothing asked it.** I wrote that ratchet and its limitation was already stated in `2026-08-17-video-and-badge-verified-before-building.md`; I then shipped the defect it describes.

## How it spread

`core/form` shipped it in #888 with a docblock arguing that spacing should come from a token, citing `container.tsx`. `core/accordion` (#890) and `core/gallery` (#893) followed that pattern, and their tests asserted it — one is named *"uses only guaranteed tokens, so it resolves under every theme"*.

**That is design pressure, not three mistakes.** The same shape produced the `--nx-*` pull in the older page-builder blocks: when the correct mechanism is unreachable, the thing that *looks* like it works gets reached for. This is the `--site-*` version, with my docblock as the source.

## The fix

Each block now uses `1rem` — the length `space.4` itself declares — so the value does not change when this becomes a token again.

`base-styles.test.tsx` gains the check that asks the third question. It walks to the **leaf**, so a token nested inside an object-shaped declaration (a per-corner radius, a per-side border colour) is caught too, and it carries a positive control for both the flat and nested shapes because every other assertion in that file passes by finding nothing.

**It is a ratchet with an expiry**, stated in the test: when the site stylesheet is wired into the render path, tokens become the *right* way to express a default, and this case should be deleted by the change that wires it — not weakened, and not exempted per block.

## Verification

- **`blocks-react` 585/585**, **`plugin-page-builder` 828/828**, both exit 0 — the consuming package run against a **freshly rebuilt** `dist`, since a stale one makes that check meaningless
- `lint` and `check-types` exit 0 for both packages
- **Mutation-verified**: restoring `{ $token: "space.4" }` to `core/form` fails exactly `core/form uses no token reference` and nothing else; restored after

## Follow-up, not in this PR

**Wiring `compileSiteSheet` into the render path is the real gap**, and it is larger than a block fix. It unblocks tokens generally, lets `core/card` carry the background and border it currently declines, and makes `badge` buildable at all — its tinted background is inexpressible without a surface colour. Recorded in `tasks/left-tasks/2026-08-17-video-and-badge-verified-before-building.md`.
