### PR TITLE
docs(plugin-page-builder): name the builder peer in the fallback install

### DIFF
--- a/packages/plugin-page-builder/GUIDE.md
+++ b/packages/plugin-page-builder/GUIDE.md
@@ -44,8 +44,13 @@ That's it — the plugin and the pieces it depends on are now in your project.
 > install with:
 >
 > ```bash
-> npm install @nextlyhq/plugin-page-builder --legacy-peer-deps
+> npm install @nextlyhq/plugin-page-builder @nextlyhq/builder --legacy-peer-deps
 > ```
+>
+> `@nextlyhq/builder` is named explicitly on purpose. `--legacy-peer-deps` tells
+> npm to skip peer dependencies altogether, and the editor's chrome is a peer that
+> this plugin imports at runtime — so the flag on its own gives you an install that
+> resolves and then fails when the editor loads. Asking for it by name puts it back.
 >
 > This is safe for experimenting. Once the corrected version is released, the plain
 > command above works and you can delete this note.
@@ -354,7 +359,9 @@ Your built page is now served to the public. 🎉
 ## Troubleshooting
 
 **Install fails with `ERESOLVE` / peer dependency error**
-See the temporary note in Step 1 — install with `--legacy-peer-deps` for now.
+See the temporary note in Step 1. Install with `--legacy-peer-deps` for now, and
+name `@nextlyhq/builder` alongside the plugin — the flag skips peers, and that one
+is a peer the editor needs at runtime.
 
 **The `/admin` page or editor shows an error like `Can't resolve '@nextlyhq/plugin-sdk'`
 or `Cannot find module 'next/link'`**
@@ -391,7 +398,7 @@ add at least one block, and Publish again.
 
 ```bash
 # 1. Install
-npm install @nextlyhq/plugin-page-builder        # add --legacy-peer-deps for now
+npm install @nextlyhq/plugin-page-builder        # see Step 1 if this hits ERESOLVE
 
 # 2. next.config.ts  -> add plugin to transpilePackages (NOT serverExternalPackages)
 


### PR DESCRIPTION
Closes the last open thread on #865.

## The documented install is currently a broken install

`GUIDE.md` tells users to work around an `ERESOLVE` error with:

```bash
npm install @nextlyhq/plugin-page-builder --legacy-peer-deps
```

npm documents that flag as ignoring `peerDependencies` altogether. Measured against `main`:

- `@nextlyhq/builder` is a **peer** of this plugin (`package.json` `peerDependencies`)
- the plugin imports it **at runtime** — `EditorSurface.tsx:12` loads `@nextlyhq/builder/shell`, `controls/MediaControl.tsx:10` loads `useShellIsActive`, and `styles/editor.css:24` imports `@nextlyhq/builder/styles.css`

So the command resolves and then fails when the editor loads. That is worse than the `ERESOLVE` it exists to avoid: a resolution error is loud and immediate, while this one arrives later, somewhere else, as a missing module.

It became true with #865, which added the builder peer. Before that, skipping peers was survivable here.

## The change

Name the package explicitly in the fallback, and say why:

```bash
npm install @nextlyhq/plugin-page-builder @nextlyhq/builder --legacy-peer-deps
```

Three places: the Step 1 note, the Troubleshooting entry that points at it, and the quick reference, which now defers to Step 1 rather than carrying a half-instruction.

## What I deliberately did NOT do

**Make `@nextlyhq/builder` a real `dependency`.** That is the tempting fix and it is wrong here. `packages/ui`'s `STABILITY.md` states that a second copy means a second context; builder is a React UI package, so it has to be a single shared copy in the host's tree, which is what a peer expresses. `@nextlyhq/ui` and `@nextlyhq/admin` are peers of this plugin for the same reason. A dependency would trade a documented install step for duplicated-copy bugs that are far harder to diagnose.

**Delete the note.** Its stated cause — the plugin advertising `^18.0.0 || ^19.0.0` against `blocks-react`'s `^19.0.0` — is already fixed in source, so the note becomes deletable at the next publish. It is not deletable yet, because the version on npm still has the mismatch. The note keeps saying to remove it once the corrected version ships.

## The gap this leaves, which is real and separate

Nothing checks that the documented install command actually resolves. The guide and the manifest are two answers to "what does a consumer need to install", and only the manifest is tested — which is why this drifted silently and was found by a reviewer reading a diff rather than by anything running.

A check that installs the published tarball into a scratch project and imports the plugin's admin entry would make it a boundary rather than a habit. That is its own piece of work, larger than this, and I am flagging it rather than smuggling it in.

## Verification

Docs-only, and `GUIDE.md` is not in the package's `files` (`["dist", "README.md"]`), so nothing ships from this. **No changeset**, per `AGENTS.md`: docs-only PRs get none.

The three factual claims above are each measured rather than recalled: the peer list from `package.json`, the runtime imports by grep over `src`, and the flag's semantics from npm's own documentation.
