### PR TITLE
docs(blocks-react): correct a docblock that asserted the renderer emits token CSS

### DIFF
--- a/packages/blocks-react/src/blocks/accordion.tsx
+++ b/packages/blocks-react/src/blocks/accordion.tsx
@@ -28,16 +28,25 @@
  * node like any other. A value hardcoded in the render function could not be
  * overridden at all.
  *
- * **No default border, and no default background.** `defaultSiteTokens()`
- * guarantees `color.text`, `color.background`, `color.primary`, `font.body`,
- * `content.width` and `space.4` — there is no surface colour and no border
- * colour among them. The older page-builder drew its dividers with
- * `var(--nx-color-border)`, which is the ADMIN token namespace: this renderer
- * emits `--site-*`, so that declaration validates, compiles, ships, and then
- * resolves to nothing on the visitor's page while looking correct inside an
- * admin preview. Separation between sections is therefore spacing, which every
- * theme can express, and the divider is left to the author until a surface
- * token exists to carry it.
+ * **No default border, and no default background.** The older page-builder drew
+ * its dividers with `var(--nx-color-border)`, which is the ADMIN token
+ * namespace — so that declaration validates, compiles, ships, and then resolves
+ * to nothing on the visitor's page while looking correct inside an admin
+ * preview.
+ *
+ * This docblock used to continue "…this renderer emits `--site-*`", and to say
+ * `defaultSiteTokens()` "guarantees" a named set. **Both were false and the
+ * second is the load-bearing one: this renderer emits NOTHING.**
+ * `compileSiteSheet` — the only thing that turns a token set into CSS — has zero
+ * consumers outside `blocks-engine`, and `--site-` appears in no source file
+ * outside the engine (positive control: `--nx-` appears in over a hundred). So
+ * the default token set is a default nobody applies, and a `{ $token }` here
+ * would dangle for the same reason `--nx-*` does — not a different namespace,
+ * the same emptiness.
+ *
+ * Separation between sections is therefore a LENGTH, which needs no stylesheet
+ * to resolve, and the divider is left to the author until the site stylesheet
+ * is wired and a surface token can carry it.
  *
  * @module blocks/library/accordion
  */


### PR DESCRIPTION
**Recovers a commit stranded by #896's merge.** Docs only, no behaviour change.

## What happened

`42d387788` was pushed to #896 minutes before it merged, and the merge was computed from the previous head — so the commit is absent from the merge. This is the danger window the repo's own rule names: *push-a-fix-then-merge-immediately*.

Confirmed by content rather than by ancestry, with a positive control:

| probe | result |
| --- | --- |
| marker `the same emptiness` in merge commit `3ff3da6e7` | **absent** |
| same marker at branch head `42d387788` (control) | **present** — so the search works and the content is real |
| the false sentence on `main` | **still there** |

**#896's substantive fix DID land** — `gap: "1rem"` in all three blocks, and the ratchet. Verified separately. Only this docblock correction was lost, which is why this is a small follow-up rather than a re-land.

## Why it is worth recovering rather than dropping

The sentence on `main` reads:

> "…which is the ADMIN token namespace: **this renderer emits `--site-*`**, so that declaration validates, compiles, ships, and then resolves to nothing…"

That explains the `--nx-*` failure as a **wrong namespace**, which implies `--site-*` would have worked. **It would not.** `compileSiteSheet` has zero consumers outside `blocks-engine` and `--site-` appears in no source file outside it, so a token reference dangles for the same reason — not a different namespace, the same emptiness.

Left as-is, the next author reading that docblock swaps one dangling variable for another. That is exactly how three blocks arrived at `{ $token: "space.4" }` in the first place.

The paragraph now states what was measured, and marks the correction rather than quietly replacing the text.
