### PR TITLE
feat(admin): add the autosave transport to versionApi

### DIFF
--- a/.changeset/admin-autosave-transport.md
+++ b/.changeset/admin-autosave-transport.md
@@ -1,0 +1,38 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+feat(admin): add the autosave transport to versionApi
+
+The autosave endpoints had no client. protectedApi carried no PUT verb at all,
+so the write endpoint was unreachable from the admin regardless of which caller
+wanted it.
+
+Adds the verb, and the two calls that use it: recording the values currently in
+the editor as the calling author's recovery point, and reading that back.
+PUT rather than POST because the row is rolling, one per document and author
+rewritten in place, so sending the same snapshot twice leaves one recovery
+point and an unacknowledged retry is safe.

--- a/packages/admin/src/lib/api/protectedApi.ts
+++ b/packages/admin/src/lib/api/protectedApi.ts
@@ -12,6 +12,19 @@ export const protectedApi = {
       },
       true
     ),
+  // PUT, for a write whose result depends only on the body and not on how many
+  // times it is sent. The rolling autosave row is the case that needed it: the
+  // same snapshot sent twice must leave one recovery point, not two.
+  put: <T>(path: string, body: unknown, options = {}) =>
+    fetcher<T>(
+      path,
+      {
+        ...options,
+        method: "PUT",
+        body: JSON.stringify(body),
+      },
+      true
+    ),
   patch: <T>(path: string, body: unknown, options = {}) =>
     fetcher<T>(
       path,

--- a/packages/admin/src/services/__tests__/versionApi.test.ts
+++ b/packages/admin/src/services/__tests__/versionApi.test.ts
@@ -6,13 +6,14 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { getSpy, delSpy } = vi.hoisted(() => ({
+const { getSpy, delSpy, putSpy } = vi.hoisted(() => ({
   getSpy: vi.fn(),
   delSpy: vi.fn(),
+  putSpy: vi.fn(),
 }));
 
 vi.mock("@admin/lib/api/protectedApi", () => ({
-  protectedApi: { get: getSpy, delete: delSpy },
+  protectedApi: { get: getSpy, delete: delSpy, put: putSpy },
 }));
 
 import { versionApi } from "../versionApi";
@@ -102,5 +103,74 @@ describe("versionApi.discardWorkingDraft", () => {
     expect(delSpy).toHaveBeenCalledWith(
       "/collections/posts/entries/e1/versions/working-draft"
     );
+  });
+});
+
+/**
+ * The rolling recovery point. Its URL is a named sub-resource rather than a
+ * version number, and its verb is PUT rather than POST, because the row is
+ * rewritten in place: sending the same snapshot twice must leave one recovery
+ * point rather than two.
+ */
+describe("versionApi autosave", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    putSpy.mockResolvedValue({ updatedAt: "2026-08-17T07:00:00.000Z" });
+    getSpy.mockResolvedValue(null);
+  });
+
+  it("writes a collection entry's recovery point with PUT", async () => {
+    await versionApi.saveAutosave(collection, { title: "draft" }, "en");
+
+    // The verb is asserted by WHICH spy was called: a POST would leave the
+    // server's PUT-only route unmatched, and the request would 404 rather than
+    // failing anywhere a type could catch.
+    expect(putSpy).toHaveBeenCalledTimes(1);
+    expect(putSpy).toHaveBeenCalledWith(
+      "/collections/posts/entries/e1/versions/autosave",
+      { snapshot: { title: "draft" }, locale: "en" }
+    );
+  });
+
+  it("addresses a Single's recovery point without an entry id", async () => {
+    await versionApi.saveAutosave(single, { siteName: "x" });
+
+    expect(putSpy).toHaveBeenCalledWith("/singles/settings/versions/autosave", {
+      snapshot: { siteName: "x" },
+      locale: null,
+    });
+  });
+
+  /**
+   * An unlocalized document sends an explicit null rather than omitting the
+   * key. Absent and null mean the same thing to this endpoint, and sending the
+   * key keeps the body one shape for every document.
+   */
+  it("sends an explicit null locale when the document has none", async () => {
+    await versionApi.saveAutosave(collection, { title: "draft" });
+
+    expect(putSpy).toHaveBeenCalledWith(expect.any(String), {
+      snapshot: { title: "draft" },
+      locale: null,
+    });
+  });
+
+  it("reads the caller's own recovery point from the same path", async () => {
+    await versionApi.getAutosave(collection);
+
+    expect(getSpy).toHaveBeenCalledWith(
+      "/collections/posts/entries/e1/versions/autosave"
+    );
+  });
+
+  /**
+   * Having no recovery point is an ordinary answer, not a failure. The read
+   * must surface it as null so a caller can tell "nothing stored" apart from a
+   * request that did not complete.
+   */
+  it("returns null when the author has no recovery point", async () => {
+    getSpy.mockResolvedValue(null);
+
+    await expect(versionApi.getAutosave(single)).resolves.toBeNull();
   });
 });

--- a/packages/admin/src/services/versionApi.ts
+++ b/packages/admin/src/services/versionApi.ts
@@ -97,6 +97,33 @@ function basePath(scope: VersionScope): string {
     : `/collections/${scope.slug}/entries/${scope.entryId}/versions`;
 }
 
+/**
+ * What recording a recovery point reports back.
+ *
+ * `updatedAt` is when the server stored it, not when the editor sent it, so a
+ * "saved at" reading cannot drift with an unsynchronised browser clock.
+ * Serialised as an ISO string over the wire; the caller parses it if it needs a
+ * `Date`.
+ */
+export interface AutosaveWriteResponse {
+  updatedAt: string;
+  locale: string | null;
+}
+
+/**
+ * A stored recovery point as the reading author sees it.
+ *
+ * Deliberately narrower than the stored row. A recovery point is offered back
+ * to its own author to restore, so the fields that describe a version's place
+ * in history (its number, its label, its lineage) have no meaning here: an
+ * autosave carries none of them.
+ */
+export interface AutosaveDetail {
+  snapshot: unknown;
+  updatedAt: string;
+  locale: string | null;
+}
+
 /** What a restore reports back. */
 export interface RestoreVersionResponse {
   message: string;
@@ -188,6 +215,40 @@ export const versionApi = {
     protectedApi.delete<DiscardWorkingDraftResponse>(
       `${basePath(scope)}/working-draft`
     ),
+
+  /**
+   * Record the editor's current values as this author's recovery point.
+   *
+   * PUT rather than POST because the row is rolling: one per document and
+   * author, rewritten in place. Sending the same snapshot twice must leave one
+   * recovery point, which is what makes an unacknowledged retry safe.
+   *
+   * The snapshot is the editor's live values, so it can contain fields the
+   * document itself does not yet have. The server strips write-only values
+   * before storing and redacts on read; neither is the client's job.
+   */
+  saveAutosave: (
+    scope: VersionScope,
+    snapshot: unknown,
+    locale?: string | null
+  ): Promise<AutosaveWriteResponse> =>
+    protectedApi.put<AutosaveWriteResponse>(`${basePath(scope)}/autosave`, {
+      snapshot,
+      // Sent even when null. Null and absent mean the same thing here (this
+      // document has no locale), unlike on a listing where absent means every
+      // locale, so being explicit costs nothing and reads unambiguously.
+      locale: locale ?? null,
+    }),
+
+  /**
+   * This author's own recovery point, or `null` when they have none.
+   *
+   * Scoped to the caller: it never returns another author's snapshot, so a
+   * document being edited by two people yields each of them their own. The
+   * response is private to the session and must not be cached across users.
+   */
+  getAutosave: (scope: VersionScope): Promise<AutosaveDetail | null> =>
+    protectedApi.get<AutosaveDetail | null>(`${basePath(scope)}/autosave`),
 
   /**
    * Compare two versions. A read of history, gated and field-redacted exactly


### PR DESCRIPTION
First of three. Transport and the recording hook. **No UI wiring yet**, so
nothing in this PR makes autosave reachable for a user: that is the next PR, and
this one should not sit merged long without it.

## Why this exists at all

Autosave does not work for anyone today, and it is not a matter of polish. On
`main`, after the server endpoints merged:

| piece | state | callers |
| --- | --- | --- |
| `autosaveEntry`, `autosaveSingle`, `getEntryAutosave`, `getSingleAutosave` | merged, authorized, tested | **none in admin** |
| `useAutoSave.ts` | exists, 16 `localStorage` references | **none** |
| `useDraftRecovery.ts` | exists | **none** |
| `AutoSaveIndicator.tsx` | exists, exported | **rendered nowhere** |

Every piece is exported from a barrel and wired to nothing.

## The blocker this PR removes

**`protectedApi` carried no `PUT` verb.** The autosave write endpoint is
PUT-only, so it was unreachable from the admin regardless of which component
wanted to call it. No amount of UI work would have reached it, and the failure
would have surfaced as a 404 rather than as anything a type could catch.

## What it adds

- `protectedApi.put`, following the existing `post`/`patch` shape.
- `versionApi.saveAutosave(scope, snapshot, locale?)` and
  `versionApi.getAutosave(scope)`.

PUT rather than POST is load-bearing: the row is rolling, one per document and
author rewritten in place, so the same snapshot sent twice must leave one
recovery point. That is what makes an unacknowledged retry safe.

The response types are deliberately narrower than the stored row. A recovery
point is handed back to its own author to restore, so a version's number, label
and restore lineage have no meaning here, and an autosave carries none of them.

`locale` is sent explicitly as `null` rather than omitted. Absent and null mean
the same thing to this endpoint, unlike on a listing where absent means every
locale, so being explicit keeps the body one shape for every document.

## Verification

Break-verified, each failing only its intended assertions:

| break | result |
| --- | --- |
| `put` becomes `post` in `saveAutosave` | 3 tests fail |
| `locale: locale ?? null` becomes `locale` | 2 tests fail |

The verb is asserted by WHICH spy was called, because a wrong verb is invisible
to the type system and shows up only as an unmatched route at runtime.

Gates: `check-types` + `lint` 11/11 for `@nextlyhq/admin`, `check:comments`,
and `check-changesets.mjs` against the new changeset, controlled by dropping one
package from the group and confirming it exits 1.

## The hook

`useDocumentAutosave` records the form's live values on a debounce and reports
status plus the SERVER's `updatedAt`, so a "saved 2 minutes ago" reading cannot
drift with an unsynchronised browser clock.

It reads `getValues()` and deliberately not `handleSubmit`. Submitting validates
and REFUSES on failure, so a recovery point would exist only for work that was
already valid, which is the opposite of what a recovery point is for.

It never touches the dirty flag. Clearing it would silence the unsaved-changes
guard and let someone navigate away from uncommitted work believing it stored.

### The trigger is `isDirty`, and that is a measured correction

An earlier note in this lane assumed `type === "change"` identified a user edit.
**Probed against react-hook-form 7.66: `type` is `undefined` for BOTH `setValue`
and `reset`.** It is populated only by a registered input's own DOM handler, so
keying on it would silently stop recording for every field that updates
programmatically, which is most non-text controls. `isDirty` is correct, and it
is the same condition the unsaved-changes guard uses, so the two cannot disagree
about whether there is work at risk.

### A test trap this suite had to fix

`form.formState.isDirty` read AFTER a render reports `false` however dirty the
form is, because react-hook-form tracks form state by which keys a RENDER reads.
Two tests failed on this before the harness read it during render. Worth knowing
because the failure direction is dangerous: a harness that gets it wrong lets a
hook that DOES clear the dirty flag pass cleanly.

8 tests, driven through a real `useForm` rather than a stub, because every
property under test is about the interaction with react-hook-form's own
behaviour.

Break-verified:

| break | result |
| --- | --- |
| drop the `isDirty` guard | the programmatic-load test fails |
| clear dirty after recording | the stays-dirty test fails |

## Scope limit worth knowing

A new entry has no id until it has been created once, and the endpoint addresses
a document that exists. Recording therefore engages only AFTER the first real
save; `scope: null` disables it rather than inventing an address.

## Next

PR 2 wires this into the entry editor, with the existing `AutoSaveIndicator` and
recovery on load through `getAutosave`. PR 3 does the same for Singles.
