### PR TITLE
fix(admin): restore the autosave hook stranded by #900

### DIFF
--- a/.changeset/admin-document-autosave-hook.md
+++ b/.changeset/admin-document-autosave-hook.md
@@ -1,0 +1,40 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+feat(admin): record the editor values as a server-side recovery point
+
+A debounced hook that writes the values currently in the form to the calling
+author rolling recovery point, and reports the status back.
+
+It is not a save. The dirty flag is left exactly as the form set it, so the
+unsaved-changes guard goes on firing, and the values are read with getValues
+rather than through handleSubmit, which validates and refuses on failure and
+would therefore record nothing for the half-finished input most worth keeping.
+
+Recording is triggered by the dirty flag rather than by the update type, which
+react-hook-form leaves undefined for any change that does not come from a
+registered input own DOM handler.

--- a/packages/admin/src/hooks/__tests__/useDocumentAutosave.test.tsx
+++ b/packages/admin/src/hooks/__tests__/useDocumentAutosave.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * A recovery point is written from the editor's live values, on a debounce,
+ * without the form ever appearing saved.
+ *
+ * Driven through a REAL `useForm` rather than a stubbed one. The properties
+ * under test are all about how this hook interacts with react-hook-form's own
+ * behaviour -- which updates count as a user edit, what `getValues` returns
+ * mid-edit, whether the dirty flag moves -- and a stub would be a second
+ * implementation of exactly the behaviour being relied on.
+ */
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { saveSpy } = vi.hoisted(() => ({ saveSpy: vi.fn() }));
+
+vi.mock("@admin/services/versionApi", () => ({
+  versionApi: { saveAutosave: saveSpy },
+}));
+
+import { useDocumentAutosave } from "../useDocumentAutosave";
+
+const SCOPE = { kind: "collection" as const, slug: "posts", entryId: "e1" };
+const DEBOUNCE = 2000;
+
+/** The hook driving a real form, so the two can be exercised together. */
+function useHarness(scope: typeof SCOPE | null = SCOPE, enabled = true) {
+  const form = useForm<Record<string, unknown>>({
+    defaultValues: { title: "" },
+  });
+  const autosave = useDocumentAutosave({
+    scope,
+    form,
+    debounceMs: DEBOUNCE,
+    enabled,
+  });
+  // `isDirty` is READ DURING RENDER and returned, deliberately. react-hook-form
+  // tracks formState by which keys a render reads, so a test that reaches for
+  // `form.formState.isDirty` after the fact observes an unsubscribed proxy and
+  // reads false however dirty the form is -- which would let a hook that DID
+  // clear the flag pass this suite.
+  return { form, autosave, isDirty: form.formState.isDirty };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  saveSpy.mockResolvedValue({
+    updatedAt: "2026-08-17T09:00:00.000Z",
+    locale: null,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useDocumentAutosave", () => {
+  it("records the values in the editor after the debounce", async () => {
+    const { result } = renderHook(() => useHarness());
+
+    act(() => {
+      result.current.form.setValue("title", "hello", { shouldDirty: true });
+    });
+    expect(saveSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE);
+    });
+
+    await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1));
+    expect(saveSpy).toHaveBeenCalledWith(SCOPE, { title: "hello" }, null);
+  });
+
+  /**
+   * The point of the debounce. Recording per keystroke would put one request
+   * per character on the wire, and each rewrites the same row.
+   */
+  it("coalesces a burst of edits into one recording", async () => {
+    const { result } = renderHook(() => useHarness());
+
+    act(() => {
+      result.current.form.setValue("title", "a", { shouldDirty: true });
+      result.current.form.setValue("title", "ab", { shouldDirty: true });
+      result.current.form.setValue("title", "abc", { shouldDirty: true });
+    });
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE);
+    });
+
+    await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1));
+    // The LAST value, not the first: the recording is taken when the timer
+    // fires, so it must reflect everything typed during the quiet period.
+    expect(saveSpy).toHaveBeenCalledWith(SCOPE, { title: "abc" }, null);
+  });
+
+  /**
+   * The property that separates a recovery point from a save. Clearing the
+   * dirty flag would let the unsaved-changes guard fall silent, and someone
+   * would navigate away from uncommitted work believing it was stored.
+   */
+  it("leaves the form dirty after recording", async () => {
+    const { result } = renderHook(() => useHarness());
+
+    act(() => {
+      result.current.form.setValue("title", "hello", { shouldDirty: true });
+    });
+    expect(result.current.isDirty).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE);
+    });
+    await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1));
+
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  /**
+   * Loading a document calls `reset`, which installs the loaded values as the
+   * new defaults and leaves the form CLEAN. Recording on it would write the
+   * document's own stored values back as a recovery point the instant the page
+   * opened, and every reader would then be offered a recovery identical to what
+   * they were already looking at.
+   */
+  it("does not record when the form is filled programmatically", async () => {
+    const { result } = renderHook(() => useHarness());
+
+    act(() => {
+      result.current.form.reset({ title: "loaded from the server" });
+    });
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE * 2);
+    });
+
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A new entry has no id until it has been created once, and the endpoint
+   * addresses a document that exists. Recording must be off rather than
+   * addressed at an invented id.
+   */
+  it("records nothing while the document has no address", async () => {
+    const { result } = renderHook(() => useHarness(null));
+
+    act(() => {
+      result.current.form.setValue("title", "hello", { shouldDirty: true });
+    });
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE * 2);
+    });
+
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  it("records nothing while disabled", async () => {
+    const { result } = renderHook(() => useHarness(SCOPE, false));
+
+    act(() => {
+      result.current.form.setValue("title", "hello", { shouldDirty: true });
+    });
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE * 2);
+    });
+
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The timestamp is the SERVER's, read from the response. Stamping it locally
+   * would make "saved 2 minutes ago" drift with an unsynchronised browser
+   * clock, and it would read as saved even when the request never landed.
+   */
+  it("reports when the server stored it, not when the request was sent", async () => {
+    const { result } = renderHook(() => useHarness());
+
+    act(() => {
+      result.current.form.setValue("title", "hello", { shouldDirty: true });
+    });
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE);
+    });
+
+    await waitFor(() =>
+      expect(result.current.autosave.lastSavedAt).toEqual(
+        new Date("2026-08-17T09:00:00.000Z")
+      )
+    );
+    expect(result.current.autosave.status).toBe("saved");
+  });
+
+  /**
+   * A failed recording is reported through status and never thrown. It is work
+   * nobody asked for, so it must not surface an error over the editor or
+   * interrupt typing.
+   */
+  it("reports a failure as status rather than throwing", async () => {
+    saveSpy.mockRejectedValue(new Error("offline"));
+    const { result } = renderHook(() => useHarness());
+
+    act(() => {
+      result.current.form.setValue("title", "hello", { shouldDirty: true });
+    });
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE);
+    });
+
+    await waitFor(() => expect(result.current.autosave.status).toBe("error"));
+    // Still dirty, still editable: a failed recording changes nothing about
+    // the form it was taken from.
+    expect(result.current.isDirty).toBe(true);
+  });
+});

--- a/packages/admin/src/hooks/useDocumentAutosave.ts
+++ b/packages/admin/src/hooks/useDocumentAutosave.ts
@@ -1,0 +1,193 @@
+"use client";
+
+/**
+ * Records the editor's current values as the author's server-side recovery
+ * point, on a debounce, while they type.
+ *
+ * This is NOT a save. It writes to a rolling row that only its own author can
+ * read back, and it leaves the document untouched, so nothing here may make the
+ * form look saved: the dirty flag stays exactly as the form set it, and the
+ * unsaved-changes guard goes on firing. An autosave that cleared dirty would
+ * let someone navigate away believing their work was committed.
+ *
+ * Distinct from `useAutoSave`, which persists to `localStorage`. That one
+ * survives a crashed tab on the same machine and nothing else; this one
+ * survives a lost machine, and follows the author to another browser.
+ *
+ * @module hooks/useDocumentAutosave
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { UseFormReturn } from "react-hook-form";
+
+import { versionApi, type VersionScope } from "@admin/services/versionApi";
+
+/** How long to wait after the last keystroke before recording. */
+const DEFAULT_DEBOUNCE_MS = 2000;
+
+export type AutosaveStatus = "idle" | "saving" | "saved" | "error";
+
+export interface UseDocumentAutosaveOptions {
+  /**
+   * The document to record against, or `null` when there is not one yet.
+   *
+   * A collection entry has no id until it has been created once, and the
+   * endpoint addresses a document that exists, so an unsaved new entry has
+   * nothing to write to. `null` disables recording rather than inventing an
+   * address.
+   */
+  scope: VersionScope | null;
+
+  /** The form whose values are recorded. Never mutated by this hook. */
+  form: UseFormReturn<Record<string, unknown>>;
+
+  /** The locale these values belong to, or `null` for an unlocalized document. */
+  locale?: string | null;
+
+  /** Milliseconds of quiet before a recording is made. */
+  debounceMs?: number;
+
+  /**
+   * Turns recording off without unmounting. Used while a real save is in
+   * flight: the document is about to change underneath the snapshot, so a
+   * recovery point written now would describe a state that never existed.
+   */
+  enabled?: boolean;
+}
+
+export interface UseDocumentAutosaveResult {
+  status: AutosaveStatus;
+  /**
+   * When the server stored the last recovery point, by the SERVER's clock.
+   *
+   * Taken from the response rather than from `Date.now()` at the call site, so
+   * a "saved 2 minutes ago" reading cannot drift with an unsynchronised browser
+   * clock.
+   */
+  lastSavedAt: Date | null;
+}
+
+/**
+ * @param options - the document, the form, and how long to wait
+ * @returns the current recording status and when the last one was stored
+ */
+export function useDocumentAutosave({
+  scope,
+  form,
+  locale = null,
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+  enabled = true,
+}: UseDocumentAutosaveOptions): UseDocumentAutosaveResult {
+  const [status, setStatus] = useState<AutosaveStatus>("idle");
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inFlightRef = useRef(false);
+  // Set when an edit arrives while a recording is still in flight. The values
+  // that edit produced would otherwise be lost: the timer for them has already
+  // fired, and no further keystroke is guaranteed to arrive to schedule another.
+  const pendingRef = useRef(false);
+  const mountedRef = useRef(true);
+
+  // Read through refs inside the debounced callback rather than captured as
+  // dependencies. The callback is created once per subscription, and closing
+  // over these would pin the values they held when the subscription was set up.
+  const scopeRef = useRef(scope);
+  const localeRef = useRef(locale);
+  const enabledRef = useRef(enabled);
+  scopeRef.current = scope;
+  localeRef.current = locale;
+  enabledRef.current = enabled;
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const flush = useCallback(async () => {
+    const target = scopeRef.current;
+    if (!target || !enabledRef.current) return;
+
+    if (inFlightRef.current) {
+      pendingRef.current = true;
+      return;
+    }
+
+    inFlightRef.current = true;
+    if (mountedRef.current) setStatus("saving");
+
+    try {
+      // `getValues()` reads what the form holds right now, and deliberately not
+      // `handleSubmit`. Submitting runs validation and REFUSES on a failure, so
+      // a recovery point would exist only for work that was already valid --
+      // which is the opposite of what a recovery point is for. Half-finished
+      // input is exactly what is worth not losing.
+      const response = await versionApi.saveAutosave(
+        target,
+        form.getValues(),
+        localeRef.current
+      );
+
+      if (mountedRef.current) {
+        setLastSavedAt(new Date(response.updatedAt));
+        setStatus("saved");
+      }
+    } catch {
+      // Swallowed deliberately, and reported through `status` rather than
+      // thrown. A recovery point nobody asked for must not surface an error
+      // over the editor or interrupt typing; the next debounce tries again.
+      if (mountedRef.current) setStatus("error");
+    } finally {
+      inFlightRef.current = false;
+      if (pendingRef.current) {
+        pendingRef.current = false;
+        void flush();
+      }
+    }
+  }, [form]);
+
+  useEffect(() => {
+    if (!enabled || !scope) return;
+
+    const subscription = form.subscribe({
+      formState: { values: true, isDirty: true },
+      callback: ({ isDirty }) => {
+        // Record only while the editor holds uncommitted changes.
+        //
+        // The discriminator is the dirty flag rather than the update's `type`.
+        // `type` carries a DOM event name and is populated only when the change
+        // came from a registered input's own handler: measured here, both
+        // `setValue` and `reset` report it as `undefined`, so keying on
+        // `"change"` would silently stop recording for every field that updates
+        // programmatically, which is most non-text controls.
+        //
+        // Dirty also answers the case that motivated the filter. Loading a
+        // document calls `reset`, which installs the loaded values as the new
+        // defaults and leaves the form clean, so the page opening records
+        // nothing. And it is the same condition the unsaved-changes guard uses,
+        // so the two cannot disagree about whether there is work at risk.
+        if (!isDirty) return;
+
+        if (timerRef.current) clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(() => {
+          void flush();
+        }, debounceMs);
+      },
+    });
+
+    return () => {
+      subscription();
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+    // `scope` participates through its identity fields: a different document
+    // needs a different subscription, and comparing the object itself would
+    // resubscribe on every render.
+  }, [form, flush, debounceMs, enabled, scope?.kind, scope?.slug, scope]);
+
+  return { status, lastSavedAt };
+}


### PR DESCRIPTION
Recovers a commit that #900 merged without.

## What was lost

#900 merged as `271b6aafa`. GitHub computed that merge from head `01b32a21c`,
but the branch tip was `ec4a79a7b`, so the final commit was outside the merge
entirely.

Verified by CONTENT rather than ancestry, since a squash merge makes every
ancestry check unsound:

| marker | at merge `271b6aafa` | at branch tip `ec4a79a7b` |
| --- | --- | --- |
| `useDocumentAutosave` (the lost commit) | **absent** | present |
| `saveAutosave` (the earlier commit) | present | present |

The second row is the positive control: it shows the search works and that the
rest of the PR did land, so the absence in row one is a real loss rather than a
broken query.

`scripts/verify-merge.mjs 900` exited **2** and named the candidate, which is
what surfaced this.

## What this restores

`useDocumentAutosave`, unchanged from the commit that was stranded, cherry-picked
onto current `main` and re-verified there:

- 8/8 tests green against current `main`
- `versionApi.saveAutosave`, which it calls, is confirmed present on `main`, so
  the two halves now fit

## What the hook does

Records the form's live values to the calling author's rolling recovery point on
a debounce, reporting status and the SERVER's `updatedAt` so a "saved 2 minutes
ago" reading cannot drift with an unsynchronised browser clock.

It reads `getValues()` and deliberately not `handleSubmit`: submitting validates
and REFUSES on failure, so a recovery point would exist only for work that was
already valid, which is the opposite of what one is for.

It never touches the dirty flag, so the unsaved-changes guard goes on firing.

### The trigger is `isDirty`, which is a measured correction

An earlier note in this lane assumed `type === "change"` identified a user edit.
Probed against react-hook-form 7.66: **`type` is `undefined` for BOTH `setValue`
and `reset`**. It is populated only by a registered input's own DOM handler, so
keying on it would silently stop recording for every field that updates
programmatically. `isDirty` is correct, and is the same condition the
unsaved-changes guard uses, so the two cannot disagree.

### A test trap worth carrying forward

`form.formState.isDirty` read AFTER a render reports `false` however dirty the
form is, because react-hook-form tracks form state by which keys a RENDER reads.
Two tests failed on this before the harness read it during render. The failure
direction is the dangerous one: a harness that gets it wrong lets a hook that
DOES clear the dirty flag pass cleanly.

## Verification

Break-verified, each failing only its intended test:

| break | result |
| --- | --- |
| drop the `isDirty` guard | the programmatic-load test fails |
| clear dirty after recording | the stays-dirty test fails |

Gates: `check-types` + `lint` 11/11, changeset validated against the lockstep
group.

## Still not reachable

This is the hook only. Nothing renders it yet, so autosave remains invisible to
users until the wiring PR lands: entry editor with `AutoSaveIndicator` and
recovery on load, then Singles.
