### PR TITLE
feat(blocks-react): emit the site stylesheet, so design tokens resolve at all

### DIFF
--- a/.changeset/site-stylesheet.md
+++ b/.changeset/site-stylesheet.md
@@ -1,0 +1,53 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+feat(blocks-react): emit the site stylesheet, so design tokens resolve at all
+
+`PageRenderer` gains an opt-in `siteStyles` prop that compiles the shared sheet
+and emits it BEFORE the page's own, and `blocks-engine` gains
+`resolveSiteTokens`, which layers a site's own tokens over the defaults by name.
+
+Until now nothing in the repository called `compileSiteSheet`. The token
+pipeline was built, tested and unreachable: `defaultSiteTokens()` was a default
+nobody applied, and every `{ $token }` compiled to a `var()` with nothing behind
+it. Three shipped blocks were broken by that and nothing reported it, because an
+unresolved custom property makes the declaration invalid at computed-value time
+and the property silently falls back to its initial value.
+
+Order is the cascade: font faces, tokens and block-type defaults first, the
+page's own sheet after, which is what lets a node's own value beat a class and a
+class beat a block default.
+
+Layering rather than replacing means a site supplying one brand colour does not
+thereby lose `content.width` and `space.4`. This is the arrangement Gutenberg's
+`theme.json` reaches — core defaults, then the theme's file, then the user's
+saved styles — and a stored per-site override layers the same way, so the third
+tier needs no new mechanism.
+
+Opt-in rather than automatic: emitting token definitions unasked changes what a
+stored token reference resolves to, and a page whose current appearance depends
+on one dangling is a page that moves.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -245,6 +245,7 @@ export {
   DARK_MODE_ATTRIBUTE,
   TOKEN_MODES,
   defaultSiteTokens,
+  resolveSiteTokens,
   emitFontFaces,
   emitTokenBlocks,
   isTokenName,

--- a/packages/blocks-engine/src/style/site-tokens.test.ts
+++ b/packages/blocks-engine/src/style/site-tokens.test.ts
@@ -12,6 +12,7 @@ import {
   checkTokenKind,
   DARK_MODE_ATTRIBUTE,
   defaultSiteTokens,
+  resolveSiteTokens,
   emitFontFaces,
   emitTokenBlocks,
   isTokenName,
@@ -622,5 +623,77 @@ describe("stored data reaching the stylesheet", () => {
       { family: "B", src: [{ url: "/f.woff2", format: 'woff2");}body{x:y' }] },
     ]);
     expect(css).toBe("");
+  });
+});
+
+describe("resolveSiteTokens", () => {
+  it("returns the defaults when a site defines nothing", () => {
+    expect(
+      resolveSiteTokens()
+        .tokens.map(t => t.name)
+        .sort()
+    ).toEqual(
+      defaultSiteTokens()
+        .map(t => t.name)
+        .sort()
+    );
+  });
+
+  it("lets a site override a default BY NAME without losing the others", () => {
+    // The defect this exists to make unreachable. A site that REPLACES the set
+    // to change one colour loses `content.width` and `space.4`, and every block
+    // reading those falls back to its initial value — silently, because an
+    // unresolved custom property invalidates the declaration rather than
+    // reporting anything.
+    const resolved = resolveSiteTokens({
+      tokens: [
+        { name: "color.primary", kind: "color", values: { light: "#ff0000" } },
+      ],
+    });
+
+    expect(
+      resolved.tokens.find(t => t.name === "color.primary")?.values.light
+    ).toBe("#ff0000");
+    // The SURVIVORS are the assertion, not the override.
+    const names = resolved.tokens.map(t => t.name);
+    expect(names).toContain("content.width");
+    expect(names).toContain("space.4");
+    expect(names).toContain("color.text");
+  });
+
+  it("adds a token the defaults do not define", () => {
+    const resolved = resolveSiteTokens({
+      tokens: [
+        { name: "color.surface", kind: "color", values: { light: "#f6f6f6" } },
+      ],
+    });
+
+    expect(resolved.tokens.map(t => t.name)).toContain("color.surface");
+    expect(resolved.tokens.length).toBe(defaultSiteTokens().length + 1);
+  });
+
+  it("takes the LAST duplicate within the override, not the first", () => {
+    // An imported DTCG file can carry a duplicate name; taking the first would
+    // apply the value the author replaced.
+    const resolved = resolveSiteTokens({
+      tokens: [
+        { name: "color.primary", kind: "color", values: { light: "#111111" } },
+        { name: "color.primary", kind: "color", values: { light: "#222222" } },
+      ],
+    });
+
+    expect(
+      resolved.tokens.find(t => t.name === "color.primary")?.values.light
+    ).toBe("#222222");
+  });
+
+  it("carries prefix and darkMode from the override, and omits them otherwise", () => {
+    // Site-wide decisions rather than per-token values. A prefix set in two
+    // places is how a site declares `--brand-x` while its pages ask for
+    // `--site-x`; `compileSiteSheet` derives ONE prefix for that reason.
+    expect(resolveSiteTokens().prefix).toBeUndefined();
+    expect(
+      resolveSiteTokens({ tokens: [], prefix: "brand", darkMode: "media" })
+    ).toMatchObject({ prefix: "brand", darkMode: "media" });
   });
 });

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -430,6 +430,51 @@ export function checkTokenKind(
  * one token re-widths every container on the site. A default set that tried to
  * be a design system would be a set most sites delete.
  */
+/**
+ * The token set a site actually renders with: the defaults, with a site's own
+ * definitions layered over them by NAME.
+ *
+ * **Layered rather than replacing, and that is the whole point.** A site that
+ * defines a brand colour should not thereby lose `content.width` and
+ * `space.4` — every block reading those would fall back to its initial value,
+ * silently, because an unresolved custom property invalidates the declaration
+ * rather than reporting anything. Replacing is the shape that produces that,
+ * and it is the shape a caller writes by accident when the merge is left to
+ * them.
+ *
+ * The three-tier arrangement this implements is the one Gutenberg's
+ * `theme.json` reaches: core defaults, then the theme's file, then the user's
+ * saved styles, each overriding the last by name. This function is the first
+ * two tiers; a stored per-site override is the third and layers the same way.
+ *
+ * **ONE implementation of "what tokens does this site have", deliberately.** The
+ * emitter and any future editor must not answer it separately — two answers
+ * that agree today drift, and the drift is invisible because a missing token
+ * looks exactly like a token whose value did not apply.
+ *
+ * `prefix` and `darkMode` come from the override when it states them, because
+ * they are site-wide decisions rather than per-token values. A site that sets a
+ * prefix must set it in ONE place: `compileSiteSheet` derives the prefix used
+ * for declaring and for referencing from a single value for exactly this
+ * reason.
+ */
+export function resolveSiteTokens(override?: SiteTokenSet): SiteTokenSet {
+  const byName = new Map<string, SiteToken>();
+  for (const token of defaultSiteTokens()) byName.set(token.name, token);
+  // Second, so a site's own definition wins the name. Iterated rather than
+  // spread, because a later duplicate WITHIN the override must also win — an
+  // imported DTCG file can carry one, and taking the first would apply a value
+  // the author replaced.
+  for (const token of override?.tokens ?? []) byName.set(token.name, token);
+  return {
+    tokens: [...byName.values()],
+    ...(override?.prefix === undefined ? {} : { prefix: override.prefix }),
+    ...(override?.darkMode === undefined
+      ? {}
+      : { darkMode: override.darkMode }),
+  };
+}
+
 export function defaultSiteTokens(): SiteToken[] {
   return [
     {

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -1,8 +1,11 @@
 import {
+  compileSiteSheet,
   DOCUMENT_FORMAT_VERSION,
   PAGE_ROOT_CLASS,
+  resolveSiteTokens,
   type BlockDocument,
   type DocumentLimits,
+  type SiteSheetInput,
   type StyleCompileContext,
 } from "@nextlyhq/blocks-engine";
 import type { ReactElement, ReactNode } from "react";
@@ -53,6 +56,30 @@ export interface PageRendererProps {
    * write path. Ignored when `styles` is supplied.
    */
   styleContext?: StyleCompileContext;
+  /**
+   * The site's design tokens, fonts and named classes, compiled into the sheet
+   * every page shares and emitted BEFORE the page's own.
+   *
+   * **Order is the cascade and is not negotiable.** `compileSiteSheet` emits
+   * font faces, then tokens, then block-type defaults, then named classes; the
+   * page sheet is appended after, which is what lets a node's own value beat a
+   * class and a class beat a block default. Emitting these in the other order
+   * would invert every one of those.
+   *
+   * **Its tokens LAYER over the defaults rather than replacing them**, through
+   * `resolveSiteTokens`. A site that supplied one brand colour and thereby lost
+   * `content.width` and `space.4` would break every block reading those, and
+   * break it silently: an unresolved custom property invalidates the
+   * declaration rather than reporting anything.
+   *
+   * Omitted means no site sheet is emitted at all, which is the behaviour every
+   * existing consumer had before this prop existed. That is deliberate rather
+   * than lazy — a renderer that started emitting token definitions on its own
+   * would change what stored `{ $token }` references resolve to, and a page
+   * whose current appearance depends on one of those dangling is a page that
+   * moves. The host decides when to take that step.
+   */
+  siteStyles?: SiteSheetInput;
   /** Shown in place of an asynchronous block until its output arrives. */
   blockFallback?: ReactNode;
   /**
@@ -128,6 +155,7 @@ export function PageRenderer({
   blocks,
   styles,
   styleContext,
+  siteStyles,
   blockFallback,
   limits,
   hostPolicy,
@@ -349,8 +377,40 @@ export function PageRenderer({
   );
   const rootClassName = scope ? `${PAGE_ROOT_CLASS} ${scope}` : PAGE_ROOT_CLASS;
 
+  // Tokens LAYERED over the defaults, never replacing them: a site supplying
+  // one brand colour must not thereby lose `content.width` and `space.4`, and
+  // losing them is silent because an unresolved custom property invalidates the
+  // declaration rather than reporting anything. `resolveSiteTokens` is the one
+  // answer to "what tokens does this site have" — asked here and by anything
+  // that edits them, so the two cannot drift.
+  //
+  // Resolved even when the host names no tokens of its own, which is what makes
+  // the default set reach a page at all. Until this existed nothing called
+  // `compileSiteSheet`, so `defaultSiteTokens()` was a default nobody applied
+  // and every `{ $token }` compiled to a `var()` with nothing behind it.
+  const siteSheet =
+    siteStyles === undefined
+      ? undefined
+      : compileSiteSheet({
+          ...siteStyles,
+          tokens: resolveSiteTokens(siteStyles.tokens),
+        });
+
   return (
     <div className={rootClassName}>
+      {siteSheet?.css ? (
+        // FIRST, because order is the cascade: the site sheet carries font
+        // faces, tokens and block-type defaults, and the page's own sheet is
+        // appended after so a node's value beats a class and a class beats a
+        // block default. Emitted with its content hash, which is what lets a
+        // host recognise the same bytes across pages and serve them once.
+        <style
+          data-nx-site-sheet={siteSheet.contentHash}
+          dangerouslySetInnerHTML={{
+            __html: styleTextForInjection(siteSheet.css),
+          }}
+        />
+      ) : null}
       {css ? (
         // Injected as raw text rather than as a child, because React escapes a
         // text child and a stylesheet cannot survive that: `&` and `>` are

--- a/packages/blocks-react/src/site-sheet.test.tsx
+++ b/packages/blocks-react/src/site-sheet.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * The site stylesheet reaches the page.
+ *
+ * Until this existed, nothing in the repository called `compileSiteSheet`: the
+ * token pipeline was built, tested and unreachable, so `defaultSiteTokens()`
+ * was a default nobody applied and every `{ $token }` in a block compiled to a
+ * `var()` with nothing behind it. Three shipped blocks were broken by that and
+ * nobody noticed, because an unresolved custom property makes the declaration
+ * invalid at computed-value time — the property silently falls back to its
+ * initial value rather than reporting anything.
+ *
+ * So these assert the EMITTED MARKUP, not that a function was called. A test
+ * that checked `compileSiteSheet` had been invoked would have passed on the
+ * arrangement that shipped the defect.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { BlockDocument } from "@nextlyhq/blocks-engine";
+
+import { box } from "./blocks/box";
+import { PageRenderer } from "./page-renderer";
+import { createBlockResolver } from "./resolver";
+
+const DOC: BlockDocument = {
+  formatVersion: 1,
+  kind: "page",
+  nodes: [{ id: "n1", type: "core/box", version: 1, props: {} }],
+};
+
+const BREAKPOINTS = {
+  viewport: [{ id: "base", label: "Desktop" }],
+  container: [],
+};
+
+function html(siteStyles?: Parameters<typeof PageRenderer>[0]["siteStyles"]) {
+  return renderToStaticMarkup(
+    <PageRenderer
+      document={DOC}
+      blocks={createBlockResolver([box])}
+      styleContext={{ breakpoints: BREAKPOINTS }}
+      {...(siteStyles === undefined ? {} : { siteStyles })}
+    />
+  );
+}
+
+describe("the site stylesheet", () => {
+  it("puts the DEFAULT tokens on the page when the host names none of its own", () => {
+    // The whole point. A host that supplies only its breakpoints still gets the
+    // default token set as real custom properties, which is what makes a
+    // `{ $token }` anywhere resolve to something.
+    const out = html({ breakpoints: BREAKPOINTS });
+
+    expect(out).toContain("--site-space-4");
+    expect(out).toContain("--site-color-primary");
+    expect(out).toContain("--site-content-width");
+  });
+
+  it("emits NOTHING when the host asks for no site sheet", () => {
+    // The behaviour every existing consumer had before this prop existed, and
+    // the reason it is opt-in: emitting token definitions unasked changes what
+    // a stored `{ $token }` resolves to, and a page whose appearance depends on
+    // one of those dangling is a page that moves.
+    const out = html();
+
+    expect(out).not.toContain("--site-");
+    expect(out).not.toContain("data-nx-site-sheet");
+  });
+
+  it("lets a site override a default by NAME while the others survive", () => {
+    // The failure this guards is silent: replacing the set to change one colour
+    // drops `content.width` and `space.4`, every block reading them falls back
+    // to its initial value, and nothing reports it.
+    const out = html({
+      breakpoints: BREAKPOINTS,
+      tokens: {
+        tokens: [
+          {
+            name: "color.primary",
+            kind: "color",
+            values: { light: "#ff0000" },
+          },
+        ],
+      },
+    });
+
+    expect(out).toContain("#ff0000");
+    // The SURVIVORS are the assertion, not the override.
+    expect(out).toContain("--site-space-4");
+    expect(out).toContain("--site-content-width");
+  });
+
+  it("emits the site sheet BEFORE the page's own, because order is the cascade", () => {
+    // `compileSiteSheet` carries font faces, tokens and block-type defaults;
+    // the page sheet is appended after, which is what lets a node's own value
+    // beat a class and a class beat a block default. Reversed, every one of
+    // those inverts — and nothing else in the output would look different.
+    // A node carrying its OWN style, so a page sheet exists at all to be
+    // ordered against. A bare box compiles to no page CSS, and the comparison
+    // would then be against nothing — passing or failing for a reason that has
+    // nothing to do with order.
+    const styled: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/box",
+          version: 1,
+          props: {},
+          styles: { base: { base: { minWidth: "0" } } },
+        },
+      ],
+    };
+    const out = renderToStaticMarkup(
+      <PageRenderer
+        document={styled}
+        blocks={createBlockResolver([box])}
+        styleContext={{ breakpoints: BREAKPOINTS }}
+        siteStyles={{ breakpoints: BREAKPOINTS }}
+      />
+    );
+
+    const site = out.indexOf("data-nx-site-sheet");
+    const page = out.indexOf("min-width");
+
+    expect(site).toBeGreaterThanOrEqual(0);
+    expect(page).toBeGreaterThanOrEqual(0);
+    expect(site).toBeLessThan(page);
+  });
+
+  it("addresses the sheet by a content hash, so a host can serve it once", () => {
+    // Same bytes, same name, on every machine and run — which is what lets a
+    // host recognise the shared sheet across pages instead of inlining it per
+    // page. Two renders of the same input must agree.
+    const first = html({ breakpoints: BREAKPOINTS });
+    const second = html({ breakpoints: BREAKPOINTS });
+    const hashOf = (markup: string) =>
+      /data-nx-site-sheet="([^"]+)"/.exec(markup)?.[1];
+
+    expect(hashOf(first)).toBeDefined();
+    expect(hashOf(first)).toBe(hashOf(second));
+    // And it MOVES when the tokens do, or it would name stale bytes.
+    const changed = html({
+      breakpoints: BREAKPOINTS,
+      tokens: {
+        tokens: [
+          {
+            name: "color.primary",
+            kind: "color",
+            values: { light: "#0000ff" },
+          },
+        ],
+      },
+    });
+    expect(hashOf(changed)).not.toBe(hashOf(first));
+  });
+});


### PR DESCRIPTION
**Nothing in this repository called `compileSiteSheet`.** The design-token pipeline was built, tested, and unreachable — a fourth member of the built-but-unreachable set beside `style-trace.ts` and the breakpoint dialog.

So `defaultSiteTokens()` was **a default nobody applied**, and every `{ $token }` compiled to a `var()` with nothing behind it. Three shipped blocks were broken by exactly that (#896) and nothing reported it: an unresolved custom property makes the declaration invalid at computed-value time, so the property silently falls back to its initial value.

## What this adds

**`resolveSiteTokens` (blocks-engine)** — layers a site's own tokens over the defaults **by name**. Layering rather than replacing is the point: a site supplying one brand colour must not thereby lose `content.width` and `space.4`, and losing them is silent for the reason above. Replacing is the shape a caller writes by accident when the merge is left to them.

**`siteStyles` on `PageRenderer` (blocks-react)** — compiles the shared sheet and emits it **before** the page's own.

## Architecture

This is the three-tier arrangement Gutenberg's `theme.json` reaches, and the research is deliberate rather than incidental: **core defaults → the theme's file → the user's saved styles**, each overriding the last by name.

`resolveSiteTokens` implements the first two tiers. **A stored per-site override layers the same way, so the third tier needs no new mechanism** — which is what makes this the first half of the eventual design rather than a step to be undone.

One implementation of *"what tokens does this site have"*, deliberately: the emitter and any future editor must not answer it separately, because **a missing token looks exactly like a token whose value did not apply**.

## Order is the cascade, and is not negotiable

`compileSiteSheet` emits font faces, then tokens, then block-type defaults, then named classes. The page sheet is appended after — which is what lets a node's own value beat a class, and a class beat a block default. Reversed, every one of those inverts and **nothing else in the output would look different**, so it is asserted directly.

## Opt-in, deliberately

Omitting `siteStyles` emits nothing, which is exactly the behaviour every existing consumer had. That is a decision, not laziness: **emitting token definitions unasked changes what a stored `{ $token }` resolves to**, and a page whose current appearance depends on one dangling is a page that visibly moves. The host decides when to take that step. (Raised by lane 09 as the landing risk, and this is the answer to it.)

The sheet carries its `contentHash` as `data-nx-site-sheet`, which is what lets a host recognise the same bytes across pages and serve them once rather than inlining per page.

## Tests assert the EMITTED MARKUP, not that a function was called

That distinction is the whole lesson of #896: a test checking `compileSiteSheet` had been *invoked* would have passed on the arrangement that shipped the defect. These check the bytes:

- the **default** tokens appear as real custom properties when the host names none of its own
- **nothing** is emitted when the host asks for no site sheet
- a site override wins by name **while `content.width` and `space.4` survive** — the survivors are the assertion, not the override
- the site sheet **precedes** the page sheet
- the content hash is **stable across renders and moves when the tokens do**

Mutation-verified: making `resolveSiteTokens` replace instead of layer fails three tests including the survivors one.

## Verification

- `blocks-engine` **1256/1256**, `blocks-react` **590/590**, `plugin-page-builder` **828/828** — all exit 0, the consuming package against a freshly rebuilt `dist`
- `lint` and `check-types` exit 0 across all three

## Not in this PR

Wiring `createBlocksPage` to supply `siteStyles` by default, moving `blockBases` from the page sheet into the shared sheet (they are recompiled per page today), the stored per-site override tier, and `color.surface` / `color.border` — which unblock `core/card`'s background and border and make `badge` buildable. Sequenced in `tasks/left-tasks/2026-08-17-wire-the-site-stylesheet.md`.

**The #896 ratchet stays** until stored documents are measured for `{ $token }` references. It is written with that expiry stated.
