### PR TITLE
feat(nextly): repair a diverged field group, previewed first

### DIFF
--- a/.changeset/field-group-repair-surface.md
+++ b/.changeset/field-group-repair-surface.md
@@ -1,0 +1,36 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A field group whose stored definition no longer describes its tables can now be repaired from the admin, and the repair is shown before it runs.
+
+A field group is marked `diverged` when its tables changed and the record describing them did not, and it refuses every schema edit until that record is repaired. The repair existed but nothing could reach it. The Schema Builder now explains the block where it happens — on the field group being edited, which is where saving is refused — and the field group list offers the same repair on any row marked `diverged` or `failed`.
+
+The repair is previewed first. Reviewing it lists what would change by name rather than by count: fields whose columns are gone, attributes being brought back in line, and columns nobody declared, which are adopted under a type guessed from the physical column and are the ones worth correcting afterwards. Where the definition cannot be repaired without guessing — a column present on both tables, a physical type that no longer matches — each reason is reported individually and nothing is written. Approving a repair sends the version it was read against, so a plan reviewed in one tab can never be applied to a field group another tab has changed since. Previewing writes nothing and takes no lock, so it is safe to run at any time.
+
+The same operation is available as `GET` and `POST` on `/api/field-groups/schema/[slug]/reconcile` for callers driving it directly, and the result types are exported from `nextly/field-group-reconcile` for anyone rendering them.
+
+Note for anyone managing roles: saving in the Schema Builder requires `update-settings`. A role holding `create-settings` without it can open the builder and cannot save, which surfaces as saving being broken for one person rather than as a permission.

--- a/packages/admin/src/components/features/field-groups/ReconcileFieldGroupDialog.tsx
+++ b/packages/admin/src/components/features/field-groups/ReconcileFieldGroupDialog.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+/**
+ * Repair a field group's stored definition, showing the plan before it runs.
+ *
+ * ## Why a plan comes first
+ *
+ * The repair rewrites the definition to describe the tables, and parts of that are not undone by
+ * running it again: a field whose column vanished loses its authored label, validation and
+ * options, and a column nobody declared is adopted under a logical type GUESSED from a physical
+ * one — so an `email` column comes back as `text`. An operator asked to approve that has to be
+ * able to read it first.
+ *
+ * ## Why one dialog rather than a confirm and a result
+ *
+ * The confirm step has content: it IS the plan. Splitting it would show that plan on one surface,
+ * close it, and reopen a second showing overlapping information. Phases keep the operator's eye in
+ * one place, and the outcome replaces the plan where the plan was.
+ *
+ * ## Why three lists rather than one
+ *
+ * They ask different things. A repair is informational; a removal states a loss that has already
+ * happened in the database; an adoption is the only one carrying an action, because the guessed
+ * type usually needs correcting afterwards. Identities rather than counts throughout — the
+ * operator's question is whether THEIR field is in the list, which a number cannot answer.
+ *
+ * @module components/features/field-groups/ReconcileFieldGroupDialog
+ */
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@nextlyhq/ui";
+import type { ReconcileFieldGroupPreview } from "nextly/field-group-reconcile";
+
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Info,
+  Loader2,
+} from "@admin/components/icons";
+import {
+  useFieldGroupReconcile,
+  useFieldGroupReconcilePreview,
+} from "@admin/hooks/queries/useFieldGroupReconcile";
+
+export interface ReconcileFieldGroupDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  fieldGroupSlug: string;
+  /** Shown in the heading, because a slug is not what the operator calls this thing. */
+  fieldGroupLabel?: string;
+}
+
+/** A titled block of identities. Renders nothing at all when it has none to show. */
+function Section({
+  title,
+  tone = "neutral",
+  note,
+  items,
+}: {
+  title: string;
+  tone?: "neutral" | "warning";
+  note?: string;
+  items: string[];
+}) {
+  if (items.length === 0) return null;
+  return (
+    <section className="space-y-1">
+      <h4
+        className={
+          tone === "warning"
+            ? "text-sm font-medium text-destructive"
+            : "text-sm font-medium text-foreground"
+        }
+      >
+        {title}
+      </h4>
+      {note ? <p className="text-xs text-muted-foreground">{note}</p> : null}
+      <ul className="space-y-1">
+        {items.map(item => (
+          <li
+            key={item}
+            className="rounded-md bg-muted px-2 py-1 font-mono text-xs text-foreground"
+          >
+            {item}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+/** The plan, as three lists of identities. */
+function PlanBody({ plan }: { plan: ReconcileFieldGroupPreview }) {
+  return (
+    <div className="space-y-4">
+      <Section
+        title="Corrected"
+        note="Kept as they are, with one physical attribute brought back in line."
+        items={plan.repaired.map(
+          r =>
+            `${r.fieldName}.${r.attribute}: ${String(r.from)} → ${String(r.to)}`
+        )}
+      />
+      <Section
+        title="Removed"
+        note="These columns are already gone from the database, so their data went with them. Removing them from the definition is what makes the record honest again."
+        items={plan.removed.map(r => `${r.fieldName} (column ${r.columnName})`)}
+      />
+      <Section
+        title="Adopted — needs your attention"
+        tone="warning"
+        note="A column nothing described. Its type is a guess made from the physical column, so check each one in the field editor afterwards and correct it if the guess is wrong."
+        items={plan.adopted.map(
+          a => `${a.fieldName} → ${a.guessedType} (from ${a.liveType})`
+        )}
+      />
+    </div>
+  );
+}
+
+export function ReconcileFieldGroupDialog({
+  open,
+  onOpenChange,
+  fieldGroupSlug,
+  fieldGroupLabel,
+}: ReconcileFieldGroupDialogProps) {
+  const preview = useFieldGroupReconcilePreview(fieldGroupSlug, open);
+  const repair = useFieldGroupReconcile();
+
+  const plan = preview.data;
+  const outcome = repair.data;
+  const blocked = Boolean(plan && plan.blockers.length > 0);
+  const name = fieldGroupLabel ?? fieldGroupSlug;
+
+  // Only an approvable plan gets a confirm button. A plan that would write nothing, one the server
+  // refuses, and one still loading are all states where confirming means nothing.
+  const canApply = Boolean(
+    plan && !blocked && plan.wouldWrite && !outcome && !repair.isPending
+  );
+
+  const handleConfirm = () => {
+    if (!plan) return;
+    repair.mutate({
+      fieldGroupSlug,
+      // The version the plan was read against. The server refuses if the row has moved since, so
+      // approving a plan can never apply a different one.
+      expectedSchemaVersion: plan.schemaVersion,
+    });
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) repair.reset();
+    onOpenChange(next);
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {outcome ? `Repaired “${name}”` : `Repair “${name}”?`}
+          </AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-4 text-sm text-muted-foreground">
+              {preview.isPending ? (
+                <p className="flex items-center gap-2">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Checking what would change…
+                </p>
+              ) : null}
+
+              {preview.isError ? (
+                <p className="flex items-start gap-2 text-destructive">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>{preview.error.message}</span>
+                </p>
+              ) : null}
+
+              {/* The server saw drift it must not decide. Each one is named because the operator's
+                  next step differs per kind, and nothing was changed. */}
+              {plan && blocked ? (
+                <div className="space-y-2">
+                  <p className="flex items-start gap-2 text-destructive">
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                    <span>
+                      This cannot be repaired automatically. Nothing was
+                      changed.
+                    </span>
+                  </p>
+                  <ul className="space-y-1">
+                    {plan.blockers.map(b => (
+                      <li
+                        key={`${b.kind}:${b.columnName}`}
+                        className="rounded-md bg-muted px-2 py-1 text-xs text-foreground"
+                      >
+                        <span className="font-mono">{b.columnName}</span> —{" "}
+                        {b.detail}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+
+              {/* Healthy and unmarked: applying would write nothing at all. */}
+              {plan && !blocked && !plan.wouldWrite ? (
+                <p className="flex items-start gap-2">
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>
+                    The stored definition already describes the tables. There is
+                    nothing to repair.
+                  </span>
+                </p>
+              ) : null}
+
+              {/* The definition matches but a failure mark still stands, so applying DOES write —
+                  saying so is what keeps an empty change list from contradicting a live button. */}
+              {plan && !blocked && plan.wouldWrite && plan.unchanged ? (
+                <p className="flex items-start gap-2">
+                  <Info className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>
+                    The fields already match the tables. Applying clears the
+                    stale “{plan.staleStatus}” status that is refusing schema
+                    edits.
+                  </span>
+                </p>
+              ) : null}
+
+              {plan && !blocked && !outcome ? <PlanBody plan={plan} /> : null}
+
+              {repair.isError ? (
+                <p className="flex items-start gap-2 text-destructive">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>{repair.error.message}</span>
+                </p>
+              ) : null}
+
+              {outcome ? (
+                <div className="space-y-4">
+                  <p className="flex items-start gap-2">
+                    <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
+                    <span>
+                      The definition now describes the tables, and schema edits
+                      are allowed again.
+                    </span>
+                  </p>
+                  {/* Reported rather than assumed: the repair is durable in the database whether
+                      or not this process picked it up, and only a restart fixes the second. */}
+                  {!outcome.runtimeRefreshed ? (
+                    <p className="flex items-start gap-2 text-destructive">
+                      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                      <span>
+                        The repair is saved, but this running server is still
+                        holding the old shape. Restart it before editing entries
+                        in this field group.
+                      </span>
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          {outcome || blocked || (plan && !plan.wouldWrite) ? (
+            <AlertDialogAction onClick={() => handleOpenChange(false)}>
+              Done
+            </AlertDialogAction>
+          ) : (
+            <>
+              <AlertDialogCancel disabled={repair.isPending}>
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                onClick={event => {
+                  // The dialog stays open so the outcome lands where the plan was.
+                  event.preventDefault();
+                  handleConfirm();
+                }}
+                disabled={!canApply}
+              >
+                {repair.isPending ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Repairing…
+                  </>
+                ) : (
+                  "Repair definition"
+                )}
+              </AlertDialogAction>
+            </>
+          )}
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/admin/src/components/features/field-groups/__tests__/ReconcileFieldGroupDialog.test.tsx
+++ b/packages/admin/src/components/features/field-groups/__tests__/ReconcileFieldGroupDialog.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * The dialog an operator approves a definition repair from.
+ *
+ * Its job is to be accurate about three things they would otherwise have to guess: what the repair
+ * will change, which parts of that need following up afterwards, and whether pressing the button
+ * does anything at all. Each is asserted by IDENTITY rather than by shape, because the operator's
+ * real question is whether their own field is in the list.
+ */
+import userEvent from "@testing-library/user-event";
+import type { ReconcileFieldGroupPreview } from "nextly/field-group-reconcile";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+import { ReconcileFieldGroupDialog } from "../ReconcileFieldGroupDialog";
+
+const mutate = vi.fn();
+
+const previewState: {
+  data?: ReconcileFieldGroupPreview;
+  isPending: boolean;
+  isError: boolean;
+  error?: Error;
+} = { isPending: false, isError: false };
+
+const repairState: {
+  data?: unknown;
+  isPending: boolean;
+  isError: boolean;
+  error?: Error;
+} = { isPending: false, isError: false };
+
+vi.mock("@admin/hooks/queries/useFieldGroupReconcile", () => ({
+  useFieldGroupReconcilePreview: () => previewState,
+  useFieldGroupReconcile: () => ({ ...repairState, mutate, reset: vi.fn() }),
+}));
+
+/** A plan with nothing to do, which each test narrows to the case it is about. */
+function plan(
+  over: Partial<ReconcileFieldGroupPreview> = {}
+): ReconcileFieldGroupPreview {
+  return {
+    slug: "hero",
+    localized: false,
+    removed: [],
+    repaired: [],
+    adopted: [],
+    blockers: [],
+    unchanged: true,
+    wouldWrite: false,
+    schemaVersion: 7,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  mutate.mockClear();
+  previewState.data = undefined;
+  previewState.isPending = false;
+  previewState.isError = false;
+  repairState.data = undefined;
+  repairState.isPending = false;
+  repairState.isError = false;
+});
+
+function open() {
+  return render(
+    <ReconcileFieldGroupDialog
+      open
+      onOpenChange={vi.fn()}
+      fieldGroupSlug="hero"
+      fieldGroupLabel="Hero"
+    />
+  );
+}
+
+describe("ReconcileFieldGroupDialog", () => {
+  it("names an adopted column and the type that was guessed for it", () => {
+    // The one category carrying follow-up work. A count would answer a question nobody asked --
+    // the operator needs to know it was THEIR field and what it became.
+    previewState.data = plan({
+      unchanged: false,
+      wouldWrite: true,
+      adopted: [
+        {
+          fieldName: "contact_email",
+          columnName: "contact_email",
+          table: "main",
+          liveType: "varchar(255)",
+          guessedType: "text",
+        },
+      ],
+    });
+    open();
+
+    expect(screen.getByText(/contact_email → text/)).toBeInTheDocument();
+    expect(screen.getByText(/varchar\(255\)/)).toBeInTheDocument();
+    expect(screen.getByText(/needs your attention/i)).toBeInTheDocument();
+  });
+
+  it("names every blocker and offers no way to apply", () => {
+    // A refusal that showed a live button would invite the operator to press something that
+    // cannot work, and the reason differs per blocker, so each is named.
+    previewState.data = plan({
+      blockers: [
+        {
+          fieldName: "title",
+          columnName: "title",
+          kind: "column-on-both-tables",
+          detail: "The column exists on both tables.",
+        },
+      ],
+    });
+    open();
+
+    expect(screen.getByText(/exists on both tables/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /repair definition/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("says there is nothing to repair on a healthy field group", () => {
+    previewState.data = plan();
+    open();
+
+    expect(screen.getByText(/nothing to repair/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /repair definition/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("explains why applying still writes when only the status is stale", () => {
+    // 🔴 The case where the plan and the write decision genuinely differ. Reading `unchanged`
+    // alone would render an empty change list beside an enabled button, so the dialog has to say
+    // what applying is FOR when no field is changing.
+    previewState.data = plan({
+      unchanged: true,
+      wouldWrite: true,
+      staleStatus: "diverged",
+    });
+    open();
+
+    expect(screen.getByText(/already match the tables/i)).toBeInTheDocument();
+    expect(screen.getByText(/diverged/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /repair definition/i })
+    ).toBeEnabled();
+  });
+
+  it("approves the exact version the plan was read against", async () => {
+    // The pin. Sending anything else -- or nothing -- would let the server repair against a row
+    // this operator never saw.
+    previewState.data = plan({
+      unchanged: false,
+      wouldWrite: true,
+      schemaVersion: 42,
+      removed: [{ fieldName: "subtitle", columnName: "subtitle" }],
+    });
+    open();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /repair definition/i })
+    );
+
+    expect(mutate).toHaveBeenCalledWith({
+      fieldGroupSlug: "hero",
+      expectedSchemaVersion: 42,
+    });
+  });
+
+  it("warns that a landed repair has not reached the running server", () => {
+    // Reported rather than folded into success: the database is correct and the process is not,
+    // and only a restart fixes the second. Telling the operator "done" would strand them.
+    repairState.data = {
+      slug: "hero",
+      localized: false,
+      removed: [],
+      repaired: [],
+      adopted: [],
+      unchanged: false,
+      schemaVersion: 43,
+      runtimeRefreshed: false,
+    };
+    previewState.data = plan({ unchanged: false, wouldWrite: true });
+    open();
+
+    expect(screen.getByText(/Restart it before editing/i)).toBeInTheDocument();
+  });
+
+  it("carries no hardcoded colours, so it renders in both themes", () => {
+    // Every colour comes from a --nx-* backed token class. A literal hex, rgb() or black/white
+    // utility is the recurring defect this guards, and it only shows up in one mode.
+    previewState.data = plan({
+      unchanged: false,
+      wouldWrite: true,
+      adopted: [
+        {
+          fieldName: "x",
+          columnName: "x",
+          table: "main",
+          liveType: "text",
+          guessedType: "text",
+        },
+      ],
+    });
+    const { baseElement } = open();
+
+    const markup = baseElement.innerHTML;
+    expect(markup).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+    expect(markup).not.toMatch(/rgba?\(/);
+    expect(markup).not.toMatch(/\b(?:text|bg|border)-(?:white|black)\b/);
+    // The control: the tokens ARE present, so the assertions above are checking real markup
+    // rather than an element that failed to render.
+    expect(markup).toMatch(/text-destructive/);
+  });
+});

--- a/packages/admin/src/hooks/queries/useFieldGroupReconcile.ts
+++ b/packages/admin/src/hooks/queries/useFieldGroupReconcile.ts
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * Reading and applying a field group's definition repair.
+ *
+ * Two hooks for two genuinely different operations, rather than one that does both: the preview is
+ * a read that may run on any field group at any time, and the repair is a write the operator has
+ * to approve. Keeping them apart is what lets the dialog show a plan before anything happens.
+ *
+ * @module hooks/queries/useFieldGroupReconcile
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type {
+  ReconcileFieldGroupPreview,
+  ReconcileFieldGroupResult,
+} from "nextly/field-group-reconcile";
+
+import { fieldGroupApi } from "@admin/services/fieldGroupApi";
+
+import { fieldGroupKeys } from "./useFieldGroups";
+
+/** Query key for one field group's repair plan. */
+const reconcilePreviewKey = (fieldGroupSlug: string) =>
+  [...fieldGroupKeys.detail(fieldGroupSlug), "reconcile-preview"] as const;
+
+/**
+ * What repairing this field group would change.
+ *
+ * 🔴 Never served from cache. A plan describes the database at one moment, and the operator is
+ * about to approve it — showing a remembered one would put a stale list in front of the decision
+ * that acts on it. The server refuses a stale approval regardless, so a cached plan could not
+ * produce a wrong write; it would produce a confusing refusal, which is a worse experience than
+ * simply asking again.
+ *
+ * `enabled` is what keeps this from running on every rendered row: the dialog turns it on.
+ */
+export function useFieldGroupReconcilePreview(
+  fieldGroupSlug: string,
+  enabled: boolean
+) {
+  return useQuery<ReconcileFieldGroupPreview, Error>({
+    queryKey: reconcilePreviewKey(fieldGroupSlug),
+    queryFn: () => fieldGroupApi.previewReconcile(fieldGroupSlug),
+    enabled: enabled && Boolean(fieldGroupSlug),
+    staleTime: 0,
+    gcTime: 0,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: false,
+    // A refused preview is a considered answer from the server — a locked group, a missing table.
+    // Retrying re-asks a question already answered and delays showing the operator why.
+    retry: false,
+  });
+}
+
+/**
+ * Apply the repair the operator approved.
+ *
+ * `expectedSchemaVersion` is required rather than optional on purpose: this hook exists to serve
+ * an approval, and an approval that does not name the plan it approves is the failure the pin
+ * exists to prevent. A caller with no plan in hand should not be using this hook.
+ */
+export function useFieldGroupReconcile() {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    ReconcileFieldGroupResult,
+    Error,
+    { fieldGroupSlug: string; expectedSchemaVersion: number }
+  >({
+    mutationFn: async ({ fieldGroupSlug, expectedSchemaVersion }) => {
+      const result = await fieldGroupApi.reconcile(
+        fieldGroupSlug,
+        expectedSchemaVersion
+      );
+      return result.item;
+    },
+    onSuccess: (_result, { fieldGroupSlug }) => {
+      // The repair rewrites the definition and clears the status, so every view of this group is
+      // now stale — the list badge, the detail, and any plan still held for it.
+      void queryClient.invalidateQueries({ queryKey: fieldGroupKeys.all() });
+      void queryClient.invalidateQueries({
+        queryKey: fieldGroupKeys.detail(fieldGroupSlug),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: reconcilePreviewKey(fieldGroupSlug),
+      });
+    },
+  });
+}

--- a/packages/admin/src/pages/dashboard/field-group/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/field-group/builder/[slug].tsx
@@ -19,11 +19,12 @@
 import { DndContext, type DragEndEvent } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Skeleton } from "@nextlyhq/ui";
+import { Button, Skeleton } from "@nextlyhq/ui";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { z } from "zod";
 
+import { ReconcileFieldGroupDialog } from "@admin/components/features/field-groups/ReconcileFieldGroupDialog";
 import {
   BuilderFieldList,
   BuilderReadOnlyNotice,
@@ -36,6 +37,7 @@ import {
   type BuilderSettingsValues,
 } from "@admin/components/features/schema-builder";
 import type { BuilderField } from "@admin/components/features/schema-builder/types";
+import { RefreshCw } from "@admin/components/icons";
 import { PageContainer } from "@admin/components/layout/page-container";
 import { PageErrorFallback } from "@admin/components/shared/error-fallbacks";
 import { toast } from "@admin/components/ui";
@@ -113,6 +115,7 @@ export default function FieldGroupBuilderEditPage({
     useState<BuilderSettingsValues | null>(null);
   const [active, setActive] = useState<ActiveOverlay>({ kind: "none" });
   const [isInitialized, setIsInitialized] = useState(false);
+  const [reconcileOpen, setReconcileOpen] = useState(false);
   const [originalFields, setOriginalFields] = useState<
     readonly BuilderField[] | null
   >(null);
@@ -167,6 +170,17 @@ export default function FieldGroupBuilderEditPage({
   }, [fieldGroup, builder, isInitialized]);
 
   const isLocked = fieldGroup?.locked === true;
+
+  /**
+   * Whether this field group's record needs repairing before it will accept a save.
+   *
+   * `diverged` refuses schema edits outright; `failed` stands over tables that may already match.
+   * The same operation clears both, so one list covers them. Server-side is where this is
+   * enforced — this only decides whether the page explains it up front.
+   */
+  const needsRepair =
+    fieldGroup?.migrationStatus === "diverged" ||
+    fieldGroup?.migrationStatus === "failed";
 
   const settingsDirty = useMemo(() => {
     if (!originalSettings || !settings) return false;
@@ -504,6 +518,33 @@ export default function FieldGroupBuilderEditPage({
             configPath={fieldGroup?.configPath}
           />
         )}
+        {/* 🔴 This page is where the refusal actually happens: a diverged field group loads and
+            edits normally, and only the SAVE is refused. An affordance living only on the list
+            would let an operator do the work, lose it to a refusal, and then navigate away to
+            find the repair. */}
+        {needsRepair && (
+          <div className="mb-4 rounded-lg border border-destructive/40 bg-destructive/5 p-4">
+            <h2 className="text-sm font-medium text-destructive">
+              Saving is blocked until this definition is repaired
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              This field group&apos;s tables changed and the record describing
+              them did not, so schema edits are refused. Repairing rewrites the
+              record to describe the tables — it moves no data and creates no
+              columns.
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-3"
+              onClick={() => setReconcileOpen(true)}
+            >
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Review the repair
+            </Button>
+          </div>
+        )}
         <DndContext
           sensors={builder.sensors}
           onDragStart={builder.handleDragStart}
@@ -530,6 +571,15 @@ export default function FieldGroupBuilderEditPage({
           />
         </DndContext>
       </PageContainer>
+
+      {slug && (
+        <ReconcileFieldGroupDialog
+          open={reconcileOpen}
+          onOpenChange={setReconcileOpen}
+          fieldGroupSlug={slug}
+          fieldGroupLabel={settings?.singularName || slug}
+        />
+      )}
 
       {active.kind === "settings" && (
         <BuilderSettingsModal

--- a/packages/admin/src/pages/dashboard/field-group/components/FieldGroupTable.tsx
+++ b/packages/admin/src/pages/dashboard/field-group/components/FieldGroupTable.tsx
@@ -15,10 +15,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@nextlyhq/ui";
-import { Eye, Pencil, Trash2, Filter } from "lucide-react";
+import { Eye, Pencil, Trash2, Filter, RefreshCw } from "lucide-react";
 import { useState, useEffect, useMemo, useCallback } from "react";
 
 import { BulkActionBar } from "@admin/components/features/entries/EntryList/BulkActionBar";
+import { ReconcileFieldGroupDialog } from "@admin/components/features/field-groups/ReconcileFieldGroupDialog";
 import * as Icons from "@admin/components/icons";
 import { Lock } from "@admin/components/icons";
 import { BulkDeleteDialog } from "@admin/components/shared/bulk-action-dialogs";
@@ -82,6 +83,15 @@ const MIGRATION_BADGES: Record<FieldGroupMigrationStatus, MigrationBadge> = {
   failed: { variant: "destructive", label: "Failed" },
   diverged: { variant: "destructive", label: "Diverged" },
 };
+
+/**
+ * Statuses a definition repair is the answer to.
+ *
+ * `diverged` refuses every schema edit until it is cleared; `failed` does not refuse anything but
+ * stands over tables that may already match, so it is stale in the same way. Both are cleared by
+ * the same operation, which is why one list covers them.
+ */
+const REPAIRABLE_STATUSES = new Set<string>(["diverged", "failed"]);
 
 function getMigrationBadge(status?: FieldGroupMigrationStatus): MigrationBadge {
   // 🔴 An exhaustive Record rather than a switch with a `default`, and that is the control.
@@ -150,6 +160,11 @@ export default function FieldGroupTable() {
     slug: string;
     label: string;
   } | null>(null);
+  // The field group whose repair plan is open, or null. Holding the row rather than a boolean lets
+  // the dialog title name the group the operator picked.
+  const [reconcileTarget, setReconcileTarget] = useState<ApiFieldGroup | null>(
+    null
+  );
   const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false);
   const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set());
 
@@ -446,6 +461,19 @@ export default function FieldGroupTable() {
         ),
         onSelect: () => handleEdit(fieldGroup),
       },
+      // Offered only where a repair is the answer to something. The preview itself is safe on any
+      // field group, so this list decides DISCOVERABILITY, not permission — the server still
+      // decides whether the operation may run, and says so in the dialog when it may not.
+      ...(REPAIRABLE_STATUSES.has(fieldGroup.migrationStatus ?? "")
+        ? [
+            {
+              id: "reconcile",
+              label: "Repair definition",
+              icon: <RefreshCw className="h-4 w-4" />,
+              onSelect: () => setReconcileTarget(fieldGroup),
+            } satisfies RowAction<ApiFieldGroup>,
+          ]
+        : []),
       {
         id: "delete",
         label: "Delete",
@@ -662,6 +690,19 @@ export default function FieldGroupTable() {
           />
         </>
       )}
+
+      {/* Mounted only while a target is held, so each opening fetches a fresh plan rather than
+          reusing the one belonging to whichever group was picked last. */}
+      {reconcileTarget ? (
+        <ReconcileFieldGroupDialog
+          open
+          onOpenChange={next => {
+            if (!next) setReconcileTarget(null);
+          }}
+          fieldGroupSlug={reconcileTarget.slug}
+          fieldGroupLabel={reconcileTarget.label}
+        />
+      ) : null}
 
       <BulkDeleteDialog
         open={deleteDialogOpen}

--- a/packages/admin/src/services/fieldGroupApi.ts
+++ b/packages/admin/src/services/fieldGroupApi.ts
@@ -8,6 +8,10 @@
  */
 
 import type { ListResponse, TableParams } from "@nextlyhq/ui";
+import type {
+  ReconcileFieldGroupPreview,
+  ReconcileFieldGroupResult,
+} from "nextly/field-group-reconcile";
 
 import type { ApiFieldGroup } from "@admin/types/entities";
 
@@ -235,5 +239,36 @@ export const fieldGroupApi = {
       newSchemaVersion: result.newSchemaVersion,
       toastSummary: result.toastSummary,
     };
+  },
+
+  /**
+   * What repairing this field group's stored definition WOULD change.
+   *
+   * A GET on the same path the repair posts to: the verb is what separates asking from doing, and
+   * this half writes nothing. Safe to call on any field group, including a healthy one.
+   */
+  previewReconcile: async (
+    fieldGroupSlug: string
+  ): Promise<ReconcileFieldGroupPreview> => {
+    return protectedApi.get<ReconcileFieldGroupPreview>(
+      `/field-groups/schema/${fieldGroupSlug}/reconcile`
+    );
+  },
+
+  /**
+   * Repair the stored definition to describe the live tables.
+   *
+   * `expectedSchemaVersion` is the version the preview reported, and passing it is what makes the
+   * approval specific: the server refuses rather than repairing if the row has moved since, so a
+   * stale tab can never apply a plan its operator never read.
+   */
+  reconcile: async (
+    fieldGroupSlug: string,
+    expectedSchemaVersion: number
+  ): Promise<MutationResponse<ReconcileFieldGroupResult>> => {
+    return protectedApi.post<MutationResponse<ReconcileFieldGroupResult>>(
+      `/field-groups/schema/${fieldGroupSlug}/reconcile`,
+      { expectedSchemaVersion }
+    );
   },
 } as const;

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -39,6 +39,10 @@
       "types": "./dist/field-group-type.d.ts",
       "import": "./dist/field-group-type.mjs"
     },
+    "./field-group-reconcile": {
+      "types": "./dist/field-group-reconcile.d.ts",
+      "import": "./dist/field-group-reconcile.mjs"
+    },
     "./field-catalog": {
       "types": "./dist/field-catalog.d.ts",
       "import": "./dist/collections/fields/catalog.mjs"

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -687,6 +687,44 @@ export const COMPONENTS_METHODS: Record<
     },
   },
 
+  // What reconciling a field group WOULD change, computed without changing anything.
+  //
+  // 🔴 Deliberately OUTSIDE `withSchemaChangeExcluded`, unlike the repair below. Two reasons, and
+  // the first is the decisive one: the exclusion is entered with `issuesDdl: true`, so asking it
+  // CREATES a lock table on a database that has never run a storage migration — a preview that
+  // writes to the database to tell you what a write would do. The storage migration's own dry run
+  // takes no lock for exactly this reason, so a preview stays usable with a read-only credential.
+  //
+  // The looser guarantee that buys is the right one for what this answers. A plan read outside the
+  // exclusion can be stale by the time it is approved, and nothing here relies on it not being:
+  // the repair re-plans under the exclusion and refuses unless the row still carries the version
+  // this preview reported. So a stale preview cannot become a wrong write — it becomes a refusal.
+  previewComponentReconcile: {
+    execute: async (svc, p) => {
+      const slug = requireParam(p, "slug", "Component slug");
+
+      const adapter = getAdapterFromDI();
+      if (!adapter) {
+        throw NextlyError.internal({
+          logContext: { reason: "reconcile-preview-requires-adapter", slug },
+        });
+      }
+
+      const { previewFieldGroupReconcile } = await import(
+        "../../domains/field-groups/services/field-group-reconcile-service"
+      );
+      const preview = await previewFieldGroupReconcile({
+        registry: svc.registry,
+        adapter,
+        slug,
+      });
+
+      // A read, so the document envelope rather than the mutation one: nothing was changed and
+      // there is no message to report about a change that did not happen.
+      return respondDoc(preview);
+    },
+  },
+
   // Repair a field group's stored definition to describe its live tables.
   //
   // The exit from `diverged`, so `assertNotDiverged` is deliberately NOT called: this is the one
@@ -694,8 +732,28 @@ export const COMPONENTS_METHODS: Record<
   // `diverged` — a recording write that failed after its DDL committed leaves a divergence with no
   // mark, and the operation is idempotent on a healthy group.
   reconcileComponent: {
-    execute: async (svc, p) => {
+    execute: async (svc, p, body) => {
       const slug = requireParam(p, "slug", "Component slug");
+
+      // The version a preview reported, when this call is approving one. Absent for a caller that
+      // never previewed, which keeps repairing against whatever it reads.
+      const b = body as { expectedSchemaVersion?: number } | undefined;
+      const expectedSchemaVersion = b?.expectedSchemaVersion;
+      if (
+        expectedSchemaVersion !== undefined &&
+        !Number.isInteger(expectedSchemaVersion)
+      ) {
+        throw NextlyError.validation({
+          errors: [
+            {
+              path: "expectedSchemaVersion",
+              code: "INVALID_VALUE",
+              message: "Must be the whole number a preview reported.",
+            },
+          ],
+          logContext: { slug, received: typeof expectedSchemaVersion },
+        });
+      }
 
       const adapter = getAdapterFromDI();
       if (!adapter) {
@@ -742,6 +800,12 @@ export const COMPONENTS_METHODS: Record<
             adapter,
             logger,
             slug,
+            // Spread so an absent value stays absent: passing `undefined` explicitly would be
+            // indistinguishable from "no preview to honour" only by luck of how the callee reads
+            // it, and this way the two cases differ in the object itself.
+            ...(expectedSchemaVersion !== undefined
+              ? { expectedSchemaVersion }
+              : {}),
           });
 
           // The canonical mutation envelope: this method can rewrite the registry row, so its

--- a/packages/nextly/src/domains/field-groups/__tests__/field-group-reconcile-preview.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/field-group-reconcile-preview.integration.test.ts
@@ -1,0 +1,191 @@
+/**
+ * A reconcile preview must describe the repair WITHOUT performing any part of it, and must
+ * describe the repair that will actually run.
+ *
+ * 🔴 Two failures this file exists to catch, and neither shows up in a report-shape assertion:
+ *
+ * 1. A preview that writes. The operation reads the registry and the catalog and plans a repair —
+ *    every ingredient of the write is in hand, so a preview is one stray call away from being an
+ *    apply. Asserted on the ROW, never on the returned object, because a preview that wrote would
+ *    return exactly the same object as one that did not.
+ *
+ * 2. A preview that mispredicts. `plan.unchanged` answers whether the DEFINITION describes the
+ *    tables, which is a narrower question than whether applying writes: a group whose every field
+ *    matches while its status still reads `diverged` needs a write that `plan.unchanged` does not
+ *    predict. A preview deriving "nothing will happen" from the plan reports a quiet apply and
+ *    then the version moves. The two answers are computed once and shared, and the stale-marker
+ *    case below is what holds them together.
+ *
+ * The approval pin is the third property: an apply carrying the version a preview reported must
+ * refuse once the row has moved, so an operator can never approve one plan and execute another.
+ *
+ * Self-skips per dialect on the standard rule.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const FIELDS = [
+  { name: "heading", type: "text" },
+  { name: "weight", type: "number" },
+];
+
+for (const dialect of getConfiguredTestDialects()) {
+  describe(`the reconcile preview — ${dialect}`, () => {
+    const slug = `fgpv_${dialect.slice(0, 2)}`;
+
+    /** A healthy group: its tables and its definition already agree. */
+    async function seedHealthy() {
+      current = await createTestNextly({ dialect });
+      const registry = current.getService("fieldGroupRegistryService");
+      await current.nextly.fieldGroups.create({
+        slug,
+        label: "Preview subject",
+        fields: FIELDS,
+      });
+      return { registry, row: await registry.getComponent(slug) };
+    }
+
+    async function preview(registry: unknown) {
+      const { previewFieldGroupReconcile } = await import(
+        "../services/field-group-reconcile-service"
+      );
+      return previewFieldGroupReconcile({
+        registry: registry as Parameters<
+          typeof previewFieldGroupReconcile
+        >[0]["registry"],
+        adapter: current!.adapter,
+        slug,
+      });
+    }
+
+    it("changes nothing on the row it describes", async () => {
+      const { registry, row } = await seedHealthy();
+
+      const report = await preview(registry);
+      expect(report.slug).toBe(slug);
+      expect(report.schemaVersion).toBe(row.schemaVersion);
+
+      // 🔴 The row, not the report. A preview that performed the repair would return this same
+      // object, so only the stored version and status separate the two outcomes.
+      const after = await registry.getComponent(slug);
+      expect(after.schemaVersion).toBe(row.schemaVersion);
+      expect(after.migrationStatus).toBe(row.migrationStatus);
+      expect(after.fields).toEqual(row.fields);
+    });
+
+    it("reports no write pending on a group that is genuinely healthy", async () => {
+      const { registry, row } = await seedHealthy();
+
+      const report = await preview(registry);
+      expect(report.blockers).toEqual([]);
+      expect(report.unchanged).toBe(true);
+      expect(report.wouldWrite).toBe(false);
+      expect(report.staleStatus).toBeUndefined();
+
+      // And the prediction holds: applying really does leave the version where it was.
+      const { reconcileFieldGroup } = await import(
+        "../services/field-group-reconcile-service"
+      );
+      await reconcileFieldGroup({
+        registry,
+        adapter: current!.adapter,
+        logger: current!.getService("logger"),
+        slug,
+      });
+      const after = await registry.getComponent(slug);
+      expect(after.schemaVersion).toBe(row.schemaVersion);
+    });
+
+    it("still reports a pending write when only the STATUS is stale", async () => {
+      const { registry, row } = await seedHealthy();
+      // The tables and the definition agree; the mark does not. This is the case where the plan
+      // and the write decision genuinely differ, and where a preview reading `plan.unchanged`
+      // would promise that applying does nothing.
+      await registry.updateComponent(
+        slug,
+        { migrationStatus: "diverged" },
+        { source: "code" }
+      );
+
+      const report = await preview(registry);
+      expect(report.unchanged).toBe(true);
+      expect(report.wouldWrite).toBe(true);
+      expect(report.staleStatus).toBe("diverged");
+
+      // The prediction is what is under test, so it is checked against the apply rather than
+      // asserted on its own: the version MOVES, which `unchanged` alone would have denied.
+      const { reconcileFieldGroup } = await import(
+        "../services/field-group-reconcile-service"
+      );
+      await reconcileFieldGroup({
+        registry,
+        adapter: current!.adapter,
+        logger: current!.getService("logger"),
+        slug,
+        expectedSchemaVersion: report.schemaVersion,
+      });
+      const after = await registry.getComponent(slug);
+      expect(after.migrationStatus).toBe("synced");
+      expect(after.schemaVersion).toBeGreaterThan(row.schemaVersion);
+    });
+
+    it("refuses an apply whose approved version the row has moved past", async () => {
+      const { registry } = await seedHealthy();
+      await registry.updateComponent(
+        slug,
+        { migrationStatus: "diverged" },
+        { source: "code" }
+      );
+
+      const report = await preview(registry);
+      const approved = report.schemaVersion;
+
+      const { reconcileFieldGroup } = await import(
+        "../services/field-group-reconcile-service"
+      );
+
+      // The row moves between the preview and the approval, by a repair somebody else already
+      // ran — the double-submit this pin exists for, where two tabs both hold the same plan.
+      //
+      // Moved with a reconcile rather than a metadata edit on purpose: `schemaVersion` tracks the
+      // SCHEMA, so a label-only update does not advance it. That is the right granularity for this
+      // pin (renaming a group cannot invalidate a plan about its columns) and it means a fixture
+      // reaching for a label change moves nothing and proves nothing.
+      await reconcileFieldGroup({
+        registry,
+        adapter: current!.adapter,
+        logger: current!.getService("logger"),
+        slug,
+      });
+      const moved = await registry.getComponent(slug);
+      expect(moved.schemaVersion).toBeGreaterThan(approved);
+      await expect(
+        reconcileFieldGroup({
+          registry,
+          adapter: current!.adapter,
+          logger: current!.getService("logger"),
+          slug,
+          expectedSchemaVersion: approved,
+        })
+      ).rejects.toMatchObject({ code: "CONFLICT" });
+
+      // The refusal wrote nothing — the row is exactly where the earlier repair left it, so the
+      // second approval neither re-applied nor bumped the version a second time.
+      const after = await registry.getComponent(slug);
+      expect(after.schemaVersion).toBe(moved.schemaVersion);
+      expect(after.migrationStatus).toBe(moved.migrationStatus);
+    });
+  });
+}

--- a/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
@@ -34,6 +34,8 @@ import {
   planFieldGroupReconcile,
   type ExpectedColumnDefault,
   type ReconcileAdoption,
+  type ReconcileBlocker,
+  type ReconcilePlan,
   type ReconcileRemoval,
   type ReconcileRepair,
   type ReconcileTable,
@@ -66,6 +68,40 @@ export interface ReconcileFieldGroupResult {
   runtimeRefreshed: boolean;
   /** Why the refresh did not happen; present only when `runtimeRefreshed` is false. */
   runtimeRefreshReason?: string;
+}
+
+/**
+ * What a reconcile WOULD do, computed without writing anything.
+ *
+ * The repair rewrites a definition in ways re-running cannot undo — a field whose column vanished
+ * loses its authored label, validation and options, and an adopted column is recorded under a
+ * logical type that was GUESSED from a physical one. An operator asked to approve that has to be
+ * able to read it first, so the plan is offered before the write rather than reported after it.
+ *
+ * `blockers` is the reason this is a result rather than a thrown refusal. The repair throws on a
+ * drift it must not decide, and a thrown error carries no structured payload to the browser — its
+ * `logContext` is stripped from the response — so the only channel that can name each blocker
+ * individually is a successful one.
+ */
+export interface ReconcileFieldGroupPreview {
+  slug: string;
+  /** Re-derived from which table holds the columns, exactly as the repair would derive it. */
+  localized: boolean;
+  removed: ReconcileRemoval[];
+  repaired: ReconcileRepair[];
+  adopted: ReconcileAdoption[];
+  /** Non-empty means the repair would REFUSE. Nothing here is applicable until each is resolved. */
+  blockers: ReconcileBlocker[];
+  /** True when the definition already describes the tables, so applying would write nothing. */
+  unchanged: boolean;
+  /**
+   * The version this plan was computed against.
+   *
+   * Sent back on the apply so the operator cannot approve one plan and have another execute: the
+   * repair refuses when the row has moved since. Without it the apply re-plans against whatever
+   * the row says by then, which may be a different repair than the one that was shown.
+   */
+  schemaVersion: number;
 }
 
 /**
@@ -174,8 +210,29 @@ async function expectedColumnDefaultResolver(
   };
 }
 
+/** What the preview and the repair both need before either can decide anything. */
+interface ReconcileAssessment {
+  existing: Awaited<ReturnType<FieldGroupRegistryService["getComponent"]>>;
+  plan: ReconcilePlan<FieldDefinition>;
+  typeColumn: string;
+  dialect: SupportedDialect;
+}
+
+/** The inputs that decide a plan. The repair takes more; none of the extra changes the plan. */
+interface ReconcileAssessmentArgs {
+  registry: FieldGroupRegistryService;
+  adapter: DrizzleAdapter;
+  slug: string;
+  fromCode?: boolean;
+}
+
 /**
- * Reconcile one field group's registry row against its live tables.
+ * Read the row and the tables, and plan the repair — without writing.
+ *
+ * 🔴 The preview and the repair share THIS function rather than each computing a plan of their
+ * own. A preview's entire value is that it describes what the apply will do, and two
+ * implementations of one question agree on the day they are written and drift silently afterwards.
+ * Deriving both from one call makes a disagreement unrepresentable rather than merely unlikely.
  *
  * Preconditions, in order and before anything is decided:
  * - the group must exist (`getComponent` raises NOT_FOUND itself);
@@ -185,26 +242,14 @@ async function expectedColumnDefaultResolver(
  * - the MAIN table must exist. A vanished table is not a definition drift: the honest repair for
  *   it is deleting the group, which is a different, destructive decision this operation must not
  *   make on the operator's behalf.
+ *
+ * All three are refused for the PREVIEW too, deliberately. A preview that answered where the apply
+ * would refuse would be inviting the operator to approve an operation that cannot run.
  */
-export async function reconcileFieldGroup(args: {
-  registry: FieldGroupRegistryService;
-  adapter: DrizzleAdapter;
-  logger: Logger;
-  slug: string;
-  /**
-   * The code sync is asking, so a LOCKED group may be repaired.
-   *
-   * Never settable from the HTTP surface: the dispatcher does not pass it. It exists so the caller
-   * that owns a code-managed definition can clear a marker that would otherwise leave the group
-   * unreachable from both directions — a locked row marked `diverged` is refused by
-   * `assertNotDiverged` on the sync path and by the lock check here.
-   *
-   * Wired: `syncCodeFirstComponents` passes it when it finds a `diverged` code-managed row, so
-   * that state clears on the next sync rather than needing a hand-edited database.
-   */
-  fromCode?: boolean;
-}): Promise<ReconcileFieldGroupResult> {
-  const { registry, adapter, logger, slug } = args;
+async function assessFieldGroupReconcile(
+  args: ReconcileAssessmentArgs
+): Promise<ReconcileAssessment> {
+  const { registry, adapter, slug } = args;
 
   const existing = await registry.getComponent(slug);
 
@@ -252,8 +297,9 @@ export async function reconcileFieldGroup(args: {
   // 🔴 Probed BEFORE the write, mirroring the transition path's contract: the discriminator column
   // is a fact about the table the storage migration may have moved, and asking after the registry
   // write would leave a repair recorded while the runtime refresh below cannot describe the table.
-  const { resolveComponentTypeColumn, registerComponentRuntimeSchema } =
-    await import("./field-group-table-provisioning");
+  const { resolveComponentTypeColumn } = await import(
+    "./field-group-table-provisioning"
+  );
   const typeColumn = await resolveComponentTypeColumn(
     adapter,
     existing.tableName
@@ -272,6 +318,102 @@ export async function reconcileFieldGroup(args: {
     expectedColumnDefault: await expectedColumnDefaultResolver(dialect),
     structuralColumnDefaults: await structuralColumnDefaults(dialect),
   });
+
+  return { existing, plan, typeColumn, dialect };
+}
+
+/**
+ * What reconciling this field group WOULD do, without doing any of it.
+ *
+ * Reports blockers rather than throwing on them: a refusal thrown from the repair carries its
+ * blockers in `logContext`, which never reaches the caller, so the operator is told only that
+ * something is ambiguous. Here each one is named, and the caller can explain them individually.
+ *
+ * Writes nothing and registers nothing, so it is safe to run on any group at any time.
+ */
+export async function previewFieldGroupReconcile(
+  args: ReconcileAssessmentArgs
+): Promise<ReconcileFieldGroupPreview> {
+  const { existing, plan } = await assessFieldGroupReconcile(args);
+
+  return {
+    slug: args.slug,
+    localized: plan.localized,
+    removed: plan.removed,
+    repaired: plan.repaired,
+    adopted: plan.adopted,
+    blockers: plan.blockers,
+    unchanged: plan.unchanged,
+    schemaVersion: existing.schemaVersion,
+  };
+}
+
+/**
+ * Reconcile one field group's registry row against its live tables.
+ *
+ * Preconditions are `assessFieldGroupReconcile`'s, which this shares with the preview.
+ */
+export async function reconcileFieldGroup(args: {
+  registry: FieldGroupRegistryService;
+  adapter: DrizzleAdapter;
+  logger: Logger;
+  slug: string;
+  /**
+   * The code sync is asking, so a LOCKED group may be repaired.
+   *
+   * Never settable from the HTTP surface: the dispatcher does not pass it. It exists so the caller
+   * that owns a code-managed definition can clear a marker that would otherwise leave the group
+   * unreachable from both directions — a locked row marked `diverged` is refused by
+   * `assertNotDiverged` on the sync path and by the lock check here.
+   *
+   * Wired: `syncCodeFirstComponents` passes it when it finds a `diverged` code-managed row, so
+   * that state clears on the next sync rather than needing a hand-edited database.
+   */
+  fromCode?: boolean;
+  /**
+   * The version a PREVIEW was computed against, when this apply is approving one.
+   *
+   * 🔴 Without it an approved plan and the executed plan are different questions. The operator
+   * reads a preview describing two removals, the row moves, they confirm, and this function
+   * re-plans against the newer row and may remove five — having been told about two. Supplying it
+   * makes the repair refuse instead, so an approval can only ever apply to the state it was shown.
+   *
+   * Omitted by a caller with no preview to honour (the code sync), which keeps repairing against
+   * whatever it reads.
+   */
+  expectedSchemaVersion?: number;
+}): Promise<ReconcileFieldGroupResult> {
+  const { registry, adapter, logger, slug } = args;
+
+  const { existing, plan, typeColumn, dialect } =
+    await assessFieldGroupReconcile(args);
+
+  // Imported here rather than in the assessment: only the repair points the running process at a
+  // new shape. A preview that pulled this in would be loading the code that performs the change it
+  // exists to avoid performing.
+  const { registerComponentRuntimeSchema } = await import(
+    "./field-group-table-provisioning"
+  );
+
+  // 🔴 Refused BEFORE the repair is described or attempted, so an operator approving a preview can
+  // never apply a different plan than the one they read. The conditional write below would also
+  // reject this, but only after the whole repair had been planned against a row the operator never
+  // saw — and its message names a race rather than a stale approval.
+  if (
+    args.expectedSchemaVersion !== undefined &&
+    args.expectedSchemaVersion !== existing.schemaVersion
+  ) {
+    throw NextlyError.conflict({
+      reason: "state",
+      message: `"${slug}" changed after the repair was previewed, so the preview no longer describes it. Nothing was written. Preview it again and review the new plan before applying.`,
+      logContext: {
+        reason: "reconcile-preview-stale",
+        slug,
+        expectedSchemaVersion: args.expectedSchemaVersion,
+        actualSchemaVersion: existing.schemaVersion,
+      },
+    });
+  }
 
   // 🔴 REFUSE before writing anything when the tables hold a state the planner can see but must
   // not decide — a column on both tables, a column whose physical type no longer matches its

--- a/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-reconcile-service.ts
@@ -92,8 +92,22 @@ export interface ReconcileFieldGroupPreview {
   adopted: ReconcileAdoption[];
   /** Non-empty means the repair would REFUSE. Nothing here is applicable until each is resolved. */
   blockers: ReconcileBlocker[];
-  /** True when the definition already describes the tables, so applying would write nothing. */
+  /**
+   * True when the definition already describes the tables.
+   *
+   * This is NOT the same as "applying does nothing" — read `wouldWrite` for that. A group whose
+   * every field matches can still carry a stale failure mark, and clearing that is a write.
+   */
   unchanged: boolean;
+  /** Whether applying would write at all, decided by the same expression the repair uses. */
+  wouldWrite: boolean;
+  /**
+   * The stale status applying would clear, when one stands over healthy tables.
+   *
+   * Present so the surface can say WHY applying still does something on a group it just described
+   * as unchanged, rather than showing an empty change list beside an enabled button.
+   */
+  staleStatus?: string;
   /**
    * The version this plan was computed against.
    *
@@ -210,12 +224,34 @@ async function expectedColumnDefaultResolver(
   };
 }
 
+/**
+ * A status that MEANS unhealthy, so a reconcile that finds the tables fine still has work to do.
+ *
+ * `failed` counts alongside `diverged`, and it is the commoner way in: a create whose table landed
+ * and whose verification query failed records `failed` over a table that may already match the
+ * definition exactly. Listing the statuses that mean unhealthy, rather than testing for one of
+ * them, is what keeps a status added later from silently becoming permanent.
+ */
+const UNHEALTHY_STATUSES = new Set(["diverged", "failed"]);
+
 /** What the preview and the repair both need before either can decide anything. */
 interface ReconcileAssessment {
   existing: Awaited<ReturnType<FieldGroupRegistryService["getComponent"]>>;
   plan: ReconcilePlan<FieldDefinition>;
   typeColumn: string;
   dialect: SupportedDialect;
+  /** A standing failure mark over tables the plan found healthy — stale, and itself a repair. */
+  markerStandsWrongly: boolean;
+  /**
+   * Whether applying would write at all.
+   *
+   * 🔴 Computed HERE so the preview and the repair cannot disagree about it. `plan.unchanged`
+   * alone answers a narrower question — whether the DEFINITION describes the tables — and a group
+   * whose definition matches while its status still reads `diverged` needs a write that
+   * `plan.unchanged` does not predict. A preview deriving "nothing will happen" from the plan
+   * would report exactly that, and then the apply would bump the version.
+   */
+  wouldWrite: boolean;
 }
 
 /** The inputs that decide a plan. The repair takes more; none of the extra changes the plan. */
@@ -319,7 +355,18 @@ async function assessFieldGroupReconcile(
     structuralColumnDefaults: await structuralColumnDefaults(dialect),
   });
 
-  return { existing, plan, typeColumn, dialect };
+  const markerStandsWrongly = UNHEALTHY_STATUSES.has(
+    existing.migrationStatus ?? ""
+  );
+
+  return {
+    existing,
+    plan,
+    typeColumn,
+    dialect,
+    markerStandsWrongly,
+    wouldWrite: !(plan.unchanged && !markerStandsWrongly),
+  };
 }
 
 /**
@@ -334,7 +381,8 @@ async function assessFieldGroupReconcile(
 export async function previewFieldGroupReconcile(
   args: ReconcileAssessmentArgs
 ): Promise<ReconcileFieldGroupPreview> {
-  const { existing, plan } = await assessFieldGroupReconcile(args);
+  const { existing, plan, markerStandsWrongly, wouldWrite } =
+    await assessFieldGroupReconcile(args);
 
   return {
     slug: args.slug,
@@ -344,6 +392,10 @@ export async function previewFieldGroupReconcile(
     adopted: plan.adopted,
     blockers: plan.blockers,
     unchanged: plan.unchanged,
+    wouldWrite,
+    ...(markerStandsWrongly && existing.migrationStatus
+      ? { staleStatus: existing.migrationStatus }
+      : {}),
     schemaVersion: existing.schemaVersion,
   };
 }
@@ -385,7 +437,7 @@ export async function reconcileFieldGroup(args: {
 }): Promise<ReconcileFieldGroupResult> {
   const { registry, adapter, logger, slug } = args;
 
-  const { existing, plan, typeColumn, dialect } =
+  const { existing, plan, typeColumn, dialect, wouldWrite } =
     await assessFieldGroupReconcile(args);
 
   // Imported here rather than in the assessment: only the repair points the running process at a
@@ -449,20 +501,10 @@ export async function reconcileFieldGroup(args: {
 
   // A standing failure mark is itself part of what this operation repairs: once the definition
   // describes the tables, leaving the mark would keep refusing schema edits on a group that is
-  // now fine — the plan can be unchanged while the STATUS is still the thing that is wrong.
-  //
-  // `failed` counts for the same reason `diverged` does, and it is the commoner way in: a create
-  // whose table landed and whose verification query failed records `failed` over a table that may
-  // already match the definition exactly. Introspection has just proved whether it does, so the
-  // status is stale in precisely the way this operation exists to clear. Listing the statuses that
-  // MEAN unhealthy, rather than testing for one of them, is what keeps a status added later from
-  // silently becoming permanent.
-  const UNHEALTHY_STATUSES = new Set(["diverged", "failed"]);
-  const markerStandsWrongly = UNHEALTHY_STATUSES.has(
-    existing.migrationStatus ?? ""
-  );
-
-  if (plan.unchanged && !markerStandsWrongly) {
+  // now fine — the plan can be unchanged while the STATUS is still the thing that is wrong. That
+  // is why the decision is `wouldWrite` rather than `plan.unchanged`, and why it is computed in
+  // the assessment: the preview reports the same value, so it can never promise a quiet apply.
+  if (!wouldWrite) {
     // Nothing to WRITE — and writing anyway would bump the version and invalidate every open
     // editor for a repair that repaired nothing.
     //

--- a/packages/nextly/src/field-group-reconcile.ts
+++ b/packages/nextly/src/field-group-reconcile.ts
@@ -1,0 +1,34 @@
+/**
+ * The shapes a field-group reconcile reports, for whoever renders them.
+ *
+ * ## Why this is a public entry point
+ *
+ * The reconcile surface has to show a repair by IDENTITY — which field lost its column, which
+ * column was adopted under a guessed type, which drift refused the whole operation — because a
+ * count cannot tell an operator whether the thing they care about is in the list. That means the
+ * admin renders these structures rather than a message, and rendering them needs the types.
+ *
+ * Published as its own subpath rather than reached for through the package root: the root pulls in
+ * the runtime, and the only thing a renderer needs here is the vocabulary. Everything below is a
+ * TYPE, so this entry contributes no runtime code to a browser bundle at all.
+ *
+ * Re-exported rather than re-declared. A second copy of these shapes in the admin would agree with
+ * the service on the day it was written and drift silently afterwards, and the drift would surface
+ * as a repair summary quietly missing a category — which is the one failure this surface exists to
+ * prevent.
+ *
+ * @module field-group-reconcile
+ */
+
+export type {
+  ReconcileFieldGroupPreview,
+  ReconcileFieldGroupResult,
+} from "./domains/field-groups/services/field-group-reconcile-service";
+
+export type {
+  ReconcileAdoption,
+  ReconcileBlocker,
+  ReconcileRemoval,
+  ReconcileRepair,
+  ReconcileTable,
+} from "./domains/field-groups/services/reconcile-field-group-plan";

--- a/packages/nextly/src/route-handler/__tests__/field-group-routes.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/field-group-routes.test.ts
@@ -36,6 +36,28 @@ describe("field group REST routes", () => {
     expect(apply.service).toBe("field-groups");
   });
 
+  it("separates the reconcile preview from the repair by VERB, on one path", () => {
+    // The two share a path and differ only in method, so the risk is one branch swallowing the
+    // other: a GET falling through to the repair would apply a change nobody asked for, and a POST
+    // caught by the preview would report a repair it never performed. Both directions are pinned
+    // here because each reads as working from the other's side.
+    const preview = parseRestRoute(
+      ["field-groups", "schema", "seo", "reconcile"],
+      "GET"
+    );
+    expect(preview.service).toBe("field-groups");
+    expect(preview.method).toBe("previewComponentReconcile");
+    expect(preview.routeParams?.slug).toBe("seo");
+
+    const apply = parseRestRoute(
+      ["field-groups", "schema", "seo", "reconcile"],
+      "POST"
+    );
+    expect(apply.service).toBe("field-groups");
+    expect(apply.method).toBe("reconcileComponent");
+    expect(apply.routeParams?.slug).toBe("seo");
+  });
+
   it("no longer answers on the pre-rename segment", () => {
     // Removed rather than aliased, so it must resolve to nothing at all — not
     // merely to something other than `field-groups`, which would still pass if

--- a/packages/nextly/src/route-handler/__tests__/route-parser-auth.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser-auth.test.ts
@@ -35,6 +35,10 @@ describe("component route auth tier", () => {
       "previewComponentSchemaChanges",
       "applyComponentSchemaChanges",
       "reconcileComponent",
+      // Writes nothing, and still belongs in this list: it reports live column shapes and the
+      // drift against the stored definition, so it must be no more reachable than the repair it
+      // describes. Its verb is GET, which is exactly why leaving it out would be easy.
+      "previewComponentReconcile",
     ]) {
       expect(isPublicEndpoint("field-groups", method)).toBe(false);
       expect(requiresAuthOnly("field-groups", method)).toBe(false);

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -1410,6 +1410,28 @@ function parseComponentRoutes(
     };
   }
 
+  // GET /api/field-groups/schema/[slug]/reconcile → what that repair WOULD change, changing
+  // nothing. The same path as the repair below, separated by verb: GET asks, POST does.
+  //
+  // Classified as `update` rather than the `read` its verb implies, and the override in
+  // `routeHandler` is what enforces that. The plan names live columns and the drift between them
+  // and the stored definition, which is not something a principal who may only read definitions
+  // should be able to enumerate — and nobody who cannot perform the repair needs to preview it.
+  if (
+    id === "schema" &&
+    subresource &&
+    subId === "reconcile" &&
+    httpMethod === "GET"
+  ) {
+    routeParams.slug = subresource;
+    return {
+      service: "field-groups",
+      operation: "single",
+      method: "previewComponentReconcile",
+      routeParams,
+    };
+  }
+
   // POST /api/field-groups/schema/[slug]/reconcile → repair the stored definition to describe the
   // live tables. Classified as `update`: it writes the registry row, so it takes the same
   // authorization as the other definition writes — a reader must not be able to rewrite a

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -784,6 +784,11 @@ async function resolveAuthorization(
     const FIELD_GROUP_ACTION_OVERRIDES: Readonly<Record<string, string>> = {
       applyComponentSchemaChanges: "update",
       reconcileComponent: "update",
+      // The one entry here that makes the requirement STRICTER than its verb rather than merely
+      // correcting it: a GET would otherwise resolve to `read`. The repair plan exposes live
+      // column shapes and the drift against the stored definition, so it takes the permission the
+      // repair takes — a principal who may only read definitions must not enumerate that.
+      previewComponentReconcile: "update",
     };
     const action =
       FIELD_GROUP_ACTION_OVERRIDES[method] ?? getActionFromMethod(httpMethod);

--- a/packages/nextly/src/shared/__tests__/builder-access.test.ts
+++ b/packages/nextly/src/shared/__tests__/builder-access.test.ts
@@ -217,6 +217,7 @@ describe("the builder-guarded set stays joined to the dispatcher", () => {
       "previewComponentSchemaChanges",
       "applyComponentSchemaChanges",
       "reconcileComponent",
+      "previewComponentReconcile",
     ].filter(method => isBuilderRoute("field-groups", method));
 
     // The population first: an empty list would satisfy every assertion below while proving that

--- a/packages/nextly/src/shared/builder-access.ts
+++ b/packages/nextly/src/shared/builder-access.ts
@@ -100,6 +100,10 @@ const BUILDER_METHODS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
       // the builder cannot run, the repair it feeds cannot either — and leaving it out would let
       // a direct call rewrite schema on a deployment whose builder is disabled.
       "reconcileComponent",
+      // Its preview belongs with it for the reason the other previews do: it exists to feed the
+      // builder's own repair dialog, and answering it where the repair cannot run would describe a
+      // change the caller has no way to make.
+      "previewComponentReconcile",
     ]),
   ],
 ]);

--- a/packages/nextly/tsup.config.js
+++ b/packages/nextly/tsup.config.js
@@ -86,6 +86,8 @@ const clientEntries = [
   "src/config.ts",
   "src/next.ts",
   "src/field-group-type.ts",
+  // Types only, consumed by the admin's reconcile surface. Contributes no runtime code.
+  "src/field-group-reconcile.ts",
   // Pure serializable data, consumed by the admin's field pickers and by plugins.
   "src/collections/fields/catalog.ts",
 ];


### PR DESCRIPTION
PR-2 of the components → field groups transition. PR-1 (the reconcile operation) merged as #863, #880, #882, #883 and #886; it built the repair and left it unreachable. This makes it reachable, and shows the operator what it will do before it does it.

## The problem

A field group is marked `diverged` when its tables changed and the record describing them did not. That state refuses every schema edit until the record is repaired. The repair existed on `main` with no caller: no CLI command, no admin control. An operator hitting it had nothing to do about it.

## What this adds

**A preview, then an apply, separated by verb on one path.**

- `GET /api/field-groups/schema/[slug]/reconcile` — what the repair would change. Writes nothing.
- `POST` on the same path — performs it, carrying the version the preview reported.

**In the admin**, the repair is offered in two places, and the second is the load-bearing one:

- a row action on any field group marked `diverged` or `failed`;
- a banner on the **builder page**, because that is where the refusal actually happens. A diverged field group loads and edits normally and only the *save* is refused (`assertNotDiverged`). An affordance living only on the list would let someone do the work, lose it to a refusal, and then navigate away to find the fix.

**The dialog shows the plan by identity, in three lists**, because they ask different things of the reader: corrected attributes are informational, removed fields state a loss that already happened in the database, and adopted columns are the only ones carrying follow-up work — their logical type is a *guess* made from the physical column, so an `email` column comes back as `text`.

## Design decisions worth reviewing

**Blockers ride in a success envelope, not an error.** The repair refuses on drift it must not decide. A thrown `NextlyError` carries its blockers in `logContext`, which `toResponseJSON` strips — so the browser could only ever receive one concatenated sentence. Publishing them structurally through the error channel would have meant widening `PublicData`, a closed union documented as safe by construction. The preview returns them as data instead, and the core error contract is untouched.

**The preview takes no schema-change exclusion.** Entering it with `issuesDdl: true` *creates a lock table* — a preview that writes to the database to describe a write. The storage migration's own dry run takes no lock for exactly this reason, so a preview stays usable with a read-only credential. The looser guarantee is sound here because the apply re-plans under the exclusion and refuses unless the row still carries the version the preview reported: a stale preview becomes a refusal, never a wrong write.

**The apply accepts `expectedSchemaVersion`.** Without it an operator approves one plan and a different one executes. The pre-existing compare-and-set does **not** cover this — verified by break control: with the new guard disabled, the apply *succeeds* against a moved row.

**`GET` is classified as `update`, not the `read` its verb implies.** The plan exposes live column shapes and the drift against the stored definition; nobody who cannot perform the repair needs to enumerate that. The override in `routeHandler` is what enforces it.

**One shared assessment decides the plan AND whether applying writes.** `plan.unchanged` answers a narrower question than "would this write" — a group whose fields already match can still carry a stale `diverged` mark, and clearing that is a write. Computing them separately made the preview promise a quiet apply that then bumped the version; that defect was found and fixed in this PR, and the stale-marker integration test is its regression guard.

## Verification

- **Integration 133/133**, exit 0, across PostgreSQL, MySQL and SQLite. Baseline was 121; this adds 4 tests × 3 dialects.
- `check-types` exit 0 on `nextly`, `adapter-drizzle` and `admin`; `pnpm lint` exit 0 (23/23); `check-drizzle-v1-legacy`, `check:storage-format-literals`, `check-comment-convention` all exit 0.
- Admin dialog suite 7/7.
- **Five break controls**, each failing for the property under test and only that:
  - disabling the GET route branch → the URL resolves to `getComponent` instead;
  - unregistering the dispatcher method → the builder-guard join test names it;
  - deriving `wouldWrite` from `plan.unchanged` → the stale-marker test fails on all three dialects;
  - disabling the stale-approval guard → the apply *succeeds* where it must refuse;
  - sending a fixed version from the dialog → the approval test fails `42` vs `1`.

## Pre-existing, not introduced here

`pnpm --filter nextly test -- field-group` reports **5 failures on this branch and on `main` alike**. Four are one stale mock: `field-group-route-delegates.test.ts` mocks `../../di` without `isServicesRegistered`, which `bootView` has required since fb1d2baf0 (#782, 2026-08-14). The fifth is the long-standing `deleteComponentDataInTransaction`. Every file in that call path is unchanged by this branch; the only edit to `builder-access.ts` is one added string. Left alone rather than fixed here so this PR stays about one thing.

## Deliberately not fixed

Extra path segments are silently ignored, so `POST /field-groups/schema/<slug>/reconcile/anything` performs the repair. This affects the pre-existing `preview` and `apply` routes too, and closing it means changing `parseComponentRoutes`' signature and altering three shipped endpoints' behaviour. Its own change, not this one.
