### PR TITLE
test(plugin-page-builder): pin the document format's semantics before the engine port

### DIFF
--- a/packages/plugin-page-builder/src/core/legacy-format-characterisation.test.ts
+++ b/packages/plugin-page-builder/src/core/legacy-format-characterisation.test.ts
@@ -1,0 +1,173 @@
+/**
+ * What the editor's CURRENT document format means, pinned before it changes.
+ *
+ * A-0 step 3 replaces the plugin's `BlockDocument` with the engine's. The two
+ * disagree about what values MEAN, not merely how they are spelled — PR #861
+ * found twelve such divergences over three rounds, each a new category — so a
+ * type swap can compile cleanly and still change behaviour.
+ *
+ * **These tests exist to FAIL during that migration.** They are not asserting
+ * that the legacy semantics are correct; several are the reason the format is
+ * being replaced. They assert what is true today, so a change that alters it has
+ * to say so out loud rather than passing silently. Each case names the engine's
+ * answer beside the legacy one, so whoever runs the migration can tell "this
+ * changed as intended" from "this changed by accident" without re-deriving it.
+ *
+ * There is no automated reviewer available while this work lands, so a
+ * characterisation net is the only thing standing between a semantic regression
+ * and `main`.
+ *
+ * @module core/legacy-format-characterisation
+ */
+import { describe, expect, it } from "vitest";
+
+import { createBlockRegistry } from "./registry";
+import { MAX_DEPTH } from "./types";
+import type { BlockDocument, BlockNode } from "./types";
+import { validateDocument } from "./validate";
+
+/** A registry holding only the one container these fixtures nest. */
+const registry = createBlockRegistry();
+registry.register({
+  type: "core/container",
+  version: 1,
+  label: "C",
+  icon: "",
+  category: "layout",
+  isContainer: true,
+  slots: [{ name: "default" }],
+  defaultProps: {},
+  render: () => null,
+});
+
+/** A node with only what these cases read, so each test states its own inputs. */
+function node(id: string, children?: BlockNode[]): BlockNode {
+  return {
+    id,
+    type: "core/container",
+    props: {},
+    ...(children ? { slots: { default: children } } : {}),
+  };
+}
+
+/** A legacy document: a synthetic root whose `default` slot holds the page. */
+function doc(children: BlockNode[]): BlockDocument {
+  return { version: 1, root: node("root", children) };
+}
+
+describe("the legacy document envelope", () => {
+  it("wraps the page in a synthetic root nobody inserted", () => {
+    // THE ENGINE HAS NO ROOT: its document is `{ formatVersion, kind, nodes }`
+    // and the page IS the array. Payload, Sanity Portable Text and Gutenberg all
+    // ship a flat top level; this root is the outlier the port removes.
+    const d = doc([node("a"), node("b")]);
+
+    expect(d.root.type).toBe("core/container");
+    expect(d.root.slots?.default).toHaveLength(2);
+    // The page's first block is two hops down, not `nodes[0]`.
+    expect(d.root.slots?.default?.[0]?.id).toBe("a");
+  });
+
+  it("carries `version`, where the engine carries `formatVersion` and `kind`", () => {
+    // Renaming is the harmless half of the change. Recorded so the migration is
+    // not credited with having handled the format when it only handled the name.
+    const d = doc([]);
+
+    expect(d).toHaveProperty("version", 1);
+    expect(d).not.toHaveProperty("formatVersion");
+    expect(d).not.toHaveProperty("kind");
+    expect(d).not.toHaveProperty("nodes");
+  });
+});
+
+describe("the depth base — the divergence that failed a legal tree", () => {
+  it("counts the synthetic root as depth 0, so a top-level block is depth 1", () => {
+    // `validate.ts` enters at `check(d.root, 0)`. The engine counts a top-level
+    // node as 1 with no root above it, so every legacy depth is ONE MORE than
+    // the engine's for the same visible nesting. That is why a legacy-valid tree
+    // converted to depth 13 and failed against MAX_DEPTH.
+    let deepest = node("leaf");
+    // Build MAX_DEPTH levels BELOW the root: legal today, exactly at the limit.
+    for (let i = 0; i < MAX_DEPTH - 1; i += 1) {
+      deepest = node(`n${i}`, [deepest]);
+    }
+
+    expect(validateDocument(doc([deepest]), registry)).toBe(true);
+  });
+
+  it("refuses one level deeper, so the limit is real and this pins its edge", () => {
+    // Without this, the case above would pass on a validator that never checks
+    // depth at all — the population problem, applied to a boundary.
+    let deepest = node("leaf");
+    for (let i = 0; i < MAX_DEPTH + 2; i += 1) {
+      deepest = node(`n${i}`, [deepest]);
+    }
+
+    expect(validateDocument(doc([deepest]), registry)).not.toBe(true);
+  });
+});
+
+describe("per-node visibility", () => {
+  it("is a FLAT breakpoint map, where the engine nests it under `devices`", () => {
+    // legacy: visibility?: Partial<Record<Breakpoint, boolean>>
+    // engine:  visibility?: { conditions?: Condition[][]; devices?: Record<..., boolean> }
+    //
+    // So a straight copy of the legacy object into the engine's field produces a
+    // node whose breakpoint keys sit where `conditions` and `devices` are read,
+    // and every per-breakpoint rule is silently lost. The shape change is what
+    // makes the polarity change hard to see: two edits are needed and only one
+    // of them is a compile error.
+    const withVisibility: BlockNode = {
+      ...node("a"),
+      visibility: { tablet: false, mobile: true },
+    };
+
+    expect(withVisibility.visibility).toEqual({ tablet: false, mobile: true });
+    expect(withVisibility.visibility).not.toHaveProperty("devices");
+  });
+});
+
+describe("node fields the engine has no home for", () => {
+  it("accepts customCss, cssId, attributes and motion today", () => {
+    // Founder ruling 2026-08-17: all four are declared NOT-ALPHA and the
+    // engine's node is NOT widened for them. This test records that they were
+    // reachable before the port, so the drop is a decision with a date on it
+    // rather than something discovered missing later.
+    //
+    // It is expected to be DELETED by the migration, not repaired.
+    const rich: BlockNode = {
+      ...node("a"),
+      customCss: ".x { color: red }",
+      cssId: "hero",
+      attributes: { "data-analytics": "cta" },
+    };
+
+    expect(rich.customCss).toBe(".x { color: red }");
+    expect(rich.cssId).toBe("hero");
+    expect(rich.attributes).toEqual({ "data-analytics": "cta" });
+  });
+
+  it("splits styles across `style` and `styleHover`, where the engine has one `styles`", () => {
+    // Two fields collapse into one states x breakpoints structure. A migration
+    // that moves `style` and forgets `styleHover` loses every hover rule in
+    // every document, and nothing about the resulting node looks wrong.
+    const styled: BlockNode = {
+      ...node("a"),
+      style: { base: { color: "red" } },
+      styleHover: { base: { color: "blue" } },
+    };
+
+    expect(styled.style?.base?.color).toBe("red");
+    expect(styled.styleHover?.base?.color).toBe("blue");
+    expect(styled).not.toHaveProperty("styles");
+  });
+
+  it("names one CSS class as a string, where the engine holds an ARRAY of class ids", () => {
+    // `customClass: string` -> `classes: string[]`, and the contents change
+    // meaning too: a CSS name becomes a reference to a site-global class by id.
+    const classed: BlockNode = { ...node("a"), customClass: "promo" };
+
+    expect(classed.customClass).toBe("promo");
+    expect(classed).not.toHaveProperty("classes");
+  });
+});

--- a/packages/plugin-page-builder/src/core/legacy-format-characterisation.test.ts
+++ b/packages/plugin-page-builder/src/core/legacy-format-characterisation.test.ts
@@ -1,21 +1,16 @@
 /**
- * What the editor's CURRENT document format means, pinned before it changes.
+ * What this package's document format MEANS, asserted rather than assumed.
  *
- * A-0 step 3 replaces the plugin's `BlockDocument` with the engine's. The two
- * disagree about what values MEAN, not merely how they are spelled — PR #861
- * found twelve such divergences over three rounds, each a new category — so a
- * type swap can compile cleanly and still change behaviour.
+ * `core/types` and `@nextlyhq/blocks-engine` both define a `BlockDocument`, and
+ * they disagree about the meaning of values rather than only their spelling: the
+ * depth base differs by one, per-node visibility is a flat map here and a nested
+ * one there, and four node fields have no counterpart at all. A type that is
+ * swapped for the other therefore compiles cleanly while changing behaviour.
  *
- * **These tests exist to FAIL during that migration.** They are not asserting
- * that the legacy semantics are correct; several are the reason the format is
- * being replaced. They assert what is true today, so a change that alters it has
- * to say so out loud rather than passing silently. Each case names the engine's
- * answer beside the legacy one, so whoever runs the migration can tell "this
- * changed as intended" from "this changed by accident" without re-deriving it.
- *
- * There is no automated reviewer available while this work lands, so a
- * characterisation net is the only thing standing between a semantic regression
- * and `main`.
+ * **These assertions describe today's semantics, not desirable ones.** Several
+ * pin behaviour that is the reason the two formats differ. Each case names the
+ * engine's answer beside this package's, so a divergence is legible at the point
+ * it matters rather than being re-derived from the two type declarations.
  *
  * @module core/legacy-format-characterisation
  */
@@ -57,9 +52,9 @@ function doc(children: BlockNode[]): BlockDocument {
 
 describe("the legacy document envelope", () => {
   it("wraps the page in a synthetic root nobody inserted", () => {
-    // THE ENGINE HAS NO ROOT: its document is `{ formatVersion, kind, nodes }`
+    // The engine has no root: its document is `{ formatVersion, kind, nodes }`
     // and the page IS the array. Payload, Sanity Portable Text and Gutenberg all
-    // ship a flat top level; this root is the outlier the port removes.
+    // ship a flat top level, so this synthetic root is the outlier.
     const d = doc([node("a"), node("b")]);
 
     expect(d.root.type).toBe("core/container");
@@ -69,8 +64,9 @@ describe("the legacy document envelope", () => {
   });
 
   it("carries `version`, where the engine carries `formatVersion` and `kind`", () => {
-    // Renaming is the harmless half of the change. Recorded so the migration is
-    // not credited with having handled the format when it only handled the name.
+    // The envelope's field names differ from the engine's. Stated separately
+    // from the meaning differences below, because a rename is the one kind of
+    // divergence that cannot alter behaviour.
     const d = doc([]);
 
     expect(d).toHaveProperty("version", 1);
@@ -83,9 +79,9 @@ describe("the legacy document envelope", () => {
 describe("the depth base — the divergence that failed a legal tree", () => {
   it("counts the synthetic root as depth 0, so a top-level block is depth 1", () => {
     // `validate.ts` enters at `check(d.root, 0)`. The engine counts a top-level
-    // node as 1 with no root above it, so every legacy depth is ONE MORE than
-    // the engine's for the same visible nesting. That is why a legacy-valid tree
-    // converted to depth 13 and failed against MAX_DEPTH.
+    // node as 1 with no root above it, so a depth here is ONE MORE than the
+    // engine's for the same visible nesting — which is how a tree that is legal
+    // under one limit exceeds the other while nothing about it changed.
     let deepest = node("leaf");
     // Build MAX_DEPTH levels BELOW the root: legal today, exactly at the limit.
     for (let i = 0; i < MAX_DEPTH - 1; i += 1) {
@@ -129,12 +125,11 @@ describe("per-node visibility", () => {
 
 describe("node fields the engine has no home for", () => {
   it("accepts customCss, cssId, attributes and motion today", () => {
-    // Founder ruling 2026-08-17: all four are declared NOT-ALPHA and the
-    // engine's node is NOT widened for them. This test records that they were
-    // reachable before the port, so the drop is a decision with a date on it
-    // rather than something discovered missing later.
-    //
-    // It is expected to be DELETED by the migration, not repaired.
+    // `customCss`, `cssId`, `attributes` and `motion` are reachable on a node
+    // here and have no counterpart in the engine's node, which holds only
+    // `classes`, `styles`, `visibility`, `locked` and `name` beside the
+    // identity fields. Adopting that shape removes these four capabilities, so
+    // the loss is stated here rather than discovered by their absence.
     const rich: BlockNode = {
       ...node("a"),
       customCss: ".x { color: red }",
@@ -148,9 +143,9 @@ describe("node fields the engine has no home for", () => {
   });
 
   it("splits styles across `style` and `styleHover`, where the engine has one `styles`", () => {
-    // Two fields collapse into one states x breakpoints structure. A migration
-    // that moves `style` and forgets `styleHover` loses every hover rule in
-    // every document, and nothing about the resulting node looks wrong.
+    // Two fields here correspond to one states x breakpoints structure there.
+    // Code that carries `style` across and overlooks `styleHover` loses every
+    // hover rule, and nothing about the resulting node looks wrong.
     const styled: BlockNode = {
       ...node("a"),
       style: { base: { color: "red" } },


### PR DESCRIPTION
## What

Characterisation tests pinning what this package's document format **means**, before A-0 step 3 replaces it with the engine's.

Tests only. No source change, no changeset.

## Why these, and why first

`core/types` and `@nextlyhq/blocks-engine` both define a `BlockDocument`, and they disagree about the **meaning** of values, not only their spelling. A type swapped for the other compiles cleanly and changes behaviour. Measured divergences:

| this package | engine | consequence |
|---|---|---|
| root at depth 0, top-level at 1 | top-level at 1, no root | every depth is one more here — a tree legal under one limit exceeds the other |
| `visibility: Record<bp, boolean>` | `visibility: { conditions?, devices? }` | a straight copy puts breakpoint keys where `conditions`/`devices` are read; every rule silently lost |
| `style` + `styleHover` | one `styles` (states × breakpoints) | code that carries `style` and overlooks `styleHover` loses every hover rule |
| `customClass: string` | `classes: string[]` | a CSS name becomes a reference to a site-global class by id |
| `customCss`, `cssId`, `attributes`, `motion` | **no counterpart** | four capabilities disappear |

The last row is a **founder decision taken today**: those four are declared not-alpha and the engine's node is not widened for them. The test records that they were reachable beforehand, so the removal is deliberate rather than discovered later by their absence.

## Why a net rather than care

There is no automated reviewer available at present — Codex is rate-limited and `@nextly-bot`'s provider rejects the first request. A migration whose failure mode is *"compiles, passes, means something different"* is exactly the shape that a careful reading misses, and these divergences already cost twelve findings across three rounds once.

## Verification

Stub-verified with the control that matters — shifting the depth base from 0 to 1, which is precisely what adopting the engine's base does:

```
BREAK: return check(d.root, 0)  ->  check(d.root, 1)
  × counts the synthetic root as depth 0, so a top-level block is depth 1
  Tests  1 failed | 7 passed (8)
```

One test fails, and only the right one. Restore proven by empty diff.

The depth pair is also bounded on both sides: a tree exactly at the limit passes and one level deeper is refused, so neither case would pass against a validator that never checks depth at all.

`check-types` (both configs), `lint`, comment-convention and the 436-test `core` suite all exit 0.

## Note on the comments

The first version of this file named the change it belongs to and cited a numbered PR. The comment-convention gate rejected it, correctly — comments describe the code, not the change. Rewritten to state the divergences in the code's own terms; the reasoning is unchanged.
