### PR TITLE
feat(admin): record recovery points from the entry editor

### DIFF
--- a/.changeset/admin-autosave-wiring.md
+++ b/.changeset/admin-autosave-wiring.md
@@ -1,0 +1,37 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+feat(admin): record recovery points from the entry editor
+
+Mounts the autosave hook in the entry editor and shows its state in the header
+action cluster, which is what makes server-side recovery points reachable for
+the first time: the endpoints, the transport and the hook all existed with
+nothing calling them.
+
+Recording engages only once an entry has an id, since the endpoint addresses a
+document that exists, and pauses while a real save is in flight so a snapshot
+cannot describe a state that never existed.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -22,6 +22,7 @@ import { historyEnabledFrom } from "@admin/components/features/versions/history-
 import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { useGeneralSettings } from "@admin/hooks/queries/useGeneralSettings";
 import { useAutoSlug } from "@admin/hooks/useAutoSlug";
+import { useDocumentAutosave } from "@admin/hooks/useDocumentAutosave";
 import { useEntryFormShortcuts } from "@admin/hooks/useKeyboardShortcuts";
 import { useLocalization } from "@admin/hooks/useLocalization";
 import { usePreviewLink } from "@admin/hooks/usePreviewLink";
@@ -362,6 +363,31 @@ export function EntryForm({
   // reachable, since the control that would call it is not rendered.
   const { data: generalSettings } = useGeneralSettings();
   const savedEntryId = entry?.id === undefined ? "" : String(entry.id);
+
+  // Recovery points for this author, recorded while they type. Addressed only
+  // once the entry has an id: a document that has never been saved has nothing
+  // for the endpoint to address, and `null` turns recording off rather than
+  // inventing one.
+  const autosaveScope = useMemo(
+    () =>
+      savedEntryId === ""
+        ? null
+        : {
+            kind: "collection" as const,
+            slug: collection.name,
+            entryId: savedEntryId,
+          },
+    [savedEntryId, collection.name]
+  );
+  const autosave = useDocumentAutosave({
+    scope: autosaveScope,
+    form,
+    locale: locale ?? null,
+    // Held off while a real save is in flight. The document is about to change
+    // underneath the snapshot, so a recovery point written now would describe a
+    // state that never existed.
+    enabled: !isSubmitting,
+  });
   const linkLocale = previewLinkLocale({
     localized: collection.localized === true,
     locale,
@@ -476,6 +502,8 @@ export function EntryForm({
                   draftsEnabled={collection.draftsEnabled === true}
                   isSubmitting={isSubmitting}
                   isDirty={isDirty}
+                  autosaveStatus={autosave.status}
+                  autosaveLastSavedAt={autosave.lastSavedAt}
                   entry={entry}
                   collectionSlug={collection.name}
                   historyFields={getCollectionFields(collection)}

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -22,7 +22,10 @@ import { historyEnabledFrom } from "@admin/components/features/versions/history-
 import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { useGeneralSettings } from "@admin/hooks/queries/useGeneralSettings";
 import { useAutoSlug } from "@admin/hooks/useAutoSlug";
-import { useDocumentAutosave } from "@admin/hooks/useDocumentAutosave";
+import {
+  autosaveScopeFor,
+  useDocumentAutosave,
+} from "@admin/hooks/useDocumentAutosave";
 import { useEntryFormShortcuts } from "@admin/hooks/useKeyboardShortcuts";
 import { useLocalization } from "@admin/hooks/useLocalization";
 import { usePreviewLink } from "@admin/hooks/usePreviewLink";
@@ -369,14 +372,7 @@ export function EntryForm({
   // for the endpoint to address, and `null` turns recording off rather than
   // inventing one.
   const autosaveScope = useMemo(
-    () =>
-      savedEntryId === ""
-        ? null
-        : {
-            kind: "collection" as const,
-            slug: collection.name,
-            entryId: savedEntryId,
-          },
+    () => autosaveScopeFor("collection", collection.name, savedEntryId),
     [savedEntryId, collection.name]
   );
   const autosave = useDocumentAutosave({

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -27,12 +27,14 @@ import {
   Trash2,
 } from "@admin/components/icons";
 import { useCan } from "@admin/hooks/useCan";
+import type { AutosaveStatus } from "@admin/hooks/useDocumentAutosave";
 import { useLocalization } from "@admin/hooks/useLocalization";
 import { cn } from "@admin/lib/utils";
 
 import { useEntryLocale } from "../EntryLocaleContext";
 import { LanguageSwitcher } from "../LanguageSwitcher";
 
+import { AutoSaveIndicator } from "./AutoSaveIndicator";
 import { DiscardDraftConfirmDialog } from "./DiscardDraftConfirmDialog";
 import { effectiveEntryStatus } from "./entry-address";
 import { PreviewActions } from "./PreviewActions";
@@ -68,6 +70,10 @@ export interface EntrySystemHeaderProps {
   isInvalid?: boolean;
   /** Whether the form has unsaved changes. Toggles Discard menu item. */
   isDirty?: boolean;
+  /** Recording state of this author's recovery point. */
+  autosaveStatus?: AutosaveStatus;
+  /** When the server last stored a recovery point, by the server's clock. */
+  autosaveLastSavedAt?: Date | null;
   /** Form id for the single submit button when drafts are off. */
   formId?: string;
   /** Entry data; needed for Show JSON dialog (entry id) and Duplicate (id). */
@@ -209,6 +215,8 @@ export function EntrySystemHeader({
   isSubmitting = false,
   isInvalid = false,
   isDirty = false,
+  autosaveStatus = "idle",
+  autosaveLastSavedAt = null,
   formId = "entry-form",
   entry,
   collectionSlug,
@@ -405,6 +413,17 @@ export function EntrySystemHeader({
           isCopyingLink={isCopyingLink}
           disabled={isSubmitting}
         />
+        {/* Sits with the actions rather than beside the title: it reports on
+            the same work the save buttons act on, and reads as status for that
+            cluster. Rendered only where recording can happen, so an unsaved new
+            entry shows nothing rather than a permanently idle indicator. */}
+        {autosaveStatus !== "idle" || autosaveLastSavedAt ? (
+          <AutoSaveIndicator
+            lastSavedAt={autosaveLastSavedAt}
+            isSaving={autosaveStatus === "saving"}
+            isDirty={isDirty}
+          />
+        ) : null}
         {hasStatus && isPublishedEdit ? (
           <>
             <Button

--- a/packages/admin/src/hooks/__tests__/useDocumentAutosave.test.tsx
+++ b/packages/admin/src/hooks/__tests__/useDocumentAutosave.test.tsx
@@ -18,7 +18,7 @@ vi.mock("@admin/services/versionApi", () => ({
   versionApi: { saveAutosave: saveSpy },
 }));
 
-import { useDocumentAutosave } from "../useDocumentAutosave";
+import { autosaveScopeFor, useDocumentAutosave } from "../useDocumentAutosave";
 
 const SCOPE = { kind: "collection" as const, slug: "posts", entryId: "e1" };
 const DEBOUNCE = 2000;
@@ -209,5 +209,45 @@ describe("useDocumentAutosave", () => {
     // Still dirty, still editable: a failed recording changes nothing about
     // the form it was taken from.
     expect(result.current.isDirty).toBe(true);
+  });
+});
+
+/**
+ * The rule that decides whether recording happens at all, kept out of the
+ * editors so it is answered once and can be asserted directly.
+ *
+ * A rendered editor cannot cover this cheaply, and leaving it inline meant the
+ * guard could be removed with no test moving.
+ */
+describe("autosaveScopeFor", () => {
+  it("addresses a saved collection entry by its id", () => {
+    expect(autosaveScopeFor("collection", "posts", "e1")).toEqual({
+      kind: "collection",
+      slug: "posts",
+      entryId: "e1",
+    });
+  });
+
+  it("addresses a saved Single by its document id", () => {
+    expect(autosaveScopeFor("single", "settings", "s1")).toEqual({
+      kind: "single",
+      slug: "settings",
+      documentId: "s1",
+    });
+  });
+
+  /**
+   * The guard. An entry that has never been saved has no id, and the endpoint
+   * addresses a document that exists -- so recording must be OFF rather than
+   * aimed at an empty or invented id, which would address a route that cannot
+   * resolve.
+   */
+  it("refuses to address a document that has never been saved", () => {
+    expect(autosaveScopeFor("collection", "posts", "")).toBeNull();
+    expect(autosaveScopeFor("single", "settings", "")).toBeNull();
+  });
+
+  it("refuses to address a document with no slug", () => {
+    expect(autosaveScopeFor("collection", "", "e1")).toBeNull();
   });
 });

--- a/packages/admin/src/hooks/useDocumentAutosave.ts
+++ b/packages/admin/src/hooks/useDocumentAutosave.ts
@@ -25,6 +25,31 @@ import { versionApi, type VersionScope } from "@admin/services/versionApi";
 /** How long to wait after the last keystroke before recording. */
 const DEFAULT_DEBOUNCE_MS = 2000;
 
+/**
+ * The document to record against, or `null` when there is not one yet.
+ *
+ * Extracted as a function rather than written inline at each editor because it
+ * encodes a rule that is easy to lose in a ternary: a document with no id has
+ * nothing for the endpoint to address, and passing an empty or placeholder id
+ * would address a document that does not exist. Both editors ask the same
+ * question, and answering it twice is how the two drift apart.
+ *
+ * @param kind - which document family this editor edits
+ * @param slug - the collection or Single slug
+ * @param documentId - the SAVED id, empty while the document has never been saved
+ * @returns an addressable scope, or `null` when recording must stay off
+ */
+export function autosaveScopeFor(
+  kind: "collection" | "single",
+  slug: string,
+  documentId: string
+): VersionScope | null {
+  if (documentId === "" || slug === "") return null;
+  return kind === "single"
+    ? { kind: "single", slug, documentId }
+    : { kind: "collection", slug, entryId: documentId };
+}
+
 export type AutosaveStatus = "idle" | "saving" | "saved" | "error";
 
 export interface UseDocumentAutosaveOptions {


### PR DESCRIPTION
The point at which autosave becomes reachable for a user. Everything before this
existed and was called by nothing.

## What changes

The entry editor mounts `useDocumentAutosave` and reports its state in the
header action cluster, beside the save buttons, because it reports on the same
work those buttons act on.

Two conditions gate recording, and both are deliberate:

- **Addressed only once the entry has an id.** The endpoint addresses a document
  that exists, so a new entry that has never been saved has nothing to write to.
  `scope: null` turns recording off rather than inventing an address.
- **Held off while a real save is in flight.** The document is about to change
  underneath the snapshot, so a recovery point written then would describe a
  state that never existed.

The indicator renders only where recording can happen, so an unsaved new entry
shows nothing rather than a permanently idle indicator.

## A gap found by break-verifying, then closed

Worth recording because the first version of this PR shipped the rule uncovered.

Break-verifying the unsaved-entry guard moved NOTHING: forcing the scope to be
addressed even with no entry id left all 152 tests passing. The rule was written
inline in the editor, where only a rendered-component test could reach it, and
no such test exists.

Rather than add a heavy render harness, the rule is now a pure function beside
the hook, `autosaveScopeFor`, and asserted directly. Re-broken after the change:
removing the guard fails 2 tests.

That placement earns its keep twice. Both editors ask the same question, so
answering it once is also what stops the entry editor and Singles drifting apart
when Singles are wired.

## Verification

- 17 test files / 160 tests green across the entry editor and the hook
- `check-types` + `lint` 11/11 for `@nextlyhq/admin`
- `check:comments` clean, changeset validated against the lockstep group

### One environmental note

`check-types` initially failed on `nextly/field-group-reconcile`, a subpath added
by #904. `pnpm --filter nextly... build` cleared it completely. It is the
missing-`dist` case, not a regression, and it is worth flagging because the error
names another lane's module while appearing in this branch's run.

## Not done yet

- Singles get the same treatment in the next PR.
- Recovery ON LOAD (`getAutosave` plus the existing `DraftRecoveryDialog`, which
  is still rendered nowhere) is not in this PR. Until it lands, recovery points
  are written and never offered back, so this is half the loop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic saving for existing entries.
  * Added a visible autosave indicator showing saving activity and the most recent save time.
  * Autosave is paused while an entry is actively being submitted.
  * Autosave now supports both collection entries and single documents.

* **Bug Fixes**
  * Improved handling of incomplete entry details so autosave is not attempted without the required information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->