### PR TITLE
fix(admin): show the recovery-point indicator before the first recording

### DIFF
--- a/.changeset/admin-autosave-indicator-pending.md
+++ b/.changeset/admin-autosave-indicator-pending.md
@@ -1,0 +1,38 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(admin): show the recovery-point indicator before the first recording
+
+The entry header hid the indicator until a recording had happened, so the first
+edit to a saved entry showed nothing for the whole debounce window, which is
+exactly when a reader most needs telling their change is not stored yet.
+
+The header now asks only whether recording is possible at all. AutoSaveIndicator
+already returns nothing when it has no state to report, so the header restating
+that was a duplicate that could disagree with it.
+
+The indicator copy also described a local draft, which it no longer is.

--- a/packages/admin/src/components/features/entries/EntryForm/AutoSaveIndicator.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/AutoSaveIndicator.tsx
@@ -99,24 +99,24 @@ export function AutoSaveIndicator({
   if (isSaving) {
     icon = <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />;
     label = "Saving...";
-    tooltipContent = "Saving your changes locally";
+    tooltipContent = "Storing a recovery point";
   } else if (lastSavedAt) {
     const timeAgo = formatTimeAgo(lastSavedAt);
     if (isDirty) {
       icon = <Cloud className="h-4 w-4 text-muted-foreground" />;
       label = "Unsaved changes";
-      tooltipContent = `Draft saved ${timeAgo}. New changes pending...`;
+      tooltipContent = `Recovery point stored ${timeAgo}. Newer changes not in it yet.`;
     } else {
       // No dark variant: `success` is tuned to read in both modes, and
       // `success-500` aliases it, so the override said nothing.
       icon = <Check className="h-4 w-4 text-success" />;
       label = "Saved";
-      tooltipContent = `All changes saved ${timeAgo}`;
+      tooltipContent = `Recovery point stored ${timeAgo}`;
     }
   } else if (isDirty) {
     icon = <CloudOff className="h-4 w-4 text-muted-foreground" />;
     label = "Not saved";
-    tooltipContent = "Changes will be saved automatically";
+    tooltipContent = "A recovery point will be stored shortly";
   } else {
     // No changes, no saves - don't show anything
     return null;

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -498,6 +498,7 @@ export function EntryForm({
                   draftsEnabled={collection.draftsEnabled === true}
                   isSubmitting={isSubmitting}
                   isDirty={isDirty}
+                  autosaveEnabled={autosaveScope !== null}
                   autosaveStatus={autosave.status}
                   autosaveLastSavedAt={autosave.lastSavedAt}
                   entry={entry}

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -70,6 +70,11 @@ export interface EntrySystemHeaderProps {
   isInvalid?: boolean;
   /** Whether the form has unsaved changes. Toggles Discard menu item. */
   isDirty?: boolean;
+  /**
+   * Whether recording is possible for this document at all. False for an entry
+   * that has never been saved, which has no id for the endpoint to address.
+   */
+  autosaveEnabled?: boolean;
   /** Recording state of this author's recovery point. */
   autosaveStatus?: AutosaveStatus;
   /** When the server last stored a recovery point, by the server's clock. */
@@ -215,6 +220,7 @@ export function EntrySystemHeader({
   isSubmitting = false,
   isInvalid = false,
   isDirty = false,
+  autosaveEnabled = false,
   autosaveStatus = "idle",
   autosaveLastSavedAt = null,
   formId = "entry-form",
@@ -415,9 +421,16 @@ export function EntrySystemHeader({
         />
         {/* Sits with the actions rather than beside the title: it reports on
             the same work the save buttons act on, and reads as status for that
-            cluster. Rendered only where recording can happen, so an unsaved new
-            entry shows nothing rather than a permanently idle indicator. */}
-        {autosaveStatus !== "idle" || autosaveLastSavedAt ? (
+            cluster.
+
+            The condition is only whether recording is POSSIBLE, never whether
+            there is anything to show. `AutoSaveIndicator` already returns null
+            when it has no state to report, and restating that here suppressed
+            its "Not saved" state for the whole debounce window: on the first
+            edit to a saved entry the status is still idle and no recovery point
+            exists yet, which is exactly when the reader most wants to be told
+            their change is not stored. */}
+        {autosaveEnabled ? (
           <AutoSaveIndicator
             lastSavedAt={autosaveLastSavedAt}
             isSaving={autosaveStatus === "saving"}

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.autosave-indicator.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.autosave-indicator.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * When the recovery-point indicator is shown, and when it is not.
+ *
+ * The header's condition is only whether recording is POSSIBLE.
+ * `AutoSaveIndicator` already decides whether it has anything to report and
+ * returns null when it does not, so any second opinion here is a duplicate that
+ * can disagree with it -- and did: gating on "status is non-idle OR a recovery
+ * point exists" hid the indicator for the whole debounce window after the first
+ * edit, which is precisely when a reader most needs telling their change is not
+ * stored yet.
+ */
+import { useForm, FormProvider } from "react-hook-form";
+import { describe, it, expect, vi } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+import { EntrySystemHeader } from "../EntrySystemHeader";
+
+vi.mock("@admin/hooks/useCan", () => ({ useCan: () => true }));
+
+function Harness({
+  autosaveEnabled,
+  isDirty = false,
+  autosaveStatus = "idle" as const,
+  autosaveLastSavedAt = null,
+}: {
+  autosaveEnabled: boolean;
+  isDirty?: boolean;
+  autosaveStatus?: "idle" | "saving" | "saved" | "error";
+  autosaveLastSavedAt?: Date | null;
+}) {
+  const methods = useForm({ defaultValues: { title: "" } });
+  return (
+    <FormProvider {...methods}>
+      <EntrySystemHeader
+        mode="edit"
+        hasStatus
+        isDirty={isDirty}
+        entry={{ id: "e1", status: "draft" }}
+        collectionSlug="posts"
+        autosaveEnabled={autosaveEnabled}
+        autosaveStatus={autosaveStatus}
+        autosaveLastSavedAt={autosaveLastSavedAt}
+        onSaveDraft={vi.fn()}
+        onPublish={vi.fn()}
+        onSaveChanges={vi.fn()}
+        onSaveWorkingDraft={vi.fn()}
+        onUnpublish={vi.fn()}
+        onDiscardWorkingDraft={vi.fn()}
+      />
+    </FormProvider>
+  );
+}
+
+describe("EntrySystemHeader autosave indicator", () => {
+  /**
+   * The regression this file exists for. First edit to a saved entry: the
+   * debounce has not fired, so the status is still idle and no recovery point
+   * exists. The reader must still be told the change is not stored.
+   */
+  it("reports an unstored change before the first recording", () => {
+    render(<Harness autosaveEnabled isDirty />);
+
+    expect(screen.getByText(/not saved/i)).toBeInTheDocument();
+  });
+
+  it("reports a stored recovery point once one exists", () => {
+    render(
+      <Harness
+        autosaveEnabled
+        autosaveLastSavedAt={new Date("2026-08-17T09:00:00.000Z")}
+      />
+    );
+
+    expect(screen.getByText(/saved/i)).toBeInTheDocument();
+  });
+
+  it("reports the recording in progress", () => {
+    render(<Harness autosaveEnabled isDirty autosaveStatus="saving" />);
+
+    expect(screen.getByText(/saving/i)).toBeInTheDocument();
+  });
+
+  /**
+   * An entry that has never been saved has no id for the endpoint to address,
+   * so recording cannot happen and the indicator must stay absent rather than
+   * promise a recovery point that will never be written.
+   *
+   * Dirty here deliberately: `isDirty` alone would render "Not saved", so this
+   * separates "nothing to report" from "cannot record at all".
+   */
+  it("shows nothing while the document cannot be recorded against", () => {
+    render(<Harness autosaveEnabled={false} isDirty />);
+
+    expect(screen.queryByText(/not saved/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/saving/i)).not.toBeInTheDocument();
+  });
+
+  /**
+   * Enabled but with nothing to say: the component's own null return, not a
+   * condition restated in the header.
+   */
+  it("shows nothing when there is no change and no recovery point", () => {
+    render(<Harness autosaveEnabled />);
+
+    expect(screen.queryByText(/not saved/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Works a CodeRabbit finding on #906.

## The defect

`AutoSaveIndicator` has an `isDirty && !lastSavedAt` state: **"Not saved"**. My header condition (`status !== "idle" || lastSavedAt`) made it unreachable for the whole debounce window after the first edit to a saved entry, which is exactly when a reader most needs telling their change is not stored yet.

## The fix, narrower than the one proposed

The suggestion was to render when enabled AND (`isDirty` OR non-idle status OR a timestamp). That works, and it restates in the parent a decision the child already makes: the component returns `null` when it has nothing to report.

Two copies of one rule is how they drift, and **this finding is an instance of exactly that** -- my duplicate had already disagreed with the child. So the header now passes only a capability, `autosaveEnabled`, true when the document has an id to record against. Visibility stays in the component. Unsaved entries stay hidden, by the flag rather than by re-derivation.

## Copy correction, outside the finding's scope

The tooltips still described a local draft: "Saving your changes locally", "Draft saved". It is a server-side recovery point now, readable only by its own author and surviving a lost machine, so they said something untrue about where the work went.

## Coverage

There was **no test on this file at all**, which is why the regression was reachable. Added five cases, including the reported one and a negative control on an entry that cannot be recorded against -- deliberately dirty, so it separates "nothing to report" from "cannot record at all", which `isDirty` alone would conflate.

Break-verified: restoring the old condition fails the regression case and nothing else.

Gates: check-types + lint 11/11, 17 files / 157 tests green, changeset validated.