### PR TITLE
feat(blocks-react): a route emits the site stylesheet by default

### DIFF
--- a/.changeset/route-site-sheet.md
+++ b/.changeset/route-site-sheet.md
@@ -1,0 +1,49 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+feat(blocks-react): a route emits the site stylesheet by default
+
+`createBlocksPage` gains `siteStyles` and supplies a sheet by DEFAULT, unlike the
+bare `PageRenderer`. Without one, every `{ $token }` resolves to nothing — and a
+framework route is exactly where "it should already work" is the right answer.
+`PageRenderer` stays opt-in because a standalone consumer owns its own `<head>`
+and may already emit a token sheet; a Nextly route owns neither.
+
+Default-on was licensed by measurement rather than assumed safe: no block
+declares a token (enforced by a ratchet over every `baseStyles`) and no seeded or
+fixture document references one, so nothing's appearance can change by the
+definitions arriving.
+
+`breakpoints` falls back to `styleContext`'s, derived once — two answers to "what
+are this site's breakpoints" is how the shared sheet and the page sheet come to
+disagree about which at-rules a tier compiles under, invisibly, because each
+sheet is internally consistent on its own.
+
+The root entry now re-exports `SiteSheetInput` and its transitive closure
+(`SiteTokenSet`, `SiteToken`, `TokenKind`, `FontFaceDef`, `FontSource`,
+`DarkModeStrategy`), so a consumer can construct a site's design system rather
+than merely name the prop.

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -32,6 +32,28 @@ export {
 
 export { PageRenderer } from "./page-renderer";
 export type { PageRendererProps } from "./page-renderer";
+// Re-exported because `PageRendererProps.siteStyles` NAMES it, and a prop a
+// consumer cannot type is a prop they cannot pass without reaching past this
+// package into the engine. The type-surface ratchet is what caught it: a public
+// declaration naming an engine type the entry does not export is a surface that
+// compiles here and not at the call site.
+//
+// The rest are `SiteSheetInput`'s TRANSITIVE closure, and they are not padding.
+// Naming the outer type alone lets a consumer declare a variable and not build
+// one: the tokens are a `SiteTokenSet` of `SiteToken`s whose `kind` is a
+// `TokenKind`, the fonts are `FontFaceDef`s of `FontSource`s, and `darkMode` is
+// a `DarkModeStrategy`. A caller writing a site's design system needs every one
+// of them by name, so withholding any makes the prop typeable but unusable —
+// which is the same defect as not exporting the outer type, one level in.
+export type {
+  DarkModeStrategy,
+  FontFaceDef,
+  FontSource,
+  SiteSheetInput,
+  SiteToken,
+  SiteTokenSet,
+  TokenKind,
+} from "@nextlyhq/blocks-engine";
 
 export { BlockBoundary, BlockList } from "./block-boundary";
 export type { BlockBoundaryProps, BlockListProps } from "./block-boundary";

--- a/packages/blocks-react/src/next.test.ts
+++ b/packages/blocks-react/src/next.test.ts
@@ -1770,3 +1770,88 @@ describe("createBlocksPage", () => {
     expect(props.styles).toEqual(styles);
   });
 });
+
+describe("createBlocksPage and the site stylesheet", () => {
+  const BREAKPOINTS = {
+    viewport: [{ id: "base", label: "Desktop" }],
+    container: [],
+  };
+
+  it("supplies a site sheet BY DEFAULT, unlike the bare renderer", async () => {
+    // A route is where "it should already work" is the right answer: without a
+    // site sheet every `{ $token }` resolves to nothing, which is the defect
+    // this closes. `PageRenderer` stays opt-in because a standalone consumer
+    // owns its own `<head>`; a Nextly route owns neither.
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: reader({ slug: "about", content: document }),
+      styleContext: { breakpoints: BREAKPOINTS },
+    });
+
+    expect(props.siteStyles).toBeDefined();
+    expect(props.siteStyles?.breakpoints).toEqual(BREAKPOINTS);
+  });
+
+  it("reuses the breakpoints the site already stated", async () => {
+    // Two answers to "what are this site's breakpoints" is how the shared sheet
+    // and the page sheet come to disagree about which at-rules a tier compiles
+    // under — and the disagreement is invisible, because each sheet is
+    // internally consistent on its own.
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: reader({ slug: "about", content: document }),
+      styleContext: { breakpoints: BREAKPOINTS },
+    });
+
+    expect(props.siteStyles?.breakpoints).toBe(props.styleContext?.breakpoints);
+  });
+
+  it("lets the route state its own breakpoints instead", async () => {
+    const own = {
+      viewport: [{ id: "base", label: "Wide" }],
+      container: [],
+    };
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: reader({ slug: "about", content: document }),
+      styleContext: { breakpoints: BREAKPOINTS },
+      siteStyles: { breakpoints: own },
+    });
+
+    expect(props.siteStyles?.breakpoints).toEqual(own);
+  });
+
+  it("carries the site's own tokens through to the sheet", async () => {
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: reader({ slug: "about", content: document }),
+      styleContext: { breakpoints: BREAKPOINTS },
+      siteStyles: {
+        tokens: {
+          tokens: [
+            { name: "color.primary", kind: "color", values: { light: "#abc" } },
+          ],
+        },
+      },
+    });
+
+    expect(props.siteStyles?.tokens?.tokens[0]?.name).toBe("color.primary");
+  });
+
+  it("emits NO site sheet when the site states no breakpoints anywhere", async () => {
+    // A sheet compiled against breakpoints nobody chose would put the
+    // block-default tier under at-rules the page sheet does not use. Refusing is
+    // the answer that cannot silently disagree.
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: reader({ slug: "about", content: document }),
+    });
+
+    expect(props.siteStyles).toBeUndefined();
+  });
+});

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -24,6 +24,7 @@ import type {
   DocumentLimits,
   RemotePatternInput,
   SeoImageCandidate,
+  SiteSheetInput,
   StyleCompileContext,
 } from "@nextlyhq/blocks-engine";
 import type { Metadata } from "next";
@@ -118,6 +119,30 @@ export interface BlocksPageConfig
    * artifact yet. Ignored for an entry whose `styles` produced a sheet.
    */
   styleContext?: StyleCompileContext;
+  /**
+   * The site's design tokens, fonts and named classes — the sheet every page
+   * shares, emitted before the page's own.
+   *
+   * **A route supplies this by DEFAULT, unlike the bare renderer.** Omitting it
+   * still emits the default token set, because a `{ $token }` that resolves to
+   * nothing is the defect this exists to close and a framework route is exactly
+   * where "it should already work" is the right answer. `PageRenderer` stays
+   * opt-in because a standalone consumer owns its own `<head>` and may already
+   * emit a token sheet of its own; a Nextly route owns neither.
+   *
+   * Making it a default was licensed by measurement rather than assumed safe:
+   * no block declares a token (enforced by a ratchet over every `baseStyles`),
+   * and no seeded or fixture document references one — so there is nothing whose
+   * appearance can change by the definitions arriving. When that stops being
+   * true, the honest move is to measure again rather than to reason about it.
+   *
+   * `breakpoints` falls back to `styleContext`'s, because a site that stated its
+   * breakpoints once should not have to state them twice — and two answers to
+   * "what are this site's breakpoints" is how the shared sheet and the page
+   * sheet come to disagree about which at-rules a tier is emitted under.
+   */
+  siteStyles?: Omit<SiteSheetInput, "breakpoints"> &
+    Partial<Pick<SiteSheetInput, "breakpoints">>;
   /**
    * A dynamic collection to resolve media ids against, for a site storing its
    * images in one of its own.
@@ -1029,6 +1054,23 @@ function blocksRouteConfig(
         resolveEntryPath,
       });
 
+      // Derived ONCE, from the breakpoints the site already stated. A second
+      // answer to "what are this site's breakpoints" is how the shared sheet
+      // and the page sheet come to disagree about which at-rules a tier is
+      // emitted under — and the disagreement is invisible, because each sheet
+      // is internally consistent.
+      const siteBreakpoints =
+        config.siteStyles?.breakpoints ?? styleContext?.breakpoints;
+      // A route emits the site sheet by DEFAULT: without it every `{ $token }`
+      // resolves to nothing, which is the defect this closes. It needs a
+      // breakpoint set to compile the block-default tier under, so a route that
+      // states neither its own nor a style context gets no sheet rather than one
+      // compiled against breakpoints nobody chose.
+      const siteStyles =
+        siteBreakpoints === undefined
+          ? undefined
+          : { ...config.siteStyles, breakpoints: siteBreakpoints };
+
       return createElement(PageRenderer, {
         document,
         context: pageContext,
@@ -1037,6 +1079,7 @@ function blocksRouteConfig(
         styleContext,
         blockFallback,
         limits,
+        ...(siteStyles === undefined ? {} : { siteStyles }),
         // Spread conditionally: `PageRenderer` distinguishes an absent policy
         // from one present and undefined, and passing the second would state a
         // posture the site never chose.


### PR DESCRIPTION
Follows #903, which made the site stylesheet *possible*. This makes it **actual**: a Nextly route now emits it by default, so `{ $token }` resolves on a real published page rather than only when a host opts in.

## The split, and why it is not arbitrary

| | behaviour | reason |
| --- | --- | --- |
| `createBlocksPage` (a route) | **emits by default** | a framework route is where "it should already work" is the right answer; it owns the page's `<head>` |
| `PageRenderer` (bare) | **opt-in**, unchanged | a standalone consumer owns its own `<head>` and may already emit a token sheet of its own |

## Default-on was measured, not assumed

The landing risk on this step was always "a stored `{ $token }` that currently dangles starts applying, and a page whose appearance depends on that moves". So it was checked rather than reasoned about:

- **no block declares a token** — enforced by the #896 ratchet, which walks every `baseStyles` to the leaf
- **no seeded or fixture document references one** — 0 files across `apps/`, `templates/`, `e2e/` (positive control: 2 files in that scope carry `styles`, so the search works)

Nothing's appearance can change by the definitions arriving. When that stops being true, the honest move is to measure again rather than reason about it.

## `breakpoints` is derived ONCE

It falls back to `styleContext`'s. **Two answers to "what are this site's breakpoints" is how the shared sheet and the page sheet come to disagree about which at-rules a tier compiles under** — and the disagreement is invisible, because each sheet is internally consistent on its own.

A route stating neither gets **no sheet**, rather than one compiled against breakpoints nobody chose.

## Two ratchet findings worth reading

`type-surface.test.ts` caught a real DX defect in two stages, and both are the same shape one level apart:

1. `PageRendererProps.siteStyles` **named** `SiteSheetInput` while the entry withheld it — a prop that compiles here and not at the call site.
2. Exporting the outer type alone let a consumer **declare** a design system without being able to **build** one. Its transitive closure — `SiteTokenSet`, `SiteToken`, `TokenKind`, `FontFaceDef`, `FontSource`, `DarkModeStrategy` — is what a caller writing tokens actually needs by name.

Both are now re-exported. I fixed (1), the ratchet then reported (2), which is the guard doing exactly what it exists for.

## Verification

- `blocks-react` **595/595**, `plugin-page-builder` **828/828**, both exit 0 — the consuming package against a freshly rebuilt `dist`
- `lint` and `check-types` exit 0 across `blocks-engine`, `blocks-react`, `plugin-page-builder`
- five new route tests: default-on, breakpoint reuse (asserted by identity), a route's own breakpoints winning, tokens carried through, and no sheet when the site states no breakpoints anywhere

## 🔴 Sequencing note for the canvas lane

**The next step is held deliberately.** Moving `blockBases` from the page sheet into the shared sheet means **a consumer emitting only the page sheet loses every block-type default** — `core/columns` stops being a grid, `core/card` stops clipping, in the editor preview only.

The PoC canvas has its own style compiler and its own `--nx-*` convention, so it does not receive this sheet. **I will not land that move until the canvas emits the site sheet.** Flagged to lane 09 already.
