### PR TITLE
fix(admin): tidy the sidebar chrome — divider, settings order, brand mark

### DIFF
--- a/.changeset/admin-sidebar-chrome.md
+++ b/.changeset/admin-sidebar-chrome.md
@@ -1,0 +1,36 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Tidy up the admin sidebar.
+
+The Settings panel now lists system configuration before user administration,
+and its groups are declared as data, so a group's heading appears only when it
+actually has something under it.
+
+On the dashboard, the collapsed secondary panel no longer draws a stray second
+line beside the icon rail, and no longer nudges the page a pixel to the right.
+
+The built-in Nextly mark sits on a rounded tile in the sidebar and takes its
+colours from the theme in both light and dark mode. A logo you have configured
+yourself is left exactly as you uploaded it.

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -503,7 +503,8 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
           className="mb-8 flex items-center justify-center h-10 w-10 group"
         >
           <ThemeAwareLogo
-            className="w-6 h-6 object-contain"
+            boxed
+            className="w-8 h-8 object-contain"
             alt={branding.logoText ?? "Logo"}
           />
         </Link>

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -30,6 +30,7 @@ import type { ApiCollection } from "@admin/types/entities";
 import { hasPluginsSection } from "./lib/has-plugins-section";
 import { isSubSidebarCategory, isSubSidebarOpen } from "./lib/has-sub-sidebar";
 import { resolveItemHref as resolveItemHrefHelper } from "./lib/resolve-item-href";
+import { subSidebarBorderClass } from "./lib/sub-sidebar-classes";
 import type { MainMenuCategory, MainMenuItem } from "./sidebar-types";
 import { getFilteredMenuItems } from "./sidebar-types";
 import { SubSidebarContent } from "./SubSidebarContent";
@@ -576,8 +577,9 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
         className={cn(
           "flex flex-col bg-background overflow-hidden shrink-0",
           isMobile
-            ? "relative flex  border-l border-border"
-            : "border-r border-border fixed inset-y-0 left-[72px] z-45 lg:static lg:flex", // Absolute on tablet, static on desktop
+            ? "relative flex"
+            : "fixed inset-y-0 left-[72px] z-45 lg:static lg:flex", // Absolute on tablet, static on desktop
+          subSidebarBorderClass({ isMobile, hasSubSidebar }),
           hasSubSidebar
             ? "w-64 opacity-100 translate-x-0"
             : "w-0 opacity-0 -translate-x-full pointer-events-none lg:w-0 lg:-translate-x-0",

--- a/packages/admin/src/components/layout/sidebar/SubSidebarContent.tsx
+++ b/packages/admin/src/components/layout/sidebar/SubSidebarContent.tsx
@@ -3,24 +3,12 @@ import { DynamicPluginNav } from "@admin/components/features/dashboard/DynamicPl
 import { DynamicPluginSectionItems } from "@admin/components/features/dashboard/DynamicPluginSectionItems";
 import { DynamicSingleNav } from "@admin/components/features/dashboard/DynamicSingleNav";
 import * as Icons from "@admin/components/icons";
-import {
-  Layers,
-  Settings,
-  Puzzle,
-  Users,
-  ShieldAlert,
-  Mail,
-  Key,
-  List,
-  FileText,
-  Database,
-  Image,
-  Webhook,
-} from "@admin/components/icons";
+import { Layers, Puzzle, FileText, Database } from "@admin/components/icons";
 import { Link } from "@admin/components/ui/link";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import type { ApiCollection } from "@admin/types/entities";
 
+import { visibleSettingsNav } from "./lib/settings-nav";
 import { MediaSidebarContent } from "./MediaSidebarContent";
 import type { MainMenuCategory } from "./sidebar-types";
 import { SidebarSearch } from "./SidebarSearch";
@@ -202,178 +190,52 @@ export function SubSidebarContent({
   }
 
   if (selectedMain === "settings") {
+    const groups = visibleSettingsNav({
+      hasPermission,
+      canAccessApiKeys,
+      canAccessWebhooks,
+    });
+
     return (
       <div className="space-y-8 px-4 py-6">
-        {/* User Management Group — Users, User Fields, and Roles moved here
-            from the former top-level Users icon (id "manage"), which no
-            longer has its own main-menu entry. */}
-        <div className="space-y-1">
-          {(hasPermission("read-users") ||
-            hasPermission("manage-settings") ||
-            hasPermission("read-roles")) && (
-            <p className="text-xs font-bold uppercase tracking-wider text-sidebar-foreground px-3 mb-2">
-              User Management
-            </p>
-          )}
-          <SidebarMenu>
-            {hasPermission("read-users") && (
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={
-                    isActive(ROUTES.USERS) && !isActive(ROUTES.USERS_FIELDS)
-                  }
-                  className="justify-start px-3"
-                >
-                  <Link href={ROUTES.USERS}>
-                    <Users className="h-4 w-4" />
-                    <span>Users</span>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
+        {groups.map(group => (
+          <div key={group.id} className="space-y-1">
+            {group.items.length > 0 && (
+              <p className="text-xs font-bold uppercase tracking-wider text-sidebar-foreground px-3 mb-2">
+                {group.label}
+              </p>
             )}
-            {hasPermission("manage-settings") && (
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={isActive(ROUTES.USERS_FIELDS)}
-                  className="justify-start px-3"
-                >
-                  <Link href={ROUTES.USERS_FIELDS}>
-                    <List className="h-4 w-4" />
-                    <span>User Fields</span>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            )}
-            {hasPermission("read-roles") && (
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={isActive(ROUTES.SECURITY_ROLES)}
-                  className="justify-start px-3"
-                >
-                  <Link href={ROUTES.SECURITY_ROLES}>
-                    <ShieldAlert className="h-4 w-4" />
-                    <span>Roles</span>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            )}
-          </SidebarMenu>
-          {/* Plugin collections explicitly placed under the old "users"
-              section follow User Management, matching the prior grouping. */}
-          <DynamicPluginSectionItems placement="users" isActive={isActive} />
-        </div>
+            <SidebarMenu>
+              {group.items.map(item => {
+                const ItemIcon = item.icon;
+                const active =
+                  isActive(item.href, item.exact) &&
+                  !(item.excludedBy ?? []).some(href => isActive(href));
 
-        {/* System Settings Group */}
-        <div className="space-y-1">
-          {(hasPermission("manage-settings") ||
-            canAccessApiKeys ||
-            canAccessWebhooks) && (
-            <p className="text-xs font-bold uppercase tracking-wider text-sidebar-foreground px-3 mb-2">
-              System Settings
-            </p>
-          )}
-          <SidebarMenu>
-            {hasPermission("manage-settings") && (
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={isActive(ROUTES.SETTINGS, true)}
-                  className="justify-start px-3"
-                >
-                  <Link href={ROUTES.SETTINGS}>
-                    <Settings className="h-4 w-4" />
-                    <span>General</span>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
+                return (
+                  <SidebarMenuItem key={item.id}>
+                    <SidebarMenuButton
+                      asChild
+                      isActive={active}
+                      className="justify-start px-3"
+                    >
+                      <Link href={item.href}>
+                        <ItemIcon className="h-4 w-4" />
+                        <span>{item.label}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                );
+              })}
+            </SidebarMenu>
+            {group.pluginPlacement && (
+              <DynamicPluginSectionItems
+                placement={group.pluginPlacement}
+                isActive={isActive}
+              />
             )}
-            {canAccessApiKeys && (
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={isActive(ROUTES.SETTINGS_API_KEYS)}
-                  className="justify-start px-3"
-                >
-                  <Link href={ROUTES.SETTINGS_API_KEYS}>
-                    <Key className="h-4 w-4" />
-                    <span>API Keys</span>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            )}
-            {canAccessWebhooks && (
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={isActive(ROUTES.SETTINGS_WEBHOOKS)}
-                  className="justify-start px-3"
-                >
-                  <Link href={ROUTES.SETTINGS_WEBHOOKS}>
-                    <Webhook className="h-4 w-4" />
-                    <span>Webhooks</span>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            )}
-            {hasPermission("manage-settings") && (
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={isActive(ROUTES.SETTINGS_IMAGE_SIZES)}
-                  className="justify-start px-3"
-                >
-                  <Link href={ROUTES.SETTINGS_IMAGE_SIZES}>
-                    <Image className="h-4 w-4" />
-                    <span>Image Sizes</span>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            )}
-          </SidebarMenu>
-        </div>
-
-        {/* Email Configuration Group */}
-        <div className="space-y-1">
-          {(hasPermission("manage-email-providers") ||
-            hasPermission("manage-email-templates")) && (
-            <p className="text-xs font-bold uppercase tracking-wider text-sidebar-foreground px-3 mb-2">
-              Email Configuration
-            </p>
-          )}
-          <SidebarMenu>
-            {hasPermission("manage-email-providers") && (
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={isActive(ROUTES.SETTINGS_EMAIL_PROVIDERS)}
-                  className="justify-start px-3"
-                >
-                  <Link href={ROUTES.SETTINGS_EMAIL_PROVIDERS}>
-                    <Mail className="h-4 w-4" />
-                    <span>Providers</span>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            )}
-            {hasPermission("manage-email-templates") && (
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={isActive(ROUTES.SETTINGS_EMAIL_TEMPLATES)}
-                  className="justify-start px-3"
-                >
-                  <Link href={ROUTES.SETTINGS_EMAIL_TEMPLATES}>
-                    <FileText className="h-4 w-4" />
-                    <span>Templates</span>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            )}
-          </SidebarMenu>
-        </div>
+          </div>
+        ))}
         <DynamicPluginSectionItems placement="settings" isActive={isActive} />
       </div>
     );

--- a/packages/admin/src/components/layout/sidebar/__tests__/settings-nav.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/settings-nav.test.ts
@@ -1,0 +1,145 @@
+/**
+ * The Settings panel's navigation table.
+ *
+ * These assert the table itself rather than a render, which is the reason it is
+ * a table: order, visibility and grouping are decidable from the data, so they
+ * can be checked without standing up the sidebar and its providers.
+ */
+import { describe, expect, it } from "vitest";
+
+import { ROUTES } from "@admin/constants/routes";
+
+import {
+  SETTINGS_NAV,
+  isSettingsNavItemVisible,
+  visibleSettingsNav,
+  type SettingsNavAccess,
+} from "../lib/settings-nav";
+
+/** Sees everything, so a hidden entry is the table's doing and not the gate's. */
+const superuser: SettingsNavAccess = {
+  hasPermission: () => true,
+  canAccessApiKeys: true,
+  canAccessWebhooks: true,
+};
+
+/** Sees nothing. */
+const nobody: SettingsNavAccess = {
+  hasPermission: () => false,
+  canAccessApiKeys: false,
+  canAccessWebhooks: false,
+};
+
+/** Sees exactly one permission, and no capability. */
+const only = (permission: string): SettingsNavAccess => ({
+  hasPermission: p => p === permission,
+  canAccessApiKeys: false,
+  canAccessWebhooks: false,
+});
+
+const allItems = SETTINGS_NAV.flatMap(g => g.items);
+
+describe("settings nav table", () => {
+  it("configures the system before the people in it", () => {
+    expect(visibleSettingsNav(superuser).map(g => g.id)).toEqual([
+      "system",
+      "email",
+      "users",
+    ]);
+  });
+
+  it("is a non-empty table with unique group and item ids", () => {
+    // Population first: every assertion below is about members of this table,
+    // and an empty or duplicated table satisfies most of them vacuously.
+    expect(SETTINGS_NAV.length).toBeGreaterThan(0);
+    expect(allItems.length).toBeGreaterThan(0);
+
+    const groupIds = SETTINGS_NAV.map(g => g.id);
+    expect(new Set(groupIds).size).toBe(groupIds.length);
+
+    const itemIds = allItems.map(i => i.id);
+    expect(new Set(itemIds).size).toBe(itemIds.length);
+  });
+
+  it("routes every destination through the route table", () => {
+    // A path composed by hand tracks the page file's location, and the router
+    // does not: `pages/dashboard/roles/create.tsx` is served at
+    // `/admin/security/roles/create`. Requiring each href to be a declared
+    // route makes that divergence impossible to introduce here.
+    const declared = new Set<string>(Object.values(ROUTES));
+    for (const item of allItems) {
+      expect(declared, `${item.id} -> ${item.href}`).toContain(item.href);
+    }
+  });
+});
+
+describe("visibility", () => {
+  it("shows nothing to a reader with no permissions, except a plugin slot", () => {
+    const groups = visibleSettingsNav(nobody);
+
+    // The users group survives with zero of its OWN items because it carries a
+    // plugin slot whose contents this table does not gate.
+    expect(groups.map(g => g.id)).toEqual(["users"]);
+    expect(groups[0].items).toHaveLength(0);
+    expect(groups[0].pluginPlacement).toBe("users");
+  });
+
+  it("never presents a group heading with no destinations under it", () => {
+    // The property the derived heading exists to guarantee. Previously each
+    // group restated its items' permissions in its own heading condition, so a
+    // new item under a new permission would appear with no heading above it.
+    // Exercised against every permission the table mentions, one at a time.
+    const permissions = [
+      ...new Set(
+        allItems
+          .filter(i => i.gate.kind === "permission")
+          .map(i => (i.gate as { permission: string }).permission)
+      ),
+    ];
+    expect(permissions.length).toBeGreaterThan(0);
+
+    for (const permission of permissions) {
+      for (const group of visibleSettingsNav(only(permission))) {
+        if (group.items.length === 0) {
+          // Only a plugin-slot group may be empty, and it renders no heading.
+          expect(group.pluginPlacement).toBeDefined();
+          continue;
+        }
+        expect(group.items.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("gates the two capability-backed destinations independently", () => {
+    const apiOnly: SettingsNavAccess = {
+      hasPermission: () => false,
+      canAccessApiKeys: true,
+      canAccessWebhooks: false,
+    };
+
+    const visible = visibleSettingsNav(apiOnly).flatMap(g =>
+      g.items.map(i => i.id)
+    );
+    expect(visible).toContain("api-keys");
+    expect(visible).not.toContain("webhooks");
+  });
+
+  it("honours each destination's own gate", () => {
+    for (const item of allItems) {
+      expect(
+        isSettingsNavItemVisible(item, superuser),
+        `${item.id} hidden from a reader who may see everything`
+      ).toBe(true);
+      expect(
+        isSettingsNavItemVisible(item, nobody),
+        `${item.id} shown to a reader who may see nothing`
+      ).toBe(false);
+    }
+  });
+
+  it("leaves the source table untouched when filtering", () => {
+    const before = SETTINGS_NAV.map(g => g.items.length);
+    visibleSettingsNav(nobody);
+    expect(SETTINGS_NAV.map(g => g.items.length)).toEqual(before);
+  });
+});

--- a/packages/admin/src/components/layout/sidebar/__tests__/sub-sidebar-classes.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/sub-sidebar-classes.test.ts
@@ -1,0 +1,63 @@
+/**
+ * The secondary panel draws a divider only when it has width.
+ *
+ * The panel stays mounted while closed so the transition has something to
+ * animate, so "closed" is a zero-width box rather than an absent element. A
+ * border on a zero-width box is still a 1px box, and in the wide layout the
+ * closed panel keeps its opacity — so an unconditional border renders a second
+ * vertical line a pixel from the rail's own, and widens the panel from 0 to 1.
+ *
+ * The assertion is "no border utility at all" rather than "not `border-r`",
+ * because the defect is a painted edge and any side would paint one.
+ */
+import { describe, expect, it } from "vitest";
+
+import { subSidebarBorderClass } from "../lib/sub-sidebar-classes";
+
+describe("subSidebarBorderClass", () => {
+  it("draws nothing when the panel is collapsed, in either layout", () => {
+    for (const isMobile of [true, false]) {
+      expect(subSidebarBorderClass({ isMobile, hasSubSidebar: false })).toBe(
+        ""
+      );
+    }
+  });
+
+  it("divides on the right when the panel sits in flow beside the rail", () => {
+    expect(
+      subSidebarBorderClass({ isMobile: false, hasSubSidebar: true })
+    ).toContain("border-r");
+  });
+
+  it("divides on the left when the panel overlays from the left edge", () => {
+    expect(
+      subSidebarBorderClass({ isMobile: true, hasSubSidebar: true })
+    ).toContain("border-l");
+  });
+
+  it("pairs every border side with the token that colours it", () => {
+    // A side utility with no colour utility inherits `currentColor`, which is
+    // the text colour rather than the divider token, so the panel would still
+    // paint an edge and it would be the wrong one.
+    for (const isMobile of [true, false]) {
+      const className = subSidebarBorderClass({
+        isMobile,
+        hasSubSidebar: true,
+      });
+      expect(className).toContain("border-border");
+    }
+  });
+
+  it("emits no border utility of any side while collapsed", () => {
+    // The separating property: an implementation that swapped `border-r` for
+    // `border-l` when collapsed would satisfy the first case's exact-match on
+    // "" only by accident. This states the invariant the pixel depends on.
+    for (const isMobile of [true, false]) {
+      const className = subSidebarBorderClass({
+        isMobile,
+        hasSubSidebar: false,
+      });
+      expect(className).not.toMatch(/\bborder(-[a-z]+)?\b/);
+    }
+  });
+});

--- a/packages/admin/src/components/layout/sidebar/__tests__/sub-sidebar-classes.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/sub-sidebar-classes.test.ts
@@ -48,6 +48,15 @@ describe("subSidebarBorderClass", () => {
     }
   });
 
+  it("treats an unresolved layout as the wide one", () => {
+    // The media query has no answer on the first render. Choosing the narrow
+    // arrangement there would divide on the wrong side and then switch sides
+    // once it resolves, moving the panel on the first paint of every load.
+    expect(
+      subSidebarBorderClass({ isMobile: undefined, hasSubSidebar: true })
+    ).toBe(subSidebarBorderClass({ isMobile: false, hasSubSidebar: true }));
+  });
+
   it("emits no border utility of any side while collapsed", () => {
     // The separating property: an implementation that swapped `border-r` for
     // `border-l` when collapsed would satisfy the first case's exact-match on

--- a/packages/admin/src/components/layout/sidebar/lib/settings-nav.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/settings-nav.ts
@@ -1,0 +1,200 @@
+/**
+ * The Settings panel's navigation, declared as data.
+ *
+ * Order is the order of this list, so changing it is a data edit rather than
+ * moving JSX. Each destination states its own visibility gate once, and a
+ * group's heading is DERIVED from whether any of its destinations survive that
+ * gate — a group that computes its own heading condition alongside its items is
+ * a second answer to the same question, and the two drift the moment an item is
+ * added, showing destinations under no heading to whoever holds only the new
+ * permission.
+ */
+import {
+  FileText,
+  Image,
+  Key,
+  List,
+  Mail,
+  Settings,
+  ShieldAlert,
+  Users,
+  Webhook,
+} from "@admin/components/icons";
+import { ROUTES } from "@admin/constants/routes";
+
+/**
+ * What a destination needs before it is shown.
+ *
+ * Kept as data rather than a predicate so the whole table stays comparable and
+ * assertable without a renderer. `capability` covers the two access answers the
+ * panel receives already resolved, because they are computed from more than a
+ * single permission name.
+ */
+export type SettingsNavGate =
+  | { kind: "permission"; permission: string }
+  | { kind: "capability"; capability: "apiKeys" | "webhooks" };
+
+export interface SettingsNavItem {
+  id: string;
+  label: string;
+  icon: typeof Settings;
+  href: string;
+  gate: SettingsNavGate;
+  /**
+   * Match the route exactly instead of by prefix, for a destination whose path
+   * is a prefix of its siblings'.
+   */
+  exact?: boolean;
+  /**
+   * Sibling routes that own a path nested under this one. Without it, a parent
+   * highlights alongside the child the reader actually navigated to.
+   */
+  excludedBy?: readonly string[];
+}
+
+export interface SettingsNavGroup {
+  id: string;
+  label: string;
+  items: readonly SettingsNavItem[];
+  /**
+   * A plugin contribution slot rendered after this group's own destinations,
+   * for plugins that asked to appear beside a particular section.
+   */
+  pluginPlacement?: "users";
+}
+
+/**
+ * Configuration of the system comes before configuration of the people in it.
+ *
+ * The two groups that configure the installation sit together rather than being
+ * separated by the group that administers accounts, which is also the split
+ * every comparable admin makes: Strapi declares its global application settings
+ * ahead of its administration-panel settings, and Directus keeps project
+ * settings apart from roles and permissions.
+ */
+export const SETTINGS_NAV: readonly SettingsNavGroup[] = [
+  {
+    id: "system",
+    label: "System Settings",
+    items: [
+      {
+        id: "general",
+        label: "General",
+        icon: Settings,
+        href: ROUTES.SETTINGS,
+        gate: { kind: "permission", permission: "manage-settings" },
+        exact: true,
+      },
+      {
+        id: "api-keys",
+        label: "API Keys",
+        icon: Key,
+        href: ROUTES.SETTINGS_API_KEYS,
+        gate: { kind: "capability", capability: "apiKeys" },
+      },
+      {
+        id: "webhooks",
+        label: "Webhooks",
+        icon: Webhook,
+        href: ROUTES.SETTINGS_WEBHOOKS,
+        gate: { kind: "capability", capability: "webhooks" },
+      },
+      {
+        id: "image-sizes",
+        label: "Image Sizes",
+        icon: Image,
+        href: ROUTES.SETTINGS_IMAGE_SIZES,
+        gate: { kind: "permission", permission: "manage-settings" },
+      },
+    ],
+  },
+  {
+    id: "email",
+    label: "Email Configuration",
+    items: [
+      {
+        id: "email-providers",
+        label: "Providers",
+        icon: Mail,
+        href: ROUTES.SETTINGS_EMAIL_PROVIDERS,
+        gate: { kind: "permission", permission: "manage-email-providers" },
+      },
+      {
+        id: "email-templates",
+        label: "Templates",
+        icon: FileText,
+        href: ROUTES.SETTINGS_EMAIL_TEMPLATES,
+        gate: { kind: "permission", permission: "manage-email-templates" },
+      },
+    ],
+  },
+  {
+    id: "users",
+    label: "User Management",
+    pluginPlacement: "users",
+    items: [
+      {
+        id: "users",
+        label: "Users",
+        icon: Users,
+        href: ROUTES.USERS,
+        gate: { kind: "permission", permission: "read-users" },
+        excludedBy: [ROUTES.USERS_FIELDS],
+      },
+      {
+        id: "user-fields",
+        label: "User Fields",
+        icon: List,
+        href: ROUTES.USERS_FIELDS,
+        gate: { kind: "permission", permission: "manage-settings" },
+      },
+      {
+        id: "roles",
+        label: "Roles",
+        icon: ShieldAlert,
+        href: ROUTES.SECURITY_ROLES,
+        gate: { kind: "permission", permission: "read-roles" },
+      },
+    ],
+  },
+];
+
+export interface SettingsNavAccess {
+  hasPermission: (permission: string) => boolean;
+  canAccessApiKeys: boolean;
+  canAccessWebhooks: boolean;
+}
+
+/** Whether one destination is shown to the current reader. */
+export function isSettingsNavItemVisible(
+  item: SettingsNavItem,
+  access: SettingsNavAccess
+): boolean {
+  if (item.gate.kind === "permission") {
+    return access.hasPermission(item.gate.permission);
+  }
+  return item.gate.capability === "apiKeys"
+    ? access.canAccessApiKeys
+    : access.canAccessWebhooks;
+}
+
+/**
+ * The panel as this reader sees it: destinations they may reach, and only the
+ * groups that still contain one.
+ *
+ * A group carrying a plugin slot is kept even when its own destinations are all
+ * hidden, because the slot's contents are gated by the plugin rather than by
+ * this table and dropping the group would hide them on a permission they do not
+ * depend on.
+ */
+export function visibleSettingsNav(
+  access: SettingsNavAccess,
+  nav: readonly SettingsNavGroup[] = SETTINGS_NAV
+): SettingsNavGroup[] {
+  return nav
+    .map(group => ({
+      ...group,
+      items: group.items.filter(item => isSettingsNavItemVisible(item, access)),
+    }))
+    .filter(group => group.items.length > 0 || group.pluginPlacement);
+}

--- a/packages/admin/src/components/layout/sidebar/lib/sub-sidebar-classes.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/sub-sidebar-classes.ts
@@ -1,0 +1,35 @@
+/**
+ * The secondary panel's layout classes, as one decision.
+ *
+ * The panel is always mounted so that opening and closing it can animate, so
+ * "closed" is a zero-width box rather than an absent element. That makes its
+ * decoration a separate question from its presence, and the two disagree: a
+ * border on a `w-0` box is still a 1px box.
+ */
+
+export interface SubSidebarClassInput {
+  /** The narrow layout, where the panel overlays instead of sitting in flow. */
+  isMobile: boolean;
+  /** Whether the current rail selection owns a panel to show. */
+  hasSubSidebar: boolean;
+}
+
+/**
+ * The divider the panel contributes, or none.
+ *
+ * A panel with no width has no edge to divide, so it draws nothing. Leaving the
+ * border on unconditionally paints it flush against the icon rail's own border
+ * — two 1px lines a pixel apart — and widens the collapsed panel from 0 to 1px,
+ * shifting the content region right. The wide layout is where this shows,
+ * because there the panel keeps its opacity when closed.
+ *
+ * The side follows the panel's position: overlaying from the left edge it
+ * divides on its left, and in flow beside the rail it divides on its right.
+ */
+export function subSidebarBorderClass({
+  isMobile,
+  hasSubSidebar,
+}: SubSidebarClassInput): string {
+  if (!hasSubSidebar) return "";
+  return isMobile ? "border-l border-border" : "border-r border-border";
+}

--- a/packages/admin/src/components/layout/sidebar/lib/sub-sidebar-classes.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/sub-sidebar-classes.ts
@@ -8,8 +8,15 @@
  */
 
 export interface SubSidebarClassInput {
-  /** The narrow layout, where the panel overlays instead of sitting in flow. */
-  isMobile: boolean;
+  /**
+   * The narrow layout, where the panel overlays instead of sitting in flow.
+   *
+   * Undefined until the media query resolves, which the panel's other classes
+   * already treat as the wide layout, so this does too. Rendering the narrow
+   * arrangement first and correcting it would move the panel on the first
+   * paint of every load.
+   */
+  isMobile: boolean | undefined;
   /** Whether the current rail selection owns a panel to show. */
   hasSubSidebar: boolean;
 }

--- a/packages/admin/src/components/shared/ThemeAwareLogo.tsx
+++ b/packages/admin/src/components/shared/ThemeAwareLogo.tsx
@@ -8,6 +8,7 @@ import {
   DEFAULT_MARK_PATHS,
   DEFAULT_MARK_VIEWBOX,
 } from "@admin/lib/branding/default-mark";
+import { cn } from "@admin/lib/utils";
 
 export interface ThemeAwareLogoProps {
   alt?: string;
@@ -18,6 +19,16 @@ export interface ThemeAwareLogoProps {
   defaultLightSrc?: string;
   defaultDarkSrc?: string;
   forceTheme?: "light" | "dark";
+  /**
+   * Render the built-in mark on a filled, rounded tile.
+   *
+   * Opt-in, and it applies to the built-in mark ONLY. A configured logo is
+   * someone else's brand: it may already carry its own container or padding,
+   * and a tile behind a wordmark drawn for a transparent background can hide
+   * it outright. So a project that sets `logoUrl` keeps exactly what it
+   * uploaded, and this changes nothing for them.
+   */
+  boxed?: boolean;
 }
 
 /**
@@ -27,7 +38,7 @@ export interface ThemeAwareLogoProps {
  * 1) `branding.logoUrl` (highest priority, e.g. user-configured custom logo)
  * 2) `branding.logoUrlLight`/`branding.logoUrlDark` based on resolved theme
  * 3) `defaultLightSrc`/`defaultDarkSrc` if provided
- * 4) Inline SVG fallback (fill color follows the resolved theme)
+ * 4) Inline SVG fallback (ink comes from a theme token, optionally on a tile)
  */
 export function ThemeAwareLogo({
   alt,
@@ -35,6 +46,7 @@ export function ThemeAwareLogo({
   defaultLightSrc,
   defaultDarkSrc,
   forceTheme,
+  boxed = false,
 }: ThemeAwareLogoProps) {
   const branding = useBranding();
   const { resolvedTheme } = useTheme();
@@ -60,19 +72,39 @@ export function ThemeAwareLogo({
   const computedAlt = alt ?? branding.logoText ?? "Logo";
 
   if (!src) {
-    const fillColor = theme === "dark" ? "white" : "black";
-    return (
+    // `currentColor` rather than a literal, so the mark takes its ink from a
+    // theme token like everything else the admin paints. The tile pairs the
+    // surface with the foreground declared against it, which is the pairing
+    // the token system guarantees a contrast for.
+    const mark = (
       <svg
         viewBox={DEFAULT_MARK_VIEWBOX}
         xmlns="http://www.w3.org/2000/svg"
-        className={className}
+        className={boxed ? "h-1/2 w-1/2" : cn("text-foreground", className)}
+        fill="currentColor"
+        role={boxed ? undefined : "img"}
+        aria-label={boxed ? undefined : computedAlt}
+        aria-hidden={boxed ? true : undefined}
+      >
+        {DEFAULT_MARK_PATHS.map(d => (
+          <path key={d} d={d} />
+        ))}
+      </svg>
+    );
+
+    if (!boxed) return mark;
+
+    return (
+      <span
+        className={cn(
+          "inline-flex shrink-0 items-center justify-center rounded-md bg-primary text-primary-foreground",
+          className
+        )}
         role="img"
         aria-label={computedAlt}
       >
-        {DEFAULT_MARK_PATHS.map(d => (
-          <path key={d} d={d} fill={fillColor} />
-        ))}
-      </svg>
+        {mark}
+      </span>
     );
   }
 

--- a/packages/admin/src/components/shared/__tests__/ThemeAwareLogo.test.tsx
+++ b/packages/admin/src/components/shared/__tests__/ThemeAwareLogo.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * The brand mark: where its ink comes from, and who may sit on a tile.
+ *
+ * The tile is opt-in and applies to the BUILT-IN mark only. A configured logo
+ * belongs to the project that uploaded it — it may carry its own container, and
+ * a filled tile behind a wordmark drawn for a transparent background can hide
+ * it — so the boxed request is deliberately ignored once `logoUrl` is set.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ThemeAwareLogo } from "../ThemeAwareLogo";
+
+const branding = vi.hoisted(() => ({ current: {} as Record<string, unknown> }));
+
+vi.mock("@admin/context/providers/BrandingProvider", () => ({
+  useBranding: () => branding.current,
+}));
+vi.mock("@admin/context/providers/ThemeProvider", () => ({
+  useTheme: () => ({ resolvedTheme: "light" }),
+}));
+
+describe("ThemeAwareLogo", () => {
+  it("takes the built-in mark's ink from a token, not a literal colour", () => {
+    branding.current = {};
+    const { container } = render(<ThemeAwareLogo alt="Nextly" />);
+
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    // Population before verdict: the paths are what would carry a literal.
+    const paths = container.querySelectorAll("path");
+    expect(paths.length).toBeGreaterThan(0);
+
+    expect(svg?.getAttribute("fill")).toBe("currentColor");
+    for (const path of paths) {
+      expect(path.getAttribute("fill")).toBeNull();
+    }
+    expect(container.innerHTML).not.toMatch(
+      /fill="(white|black|#[0-9a-f]{3,8})"/i
+    );
+  });
+
+  it("puts the built-in mark on a tile when asked", () => {
+    branding.current = {};
+    const { container } = render(<ThemeAwareLogo alt="Nextly" boxed />);
+
+    const tile = screen.getByRole("img", { name: "Nextly" });
+    expect(tile.tagName).toBe("SPAN");
+    expect(tile.className).toContain("bg-primary");
+    expect(tile.className).toContain("text-primary-foreground");
+    // The mark is inside the tile and no longer announces itself separately,
+    // so assistive technology reads one image rather than two.
+    expect(container.querySelectorAll("[role='img']")).toHaveLength(1);
+    expect(container.querySelector("svg")?.getAttribute("aria-hidden")).toBe(
+      "true"
+    );
+  });
+
+  it("leaves the built-in mark bare when not asked", () => {
+    branding.current = {};
+    render(<ThemeAwareLogo alt="Nextly" />);
+
+    const mark = screen.getByRole("img", { name: "Nextly" });
+    expect(mark.tagName).toBe("svg");
+    expect(mark.className.toString()).not.toContain("bg-primary");
+  });
+
+  it("never boxes a configured logo, even when boxed is requested", () => {
+    // The separating property. Without it, an implementation that wrapped
+    // everything would satisfy the tile test above and quietly put a brand
+    // colour behind somebody else's logo.
+    branding.current = { logoUrl: "https://example.test/logo.svg" };
+    const { container } = render(<ThemeAwareLogo alt="Acme" boxed />);
+
+    const img = screen.getByAltText("Acme");
+    expect(img.tagName).toBe("IMG");
+    expect(container.querySelector("span")).toBeNull();
+    expect(container.innerHTML).not.toContain("bg-primary");
+  });
+});


### PR DESCRIPTION
Three fixes to the admin sidebar chrome, from rows T-03, T-05 and T-16 of the general UI tweaks list. One surface, mostly one file, so they ship together.

## T-05 — the dashboard's double right border

Not cosmetic. The secondary panel stays mounted while closed so its transition has something to animate, and it carried `border-r` unconditionally. A border on a `w-0` box is still a **1px box**, and in the wide layout `lg:opacity-100` restores its opacity — so it painted a second vertical line flush against the icon rail's own border **and shifted the content region one pixel right**.

Measured at 1440px, before and after, same instrument:

| route | before | after |
|---|---|---|
| `/admin` | `x=72 w=1 borderR=1px` | **`x=72 w=0 borderR=0px`** |
| `/admin/settings` | `x=72 w=256 borderR=1px` | unchanged |
| `/admin/collections` | `x=72 w=256 borderR=1px` | unchanged |

The decision moved into a pure helper beside the folder's other predicates, so the contract is assertable without mounting the sidebar.

## T-16 — settings nav order, and a latent defect it exposed

The panel's three groups were hand-rolled JSX. Two consequences:

1. Order was source order, so User Management came first.
2. **Each group restated its own items' permissions in the condition that showed its heading.** They agree today, so nothing is visibly broken — but add an item under a new permission and whoever holds only that permission sees a destination with **no heading above it**.

Destinations are now a table, each stating its gate once, and a group's heading is **derived** from whether any destination survived that gate, so a heading without destinations is unrepresentable.

Rendered order is now System Settings → Email Configuration → User Management: the two groups that configure the installation sit together, and account administration follows. That is also where Strapi puts it (`global` declared ahead of `permissions`) and how Directus splits Project Settings from Roles & Permissions.

There is also a new guard requiring every `href` to be a declared route. That is the class of bug where a path is composed from a page file's location: `pages/dashboard/roles/create.tsx` is served at `/admin/security/roles/create`, and a hand-written `/admin/roles/create` 404s while looking correct.

## T-03 — the built-in mark on a themed tile

The rail rendered the mark bare, and its fallback picked a literal `white` or `black` — the one thing the admin painted outside the token system. It now takes its ink from `currentColor` and, in the rail, sits on a rounded tile.

**The tile is opt-in and reaches the built-in mark only.** A configured logo belongs to whoever uploaded it: it may already carry its own container, and a filled tile behind a wordmark drawn for a transparent background can hide it. Verified live — with branding configured the playground still renders a bare `<img>`, no tile.

Verified in the browser in both themes: `SPAN`, 32×32, `rounded-md`, black tile / white mark in light and white tile / black mark in dark.

## Test plan

- **18 new unit tests**, all **stub-verified** — the code was broken and each test seen to fail for its intended reason before being restored.
  - One stub-verification initially passed when it should have failed: the "break" replaced `ROUTES.SETTINGS_API_KEYS` with that constant's own literal value. Redone with a genuinely wrong file-tree-derived path, it failed correctly and named the offending item.
- **No new test failures.** Baseline on the merge-base was 4 failing files / 15 tests in `@nextlyhq/admin`; identical after. Tests 1895 → 1913 (+18 mine), files 222 → 225 (+3). Compared as file sets with `comm -13`, same worktree and flags.
- `check-types` clean, `lint` clean (0 warnings), comment-convention gate clean with the allowlist unchanged at 402.
- Browser-verified on a dev server confirmed to be serving this worktree.

**Changeset added: yes (patch).**

## Pre-existing failures, not caused by this PR

`StatsCard.test.tsx`, `BasicsTab.test.tsx`, `SlugInput.test.tsx`, `DefaultValueField.test.tsx` — 15 tests. Present on the merge base before any change here.

## Scope explicitly left out

- **No e2e spec.** Unit coverage plus live browser verification in both themes is what this carries. Called out rather than implied.
- `MobileSidebarDrawer` is **not** boxed: its slot is a wide `w-auto max-w-[140px]` wordmark, which a square tile would be wrong for.
- `DynamicFieldGroupNav.tsx` is dead code (zero importers) and sits next to this work. Deliberately untouched — it is removed by the field-groups lane's own sequence.
- A configured logo in the rail renders at 32px rather than 24px, since the size prop is shared with the tile. Inside a 40px link; flagged as the one visual change to branded installs.

## Review status

**No bot reviewed this.** Codex is quota-exhausted and answers with an explicit usage-limit message; `@nextly-bot` produced zero comments and zero reviews on #888/#889/#890 after being tagged. Merging on green CI per the maintainer's decision — recording it so the quiet is not mistaken for a pass.
