### PR TITLE
fix(nextly): record a stranded schema transition, never report success

### DIFF
--- a/.changeset/builder-apply-records-divergence.md
+++ b/.changeset/builder-apply-records-divergence.md
@@ -1,0 +1,36 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Saving a field group in the Schema Builder no longer reports success when the change was only half made.
+
+The save changes the database tables first and then records what it did. If that recording step failed, the failure was written to the server console and the response still said the schema had been applied. The tables held the new shape, the stored definition still described the old one, and nothing marked the field group as needing repair.
+
+That was worse than it sounds, because the version number was deliberately left where it was. An editor already open would therefore pass its staleness check and plan its next change from a shape the database no longer had — the exact retry the `diverged` state exists to refuse, arriving through the one path that never marked it.
+
+A failed recording is now recorded. The field group is marked `diverged`, and the response says which of three things actually happened, because the operator's next step differs for each: the failure was marked, so reconcile and do not retry; the record turned out to have moved on, so reload before doing anything, since the change was probably saved and the field group may also have been deleted; or nothing could be recorded at all, so the server log is the only trace.
+
+One case that used to be reported as a failure now correctly reports success. MySQL has no `RETURNING`, so a write is an update followed by a read, and a read that fails after the update has already committed used to be treated as though nothing was written. The save now re-reads the row and reports success when it already carries the change.

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -635,7 +635,6 @@ export const COMPONENTS_METHODS: Record<
           // flag. The write is non-fatal (the DDL already succeeded), but track
           // whether it landed so the response never reports a version the DB did not
           // persist.
-          let versionPersisted = true;
           try {
             await adapter.update(
               // The registry this database holds. The failure is otherwise silent
@@ -654,12 +653,48 @@ export const COMPONENTS_METHODS: Record<
               { and: [{ column: "slug", op: "=", value: slug }] }
             );
           } catch (err) {
-            versionPersisted = false;
-            const msg = err instanceof Error ? err.message : String(err);
-            console.warn(
-              `[applyComponentSchemaChanges] Post-apply metadata write failed for '${slug}': ${msg}. ` +
-                `schema_version was not advanced; the save is reported at the current version so a retry re-attempts the bump.`
+            // 🔴 The DDL has ALREADY COMMITTED. Reporting success here is worse than the failure
+            // itself: the tables hold the new shape, the row still describes the old one, and the
+            // version is deliberately not advanced — so an editor loaded before this save still
+            // PASSES the optimistic-lock check and plans its next transition from a shape the
+            // database no longer has. That is the retry `assertNotDiverged` exists to refuse,
+            // arriving through the one door that had no guard.
+            //
+            // Recorded through the shared decision so this path and the metadata service answer
+            // the same state identically. It returns only when the row turns out to already carry
+            // this edit — the write landed and the raise was in reading it back, which MySQL
+            // produces routinely because its update is an UPDATE followed by a SELECT. Every other
+            // outcome throws, which is the point: nobody is told the schema was applied.
+            const { recordStrandedTransition } = await import(
+              "../../domains/field-groups/services/record-stranded-transition"
             );
+            const expectedHash = calculateSchemaHash(fields as FieldConfig[]);
+            await recordStrandedTransition({
+              registry: svc.registry,
+              logger: getLoggerFromDI() ?? DISCARDED_LOG,
+              slug,
+              expectedSchemaVersion: currentVersion,
+              tableName,
+              wasLocalized: isLocalized,
+              cause: err,
+              // This edit is carried by the row only if BOTH the shape it wrote and the version it
+              // wrote are there. The hash alone would accept a row another writer had advanced
+              // past to the same field set, and the version alone would accept any later write.
+              readBackSettled: async () => {
+                try {
+                  const current = await svc.registry.getComponent(slug);
+                  if (current.schemaHash !== expectedHash) return null;
+                  if (current.schemaVersion !== newSchemaVersion) return null;
+                  if ((current.localized === true) !== isLocalized) return null;
+                  return current;
+                } catch {
+                  // A re-read that fails is the likely case when the database is why the write
+                  // raised, and doubt must resolve to "not settled" — treating an unreadable row
+                  // as written would swallow the divergence this path exists to surface.
+                  return null;
+                }
+              },
+            });
           }
 
           // Post-apply: refresh in-memory runtime schema so CRUD paths reflect
@@ -677,10 +712,11 @@ export const COMPONENTS_METHODS: Record<
             isLocalized
           );
 
+          // Reached only when the registry write landed, or when it raised and the row was found
+          // to carry this edit anyway. Either way the version reported is the one now stored, so
+          // there is no longer a branch that reports a version the database did not persist.
           return respondAction(`Schema applied for component '${slug}'`, {
-            newSchemaVersion: versionPersisted
-              ? newSchemaVersion
-              : currentVersion,
+            newSchemaVersion,
           });
         }
       );

--- a/packages/nextly/src/domains/field-groups/services/__tests__/record-stranded-transition.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/record-stranded-transition.test.ts
@@ -1,0 +1,162 @@
+/**
+ * The decision taken when a schema transition committed and recording it did not.
+ *
+ * 🔴 Each ending tells the operator to do something DIFFERENT, so conflating any two is worse than
+ * the original failure: "marked" says reconcile and do not retry, "advanced" says reload before
+ * touching anything because the change probably landed, and "unrecorded" says the log is the only
+ * trace. A test that asserted merely "it throws" would pass on an implementation that always
+ * reported the same one.
+ *
+ * Two callers depend on this — the metadata service's update and the builder's apply — which is why
+ * it is tested here rather than through either of them.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { FieldGroupRegistryService } from "../field-group-registry-service";
+import { recordStrandedTransition } from "../record-stranded-transition";
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+
+/** A registry whose two consulted methods are supplied per case. */
+function registryOf(over: {
+  updateComponentIfVersion?: unknown;
+  getComponent?: unknown;
+}) {
+  return {
+    updateComponentIfVersion: vi.fn(),
+    getComponent: vi.fn(),
+    ...over,
+  } as unknown as FieldGroupRegistryService;
+}
+
+function run(
+  registry: FieldGroupRegistryService,
+  readBackSettled: () => Promise<unknown>
+) {
+  return recordStrandedTransition({
+    registry,
+    logger,
+    slug: "hero",
+    expectedSchemaVersion: 4,
+    tableName: "comp_hero",
+    wasLocalized: false,
+    cause: new Error("write failed"),
+    readBackSettled: readBackSettled as () => Promise<never | null>,
+  });
+}
+
+describe("recordStrandedTransition", () => {
+  it("marks the group diverged at the version the edit started from", async () => {
+    const updateComponentIfVersion = vi.fn(async () => ({ matched: true }));
+    const registry = registryOf({ updateComponentIfVersion });
+
+    await expect(run(registry, async () => null)).rejects.toMatchObject({
+      code: "INTERNAL_ERROR",
+    });
+
+    // The predicate is the edit's OWN version. Marking at whatever the row happens to say now
+    // would overwrite a concurrent writer's state rather than recording this failure against it.
+    expect(updateComponentIfVersion).toHaveBeenCalledWith(
+      "hero",
+      { migrationStatus: "diverged" },
+      4,
+      { source: "code" }
+    );
+    await expect(run(registry, async () => null)).rejects.toThrow(
+      /marked as diverged/
+    );
+  });
+
+  it("returns the row when it turns out to already carry the edit", async () => {
+    // The write landed and the raise was in reading it back — routine on MySQL, whose update is an
+    // UPDATE followed by a SELECT. This is the ONE path that must not throw: the caller may report
+    // success, because the edit really is recorded.
+    const settled = { slug: "hero", schemaVersion: 5 };
+    const registry = registryOf({
+      updateComponentIfVersion: vi.fn(async () => ({ matched: false })),
+    });
+
+    await expect(run(registry, async () => settled)).resolves.toEqual({
+      record: settled,
+    });
+  });
+
+  it("re-marks at the version now stored when another writer moved the row", async () => {
+    const updateComponentIfVersion = vi
+      .fn()
+      .mockResolvedValueOnce({ matched: false })
+      .mockResolvedValueOnce({ matched: true });
+    const registry = registryOf({
+      updateComponentIfVersion,
+      getComponent: vi.fn(async () => ({ schemaVersion: 9 })),
+    });
+
+    await expect(run(registry, async () => null)).rejects.toThrow(
+      /marked as diverged/
+    );
+    // Second attempt uses the version just READ, because the row is past the edit's by definition.
+    expect(updateComponentIfVersion).toHaveBeenLastCalledWith(
+      "hero",
+      { migrationStatus: "diverged" },
+      9,
+      { source: "code" }
+    );
+  });
+
+  it("says the row advanced when it moved again before it could be marked", async () => {
+    const registry = registryOf({
+      updateComponentIfVersion: vi.fn(async () => ({ matched: false })),
+      getComponent: vi.fn(async () => ({ schemaVersion: 9 })),
+    });
+
+    // Distinct from "marked": this operator must RELOAD, not reconcile, because the change was
+    // probably recorded — and the group may equally have been deleted.
+    await expect(run(registry, async () => null)).rejects.toThrow(
+      /no longer at the version this edit started from/
+    );
+  });
+
+  it("admits when nothing at all could be recorded", async () => {
+    const registry = registryOf({
+      updateComponentIfVersion: vi.fn(async () => {
+        throw new Error("database unreachable");
+      }),
+    });
+
+    // The worst ending, and the one that must never be reported as either of the others: the group
+    // reads as though nothing happened.
+    await expect(run(registry, async () => null)).rejects.toThrow(
+      /neither the change nor the failure could be recorded/
+    );
+  });
+
+  it("never reports the edit as applied, whichever ending it reaches", async () => {
+    // The property the builder's apply path was violating: it returned "Schema applied" while the
+    // row still described the previous shape. No ending here may resolve except the settled one.
+    const endings = [
+      registryOf({
+        updateComponentIfVersion: vi.fn(async () => ({ matched: true })),
+      }),
+      registryOf({
+        updateComponentIfVersion: vi.fn(async () => ({ matched: false })),
+        getComponent: vi.fn(async () => ({ schemaVersion: 9 })),
+      }),
+      registryOf({
+        updateComponentIfVersion: vi.fn(async () => {
+          throw new Error("down");
+        }),
+      }),
+    ];
+
+    for (const registry of endings) {
+      await expect(run(registry, async () => null)).rejects.toBeInstanceOf(
+        Error
+      );
+    }
+  });
+});

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -33,7 +33,7 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import { readRequestLocalized } from "../../../dispatcher/helpers/request-localized";
-import { NEXTLY_ERROR_STATUS, NextlyError } from "../../../errors";
+import { NextlyError } from "../../../errors";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import type {
   DynamicFieldGroupInsert,
@@ -46,6 +46,7 @@ import { withSchemaChangeExcluded } from "../../schema/services/schema-change-ex
 
 import { assertNotDiverged } from "./assert-not-diverged";
 import type { FieldGroupRegistryService } from "./field-group-registry-service";
+import { recordStrandedTransition } from "./record-stranded-transition";
 
 /**
  * 🔴 The schema service and the table provisioning are loaded on demand, NOT at the top of this
@@ -794,123 +795,19 @@ export class FieldGroupMetadataService {
     existing: DynamicFieldGroupRecord,
     cause: unknown
   ): Promise<UpdateFieldGroupResult> {
-    const slug = input.slug;
-    this.logger.error(
-      "[FieldGroups] Schema transition committed but its registry row was not written.",
-      {
-        slug,
-        tableName: existing.tableName,
-        wasLocalized: existing.localized === true,
-        error: cause instanceof Error ? cause.message : String(cause),
-      }
-    );
-
-    // Three endings, and the message below must not conflate them: the mark was persisted, the row
-    // turned out to have advanced (so the CHANGE was recorded, and only the confirmation is
-    // missing), or nothing about the state could be recorded at all.
-    let recordState: "marked" | "advanced" | "unrecorded" = "unrecorded";
-    try {
-      const outcome = await this.registry.updateComponentIfVersion(
-        slug,
-        { migrationStatus: "diverged" },
-        existing.schemaVersion,
-        { source: "code" }
-      );
-      if (outcome.matched) {
-        recordState = "marked";
-      } else {
-        // The row is past the version this edit started from, which is what the original write
-        // leaves behind — so the change was recorded and the raise was in reading it back. Look
-        // once more before answering: connectivity good enough for the conditional statement is
-        // usually good enough for a read now.
-        const settled = await this.readBackSettledRow(
-          input,
-          requestedLocalized
-        );
-        if (settled) {
-          this.logger.warn(
-            "[FieldGroups] The registry write raised but the row already carries the change; the error was in reading it back.",
-            { slug }
-          );
-          return { record: settled };
-        }
-        // 🔴 The version moved AND the row does not carry this edit — `readBackSettledRow` just
-        // established the second half. So another writer advanced the row while this edit's tables
-        // had already moved, and the definition now stored describes neither: that is divergence,
-        // and it is the state the mark exists for. Leaving it unmarked lets the next schema edit
-        // proceed from a definition known not to describe the tables, and the refusal below even
-        // invites a retry that would compound it.
-        //
-        // Marked at the version just READ rather than at this edit's, because the row is past that
-        // one by definition. Attempted ONCE: a writer racing this second attempt has itself just
-        // written the row, so retrying in a loop trades a bounded failure for an unbounded one, and
-        // the answer below still distinguishes what was actually persisted.
-        const current = await this.registry.getComponent(slug);
-        const remark = await this.registry.updateComponentIfVersion(
-          slug,
-          { migrationStatus: "diverged" },
-          current.schemaVersion,
-          { source: "code" }
-        );
-        if (remark.matched) {
-          recordState = "marked";
-          this.logger.warn(
-            "[FieldGroups] The row advanced past this edit's version without carrying it; marked diverged at the version now stored.",
-            {
-              slug,
-              expectedSchemaVersion: existing.schemaVersion,
-              markedAtSchemaVersion: current.schemaVersion,
-            }
-          );
-        } else {
-          recordState = "advanced";
-          this.logger.error(
-            "[FieldGroups] The row advanced past this edit's version and moved again before it could be marked diverged.",
-            { slug, expectedSchemaVersion: existing.schemaVersion }
-          );
-        }
-      }
-    } catch (markError) {
-      this.logger.error(
-        "[FieldGroups] Could not mark the field group as diverged either.",
-        {
-          slug,
-          error:
-            markError instanceof Error ? markError.message : String(markError),
-        }
-      );
-    }
-
-    // Constructed rather than `NextlyError.internal`, which fixes the public message to "An
-    // unexpected error occurred." That is the one thing this caller must NOT be told: the whole
-    // point is that the edit half-happened and repeating it is harmful. The status still comes from
-    // the central mapping rather than a literal, so this cannot drift from the code it carries.
-    //
-    // 🔴 The message distinguishes what was PERSISTED. Claiming a durable record that does not
-    // exist is worse than admitting the log is the only trace — and claiming nothing was recorded
-    // when the row demonstrably advanced sends an operator repairing a group that likely carries
-    // the change already. Each ending tells them where to look and what not to do.
-    const publicMessages: Record<typeof recordState, string> = {
-      marked: `The field group's tables were changed, but recording the change failed. "${slug}" is marked as diverged and its stored definition still describes the previous shape. Do not retry the same edit: check the server logs and reconcile the field group before editing it again.`,
-      // 🔴 Says only what the write PROVED: the row is no longer at the version this edit started
-      // from. `matched: false` has two causes — the row advanced, or it was deleted — and a
-      // concurrent delete reaches here through the same path, because the confirming read then
-      // raises NOT_FOUND and reports the same "could not confirm". Claiming a newer version exists
-      // would send that operator to reload a field group that is gone.
-      advanced: `The field group's tables were changed, and its record is no longer at the version this edit started from — most likely the change was recorded and only confirming it failed, though the field group may also have been deleted. Reload "${slug}" before doing anything else; retry the edit only if it still exists and the reloaded definition does not show the change.`,
-      unrecorded: `The field group's tables were changed, but neither the change nor the failure could be recorded. "${slug}" still reads as though nothing happened, and the only trace is the server log. Do not retry the same edit: reconcile the field group against its tables before editing it again.`,
-    };
-    throw new NextlyError({
-      code: "INTERNAL_ERROR",
-      statusCode: NEXTLY_ERROR_STATUS.INTERNAL_ERROR,
-      publicMessage: publicMessages[recordState],
-      cause: cause instanceof Error ? cause : undefined,
-      logContext: {
-        reason: "registry write failed after committed schema transition",
-        slug,
-        recordState,
-        tableName: existing.tableName,
-      },
+    // The decision, the logging and the three public messages live in one module because the
+    // builder's apply path reaches the same state and must answer it identically. Only the
+    // "does the row already carry MY edit" question is answered here, because only this caller
+    // knows what it sent.
+    return await recordStrandedTransition<DynamicFieldGroupRecord>({
+      registry: this.registry,
+      logger: this.logger,
+      slug: input.slug,
+      expectedSchemaVersion: existing.schemaVersion,
+      tableName: existing.tableName,
+      wasLocalized: existing.localized === true,
+      cause,
+      readBackSettled: () => this.readBackSettledRow(input, requestedLocalized),
     });
   }
 

--- a/packages/nextly/src/domains/field-groups/services/record-stranded-transition.ts
+++ b/packages/nextly/src/domains/field-groups/services/record-stranded-transition.ts
@@ -1,0 +1,179 @@
+/**
+ * What to do when a schema transition COMMITTED and recording it did not.
+ *
+ * The tables have moved. The row describing them has not. Every caller that can reach this state
+ * owes the operator the same three answers, and getting any of them wrong is worse than the
+ * original failure:
+ *
+ * - the failure was recorded, so the group is marked and must be reconciled, not retried;
+ * - the row turned out to have advanced, so the CHANGE was probably recorded and only confirming
+ *   it failed — reload before doing anything;
+ * - nothing could be recorded at all, so the log is the only trace.
+ *
+ * 🔴 This lives in one place because two paths reach it — the metadata service's update and the
+ * builder's apply — and they write genuinely different rows. Sharing the WRITE is not possible;
+ * sharing the DECISION is, and the decision is the part that must not drift. Two copies of it
+ * would agree on the day they were written and diverge silently afterwards, which is the failure
+ * mode this repository has hit in five unrelated packages.
+ *
+ * The caller supplies its own answer to "does the stored row already carry MY edit", because only
+ * the caller knows what it sent. Everything downstream of that answer is decided here.
+ *
+ * @module domains/field-groups/services/record-stranded-transition
+ */
+
+import { NextlyError } from "../../../errors";
+import { NEXTLY_ERROR_STATUS } from "../../../errors/error-codes";
+import type { Logger } from "../../../shared/types";
+
+import type { FieldGroupRegistryService } from "./field-group-registry-service";
+
+/** Which of the three endings actually happened, in the order they are attempted. */
+type RecordState = "marked" | "advanced" | "unrecorded";
+
+export interface RecordStrandedTransitionArgs<R> {
+  registry: FieldGroupRegistryService;
+  logger: Logger;
+  slug: string;
+  /** The version the edit started from — the predicate the conditional mark is attempted at. */
+  expectedSchemaVersion: number;
+  /** For the log only, so the group is findable when the mark itself could not be written. */
+  tableName: string;
+  wasLocalized: boolean;
+  /** Whatever the failed write raised. */
+  cause: unknown;
+  /**
+   * Re-read the row and answer whether it ALREADY carries this edit, or `null` on ANY doubt.
+   *
+   * Doubt must resolve to "not settled": treating an unreadable row as written would swallow a
+   * real divergence, which is the state this whole path exists to surface. A re-read that itself
+   * fails is the likely case when the database is why the first write raised.
+   */
+  readBackSettled: () => Promise<R | null>;
+}
+
+/**
+ * Record a committed-but-unrecorded transition, then either report success or refuse.
+ *
+ * Returns ONLY when the row turned out to already carry the edit — the write landed and the raise
+ * was in reading it back, which is a success the caller may report. Every other path throws,
+ * because the caller must not tell anyone the edit succeeded.
+ */
+export async function recordStrandedTransition<R>(
+  args: RecordStrandedTransitionArgs<R>
+): Promise<{ record: R }> {
+  const {
+    registry,
+    logger,
+    slug,
+    expectedSchemaVersion,
+    tableName,
+    wasLocalized,
+    cause,
+    readBackSettled,
+  } = args;
+
+  logger.error(
+    "[FieldGroups] Schema transition committed but its registry row was not written.",
+    {
+      slug,
+      tableName,
+      wasLocalized,
+      error: cause instanceof Error ? cause.message : String(cause),
+    }
+  );
+
+  let recordState: RecordState = "unrecorded";
+  try {
+    const outcome = await registry.updateComponentIfVersion(
+      slug,
+      { migrationStatus: "diverged" },
+      expectedSchemaVersion,
+      { source: "code" }
+    );
+    if (outcome.matched) {
+      recordState = "marked";
+    } else {
+      // The row is past the version this edit started from, which is what the original write
+      // leaves behind — so the change may well have been recorded and the raise was in reading it
+      // back. Look once more: connectivity good enough for the conditional statement is usually
+      // good enough for a read now.
+      const settled = await readBackSettled();
+      if (settled !== null) {
+        logger.warn(
+          "[FieldGroups] The registry write raised but the row already carries the change; the error was in reading it back.",
+          { slug }
+        );
+        return { record: settled };
+      }
+      // 🔴 The version moved AND the row does not carry this edit. So another writer advanced the
+      // row while this edit's tables had already moved, and the definition now stored describes
+      // neither: that is divergence, and it is the state the mark exists for.
+      //
+      // Marked at the version just READ rather than at this edit's, because the row is past that
+      // one by definition. Attempted ONCE: a writer racing this second attempt has itself just
+      // written the row, so retrying in a loop trades a bounded failure for an unbounded one.
+      const current = await registry.getComponent(slug);
+      const remark = await registry.updateComponentIfVersion(
+        slug,
+        { migrationStatus: "diverged" },
+        current.schemaVersion,
+        { source: "code" }
+      );
+      if (remark.matched) {
+        recordState = "marked";
+        logger.warn(
+          "[FieldGroups] The row advanced past this edit's version without carrying it; marked diverged at the version now stored.",
+          {
+            slug,
+            expectedSchemaVersion,
+            markedAtSchemaVersion: current.schemaVersion,
+          }
+        );
+      } else {
+        recordState = "advanced";
+        logger.error(
+          "[FieldGroups] The row advanced past this edit's version and moved again before it could be marked diverged.",
+          { slug, expectedSchemaVersion }
+        );
+      }
+    }
+  } catch (markError) {
+    logger.error(
+      "[FieldGroups] Could not mark the field group as diverged either.",
+      {
+        slug,
+        error:
+          markError instanceof Error ? markError.message : String(markError),
+      }
+    );
+  }
+
+  // Constructed rather than `NextlyError.internal`, which fixes the public message to "An
+  // unexpected error occurred." That is the one thing this caller must NOT be told: the edit
+  // half-happened and repeating it is harmful. The status still comes from the central mapping
+  // rather than a literal, so this cannot drift from the code it carries.
+  //
+  // 🔴 The message distinguishes what was PERSISTED. Claiming a durable record that does not exist
+  // is worse than admitting the log is the only trace — and claiming nothing was recorded when the
+  // row demonstrably advanced sends an operator repairing a group that likely carries the change
+  // already. Each ending tells them where to look and what not to do.
+  const publicMessages: Record<RecordState, string> = {
+    marked: `The field group's tables were changed, but recording the change failed. "${slug}" is marked as diverged and its stored definition still describes the previous shape. Do not retry the same edit: check the server logs and reconcile the field group before editing it again.`,
+    // 🔴 Says only what the write PROVED: the row is no longer at the version this edit started
+    // from. `matched: false` has two causes — the row advanced, or it was deleted — and a
+    // concurrent delete reaches here through the same path, because the confirming read then
+    // raises NOT_FOUND and reports the same "could not confirm". Claiming a newer version exists
+    // would send that operator to reload a field group that is gone.
+    advanced: `The field group's tables were changed, and its record is no longer at the version this edit started from — most likely the change was recorded and only confirming it failed, though the field group may also have been deleted. Reload "${slug}" before doing anything else; retry the edit only if it still exists and the reloaded definition does not show the change.`,
+    unrecorded: `The field group's tables were changed, but neither the change nor the failure could be recorded. "${slug}" still reads as though nothing happened, and the only trace is the server log. Do not retry the same edit: reconcile the field group against its tables before editing it again.`,
+  };
+
+  throw new NextlyError({
+    code: "INTERNAL_ERROR",
+    statusCode: NEXTLY_ERROR_STATUS.INTERNAL_ERROR,
+    publicMessage: publicMessages[recordState],
+    logContext: { slug, tableName, recordState, expectedSchemaVersion },
+    cause: cause instanceof Error ? cause : undefined,
+  });
+}


### PR DESCRIPTION
PR-3 of the components → field groups transition. Follows #904 (the reconcile surface), which is what makes this safe to land: this change deliberately produces MORE correctly-`diverged` field groups, and until #904 there was no way for an operator to clear one.

## The defect

`applyComponentSchemaChanges` commits main-table DDL through the push pipeline, then writes the registry row. **That write's failure was swallowed** — `versionPersisted = false`, a `console.warn`, and the handler still returned `Schema applied for component '<slug>'`.

So the tables moved, the row still described the previous shape, and the caller was told the schema was applied. The only trace was a console line.

**Worse than the state `diverged` exists to declare.** `recordUnrecordedTransition` advances `schema_version` deliberately, so an editor loaded before the transition fails `assertSchemaVersionMatch` and cannot apply stale resolutions. Here the version was deliberately NOT advanced — the response reported `currentVersion` — so a stale editor **passes** the version check and plans its next transition from a shape the database no longer has. That is precisely the retry `assertNotDiverged` was shared across both transports to prevent, arriving through the one door with no guard.

The refusal side was shared in #807. The recording side never was.

## The fix, and why it is shaped this way

The metadata service already handles this state correctly, with three endings that ask the operator for different things. The dispatcher must not grow a second copy — this repository has had defects in five unrelated packages from two implementations of one question drifting apart.

But the two writes are legitimately different: the builder bypasses the registry helper on purpose, because its auto-bump would reset the `migration_status` it needs to set. So the **write** cannot be shared and the **decision** can.

`record-stranded-transition.ts` owns the decision, the logging and the three public messages. Each caller supplies only its own answer to "does the stored row already carry MY edit", because only the caller knows what it sent. `field-group-metadata-service.ts` now delegates to it — a net deletion there — and the builder's apply path calls it instead of warning.

**One case flips from failure to success.** `DrizzleAdapter.update` is UPDATE-then-SELECT on MySQL, so a failed read-back raises out of a write that already committed. The old code read that as "not persisted" and under-reported a version the database had advanced. The shared path re-reads and reports success when the row already carries the edit — matching on schema hash, version AND localized, because the hash alone would accept a row another writer advanced to the same field set, and the version alone would accept any later write.

## Verification

- **Integration 133/133**, exit 0, across PostgreSQL, MySQL and SQLite.
- `pnpm build`, `check-types` (nextly + adapter-drizzle), `pnpm lint`, `check-drizzle-v1-legacy`, `check:storage-format-literals`, `check-comment-convention` — all exit 0.
- New unit suite 6/6 pinning each ending separately, because a test asserting only "it throws" would pass on an implementation that always reported the same one.
- **Break control**: collapsing the three public messages into one makes exactly the two tests that distinguish the endings fail, and only those.
- Field-group unit suite compared by **membership**: the same 5 failures as `main`, by name, and no new ones. Four are one stale mock (`field-group-route-delegates.test.ts` mocks `../../di` without `isServicesRegistered`, required by `bootView` since #782); the fifth is the long-standing `deleteComponentDataInTransaction`. Neither is touched by this branch.

## A note on CI

`main`'s Integration jobs have not completed on any of the last 12 commits — all `queued`. This branch's local verification is therefore the only evidence available at the time of opening, and the merge gate stays as it is: `success` asserted per required job, never inferred from the absence of a failure.
