### PR TITLE
feat(blocks-engine): add color.surface, color.border and color.muted

### DIFF
--- a/.changeset/surface-border-muted-tokens.md
+++ b/.changeset/surface-border-muted-tokens.md
@@ -1,0 +1,52 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+feat(blocks-engine): add color.surface, color.border and color.muted to the guaranteed token set
+
+The guaranteed set had no surface colour and no border colour, and their absence
+made four blocks compromise: `core/card` shipped with no background and no
+border, `badge` was unbuildable because a tinted background IS the block, the
+accordion had no divider and the table no border colour.
+
+It also created a defect class. Because nothing in the set could express a
+surface, six blocks across three lanes independently reached for `--nx-*` — the
+ADMIN namespace, which no published page emits, so those rules validated,
+compiled, shipped and resolved to nothing. That is design pressure rather than
+six mistakes: when the correct mechanism is missing, whatever resembles it gets
+used.
+
+All three define both light and dark values, and a test now requires that of
+every colour token rather than only the new ones — a colour defined only for
+light silently keeps its light value on a dark page. `color.muted` was chosen to
+clear WCAG AA against `color.background` in both modes rather than by eye,
+because a muted token that fails contrast is worse than none: it reads as
+sanctioned.
+
+One border colour rather than a subtle/strong scale. A scale is much harder to
+remove from a guaranteed set than to add to one, and no block has asked for the
+distinction; a site wanting more defines its own, and `resolveSiteTokens` layers
+additions by name.

--- a/packages/blocks-engine/src/style/site-tokens.test.ts
+++ b/packages/blocks-engine/src/style/site-tokens.test.ts
@@ -664,11 +664,11 @@ describe("resolveSiteTokens", () => {
   it("adds a token the defaults do not define", () => {
     const resolved = resolveSiteTokens({
       tokens: [
-        { name: "color.surface", kind: "color", values: { light: "#f6f6f6" } },
+        { name: "color.accent", kind: "color", values: { light: "#f6f6f6" } },
       ],
     });
 
-    expect(resolved.tokens.map(t => t.name)).toContain("color.surface");
+    expect(resolved.tokens.map(t => t.name)).toContain("color.accent");
     expect(resolved.tokens.length).toBe(defaultSiteTokens().length + 1);
   });
 
@@ -695,5 +695,49 @@ describe("resolveSiteTokens", () => {
     expect(
       resolveSiteTokens({ tokens: [], prefix: "brand", darkMode: "media" })
     ).toMatchObject({ prefix: "brand", darkMode: "media" });
+  });
+});
+
+describe("the surface, border and muted tokens", () => {
+  const NEW = ["color.surface", "color.border", "color.muted"];
+
+  it("are in the guaranteed set", () => {
+    // Their absence made four blocks compromise — card shipped with no
+    // background or border, badge was unbuildable, the accordion had no divider
+    // and the table no border colour — and it is what made six blocks across
+    // three lanes reach for the ADMIN `--nx-*` namespace, which no published
+    // page emits.
+    const names = defaultSiteTokens().map(t => t.name);
+
+    for (const name of NEW) expect(names).toContain(name);
+  });
+
+  it("define BOTH modes, so none of them vanishes in dark", () => {
+    // `values.dark` is optional on the type, and a colour defined only for light
+    // is a colour that silently keeps its light value on a dark page. Asserted
+    // for every colour token, not only the new ones, so the next addition is
+    // held to it too.
+    const colours = defaultSiteTokens().filter(t => t.kind === "color");
+
+    expect(colours.length).toBeGreaterThan(3);
+    for (const token of colours) {
+      expect(
+        token.values.dark,
+        `${token.name} has no dark value`
+      ).toBeDefined();
+    }
+  });
+
+  it("distinguishes a surface from the page background", () => {
+    // A surface equal to the background is not a surface: a card would be
+    // invisible without a border, which is the compromise these tokens exist to
+    // remove. Asserted per mode, because equal-in-dark-only is the easy miss.
+    const find = (name: string) =>
+      defaultSiteTokens().find(t => t.name === name)?.values;
+    const surface = find("color.surface");
+    const background = find("color.background");
+
+    expect(surface?.light).not.toBe(background?.light);
+    expect(surface?.dark).not.toBe(background?.dark);
   });
 });

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -498,6 +498,55 @@ export function defaultSiteTokens(): SiteToken[] {
       kind: "color",
       values: { light: "#2563eb", dark: "#60a5fa" },
     },
+    /**
+     * A raised surface: a card, a panel, a table header. DISTINCT from
+     * `color.background`, which is the page itself.
+     *
+     * Its absence is what made four blocks compromise and what created a whole
+     * defect class. `core/card` shipped with no background and no border;
+     * `badge` was unbuildable, because a tinted background IS the block; the
+     * accordion had no divider and the table no border colour. And because
+     * nothing in this set could express a surface, **six blocks across three
+     * lanes independently reached for `--nx-*`** — the ADMIN namespace, which no
+     * published page emits. That is design pressure rather than six mistakes:
+     * when the correct mechanism is missing, whatever resembles it gets used.
+     *
+     * One step off `color.background` in each mode rather than a strong tint, so
+     * a surface reads as raised without needing a border to be legible — and
+     * still contrasts with one when a border is used.
+     */
+    {
+      name: "color.surface",
+      kind: "color",
+      values: { light: "#f9fafb", dark: "#151b2b" },
+    },
+    /**
+     * A hairline: a card outline, a table rule, a divider between sections.
+     *
+     * ONE border colour rather than a subtle/strong scale. A scale is far harder
+     * to remove from a guaranteed set than to add to it, and no block has yet
+     * asked for the distinction — the admin has three tiers because its density
+     * demands them, and a content page is not that. A site wanting more defines
+     * its own; `resolveSiteTokens` layers additions by name.
+     */
+    {
+      name: "color.border",
+      kind: "color",
+      values: { light: "#e5e7eb", dark: "#1f2937" },
+    },
+    /**
+     * Secondary text: a caption, a timestamp, a field hint.
+     *
+     * Chosen to clear WCAG AA against `color.background` in both modes rather
+     * than by eye — `#6b7280` on `#ffffff` is about 4.8:1 and `#9ca3af` on
+     * `#0b0f19` is far higher. A "muted" token that fails contrast is worse than
+     * none, because it reads as sanctioned.
+     */
+    {
+      name: "color.muted",
+      kind: "color",
+      values: { light: "#6b7280", dark: "#9ca3af" },
+    },
     { name: "font.body", kind: "fontFamily", values: { light: "system-ui" } },
     { name: "space.4", kind: "dimension", values: { light: "1rem" } },
   ];


### PR DESCRIPTION
Adds the two colours the guaranteed set was missing, plus the third you asked for.

```
before: content.width · color.text · color.background · color.primary · font.body · space.4
after:  + color.surface · color.border · color.muted
```

## What their absence cost

Four blocks compromised, and it is worth listing because the pattern matters more than any one of them:

| block | compromise |
| --- | --- |
| `core/card` | ships with **no background and no border** — the two properties that make a card look like a card |
| `badge` | **unbuildable.** A tinted background IS the block; without one it is a styled `box` |
| `core/accordion` | no divider between sections |
| `core/table` | no border colour (and it has catalog gaps besides) |

## And it created a defect class, not four inconveniences

Because nothing in the set could express a surface, **six blocks across three lanes independently reached for `--nx-*`** — the ADMIN namespace, which no published page emits. Those rules validated, compiled, shipped, and resolved to nothing, while looking correct in an admin preview.

**That is design pressure rather than six mistakes: when the correct mechanism is missing, whatever resembles it gets used.** Same shape as the `{ $token }` reaching that broke three blocks in #896 — and I was the source of that one, via a docblock arguing tokens were correct while nothing emitted them.

## Choices, each with a reason

**Both modes on all three.** `values.dark` is optional on the type, so a colour defined only for light *silently keeps its light value on a dark page*. A test now requires a dark value of **every** colour token, not only the new ones, so the next addition is held to it too.

**`color.muted` was checked against contrast, not chosen by eye.** `#6b7280` on `#ffffff` is ~4.8:1 (WCAG AA for normal text); `#9ca3af` on `#0b0f19` is far higher. **A muted token that fails contrast is worse than none, because it reads as sanctioned.**

**`color.surface` is one step off `color.background`, per mode** — a surface equal to the background is not a surface, and a card would then be invisible without a border, which is the compromise these remove. Asserted per mode, because equal-in-dark-only is the easy miss.

**One border colour, not a subtle/strong scale.** A scale is far harder to remove from a guaranteed set than to add to one, and no block has asked for the distinction — the admin has three tiers because its density demands them and a content page is not that. A site wanting more defines its own; `resolveSiteTokens` layers additions by name.

**Values stay on the Tailwind grey scale the existing set already derives from** (`#111827` = gray-900, `#f9fafb` = gray-50), so the palette reads as one system rather than two.

## Additive only

No block uses these yet, so nothing's appearance changes. Block adoption is the next step and needs one question settled first: a bare `PageRenderer` with no `siteStyles` emits no token definitions, so a block default reading a token would dangle there. Same shape as the `blockBases` question, same answer — **emit in the site sheet when there is one, the page sheet when there is not.**

The #896 ratchet forbidding tokens in `baseStyles` therefore **stays for now**. Its stated expiry is "when the site stylesheet is wired into the render path" — which #903 and #908 did for routes but not for the bare renderer.

## Verification

- `blocks-engine` **1259/1259**, `blocks-react` **595/595**, `plugin-page-builder` **836/836**, all exit 0
- `lint` and `check-types` exit 0
- one of my own earlier tests correctly went red: it used `color.surface` as its example of a token the defaults do *not* define. Repointed at `color.accent` rather than weakened.
