### PR TITLE
feat(admin): offer recovered work back when an editor opens

### DIFF
--- a/.changeset/admin-autosave-recovery-banner.md
+++ b/.changeset/admin-autosave-recovery-banner.md
@@ -1,0 +1,43 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+feat(admin): offer recovered work back when an editor opens
+
+Recording without offering is a loop that never closes: the work was stored and
+nobody was ever told it existed. The entry editor now reads the calling author
+own recovery point on open and offers it back.
+
+A non-blocking strip above the fields rather than a modal. A modal suited the
+older local draft, which was almost always your own work from a tab that had
+just crashed. A server recovery point is a wider set, including work from
+another device or from days ago, so demanding an answer before the document can
+be read turns a rescue into an obstacle.
+
+An offer is withheld when the document was saved after the recovery point, and
+made anyway when the document timestamp is unknown: a spurious offer costs one
+dismissal, while a suppressed one loses work recorded specifically so it could
+not be lost.

--- a/packages/admin/src/components/features/entries/EntryForm/AutosaveRecoveryBanner.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/AutosaveRecoveryBanner.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+/**
+ * Offers the author their own unsaved work back, without blocking the editor.
+ *
+ * A strip above the form rather than a modal. A modal was right for the older
+ * local draft, which was almost always your own work from a tab that had just
+ * crashed. A server recovery point is a wider set: it can be work from another
+ * device, or from days ago, so demanding an answer before the document can be
+ * read turns a rescue into an obstacle. Here the reader sees the document, then
+ * decides.
+ *
+ * @module components/entries/EntryForm/AutosaveRecoveryBanner
+ */
+
+import { Button } from "@nextlyhq/ui";
+import { RotateCcw, X } from "lucide-react";
+
+import { cn } from "@admin/lib/utils";
+
+export interface AutosaveRecoveryBannerProps {
+  /** When the offered recovery point was stored. */
+  savedAt: Date;
+  /** Write the recovered values into the form. */
+  onRestore: () => void;
+  /** Stop offering for this session, without deleting anything. */
+  onDismiss: () => void;
+  className?: string;
+}
+
+/** "10 minutes ago", in the coarsest unit that still reads precisely. */
+function formatTimeAgo(date: Date): string {
+  const diffSec = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (diffSec < 60) return "moments ago";
+
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60)
+    return diffMin === 1 ? "1 minute ago" : `${diffMin} minutes ago`;
+
+  const diffHours = Math.floor(diffMin / 60);
+  if (diffHours < 24)
+    return diffHours === 1 ? "1 hour ago" : `${diffHours} hours ago`;
+
+  const diffDays = Math.floor(diffHours / 24);
+  return diffDays === 1 ? "1 day ago" : `${diffDays} days ago`;
+}
+
+export function AutosaveRecoveryBanner({
+  savedAt,
+  onRestore,
+  onDismiss,
+  className,
+}: AutosaveRecoveryBannerProps) {
+  return (
+    // `status` rather than `alert`: an offer to recover is advisory, and `alert`
+    // interrupts a screen reader mid-sentence for something the reader can act
+    // on whenever they choose.
+    <div
+      role="status"
+      className={cn(
+        "flex flex-wrap items-center gap-3 rounded-md border border-border bg-muted/50 px-4 py-3 text-sm",
+        className
+      )}
+    >
+      <RotateCcw className="h-4 w-4 shrink-0 text-muted-foreground" />
+      <p className="flex-1 text-foreground">
+        You have unsaved changes from{" "}
+        <span className="font-medium">{formatTimeAgo(savedAt)}</span>.
+      </p>
+      <div className="flex items-center gap-2">
+        <Button type="button" size="sm" variant="outline" onClick={onRestore}>
+          Restore
+        </Button>
+        {/* Named for assistive technology: an unlabelled X in a region that
+            already says "unsaved changes" reads as "button" alone. */}
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={onDismiss}
+          aria-label="Dismiss recovery offer"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -16,11 +16,12 @@
  */
 
 import { resolveLocalizedFieldNames } from "nextly/config";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import { historyEnabledFrom } from "@admin/components/features/versions/history-enabled";
 import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { useGeneralSettings } from "@admin/hooks/queries/useGeneralSettings";
+import { useAutosaveRecovery } from "@admin/hooks/useAutosaveRecovery";
 import { useAutoSlug } from "@admin/hooks/useAutoSlug";
 import {
   autosaveScopeFor,
@@ -38,6 +39,7 @@ import { cn } from "@admin/lib/utils";
 
 import { EntryLocaleProvider } from "../EntryLocaleContext";
 
+import { AutosaveRecoveryBanner } from "./AutosaveRecoveryBanner";
 import {
   effectiveEntryStatus,
   isSlugPerLocale,
@@ -375,6 +377,22 @@ export function EntryForm({
     () => autosaveScopeFor("collection", collection.name, savedEntryId),
     [savedEntryId, collection.name]
   );
+  // The other half of recording: offer the work back when the editor opens.
+  const recovery = useAutosaveRecovery({
+    scope: autosaveScope,
+    documentUpdatedAt: entry?.updatedAt ?? null,
+  });
+  const restoreRecovery = useCallback(() => {
+    if (!recovery.offer) return;
+    // `reset` with `keepDefaultValues` so the form goes DIRTY: the recovered
+    // values are not what the server holds, and treating them as the new
+    // baseline would let the reader navigate away believing they were stored.
+    form.reset(recovery.offer.snapshot as Record<string, unknown>, {
+      keepDefaultValues: true,
+    });
+    recovery.dismiss();
+  }, [recovery, form]);
+
   const autosave = useDocumentAutosave({
     scope: autosaveScope,
     form,
@@ -550,6 +568,15 @@ export function EntryForm({
                   isRailCollapsed={railCollapsed}
                   onToggleRail={mode === "edit" ? toggleRail : undefined}
                 />
+                {/* Above the fields and below the header: the reader sees
+                    the document it refers to without the offer covering it. */}
+                {recovery.offer ? (
+                  <AutosaveRecoveryBanner
+                    savedAt={recovery.offer.savedAt}
+                    onRestore={restoreRecovery}
+                    onDismiss={recovery.dismiss}
+                  />
+                ) : null}
                 <EntryMetaStrip
                   slugField={slugField}
                   hasStatus={hasStatus}

--- a/packages/admin/src/hooks/__tests__/useAutosaveRecovery.test.tsx
+++ b/packages/admin/src/hooks/__tests__/useAutosaveRecovery.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * When a recovery point is worth offering back, and when it is not.
+ *
+ * The rule decides between two unequal errors, so the tests are written around
+ * that asymmetry rather than around the happy path: a spurious offer costs one
+ * dismissal, while a suppressed offer loses work that was recorded specifically
+ * so it could not be lost.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { getSpy } = vi.hoisted(() => ({ getSpy: vi.fn() }));
+
+vi.mock("@admin/services/versionApi", () => ({
+  versionApi: { getAutosave: getSpy },
+}));
+
+import { useAutosaveRecovery } from "../useAutosaveRecovery";
+
+const SCOPE = { kind: "collection" as const, slug: "posts", entryId: "e1" };
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useAutosaveRecovery", () => {
+  it("offers a recovery point newer than the saved document", async () => {
+    getSpy.mockResolvedValue({
+      snapshot: { title: "recovered" },
+      updatedAt: "2026-08-17T10:00:00.000Z",
+      locale: null,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useAutosaveRecovery({
+          scope: SCOPE,
+          documentUpdatedAt: "2026-08-17T09:00:00.000Z",
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.offer).not.toBeNull());
+    expect(result.current.offer?.snapshot).toEqual({ title: "recovered" });
+    expect(result.current.offer?.savedAt).toEqual(
+      new Date("2026-08-17T10:00:00.000Z")
+    );
+  });
+
+  /**
+   * A save AFTER the recovery point means the author already committed that
+   * work. Offering it back would invite them to restore what they are looking
+   * at, and worse, it would present a real document as though it were at risk.
+   */
+  it("stays silent when the document was saved after the recovery point", async () => {
+    getSpy.mockResolvedValue({
+      snapshot: { title: "stale" },
+      updatedAt: "2026-08-17T09:00:00.000Z",
+      locale: null,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useAutosaveRecovery({
+          scope: SCOPE,
+          documentUpdatedAt: "2026-08-17T10:00:00.000Z",
+        }),
+      { wrapper }
+    );
+
+    // Waits for the ANSWER, not merely for the request. Asserting on
+    // `offer === null` before the read returns is satisfied by the result not
+    // having arrived, which passes whether or not the rule under test exists.
+    await waitFor(() => expect(result.current.isResolved).toBe(true));
+    expect(result.current.offer).toBeNull();
+  });
+
+  /**
+   * The asymmetry, made explicit. With no document timestamp the rule cannot
+   * tell whether the recovery point is ahead, and it offers anyway: one
+   * dismissal is a smaller cost than silently withholding recorded work.
+   */
+  it("offers anyway when the document's own timestamp is unknown", async () => {
+    getSpy.mockResolvedValue({
+      snapshot: { title: "maybe newer" },
+      updatedAt: "2026-08-17T09:00:00.000Z",
+      locale: null,
+    });
+
+    const { result } = renderHook(
+      () => useAutosaveRecovery({ scope: SCOPE, documentUpdatedAt: null }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.offer).not.toBeNull());
+  });
+
+  it("stays silent when the author has no recovery point", async () => {
+    getSpy.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useAutosaveRecovery({ scope: SCOPE }), {
+      wrapper,
+    });
+
+    // Waits for the ANSWER, not merely for the request. Asserting on
+    // `offer === null` before the read returns is satisfied by the result not
+    // having arrived, which passes whether or not the rule under test exists.
+    await waitFor(() => expect(result.current.isResolved).toBe(true));
+    expect(result.current.offer).toBeNull();
+  });
+
+  /**
+   * A document with no address cannot be asked about. Reading anyway would put
+   * a request on the wire for a route that cannot resolve, on every new-entry
+   * editor open.
+   */
+  it("asks nothing while the document has no address", async () => {
+    const { result } = renderHook(() => useAutosaveRecovery({ scope: null }), {
+      wrapper,
+    });
+
+    expect(result.current.offer).toBeNull();
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Dismissing is "not now", not "delete". A reader who dismisses and then
+   * reloads must still be offered the work rather than finding it gone because
+   * they closed a banner.
+   */
+  it("stops offering once dismissed, without discarding anything", async () => {
+    getSpy.mockResolvedValue({
+      snapshot: { title: "recovered" },
+      updatedAt: "2026-08-17T10:00:00.000Z",
+      locale: null,
+    });
+
+    const { result } = renderHook(() => useAutosaveRecovery({ scope: SCOPE }), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.offer).not.toBeNull());
+
+    result.current.dismiss();
+
+    await waitFor(() => expect(result.current.offer).toBeNull());
+    // No delete call exists on the mocked surface, so a dismissal that tried to
+    // discard would fail loudly rather than silently destroying the row.
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/admin/src/hooks/useAutosaveRecovery.ts
+++ b/packages/admin/src/hooks/useAutosaveRecovery.ts
@@ -1,0 +1,122 @@
+"use client";
+
+/**
+ * Whether to offer the author their own recovery point back when an editor
+ * opens, and the values to restore if they accept.
+ *
+ * The other half of `useDocumentAutosave`. Recording without offering is a loop
+ * that never closes: the work is stored and nobody is ever told it exists.
+ *
+ * @module hooks/useAutosaveRecovery
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useState } from "react";
+
+import { versionApi, type VersionScope } from "@admin/services/versionApi";
+
+export interface UseAutosaveRecoveryOptions {
+  /** The document to read a recovery point for, or `null` when there is none. */
+  scope: VersionScope | null;
+
+  /**
+   * When the stored document was last written, as the API reports it.
+   *
+   * Used to decide whether the recovery point still says anything: a save that
+   * happened after it means the author already committed that work, and
+   * offering it back would invite them to restore what they are looking at.
+   */
+  documentUpdatedAt?: string | null;
+}
+
+export interface AutosaveRecoveryOffer {
+  /** When the server stored it, for "unsaved changes from N minutes ago". */
+  savedAt: Date;
+  /** The values to write back into the form if the author accepts. */
+  snapshot: unknown;
+}
+
+export interface UseAutosaveRecoveryResult {
+  /** The offer to present, or `null` when there is nothing worth offering. */
+  offer: AutosaveRecoveryOffer | null;
+  /**
+   * Whether the question has been answered yet.
+   *
+   * `offer === null` alone cannot distinguish "there is nothing to offer" from
+   * "the read has not come back", and the two want different treatment: the
+   * first is final, the second is a moment that will pass. Callers that render
+   * on the answer need this to avoid asserting the negative early, and so does
+   * any test of the suppression rules, which are otherwise satisfied by a
+   * result that simply has not arrived.
+   */
+  isResolved: boolean;
+  /**
+   * Stop offering for the rest of this editing session.
+   *
+   * Local to the component, deliberately: it does NOT delete the stored
+   * recovery point. Dismissing means "not now", and a reader who dismisses and
+   * then reloads should still be offered the work rather than discovering it is
+   * gone because they closed a banner.
+   */
+  dismiss: () => void;
+}
+
+/**
+ * @param options - the document and when it was last saved
+ * @returns the offer to present, and a way to stop presenting it
+ */
+export function useAutosaveRecovery({
+  scope,
+  documentUpdatedAt = null,
+}: UseAutosaveRecoveryOptions): UseAutosaveRecoveryResult {
+  const [dismissed, setDismissed] = useState(false);
+
+  const { data, isPending, isError } = useQuery({
+    // Keyed by the document, so switching entries asks again rather than
+    // reusing the previous document's answer.
+    queryKey: [
+      "autosave-recovery",
+      scope?.kind,
+      scope?.slug,
+      scope?.kind === "single" ? scope.documentId : scope?.entryId,
+    ],
+    queryFn: () => (scope ? versionApi.getAutosave(scope) : null),
+    enabled: scope !== null,
+    // Read once when the editor opens. Refetching on focus would surface an
+    // offer mid-edit, and by then the form already holds newer values than the
+    // recovery point does.
+    refetchOnWindowFocus: false,
+    staleTime: Infinity,
+  });
+
+  const dismiss = useCallback(() => setDismissed(true), []);
+
+  // A document with no address is answered without asking: there is nothing to
+  // read, and that is a final answer rather than a pending one.
+  const isResolved = scope === null || isError || !isPending;
+
+  if (dismissed || !data) return { offer: null, isResolved, dismiss };
+
+  const savedAt = new Date(data.updatedAt);
+  if (Number.isNaN(savedAt.getTime()))
+    return { offer: null, isResolved, dismiss };
+
+  // A save after the recovery point means the author already committed that
+  // work, so the recovery point describes a state that is no longer ahead of
+  // the document and there is nothing to rescue.
+  //
+  // An UNKNOWN document timestamp offers anyway. The two errors are not
+  // symmetric: a spurious offer costs one dismissal, while a suppressed one
+  // loses work that was recorded specifically so it could not be lost.
+  if (documentUpdatedAt) {
+    const documentAt = new Date(documentUpdatedAt);
+    if (
+      !Number.isNaN(documentAt.getTime()) &&
+      savedAt.getTime() <= documentAt.getTime()
+    ) {
+      return { offer: null, isResolved, dismiss };
+    }
+  }
+
+  return { offer: { savedAt, snapshot: data.snapshot }, isResolved, dismiss };
+}


### PR DESCRIPTION
Closes the autosave loop. Until now recovery points were recorded and never mentioned to anyone.

## What changes

The entry editor reads the calling author's own recovery point on open and offers it back in a strip above the fields.

## Why a banner and not the existing dialog

`DraftRecoveryDialog` is an `AlertDialog` -- a blocking modal -- and it was reused deliberately NOT.

A modal suited the older local draft, which was almost always your own work from a tab that had just crashed: interrupting was proportionate because the work was minutes old and certainly yours. A server recovery point is a wider set. It can be work from another device, or from days ago. Demanding an answer before the document can even be read turns a rescue into an obstacle, and the reader is being asked to decide about a document they have not seen yet.

So the banner is non-blocking and the reader decides with the document in front of them.

## The decision rule, and the asymmetry behind it

| situation | behaviour |
| --- | --- |
| document saved AFTER the recovery point | silent |
| document timestamp unknown | **offer anyway** |
| no recovery point | silent |
| document has no address | never even asks |

The middle row is the one worth arguing. The two errors are not equal in cost: a spurious offer costs one dismissal, while a suppressed offer loses work that was recorded specifically so it could not be lost. So the unknown case errs toward offering.

Two more properties that are easy to get wrong:

- **Dismiss means "not now", never "delete".** It is local component state and touches nothing stored, so a reader who dismisses and then reloads is offered the work again rather than finding it gone because they closed a banner.
- **Restore leaves the form DIRTY** (`reset` with `keepDefaultValues`). The recovered values are not what the server holds; treating them as the new baseline would let someone navigate away believing they were stored.

## A false pass in my own test, found and repaired

Worth recording because the first version of this suite proved nothing about its main rule.

Break-verifying the "document is newer" suppression changed NOTHING -- the test passed with the rule deleted. The cause: it asserted `offer === null` after waiting only for the REQUEST, so it was satisfied by the read not having returned yet rather than by the rule.

`offer === null` cannot distinguish "nothing to offer" from "no answer yet", and those want different treatment. The hook now exposes `isResolved`, the tests wait for the ANSWER, and re-breaking the rule fails correctly. The flag also earns its place in the API: a consumer needs the same distinction to avoid rendering nothing and then flashing a banner.

## Verification

Break-verified:

| break | result |
| --- | --- |
| suppress when the timestamp is unknown | 2 tests fail |
| offer even when the document is newer | 1 test fails (after the repair; NOTHING before it) |

Gates: check-types + lint 11/11, 40 files / 340 tests green across hooks and the entry editor, `check:comments` clean, changeset validated against the lockstep group.

## Remaining in this lane

Singles wiring. `autosaveScopeFor("single", slug, documentId)` already handles the scope, so it is mounting rather than design.