### PR TITLE
test(admin): assert the header rendered before asserting the indicator is absent

### DIFF
--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.autosave-indicator.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.autosave-indicator.test.tsx
@@ -92,6 +92,15 @@ describe("EntrySystemHeader autosave indicator", () => {
   it("shows nothing while the document cannot be recorded against", () => {
     render(<Harness autosaveEnabled={false} isDirty />);
 
+    // Population before verdict. An assertion that something is ABSENT is
+    // satisfied by a header that failed to render, by a renamed label, and by a
+    // typo in the matcher, all identically to the rule working. Requiring a
+    // control the header always renders makes the difference observable inside
+    // this test rather than relying on a positive case elsewhere in the file
+    // continuing to exist.
+    expect(
+      screen.getByRole("button", { name: /save draft/i })
+    ).toBeInTheDocument();
     expect(screen.queryByText(/not saved/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/saving/i)).not.toBeInTheDocument();
   });
@@ -103,6 +112,9 @@ describe("EntrySystemHeader autosave indicator", () => {
   it("shows nothing when there is no change and no recovery point", () => {
     render(<Harness autosaveEnabled />);
 
+    expect(
+      screen.getByRole("button", { name: /save draft/i })
+    ).toBeInTheDocument();
     expect(screen.queryByText(/not saved/i)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Test-only, no changeset.

## The flaw, measured rather than suspected

Two cases in `EntrySystemHeader.autosave-indicator.test.tsx` asserted only that the indicator was ABSENT. That is satisfied by a renamed label, a matcher typo, or a component that renders nothing, all identically to the rule working.

I relabelled the indicator so the matcher could not find it:

```
× reports an unstored change before the first recording
  4 passed, INCLUDING both negatives
```

The positives in the same file were the only thing proving the matcher resolves. That is a control by adjacency: rewrite or delete those positives and the negatives keep passing while meaning nothing, and nobody would see it happen.

## The control that settles it

Not gutting the feature -- absence stays legitimately true then. Gutting the RENDER:

| `EntrySystemHeader` returns null | negatives |
| --- | --- |
| before this change | **pass** |
| after | fail, with all five |

Two tests passing against a component that renders literally nothing is the blind spot worth closing.

## The fix

Each negative now requires a control the header always renders (`Save Draft`) before asserting the indicator is absent. Population first, verdict second.

## Why it is worth a PR of its own

This is the third instance of one property today, across three mechanisms: a peer lane found it in a dialog suite (absence satisfied by a renamed button), I found it in the recovery hook (absence satisfied by a result that had not arrived), and here (absence satisfied by a component that never rendered). A fourth is the CI queue, where a queued job and a passing job produce the same silence.

None of them would have been caught by reading the tests. All were caught by breaking the code and watching what failed.