### PR TITLE
feat(blocks-react): emit the design-token sheet by default from PageRenderer too

### DIFF
--- a/.changeset/site-sheet-default-on.md
+++ b/.changeset/site-sheet-default-on.md
@@ -1,0 +1,44 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+feat(blocks-react): emit the design-token sheet by default from PageRenderer too
+
+`PageRenderer` was opt-in while a Nextly route emitted by default, and the
+asymmetry cost more than it saved: a block could not reference a token at all,
+because a default reading `color.surface` resolved on a route and silently
+resolved to nothing in a standalone render. `core/card` shipped with no
+background and no border for that reason, and the pressure that produced six
+blocks reaching for the admin `--nx-*` namespace stayed exactly where it was.
+
+Both paths now emit, and a host opts out with `siteStyles={false}` — an explicit
+refusal rather than an empty token list, because `resolveSiteTokens` LAYERS, so
+an empty override means "no overrides" and still yields every default. A test is
+what found that the opt-out did not exist at all.
+
+Breakpoints come from the RECONCILED compile context rather than the caller's
+`styleContext`, so a consumer rendering a stored artifact — the ordinary
+production path — gets a sheet instead of nothing.

--- a/packages/blocks-react/src/next.test.ts
+++ b/packages/blocks-react/src/next.test.ts
@@ -11,7 +11,7 @@ import {
   DEFAULT_LIMITS,
   DOCUMENT_FORMAT_VERSION,
 } from "@nextlyhq/blocks-engine";
-import type { BlockDocument } from "@nextlyhq/blocks-engine";
+import type { BlockDocument, SiteSheetInput } from "@nextlyhq/blocks-engine";
 import type { ReactElement } from "react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -1771,6 +1771,20 @@ describe("createBlocksPage", () => {
   });
 });
 
+/**
+ * A route's site-sheet input, narrowed.
+ *
+ * `PageRendererProps.siteStyles` is `SiteSheetInput | false`, because a
+ * standalone host may refuse the sheet outright. A ROUTE never does — so this
+ * narrows by ASSERTING that rather than by casting, which keeps "a route does
+ * not disable the site sheet" a checked claim instead of a silenced one.
+ */
+function siteOf(props: PageRendererProps): SiteSheetInput | undefined {
+  const site = props.siteStyles;
+  expect(site, "a route must never disable the site sheet").not.toBe(false);
+  return site === false ? undefined : site;
+}
+
 describe("createBlocksPage and the site stylesheet", () => {
   const BREAKPOINTS = {
     viewport: [{ id: "base", label: "Desktop" }],
@@ -1790,7 +1804,7 @@ describe("createBlocksPage and the site stylesheet", () => {
     });
 
     expect(props.siteStyles).toBeDefined();
-    expect(props.siteStyles?.breakpoints).toEqual(BREAKPOINTS);
+    expect(siteOf(props)?.breakpoints).toEqual(BREAKPOINTS);
   });
 
   it("reuses the breakpoints the site already stated", async () => {
@@ -1805,7 +1819,7 @@ describe("createBlocksPage and the site stylesheet", () => {
       styleContext: { breakpoints: BREAKPOINTS },
     });
 
-    expect(props.siteStyles?.breakpoints).toBe(props.styleContext?.breakpoints);
+    expect(siteOf(props)?.breakpoints).toBe(props.styleContext?.breakpoints);
   });
 
   it("lets the route state its own breakpoints instead", async () => {
@@ -1821,7 +1835,7 @@ describe("createBlocksPage and the site stylesheet", () => {
       siteStyles: { breakpoints: own },
     });
 
-    expect(props.siteStyles?.breakpoints).toEqual(own);
+    expect(siteOf(props)?.breakpoints).toEqual(own);
   });
 
   it("carries the site's own tokens through to the sheet", async () => {
@@ -1839,7 +1853,7 @@ describe("createBlocksPage and the site stylesheet", () => {
       },
     });
 
-    expect(props.siteStyles?.tokens?.tokens[0]?.name).toBe("color.primary");
+    expect(siteOf(props)?.tokens?.tokens[0]?.name).toBe("color.primary");
   });
 
   it("emits NO site sheet when the site states no breakpoints anywhere", async () => {

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -72,14 +72,32 @@ export interface PageRendererProps {
    * break it silently: an unresolved custom property invalidates the
    * declaration rather than reporting anything.
    *
-   * Omitted means no site sheet is emitted at all, which is the behaviour every
-   * existing consumer had before this prop existed. That is deliberate rather
-   * than lazy — a renderer that started emitting token definitions on its own
-   * would change what stored `{ $token }` references resolve to, and a page
-   * whose current appearance depends on one of those dangling is a page that
-   * moves. The host decides when to take that step.
+   * **Omitting it still emits the DEFAULT token set.** This was opt-in when the
+   * prop was introduced, on the argument that a standalone consumer owns its own
+   * `<head>`. That argument does not survive contact with what the asymmetry
+   * cost: a block could not reference a token at all, because a default reading
+   * `color.surface` would resolve on a Nextly route and silently resolve to
+   * nothing here. So `core/card` shipped with no background and no border, and
+   * `badge` was unbuildable — and the pressure that produced six blocks reaching
+   * for the admin `--nx-*` namespace stayed exactly where it was.
+   *
+   * What a host receives unasked is a block of `--site-*` custom-property
+   * DEFINITIONS. They are additive and namespaced, and the engine reserves that
+   * prefix — `safeTokenPrefix` refuses `--nx-` and `--tw-` precisely so a site
+   * cannot restyle surfaces it does not own — so they cannot collide with a
+   * host's own variables. A host that wants its own set supplies one; a host
+   * that wants NONE passes `siteStyles={false}` — an explicit refusal rather
+   * than an empty token list, because `resolveSiteTokens` LAYERS, so an empty
+   * override means "no overrides" and still yields every default. A test found
+   * that: the opt-out did not exist until it was given its own value.
+   *
+   * A sheet needs a breakpoint set to compile the block-default tier under, and
+   * it is taken from the RECONCILED compile context rather than from
+   * `styleContext` alone — a consumer rendering a stored artifact supplies no
+   * context of its own and would otherwise get no sheet, which is the ordinary
+   * production path.
    */
-  siteStyles?: SiteSheetInput;
+  siteStyles?: SiteSheetInput | false;
   /** Shown in place of an asynchronous block until its output arrives. */
   blockFallback?: ReactNode;
   /**
@@ -388,12 +406,30 @@ export function PageRenderer({
   // the default set reach a page at all. Until this existed nothing called
   // `compileSiteSheet`, so `defaultSiteTokens()` was a default nobody applied
   // and every `{ $token }` compiled to a `var()` with nothing behind it.
+  // Derived ONCE, and from the RECONCILED context rather than from the caller's
+  // `styleContext`: a consumer rendering a stored artifact supplies no context
+  // of its own, and taking the raw prop would leave the ordinary production path
+  // with no sheet. Two answers to "what are this site's breakpoints" is also how
+  // the shared sheet and the page sheet come to disagree about which at-rules a
+  // tier is emitted under, invisibly, since each sheet is consistent on its own.
+  const siteInput = siteStyles === false ? undefined : siteStyles;
+  const siteBreakpoints =
+    siteStyles === false
+      ? undefined
+      : (siteInput?.breakpoints ?? compileContext?.breakpoints);
+  // A sheet by DEFAULT. Without one a block cannot reference a token at all —
+  // a default reading `color.surface` would resolve on a route and resolve to
+  // nothing here — which is why `core/card` shipped with no background.
+  // Withheld only when no breakpoints are known, because a sheet compiled
+  // against breakpoints nobody chose would put the block-default tier under
+  // at-rules the page sheet does not use.
   const siteSheet =
-    siteStyles === undefined
+    siteBreakpoints === undefined
       ? undefined
       : compileSiteSheet({
-          ...siteStyles,
-          tokens: resolveSiteTokens(siteStyles.tokens),
+          ...siteInput,
+          breakpoints: siteBreakpoints,
+          tokens: resolveSiteTokens(siteInput?.tokens),
         });
 
   return (

--- a/packages/blocks-react/src/site-sheet.test.tsx
+++ b/packages/blocks-react/src/site-sheet.test.tsx
@@ -56,15 +56,27 @@ describe("the site stylesheet", () => {
     expect(out).toContain("--site-content-width");
   });
 
-  it("emits NOTHING when the host asks for no site sheet", () => {
-    // The behaviour every existing consumer had before this prop existed, and
-    // the reason it is opt-in: emitting token definitions unasked changes what
-    // a stored `{ $token }` resolves to, and a page whose appearance depends on
-    // one of those dangling is a page that moves.
+  it("emits the DEFAULT set even when the host says nothing", () => {
+    // Changed deliberately: this asserted the opposite while the prop was
+    // opt-in. The asymmetry it protected cost more than it saved — a block
+    // could not reference a token at all, because a default reading
+    // `color.surface` resolved on a Nextly route and resolved to nothing here.
+    // `core/card` shipped with no background because of it.
     const out = html();
 
-    expect(out).not.toContain("--site-");
-    expect(out).not.toContain("data-nx-site-sheet");
+    expect(out).toContain("data-nx-site-sheet");
+    expect(out).toContain("--site-color-surface");
+  });
+
+  it("lets a host opt OUT explicitly, with false", () => {
+    // The escape hatch, and it must be reachable or "default on" becomes
+    // "mandatory". `false` rather than an empty token list, because
+    // `resolveSiteTokens` LAYERS: an empty override means "no overrides" and
+    // still yields every default. This test is what found that the opt-out did
+    // not exist at all.
+    const out = html(false);
+
+    expect(out).not.toContain("--site-color-surface");
   });
 
   it("lets a site override a default by NAME while the others survive", () => {


### PR DESCRIPTION
Founder decision: make the design-token sheet emit by default everywhere, not only from a Nextly route.

## What the asymmetry cost

`PageRenderer` was opt-in while `createBlocksPage` emitted by default (#908). That looked conservative and was not: **a block could not reference a token at all.** A default reading `color.surface` would resolve on a Nextly page and **silently resolve to nothing** in a standalone render — so `core/card` shipped with no background and no border, `badge` stayed unbuildable, and the pressure that made six blocks across three lanes reach for the admin `--nx-*` namespace stayed exactly where it was.

Both paths now emit. **That is what unblocks blocks using the tokens `#911` added.**

## A test found a real gap: there was no way to opt out

The obvious opt-out — an empty token list — **does not work**, and it took writing the test to see why: `resolveSiteTokens` **layers**, so `tokens: { tokens: [] }` means *"no overrides"* and still yields every default. There was no refusal available at all.

So the opt-out is now explicit: **`siteStyles={false}`**. A host that emits its own `--site-*` set from its own build can turn ours off; anyone else gets working tokens.

## Breakpoints come from the RECONCILED context

Not from the caller's `styleContext`. A consumer rendering a **stored artifact** supplies no context of its own — the ordinary production path — and taking the raw prop would have left exactly that case with no sheet. Derived once, so the shared sheet and the page sheet cannot disagree about which at-rules a tier compiles under.

## Two deliberate edits, both mine

1. **A test asserting "emits NOTHING when the host asks for no site sheet" now asserts the opposite.** The contract changed; the test is a deliberate edit rather than a fix to go green, and it says so in place.
2. **Four route tests hit `TS2339` from widening to `SiteSheetInput | false`.** Fixed by **narrowing through a helper that ASSERTS a route never disables the sheet** — not by casting. The claim stays checked instead of silenced, and `TS2339` is exactly the error whose tempting remedy is deleting the call.

## Verification

- `blocks-react` **596/596**, `plugin-page-builder` **836/836**, both exit 0 — consumer run against a freshly rebuilt `dist`
- `lint` and `check-types` exit 0

I caught the type failure only because I read the gate's exit code directly (`GATES=2`) after having already pushed. It is now green.

## Next

`core/card` can finally take `color.surface` and `color.border`, and `badge` becomes buildable. That needs the **#896 ratchet deleted** — its stated expiry was "when the site stylesheet is wired into the render path", which this completes for both paths. Deleted by the change that adopts tokens, as written, rather than weakened or exempted per block.
