### PR TITLE
fix(admin): give every form field a name and a description that exist

### DIFF
--- a/.changeset/form-control-describedby.md
+++ b/.changeset/form-control-describedby.md
@@ -1,0 +1,40 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(admin): describe a field only when a description renders
+
+`FormControl` named the description element in `aria-describedby`
+unconditionally, while `FormDescription` renders nothing when it has no
+children. Every field without a description therefore pointed assistive
+technology at an element that was never on the page: the admin has 76
+`FormControl` usages against 3 `FormDescription`, and 13 of the 14 files using
+`FormControl` contain no description at all.
+
+`FormDescription` now registers its presence on the field context and
+`FormControl` composes `aria-describedby` from the elements that actually
+render. Measured in a browser across eight admin form routes in both themes:
+five dangling references before, zero after.

--- a/packages/admin/src/components/features/entries/fields/FieldRenderer.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldRenderer.tsx
@@ -331,11 +331,27 @@ export function FieldRenderer({
   // to match the vertical layout of radio buttons.
   const useHorizontalLayout = false;
 
+  // Whether the editor for this field comes from a plugin rather than from the
+  // built-in type dispatch — either a per-field `admin.component` override
+  // (D24) or a plugin-registered field type (C7/D16). Both render through
+  // `PluginSlot`, so nothing here can know whether the result exposes a single
+  // labelable control, and it must not claim one does.
+  //
+  // This is deliberately a STRUCTURAL question rather than a check against the
+  // field's type name: an override leaves the type untouched while replacing
+  // the component entirely, so no list of composite type names can see it.
+  const hasPluginEditor =
+    Boolean(adminOptions?.component) ||
+    (branding?.plugins ?? [])
+      .flatMap(p => p.fieldTypes ?? [])
+      .some(ft => ft.type === (field.type as string));
+
   return (
     <FieldWrapper
       field={field}
       error={error?.message}
       horizontal={useHorizontalLayout}
+      editorIsOpaque={hasPluginEditor}
     >
       {renderField()}
     </FieldWrapper>

--- a/packages/admin/src/components/features/entries/fields/FieldWrapper.rtl.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldWrapper.rtl.test.tsx
@@ -97,19 +97,28 @@ describe("FieldWrapper RTL direction", () => {
 });
 
 describe("FieldWrapper shared-across-languages affordance", () => {
+  // The badge states the whole fact instead of abbreviating to "Shared" behind
+  // a `title` tooltip. All three queries below name the full string: matching
+  // on the old short text would make the two NEGATIVE assertions pass for the
+  // wrong reason, since an exact query for "Shared" no longer matches the
+  // element that is now rendered either.
   it("marks a shared field in a multilingual collection", () => {
     renderField(numberField, { collectionLocalized: true });
-    expect(screen.getByText("Shared")).toBeInTheDocument();
+    expect(screen.getByText("Shared across languages")).toBeInTheDocument();
   });
 
   it("does NOT mark a translatable field", () => {
     renderField(textField, { collectionLocalized: true });
-    expect(screen.queryByText("Shared")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Shared across languages")
+    ).not.toBeInTheDocument();
   });
 
   it("shows no affordance when the collection is not localized", () => {
     renderField(numberField, { collectionLocalized: false });
-    expect(screen.queryByText("Shared")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Shared across languages")
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/packages/admin/src/components/features/entries/fields/FieldWrapper.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldWrapper.tsx
@@ -59,6 +59,25 @@ export interface FieldWrapperProps {
    * @default false
    */
   horizontal?: boolean;
+
+  /**
+   * Whether the editor rendering this field comes from a plugin rather than
+   * from the built-in type dispatch.
+   *
+   * Such a field is exposed as a GROUP, because nothing here can know whether
+   * plugin-supplied markup contains a single labelable control — and a
+   * `<label for>` aimed at an id no element carries names nothing at all.
+   *
+   * Classifying by the field's TYPE cannot answer this, which is why it is a
+   * prop rather than another entry in {@link GROUP_FIELD_TYPES}: an override
+   * replaces the component while leaving the type untouched. Measured — the
+   * page builder renders over a `json` field and its label pointed at nothing,
+   * while an ordinary `json` field on another collection was labelled
+   * correctly.
+   *
+   * @default false
+   */
+  editorIsOpaque?: boolean;
 }
 
 // ============================================================
@@ -168,6 +187,7 @@ export function FieldWrapper({
   className,
   fieldPath,
   horizontal = false,
+  editorIsOpaque = false,
 }: FieldWrapperProps) {
   // i18n M7: active content-language direction (RTL for Arabic/Hebrew/…).
   const entryLocale = useEntryLocale();
@@ -204,7 +224,7 @@ export function FieldWrapper({
 
   // A group is named by `aria-labelledby` on a `role="group"` container rather
   // than by a `<label for>`, because there is no single control to point at.
-  const isGroup = GROUP_FIELD_TYPES.has(_fieldType);
+  const isGroup = GROUP_FIELD_TYPES.has(_fieldType) || editorIsOpaque;
   // Only the non-group path claims a control carries the id, so only it is
   // checked. A group makes no such claim and cannot fail this way.
   useLabelLandingCheck(!isGroup && !isHidden, fieldId, label, _fieldType);

--- a/packages/admin/src/components/features/entries/fields/FieldWrapper.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldWrapper.tsx
@@ -14,7 +14,7 @@ import { Label } from "@nextlyhq/ui";
 import { Globe } from "lucide-react";
 import { isFieldLocalized, type FieldConfig } from "nextly/config";
 import type { ReactNode } from "react";
-import { useId } from "react";
+import { useEffect, useId } from "react";
 
 import { cn } from "@admin/lib/utils";
 
@@ -78,6 +78,60 @@ const WIDTH_STYLES: Record<string, string> = {
   "100%": "w-full",
 };
 
+/**
+ * Field types whose input renders a GROUP of controls rather than one element an
+ * id can attach to.
+ *
+ * This wrapper renders `{children}` as-is — it never clones — so a `<label for>`
+ * only resolves when the input component independently sets a matching `id`.
+ * `TextInput` and friends do (`id={name}`); these do not, because there is no
+ * single control to put it on: rich text is a contenteditable surface plus a
+ * toolbar, relationship is a search box plus a result list plus remove buttons,
+ * and upload is a drop zone plus a preview plus actions. Pointing a label at
+ * the wrapping `<div>` would resolve the reference while naming something that
+ * cannot be focused, which is worse than leaving it dangling.
+ *
+ * Measured dangling on `/admin/collections/posts/create` in both themes before
+ * this list existed: `richText:content`, `relationship:categories`,
+ * `relationship:tags`, `upload:featuredImage`.
+ *
+ * The list covers the types this codebase has evidence for. It is deliberately
+ * NOT a guess at the rest: `assertLabelLanded` below fires in development for
+ * any other type whose label finds no target, so a missing entry announces
+ * itself the first time the field is opened instead of failing silently.
+ */
+const GROUP_FIELD_TYPES: ReadonlySet<string> = new Set([
+  "richText",
+  "relationship",
+  "upload",
+]);
+
+/**
+ * Development-time check that a `<label for>` actually found something.
+ *
+ * The failure this guards is silent by construction: the label renders, the
+ * input renders, and only the association is missing. `FieldShell` in
+ * `@nextlyhq/ui` carries the same check for the same reason.
+ */
+function useLabelLandingCheck(
+  enabled: boolean,
+  targetId: string,
+  label: string,
+  fieldType: string
+): void {
+  useEffect(() => {
+    if (!enabled || process.env.NODE_ENV === "production") return;
+    if (typeof document === "undefined") return;
+    if (document.getElementById(targetId)) return;
+    console.warn(
+      `[Nextly] The label "${label}" points at #${targetId}, but no element carries that id. ` +
+        `Field type "${fieldType}" renders no single control the id can attach to, so its label ` +
+        `names nothing. Add "${fieldType}" to GROUP_FIELD_TYPES in FieldWrapper.tsx so the field ` +
+        `is exposed as a group instead.`
+    );
+  }, [enabled, targetId, label, fieldType]);
+}
+
 // ============================================================
 // Component
 // ============================================================
@@ -123,6 +177,9 @@ export function FieldWrapper({
   const fieldName = "name" in field ? (field.name as string) : undefined;
   const fieldId = fieldPath || fieldName || generatedId;
   const errorId = `${fieldId}-error`;
+  const descriptionId = `${fieldId}-description`;
+  // Names the group when the field has no single control to point a label at.
+  const groupLabelId = `${fieldId}-group-label`;
 
   // Extract field properties - cast to common optional properties
   const fieldWithCommonProps = field as {
@@ -145,6 +202,19 @@ export function FieldWrapper({
   const isHidden = fieldWithCommonProps.admin?.hidden;
   const _fieldType = field.type as string;
 
+  // A group is named by `aria-labelledby` on a `role="group"` container rather
+  // than by a `<label for>`, because there is no single control to point at.
+  const isGroup = GROUP_FIELD_TYPES.has(_fieldType);
+  // Only the non-group path claims a control carries the id, so only it is
+  // checked. A group makes no such claim and cannot fail this way.
+  useLabelLandingCheck(!isGroup && !isHidden, fieldId, label, _fieldType);
+  // Announced with the group. The single-control path cannot do this from here:
+  // the id lives on an element this component never touches.
+  const groupDescribedBy =
+    [description ? descriptionId : null, error ? errorId : null]
+      .filter(Boolean)
+      .join(" ") || undefined;
+
   // i18n M7: is this field translatable (a per-language value) or shared across all languages?
   // Uses the same classifier as storage generation (nextly/config) so the editor and the DB
   // agree. For non-localized collections this is always false and everything below is inert.
@@ -166,12 +236,13 @@ export function FieldWrapper({
     entryLocale.collectionLocalized &&
     !isLocalizedField &&
     fieldName != null ? (
-      <span
-        className="inline-flex items-center gap-1 text-xs font-medium normal-case tracking-normal text-muted-foreground"
-        title="Shared across languages — editing this field changes it for every language."
-      >
+      // The whole fact is written out rather than abbreviated to "Shared"
+      // behind a `title` tooltip. A tooltip is unreachable by touch and
+      // awkward by keyboard — the same objection this file already records
+      // against putting description text behind a hover target.
+      <span className="inline-flex w-fit items-center gap-1.5 rounded-sm bg-muted px-2 py-0.5 text-xs font-medium normal-case tracking-normal text-muted-foreground">
         <Globe className="size-3" aria-hidden="true" />
-        Shared
+        Shared across languages
       </span>
     ) : null;
 
@@ -224,10 +295,12 @@ export function FieldWrapper({
       >
         <div className="pt-0.5">{children}</div>
         <div className="grid gap-1.5 leading-none">
+          {/* Outside the label, for the reason given in the vertical layout. */}
+          {sharedHint}
           <Label
             htmlFor={fieldId}
             className={cn(
-              "flex items-center gap-2 text-xs font-bold tracking-[0.08em] text-muted-foreground",
+              "flex items-center gap-2 text-sm font-medium text-foreground",
               error && "text-destructive"
             )}
           >
@@ -237,7 +310,6 @@ export function FieldWrapper({
                 *
               </span>
             )}
-            {sharedHint}
           </Label>
           {description && (
             <p className="text-xs text-muted-foreground leading-relaxed">
@@ -276,36 +348,74 @@ export function FieldWrapper({
       // i18n M7: render the field right-to-left when a translatable field is edited in an RTL
       // language (Arabic, Hebrew, …). Shared / non-localized editors are unaffected.
       {...(rtlField ? { dir: "rtl" as const } : {})}
+      // A field with no single focusable control is exposed as a named group.
+      {...(isGroup
+        ? {
+            role: "group" as const,
+            "aria-labelledby": groupLabelId,
+            ...(groupDescribedBy
+              ? { "aria-describedby": groupDescribedBy }
+              : {}),
+          }
+        : {})}
     >
-      {/* Label */}
-      <Label
-        htmlFor={fieldId}
-        className={cn(
-          "flex items-center gap-2 text-xs font-bold tracking-[0.08em] text-muted-foreground mb-1",
-          error && "text-destructive"
-        )}
-      >
-        {label}
-        {isRequired && (
-          <span className="text-destructive-500 ml-1" aria-hidden="true">
-            *
-          </span>
-        )}
-        {sharedHint}
-      </Label>
+      {/* Language status sits ABOVE the label, not inside it. Anything inside a
+          <label> joins the field's accessible name, so rendering the badge there
+          made a screen reader announce the field as "Title Shared" — describing
+          the field with a word that is not part of what it is called. */}
+      {sharedHint}
+
+      {isGroup ? (
+        <span
+          id={groupLabelId}
+          className={cn(
+            "flex items-center gap-2 text-sm font-medium text-foreground",
+            error && "text-destructive"
+          )}
+        >
+          {label}
+          {isRequired && (
+            <span className="text-destructive-500 ml-1" aria-hidden="true">
+              *
+            </span>
+          )}
+        </span>
+      ) : (
+        <Label
+          htmlFor={fieldId}
+          className={cn(
+            "flex items-center gap-2 text-sm font-medium text-foreground",
+            error && "text-destructive"
+          )}
+        >
+          {label}
+          {isRequired && (
+            <span className="text-destructive-500 ml-1" aria-hidden="true">
+              *
+            </span>
+          )}
+        </Label>
+      )}
+
+      {/* i18n M7: the default language's value, shown while translating another
+          language. It sits ABOVE the input because it is what the translator
+          reads FROM: source first, then the box they type the translation into.
+          Below the input it read as a footnote about the field rather than as
+          the text being translated. */}
+      {sourceHint}
 
       {/* Input (children) */}
       {children}
-
-      {/* i18n M7: default-language source text, shown while translating another language. */}
-      {sourceHint}
 
       {/* Description / helper text — always visible below the input, rather
           than behind a tooltip on an info icon. Help that only appears on
           hover is unreachable by touch and easy to miss by keyboard, and it
           arrives after the user has already decided what to type. */}
       {description && (
-        <p className="text-xs text-muted-foreground leading-relaxed">
+        <p
+          id={descriptionId}
+          className="text-xs text-muted-foreground leading-relaxed"
+        >
           {description}
         </p>
       )}

--- a/packages/admin/src/components/ui/form/index.tsx
+++ b/packages/admin/src/components/ui/form/index.tsx
@@ -5,7 +5,14 @@ import type * as LabelPrimitive from "@radix-ui/react-label";
 import { Slot } from "@radix-ui/react-slot";
 import type * as React from "react";
 import type { ComponentProps } from "react";
-import { createContext, useContext, useId } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from "react";
 import {
   Controller,
   FormProvider,
@@ -27,6 +34,18 @@ type FormFieldContextValue<
 
 type FormItemContextValue = {
   id: string;
+  /**
+   * Whether a `FormDescription` with content is actually on the page.
+   *
+   * `FormControl` has to name the description in `aria-describedby`, but it is
+   * a SIBLING of `FormDescription` and React offers no synchronous way for one
+   * sibling to observe another during render. So the description registers
+   * itself here on mount and `FormControl` reads the registration, rather than
+   * assuming a description exists — which is what it used to do, pointing every
+   * control without one at an element that never rendered.
+   */
+  hasDescription: boolean;
+  setHasDescription: (present: boolean) => void;
 };
 
 const Form: typeof FormProvider = FormProvider;
@@ -59,7 +78,7 @@ const useFormField = () => {
     throw new Error("useFormField should be used within <FormField>");
   }
 
-  const { id } = itemContext;
+  const { id, hasDescription, setHasDescription } = itemContext;
 
   return {
     id,
@@ -67,6 +86,8 @@ const useFormField = () => {
     formItemId: `${id}-form-item`,
     formDescriptionId: `${id}-form-item-description`,
     formMessageId: `${id}-form-item-message`,
+    hasDescription,
+    setHasDescription,
     ...fieldState,
   };
 };
@@ -77,9 +98,17 @@ const FormItemContext = createContext<FormItemContextValue>(
 
 function FormItem({ className, ...props }: ComponentProps<"div">) {
   const id = useId();
+  const [hasDescription, setHasDescription] = useState(false);
+
+  // Memoised so the context value is not a new object on every render, which
+  // would re-render every consumer of this field on each keystroke.
+  const context = useMemo(
+    () => ({ id, hasDescription, setHasDescription }),
+    [id, hasDescription]
+  );
 
   return (
-    <FormItemContext.Provider value={{ id }}>
+    <FormItemContext.Provider value={context}>
       <div
         data-slot="form-item"
         className={cn("space-y-1.5", className)}
@@ -107,18 +136,29 @@ function FormLabel({
 }
 
 function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
-  const { error, formItemId, formDescriptionId, formMessageId } =
-    useFormField();
+  const {
+    error,
+    formItemId,
+    formDescriptionId,
+    formMessageId,
+    hasDescription,
+  } = useFormField();
+
+  // Name only the elements that actually render. Referencing an id that is not
+  // on the page tells assistive technology a description exists and then gives
+  // it nothing, which is why this composes the list from what is present rather
+  // than always naming the description. `undefined` when neither exists, so no
+  // empty attribute is emitted.
+  const describedBy =
+    [hasDescription ? formDescriptionId : null, error ? formMessageId : null]
+      .filter(Boolean)
+      .join(" ") || undefined;
 
   return (
     <Slot
       data-slot="form-control"
       id={formItemId}
-      aria-describedby={
-        !error
-          ? `${formDescriptionId}`
-          : `${formDescriptionId} ${formMessageId}`
-      }
+      aria-describedby={describedBy}
       aria-invalid={error ? "true" : "false"}
       data-invalid={error ? "true" : "false"}
       {...props}
@@ -136,9 +176,19 @@ function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
  * has always claimed it was.
  */
 function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
-  const { formDescriptionId } = useFormField();
+  const { formDescriptionId, setHasDescription } = useFormField();
+  const present = Boolean(props.children);
 
-  if (!props.children) return null;
+  // Publish presence so `FormControl` can decide whether to name this element.
+  // The effect covers the whole lifecycle: mounting with content registers,
+  // content becoming empty deregisters, and unmounting cleans up — so a
+  // description that disappears does not leave a stale reference behind.
+  useEffect(() => {
+    setHasDescription(present);
+    return () => setHasDescription(false);
+  }, [present, setHasDescription]);
+
+  if (!present) return null;
 
   return (
     <p


### PR DESCRIPTION
Three accessibility defects in the admin's form layer, each found by measuring a
running browser rather than by reading code, and each verified fixed the same way.

## 1. A description that was never on the page

`FormControl` named the description element in `aria-describedby`
unconditionally, while `FormDescription` renders nothing when it has no
children. Every field without a description pointed assistive technology at an
element that did not exist — the admin has **76 `FormControl` usages against 3
`FormDescription`**, and 13 of the 14 files using `FormControl` contain no
description at all.

`FormDescription` now registers its presence on the field context, and
`FormControl` composes `aria-describedby` from what actually renders.

## 2. Four content field types had no accessible name

`FieldWrapper` renders `{children}` without cloning, so its `<label for>` only
resolved when the input independently set a matching `id`. Text and textarea do;
rich text, relationship and upload cannot, because each renders a *group* of
controls rather than one element an id can attach to — a contenteditable surface
plus a toolbar, a search box plus a result list, a drop zone plus a preview.

Measured on `/admin/collections/posts/create`, both themes:

```
richText:content        — "Content"        -> #content        (nothing)
relationship:categories — "Categories"     -> #categories     (nothing)
relationship:tags       — "Tags"           -> #tags           (nothing)
upload:featuredImage    — "Featured Image" -> #featuredImage  (nothing)
```

Those types are now exposed as `role="group"` + `aria-labelledby`, the same
answer already used for the webhook subscription/headers rows and the email
provider type picker. Pointing the label at the wrapping `<div>` would have
resolved the reference while naming something unfocusable, which is worse.

A development-time warning now fires for any other field type whose label finds
no target, so a missing entry announces itself instead of failing silently.

## 3. A plugin-supplied editor cannot be classified by field type

The page builder renders over a `json` field through a per-field component
override, so its label dangled while an ordinary `json` field on another
collection was labelled correctly. **No list of composite type names can catch
this** — an override replaces the component and leaves the type untouched.

`FieldRenderer` now tells `FieldWrapper` when the editor came from a plugin
(`admin.component` override, or a plugin-registered field type — both render
through `PluginSlot`), and such a field is named as a group. That is a
structural fact the admin knows for certain, rather than a guess about the type.

## Also here

Content-field labels adopt the 14px / 500 / foreground scale the rest of the
admin's forms use, replacing a 12px bold letter-spaced muted treatment.
Measured contrast 7.77 : 1 before and 21.00 : 1 after — **both pass WCAG AA**,
so this is consistency rather than an accessibility fix, and is listed
separately for that reason.

The shared-language badge moves out of the `<label>` element, where its text was
being read as part of the field's accessible name ("Title Shared"), and states
the whole fact rather than hiding it behind a `title` tooltip. The
default-language source text moves above the input, which is the order the work
is done in: read the source, then type the translation.

## Verification

Two browser probes, both asserting the POPULATION before the verdict — a route
that rendered no page cannot testify that it has no dangling references:

- 8 settings routes × 2 themes → **16/16 measured, zero dangling**
- 5 content collections, 8 field types → **zero dangling, zero orphan error ids**
- group semantics asserted positively: 4 groups present, all names resolving,
  `unnamed: []` across all 9 fields on a post

`check-types` and `lint` clean in `packages/admin`. Admin test suite shows the
same 4 pre-existing failures as `main`, zero new.

## Pre-existing failure, not from this PR

`packages/ui` → `alpha-utilities.test.ts` fails on
`border-destructive/40 = 1.69:1`. That utility lives in
`pages/dashboard/field-group/builder/[slug].tsx`, which this branch does not
touch, and it is present on `origin/main`. Flagging rather than fixing, since it
belongs to whichever change introduced it.
