### PR TITLE
feat(admin): record and recover autosaved work in Singles

### DIFF
--- a/.changeset/singles-autosave.md
+++ b/.changeset/singles-autosave.md
@@ -1,0 +1,36 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+feat(admin): record and recover autosaved work in Singles
+
+Singles get the same recovery points the entry editor already had: recorded
+while the author types, offered back on open, and reported in the header beside
+the save action.
+
+Autosave was previously present in one editor and silently absent in the other,
+which is a worse state than either extreme because nothing tells the author
+which one they are in.

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -28,6 +28,7 @@ import { useEffect, useMemo, useCallback, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
+import { AutosaveRecoveryBanner } from "@admin/components/features/entries/EntryForm/AutosaveRecoveryBanner";
 import { EntryFormContent } from "@admin/components/features/entries/EntryForm/EntryFormContent";
 import { EntryFormProvider } from "@admin/components/features/entries/EntryForm/EntryFormProvider";
 import { EntryFormSidebar } from "@admin/components/features/entries/EntryForm/EntryFormSidebar";
@@ -47,7 +48,12 @@ import {
 } from "@admin/components/features/entries/EntryLocaleContext";
 import { historyEnabledFrom } from "@admin/components/features/versions/history-enabled";
 import { useBranding } from "@admin/context/providers/BrandingProvider";
+import { useAutosaveRecovery } from "@admin/hooks/useAutosaveRecovery";
 import { useAutoSlug } from "@admin/hooks/useAutoSlug";
+import {
+  autosaveScopeFor,
+  useDocumentAutosave,
+} from "@admin/hooks/useDocumentAutosave";
 import { useEntryFormShortcuts } from "@admin/hooks/useKeyboardShortcuts";
 import { useLocalization } from "@admin/hooks/useLocalization";
 import {
@@ -567,10 +573,48 @@ export function SingleForm({
     onLocaleChange,
   };
 
+  // Recovery points for this author, the same mechanism the entry editor uses.
+  // A Single always exists once its schema does, so unlike an entry there is no
+  // pre-creation state -- but the address still comes from the stored document,
+  // so a schema whose row has not been materialised yet records nothing rather
+  // than addressing a document that is not there.
+  const autosaveScope = useMemo(
+    () => autosaveScopeFor("single", schema.slug, document?.id ?? ""),
+    [schema.slug, document?.id]
+  );
+  const autosave = useDocumentAutosave({
+    scope: autosaveScope,
+    form,
+    locale: locale ?? null,
+    enabled: !isSubmitting,
+  });
+  const recovery = useAutosaveRecovery({
+    scope: autosaveScope,
+    documentUpdatedAt: document?.updatedAt ?? null,
+  });
+  const restoreRecovery = useCallback(() => {
+    if (!recovery.offer) return;
+    // `keepDefaultValues` so the form goes DIRTY: the recovered values are not
+    // what the server holds, and treating them as the new baseline would let
+    // the reader navigate away believing they were stored.
+    form.reset(recovery.offer.snapshot as Record<string, unknown>, {
+      keepDefaultValues: true,
+    });
+    recovery.dismiss();
+  }, [recovery, form]);
+
   return (
     <EntryLocaleProvider value={localeCtx}>
       <div className={cn("space-y-0", className)}>
         <EntryFormProvider form={form} onSubmit={handleSubmit}>
+          {recovery.offer ? (
+            <AutosaveRecoveryBanner
+              savedAt={recovery.offer.savedAt}
+              onRestore={restoreRecovery}
+              onDismiss={recovery.dismiss}
+              className="mx-6 mt-3"
+            />
+          ) : null}
           <FormErrorSummary
             errors={errors}
             submitCount={submitCount}
@@ -585,6 +629,9 @@ export function SingleForm({
                 strip in another -mx-8 was double-negative and pushed them
                 past the page edges. */}
               <EntrySystemHeader
+                autosaveEnabled={autosaveScope !== null}
+                autosaveStatus={autosave.status}
+                autosaveLastSavedAt={autosave.lastSavedAt}
                 mode="edit"
                 titleField={titleField}
                 historyFields={schema.fields}


### PR DESCRIPTION
The last surface in the autosave lane. Singles now do what the entry editor already does.

## What changes

Recorded while the author types, offered back on open in the same non-blocking banner, and reported in the header beside the save action. All three pieces are the ones the entry editor uses -- `useDocumentAutosave`, `useAutosaveRecovery`, `AutosaveRecoveryBanner` -- so this is mounting rather than new design.

## Why it matters more than "one more surface"

Autosave was present in one editor and silently absent in the other. That is worse than having it in neither, because nothing tells the author which one they are in: the same action in two places, one of which quietly protects your work and one of which does not.

## One difference from entries, deliberately

The scope comes from the stored DOCUMENT, not from the schema:

```ts
autosaveScopeFor("single", schema.slug, document?.id ?? "")
```

A Single is conceptually always present once its schema exists, so the temptation is to address it by slug alone. But the endpoint addresses a stored row, and a Single whose row has not been materialised yet has none. Reading through the document means that case records nothing rather than addressing something that is not there.

## A gap I am naming rather than implying

**The guard above is not covered at this level, and I am reporting it rather than letting a green suite speak for it.**

Break-verified by pointing the scope at a placeholder id instead of the real document: 186 tests passed either way. Nothing moved.

What IS covered: `autosaveScopeFor("single", slug, "")` returns null (`useDocumentAutosave.test.tsx`). What is NOT: this component passing `document?.id ?? ""` into it. Closing it needs a rendered-`SingleForm` test, and it mirrors exactly the EntryForm gap I closed earlier by extracting the rule and asserting it directly.

This is the tell the rules PR (#915) describes in as many words: a break-verify that moves nothing is not a clean bill, it means the property has no coverage yet. It would be poor form to write that and ship an uncovered guard in the same session without saying so.

## Verification

- check-types + lint 11/11 for `@nextlyhq/admin`
- 42 files / 343 tests green across singles, hooks and the entry editor
- `check:comments` clean, changeset validated against the lockstep group