### PR TITLE
fix(admin): let the autosave scope helper accept an absent document id

### DIFF
--- a/.changeset/autosave-scope-absent-id.md
+++ b/.changeset/autosave-scope-absent-id.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(admin): let the autosave scope helper accept an absent document id
+
+The helper required a string, so every call site supplied its own empty-string
+fallback. That put one rule in two places: the helper, which its tests reach,
+and a fallback at each caller, which they do not.
+
+Accepting null and undefined removes the fallback rather than testing it, so
+there is no longer a per-caller decision to get wrong.

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -579,7 +579,7 @@ export function SingleForm({
   // so a schema whose row has not been materialised yet records nothing rather
   // than addressing a document that is not there.
   const autosaveScope = useMemo(
-    () => autosaveScopeFor("single", schema.slug, document?.id ?? ""),
+    () => autosaveScopeFor("single", schema.slug, document?.id),
     [schema.slug, document?.id]
   );
   const autosave = useDocumentAutosave({

--- a/packages/admin/src/hooks/__tests__/useDocumentAutosave.test.tsx
+++ b/packages/admin/src/hooks/__tests__/useDocumentAutosave.test.tsx
@@ -245,6 +245,11 @@ describe("autosaveScopeFor", () => {
   it("refuses to address a document that has never been saved", () => {
     expect(autosaveScopeFor("collection", "posts", "")).toBeNull();
     expect(autosaveScopeFor("single", "settings", "")).toBeNull();
+    // The absent forms too, so a caller holding an optional id can pass it
+    // straight through. Requiring a string here only moved the decision into a
+    // `?? ""` at each call site, where the helper's own tests cannot see it.
+    expect(autosaveScopeFor("single", "settings", undefined)).toBeNull();
+    expect(autosaveScopeFor("collection", "posts", null)).toBeNull();
   });
 
   it("refuses to address a document with no slug", () => {

--- a/packages/admin/src/hooks/useDocumentAutosave.ts
+++ b/packages/admin/src/hooks/useDocumentAutosave.ts
@@ -36,15 +36,19 @@ const DEFAULT_DEBOUNCE_MS = 2000;
  *
  * @param kind - which document family this editor edits
  * @param slug - the collection or Single slug
- * @param documentId - the SAVED id, empty while the document has never been saved
+ * @param documentId - the SAVED id; absent while the document has never been saved
  * @returns an addressable scope, or `null` when recording must stay off
  */
 export function autosaveScopeFor(
   kind: "collection" | "single",
   slug: string,
-  documentId: string
+  // Accepts the absent forms rather than requiring a string, so a caller holding
+  // an optional id passes it straight through. Requiring a string pushed a `??
+  // ""` into every call site, which is a second place the rule is decided and
+  // one the helper's own tests cannot reach.
+  documentId: string | null | undefined
 ): VersionScope | null {
-  if (documentId === "" || slug === "") return null;
+  if (!documentId || slug === "") return null;
   return kind === "single"
     ? { kind: "single", slug, documentId }
     : { kind: "collection", slug, entryId: documentId };


### PR DESCRIPTION
Closes a gap I named in #918 rather than leaving it as a follow-up.

## The gap

`SingleForm` passed `document?.id ?? ""` into `autosaveScopeFor`. Break-verified by substituting a placeholder id: **186 tests passed either way. Nothing moved.**

The helper was covered. The call site was not.

## The fix removes the rule from the call site rather than testing it there

The helper required a `string`, which is what forced every caller to invent its own empty-string default. That put ONE rule in TWO places: the helper, which its own tests reach, and a fallback at each caller, which they cannot.

`autosaveScopeFor` now accepts `string | null | undefined`, so a caller holding an optional id passes it straight through and there is no per-caller decision left to get wrong.

That is the boundary-over-check preference `AGENTS.md` states: a rule the callers cannot express incorrectly beats a rule each caller restates and each test has to chase. It also means the next editor wired to autosave inherits the behaviour instead of re-deriving it.

## Verification

Break-verified: dropping the guard from the helper fails its own test.

The helpers cases now cover the empty string AND the absent forms, which is what the call sites actually hold:

```ts
expect(autosaveScopeFor("single", "settings", undefined)).toBeNull();
expect(autosaveScopeFor("collection", "posts", null)).toBeNull();
```

Gates: check-types + lint 11/11, 42 files / 343 tests green, changeset validated against the lockstep group.