### PR TITLE
test(plugin-page-builder): refuse a press that never became a drag

### DIFF
--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -87,6 +87,18 @@ const PLAN_POINT = {
 const ESCAPE_SETTLE_MS = 2_000;
 
 /**
+ * Idle wall-clock between one gesture ending and the next beginning, in milliseconds.
+ *
+ * Not a settle, and not interchangeable with one. Polling the previous drag to
+ * `isDragging() === false` is a barrier against teardown and returns the moment the
+ * engine says it is finished; this is the separate fact that a person cannot press
+ * again within a frame of releasing. Gestures issued back-to-back lose every second
+ * activation — measured over ten, with the geometry varied on each — so a probe
+ * without this measures the harness rather than the canvas.
+ */
+const GESTURE_GAP_MS = 500;
+
+/**
  * Time budgets for the autoscroll case, in milliseconds.
  *
  * Durations rather than move counts. The scroll advances on the canvas's own timer, so a number of
@@ -1067,7 +1079,7 @@ test.describe("a canvas any Nextly editor could ship", () => {
     note(
       PLAN_POINT.oneEngineForBothDrags,
       "B-15",
-      "a drag started after a cancelled drag does not activate"
+      "agreement on observable behaviour, which is necessary for one engine and not sufficient"
     );
     const fixture = await seedPage(request, FLAT_LIST_FIXTURE);
     await driver.mountTree(fixture);
@@ -1114,19 +1126,24 @@ test.describe("a canvas any Nextly editor could ship", () => {
       })
       .toBe(false);
 
+    // The settle above is necessary and NOT sufficient, and this is the missing half.
+    //
+    // Waiting for the previous drag to report that it ENDED is a barrier against
+    // teardown; it is not a gap. The two are different quantities, and the poll
+    // above returns as soon as the engine says it is done — which is far sooner
+    // than a person could press again. A gesture issued inside that window does
+    // not activate, so this case spent a long time recorded as a canvas that
+    // could not drag its own blocks, when what it had was a probe pressing
+    // faster than the input a person produces.
+    //
+    // Measured over ten gestures with the geometry varied on every one: issued
+    // back-to-back, exactly every second gesture fails to activate, identically
+    // whether the previous one ended in a drop or in Escape; with an idle pause
+    // between them, all ten activate. Neither the cancel nor the canvas is the
+    // variable, so neither is what this waits for.
+    await new Promise(resolve => setTimeout(resolve, GESTURE_GAP_MS));
+
     await chrome.startDragOfBlock(fixture.blockIds[1] ?? "");
-    // Marked HERE, with the panel-side control and the settle above it.
-    //
-    // The shortfall is an interaction between consecutive drags, not a missing capability
-    // and not a failure to cancel. `CanvasNode` makes every placed block a drag source,
-    // and started on its own this drag activates: the source inside the frame reports
-    // `aria-grabbed="true"` and carries the dragging class across repeated moves. Started
-    // after a panel drag has run and been cancelled, it does not, and waiting for the
-    // first drag to report that it ended does not change that.
-    //
-    // So the settle above is necessary and NOT sufficient, and what survives a cancel to
-    // block the next drag is not yet isolated.
-    test.fail(true, "a drag started after a cancelled drag does not activate");
     // Advanced INSIDE a zone, exactly as the panel side is. Sampling the two
     // under different conditions makes the comparison a statement about the
     // harness: `dragUntilTarget` can resolve through overlap with the pointer

--- a/e2e/tests/canvas/poc-driver.ts
+++ b/e2e/tests/canvas/poc-driver.ts
@@ -137,6 +137,15 @@ const DRAG_THRESHOLD_PX = 12;
  * guessing produce two seams. This is the contract, such as it is — one element carrying a
  * base-10 count of undoable entries, in either document.
  */
+/**
+ * How long `startDragAt` waits for its press to become a drag, in milliseconds.
+ *
+ * A ceiling the poll stops early on rather than a wait anyone pays: activation
+ * is synchronous with the threshold-crossing move in the healthy case. Generous
+ * enough that a loaded runner does not read as a refusal.
+ */
+const ACTIVATION_TIMEOUT_MS = 2_000;
+
 const UNDO_DEPTH_ATTR = "data-nx-undo-depth";
 const UNDO_DEPTH_SELECTOR = `[${UNDO_DEPTH_ATTR}]`;
 
@@ -494,6 +503,28 @@ export function createPocDriver(page: Page): CanvasDriver {
       await page.mouse.move(pointer.x, pointer.y);
       await page.mouse.down();
       await driver.crossActivationThreshold();
+      // Crossing the threshold is this method's whole contract, so a press that
+      // did not become a drag is a broken precondition rather than a result, and
+      // it is refused here instead of being returned as one.
+      //
+      // The refusal is load-bearing rather than defensive. Gestures issued
+      // back-to-back faster than a person can produce them lose every second
+      // activation, and a caller that reads the drag state itself sees a
+      // plausible `false`, while one that goes straight on to move the pointer
+      // measures a drag that never started and reports it as a canvas result.
+      // Both are silent. Anything wanting a press WITHOUT activation has
+      // `pressAt`, which makes no such promise.
+      //
+      // Bounded by a poll rather than a fixed wait, so the happy path costs one
+      // read and only a genuine failure pays the timeout.
+      await expect
+        .poll(async () => driver.isDragging(), {
+          message:
+            "the press did not become a drag; if gestures are being issued in " +
+            "a loop, they need an idle gap between them",
+          timeout: ACTIVATION_TIMEOUT_MS,
+        })
+        .toBe(true);
     },
 
     async pressAt(point: Point) {


### PR DESCRIPTION
## What

`startDragAt` now refuses a press that did not become a drag, and **B-15 graduates** as a direct consequence.

## Why the guard

Crossing the activation threshold is `startDragAt`'s entire contract, so a press that stayed a press is a broken precondition rather than a result. Returning it as a plausible `false` is silent in both directions: a caller reading the drag state sees a believable negative, and a caller that goes straight on to move the pointer measures a drag that never started and reports it as a canvas result.

Safe to make an assertion rather than an appeal, because all seven `startDragAt` call sites expect a live drag, and the single case wanting a press *without* activation already uses `pressAt` deliberately with a comment saying so. It is a bounded poll, so the happy path costs one read and only a genuine failure pays the timeout — no existing test gets slower.

## B-15 graduates, and this is the evidence the guard works

The guard fired immediately on `drives a canvas drag with the same engine as a panel drag`, which was carrying:

```
test.fail(true, "a drag started after a cancelled drag does not activate")
```

That claim is false. It was refuted separately today (#914): gestures issued back-to-back lose exactly every second activation, identically whether the previous one ended in a drop or in Escape, and an idle pause makes all ten activate.

This test polled `isDragging()` to `false` before starting the next drag, which is a correct barrier against **teardown** but is not a **gap** — the poll returns the moment the engine says it is finished, far sooner than a person could press again. So the case was measuring the harness artefact and recording it as a missing canvas capability.

Adding the gap and removing the `test.fail` makes it pass genuinely.

**That firing is stronger evidence than a synthetic break would have been**: the guard found a real instance nobody knew about, named the cause in its failure message, and the named cause was correct — the fix it pointed at is the one that worked.

## Measured, whole canvas suite

| | before | after |
|---|---|---|
| passed | 104 | **105** |
| failed | 1 | **0** |
| total | 105 | 105 |

Total is unchanged, so no test went missing; B-15 moved from failed to passed. The five remaining expected failures are the pre-existing unbuilt points (hysteresis jitter x2, single indicator, one-undo-per-drop, keyboard move) and are untouched.

## Scope

Test-only, so no changeset. No product code is modified — in particular `dragSensors.ts` is untouched, for the reason recorded in #914.