### PR TITLE
fix(nextly): hold a migration out of two unguarded field-group writers

### DIFF
--- a/.changeset/converge-field-group-writers.md
+++ b/.changeset/converge-field-group-writers.md
@@ -1,0 +1,36 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Two paths that change field-group storage now hold a storage migration out while they run.
+
+A field-group storage migration renames the registry table and every field group's data table. Two paths could previously run at the same time as one: the code-first sync that materialises field groups defined in your config at boot and on hot reload, and the `db:sync` pass that deletes field groups no longer present in code.
+
+The deletion pass was the more consequential of the two. It reads the table names first and then drops them one at a time, so a migration renaming those tables partway through left the remaining drops addressing names that no longer existed. Because those statements are `DROP TABLE IF EXISTS`, that failed silently: the field group survived as a table nothing scanned for again. The exclusion is now held across the whole pass rather than per field group, so the names it read stay valid until it finishes.
+
+The code-first sync writes definition rows only and creates no tables, so it holds the migration out without being able to create the lock itself — a deployment whose database role has permission to write rows but not to create tables keeps booting exactly as before.
+
+Neither path changes what it does when no migration is running.

--- a/packages/nextly/src/cli/commands/__tests__/orphan-teardown-excludes-migration.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/orphan-teardown-excludes-migration.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Deleting orphaned field groups must hold a storage migration out for the WHOLE pass.
+ *
+ * 🔴 The property is an ORDER, and order is what an "it works" test cannot see. This path drops
+ * tables and deletes registry rows from a list of table names read BEFORE any of it runs, so a
+ * migration renaming `comp_<slug>` to `fg_<slug>` partway through leaves the remaining drops
+ * addressing names that no longer exist — silently, because they are `DROP TABLE IF EXISTS`. The
+ * field group then survives as a table nothing scans for again.
+ *
+ * So the assertions are: the exclusion is entered BEFORE the first destructive statement, and it
+ * spans every component rather than being taken and released per iteration. Asserting merely that
+ * it was called would pass on a guard taken after the first drop, which is the arrangement that
+ * fails.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/** Every observable step, in the order it happened. */
+const events: string[] = [];
+
+vi.mock("../../../domains/schema/services/schema-change-exclusion", () => ({
+  withSchemaChangeExcluded: vi.fn(
+    async (args: { issuesDdl: boolean }, work: () => Promise<unknown>) => {
+      events.push(`exclusion:enter(issuesDdl=${String(args.issuesDdl)})`);
+      const result = await work();
+      events.push("exclusion:exit");
+      return result;
+    }
+  ),
+}));
+
+vi.mock(
+  "../../../domains/field-groups/services/teardown-entity-field-group-data",
+  () => ({ teardownEntityComponentData: vi.fn(async () => undefined) })
+);
+vi.mock("../../../domains/i18n/migration/teardown-entity-i18n", () => ({
+  teardownEntityI18n: vi.fn(async () => undefined),
+}));
+vi.mock("../../../domains/field-groups/storage/resolve-storage-names", () => ({
+  resolveFieldGroupRegistryName: vi.fn(async () => "dynamic_field_groups"),
+  resolveTypeColumns: vi.fn(async () => new Map()),
+}));
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+
+import { handleRemovedComponents } from "../dev-build";
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  success: vi.fn(),
+  newline: vi.fn(),
+} as unknown as Parameters<typeof handleRemovedComponents>[2];
+
+const adapter = {
+  getCapabilities: () => ({ dialect: "postgresql" }),
+  delete: vi.fn(async () => {
+    events.push("delete:registry-row");
+  }),
+  executeQuery: vi.fn(async () => {
+    events.push("drop:table");
+  }),
+} as unknown as DrizzleAdapter;
+
+beforeEach(() => {
+  events.length = 0;
+});
+
+describe("deleting orphaned field groups", () => {
+  it("enters the exclusion before anything destructive happens", async () => {
+    await handleRemovedComponents(
+      [{ slug: "hero", tableName: "comp_hero" }],
+      adapter,
+      logger
+    );
+
+    // The population first: an empty list would satisfy every ordering assertion below while
+    // proving the pass never ran at all.
+    expect(events).toContain("delete:registry-row");
+    expect(events).toContain("drop:table");
+
+    expect(events.indexOf("exclusion:enter(issuesDdl=true)")).toBe(0);
+    expect(events.indexOf("exclusion:enter(issuesDdl=true)")).toBeLessThan(
+      events.indexOf("delete:registry-row")
+    );
+    expect(events.indexOf("exclusion:enter(issuesDdl=true)")).toBeLessThan(
+      events.indexOf("drop:table")
+    );
+  });
+
+  it("holds it across every component rather than per component", async () => {
+    await handleRemovedComponents(
+      [
+        { slug: "hero", tableName: "comp_hero" },
+        { slug: "cta", tableName: "comp_cta" },
+      ],
+      adapter,
+      logger
+    );
+
+    // Taken once, released once, with both components inside. A per-iteration guard would show two
+    // enters — and would leave a migration free to rename between them, which is the whole risk.
+    expect(events.filter(e => e.startsWith("exclusion:enter"))).toHaveLength(1);
+    expect(events.filter(e => e === "exclusion:exit")).toHaveLength(1);
+    expect(events.filter(e => e === "drop:table")).toHaveLength(2);
+    expect(events[events.length - 1]).toBe("exclusion:exit");
+  });
+
+  it("declares that it may create the lock, because it drops tables", async () => {
+    // `issuesDdl` is not cosmetic. With `false`, a first-ever storage migration could create the
+    // lock table, claim it, and begin renaming while this pass was already deleting unguarded.
+    await handleRemovedComponents(
+      [{ slug: "hero", tableName: "comp_hero" }],
+      adapter,
+      logger
+    );
+
+    expect(events).toContain("exclusion:enter(issuesDdl=true)");
+    expect(events).not.toContain("exclusion:enter(issuesDdl=false)");
+  });
+});

--- a/packages/nextly/src/cli/commands/dev-build.ts
+++ b/packages/nextly/src/cli/commands/dev-build.ts
@@ -24,6 +24,7 @@ import {
   settleI18nTransition,
   type I18nTransitionKind,
 } from "../../domains/i18n/migration/transition-state";
+import { withSchemaChangeExcluded } from "../../domains/schema/services/schema-change-exclusion";
 // Resolve the versioning config so `db:sync` persists it (parity with boot/HMR).
 import { resolveVersionsConfig } from "../../domains/versions/resolve-config";
 import {
@@ -743,6 +744,36 @@ async function detectRemovedComponents(
  * Uses raw delete to avoid re-fetch issues with getComponent/updateComponent.
  */
 async function handleRemovedComponents(
+  removed: OrphanRecord[],
+  adapter: DrizzleAdapter,
+  logger: CommandContext["logger"]
+): Promise<void> {
+  // 🔴 The whole pass, not each component, and not nothing.
+  //
+  // This path does its own schema work rather than calling a service, so the exclusion belongs at
+  // the one depth where the table drop and the registry delete meet — the same reasoning that put
+  // it on the field group apply handler.
+  //
+  // It spans the LOOP because `removed` carries table names read before any of this ran. A storage
+  // migration renaming `comp_<slug>` to `fg_<slug>` between two iterations would leave the later
+  // drops addressing names that no longer exist — silently, since they are `DROP TABLE IF EXISTS` —
+  // and the field group would survive as an orphaned table nothing scans for again.
+  //
+  // `issuesDdl: true` because this genuinely drops tables: a first-ever migration must not be able
+  // to create the lock, claim it, and start renaming while this pass is already deleting.
+  //
+  // The boundary this does NOT close: `removed` was computed by a scan that ran before the lock was
+  // taken, so a migration completing between that scan and this call remains possible. Holding from
+  // the scan means moving the exclusion up into the caller, which is convergence work rather than
+  // this guard.
+  await withSchemaChangeExcluded(
+    { adapter, logger, label: "delete orphaned field groups", issuesDdl: true },
+    () => deleteOrphanedComponents(removed, adapter, logger)
+  );
+}
+
+/** The teardown itself, split out so the exclusion above reads as one decision. */
+async function deleteOrphanedComponents(
   removed: OrphanRecord[],
   adapter: DrizzleAdapter,
   logger: CommandContext["logger"]

--- a/packages/nextly/src/cli/commands/dev-build.ts
+++ b/packages/nextly/src/cli/commands/dev-build.ts
@@ -743,7 +743,16 @@ async function detectRemovedComponents(
  * Delete orphaned components: remove registry entry and drop data table.
  * Uses raw delete to avoid re-fetch issues with getComponent/updateComponent.
  */
-async function handleRemovedComponents(
+/**
+ * Exported for its own test.
+ *
+ * The guard below is an ORDERING property — the exclusion is taken before the first drop — and the
+ * only way to observe an ordering is to invoke the thing that does it. Reaching this through
+ * `syncComponents` would mean standing up a config, a registry and a scan whose failure modes are
+ * unrelated to what is being asserted, so the test would be answering a broader question than the
+ * one it claims.
+ */
+export async function handleRemovedComponents(
   removed: OrphanRecord[],
   adapter: DrizzleAdapter,
   logger: CommandContext["logger"]

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -853,19 +853,43 @@ export async function registerServices(
         );
         const reg = new FieldGroupRegistryService(adapter, resolvedLogger);
         const compSchema = new FieldGroupSchemaService(dialect);
-        await materializeKind(
-          "fieldGroup",
-          "component",
-          compChanged,
-          builderEntities.components,
-          (slug, fields) => reg.updateComponent(slug, { fields: fields }),
-          async (tableName, fields) =>
-            compSchema.generateRuntimeSchema(tableName, fields, {
-              typeColumn:
-                (await resolveTypeColumns(adapter, [tableName])).get(
-                  tableName
-                ) ?? STORAGE_FORMAT.columns.type,
-            })
+        const { withSchemaChangeExcluded } = await import(
+          "../domains/schema/services/schema-change-exclusion"
+        );
+        // 🔴 A storage migration held out for the whole materialisation, not for each write.
+        //
+        // This is the code-first sync: it reaches the registry directly rather than through the
+        // metadata service, so there is no service depth for it to inherit the exclusion from, and
+        // the pass itself is the depth where its reads and its writes meet. Taking it per component
+        // would leave a migration free to rename the registry between two of them, so the second
+        // half of one sync would describe storage the first half no longer names.
+        //
+        // `issuesDdl: false`: this writes definition rows and generates runtime schema in memory —
+        // it creates and alters nothing. A path that only writes a row must not create the lock
+        // table, because creating a table is DDL and a deployment whose role holds DML but not DDL
+        // would start failing a boot that used to succeed.
+        await withSchemaChangeExcluded(
+          {
+            adapter,
+            logger: resolvedLogger,
+            label: "materialise code-first field groups",
+            issuesDdl: false,
+          },
+          () =>
+            materializeKind(
+              "fieldGroup",
+              "component",
+              compChanged,
+              builderEntities.components,
+              (slug, fields) => reg.updateComponent(slug, { fields: fields }),
+              async (tableName, fields) =>
+                compSchema.generateRuntimeSchema(tableName, fields, {
+                  typeColumn:
+                    (await resolveTypeColumns(adapter, [tableName])).get(
+                      tableName
+                    ) ?? STORAGE_FORMAT.columns.type,
+                })
+            )
         );
       }
     }


### PR DESCRIPTION
PR-4 of the components → field groups transition, part one. Follows #904 (reconcile surface) and #910 (builder apply records what happened).

## What this closes

A field-group storage migration renames the registry table and every `comp_<slug>` data table. Two paths could run concurrently with one, and neither took the schema-change exclusion:

- **`cli/commands/dev-build.ts`** — the `db:sync` pass deleting field groups no longer present in code. Tears down nested data, deletes the registry row, then drops the table.
- **`di/register.ts`** — the code-first sync materialising config-defined field groups at boot and on hot reload.

The deletion pass is the consequential one. It reads table names into `removed` **before** the loop runs, then drops them one at a time. A migration renaming `comp_<slug>` → `fg_<slug>` between two iterations leaves the remaining drops addressing names that no longer exist — and because they are `DROP TABLE IF EXISTS`, that fails **silently**. The field group survives as a table nothing scans for again.

## The classification behind the scope

The tracker recorded "15 candidate writers". Classified against the code, that resolves to **3** genuine writers outside the boundary, and this PR covers **2** of them:

| Path | Verdict |
|---|---|
| `cli/commands/dev-build.ts:771` | writer — guarded here, `issuesDdl: true` |
| `di/register.ts:861` | writer — guarded here, `issuesDdl: false` |
| `services/system/system-table-service.ts` | writer, **deliberately out of scope** — see below |
| `di/load-dynamic-tables.ts`, `storage/resolve-storage-names.ts`, `init/field-group-reload-plan.ts` | **not writers** — their apparent mutations are in-memory `Map.set`/`Map.delete`, not SQL |
| `component-dispatcher.ts`, `field-group-metadata-service.ts` | already inside the boundary |

Worth recording how that was established, because two of the three passes were wrong: a narrow query (`adapter.update|insert|delete`) **under-reported** and missed `system-table-service` entirely; a wide one (any INSERT/UPDATE/DELETE/CREATE token) **over-reported** and flagged three files whose only hits were JavaScript `Map` calls. Neither was trustworthy alone — reading the hits is what separated them.

## Why the guards are here rather than routed through a service

`schema-change-exclusion.ts` sets the precedent: when a path does the schema work itself instead of calling a service, it still has **one depth where the read, the DDL and the registry write meet, and that is where the lock belongs** — which is why the field-group apply handler takes it directly. Both paths here are that shape; neither has a service depth to inherit from.

The exclusion spans the **whole pass** in each case, not each item, because the names both paths operate on were read before the work started.

`issuesDdl` differs deliberately and is not cosmetic. The deletion pass drops tables, so it must be able to create the lock — otherwise a first-ever migration could create it, claim it, and start renaming while the pass was already deleting. The code-first sync writes rows only, so it must **not**: creating a table is DDL, and a deployment whose role holds DML but not DDL would start failing a boot that used to succeed.

Each guard also documents the boundary it does **not** close, rather than reading as complete.

## Deliberately out of scope

`system-table-service.ts` creates and drops the registry table at startup. It is a different shape — setup, not a field-group edit — and guarding startup with a lock startup may itself need to create is an ordering question whose failure case is a brand-new database's first boot. Filed as `tasks/left-tasks/2026-08-17-system-table-service-unguarded-registry-ddl.md`, with the note that **PR-6 may dissolve it**: once fresh installs create generation-2 names directly, the concurrent-rename window closes for new databases entirely.

One hazard was measured and cleared: `system-table-service` does not create the exclusion's lock table, so there is no recursion (its `locked` hits are BOOLEAN column definitions).

**Also deferred:** the #850 interrupt harness, the other half of PR-4. The tracker records four failed attempts at it; it deserves its own change rather than a tired addition to this one.

## Verification

- **Integration 133/133**, exit 0, across PostgreSQL, MySQL and SQLite.
- `pnpm build`, `check-types`, `pnpm lint`, `check-drizzle-v1-legacy`, `check:storage-format-literals`, `check-comment-convention` — all exit 0.
- New suite 3/3 asserting the **ordering**, which is the property "it works" cannot see: the exclusion is entered before the first destructive statement, held once across every component rather than per iteration, and declares `issuesDdl: true`.
- **Break control**: removing the guard fails all three, and only those. The suite also asserts its own population first — an empty event list would satisfy every ordering assertion while proving the pass never ran.

`handleRemovedComponents` is exported solely so that ordering can be observed; reaching it through `syncComponents` would answer a broader question than the one being asserted.

## CI

`main`'s Integration jobs have not completed on any recent commit — measured independently by three lanes today. Local dialect runs are the only evidence available at opening. The merge gate is unchanged: `success` asserted per required job, never inferred from the absence of a failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema-change handling during field-group synchronization and orphaned component cleanup.
  * Prevented schema-change processing from interfering with destructive cleanup operations.
  * Preserved reliable registry removal, table cleanup, and per-component error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->