### PR TITLE
feat(admin): announce document status, and pin how a field gets its name

### DIFF
--- a/packages/admin/src/components/features/entries/fields/FieldWrapper.labelling.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldWrapper.labelling.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * FieldWrapper — how a field gets an accessible name.
+ *
+ * `FieldWrapper` renders `{children}` without cloning, so a `<label for>` only
+ * resolves when the input independently sets a matching `id`. Text-like inputs
+ * do; composite widgets (rich text, relationship, upload) cannot, because there
+ * is no single element to put it on. Those are exposed as `role="group"` with
+ * `aria-labelledby` instead.
+ *
+ * Every assertion here carries its control INSIDE the test rather than relying
+ * on a neighbouring one: a query that resolves nothing and a query for an
+ * element that was never rendered return the same thing, so each negative is
+ * paired with a positive on the same render.
+ */
+
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { EntryLocaleProvider } from "../EntryLocaleContext";
+
+import { FieldWrapper } from "./FieldWrapper";
+
+const locale = {
+  rtl: false,
+  collectionLocalized: false,
+  isNonDefaultLocale: false,
+};
+
+/** A control that claims the id FieldWrapper points its label at. */
+function renderWith(
+  field: { name: string; type: string; label: string },
+  opts: { editorIsOpaque?: boolean; controlCarriesId?: boolean } = {}
+) {
+  const { editorIsOpaque = false, controlCarriesId = true } = opts;
+  return render(
+    <EntryLocaleProvider value={locale as never}>
+      <FieldWrapper field={field as never} editorIsOpaque={editorIsOpaque}>
+        <input
+          data-testid="control"
+          {...(controlCarriesId ? { id: field.name } : {})}
+        />
+      </FieldWrapper>
+    </EntryLocaleProvider>
+  );
+}
+
+/** The wrapper element FieldWrapper puts `data-field-type` on. */
+function wrapper(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>("[data-field-type]");
+  if (!el)
+    throw new Error("FieldWrapper rendered no [data-field-type] element");
+  return el;
+}
+
+describe("FieldWrapper labelling — atomic fields", () => {
+  it("points its label at the control, and that control exists", () => {
+    const { container } = renderWith({
+      name: "title",
+      type: "text",
+      label: "Title",
+    });
+
+    const label = container.querySelector<HTMLLabelElement>("label[for]");
+    expect(label, "a text field renders a <label for>").not.toBeNull();
+
+    // The control is the positive half: it proves the query below can resolve
+    // at all, so a null result means a broken association rather than a
+    // missing render.
+    const control = screen.getByTestId("control");
+    expect(control.id).toBe("title");
+    expect(label?.htmlFor).toBe(control.id);
+    expect(container.ownerDocument.getElementById(label!.htmlFor)).toBe(
+      control
+    );
+  });
+
+  it("is NOT exposed as a group", () => {
+    const { container } = renderWith({
+      name: "title",
+      type: "text",
+      label: "Title",
+    });
+    // Paired with the positive above: the wrapper exists, it simply is not a
+    // group — so this is not passing because nothing rendered.
+    expect(wrapper(container).getAttribute("role")).toBeNull();
+  });
+});
+
+describe("FieldWrapper labelling — composite fields are named groups", () => {
+  // These are the types measured as having a label pointing at nothing before
+  // the group treatment existed.
+  it.each([
+    ["richText", "content", "Content"],
+    ["relationship", "categories", "Categories"],
+    ["upload", "featuredImage", "Featured Image"],
+  ])("names a %s field through role=group", (type, name, label) => {
+    const { container } = renderWith({ name, type, label });
+    const el = wrapper(container);
+
+    expect(el.getAttribute("role")).toBe("group");
+
+    const labelledBy = el.getAttribute("aria-labelledby");
+    expect(labelledBy, "the group declares what names it").toBeTruthy();
+
+    // The reference must RESOLVE, and to the right text. Asserting only that
+    // the attribute is present would pass against an id nothing carries, which
+    // is the exact defect this treatment replaced.
+    const namer = container.ownerDocument.getElementById(labelledBy!);
+    expect(namer, `#${labelledBy} exists`).not.toBeNull();
+    expect(namer).toHaveTextContent(label);
+  });
+
+  it("does not also emit a dangling label[for]", () => {
+    const { container } = renderWith({
+      name: "content",
+      type: "richText",
+      label: "Content",
+    });
+
+    // Positive control on the same render: the group naming IS present, so a
+    // null label below means "no label was emitted", not "nothing rendered".
+    expect(wrapper(container).getAttribute("role")).toBe("group");
+    expect(container.querySelector("label[for]")).toBeNull();
+  });
+});
+
+describe("FieldWrapper labelling — a plugin-supplied editor is opaque", () => {
+  it("names a plugin-rendered field as a group even when its type is atomic", () => {
+    // `json` is not in the composite list. A per-field `admin.component`
+    // override replaces the component while leaving the type untouched, so
+    // classifying by type name cannot see it — which is why the renderer states
+    // the fact instead. Measured: the page builder renders over a `json` field.
+    const { container } = renderWith(
+      { name: "content", type: "json", label: "Page Builder" },
+      { editorIsOpaque: true }
+    );
+
+    const el = wrapper(container);
+    expect(el.getAttribute("role")).toBe("group");
+    const namer = container.ownerDocument.getElementById(
+      el.getAttribute("aria-labelledby")!
+    );
+    expect(namer).not.toBeNull();
+    expect(namer).toHaveTextContent("Page Builder");
+  });
+
+  it("leaves the same field as a labelled control when it is NOT opaque", () => {
+    // The discriminating half: same type, same name, only `editorIsOpaque`
+    // differs. Without this pair the test above would pass for a component
+    // that made every field a group.
+    const { container } = renderWith({
+      name: "content",
+      type: "json",
+      label: "Page Builder",
+    });
+
+    expect(wrapper(container).getAttribute("role")).toBeNull();
+    const label = container.querySelector<HTMLLabelElement>("label[for]");
+    expect(label).not.toBeNull();
+    expect(container.ownerDocument.getElementById(label!.htmlFor)).toBe(
+      screen.getByTestId("control")
+    );
+  });
+});
+
+describe("FieldWrapper labelling — the group carries its own description", () => {
+  it("points aria-describedby at a description that renders", () => {
+    const { container } = render(
+      <EntryLocaleProvider value={locale as never}>
+        <FieldWrapper
+          field={
+            {
+              name: "content",
+              type: "richText",
+              label: "Content",
+              admin: { description: "The body of the post." },
+            } as never
+          }
+        >
+          <input data-testid="control" />
+        </FieldWrapper>
+      </EntryLocaleProvider>
+    );
+
+    const el = wrapper(container);
+    const describedBy = el.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+
+    const described = container.ownerDocument.getElementById(describedBy!);
+    expect(described, `#${describedBy} exists`).not.toBeNull();
+    expect(within(described!).getByText("The body of the post.")).toBeTruthy();
+  });
+
+  it("omits aria-describedby entirely when there is nothing to describe", () => {
+    const { container } = renderWith({
+      name: "content",
+      type: "richText",
+      label: "Content",
+    });
+    const el = wrapper(container);
+    // Control: the group itself IS present, so the null below is about the
+    // description rather than about the render.
+    expect(el.getAttribute("role")).toBe("group");
+    expect(el.getAttribute("aria-describedby")).toBeNull();
+  });
+});


### PR DESCRIPTION
Two things, both about a property being *verifiable* rather than merely correct.

## 1. Standing coverage for #917's accessible-name work (tests only)

#917 gave composite content fields (`richText`, `relationship`, `upload`) and
plugin-rendered fields a `role="group"` + `aria-labelledby` treatment, replacing
a `<label for>` that pointed at nothing. It was verified in a browser and had
**no unit coverage** — a browser probe is evidence about the moment it ran and
none about the next commit.

**Break-verified in both directions:**

| break | result |
|---|---|
| `GROUP_FIELD_TYPES` emptied | **6 of 10 fail** |
| `\|\| editorIsOpaque` removed | **1 fails** — exactly the plugin-editor test |
| restored | 10 pass, clean tree |

## 2. The entry header now announces document status

`AutoSaveIndicator` cycles through "Saving…", "Saved", "Unsaved changes" and
"Not saved", and **the header carried no live region at all** — so the control
whose entire purpose is reassuring an author their work is safe did that for
sighted users only.

One `role="status"` / `aria-live="polite"` region, not one per concern: two live
regions in a header interrupt each other, and a listener cannot tell which
announcement belongs to what they just did. It also accepts translation
progress, so a multilingual entry reports both kinds of document state through
the same channel.

**Two deliberate choices:**

- **The transient "saving" state is silent.** Autosave debounces, so announcing
  it speaks over the reader every few seconds *while they are typing*. What
  matters is where the state came to rest, not that it is in motion.
- **The spoken wording is a full sentence** ("Your work is stored") rather than
  the chip's terse label. An announcement arrives with no visual context to tell
  the listener what the word refers to. This also stops the same text existing
  twice in the accessibility tree — the collision surfaced as a real test
  failure, and the fix was better copy rather than a weakened assertion.

Break-verified too: announcing the transient state fails 2 tests, dropping the
single-language guard fails 1, restore passes 10.

> A note on that second break — my first attempt reported **no failure**, and
> that was my instrument, not the code. Prettier had reformatted the file during
> the pre-commit hook so my replacement string no longer matched and the break
> never applied. A break that does not apply proves nothing. The result above is
> from a rerun that asserts the file actually changed first.

## Verification

`packages/admin`: same 4 pre-existing failing files as `main`, **zero new**.
`check-types` and `lint` clean.

## Reviewer state, stated plainly

Neither bot reviewed this. Codex returns its usage-limit message; CodeRabbit
posted a **passing check** alongside a comment saying "Review limit reached — we
couldn't start this review". Its green is not coverage.

## Pre-existing, not from this branch

`packages/ui` → `alpha-utilities.test.ts` fails on `border-destructive/40 =
1.69:1`, from `field-group/builder/[slug].tsx`, which this branch does not touch
and which is present on `main`.
