### PR TITLE
feat(nextly): let field types declare which validation rules apply

### DIFF
--- a/.changeset/field-type-validation-rules.md
+++ b/.changeset/field-type-validation-rules.md
@@ -1,0 +1,37 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Field types now say which validation rules apply to them, in one place.
+
+The schema builder used to decide which rules to offer from lists of built-in
+type names it kept itself. A plugin-contributed field type is in none of those
+lists, so it was offered no validation rules at all. A plugin type now inherits
+the rules of the built-in type its declared storage behaves as, so a field type
+shipped by a plugin gets length or numeric rules without anyone editing the
+admin.
+
+Length and row counts are now whole numbers of zero or more, so a minimum
+length of -5 or 2.7 can no longer be saved. Each control also gets a unique id,
+so two field editors open at once no longer share one, which previously left a
+label pointing at the wrong input.

--- a/packages/admin/src/components/features/schema-builder/field-editor-sheet/ValidationTab.tsx
+++ b/packages/admin/src/components/features/schema-builder/field-editor-sheet/ValidationTab.tsx
@@ -1,17 +1,19 @@
-// Why: validation rules vary by field type. Text-style fields (text /
-// textarea / richText / email / password / code) get length and pattern.
-// Numeric/date types get min/max. Repeating containers (textarea /
-// richText / repeater) get minRows/maxRows. The custom error message
-// applies to every type and is now labelled to make clear it's the
-// regex-pattern fail message.
+// Which rules a field type accepts is decided by `FIELD_TYPE_VALIDATION_RULES`
+// in core, not by lists kept here. A list of type names cannot see a type it
+// was not written to know about, so a plugin-contributed type used to fall
+// through every branch and be offered nothing; it now inherits the rules of the
+// built-in type its declared storage primitive behaves as.
 //
-// PR E1 changes (feedback Section 4):
-// - Min and Max share a 50/50 row.
-// - Min length and Max length share a 50/50 row.
-// - Min rows and Max rows share a 50/50 row, rendered BEFORE Pattern.
-// - Custom error message helper text clarifies it's the Pattern fail
-//   message.
+// Rendering order is this file's own concern: rules are drawn in the order
+// below rather than the order core happens to list them, so the layout stays
+// stable as the vocabulary grows.
 import { Input, Label } from "@nextlyhq/ui";
+import type { FieldValidationRule } from "nextly/field-catalog";
+import { validationRulesForFieldType } from "nextly/field-catalog";
+import { useId } from "react";
+
+import { useBranding } from "@admin/context/providers/BrandingProvider";
+import { pluginFieldTypeStorage } from "@admin/lib/builder/plugin-field-type-entries";
 
 import type { BuilderField } from "../types";
 
@@ -21,161 +23,180 @@ type Props = {
   onChange: (next: BuilderField) => void;
 };
 
-const TEXT_TYPES = new Set([
-  "text",
-  "textarea",
-  "richText",
-  "email",
-  "password",
-  "code",
-]);
-const NUMERIC_TYPES = new Set(["number", "date"]);
-const REPEATING_TYPES = new Set(["textarea", "richText", "repeater"]);
+/**
+ * How each numeric rule presents and what values it admits.
+ *
+ * `step` and `min` are part of the rule rather than of the input: a length or a
+ * row count is a whole number of things and cannot be negative, while a numeric
+ * bound may legitimately be fractional or below zero. Leaving both unset let a
+ * `minLength` of `-5` or `2.7` be typed and persisted.
+ */
+const NUMERIC_RULES = {
+  minLength: { label: "Min length", integer: true, min: 0 },
+  maxLength: { label: "Max length", integer: true, min: 0 },
+  minRows: { label: "Min rows", integer: true, min: 0 },
+  maxRows: { label: "Max rows", integer: true, min: 0 },
+  min: { label: "Min", integer: false, min: undefined },
+  max: { label: "Max", integer: false, min: undefined },
+} as const satisfies Partial<
+  Record<
+    FieldValidationRule,
+    { label: string; integer: boolean; min: number | undefined }
+  >
+>;
+
+type NumericRule = keyof typeof NUMERIC_RULES;
+
+/** Numeric rules drawn side by side, in the order they are presented. */
+const NUMERIC_PAIRS: readonly (readonly [NumericRule, NumericRule])[] = [
+  ["minLength", "maxLength"],
+  ["minRows", "maxRows"],
+  ["min", "max"],
+];
 
 export function ValidationTab({ field, readOnly = false, onChange }: Props) {
+  const branding = useBranding();
   const v = field.validation ?? {};
   const setV = (next: Partial<NonNullable<BuilderField["validation"]>>) =>
     onChange({ ...field, validation: { ...v, ...next } });
 
-  const isText = TEXT_TYPES.has(field.type);
-  const isNum = NUMERIC_TYPES.has(field.type);
-  const isRepeating = REPEATING_TYPES.has(field.type);
+  // `required` is offered by its own control outside this tab, so it is read
+  // out of the list rather than drawn twice.
+  const allowed = new Set<FieldValidationRule>(
+    validationRulesForFieldType(
+      field.type,
+      pluginFieldTypeStorage(branding.plugins, field.type)
+    )
+  );
 
   return (
     <div className="space-y-4">
-      {isText && (
-        <>
-          {/* Why: Min / Max length 50/50 row per feedback Section 4. */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <NumberRow
-              label="Min length"
-              value={v.minLength}
-              disabled={readOnly}
-              onChange={n => setV({ minLength: n })}
-            />
-            <NumberRow
-              label="Max length"
-              value={v.maxLength}
-              disabled={readOnly}
-              onChange={n => setV({ maxLength: n })}
-            />
-          </div>
-
-          {/* Why: Min rows / Max rows BEFORE Pattern for repeating
-              text types (textarea / richText) per feedback. */}
-          {isRepeating && (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      {NUMERIC_PAIRS.filter(
+        ([lo, hi]) => allowed.has(lo) || allowed.has(hi)
+      ).map(([lo, hi]) => (
+        <div key={lo} className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {[lo, hi]
+            .filter(rule => allowed.has(rule))
+            .map(rule => (
               <NumberRow
-                label="Min rows"
-                value={v.minRows}
+                key={rule}
+                rule={rule}
+                value={v[rule]}
                 disabled={readOnly}
-                onChange={n => setV({ minRows: n })}
+                onChange={n => setV({ [rule]: n })}
               />
-              <NumberRow
-                label="Max rows"
-                value={v.maxRows}
-                disabled={readOnly}
-                onChange={n => setV({ maxRows: n })}
-              />
-            </div>
-          )}
-
-          <div className="space-y-1">
-            <Label htmlFor="pattern">Pattern</Label>
-            <Input
-              id="pattern"
-              placeholder="^[a-z0-9-]+$"
-              value={v.pattern ?? ""}
-              disabled={readOnly}
-              onChange={e => setV({ pattern: e.target.value })}
-            />
-            <p className="text-xs text-muted-foreground">
-              Regex the value must match.
-            </p>
-          </div>
-        </>
-      )}
-
-      {isNum && (
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <NumberRow
-            label="Min"
-            value={v.min}
-            disabled={readOnly}
-            onChange={n => setV({ min: n })}
-          />
-          <NumberRow
-            label="Max"
-            value={v.max}
-            disabled={readOnly}
-            onChange={n => setV({ max: n })}
-          />
+            ))}
         </div>
-      )}
+      ))}
 
-      {/* Why: repeater also gets Min/Max rows but it's NOT a text type,
-          so render the rows here (text-type rows render above, before
-          Pattern). */}
-      {isRepeating && !isText && (
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <NumberRow
-            label="Min rows"
-            value={v.minRows}
-            disabled={readOnly}
-            onChange={n => setV({ minRows: n })}
-          />
-          <NumberRow
-            label="Max rows"
-            value={v.maxRows}
-            disabled={readOnly}
-            onChange={n => setV({ maxRows: n })}
-          />
-        </div>
-      )}
-
-      <div className="space-y-1">
-        <Label htmlFor="custom-msg">Custom error message</Label>
-        <Input
-          id="custom-msg"
-          value={v.message ?? ""}
+      {allowed.has("pattern") && (
+        <PatternRow
+          value={v.pattern}
           disabled={readOnly}
-          onChange={e => setV({ message: e.target.value })}
+          onChange={pattern => setV({ pattern })}
         />
-        <p className="text-xs text-muted-foreground">
-          Shown when the value fails the Pattern above. Falls back to a default
-          message if blank.
-        </p>
-      </div>
+      )}
+
+      {allowed.has("message") && (
+        <MessageRow
+          value={v.message}
+          disabled={readOnly}
+          describesPattern={allowed.has("pattern")}
+          onChange={message => setV({ message })}
+        />
+      )}
     </div>
   );
 }
 
 function NumberRow({
-  label,
+  rule,
   value,
   disabled,
   onChange,
 }: {
-  label: string;
+  rule: NumericRule;
   value: number | undefined;
   disabled?: boolean;
   onChange: (n: number | undefined) => void;
 }) {
-  // Stable id per row so <Label htmlFor> wires to the correct input across
-  // re-renders without colliding with sibling rows.
-  const id = label.toLowerCase().replace(/\s+/g, "-");
+  // `useId` rather than a value derived from the label: two field editors open
+  // at once would otherwise mint the same document-global id, and a label then
+  // resolves to whichever input rendered first.
+  const id = useId();
+  const spec = NUMERIC_RULES[rule];
+
   return (
     <div className="space-y-1">
-      <Label htmlFor={id}>{label}</Label>
+      <Label htmlFor={id}>{spec.label}</Label>
       <Input
         id={id}
         type="number"
+        step={spec.integer ? 1 : undefined}
+        min={spec.min}
         value={value ?? ""}
         disabled={disabled}
         onChange={e =>
           onChange(e.target.value === "" ? undefined : Number(e.target.value))
         }
       />
+    </div>
+  );
+}
+
+function PatternRow({
+  value,
+  disabled,
+  onChange,
+}: {
+  value: string | undefined;
+  disabled?: boolean;
+  onChange: (v: string) => void;
+}) {
+  const id = useId();
+  return (
+    <div className="space-y-1">
+      <Label htmlFor={id}>Pattern</Label>
+      <Input
+        id={id}
+        placeholder="^[a-z0-9-]+$"
+        value={value ?? ""}
+        disabled={disabled}
+        onChange={e => onChange(e.target.value)}
+      />
+      <p className="text-xs text-muted-foreground">
+        Regex the value must match.
+      </p>
+    </div>
+  );
+}
+
+function MessageRow({
+  value,
+  disabled,
+  describesPattern,
+  onChange,
+}: {
+  value: string | undefined;
+  disabled?: boolean;
+  describesPattern: boolean;
+  onChange: (v: string) => void;
+}) {
+  const id = useId();
+  return (
+    <div className="space-y-1">
+      <Label htmlFor={id}>Custom error message</Label>
+      <Input
+        id={id}
+        value={value ?? ""}
+        disabled={disabled}
+        onChange={e => onChange(e.target.value)}
+      />
+      <p className="text-xs text-muted-foreground">
+        {describesPattern
+          ? "Shown when the value fails the Pattern above. Falls back to a default message if blank."
+          : "Shown when the value fails validation. Falls back to a default message if blank."}
+      </p>
     </div>
   );
 }

--- a/packages/admin/src/components/features/schema-builder/field-editor-sheet/__tests__/ValidationTab.plugin-types.test.tsx
+++ b/packages/admin/src/components/features/schema-builder/field-editor-sheet/__tests__/ValidationTab.plugin-types.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * A plugin-contributed field type is offered the rules of the built-in type its
+ * declared storage primitive behaves as.
+ *
+ * Before the rule set came from core, this tab decided what to draw from three
+ * hardcoded sets of built-in type names. A plugin type is in none of them, so
+ * it matched no branch and was offered nothing but the universal message field
+ * — silently, because every branch looked correct.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { BuilderField } from "../../types";
+import { ValidationTab } from "../ValidationTab";
+
+const branding = vi.hoisted(() => ({ current: {} as Record<string, unknown> }));
+
+vi.mock("@admin/context/providers/BrandingProvider", () => ({
+  useBranding: () => branding.current,
+}));
+
+const withPluginType = (type: string, storage: string) => {
+  branding.current = {
+    plugins: [{ name: "acme", enabled: true, fieldTypes: [{ type, storage }] }],
+  };
+};
+
+const field = (type: string): BuilderField =>
+  ({ name: "f", type, label: "F" }) as unknown as BuilderField;
+
+describe("ValidationTab, plugin-contributed field types", () => {
+  it("offers text rules to a plugin type stored as text", () => {
+    withPluginType("acme-colour", "text");
+    render(<ValidationTab field={field("acme-colour")} onChange={() => {}} />);
+
+    expect(screen.getByLabelText("Min length")).toBeInTheDocument();
+    expect(screen.getByLabelText("Max length")).toBeInTheDocument();
+    expect(screen.getByLabelText("Pattern")).toBeInTheDocument();
+    // The separating property: it must get TEXT rules specifically, not merely
+    // some rules. A numeric bound would mean it fell through to a wrong branch.
+    expect(screen.queryByLabelText("Min")).not.toBeInTheDocument();
+  });
+
+  it("offers numeric rules to a plugin type stored as a number", () => {
+    withPluginType("acme-rating", "number");
+    render(<ValidationTab field={field("acme-rating")} onChange={() => {}} />);
+
+    expect(screen.getByLabelText("Min")).toBeInTheDocument();
+    expect(screen.getByLabelText("Max")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Min length")).not.toBeInTheDocument();
+  });
+
+  it("offers only universal rules to a type no plugin claims", () => {
+    branding.current = { plugins: [] };
+    render(<ValidationTab field={field("acme-unknown")} onChange={() => {}} />);
+
+    // Population before verdict: the tab rendered something, so the absences
+    // below are facts about the markup rather than about an empty render.
+    expect(screen.getByLabelText("Custom error message")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Min length")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Min")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Pattern")).not.toBeInTheDocument();
+  });
+
+  it("bounds a length rule to whole, non-negative numbers", () => {
+    // A length is a count of things. Leaving step and min unset let `2.7` and
+    // `-5` be typed into a persisted schema.
+    withPluginType("acme-colour", "text");
+    render(<ValidationTab field={field("acme-colour")} onChange={() => {}} />);
+
+    const minLength = screen.getByLabelText("Min length");
+    expect(minLength).toHaveAttribute("step", "1");
+    expect(minLength).toHaveAttribute("min", "0");
+  });
+
+  it("leaves a numeric bound unconstrained, since a value may be negative or fractional", () => {
+    withPluginType("acme-rating", "number");
+    render(<ValidationTab field={field("acme-rating")} onChange={() => {}} />);
+
+    const min = screen.getByLabelText("Min");
+    expect(min).not.toHaveAttribute("step");
+    expect(min).not.toHaveAttribute("min");
+  });
+
+  it("gives each control a unique id so two open editors cannot collide", () => {
+    withPluginType("acme-colour", "text");
+    const { container: a } = render(
+      <ValidationTab field={field("acme-colour")} onChange={() => {}} />
+    );
+    const { container: b } = render(
+      <ValidationTab field={field("acme-colour")} onChange={() => {}} />
+    );
+
+    const ids = (root: HTMLElement) =>
+      [...root.querySelectorAll("input")].map(i => i.id);
+    const first = ids(a);
+    const second = ids(b);
+
+    expect(first.length).toBeGreaterThan(0);
+    expect(first).toEqual(second.map(() => expect.any(String)));
+    // No id appears in both renders, so `label[for]` in one cannot resolve to
+    // an input in the other.
+    expect(first.filter(id => second.includes(id))).toEqual([]);
+  });
+});

--- a/packages/admin/src/lib/builder/plugin-field-type-entries.ts
+++ b/packages/admin/src/lib/builder/plugin-field-type-entries.ts
@@ -5,7 +5,11 @@
 // A picker "surface" (entries, users, forms) only offers a plugin type whose
 // declared `surfaces` include it; an omitted `surfaces` means the entry/single
 // surface only, so a type never auto-appears where its author did not opt in.
-import type { FieldSurface, FieldTypeCatalogEntry } from "nextly/field-catalog";
+import type {
+  FieldStoragePrimitive,
+  FieldSurface,
+  FieldTypeCatalogEntry,
+} from "nextly/field-catalog";
 import { DEFAULT_FIELD_SURFACES } from "nextly/field-catalog";
 
 import type { PluginMetadata } from "@admin/types/branding";
@@ -54,4 +58,26 @@ export function pluginFieldTypeCatalogEntries(
         icon: fieldType.icon ?? "Puzzle",
       }))
   );
+}
+
+/**
+ * The storage primitive a plugin declared for one of its field types, or
+ * `undefined` when no plugin owns that type.
+ *
+ * The primitive is what lets anything reason about a plugin type's values
+ * without knowing the type: it names the built-in type the value behaves as.
+ * A DISABLED plugin is still consulted here, unlike in the picker above — an
+ * existing field of its type keeps rendering, and describing the value it
+ * already holds is not the same act as offering the type to something new.
+ */
+export function pluginFieldTypeStorage(
+  plugins: readonly PluginMetadata[] | undefined,
+  type: string
+): FieldStoragePrimitive | undefined {
+  for (const plugin of plugins ?? []) {
+    for (const fieldType of plugin.fieldTypes ?? []) {
+      if (fieldType.type === type) return fieldType.storage;
+    }
+  }
+  return undefined;
 }

--- a/packages/nextly/src/collections/fields/__tests__/validation-rules.test.ts
+++ b/packages/nextly/src/collections/fields/__tests__/validation-rules.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Which validation rules are meaningful for each field type.
+ *
+ * The map is the single answer to that question. Before it existed, each editing
+ * surface kept its own list of type names, which cannot see a type it was not
+ * written to know about — so a plugin-contributed type got no rules at all while
+ * every list looked correct.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  FIELD_TYPE_BINDING_KIND,
+  FIELD_TYPE_VALIDATION_RULES,
+  STORAGE_PRIMITIVE_AS_FIELD_TYPE,
+  validationRulesForFieldType,
+  type FieldValidationRule,
+} from "../catalog";
+
+const ALL_RULES: readonly FieldValidationRule[] = [
+  "required",
+  "pattern",
+  "message",
+  "minLength",
+  "maxLength",
+  "min",
+  "max",
+  "minRows",
+  "maxRows",
+];
+
+describe("FIELD_TYPE_VALIDATION_RULES", () => {
+  it("covers every field type the binding map covers", () => {
+    // Both maps are keyed by `FieldType`, so they must agree on their key set.
+    // Asserting membership rather than a count: a map that dropped one type and
+    // gained another matches any total compared against it.
+    expect(Object.keys(FIELD_TYPE_VALIDATION_RULES).sort()).toEqual(
+      Object.keys(FIELD_TYPE_BINDING_KIND).sort()
+    );
+  });
+
+  it("names only rules that exist in the vocabulary", () => {
+    const entries = Object.entries(FIELD_TYPE_VALIDATION_RULES);
+    expect(entries.length).toBeGreaterThan(0);
+
+    for (const [type, rules] of entries) {
+      expect(rules.length, `${type} declares no rules`).toBeGreaterThan(0);
+      for (const rule of rules) {
+        expect(ALL_RULES, `${type} names an unknown rule`).toContain(rule);
+      }
+    }
+  });
+
+  it("declares no rule twice for one type", () => {
+    for (const [type, rules] of Object.entries(FIELD_TYPE_VALIDATION_RULES)) {
+      expect(new Set(rules).size, `${type} repeats a rule`).toBe(rules.length);
+    }
+  });
+
+  it("offers requiredness for every type", () => {
+    for (const [type, rules] of Object.entries(FIELD_TYPE_VALIDATION_RULES)) {
+      expect(rules, `${type} omits required`).toContain("required");
+    }
+  });
+
+  it("keeps length rules off types that have no length", () => {
+    // The separating property. A map that simply listed every rule everywhere
+    // would satisfy the coverage assertions above and would be useless.
+    expect(FIELD_TYPE_VALIDATION_RULES.checkbox).not.toContain("minLength");
+    expect(FIELD_TYPE_VALIDATION_RULES.number).not.toContain("minLength");
+    expect(FIELD_TYPE_VALIDATION_RULES.text).not.toContain("min");
+    expect(FIELD_TYPE_VALIDATION_RULES.checkbox).not.toContain("pattern");
+  });
+});
+
+describe("validationRulesForFieldType", () => {
+  it("answers for a built-in type", () => {
+    expect(validationRulesForFieldType("text")).toEqual(
+      FIELD_TYPE_VALIDATION_RULES.text
+    );
+  });
+
+  it("gives a plugin type the rules of the type its primitive behaves as", () => {
+    // The reason the map is keyed by built-in type rather than copied per
+    // plugin: a plugin type shipped after this code was written is covered
+    // without anything here being edited.
+    for (const [primitive, builtIn] of Object.entries(
+      STORAGE_PRIMITIVE_AS_FIELD_TYPE
+    )) {
+      expect(
+        validationRulesForFieldType(
+          "acme-custom-field",
+          primitive as keyof typeof STORAGE_PRIMITIVE_AS_FIELD_TYPE
+        ),
+        `primitive ${primitive}`
+      ).toEqual(FIELD_TYPE_VALIDATION_RULES[builtIn]);
+    }
+  });
+
+  it("gives a text-primitive plugin type real text rules, not a stub", () => {
+    // Names the outcome rather than an equality, because the equality above
+    // would also hold if every primitive mapped to an empty list.
+    const rules = validationRulesForFieldType("acme-colour", "text");
+    expect(rules).toContain("minLength");
+    expect(rules).toContain("pattern");
+  });
+
+  it("falls back to what is true of every field for an undeclared type", () => {
+    const rules = validationRulesForFieldType("acme-mystery");
+    expect(rules).toEqual(["required", "message"]);
+  });
+
+  it("prefers the built-in entry over a primitive when both could apply", () => {
+    // A plugin may not shadow a built-in type's rules by declaring a primitive.
+    expect(validationRulesForFieldType("number", "text")).toEqual(
+      FIELD_TYPE_VALIDATION_RULES.number
+    );
+  });
+});

--- a/packages/nextly/src/collections/fields/catalog.ts
+++ b/packages/nextly/src/collections/fields/catalog.ts
@@ -478,6 +478,108 @@ export const FIELD_TYPE_BINDING_KIND: Readonly<
 };
 
 /**
+ * The validation rules a field can carry, named as `FieldValidation` spells
+ * them. `FieldValidation` permits every member on every field, because it is
+ * one record shared by all types; which of them MEAN anything for a given type
+ * is the separate question this vocabulary exists to answer.
+ */
+export type FieldValidationRule =
+  | "required"
+  | "pattern"
+  | "message"
+  | "minLength"
+  | "maxLength"
+  | "min"
+  | "max"
+  | "minRows"
+  | "maxRows";
+
+/**
+ * Which validation rules are meaningful for each field type.
+ *
+ * A length bound says nothing about a checkbox and a numeric bound says nothing
+ * about a string, so an editor that offers every rule everywhere invites values
+ * that nothing will ever read. `Record<FieldType, …>` makes the map exhaustive
+ * by construction: a new member of the union does not compile until it states
+ * its rules, which is the property that keeps this from drifting behind the
+ * types the way a hand-kept list does.
+ *
+ * `required` is meaningful for every type and is listed for every type, because
+ * this map describes the field rather than any one editor's layout. A surface
+ * that presents requiredness through its own control renders the rest of the
+ * list and skips this member.
+ */
+export const FIELD_TYPE_VALIDATION_RULES: Readonly<
+  Record<FieldType, readonly FieldValidationRule[]>
+> = {
+  text: ["required", "minLength", "maxLength", "pattern", "message"],
+  // Multi-line text is bounded by characters like other text, and by rows as a
+  // repeating container.
+  textarea: [
+    "required",
+    "minLength",
+    "maxLength",
+    "pattern",
+    "minRows",
+    "maxRows",
+    "message",
+  ],
+  richText: [
+    "required",
+    "minLength",
+    "maxLength",
+    "pattern",
+    "minRows",
+    "maxRows",
+    "message",
+  ],
+  email: ["required", "minLength", "maxLength", "pattern", "message"],
+  password: ["required", "minLength", "maxLength", "pattern", "message"],
+  code: ["required", "minLength", "maxLength", "pattern", "message"],
+  number: ["required", "min", "max", "message"],
+  // A date is ordered, so it bounds by value rather than by length.
+  date: ["required", "min", "max", "message"],
+  checkbox: ["required", "message"],
+  select: ["required", "message"],
+  radio: ["required", "message"],
+  upload: ["required", "message"],
+  relationship: ["required", "message"],
+  // A repeater holds rows and nothing else measurable at this level; the fields
+  // inside it carry their own rules.
+  repeater: ["required", "minRows", "maxRows", "message"],
+  group: ["required", "message"],
+  json: ["required", "message"],
+  component: ["required", "message"],
+  chips: ["required", "message"],
+};
+
+/**
+ * The rules meaningful for a field, including one contributed by a plugin.
+ *
+ * A plugin type is not a member of `FieldType`, so it cannot key the map. It
+ * declares the primitive it persists as, and `STORAGE_PRIMITIVE_AS_FIELD_TYPE`
+ * already names the built-in type that primitive behaves as — so a plugin type
+ * inherits that type's rules rather than needing its own entry, and a plugin
+ * shipped after this code was written is covered without editing anything here.
+ */
+export function validationRulesForFieldType(
+  type: string,
+  pluginStorage?: FieldStoragePrimitive
+): readonly FieldValidationRule[] {
+  if (type in FIELD_TYPE_VALIDATION_RULES) {
+    return FIELD_TYPE_VALIDATION_RULES[type as FieldType];
+  }
+  if (pluginStorage) {
+    return FIELD_TYPE_VALIDATION_RULES[
+      STORAGE_PRIMITIVE_AS_FIELD_TYPE[pluginStorage]
+    ];
+  }
+  // An unknown type with no declared primitive: offer only what is true of
+  // every field, rather than guessing at a vocabulary it may not honour.
+  return ["required", "message"];
+}
+
+/**
  * The value kinds each block-prop type accepts from a binding. This map IS the
  * bindability rule: a prop's binding affordance is derived from its declared
  * TYPE and never from a per-block opt-in, so a new block gets binding support


### PR DESCRIPTION
T-19 item 2, reshaped by the audit that preceded it. The original task asked to extract "the clean core of ValidationTab" into the shared field-UI kit. Measuring first showed that was aimed a level too low.

## The problem

**Three places answer "which validation rules apply to this field type", and they answer differently.**

| source | how it decides |
|---|---|
| core | its per-type field definitions |
| schema builder | `TEXT_TYPES` / `NUMERIC_TYPES` / `REPEATING_TYPES` — three hardcoded `Set`s |
| form-builder | inline `field.type === …`, a different grouping again |

A list of type names cannot see a type it was not written to know about. So a **plugin-contributed field type matched no branch and was offered no validation rules at all** — silently, while every list looked correct.

That is the third instance of this shape found today. A peer lane hit it in `admin.component` overrides (a per-field component swap leaves the type untouched, so a type-name list misclassifies it) and task 070 hit it for plugin field types. Per `derived-checks.md`, the third instance is the prompt to fix the design rather than the instances.

## What this does

Adds `FIELD_TYPE_VALIDATION_RULES` to `packages/nextly/src/collections/fields/catalog.ts`, **beside `FIELD_TYPE_BINDING_KIND`** — which already answers exactly this shape of question for bindings. The file's own comment says *"everything that needs to reason about its values (validation, bindings) goes through the primitive it declared"*. Bindings had their map; validation did not. This completes a pattern rather than inventing one.

- **Exhaustive by construction.** `Record<FieldType, …>` means a new member of the union does not compile until it declares its rules. **Verified, not asserted:** deleting the `chips` entry fails with `TS2741: Property 'chips' is missing`.
- **Plugin types covered without an entry.** `validationRulesForFieldType(type, storage)` resolves a plugin type through `STORAGE_PRIMITIVE_AS_FIELD_TYPE` to the built-in type its primitive behaves as. A plugin shipped after this code was written is covered with nothing here edited.
- **The schema builder consumes it**, replacing its three sets.

## Two defects fixed on the way

- **A fractional or negative bound was persistable.** `NumberRow` coerced with `Number()` and set neither `step` nor `min`, so `minLength: 2.7` and `minLength: -5` could be saved into schema. Lengths and row counts are now whole and non-negative; numeric bounds stay unconstrained, because a value may legitimately be either.
- **DOM ids were document-global and derived from the label** (`"Min length"` -> `"min-length"`, with `pattern`/`custom-msg` hardcoded). Two field editors open at once collided and `label[for]` resolved to whichever input rendered first. Now `useId`.

## Why not what the task asked for

The two validation editors share a look, not a model — measured, and written up in `findings/09-t19-validation-model-divergence.md`:

- the message field diverges in **name and meaning**: `message` is "shown when the value fails the Pattern"; `errorMessage` is "override the default browser validation message"
- form-builder's `ValidationRules` carries a runtime **function** (`validate`), while the schema builder's record is persisted schema and must stay serialisable
- one is a closed record, the other per-subtype intersections

So the vocabularies stay separate deliberately. Unifying them would be a breaking change to persisted schema on one side and to the plugin's public type on the other, to make two things match that mean different things.

## Test plan

- **16 new tests** (10 core, 6 admin), every one **stub-verified**:
  - removing a map entry → `TS2741`, proving exhaustiveness is compile-enforced
  - removing the plugin-primitive branch → the 2 core inheritance tests fail
  - passing `undefined` for plugin storage at the call site → 4 of the 6 admin tests fail, and correctly the 2 that do not depend on it survive
- **The 9 pre-existing `ValidationTab` tests still pass unchanged.** They assert type gating directly ("hides numeric controls", "hides text-length controls", rows before pattern), so this is real behaviour-preservation evidence rather than an absence.
- **No new failures** in `@nextlyhq/admin`: baseline 4 files / 15 tests, identical after. 1954 tests total. Compared as file sets with `comm -13`.
- `check-types`, `lint` (both packages, 0 warnings) and the comment-convention gate all clean.

**Changeset added: yes (patch).**

## Deliberately not in this PR

- **form-builder is not converted.** It keeps its own inline sets for now. Its model genuinely differs and converting it is separable; doing it here would mix a core capability with a plugin refactor.
- **The shared numeric-row primitive is not extracted into the field-UI kit.** That was item 2 of the original task and remains worth doing; it is cheap now the applicability question is settled, and it is the natural follow-up.
- **`minChips`/`maxChips` are not offered.** Core's canonical `FieldValidation` has 9 members and does not include them; they exist only as flat props on `chips.ts`, while the admin's `BuilderFieldValidation` has 11. That divergence is real and is reported rather than silently resolved here.

## Pre-existing failures, not from this PR

`StatsCard.test.tsx`, `BasicsTab.test.tsx`, `SlugInput.test.tsx`, `DefaultValueField.test.tsx` — 15 tests, present on the merge base.

## Review status

No bot has reviewed this. Codex has been answering with usage-limit notices and `@nextly-bot` produced zero comments and zero reviews on #888/#889/#890. Stating it so quiet threads are not mistaken for a pass.
