### PR TITLE
feat(blocks-react): give the editor a per-node DOM address

### DIFF
--- a/.changeset/node-dom-address.md
+++ b/.changeset/node-dom-address.md
@@ -1,0 +1,48 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+feat(blocks-react): give the editor a per-node DOM address
+
+`PageRenderer` gains `nodeAttribute`, OFF by default. Turned on, each block's
+root carries `data-nx-node="<node id>"` — the only per-node hook that reaches the
+DOM independently of styling.
+
+The scoped class cannot serve: `classNameFor` returns the block-TYPE class alone
+for a node with no compiled styles, so hit-testing on the class cannot address an
+unstyled node and would resolve to the wrong instance. Most nodes on a real page
+are unstyled.
+
+The attribute is applied ABOVE `withNodeAttributes`' early return rather than
+joined to its allowlist loop, because that return fires for any node with no
+`cssId` and no `attributes` — nearly every node — so an address on the loop would
+have landed on almost nothing while a fixture setting either field passed.
+
+Off by default because a published page should not carry editor concerns, which
+is why Gutenberg's `data-block` is editor-only. Opt-in is also reversible;
+always-on would be a breaking change to remove.
+
+`NODE_ID_ATTRIBUTE` is published so an editor never hard-codes the spelling.

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -23,6 +23,19 @@ export interface BlockBoundaryProps {
    * own object is never rewritten and no block can supply its own.
    */
   hostPolicy?: BlockHostPolicy;
+  /**
+   * Emit `data-nx-node="<node id>"` on each block's root element.
+   *
+   * OFF by default: a published page should not carry editor concerns, which is
+   * the same reason Gutenberg emits its `data-block` in the editor and not in
+   * post content. An editor turns it on and gets a stable address per node.
+   *
+   * It is the ONLY per-node hook that reaches the DOM independently of styling.
+   * The scoped class does not: `classNameFor` returns the block-TYPE class alone
+   * for a node with no compiled styles, so hit-testing on the class cannot
+   * address an unstyled node and would resolve to the wrong one.
+   */
+  nodeAttribute?: boolean;
 }
 
 /**
@@ -99,7 +112,14 @@ function isAllowedAttribute(name: string): boolean {
  * root. Output that is not a single element has no root to carry them and is
  * returned untouched rather than guessed at.
  */
-function withNodeAttributes(output: ReactNode, node: BlockNode): ReactNode {
+/** The attribute an editor addresses a node by. Named, so one string decides it. */
+export const NODE_ID_ATTRIBUTE = "data-nx-node";
+
+function withNodeAttributes(
+  output: ReactNode,
+  node: BlockNode,
+  nodeAttribute = false
+): ReactNode {
   const cssId = typeof node.cssId === "string" ? node.cssId : undefined;
   // A stored envelope is whatever the database returned: `attributes: null`
   // reaches `Object.keys` and throws here, after the render try/catch and after
@@ -112,7 +132,13 @@ function withNodeAttributes(output: ReactNode, node: BlockNode): ReactNode {
       : undefined;
   const hasAttributes =
     attributes !== undefined && Object.keys(attributes).length > 0;
-  if (cssId === undefined && !hasAttributes) return output;
+  // The node-id attribute is applied UNCONDITIONALLY when asked for, which is
+  // why it is checked before this early return rather than added to the
+  // allowlist loop below. That return fires for any node carrying no `cssId`
+  // and no `attributes` — which is nearly every node on a real page — so an
+  // editor address joined to the loop would land on almost nothing while a
+  // fixture that happened to set either field passed.
+  if (cssId === undefined && !hasAttributes && !nodeAttribute) return output;
   if (!isValidElement(output)) return output;
   // Only a host element has a DOM root to carry them. `nodeRootReason` has
   // already refused the combination that would land here otherwise, so this is
@@ -120,6 +146,9 @@ function withNodeAttributes(output: ReactNode, node: BlockNode): ReactNode {
   if (typeof output.type !== "string") return output;
 
   const extra: Record<string, string> = {};
+  // Written before the author's own attributes so it cannot be overwritten by
+  // one: the editor's address for a node is not a value the document may set.
+  if (nodeAttribute) extra[NODE_ID_ATTRIBUTE] = node.id;
   if (attributes) {
     for (const [name, value] of Object.entries(attributes)) {
       if (!isAllowedAttribute(name)) continue;
@@ -297,7 +326,9 @@ function checkedOutput(
   // block's root, being a list, received none of them.
   isBlockRoot: boolean,
   /** What the block declared about these props, decided once by the caller. */
-  declaresNothing: boolean
+  declaresNothing: boolean,
+  /** Whether the editor asked for a per-node DOM address. */
+  nodeAttribute = false
 ): ReactNode {
   const result = normalizeRenderable(value, {
     // A promise the block returned inside a list is awaited under the same
@@ -313,6 +344,7 @@ function checkedOutput(
           fallback={fallback}
           isBlockRoot={false}
           declaresNothing={declaresNothing}
+          nodeAttribute={nodeAttribute}
         />
       </Suspense>
     ),
@@ -347,7 +379,7 @@ function checkedOutput(
   // nothing can be substituted into an element that already exists. React
   // suspends on them, so they still need a boundary above.
   const withAttributes = isBlockRoot
-    ? withNodeAttributes(result.node, node)
+    ? withNodeAttributes(result.node, node, nodeAttribute)
     : result.node;
   if (!result.hasUnwrappedThenable) return withAttributes;
   return <Suspense fallback={fallback}>{withAttributes}</Suspense>;
@@ -369,6 +401,7 @@ async function AsyncBlockOutput({
   fallback,
   isBlockRoot,
   declaresNothing,
+  nodeAttribute,
 }: {
   pending: PromiseLike<unknown>;
   node: BlockNode;
@@ -376,6 +409,8 @@ async function AsyncBlockOutput({
   isBlockRoot: boolean;
   /** Carried from the caller, which asked the definition once before rendering. */
   declaresNothing: boolean;
+  /** Whether the editor asked for a per-node DOM address. */
+  nodeAttribute?: boolean;
 }): Promise<ReactNode> {
   try {
     return checkedOutput(
@@ -383,7 +418,8 @@ async function AsyncBlockOutput({
       node,
       fallback,
       isBlockRoot,
-      declaresNothing
+      declaresNothing,
+      nodeAttribute
     );
   } catch (error) {
     return (
@@ -427,6 +463,7 @@ export function BlockBoundary({
   classes,
   fallback,
   hostPolicy,
+  nodeAttribute,
 }: BlockBoundaryProps): ReactNode {
   // A node the migration pass could not bring to its block's current version
   // keeps its last-good props, which the current render would misread. The
@@ -519,6 +556,7 @@ export function BlockBoundary({
           classes={classes}
           fallback={fallback}
           {...(hostPolicy === undefined ? {} : { hostPolicy })}
+          {...(nodeAttribute === undefined ? {} : { nodeAttribute })}
         />
       ),
     });
@@ -538,7 +576,14 @@ export function BlockBoundary({
   // block's placeholder. A predicate that could raise would do so out here,
   // past the try block above, and take the page with it.
   if (!isThenable(output)) {
-    return checkedOutput(output, node, fallback, true, declaresNothing);
+    return checkedOutput(
+      output,
+      node,
+      fallback,
+      true,
+      declaresNothing,
+      nodeAttribute
+    );
   }
 
   return (
@@ -549,6 +594,7 @@ export function BlockBoundary({
         fallback={fallback}
         isBlockRoot
         declaresNothing={declaresNothing}
+        nodeAttribute={nodeAttribute}
       />
     </Suspense>
   );
@@ -561,6 +607,19 @@ export interface BlockListProps {
   classes: Record<string, string>;
   fallback?: ReactNode;
   hostPolicy?: BlockHostPolicy;
+  /**
+   * Emit `data-nx-node="<node id>"` on each block's root element.
+   *
+   * OFF by default: a published page should not carry editor concerns, which is
+   * the same reason Gutenberg emits its `data-block` in the editor and not in
+   * post content. An editor turns it on and gets a stable address per node.
+   *
+   * It is the ONLY per-node hook that reaches the DOM independently of styling.
+   * The scoped class does not: `classNameFor` returns the block-TYPE class alone
+   * for a node with no compiled styles, so hit-testing on the class cannot
+   * address an unstyled node and would resolve to the wrong one.
+   */
+  nodeAttribute?: boolean;
 }
 
 /**
@@ -577,6 +636,7 @@ export function BlockList({
   classes,
   fallback,
   hostPolicy,
+  nodeAttribute,
 }: BlockListProps): ReactNode {
   return nodes
     .filter(isUnconditional)
@@ -589,6 +649,7 @@ export function BlockList({
         classes={classes}
         fallback={fallback}
         {...(hostPolicy === undefined ? {} : { hostPolicy })}
+        {...(nodeAttribute === undefined ? {} : { nodeAttribute })}
       />
     ));
 }

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -212,6 +212,7 @@ describe("the root entry", () => {
       "BlockBoundary",
       "BlockList",
       "BlockPlaceholder",
+      "NODE_ID_ATTRIBUTE",
       "PageRenderer",
       "createBlockResolver",
       "createStandaloneContext",

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -56,6 +56,10 @@ export type {
 } from "@nextlyhq/blocks-engine";
 
 export { BlockBoundary, BlockList } from "./block-boundary";
+// `NODE_ID_ATTRIBUTE` is published deliberately: an editor hit-testing on the
+// attribute must not hard-code its spelling, or the renderer and the editor hold
+// two copies of one string and the editor breaks silently when it moves.
+export { NODE_ID_ATTRIBUTE } from "./block-boundary";
 export type { BlockBoundaryProps, BlockListProps } from "./block-boundary";
 
 export { BlockPlaceholder } from "./placeholder";

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -122,6 +122,15 @@ export interface PageRendererProps {
    * omitting this does not deny remote fetches.
    */
   hostPolicy?: BlockHostPolicy;
+  /**
+   * Emit `data-nx-node="<node id>"` on each block's root element.
+   *
+   * OFF by default: a published page should not carry editor concerns. An editor
+   * turns it on to get a stable address per node — and it is the ONLY per-node
+   * hook that reaches the DOM independently of styling, because a node with no
+   * compiled styles receives only the block-TYPE class.
+   */
+  nodeAttribute?: boolean;
 }
 
 /**
@@ -174,6 +183,7 @@ export function PageRenderer({
   styles,
   styleContext,
   siteStyles,
+  nodeAttribute,
   blockFallback,
   limits,
   hostPolicy,
@@ -463,6 +473,7 @@ export function PageRenderer({
         classes={classes}
         fallback={blockFallback}
         {...(hostPolicy === undefined ? {} : { hostPolicy })}
+        {...(nodeAttribute === undefined ? {} : { nodeAttribute })}
       />
     </div>
   );

--- a/packages/blocks-react/src/site-sheet.test.tsx
+++ b/packages/blocks-react/src/site-sheet.test.tsx
@@ -18,6 +18,7 @@ import { describe, expect, it } from "vitest";
 
 import type { BlockDocument } from "@nextlyhq/blocks-engine";
 
+import { NODE_ID_ATTRIBUTE } from "./block-boundary";
 import { box } from "./blocks/box";
 import { PageRenderer } from "./page-renderer";
 import { createBlockResolver } from "./resolver";
@@ -166,5 +167,60 @@ describe("the site stylesheet", () => {
       },
     });
     expect(hashOf(changed)).not.toBe(hashOf(first));
+  });
+});
+
+describe("the per-node DOM address", () => {
+  /**
+   * The case that DECIDES this, and the one both existing mechanisms skip.
+   *
+   * A node with no compiled styles, no `cssId` and no `attributes` — which is
+   * nearly every node on a real page. `classNameFor` gives such a node only the
+   * block-TYPE class, so hit-testing on the class cannot address it and would
+   * resolve to the wrong instance; and `withNodeAttributes` early-returns before
+   * its clone for exactly this node, so an address joined to the attribute
+   * allowlist would land on almost nothing.
+   *
+   * A fixture carrying styles, a `cssId` or an attribute passes while the common
+   * node stays uncovered, which is why this one carries none of the three.
+   */
+  const BARE: BlockDocument = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [{ id: "bare-node", type: "core/box", version: 1, props: {} }],
+  };
+
+  function render(nodeAttribute?: boolean) {
+    return renderToStaticMarkup(
+      <PageRenderer
+        document={BARE}
+        blocks={createBlockResolver([box])}
+        styleContext={{ breakpoints: BREAKPOINTS }}
+        {...(nodeAttribute === undefined ? {} : { nodeAttribute })}
+      />
+    );
+  }
+
+  it("is ABSENT by default, so a published page carries no editor concern", () => {
+    // The same reason Gutenberg emits `data-block` in the editor and not in post
+    // content. Opt-in is also reversible; always-on would be a breaking change
+    // to remove once anything scraped it.
+    expect(render()).not.toContain(NODE_ID_ATTRIBUTE);
+  });
+
+  it("reaches the DOM for a node with no styles, no cssId and no attributes", () => {
+    const out = render(true);
+
+    expect(out).toContain(`${NODE_ID_ATTRIBUTE}="bare-node"`);
+  });
+
+  it("carries the node's own id, not the block type", () => {
+    // A type class is shared by every instance, which is why the class cannot
+    // serve as an address. The attribute must be per NODE or it selects the
+    // wrong one confidently.
+    const out = render(true);
+
+    expect(out).toContain('="bare-node"');
+    expect(out).not.toContain(`${NODE_ID_ATTRIBUTE}="core/box"`);
   });
 });


### PR DESCRIPTION
Unblocks the canvas (lane 09), which needs to answer "which node did the author just click?".

`PageRenderer` gains `nodeAttribute`, **OFF by default**. Turned on, each block's root carries `data-nx-node="<node id>"`.

## Why the scoped class cannot serve

```ts
return nodeClass ? `${nodeClass} ${typeClass}` : typeClass;   // classNameFor
```

**A node with no compiled styles gets NO node class** — only the block-TYPE class, which every instance of that type shares. So hit-testing on the class cannot address an unstyled node, and the type class would select the wrong one. **Most nodes on a real page are unstyled.** Not "coupled to styling" — unaddressable.

## Applied ABOVE the early return, and that is the whole implementation detail

I first argued this was "one more entry in a pass that ships today". **Lane 09 measured it and I was wrong**, in a way that would have shipped a feature landing on almost nothing:

```ts
if (cssId === undefined && !hasAttributes) return output;   // fires FIRST
```

That return fires for any node with **no `cssId` and no `attributes`** — nearly every node. An address joined to the allowlist loop below it would have been skipped for exactly the nodes that need it, while a fixture setting either field passed. So the attribute is checked before that return, and written into `extra` before the author's own attributes so a document cannot overwrite the editor's address.

They also measured that `nodeRootReason`'s refusal is **gated on those same fields** (`if (!hasCssId && !hasAttributes) return null`), so the fragment/component case is **reachable, not theoretical** — an ordinary node whose block returns a fragment carries no root and therefore no address. That is a real limit neither package can patch, and 09 is redesigning their walk to yield **null** rather than the nearest ancestor for it. A missed selection is visible to the author; a wrong one is not.

## Off by default

A published page should not carry editor concerns — the same reason Gutenberg's `data-block` is editor-only and not in post content. Opt-in is also **reversible**: widening later is additive, removing an always-on attribute is a breaking change to anyone who scraped it. 09 withdrew the agent/diffing counter-argument themselves, on the grounds that an agent addresses nodes through the DOCUMENT it already has.

`NODE_ID_ATTRIBUTE` is published so an editor never hard-codes the spelling — otherwise the renderer and the editor hold two copies of one string and the editor breaks silently when it moves.

## The test is the deciding case

A node with **no styles, no `cssId` and no `attributes`** — the one both mechanisms currently skip. A fixture carrying any of the three passes while the common node stays uncovered, which is exactly the trap 09 caught in their own five tests before pushing.

Also asserted: absent by default, and the value is the **node's** id rather than the block type.

## Verification

- `blocks-react` **599/599**, exit 0
- `lint` and `check-types` exit 0
- the entry-surface ratchet correctly demanded `NODE_ID_ATTRIBUTE` be re-exported and in sorted position — a deliberate edit, not a fix to go green
