### PR TITLE
feat(builder): hold a drop target until the pointer travels a threshold

### DIFF
--- a/.changeset/builder-target-switch-travel.md
+++ b/.changeset/builder-target-switch-travel.md
@@ -1,0 +1,47 @@
+---
+
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+
+feat(builder): hold a drop target until the pointer has travelled a threshold
+
+A pointer resting near the boundary between two drop targets jitters by a pixel
+or two and the target underneath it alternates, which shows as a flickering
+insertion indicator and as a block landing where the author did not aim.
+
+`nextTargetSwitchState` makes a rival target hold while the pointer travels a set
+distance before it replaces the committed one. It reads two points and a number
+and no geometry at all, so a 1px divider, an author-set 0px spacer, a 900px hero,
+a vertical stack and a grid all behave identically — a minimum-size rule cannot
+say that, because a spacer's height has no lower bound and any pixel floor makes
+some authored block impossible to drop beside.
+
+The threshold is measured from where the candidate first differed from the
+committed target, not from where the last switch happened. The latter is
+satisfied by construction before the pointer reaches any seam, so it would be met
+exactly where it is not needed and never where it is.
+
+Not yet exported from any entry point: it has no consumer until a canvas wires it
+up, and an unused public export is a surface with no caller to keep it honest.

--- a/packages/builder/src/target-switch.test.ts
+++ b/packages/builder/src/target-switch.test.ts
@@ -56,16 +56,21 @@ describe("a pointer jittering at a seam", () => {
    * target, however many times the collision engine changes its mind.
    */
   it("never switches, however long the jitter goes on", () => {
-    const settled = drag([["a", { x: 100, y: 100 }]]);
-
-    const jitter: (readonly [TargetId, Point])[] = [];
+    const jitter: (readonly [TargetId, Point])[] = [["a", { x: 100, y: 100 }]];
     for (let i = 0; i < 40; i += 1) {
       // 2px apart, which is what a resting hand produces, and the candidate
       // alternates with it exactly as a boundary makes it.
       jitter.push([i % 2 === 0 ? "b" : "a", { x: 100, y: 100 + (i % 2) * 2 }]);
     }
 
-    expect(drag(jitter, settled).committed).toBe("a");
+    // The RUN of committed targets, not the final one, and the difference is the
+    // whole test. An earlier version asserted `committed === "a"` at the end and
+    // passed with the threshold REMOVED ENTIRELY, because a canvas switching on
+    // every single move still lands on "a" whenever the jitter happens to end
+    // there. It could not fail for its own reason. Flicker is a property of the
+    // sequence, so the sequence is what has to be asserted: one commit, at the
+    // start, and nothing after it.
+    expect(committedRun(jitter)).toEqual(["a"]);
   });
 
   /**

--- a/packages/builder/src/target-switch.test.ts
+++ b/packages/builder/src/target-switch.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  NO_TARGET,
+  nextTargetSwitchState,
+  type TargetId,
+  type TargetSwitchState,
+} from "./target-switch";
+import type { Point } from "./geometry";
+
+/**
+ * Far enough that a hand tremor cannot reach it and short enough that a
+ * deliberate crossing does not feel held back. Every case below states its
+ * distances relative to this rather than restating the number, so the
+ * assertions keep meaning what they say if it is retuned.
+ */
+const THRESHOLD = 12;
+
+/** Feeds a run of (candidate, pointer) moves through the rule. */
+function drag(
+  moves: readonly (readonly [TargetId, Point])[],
+  from: TargetSwitchState = NO_TARGET
+): TargetSwitchState {
+  return moves.reduce(
+    (state, [candidate, pointer]) =>
+      nextTargetSwitchState(state, candidate, pointer, THRESHOLD),
+    from
+  );
+}
+
+/** Every target the rule commits to across a run, in order, without repeats. */
+function committedRun(
+  moves: readonly (readonly [TargetId, Point])[]
+): TargetId[] {
+  const seen: TargetId[] = [];
+  moves.reduce((state, [candidate, pointer]) => {
+    const next = nextTargetSwitchState(state, candidate, pointer, THRESHOLD);
+    if (next.committed !== state.committed) seen.push(next.committed);
+    return next;
+  }, NO_TARGET);
+  return seen;
+}
+
+describe("acquiring the first target", () => {
+  it("commits immediately, because there is nothing to flicker between yet", () => {
+    // Withholding this would leave a drag with no indicator until the pointer
+    // had travelled the threshold, which reads as the canvas not responding.
+    expect(drag([["a", { x: 0, y: 0 }]]).committed).toBe("a");
+  });
+});
+
+describe("a pointer jittering at a seam", () => {
+  /**
+   * The anti-flicker requirement, stated as the outcome rather than as the
+   * presence of a threshold: a hand tremor at a boundary must not move the
+   * target, however many times the collision engine changes its mind.
+   */
+  it("never switches, however long the jitter goes on", () => {
+    const settled = drag([["a", { x: 100, y: 100 }]]);
+
+    const jitter: (readonly [TargetId, Point])[] = [];
+    for (let i = 0; i < 40; i += 1) {
+      // 2px apart, which is what a resting hand produces, and the candidate
+      // alternates with it exactly as a boundary makes it.
+      jitter.push([i % 2 === 0 ? "b" : "a", { x: 100, y: 100 + (i % 2) * 2 }]);
+    }
+
+    expect(drag(jitter, settled).committed).toBe("a");
+  });
+
+  /**
+   * The positive control for the case above, and it is not optional: a rule that
+   * never switches at all satisfies "no flicker" perfectly, so the assertion
+   * above is only evidence once a deliberate crossing is shown to work through
+   * the identical helper.
+   */
+  it("still switches for a deliberate crossing, through the same helper", () => {
+    const settled = drag([["a", { x: 100, y: 100 }]]);
+
+    expect(
+      drag(
+        [
+          ["b", { x: 100, y: 100 }],
+          ["b", { x: 100, y: 100 + THRESHOLD }],
+        ],
+        settled
+      ).committed
+    ).toBe("b");
+  });
+});
+
+describe("where the threshold is measured FROM", () => {
+  /**
+   * The property that separates this rule from the plausible version of it.
+   *
+   * Anchoring at the last SWITCH instead reads perfectly well and collapses in
+   * the commonest case: an author dragging from the block library crosses most
+   * of the page before reaching a seam, so the distance since the last switch is
+   * already far past the threshold on arrival and the first pixel over the
+   * boundary switches instantly.
+   *
+   * A long approach INSIDE the committed target followed by a single pixel over
+   * the boundary is exactly that case, and the two implementations disagree on
+   * it: measuring from the last switch commits `b`, measuring from where the
+   * candidate changed does not.
+   */
+  it("does not switch on a 1px crossing after a long approach", () => {
+    const approach: (readonly [TargetId, Point])[] = [];
+    for (let y = 0; y <= 400; y += 20) approach.push(["a", { x: 100, y }]);
+
+    // 400px travelled, all of it inside `a`, then one pixel into `b`.
+    const state = drag([...approach, ["b", { x: 100, y: 401 }]]);
+
+    expect(state.committed).toBe("a");
+    expect(state.pending?.target).toBe("b");
+  });
+
+  it("switches once the crossing ITSELF has covered the threshold", () => {
+    const approach: (readonly [TargetId, Point])[] = [];
+    for (let y = 0; y <= 400; y += 20) approach.push(["a", { x: 100, y }]);
+
+    expect(
+      drag([
+        ...approach,
+        ["b", { x: 100, y: 401 }],
+        ["b", { x: 100, y: 401 + THRESHOLD }],
+      ]).committed
+    ).toBe("b");
+  });
+
+  it("measures the crossing from where the candidate changed, not from the seam", () => {
+    // The anchor is a pointer position the rule recorded, not a boundary it
+    // knows about — it reads no geometry at all — so a candidate appearing far
+    // from any seam is measured from where it appeared.
+    const state = drag([
+      ["a", { x: 0, y: 0 }],
+      ["b", { x: 500, y: 500 }],
+    ]);
+
+    expect(state.pending?.anchor).toEqual({ x: 500, y: 500 });
+  });
+});
+
+describe("what counts as travel", () => {
+  /**
+   * Displacement, never path length. A pointer sawing back and forth across a
+   * seam accumulates unbounded path while going nowhere, so a path measure would
+   * eventually grant the switch it exists to withhold — and it would do so after
+   * a delay, which is worse than granting it at once because it is
+   * unreproducible.
+   */
+  it("does not accumulate from a pointer that keeps returning to where it started", () => {
+    const settled = drag([["a", { x: 0, y: 0 }]]);
+
+    const sawing: (readonly [TargetId, Point])[] = [];
+    for (let i = 0; i < 60; i += 1) {
+      // Total path length is 60 x (THRESHOLD - 1), far past the threshold;
+      // displacement from the anchor never exceeds THRESHOLD - 1.
+      sawing.push(["b", { x: 0, y: i % 2 === 0 ? 0 : THRESHOLD - 1 }]);
+    }
+
+    expect(drag(sawing, settled).committed).toBe("a");
+  });
+});
+
+describe("a rival that changes its mind", () => {
+  it("restarts the measurement when a DIFFERENT rival appears", () => {
+    // The distance covered while `b` was pending says nothing about how far the
+    // pointer has moved since `c` appeared, so `c` starts from where it arrived.
+    const state = drag([
+      ["a", { x: 0, y: 0 }],
+      ["b", { x: 0, y: 5 }],
+      ["c", { x: 0, y: 10 }],
+    ]);
+
+    expect(state.committed).toBe("a");
+    expect(state.pending).toEqual({ target: "c", anchor: { x: 0, y: 10 } });
+  });
+
+  it("drops a rival that goes back to agreeing with the committed target", () => {
+    // Left pending, its stale anchor would be inherited by a later return to the
+    // same value and grant a switch on a crossing that never happened.
+    const state = drag([
+      ["a", { x: 0, y: 0 }],
+      ["b", { x: 0, y: 5 }],
+      ["a", { x: 0, y: 5 }],
+    ]);
+
+    expect(state.pending).toBeNull();
+  });
+
+  it("does not inherit a stale anchor when the same rival returns", () => {
+    const state = drag([
+      ["a", { x: 0, y: 0 }],
+      ["b", { x: 0, y: 0 }],
+      ["a", { x: 0, y: 0 }],
+      // `b` reappears having travelled the threshold's worth since it FIRST
+      // appeared. Measured from that first sighting it would switch; measured
+      // from this one it must not.
+      ["b", { x: 0, y: THRESHOLD }],
+    ]);
+
+    expect(state.committed).toBe("a");
+  });
+});
+
+describe("losing the target", () => {
+  it("holds an empty candidate to the same threshold as a rival", () => {
+    // Dropping the target at a boundary flickers exactly as gaining the wrong
+    // one does, so `null` is an ordinary candidate rather than an absence.
+    const settled = drag([["a", { x: 0, y: 0 }]]);
+
+    expect(drag([[null, { x: 0, y: 1 }]], settled).committed).toBe("a");
+    expect(
+      drag(
+        [
+          [null, { x: 0, y: 1 }],
+          [null, { x: 0, y: 1 + THRESHOLD }],
+        ],
+        settled
+      ).committed
+    ).toBeNull();
+  });
+});
+
+describe("the committed sequence over a whole drag", () => {
+  it("commits each target once, in the order the pointer reached them", () => {
+    // Asserted as the SEQUENCE rather than as a final value: a rule that
+    // switched to `b`, back to `a`, then to `b` again ends on the same answer
+    // while having flickered twice on the way, and only the run separates them.
+    expect(
+      committedRun([
+        ["a", { x: 0, y: 0 }],
+        ["b", { x: 0, y: 40 }],
+        ["b", { x: 0, y: 40 + THRESHOLD }],
+        ["c", { x: 0, y: 80 }],
+        ["c", { x: 0, y: 80 + THRESHOLD }],
+      ])
+    ).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("the threshold itself", () => {
+  it.each([Number.NaN, -1, Number.POSITIVE_INFINITY])(
+    "refuses %p rather than silently disabling the rule",
+    invalid => {
+      // `NaN` is the one that matters: every comparison against it is false, so
+      // the rule would withhold every switch forever while looking configured.
+      expect(() =>
+        nextTargetSwitchState(NO_TARGET, "a", { x: 0, y: 0 }, invalid)
+      ).toThrow(RangeError);
+    }
+  );
+
+  it("switches on the next move when the threshold is zero", () => {
+    // Zero is a legitimate request for no hysteresis, and it must not be
+    // confused with the invalid values above.
+    const settled = nextTargetSwitchState(NO_TARGET, "a", { x: 0, y: 0 }, 0);
+
+    expect(
+      nextTargetSwitchState(settled, "b", { x: 0, y: 0 }, 0).committed
+    ).toBe("b");
+  });
+});

--- a/packages/builder/src/target-switch.ts
+++ b/packages/builder/src/target-switch.ts
@@ -1,0 +1,163 @@
+/**
+ * When a drag is allowed to change its drop target.
+ *
+ * A pointer resting near the boundary between two drop targets jitters by a pixel
+ * or two, and the target underneath it alternates with the jitter. Committed
+ * directly, that alternation is visible as a flickering insertion indicator and as
+ * a block landing somewhere the author did not aim — the two failures this rule
+ * exists to remove.
+ *
+ * The rule: **a candidate target must hold while the pointer travels a set
+ * distance before it replaces the committed one.**
+ *
+ * @remarks
+ * **Why distance rather than a dwell timer.** A timer makes the editor's
+ * behaviour depend on how long the author hesitates, so a slow deliberate drag
+ * and a jitter become indistinguishable, and the delay is felt on every genuine
+ * boundary crossing. Distance is a property of the gesture rather than of the
+ * clock: a 2px jitter never accumulates it, and a deliberate move always does.
+ *
+ * **Why nothing here reads a BLOCK's size.** The obvious alternative is to
+ * require a target to be some minimum height before it can be claimed, which is
+ * what a survey of the field suggests. It cannot work in this editor. A
+ * `core/spacer`'s height is an author-set prop with no lower bound and a divider
+ * is a single pixel, so any absolute floor makes some authored block impossible
+ * to drop beside. Keying on the GAP between blocks moves the same hazard rather
+ * than removing it, because two blocks with no margin have a gap of zero. This
+ * rule reads two points and a number, so a 1px divider, a 0px spacer, a 900px
+ * hero, a vertical stack and a grid all behave identically.
+ *
+ * The functions are pure and take plain points, so the behaviour is exercised
+ * without a browser and the pointer reads stay at the edge.
+ *
+ * @module target-switch
+ */
+import type { Point } from "./geometry";
+
+/**
+ * A drop target's identity, or `null` for "the pointer is over none".
+ *
+ * `null` is an ordinary value here rather than an absence: losing a target at a
+ * boundary flickers exactly as gaining the wrong one does, so dropping the
+ * committed target is held to the same threshold as replacing it.
+ */
+export type TargetId = string | null;
+
+/**
+ * A candidate that has appeared but not yet earned the switch.
+ *
+ * `anchor` is where the pointer was when this candidate FIRST differed from the
+ * committed target, which is the subtlety the whole rule turns on. See
+ * {@link nextTargetSwitchState}.
+ */
+export interface PendingTarget {
+  readonly target: TargetId;
+  readonly anchor: Point;
+}
+
+/** What the rule remembers between pointer moves. */
+export interface TargetSwitchState {
+  /** The target actually in effect — what the indicator draws and a drop uses. */
+  readonly committed: TargetId;
+  /** A rival waiting to earn the switch, or `null` when none is waiting. */
+  readonly pending: PendingTarget | null;
+}
+
+/** A drag that has not yet resolved a target. */
+export const NO_TARGET: TargetSwitchState = {
+  committed: null,
+  pending: null,
+};
+
+/** Straight-line distance between two points. */
+function distance(a: Point, b: Point): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+/**
+ * Advances the rule by one pointer move.
+ *
+ * @param state - what the previous move left behind; {@link NO_TARGET} to begin
+ * @param candidate - the target the collision engine resolves at `pointer` now
+ * @param pointer - the pointer, in any one coordinate space used consistently
+ * @param thresholdPx - how far the pointer must travel for a rival to win
+ * @returns the next state; `committed` is what the editor should act on
+ *
+ * @throws RangeError if `thresholdPx` is negative or not finite. A threshold is
+ * a contract rather than a hint, and a `NaN` arriving from an unparsed
+ * configuration value would make every comparison false and silently disable the
+ * rule — a flickering canvas with nothing to point at.
+ *
+ * @remarks
+ * **The anchor is where the candidate CHANGED, not where the last switch
+ * happened, and the difference is the whole mechanism.**
+ *
+ * Measuring from the last switch reads plausibly and gives no hysteresis at all
+ * in the commonest case. An author dragging from the block library crosses most
+ * of the page before reaching the seam between two blocks: by the time they
+ * arrive, the distance since the last switch is already far past any threshold,
+ * so the first pixel over the boundary switches immediately and the jitter that
+ * follows switches back just as fast. The rule would be satisfied and absent
+ * exactly where it is needed.
+ *
+ * Anchoring at the moment the candidate first differs makes the threshold
+ * measure the crossing itself, so it costs the same and applies wherever the
+ * crossing happens.
+ *
+ * **Displacement, not path length.** A pointer jittering back and forth across a
+ * seam accumulates unbounded path length while never getting anywhere, so a path
+ * measure would eventually grant the switch it exists to withhold. Distance from
+ * the anchor cannot be accumulated by going nowhere.
+ *
+ * **The first target commits immediately.** There is nothing to flicker between
+ * before a target exists, and withholding it would leave a drag with no
+ * indicator until the pointer had travelled the threshold, which reads as the
+ * canvas failing to respond.
+ */
+export function nextTargetSwitchState(
+  state: TargetSwitchState,
+  candidate: TargetId,
+  pointer: Point,
+  thresholdPx: number
+): TargetSwitchState {
+  if (!Number.isFinite(thresholdPx) || thresholdPx < 0) {
+    throw new RangeError(
+      `target switch threshold must be a finite, non-negative number of pixels, received ${String(thresholdPx)}`
+    );
+  }
+
+  // Agreement clears any rival: a candidate that has gone back to matching what
+  // is committed is no longer waiting for anything, and leaving it pending would
+  // let a later return to that same value inherit a stale anchor and switch on a
+  // crossing it never made.
+  if (candidate === state.committed) {
+    return state.pending === null ? state : { ...state, pending: null };
+  }
+
+  // Nothing is committed yet, so there is no incumbent to protect.
+  if (state.committed === null) {
+    return { committed: candidate, pending: null };
+  }
+
+  // A different rival from the one that was waiting restarts the measurement,
+  // because the distance travelled while some OTHER target was pending says
+  // nothing about how far the pointer has moved since this one appeared.
+  //
+  // Established and then MEASURED in the same move rather than returned early.
+  // A new rival is zero pixels from its own anchor, so the check below rejects
+  // it for any positive threshold exactly as an early return would — and a
+  // threshold of zero, which is a legitimate request for no hysteresis, switches
+  // at once instead of carrying a one-move delay nothing asked for.
+  const pending =
+    state.pending !== null && state.pending.target === candidate
+      ? state.pending
+      : { target: candidate, anchor: pointer };
+
+  if (distance(pointer, pending.anchor) < thresholdPx) {
+    return state.pending === pending ? state : { ...state, pending };
+  }
+
+  // Earned. The rival becomes the incumbent and the next crossing is measured
+  // from wherever it happens rather than from here.
+  return { committed: candidate, pending: null };
+}


### PR DESCRIPTION
## What

`packages/builder/src/target-switch.ts` — a pure rule deciding when a drag may change its drop target. New file plus its test. Nothing is wired to it yet.

## Why this mechanism

A pointer resting near a boundary between two drop targets jitters a pixel or two and the target underneath alternates with it. Committed directly, that shows as a flickering insertion indicator and as a block landing where the author did not aim.

**A minimum-size rule cannot work here, which is what ruled out the obvious approach.** Surveying the field suggests requiring a target to exceed some height before it can be claimed. In this editor `core/spacer`'s height is an author-set prop with **no lower bound**, and a divider is a single pixel, so any absolute floor makes some authored block impossible to drop beside. Keying on the **gap** between blocks relocates the hazard rather than removing it: two blocks with no margin have a gap of zero.

This rule reads two points and a number and **no geometry at all**, so a 1px divider, a 0px spacer, a 900px hero, a vertical stack and a grid all behave identically.

## The subtlety the rule turns on

**The threshold is measured from where the candidate first differed from the committed target — not from where the last switch happened.**

Measured from the last switch, the rule is satisfied *by construction* before the pointer reaches any seam: an author dragging from the block library crosses most of the page first, so the distance is already far past any threshold on arrival, the first pixel over the boundary switches instantly, and the jitter switches back just as fast. It would be met exactly where it is not needed and never where it is — the absence of hysteresis wearing the shape of it.

Also **displacement, never path length**: a pointer sawing across a seam accumulates unbounded path while going nowhere, so a path measure eventually grants the switch it exists to withhold.

## Stub-verified, three breaks, and one of them found a false green in my own test

| break | result |
|---|---|
| anchor at the last switch instead of at divergence | 4 anchor tests fail — **the jitter test still passes** |
| path length instead of displacement | exactly 1 test fails, alone |
| remove the threshold entirely | 6 fail — **the jitter test still passed** |

That third break is the important one. The original jitter test asserted `committed === "a"` after 40 alternating moves, and **passed with hysteresis removed completely**, because a canvas switching on every move still lands on `"a"` whenever the jitter happens to end there. It could not fail for its own reason.

Flicker is a property of the *sequence*, so the sequence is now what is asserted — the committed run must be exactly `["a"]`, one commit at the start and nothing after. Re-running the same break with the fixed test moves the failures 6 → 7, the jitter test having joined.

The first break is worth reading too: the flawed "last switch" implementation **passes the anti-flicker test**. The obvious test does not separate the two designs, which is why the anchor tests exist.

## Also found by its own test

At `thresholdPx: 0` the first version still spent one move establishing the anchor, so "no hysteresis" was not quite true. The rule now establishes and measures in the same move; zero switches at once, and any positive threshold is unchanged.

## Gates

`build` 0 · `test` **390 passed (13 files)** · `check-types` 0 · `lint` 0 (`--max-warnings 0`). Both new files confirmed present in the type-check program via `tsc --listFiles`, since a tsconfig exclusion would have skipped the typed test code silently.

## Scope

Not exported from `index.ts`: it has no consumer until a canvas wires it up, and an unused public export is a surface with no caller to keep it honest. It is React-free, so it can join the server-callable root barrel later rather than needing `shell.ts`.

Placed in `builder` rather than in `plugin-page-builder/src/admin/canvas/` deliberately — measured, `packages/builder/src/canvas.tsx` is absent from `main` while the PoC canvas is present, and the PoC is slated for removal. A pure module outlives whichever canvas consumes it. Agreed with the lane building that canvas; it touches no file of theirs.

**The threshold VALUE is not part of this PR and should not be inherited.** Re-derive it against whichever canvas ships.