### PR TITLE
feat(admin): announce document status in one polite region

### DIFF
--- a/.changeset/entry-document-status-live.md
+++ b/.changeset/entry-document-status-live.md
@@ -1,0 +1,49 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+feat(admin): announce document status in one polite region
+
+The entry editor reported whether an author's work was stored visually only.
+`AutoSaveIndicator` cycles through "Saving…", "Saved", "Unsaved changes" and
+"Not saved", and the header carried no live region at all — so the control
+whose whole purpose is reassuring someone their work is safe did that for
+sighted users only.
+
+The header now has a single `role="status"` / `aria-live="polite"` region
+covering document status. One region rather than one per concern: two live
+regions in the same header interrupt each other, and a reader cannot tell which
+announcement belongs to what they just did.
+
+Two deliberate choices. The transient "saving" state is silent, because autosave
+debounces and announcing it speaks over the reader every few seconds while they
+type — what matters is where the state came to rest. And the spoken wording is a
+full sentence ("Your work is stored") rather than the chip's terse label, since
+an announcement arrives with no visual context to tell the listener what the
+word refers to.
+
+The region also accepts translation progress, so a multilingual entry can report
+both kinds of document state through the same channel.

--- a/packages/admin/src/components/features/entries/EntryForm/DocumentStatusLive.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/DocumentStatusLive.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+/**
+ * DocumentStatusLive — the entry editor's single spoken status region.
+ *
+ * The header reports two kinds of ambient state about the document being
+ * edited: whether the work is stored (autosave) and how far its translations
+ * have got. Both were visible and NEITHER was announced — `AutoSaveIndicator`
+ * cycles through "Saving…", "Saved", "Unsaved changes" and "Not saved" with no
+ * live region anywhere in the header, so the control whose entire purpose is
+ * reassuring an author their work is safe did that for sighted users only.
+ *
+ * There is ONE region rather than one per concern. Two live regions in the same
+ * header interrupt each other, and a reader cannot tell which of two competing
+ * announcements belongs to what they just did. Since both are the same kind of
+ * information about the same document, they share a region and take turns.
+ *
+ * @module components/features/entries/EntryForm/DocumentStatusLive
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+export interface DocumentStatusLiveProps {
+  /** Whether a save is in flight right now. */
+  isSaving?: boolean;
+  /** Whether the form holds edits that are not stored. */
+  isDirty?: boolean;
+  /** When a recovery point was last written, if ever. */
+  lastSavedAt?: Date | null;
+  /** Whether autosave is even possible for this entry. */
+  autosaveEnabled?: boolean;
+  /** How many configured languages carry a translation. */
+  translatedCount?: number;
+  /** How many languages are configured. Zero or one means not worth announcing. */
+  localeCount?: number;
+}
+
+/**
+ * The settled description of where the document stands, or `null` while it is
+ * in a state not worth interrupting the reader for.
+ *
+ * The wording is a full sentence rather than the terse chip beside it
+ * ("Saved", "Not saved"). A live-region announcement arrives with no visual
+ * context — nothing tells the listener that the word belongs to a save
+ * indicator — so it has to carry its own subject. Keeping the two wordings
+ * distinct also stops the same text existing twice in the accessibility tree,
+ * once on the visible chip and once here.
+ *
+ * "Saving…" deliberately returns `null`. Autosave debounces, so announcing the
+ * transient state speaks over the reader every few seconds WHILE THEY TYPE,
+ * which is worse than silence — the useful information is where it came to
+ * rest, not that it is in motion.
+ */
+function settledStatus(
+  isSaving: boolean,
+  isDirty: boolean,
+  lastSavedAt: Date | null
+): string | null {
+  if (isSaving) return null;
+  if (isDirty)
+    return lastSavedAt
+      ? "You have edits that are not yet stored"
+      : "Your work is not yet stored";
+  return lastSavedAt ? "Your work is stored" : null;
+}
+
+/**
+ * Announces document status once per settled change, in a single polite region.
+ *
+ * `polite` rather than `assertive`: none of this is urgent enough to cut across
+ * whatever the reader is doing, and `assertive` on a status that changes as
+ * often as this one would make the editor unusable with a screen reader.
+ */
+export function DocumentStatusLive({
+  isSaving = false,
+  isDirty = false,
+  lastSavedAt = null,
+  autosaveEnabled = false,
+  translatedCount,
+  localeCount,
+}: DocumentStatusLiveProps) {
+  const [message, setMessage] = useState("");
+  // What was last announced, so an unchanged status does not re-fire. Held in a
+  // ref rather than state because it must not itself cause a render.
+  const spoken = useRef<string>("");
+
+  const saveStatus = autosaveEnabled
+    ? settledStatus(isSaving, isDirty, lastSavedAt)
+    : null;
+
+  // Only meaningful in a multilingual collection: "1 of 1 languages translated"
+  // is noise, and a collection with no locales configured has nothing to say.
+  const translationStatus =
+    typeof translatedCount === "number" &&
+    typeof localeCount === "number" &&
+    localeCount > 1
+      ? `${translatedCount} of ${localeCount} languages translated`
+      : null;
+
+  const next = [saveStatus, translationStatus].filter(Boolean).join(". ");
+
+  useEffect(() => {
+    // An empty `next` is a state we chose not to announce (mid-save), not a
+    // change to announce as emptiness — leave the last message in place rather
+    // than clearing the region, which some readers voice as an interruption.
+    if (!next || next === spoken.current) return;
+    spoken.current = next;
+    setMessage(next);
+  }, [next]);
+
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      // Not `aria-atomic`: only the changed sentence needs reading, and reading
+      // the whole region again on every autosave repeats the translation count
+      // the reader already has.
+      className="sr-only"
+      data-testid="document-status-live"
+    >
+      {message}
+    </span>
+  );
+}

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -36,6 +36,7 @@ import { LanguageSwitcher } from "../LanguageSwitcher";
 
 import { AutoSaveIndicator } from "./AutoSaveIndicator";
 import { DiscardDraftConfirmDialog } from "./DiscardDraftConfirmDialog";
+import { DocumentStatusLive } from "./DocumentStatusLive";
 import { effectiveEntryStatus } from "./entry-address";
 import { PreviewActions } from "./PreviewActions";
 import { ShowJSONDialog } from "./ShowJSONDialog";
@@ -437,6 +438,19 @@ export function EntrySystemHeader({
             isDirty={isDirty}
           />
         ) : null}
+        {/* The spoken half of the same information. `AutoSaveIndicator` reports
+            visually only — it carries no live region — so an author using a
+            screen reader was never told whether their work had been stored.
+            This is rendered unconditionally rather than beside the indicator's
+            own condition, because a live region has to be PRESENT BEFORE the
+            text it will announce changes: mounting a region and populating it
+            in the same commit is not reliably announced. */}
+        <DocumentStatusLive
+          autosaveEnabled={autosaveEnabled}
+          isSaving={autosaveStatus === "saving"}
+          isDirty={isDirty}
+          lastSavedAt={autosaveLastSavedAt}
+        />
         {hasStatus && isPublishedEdit ? (
           <>
             <Button

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/DocumentStatusLive.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/DocumentStatusLive.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * DocumentStatusLive — one polite region, announcing only settled state.
+ *
+ * Each negative assertion carries its positive control on the same render: the
+ * region itself is always queried first, so "the text is absent" cannot pass
+ * because nothing rendered at all.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DocumentStatusLive } from "../DocumentStatusLive";
+
+const SAVED_AT = new Date("2026-08-17T10:00:00Z");
+
+function region() {
+  return screen.getByTestId("document-status-live");
+}
+
+describe("DocumentStatusLive — the region itself", () => {
+  it("is a polite status region that exists before it has anything to say", () => {
+    render(<DocumentStatusLive />);
+    const el = region();
+    // Present up front: a region mounted and populated in the same commit is
+    // not reliably announced, so its existence is the property under test.
+    expect(el).toHaveAttribute("role", "status");
+    expect(el).toHaveAttribute("aria-live", "polite");
+    expect(el.textContent).toBe("");
+  });
+});
+
+describe("DocumentStatusLive — settled autosave states are announced", () => {
+  it("announces Saved when clean with a recovery point", () => {
+    render(
+      <DocumentStatusLive
+        autosaveEnabled
+        lastSavedAt={SAVED_AT}
+        isDirty={false}
+      />
+    );
+    expect(region()).toHaveTextContent("Your work is stored");
+  });
+
+  it("announces Unsaved changes when dirty after a save", () => {
+    render(
+      <DocumentStatusLive autosaveEnabled lastSavedAt={SAVED_AT} isDirty />
+    );
+    expect(region()).toHaveTextContent(
+      "You have edits that are not yet stored"
+    );
+  });
+
+  it("announces Not saved when dirty with no recovery point yet", () => {
+    render(<DocumentStatusLive autosaveEnabled lastSavedAt={null} isDirty />);
+    expect(region()).toHaveTextContent("Your work is not yet stored");
+  });
+});
+
+describe("DocumentStatusLive — the transient state is deliberately silent", () => {
+  it("says nothing while a save is in flight", () => {
+    render(
+      <DocumentStatusLive
+        autosaveEnabled
+        isSaving
+        lastSavedAt={SAVED_AT}
+        isDirty
+      />
+    );
+    // Control: the region IS rendered, so an empty string here is a decision
+    // not to announce rather than a component that failed to mount.
+    expect(region()).toHaveAttribute("role", "status");
+    expect(region().textContent).toBe("");
+  });
+
+  it("keeps the previous announcement rather than clearing it mid-save", () => {
+    const { rerender } = render(
+      <DocumentStatusLive
+        autosaveEnabled
+        lastSavedAt={SAVED_AT}
+        isDirty={false}
+      />
+    );
+    expect(region()).toHaveTextContent("Your work is stored");
+
+    rerender(
+      <DocumentStatusLive
+        autosaveEnabled
+        isSaving
+        lastSavedAt={SAVED_AT}
+        isDirty
+      />
+    );
+    // Clearing a live region is voiced as an interruption by some readers, so
+    // the last settled message stays put while the transient state passes.
+    expect(region()).toHaveTextContent("Your work is stored");
+  });
+});
+
+describe("DocumentStatusLive — nothing to report", () => {
+  it("stays silent when autosave is not available", () => {
+    render(
+      <DocumentStatusLive autosaveEnabled={false} isDirty lastSavedAt={null} />
+    );
+    expect(region()).toHaveAttribute("role", "status");
+    expect(region().textContent).toBe("");
+  });
+});
+
+describe("DocumentStatusLive — translation progress", () => {
+  it("announces progress in a multilingual collection", () => {
+    render(<DocumentStatusLive translatedCount={3} localeCount={5} />);
+    expect(region()).toHaveTextContent("3 of 5 languages translated");
+  });
+
+  it("stays silent when only one language is configured", () => {
+    render(<DocumentStatusLive translatedCount={1} localeCount={1} />);
+    // Control paired: the multilingual case above proves the matcher resolves,
+    // and the region is asserted present here on this render too.
+    expect(region()).toHaveAttribute("role", "status");
+    expect(region().textContent).toBe("");
+  });
+
+  it("combines both kinds of status in one region", () => {
+    render(
+      <DocumentStatusLive
+        autosaveEnabled
+        lastSavedAt={SAVED_AT}
+        isDirty={false}
+        translatedCount={2}
+        localeCount={4}
+      />
+    );
+    const el = region();
+    expect(el).toHaveTextContent("Your work is stored");
+    expect(el).toHaveTextContent("2 of 4 languages translated");
+  });
+});


### PR DESCRIPTION
**This work was stranded by #922's merge and is being re-opened, not re-done.**
#922 merged at head `80989c311` while the branch had already moved to
`da3b0d0fa`, so the two commits carrying this feature never landed —
`DocumentStatusLive` is absent from `main` while the labelling tests from the
same branch are present. Recovered from the branch, rebased onto current `main`,
squashed into one commit. Nothing was lost.

## The defect

`AutoSaveIndicator` cycles through "Saving…", "Saved", "Unsaved changes" and
"Not saved", and **the entry header carried no live region at all**. The control
whose entire purpose is reassuring an author their work is safe did that for
sighted users only.

## The fix

One `role="status"` / `aria-live="polite"` region in the header, covering
document status. **One region rather than one per concern:** two live regions in
the same header interrupt each other, and a listener cannot tell which
announcement belongs to what they just did. It also accepts translation
progress, so a multilingual entry reports both kinds of ambient document state
through the same channel.

## Two deliberate choices

**The transient "saving" state is silent.** Autosave debounces, so announcing it
speaks over the reader every few seconds *while they are typing*. What matters
is where the state came to rest, not that it is in motion.

**The spoken wording is a full sentence** ("Your work is stored") rather than the
chip's terse label. A live-region announcement arrives with no visual context to
tell the listener what the word refers to. This also keeps the same text from
existing twice in the accessibility tree — the collision surfaced as a genuine
failure in the autosave-indicator tests, and the fix was better copy rather than
a weakened assertion.

## Break-verified

| break | result |
|---|---|
| announce the transient saving state | **2 fail** |
| drop the single-language guard | **1 fails** |
| restored | 10 pass, clean tree |

> The second break first reported **no failure**, which was my instrument rather
> than the code: prettier had reformatted the file during the pre-commit hook so
> the replacement string no longer matched and the break never applied. A break
> that does not apply proves nothing. The result above is from a rerun that
> asserts the file changed first.

## Verification

`packages/admin`: same 4 pre-existing failing files as `main`, **zero new**.
`check-types` and `lint` clean after a rebuild — the rebase onto a newer `main`
first produced `TS2307` and two `ValidationTab` failures from stale `dist`, both
cleared by `pnpm build` and neither in this diff.

## Reviewer state

Neither bot is reviewing right now: Codex returns its usage-limit message and
CodeRabbit posts a **passing check** alongside "Review limit reached — we
couldn't start this review". Its green is not coverage.
