### PR TITLE
feat(nextly): add migrate:field-groups, which previews by default

### DIFF
--- a/.changeset/migrate-field-groups-command.md
+++ b/.changeset/migrate-field-groups-command.md
@@ -1,0 +1,36 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+`nextly migrate:field-groups` renames field-group storage to its current names, and previews by default.
+
+Field groups were called components once, and the old vocabulary is still in the database: the registry table, each field group's data table, and the column naming which field group a stored row belongs to. Nextly reads whichever generation a database holds, so nothing forces this — a site that never runs it keeps working. This is the command for tidying it up, one site at a time.
+
+Running it with no flags writes nothing and prints the plan. Applying is `--apply`, which requires `--backup-confirmed` alongside it, and `--down` rolls a completed migration back. A preview takes no lock and issues no DDL, so it can be run with a read-only credential.
+
+The preview reports three things separately, because they answer different questions: every storage object that would be renamed, listed by name rather than counted; whether the plan was checked against your database or merely proposed, since another run writing at the same time makes the list an upper bound; and what could be seen of the migration lock, where "nothing is running" and "the lock could not be read" are reported as the different answers they are.
+
+A new guide, Field group storage migration, covers the per-site runbook, how to read the preview, and rollback.

--- a/docs/guides/field-group-storage-migration.mdx
+++ b/docs/guides/field-group-storage-migration.mdx
@@ -1,0 +1,106 @@
+---
+title: Field group storage migration
+description: Rename field-group tables and columns to their current names, per site, with a preview-first CLI. Includes a step-by-step runbook and rollback.
+---
+
+Field groups used to be called components, and the old name is still in the database even though it is gone from the API and the admin. Three things still carry it:
+
+| What | Old name | New name |
+|---|---|---|
+| The registry table | `dynamic_components` | `dynamic_field_groups` |
+| Each field group's data table | `comp_<slug>` | `fg_<slug>` |
+| The column naming a stored row's field group | `_component_type` | `_field_group_type` |
+
+`nextly migrate:field-groups` renames them.
+
+## You do not have to do this
+
+Nextly reads whichever generation your database holds. A site that never runs this keeps working, and a site that runs it keeps working. There is no flag day, no coordinated release, and no window where half your fleet is broken.
+
+That is deliberate: the migration is **expand → migrate → contract**, and the expand half already shipped. The application probes each database and serves whatever it finds.
+
+So treat this as tidying up, done per site, at a time you choose.
+
+## It previews by default
+
+Running the command with no flags **writes nothing**:
+
+```bash
+nextly migrate:field-groups
+```
+
+It prints every storage object that would be renamed, by name, and stops.
+
+Applying is explicit, and needs you to confirm a backup exists:
+
+```bash
+nextly migrate:field-groups --apply --backup-confirmed
+```
+
+`--backup-confirmed` is not a formality and it is not defaulted. This rewrites stored content. The migration is resumable and reversible, but neither property helps against the failures that actually motivate a backup — a run on a database whose disk fills, a rollback whose recorded plan was lost, or discovering afterwards that you were pointed at the wrong database.
+
+<Callout type="info">
+  A preview takes no lock and issues no DDL, so it works with a **read-only credential**. That is the credential you should preview production with.
+</Callout>
+
+## Reading the preview
+
+Three things in the output matter, and each answers a different question.
+
+**The rename list** names every object that changes. It is a list rather than a count on purpose: a run also rewrites stored rows and passes settlement gates, so any number derived from renames alone understates the work while looking authoritative. Your question when reading it is whether *your* table is there, which a total cannot answer.
+
+**Whether the plan was checked against your database.** A preview takes no lock, so another run can be writing while it reads. When that happens the command says so:
+
+> This plan was NOT checked against your database.
+
+That list is then the *most* that could change rather than what will — some of it may already have been applied by whoever is writing. Re-run the preview when nothing else is writing.
+
+**Whether a migration is already running.** Three outcomes, and the third is not the first:
+
+- *No migration is currently running* — nothing holds the lock.
+- *A migration is running right now* — someone else is mid-flight; wait.
+- *The lock could not be read* — your role cannot read the lock table. **This is not the same as "nothing is running."** Find out why before you write anything.
+
+## Runbook, per site
+
+Do one site at a time and let each soak before starting the next. Suggested order: playground → your own sites → client sites last.
+
+1. **Upgrade** the site to a Nextly release that includes this command.
+
+2. **Take a backup**, and confirm you can restore it. Not that it exists — that it restores.
+
+3. **Preview**, ideally with a read-only credential:
+
+   ```bash
+   nextly migrate:field-groups
+   ```
+
+   Read all three signals above. If the plan was not checked against the database, or the lock is held or unreadable, stop and resolve that first.
+
+4. **Apply:**
+
+   ```bash
+   nextly migrate:field-groups --apply --backup-confirmed
+   ```
+
+5. **Verify** before moving on:
+   - the admin loads and lists your field groups;
+   - opening a field group in the Schema Builder works, and saving a trivial edit succeeds;
+   - an entry containing a field group reads and writes correctly.
+
+6. **Soak.** Leave it running normally before starting the next site.
+
+## Rolling back
+
+The migration is reversible. Preview the rollback first, exactly as you previewed the migration:
+
+```bash
+nextly migrate:field-groups --down
+nextly migrate:field-groups --down --apply --backup-confirmed
+```
+
+## If something goes wrong midway
+
+The run is resumable — re-running continues rather than starting over, and a database already at the target reports that there is nothing to do rather than acting again.
+
+If a field group ends up marked **diverged** — its tables changed and the record describing them did not — the admin will refuse further schema edits on it and offer a repair. Open that field group in the Schema Builder, review what the repair would change, and apply it. Nothing there moves data; it only makes the stored description match the tables.

--- a/docs/guides/meta.json
+++ b/docs/guides/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "deployment",
     "production-migrations",
+    "field-group-storage-migration",
     "authentication",
     "media-storage",
     "email",

--- a/packages/nextly/src/cli/commands/__tests__/migrate-field-groups.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/migrate-field-groups.test.ts
@@ -1,0 +1,196 @@
+/**
+ * `nextly migrate:field-groups` — what it asks the engine for, and what it tells the operator.
+ *
+ * 🔴 The property that matters most is that PREVIEW IS THE DEFAULT. This command rewrites stored
+ * customer content, and the difference between a safe first run and a destructive one is a single
+ * boolean the operator never sees. A test asserting the command "works" would pass on a version
+ * that applied by default, so the assertions below are about the ARGUMENTS handed to the engine,
+ * not about it returning successfully.
+ *
+ * The second group is about the report. The engine deliberately refuses to summarise renames as a
+ * count, and refuses to hide that a preview may describe a moving database. A caller that printed a
+ * total, or quietly dropped `basis` and `lock`, would satisfy every "it ran" assertion while giving
+ * the operator less than the engine took care to provide.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const runFieldGroupMigration = vi.fn();
+
+vi.mock("../../../domains/field-groups/migration/run", () => ({
+  runFieldGroupMigration,
+}));
+
+vi.mock("../../utils/adapter", () => ({
+  validateDatabaseEnv: () => ({ valid: true, errors: [] }),
+  withAdapter: async (
+    work: (adapter: unknown) => Promise<void>
+  ): Promise<void> => {
+    await work({ getCapabilities: () => ({ dialect: "postgresql" }) });
+  },
+}));
+
+import { runMigrateFieldGroups } from "../migrate-field-groups";
+
+/** Everything printed, in order, so the report can be asserted by content. */
+const printed: string[] = [];
+
+const logger = {
+  info: (m: string) => printed.push(m),
+  warn: (m: string) => printed.push(`WARN ${m}`),
+  error: (m: string) => printed.push(`ERROR ${m}`),
+  debug: vi.fn(),
+  success: (m: string) => printed.push(`OK ${m}`),
+  newline: vi.fn(),
+  keyValue: (k: string, v: string) => printed.push(`${k}=${v}`),
+} as unknown as Parameters<typeof runMigrateFieldGroups>[1]["logger"];
+
+const context = { logger } as Parameters<typeof runMigrateFieldGroups>[1];
+
+const DRY_RUN_OUTCOME = {
+  ran: false as const,
+  reason: "dry-run" as const,
+  direction: "up" as const,
+  renames: [
+    { from: "dynamic_components", to: "dynamic_field_groups" },
+    { from: "comp_hero", to: "fg_hero" },
+  ],
+  basis: { kind: "reconciled" as const },
+  lock: { kind: "not-held" as const },
+};
+
+beforeEach(() => {
+  printed.length = 0;
+  runFieldGroupMigration.mockReset();
+  runFieldGroupMigration.mockResolvedValue(DRY_RUN_OUTCOME);
+});
+
+describe("migrate:field-groups — what it asks the engine for", () => {
+  it("previews by DEFAULT, with no flags at all", async () => {
+    // The safety property of the whole command. A version that applied here would pass any test
+    // that only checked the command completed.
+    await runMigrateFieldGroups({}, context);
+
+    expect(runFieldGroupMigration).toHaveBeenCalledTimes(1);
+    expect(runFieldGroupMigration.mock.calls[0]![0]).toMatchObject({
+      dryRun: true,
+      direction: "up",
+      backupConfirmed: false,
+    });
+  });
+
+  it("only writes when --apply is given", async () => {
+    runFieldGroupMigration.mockResolvedValue({
+      ran: true,
+      direction: "up",
+      steps: 9,
+    });
+
+    await runMigrateFieldGroups(
+      { apply: true, backupConfirmed: true },
+      context
+    );
+
+    expect(runFieldGroupMigration.mock.calls[0]![0]).toMatchObject({
+      dryRun: false,
+      backupConfirmed: true,
+    });
+  });
+
+  it("passes the backup acknowledgement through rather than judging it", async () => {
+    // The engine refuses first, before it has read a catalog or contended for the lock. Deciding
+    // it here as well would be a second implementation of one precondition, free to drift.
+    await runMigrateFieldGroups({ apply: true }, context);
+
+    expect(runFieldGroupMigration.mock.calls[0]![0]).toMatchObject({
+      dryRun: false,
+      backupConfirmed: false,
+    });
+  });
+
+  it("rolls back only when --down is given", async () => {
+    await runMigrateFieldGroups({ down: true }, context);
+    expect(runFieldGroupMigration.mock.calls[0]![0]).toMatchObject({
+      direction: "down",
+      dryRun: true,
+    });
+  });
+});
+
+describe("migrate:field-groups — what it tells the operator", () => {
+  it("lists every rename by name, and does not reduce them to a count", async () => {
+    await runMigrateFieldGroups({}, context);
+
+    const output = printed.join("\n");
+    // By identity: the operator's question is whether THEIR table is in the list.
+    expect(output).toContain("dynamic_components");
+    expect(output).toContain("dynamic_field_groups");
+    expect(output).toContain("comp_hero");
+    expect(output).toContain("fg_hero");
+    // And the count is not offered as the answer, because a run does more than rename.
+    expect(output).not.toMatch(/\b2 (renames|tables|objects)\b/);
+  });
+
+  it("warns when the plan was NOT checked against the database", async () => {
+    // An unreconciled plan is the manifest's proposal and an upper bound. Printing it identically
+    // to a checked one would let an operator act on a list that may already be half applied.
+    runFieldGroupMigration.mockResolvedValue({
+      ...DRY_RUN_OUTCOME,
+      basis: { kind: "unreconciled", reason: "a writer kept moving" },
+    });
+
+    await runMigrateFieldGroups({}, context);
+
+    const output = printed.join("\n");
+    expect(output).toContain("WARN");
+    expect(output).toContain("NOT checked against your database");
+    expect(output).toContain("a writer kept moving");
+  });
+
+  it("says a migration is in flight rather than printing a settled-looking plan", async () => {
+    runFieldGroupMigration.mockResolvedValue({
+      ...DRY_RUN_OUTCOME,
+      lock: { kind: "held", owner: "host-7" },
+    });
+
+    await runMigrateFieldGroups({}, context);
+
+    const output = printed.join("\n");
+    expect(output).toContain("WARN");
+    expect(output).toContain("running right now");
+    expect(output).toContain("host-7");
+  });
+
+  it("separates 'nothing holds the lock' from 'the lock could not be read'", async () => {
+    // The two send an operator in opposite directions, so collapsing them into silence would be
+    // the more dangerous of the two reported as the safer one.
+    runFieldGroupMigration.mockResolvedValue({
+      ...DRY_RUN_OUTCOME,
+      lock: { kind: "unknown", reason: "permission denied" },
+    });
+
+    await runMigrateFieldGroups({}, context);
+
+    const output = printed.join("\n");
+    expect(output).toContain("WARN");
+    expect(output).toContain("could not be read");
+    expect(output).not.toContain("No migration is currently running");
+  });
+
+  it("names the exact command that applies what was just previewed", async () => {
+    await runMigrateFieldGroups({}, context);
+    expect(printed.join("\n")).toContain(
+      "nextly migrate:field-groups --apply --backup-confirmed"
+    );
+  });
+
+  it("names the ROLLBACK command when previewing a rollback", async () => {
+    runFieldGroupMigration.mockResolvedValue({
+      ...DRY_RUN_OUTCOME,
+      direction: "down",
+    });
+    await runMigrateFieldGroups({ down: true }, context);
+    expect(printed.join("\n")).toContain(
+      "nextly migrate:field-groups --down --apply --backup-confirmed"
+    );
+  });
+});

--- a/packages/nextly/src/cli/commands/migrate-field-groups.ts
+++ b/packages/nextly/src/cli/commands/migrate-field-groups.ts
@@ -1,0 +1,249 @@
+/**
+ * `nextly migrate:field-groups` — move field-group storage to its current names.
+ *
+ * Field groups were once called components, and the old vocabulary is still in the database: the
+ * registry table, every field group's data table, and the column that says which field group a
+ * stored row belongs to. This command renames them. Nothing about the running application changes —
+ * it already reads whichever generation a database holds — so this is a tidy-up that can be done
+ * per site, at a time of the operator's choosing, rather than a flag day.
+ *
+ * ## It previews by default, and that is the interface
+ *
+ * Running it with no flags writes NOTHING and prints the plan. Applying is `--apply`, and `--apply`
+ * needs `--backup-confirmed` alongside it. The engine owns that requirement; this command does not
+ * restate it, because two implementations of one precondition drift and the engine's is the one
+ * that runs first, before it has contended for anything.
+ *
+ * A preview takes no lock and issues no DDL, which is what lets it run against a read-only
+ * credential — the credential an operator should be previewing production with. What that gives up
+ * is exclusion, so the plan is a snapshot of a database that may be moving. Both facts the engine
+ * reports about that are printed rather than summarised away: whether the plan was scored against
+ * this database, and what could be seen of the migration lock.
+ *
+ * ## What it prints, and what it refuses to print
+ *
+ * Renames are listed by NAME. The engine deliberately does not summarise them as a count, because a
+ * run also rewrites stored rows and passes settlement gates, so any number derived from renames
+ * alone understates the work while looking authoritative. This command keeps that promise: an
+ * operator reading a preview is asking whether THEIR table is in the list, which a total cannot
+ * answer.
+ *
+ * @module cli/commands/migrate-field-groups
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import type { Command } from "commander";
+
+// Type-only, so it is erased at runtime and does not pull the migration engine into the boot
+// graph the way the value import inside the action deliberately avoids.
+import type { MigrationOutcome } from "../../domains/field-groups/migration/run";
+import { describeError } from "../../errors/index";
+import { createContext, type CommandContext } from "../program";
+import { validateDatabaseEnv, withAdapter } from "../utils/adapter";
+
+export interface MigrateFieldGroupsCommandOptions {
+  /** Perform the migration. Without it the command previews and writes nothing. */
+  apply?: boolean;
+  /** Roll a completed migration back to the previous names. */
+  down?: boolean;
+  /** The operator states a restorable backup exists. Required by the engine for any write. */
+  backupConfirmed?: boolean;
+  config?: string;
+  cwd?: string;
+  verbose?: boolean;
+  quiet?: boolean;
+}
+
+export async function runMigrateFieldGroups(
+  options: MigrateFieldGroupsCommandOptions,
+  context: CommandContext
+): Promise<void> {
+  const { logger } = context;
+
+  // Fail before touching the network if the database environment is unusable, matching every other
+  // command that needs a connection.
+  const dbValidation = validateDatabaseEnv();
+  if (!dbValidation.valid) {
+    for (const error of dbValidation.errors) logger.error(error);
+    logger.newline();
+    logger.info(
+      "Set DATABASE_URL and optionally DB_DIALECT environment variables."
+    );
+    process.exit(1);
+  }
+
+  const dryRun = options.apply !== true;
+  const direction = options.down === true ? "down" : "up";
+
+  logger.keyValue("Direction", direction);
+  logger.keyValue("Mode", dryRun ? "preview (nothing is written)" : "apply");
+  logger.newline();
+
+  await withAdapter(
+    async adapter => {
+      const { runFieldGroupMigration } = await import(
+        "../../domains/field-groups/migration/run"
+      );
+
+      const outcome = await runFieldGroupMigration({
+        adapter: adapter as unknown as DrizzleAdapter,
+        logger: {
+          info: (msg: string) => logger.debug(msg),
+          warn: (msg: string) => logger.warn(msg),
+          error: (msg: string) => logger.error(msg),
+          debug: (msg: string) => logger.debug(msg),
+        },
+        direction,
+        dryRun,
+        // Passed through rather than checked here. The engine refuses first, before it has read a
+        // catalog or contended for the lock, and restating that decision would make this a second
+        // place it could drift from.
+        backupConfirmed: options.backupConfirmed === true,
+      });
+
+      reportOutcome(outcome, logger);
+    },
+    { logger }
+  );
+}
+
+/** Everything the engine reported, printed without being summarised into a smaller claim. */
+function reportOutcome(
+  outcome: MigrationOutcome,
+  logger: CommandContext["logger"]
+): void {
+  if (outcome.ran) {
+    logger.success(
+      `Field-group storage migrated ${outcome.direction}. ${String(outcome.steps)} step(s) completed.`
+    );
+    return;
+  }
+
+  if (outcome.reason !== "dry-run") {
+    logger.success(
+      outcome.reason === "already-migrated"
+        ? "This database is already at the current storage names. Nothing to do."
+        : "There are no field groups to migrate. Nothing to do."
+    );
+    // Present only on a preview, and only when something holds the lock — so a database that reads
+    // as settled while a run is mid-flight says so rather than looking finished.
+    reportLock(outcome.lock, logger);
+    return;
+  }
+
+  logger.info(
+    `Preview of a ${outcome.direction} migration. Nothing was written.`
+  );
+  logger.newline();
+
+  if (outcome.renames.length === 0) {
+    logger.info("No storage objects would be renamed.");
+  } else {
+    logger.info("These storage objects would be renamed, in this order:");
+    for (const rename of outcome.renames) {
+      logger.info(`  ${rename.from}  ->  ${rename.to}`);
+    }
+    logger.newline();
+    // Said plainly because the list is the honest part of the answer and also the incomplete part:
+    // a run rewrites stored rows and passes settlement gates too, and those outnumber the renames.
+    logger.info(
+      "Renaming is not all a run does — it also rewrites stored rows — so this list is what changes name, not the whole of the work."
+    );
+  }
+
+  logger.newline();
+  if (outcome.basis.kind === "unreconciled") {
+    // The plan could not be scored against this database, so the list above is the manifest's
+    // proposal and an UPPER BOUND: some of it may already have been applied by whoever was writing.
+    logger.warn(
+      `This plan was NOT checked against your database (${outcome.basis.reason}).`
+    );
+    logger.warn(
+      "Treat the list above as the most that could change rather than what will. Re-run the preview when nothing else is writing."
+    );
+  } else {
+    logger.info("This plan was checked against your database.");
+  }
+
+  reportLock(outcome.lock, logger);
+
+  logger.newline();
+  logger.info(
+    describeApplyCommand(outcome.direction) +
+      " Take a backup first, then confirm it exists with --backup-confirmed."
+  );
+}
+
+/** The exact command that applies what was just previewed. */
+function describeApplyCommand(direction: "up" | "down"): string {
+  return direction === "down"
+    ? "To roll back for real, run: nextly migrate:field-groups --down --apply --backup-confirmed."
+    : "To apply this for real, run: nextly migrate:field-groups --apply --backup-confirmed.";
+}
+
+/**
+ * What was visible of the migration lock.
+ *
+ * Three states and never silence, because "nothing holds it" and "I could not look" send an
+ * operator in opposite directions: the first says go ahead, the second says find out why your role
+ * cannot read the lock table before you write anything.
+ */
+function reportLock(
+  lock: { kind: string; owner?: string; reason?: string } | undefined,
+  logger: CommandContext["logger"]
+): void {
+  if (!lock) return;
+  if (lock.kind === "held") {
+    logger.warn(
+      `A migration is running right now${lock.owner ? ` (owner: ${lock.owner})` : ""}. What you are reading describes a database that is moving.`
+    );
+    return;
+  }
+  if (lock.kind === "unknown") {
+    logger.warn(
+      `The migration lock could not be read${lock.reason ? ` (${lock.reason})` : ""}, so it is unknown whether a run is in flight.`
+    );
+    return;
+  }
+  logger.info("No migration is currently running.");
+}
+
+export function registerMigrateFieldGroupsCommand(program: Command): void {
+  program
+    .command("migrate:field-groups")
+    .description(
+      "Preview or apply the rename of field-group storage to its current names"
+    )
+    .option(
+      "--apply",
+      "Perform the migration (without this, the command only previews)",
+      false
+    )
+    .option("--down", "Roll a completed migration back", false)
+    .option(
+      "--backup-confirmed",
+      "You confirm a restorable backup exists (required with --apply)",
+      false
+    )
+    .action(
+      async (cmdOptions: MigrateFieldGroupsCommandOptions, cmd: Command) => {
+        const globalOpts = cmd.optsWithGlobals();
+        const context = createContext(globalOpts);
+        try {
+          await runMigrateFieldGroups(
+            {
+              ...cmdOptions,
+              config: globalOpts.config,
+              verbose: globalOpts.verbose,
+              quiet: globalOpts.quiet,
+              cwd: globalOpts.cwd,
+            },
+            context
+          );
+        } catch (error) {
+          context.logger.error(describeError(error));
+          process.exit(1);
+        }
+      }
+    );
+}

--- a/packages/nextly/src/cli/program.ts
+++ b/packages/nextly/src/cli/program.ts
@@ -26,6 +26,7 @@ import { registerMigrateBaselineCommand } from "./commands/migrate-baseline";
 import { registerMigrateCheckCommand } from "./commands/migrate-check";
 import { registerMigrateCreateCommand } from "./commands/migrate-create";
 import { registerMigrateDownCommand } from "./commands/migrate-down";
+import { registerMigrateFieldGroupsCommand } from "./commands/migrate-field-groups";
 import { registerMigrateFreshCommand } from "./commands/migrate-fresh";
 import { registerMigrateResolveCommand } from "./commands/migrate-resolve";
 // F11 PR 2 (Q4=A): migrate:reset deleted. SP-2 adds single-step rollback via
@@ -217,6 +218,7 @@ function registerCommands(program: Command): void {
   registerMigrateCheckCommand(program); // F11 PR 4
   registerMigrateStatusCommand(program);
   registerMigrateBaselineCommand(program); // adopt an existing DB into the history
+  registerMigrateFieldGroupsCommand(program); // rename field-group storage, previewing by default
   registerMigrateResolveCommand(program); // Plan C3 — recovery command
   registerPruneCommand(program); // P2b — drop orphaned plugin/code schema (D14)
   registerWebhooksPruneCommand(program); // manual webhook-queue retention pass


### PR DESCRIPTION
PR-5 of the components → field groups transition. **This is the one that makes a migration possible.** The engine has existed and been tested across three dialects since before this program started, with zero product callers — no CLI command, no route, nothing. It was built, tested, and unreachable.

## The command

```bash
nextly migrate:field-groups                              # preview; writes nothing
nextly migrate:field-groups --apply --backup-confirmed   # apply
nextly migrate:field-groups --down                       # preview a rollback
```

**Preview is the default.** Running it with no flags takes no lock, issues no DDL, and prints the plan — which is what lets an operator preview production with a **read-only credential**, the credential they should be using for that.

## It is a thin caller, deliberately

The engine already carries dry-run, rename-listing and lock-observation semantics, and its documentation is emphatic about why each is shaped as it is. This command's job is to hand those through without quietly narrowing them:

- **`--backup-confirmed` is passed through, not checked here.** The engine refuses first, before it has read a catalog or contended for the lock. Restating that precondition in the CLI would be a second implementation of one decision, free to drift — and the engine's runs earlier.
- **Renames are printed by NAME, never as a count.** The engine explicitly refuses to summarise them, because a run also rewrites stored rows and passes settlement gates, so a number derived from renames alone understates the work while looking authoritative. An operator reading a preview is asking whether *their* table is in the list, which a total cannot answer.
- **`basis` and `lock` are printed rather than dropped.** A preview trades exclusion for read-only safety, so the plan may describe a moving database — and the engine reports both facts about that. Summarising them away would hand back less than it took care to provide.
- **Three lock states, not two.** *Nothing is running*, *a migration is running now*, and *the lock could not be read* are reported distinctly. The third is not the first: a role that cannot read the lock table would otherwise be told the coast is clear.

Comparable commands here run 170 lines (`i18n-restore`) to 1115 (`migrate`); this sits near the low end, which is the intended shape. If it ever grows toward `migrate.ts`, that is logic leaking out of the engine.

## Docs

New guide, `docs/guides/field-group-storage-migration.mdx`, registered in the guides nav after `production-migrations`. It covers what actually renames, **why nobody is forced to run this** (the application reads whichever generation a database holds — expand → migrate → contract, with the expand half already shipped), how to read each of the three preview signals, a per-site runbook with verification steps, and rollback.

## Verification

- **Integration 133/133**, exit 0, across PostgreSQL, MySQL and SQLite.
- `pnpm build`, `check-types`, `pnpm lint`, `check-drizzle-v1-legacy`, `check:storage-format-literals`, `check-comment-convention` — all exit 0.
- New suite **10/10**, split into what the command asks the engine for and what it tells the operator. The assertions are on the ARGUMENTS handed to the engine, not on the command completing — a version that applied by default would satisfy any "it ran" test.
- **Break control**: forcing `dryRun = false` fails exactly the two tests that assert preview-by-default, and only those.

## CI

`main`'s Integration jobs have not completed on any recent commit — measured independently by three lanes today. Local dialect runs are the only evidence available at opening. The merge gate is unchanged: `success` asserted per required job, never inferred from the absence of a failure.

## What still stands between this and a first migration

Nothing in code. After this lands, the sequence is operational: upgrade a site, back it up, preview, apply, verify, soak — playground first, client sites last.

Two items remain in the program and neither blocks a migration: the #850 interrupt-harness test (PR-4 part two, deferred — the fix is already merged, the test is what is missing), and PR-6/PR-7, which stop fresh installs creating the legacy names and then remove the machinery.
