### PR TITLE
fix(admin): send the autosave snapshot as the request body

### DIFF
--- a/.changeset/autosave-restore-body-contract.md
+++ b/.changeset/autosave-restore-body-contract.md
@@ -1,0 +1,40 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(admin): send the autosave snapshot as the request body
+
+Restoring a recovery point put nothing back in the form.
+
+The autosave endpoint treats the request BODY as the snapshot and reads the
+locale from the request params. The client wrapped the values in an envelope
+instead, so that envelope was stored as the snapshot and every field ended up
+one level too deep; a restore then wrote an object with no field names the form
+recognised. The locale it carried in the body was never read.
+
+Also enables drafts and autosave on the playground posts collection. No
+collection there or in any template enabled it, so the policy gate refused every
+write and nothing had ever exercised the path.

--- a/apps/playground/src/collections/posts.ts
+++ b/apps/playground/src/collections/posts.ts
@@ -80,6 +80,14 @@ export const Posts = defineCollection({
   // buttons in the entry editor and Bulk Publish / Unpublish actions in
   // the entry-table bulk-action bar.
   status: true,
+  // Drafts and autosave, ON, so the dev harness exercises the working-draft
+  // split and the recovery-point path rather than only the simple lifecycle.
+  //
+  // `status: true` alone resolves to `{ drafts: false }`, which disables
+  // autosave at the policy gate -- so without this the editor records nothing
+  // and the endpoint answers forbidden. No collection here or in any template
+  // set it, which is why nothing had ever exercised that path.
+  versions: { drafts: true },
   admin: {
     useAsTitle: "title",
   },

--- a/e2e/tests/autosave-recovery.spec.ts
+++ b/e2e/tests/autosave-recovery.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Autosave, end to end: typing produces a stored recovery point, and reopening
+ * the document offers it back.
+ *
+ * Everything else covering this path is a unit test with the transport mocked,
+ * which by construction cannot see the failures most likely to exist here: a
+ * route that is not registered, a policy gate that refuses, a body the server
+ * rejects, a snapshot that does not survive serialisation, or a banner that
+ * never appears because the read is scoped to the wrong author. Each of those
+ * leaves every mocked test green.
+ *
+ * The properties below are therefore chosen for what only a real browser and a
+ * real database can answer, not for coverage of the hook's branches.
+ *
+ * Requires `versions: { drafts: true }` on the collection. `status: true` alone
+ * resolves to `{ drafts: false }` and the policy gate then refuses every write,
+ * so a spec pointed at a collection without it fails for a configuration reason
+ * that looks like a broken feature.
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+import { gotoAdmin } from "./support/admin";
+
+/** The autosave write, which is a PUT to a named sub-resource of the entry. */
+const AUTOSAVE_WRITE =
+  /\/collections\/posts\/entries\/[^/]+\/versions\/autosave$/;
+
+/**
+ * Create a post and save it, returning its editor URL.
+ *
+ * Autosave cannot engage before this: the endpoint addresses a document that
+ * exists, and a new entry has no id until it has been saved once. A spec that
+ * typed into an unsaved form and waited for a write would hang for the right
+ * reason and read as a broken feature.
+ */
+async function createSavedPost(page: Page, title: string): Promise<string> {
+  // `/create`, from `routes.ts`, NOT `/new`. The page FILE tree says otherwise
+  // and the router remaps it, so a path derived by reading the directory
+  // resolves to nothing and the editor renders empty -- which reads as a broken
+  // feature rather than a wrong URL.
+  await gotoAdmin(page, "/collections/posts/create");
+
+  // Only the title. The slug is derived from it by the editor, so filling one
+  // that does not exist as its own control times out on a field the form never
+  // renders.
+  await // `exact`, because Playwright matches an accessible name as a SUBSTRING by
+  // default and this form also has a "Meta Title".
+  page.getByRole("textbox", { name: "Title", exact: true }).fill(title);
+  await page.getByRole("button", { name: /save draft/i }).click();
+
+  // The editor moves to the saved entry's own URL, which is also the signal
+  // that an id now exists. Waiting on the URL rather than on a toast keeps this
+  // independent of notification copy.
+  // Saving a NEW entry returns to the LIST rather than staying in the editor,
+  // so the entry has to be reopened from there. Measured, not assumed: waiting
+  // for an entry-shaped url here times out on a page that is showing the list.
+  await page.waitForURL(/\/collections\/posts$/, { timeout: 30_000 });
+  await page.getByRole("link", { name: title }).click();
+
+  // Now an entry url, and the negative lookahead keeps `create` from matching.
+  await page.waitForURL(/\/collections\/posts\/(?!create$)[^/]+$/, {
+    timeout: 30_000,
+  });
+  await expect(page.locator("main")).toBeVisible({ timeout: 30_000 });
+  return page.url();
+}
+
+test.describe("autosave recovery", () => {
+  test("records what was typed and offers it back after a reload", async ({
+    page,
+  }) => {
+    const url = await createSavedPost(page, `Autosave ${Date.now()}`);
+    const recovered = "text that was never saved";
+
+    // Arm the wait BEFORE typing. Registering it afterwards races the debounce,
+    // and a request that already completed is one this would wait for forever.
+    const written = page.waitForResponse(
+      r => AUTOSAVE_WRITE.test(r.url()) && r.request().method() === "PUT",
+      { timeout: 30_000 }
+    );
+
+    await page
+      .getByRole("textbox", { name: "Excerpt", exact: true })
+      .fill(recovered);
+
+    // POPULATION BEFORE VERDICT. The banner assertion below is about something
+    // being PRESENT, but the failure it must not be confused with is "nothing
+    // was ever recorded" -- and that produces no banner just as convincingly as
+    // a broken recovery read. Requiring a successful write first separates
+    // them, and names which half broke when it does.
+    const response = await written;
+    expect(
+      response.status(),
+      "the autosave write must be accepted"
+    ).toBeLessThan(400);
+
+    // Reload rather than navigate away and back: this is the case the feature
+    // exists for, and it discards all client state, so anything offered
+    // afterwards came from the server.
+    await page.reload();
+    await expect(page.locator("main")).toBeVisible({ timeout: 30_000 });
+
+    await expect(
+      page.getByText(/unsaved changes from/i),
+      "the recovery offer must survive a reload"
+    ).toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole("button", { name: /^restore$/i }).click();
+
+    await expect(
+      page.getByRole("textbox", { name: "Excerpt", exact: true }),
+      "restoring must put the recorded values back in the form"
+    ).toHaveValue(recovered);
+  });
+
+  /**
+   * Dismissing is "not now", never "delete". Someone who dismisses and then
+   * reloads must still be offered the work, rather than discovering it is gone
+   * because they closed a banner.
+   *
+   * This is the property most likely to be broken by a well-meaning change --
+   * clearing the row on dismiss looks like tidying up -- and it is invisible to
+   * any test that does not reload.
+   */
+  test("dismissing the offer does not discard the recorded work", async ({
+    page,
+  }) => {
+    await createSavedPost(page, `Dismiss ${Date.now()}`);
+
+    const written = page.waitForResponse(
+      r => AUTOSAVE_WRITE.test(r.url()) && r.request().method() === "PUT",
+      { timeout: 30_000 }
+    );
+    await page
+      .getByRole("textbox", { name: "Excerpt", exact: true })
+      .fill("work that must survive a dismissal");
+    expect((await written).status()).toBeLessThan(400);
+
+    await page.reload();
+    await expect(page.locator("main")).toBeVisible({ timeout: 30_000 });
+
+    const offer = page.getByText(/unsaved changes from/i);
+    await expect(offer).toBeVisible({ timeout: 15_000 });
+    await page.getByRole("button", { name: /dismiss recovery offer/i }).click();
+    await expect(offer).toBeHidden();
+
+    await page.reload();
+    await expect(page.locator("main")).toBeVisible({ timeout: 30_000 });
+
+    await expect(
+      page.getByText(/unsaved changes from/i),
+      "a dismissal must not delete the stored recovery point"
+    ).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/packages/admin/src/services/__tests__/versionApi.test.ts
+++ b/packages/admin/src/services/__tests__/versionApi.test.ts
@@ -126,9 +126,13 @@ describe("versionApi autosave", () => {
     // server's PUT-only route unmatched, and the request would 404 rather than
     // failing anywhere a type could catch.
     expect(putSpy).toHaveBeenCalledTimes(1);
+    // The BODY IS THE SNAPSHOT, not an envelope containing one, and the locale
+    // rides in the query string. This pins the SERVER's contract: the
+    // dispatcher stores the body itself, so an envelope here would be stored as
+    // the snapshot and every field would sit one level too deep.
     expect(putSpy).toHaveBeenCalledWith(
-      "/collections/posts/entries/e1/versions/autosave",
-      { snapshot: { title: "draft" }, locale: "en" }
+      "/collections/posts/entries/e1/versions/autosave?locale=en",
+      { title: "draft" }
     );
   });
 
@@ -136,8 +140,7 @@ describe("versionApi autosave", () => {
     await versionApi.saveAutosave(single, { siteName: "x" });
 
     expect(putSpy).toHaveBeenCalledWith("/singles/settings/versions/autosave", {
-      snapshot: { siteName: "x" },
-      locale: null,
+      siteName: "x",
     });
   });
 
@@ -146,13 +149,18 @@ describe("versionApi autosave", () => {
    * key. Absent and null mean the same thing to this endpoint, and sending the
    * key keeps the body one shape for every document.
    */
-  it("sends an explicit null locale when the document has none", async () => {
+  /**
+   * An unlocalized document sends no locale at all rather than an empty one.
+   * The server reads it from the request params, so an empty value would be a
+   * locale named "" rather than the absence of one.
+   */
+  it("omits the locale entirely when the document has none", async () => {
     await versionApi.saveAutosave(collection, { title: "draft" });
 
-    expect(putSpy).toHaveBeenCalledWith(expect.any(String), {
-      snapshot: { title: "draft" },
-      locale: null,
-    });
+    expect(putSpy).toHaveBeenCalledWith(
+      "/collections/posts/entries/e1/versions/autosave",
+      { title: "draft" }
+    );
   });
 
   it("reads the caller's own recovery point from the same path", async () => {

--- a/packages/admin/src/services/versionApi.ts
+++ b/packages/admin/src/services/versionApi.ts
@@ -231,14 +231,22 @@ export const versionApi = {
     scope: VersionScope,
     snapshot: unknown,
     locale?: string | null
-  ): Promise<AutosaveWriteResponse> =>
-    protectedApi.put<AutosaveWriteResponse>(`${basePath(scope)}/autosave`, {
-      snapshot,
-      // Sent even when null. Null and absent mean the same thing here (this
-      // document has no locale), unlike on a listing where absent means every
-      // locale, so being explicit costs nothing and reads unambiguously.
-      locale: locale ?? null,
-    }),
+  ): Promise<AutosaveWriteResponse> => {
+    // The BODY IS THE SNAPSHOT, and the locale rides in the query string.
+    //
+    // Wrapping the values in `{ snapshot }` stores that envelope AS the
+    // snapshot, so every field ends up one level too deep and a restore writes
+    // an object with no field names the form recognises. The locale is read
+    // from the request params, so a body-carried one is silently ignored.
+    const search = new URLSearchParams();
+    if (locale) search.set("locale", locale);
+    const query = search.toString();
+
+    return protectedApi.put<AutosaveWriteResponse>(
+      `${basePath(scope)}/autosave${query ? `?${query}` : ""}`,
+      snapshot
+    );
+  },
 
   /**
    * This author's own recovery point, or `null` when they have none.


### PR DESCRIPTION
Restore put nothing back in the form. Found end to end, fixed, and the spec that found it ships with the fix.

## The bug

The dispatcher states its contract in as many words:

```ts
// The body IS the snapshot.
snapshot: requireSnapshotBody(body),
locale: typeof p.locale === "string" ... // from PARAMS
```

The client wrapped the values in `{ snapshot, locale }`. That envelope was therefore stored AS the snapshot, so every field sat one level too deep and a restore wrote an object with no field names the form recognised. The `locale` carried in the body was never read at all.

Measured, not inferred. The stored snapshot read back as:

```
{"snapshot":{"title":"...","excerpt":"text that was never saved",...},"locale":null}
```

## Why nothing caught it, which is the part worth reading

**The unit tests asserted the wrong contract and passed.** They pinned the body shape the CLIENT invented rather than the one the SERVER publishes, so they were self-consistent and wrong together, and they passed identically before and after this fix.

A mocked transport cannot know what the real endpoint expects. Those tests were answering "does the client send what I told it to" while appearing to answer "does the server accept it". Only a real round trip separates the two.

The assertions are re-pinned to the server contract here, with the reasoning recorded next to them, so the envelope cannot be quietly reintroduced.

## Two findings from writing the spec

**1. Autosave was UNREACHABLE everywhere.** No collection in the playground, and none in any shipped template, set `versions: { drafts: true }`. `status: true` alone resolves to `{ drafts: false }`, which makes the policy gate refuse every autosave write. Nothing had ever exercised the path in an environment a human or a test could reach, which is why there was no e2e coverage to extend. This branch enables it on playground `posts`.

**2. Restore was broken** — the subject of this PR.

## The spec

First end-to-end coverage of autosave. It asserts the properties only a real browser and a real database can answer: that the write is accepted, that the offer survives a RELOAD, that Restore returns the values, and that a dismissal does NOT delete the stored work.

It also asserts the POPULATION before the verdict: the write must succeed before the banner is asserted, because "nothing was ever recorded" produces no banner just as convincingly as a broken read, and the two need to be told apart.

Four wrong assumptions surfaced while making it run, each noted in the spec so the next reader does not repeat them: the entry create route is `/create` not `/new`; `waitForURL(/posts\/[^/]+$/)` also matches the create page and resolves instantly; saving a new entry returns to the LIST; and Playwright matches an accessible name as a SUBSTRING, so `"Title"` also matched `"Meta Title"`.

## Verification

- **e2e: 2 passed.** Break-verified by history rather than by contrivance: this exact spec failed on `Received: ""` before the fix and passes after, with no change to the test.
- check-types + lint 11/11, 55 files / 423 tests green, `check:comments` clean, changeset validated against the lockstep group.