### PR TITLE
feat(admin): share one control for numeric validation bounds

### DIFF
--- a/.changeset/validation-number-field.md
+++ b/.changeset/validation-number-field.md
@@ -1,0 +1,38 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+The schema builder and the form builder now draw validation bounds with the
+same control.
+
+Both drew their own before, and they disagreed about what a bound accepts: one
+allowed a minimum length of -5 or 2.7, the other did not. Lengths and row
+counts are now whole numbers of zero or more everywhere, while a bound on a
+value stays free to be negative or fractional.
+
+Clearing a bound now means "no bound" rather than zero, in both builders, and
+each control carries its own identifier so two editors open at once no longer
+share one.
+
+Plugin authors can use the same control: `ValidationNumberField` is available
+from `@nextlyhq/plugin-sdk/admin`.

--- a/packages/admin/src/components/features/schema-builder/field-editor-sheet/ValidationTab.tsx
+++ b/packages/admin/src/components/features/schema-builder/field-editor-sheet/ValidationTab.tsx
@@ -12,6 +12,7 @@ import type { FieldValidationRule } from "nextly/field-catalog";
 import { validationRulesForFieldType } from "nextly/field-catalog";
 import { useId } from "react";
 
+import { ValidationNumberField } from "@admin/components/field-ui";
 import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { pluginFieldTypeStorage } from "@admin/lib/builder/plugin-field-type-entries";
 
@@ -26,23 +27,20 @@ type Props = {
 /**
  * How each numeric rule presents and what values it admits.
  *
- * `step` and `min` are part of the rule rather than of the input: a length or a
- * row count is a whole number of things and cannot be negative, while a numeric
- * bound may legitimately be fractional or below zero. Leaving both unset let a
- * `minLength` of `-5` or `2.7` be typed and persisted.
+ * Whether a bound COUNTS things decides what it admits: a length or a row count
+ * is a whole number of zero or more, while a bound on a value may legitimately
+ * be fractional or negative. The kit control turns that one flag into the input
+ * constraints, so every surface applies the same answer.
  */
 const NUMERIC_RULES = {
-  minLength: { label: "Min length", integer: true, min: 0 },
-  maxLength: { label: "Max length", integer: true, min: 0 },
-  minRows: { label: "Min rows", integer: true, min: 0 },
-  maxRows: { label: "Max rows", integer: true, min: 0 },
-  min: { label: "Min", integer: false, min: undefined },
-  max: { label: "Max", integer: false, min: undefined },
+  minLength: { label: "Min length", counts: true },
+  maxLength: { label: "Max length", counts: true },
+  minRows: { label: "Min rows", counts: true },
+  maxRows: { label: "Max rows", counts: true },
+  min: { label: "Min", counts: false },
+  max: { label: "Max", counts: false },
 } as const satisfies Partial<
-  Record<
-    FieldValidationRule,
-    { label: string; integer: boolean; min: number | undefined }
-  >
+  Record<FieldValidationRule, { label: string; counts: boolean }>
 >;
 
 type NumericRule = keyof typeof NUMERIC_RULES;
@@ -78,12 +76,13 @@ export function ValidationTab({ field, readOnly = false, onChange }: Props) {
           {[lo, hi]
             .filter(rule => allowed.has(rule))
             .map(rule => (
-              <NumberRow
+              <ValidationNumberField
                 key={rule}
-                rule={rule}
+                label={NUMERIC_RULES[rule].label}
+                counts={NUMERIC_RULES[rule].counts}
                 value={v[rule]}
                 disabled={readOnly}
-                onChange={n => setV({ [rule]: n })}
+                onChange={(n: number | undefined) => setV({ [rule]: n })}
               />
             ))}
         </div>
@@ -105,41 +104,6 @@ export function ValidationTab({ field, readOnly = false, onChange }: Props) {
           onChange={message => setV({ message })}
         />
       )}
-    </div>
-  );
-}
-
-function NumberRow({
-  rule,
-  value,
-  disabled,
-  onChange,
-}: {
-  rule: NumericRule;
-  value: number | undefined;
-  disabled?: boolean;
-  onChange: (n: number | undefined) => void;
-}) {
-  // `useId` rather than a value derived from the label: two field editors open
-  // at once would otherwise mint the same document-global id, and a label then
-  // resolves to whichever input rendered first.
-  const id = useId();
-  const spec = NUMERIC_RULES[rule];
-
-  return (
-    <div className="space-y-1">
-      <Label htmlFor={id}>{spec.label}</Label>
-      <Input
-        id={id}
-        type="number"
-        step={spec.integer ? 1 : undefined}
-        min={spec.min}
-        value={value ?? ""}
-        disabled={disabled}
-        onChange={e =>
-          onChange(e.target.value === "" ? undefined : Number(e.target.value))
-        }
-      />
     </div>
   );
 }

--- a/packages/admin/src/components/field-ui/ValidationNumberField.tsx
+++ b/packages/admin/src/components/field-ui/ValidationNumberField.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Input, Label } from "@nextlyhq/ui";
+import { useId } from "react";
+
+export interface ValidationNumberFieldProps {
+  /** Visible name of the rule, e.g. "Min length". */
+  label: string;
+  /** The rule's current bound, or `undefined` when it is not set. */
+  value: number | undefined;
+  /** Called with `undefined` when the field is cleared. */
+  onChange: (value: number | undefined) => void;
+  /** Help text under the control. */
+  description?: string;
+  disabled?: boolean;
+  /**
+   * The bound counts things — characters, rows, items — so it admits whole
+   * numbers of zero or more. Leave it off for a bound on a VALUE, which may
+   * legitimately be fractional or negative.
+   */
+  counts?: boolean;
+  placeholder?: string;
+}
+
+/**
+ * One numeric validation bound.
+ *
+ * Every surface that edits validation draws the same control, and the two that
+ * did so independently disagreed about it: one coerced with `Number` and set no
+ * limits, so a length of `2.7` or `-5` could be typed and persisted, while the
+ * other used `parseInt` with a floor of zero. Those are different answers to
+ * one question, and the divergence is invisible until a value nothing enforces
+ * reaches the database.
+ *
+ * The empty field means "no bound" rather than zero, so clearing it yields
+ * `undefined` and not `0` — a distinction the browser's own value cannot carry,
+ * since an empty numeric input and a zero both read as falsy.
+ *
+ * The id is generated rather than derived from the label. A label-derived id is
+ * document-global, so two editors open at once mint the same one and `htmlFor`
+ * resolves to whichever control rendered first.
+ */
+export function ValidationNumberField({
+  label,
+  value,
+  onChange,
+  description,
+  disabled,
+  counts = false,
+  placeholder,
+}: ValidationNumberFieldProps) {
+  const id = useId();
+  const describedBy = description ? `${id}-description` : undefined;
+
+  return (
+    <div className="space-y-1">
+      <Label htmlFor={id}>{label}</Label>
+      <Input
+        id={id}
+        type="number"
+        step={counts ? 1 : undefined}
+        min={counts ? 0 : undefined}
+        placeholder={placeholder}
+        value={value ?? ""}
+        disabled={disabled}
+        aria-describedby={describedBy}
+        onChange={event =>
+          onChange(
+            event.target.value === "" ? undefined : Number(event.target.value)
+          )
+        }
+      />
+      {description ? (
+        <p id={describedBy} className="text-xs text-muted-foreground">
+          {description}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/admin/src/components/field-ui/__tests__/ValidationNumberField.test.tsx
+++ b/packages/admin/src/components/field-ui/__tests__/ValidationNumberField.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * The one numeric validation bound every editing surface draws.
+ *
+ * It exists because two surfaces drew it independently and disagreed: one
+ * coerced with `Number` and constrained nothing, so a length of `2.7` or `-5`
+ * could be typed and persisted; the other used `parseInt` with a floor of zero.
+ * The three behaviours asserted here are exactly the ones they disagreed about.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ValidationNumberField } from "../ValidationNumberField";
+
+describe("ValidationNumberField", () => {
+  it("constrains a bound that counts things to whole, non-negative numbers", () => {
+    render(
+      <ValidationNumberField
+        label="Min length"
+        counts
+        value={undefined}
+        onChange={() => {}}
+      />
+    );
+
+    const input = screen.getByLabelText("Min length");
+    expect(input).toHaveAttribute("step", "1");
+    expect(input).toHaveAttribute("min", "0");
+  });
+
+  it("leaves a bound on a value unconstrained", () => {
+    // The separating property: a component that constrained everything would
+    // satisfy the case above and silently forbid a negative minimum price.
+    render(
+      <ValidationNumberField
+        label="Min"
+        value={undefined}
+        onChange={() => {}}
+      />
+    );
+
+    const input = screen.getByLabelText("Min");
+    expect(input).not.toHaveAttribute("step");
+    expect(input).not.toHaveAttribute("min");
+  });
+
+  it("reports a cleared field as unset rather than as zero", async () => {
+    const onChange = vi.fn();
+    render(
+      <ValidationNumberField
+        label="Max length"
+        counts
+        value={5}
+        onChange={onChange}
+      />
+    );
+
+    await userEvent.clear(screen.getByLabelText("Max length"));
+
+    expect(onChange).toHaveBeenCalledWith(undefined);
+    // Zero is a legitimate bound, so it must never stand in for "no bound".
+    expect(onChange).not.toHaveBeenCalledWith(0);
+  });
+
+  it("still reports an explicit zero as zero", async () => {
+    const onChange = vi.fn();
+    render(
+      <ValidationNumberField
+        label="Min length"
+        counts
+        value={undefined}
+        onChange={onChange}
+      />
+    );
+
+    await userEvent.type(screen.getByLabelText("Min length"), "0");
+
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+
+  it("gives two instances different ids so their labels cannot cross", () => {
+    render(
+      <>
+        <ValidationNumberField
+          label="Min length"
+          value={undefined}
+          onChange={() => {}}
+        />
+        <ValidationNumberField
+          label="Max length"
+          value={undefined}
+          onChange={() => {}}
+        />
+      </>
+    );
+
+    const a = screen.getByLabelText("Min length");
+    const b = screen.getByLabelText("Max length");
+    expect(a.id).toBeTruthy();
+    expect(b.id).toBeTruthy();
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it("connects its help text to the control", () => {
+    render(
+      <ValidationNumberField
+        label="Min length"
+        description="Minimum characters required."
+        value={undefined}
+        onChange={() => {}}
+      />
+    );
+
+    const input = screen.getByLabelText("Min length");
+    const describedBy = input.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy as string)).toHaveTextContent(
+      "Minimum characters required."
+    );
+  });
+
+  it("names no description when it has none", () => {
+    render(
+      <ValidationNumberField
+        label="Min"
+        value={undefined}
+        onChange={() => {}}
+      />
+    );
+
+    // A dangling `aria-describedby` points assistive technology at nothing.
+    expect(screen.getByLabelText("Min")).not.toHaveAttribute(
+      "aria-describedby"
+    );
+  });
+});

--- a/packages/admin/src/components/field-ui/index.ts
+++ b/packages/admin/src/components/field-ui/index.ts
@@ -53,3 +53,10 @@ export type {
   ConditionSourceOption,
   ConditionValue,
 } from "./ConditionRow";
+
+// One numeric validation bound: label, control, optional help text. Owns the
+// empty-means-unset coercion, the whole/non-negative constraint for bounds that
+// count things, and its own id — the three details the surfaces that drew this
+// control independently disagreed about.
+export { ValidationNumberField } from "./ValidationNumberField";
+export type { ValidationNumberFieldProps } from "./ValidationNumberField";

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -166,6 +166,7 @@ export {
   ConditionRow,
   operatorsForType,
   operatorTakesValue,
+  ValidationNumberField,
 } from "./components/field-ui";
 export type {
   FieldTypePickerProps,
@@ -179,6 +180,7 @@ export type {
   ConditionSource,
   ConditionSourceOption,
   ConditionValue,
+  ValidationNumberFieldProps,
 } from "./components/field-ui";
 
 // Error Fallback Components

--- a/packages/plugin-form-builder/src/admin/components/builder/FieldEditor.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FieldEditor.tsx
@@ -13,6 +13,7 @@
 "use client";
 import {
   FieldOptionsEditor,
+  ValidationNumberField,
   withOptionIds,
   type FieldOptionsEditorProps,
 } from "@nextlyhq/plugin-sdk/admin";
@@ -488,90 +489,38 @@ function ValidationTab({
       {/* Text/Textarea length validation */}
       {(field.type === "text" || field.type === "textarea") && (
         <div className="grid grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <FormLabelWithTooltip
-              label="Min Length"
-              htmlFor="min-len"
-              description="Minimum characters required."
-            />
-            <Input
-              id="min-len"
-              type="number"
-              min={0}
-              value={(field as TextFormField).validation?.minLength ?? ""}
-              onChange={e =>
-                updateValidation(
-                  "minLength",
-                  e.target.value ? parseInt(e.target.value) : undefined
-                )
-              }
-              className="bg-transparent"
-            />
-          </div>
-          <div className="space-y-2">
-            <FormLabelWithTooltip
-              label="Max Length"
-              htmlFor="max-len"
-              description="Maximum characters allowed."
-            />
-            <Input
-              id="max-len"
-              type="number"
-              min={0}
-              value={(field as TextFormField).validation?.maxLength ?? ""}
-              onChange={e =>
-                updateValidation(
-                  "maxLength",
-                  e.target.value ? parseInt(e.target.value) : undefined
-                )
-              }
-              className="bg-transparent"
-            />
-          </div>
+          <ValidationNumberField
+            label="Min Length"
+            description="Minimum characters required."
+            counts
+            value={field.validation?.minLength}
+            onChange={n => updateValidation("minLength", n)}
+          />
+          <ValidationNumberField
+            label="Max Length"
+            description="Maximum characters allowed."
+            counts
+            value={field.validation?.maxLength}
+            onChange={n => updateValidation("maxLength", n)}
+          />
         </div>
       )}
 
       {/* Number min/max validation */}
       {field.type === "number" && (
         <div className="grid grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <FormLabelWithTooltip
-              label="Min Value"
-              htmlFor="min-val"
-              description="Minimum numerical value."
-            />
-            <Input
-              id="min-val"
-              type="number"
-              value={field.validation?.min ?? ""}
-              onChange={e =>
-                updateValidation(
-                  "min",
-                  e.target.value ? parseFloat(e.target.value) : undefined
-                )
-              }
-              className="bg-transparent"
-            />
-          </div>
-          <div className="space-y-2">
-            <FormLabelWithTooltip
-              label="Max Value"
-              htmlFor="max-val"
-              description="Maximum numerical value."
-            />
-            <Input
-              id="max-val"
-              type="number"
-              value={field.validation?.max ?? ""}
-              onChange={e =>
-                updateValidation(
-                  "max",
-                  e.target.value ? parseFloat(e.target.value) : undefined
-                )
-              }
-              className="bg-transparent"
-            />
-          </div>
+          <ValidationNumberField
+            label="Min Value"
+            description="Minimum numerical value."
+            value={field.validation?.min}
+            onChange={n => updateValidation("min", n)}
+          />
+          <ValidationNumberField
+            label="Max Value"
+            description="Maximum numerical value."
+            value={field.validation?.max}
+            onChange={n => updateValidation("max", n)}
+          />
         </div>
       )}
 

--- a/packages/plugin-sdk/src/admin.ts
+++ b/packages/plugin-sdk/src/admin.ts
@@ -86,6 +86,9 @@ export type {
  *   values, CSV/JSON import, and whole-batch duplicate reporting;
  *   `withOptionIds` seeds drag ids onto plain `{label,value}` data.
  * - `FieldDefaultValueInput` — a type-aware default-value input.
+ * - `ValidationNumberField` — one numeric validation bound, owning the
+ *   empty-means-unset coercion, the whole/non-negative constraint for bounds
+ *   that count things, and its own id.
  * - `ConditionRow` — one condition as source / operator / value, with the
  *   operators and value editor chosen from the source's type. It owns the ROW
  *   and not the container, so your surface keeps its own chrome; pass
@@ -108,6 +111,7 @@ export {
   ConditionRow,
   operatorsForType,
   operatorTakesValue,
+  ValidationNumberField,
 } from "@nextlyhq/admin";
 
 /**
@@ -131,6 +135,7 @@ export type {
   ConditionSource,
   ConditionSourceOption,
   ConditionValue,
+  ValidationNumberFieldProps,
 } from "@nextlyhq/admin";
 
 // The declarative `contributes.admin` contract types (the same ones exported


### PR DESCRIPTION
Completes T-19 item 2. Stacked conceptually on #923 (merged), which settled *which* rules apply to a field type; this settles *how* one is edited.

## The problem

The schema builder and the form builder each drew their own numeric bound control, and **they disagreed about what a bound accepts**:

| | schema builder | form-builder |
|---|---|---|
| coercion | `Number(...)` | `parseInt(...)` / `parseFloat(...)` |
| lower limit | none | `min={0}` on lengths |
| step | none | none |

So a **minimum length of `-5` or `2.7` was typeable and persistable** in the schema builder and not in the form builder. Two answers to one question, and the divergence is invisible until a value nothing enforces reaches the database.

Separately, the schema builder derived each control's DOM id from its label (`"Min length"` -> `"min-length"`). Those are document-global, so two field editors open at once minted the same id and `label[for]` resolved to whichever rendered first.

## What this does

`ValidationNumberField` in the field-UI kit owns the three details they disagreed about:

- **whether a bound counts things.** A length or a row count is a whole number of zero or more; a bound on a *value* may legitimately be negative or fractional. One `counts` flag, and the control turns it into the input constraints — so `min` on a price stays free while `minLength` cannot go below zero or take a fraction.
- **empty means unset, not zero.** Clearing yields `undefined`. Zero is a legitimate bound and must never be what "no bound" collapses to — a distinction the browser's own value cannot carry, since an empty numeric input and a zero both read as falsy.
- **its own id**, generated rather than derived.

Exported through `@nextlyhq/plugin-sdk/admin`, so a plugin editing field settings draws the same control rather than a fourth variant.

**Both surfaces converted.** This is the ConditionRow shape: share the row, not the container. The two rule VOCABULARIES stay separate deliberately — they mean different things, as measured in `findings/09-t19-validation-model-divergence.md`.

## Test plan

- **7 new tests** for the kit component, **stub-verified**: breaking the empty-means-unset coercion fails exactly the cleared-field test and nothing else.
- **The 15 existing `ValidationTab` tests pass unchanged** after the swap, including the id-uniqueness and step/min assertions, which now exercise the kit implementation. Behaviour preservation, not an absence.
- **All 89 `plugin-form-builder` tests pass** (20 files) after its conversion.
- **No new failures** in `@nextlyhq/admin`: baseline 4 files / 15 tests, identical after; 1981 tests total, compared as file sets with `comm -13`.
- `check-types` and `lint` clean on `admin`, `plugin-sdk` and `plugin-form-builder` (0 warnings); comment-convention gate clean.

**Changeset added: yes (patch).**

## One thing worth a reviewer's eye

Converting form-builder surfaced 4 `no-unnecessary-type-assertion` errors from assertions I had added (`as number | undefined`) that its validation types already provide. Removed rather than suppressed. Flagging because that rule is also what a stale sibling `dist` produces — I rebuilt first and confirmed these were genuine.

## Deliberately not in this PR

- `maxFileSize` and the date bounds in form-builder are left on their own inputs. They are bounds of a different kind (bytes; dates), and folding them in would widen a control that is currently about numbers.
- `minChips` / `maxChips` still are not offered anywhere. Core's canonical `FieldValidation` has 9 members and excludes them; they exist only as flat props on `chips.ts`. Reported, not silently resolved.

## Review status

No bot has reviewed this. Codex has been answering with usage-limit notices and `@nextly-bot` produced zero comments and zero reviews on recent PRs. Stating it so quiet threads are not read as a pass.
