### PR TITLE
feat(admin): let an immersive surface take the window

### DIFF
--- a/.changeset/admin-chrome-suppression.md
+++ b/.changeset/admin-chrome-suppression.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The page editor now takes the whole window. The admin's sidebars, header and page frame step aside while an immersive surface is mounted, and restore themselves when you leave it.

--- a/packages/admin/src/components/layout/ChromeSuppression.tsx
+++ b/packages/admin/src/components/layout/ChromeSuppression.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import React from "react";
+
+import {
+  resolveSuppressedChrome,
+  type AdminChromeLayer,
+  type ChromeSuppressionRequest,
+} from "./lib/chrome-suppression";
+
+interface ChromeSuppressionContextValue {
+  hidden: Set<AdminChromeLayer>;
+  register: (request: ChromeSuppressionRequest) => () => void;
+}
+
+/**
+ * Defaults to hiding nothing and accepting registrations that do nothing.
+ *
+ * A surface rendered outside the dashboard layout — a test, a standalone auth
+ * page, Storybook — then calls the hook harmlessly instead of throwing. The
+ * alternative is every consumer guarding the call, which is a rule each new call
+ * site has to remember.
+ */
+const ChromeSuppressionContext =
+  React.createContext<ChromeSuppressionContextValue>({
+    hidden: new Set(),
+    register: () => () => {},
+  });
+
+/**
+ * Holds what the currently mounted surfaces have asked to hide.
+ *
+ * State lives here rather than in each surface because the consumers are the
+ * layout's own children: React data flows down, so the layout cannot read a
+ * request made below it without the request being lifted to a provider above.
+ */
+export function ChromeSuppressionProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [requests, setRequests] = React.useState<
+    readonly ChromeSuppressionRequest[]
+  >([]);
+
+  const register = React.useCallback((request: ChromeSuppressionRequest) => {
+    setRequests(current => [...current, request]);
+    // Identity removal, not value removal: two surfaces asking for the same
+    // layers produce equal objects, and removing by value would release both
+    // when one unmounts.
+    return () =>
+      setRequests(current => {
+        const at = current.indexOf(request);
+        if (at === -1) return current;
+        return [...current.slice(0, at), ...current.slice(at + 1)];
+      });
+  }, []);
+
+  const value = React.useMemo<ChromeSuppressionContextValue>(
+    () => ({ hidden: resolveSuppressedChrome(requests), register }),
+    [requests, register]
+  );
+
+  return (
+    <ChromeSuppressionContext.Provider value={value}>
+      {children}
+    </ChromeSuppressionContext.Provider>
+  );
+}
+
+/**
+ * Read which layers are hidden. For the layout's own chrome components.
+ */
+export function useSuppressedChrome(): Set<AdminChromeLayer> {
+  return React.useContext(ChromeSuppressionContext).hidden;
+}
+
+/**
+ * Ask for admin chrome to be hidden for as long as this component is mounted.
+ *
+ * Mount-scoped on purpose: the request is released on unmount, so navigating
+ * away restores the chrome with nothing to remember to undo. That is also why
+ * there is no route list — the surface that wants the window is the one that
+ * knows, and it only claims it while it is on screen.
+ *
+ * `canExit` must be the truth about whether this surface renders a way back,
+ * derived from the affordance rather than declared beside it. Passing `true`
+ * from a surface with no exit is how an author gets stranded, and the resolver
+ * cannot detect the lie — it can only withhold the rail when told `false`.
+ */
+export function useSuppressAdminChrome(options: {
+  layers: readonly AdminChromeLayer[];
+  canExit: boolean;
+}): void {
+  const { register } = React.useContext(ChromeSuppressionContext);
+  const { canExit } = options;
+  // Joined so a caller passing a fresh array literal each render — which is the
+  // natural way to call this — does not re-register on every render.
+  const key = options.layers.join(",");
+
+  React.useEffect(() => {
+    const layers = key === "" ? [] : (key.split(",") as AdminChromeLayer[]);
+    return register({ layers, canExit });
+  }, [key, canExit, register]);
+}

--- a/packages/admin/src/components/layout/ChromeSuppression.tsx
+++ b/packages/admin/src/components/layout/ChromeSuppression.tsx
@@ -98,8 +98,23 @@ export function useSuppressAdminChrome(options: {
   // natural way to call this — does not re-register on every render.
   const key = options.layers.join(",");
 
-  React.useEffect(() => {
+  useRegistrationEffect(() => {
     const layers = key === "" ? [] : (key.split(",") as AdminChromeLayer[]);
     return register({ layers, canExit });
   }, [key, canExit, register]);
 }
+
+/**
+ * A LAYOUT effect on the client, because the chrome this releases is on screen
+ * until the request lands.
+ *
+ * Registering in a passive effect means the first paint shows the full admin
+ * frame — both sidebars, the header, the page padding — which is then removed on
+ * the following frame. The editor is the widest thing in the admin, so that is a
+ * whole-layout reflow visible as a flash on every open.
+ *
+ * Falls back to a passive effect where there is no DOM. A layout effect during a
+ * server render warns and cannot run, and nothing has painted there anyway.
+ */
+const useRegistrationEffect =
+  typeof window === "undefined" ? React.useEffect : React.useLayoutEffect;

--- a/packages/admin/src/components/layout/__tests__/chrome-suppression.test.ts
+++ b/packages/admin/src/components/layout/__tests__/chrome-suppression.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveSuppressedChrome,
+  type ChromeSuppressionRequest,
+} from "../lib/chrome-suppression";
+
+const immersive: ChromeSuppressionRequest = {
+  layers: ["primaryRail", "subSidebar", "documentSidebar", "header"],
+  canExit: true,
+};
+
+describe("resolveSuppressedChrome", () => {
+  it("hides nothing while no surface is asking", () => {
+    expect(resolveSuppressedChrome([]).size).toBe(0);
+  });
+
+  it("grants every layer to a requester that can be left", () => {
+    const hidden = resolveSuppressedChrome([immersive]);
+    // Asserted by membership rather than by size: a resolver that returned a
+    // different set of four would satisfy a count.
+    expect([...hidden].sort()).toEqual([
+      "documentSidebar",
+      "header",
+      "primaryRail",
+      "subSidebar",
+    ]);
+  });
+
+  it("withholds the primary rail from a requester with no way back", () => {
+    const hidden = resolveSuppressedChrome([
+      { layers: ["primaryRail", "subSidebar", "header"], canExit: false },
+    ]);
+    expect(hidden.has("primaryRail")).toBe(false);
+    // The rest of the request is still honoured — the floor is one layer, not a
+    // refusal of the whole request.
+    expect(hidden.has("subSidebar")).toBe(true);
+    expect(hidden.has("header")).toBe(true);
+  });
+
+  it("does not let an exitless request borrow another request's rail grant", () => {
+    // Both mounted at once. The union must not promote the exitless one: a
+    // per-LAYER floor would grant the rail here, because some request had an
+    // exit, which is the bug this asserts against.
+    const hidden = resolveSuppressedChrome([
+      { layers: ["subSidebar"], canExit: true },
+      { layers: ["primaryRail"], canExit: false },
+    ]);
+    expect(hidden.has("primaryRail")).toBe(false);
+    expect(hidden.has("subSidebar")).toBe(true);
+  });
+
+  it("union-merges so one surface cannot un-hide another's chrome", () => {
+    const hidden = resolveSuppressedChrome([
+      { layers: ["header"], canExit: true },
+      { layers: ["subSidebar"], canExit: true },
+    ]);
+    expect(hidden.has("header")).toBe(true);
+    expect(hidden.has("subSidebar")).toBe(true);
+  });
+
+  it("hides nothing again once the asking surface has released", () => {
+    // Release is modelled as the request leaving the collection, which is what
+    // unmounting does. Asserted because a resolver that memoised into a
+    // module-level set would pass every test above and never restore chrome.
+    const mounted = new Set<ChromeSuppressionRequest>([immersive]);
+    expect(resolveSuppressedChrome(mounted).size).toBe(4);
+    mounted.delete(immersive);
+    expect(resolveSuppressedChrome(mounted).size).toBe(0);
+  });
+});

--- a/packages/admin/src/components/layout/__tests__/chrome-suppression.test.ts
+++ b/packages/admin/src/components/layout/__tests__/chrome-suppression.test.ts
@@ -6,7 +6,13 @@ import {
 } from "../lib/chrome-suppression";
 
 const immersive: ChromeSuppressionRequest = {
-  layers: ["primaryRail", "subSidebar", "documentSidebar", "header"],
+  layers: [
+    "primaryRail",
+    "subSidebar",
+    "documentSidebar",
+    "header",
+    "pageFrame",
+  ],
   canExit: true,
 };
 
@@ -22,9 +28,21 @@ describe("resolveSuppressedChrome", () => {
     expect([...hidden].sort()).toEqual([
       "documentSidebar",
       "header",
+      "pageFrame",
       "primaryRail",
       "subSidebar",
     ]);
+  });
+
+  it("grants the page frame to a surface with no way back", () => {
+    // The floor covers the navigation rail ONLY. An embedded mount still gets
+    // its padding dropped — it is inside a form that provides the way out, so
+    // withholding the frame would leave it boxed for no safety benefit.
+    const hidden = resolveSuppressedChrome([
+      { layers: ["pageFrame", "primaryRail"], canExit: false },
+    ]);
+    expect(hidden.has("pageFrame")).toBe(true);
+    expect(hidden.has("primaryRail")).toBe(false);
   });
 
   it("withholds the primary rail from a requester with no way back", () => {
@@ -64,8 +82,12 @@ describe("resolveSuppressedChrome", () => {
     // unmounting does. Asserted because a resolver that memoised into a
     // module-level set would pass every test above and never restore chrome.
     const mounted = new Set<ChromeSuppressionRequest>([immersive]);
-    expect(resolveSuppressedChrome(mounted).size).toBe(4);
+    // Asserted by membership rather than by a count, which goes stale the moment
+    // a layer is added and then reads as a real failure.
+    expect([...resolveSuppressedChrome(mounted)].sort()).toEqual(
+      [...immersive.layers].sort()
+    );
     mounted.delete(immersive);
-    expect(resolveSuppressedChrome(mounted).size).toBe(0);
+    expect([...resolveSuppressedChrome(mounted)]).toEqual([]);
   });
 });

--- a/packages/admin/src/components/layout/lib/chrome-suppression.ts
+++ b/packages/admin/src/components/layout/lib/chrome-suppression.ts
@@ -1,0 +1,62 @@
+/**
+ * Which pieces of admin furniture a mounted surface may ask to have removed.
+ *
+ * An immersive editor is not the only screen that will ever want the window to
+ * itself — a media browser or a preview mode wants the same thing — so this is a
+ * capability the admin owns rather than a special case for one route.
+ */
+export type AdminChromeLayer =
+  | "primaryRail"
+  | "subSidebar"
+  | "documentSidebar"
+  | "header";
+
+/**
+ * One surface's request, held for as long as that surface is mounted.
+ *
+ * `canExit` is the requester stating that it renders its own way back to the
+ * admin. It decides whether the request is allowed to take the primary rail,
+ * which is otherwise the only remaining route out — see `resolveSuppressedChrome`.
+ */
+export interface ChromeSuppressionRequest {
+  layers: readonly AdminChromeLayer[];
+  canExit: boolean;
+}
+
+/**
+ * The layer that is only grantable to a requester that can be left.
+ *
+ * The rail is the whole of the admin's navigation. Removing it while the surface
+ * offers no way back leaves an author with no route anywhere except the browser
+ * URL, and the surfaces most likely to ask are exactly the ones holding unsaved
+ * work. `header-visibility.ts` keeps the account dropdown for the same reason:
+ * logout must stay reachable.
+ */
+const REQUIRES_EXIT: AdminChromeLayer = "primaryRail";
+
+/**
+ * Resolve what is hidden right now, union-merged across every mounted request.
+ *
+ * A layer is hidden if ANY request asks for it, so two immersive surfaces cannot
+ * un-hide each other's chrome. The exception is `primaryRail`, granted per
+ * REQUEST rather than per layer: a request without its own exit does not get it,
+ * and cannot borrow the grant from a request that has one.
+ *
+ * Requests are keyed by mount rather than by route. A route list would be a
+ * second answer to "is this surface immersive" living in the admin, and it would
+ * drift every time a plugin added a route — silently, because a missing entry
+ * renders correctly, just with chrome nobody wanted. The surface that IS
+ * immersive is the one that knows, and it only says so while it exists.
+ */
+export function resolveSuppressedChrome(
+  requests: Iterable<ChromeSuppressionRequest>
+): Set<AdminChromeLayer> {
+  const hidden = new Set<AdminChromeLayer>();
+  for (const request of requests) {
+    for (const layer of request.layers) {
+      if (layer === REQUIRES_EXIT && !request.canExit) continue;
+      hidden.add(layer);
+    }
+  }
+  return hidden;
+}

--- a/packages/admin/src/components/layout/lib/chrome-suppression.ts
+++ b/packages/admin/src/components/layout/lib/chrome-suppression.ts
@@ -9,7 +9,17 @@ export type AdminChromeLayer =
   | "primaryRail"
   | "subSidebar"
   | "documentSidebar"
-  | "header";
+  | "header"
+  /**
+   * The page frame a route renders inside: the container's padding and the
+   * breadcrumb row above it.
+   *
+   * Separate from the three sidebars because it is the innermost layer and the
+   * only one a surface can be inside — suppressing the others leaves a canvas
+   * that still stops 32px short of every edge, which reads as a mistake rather
+   * than as a margin.
+   */
+  | "pageFrame";
 
 /**
  * One surface's request, held for as long as that surface is mounted.

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -243,6 +243,13 @@ export {
 } from "@nextlyhq/ui";
 export { Stack, Grid, Stat } from "@nextlyhq/ui";
 export type { StackProps, GridProps, StatProps } from "@nextlyhq/ui";
+/**
+ * Immersive surfaces ask for admin chrome to be hidden while they are mounted.
+ * Exported for `plugin-sdk/admin`, which is the only admin surface a plugin (and
+ * `@nextlyhq/builder`) may import.
+ */
+export { useSuppressAdminChrome } from "./components/layout/ChromeSuppression";
+export type { AdminChromeLayer } from "./components/layout/lib/chrome-suppression";
 export type {
   CardActionProps,
   CardContentProps,

--- a/packages/admin/src/layout/DashboardLayout.tsx
+++ b/packages/admin/src/layout/DashboardLayout.tsx
@@ -16,6 +16,10 @@ import { ThemeAwareLogo } from "@admin/components/shared/ThemeAwareLogo";
 import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { useRouter } from "@admin/hooks/useRouter";
 
+import {
+  ChromeSuppressionProvider,
+  useSuppressedChrome,
+} from "../components/layout/ChromeSuppression";
 import { DashboardHeader } from "../components/layout/header";
 import { SidebarProvider } from "../components/layout/sidebar";
 import { DualSidebar } from "../components/layout/sidebar/DualSidebar";
@@ -36,8 +40,30 @@ interface DashboardLayoutProps {
  * - **Desktop (≥ 1024px)**: Dual sidebar layout
  * - **Mobile (< 768px)**: Mobile header with a Sheet-based drawer
  */
+/**
+ * The provider sits ABOVE the chrome and above `children`, because the surfaces
+ * that ask for chrome to be hidden are rendered as `children` and React state
+ * has to be lifted past both to be read by the one and written by the other.
+ */
 export function DashboardLayout({ children }: DashboardLayoutProps) {
+  return (
+    <ChromeSuppressionProvider>
+      <DashboardChrome>{children}</DashboardChrome>
+    </ChromeSuppressionProvider>
+  );
+}
+
+function DashboardChrome({ children }: DashboardLayoutProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const hidden = useSuppressedChrome();
+  /*
+   * The rail and the panel live in one component, so "hide the rail" is asked of
+   * `DualSidebar` while "hide the whole sidebar column" is decided here. Hiding
+   * the column only when BOTH are suppressed keeps a request for one of them
+   * from silently taking the other.
+   */
+  const hideSidebarColumn =
+    hidden.has("primaryRail") && hidden.has("subSidebar");
   const { pathname } = useRouter();
   const branding = useBranding();
 
@@ -79,9 +105,11 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
           </div>
 
           <div className="flex flex-1 min-h-0 overflow-hidden">
-            <div className="hidden lg:flex h-full overflow-hidden shrink-0">
-              <DualSidebar />
-            </div>
+            {!hideSidebarColumn && (
+              <div className="hidden lg:flex h-full overflow-hidden shrink-0">
+                <DualSidebar />
+              </div>
+            )}
 
             <Sheet open={isMobileMenuOpen} onOpenChange={setIsMobileMenuOpen}>
               <SheetContent
@@ -99,7 +127,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
 
             {/* Main Content */}
             <div className="flex-1 min-w-0 flex flex-col min-h-0 overflow-hidden relative">
-              <DashboardHeader />
+              {!hidden.has("header") && <DashboardHeader />}
               {/* Named container so content responds to the panel width
                   (viewport minus sidebar), not the viewport. */}
               <main className="@container/content flex-1 overflow-y-auto bg-transparent">

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
@@ -19,6 +19,7 @@ import {
   EntryForm,
   type EntryFormCollection,
 } from "@admin/components/features/entries/EntryForm";
+import { useSuppressedChrome } from "@admin/components/layout/ChromeSuppression";
 import { PageContainer } from "@admin/components/layout/page-container";
 import { Breadcrumbs } from "@admin/components/shared";
 import { PageErrorFallback } from "@admin/components/shared/error-fallbacks";
@@ -226,6 +227,11 @@ export default function EditEntryPage({
   // routes saves to the chosen language (EntryForm → useUpdateEntry).
   const [locale, setLocale] = useState<string | undefined>(undefined);
 
+  // Read here rather than at the branch that uses it: this component returns
+  // early for loading and error states, and a hook after those runs
+  // conditionally.
+  const suppressed = useSuppressedChrome();
+
   // Fetch enriched collection schema (component fields are populated)
   const {
     data: collection,
@@ -423,6 +429,28 @@ export default function EditEntryPage({
       onDelete: handleDelete,
       onCancel: handleCancel,
     };
+
+    /*
+     * A custom Edit view may take the window. The page frame is the innermost
+     * layer of admin chrome, so it is dropped from here rather than from the
+     * layout: suppressing the sidebars alone would leave the view stopping 32px
+     * short of every edge with a breadcrumb above it, which reads as a bug.
+     *
+     * The view asks for this on mount, so this branch reacts to what it asked
+     * for rather than deciding on its behalf. Nothing here knows which views are
+     * immersive, which is the point — a list of them would drift as plugins
+     * added routes, silently, because a missing entry still renders.
+     */
+    if (suppressed.has("pageFrame")) {
+      return (
+        <QueryErrorBoundary fallback={<PageErrorFallback />}>
+          <PluginSlot
+            path={customEditViewPath}
+            props={customViewProps as unknown as Record<string, unknown>}
+          />
+        </QueryErrorBoundary>
+      );
+    }
 
     return (
       <QueryErrorBoundary fallback={<PageErrorFallback />}>

--- a/packages/plugin-page-builder/src/admin/EditorSurface.tsx
+++ b/packages/plugin-page-builder/src/admin/EditorSurface.tsx
@@ -115,7 +115,13 @@ export function EditorSurface({ onExit, surface }: EditorSurfaceProps = {}) {
    * and a request that describes the surface honestly outlives this mount.
    */
   useSuppressAdminChrome({
-    layers: ["primaryRail", "subSidebar", "documentSidebar", "header"],
+    layers: [
+      "primaryRail",
+      "subSidebar",
+      "documentSidebar",
+      "header",
+      "pageFrame",
+    ],
     canExit: exitWithGuard !== undefined,
   });
   /**

--- a/packages/plugin-page-builder/src/admin/EditorSurface.tsx
+++ b/packages/plugin-page-builder/src/admin/EditorSurface.tsx
@@ -10,6 +10,7 @@
  */
 import { DragDropProvider, DragOverlay } from "@dnd-kit/react";
 import { BuilderShell } from "@nextlyhq/builder/shell";
+import { useSuppressAdminChrome } from "@nextlyhq/plugin-sdk/admin";
 import { useMemo, useState } from "react";
 
 import { defaultBlockRegistry } from "../core/registry";
@@ -95,6 +96,28 @@ export function EditorSurface({ onExit, surface }: EditorSurfaceProps = {}) {
       if (leave) onExit();
     };
   }, [onExit, state.dirty]);
+  /*
+   * The editor takes the window while it is mounted: the shell already draws its
+   * own rail, panels, top bar and bottom bar, so admin chrome around it is a
+   * second set of the same furniture, and the canvas is the one surface whose
+   * whole purpose is the space it is given.
+   *
+   * `canExit` is read from `exitWithGuard` — the very value passed to the shell
+   * as `onExit`, and therefore the same thing that decides whether an Exit
+   * button is rendered at all. Derived rather than declared, so the claim "this
+   * surface can be left" and the affordance that leaves it cannot disagree:
+   * mounted as a field inside an entry form there is nowhere to go, no button
+   * appears, and the navigation rail correctly stays.
+   *
+   * `documentSidebar` is requested for completeness rather than for effect here.
+   * A custom Edit view replaces the entry form outright, so no document rail is
+   * rendered on this route — but a future host may mount the editor beside one,
+   * and a request that describes the surface honestly outlives this mount.
+   */
+  useSuppressAdminChrome({
+    layers: ["primaryRail", "subSidebar", "documentSidebar", "header"],
+    canExit: exitWithGuard !== undefined,
+  });
   /**
    * Why the CURRENT target refuses this block, while the drag is still in the air.
    *

--- a/packages/plugin-sdk/src/admin.ts
+++ b/packages/plugin-sdk/src/admin.ts
@@ -42,6 +42,19 @@ export type {
 } from "@nextlyhq/admin";
 
 /**
+ * Ask the admin to hide its own chrome while an immersive surface is mounted
+ * (@experimental) — a full-bleed editor, a media browser, a preview mode.
+ *
+ * Scoped to the mount rather than to a route: the request is released when the
+ * component unmounts, so navigating away restores the chrome with nothing to
+ * undo. `canExit` must state whether this surface renders its own way back to
+ * the admin, DERIVED from the affordance rather than asserted beside it — the
+ * primary navigation rail is only ever hidden for a surface that can be left.
+ */
+export { useSuppressAdminChrome } from "@nextlyhq/admin";
+export type { AdminChromeLayer } from "@nextlyhq/admin";
+
+/**
  * The unified admin data table + its extension points (@experimental). Render
  * `DataTable` (batteries-included) or `DataTableView` (controlled) to match the
  * admin's lists, and contribute cell renderers, columns, column transforms, and


### PR DESCRIPTION
Closes **T-06** — the page builder's canvas should have the window, not a corner of it.

## The problem, measured

On a 1440×900 window the canvas got **1020×675 — 52% of the window**. The other half was furniture: 328px of sidebar beside it, and two horizontal bars stacked above it totalling 112px, because the admin header (`h-16`) and the shell's own top bar (`h-12`) both render. The shell already draws its own rail, panels, top bar and bottom bar, so the admin chrome around it was a second set of the same thing.

After this change the canvas gets **1440×822 — 91%**.

## Why a mechanism and not a route check

Requests are keyed by **mount**, not by route. A list of full-bleed routes living in the admin would be a second answer to "is this surface immersive", and it drifts every time a plugin adds a route — *silently*, because a missing entry still renders correctly, just with chrome nobody wanted. The surface that is immersive is the one that knows, and it only claims the window while it is on screen, so navigating away restores everything with nothing to undo.

Shape follows the existing precedent in `layout/header/header-visibility.ts`: the consumer **declares**, the admin **resolves**. That one is plugin-scoped and static; this is mount-scoped, because full-bleed must apply while the editor is open rather than whenever the plugin is installed.

Three pieces:

- `layout/lib/chrome-suppression.ts` — a pure resolver, no React. Union-merges across mounted surfaces so two immersive surfaces cannot un-hide each other's chrome.
- `layout/ChromeSuppression.tsx` — provider + `useSuppressAdminChrome`.
- exported from `@nextlyhq/admin`, re-exported through `plugin-sdk/admin` — the only admin surface `packages/builder` and plugins may import, enforced by `builder/src/layering.test.ts`.

Five layers: `primaryRail`, `subSidebar`, `documentSidebar`, `header`, `pageFrame`.

## The exit floor is structural, not a convention

`primaryRail` is granted **only** to a request carrying `canExit: true`. Removing the navigation rail from a surface with no way back leaves an author with no route anywhere but the browser URL — and the surfaces most likely to ask are exactly the ones holding unsaved work.

Two details that make it hold:

- **Per REQUEST, not per layer.** An exitless request cannot borrow the grant from one that has an exit.
- **`canExit` is DERIVED.** The consumer passes `exitWithGuard !== undefined` — the very value it hands the shell as `onExit`, which is what decides whether an Exit button renders at all. So the claim "this can be left" and the affordance that leaves it cannot disagree. Mounted as a field inside an entry form there is nowhere to go, no button appears, and the rail correctly stays.

The floor deliberately stops at the rail. An embedded mount still gets `pageFrame`, because it sits inside a form that already provides the way out; withholding its padding would box it in for no safety gained.

`header-visibility.ts` keeps the account dropdown for the same reason this keeps the rail. The mobile header is likewise not suppressible — it carries the only navigation on small screens, where the shell declines to draw a canvas anyway.

## A layout effect, not a passive one

Registering in `useEffect` means the first paint carries the full frame and drops it on the next. Since the editor is the widest surface in the admin, that is a whole-layout reflow visible as a flash on **every** open. Falls back to `useEffect` where there is no DOM, which cannot paint anyway.

## Testing

`chrome-suppression.test.ts`, 7/7. **Every property stub-verified — broken three ways, each producing the intended red:**

| break | result |
|---|---|
| floor removed entirely | exactly 2 tests fail, `expected true to be false` |
| floor made per-LAYER instead of per-REQUEST | exactly **1** fails — the borrow test |
| floor over-applied to every layer | exactly 2 fail — the rail test and the page-frame test |

The second break is the one worth having. With a single exitless request a per-layer floor still behaves correctly, so without that test a resolver letting an exitless surface borrow another's rail grant would have passed.

Assertions are by **membership**, not count — one of mine asserted `size === 4`, broke when the fifth layer landed, and read as a real failure. Fixed in this PR.

## Not done — stated rather than implied

- **The breadcrumb is not yet in the shell's top bar.** As it stands the page hierarchy is *gone* rather than *moved*, so this is Option B of the three considered, not C. Moving it needs the hierarchy to cross the plugin boundary — `EditEntryBreadcrumbs` is admin-internal and `EditorSurface` is in the plugin — which is an addition to the core custom-edit-view contract and belongs in its own PR. The shell's footer stays reserved for the **selection path** (`aria-label="Selection path"`), which is block ancestry and a different thing from document location.
- **No e2e spec, and no browser verification yet.** The unit resolver is covered; the rendered result is not.
- `page-container` still sets `min-h-[calc(100vh-4rem)]`, subtracting exactly the header height. Moot on this route now the frame is bypassed, but wrong for any future surface that hides the header while keeping the frame.
- `documentSidebar` has **no effect on this route** — a custom Edit view early-returns, so the entry form and its rail never render. Requested anyway so the declaration describes the surface honestly for a future host.

## Pre-existing failures, not from this branch

`pnpm check-types` in `packages/admin` reports 8 × `Cannot find module 'nextly/field-group-reconcile'`. Not mine: `git diff origin/main...HEAD --name-only | grep -c field-group` → **0**. Diagnosed as a stale `dist` — the subpath *is* declared in `nextly`'s export map and four internal chunks exist, but the entry `.d.ts` was never emitted. Needs a `nextly` rebuild, not a code change.

**CI may not report.** Measured on `main`: Integration jobs `total=3 success=0 queued=3`. Both review bots are also reported down by four lanes. If nothing concludes, this merges on local evidence — please do not read a green rollup as a pass without checking the jobs actually `success`ed.

## Changeset

Added, `patch`, **generated** from `.changeset/config.json`'s `fixed` group rather than copied — 24 packages. Verified: `node scripts/release/check-changesets.mjs .changeset/admin-chrome-suppression.md` → `Checked 1 changeset(s): all cover the group.`

Worth noting the bare invocation reports `No changesets added or edited` and exits 0 — it takes explicit paths, so running it without arguments checks nothing and reads as a pass.
