### PR TITLE
test(e2e): cover autosave recovery for a Single, and pin a clock defect

### DIFF
--- a/apps/playground/src/singles/site-settings.ts
+++ b/apps/playground/src/singles/site-settings.ts
@@ -7,6 +7,11 @@ import { defineSingle, text, textarea, fieldGroup } from "nextly/config";
 
 export const SiteSettings = defineSingle({
   slug: "site-settings",
+  // Drafts and autosave, ON, so the dev harness exercises recovery points for a
+  // Single as well as for a collection entry. Without an explicit `versions`
+  // the entity resolves as unversioned and the policy gate refuses every
+  // autosave write, which is why the Single path had never run.
+  versions: { drafts: true },
   label: { singular: "Site Settings" },
   // Localized: translatable fields store per language in `single_site-settings_locales`.
   localized: true,

--- a/e2e/tests/autosave-recovery.spec.ts
+++ b/e2e/tests/autosave-recovery.spec.ts
@@ -167,6 +167,25 @@ test.describe("autosave recovery", () => {
 test.describe("autosave recovery for a Single", () => {
   const SINGLE_AUTOSAVE = /\/singles\/site-settings\/versions\/autosave/;
 
+  /**
+   * KNOWN FAILING, and deliberately kept executable rather than deleted or
+   * weakened.
+   *
+   * The write lands and the read returns the row, but the offer is suppressed
+   * because the two timestamps being compared do not share a clock. Measured on
+   * a single run, seconds apart:
+   *
+   *   recovery point updatedAt   10:25:33Z
+   *   single document updatedAt  15:25:31Z
+   *
+   * Five hours is the server's UTC offset, so the document's timestamp is local
+   * time carrying a `Z`. The recovery rule then correctly concludes, from wrong
+   * inputs, that the document is newer and withholds the offer.
+   *
+   * `test.fail()` rather than a skip: this still runs, still proves the defect
+   * is present, and turns RED the moment it is fixed, which a skip would not.
+   */
+  test.fail();
   test("records and offers back a Single's unsaved work", async ({ page }) => {
     await gotoAdmin(page, "/singles/site-settings");
 

--- a/e2e/tests/autosave-recovery.spec.ts
+++ b/e2e/tests/autosave-recovery.spec.ts
@@ -153,3 +153,54 @@ test.describe("autosave recovery", () => {
     ).toBeVisible({ timeout: 15_000 });
   });
 });
+
+/**
+ * The same loop for a Single.
+ *
+ * Worth covering separately rather than trusting the shared hook: a Single is
+ * addressed by its own document id rather than an entry id, it has no create
+ * step, and `site-settings` is LOCALIZED -- so this is also the only coverage of
+ * the locale travelling with the write. The collection path proved that a
+ * shared transport can still be wrong at one call site, which is exactly the
+ * assumption "it uses the same hook" would rest on.
+ */
+test.describe("autosave recovery for a Single", () => {
+  const SINGLE_AUTOSAVE = /\/singles\/site-settings\/versions\/autosave/;
+
+  test("records and offers back a Single's unsaved work", async ({ page }) => {
+    await gotoAdmin(page, "/singles/site-settings");
+
+    const written = page.waitForResponse(
+      r => SINGLE_AUTOSAVE.test(r.url()) && r.request().method() === "PUT",
+      { timeout: 30_000 }
+    );
+
+    const recovered = `tagline never saved ${Date.now()}`;
+    await page
+      .getByRole("textbox", { name: "Tagline", exact: true })
+      .fill(recovered);
+
+    // Population before verdict, as on the collection path: a banner that never
+    // appears means "the read is broken" only once a write is known to have
+    // landed.
+    expect(
+      (await written).status(),
+      "the Single's autosave write must be accepted"
+    ).toBeLessThan(400);
+
+    await page.reload();
+    await expect(page.locator("main")).toBeVisible({ timeout: 30_000 });
+
+    await expect(
+      page.getByText(/unsaved changes from/i),
+      "a Single's recovery offer must survive a reload"
+    ).toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole("button", { name: /^restore$/i }).click();
+
+    await expect(
+      page.getByRole("textbox", { name: "Tagline", exact: true }),
+      "restoring must put the Single's recorded values back"
+    ).toHaveValue(recovered);
+  });
+});


### PR DESCRIPTION
Extends the autosave e2e to Singles. Doing so found a defect that the collection path cannot see, and it is not in autosave.

## Two findings

**1. Singles autosave was unreachable**, for the same reason entries were: no playground Single set `versions`, so the entity resolved as unversioned and the policy gate refused every write. Enabled on `site-settings`, which is also LOCALIZED -- so this is the only coverage of the locale travelling with the write.

**2. A version timestamp and a document timestamp do not share a clock.** Measured seconds apart on one run:

```
recovery point updatedAt   10:25:33Z     <- correct UTC
single document updatedAt  15:25:31Z     <- local time, carrying a Z
```

Five hours is the server UTC offset. The recovery rule then concludes, correctly from wrong inputs, that the document is newer, and withholds the offer.

**The scope is wider than autosave.** Any comparison between a version timestamp and a document timestamp is wrong by that offset. Both values look like valid ISO strings, so neither a type nor a unit test can see it.

## Why the Single test is `test.fail()` rather than skipped or weakened

It still RUNS, still proves the defect is present, and turns RED the moment the defect is fixed. A skip would go quiet and stay quiet. Weakening the assertion would have hidden a real bug behind a green suite, which is the failure mode this lane has spent the day removing.

The two collection tests pass normally.

## A correction to my own first reading

I initially thought a real save DELETES the recovery point, which would make the comparison redundant and the fix trivial. It does not: all three `deleteAutosaves` call sites in the mutation service are DELETE paths, not saves. The comparison is load-bearing, and it is broken. Recorded because the wrong version is the more comfortable one to believe.

## The fix is a design decision, not included here

Three options, put to the founder rather than chosen unilaterally, because two of them touch code this lane does not own:

- delete the recovery point ON SAVE, so its existence alone means unsaved work and no clock comparison is needed anywhere (my recommendation; also fixes a saved Single offering stale work forever)
- fix the document timestamp serialization at source (true root cause, but changes a value already in API responses)
- normalise inside the recovery rule only (smallest, and the one I argued against: it hard-codes a deployment timezone)

## Verification

- **e2e: 3 passed** (2 real, 1 expected-failure) against a full `pnpm build` (19/19 successful)
- check-types + lint 11/11, `check:comments` clean

Test-only, no changeset.