### PR TITLE
feat(blocks-react): core/card adopts the surface and border tokens

### DIFF
--- a/.changeset/card-adopts-tokens.md
+++ b/.changeset/card-adopts-tokens.md
@@ -1,0 +1,44 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+feat(blocks-react): core/card adopts the surface and border tokens
+
+`core/card` declined a background and a border for as long as no design token
+resolved. Both `color.surface` and `color.border` are now in the guaranteed set
+and both render paths emit the sheet that defines them, so the block carries
+them — as `{ $token }` references rather than literals, because a literal colour
+is wrong in whichever of light and dark it was not chosen for, which is the whole
+reason a token set exists. The border is written per LOGICAL side, so a
+right-to-left page borders the side an author means.
+
+This also DELETES the ratchet that forbade `{ $token }` in `baseStyles`, which is
+the swap it was written for: its stated expiry was "when the site stylesheet is
+wired into the render path", and both paths now emit it. It is replaced by the
+question that matters now — a default may only name a token the guaranteed set
+DEFINES, because a reference to an undefined name dangles for exactly the reason
+the old defect did, and neither the catalog check nor the compiled-CSS check can
+see it.

--- a/packages/blocks-react/src/blocks/base-styles.test.tsx
+++ b/packages/blocks-react/src/blocks/base-styles.test.tsx
@@ -23,7 +23,11 @@
  *    still be dropped for a VALUE the grammar refuses, which the first question
  *    cannot see.
  */
-import { blockTypeClassName, getStyleProperty } from "@nextlyhq/blocks-engine";
+import {
+  blockTypeClassName,
+  defaultSiteTokens,
+  getStyleProperty,
+} from "@nextlyhq/blocks-engine";
 import type {
   AnyBlockDefinition,
   BlockDocument,
@@ -259,57 +263,70 @@ function tokenNamesIn(value: unknown): string[] {
   return Object.values(record).flatMap(tokenNamesIn);
 }
 
-describe("a default may not depend on a design token yet", () => {
+describe("a token a default depends on must be one the site set defines", () => {
   /**
-   * **A token reference compiles to a `var()` that NOTHING DEFINES.**
+   * **This REPLACES a ratchet that forbade tokens outright**, and the swap is the
+   * point rather than a relaxation.
    *
-   * `compileSiteSheet` is the only thing that turns a token set into CSS, and it
-   * has zero consumers outside `blocks-engine` — so `--site-*` is emitted by no
-   * product path, and `defaultSiteTokens()` is a default nobody applies. An
-   * undefined custom property makes the whole declaration invalid at
-   * computed-value time, so the property falls back to its initial value.
+   * That ratchet existed because nothing emitted token CSS: `compileSiteSheet`
+   * had no consumers, so `{ $token }` compiled to a `var()` with nothing behind
+   * it and three shipped blocks rendered with their children touching. Its
+   * stated expiry was "when the site stylesheet is wired into the render path",
+   * and both render paths now emit it — a route by default and `PageRenderer` by
+   * default. So it is deleted by the change that met its condition, exactly as
+   * written, rather than weakened or exempted per block.
    *
-   * `core/form` shipped that way: `gap: { $token: "space.4" }` became
-   * `gap: var(--site-space-4)`, which resolved to nothing, so a grid whose
-   * fields were supposed to be spaced rendered with them touching.
-   *
-   * **Neither check above can see it.** The property is in the catalog, and the
-   * declaration DOES reach the compiled stylesheet — it is the `var()` inside
-   * the value that dangles. Whether a reference resolves is a third question,
-   * and this is the one that asks it.
-   *
-   * **This is a ratchet with an expiry.** When the site stylesheet is wired into
-   * the render path, tokens become the RIGHT way to express a default and this
-   * case should be deleted in the change that wires it — not weakened, and not
-   * exempted per block.
+   * What replaces it is the question that actually matters now. A token is only
+   * as good as its DEFINITION: a default naming `color.nonesuch` compiles to a
+   * `var()` that dangles for the same reason the old defect did, and neither the
+   * catalog check nor the compiled-CSS check above can see it — the property is
+   * legitimate and the declaration reaches the stylesheet carrying a `var()`
+   * nobody defined.
    */
   it.each(DECLARING.map(block => [block.name, block] as const))(
-    "%s uses no token reference",
+    "%s names only tokens the guaranteed set defines",
     (name, block) => {
+      const guaranteed = new Set(defaultSiteTokens().map(token => token.name));
+      const named = tokenNamesIn(block.baseStyles);
+
+      // A block naming no token passes vacuously, which is correct — but the
+      // population is asserted below so this file cannot pass having inspected
+      // nothing.
+      const undefinedTokens = named.filter(token => !guaranteed.has(token));
+
       expect(
-        tokenNamesIn(block.baseStyles),
-        `${name} declares a { $token } default. Nothing emits token CSS yet ` +
-          `(compileSiteSheet has no consumers outside blocks-engine), so the ` +
-          `reference compiles to a var() with nothing behind it and the ` +
-          `property silently falls back to its initial value. Use a literal ` +
-          `until the site stylesheet is wired, then delete this case.`
+        undefinedTokens,
+        `${name} depends on ${undefinedTokens.join(", ")}, which no guaranteed ` +
+          `token defines. The reference compiles to a var() with nothing behind ` +
+          `it, so the property silently falls back to its initial value — the ` +
+          `same failure as the tokens nothing emitted, one level in.`
       ).toEqual([]);
     }
   );
 
+  it("inspects at least one block that DOES depend on a token", () => {
+    // The population control. Every case above passes by finding nothing, so a
+    // library that stopped using tokens entirely — or a walker that returned
+    // nothing — would leave the whole describe green while checking no token at
+    // all. `core/card` is the reason this check exists.
+    const withTokens = DECLARING.filter(
+      block => tokenNamesIn(block.baseStyles).length > 0
+    ).map(block => block.name);
+
+    expect(withTokens).toContain("core/card");
+  });
+
   it("detects a token reference at any depth, including inside an object", () => {
-    // The positive control. Every assertion above passes by finding NOTHING, so
-    // a walker that returned nothing under all circumstances would leave the
-    // whole case green — and the nested form is the one a shallow reader misses.
+    // The walker's own control, and the nested form is the one that matters:
+    // `core/card`'s border colour sits INSIDE an object-shaped declaration, so a
+    // shallow reader would report it clean.
     expect(
       tokenNamesIn({ base: { base: { gap: { $token: "space.4" } } } })
     ).toEqual(["space.4"]);
     expect(
       tokenNamesIn({
-        base: {
-          base: { borderRadius: { startStart: { $token: "radius.sm" } } },
-        },
+        base: { base: { border: { color: { $token: "color.border" } } } },
       })
-    ).toEqual(["radius.sm"]);
+    ).toEqual(["color.border"]);
   });
 });

--- a/packages/blocks-react/src/blocks/card.test.tsx
+++ b/packages/blocks-react/src/blocks/card.test.tsx
@@ -9,7 +9,11 @@
  * by `base-styles.test.tsx`, which derives the check from every block that
  * declares them rather than repeating one here.
  */
+import type { BlockDocument } from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
+
+import type { BlockResolver } from "../resolver";
+import { resolvePageStyles } from "../styles";
 
 import { box } from "./box";
 import { card, CARD_BLOCK } from "./card";
@@ -80,5 +84,67 @@ describe("core/card", () => {
       expect(card.name).toBe(CARD_BLOCK);
       expect(coreBlocks.map(block => block.name)).toContain(CARD_BLOCK);
     });
+  });
+});
+
+describe("the surface and border it carries", () => {
+  /**
+   * Asserts the COMPILED CSS, because that is where this block's history lives:
+   * it declined a background and a border for as long as no token resolved, and
+   * an object assertion would have passed throughout — the declaration was never
+   * the missing part.
+   */
+  function compiledCss(): string {
+    const doc: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "c", type: CARD_BLOCK, version: 1, props: {} }],
+    };
+    const resolver: BlockResolver = {
+      get: (name: string) =>
+        coreBlocks.find(block => block.name === name) as never,
+    };
+    return (
+      resolvePageStyles(
+        doc,
+        undefined,
+        {
+          breakpoints: {
+            viewport: [{ id: "base", label: "Desktop" }],
+            container: [],
+          },
+        },
+        resolver
+      ).css ?? ""
+    );
+  }
+
+  it("emits a surface colour and a hairline, as token references", () => {
+    const css = compiledCss();
+
+    // The VAR, not a hex. A literal colour is wrong in whichever of light and
+    // dark it was not chosen for, which is the whole reason the token set exists
+    // — so a compiled hex here would mean the token had been abandoned.
+    expect(css).toContain("background-color: var(--site-color-surface)");
+    expect(css).toContain("border-color: var(--site-color-border)");
+  });
+
+  it("emits the hairline on all four LOGICAL sides", () => {
+    // Logical rather than physical, so a right-to-left page borders the side an
+    // author means rather than the side an English-speaking author assumed.
+    const css = compiledCss();
+
+    expect(css).toContain("border-block-start-width: 1px");
+    expect(css).toContain("border-inline-start-width: 1px");
+    expect(css).toContain("border-style: solid");
+  });
+
+  it("still clips, because a border does not remove the reason for the clip", () => {
+    // A bordered card with square-cornered image children is the same defect the
+    // clip exists for; adding the border must not have displaced it.
+    const css = compiledCss();
+
+    expect(css).toContain("overflow: hidden");
+    expect(css).toContain("border-radius: 12px");
   });
 });

--- a/packages/blocks-react/src/blocks/card.tsx
+++ b/packages/blocks-react/src/blocks/card.tsx
@@ -30,39 +30,19 @@
  * author adds padding to the card when there is no image, or to a box inside it
  * when there is, and both stay available. A default would remove the second.
  *
- * **No default background or border, and the reason is stronger than first
- * recorded.** This docblock used to say `defaultSiteTokens()` "guarantees"
- * `color.text`, `color.background`, `color.primary`, `font.body`,
- * `content.width` and `space.4`, and that a surface colour was merely absent
- * from that set. **It guarantees none of them.** `compileSiteSheet` — the only
- * thing that turns a token set into CSS — has ZERO consumers outside
- * `blocks-engine`, and the string `--site-` appears in no source file outside
- * the engine (positive control: `--nx-` appears in four). The default token set
- * is a default nobody applies.
+ * **It carries a background and a border, and it did not until today.** This
+ * docblock argued at length that it could not: `defaultSiteTokens()` named no
+ * surface colour, `compileSiteSheet` had no consumers so no token resolved at
+ * all, and a hardcoded hex is wrong in whichever of light and dark it was not
+ * chosen for. Every clause was true and the conclusion has been overtaken —
+ * `color.surface` and `color.border` are in the guaranteed set, and both render
+ * paths emit the sheet that defines them.
  *
- * So a `{ $token }` reference here would compile to a `var()` with nothing
- * behind it — not because the name is unlisted, but because **no token name
- * resolves at all yet.** A hardcoded hex is wrong in whichever of light and
- * dark it was not chosen for.
- *
- * The obvious way around that is to DERIVE a surface from the two colours that
- * are guaranteed, which is what the older page-builder blocks do:
- * `color-mix(in srgb, var(--nx-color-primary) 12%, var(--nx-color-background))`.
- * It is refused here, and the reason is worth stating because the catalog does
- * NOT refuse it — that value validates and compiles through verbatim.
- *
- * `--nx-*` is the ADMIN's token namespace. This renderer emits none of it: the
- * engine writes site tokens as `--site-*`, which is what `{ $token }` compiles
- * to, and a hand-written `var(--site-…)` is refused in turn. So a `color-mix`
- * over `--nx-*` would pass validation, reach the stylesheet, and resolve to
- * nothing on a published page, while looking correct in an admin preview that
- * happens to define those variables. A default that is right only where the
- * admin's stylesheet is loaded is worse than no default, because the failure
- * appears on the visitor's page and nowhere a person is looking.
- *
- * So the two properties that would make a card look like a card on a plain page
- * are left to the author until a surface token exists to carry them, and the
- * defaults here are the ones that are correct under every theme.
+ * Kept as a record rather than deleted, because the SHAPE recurs: the reason a
+ * default was declined was never the block's own, and a reader finding only
+ * "carries a background" would not know the correct mechanism had been missing
+ * rather than the design undecided. Six blocks across three lanes reached for
+ * the admin `--nx-*` namespace while it was.
  *
  * @module blocks/library/card
  */
@@ -93,6 +73,24 @@ export const CARD_BASE_STYLES = {
     base: {
       borderRadius: "12px",
       overflow: "hidden",
+      // The two properties this block declined until the tokens existed. Both
+      // are `{ $token }` rather than literals BECAUSE they are colours: a
+      // literal is wrong in whichever of light and dark it was not chosen for,
+      // which is the whole reason a token set exists. Spacing could take a
+      // literal safely; a surface cannot.
+      backgroundColor: { $token: "color.surface" },
+      border: {
+        // A hairline on all four sides, written per LOGICAL side so it follows
+        // writing direction rather than assuming left-to-right.
+        width: {
+          blockStart: "1px",
+          blockEnd: "1px",
+          inlineStart: "1px",
+          inlineEnd: "1px",
+        },
+        style: "solid",
+        color: { $token: "color.border" },
+      },
     },
   },
 } as const;


### PR DESCRIPTION
The payoff for the whole token arc. `core/card` finally looks like a card.

## What it declined, and why it can stop

The block shipped with **no background and no border** — the two properties that make a card a card. Its docblock argued at length that it could not have them, and every clause was true:

- `defaultSiteTokens()` named no surface colour
- `compileSiteSheet` had **zero consumers**, so no token resolved at all
- a hardcoded hex is wrong in whichever of light and dark it was not chosen for

All three have since been fixed (#903, #908, #911, #916). So the block now carries both, as `{ $token }` references rather than literals — **because they are colours.** Spacing could take a literal safely; a surface cannot.

The border is written per **logical** side, so a right-to-left page borders the side an author means rather than the side an English-speaking author assumed.

## The ratchet is DELETED, which is the swap it was written for

#896 added a check forbidding `{ $token }` in any `baseStyles`, with a stated expiry: *"when the site stylesheet is wired into the render path, tokens become the RIGHT way to express a default and this case should be deleted in the change that wires it — not weakened, and not exempted per block."*

Both render paths now emit the sheet. **So it is deleted by the change that met its condition, exactly as written.**

**Replaced by the question that matters now:** a default may only name a token the guaranteed set **defines**. A reference to `color.nonesuch` dangles for precisely the reason the old defect did — and **neither existing check can see it**: the property is legitimate and the declaration reaches the stylesheet carrying a `var()` nobody defined. That is the third question, one level in from the one #896 asked.

It carries a population control (`core/card` must be among the blocks that DO depend on a token), because every case passes by finding nothing and a library that stopped using tokens would leave the whole block green.

## Tests assert compiled CSS, not the declaration

That is where this block's history lives: **the declaration was never the missing part.** An object assertion would have passed throughout the period the background silently did nothing.

- `background-color: var(--site-color-surface)` and `border-color: var(--site-color-border)` — **the var, not a hex.** A compiled hex here would mean the token had been abandoned.
- the hairline on all four **logical** sides
- it **still clips** — a bordered card with square-cornered image children is the same defect the clip exists for, so adding a border must not have displaced it

**Mutation-verified twice:** swapping the token for `#f9fafb` fails the token assertion; renaming it to `color.nonesuch` fails the new definition check by name.

## Verification, repo-wide

- **`pnpm build`: exit 0, 19/19 tasks**
- **`pnpm turbo run check-types lint`: exit 0, 45/45 tasks** — nothing in the repo carries an error
- `blocks-react` **603/603**, `plugin-page-builder` **836/836**, both exit 0

## One process note against myself

While mutation-testing I ran `git checkout` on `card.tsx` with the work **uncommitted**, and wiped it — the exact rule I have been citing all day (*restores to the last COMMIT; commit before mutating*). Recovered by re-applying, then committed **before** repeating the mutation. Recording it because the rule was known and stored as a sentence rather than as a step.
