### PR TITLE
fix(nextly): install a table resolver before the migration runs

### DIFF
--- a/.changeset/migrate-field-groups-resolver.md
+++ b/.changeset/migrate-field-groups-resolver.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+`nextly migrate:field-groups --apply` could not complete.
+
+The command installed no table resolver, so the migration failed at its first system-table read with "Table \"dynamic_collections\" not found in schema registry" — on every database. Previewing was unaffected, which is why it was not caught: a preview stops before the writes that resolve tables, so the command previewed correctly and then failed on the first real run.
+
+Both spellings of the field-group registry are now registered, because this is the one operation that runs while that name is changing.

--- a/packages/nextly/src/cli/commands/__tests__/migrate-field-groups.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/migrate-field-groups.test.ts
@@ -20,12 +20,17 @@ vi.mock("../../../domains/field-groups/migration/run", () => ({
   runFieldGroupMigration,
 }));
 
+const setTableResolver = vi.fn();
+
 vi.mock("../../utils/adapter", () => ({
   validateDatabaseEnv: () => ({ valid: true, errors: [] }),
   withAdapter: async (
     work: (adapter: unknown) => Promise<void>
   ): Promise<void> => {
-    await work({ getCapabilities: () => ({ dialect: "postgresql" }) });
+    await work({
+      getCapabilities: () => ({ dialect: "postgresql" }),
+      setTableResolver,
+    });
   },
 }));
 
@@ -61,6 +66,7 @@ const DRY_RUN_OUTCOME = {
 beforeEach(() => {
   printed.length = 0;
   runFieldGroupMigration.mockReset();
+  setTableResolver.mockReset();
   runFieldGroupMigration.mockResolvedValue(DRY_RUN_OUTCOME);
 });
 
@@ -105,6 +111,26 @@ describe("migrate:field-groups — what it asks the engine for", () => {
       dryRun: false,
       backupConfirmed: false,
     });
+  });
+
+  it("installs a table resolver before the engine runs", async () => {
+    // 🔴 A CLI process has no boot, so nothing installs the adapter's table resolver. Without it
+    // the engine fails at its first registry read with "not found in schema registry", which reads
+    // as a corrupt database rather than a missing wiring step.
+    //
+    // The PREVIEW does not reveal this — it stops before the writes that resolve tables — so a
+    // command verified only by previewing looks correct and fails on the first real run, on every
+    // database. That is exactly what happened before this assertion existed.
+    await runMigrateFieldGroups(
+      { apply: true, backupConfirmed: true },
+      context
+    );
+
+    expect(setTableResolver).toHaveBeenCalledTimes(1);
+    // Installed BEFORE the engine is asked to do anything, not after.
+    expect(setTableResolver.mock.invocationCallOrder[0]).toBeLessThan(
+      runFieldGroupMigration.mock.invocationCallOrder[0]!
+    );
   });
 
   it("rolls back only when --down is given", async () => {

--- a/packages/nextly/src/cli/commands/migrate-field-groups.ts
+++ b/packages/nextly/src/cli/commands/migrate-field-groups.ts
@@ -36,7 +36,10 @@ import type { Command } from "commander";
 
 // Type-only, so it is erased at runtime and does not pull the migration engine into the boot
 // graph the way the value import inside the action deliberately avoids.
+import { getDialectTables } from "../../database/index";
+import { SchemaRegistry } from "../../database/schema-registry";
 import type { MigrationOutcome } from "../../domains/field-groups/migration/run";
+import { getFieldGroupRegistryAliases } from "../../domains/field-groups/storage/registry-schemas";
 import { describeError } from "../../errors/index";
 import { createContext, type CommandContext } from "../program";
 import { validateDatabaseEnv, withAdapter } from "../utils/adapter";
@@ -81,12 +84,29 @@ export async function runMigrateFieldGroups(
 
   await withAdapter(
     async adapter => {
+      // 🔴 The engine reaches system tables through the adapter's table resolver, and a CLI process
+      // has no boot to install one — so without this the run fails at the first registry read with
+      // "not found in schema registry", which reads as a corrupt database rather than a missing
+      // wiring step. A preview does not reveal this: it stops before the writes that resolve tables.
+      //
+      // BOTH spellings of the field-group registry are registered, because this command is the one
+      // operation that runs while that name is changing: resolving only the name the database
+      // started with leaves it with no handle the moment the rename lands.
+      const drizzleAdapter = adapter as unknown as DrizzleAdapter;
+      const { dialect } = drizzleAdapter.getCapabilities();
+      const schemaRegistry = new SchemaRegistry(dialect);
+      schemaRegistry.registerStaticSchemas({
+        ...getDialectTables(dialect),
+        ...getFieldGroupRegistryAliases(dialect),
+      });
+      drizzleAdapter.setTableResolver(schemaRegistry);
+
       const { runFieldGroupMigration } = await import(
         "../../domains/field-groups/migration/run"
       );
 
       const outcome = await runFieldGroupMigration({
-        adapter: adapter as unknown as DrizzleAdapter,
+        adapter: drizzleAdapter,
         logger: {
           info: (msg: string) => logger.debug(msg),
           warn: (msg: string) => logger.warn(msg),


### PR DESCRIPTION
🔴 **`nextly migrate:field-groups --apply` cannot complete on any database.** Found by rehearsing the migration end to end on the playground against PostgreSQL.

## What happens

```
✗ Table "dynamic_collections" not found in schema registry.
  Ensure setTableResolver() has been called during boot.
```

A CLI process has no boot, so nothing installs the adapter's table resolver. The engine reaches system tables through it and fails at the first registry read.

## Why #928 shipped with it

**Previewing does not reveal this.** A dry run stops before the writes that resolve tables, so the command previews perfectly and then fails on the first real run. Every check I ran on #928 was a preview or a mocked unit test, and neither can see it.

That is the same shape this program has hit repeatedly: the verification answered a narrower question than the claim it was used for.

## The fix

Register the static schemas plus **both spellings** of the field-group registry, then install the resolver — before the engine is asked to do anything. Both spellings matter because this is the one operation that runs *while* that name is changing: resolving only the name the database started with leaves it with no handle the moment the rename lands. Same pattern as `prune.ts`.

## Verification

Rehearsed on a PostgreSQL playground database carrying **72 field-group rows** across single embeds, repeatables, a dynamic zone, and two localized field groups with `_locales` companions:

- before the fix: apply fails as above;
- after the fix: **25 steps, clean**;
- data compared before/after by content with names normalised — **byte-identical**, the only differences being the intended `table_name` and `config_path` rewrites. `schema_hash` unchanged.
- re-running reports "already at the current storage names", so it stays idempotent.

New regression test asserts the resolver is installed **before** the engine runs. Break control: removing the install fails that test and only that test.

`pnpm build`, `check-types`, `pnpm lint`, `check-comment-convention` all exit 0; command suite 11/11.