### PR TITLE
fix(plugin-page-builder): register the blocks field's control, and drop dead specifiers

### DIFF
--- a/.changeset/fix-admin-component-registration.md
+++ b/.changeset/fix-admin-component-registration.md
@@ -1,0 +1,23 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Fix the page-builder plugin's admin registration. The blocks field named a component the admin could not resolve, so it rendered as an empty group, and three slot specifiers still pointed at components the plugin no longer ships.

--- a/packages/plugin-page-builder/src/admin/index.ts
+++ b/packages/plugin-page-builder/src/admin/index.ts
@@ -1,23 +1,60 @@
 "use client";
 
 /**
- * "./admin" entry — the React surface the entry form mounts for this plugin.
+ * "./admin" entry — REGISTERS the plugin's React admin components, and exports
+ * them.
+ *
+ * The registration is the load-bearing half. A field names its control by
+ * SPECIFIER (`BLOCKS_FIELD_COMPONENT`), and the admin resolves that string
+ * through the component registry — so an entry that exports a component without
+ * registering it leaves every blocks field rendering an empty group with its
+ * label and nothing inside. Nothing type-checks the link, because the link is a
+ * string.
  *
  * One component, where there were five. The other four were the previous
- * editor: an edit view, a field wrapper and two mode toggles, all rendering a
- * canvas and inspector this package implemented itself. Editing now belongs to
- * `@nextlyhq/builder`, and blocks draw through `@nextlyhq/blocks-react`, so the
- * plugin contributes the FIELD and not the editor behind it.
+ * editor: an edit view, a field wrapper and two schema/entry toggles, all
+ * rendering a canvas and inspector this package implemented itself. Editing now
+ * belongs to `@nextlyhq/builder` and blocks draw through
+ * `@nextlyhq/blocks-react`, so the plugin contributes the FIELD and not the
+ * editor behind it.
  *
  * `BlocksSummary` stays because it is the blocks field's own admin surface
  * rather than part of that editor: it reads the stored document through the
  * entry form's control and describes it, importing nothing from this package.
- * `BLOCKS_FIELD_COMPONENT` names it, so removing it would leave every blocks
- * field pointing at a component that no longer resolves — a field that fails to
- * render rather than a field with no editor.
  *
  * @module @nextlyhq/plugin-page-builder/admin
  */
 
-export { BlocksSummary } from "./BlocksSummary";
+import {
+  registerComponents,
+  registerKnownPlugin,
+} from "@nextlyhq/plugin-sdk/admin";
+
+import { BlocksSummary } from "./BlocksSummary";
+
+/**
+ * The blocks field's editor-form control.
+ *
+ * Must match `BLOCKS_FIELD_COMPONENT` exported from the "." entry. The two are
+ * separate declarations of one string because the field is declared in a
+ * Node-safe module and the component only exists behind this client boundary —
+ * so the entry cannot import the constant without dragging React into the
+ * isomorphic bundle. A mismatch is silent: the field renders empty.
+ */
+const BLOCKS_SUMMARY_PATH = "@nextlyhq/plugin-page-builder/admin#BlocksSummary";
+
+const COMPONENTS = {
+  [BLOCKS_SUMMARY_PATH]: BlocksSummary,
+};
+
+// Eager registration on module load.
+registerComponents(COMPONENTS);
+
+// Lazy fallback: the host can trigger registration on demand by package prefix.
+registerKnownPlugin("@nextlyhq/plugin-page-builder", () => {
+  registerComponents(COMPONENTS);
+  return Promise.resolve();
+});
+
+export { BlocksSummary };
 export type { BlocksSummaryProps } from "./BlocksSummary";

--- a/packages/plugin-page-builder/src/admin/registration.test.ts
+++ b/packages/plugin-page-builder/src/admin/registration.test.ts
@@ -1,0 +1,66 @@
+/**
+ * That the component a field NAMES is a component the admin can FIND.
+ *
+ * The blocks field declares its control as a specifier string
+ * (`BLOCKS_FIELD_COMPONENT`), and the admin resolves that string through the
+ * component registry at render time. Nothing type-checks the link, because a
+ * string is not a reference: the field compiles, the entry builds, the suite
+ * passes, and the field renders as an empty group carrying its label and
+ * nothing else — in the admin, at the moment an author opens the form.
+ *
+ * That is not hypothetical. This entry was once rewritten to export the
+ * component without registering it, and every existing test stayed green while
+ * every blocks field in the product rendered blank.
+ *
+ * The two declarations cannot be collapsed into one: the field lives in the
+ * Node-safe "." bundle and the component only exists behind this entry's client
+ * boundary, so importing the constant there would pull React into the
+ * isomorphic bundle. Since the duplication is forced, this asserts the two
+ * agree.
+ *
+ * @module admin/registration.test
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { BLOCKS_FIELD_COMPONENT } from "../fields/blocksField";
+
+// Captured rather than reconstructed. The assertion is about what this module
+// ACTUALLY registers on load, so a test that rebuilt the map from its own
+// literal would keep passing after the real call stopped happening — which is
+// precisely the defect this file exists to catch.
+const registered: Record<string, unknown> = {};
+vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
+  registerComponents: (map: Record<string, unknown>) => {
+    Object.assign(registered, map);
+  },
+  registerKnownPlugin: () => undefined,
+}));
+
+describe("the admin entry's component registration", () => {
+  it("registers the exact specifier the blocks field declares", async () => {
+    // Imported for its side effect, after the mock is in place.
+    await import("./index");
+
+    // The specifier, not merely "something was registered" — a map with one
+    // unrelated entry satisfies a count and leaves the field unresolvable.
+    expect(Object.keys(registered)).toContain(BLOCKS_FIELD_COMPONENT);
+    expect(registered[BLOCKS_FIELD_COMPONENT]).toBeTypeOf("function");
+  });
+
+  it("registers nothing it does not export, so no specifier dangles", async () => {
+    await import("./index");
+    const entry = await import("./index");
+
+    // Every registered path must name an export of this module. A registration
+    // pointing at a component that was deleted resolves to `undefined` and
+    // renders blank, which is the same failure from the other direction.
+    for (const path of Object.keys(registered)) {
+      const name = path.split("#")[1];
+      expect(name, `${path} has no #ComponentName`).toBeTruthy();
+      expect(
+        entry,
+        `${path} names an export this module does not have`
+      ).toHaveProperty(name as string);
+    }
+  });
+});

--- a/packages/plugin-page-builder/src/collections/pages.ts
+++ b/packages/plugin-page-builder/src/collections/pages.ts
@@ -15,16 +15,18 @@ import { editorChoiceFields } from "./editorChoice";
 export const PAGE_BUILDER_CUSTOM_CSS_FIELD = "customCss";
 
 /**
- * Registry path of the full-screen builder Edit view — still exported (and registered)
- * for hosts that want a builder-only collection. The default `pages` collection below
- * instead offers a per-entry CHOICE between the normal Nextly editor and the builder.
+ * There is no builder Edit-view path any more.
+ *
+ * This named a full-screen edit view a host could register for a builder-only
+ * collection. The view is gone with the editor that backed it, and the constant
+ * went with it rather than being kept pointing at a component nothing exports —
+ * a registry path is a STRING, so an unresolvable one fails at render time in
+ * the admin rather than at build time here.
  */
-export const EDIT_VIEW_PATH =
-  "@nextlyhq/plugin-page-builder/admin#PageBuilderEditView";
 
 /**
  * The plugin-owned `pages` collection. Each page CHOOSES its editor (Elementor-style):
- *  - "Page Builder" → the visual block tree (`content`, a `pageBuilderField`).
+ *  - "Page Builder" → the visual block tree (`content`, a `blocks` field).
  *  - "Normal editor" → Nextly's default rich-text form (`body`).
  * The front-end renders whichever was chosen. Using field conditions (not an Edit-view
  * override) keeps the normal editor available — a single Edit view can't offer both.

--- a/packages/plugin-page-builder/src/index.ts
+++ b/packages/plugin-page-builder/src/index.ts
@@ -55,7 +55,7 @@ export type {
   BlocksFieldConfig,
 } from "./fields/blocks-options";
 export { blocks, isBlocksField } from "./fields/blocksHelper";
-export { pagesCollection, EDIT_VIEW_PATH } from "./collections/pages";
+export { pagesCollection } from "./collections/pages";
 export { editorChoiceFields } from "./collections/editorChoice";
 export type { EditorChoiceOptions } from "./collections/editorChoice";
 

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -199,14 +199,20 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) =>
         menu: [
           { label: "Pages", to: "/admin/collections/pages", icon: "Layout" },
         ],
-        // Schema-builder "Use Page Builder" toggle, rendered generically by the
-        // admin above the field list in the collection/single builders.
-        schemaBuilderSlot:
-          "@nextlyhq/plugin-page-builder/admin#PageBuilderToggle",
-        // Per-entry Normal / Page Builder toggle, rendered in the entry/single
-        // form header toolbar (drives the hidden editor-mode field).
-        entryFormToolbarSlot:
-          "@nextlyhq/plugin-page-builder/admin#PageBuilderModeToggle",
+        // No `schemaBuilderSlot` and no `entryFormToolbarSlot`.
+        //
+        // Both named components this package no longer ships: a schema-builder
+        // toggle for turning a collection into a page-builder one, and a
+        // per-entry Normal / Page Builder switch. They belonged to an editor
+        // that stored its own document format, so the choice they offered was
+        // between two storage shapes rather than between two ways of editing
+        // one.
+        //
+        // A slot is registered by SPECIFIER, so nothing type-checks the name:
+        // pointing at a component that is not exported resolves to nothing at
+        // render time, in the admin, at the moment an author opens the form.
+        // Declaring them is therefore worse than omitting them — the admin
+        // reserves the slot either way and only the populated case works.
       },
     },
   });


### PR DESCRIPTION
**A defect I introduced in #934, found by opening the admin rather than by any check.**

## The bug

The `./admin` entry **exported** its component without **registering** it. A
field names its control by specifier string (`BLOCKS_FIELD_COMPONENT`), and the
admin resolves that string through the component registry — so the blocks field
resolved to nothing and rendered as a group carrying its label and an empty
body.

**Nothing failed.** A string is not a reference: build, types, lint and 52 tests
were all green while every blocks field in the product rendered blank.

Measured in the running admin (`/admin/collections/pages/create`):

| | before | after |
| --- | --- | --- |
| "Page Builder" group | `758×20` px, empty | `758×82` px, renders the summary |
| console errors | 0 | 0 |

## Three dead specifiers, same class

Each pointed at a component removed with the previous editor:

- `EDIT_VIEW_PATH` → `#PageBuilderEditView` (exported from the package root)
- `contributes.admin.schemaBuilderSlot` → `#PageBuilderToggle`
- `contributes.admin.entryFormToolbarSlot` → `#PageBuilderModeToggle`

A slot registered against a missing component **reserves the slot and renders
nothing**, so declaring it is worse than omitting it.

## The guard

`admin/registration.test.ts` asserts the specifier the field DECLARES is the
specifier this entry REGISTERS, and that nothing is registered which the module
does not export — covering both directions of the same failure.

It **captures the real call** via a mock rather than rebuilding the map from a
literal. A test that reconstructed the map would keep passing after registration
stopped happening, which is exactly the defect being guarded.

**Stub-verified**: commenting out `registerComponents(COMPONENTS)` — the precise
bug shipped in #934 — fails this test and only this test
(`expected [] to include '…#BlocksSummary'`). Restore proved identical by diff.

## Verification

- 13 files / **54 tests** pass · `check-types` 0 · `lint` clean
- `turbo run build --force` — 20/20, 0 cached
- Verified visually in a real browser against a cleared `.next`

## Not fixed here

The blocks field still shows a **read-only summary** — the editor gap is
deliberate and separate. `packages/builder`'s canvas (#935) is the replacement
and is not yet mounted.