### PR TITLE
feat(builder): move a block with the keyboard, on two axes

### DIFF
--- a/.changeset/builder-keyboard-move.md
+++ b/.changeset/builder-keyboard-move.md
@@ -1,0 +1,52 @@
+---
+
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+
+feat(builder): move a block with the keyboard, on two axes
+
+Dragging was the only way to reorder a block, so the editor could not be used by
+anyone who does not use a pointer.
+
+`keyboardMovePosition` answers where the selected block goes for four intents,
+split across two axes so that each has an inverse: `up` / `down` reorder among
+siblings and never change the parent, `indent` / `outdent` change the parent and
+never reorder anything that stays put. Every press is undone by the opposite
+press, which is what lets someone driving the editor without sight of the result
+recover from a mistaken key.
+
+It reports what the move DOES as well as where it lands, so the wiring can
+announce "moved down" and "moved into Group" differently without re-deriving the
+difference by comparing parents. Moves that change parent also name the slot they
+vacate, because a keyboard author moves one block at a time and emptying a
+container is the common case rather than the rare one.
+
+One asymmetry is deliberate and pinned by a test: `indent` appends, so outdenting
+a block that was not its container's last child and indenting it back returns it
+at the end. Recovering the original index would mean carrying state across
+presses.
+
+Not yet exported from any entry point: it has no consumer until the canvas wires
+it up.

--- a/packages/builder/src/keyboard-move.test.ts
+++ b/packages/builder/src/keyboard-move.test.ts
@@ -1,7 +1,11 @@
 import { moveNode, type BlockNode } from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
 
-import { keyboardMovePosition, type MoveDirection } from "./keyboard-move";
+import {
+  keyboardMovePosition,
+  type MoveDirection,
+  type MoveEffect,
+} from "./keyboard-move";
 
 /** A leaf block. `version` and `props` are required by the node shape. */
 function leaf(id: string): BlockNode {
@@ -49,9 +53,9 @@ function afterMove(
   id: string,
   direction: MoveDirection
 ): string {
-  const to = keyboardMovePosition(nodes, id, direction);
-  if (to === null) return shape(nodes);
-  return shape(moveNode(nodes, id, to));
+  const move = keyboardMovePosition(nodes, id, direction);
+  if (move === null) return shape(nodes);
+  return shape(moveNode(nodes, id, move.to));
 }
 
 describe("up and down reorder among siblings", () => {
@@ -174,7 +178,7 @@ describe("every press is undone by the opposite press", () => {
       out,
       "the fixture must be able to make the first move"
     ).not.toBeNull();
-    const moved = out === null ? nodes : moveNode(nodes, id, out);
+    const moved = out === null ? nodes : moveNode(nodes, id, out.to);
     expect(
       shape(moved),
       "the first move must actually change the document, or the round trip is vacuous"
@@ -182,7 +186,7 @@ describe("every press is undone by the opposite press", () => {
 
     const home = keyboardMovePosition(moved, id, back);
     expect(home, "the block must be able to come back").not.toBeNull();
-    const returned = home === null ? moved : moveNode(moved, id, home);
+    const returned = home === null ? moved : moveNode(moved, id, home.to);
 
     expect(shape(returned)).toBe(before);
   });
@@ -209,14 +213,71 @@ describe("the one asymmetry, asserted rather than left to be discovered", () => 
 
     const out = keyboardMovePosition(nodes, "x", "outdent");
     expect(out).not.toBeNull();
-    const moved = out === null ? nodes : moveNode(nodes, "x", out);
+    const moved = out === null ? nodes : moveNode(nodes, "x", out.to);
     expect(shape(moved)).toBe("a box(y) x");
 
     const back = keyboardMovePosition(moved, "x", "indent");
     expect(back).not.toBeNull();
-    const returned = back === null ? moved : moveNode(moved, "x", back);
+    const returned = back === null ? moved : moveNode(moved, "x", back.to);
 
     // Back inside the container, at the END rather than at index 0.
     expect(shape(returned)).toBe("a box(y x)");
+  });
+});
+
+describe("what the move reports beyond where it lands", () => {
+  /**
+   * A keyboard author cannot see the result, so "moved down" and "moved into
+   * Group" have to be announced differently — and the wiring can only say which
+   * happened if this function tells it. Re-deriving it there by comparing
+   * parents before and after would be a second implementation of a decision
+   * already made here.
+   */
+  it.each<[MoveDirection, string, MoveEffect]>([
+    ["down", "x", "reorder"],
+    ["up", "y", "reorder"],
+    ["outdent", "x", "outdent"],
+  ])("reports %s of a nested block as %s", (direction, id, effect) => {
+    const nodes = [leaf("a"), box("box", [leaf("x"), leaf("y")])];
+    expect(keyboardMovePosition(nodes, id, direction)?.effect).toBe(effect);
+  });
+
+  it("reports an indent as indent", () => {
+    expect(
+      keyboardMovePosition([box("box", [leaf("x")]), leaf("b")], "b", "indent")
+        ?.effect
+    ).toBe("indent");
+  });
+});
+
+describe("the slot a departing block leaves behind", () => {
+  /**
+   * A keyboard author moves ONE block at a time, so emptying a container is the
+   * common case rather than the rare one — and the page-builder validator
+   * rejects a slot left behind empty and undeclared.
+   */
+  it("names the vacated slot when outdenting out of a container", () => {
+    const nodes = [leaf("a"), box("box", [leaf("x")])];
+    expect(
+      keyboardMovePosition(nodes, "x", "outdent")?.dropSlotIfEmpty
+    ).toEqual({ parentId: "box", slot: "default" });
+  });
+
+  it("names nothing when reordering, because nothing is vacated", () => {
+    // Asserted rather than assumed: naming a slot the block has NOT left is
+    // refused by the store, so a blanket value here would turn every reorder
+    // inside a container into an error.
+    const nodes = [box("box", [leaf("x"), leaf("y")])];
+    expect(
+      keyboardMovePosition(nodes, "x", "down")?.dropSlotIfEmpty
+    ).toBeUndefined();
+  });
+
+  it("names nothing when the block was at the top level", () => {
+    // Top level is not a slot, so there is nothing to clean up.
+    expect(
+      keyboardMovePosition([box("box", [leaf("x")]), leaf("b")], "b", "indent")
+        ?.dropSlotIfEmpty
+    ).toBeUndefined();
   });
 });

--- a/packages/builder/src/keyboard-move.test.ts
+++ b/packages/builder/src/keyboard-move.test.ts
@@ -1,0 +1,222 @@
+import { moveNode, type BlockNode } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import { keyboardMovePosition, type MoveDirection } from "./keyboard-move";
+
+/** A leaf block. `version` and `props` are required by the node shape. */
+function leaf(id: string): BlockNode {
+  return { id, type: "core/paragraph", version: 1, props: {} };
+}
+
+/** A container holding `children` in its default slot. */
+function box(id: string, children: BlockNode[]): BlockNode {
+  return {
+    id,
+    type: "core/group",
+    version: 1,
+    props: {},
+    slots: { default: children },
+  };
+}
+
+/**
+ * Every id in the forest, with a container's children in parentheses, so a move
+ * that changes NESTING is visible and not only a reordering.
+ */
+function shape(nodes: BlockNode[]): string {
+  return nodes
+    .map(node => {
+      const children = node.slots?.default;
+      if (children === undefined) return node.id;
+      return `${node.id}(${children.map(c => c.id).join(" ")})`;
+    })
+    .join(" ");
+}
+
+/**
+ * Asks for a move and APPLIES it through the engine, returning the resulting
+ * shape.
+ *
+ * The application is the point. Asserting the returned index would compare this
+ * module's arithmetic against the same arithmetic restated in the test, which
+ * agrees with itself whether or not it agrees with the store — and the store
+ * removes before it inserts, which is exactly where an index is easy to get
+ * wrong. Moving the node for real and reading the tree back cannot pass on an
+ * off-by-one.
+ */
+function afterMove(
+  nodes: BlockNode[],
+  id: string,
+  direction: MoveDirection
+): string {
+  const to = keyboardMovePosition(nodes, id, direction);
+  if (to === null) return shape(nodes);
+  return shape(moveNode(nodes, id, to));
+}
+
+describe("up and down reorder among siblings", () => {
+  it("swaps with the next sibling on the way down", () => {
+    expect(afterMove([leaf("a"), leaf("b"), leaf("c")], "a", "down")).toBe(
+      "b a c"
+    );
+  });
+
+  it("swaps with the previous sibling on the way up", () => {
+    expect(afterMove([leaf("a"), leaf("b"), leaf("c")], "c", "up")).toBe(
+      "a c b"
+    );
+  });
+
+  it("moves ONE place, not two, on the way down", () => {
+    // The direction-specific failure the store's remove-then-insert order
+    // invites. An implementation that forgot the removal shifts later siblings
+    // back would land `a` after `c` while behaving correctly on the way up, so a
+    // suite asserting only "it moved" passes on it.
+    expect(
+      afterMove([leaf("a"), leaf("b"), leaf("c"), leaf("d")], "a", "down")
+    ).toBe("b a c d");
+  });
+
+  it("reorders inside a slot without leaving it", () => {
+    expect(afterMove([box("box", [leaf("x"), leaf("y")])], "x", "down")).toBe(
+      "box(y x)"
+    );
+  });
+
+  it("never changes the parent, even at the end of a container", () => {
+    // The whole reason this axis refuses here. Stepping out on `down` is the
+    // design that has no inverse, and it is the other axis's job.
+    expect(
+      afterMove([leaf("a"), box("box", [leaf("x"), leaf("y")])], "y", "down")
+    ).toBe("a box(x y)");
+  });
+});
+
+describe("indent and outdent change the parent", () => {
+  it("indents into the sibling above, at the end of its children", () => {
+    expect(afterMove([box("box", [leaf("x")]), leaf("b")], "b", "indent")).toBe(
+      "box(x b)"
+    );
+  });
+
+  it("outdents to become the parent's next sibling", () => {
+    expect(
+      afterMove(
+        [leaf("a"), box("box", [leaf("x"), leaf("y")]), leaf("b")],
+        "x",
+        "outdent"
+      )
+    ).toBe("a box(y) x b");
+  });
+
+  it("indents into a leaf, which becomes its parent", () => {
+    // A leaf has no slots yet; the engine creates the slot the position names.
+    // Refusing here would make depth unreachable for any document that is not
+    // already nested, which is every new page.
+    expect(afterMove([leaf("a"), leaf("b")], "b", "indent")).toBe("a(b)");
+  });
+});
+
+describe("when a move is not available", () => {
+  it.each<[string, BlockNode[], string, MoveDirection]>([
+    ["first block, up", [leaf("a"), leaf("b")], "a", "up"],
+    ["last block, down", [leaf("a"), leaf("b")], "b", "down"],
+    ["first block, indent", [leaf("a"), leaf("b")], "a", "indent"],
+    ["top level, outdent", [leaf("a"), leaf("b")], "a", "outdent"],
+    ["an id the document does not hold", [leaf("a")], "ghost", "down"],
+  ])("refuses: %s", (_name, nodes, id, direction) => {
+    expect(keyboardMovePosition(nodes, id, direction)).toBeNull();
+  });
+});
+
+describe("every press is undone by the opposite press", () => {
+  /**
+   * The property that makes a keyboard path usable without sight of the result,
+   * and the one that refuted the first design: a single up/down that stepped out
+   * of a container at its ends had no inverse, because `up` passed the container
+   * rather than re-entering it.
+   *
+   * Asserted per axis, and the intermediate state is required to DIFFER — a pair
+   * of moves that both refused would satisfy "the document is unchanged"
+   * perfectly while proving nothing happened at all.
+   */
+  it.each<[string, BlockNode[], string, MoveDirection, MoveDirection]>([
+    ["reorder, flat", [leaf("a"), leaf("b"), leaf("c")], "b", "down", "up"],
+    [
+      "reorder, in a slot",
+      [box("box", [leaf("x"), leaf("y")])],
+      "x",
+      "down",
+      "up",
+    ],
+    [
+      "depth, into a container",
+      [box("box", [leaf("x")]), leaf("b")],
+      "b",
+      "indent",
+      "outdent",
+    ],
+    // The LAST child, deliberately. `indent` appends, so it can only return a
+    // block to where it started if that was the end of the container — see the
+    // asymmetry asserted below.
+    [
+      "depth, out of a container",
+      [leaf("a"), box("box", [leaf("x"), leaf("y")])],
+      "y",
+      "outdent",
+      "indent",
+    ],
+  ])("%s", (_name, nodes, id, forward, back) => {
+    const before = shape(nodes);
+
+    const out = keyboardMovePosition(nodes, id, forward);
+    expect(
+      out,
+      "the fixture must be able to make the first move"
+    ).not.toBeNull();
+    const moved = out === null ? nodes : moveNode(nodes, id, out);
+    expect(
+      shape(moved),
+      "the first move must actually change the document, or the round trip is vacuous"
+    ).not.toBe(before);
+
+    const home = keyboardMovePosition(moved, id, back);
+    expect(home, "the block must be able to come back").not.toBeNull();
+    const returned = home === null ? moved : moveNode(moved, id, home);
+
+    expect(shape(returned)).toBe(before);
+  });
+});
+
+describe("the one asymmetry, asserted rather than left to be discovered", () => {
+  /**
+   * `indent` appends to the end of the container above, so it cannot know where
+   * in that container a previously-outdented block came from. Outdenting a block
+   * that was NOT the last child therefore loses its position within the slot,
+   * and a single indent brings it back at the end instead.
+   *
+   * This is what every outliner does and it is a real limit rather than a defect
+   * to fix here: recovering the original index would mean the rule carrying
+   * state across presses, which a pure position function cannot do and which
+   * would make each key's effect depend on invisible history.
+   *
+   * Pinned so the limit is a decision on the record. Anyone who later makes the
+   * pair symmetric will have to change this test deliberately, rather than
+   * discovering the behaviour from a bug report.
+   */
+  it("loses the slot position when outdenting a block that was not last", () => {
+    const nodes = [leaf("a"), box("box", [leaf("x"), leaf("y")])];
+
+    const out = keyboardMovePosition(nodes, "x", "outdent");
+    expect(out).not.toBeNull();
+    const moved = out === null ? nodes : moveNode(nodes, "x", out);
+    expect(shape(moved)).toBe("a box(y) x");
+
+    const back = keyboardMovePosition(moved, "x", "indent");
+    expect(back).not.toBeNull();
+    const returned = back === null ? moved : moveNode(moved, "x", back);
+
+    // Back inside the container, at the END rather than at index 0.
+    expect(shape(returned)).toBe("a box(y x)");
+  });
+});

--- a/packages/builder/src/keyboard-move.ts
+++ b/packages/builder/src/keyboard-move.ts
@@ -63,7 +63,7 @@
  */
 import { locateNode, type BlockNode } from "@nextlyhq/blocks-engine";
 
-import type { OpPosition } from "./ops";
+import type { OpPosition, SlotAddress } from "./ops";
 
 /**
  * What the author asked for.
@@ -76,6 +76,48 @@ export type MoveDirection = "up" | "down" | "indent" | "outdent";
 
 /** The default slot a block enters when it is indented into a container. */
 const DEFAULT_SLOT = "default";
+
+/**
+ * What a move does, beyond where it lands.
+ *
+ * A bare position cannot say whether the block stayed among its siblings or
+ * changed parent, and the difference is the whole thing a keyboard author cannot
+ * see. Someone driving the editor through a screen reader needs "moved down" and
+ * "moved into Group" announced differently, and the focus draw needs to know the
+ * block left its container. Deriving it in the wiring by comparing parents
+ * before and after would be a second implementation of a decision this function
+ * has already made.
+ */
+export type MoveEffect = "reorder" | "indent" | "outdent";
+
+/** Where a block goes, what that does, and what it leaves behind. */
+export interface KeyboardMove {
+  /** The position, in the shape the op store's `move` consumes. */
+  readonly to: OpPosition;
+  readonly effect: MoveEffect;
+  /**
+   * The slot the block is leaving, when leaving it may empty it.
+   *
+   * Supplied for the depth axis only, because `up` and `down` land the block in
+   * the container it started in and vacate nothing. Without it, moving the last
+   * child out of a container leaves an empty slot the page-builder validator
+   * rejects — and a keyboard author meets that far sooner than a pointer one,
+   * because they move a single block at a time.
+   *
+   * A request rather than a command: the store drops the slot only if it is
+   * actually empty afterwards, so a slot something else has filled stays.
+   */
+  readonly dropSlotIfEmpty?: SlotAddress;
+}
+
+/** The slot a node is vacating, when it sits in one. */
+function vacating(
+  parent: BlockNode | undefined,
+  slot: string | undefined
+): SlotAddress | undefined {
+  if (parent === undefined || slot === undefined) return undefined;
+  return { parentId: parent.id, slot };
+}
 
 /**
  * The list a located node actually sits in.
@@ -139,7 +181,7 @@ export function keyboardMovePosition(
   nodes: BlockNode[],
   selectedId: string,
   direction: MoveDirection
-): OpPosition | null {
+): KeyboardMove | null {
   const here = locateNode(nodes, selectedId);
   if (here === undefined) return null;
 
@@ -151,7 +193,9 @@ export function keyboardMovePosition(
     // Refused at the ends rather than escaping the container. Escaping is the
     // other axis, and doing it here is what cost the inverse.
     if (target < 0 || target >= siblings.length) return null;
-    return positionIn(here.parent, here.slot, target);
+    const to = positionIn(here.parent, here.slot, target);
+    // Reordering lands in the container it started in, so nothing is vacated.
+    return to === null ? null : { to, effect: "reorder" };
   }
 
   if (direction === "outdent") {
@@ -164,7 +208,13 @@ export function keyboardMovePosition(
     // AFTER the parent, so that indenting back in returns the block to where it
     // started. Removing it from inside the parent does not move the parent, so
     // this index needs no correction.
-    return positionIn(outer.parent, outer.slot, outer.index + 1);
+    const to = positionIn(outer.parent, outer.slot, outer.index + 1);
+    if (to === null) return null;
+    return {
+      to,
+      effect: "outdent",
+      dropSlotIfEmpty: vacating(here.parent, here.slot),
+    };
   }
 
   // Indent: become the last child of the sibling immediately above.
@@ -179,8 +229,12 @@ export function keyboardMovePosition(
   // cannot see.
   const into = above.slots?.[DEFAULT_SLOT];
   return {
-    parentId: above.id,
-    slot: DEFAULT_SLOT,
-    index: into?.length ?? 0,
+    to: {
+      parentId: above.id,
+      slot: DEFAULT_SLOT,
+      index: into?.length ?? 0,
+    },
+    effect: "indent",
+    dropSlotIfEmpty: vacating(here.parent, here.slot),
   };
 }

--- a/packages/builder/src/keyboard-move.ts
+++ b/packages/builder/src/keyboard-move.ts
@@ -1,0 +1,186 @@
+/**
+ * Where a block goes when the author moves it with the keyboard.
+ *
+ * Dragging is the only way to reorder a block today, which means the editor is
+ * unusable by anyone who does not use a pointer — a keyboard user, a switch
+ * user, anyone driving the page through a screen reader. That is an
+ * accessibility gap rather than a missing convenience, and it is not closed by
+ * making the drag easier.
+ *
+ * **Two axes, not one.** Order and depth are separate questions, and each key
+ * answers exactly one of them:
+ *
+ * - `up` / `down` — reorder among siblings. Never changes the parent.
+ * - `indent` / `outdent` — change the parent. Never reorders among the blocks
+ *   that stay put.
+ *
+ * @remarks
+ * **Why this is two axes rather than one key that does both.** The tempting
+ * design is a single up/down that reorders in the middle of a container and
+ * steps OUT at its ends, so one key does everything. It was built that way
+ * first, and its round-trip test refuted it: a block that steps out of a
+ * container on `down` does not step back in on `up`, because passing a container
+ * and entering it are different intents and one key cannot mean both. Every
+ * press being undone by the opposite press is not a nicety here — it is what
+ * lets someone driving the editor without sight of the result recover from a
+ * mistaken key. A gesture with no inverse costs exactly the people this exists
+ * for.
+ *
+ * Split across two axes, each operation has an inverse in its own axis:
+ * `up` undoes `down`, and `outdent` undoes `indent`, including the nesting.
+ *
+ * **One asymmetry, stated because it is real and not a defect to fix here.**
+ * `indent` appends to the end of the container above, so it cannot know where in
+ * that container a previously-outdented block came from. Outdenting a block that
+ * was NOT its container's last child therefore loses its position within the
+ * slot, and a single `indent` returns it at the end. Recovering the original
+ * index would mean carrying state across presses, which a pure position function
+ * cannot do and which would make each key's effect depend on invisible history.
+ * Every outliner behaves this way. It is pinned by a test rather than left to be
+ * met in a bug report.
+ *
+ * **This is the outliner convention** — arrows reorder, Tab and Shift-Tab
+ * change depth — which is worth following because it is what an author who has
+ * used any nested-list editor already expects, and because it is the arrangement
+ * that makes both axes total: every position is reachable, and every move is
+ * reversible.
+ *
+ * **This module answers WHERE, never WHETHER.** Locking, validity and cycles are
+ * enforced by the op store, which already owns them; asking here would be a
+ * second implementation of a question that has one. The consequence is real and
+ * repeated in {@link keyboardMovePosition}: a position returned here can still
+ * be refused, so the wiring must handle a refusal rather than assume a non-null
+ * result will apply.
+ *
+ * **Which KEYS produce these directions is not decided here.** This module names
+ * intents; the binding is the wiring's, and belongs with whatever shortcut
+ * resolver the editor already has rather than in a second listener.
+ *
+ * Pure and dependency-light: a forest, an id and a direction in, a position out.
+ * No DOM, no React, no event handling.
+ *
+ * @module keyboard-move
+ */
+import { locateNode, type BlockNode } from "@nextlyhq/blocks-engine";
+
+import type { OpPosition } from "./ops";
+
+/**
+ * What the author asked for.
+ *
+ * `indent` makes the block the last child of the sibling above it; `outdent`
+ * makes it the next sibling of its parent. Those two are inverses, which is the
+ * property the whole design rests on.
+ */
+export type MoveDirection = "up" | "down" | "indent" | "outdent";
+
+/** The default slot a block enters when it is indented into a container. */
+const DEFAULT_SLOT = "default";
+
+/**
+ * The list a located node actually sits in.
+ *
+ * Derived from the location rather than re-walked: `locateNode` already decided
+ * which container holds the node, and a second walk that disagreed with it would
+ * produce an index into a list the node is not in.
+ */
+function siblingsOf(
+  nodes: BlockNode[],
+  parent: BlockNode | undefined,
+  slot: string | undefined
+): BlockNode[] | undefined {
+  if (parent === undefined) return nodes;
+  if (slot === undefined) return undefined;
+  return parent.slots?.[slot];
+}
+
+/** A position addressing a container, or `null` when it cannot be addressed. */
+function positionIn(
+  parent: BlockNode | undefined,
+  slot: string | undefined,
+  index: number
+): OpPosition | null {
+  if (parent === undefined) return { index };
+  // A slot position must name its slot. The engine's `moveNode` silently
+  // declines one that does not, so returning it would read as a key that does
+  // nothing rather than as the malformed request it is.
+  if (slot === undefined) return null;
+  return { parentId: parent.id, slot, index };
+}
+
+/**
+ * Where the selected block lands if the author moves it one step.
+ *
+ * @param nodes - the document's top-level blocks
+ * @param selectedId - the block the author has selected
+ * @param direction - which move they asked for
+ * @returns the position to move it to, or `null` when that move is not
+ * available — the id is not in the document, the block is already at the end of
+ * its container, there is no sibling above it to indent into, or it is already
+ * at the top level and cannot outdent further.
+ *
+ * @remarks
+ * **Indices are stated as the op store consumes them, which is AFTER the node
+ * has been removed.** `moveNode` removes and then re-inserts, so a same-list
+ * step down to `index + 1` is a move of one place rather than two: taking the
+ * node out shifts every later sibling back by one, which exactly absorbs the
+ * difference. Written against a store that inserted before removing, the same
+ * arithmetic would skip a sibling going down and be correct going up — a defect
+ * that appears in only one direction.
+ *
+ * The same removal is why `indent` targets the previous sibling's child count
+ * unadjusted: the node leaves a DIFFERENT list from the one it arrives in, so
+ * that list's length does not change under it.
+ *
+ * **A returned position is not permission.** Locking and validity belong to the
+ * store, so a caller must handle a refusal rather than assume this will apply.
+ */
+export function keyboardMovePosition(
+  nodes: BlockNode[],
+  selectedId: string,
+  direction: MoveDirection
+): OpPosition | null {
+  const here = locateNode(nodes, selectedId);
+  if (here === undefined) return null;
+
+  const siblings = siblingsOf(nodes, here.parent, here.slot);
+  if (siblings === undefined) return null;
+
+  if (direction === "up" || direction === "down") {
+    const target = here.index + (direction === "up" ? -1 : 1);
+    // Refused at the ends rather than escaping the container. Escaping is the
+    // other axis, and doing it here is what cost the inverse.
+    if (target < 0 || target >= siblings.length) return null;
+    return positionIn(here.parent, here.slot, target);
+  }
+
+  if (direction === "outdent") {
+    // Already at the top level: there is no parent to become a sibling of.
+    if (here.parent === undefined) return null;
+
+    const outer = locateNode(nodes, here.parent.id);
+    if (outer === undefined) return null;
+
+    // AFTER the parent, so that indenting back in returns the block to where it
+    // started. Removing it from inside the parent does not move the parent, so
+    // this index needs no correction.
+    return positionIn(outer.parent, outer.slot, outer.index + 1);
+  }
+
+  // Indent: become the last child of the sibling immediately above.
+  const above = siblings[here.index - 1];
+  // Nothing above, so there is nothing to indent into. The first block in a
+  // container has no parent-to-be that would not be itself.
+  if (above === undefined) return null;
+
+  // The block lands in the default slot. A container that already uses a
+  // different slot name keeps it for the children it has; this one addresses
+  // the slot a keyboard author can reach without choosing between regions they
+  // cannot see.
+  const into = above.slots?.[DEFAULT_SLOT];
+  return {
+    parentId: above.id,
+    slot: DEFAULT_SLOT,
+    index: into?.length ?? 0,
+  };
+}


### PR DESCRIPTION
## What

`packages/builder/src/keyboard-move.ts` + test. A pure rule answering where the selected block goes when the author moves it by keyboard. Nothing is wired to it yet.

## Why

Dragging is the only way to reorder a block, so the editor cannot be used by anyone who does not use a pointer — a keyboard user, a switch user, anyone driving the page through a screen reader. That is an accessibility gap, not a missing convenience, and making the drag nicer does not close it.

## Two axes, and the first design was wrong

- `up` / `down` — reorder among siblings. Never changes the parent.
- `indent` / `outdent` — change the parent. Never reorders anything that stays put.

**It was first built as one axis**: up/down that reorders in the middle of a container and steps OUT at its ends, so one key does everything. That is the obvious design and it survived every test I wrote for it except one — the round trip. A block that steps out on `down` does not step back in on `up`, because passing a container and entering it are different intents and one key cannot mean both.

Every press being undone by the opposite press is not a nicety here. It is what lets someone who cannot see the result recover from a mistaken key, so a gesture with no inverse costs exactly the people this exists for. Split across two axes, each operation has an inverse in its own axis.

This is also the outliner convention — arrows reorder, Tab and Shift-Tab change depth — which an author who has used any nested-list editor already expects.

## It reports what it DID, not only where it lands

A bare position cannot say whether the block stayed among its siblings or changed parent, and that difference is precisely what a keyboard author cannot see: "moved down" and "moved into Group" need announcing differently, and the focus draw needs to know the block left its container. `effect` carries it, so the wiring does not re-derive it by comparing parents before and after — which would be a second implementation of a decision already made here.

Moves that change parent also name the slot they vacate. A keyboard author moves one block at a time, so emptying a container is the common case rather than the rare one, and the page-builder validator rejects a slot left behind empty and undeclared. It is a request rather than a command: the store drops the slot only if it really is empty afterwards.

## One asymmetry, pinned rather than left to be discovered

`indent` appends, so it cannot know where in a container a previously-outdented block came from. Outdenting a block that was NOT its container's last child and indenting it back returns it at the end. Recovering the original index would mean carrying state across presses, which a pure position function cannot do and which would make each key's effect depend on invisible history. Every outliner behaves this way. There is a test asserting it, so anyone making the pair symmetric later has to change that test deliberately.

## Verified against the engine, not against my own arithmetic

The tests apply each returned position through `moveNode` and assert the resulting tree SHAPE, with nesting visible. Asserting the returned index would compare this module's arithmetic against the same arithmetic restated in the test — which agrees with itself whether or not it agrees with the store, and the store removes before it inserts, which is exactly where an index is easy to get wrong.

Three stub-verifications, each failing only its intended tests:

| break | result |
|---|---|
| forget the removal shift going down | 5 fail, incl. "moves ONE place, not two" |
| `effect` always `reorder` | exactly 2 fail |
| vacate a slot on every move | exactly 1 fail |

That first break is direction-specific: an implementation that forgot the shift lands a block two places down while behaving correctly going up, so a suite asserting only "it moved" passes on it.

## Gates

`build` 0 · `test` **421 passed (15 files)** · `check-types` 0 · `lint` 0.

## Scope

Not exported from `index.ts` — no consumer until the canvas wires it up, and an unused public export is a surface with no caller to keep it honest. React-free and DOM-free.

**Which KEYS produce these intents is deliberately not decided here.** The binding belongs with the editor's existing shortcut resolver rather than in a second listener. Wiring is one change against the canvas, reviewed by the lane that owns it.