### PR TITLE
feat(builder): hold the edited document in one place, with undo from op inverses

### DIFF
--- a/.changeset/builder-editor-state.md
+++ b/.changeset/builder-editor-state.md
@@ -1,0 +1,23 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Add the builder's editor state: one place a document changes, with undo built from the op layer's own inverses rather than from document snapshots.

--- a/packages/builder/src/editor-state.test.ts
+++ b/packages/builder/src/editor-state.test.ts
@@ -1,0 +1,212 @@
+// @vitest-environment jsdom
+
+/**
+ * What the editor state guarantees beyond what the op layer already does.
+ *
+ * `applyOp` is tested in `ops.test.ts`; nothing here re-asserts that an insert
+ * inserts. What is only true HERE is the bookkeeping around it: that history is
+ * built from the op layer's own inverses, that a new edit invalidates the redo
+ * branch, that a refused op changes nothing at all, and that a selection cannot
+ * outlive the node it names.
+ *
+ * @module editor-state.test
+ */
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { useEditorState, MAX_HISTORY } from "./editor-state";
+import type { BlockDocument, BlockNode } from "@nextlyhq/blocks-engine";
+
+function node(id: string, slots?: Record<string, BlockNode[]>): BlockNode {
+  return {
+    id,
+    type: "core/box",
+    version: 1,
+    props: {},
+    ...(slots ? { slots } : {}),
+  };
+}
+
+function doc(nodes: BlockNode[]): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes };
+}
+
+function ids(d: BlockDocument): string[] {
+  return d.nodes.map(n => n.id);
+}
+
+describe("applying edits", () => {
+  it("moves the document forward and records an undo step", () => {
+    const { result } = renderHook(() =>
+      useEditorState({ initialDocument: doc([node("a")]) })
+    );
+
+    expect(result.current.canUndo).toBe(false);
+
+    act(() => {
+      result.current.apply({
+        kind: "insert",
+        node: node("b"),
+        at: { index: 1 },
+      });
+    });
+
+    expect(ids(result.current.document)).toEqual(["a", "b"]);
+    // The flag must be STATE, not a ref read: a ref mutation schedules no
+    // render, so an undo control would stay disabled after a real edit.
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.undoDepth).toBe(1);
+  });
+
+  it("returns null and changes NOTHING when the op is refused", () => {
+    const { result } = renderHook(() =>
+      useEditorState({ initialDocument: doc([node("a")]) })
+    );
+
+    let outcome: BlockDocument | null = doc([]);
+    act(() => {
+      // Removing a node that is not there.
+      outcome = result.current.apply({ kind: "remove", id: "ghost" });
+    });
+
+    expect(outcome).toBeNull();
+    expect(ids(result.current.document)).toEqual(["a"]);
+    // The part worth pinning: a refused op must not leave a history step, or
+    // undo replays an edit that never happened.
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.undoDepth).toBe(0);
+  });
+});
+
+describe("undo and redo", () => {
+  it("takes an edit back and puts it forward again", () => {
+    const { result } = renderHook(() =>
+      useEditorState({ initialDocument: doc([node("a")]) })
+    );
+
+    act(() => {
+      result.current.apply({
+        kind: "insert",
+        node: node("b"),
+        at: { index: 1 },
+      });
+    });
+    expect(ids(result.current.document)).toEqual(["a", "b"]);
+
+    act(() => result.current.undo());
+    expect(ids(result.current.document)).toEqual(["a"]);
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => result.current.redo());
+    expect(ids(result.current.document)).toEqual(["a", "b"]);
+    expect(result.current.canUndo).toBe(true);
+  });
+
+  it("INVALIDATES the redo branch when a new edit arrives", () => {
+    const { result } = renderHook(() =>
+      useEditorState({ initialDocument: doc([node("a")]) })
+    );
+
+    act(() => {
+      result.current.apply({
+        kind: "insert",
+        node: node("b"),
+        at: { index: 1 },
+      });
+    });
+    act(() => result.current.undo());
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => {
+      result.current.apply({
+        kind: "insert",
+        node: node("c"),
+        at: { index: 1 },
+      });
+    });
+
+    // Those inverses were computed against a document that no longer exists.
+    // Replaying one would apply an edit derived from a tree that has changed
+    // underneath it.
+    expect(result.current.canRedo).toBe(false);
+    expect(ids(result.current.document)).toEqual(["a", "c"]);
+  });
+
+  it("bounds history from the OLD end, keeping the most recent edits", () => {
+    const { result } = renderHook(() =>
+      useEditorState({ initialDocument: doc([]) })
+    );
+
+    act(() => {
+      for (let i = 0; i < MAX_HISTORY + 5; i += 1) {
+        result.current.apply({
+          kind: "insert",
+          node: node(`n${i}`),
+          at: { index: i },
+        });
+      }
+    });
+
+    // Asserted as the CAP, not merely "some number": a stack that dropped the
+    // newest instead would also stay bounded, and would make the last edit the
+    // one an author cannot take back.
+    expect(result.current.undoDepth).toBe(MAX_HISTORY);
+    act(() => result.current.undo());
+    // The most recent insert is what comes off first.
+    expect(ids(result.current.document)).not.toContain(`n${MAX_HISTORY + 4}`);
+  });
+});
+
+describe("selection", () => {
+  it("clears when the selected node is removed", () => {
+    const { result } = renderHook(() =>
+      useEditorState({ initialDocument: doc([node("a"), node("b")]) })
+    );
+
+    act(() => result.current.select("b"));
+    expect(result.current.selectedId).toBe("b");
+
+    act(() => {
+      result.current.apply({ kind: "remove", id: "b" });
+    });
+
+    // A selection outliving its node leaves every panel describing something
+    // the author cannot see.
+    expect(result.current.selectedId).toBeNull();
+  });
+
+  it("clears when the selected node is removed as part of a SUBTREE", () => {
+    // The case an op-inspecting implementation gets wrong: the op names the
+    // container, and the child disappears without being mentioned.
+    const { result } = renderHook(() =>
+      useEditorState({
+        initialDocument: doc([node("parent", { default: [node("child")] })]),
+      })
+    );
+
+    act(() => result.current.select("child"));
+    expect(result.current.selectedId).toBe("child");
+
+    act(() => {
+      result.current.apply({ kind: "remove", id: "parent" });
+    });
+
+    expect(result.current.selectedId).toBeNull();
+  });
+
+  it("SURVIVES an edit that leaves the selected node in place", () => {
+    // The control for the two above. A rule that cleared the selection on every
+    // edit would pass both of them and be useless, so this pins the other side.
+    const { result } = renderHook(() =>
+      useEditorState({ initialDocument: doc([node("a"), node("b")]) })
+    );
+
+    act(() => result.current.select("a"));
+    act(() => {
+      result.current.apply({ kind: "remove", id: "b" });
+    });
+
+    expect(result.current.selectedId).toBe("a");
+  });
+});

--- a/packages/builder/src/editor-state.ts
+++ b/packages/builder/src/editor-state.ts
@@ -1,0 +1,211 @@
+"use client";
+
+/**
+ * The editor's document state: what is being edited, what is selected, and how
+ * to take an edit back.
+ *
+ * The op layer already answers "what does this edit do to the document" and
+ * hands back an inverse with every application. What was missing is the thing
+ * that HOLDS the answer — so every consumer that wanted to edit had to keep its
+ * own copy of the document, its own idea of the selection, and its own undo
+ * stack. Three of those disagree the moment one of them applies an op the
+ * others do not see.
+ *
+ * So this is deliberately the only place a document changes. A panel, a canvas,
+ * a keyboard handler and an agent all reach the same `apply`, and undo works
+ * for all of them because it is built from what the op layer actually did
+ * rather than from what each caller believed it was doing.
+ *
+ * **Undo is the op layer's inverse, not a snapshot of the document.** Snapshots
+ * are the obvious design and they are wrong here for a reason that shows up
+ * late: a document is a tree of unbounded size, so a stack of snapshots grows
+ * with page size times history depth, and the copies are of a value that is
+ * mostly unchanged between steps. An inverse is one op. It also composes with
+ * anything else that produces ops — a collaborative stream, a replayed agent
+ * edit — which a snapshot stack does not.
+ *
+ * @module editor-state
+ */
+
+import type { BlockDocument, DocumentLimits } from "@nextlyhq/blocks-engine";
+import { useCallback, useMemo, useRef, useState } from "react";
+
+import { applyOp, type BuilderOp } from "./ops";
+
+/** How deep the undo history goes before the oldest step is dropped. */
+export const MAX_HISTORY = 100;
+
+export interface EditorState {
+  /** The document as it currently stands. */
+  document: BlockDocument;
+  /** The selected node's id, or null when nothing is selected. */
+  selectedId: string | null;
+  /** Select a node, or clear the selection with null. */
+  select: (id: string | null) => void;
+  /**
+   * Apply an edit. Returns the applied op's outcome, or null when the op was
+   * refused — a caller that needs to know whether its edit landed can ask,
+   * rather than comparing documents afterwards.
+   */
+  apply: (op: BuilderOp) => BlockDocument | null;
+  undo: () => void;
+  redo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  /**
+   * How many edits are on the undo stack.
+   *
+   * Exported because "did anything change" is not answerable from the document
+   * alone: an edit and its undo leave a document equal to the original but not
+   * identical to it, so a host comparing references sees a change and a host
+   * comparing values misses a real one. A depth is the honest signal, and a
+   * test can read it — which a boolean derived inside a component cannot.
+   */
+  undoDepth: number;
+}
+
+export interface UseEditorStateArgs {
+  /** The document to start from. */
+  initialDocument: BlockDocument;
+  /** The caps this site holds its documents to. */
+  limits?: DocumentLimits;
+}
+
+/**
+ * Hold a document and the edits made to it.
+ *
+ * The document is state and the history is a ref: history changes on every edit
+ * but nothing RENDERS from the stacks themselves, only from whether they are
+ * empty, so keeping them in state would re-render every consumer on each edit
+ * to deliver a value none of them read.
+ */
+export function useEditorState({
+  initialDocument,
+  limits,
+}: UseEditorStateArgs): EditorState {
+  const [document, setDocument] = useState<BlockDocument>(initialDocument);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const undoStack = useRef<BuilderOp[]>([]);
+  const redoStack = useRef<BuilderOp[]>([]);
+  // Mirrors the stack lengths so the flags below are STATE and re-render when
+  // they change. Reading `undoStack.current.length` directly would leave an
+  // undo button disabled after the first edit, because a ref mutation does not
+  // schedule a render.
+  const [depths, setDepths] = useState({ undo: 0, redo: 0 });
+
+  /**
+   * Run an op and record its inverse on the given stack.
+   *
+   * Shared by `apply`, `undo` and `redo` because all three are the same
+   * operation with a different destination for the inverse — undo pushes onto
+   * redo and vice versa. Written once so the three cannot disagree about what
+   * a refused op does, which is nothing at all: no state change, no history
+   * entry, and the caller told.
+   */
+  const run = useCallback(
+    (op: BuilderOp, into: "undo" | "redo" | "new"): BlockDocument | null => {
+      let applied;
+      try {
+        applied = applyOp(document, op, limits);
+      } catch {
+        // A refused op is an ordinary outcome, not a crash: an insert past a
+        // cap, a move onto a node that no longer exists, an update to a node a
+        // concurrent edit removed. The caller decides what to say about it.
+        return null;
+      }
+
+      if (into === "new") {
+        undoStack.current.push(applied.inverse);
+        // Bounded from the OLD end. Dropping the newest would make the most
+        // recent edit unrepeatable, which is the one an author is most likely
+        // to want back.
+        if (undoStack.current.length > MAX_HISTORY) undoStack.current.shift();
+        // A new edit invalidates the redo branch: those inverses were computed
+        // against a document that no longer exists, so replaying one would
+        // apply an edit derived from a tree that has since changed.
+        redoStack.current = [];
+      } else if (into === "undo") {
+        undoStack.current.push(applied.inverse);
+      } else {
+        redoStack.current.push(applied.inverse);
+      }
+
+      setDepths({
+        undo: undoStack.current.length,
+        redo: redoStack.current.length,
+      });
+      setDocument(applied.document);
+
+      // A selection pointing at a node this edit removed would leave every
+      // panel describing something the author cannot see. Cleared by asking the
+      // NEW document whether the id is still there, rather than by inspecting
+      // the op — an op that removes a container removes its subtree too, and
+      // the op names only the container.
+      setSelectedId(current =>
+        current !== null && !hasNode(applied.document, current) ? null : current
+      );
+
+      return applied.document;
+    },
+    [document, limits]
+  );
+
+  const apply = useCallback((op: BuilderOp) => run(op, "new"), [run]);
+
+  const undo = useCallback(() => {
+    const op = undoStack.current.pop();
+    if (op === undefined) return;
+    // Popped before running, and NOT pushed back on failure. A refused undo
+    // means the inverse no longer applies to this document, so keeping it would
+    // leave a step that fails every time it is reached — an undo button that
+    // does nothing and never clears.
+    setDepths(d => ({ ...d, undo: undoStack.current.length }));
+    run(op, "redo");
+  }, [run]);
+
+  const redo = useCallback(() => {
+    const op = redoStack.current.pop();
+    if (op === undefined) return;
+    setDepths(d => ({ ...d, redo: redoStack.current.length }));
+    run(op, "undo");
+  }, [run]);
+
+  const select = useCallback((id: string | null) => setSelectedId(id), []);
+
+  return useMemo(
+    () => ({
+      document,
+      selectedId,
+      select,
+      apply,
+      undo,
+      redo,
+      canUndo: depths.undo > 0,
+      canRedo: depths.redo > 0,
+      undoDepth: depths.undo,
+    }),
+    [document, selectedId, select, apply, undo, redo, depths]
+  );
+}
+
+/**
+ * Whether a node id is anywhere in the document.
+ *
+ * An explicit walk rather than the engine's tree helpers, because this asks the
+ * cheapest possible question — presence — and stops at the first hit. The
+ * helpers that find a node also compute its path and parent, which nothing here
+ * reads.
+ */
+function hasNode(doc: BlockDocument, id: string): boolean {
+  const stack = [...doc.nodes];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (node === undefined) continue;
+    if (node.id === id) return true;
+    if (node.slots !== undefined) {
+      for (const children of Object.values(node.slots)) stack.push(...children);
+    }
+  }
+  return false;
+}

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -56,3 +56,14 @@ export type { BuilderCommand, CommandPaletteProps } from "./command-palette";
  */
 export { CANVAS_ROOT_CLASS, Canvas, nodeIdFromEvent } from "./canvas";
 export type { CanvasProps } from "./canvas";
+
+/**
+ * The editor's document state, published beside the canvas because it is a hook
+ * and therefore client-only for the same reason the shell is.
+ *
+ * It is the ONLY place a document changes: the canvas, the panels, a keyboard
+ * handler and an agent all reach the same `apply`, so undo covers every one of
+ * them rather than only the path that happened to implement it.
+ */
+export { MAX_HISTORY, useEditorState } from "./editor-state";
+export type { EditorState, UseEditorStateArgs } from "./editor-state";


### PR DESCRIPTION
The second piece of the new editor, and the spine the rest plugs into.

`ops.ts` already answered *what does this edit do to the document* and handed
back an inverse with every application — and **nothing held the answer**. Any
consumer that wanted to edit had to keep its own document copy, its own
selection and its own history. Three of those disagree the moment one applies
an op the others do not see.

This is now the only place a document changes. The canvas, the panels, a
keyboard handler and an agent all reach the same `apply`, so undo covers every
one of them rather than only the path that happened to implement it.

## Design decisions worth review

- **Undo is the op layer's INVERSE, not a document snapshot.** A document is a
  tree of unbounded size, so a snapshot stack grows with page size × history
  depth while copying a value mostly unchanged between steps. An inverse is one
  op, and it composes with anything else producing ops — a collaborative
  stream, a replayed agent edit.
- **A selection cannot outlive the node it names.** Cleared by asking the NEW
  document whether the id survives, not by reading the op: removing a container
  removes its subtree, and the op names only the container.
- **A refused op changes nothing** — no document change, no history entry, and
  the caller is told. Otherwise undo replays an edit that never happened.
- **History is bounded from the OLD end.** Dropping the newest would make the
  most recent edit the one an author cannot take back.
- **A new edit invalidates the redo branch.** Those inverses were computed
  against a document that no longer exists.
- **`canUndo`/`canRedo` are state, not ref reads.** A ref mutation schedules no
  render, so an undo control would stay disabled after a real edit.

## Verification

- builder suite **404/404**, 15 files · layering guard **18/18**
- `check-types` 0 · `lint` clean · build green

**Stub-verified in BOTH directions**, which is what the selection rule needed:

| break | result |
| --- | --- |
| stop invalidating redo on a new edit | fails *only* `INVALIDATES the redo branch` |
| clear selection on EVERY edit (over-apply) | fails *only* `SURVIVES an edit that leaves the selected node in place` |

That second one is why the control test exists: a naive "clear on every edit"
rule passes both removal cases and is still wrong. Restore proved identical by
diff.

## What this does NOT do

Still not mounted, and there is still no way to ADD a block — a block-library
panel is the next piece. This is the state layer those panels write through.