### PR TITLE
test(admin): cover the chrome-suppression wiring seam

### DIFF
--- a/packages/admin/src/components/layout/__tests__/chrome-suppression-wiring.test.tsx
+++ b/packages/admin/src/components/layout/__tests__/chrome-suppression-wiring.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * The pure resolver is covered in `chrome-suppression.test.ts`. This file covers
+ * the seam that file cannot reach: whether a request made by a CHILD actually
+ * arrives, and whether unmounting that child releases it.
+ *
+ * Worth having separately because the resolver being correct says nothing about
+ * the wiring. A provider that never registered, registered once and cached, or
+ * removed by value instead of by identity would leave every resolver test green.
+ */
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it } from "vitest";
+
+import {
+  ChromeSuppressionProvider,
+  useSuppressAdminChrome,
+  useSuppressedChrome,
+} from "../ChromeSuppression";
+import type { AdminChromeLayer } from "../lib/chrome-suppression";
+
+/**
+ * Stands in for the admin's own chrome: it reports what the layout would hide.
+ *
+ * Reading it out as text rather than asserting on a returned Set keeps the
+ * assertion on the value a RENDER received, which is what the layout consumes.
+ */
+function ChromeProbe() {
+  const hidden = useSuppressedChrome();
+  return (
+    <div data-testid="hidden">
+      {hidden.size === 0 ? "none" : [...hidden].sort().join(",")}
+    </div>
+  );
+}
+
+function ImmersiveSurface({
+  layers,
+  canExit,
+}: {
+  layers: readonly AdminChromeLayer[];
+  canExit: boolean;
+}) {
+  useSuppressAdminChrome({ layers, canExit });
+  return <div>editor</div>;
+}
+
+const hiddenText = () => screen.getByTestId("hidden").textContent;
+
+describe("chrome suppression wiring", () => {
+  it("hides nothing when no surface is mounted", () => {
+    render(
+      <ChromeSuppressionProvider>
+        <ChromeProbe />
+      </ChromeSuppressionProvider>
+    );
+    expect(hiddenText()).toBe("none");
+  });
+
+  it("delivers a child's request to the layout", () => {
+    render(
+      <ChromeSuppressionProvider>
+        <ChromeProbe />
+        <ImmersiveSurface layers={["header", "subSidebar"]} canExit />
+      </ChromeSuppressionProvider>
+    );
+    // The positive control for every negative assertion below: if registration
+    // did not work at all, this is the test that fails first.
+    expect(hiddenText()).toBe("header,subSidebar");
+  });
+
+  it("releases the request when the surface unmounts", () => {
+    function Host({ open }: { open: boolean }) {
+      return (
+        <ChromeSuppressionProvider>
+          <ChromeProbe />
+          {open ? (
+            <ImmersiveSurface layers={["header", "primaryRail"]} canExit />
+          ) : null}
+        </ChromeSuppressionProvider>
+      );
+    }
+    const view = render(<Host open />);
+    expect(hiddenText()).toBe("header,primaryRail");
+    // Navigating away is an unmount. Nothing calls a release explicitly, which
+    // is the property: the chrome comes back with nothing to remember to undo.
+    view.rerender(<Host open={false} />);
+    expect(hiddenText()).toBe("none");
+  });
+
+  it("withholds the rail from a surface that renders no way back", () => {
+    render(
+      <ChromeSuppressionProvider>
+        <ChromeProbe />
+        <ImmersiveSurface
+          layers={["primaryRail", "header", "pageFrame"]}
+          canExit={false}
+        />
+      </ChromeSuppressionProvider>
+    );
+    // Asserted through the real hook rather than by calling the resolver, so a
+    // provider that dropped `canExit` on the way through would fail here.
+    expect(hiddenText()).toBe("header,pageFrame");
+  });
+
+  it("releases only the surface that unmounted", () => {
+    function Host({ second }: { second: boolean }) {
+      return (
+        <ChromeSuppressionProvider>
+          <ChromeProbe />
+          <ImmersiveSurface layers={["header"]} canExit />
+          {second ? <ImmersiveSurface layers={["header"]} canExit /> : null}
+        </ChromeSuppressionProvider>
+      );
+    }
+    // Both ask for the SAME layer, so the two requests are equal by value and
+    // differ only by identity. A provider removing by value releases both and
+    // the header comes back while a surface still wants it hidden.
+    const view = render(<Host second />);
+    expect(hiddenText()).toBe("header");
+    view.rerender(<Host second={false} />);
+    expect(hiddenText()).toBe("header");
+  });
+
+  it("hides nothing when the hook is called outside a provider", () => {
+    // A surface rendered outside the dashboard layout — a test, an auth page —
+    // must not throw. Asserted because the alternative is every call site
+    // guarding, which is a rule each new one has to remember.
+    render(
+      <>
+        <ChromeProbe />
+        <ImmersiveSurface layers={["header"]} canExit />
+      </>
+    );
+    expect(hiddenText()).toBe("none");
+  });
+});


### PR DESCRIPTION
Follow-up to #931, which shipped the mechanism with its **pure resolver** tested and its **wiring untested**.

Splitting the resolver out as a pure function is what named its own blind spot: whether a request made by a CHILD arrives at the layout, and whether unmounting that child releases it. Neither is observable from the resolver, so every resolver test stays green while the wiring is broken. `.claude/rules/reading-a-ci-verdict.md` makes exactly this point — the pure functions became coverable and were covered, and the defect that survived longest lived in the seam the split left outside them.

## Two of these fail against defects the existing tests cannot see

Both confirmed by introducing them, each producing the intended red and nothing else:

| defect introduced | result |
|---|---|
| remove a request by **value** instead of identity | `releases only the surface that unmounted` fails — `expected 'none' to be 'header'` |
| drop the effect's **cleanup** | `releases the request when the surface unmounts` fails — `expected 'header,primaryRail' to be 'none'` |

The first is the one worth having. Two surfaces asking to hide the same layer produce requests equal in every field, so a value-based removal releases both — the chrome returns while a surface still wants it hidden. No resolver test can see it, because the resolver never removes anything.

The second leaves the admin with **no navigation at all** after the surface is gone.

## Also covered

- a child's request actually reaches the layout — the positive control for every negative assertion in the file
- `canExit: false` withholds `primaryRail` **through the real hook**, so a provider dropping `canExit` in transit fails here rather than passing on the resolver's behalf
- the hook outside a provider is inert rather than throwing, asserted rather than assumed — the alternative is a guard every future call site has to remember

Assertions read the value a **render** received rather than a returned `Set`, since the rendered result is what the layout consumes.

## Verification

- `packages/admin` layout suite: **12 files, 74 tests passing** (6 new)
- `pnpm run check-types`: **0 errors**

Tests only — **no changeset**, per `AGENTS.md`.