### PR TITLE
fix(admin): stop reporting a plugin field type as unknown while it loads

### DIFF
--- a/.changeset/plugin-field-type-pending.md
+++ b/.changeset/plugin-field-type-pending.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A field provided by a plugin no longer flashes "Unknown field type" while the admin is still loading which plugins are installed.

--- a/packages/admin/src/components/features/entries/fields/FieldRenderer.fieldtype.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldRenderer.fieldtype.test.tsx
@@ -16,6 +16,13 @@ import {
   registerComponent,
 } from "@admin/lib/plugins/component-registry";
 
+/**
+ * Whether the plugin list has answered. Mutable so one test can put the
+ * renderer in the moment BEFORE it arrives, which is the state every
+ * plugin-typed field passes through on load.
+ */
+let pluginsPending = false;
+
 vi.mock("@admin/context/providers/BrandingProvider", () => ({
   useBranding: () => ({
     plugins: [
@@ -26,11 +33,17 @@ vi.mock("@admin/context/providers/BrandingProvider", () => ({
       },
     ],
   }),
+  useBrandingStatus: () => ({
+    isPending: pluginsPending,
+    isUnavailable: false,
+    isBrandingUnavailable: false,
+  }),
 }));
 
 afterEach(() => {
   clearRegistry();
   vi.restoreAllMocks();
+  pluginsPending = false;
 });
 
 function Form({ children }: { children: ReactNode }) {
@@ -56,6 +69,34 @@ describe("FieldRenderer custom field types (C7/D16)", () => {
     render(
       <Form>
         <FieldRenderer field={field("totally-unknown")} />
+      </Form>
+    );
+    expect(screen.getByText(/unknown field type/i)).toBeInTheDocument();
+  });
+
+  it("does not call a type unknown while the plugin list is still loading", () => {
+    // The list lives in the session-gated half of admin-meta, so it is absent
+    // for a moment on every load — and a plugin-typed field decides what to
+    // render during exactly that moment. Reporting "unknown" there states a
+    // conclusion the data does not support, and it is wrong for every
+    // correctly-configured plugin field on the page.
+    pluginsPending = true;
+    render(
+      <Form>
+        <FieldRenderer field={field("blocks")} />
+      </Form>
+    );
+    expect(screen.queryByText(/unknown field type/i)).not.toBeInTheDocument();
+  });
+
+  it("still reports an unknown type once the list has ARRIVED without it", () => {
+    // The control for the assertion above: it passes on absence, so without
+    // this the same green would follow from a renderer that never reports an
+    // unknown type at all.
+    pluginsPending = false;
+    render(
+      <Form>
+        <FieldRenderer field={field("blocks")} />
       </Form>
     );
     expect(screen.getByText(/unknown field type/i)).toBeInTheDocument();

--- a/packages/admin/src/components/features/entries/fields/FieldRenderer.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldRenderer.tsx
@@ -37,7 +37,10 @@ import { lazy, Suspense, useState, useEffect } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 
 import { PluginSlot } from "@admin/components/shared/plugin-slot";
-import { useBranding } from "@admin/context/providers/BrandingProvider";
+import {
+  useBranding,
+  useBrandingStatus,
+} from "@admin/context/providers/BrandingProvider";
 import { evaluateCondition } from "@admin/lib/builder/condition-evaluator";
 
 import { FieldWrapper } from "./FieldWrapper";
@@ -253,6 +256,17 @@ export function FieldRenderer({
 
   // C7/D16 — plugin-registered custom field types, delivered via /admin-meta.
   const branding = useBranding();
+  /*
+   * The plugin list arrives from the SESSION-GATED half of admin-meta, so it is
+   * absent for a moment on every load — and a field whose type lives in a
+   * plugin is deciding what to render during exactly that moment.
+   *
+   * Read the request's state as well as its answer, because absence means two
+   * different things here: no plugin contributes this type, or the list that
+   * would say so has not come back. Only the first is a fact about the project;
+   * treating the second as one reports a correctly-configured field as broken.
+   */
+  const { isPending: pluginsPending } = useBrandingStatus();
 
   // Determine if field should be read-only or disabled
   // Cast to any to handle fields that don't have readOnly/disabled in their admin options
@@ -552,6 +566,13 @@ export function FieldRenderer({
             />
           );
         }
+        /*
+         * The list that would name this type has not answered yet, so nothing
+         * is known about it. Reporting it as unknown here states a conclusion
+         * the data does not support, and it is the WRONG one for every
+         * plugin-contributed field on the page.
+         */
+        if (pluginsPending) return <EditorSkeleton />;
         return (
           <div className="rounded-lg  border border-destructive bg-destructive/10 p-4 text-center">
             <p className="text-sm text-destructive">


### PR DESCRIPTION
Fixes the `Unknown field type: blocks` error on entry forms.

## The defect

A field whose type comes from a plugin resolves it through `branding.plugins[].fieldTypes`. That list arrives from the **session-gated** half of admin-meta (`/admin-meta/workspace`), so it is **absent for a moment on every load** — and a plugin-typed field is deciding what to render during exactly that moment.

`FieldRenderer` read the list but never the request's state, so "has not answered yet" reached the same branch as "no plugin contributes this type", and drew a red error over a correctly configured field.

## Why it is the state and not the list that was wrong

Absence means two different things here, and only one is a fact about the project:

| observation | meaning |
|---|---|
| list arrived, type not in it | genuinely unknown — the error is correct |
| list has not arrived | **nothing is known yet** — the error is a fabrication |

`useBrandingStatus` exists precisely for this and says so in its own docblock: *"for readers that draw a conclusion from something being MISSING from branding."* `FieldRenderer` is such a reader and was not consulting it. It now renders the editor skeleton until the list answers, and reports an unknown type only once the list has arrived without one.

This is the shape `.claude/rules/derived-checks.md` describes as **an assertion satisfied by absence** — where the passing condition is "no evidence", no evidence *at all* satisfies it perfectly. The remedy there is the same as here: establish that the population has ARRIVED before drawing a verdict from what is in it.

## Testing

Two new cases in `FieldRenderer.fieldtype.test.tsx`, and the second is why the first is worth anything:

- **the message is absent while the list is pending** — stub-verified: removing the guard fails exactly this test and nothing else.
- **the message is still shown once the list has ARRIVED without the type** — the control. The assertion above passes on absence, so without this the same green would follow from a renderer that stopped reporting unknown types altogether.

Existing coverage in that file is unchanged and still passes. The mock gained `useBrandingStatus` because the component now depends on it — a real consequence of the fix, not a workaround.

- `packages/admin` fields suite: **9 files, 52 tests** passing
- `check-types`: **0 errors**
- `lint`: exit 0

## Scope

Affects **every plugin-contributed field type**, not just `blocks` — form-builder's fields hit the same window. The blocks field is simply where it was noticed.

Changeset: `patch`, generated from the `fixed` group and verified (`Checked 1 changeset(s): all cover the group`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom field loading behavior by showing a loading placeholder while field type information is being retrieved.
  * Prevented premature “unknown field type” messages during plugin loading.
  * Unknown field types continue to display an error once loading is complete and no matching type is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->