### PR TITLE
feat(blocks-engine): enforce the parent's half of the nesting rule

### DIFF
--- a/.changeset/enforce-slot-allow.md
+++ b/.changeset/enforce-slot-allow.md
@@ -20,4 +20,4 @@
 "nextly": patch
 ---
 
-Enforce a slot's allow-list. A container declaring which blocks its slot holds is now checked on validation, where only the child half of the nesting rule was checked before.
+Enforce a slot's allow-list. A container declaring which blocks its slot holds is now checked on validation, where only the child half of the nesting rule was checked before. `canNestInSlot` is exported alongside `canNest` and `canBeRoot`, so an editor deciding what to offer or whether to accept a drop can ask both halves of the rule instead of computing one of them itself.

--- a/.changeset/enforce-slot-allow.md
+++ b/.changeset/enforce-slot-allow.md
@@ -1,0 +1,23 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Enforce a slot's allow-list. A container declaring which blocks its slot holds is now checked on validation, where only the child half of the nesting rule was checked before.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -79,7 +79,17 @@ export { measureBytes, surveyDocument } from "./measure-bytes";
 // The nesting rule and the types it answers in. Exported together: a caller
 // that can ask the question must be able to name the verdict it gets back, and
 // a refusal reason it cannot name is one it has to re-derive from the boolean.
-export { canNest, canBeRoot } from "./nesting";
+//
+// BOTH halves ship, because a placement needs both to agree and neither is
+// derivable from the other: `canNest` is the child naming the parents it may
+// sit under, `canNestInSlot` is the container naming what a given slot admits.
+// Exporting only one leaves a caller — an inserter offering block types, a
+// canvas judging a drop — able to ask half the question and obliged to compute
+// the other half itself, which is the second implementation this module exists
+// to prevent. The validator reaches them by relative path and would not have
+// noticed: a module the entry does not name is absent from `dist` however
+// thoroughly it is tested.
+export { canNest, canBeRoot, canNestInSlot } from "./nesting";
 export type { NestingSource, NestingVerdict, NestingRefusal } from "./nesting";
 // The measurement's return type travels with the function. Without it a
 // consumer naming `measureBytes`'s result has to rebuild the union by hand or

--- a/packages/blocks-engine/src/nesting.test.ts
+++ b/packages/blocks-engine/src/nesting.test.ts
@@ -8,7 +8,7 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
-import { canBeRoot, canNest } from "./nesting";
+import { canBeRoot, canNest, canNestInSlot } from "./nesting";
 import type { NestingSource } from "./nesting";
 import { clearBlocks, registerBlocks, registryNestingSource } from "./registry";
 
@@ -157,5 +157,69 @@ describe("a source that answers outside the registry's shape", () => {
     // rather than obeyed: registration is where that declaration is rejected
     // with a message naming it.
     expect(canNest("acme/x", "core/columns", source).allowed).toBe(true);
+  });
+});
+
+describe("canNestInSlot — the parent's half of the rule", () => {
+  const source: NestingSource = {
+    parentsOf: () => undefined,
+    slotAllowOf: (parent, slot) =>
+      parent === "core/accordion" && slot === "children"
+        ? ["core/accordion-item"]
+        : parent === "core/box" && slot === "wide"
+          ? ["core/*"]
+          : undefined,
+  };
+
+  it("admits a type the slot names", () => {
+    expect(
+      canNestInSlot("core/accordion-item", "core/accordion", "children", source)
+        .allowed
+    ).toBe(true);
+  });
+
+  it("REFUSES a type the slot does not name, carrying the permitted set", () => {
+    const verdict = canNestInSlot(
+      "core/heading",
+      "core/accordion",
+      "children",
+      source
+    );
+    expect(verdict.allowed).toBe(false);
+    expect(verdict.reason).toBe("not-allowed-in-slot");
+    // The permitted set travels, because the caller explaining the refusal is
+    // the only place it is still known.
+    expect(verdict.permitted).toEqual(["core/accordion-item"]);
+  });
+
+  it("admits any member of a namespace an entry ends `/*` on", () => {
+    expect(
+      canNestInSlot("core/heading", "core/box", "wide", source).allowed
+    ).toBe(true);
+  });
+
+  it("binds the wildcard to the SEPARATOR, so `core/*` refuses `coreevil/x`", () => {
+    // A prefix test without the `/` admits this, and the name is close enough
+    // to read past in a review.
+    expect(
+      canNestInSlot("coreevil/banner", "core/box", "wide", source).allowed
+    ).toBe(false);
+  });
+
+  it("admits anything when the slot declares no allow-list", () => {
+    // The control for every refusal above: a rule that refused by default would
+    // pass those and make every undeclared slot unfillable.
+    expect(
+      canNestInSlot("core/heading", "core/section", "children", source).allowed
+    ).toBe(true);
+  });
+
+  it("admits anything when the source predates `slotAllowOf` entirely", () => {
+    // An older caller supplying only `parentsOf` keeps the behaviour it had.
+    expect(
+      canNestInSlot("core/heading", "core/accordion", "children", {
+        parentsOf: () => undefined,
+      }).allowed
+    ).toBe(true);
   });
 });

--- a/packages/blocks-engine/src/nesting.test.ts
+++ b/packages/blocks-engine/src/nesting.test.ts
@@ -223,3 +223,63 @@ describe("canNestInSlot — the parent's half of the rule", () => {
     ).toBe(true);
   });
 });
+
+describe("the nesting rule is reachable from the package entry", () => {
+  // Imported as a NAMESPACE and asserted by key at runtime, rather than as
+  // named bindings. A named import of something the entry does not export is a
+  // COMPILE error, so the file would stop building and no assertion in it would
+  // ever run — a red that says the import was malformed and nothing about the
+  // surface. Reading keys off the loaded module makes a missing export a
+  // runtime failure, which is the only kind this file can observe.
+  it("exports both halves of the rule and the registry's source", async () => {
+    const entry = await import("./index");
+
+    // The population first. An entry that failed to load, or that resolved to
+    // something empty, satisfies every membership check below by having no keys
+    // to contradict them — and reports as a clean pass.
+    expect(Object.keys(entry).length).toBeGreaterThan(0);
+    expect(entry).toHaveProperty("canNest");
+
+    // The child's half, the parent's half, and the root case. A caller deciding
+    // a placement needs all three: `block.ts` is explicit that neither half
+    // implies the other, so an entry offering one obliges a consumer to compute
+    // the rest itself.
+    expect(typeof entry.canNest).toBe("function");
+    expect(typeof entry.canNestInSlot).toBe("function");
+    expect(typeof entry.canBeRoot).toBe("function");
+
+    // The adapter that answers both halves from the live registry. Without it a
+    // consumer holding only the rules has to build its own `NestingSource`,
+    // which is where the resolution — not the rule — gets restated.
+    expect(typeof entry.registryNestingSource).toBe("function");
+  });
+
+  it("answers the same verdict through the entry as through the module", async () => {
+    // Membership alone is satisfied by a re-export that resolves to a different
+    // implementation — a shadowing local, a stale barrel, a name rebound during
+    // a refactor. Asking both spellings the same question is what pins the
+    // export to THIS rule rather than to something that merely shares its name.
+    const entry = await import("./index");
+    clearBlocks();
+    registerBlocks([
+      {
+        ...base,
+        name: "core/accordion",
+        slots: { children: { allow: ["core/accordion-item"] } },
+      },
+      { ...base, name: "core/accordion-item" },
+      { ...base, name: "core/heading" },
+    ]);
+    const live = registryNestingSource();
+
+    expect(
+      entry.canNestInSlot("core/heading", "core/accordion", "children", live)
+    ).toEqual(
+      canNestInSlot("core/heading", "core/accordion", "children", live)
+    );
+    expect(
+      entry.canNestInSlot("core/heading", "core/accordion", "children", live)
+        .allowed
+    ).toBe(false);
+  });
+});

--- a/packages/blocks-engine/src/nesting.ts
+++ b/packages/blocks-engine/src/nesting.ts
@@ -38,6 +38,24 @@ export interface NestingSource {
    * declares no restriction.
    */
   parentsOf(type: string): readonly string[] | undefined;
+  /**
+   * The block names a parent's named slot admits, or undefined when the slot
+   * declares no restriction.
+   *
+   * The PARENT's half of the nesting rule, and the counterpart to
+   * {@link NestingSource.parentsOf} rather than a restatement of it. A slot's
+   * allow-list is the container saying what it will hold; `parent` is the child
+   * saying where it makes sense. `block.ts` is explicit that neither implies the
+   * other, so a document satisfying one can violate the other and only asking
+   * both settles a placement.
+   *
+   * Optional so an existing caller that supplies only `parentsOf` keeps
+   * compiling. A source omitting it answers "no restriction" for every slot,
+   * which is the behaviour those callers already had — the alternative, treating
+   * an absent method as a refusal, would make every placement invalid for a
+   * caller that simply predates the field.
+   */
+  slotAllowOf?(parentType: string, slot: string): readonly string[] | undefined;
 }
 
 /**
@@ -52,7 +70,10 @@ export interface NestingSource {
  * second answer with a sentence about choosing another container, which is
  * advice that cannot be followed.
  */
-export type NestingRefusal = "wrong-parent" | "restricted-at-root";
+export type NestingRefusal =
+  | "wrong-parent"
+  | "restricted-at-root"
+  | "not-allowed-in-slot";
 
 /**
  * A refusal carries its reason by construction.
@@ -123,6 +144,40 @@ export function canNest(
   if (parents === undefined) return ALLOWED;
   if (parents.includes(parentType)) return ALLOWED;
   return { allowed: false, reason: "wrong-parent", permitted: parents };
+}
+
+/**
+ * Whether a parent's named SLOT admits `childType`.
+ *
+ * The parent's half of the rule. `canNest` asks the child where it belongs;
+ * this asks the container what it holds, and a placement needs both — a slot
+ * naming a type does not confine that type to it, and a child that restricts
+ * its parents says nothing about which of that parent's slots may hold it.
+ *
+ * An entry ending `/*` matches a namespace, so `core/*` admits every core
+ * block. The wildcard binds to the `/`, which is what stops `core/*` admitting
+ * `coreevil/banner` — a prefix test without the separator would, and the
+ * failure is silent because the name looks close enough to read past.
+ */
+export function canNestInSlot(
+  childType: string,
+  parentType: string,
+  slot: string,
+  source: NestingSource
+): NestingVerdict {
+  const allow = source.slotAllowOf?.(parentType, slot);
+  // Absent OR empty is no restriction, matching `restrictionFor`. An empty
+  // array reaching here as a refusal would make a slot declared `allow: []`
+  // admit nothing at all, which is a slot no document can fill rather than one
+  // that accepts anything — and registration does not reject it.
+  if (!Array.isArray(allow) || allow.length === 0) return ALLOWED;
+  const admitted = allow.some(entry =>
+    entry.endsWith("/*")
+      ? childType.startsWith(entry.slice(0, -1))
+      : entry === childType
+  );
+  if (admitted) return ALLOWED;
+  return { allowed: false, reason: "not-allowed-in-slot", permitted: allow };
 }
 
 /**

--- a/packages/blocks-engine/src/registry.ts
+++ b/packages/blocks-engine/src/registry.ts
@@ -455,7 +455,16 @@ export function registryLookup(): BlockTypeLookup {
  * re-register rather than capturing the definitions present when it was built.
  */
 export function registryNestingSource(): NestingSource {
-  return { parentsOf: name => getBlock(name)?.parent };
+  return {
+    parentsOf: name => getBlock(name)?.parent,
+    // The parent's half, read from the container's own slot declaration. An
+    // unregistered parent or an undeclared slot answers `undefined` for the same
+    // reason `parentsOf` does: the missing registration is reported by the
+    // block-type lookup, and refusing the placement as well would describe it as
+    // a layout mistake.
+    slotAllowOf: (parentType, slot) =>
+      getBlock(parentType)?.slots?.[slot]?.allow,
+  };
 }
 
 /**

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -24,7 +24,7 @@ import { DEFAULT_LIMITS, LIMIT_WARNING_RATIO } from "./limits";
 import type { DocumentLimits } from "./limits";
 import { surveyDocument } from "./measure-bytes";
 import type { DocumentSurvey } from "./measure-bytes";
-import { canBeRoot, canNest } from "./nesting";
+import { canBeRoot, canNest, canNestInSlot } from "./nesting";
 import type { NestingSource } from "./nesting";
 import { isPlainRecord } from "./plain-record";
 import type { TokenKind } from "./style/catalog-types";
@@ -246,6 +246,8 @@ export const ISSUE_CODES = {
   // mapping that has to be kept in step.
   "wrong-parent":
     "A node declares the block types it may sit under, and its container is not one of them.",
+  "not-allowed-in-slot":
+    "A container's slot declares the block types it holds, and this node is not one of them.",
   "restricted-at-root":
     "A node declares the block types it may sit under, and it sits at the top level, which is inside none of them.",
 } as const;
@@ -515,10 +517,16 @@ export function validateDocument(
       // Children are still walked and still checked for everything else. Only
       // the one question that needs the container's name is recorded as
       // unanswerable rather than answered from a name that does not exist.
-      const childPlacement: Placement = isNodeType(node.type)
-        ? { at: "container", type: node.type }
-        : { at: "unnameable-container" };
+      // The container's name, resolved once; the SLOT differs per iteration, so
+      // the placement is built inside the loop. Hoisting it would carry one
+      // slot's name to every sibling slot's children and check each against the
+      // wrong allow-list — a refusal naming a slot the node is not in.
+      const containerType = isNodeType(node.type) ? node.type : undefined;
       for (const [slot, children] of Object.entries(node.slots)) {
+        const childPlacement: Placement =
+          containerType === undefined
+            ? { at: "unnameable-container" }
+            : { at: "container", type: containerType, slot };
         if (Array.isArray(children)) {
           const slotPath = pointer(pointer(path, "slots"), slot);
           for (
@@ -550,7 +558,7 @@ export function validateDocument(
  */
 type Placement =
   | { at: "root" }
-  | { at: "container"; type: string }
+  | { at: "container"; type: string; slot: string }
   | { at: "unnameable-container" };
 
 /**
@@ -586,10 +594,24 @@ function checkNesting(
   // confident answer to a question the document cannot pose.
   const raw: unknown = node;
   if (!isPlainRecord(raw) || !isNodeType(raw.type)) return;
+  // Both halves, and the CHILD's first. Either refusal is enough, so the order
+  // decides only which reason an author is shown, and "this block belongs
+  // elsewhere" is the more actionable of the two — a slot refusal for a block
+  // that never belonged under this parent describes the symptom rather than the
+  // mistake.
   const verdict =
     placement.at === "root"
       ? canBeRoot(raw.type, source)
-      : canNest(raw.type, placement.type, source);
+      : (() => {
+          const child = canNest(raw.type, placement.type, source);
+          if (!child.allowed) return child;
+          return canNestInSlot(
+            raw.type,
+            placement.type,
+            placement.slot,
+            source
+          );
+        })();
   if (verdict.allowed) return;
   // The refusal's own reason IS the issue code, so a rule added to
   // `NestingRefusal` reaches the document already named rather than through a


### PR DESCRIPTION
A slot's allow-list is the container saying what it holds; `parent` is the child saying where it makes sense. `block.ts` states neither implies the other, and **only the child's half was ever checked** — three blocks declare `allow` (accordion, columns, gallery) and nothing read it, so a `core/heading` inside a `core/accordion` validated clean.

## A correction to my own evidence

My first probe was **invalid**: it supplied `registry` but no `nesting`, so `checkNesting` returned before it looked. It failed for a different reason than the one attributed to it, and would have "found" this defect on a build that fixed it. The finding survives on the grep — `SlotSpec.allow` had no reader anywhere, and `NestingSource` had no method to reach it.

Corrected probe:

| child in `core/accordion` (allows only `accordion-item`) | before | after |
| --- | --- | --- |
| `core/accordion-item` | `[]` | `[]` — positive control, proves validation ran |
| `core/heading` | `[]` | `not-allowed-in-slot` |
| `core/box` | `[]` | `not-allowed-in-slot` |

## Decisions worth review

- **Beside `canNest` in `nesting.ts`**, not in the validator, so a canvas refusing a drop and a save refusing a document cannot drift.
- **`slotAllowOf` is optional on the source** — a caller supplying only `parentsOf` keeps its behaviour.
- **Absent AND empty are both "no restriction"**, matching the child half. Reading an empty allow-list as a refusal makes a slot nothing can fill.
- **The wildcard binds to the SEPARATOR** — `core/*` admits `core/heading`, refuses `coreevil/banner`.
- **Child's half asked FIRST** — order decides only which reason an author sees, and "belongs elsewhere" is more actionable.
- **`Placement` built INSIDE the slot loop** — hoisting carries one slot's name to sibling slots' children.

## Verification

`blocks-engine` **1265/1265** (30 files) · `blocks-react` **603/603** · check-types 0 · lint clean

**Stub-verified both directions:** slicing the wildcard -2 instead of -1 fails *only* the coreevil test; refusing when no allow-list is declared fails *only* the two "admits anything" controls. Restore proved identical by diff.

## Why before the inserter

An inserter offering only valid blocks would be the only thing respecting this rule, so any other writer (import, paste, API, migration, plugin) leaves the invariant already false in the data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for slot-specific nesting rules when placing blocks.
  - Slots can now restrict allowed block types, including namespace-based patterns.
  - Validation reports permitted block types when placement is refused.

- **Bug Fixes**
  - Improved nesting validation to distinguish invalid parent relationships from disallowed slot placements.
  - Added support for unrestricted slots and sources without slot-specific rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->