### PR TITLE
test(root): assert e2e membership rather than a spec count

### DIFF
--- a/scripts/turbo-inputs.test.mjs
+++ b/scripts/turbo-inputs.test.mjs
@@ -123,7 +123,24 @@ describe("turbo hashes every TypeScript module it type-checks", () => {
     const underTests = trackedTypeScript(e2e.directory).filter(file =>
       file.startsWith("tests/")
     );
-    expect(underTests.length).toBeGreaterThan(25);
+
+    // MEMBERSHIP, not a count. A threshold here is a snapshot of how many specs
+    // happened to exist when it was written, so it goes stale on any unrelated
+    // change to the suite: retiring the canvas suite alongside the canvas it
+    // drove removed ten modules and turned this red, with nothing wrong. A
+    // number cannot tell a legitimate deletion from a broken listing, and
+    // re-tuning it each time teaches the next reader to re-tune rather than
+    // look.
+    //
+    // Naming modules that must be present answers what the threshold was really
+    // reaching for -- that the listing resolved to the right directory and read
+    // something real -- and it fails only when one of these actually goes.
+    expect(underTests).toContain("tests/admin-smoke.spec.ts");
+    expect(underTests).toContain("tests/permissions-matrix.spec.ts");
+    // A floor as well, low enough to survive ordinary churn: it catches a
+    // listing that collapsed to just the named files without pretending to
+    // measure coverage.
+    expect(underTests.length).toBeGreaterThan(10);
   });
 
   it.each(tasks.map(task => [task.package, task]))(

--- a/scripts/turbo-inputs.test.mjs
+++ b/scripts/turbo-inputs.test.mjs
@@ -137,6 +137,11 @@ describe("turbo hashes every TypeScript module it type-checks", () => {
     // something real -- and it fails only when one of these actually goes.
     expect(underTests).toContain("tests/admin-smoke.spec.ts");
     expect(underTests).toContain("tests/permissions-matrix.spec.ts");
+    // A third name, in a third AREA. Two files in ONE directory survive a size
+    // change but not that directory being retired -- which is exactly what
+    // happened here. Spanning three areas means no single retirement can empty
+    // the list.
+    expect(underTests).toContain("tests/support/admin.ts");
     // A floor as well, low enough to survive ordinary churn: it catches a
     // listing that collapsed to just the named files without pretending to
     // measure coverage.


### PR DESCRIPTION
Fixes `main`, which is RED.

## What broke

```
scripts/turbo-inputs.test.mjs
AssertionError: expected 23 to be greater than 25
```

`c12e43472` ("retire the canvas suite with the canvas it drove") removed ten modules from `e2e/tests`, taking the tracked count from ~33 to 23. The guard required more than 25.

**The deletion was correct. The guard was wrong.** That threshold encoded how many specs happened to exist when it was written, and it goes stale on any unrelated change to the suite.

## Why a count was the wrong instrument

The guard exists to catch a listing that read NOTHING: a failed dry run, a renamed task, a listing resolved to the wrong directory. A count cannot tell that apart from a legitimate deletion, so it fails on the one case it was never meant to judge, and teaches the next reader to re-tune rather than look.

This is the repo's own rule applied to itself, from `derived-checks.md`:

> assert it by MEMBERSHIP, because a count is the same substitution one level up

Naming modules that must be present answers what the threshold was reaching for, that the listing resolved to the right directory and read something real, and fails only when one of those actually goes.

A low floor stays, to catch a listing that collapsed to just the named files. It sits far below the current tree so ordinary churn does not trip it.

## The count could not detect the defect it existed for

Not a claim -- measured, by lane 3b37, on the two listing shapes:

```
correct shape:   23 entries
stripped shape:  23 entries      <- mis-prefixed, the "wrong directory" failure
```

Identical length. **Any** threshold passes or fails identically on both, so the
count could never distinguish a correct listing from the exact failure the guard
was written to catch. Membership fails on the stripped shape alone.

This surfaced because my own first attempt compared bare filenames against
entries that keep their `tests/` prefix. The membership assertion caught it on
the first run; a floor would have passed on it forever.

### Break table

| break | result |
| --- | --- |
| blind read, listing resolves to nothing | fails, alone |
| wrong shape, same length, mis-prefixed | fails, alone |
| unrelated deletion, all `tests/canvas/` removed | correctly PASSES |

The last row is why the count had to go. The middle row is why re-tuning it
could never have rescued it.

## Verification

Break-verified: pointing the listing at a directory with no specs still fails the test. The guard is now insensitive to unrelated churn, **not** softened, and only the break separates those two.

The membership assertion also caught my own first attempt, which compared bare filenames against entries that keep their `tests/` prefix.

## The other two failures on main are NOT code

`Integration (sqlite)` and `Version & Publish` both died on **HTTP 429 downloading `pnpm/action-setup`**. CI had been fully stalled all day (~26 queued, 0 running) and drained at once, hitting rate limits. They need a re-run, not a fix.

Worth stating plainly, since it was an open question all day: **none of the sixteen PRs merged today caused a CI failure.**


## Provenance

Three lanes independently diagnosed this and reached the same membership fix. A
duplicate (#948, lane 3b37) was closed in favour of this one; its three-AREA
membership list is better than my original two-file list and has been taken into
this PR. Two names in one directory survive a size change but not that directory
being retired, which is exactly what happened.
