### PR TITLE
test(root): assert the e2e population by membership, not by a magic count

### DIFF
--- a/scripts/turbo-inputs.test.mjs
+++ b/scripts/turbo-inputs.test.mjs
@@ -111,8 +111,17 @@ describe("turbo hashes every TypeScript module it type-checks", () => {
   // resolved to the wrong directory. Naming packages that must be present, and
   // a tree whose size is known, means silence has to be earned.
   //
-  // `e2e` is named because it is the package this guard exists for: 30 modules
-  // under `tests/`, none of which the previous input globs reached.
+  // `e2e` is named because it is the package this guard exists for: its modules
+  // under `tests/` are the ones the previous input globs did not reach.
+  //
+  // Named files rather than a count, for the reason stated above and because a
+  // count broke here once. A floor of `> 25` was written when the directory held
+  // 33 modules; retiring ten of them left 23 and turned a correct deletion into a
+  // red `main` on a package the deletion had nothing to do with. A magic number
+  // is a claim about the tree's SIZE, and nobody deleting a file thinks to go and
+  // re-tune it — whereas naming files states what the read must CONTAIN, which is
+  // the property the guard is actually for and which deleting an unrelated module
+  // cannot invalidate.
   it("reads a populated set of packages and their TypeScript", () => {
     expect(tasks.length).toBeGreaterThan(15);
     const names = tasks.map(task => task.package);
@@ -123,7 +132,15 @@ describe("turbo hashes every TypeScript module it type-checks", () => {
     const underTests = trackedTypeScript(e2e.directory).filter(file =>
       file.startsWith("tests/")
     );
-    expect(underTests.length).toBeGreaterThan(25);
+    // Long-lived suites covering three different areas, so the assertion fails
+    // when the READ is blind rather than when the tree changes size.
+    expect(underTests).toEqual(
+      expect.arrayContaining([
+        "tests/admin-smoke.spec.ts",
+        "tests/permissions-matrix.spec.ts",
+        "tests/support/admin.ts",
+      ])
+    );
   });
 
   it.each(tasks.map(task => [task.package, task]))(


### PR DESCRIPTION
## Fixes a red `main`

`Lint / Typecheck / Test / Build` is failing on `origin/main`, so every open PR inherits it:

```
FAIL scripts/turbo-inputs.test.mjs:126
AssertionError: expected 23 to be greater than 25
```

**My change caused it.** `c12e43472` (#936) retired the ten e2e canvas modules that drove the deleted PoC canvas, taking TypeScript files under `e2e/tests` from **33 to 23**. The floor of `> 25` was written when the directory held 33. The deletion was correct; the magic number was not updated with it, and nothing connected the two.

## Why not just lower the number

Because it would break again, the same way, on the next correct deletion — and the file already says so. Its own comment three lines above states the principle:

> The population, before any verdict, and asserted by **MEMBERSHIP** rather than by a count. "No package has an unhashed module" is satisfied perfectly by a run that read nothing.

Then the `e2e` case uses a count. A magic number is a claim about the tree's SIZE; the property the guard actually wants is what the read must CONTAIN. Nobody deleting a file thinks to re-tune a floor in an unrelated script, which is exactly how a correct change turned `main` red on a package it had nothing to do with.

So the count is replaced by named files — three long-lived suites across three different areas:

```js
expect(underTests).toEqual(
  expect.arrayContaining([
    "tests/admin-smoke.spec.ts",
    "tests/permissions-matrix.spec.ts",
    "tests/support/admin.ts",
  ])
);
```

## Verified in both directions, and the pair is the point

| break | old floor | new assertion |
|---|---|---|
| blind read (`underTests = []`) | fails | **fails** — 1 test, the intended one |
| unrelated deletion (drop all 6 `tests/canvas/` files) | **fails** <- the bug | **passes** |

The second row is the whole fix. The old guard fired on a correct deletion and would keep doing so; the new one is immune to the tree changing size and still catches the failure it exists for.

`pnpm test:scripts` — **491 passed (11 files)**, exit 0.

## Scope

Root test-only, so no changeset. No product code.
