### PR TITLE
feat(admin): show translation progress as one instrument

### DIFF
--- a/.changeset/entry-translation-status-header.md
+++ b/.changeset/entry-translation-status-header.md
@@ -1,0 +1,44 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+feat(admin): show translation progress as one instrument
+
+The entry editor described the same fact in three places: a language switcher
+in the header, per-language status pills in the document rail, and a
+completeness badge in the list. An author had to assemble "where am I, what
+state is everywhere else, and how far along is this document" from three
+fragments two panels apart.
+
+The pills now sit beside the switcher with a completeness bar and a written
+count, as one strip. The document rail keeps the ACTIONS on other languages
+(copy from another language, publish all) — those are document management
+rather than status.
+
+The count is derived once by `translationCounts` and read by both the bar and
+the header's spoken status region, so the two cannot drift. A language present
+in the entry's translation map but no longer configured is ignored rather than
+counted, which previously made "5 of 4" reachable.

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -33,6 +33,7 @@ import { cn } from "@admin/lib/utils";
 
 import { useEntryLocale } from "../EntryLocaleContext";
 import { LanguageSwitcher } from "../LanguageSwitcher";
+import { TranslationStatus, translationCounts } from "../TranslationStatus";
 
 import { AutoSaveIndicator } from "./AutoSaveIndicator";
 import { DiscardDraftConfirmDialog } from "./DiscardDraftConfirmDialog";
@@ -259,7 +260,19 @@ export function EntrySystemHeader({
   const entryLocale = useEntryLocale();
   // The default language is edited with `locale === undefined`, and its status
   // can live on the companion, so resolve it to read the right lifecycle.
-  const { defaultLocale } = useLocalization();
+  const { defaultLocale, locales } = useLocalization();
+  // Present only when the entry was fetched with `?translation-status=1` on a
+  // localized collection; undefined otherwise, which both consumers below
+  // treat as "nothing to report" rather than as zero progress.
+  const entryTranslations = entry?._translations as
+    | Record<string, { translated: boolean; status?: string }>
+    | undefined;
+  // Derived once and handed to both the visible instrument and the spoken
+  // region, so the two can never disagree about how far along the document is.
+  const counts = translationCounts(
+    entryTranslations,
+    locales.map(l => l.code)
+  );
   const inputRef = useRef<HTMLInputElement>(null);
   const [unpublishOpen, setUnpublishOpen] = useState(false);
   const [discardDraftOpen, setDiscardDraftOpen] = useState(false);
@@ -400,6 +413,20 @@ export function EntrySystemHeader({
         {onLocaleChange && (
           <LanguageSwitcher value={locale} onChange={onLocaleChange} />
         )}
+        {/* Beside the switcher rather than in the document rail: the switcher
+            answers "which language am I editing" and this answers "what state
+            is every other language in", which is the same question continued.
+            Splitting them across two panels made the reader assemble one fact
+            from two places. Self-hides when localization is off. */}
+        <TranslationStatus
+          {...(entryTranslations === undefined
+            ? {}
+            : { translations: entryTranslations })}
+          {...(locale === undefined ? {} : { activeLocale: locale })}
+          {...(onLocaleChange === undefined
+            ? {}
+            : { onSelect: onLocaleChange })}
+        />
         {/* Directly left of the submit cluster, which is where an author looks
             for it: checking how something reads is part of deciding to publish
             it, not a document-management action like Duplicate or Delete. The
@@ -450,6 +477,12 @@ export function EntrySystemHeader({
           isSaving={autosaveStatus === "saving"}
           isDirty={isDirty}
           lastSavedAt={autosaveLastSavedAt}
+          {...(entryTranslations === undefined
+            ? {}
+            : {
+                translatedCount: counts.translated,
+                localeCount: counts.total,
+              })}
         />
         {hasStatus && isPublishedEdit ? (
           <>

--- a/packages/admin/src/components/features/entries/EntryForm/panels/DocumentPanel.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/panels/DocumentPanel.tsx
@@ -8,8 +8,6 @@ import { useAdminDateFormatter } from "@admin/hooks/useAdminDateFormatter";
 import { cn } from "@admin/lib/utils";
 
 import { CopyFromLanguageMenu } from "../../CopyFromLanguageMenu";
-import { useEntryLocale } from "../../EntryLocaleContext";
-import { LanguageStatusPills } from "../../LanguageStatusPills";
 import { PublishAllLanguagesButton } from "../../PublishAllLanguagesButton";
 import type { EntryData, EntryFormMode } from "../useEntryForm";
 
@@ -132,19 +130,18 @@ function TranslationsRow({
   translations?: Record<string, { translated: boolean; status?: string }>;
   hasStatus?: boolean;
 }) {
-  const { locale, onLocaleChange } = useEntryLocale();
   if (!translations) return null;
   return (
     <div className="mt-4 pt-4 border-t border-border">
       <p className="text-xs font-bold tracking-[0.1em] uppercase text-muted-foreground mb-2">
         Languages
       </p>
-      <LanguageStatusPills
-        translations={translations}
-        activeLocale={locale}
-        onSelect={onLocaleChange}
-      />
-      <div className="mt-3 flex flex-wrap gap-2">
+      {/* The per-language pills moved to the entry header, beside the language
+          switcher, where they sit with the completeness bar as one instrument.
+          They were describing the same fact the switcher describes, two panels
+          apart. What stays here are the ACTIONS on other languages, which are
+          document management rather than status. */}
+      <div className="flex flex-wrap gap-2">
         <CopyFromLanguageMenu />
         <PublishAllLanguagesButton hasStatus={hasStatus} />
       </div>

--- a/packages/admin/src/components/features/entries/TranslationStatus.tsx
+++ b/packages/admin/src/components/features/entries/TranslationStatus.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+/**
+ * TranslationStatus — the entry header's single translation instrument.
+ *
+ * Three separate controls used to describe the same underlying fact in three
+ * places: a language switcher, a row of per-language pills, and a completeness
+ * badge in the list view. Read together they answer one question in three
+ * fragments — where am I, what state is everywhere else in, and how far along
+ * is the document as a whole — so they are presented as one strip: a
+ * completeness bar, then one pill per language.
+ *
+ * The pills themselves stay in `LanguageStatusPills`; this composes that rather
+ * than restating it, so there is one implementation of what a language's state
+ * looks like.
+ *
+ * @module components/features/entries/TranslationStatus
+ */
+
+import { useLocalization } from "@admin/hooks/useLocalization";
+import { cn } from "@admin/lib/utils";
+
+import {
+  LanguageStatusPills,
+  type LocaleTranslationMeta,
+} from "./LanguageStatusPills";
+
+export interface TranslationCounts {
+  /** Languages carrying a translation, whatever its publish state. */
+  translated: number;
+  /** Of those, how many are published. */
+  published: number;
+  /** Languages configured for the app. */
+  total: number;
+}
+
+/**
+ * How far along the document's translations are.
+ *
+ * Exported and used by every caller that needs these numbers — the bar below,
+ * and the header's spoken status region. Two places counting "how many
+ * languages are translated" from the same map would agree on the day they were
+ * written and drift silently afterwards.
+ */
+export function translationCounts(
+  translations: Record<string, LocaleTranslationMeta> | undefined,
+  localeCodes: readonly string[]
+): TranslationCounts {
+  let translated = 0;
+  let published = 0;
+  for (const code of localeCodes) {
+    const meta = translations?.[code];
+    if (!meta?.translated) continue;
+    translated += 1;
+    if (meta.status === "published") published += 1;
+  }
+  return { translated, published, total: localeCodes.length };
+}
+
+export interface TranslationStatusProps {
+  /** The entry's `_translations` map, keyed by locale code. */
+  translations?: Record<string, LocaleTranslationMeta>;
+  /** The active editing locale (undefined = the app default). */
+  activeLocale?: string;
+  /** Called when a language is chosen. */
+  onSelect?: (code: string) => void;
+  className?: string;
+}
+
+/**
+ * The completeness bar: published languages, then merely-translated ones, then
+ * the remainder as untouched track.
+ *
+ * `aria-hidden` because the same numbers are already announced by the header's
+ * status region and written beside the bar in text. A second accessible copy
+ * would have a reader hear the progress twice.
+ */
+function CompletenessBar({ counts }: { counts: TranslationCounts }) {
+  if (counts.total === 0) return null;
+  const pct = (n: number) => `${(n / counts.total) * 100}%`;
+  const partial = Math.max(counts.translated - counts.published, 0);
+  return (
+    <div
+      aria-hidden="true"
+      className="flex h-1.5 w-24 overflow-hidden rounded-sm bg-muted"
+    >
+      <span
+        className="block bg-foreground"
+        style={{ width: pct(counts.published) }}
+      />
+      <span
+        className="block bg-muted-foreground/50"
+        style={{ width: pct(partial) }}
+      />
+    </div>
+  );
+}
+
+/**
+ * TranslationStatus — completeness bar plus per-language pills, as one control.
+ *
+ * Renders nothing when localization is off or the status map has not loaded, so
+ * a non-localized editor is visually unchanged.
+ */
+export function TranslationStatus({
+  translations,
+  activeLocale,
+  onSelect,
+  className,
+}: TranslationStatusProps) {
+  const { enabled, locales } = useLocalization();
+
+  // Nothing to report: not a multilingual app, or the entry was not fetched
+  // with `?translation-status=1`.
+  if (!enabled || !translations || locales.length === 0) return null;
+
+  const counts = translationCounts(
+    translations,
+    locales.map(l => l.code)
+  );
+
+  return (
+    <div className={cn("flex items-center gap-2.5", className)}>
+      <CompletenessBar counts={counts} />
+      {/* Written out rather than left to the bar alone: a bar is a comparison,
+          and the reader wants the number. */}
+      <span className="text-xs whitespace-nowrap text-muted-foreground tabular-nums">
+        {counts.translated} of {counts.total}
+      </span>
+      <LanguageStatusPills
+        translations={translations}
+        {...(activeLocale === undefined ? {} : { activeLocale })}
+        {...(onSelect === undefined ? {} : { onSelect })}
+      />
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/entries/__tests__/TranslationStatus.test.tsx
+++ b/packages/admin/src/components/features/entries/__tests__/TranslationStatus.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * TranslationStatus — one instrument for "how far along are the translations".
+ *
+ * `translationCounts` is the shared derivation: the visible bar and the
+ * header's spoken region both read it, so it is tested directly rather than
+ * only through what the component renders.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { translationCounts } from "../TranslationStatus";
+
+const CODES = ["en", "es", "fr", "de"] as const;
+
+describe("translationCounts", () => {
+  it("counts only languages that carry a translation", () => {
+    const counts = translationCounts(
+      {
+        en: { translated: true, status: "published" },
+        es: { translated: true, status: "draft" },
+        fr: { translated: false },
+      },
+      CODES
+    );
+    expect(counts).toEqual({ translated: 2, published: 1, total: 4 });
+  });
+
+  it("counts a language absent from the map as untranslated", () => {
+    // `de` is configured but has no entry at all, which is different from an
+    // entry saying `translated: false` and must count the same way.
+    const counts = translationCounts(
+      { en: { translated: true, status: "published" } },
+      CODES
+    );
+    expect(counts).toEqual({ translated: 1, published: 1, total: 4 });
+  });
+
+  it("treats a missing map as nothing translated rather than as an error", () => {
+    expect(translationCounts(undefined, CODES)).toEqual({
+      translated: 0,
+      published: 0,
+      total: 4,
+    });
+  });
+
+  it("ignores locales the app does not configure", () => {
+    // The map can carry a language that was removed from the config. Counting
+    // it would report progress against a denominator that does not include it,
+    // so `5 of 4` becomes possible.
+    const counts = translationCounts(
+      {
+        en: { translated: true, status: "published" },
+        zz: { translated: true, status: "published" },
+      },
+      CODES
+    );
+    expect(counts.translated).toBe(1);
+    expect(counts.total).toBe(4);
+  });
+
+  it("never reports more published than translated", () => {
+    // published is a subset of translated by construction; a language marked
+    // published without being translated would otherwise make the bar's second
+    // segment negative.
+    const counts = translationCounts(
+      { en: { translated: false, status: "published" } },
+      CODES
+    );
+    expect(counts.published).toBeLessThanOrEqual(counts.translated);
+    expect(counts.published).toBe(0);
+  });
+
+  it("reports zero total when no locales are configured", () => {
+    expect(translationCounts({ en: { translated: true } }, [])).toEqual({
+      translated: 0,
+      published: 0,
+      total: 0,
+    });
+  });
+});


### PR DESCRIPTION
Completes the multilingual UI work (tracker row **T-07**, previously unowned).
Approved from the visual proposal; this is the last of the three changes from it.

## The problem

The entry editor described one fact in three places — a language switcher in the
header, per-language status pills in the document rail, and a completeness badge
in the list. An author had to assemble *where am I*, *what state is everywhere
else*, and *how far along is this document* from three fragments two panels
apart.

## The change

The pills join the switcher in the header, with a completeness bar and a written
count, as one strip. The document rail keeps the **actions** on other languages
— copy from another language, publish all — because those are document
management rather than status.

## One derivation, two readers

`translationCounts` is exported and read by both the visible bar and the header's
spoken status region. Two places counting "how many languages are translated"
from the same map would agree the day they were written and drift silently
after, which is what `derived-checks.md` forbids.

It also fixed a reachable defect while being written: a language present in the
entry's `_translations` map but **no longer configured** was counted, so
`5 of 4` was possible. Counting now iterates the configured locales, not the map.

## Break-verified

Changing the count to accept any map entry rather than a translated one fails
**2 of 6** tests; restored, 6 pass.

> The restore initially failed and the broken line stayed on disk:
> `git checkout -- <path>` had nothing to restore from because the file was still
> **untracked**. Caught, corrected by hand, and re-verified — noting it because a
> break-verify whose restore silently fails leaves the defect in the commit.

## Verification

`packages/admin`: same 4 pre-existing failing files as `main`, **zero new**.
`check-types` and `lint` clean.

## Two things I could not do

**The `fallow` gate did not run.** `AGENTS.md` requires
`fallow audit --format json --quiet --explain --gate-marker agent` before commit,
and the binary is not installed in this environment — `command not found`, both
directly and via `pnpm fallow:audit`. The repo's own gitleaks precedent is
fail-open for a missing local tool with CI still enforcing, so I proceeded, but
the CI `code-hygiene` job is the first thing to actually run this analysis on the
change. Flagging rather than letting a skipped gate read as a passed one.

**No bot reviewed this.** Codex returns its usage-limit message; CodeRabbit
reports a passing check alongside "Review limit reached — we couldn't start this
review".

## Pre-existing, not from this branch

`packages/ui` → `alpha-utilities.test.ts` fails on `border-destructive/40`, from
`field-group/builder/[slug].tsx`, which this branch does not touch.
