### PR TITLE
fix(release): terminate the frontmatter in two changesets

### DIFF
--- a/.changeset/builder-keyboard-move.md
+++ b/.changeset/builder-keyboard-move.md
@@ -1,5 +1,4 @@
 ---
-
 "nextly": patch
 "create-nextly-app": patch
 "@nextlyhq/admin": patch
@@ -24,6 +23,7 @@
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/builder": patch
 "@nextlyhq/module-specifiers": patch
+---
 
 feat(builder): move a block with the keyboard, on two axes
 

--- a/.changeset/builder-target-switch-travel.md
+++ b/.changeset/builder-target-switch-travel.md
@@ -1,5 +1,4 @@
 ---
-
 "nextly": patch
 "create-nextly-app": patch
 "@nextlyhq/admin": patch
@@ -24,6 +23,7 @@
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/builder": patch
 "@nextlyhq/module-specifiers": patch
+---
 
 feat(builder): hold a drop target until the pointer has travelled a threshold
 


### PR DESCRIPTION
## What is broken

`Version & Publish` fails on every commit, so **no release can be cut**:

```
##[error]could not parse changeset - missing or invalid frontmatter.
```

Two changesets open with `---` and never close it, so the whole file reads as unterminated
frontmatter. `getReleasePlan` reads *every* changeset, so this is not local to those two files — two
malformed ones stop the release for the entire repository.

- `.changeset/builder-keyboard-move.md` — added in 27b8b455f
- `.changeset/builder-target-switch-travel.md` — added in c17e9f671

Each has one `---` (line 1) where it needs two: the package list runs to line 25 and the summary
starts at line 27, with no delimiter between them.

## The fix

Insert the closing `---` after the last package entry. Package lists, bump levels and summaries are
untouched, so the release these files describe is exactly the one their authors declared.

## How it was verified

Diagnosed with the real parser rather than by eye — my first reading blamed a blank line after the
opening delimiter, removed it, and the tool still refused. `@changesets/parse` over all 544
changesets names the two files and nothing else.

```
before:  changeset status -> exit 1, "could not parse changeset"
         parse over 544 changesets -> 2 unparseable
after:   changeset status -> exit 0, "Packages to be bumped at patch: ..."
         parse over 544 changesets -> 0 unparseable
```

The before/after on `changeset status` is the control: the check demonstrably fails on the current
tree and passes on this one, so a green result here means the parse, not an absent check.
Re-verified after `prettier` reformatted both files on commit.

## Scope

No changeset of its own: this alters release metadata rather than anything a user installs.

Not my lane's files — I hit this while confirming why `Version & Publish` was red on the merge
commit of #949. It predates that merge (`e17cde154` was already failing, and the first bad changeset
landed ~7 hours earlier), and it blocks shipping every pending fix, including the migration P0 in
#949.

## Unrelated red

`Lint / Typecheck / Test / Build` is failing repo-wide on a separate pre-existing issue:
`scripts/turbo-inputs.test.mjs:126` asserts more than 25 e2e TypeScript modules and the tree has 23
since c12e43472 removed the canvas suite. That is owned by the page-builder lane and is not touched
here.
