### PR TITLE
fix(admin): stop the email template panes overlapping below xl

### DIFF
--- a/.changeset/email-template-pane-overlap.md
+++ b/.changeset/email-template-pane-overlap.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The email template editor no longer draws on top of the live preview on narrower screens.

--- a/packages/admin/src/components/features/settings/EmailTemplateForm.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm.tsx
@@ -1629,9 +1629,29 @@ export function EmailTemplateForm({
         )}
 
         {/* ── Body: three panes (fixed rail + two equal panes) ── */}
+        {/*
+         * `auto-rows-min` is what makes the stacked layout scroll instead of
+         * overlap, and it is load-bearing below `xl`.
+         *
+         * Stacked, the panes are rows of a grid whose own height is definite
+         * (`flex-1` inside a fixed-height column). Default `auto` rows in a
+         * definite-height grid are STRETCHED to fill it, so three rows share
+         * the height and each lands near 250px — while the editor and preview
+         * carry `min-h-[380px]` and `min-h-[420px]` floors. A row shorter than
+         * its content would normally scroll, but each pane also carries
+         * `min-h-0` and its overflow is only hidden at `xl`, so the content
+         * spilled out of its own row and drew on top of the pane below it.
+         *
+         * Sizing the rows to their content instead lets `overflow-y-auto` on
+         * this container do the scrolling, which is what it was there for.
+         *
+         * Reset at `xl`, where the panes become side-by-side columns that must
+         * FILL the viewport height rather than shrink to their content —
+         * `min-content` there leaves a dead band below them.
+         */}
         <div
           className={cn(
-            "grid min-h-0 flex-1 grid-cols-1 overflow-y-auto xl:overflow-hidden",
+            "grid min-h-0 flex-1 auto-rows-min grid-cols-1 overflow-y-auto xl:auto-rows-auto xl:overflow-hidden",
             railOpen ? "xl:grid-cols-[320px_1fr_1fr]" : "xl:grid-cols-[1fr_1fr]"
           )}
         >


### PR DESCRIPTION
The HTML editor was **drawn on top of the live preview** on every screen narrower than 1280px — up to 233px of one pane painted over the other. Two panes occupying the same pixels, not a spacing complaint.

## Cause, measured

```
gridTemplateRows: 248px 262px 261px   ← sums to exactly the 771px container
editor pane min-height: 380px
pane overflow below xl: visible
```

The three panes are `auto` rows in a grid whose own height is **definite** (`flex-1` inside a fixed-height column), so CSS **stretches them to fit** rather than letting them grow. Each lands near 250px while the editor and preview carry `min-h-[380px]` and `min-h-[420px]` floors. Each pane also sets `min-h-0` and only hides its overflow at `xl`, so the content spilled out of its own row and onto the pane below.

The container's `overflow-y-auto` never engaged, because the rows never exceeded it — the scroll that was supposed to absorb this could not, by construction.

## Fix

`auto-rows-min xl:auto-rows-auto`. Sizing the rows to their content lets the existing `overflow-y-auto` do the scrolling it was already there for.

**Both halves are load-bearing and both were measured.** The `xl` reset is not decoration: without it, desktop panes shrink to 532px inside a 771px container, leaving a 239px dead band — the same bug pointing the other way. Above `xl` the panes are side-by-side columns that must FILL the height rather than shrink to content.

A first hypothesis, `align-content: start`, was discarded because it measured as changing nothing (rows stayed `248px 262px 261px`).

## Verified in a browser, across the band

| viewport | layout | overlap before | overlap after |
|---|---|---|---|
| 960 | stacked | 233px | **0** |
| 1279 | stacked | 210px | **0** |
| 1280 | side-by-side | — | no overflow |
| 1440 | side-by-side | — | no overflow |

The probe reports overlap **only when the panes are stacked** — comparing their `x` first. Without that, side-by-side columns produce a large meaningless "overlap" number and the measurement reads as a defect at exactly the widths where the layout is correct.

## Verification

- `packages/admin` settings suite: **10 files, 125 tests** passing
- `check-types`: **0 errors** · `lint`: exit 0
- The utility is confirmed present in the compiled stylesheet (`dist/styles/globals.css`), since a brand-new Tailwind class does not exist until the admin CSS is rebuilt.

## Note on provenance

Diagnosed earlier and parked at the founder's request; recovered onto current `main` by cherry-pick and **re-verified from scratch** rather than trusting the original measurement — which turned out to matter, because the first recorded note had the wrong viewport label on it and described a symptom ("background stops short") that does not exist.

Changeset: `patch`, generated from the `fixed` group and verified.
