### PR TITLE
fix(nextly): name the remedy when a schema lock cannot be reclaimed

### DIFF
--- a/.changeset/schema-lock-actionable-message.md
+++ b/.changeset/schema-lock-actionable-message.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+When a schema change is blocked by a stale migration lock, the error now names the command that clears it instead of advising a retry that cannot succeed.

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -901,6 +901,24 @@ export async function withMigrationSession<T>(
     // anything that is not already a DatabaseError and would strip this of its
     // status and its context.
     throw NextlyError.serviceUnavailable({
+      /*
+       * "Try again later" is wrong advice for half of what reaches here.
+       *
+       * A lock table that predates `expires_at` grants an owner-only claim,
+       * which has no takeover — so a killed process leaves a claim that no
+       * later run can reclaim, and every schema change refuses until an
+       * operator intervenes. Retrying cannot start working, and the default
+       * message asks the caller to do exactly that.
+       *
+       * Both causes are named because this code cannot tell them apart: that
+       * is the same missing expiry. Saying which one it is would be a guess,
+       * and naming only the transient one is what left a developer restarting
+       * a server that was never going to recover.
+       */
+      publicMessage:
+        "The schema is locked by another run. If none is in progress, the " +
+        "lock predates its expiry column and cannot be reclaimed " +
+        "automatically — run `nextly migrate:field-groups` to add it.",
       logMessage:
         "field-group migration could not take the migration lock; another run holds it",
       logContext: {

--- a/packages/nextly/src/errors/nextly-error.test.ts
+++ b/packages/nextly/src/errors/nextly-error.test.ts
@@ -337,3 +337,32 @@ describe("NextlyError type guards", () => {
     expect(NextlyError.isNotFound(NextlyError.forbidden())).toBe(false);
   });
 });
+
+/**
+ * Some causes of an unavailable service are not transient, and there the
+ * default advice — wait and retry — is the one thing that cannot work.
+ */
+describe("serviceUnavailable public message", () => {
+  it("advises retrying when the caller says nothing else", () => {
+    // The control for the override below: without it, an assertion that the
+    // message equals the override is satisfied by a factory that ignores its
+    // argument and happens to be called with the default text.
+    expect(NextlyError.serviceUnavailable().publicMessage).toBe(
+      "Service unavailable. Please try again later."
+    );
+  });
+
+  it("carries the caller's message when waiting is the wrong advice", () => {
+    const error = NextlyError.serviceUnavailable({
+      publicMessage: "Run `nextly migrate:field-groups`.",
+    });
+    expect(error.publicMessage).toBe("Run `nextly migrate:field-groups`.");
+  });
+
+  it("keeps the code, so callers still classify it as unavailable", () => {
+    // The override changes what a person is told and must not change what a
+    // client branches on.
+    const error = NextlyError.serviceUnavailable({ publicMessage: "anything" });
+    expect(error.code).toBe("SERVICE_UNAVAILABLE");
+  });
+});

--- a/packages/nextly/src/errors/nextly-error.ts
+++ b/packages/nextly/src/errors/nextly-error.ts
@@ -373,13 +373,24 @@ export class NextlyError extends Error {
   // route) can record a specific operator narrative ("Health check failed")
   // while the public message stays canonical per spec §13.8.5.
   static serviceUnavailable(opts?: {
+    /**
+     * What the caller is told, when "try again later" is the wrong advice.
+     *
+     * The default assumes waiting resolves it. Some causes are not transient —
+     * a lock with no expiry is held until an operator clears it — and there the
+     * default sends someone to retry a request that cannot start succeeding.
+     * Supply a message naming what to DO; it reaches an API response, so it
+     * carries a remedy rather than internal state.
+     */
+    publicMessage?: string;
     logMessage?: string;
     cause?: Error;
     logContext?: Record<string, unknown>;
   }): NextlyError {
     return new NextlyError({
       code: "SERVICE_UNAVAILABLE",
-      publicMessage: "Service unavailable. Please try again later.",
+      publicMessage:
+        opts?.publicMessage ?? "Service unavailable. Please try again later.",
       logMessage: opts?.logMessage,
       cause: opts?.cause,
       logContext: opts?.logContext,


### PR DESCRIPTION
This is the defect behind **"I am not able to create a new single"**. Reproduced in a browser: `POST /admin/api/singles` returned **503** on every attempt.

## What the user saw, and why it was the wrong advice

```
Service unavailable. Please try again later.
```

The real cause reached the server log and nothing else:

```
[Nextly HMR] schema reload skipped: [SERVICE_UNAVAILABLE]
  field-group migration could not take the migration lock; another run holds it
  heldBy: "hmr reload#f2826085-..."
```

A lock table predating `expires_at` grants an **owner-only claim**, and an owner-only claim has **no takeover** — `session.ts` documents this deliberately at `:692`. So a killed process leaves a claim no later run can reclaim, and every schema change refuses until an operator intervenes.

**Retrying never starts succeeding. Restarting the server does not clear it either.** The one thing the message told the caller to do was the one thing that could not work.

## The change

`serviceUnavailable` hardcoded its public message, so no caller could say anything else. It now takes an override and keeps the old text as the default — most causes of an unavailable service genuinely are transient, and "try again later" is right for those.

The lock refusal supplies a message naming the remedy: `nextly migrate:field-groups`, which adds the column and restores takeover.

## Why the message names both causes

This code **cannot tell a concurrently held lock from an abandoned one** — that is the same missing expiry column. Claiming either would be a guess, and naming only the transient cause is exactly what left the retry advice standing. So it states both and lets the operator check which they are in.

## Testing

Three cases in `nextly-error.test.ts`, and the second exists to make the first mean something:

| assertion | why |
|---|---|
| the override reaches `publicMessage` | the behaviour being added |
| the default still applies with no override | **control** — without it, the assertion above is satisfied by a factory that ignores its argument and happens to be called with the default text |
| `code` stays `SERVICE_UNAVAILABLE` | the override changes what a person is told; it must not change what a client branches on |

**Stub-verified:** ignoring the override fails exactly the first test, with the control still passing.

- `packages/nextly` errors + field-group migration suites: **29 files, 589 tests** passing
- `check-types`: **0 errors**

## Inherited failure

`origin/main` is red on `scripts/turbo-inputs.test.mjs` (`expected 23 to be greater than 25` — a hardcoded floor invalidated by a legitimate e2e deletion). Every open PR inherits it; a fix is in flight from another lane. This branch touches no e2e module.

Changeset: `patch`, generated from the `fixed` group and verified.
