### PR TITLE
fix(admin): name the settings secret field and verify label landing

### DIFF
--- a/.changeset/settings-label-landing-check.md
+++ b/.changeset/settings-label-landing-check.md
@@ -1,0 +1,42 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(admin): name the settings secret field and verify label landing
+
+`SettingsRow` emits a `<label for>` for every row, while whether anything claims
+that id depends entirely on what the caller passes as children. The email
+provider's secret field wrapped its control in a positioning `<div>` inside
+`FormControl`, which is a Radix `Slot` and clones onto its single child — so the
+id, `aria-describedby` and `aria-invalid` all landed on the div. A label cannot
+name a div, so the API key and SMTP password fields had no accessible name and
+their validation errors were never announced, while the id still resolved.
+
+`FormControl` now sits on the input itself, and a development-time check reports
+both ways a label can fail to reach a control: an id nothing carries, and an id
+carried by an element a label cannot name. The mechanism is shared with the
+entry-form fields, which previously carried a presence-only copy that could not
+see the second case.

--- a/packages/admin/src/components/features/entries/fields/FieldWrapper.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldWrapper.tsx
@@ -14,8 +14,9 @@ import { Label } from "@nextlyhq/ui";
 import { Globe } from "lucide-react";
 import { isFieldLocalized, type FieldConfig } from "nextly/config";
 import type { ReactNode } from "react";
-import { useEffect, useId } from "react";
+import { useId } from "react";
 
+import { useLabelLandingCheck } from "@admin/lib/forms/label-landing";
 import { cn } from "@admin/lib/utils";
 
 import { useEntryLocale } from "../EntryLocaleContext";
@@ -115,9 +116,10 @@ const WIDTH_STYLES: Record<string, string> = {
  * `relationship:tags`, `upload:featuredImage`.
  *
  * The list covers the types this codebase has evidence for. It is deliberately
- * NOT a guess at the rest: `assertLabelLanded` below fires in development for
- * any other type whose label finds no target, so a missing entry announces
- * itself the first time the field is opened instead of failing silently.
+ * NOT a guess at the rest: `useFieldLabelLandingCheck` below fires in
+ * development for any other type whose label finds no usable target, so a
+ * missing entry announces itself the first time the field is opened instead of
+ * failing silently.
  */
 const GROUP_FIELD_TYPES: ReadonlySet<string> = new Set([
   "richText",
@@ -126,29 +128,36 @@ const GROUP_FIELD_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Development-time check that a `<label for>` actually found something.
+ * Development-time check that this field's `<label for>` actually found a
+ * control that can carry a name.
  *
- * The failure this guards is silent by construction: the label renders, the
- * input renders, and only the association is missing. `FieldShell` in
- * `@nextlyhq/ui` carries the same check for the same reason.
+ * The mechanism lives in `@admin/lib/forms/label-landing` and is shared with
+ * the settings rows, which emit their own `<label for>` and can fail in exactly
+ * these two ways. This wrapper supplies only the remedies, since what to do
+ * about a dangling label differs by where the label came from.
  */
-function useLabelLandingCheck(
+function useFieldLabelLandingCheck(
   enabled: boolean,
   targetId: string,
   label: string,
   fieldType: string
 ): void {
-  useEffect(() => {
-    if (!enabled || process.env.NODE_ENV === "production") return;
-    if (typeof document === "undefined") return;
-    if (document.getElementById(targetId)) return;
-    console.warn(
-      `[Nextly] The label "${label}" points at #${targetId}, but no element carries that id. ` +
-        `Field type "${fieldType}" renders no single control the id can attach to, so its label ` +
-        `names nothing. Add "${fieldType}" to GROUP_FIELD_TYPES in FieldWrapper.tsx so the field ` +
-        `is exposed as a group instead.`
-    );
-  }, [enabled, targetId, label, fieldType]);
+  useLabelLandingCheck({
+    enabled,
+    targetId,
+    label,
+    remedies: {
+      absent:
+        `Field type "${fieldType}" renders no single control the id can attach to. ` +
+        `Add "${fieldType}" to GROUP_FIELD_TYPES in FieldWrapper.tsx so the field is ` +
+        `exposed as a group instead.`,
+      notLabelable:
+        `Field type "${fieldType}" put the id on an element a label cannot name — a ` +
+        `wrapper or an editing surface rather than a control. Either move the id onto ` +
+        `the field's focusable control, or add "${fieldType}" to GROUP_FIELD_TYPES in ` +
+        `FieldWrapper.tsx so the field is exposed as a group.`,
+    },
+  });
 }
 
 // ============================================================
@@ -227,7 +236,7 @@ export function FieldWrapper({
   const isGroup = GROUP_FIELD_TYPES.has(_fieldType) || editorIsOpaque;
   // Only the non-group path claims a control carries the id, so only it is
   // checked. A group makes no such claim and cannot fail this way.
-  useLabelLandingCheck(!isGroup && !isHidden, fieldId, label, _fieldType);
+  useFieldLabelLandingCheck(!isGroup && !isHidden, fieldId, label, _fieldType);
   // Announced with the group. The single-control path cannot do this from here:
   // the id lives on an element this component never touches.
   const groupDescribedBy =

--- a/packages/admin/src/components/features/settings/EmailProviderForm/SecretField.test.tsx
+++ b/packages/admin/src/components/features/settings/EmailProviderForm/SecretField.test.tsx
@@ -72,6 +72,31 @@ function secretInput(): HTMLInputElement {
   return input;
 }
 
+describe("the row's label", () => {
+  it("names the credential input itself", () => {
+    render(<Harness initialValue="" storedSecret={false} />);
+    // Queried the way assistive technology resolves a name, rather than by
+    // selector: the id used to land on the positioning wrapper around this
+    // input, which a lookup finds and a label cannot name. Every test in this
+    // file reached the control by `name` or by role, so none of them could see
+    // that the field had no accessible name at all.
+    expect(screen.getByLabelText("API Key")).toBe(secretInput());
+  });
+
+  it("connects the helper text to the input for a stored credential", () => {
+    render(<Harness initialValue={MASKED_SECRET} storedSecret={true} />);
+    const describedBy = secretInput().getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    // The description has to be reachable from the input, not merely present on
+    // the page: `aria-describedby` naming an id is only a promise, and the
+    // element it names is what a screen reader actually reads out.
+    const description = document.getElementById(
+      String(describedBy).split(" ")[0] ?? ""
+    );
+    expect(description?.textContent).toContain("Existing secret is configured");
+  });
+});
+
 describe("a credential made only of the characters the mask uses", () => {
   it("survives a reveal on a create", async () => {
     const user = userEvent.setup();

--- a/packages/admin/src/components/features/settings/EmailProviderForm/SecretField.tsx
+++ b/packages/admin/src/components/features/settings/EmailProviderForm/SecretField.tsx
@@ -118,8 +118,16 @@ export function SecretField({
         return (
           <FormItem className="m-0">
             <SettingsRow label={label} description={helperText}>
-              <FormControl>
-                <div className="relative">
+              {/* FormControl sits on the Input rather than around this wrapper.
+                  It is a Radix Slot, so it clones onto its single child: with
+                  the wrapper inside it, the row's id, aria-describedby and
+                  aria-invalid all landed on a positioning <div>. A <label for>
+                  cannot name a div, so this field had no accessible name and
+                  its error was never announced — while the id resolved, so
+                  every check short of asking what KIND of element received it
+                  reported the field as correctly wired. */}
+              <div className="relative">
+                <FormControl>
                   <Input
                     {...field}
                     ref={node => {
@@ -148,57 +156,57 @@ export function SecretField({
                       field.onBlur();
                     }}
                   />
-                  {showClear && (
-                    <button
-                      type="button"
-                      className="absolute right-10 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-destructive transition-colors"
-                      disabled={disabled}
-                      onClick={() => {
-                        // The keyboard cannot express this. The field shows
-                        // itself as empty while the form holds the mask, so
-                        // Backspace over the displayed blank changes no value
-                        // and fires no `onChange` — leaving an operator who
-                        // wants the credential GONE with no gesture that says
-                        // so. This is that gesture.
-                        setReplaced(true);
-                        field.onChange("");
-                        // The button is about to stop rendering, so focus has
-                        // to be put somewhere deliberate rather than dropped
-                        // onto the document.
-                        inputRef.current?.focus();
-                      }}
-                      aria-label="Remove stored value"
-                    >
-                      <X className="h-4 w-4" />
-                    </button>
-                  )}
+                </FormControl>
+                {showClear && (
                   <button
                     type="button"
-                    tabIndex={-1}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                    // Disabled with the field, as the clear button beside it
-                    // is. Revealing exposes nothing the server did not send,
-                    // but the click also focuses the input, so a submitting
-                    // form would move the caret into a field it has locked.
+                    className="absolute right-10 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-destructive transition-colors"
                     disabled={disabled}
                     onClick={() => {
-                      // A stored secret cannot be revealed — the server never
-                      // sent it. Focusing lets the user type a replacement and
-                      // watch it as they do; typing nothing leaves the stored
-                      // credential exactly as it was.
-                      setVisible(current => !current);
+                      // The keyboard cannot express this. The field shows
+                      // itself as empty while the form holds the mask, so
+                      // Backspace over the displayed blank changes no value
+                      // and fires no `onChange` — leaving an operator who
+                      // wants the credential GONE with no gesture that says
+                      // so. This is that gesture.
+                      setReplaced(true);
+                      field.onChange("");
+                      // The button is about to stop rendering, so focus has
+                      // to be put somewhere deliberate rather than dropped
+                      // onto the document.
                       inputRef.current?.focus();
                     }}
-                    aria-label={visible ? "Hide value" : "Show value"}
+                    aria-label="Remove stored value"
                   >
-                    {visible ? (
-                      <EyeOff className="h-4 w-4" />
-                    ) : (
-                      <Eye className="h-4 w-4" />
-                    )}
+                    <X className="h-4 w-4" />
                   </button>
-                </div>
-              </FormControl>
+                )}
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                  // Disabled with the field, as the clear button beside it
+                  // is. Revealing exposes nothing the server did not send,
+                  // but the click also focuses the input, so a submitting
+                  // form would move the caret into a field it has locked.
+                  disabled={disabled}
+                  onClick={() => {
+                    // A stored secret cannot be revealed — the server never
+                    // sent it. Focusing lets the user type a replacement and
+                    // watch it as they do; typing nothing leaves the stored
+                    // credential exactly as it was.
+                    setVisible(current => !current);
+                    inputRef.current?.focus();
+                  }}
+                  aria-label={visible ? "Hide value" : "Show value"}
+                >
+                  {visible ? (
+                    <EyeOff className="h-4 w-4" />
+                  ) : (
+                    <Eye className="h-4 w-4" />
+                  )}
+                </button>
+              </div>
               <FormMessage className="mt-1.5" />
             </SettingsRow>
           </FormItem>

--- a/packages/admin/src/components/features/settings/SettingsRow.test.tsx
+++ b/packages/admin/src/components/features/settings/SettingsRow.test.tsx
@@ -1,12 +1,25 @@
 import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { useForm } from "react-hook-form";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-import { Form, FormField, FormItem } from "@admin/components/ui/form";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+} from "@admin/components/ui/form";
+import { resetLabelLandingWarnings } from "@admin/lib/forms/label-landing";
 
 import { SettingsRow } from "./SettingsRow";
 
-function Harness({ description }: { description?: string }) {
+function Harness({
+  description,
+  children,
+}: {
+  description?: string;
+  children: ReactNode;
+}) {
   const form = useForm({ defaultValues: { foo: "" } });
   return (
     <Form {...form}>
@@ -16,7 +29,7 @@ function Harness({ description }: { description?: string }) {
         render={() => (
           <FormItem>
             <SettingsRow label="My Label" description={description}>
-              <input data-testid="control" />
+              {children}
             </SettingsRow>
           </FormItem>
         )}
@@ -25,19 +38,105 @@ function Harness({ description }: { description?: string }) {
   );
 }
 
+/** The shape a caller is supposed to write: FormControl directly on the control. */
+function WiredControl() {
+  return (
+    <FormControl>
+      <input data-testid="control" />
+    </FormControl>
+  );
+}
+
 describe("SettingsRow", () => {
   it("renders the label", () => {
-    render(<Harness />);
+    render(<Harness>{<WiredControl />}</Harness>);
     expect(screen.getByText("My Label")).toBeInTheDocument();
   });
 
   it("renders the description when provided", () => {
-    render(<Harness description="extra help" />);
+    render(<Harness description="extra help">{<WiredControl />}</Harness>);
     expect(screen.getByText("extra help")).toBeInTheDocument();
   });
 
   it("renders the control slot", () => {
-    render(<Harness />);
+    render(<Harness>{<WiredControl />}</Harness>);
     expect(screen.getByTestId("control")).toBeInTheDocument();
+  });
+
+  it("associates the label with the control", () => {
+    render(<Harness>{<WiredControl />}</Harness>);
+    // `getByLabelText` resolves the association the way assistive technology
+    // does, so it fails for a label pointing at nothing AND for one pointing at
+    // an element that cannot carry a name — which asserting on `htmlFor` alone
+    // would not.
+    expect(screen.getByLabelText("My Label")).toBe(
+      screen.getByTestId("control")
+    );
+  });
+});
+
+describe("SettingsRow label landing check", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resetLabelLandingWarnings();
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it("stays silent when the id reaches the control", () => {
+    render(<Harness>{<WiredControl />}</Harness>);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns when no element claims the id", () => {
+    // A control rendered without FormControl: it looks correct on screen and
+    // nothing throws, which is why this shipped three times.
+    render(
+      <Harness>
+        <input data-testid="control" />
+      </Harness>
+    );
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain(
+      "no element carries that id"
+    );
+  });
+
+  it("warns when the id lands on a wrapper instead of the control", () => {
+    // The live shape this check was written for: FormControl clones onto its
+    // single child, so a positioning wrapper absorbs the id. `getElementById`
+    // finds it and a presence-only check reports the row as correctly wired.
+    render(
+      <Harness>
+        <FormControl>
+          <div className="relative">
+            <input data-testid="control" />
+          </div>
+        </FormControl>
+      </Harness>
+    );
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain(
+      "is not one a label can name"
+    );
+    // The control the label should have reached is present and labelable, so
+    // the warning is about the id's destination rather than about a row that
+    // rendered no control at all.
+    expect(screen.getByTestId("control")).toBeInTheDocument();
+  });
+
+  it("names the field and the id it could not resolve", () => {
+    render(
+      <Harness>
+        <input data-testid="control" />
+      </Harness>
+    );
+    const message = String(warn.mock.calls[0]?.[0]);
+    expect(message).toContain('"My Label"');
+    expect(message).toContain("-form-item");
   });
 });

--- a/packages/admin/src/components/features/settings/SettingsRow.test.tsx
+++ b/packages/admin/src/components/features/settings/SettingsRow.test.tsx
@@ -73,6 +73,40 @@ describe("SettingsRow", () => {
       screen.getByTestId("control")
     );
   });
+
+  it("keeps the description out of the control's accessible name", () => {
+    render(<Harness description="extra help">{<WiredControl />}</Harness>);
+    // An exact match, which is the assertion: while the description sat INSIDE
+    // the label, the name was "My Labelextra help" and a screen reader read the
+    // whole paragraph out on every focus. The description belongs in
+    // aria-describedby, asserted below, not in the name.
+    expect(screen.getByLabelText("My Label")).toBe(
+      screen.getByTestId("control")
+    );
+  });
+
+  it("connects the description to the control", () => {
+    render(<Harness description="extra help">{<WiredControl />}</Harness>);
+    const describedBy = screen
+      .getByTestId("control")
+      .getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    // The id has to resolve to the text on the page. `aria-describedby` naming
+    // an element that does not exist is the failure this whole file is about,
+    // one attribute over.
+    expect(document.getElementById(String(describedBy))?.textContent).toBe(
+      "extra help"
+    );
+  });
+
+  it("emits no description reference when there is no description", () => {
+    render(<Harness>{<WiredControl />}</Harness>);
+    // The complement of the case above: a control that always claimed a
+    // description would point at an element that never rendered.
+    expect(
+      screen.getByTestId("control").getAttribute("aria-describedby")
+    ).toBeNull();
+  });
 });
 
 describe("SettingsRow label landing check", () => {

--- a/packages/admin/src/components/features/settings/SettingsRow.tsx
+++ b/packages/admin/src/components/features/settings/SettingsRow.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from "react";
 
-import { useFormField } from "@admin/components/ui/form";
+import { FormDescription, useFormField } from "@admin/components/ui/form";
 import { useLabelLandingCheck } from "@admin/lib/forms/label-landing";
 
 interface SettingsRowProps {
@@ -48,14 +48,26 @@ export function SettingsRow({
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-[2fr_3fr] gap-4 md:gap-8 py-5 items-start">
-      <label htmlFor={formItemId} className="cursor-pointer flex flex-col">
-        <span className="text-sm font-semibold text-foreground">{label}</span>
+      <div className="flex flex-col">
+        <label
+          htmlFor={formItemId}
+          className="cursor-pointer text-sm font-semibold text-foreground"
+        >
+          {label}
+        </label>
+        {/* A sibling of the label rather than a child of it, and rendered
+            through FormDescription rather than as plain markup. Inside the
+            label, help text became part of the control's accessible NAME — a
+            screen reader announced the whole paragraph every time focus
+            arrived — and nothing registered it with FormControl, so it reached
+            aria-describedby not at all. FormDescription publishes its presence,
+            which is what lets FormControl name it. */}
         {description && (
-          <span className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
+          <FormDescription className="mt-0.5 text-xs leading-relaxed">
             {description}
-          </span>
+          </FormDescription>
         )}
-      </label>
+      </div>
       <div className="w-full">{children}</div>
     </div>
   );

--- a/packages/admin/src/components/features/settings/SettingsRow.tsx
+++ b/packages/admin/src/components/features/settings/SettingsRow.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from "react";
 
 import { useFormField } from "@admin/components/ui/form";
+import { useLabelLandingCheck } from "@admin/lib/forms/label-landing";
 
 interface SettingsRowProps {
   label: string;
@@ -15,6 +16,13 @@ interface SettingsRowProps {
  * Two-column grid: label + help on the left, control on the right.
  * Uses the form-field id linkage from useFormField so the <label> targets
  * the input rendered through FormControl.
+ *
+ * The `<label for>` is emitted unconditionally, while whether anything claims
+ * that id depends entirely on what the caller passes as `children` — nothing
+ * here can require a `FormControl`, and a `FormControl` wrapping a positioning
+ * `<div>` puts the id on the div rather than on the control inside it. Both
+ * shapes render and read as finished, which is how three of these shipped. The
+ * landing check below turns that silence into a development warning.
  */
 export function SettingsRow({
   label,
@@ -22,6 +30,21 @@ export function SettingsRow({
   children,
 }: SettingsRowProps) {
   const { formItemId } = useFormField();
+
+  useLabelLandingCheck({
+    targetId: formItemId,
+    label,
+    remedies: {
+      absent:
+        "Wrap the control in <FormControl> so it receives the id, or — if this row " +
+        "holds a GROUP of controls rather than one — use <SettingsRowGroup>, which " +
+        "names the whole group with role=group and aria-labelledby instead.",
+      notLabelable:
+        "<FormControl> clones onto its single child, so a wrapper element around the " +
+        "control absorbs the id. Put <FormControl> directly on the focusable control " +
+        "and move the wrapper outside it.",
+    },
+  });
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-[2fr_3fr] gap-4 md:gap-8 py-5 items-start">

--- a/packages/admin/src/lib/forms/label-landing.test.ts
+++ b/packages/admin/src/lib/forms/label-landing.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+
+import { classifyLabelTarget } from "./label-landing";
+
+/**
+ * Build a real element so the classifier is exercised against the DOM's own
+ * `tagName` casing and `HTMLInputElement.type` defaulting, rather than against
+ * an object shaped like what the test author expected those to be.
+ */
+function element(html: string): Element {
+  const host = document.createElement("div");
+  host.innerHTML = html;
+  const child = host.firstElementChild;
+  if (child === null) throw new Error(`no element parsed from: ${html}`);
+  return child;
+}
+
+describe("classifyLabelTarget", () => {
+  it("reports an absent target when nothing carries the id", () => {
+    expect(classifyLabelTarget(null)).toBe("absent");
+  });
+
+  // One case per labelable element, because the set is the HTML standard's and
+  // a missing member reads as a defect in the caller's markup rather than as a
+  // gap here — the check would tell a developer to fix correct markup.
+  it.each([
+    ["<button></button>", "BUTTON"],
+    ["<input />", "INPUT"],
+    ["<meter></meter>", "METER"],
+    ["<output></output>", "OUTPUT"],
+    ["<progress></progress>", "PROGRESS"],
+    ["<select></select>", "SELECT"],
+    ["<textarea></textarea>", "TEXTAREA"],
+  ])("accepts %s as labelable", html => {
+    expect(classifyLabelTarget(element(html))).toBe("labelable");
+  });
+
+  it("rejects a wrapper div, which is the shape FormControl produces", () => {
+    // `FormControl` is a Radix `Slot`: it clones its id onto its single child.
+    // Where that child is a positioning wrapper, the id lands here and a
+    // presence-only check reports the field as correctly wired.
+    const wrapper = element('<div class="relative"><input /></div>');
+    expect(classifyLabelTarget(wrapper)).toBe("not-labelable");
+    // The positive control on the same fixture: the element the label SHOULD
+    // have reached is labelable, so the verdict above is about where the id
+    // landed and not about the classifier refusing everything.
+    expect(classifyLabelTarget(wrapper.firstElementChild)).toBe("labelable");
+  });
+
+  it("rejects a contenteditable surface, which cannot be named by a label", () => {
+    expect(
+      classifyLabelTarget(element('<div contenteditable="true"></div>'))
+    ).toBe("not-labelable");
+  });
+
+  it("rejects an anchor, which is focusable but not labelable", () => {
+    expect(classifyLabelTarget(element('<a href="#"></a>'))).toBe(
+      "not-labelable"
+    );
+  });
+
+  it("rejects a hidden input, which has nothing to name", () => {
+    expect(classifyLabelTarget(element('<input type="hidden" />'))).toBe(
+      "not-labelable"
+    );
+    // Positive control: the same tag with a real type is accepted, so the
+    // rejection above comes from the `type` and not from INPUT being excluded.
+    expect(classifyLabelTarget(element('<input type="text" />'))).toBe(
+      "labelable"
+    );
+  });
+});

--- a/packages/admin/src/lib/forms/label-landing.ts
+++ b/packages/admin/src/lib/forms/label-landing.ts
@@ -1,0 +1,190 @@
+"use client";
+
+/**
+ * Whether a `<label for>` actually reached a control that can carry a name.
+ *
+ * Every failure this module reports is silent by construction: the label
+ * renders, the control renders, they sit next to each other on screen, and only
+ * the ASSOCIATION between them is missing. Nothing throws, nothing looks wrong,
+ * and the defect is invisible until someone drives the form with a screen
+ * reader. Four such defects have shipped in this admin panel.
+ *
+ * `FieldShell` in `@nextlyhq/ui` carries an equivalent check for the same
+ * reason. This is the admin-side counterpart, shared by every row component
+ * that emits a `<label for>` of its own, so there is one implementation of the
+ * question rather than one per row type.
+ *
+ * @module lib/forms/label-landing
+ */
+
+import { useEffect } from "react";
+
+/**
+ * Elements a `<label for>` is permitted to name.
+ *
+ * This is the HTML standard's set of "labelable elements" verbatim. It is not a
+ * heuristic and not a list of what happens to work today: `for` on anything
+ * outside this set forms no association at all, so assistive technology reads
+ * the control as unnamed however sensible the markup looks.
+ *
+ * Compared against `tagName`, which the DOM reports uppercased for HTML
+ * elements.
+ */
+const LABELABLE_TAGS: ReadonlySet<string> = new Set([
+  "BUTTON",
+  "INPUT",
+  "METER",
+  "OUTPUT",
+  "PROGRESS",
+  "SELECT",
+  "TEXTAREA",
+]);
+
+/**
+ * What became of the id a label points at.
+ *
+ * Three outcomes rather than two, because the two failures have different
+ * causes and different fixes, and collapsing them would hand the developer a
+ * message that fits one of them at best.
+ */
+export type LabelTargetVerdict =
+  /** The id is on an element that can carry an accessible name. */
+  | "labelable"
+  /** No element in the document carries the id at all. */
+  | "absent"
+  /** An element carries the id, but a label cannot name that kind of element. */
+  | "not-labelable";
+
+/**
+ * Classify what a label's `for` target turned out to be.
+ *
+ * Separated from the hook below and exported so the rule is testable without a
+ * render: the property being asserted is about an ELEMENT, and a test that has
+ * to mount a component to ask about one is testing two things at once.
+ *
+ * Presence alone is deliberately NOT the verdict. An id that landed somewhere
+ * and an id that landed on a control are both "found" by a lookup, and it was
+ * exactly that gap which let a `FormControl` clone its id onto a positioning
+ * wrapper and read as correctly wired.
+ */
+export function classifyLabelTarget(
+  target: Element | null
+): LabelTargetVerdict {
+  if (target === null) return "absent";
+  if (!LABELABLE_TAGS.has(target.tagName)) return "not-labelable";
+  // The one exclusion inside the labelable set: a hidden input has no
+  // presentation to name and cannot be focused, so a label pointing at one
+  // names nothing in practice.
+  if (
+    target.tagName === "INPUT" &&
+    (target as HTMLInputElement).type === "hidden"
+  ) {
+    return "not-labelable";
+  }
+  return "labelable";
+}
+
+/**
+ * Messages already emitted, keyed by the message itself.
+ *
+ * A row that re-renders on every keystroke would otherwise repeat its warning
+ * per frame, and twenty identical lines make one defect harder to see rather
+ * than easier.
+ */
+const emitted = new Set<string>();
+
+/**
+ * Forget which warnings have been emitted.
+ *
+ * For tests, so each case observes its own warning instead of inheriting the
+ * suppression an earlier case caused.
+ */
+export function resetLabelLandingWarnings(): void {
+  emitted.clear();
+}
+
+/**
+ * The environments this check is allowed to speak in.
+ *
+ * `test` sits beside `development` because a suite asserting that the warning
+ * fires is exercising the same contract a developer relies on; omitting it
+ * would make every such test pass for the wrong reason.
+ */
+const SPEAKING_ENVIRONMENTS = new Set(["development", "test"]);
+
+/**
+ * Whether this runtime has positively identified itself as a development one.
+ *
+ * Deliberately not `!== "production"`. Asking whether the environment is
+ * production answers "no" when `NODE_ENV` is absent entirely, which would ship
+ * every warning below to real users' consoles. Silence in an environment that
+ * cannot be identified is the cheaper of the two mistakes.
+ */
+function isDevelopmentRuntime(): boolean {
+  const env = process.env.NODE_ENV;
+  return env !== undefined && SPEAKING_ENVIRONMENTS.has(env);
+}
+
+/** What to tell the developer, chosen by which way the association failed. */
+export interface LabelLandingRemedies {
+  /** Shown when nothing on the page carries the id. */
+  absent: string;
+  /** Shown when the id landed on an element a label cannot name. */
+  notLabelable: string;
+}
+
+export interface LabelLandingCheckOptions {
+  /**
+   * Whether this row claims to point a label at a single control.
+   *
+   * A row that has deliberately opted out — one exposing a GROUP of controls,
+   * which names itself with `role="group"` and `aria-labelledby` instead —
+   * passes `false` and is not checked, because it makes no claim to verify.
+   */
+  enabled?: boolean;
+  /** The value the label's `htmlFor` was given. */
+  targetId: string;
+  /** The label's text, so the console message names the field on screen. */
+  label: string;
+  remedies: LabelLandingRemedies;
+}
+
+/**
+ * Warn, in development, when a `<label for>` names nothing usable.
+ *
+ * **This observes the commit in which the row rendered, and errs toward
+ * silence.** A control that mounts in a LATER commit — one gated on a fetch
+ * that has not resolved — is not seen, and no warning is emitted. That
+ * direction is deliberate: a warning that fires on correct markup gets
+ * suppressed or deleted by the next person to read it, taking its true reports
+ * with it, whereas a missed report costs only the defect it failed to name.
+ */
+export function useLabelLandingCheck({
+  enabled = true,
+  targetId,
+  label,
+  remedies,
+}: LabelLandingCheckOptions): void {
+  const { absent, notLabelable } = remedies;
+
+  useEffect(() => {
+    // Checked before the lookup rather than only before the `console.warn`, so
+    // production pays for no DOM query at all.
+    if (!enabled || !isDevelopmentRuntime()) return;
+    if (typeof document === "undefined") return;
+
+    const verdict = classifyLabelTarget(document.getElementById(targetId));
+    if (verdict === "labelable") return;
+
+    const detail =
+      verdict === "absent"
+        ? `no element carries that id, so the label names nothing. ${absent}`
+        : `the element carrying that id is not one a label can name, so the ` +
+          `label names nothing. ${notLabelable}`;
+
+    const message = `[Nextly] The label "${label}" points at #${targetId}, but ${detail}`;
+    if (emitted.has(message)) return;
+    emitted.add(message);
+    console.warn(message);
+  }, [enabled, targetId, label, absent, notLabelable]);
+}


### PR DESCRIPTION
## What this fixes

`SettingsRow` emits a `<label for>` for every row, but whether anything claims that id depends entirely on what the caller passes as `children`. Nothing in the component could require it, and nothing checked it. Two live defects came out of that, both in the email provider's credential fields (API key, SMTP password):

**1. The field had no accessible name.** `FormControl` is a Radix `Slot`, so it clones its props onto its *single child*. In `SecretField` that child was a positioning `<div>`, so the row's `id`, `aria-describedby` and `aria-invalid` all landed on the div. A `<label for>` cannot name a div — the association simply does not form. The id still *resolved*, so any check asking "does an element carry this id" reported the field as correctly wired.

**2. The help text was displayed but never announced.** `SettingsRow` rendered its `description` as a `<span>` inside the `<label>`. That did two things at once: it never registered with `FormControl`, so `aria-describedby` was absent entirely; and being inside the label, it became part of the control's accessible **name** — a screen reader read the whole paragraph out on every focus. For a stored credential that name was `"API KeyExisting secret is configured. Focus and type a new value to replace it."`

## What changed

- `SecretField` — `FormControl` moved onto the `Input`; the positioning wrapper moved outside it.
- `SettingsRow` — the description is now a sibling of the label, rendered through `FormDescription` so it publishes its presence and `FormControl` names it.
- New `@admin/lib/forms/label-landing` — a development-time check reporting **both** ways a label can fail to reach a control: an id nothing carries, and an id carried by an element a label cannot name.
- `FieldWrapper` now uses that shared check, replacing its own presence-only copy. One implementation of the question rather than one per row type; the entry-form fields gain the second case, which their copy could not see.

The check classifies against the HTML standard's set of *labelable elements* rather than asking whether the id exists. That is the separating property: presence is satisfied by the broken shape and the correct one alike, which is exactly why this survived.

It is advisory and errs toward silence — it observes the commit the row rendered in, so a control mounting after an unresolved fetch is a miss. That direction is deliberate and documented in the module: a warning that fires on correct markup gets deleted by the next person to read it, taking its true reports with it.

## Verification

Every new test was confirmed to fail for its intended reason, with the file's md5 asserted to have changed before the result was trusted (prettier reformats during the pre-commit hook, which can silently stop a replacement from applying):

| break applied | tests that failed |
| --- | --- |
| classifier reduced to presence-only | 5 — the four `not-labelable` cases and the `SettingsRow` wrapper case. The `absent` case and every positive control still passed. |
| `FormDescription` reverted to a plain `<span>` | 2 — both `aria-describedby` assertions |
| description moved back inside the `<label>` | 1 — the accessible-name assertion |

Gates, run from the worktree root with the cache forced off:

- `pnpm build` — 19/19
- `pnpm turbo run check-types --continue --force` — 22/22
- `pnpm turbo run lint --continue --force` — 23/23
- `packages/admin` — 233 files passed, 4 failed. Failing **file set** compared with `comm -13` against the recorded baseline: **zero new failures**. The baseline lists 5; `RoleBasicInfo.test.tsx` was repaired earlier and now passes.
- `packages/ui` — 42 files passed, 1 failed: `alpha-utilities.test.ts` on `border-destructive/40`, from `field-group/builder/[slug].tsx`. Pre-existing and unrelated to this change.

One note on `check-types`: it first reported `playground#check-types` failing on three `TS2307`s in `.next/types/validator.ts`, naming route files under an `(site)` route group that does not exist in `apps/playground/src/app`. That is stale generated output from an earlier dev-server run, not a defect in this change — clearing `.next` and re-running gives 16/16.

`fallow audit` **did not run locally**: `fallow` is not installed in this environment (`command not found`). Proceeding on the gitleaks precedent — fail-open locally, enforced in CI — but flagging it rather than letting the omission pass silently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved label associations for settings and form fields, ensuring labels name the correct inputs.
  * Corrected description linking so helper text is announced through `aria-describedby`.
  * Preserved clear and reveal controls while improving their behavior and keyboard accessibility.
* **Developer Experience**
  * Added development-time warnings and guidance for missing or invalid label targets.
* **Tests**
  * Added regression coverage for label associations, descriptions, credential fields, and invalid label targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->