### PR TITLE
feat(admin): compare versions side by side in a dialog

### DIFF
--- a/.changeset/version-compare-in-its-own-dialog.md
+++ b/.changeset/version-compare-in-its-own-dialog.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Comparing two versions now opens a dialog sized for a comparison instead of a third mode inside
+the 480px history panel. A diff is a two-column reading by nature, and that panel could not hold
+two columns, so the comparison was written to stack; each field now states its before and after
+side by side under headings naming the two versions, and folds back into a stack only where the
+surface is genuinely too narrow for two. A field that exists on one side only says so on the
+other, rather than leaving a blank that reads the same as an empty value. The history panel keeps
+its list and preview and no longer swaps its body out to compare.

--- a/packages/admin/src/components/features/versions/VersionCompareDialog.tsx
+++ b/packages/admin/src/components/features/versions/VersionCompareDialog.tsx
@@ -1,0 +1,89 @@
+/**
+ * A comparison of two versions, in a surface wide enough to be one.
+ *
+ * A diff is a two-column reading by nature, and the history panel is 480px —
+ * too narrow to hold two columns of field values, which is why the comparison
+ * used to stack. Giving it a dialog of its own separates the two jobs: the
+ * panel lists and previews, this compares, and neither is squeezed by the
+ * other's constraints.
+ *
+ * A modal rather than a route, deliberately. Comparing is a step taken while
+ * reading history, and the editor returns to the panel underneath afterwards;
+ * a route would unmount the document being worked on to show a diff of it.
+ *
+ * @module components/features/versions/VersionCompareDialog
+ */
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@admin/components/ui";
+import type { VersionScope } from "@admin/services/versionApi";
+
+import { VersionDiffView } from "./diff/VersionDiffView";
+
+export interface VersionCompareDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  scope: VersionScope;
+  /** Older version being compared. */
+  from: number;
+  /** Newer version being compared. */
+  to: number;
+}
+
+export function VersionCompareDialog({
+  open,
+  onOpenChange,
+  scope,
+  from,
+  to,
+}: VersionCompareDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {/* No `size` variant: every one of them sets an unprefixed `max-w-*`
+          except `full`, which also sets a `sm:` one — and a responsive variant
+          is a different utility group, so it would survive this className and
+          win back the width above the `sm` breakpoint. Stating the cap here
+          alone keeps one rule deciding it.
+
+          The cap is the width two comfortable columns of field values need,
+          bounded by the viewport so an ultrawide screen does not stretch a
+          reading measure across the whole display. Height is fixed rather than
+          content-driven: the body scrolls, so a hundred-field document and a
+          two-field one open the same shape and the column headings stay put. */}
+      <DialogContent
+        className="flex h-[85vh] max-h-[85vh] w-full max-w-[min(72rem,calc(100vw-4rem))] flex-col gap-0 overflow-hidden p-0"
+        // The panel that opened this stays mounted behind it, so a pointer
+        // press landing outside must not also reach that panel's dismiss
+        // handling and close both at once.
+        onPointerDownOutside={event => event.preventDefault()}
+      >
+        {/* Right padding clears the primitive's absolutely positioned close
+            button, which would otherwise sit over a long title. */}
+        <DialogHeader className="border-b border-border px-4 py-3 pr-12">
+          <DialogTitle>
+            Compare version {from} with version {to}
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            Field-by-field differences between two stored versions of this
+            document, oldest on the left.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Keyed by the pair so a different comparison always mounts fresh, and
+            a cached response for one pair can never paint under another's
+            heading while the new diff loads. */}
+        <VersionDiffView
+          key={`${from}-${to}`}
+          scope={scope}
+          from={from}
+          to={to}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -5,6 +5,12 @@
  * looking at one thing — this document's history — and nesting dialogs would
  * trap focus twice for what is conceptually a step, not a new context.
  *
+ * Comparing is the exception, and for a reason about geometry rather than about
+ * navigation. A comparison is two columns of field values; this panel is 480px
+ * wide, which cannot hold two, so hosting it here forced the diff to stack.
+ * `VersionCompareDialog` gives it a surface sized for the job, mounted from
+ * here on the same terms as the restore and rename dialogs.
+ *
  * @module components/features/versions/VersionHistorySheet
  */
 
@@ -32,8 +38,8 @@ import {
 import { apiErrorMessage } from "@admin/lib/api/parseApiError";
 import type { VersionScope } from "@admin/services/versionApi";
 
-import { VersionDiffView } from "./diff/VersionDiffView";
 import { RestoreConfirmDialog } from "./RestoreConfirmDialog";
+import { VersionCompareDialog } from "./VersionCompareDialog";
 import { VersionLabelDialog } from "./VersionLabelDialog";
 import { VersionLocaleFilter } from "./VersionLocaleFilter";
 import { VersionPreview } from "./VersionPreview";
@@ -99,7 +105,9 @@ export function VersionHistorySheet({
 }: VersionHistorySheetProps) {
   const [selected, setSelected] = useState<number | null>(null);
   // The version pair being compared (older -> newer), or null when not
-  // comparing. Compare is a third mode of the panel alongside list and preview.
+  // comparing. Comparing opens a dialog over this panel rather than replacing
+  // its body, so the panel stays in whichever of its two states it was in and
+  // is there again on dismiss.
   const [comparing, setComparing] = useState<{
     from: number;
     to: number;
@@ -350,17 +358,13 @@ export function VersionHistorySheet({
         <SheetHeader className="p-4 border-b border-border">
           <div className="flex items-center justify-between gap-2">
             <SheetTitle>
-              {comparing !== null
-                ? `Compare ${comparing.from} → ${comparing.to}`
-                : selected === null
-                  ? "Version history"
-                  : `Version ${selected}`}
+              {selected === null ? "Version history" : `Version ${selected}`}
             </SheetTitle>
-            {/* Locale filter, only while browsing the list (a chosen version or
-                a compare pair is already locale-fixed) and only for a document
-                whose own history carries locales — so it never appears on a
-                non-localized document in an otherwise localized app. */}
-            {comparing === null && selected === null && isLocalizedDocument && (
+            {/* Locale filter, only while browsing the list (a chosen version is
+                already locale-fixed) and only for a document whose own history
+                carries locales — so it never appears on a non-localized
+                document in an otherwise localized app. */}
+            {selected === null && isLocalizedDocument && (
               <VersionLocaleFilter
                 value={localeFilter}
                 onChange={locale => {
@@ -383,10 +387,9 @@ export function VersionHistorySheet({
             freshness gate hides "Compare with current" and disables "Load more"
             until a refetch succeeds — which, without this, only a reopen or
             another window focus could trigger. This keeps the gate but gives the
-            recovery a visible control. Suppressed in compare mode (the pair is
-            already chosen, so head staleness no longer affects what is shown) and
-            when there are no rows (the full-panel load error covers that). */}
-        {isRefetchError && comparing === null && versions.length > 0 ? (
+            recovery a visible control. Suppressed when there are no rows, since
+            the full-panel load error covers that. */}
+        {isRefetchError && versions.length > 0 ? (
           <div className="px-4 pt-4">
             <Alert variant="warning" role="status">
               <div className="flex flex-1 flex-wrap items-center justify-between gap-3">
@@ -409,17 +412,7 @@ export function VersionHistorySheet({
         ) : null}
 
         <div className="flex-1 overflow-y-auto">
-          {comparing !== null ? (
-            // Keyed by the pair so a different comparison always mounts fresh,
-            // and `keepPreviousData` can never carry one pair's fields into
-            // another while the new diff loads.
-            <VersionDiffView
-              key={`${comparing.from}-${comparing.to}`}
-              scope={scope}
-              from={comparing.from}
-              to={comparing.to}
-            />
-          ) : selected !== null ? (
+          {selected !== null ? (
             <VersionPreview
               versionNo={selected}
               fields={fields}
@@ -495,16 +488,7 @@ export function VersionHistorySheet({
         </div>
 
         <div className="p-4 border-t border-border flex flex-wrap items-center gap-2">
-          {comparing !== null ? (
-            // Compare returns to the version that was on screen, not the list.
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setComparing(null)}
-            >
-              Back
-            </Button>
-          ) : selected !== null ? (
+          {selected !== null ? (
             <>
               <Button
                 variant="outline"
@@ -577,6 +561,23 @@ export function VersionHistorySheet({
           isPublished={liveStatus === "published"}
           isRestoring={restore.isPending}
           onConfirm={() => restore.mutate(selected)}
+        />
+      ) : null}
+
+      {/* Mounted on the same terms as the restore dialog. Its own body is far
+          wider than this panel, which is the whole reason a comparison is not a
+          mode of the panel. */}
+      {comparing !== null ? (
+        <VersionCompareDialog
+          open
+          onOpenChange={open => {
+            // Dismissing returns to the version that was on screen, not the
+            // list: the panel behind was never navigated away from.
+            if (!open) setComparing(null);
+          }}
+          scope={scope}
+          from={comparing.from}
+          to={comparing.to}
         />
       ) : null}
 

--- a/packages/admin/src/components/features/versions/__tests__/VersionCompareDialog.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionCompareDialog.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * The comparison dialog exists to give a diff a surface it fits in, so what
+ * matters is that it names the pair it is showing, hands that pair to the diff
+ * view, and mounts a fresh view when the pair changes rather than painting one
+ * comparison under another's heading.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+const { diffViewMock } = vi.hoisted(() => ({ diffViewMock: vi.fn() }));
+
+// Stubbed so this suite is about the dialog. The view's own suite covers what
+// it renders; here it stands in as a recorder of what it was handed.
+vi.mock("../diff/VersionDiffView", () => ({
+  VersionDiffView: (props: Record<string, unknown>) => {
+    diffViewMock(props);
+    return <div data-testid="diff-view" />;
+  },
+}));
+
+import { VersionCompareDialog } from "../VersionCompareDialog";
+
+const scope = { kind: "collection" as const, slug: "posts", entryId: "e1" };
+
+describe("VersionCompareDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("names the pair it is comparing", () => {
+    render(
+      <VersionCompareDialog
+        open
+        onOpenChange={vi.fn()}
+        scope={scope}
+        from={2}
+        to={5}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /Compare version 2 with version 5/ })
+    ).toBeInTheDocument();
+  });
+
+  it("hands the diff view the same pair and scope", () => {
+    render(
+      <VersionCompareDialog
+        open
+        onOpenChange={vi.fn()}
+        scope={scope}
+        from={2}
+        to={5}
+      />
+    );
+
+    expect(diffViewMock).toHaveBeenCalledWith(
+      expect.objectContaining({ scope, from: 2, to: 5 })
+    );
+  });
+
+  it("renders nothing while closed", () => {
+    render(
+      <VersionCompareDialog
+        open={false}
+        onOpenChange={vi.fn()}
+        scope={scope}
+        from={2}
+        to={5}
+      />
+    );
+
+    // The panel that owns this keeps the pair in state, so a closed dialog must
+    // not keep a diff mounted and fetching behind it.
+    expect(screen.queryByTestId("diff-view")).toBeNull();
+    expect(diffViewMock).not.toHaveBeenCalled();
+  });
+
+  it("mounts a fresh view when the pair changes", () => {
+    const { rerender } = render(
+      <VersionCompareDialog
+        open
+        onOpenChange={vi.fn()}
+        scope={scope}
+        from={2}
+        to={5}
+      />
+    );
+    const first = screen.getByTestId("diff-view");
+
+    rerender(
+      <VersionCompareDialog
+        open
+        onOpenChange={vi.fn()}
+        scope={scope}
+        from={3}
+        to={5}
+      />
+    );
+
+    // A reused instance would let a cached response for the old pair paint
+    // under the new pair's heading while the new diff loads. A different DOM
+    // node is what proves the key remounted it rather than updating props.
+    expect(screen.getByTestId("diff-view")).not.toBe(first);
+  });
+});

--- a/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
@@ -16,6 +16,7 @@ const {
   setLabelMock,
   mutateMock,
   toastErrorMock,
+  compareDialogMock,
 } = vi.hoisted(() => ({
   useVersionsMock: vi.fn(),
   useVersionMock: vi.fn(),
@@ -23,6 +24,17 @@ const {
   setLabelMock: vi.fn(),
   mutateMock: vi.fn(),
   toastErrorMock: vi.fn(),
+  compareDialogMock: vi.fn(),
+}));
+
+// Stubbed so these tests stay about the panel. The real dialog fetches a diff
+// of its own, which the panel neither requests nor knows about; its own suite
+// covers what it renders.
+vi.mock("../VersionCompareDialog", () => ({
+  VersionCompareDialog: (props: Record<string, unknown>) => {
+    compareDialogMock(props);
+    return <div data-testid="compare-dialog" />;
+  },
 }));
 
 vi.mock("@admin/components/ui", async () => {
@@ -226,6 +238,74 @@ describe("VersionHistorySheet", () => {
     ).not.toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: /Try again/ }));
     expect(refetch).toHaveBeenCalled();
+  });
+
+  it("opens the compare dialog with the pair, without replacing the panel", async () => {
+    useVersionsMock.mockReturnValue(
+      listState({
+        data: {
+          pages: [
+            { items: [version(3), version(2)], meta: { hasNext: false } },
+          ],
+        },
+      })
+    );
+    useVersionMock.mockReturnValue(detailState({ data: { snapshot: {} } }));
+
+    renderSheet();
+    await userEvent.click(screen.getByRole("button", { name: /Version 2/ }));
+    await userEvent.click(
+      screen.getByRole("button", { name: /Compare with current/ })
+    );
+
+    // Older on the left: "compare with current" reads version 2 against the
+    // head, so the chosen version is `from` and the head is `to`.
+    expect(compareDialogMock).toHaveBeenCalledWith(
+      expect.objectContaining({ open: true, from: 2, to: 3 })
+    );
+    // The preview stays underneath rather than being swapped out, which is what
+    // makes dismissing the dialog a return rather than a navigation.
+    expect(
+      screen.getByRole("button", { name: /Back to history/ })
+    ).toBeInTheDocument();
+  });
+
+  it("compares against the next older version of the same locale", async () => {
+    useVersionsMock.mockReturnValue(
+      listState({
+        data: {
+          pages: [
+            { items: [version(3), version(2)], meta: { hasNext: false } },
+          ],
+        },
+      })
+    );
+    useVersionMock.mockReturnValue(detailState({ data: { snapshot: {} } }));
+
+    renderSheet();
+    await userEvent.click(screen.getByRole("button", { name: /Version 3/ }));
+    await userEvent.click(
+      screen.getByRole("button", { name: /Compare with previous/ })
+    );
+
+    expect(compareDialogMock).toHaveBeenCalledWith(
+      expect.objectContaining({ from: 2, to: 3 })
+    );
+  });
+
+  it("mounts no compare dialog until one is asked for", () => {
+    useVersionsMock.mockReturnValue(
+      listState({
+        data: { pages: [{ items: [version(1)], meta: { hasNext: false } }] },
+      })
+    );
+
+    renderSheet();
+
+    // The assertion above is only meaningful if the stub is absent by default;
+    // a dialog mounted from the start would satisfy it without any click.
+    expect(screen.queryByTestId("compare-dialog")).toBeNull();
+    expect(compareDialogMock).not.toHaveBeenCalled();
   });
 
   it("offers more only when another page exists", () => {

--- a/packages/admin/src/components/features/versions/diff/FieldDiffNode.tsx
+++ b/packages/admin/src/components/features/versions/diff/FieldDiffNode.tsx
@@ -2,11 +2,16 @@
  * Renders one node of a version diff.
  *
  * The engine produces a typed, UI-independent tree (`FieldDiff`); this walks it
- * and paints each kind: text as inline insert/delete runs, scalars as
- * before/after values (reusing the read-only value-display kit), groups and
- * components nested, lists item-by-item with add/remove/move/change badges, and
+ * and paints each kind: text as insert/delete runs, scalars as before/after
+ * values (reusing the read-only value-display kit), groups and components
+ * nested, lists item-by-item with add/remove/move/change badges, and
  * relationships as added/removed target chips. All colours are theme tokens, so
  * it reads in light and dark alike.
+ *
+ * A changed field states its two sides in COLUMNS, which is the shape a
+ * comparison has. There is one such layout rather than a narrow variant beside
+ * it: a container query folds the columns into a stack where the surface cannot
+ * hold two, so the available width decides the arrangement and no caller has to.
  *
  * Each value node carries its own display config (`display`), which the engine
  * copied from the real field while it walked, so a `hasMany` array, a `select`
@@ -27,6 +32,8 @@ import type {
 } from "@admin/services/versionApi";
 
 import { FieldValue } from "../value-display/FieldValueDisplay";
+
+import { splitTextSegments } from "./text-segment-sides";
 
 type DiffStatus = FieldDiff["status"];
 
@@ -110,34 +117,58 @@ function TextSegmentSpan({ segment }: { segment: TextSegment }) {
 }
 
 /**
- * A screen-reader label ("Before" / "After") plus its value, struck through
- * when it reads as removed. The label keeps the two sides distinguishable for
- * assistive technology, which cannot perceive the strikethrough alone.
+ * A side of a comparison the field did not reach: it was introduced after this
+ * version, or dropped before the other one. Stated rather than left blank, so
+ * an absent field is distinguishable from one holding an empty value.
  */
-function ValueSide({
-  label,
-  struck = false,
-  children,
+function AbsentSide() {
+  return <p className="text-sm italic text-muted-foreground">Not present</p>;
+}
+
+/**
+ * The two sides of a comparison, in columns.
+ *
+ * Columns are the shape a comparison has, so the markup states them once and a
+ * container query folds them into a stack only where the surface is genuinely
+ * too narrow to hold two. The per-side caption carries the labelling in that
+ * folded state and goes screen-reader-only once the column headings above sit
+ * over the columns instead — assistive technology needs the label either way,
+ * since neither position nor a rule is perceivable to it.
+ */
+function SplitPair({
+  before,
+  after,
 }: {
-  label: string;
-  struck?: boolean;
-  children: React.ReactNode;
+  before: React.ReactNode;
+  after: React.ReactNode;
 }) {
   return (
-    <div className={struck ? "line-through text-muted-foreground" : undefined}>
-      <span className="sr-only">{label}: </span>
-      {children}
+    <div className="grid grid-cols-1 gap-3 @2xl/diff:grid-cols-2 @2xl/diff:gap-4">
+      <div className="min-w-0 @2xl/diff:border-r @2xl/diff:border-border @2xl/diff:pr-4">
+        <p className="mb-1 text-xs font-medium text-muted-foreground @2xl/diff:sr-only">
+          Before
+        </p>
+        {before}
+      </div>
+      <div className="min-w-0">
+        <p className="mb-1 text-xs font-medium text-muted-foreground @2xl/diff:sr-only">
+          After
+        </p>
+        {after}
+      </div>
     </div>
   );
 }
 
 /**
- * The before/after presentation shared by every value node: added shows one
- * value, removed shows one struck value, changed shows both labelled, and
- * unchanged shows the value once. `renderValue` draws a single side through the
- * typed value kit, so the labelling stays in one place. A relationship or upload
- * value is resolved into the kit's display shape upstream, so the kit renders
- * its label with no reference-specific handling here.
+ * The before/after presentation shared by every value node. `renderValue` draws
+ * a single side through the typed value kit, so the kit is consulted once per
+ * side and the arrangement lives here. A relationship or upload value is
+ * resolved into the kit's display shape upstream, so the kit renders its label
+ * with no reference-specific handling here.
+ *
+ * An unchanged node spans both columns rather than printing the same value
+ * twice: repeating it costs a row of height and says nothing the badge has not.
  */
 function BeforeAfter({
   status,
@@ -150,27 +181,14 @@ function BeforeAfter({
   after: unknown;
   renderValue: (value: unknown) => React.ReactNode;
 }) {
-  if (status === "added") {
-    return <ValueSide label="New value">{renderValue(after)}</ValueSide>;
-  }
-  if (status === "removed") {
-    return (
-      <ValueSide label="Removed value" struck>
-        {renderValue(before)}
-      </ValueSide>
-    );
-  }
   if (status === "unchanged") {
-    // Nothing changed: show the value once, unlabelled and not struck.
     return <>{renderValue(after)}</>;
   }
   return (
-    <div className="flex flex-col gap-1">
-      <ValueSide label="Before" struck>
-        {renderValue(before)}
-      </ValueSide>
-      <ValueSide label="After">{renderValue(after)}</ValueSide>
-    </div>
+    <SplitPair
+      before={status === "added" ? <AbsentSide /> : renderValue(before)}
+      after={status === "removed" ? <AbsentSide /> : renderValue(after)}
+    />
   );
 }
 
@@ -189,16 +207,39 @@ function targetLabel(target: RelationTarget): string {
   return target.relationTo ? `${target.relationTo}: ${display}` : display;
 }
 
+/** One sequence of text-diff runs as a paragraph of marked spans. */
+function TextRuns({ segments }: { segments: readonly TextSegment[] }) {
+  return (
+    <p className="whitespace-pre-wrap break-words leading-relaxed">
+      {segments.map((segment, index) => (
+        <TextSegmentSpan key={index} segment={segment} />
+      ))}
+    </p>
+  );
+}
+
 export function FieldDiffNode({ node }: { node: FieldDiff }) {
   switch (node.kind) {
     case "text": {
+      // An unchanged text node has only common runs, so both sides would be
+      // identical; it spans instead, matching how a value node handles the same
+      // case. A changed one distributes its runs, keeping each run's `op` so a
+      // deletion still reads as struck on the left and an insertion as inserted
+      // on the right.
+      if (node.status === "unchanged") {
+        return (
+          <FieldRow label={node.label} status={node.status}>
+            <TextRuns segments={node.segments} />
+          </FieldRow>
+        );
+      }
+      const sides = splitTextSegments(node.segments);
       return (
         <FieldRow label={node.label} status={node.status}>
-          <p className="whitespace-pre-wrap break-words leading-relaxed">
-            {node.segments.map((segment, index) => (
-              <TextSegmentSpan key={index} segment={segment} />
-            ))}
-          </p>
+          <SplitPair
+            before={<TextRuns segments={sides.before} />}
+            after={<TextRuns segments={sides.after} />}
+          />
         </FieldRow>
       );
     }
@@ -225,6 +266,11 @@ export function FieldDiffNode({ node }: { node: FieldDiff }) {
     }
 
     case "set": {
+      // A set difference spans both columns rather than splitting into them. It
+      // is not a before/after pair: it names only the targets that entered or
+      // left, so putting "removed" under a heading naming the older version
+      // would imply that version held nothing else, when the targets present in
+      // both appear on neither side.
       return (
         <FieldRow label={node.label} status={node.status}>
           <div className="flex flex-col gap-1.5">

--- a/packages/admin/src/components/features/versions/diff/VersionDiffView.tsx
+++ b/packages/admin/src/components/features/versions/diff/VersionDiffView.tsx
@@ -1,9 +1,15 @@
 /**
- * Compares two versions inside the history panel.
+ * Compares two versions of a document.
  *
  * Fetches the server-computed diff for a version pair and renders it node by
- * node. A "changed only" toggle drops unchanged fields; the whole thing is a
- * mode of the history sheet rather than a separate dialog, matching preview.
+ * node, with a "changed only" toggle that drops unchanged fields. Owns its own
+ * scrolling body and fills the height its host gives it, so a host supplies a
+ * box and this decides how the comparison sits in it.
+ *
+ * The columns each field row draws are a function of THIS element's width — it
+ * declares the container the rows query — so the same view reads as a true
+ * side-by-side wherever there is room for one and folds into a stack where
+ * there is not.
  *
  * @module components/features/versions/diff/VersionDiffView
  */
@@ -51,14 +57,21 @@ export function VersionDiffView({ scope, from, to }: VersionDiffViewProps) {
   const diff = useVersionDiff({ scope, from, to, modifiedOnly });
 
   return (
-    <div className="flex flex-col">
+    // The container the field rows query. Their columns are a function of the
+    // width available HERE, not of the viewport: the same view sits in surfaces
+    // of different widths, and only its own box knows whether two columns fit.
+    <div className="@container/diff flex min-h-0 flex-1 flex-col">
       <div className="flex items-center justify-between gap-2 px-4 py-3 border-b border-border">
-        <p className="text-sm text-muted-foreground">
+        {/* Which pair is on screen. Hidden once the column headings below are
+            showing, since those name the same two versions over the values they
+            belong to, which says it better. */}
+        <p className="text-sm text-muted-foreground @2xl/diff:hidden">
           Comparing version{" "}
           <span className="font-medium text-foreground">{from}</span> &rarr;{" "}
           <span className="font-medium text-foreground">{to}</span>
         </p>
         <Button
+          className="ml-auto"
           variant={modifiedOnly ? "default" : "outline"}
           size="sm"
           aria-pressed={modifiedOnly}
@@ -68,45 +81,61 @@ export function VersionDiffView({ scope, from, to }: VersionDiffViewProps) {
         </Button>
       </div>
 
-      {diff.isLoading ? (
-        <DiffSkeleton />
-      ) : diff.isError ? (
-        <div className="p-4 flex flex-col gap-3">
-          <Alert variant="destructive">
-            <AlertDescription>
-              {apiErrorMessage(diff.error) ||
-                "This comparison could not be loaded."}
-            </AlertDescription>
-          </Alert>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => void diff.refetch()}
-          >
-            Try again
-          </Button>
-        </div>
-      ) : diff.data && diff.data.fields.length === 0 ? (
-        // Nothing to show: "Changed only" is on and no field changed. With the
-        // filter off the response carries the unchanged fields, so the branch
-        // below renders them instead of this message.
-        <div className="px-4 py-8 text-center">
-          <p className="text-sm text-muted-foreground">
-            These two versions are identical.
-          </p>
-        </div>
-      ) : diff.data ? (
-        <div className="px-4">
-          {!diff.data.hasChanges ? (
-            <p className="py-3 text-sm text-muted-foreground">
-              No changes between these versions.
+      {/* Column headings for the two sides, on the same grid and padding as
+          each row's value pair so they sit over the columns they name. Outside
+          the scrolling body rather than sticky within it, so a field far down a
+          long document is still readable as belonging to one version or the
+          other without a stacking context to get right. */}
+      <div className="hidden grid-cols-2 gap-4 border-b border-border px-4 py-2 @2xl/diff:grid">
+        <p className="pr-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Version {from}
+        </p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Version {to}
+        </p>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {diff.isLoading ? (
+          <DiffSkeleton />
+        ) : diff.isError ? (
+          <div className="p-4 flex flex-col gap-3">
+            <Alert variant="destructive">
+              <AlertDescription>
+                {apiErrorMessage(diff.error) ||
+                  "This comparison could not be loaded."}
+              </AlertDescription>
+            </Alert>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void diff.refetch()}
+            >
+              Try again
+            </Button>
+          </div>
+        ) : diff.data && diff.data.fields.length === 0 ? (
+          // Nothing to show: "Changed only" is on and no field changed. With the
+          // filter off the response carries the unchanged fields, so the branch
+          // below renders them instead of this message.
+          <div className="px-4 py-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              These two versions are identical.
             </p>
-          ) : null}
-          {diff.data.fields.map(node => (
-            <FieldDiffNode key={childKey(node)} node={node} />
-          ))}
-        </div>
-      ) : null}
+          </div>
+        ) : diff.data ? (
+          <div className="px-4">
+            {!diff.data.hasChanges ? (
+              <p className="py-3 text-sm text-muted-foreground">
+                No changes between these versions.
+              </p>
+            ) : null}
+            {diff.data.fields.map(node => (
+              <FieldDiffNode key={childKey(node)} node={node} />
+            ))}
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/packages/admin/src/components/features/versions/diff/__tests__/FieldDiffNode.test.tsx
+++ b/packages/admin/src/components/features/versions/diff/__tests__/FieldDiffNode.test.tsx
@@ -7,10 +7,23 @@
  */
 import { describe, it, expect } from "vitest";
 
-import { render, screen } from "@admin/__tests__/utils";
+import { render, screen, within } from "@admin/__tests__/utils";
 import type { FieldDiff } from "@admin/services/versionApi";
 
 import { FieldDiffNode } from "../FieldDiffNode";
+
+/**
+ * The subtree holding one side of a comparison, found through the caption that
+ * names it. Asserting inside a named column is what separates "both values are
+ * somewhere on screen" from "each value is on its own side", which is the whole
+ * claim a side-by-side layout makes.
+ */
+function column(side: "Before" | "After"): HTMLElement {
+  const caption = screen.getByText(side);
+  const cell = caption.parentElement;
+  if (!cell) throw new Error(`the ${side} caption has no containing column`);
+  return cell;
+}
 
 describe("FieldDiffNode", () => {
   it("renders a text field as insert and delete runs", () => {
@@ -121,12 +134,58 @@ describe("FieldDiffNode", () => {
     };
     render(<FieldDiffNode node={node} />);
 
-    // Screen readers cannot see the strikethrough, so each side is labelled.
+    // Which column a value sits in is not perceivable to a screen reader, so
+    // each side names itself.
     expect(screen.getByText(/^Before/)).toBeInTheDocument();
     expect(screen.getByText(/^After/)).toBeInTheDocument();
   });
 
-  it("shows only the new value for an added field", () => {
+  it("puts each side of a changed scalar in its own column", () => {
+    const node: FieldDiff = {
+      kind: "value",
+      name: "views",
+      label: "Views",
+      type: "number",
+      status: "changed",
+      before: 1,
+      after: 2,
+    };
+    render(<FieldDiffNode node={node} />);
+
+    // Both values being on screen is what the older stacked layout also did.
+    // The claim here is stronger: the old value is in the older version's
+    // column and nowhere else.
+    expect(within(column("Before")).getByText("1")).toBeInTheDocument();
+    expect(within(column("Before")).queryByText("2")).toBeNull();
+    expect(within(column("After")).getByText("2")).toBeInTheDocument();
+    expect(within(column("After")).queryByText("1")).toBeNull();
+  });
+
+  it("distributes a changed text field's runs to the side each reaches", () => {
+    const node: FieldDiff = {
+      kind: "text",
+      name: "title",
+      label: "Title",
+      type: "text",
+      status: "changed",
+      segments: [
+        { op: 0, text: "Hello " },
+        { op: -1, text: "world" },
+        { op: 1, text: "there" },
+      ],
+    };
+    render(<FieldDiffNode node={node} />);
+
+    // A deletion belongs to the older version only, an insertion to the newer
+    // only, and the common run to both — so it appears in each column.
+    expect(within(column("Before")).getByText("world").tagName).toBe("DEL");
+    expect(within(column("Before")).queryByText("there")).toBeNull();
+    expect(within(column("After")).getByText("there").tagName).toBe("INS");
+    expect(within(column("After")).queryByText("world")).toBeNull();
+    expect(screen.getAllByText("Hello")).toHaveLength(2);
+  });
+
+  it("says a field was not present on the side it did not reach", () => {
     const node: FieldDiff = {
       kind: "value",
       name: "note",
@@ -138,8 +197,51 @@ describe("FieldDiffNode", () => {
     };
     render(<FieldDiffNode node={node} />);
 
-    expect(screen.getByText("brand new")).toBeInTheDocument();
+    // An added field HAS a before column, and leaving it blank would read the
+    // same as a field that existed and held nothing.
+    expect(
+      within(column("Before")).getByText("Not present")
+    ).toBeInTheDocument();
+    expect(within(column("After")).getByText("brand new")).toBeInTheDocument();
     expect(screen.getByText("Added")).toBeInTheDocument();
+  });
+
+  it("says a removed field is not present on the newer side", () => {
+    const node: FieldDiff = {
+      kind: "value",
+      name: "note",
+      label: "Note",
+      type: "text",
+      status: "removed",
+      before: "was here",
+      after: null,
+    };
+    render(<FieldDiffNode node={node} />);
+
+    expect(within(column("Before")).getByText("was here")).toBeInTheDocument();
+    expect(
+      within(column("After")).getByText("Not present")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Removed")).toBeInTheDocument();
+  });
+
+  it("spans an unchanged field across both columns rather than repeating it", () => {
+    const node: FieldDiff = {
+      kind: "value",
+      name: "slug",
+      label: "Slug",
+      type: "text",
+      status: "unchanged",
+      before: "same-slug",
+      after: "same-slug",
+    };
+    render(<FieldDiffNode node={node} />);
+
+    // No columns at all for an unchanged node: two of them would print the same
+    // value twice and say nothing the badge has not.
+    expect(screen.queryByText("Before")).toBeNull();
+    expect(screen.queryByText("After")).toBeNull();
+    expect(screen.getAllByText("same-slug")).toHaveLength(1);
   });
 
   it("renders a relationship set as added and removed target chips", () => {

--- a/packages/admin/src/components/features/versions/diff/__tests__/text-segment-sides.test.ts
+++ b/packages/admin/src/components/features/versions/diff/__tests__/text-segment-sides.test.ts
@@ -1,0 +1,72 @@
+/**
+ * A two-column comparison shows each version's own text, so the engine's single
+ * run of insert/delete/common segments has to be distributed: a deletion is
+ * part of the older version's text and a nonsense addition to the newer one,
+ * and vice versa. Common runs belong to both.
+ */
+import { describe, it, expect } from "vitest";
+
+import type { TextSegment } from "@admin/services/versionApi";
+
+import { splitTextSegments } from "../text-segment-sides";
+
+describe("splitTextSegments", () => {
+  it("sends a deletion left, an insertion right, and common text to both", () => {
+    const segments: TextSegment[] = [
+      { op: 0, text: "Hello " },
+      { op: -1, text: "world" },
+      { op: 1, text: "there" },
+    ];
+
+    expect(splitTextSegments(segments)).toEqual({
+      before: [
+        { op: 0, text: "Hello " },
+        { op: -1, text: "world" },
+      ],
+      after: [
+        { op: 0, text: "Hello " },
+        { op: 1, text: "there" },
+      ],
+    });
+  });
+
+  it("keeps each run's op, so a side can still mark what changed in it", () => {
+    const { before, after } = splitTextSegments([
+      { op: -1, text: "gone" },
+      { op: 1, text: "new" },
+    ]);
+
+    // Flattening to plain text would lose the mark, and a column of unmarked
+    // text cannot show WHICH part of it moved.
+    expect(before.map(segment => segment.op)).toEqual([-1]);
+    expect(after.map(segment => segment.op)).toEqual([1]);
+  });
+
+  it("keeps the runs in their original order on each side", () => {
+    const { before } = splitTextSegments([
+      { op: 0, text: "a" },
+      { op: 1, text: "skipped" },
+      { op: -1, text: "b" },
+      { op: 0, text: "c" },
+    ]);
+
+    // Dropping the other side's runs must not reorder what remains: the older
+    // version's text is these runs concatenated, in this sequence.
+    expect(before.map(segment => segment.text).join("")).toBe("abc");
+  });
+
+  it("gives both sides everything when nothing changed", () => {
+    const segments: TextSegment[] = [{ op: 0, text: "identical" }];
+    const { before, after } = splitTextSegments(segments);
+
+    expect(before).toEqual(segments);
+    expect(after).toEqual(segments);
+  });
+
+  it("leaves a side empty when the whole text is one-sided", () => {
+    const { before, after } = splitTextSegments([{ op: 1, text: "all new" }]);
+
+    expect(before).toEqual([]);
+    expect(after).toEqual([{ op: 1, text: "all new" }]);
+  });
+});

--- a/packages/admin/src/components/features/versions/diff/text-segment-sides.ts
+++ b/packages/admin/src/components/features/versions/diff/text-segment-sides.ts
@@ -1,0 +1,37 @@
+/**
+ * Splits an inline text diff into the two sides of a side-by-side comparison.
+ *
+ * The engine emits one sequence of runs carrying `op` -1 (present only on the
+ * left), 0 (present on both) or 1 (present only on the right). An inline
+ * rendering paints that sequence once; a two-column rendering needs the same
+ * runs distributed to the side each one reaches. Kept separate from the
+ * renderer so the distribution is testable without mounting anything.
+ *
+ * @module components/features/versions/diff/text-segment-sides
+ */
+
+import type { TextSegment } from "@admin/services/versionApi";
+
+export interface TextSegmentSides {
+  /** Runs the older version contained: common text and deletions. */
+  before: TextSegment[];
+  /** Runs the newer version contains: common text and insertions. */
+  after: TextSegment[];
+}
+
+/**
+ * The runs belonging to each side, with their `op` preserved.
+ *
+ * `op` is kept rather than flattened to plain text so the same segment
+ * renderer still marks a deletion on the left and an insertion on the right —
+ * the column says which version a run belongs to, and the mark says whether it
+ * survived.
+ */
+export function splitTextSegments(
+  segments: readonly TextSegment[]
+): TextSegmentSides {
+  return {
+    before: segments.filter(segment => segment.op <= 0),
+    after: segments.filter(segment => segment.op >= 0),
+  };
+}


### PR DESCRIPTION
## What

Comparing two versions moves out of the 480px history panel and into a dialog sized for a comparison. The diff renderer now states its two sides in **columns**, and a container query folds them into a stack only where the surface genuinely cannot hold two.

Tracker row **T-08** (`tasks/admin-ui-tasks/09-TRACKER.md`), step B of a founder-approved B-then-C plan.

## Why

The panel was not badly styled. It was correctly built for a container too small for the job, and every complaint followed from that:

```
VersionHistorySheet.tsx   603 lines · THREE modes in one panel (list, preview, compare)
SheetContent              w-[480px] sm:max-w-[480px]
VersionDiffView           flex flex-col — a SINGLE-column diff
```

A diff is a two-column reading by nature; 480px cannot hold two columns of field values, so the diff was written to stack. **The container chose the diff format.** Widening the sheet alone would not fix it either — preview and compare also compete with the list for the same box.

## The design landed one level below the plan, and it is the better answer

The plan was a `layout: "stacked" | "split"` switch on the diff renderer. Building it exposed the problem: once the sheet stops hosting the diff, the stacked branch has **zero consumers** — dead code, and a second implementation of "how does a diff node look" besides.

So there is no layout switch. `FieldDiffNode` always emits columns, and `@container/diff` + `@2xl/diff:` folds them where the box is too narrow. That encodes the audit's own finding as a mechanism instead of restating it as a mode: available width decides the arrangement, and no caller has to.

## Changes

| file | change |
|---|---|
| `diff/text-segment-sides.ts` | **new** — `splitTextSegments` distributes one inline run of `op` -1/0/1 segments to the two sides, keeping each run's `op` so a side can still mark what changed in it |
| `diff/FieldDiffNode.tsx` | `ValueSide` removed; `SplitPair`, `AbsentSide`, `TextRuns` added |
| `diff/VersionDiffView.tsx` | declares the container, owns its scrolling body, adds column headings naming the two versions |
| `VersionCompareDialog.tsx` | **new** — `max-w-[min(72rem,calc(100vw-4rem))] h-[85vh]` |
| `VersionHistorySheet.tsx` | compare is no longer a mode; the two compare buttons open the dialog |

Three decisions worth reading rather than inferring:

- **A field present on one side only now says "Not present" on the other.** A blank cell reads the same as a field that existed and held nothing.
- **An unchanged field spans both columns** rather than printing itself twice.
- **A relationship `set` keeps spanning too, deliberately.** It is a set *difference*, not a before/after pair: it names only the targets that entered or left, so putting "removed" under a heading naming the older version would imply that version held nothing else, when targets present in both appear on neither side.
- **`DialogContent` takes no `size` variant, deliberately.** Every variant sets an unprefixed `max-w-*` except `full`, which also sets a `sm:` one — and a responsive variant is a different tailwind-merge group, so it would survive the `className` and win the width back above the `sm` breakpoint.

## Verification

Measured with the cache **forced off**, since a cached task reports success without running anything:

```
pnpm turbo run build       --force   20 successful / 20 total,  0 cached
pnpm turbo run check-types --force   22 successful / 22 total,  0 cached
pnpm turbo run lint        --force   23 successful / 23 total,  0 cached
```

Admin suite compared by failing **file set**, not by count:

```
before   4 failed | 232 passed (236 files) · 15 failed | 1985 passed (2000 tests)
after    4 failed | 234 passed (238 files) · 15 failed | 2001 passed (2016 tests)
comm -13 baseline after  →  (empty: no new failing file)
```

The four are the documented pre-existing baseline — `StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField` — unchanged in membership.

Comment-convention gate exit 0; the allowlist stayed at 402 and did not grow.

### Every new test was stub-verified, and one result is reported as a gap

Eight breaks, each restored afterwards, each required to fail the intended test and nothing else:

| break | failed |
|---|---|
| `splitTextSegments` drops common runs from the before side | 4 — the three distribution tests + the renderer's |
| `AbsentSide` returns null | 2 — added, removed |
| the unchanged span branch removed | 3 |
| `SplitPair` puts both sides in one cell | 4 — every column-separation test |
| sheet passes the pair reversed | 1 |
| dialog's remount `key` removed | 1 |
| dialog mounted whether or not a pair is chosen | 1 — the negative test's own control |
| dialog ignores `open` | 1 |

**A ninth break passed, and it is worth stating rather than leaving as a clean row.** Collapsing the column wrapper with `contents` — a CSS-only change — failed nothing. jsdom has no layout, so the *visual* two-column claim is not reachable by any unit test here; what the tests cover is the DOM claim, that each value sits in its own labelled cell. The layout half is covered by browser verification instead, reported below.

## Reviewer status

**No automated reviewer has looked at this.** Codex has been answering with usage-limit notices and `@nextly-bot` produces zero comments and zero reviews, so quiet threads here are not a pass — they are the absence of a reader. Stated so nobody reads silence as coverage.

## Coordination

Asked all twelve live sessions by file path before starting. `packages/admin/src/components/features/versions/**` confirmed clear by every Nextly lane that answered. This lane takes **UI only** — the versions schema, revision token and version API belong to the versions/autosave lane.

The version list stays in the sheet, so this adds no new list toolbar; the list-surface lane is consolidating three competing list shells and asked to be told before a ninth appeared. There is not one.
