### PR TITLE
fix(admin): say a text field was absent instead of showing a blank

### DIFF
--- a/.changeset/absent-text-side-says-so.md
+++ b/.changeset/absent-text-side-says-so.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+An added or removed text field showed a blank space on the version it never reached, instead of
+saying it was not present there. Splitting an inline text diff leaves one side with no runs at
+all, and an empty paragraph reads as a field that existed and held nothing. Which side a field
+never reached is now decided in one place for every kind of field, so a renderer cannot answer it
+differently.

--- a/packages/admin/src/components/features/versions/VersionCompareDialog.tsx
+++ b/packages/admin/src/components/features/versions/VersionCompareDialog.tsx
@@ -52,11 +52,15 @@ export function VersionCompareDialog({
 
           The cap is the width two comfortable columns of field values need,
           bounded by the viewport so an ultrawide screen does not stretch a
-          reading measure across the whole display. Height is fixed rather than
-          content-driven: the body scrolls, so a hundred-field document and a
-          two-field one open the same shape and the column headings stay put. */}
+          reading measure across the whole display.
+
+          Height follows the content between a floor and a cap. A fixed height
+          would open the same tall box for a two-field diff as for a
+          hundred-field one, leaving most of the screen blank; the floor keeps a
+          one-field comparison from opening as a sliver, and past the cap the
+          body scrolls under headings that stay put. */}
       <DialogContent
-        className="flex h-[85vh] max-h-[85vh] w-full max-w-[min(72rem,calc(100vw-4rem))] flex-col gap-0 overflow-hidden p-0"
+        className="flex max-h-[85vh] min-h-[20rem] w-full max-w-[min(72rem,calc(100vw-4rem))] flex-col gap-0 overflow-hidden p-0"
         // The panel that opened this stays mounted behind it, so a pointer
         // press landing outside must not also reach that panel's dismiss
         // handling and close both at once.

--- a/packages/admin/src/components/features/versions/diff/FieldDiffNode.tsx
+++ b/packages/admin/src/components/features/versions/diff/FieldDiffNode.tsx
@@ -134,11 +134,18 @@ function AbsentSide() {
  * folded state and goes screen-reader-only once the column headings above sit
  * over the columns instead — assistive technology needs the label either way,
  * since neither position nor a rule is perceivable to it.
+ *
+ * `status` is taken rather than a pre-decided pair of sides, so which side the
+ * field never reached is answered HERE and only here. A caller that renders its
+ * own sides cannot then forget the rule: an added field's rendering of its
+ * before side is not consulted at all.
  */
 function SplitPair({
+  status,
   before,
   after,
 }: {
+  status: DiffStatus;
   before: React.ReactNode;
   after: React.ReactNode;
 }) {
@@ -148,13 +155,13 @@ function SplitPair({
         <p className="mb-1 text-xs font-medium text-muted-foreground @2xl/diff:sr-only">
           Before
         </p>
-        {before}
+        {status === "added" ? <AbsentSide /> : before}
       </div>
       <div className="min-w-0">
         <p className="mb-1 text-xs font-medium text-muted-foreground @2xl/diff:sr-only">
           After
         </p>
-        {after}
+        {status === "removed" ? <AbsentSide /> : after}
       </div>
     </div>
   );
@@ -186,8 +193,9 @@ function BeforeAfter({
   }
   return (
     <SplitPair
-      before={status === "added" ? <AbsentSide /> : renderValue(before)}
-      after={status === "removed" ? <AbsentSide /> : renderValue(after)}
+      status={status}
+      before={renderValue(before)}
+      after={renderValue(after)}
     />
   );
 }
@@ -233,10 +241,16 @@ export function FieldDiffNode({ node }: { node: FieldDiff }) {
           </FieldRow>
         );
       }
+      // An added or removed text field has no runs at all on the side it never
+      // reached, so its sides are handed over unconditionally and `SplitPair`
+      // substitutes the absence marker. Rendering the empty list here would
+      // paint a blank paragraph, which reads as a field that existed and held
+      // nothing.
       const sides = splitTextSegments(node.segments);
       return (
         <FieldRow label={node.label} status={node.status}>
           <SplitPair
+            status={node.status}
             before={<TextRuns segments={sides.before} />}
             after={<TextRuns segments={sides.after} />}
           />

--- a/packages/admin/src/components/features/versions/diff/VersionDiffView.tsx
+++ b/packages/admin/src/components/features/versions/diff/VersionDiffView.tsx
@@ -62,16 +62,23 @@ export function VersionDiffView({ scope, from, to }: VersionDiffViewProps) {
     // of different widths, and only its own box knows whether two columns fit.
     <div className="@container/diff flex min-h-0 flex-1 flex-col">
       <div className="flex items-center justify-between gap-2 px-4 py-3 border-b border-border">
-        {/* Which pair is on screen. Hidden once the column headings below are
-            showing, since those name the same two versions over the values they
-            belong to, which says it better. */}
-        <p className="text-sm text-muted-foreground @2xl/diff:hidden">
-          Comparing version{" "}
-          <span className="font-medium text-foreground">{from}</span> &rarr;{" "}
-          <span className="font-medium text-foreground">{to}</span>
+        {/* What is on screen, in words. The pair is named only while the column
+            headings below are hidden, since those say it better by sitting over
+            the values; what the filter is doing is said at every width, because
+            a pressed button state alone does not tell a reader whether the
+            fields they cannot see are unchanged or filtered out. */}
+        <p className="text-sm text-muted-foreground">
+          <span className="@2xl/diff:hidden">
+            Comparing version{" "}
+            <span className="font-medium text-foreground">{from}</span> &rarr;{" "}
+            <span className="font-medium text-foreground">{to}</span>.{" "}
+          </span>
+          {modifiedOnly
+            ? "Showing only fields that changed."
+            : "Showing every field."}
         </p>
         <Button
-          className="ml-auto"
+          className="ml-auto shrink-0"
           variant={modifiedOnly ? "default" : "outline"}
           size="sm"
           aria-pressed={modifiedOnly}

--- a/packages/admin/src/components/features/versions/diff/__tests__/FieldDiffNode.test.tsx
+++ b/packages/admin/src/components/features/versions/diff/__tests__/FieldDiffNode.test.tsx
@@ -206,6 +206,46 @@ describe("FieldDiffNode", () => {
     expect(screen.getByText("Added")).toBeInTheDocument();
   });
 
+  it("says an added TEXT field was not present, rather than painting a blank", () => {
+    const node: FieldDiff = {
+      kind: "text",
+      name: "body",
+      label: "Body",
+      type: "textarea",
+      status: "added",
+      segments: [{ op: 1, text: "written from scratch" }],
+    };
+    render(<FieldDiffNode node={node} />);
+
+    // Splitting leaves the older side with no runs at all, and an empty
+    // paragraph reads as a field that existed and held nothing.
+    expect(
+      within(column("Before")).getByText("Not present")
+    ).toBeInTheDocument();
+    expect(
+      within(column("After")).getByText("written from scratch")
+    ).toBeInTheDocument();
+  });
+
+  it("says a removed TEXT field is not present on the newer side", () => {
+    const node: FieldDiff = {
+      kind: "text",
+      name: "body",
+      label: "Body",
+      type: "textarea",
+      status: "removed",
+      segments: [{ op: -1, text: "deleted wholesale" }],
+    };
+    render(<FieldDiffNode node={node} />);
+
+    expect(
+      within(column("Before")).getByText("deleted wholesale")
+    ).toBeInTheDocument();
+    expect(
+      within(column("After")).getByText("Not present")
+    ).toBeInTheDocument();
+  });
+
   it("says a removed field is not present on the newer side", () => {
     const node: FieldDiff = {
       kind: "value",


### PR DESCRIPTION
## What

An added or removed **text** field showed a blank space on the version it never reached, instead of saying it was not present there.

Follow-up to #956, from a `greptile-apps` P1 on that PR. The finding is correct and worth stating plainly: it is a rule I wrote a comment about honouring, then failed to apply in the branch immediately below it.

## The defect

`splitTextSegments` distributes an inline diff's runs to the side each one reaches. When a text field was *added*, every run is an insertion, so the before side gets an **empty** list — and `TextRuns` renders that as an empty `<p>`.

Value nodes already substituted an absence marker for exactly this reason. Text nodes did not, so the same absence read two different ways depending on the field's type: `Not present` for a number, a blank cell for a textarea. A blank cell reads as a field that existed and held nothing.

## The fix is structural, not the suggested patch

The review suggested duplicating the `status === "added" ? <AbsentSide/> : ...` ternary into the text branch. That fixes this instance and leaves the next node kind free to forget it again — two places answering "which side did this field never reach", which is the drift shape this repo has a rule about.

Instead, `SplitPair` now takes `status` and decides:

```tsx
{status === "added"   ? <AbsentSide /> : before}
{status === "removed" ? <AbsentSide /> : after}
```

Callers hand over both sides unconditionally and the absent one is simply **not consulted**. `BeforeAfter` gets simpler as a result, and a future node kind that renders through `SplitPair` inherits the rule rather than having to remember it.

## Verification

Two new tests, both stub-verified in both directions, and a second break confirming the *structural* claim rather than only the symptom:

| break | failed |
|---|---|
| text branch passes `status="changed"` (the original defect exactly) | 2 — both new text tests, nothing else |
| `SplitPair` stops applying the added rule | 2 — the new text test **and** the existing value test, which is the proof the rule is now shared rather than duplicated |

Restored clean after each.

```
versions suite                    13 files / 184 tests, all passing
admin check-types + lint --force  11 successful / 11 total, 0 cached
comment-convention gate           exit 0, allowlist unchanged at 402
```

## Reviewer status

**Correcting a standing note rather than repeating it:** several handoffs in this repo say there is no working automated reviewer. That is now half wrong — `greptile-apps` reviewed #956 within minutes and found this. Codex is still returning usage-limit notices and `@nextly-bot` still produces zero reviews.
