### PR TITLE
feat(builder): add the three-tier block inserter

### DIFF
--- a/packages/builder/src/insert-panel.test.tsx
+++ b/packages/builder/src/insert-panel.test.tsx
@@ -1,0 +1,227 @@
+// @vitest-environment jsdom
+
+/**
+ * What the panel adds on top of the derivations: that choosing a row inserts
+ * the block the row names, through the one path a document changes by.
+ *
+ * `jsdom` per file, matching the canvas suite: the rest of this package's tests
+ * are static analysis or arithmetic and gain nothing from a DOM but its startup
+ * cost. These cases need real focus and real selection events.
+ *
+ * What is deliberately NOT re-asserted here is everything `inserter.test.ts`
+ * already covers — which entries a target admits, what a query matches, where a
+ * block lands. Re-checking them through a rendered list would test the same
+ * derivation twice while making the failures harder to read, and the second
+ * copy is the one that rots.
+ *
+ * @module insert-panel.test
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+  clearBlocks,
+  registerBlocks,
+  type BlockDocument,
+} from "@nextlyhq/blocks-engine";
+
+import { InsertPanel } from "./insert-panel";
+import type { EditorState } from "./editor-state";
+
+// The command primitives observe their list box to size it, and jsdom
+// implements no ResizeObserver. Without this every case dies at render with a
+// ReferenceError, which reads as the panel being broken rather than as the
+// environment lacking an API the panel never calls itself.
+beforeAll(() => {
+  globalThis.ResizeObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  // Same class of gap: the list scrolls its active row into view as focus
+  // moves, and jsdom implements no layout, so the method simply is not there.
+  Element.prototype.scrollIntoView ??= () => {};
+});
+
+// Explicit because this package does not enable vitest globals, so without it
+// testing-library never registers its own cleanup and a later query matches
+// this test's markup as well as the previous one's.
+afterEach(() => {
+  cleanup();
+  clearBlocks();
+});
+
+const base = {
+  version: 1,
+  description: "A block.",
+  example: { props: {} },
+  render: () => null,
+};
+
+function documentOf(nodes: BlockDocument["nodes"] = []): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+}
+
+/**
+ * An editor whose `apply` is observed rather than reconstructed.
+ *
+ * The assertion is on the op the panel actually passes, so a change to the call
+ * site shows up here. A test that rebuilt the expected op from the same inputs
+ * would keep passing after someone edited the line it exists to watch.
+ */
+function editorSpy(document: BlockDocument): EditorState & {
+  apply: ReturnType<typeof vi.fn>;
+  select: ReturnType<typeof vi.fn>;
+} {
+  return {
+    document,
+    selectedId: null,
+    select: vi.fn(),
+    apply: vi.fn(() => document),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+    undoDepth: 0,
+  } as unknown as EditorState & {
+    apply: ReturnType<typeof vi.fn>;
+    select: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("InsertPanel", () => {
+  it("inserts the block a chosen row names, at the derived position", () => {
+    registerBlocks(
+      [{ ...base, name: "acme/text", editor: { label: "Text" } }] as never,
+      { source: "acme" }
+    );
+    const editor = editorSpy(documentOf());
+    const onInsert = vi.fn();
+    render(<InsertPanel editor={editor} onInsert={onInsert} />);
+
+    fireEvent.click(screen.getByText("Text"));
+
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+    const op = editor.apply.mock.calls[0][0];
+    expect(op.kind).toBe("insert");
+    expect(op.node.type).toBe("acme/text");
+    // Position derived from an empty document and no selection: the end, which
+    // is index 0. A panel that inserted at a hardcoded 0 would pass this and
+    // fail the populated case below.
+    expect(op.at).toEqual({ index: 0 });
+    expect(onInsert).toHaveBeenCalledWith(op.node);
+  });
+
+  it("appends after the existing blocks rather than at a fixed index", () => {
+    // The separating case for the assertion above.
+    registerBlocks(
+      [{ ...base, name: "acme/text", editor: { label: "Text" } }] as never,
+      { source: "acme" }
+    );
+    const editor = editorSpy(
+      documentOf([
+        { id: "a", type: "acme/text", version: 1, props: {} },
+        { id: "b", type: "acme/text", version: 1, props: {} },
+      ])
+    );
+    render(<InsertPanel editor={editor} />);
+
+    fireEvent.click(screen.getByText("Text"));
+
+    expect(editor.apply.mock.calls[0][0].at).toEqual({ index: 2 });
+  });
+
+  it("selects what it inserted, so a second insert lands after the first", () => {
+    registerBlocks(
+      [{ ...base, name: "acme/text", editor: { label: "Text" } }] as never,
+      { source: "acme" }
+    );
+    const editor = editorSpy(documentOf());
+    render(<InsertPanel editor={editor} />);
+
+    fireEvent.click(screen.getByText("Text"));
+
+    const inserted = editor.apply.mock.calls[0][0].node;
+    expect(editor.select).toHaveBeenCalledWith(inserted.id);
+  });
+
+  it("does not report an insert the op layer refused", () => {
+    registerBlocks(
+      [{ ...base, name: "acme/text", editor: { label: "Text" } }] as never,
+      { source: "acme" }
+    );
+    const editor = editorSpy(documentOf());
+    editor.apply.mockReturnValue(null);
+    const onInsert = vi.fn();
+    render(<InsertPanel editor={editor} onInsert={onInsert} />);
+
+    fireEvent.click(screen.getByText("Text"));
+
+    // A refusal means the document moved underneath the panel. Announcing it as
+    // an insert would have the host record an edit that never happened.
+    expect(onInsert).not.toHaveBeenCalled();
+    expect(editor.select).not.toHaveBeenCalled();
+  });
+
+  it("narrows the list by the tested filter rather than the widget's own", () => {
+    // The panel passes `shouldFilter={false}` and supplies pre-filtered rows.
+    // Leaving cmdk's filter on would put a second matcher beside
+    // `filterEntries`, and the two disagree here on purpose: cmdk matches the
+    // VALUE, which is the entry id, so a search for the label "Picture" would
+    // find nothing while the tested filter finds it.
+    registerBlocks(
+      [
+        { ...base, name: "acme/aaa", editor: { label: "Picture" } },
+        { ...base, name: "acme/zzz", editor: { label: "Heading" } },
+      ] as never,
+      { source: "acme" }
+    );
+    render(<InsertPanel editor={editorSpy(documentOf())} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Search blocks"), {
+      target: { value: "Picture" },
+    });
+
+    expect(screen.getByText("Picture")).toBeTruthy();
+    expect(screen.queryByText("Heading")).toBeNull();
+  });
+
+  it("says nothing matched, distinctly from nothing being placeable", () => {
+    registerBlocks(
+      [{ ...base, name: "acme/text", editor: { label: "Text" } }] as never,
+      { source: "acme" }
+    );
+    render(<InsertPanel editor={editorSpy(documentOf())} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Search blocks"), {
+      target: { value: "nonexistent" },
+    });
+
+    expect(screen.getByText(/No blocks match/)).toBeTruthy();
+  });
+
+  it("offers only what the target admits, and inserts none of the rest", () => {
+    // The rule reaches the rendered list, rather than being applied somewhere
+    // the panel then ignores. `acme/column` may only sit in `acme/columns`, and
+    // the position here is the document root.
+    registerBlocks(
+      [
+        { ...base, name: "acme/columns", editor: { label: "Columns" } },
+        {
+          ...base,
+          name: "acme/column",
+          parent: ["acme/columns"],
+          editor: { label: "Column" },
+        },
+      ] as never,
+      { source: "acme" }
+    );
+    render(<InsertPanel editor={editorSpy(documentOf())} />);
+
+    // Both halves: the refused entry is absent AND the permitted one is
+    // present. Asserting only the absence passes on a panel that renders
+    // nothing at all.
+    expect(screen.getByText("Columns")).toBeTruthy();
+    expect(screen.queryByText("Column")).toBeNull();
+  });
+});

--- a/packages/builder/src/insert-panel.tsx
+++ b/packages/builder/src/insert-panel.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+/**
+ * The inserter: what an author can add, and adding it.
+ *
+ * **Draws what `inserter` decides and decides nothing itself.** Every question
+ * with an answer worth testing — what may be offered here, what a query
+ * matches, where the block lands, what node to build — lives in that module,
+ * where it can be asserted without a DOM. This file is the surface: focus,
+ * keyboard, markup and the words an author reads.
+ *
+ * **Interaction is composed from `@nextlyhq/ui`'s command primitives rather
+ * than rebuilt.** They already own the roving focus, the ARIA listbox wiring
+ * and the type-ahead that the command palette uses, so an inserter with its own
+ * keyboard handling would be a second implementation of the same widget that
+ * drifts from it the first time either is corrected — and the two sit one panel
+ * apart in the same editor.
+ *
+ * `shouldFilter={false}` is the load-bearing half of that composition. cmdk
+ * filters by default, so leaving it on would put a SECOND filter beside
+ * `filterEntries` — two answers to "does this row match", disagreeing about
+ * block names and keywords, with the tested one silently overruled.
+ *
+ * @module insert-panel
+ */
+
+import {
+  allBlocks,
+  registryNestingSource,
+  type AnyBlockDefinition,
+  type BlockNode,
+  type NestingSource,
+} from "@nextlyhq/blocks-engine";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@nextlyhq/ui";
+import * as React from "react";
+
+import type { EditorState } from "./editor-state";
+import {
+  allowedEntries,
+  catalogFrom,
+  filterEntries,
+  groupByCategory,
+  insertionPointFor,
+  nodeForEntry,
+  type InsertEntry,
+} from "./inserter";
+
+export interface InsertPanelProps {
+  /**
+   * The editor whose document this inserts into.
+   *
+   * The whole state rather than a document and an `apply` separately, because
+   * the panel needs the selection and the document to agree with the `apply`
+   * it calls. Passed apart, a caller can hand a document from one render and an
+   * `apply` bound to another, and the insert lands at a position computed
+   * against a document that no longer exists.
+   */
+  editor: EditorState;
+  /**
+   * The blocks to offer. Defaults to everything registered.
+   *
+   * Read ONCE per mount rather than subscribed to: the registry is global
+   * mutable state with no change notification, so there is nothing to subscribe
+   * to. A plugin registering while the panel is open is not reflected until it
+   * remounts, which is the honest behaviour rather than a stale cache — and it
+   * is why the version to stamp travels on the entry rather than being looked
+   * up again at insert time.
+   */
+  definitions?: readonly AnyBlockDefinition[];
+  /** How nesting is resolved. Defaults to the live registry. */
+  nesting?: NestingSource;
+  /** Notified after a successful insert, with the node that was added. */
+  onInsert?: (node: BlockNode) => void;
+}
+
+/** Sentence describing where the next insert will land. */
+function placementLabel(kind: "after-selection" | "document-end"): string {
+  return kind === "after-selection"
+    ? "Adds after the selected block"
+    : "Adds at the end of the page";
+}
+
+export function InsertPanel({
+  editor,
+  definitions,
+  nesting,
+  onInsert,
+}: InsertPanelProps): React.JSX.Element {
+  const [query, setQuery] = React.useState("");
+
+  const catalog = React.useMemo(
+    () => catalogFrom(definitions ?? allBlocks()),
+    [definitions]
+  );
+  const source = React.useMemo(
+    () => nesting ?? registryNestingSource(),
+    [nesting]
+  );
+
+  // Recomputed from the CURRENT document and selection on every render rather
+  // than remembered. The position is only valid against the document it was
+  // read from, and an undo or a remote edit can move it without the selection
+  // changing — a memo keyed on the selection alone would keep a position whose
+  // index no longer names the same place.
+  const point = insertionPointFor(editor.document, editor.selectedId);
+
+  // Computed on every render rather than memoised. `insertionPointFor` builds a
+  // fresh target each call, so a memo keyed on it could never hit — it would
+  // recompute exactly as often while reading as though it cached. The work is a
+  // filter and a group over one array, and the render it happens in is already
+  // driven by a keystroke.
+  const groups =
+    point === null
+      ? []
+      : // Allowed first, then the query. Both orders yield the same set, but
+        // this one keeps the empty state honest: "no blocks match" after a
+        // search is a different message from "nothing can go here", and
+        // filtering first would collapse them into one.
+        groupByCategory(
+          filterEntries(allowedEntries(catalog, point.target, source), query)
+        );
+
+  const insert = (entry: InsertEntry) => {
+    if (point === null) return;
+    const node = nodeForEntry(entry);
+    // `apply` is the only path a document changes by, so undo covers this
+    // insert for free. It answers null when the op is refused, and a refusal
+    // must not be reported as an insert — the panel offers only placements the
+    // rule permits, so a null here means the document moved underneath it.
+    if (editor.apply({ kind: "insert", node, at: point.at }) === null) return;
+    // Selecting what was just added is what makes a second insert land after
+    // it, so repeated inserts build downward instead of stacking at one point.
+    editor.select(node.id);
+    onInsert?.(node);
+  };
+
+  if (point === null) {
+    return (
+      <div className="nx-insert-panel" data-empty="unplaceable">
+        <p className="nx-insert-panel__note">
+          The selected block sits somewhere a new block cannot be addressed.
+          Select a different block, or clear the selection to add at the end of
+          the page.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="nx-insert-panel">
+      <Command shouldFilter={false} label="Insert a block">
+        <CommandInput
+          value={query}
+          onValueChange={setQuery}
+          placeholder="Search blocks"
+        />
+        <p className="nx-insert-panel__placement" aria-live="polite">
+          {placementLabel(point.kind)}
+        </p>
+        <CommandList>
+          <CommandEmpty>
+            {query.trim() === ""
+              ? "No blocks can be added here."
+              : `No blocks match "${query.trim()}".`}
+          </CommandEmpty>
+          {groups.map(group => (
+            <CommandGroup key={group.category} heading={group.category}>
+              {group.entries.map(entry => (
+                <CommandItem
+                  // `value` is what cmdk reports on selection. The entry id is
+                  // unique across blocks AND their variations, while a label is
+                  // not — two plugins may both label a block "Card".
+                  key={entry.id}
+                  value={entry.id}
+                  onSelect={() => insert(entry)}
+                >
+                  <span className="nx-insert-panel__label">{entry.label}</span>
+                  <span className="nx-insert-panel__description">
+                    {entry.description}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          ))}
+        </CommandList>
+      </Command>
+    </div>
+  );
+}

--- a/packages/builder/src/inserter.test.ts
+++ b/packages/builder/src/inserter.test.ts
@@ -1,0 +1,523 @@
+/**
+ * What the inserter offers, and where a chosen entry lands.
+ *
+ * Driven through the real registry wherever a definition is involved, and
+ * through the engine's real nesting source, rather than a hand-written stub
+ * that restates what the registry would have answered. A stub reproduces the
+ * resolution instead of observing it, so it keeps passing after the registry
+ * changes what a definition means.
+ *
+ * @module inserter.test
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  allBlocks,
+  clearBlocks,
+  registerBlocks,
+  registryNestingSource,
+  type BlockDocument,
+} from "@nextlyhq/blocks-engine";
+
+import {
+  UNCATEGORISED,
+  allowedEntries,
+  catalogFrom,
+  entryAllowedAt,
+  filterEntries,
+  groupByCategory,
+  insertionPointFor,
+  nodeForEntry,
+  type InsertEntry,
+} from "./inserter";
+
+const base = {
+  version: 1,
+  description: "A block.",
+  example: { props: {} },
+  render: () => null,
+};
+
+afterEach(() => {
+  clearBlocks();
+});
+
+/** Register a palette and return the catalog the panel would be handed. */
+function catalog(definitions: readonly unknown[]): InsertEntry[] {
+  registerBlocks(definitions as never, { source: "acme" });
+  return catalogFrom(allBlocks());
+}
+
+function entry(entries: readonly InsertEntry[], id: string): InsertEntry {
+  const found = entries.find(candidate => candidate.id === id);
+  if (found === undefined) {
+    throw new Error(
+      `no entry ${id}; the catalog holds ${entries.map(e => e.id).join(", ")}`
+    );
+  }
+  return found;
+}
+
+function documentOf(nodes: BlockDocument["nodes"]): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+}
+
+describe("catalogFrom", () => {
+  it("offers every registered block, named by its editor label", () => {
+    const entries = catalog([
+      { ...base, name: "acme/zeta", editor: { label: "Zeta" } },
+      { ...base, name: "acme/alpha", editor: { label: "Alpha" } },
+    ]);
+
+    // Membership, not a count: a selector that dropped one block and duplicated
+    // another matches any total this could be compared against.
+    expect(entries.map(e => e.id)).toEqual(["acme/alpha", "acme/zeta"]);
+    expect(entry(entries, "acme/alpha").label).toBe("Alpha");
+  });
+
+  it("orders by the label an author reads, not by registration order", () => {
+    // The separating property. Registration order here is the REVERSE of label
+    // order, so a catalog that simply preserved input order would produce the
+    // opposite list and no assertion on membership alone would notice.
+    const entries = catalog([
+      { ...base, name: "acme/one", editor: { label: "Zulu" } },
+      { ...base, name: "acme/two", editor: { label: "Alpha" } },
+    ]);
+
+    expect(entries.map(e => e.label)).toEqual(["Alpha", "Zulu"]);
+  });
+
+  it("falls back to the namespaced name when a block declares no label", () => {
+    const entries = catalog([{ ...base, name: "acme/unlabelled" }]);
+
+    expect(entry(entries, "acme/unlabelled").label).toBe("acme/unlabelled");
+    expect(entry(entries, "acme/unlabelled").category).toBe(UNCATEGORISED);
+  });
+
+  it("emits one entry per variation, directly after its block", () => {
+    const entries = catalog([
+      {
+        ...base,
+        name: "acme/card",
+        editor: {
+          label: "Card",
+          variations: [{ name: "wide", label: "Wide card" }, { name: "tall" }],
+        },
+      },
+    ]);
+
+    expect(entries.map(e => e.id)).toEqual([
+      "acme/card",
+      "acme/card#wide",
+      "acme/card#tall",
+    ]);
+    expect(entry(entries, "acme/card#wide").label).toBe("Wide card");
+    // A variation with no label is named by its own `name`. Falling back to the
+    // block's label would render two rows reading "Card" with nothing to choose
+    // between them.
+    expect(entry(entries, "acme/card#tall").label).toBe("tall");
+    expect(entry(entries, "acme/card#tall").variationName).toBe("tall");
+    expect(entry(entries, "acme/card").variationName).toBeUndefined();
+  });
+
+  it("overlays a variation's props onto the block's defaults", () => {
+    const entries = catalog([
+      {
+        ...base,
+        name: "acme/card",
+        defaultProps: { tone: "plain", size: "md" },
+        editor: { variations: [{ name: "loud", props: { tone: "shout" } }] },
+      },
+    ]);
+
+    // The overlay REPLACES the named prop and leaves the rest, which is what
+    // distinguishes an overlay from a replacement of the whole props object.
+    expect(entry(entries, "acme/card#loud").props).toEqual({
+      tone: "shout",
+      size: "md",
+    });
+    expect(entry(entries, "acme/card").props).toEqual({
+      tone: "plain",
+      size: "md",
+    });
+  });
+
+  it("gives an entry its own props, so the definition cannot be reached through it", () => {
+    const defaults = { tone: "plain" };
+    const entries = catalog([
+      { ...base, name: "acme/card", defaultProps: defaults },
+    ]);
+
+    (entry(entries, "acme/card").props as Record<string, unknown>).tone =
+      "mutated";
+
+    expect(defaults.tone).toBe("plain");
+  });
+
+  it("returns nothing when nothing is registered", () => {
+    // The vacuity control for every case above: they assert what a populated
+    // catalog contains, and none of them would fail if `catalogFrom` returned
+    // its input unread. This pins the empty case as empty rather than as
+    // whatever a broken read happens to produce.
+    expect(catalogFrom([])).toEqual([]);
+  });
+});
+
+describe("filterEntries", () => {
+  // Registered once per case rather than per call. `registerBlocks` refuses a
+  // redefinition, so a helper invoked twice inside one test fails on the
+  // collision rather than on anything it was asserting.
+  let palette: InsertEntry[];
+  const entries = (): InsertEntry[] => palette;
+
+  const register = (): InsertEntry[] =>
+    catalog([
+      {
+        ...base,
+        name: "acme/heading",
+        description: "A title for a section.",
+        editor: { label: "Heading", keywords: ["title", "h1"] },
+      },
+      {
+        ...base,
+        name: "acme/image",
+        description: "A picture.",
+        editor: { label: "Image" },
+      },
+    ]);
+
+  beforeEach(() => {
+    palette = register();
+  });
+
+  it("matches the label", () => {
+    expect(filterEntries(entries(), "head").map(e => e.id)).toEqual([
+      "acme/heading",
+    ]);
+  });
+
+  it("matches the namespaced block name", () => {
+    // Someone reading docs or an agent's output knows `acme/image`, not
+    // necessarily that it is labelled "Image".
+    expect(filterEntries(entries(), "acme/image").map(e => e.id)).toEqual([
+      "acme/image",
+    ]);
+  });
+
+  it("matches a declared keyword", () => {
+    expect(filterEntries(entries(), "h1").map(e => e.id)).toEqual([
+      "acme/heading",
+    ]);
+  });
+
+  it("matches the description", () => {
+    expect(filterEntries(entries(), "picture").map(e => e.id)).toEqual([
+      "acme/image",
+    ]);
+  });
+
+  it("ignores case", () => {
+    expect(filterEntries(entries(), "HEADING").map(e => e.id)).toEqual([
+      "acme/heading",
+    ]);
+  });
+
+  it("returns everything for an empty or whitespace query", () => {
+    // The panel opens with no query. A filter treating that as "match nothing"
+    // would show an empty palette on open, which is the state this guards.
+    expect(filterEntries(entries(), "").map(e => e.id)).toEqual([
+      "acme/heading",
+      "acme/image",
+    ]);
+    expect(filterEntries(entries(), "   ")).toHaveLength(2);
+  });
+
+  it("returns nothing when nothing matches", () => {
+    // The negative control. Without it every assertion above is satisfied by a
+    // filter that returns its input unchanged.
+    expect(filterEntries(entries(), "nonexistent")).toEqual([]);
+  });
+});
+
+describe("groupByCategory", () => {
+  it("groups under declared categories and preserves arrival order", () => {
+    const entries = catalog([
+      { ...base, name: "acme/b", editor: { label: "B", category: "media" } },
+      { ...base, name: "acme/a", editor: { label: "A", category: "text" } },
+      { ...base, name: "acme/c", editor: { label: "C", category: "media" } },
+    ]);
+
+    // Sorted by label, so arrival order is A(text), B(media), C(media) — which
+    // makes "text" the first category even though "media" is alphabetically
+    // first. That is the separating property between preserving arrival order
+    // and sorting the headings.
+    expect(groupByCategory(entries)).toEqual([
+      { category: "text", entries: [entry(entries, "acme/a")] },
+      {
+        category: "media",
+        entries: [entry(entries, "acme/b"), entry(entries, "acme/c")],
+      },
+    ]);
+  });
+
+  it("puts uncategorised blocks under one heading rather than dropping them", () => {
+    const entries = catalog([{ ...base, name: "acme/loose" }]);
+
+    expect(groupByCategory(entries)).toEqual([
+      { category: UNCATEGORISED, entries: [entry(entries, "acme/loose")] },
+    ]);
+  });
+});
+
+describe("entryAllowedAt and allowedEntries", () => {
+  function palette(): InsertEntry[] {
+    return catalog([
+      { ...base, name: "acme/columns" },
+      { ...base, name: "acme/column", parent: ["acme/columns"] },
+      { ...base, name: "acme/text" },
+    ]);
+  }
+
+  it("refuses a parent-restricted block at the root, naming the rule", () => {
+    const entries = palette();
+    const verdict = entryAllowedAt(
+      entry(entries, "acme/column"),
+      { at: "root" },
+      registryNestingSource()
+    );
+
+    expect(verdict.allowed).toBe(false);
+    // The REASON, not just the refusal. "Restricted at root" and "wrong parent"
+    // need different sentences: one says choose another container, the other
+    // says put it inside something.
+    expect(verdict.reason).toBe("restricted-at-root");
+    expect(verdict.permitted).toEqual(["acme/columns"]);
+  });
+
+  it("permits that block inside the container it declares", () => {
+    const entries = palette();
+
+    expect(
+      entryAllowedAt(
+        entry(entries, "acme/column"),
+        { at: "slot", parentType: "acme/columns", slot: "children" },
+        registryNestingSource()
+      ).allowed
+    ).toBe(true);
+  });
+
+  it("refuses it inside a container it does not declare", () => {
+    const entries = palette();
+    const verdict = entryAllowedAt(
+      entry(entries, "acme/column"),
+      { at: "slot", parentType: "acme/text", slot: "children" },
+      registryNestingSource()
+    );
+
+    expect(verdict.allowed).toBe(false);
+    expect(verdict.reason).toBe("wrong-parent");
+  });
+
+  it("permits an unrestricted block everywhere", () => {
+    // The control for the three refusals above. A rule that refused by default
+    // would satisfy all of them while making the palette permanently empty.
+    const entries = palette();
+    const source = registryNestingSource();
+
+    expect(
+      entryAllowedAt(entry(entries, "acme/text"), { at: "root" }, source)
+        .allowed
+    ).toBe(true);
+    expect(
+      entryAllowedAt(
+        entry(entries, "acme/text"),
+        { at: "slot", parentType: "acme/columns", slot: "children" },
+        source
+      ).allowed
+    ).toBe(true);
+  });
+
+  it("removes refused entries from the palette and keeps the rest", () => {
+    const entries = palette();
+    const offered = allowedEntries(
+      entries,
+      { at: "root" },
+      registryNestingSource()
+    );
+
+    // Both halves asserted: the refused one is gone AND the permitted ones
+    // remain. Asserting only the absence passes on a filter that returns
+    // nothing at all.
+    expect(offered.map(e => e.id)).toEqual(["acme/columns", "acme/text"]);
+  });
+
+  it("derives a variation's placement from its block, not from its own name", () => {
+    // A variation is an instance of its block, so it inherits the block's
+    // nesting rule. Keying the rule on the entry id would look up
+    // "acme/column#narrow", find no definition, and permit it everywhere.
+    const entries = catalog([
+      {
+        ...base,
+        name: "acme/column",
+        parent: ["acme/columns"],
+        editor: { variations: [{ name: "narrow" }] },
+      },
+    ]);
+
+    expect(
+      entryAllowedAt(
+        entry(entries, "acme/column#narrow"),
+        { at: "root" },
+        registryNestingSource()
+      ).allowed
+    ).toBe(false);
+  });
+});
+
+describe("insertionPointFor", () => {
+  it("appends at the end of the document when nothing is selected", () => {
+    const document = documentOf([
+      { id: "a", type: "acme/text", version: 1, props: {} },
+    ]);
+
+    expect(insertionPointFor(document, null)).toEqual({
+      kind: "document-end",
+      at: { index: 1 },
+      target: { at: "root" },
+    });
+  });
+
+  it("places a new block directly after the selected one", () => {
+    const document = documentOf([
+      { id: "a", type: "acme/text", version: 1, props: {} },
+      { id: "b", type: "acme/text", version: 1, props: {} },
+    ]);
+
+    // Index 1, not 0 and not 2: after "a" and before "b". A position that
+    // merely named the selection's own index would insert BEFORE it.
+    expect(insertionPointFor(document, "a")).toEqual({
+      kind: "after-selection",
+      at: { index: 1 },
+      target: { at: "root" },
+    });
+  });
+
+  it("stays inside the selected block's own region", () => {
+    const document = documentOf([
+      {
+        id: "wrap",
+        type: "acme/columns",
+        version: 1,
+        props: {},
+        slots: {
+          children: [{ id: "inner", type: "acme/text", version: 1, props: {} }],
+        },
+      },
+    ]);
+
+    const point = insertionPointFor(document, "inner");
+
+    // The position AND the target, together. This is the property the module
+    // exists for: a panel filtering against the root while inserting into a
+    // slot would offer blocks the op layer then refuses.
+    expect(point).toEqual({
+      kind: "after-selection",
+      at: { parentId: "wrap", slot: "children", index: 1 },
+      target: { at: "slot", parentType: "acme/columns", slot: "children" },
+    });
+  });
+
+  it("falls back to the end when the selection names a node the document lost", () => {
+    // A stale id after an undo, or a selection made against a document that has
+    // since been replaced. Appending is right here because there is no
+    // surrounding region to be surprised about.
+    const document = documentOf([
+      { id: "a", type: "acme/text", version: 1, props: {} },
+    ]);
+
+    expect(insertionPointFor(document, "gone")?.kind).toBe("document-end");
+    expect(insertionPointFor(document, "gone")?.at).toEqual({ index: 1 });
+  });
+
+  it("is empty-document safe", () => {
+    expect(insertionPointFor(documentOf([]), null)).toEqual({
+      kind: "document-end",
+      at: { index: 0 },
+      target: { at: "root" },
+    });
+  });
+});
+
+describe("nodeForEntry", () => {
+  it("stamps the type and the version the entry carries", () => {
+    // Version 3 with its migration steps, rather than the default 1: a stamp
+    // hardcoded to 1 would pass every assertion a version-1 fixture can make.
+    const entries = catalog([
+      {
+        ...base,
+        name: "acme/text",
+        version: 3,
+        migrate: {
+          1: (p: Record<string, unknown>) => p,
+          2: (p: Record<string, unknown>) => p,
+        },
+      },
+    ]);
+    const node = nodeForEntry(entry(entries, "acme/text"));
+
+    expect(node.type).toBe("acme/text");
+    expect(node.version).toBe(3);
+    expect(typeof node.id).toBe("string");
+    expect(node.id.length).toBeGreaterThan(0);
+  });
+
+  it("inserts a variation as its block, carrying the variation's props", () => {
+    // The node records what it IS — a block — not which palette row produced
+    // it. A node typed "acme/card#loud" would match no registered block and
+    // would render as unknown.
+    const entries = catalog([
+      {
+        ...base,
+        name: "acme/card",
+        defaultProps: { tone: "plain" },
+        editor: { variations: [{ name: "loud", props: { tone: "shout" } }] },
+      },
+    ]);
+
+    const node = nodeForEntry(entry(entries, "acme/card#loud"));
+
+    expect(node.type).toBe("acme/card");
+    expect(node.props).toEqual({ tone: "shout" });
+  });
+
+  it("gives every inserted node its own props, nested values included", () => {
+    // The failure this prevents is delayed and looks unrelated: editing one
+    // inserted block changes another inserted long before it, because both
+    // share the catalog's object. A shallow copy passes a top-level check and
+    // still shares the array.
+    const entries = catalog([
+      {
+        ...base,
+        name: "acme/list",
+        defaultProps: { items: ["one"], meta: { deep: true } },
+      },
+    ]);
+    const source = entry(entries, "acme/list");
+
+    const first = nodeForEntry(source);
+    const second = nodeForEntry(source);
+    (first.props.items as string[]).push("two");
+    (first.props.meta as { deep: boolean }).deep = false;
+
+    expect(second.props.items).toEqual(["one"]);
+    expect(second.props.meta).toEqual({ deep: true });
+    expect(source.props.items).toEqual(["one"]);
+  });
+
+  it("gives two inserts distinct ids", () => {
+    const entries = catalog([{ ...base, name: "acme/text" }]);
+    const source = entry(entries, "acme/text");
+
+    expect(nodeForEntry(source).id).not.toBe(nodeForEntry(source).id);
+  });
+});

--- a/packages/builder/src/inserter.test.ts
+++ b/packages/builder/src/inserter.test.ts
@@ -372,6 +372,72 @@ describe("entryAllowedAt and allowedEntries", () => {
       ).allowed
     ).toBe(false);
   });
+
+  it("refuses a block a slot's allow-list does not admit", () => {
+    // The CONTAINER's half. This block declares no `parent`, so the child's
+    // half permits it everywhere — only the slot's allow-list can refuse it,
+    // which is what makes this case separate rather than a restatement.
+    registerBlocks(
+      [
+        {
+          ...base,
+          name: "acme/gallery",
+          slots: { children: { allow: ["acme/photo"] } },
+        },
+        { ...base, name: "acme/photo" },
+        { ...base, name: "acme/text" },
+      ] as never,
+      { source: "acme" }
+    );
+    const entries = catalogFrom(allBlocks());
+    const source = registryNestingSource();
+
+    const refused = entryAllowedAt(
+      entry(entries, "acme/text"),
+      { at: "slot", parentType: "acme/gallery", slot: "children" },
+      source
+    );
+    expect(refused.allowed).toBe(false);
+    expect(refused.reason).toBe("not-allowed-in-slot");
+    expect(refused.permitted).toEqual(["acme/photo"]);
+
+    // The control: the admitted block passes the same call. Without it a rule
+    // refusing everything in a slot would satisfy the assertion above.
+    expect(
+      entryAllowedAt(
+        entry(entries, "acme/photo"),
+        { at: "slot", parentType: "acme/gallery", slot: "children" },
+        source
+      ).allowed
+    ).toBe(true);
+  });
+
+  it("reports the CHILD's reason when both halves would refuse", () => {
+    // Both rules reject this placement. The child's reason is the actionable
+    // one — it names a container to aim at — so it is the one that survives.
+    registerBlocks(
+      [
+        {
+          ...base,
+          name: "acme/grid",
+          slots: { cells: { allow: ["acme/cell"] } },
+        },
+        { ...base, name: "acme/cell", parent: ["acme/grid"] },
+        { ...base, name: "acme/stray", parent: ["acme/elsewhere"] },
+        { ...base, name: "acme/elsewhere" },
+      ] as never,
+      { source: "acme" }
+    );
+    const entries = catalogFrom(allBlocks());
+
+    const verdict = entryAllowedAt(
+      entry(entries, "acme/stray"),
+      { at: "slot", parentType: "acme/grid", slot: "cells" },
+      registryNestingSource()
+    );
+    expect(verdict.allowed).toBe(false);
+    expect(verdict.reason).toBe("wrong-parent");
+  });
 });
 
 describe("insertionPointFor", () => {

--- a/packages/builder/src/inserter.ts
+++ b/packages/builder/src/inserter.ts
@@ -1,0 +1,362 @@
+/**
+ * What the inserter may offer, and where a chosen entry would land.
+ *
+ * Pure, and separate from the panel that draws it, for the reason
+ * `shell-state` gives: this is set membership and derivation, none of it needs
+ * React, and a component test in jsdom cannot assert it — jsdom reports every
+ * element as zero-sized and renders a filtered list identically to an unfiltered
+ * one that happens to be short. The decisions are made here, where they can be
+ * asserted; the panel only draws what this returns.
+ *
+ * **The palette and the insert must agree, and that is why the target travels
+ * with the position.** A panel that decides what to OFFER from one reading and
+ * inserts against another will show a block, accept the click, and have the op
+ * layer refuse it — a refusal the author cannot act on, because the thing they
+ * were offered is the thing that was rejected. {@link insertionPointFor}
+ * therefore answers both halves at once, and everything downstream takes the
+ * target from it rather than recomputing one.
+ *
+ * **The nesting rule is CALLED, never restated.** `canBeRoot` and `canNest`
+ * come from the engine, which documents itself as the one implementation
+ * precisely because a canvas judging a drop and a validator judging a stored
+ * document are the same question at different moments.
+ *
+ * @module inserter
+ */
+
+import {
+  canBeRoot,
+  canNest,
+  locateNode,
+  makeNode,
+  type AnyBlockDefinition,
+  type BlockDocument,
+  type BlockNode,
+  type NestingSource,
+  type NestingVerdict,
+} from "@nextlyhq/blocks-engine";
+
+import { positionOf, type OpPosition } from "./ops";
+
+/**
+ * The category an entry falls under when its block declares none.
+ *
+ * A literal rather than an empty string, because the panel groups by this value
+ * and a heading has to be nameable. Blocks arrive from plugins that need not
+ * categorise themselves, so this is the common case for third-party blocks
+ * rather than an error state.
+ */
+export const UNCATEGORISED = "other";
+
+/**
+ * One offerable thing: a block, or a block under one of its named variations.
+ *
+ * Two tiers in one list rather than a nested structure, because the panel
+ * filters and keyboard-navigates across both and a nested shape would make
+ * every consumer flatten it first. Gutenberg's third tier — patterns — has no
+ * mechanism in this engine and is therefore ABSENT rather than stubbed: an
+ * empty "Patterns" section would promise a feature that does not exist and
+ * would have to be un-promised when one arrives with a different shape.
+ */
+export interface InsertEntry {
+  /**
+   * Stable identity, for React keys and for naming a selection across a
+   * re-filter.
+   *
+   * Derived from the block and variation names rather than an index, because a
+   * search narrows the list and an index-keyed selection would silently follow
+   * the position instead of the entry — the highlighted row changing meaning
+   * under the author as they type.
+   */
+  readonly id: string;
+  readonly blockName: string;
+  /** Absent on a block's own entry; present on each of its variations. */
+  readonly variationName?: string;
+  readonly label: string;
+  readonly description: string;
+  readonly category: string;
+  readonly keywords: readonly string[];
+  readonly icon?: string;
+  /**
+   * The version to stamp, taken from the definition that produced this entry.
+   *
+   * Carried rather than looked up again at insert time. The registry is
+   * mutable — a plugin can register while a panel is open — so a second lookup
+   * can answer with a different definition than the one the author was shown,
+   * and stamp a version the props do not match.
+   */
+  readonly version: number;
+  /**
+   * The props this entry inserts with: the block's defaults, overlaid by the
+   * variation's.
+   *
+   * A variation may narrow its block's props and never introduce one the
+   * renderer does not accept, which is what makes the overlay safe to compute
+   * here rather than at the call site.
+   */
+  readonly props: Readonly<Record<string, unknown>>;
+}
+
+/** Where an insert would land, as the nesting rule needs to see it. */
+export type InsertTarget =
+  | { readonly at: "root" }
+  | { readonly at: "slot"; readonly parentType: string; readonly slot: string };
+
+/**
+ * A position to insert at, with the target that position implies.
+ *
+ * One value rather than two calls, so the filter and the insert cannot be
+ * computed from different readings of the selection.
+ *
+ * `kind` is carried because the panel says where the block will go, and
+ * "after the selected block" and "at the end of the page" are different
+ * sentences. Deriving it afterwards by re-inspecting the selection would ask
+ * the same question a second time and could answer differently.
+ */
+export interface InsertionPoint {
+  readonly kind: "after-selection" | "document-end";
+  readonly at: OpPosition;
+  readonly target: InsertTarget;
+}
+
+/**
+ * Build the offerable list from block definitions.
+ *
+ * Takes definitions rather than reading the registry, matching how the engine
+ * hands out `NestingSource`: the caller supplies `allBlocks()`, and a test
+ * supplies a fixture without a global registry to clear between cases.
+ *
+ * A block emits its own entry followed immediately by its variations, and
+ * blocks are ordered by the label the author actually reads. Registration
+ * order is an implementation detail of whichever plugin loaded first, so
+ * ordering by it would rearrange the palette when an unrelated plugin is
+ * installed.
+ */
+export function catalogFrom(
+  definitions: readonly AnyBlockDefinition[]
+): InsertEntry[] {
+  const byLabel = [...definitions].sort((a, b) =>
+    labelOf(a).localeCompare(labelOf(b))
+  );
+
+  const entries: InsertEntry[] = [];
+  for (const definition of byLabel) {
+    const editor = definition.editor;
+    const category = editor?.category ?? UNCATEGORISED;
+    const keywords = editor?.keywords ?? [];
+    // `defaultProps` is the block's own object. Spreading here means the entry
+    // owns its copy, so the clone taken at insert time cannot reach back into
+    // the definition — and two inserts of one entry cannot share substructure.
+    const defaults = { ...(definition.defaultProps ?? {}) };
+
+    entries.push({
+      id: definition.name,
+      blockName: definition.name,
+      label: labelOf(definition),
+      description: definition.description,
+      category,
+      keywords,
+      icon: editor?.icon,
+      version: definition.version,
+      props: defaults,
+    });
+
+    for (const variation of editor?.variations ?? []) {
+      entries.push({
+        id: `${definition.name}#${variation.name}`,
+        blockName: definition.name,
+        variationName: variation.name,
+        // A variation without a label is still offerable; naming it by its own
+        // `name` beats falling back to the block's label, which would show two
+        // identical rows and give the author no way to tell them apart.
+        label: variation.label ?? variation.name,
+        // Variations carry no description of their own. The block's is the
+        // honest answer: it describes what will be inserted, which is a
+        // configured instance of that block.
+        description: definition.description,
+        category,
+        keywords,
+        // No `icon` on a variation by design — the engine's `BlockVariation` has
+        // no icon field, so every variation shares its block's. Inventing one
+        // here would put a second, richer contract in the panel than the one
+        // plugin authors can actually write against.
+        icon: editor?.icon,
+        version: definition.version,
+        props: { ...defaults, ...(variation.props ?? {}) },
+      });
+    }
+  }
+  return entries;
+}
+
+/** The name an author reads, falling back to the block's namespaced identity. */
+function labelOf(definition: AnyBlockDefinition): string {
+  return definition.editor?.label ?? definition.name;
+}
+
+/**
+ * Whether this entry may be placed at this target, and why not when it may not.
+ *
+ * The verdict travels rather than a boolean, because a caller explaining a
+ * refusal is the only place the reason is still known — and recovering it means
+ * classifying the placement a second time.
+ *
+ * Only the CHILD's half of the rule is asked here, because only that half is
+ * exported by the engine on this base. The container's half — a slot's
+ * `allow` list — is answered by `canNestInSlot`, and this is the single place
+ * that call belongs when it becomes available: one line, at one call site,
+ * because the target already carries the slot.
+ */
+export function entryAllowedAt(
+  entry: InsertEntry,
+  target: InsertTarget,
+  source: NestingSource
+): NestingVerdict {
+  if (target.at === "root") return canBeRoot(entry.blockName, source);
+  return canNest(entry.blockName, target.parentType, source);
+}
+
+/**
+ * The entries a target will actually accept.
+ *
+ * Refused entries are REMOVED rather than shown disabled. A palette is a list
+ * of things you can do; a row that cannot be clicked is a question the author
+ * has to answer before every insert, and the answer never changes while the
+ * selection stands. The verdict's reason stays available through
+ * {@link entryAllowedAt} for surfaces where the author has already committed to
+ * a placement — a refused DROP has to say why, because the author aimed there.
+ */
+export function allowedEntries(
+  entries: readonly InsertEntry[],
+  target: InsertTarget,
+  source: NestingSource
+): InsertEntry[] {
+  return entries.filter(entry => entryAllowedAt(entry, target, source).allowed);
+}
+
+/**
+ * Narrow the catalog by what the author typed.
+ *
+ * Matches the label, the namespaced block name, the declared keywords and the
+ * description — the block name included because it is what appears in
+ * documentation and in an agent's output, so someone who knows `core/heading`
+ * should not have to guess that it is labelled "Heading".
+ *
+ * An empty or whitespace-only query returns the list unchanged rather than
+ * nothing: the panel opens with no query, and a filter that treated that as
+ * "match nothing" would show an empty palette on open.
+ */
+export function filterEntries(
+  entries: readonly InsertEntry[],
+  query: string
+): InsertEntry[] {
+  const needle = query.trim().toLowerCase();
+  if (needle === "") return [...entries];
+  return entries.filter(entry =>
+    [entry.label, entry.blockName, entry.description, ...entry.keywords].some(
+      field => field.toLowerCase().includes(needle)
+    )
+  );
+}
+
+/** A category heading and the entries under it, in the order the panel draws them. */
+export interface InsertGroup {
+  readonly category: string;
+  readonly entries: readonly InsertEntry[];
+}
+
+/**
+ * Group entries under their categories, preserving the order they arrive in.
+ *
+ * First appearance decides category order rather than an alphabetical sort of
+ * the headings, so a block and its variations stay adjacent and the sort
+ * applied upstream is not undone here by a second ordering rule.
+ */
+export function groupByCategory(
+  entries: readonly InsertEntry[]
+): InsertGroup[] {
+  const groups = new Map<string, InsertEntry[]>();
+  for (const entry of entries) {
+    const bucket = groups.get(entry.category);
+    if (bucket === undefined) groups.set(entry.category, [entry]);
+    else bucket.push(entry);
+  }
+  return [...groups].map(([category, grouped]) => ({
+    category,
+    entries: grouped,
+  }));
+}
+
+/**
+ * Where a new block goes, given what is selected.
+ *
+ * After the selected block, as a sibling in the same region — which is what an
+ * author who just clicked a block and reached for the inserter means. Inserting
+ * INTO a selected container is a different intention and gets its own gesture
+ * on the canvas; guessing between the two from one click would make the same
+ * action do two things depending on what kind of block happened to be selected.
+ *
+ * Falls back to the end of the document when nothing is selected, and when the
+ * selection names a node the document no longer has — a stale id after an undo,
+ * or a selection made against a document that has since been replaced.
+ *
+ * Returns `null` only when the selected node sits somewhere no op can name: a
+ * parent without a slot. Appending at the end instead would silently insert
+ * somewhere the author was not looking, so the caller is told it cannot answer
+ * rather than handed a plausible wrong position.
+ */
+export function insertionPointFor(
+  document: BlockDocument,
+  selectedId: string | null
+): InsertionPoint | null {
+  const end: InsertionPoint = {
+    kind: "document-end",
+    at: { index: document.nodes.length },
+    target: { at: "root" },
+  };
+  if (selectedId === null) return end;
+
+  const location = locateNode(document.nodes, selectedId);
+  if (location === undefined) return end;
+
+  let after: OpPosition;
+  try {
+    const here = positionOf(location);
+    after = { ...here, index: here.index + 1 };
+  } catch {
+    // `positionOf` refuses a parent with no named slot, which is a position the
+    // op vocabulary cannot express. That refusal is about the SELECTED node's
+    // surroundings rather than about anything the author did, so it is reported
+    // as "no answer" rather than raised at them.
+    return null;
+  }
+
+  if (location.parent === undefined) {
+    return { kind: "after-selection", at: after, target: { at: "root" } };
+  }
+  // `positionOf` has already refused the slot-less case, so a parent here has a
+  // slot. Read it from the location rather than re-deriving from `after`, whose
+  // type permits a top-level position that this branch has excluded.
+  return {
+    kind: "after-selection",
+    at: after,
+    target: {
+      at: "slot",
+      parentType: location.parent.type,
+      slot: location.slot ?? "",
+    },
+  };
+}
+
+/**
+ * The node an entry inserts.
+ *
+ * Props are deep-copied. The entry outlives every insert made from it, so
+ * handing out its own object would let an edit to one inserted block reach the
+ * catalog — and through it every block inserted from that entry afterwards.
+ * A shallow copy is not enough, because a default value may be an array or a
+ * nested object and those would still be shared.
+ */
+export function nodeForEntry(entry: InsertEntry): BlockNode {
+  return makeNode(entry.blockName, entry.version, structuredClone(entry.props));
+}

--- a/packages/builder/src/inserter.ts
+++ b/packages/builder/src/inserter.ts
@@ -27,6 +27,7 @@
 import {
   canBeRoot,
   canNest,
+  canNestInSlot,
   locateNode,
   makeNode,
   type AnyBlockDefinition,
@@ -201,11 +202,17 @@ function labelOf(definition: AnyBlockDefinition): string {
  * refusal is the only place the reason is still known — and recovering it means
  * classifying the placement a second time.
  *
- * Only the CHILD's half of the rule is asked here, because only that half is
- * exported by the engine on this base. The container's half — a slot's
- * `allow` list — is answered by `canNestInSlot`, and this is the single place
- * that call belongs when it becomes available: one line, at one call site,
- * because the target already carries the slot.
+ * BOTH halves are asked, and the child's first. `block.ts` is explicit that
+ * neither implies the other: a slot naming a type does not confine that type to
+ * it, and a child restricting its parents says nothing about which of that
+ * parent's slots may hold it. Asking only the allow-list would offer a column
+ * at the page root; asking only `parent` would let anything into a slot that
+ * names what it holds.
+ *
+ * The child's half runs first so its reason survives when both would refuse.
+ * "This block belongs inside a Columns" tells an author where to go; "this
+ * region does not take that block" leaves them looking for a region, which is
+ * the less actionable of the two sentences.
  */
 export function entryAllowedAt(
   entry: InsertEntry,
@@ -213,7 +220,9 @@ export function entryAllowedAt(
   source: NestingSource
 ): NestingVerdict {
   if (target.at === "root") return canBeRoot(entry.blockName, source);
-  return canNest(entry.blockName, target.parentType, source);
+  const child = canNest(entry.blockName, target.parentType, source);
+  if (!child.allowed) return child;
+  return canNestInSlot(entry.blockName, target.parentType, target.slot, source);
 }
 
 /**

--- a/packages/builder/src/ops.ts
+++ b/packages/builder/src/ops.ts
@@ -2334,7 +2334,11 @@ function assertDropSlotWasVacated(
   }
 }
 
-function positionOf(location: NodeLocation): OpPosition {
+// Exported to the module graph, deliberately not to the package entry: the
+// inserter needs the same location-to-position answer the op layer uses, and a
+// second conversion would disagree about the slot invariant below the first
+// time either changed.
+export function positionOf(location: NodeLocation): OpPosition {
   if (location.parent === undefined) return { index: location.index };
   // A parent with no slot is not a position an op can express, and building one
   // anyway would put an unapplicable op into the inverse: an undo that names

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -65,5 +65,23 @@ export type { CanvasProps } from "./canvas";
  * handler and an agent all reach the same `apply`, so undo covers every one of
  * them rather than only the path that happened to implement it.
  */
+/**
+ * The inserter, behind the same client banner as the shell it fills: it holds
+ * search state and composes the command primitives, so it is interactive in its
+ * own right.
+ *
+ * Published here rather than from the root for the reason the canvas is — the
+ * root entry stays server-callable, and a value re-export of a client component
+ * would make importing the frame geometry pull React into a server bundle.
+ *
+ * The derivations it draws from are deliberately NOT re-exported beside it.
+ * They are the editor's internal answer to what may be inserted where, and
+ * publishing them would invite a host to compute a palette of its own — which
+ * is the second implementation of the nesting rule that the engine exists to
+ * prevent.
+ */
+export { InsertPanel } from "./insert-panel";
+export type { InsertPanelProps } from "./insert-panel";
+
 export { MAX_HISTORY, useEditorState } from "./editor-state";
 export type { EditorState, UseEditorStateArgs } from "./editor-state";

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -151,3 +151,68 @@
       color 120ms ease;
   }
 }
+
+/*
+ * The inserter panel.
+ *
+ * Colours come from the admin's tokens rather than from literals, so the panel
+ * follows the host's light and dark themes without a second palette here. The
+ * list scrolls inside the panel rather than the panel growing, because the rail
+ * fixes the panel's width and height and a growing list would push the shell's
+ * own layout instead of its own.
+ */
+.nx-insert-panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+  color: var(--nx-builder-text, var(--nx-foreground));
+  background: var(--nx-builder-surface, var(--nx-background));
+}
+
+/*
+ * Where the next block lands. Announced politely rather than assertively: it
+ * changes on every selection change, and an assertive region would interrupt a
+ * screen reader mid-sentence each time the author moved.
+ */
+.nx-insert-panel__placement {
+  padding: 0.25rem 0.75rem 0.5rem;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--nx-muted-foreground);
+  border-bottom: 1px solid var(--nx-border);
+}
+
+.nx-insert-panel__note {
+  padding: 0.75rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--nx-muted-foreground);
+}
+
+/*
+ * Two lines per row, so the block's description is readable without a hover.
+ * A palette that shows only labels makes an author guess what "Section" holds,
+ * and the description is already required on every block definition.
+ */
+.nx-insert-panel__label {
+  display: block;
+  font-weight: 500;
+  color: var(--nx-foreground);
+}
+
+.nx-insert-panel__description {
+  display: block;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--nx-muted-foreground);
+  /*
+   * Clamped rather than truncated at one line: descriptions are prose written
+   * by block authors and the first few words are often a category name shared
+   * with a sibling block, so one line can render two rows indistinguishable.
+   */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -34,7 +34,12 @@
  */
 
 import type { BlockDocument } from "@nextlyhq/blocks-engine";
-import { BuilderShell, Canvas, useEditorState } from "@nextlyhq/builder/shell";
+import {
+  BuilderShell,
+  Canvas,
+  InsertPanel,
+  useEditorState,
+} from "@nextlyhq/builder/shell";
 import { useSuppressAdminChrome } from "@nextlyhq/plugin-sdk/admin";
 import { useCallback, useMemo, useState } from "react";
 import {
@@ -61,13 +66,14 @@ export interface BlocksFieldProps<
 /**
  * Every left panel the editor can fill today.
  *
- * Empty, because the inserter, layers and the rest are not built. The shell
- * draws all seven regardless and disables the ones nothing fills, so the rail
- * describes the editor's shape while never opening a region with nothing in it.
- * Listing a panel here that renders nothing would reserve space and shrink the
- * canvas to show it.
+ * The inserter only; layers and the rest are not built. The shell draws all
+ * seven regardless and disables the ones nothing fills, so the rail describes
+ * the editor's shape while never opening a region with nothing in it. Listing a
+ * panel here that renders nothing would reserve space and shrink the canvas to
+ * show it, which is why this grows one entry at a time rather than being
+ * declared ahead of the panels.
  */
-const AVAILABLE_PANELS = [] as const;
+const AVAILABLE_PANELS = ["insert"] as const;
 
 /**
  * A stored value that is not a usable document is treated as absent.
@@ -185,7 +191,17 @@ function BlocksEditor({
 
   return (
     <div className="fixed inset-0 z-50 bg-background">
-      <BuilderShell onExit={done} availablePanels={AVAILABLE_PANELS}>
+      <BuilderShell
+        onExit={done}
+        availablePanels={AVAILABLE_PANELS}
+        // Switched on the panel id rather than rendering the inserter for
+        // whatever the rail reports open. The shell asks for the panel it
+        // opened, and a renderer ignoring that argument would draw the inserter
+        // under every heading the moment a second panel is listed above.
+        renderPanel={panel =>
+          panel === "insert" ? <InsertPanel editor={editor} /> : null
+        }
+      >
         <Canvas
           document={editor.document}
           siteStyles={siteSheet()}


### PR DESCRIPTION
B-15, the three-tier inserter. The editor could open, select and undo; it could not **add a block**. This is the piece that makes it usable.

## What is here

- `packages/builder/src/inserter.ts` — the derivations: what may be offered, what a query matches, where a chosen entry lands, what node to build. Pure, no React, no DOM.
- `packages/builder/src/insert-panel.tsx` — the surface. Draws what the module decides and decides nothing.
- Wired into the editor's rail, which already drew all seven panels and disabled the ones nothing filled.

## The decision that shaped it

**The palette and the insert must agree.** A panel deciding what to OFFER from one reading of the selection while inserting against another will show a block, accept the click, and have the op layer refuse it — a refusal the author cannot act on, because the thing offered is the thing rejected. So `insertionPointFor` returns the position **and the target it implies together**, and everything downstream takes the target from that single answer.

Three things deliberately NOT done:

- **No patterns tier.** Gutenberg has three; this engine has a mechanism for one. Variations are real and wired. An empty "Patterns" section would promise a feature that does not exist and have to be un-promised when one arrives with a different shape.
- **No second nesting rule.** Both halves are called — `canNest` then `canNestInSlot` — child's half first, because "belongs inside a Columns" is actionable and "this region does not take that" leaves an author hunting for a region.
- **No second position derivation.** `positionOf` is shared with the op layer rather than restated, so the slot invariant has one implementation.

`shouldFilter={false}` is load-bearing: cmdk filters by default, and leaving it on would put a second matcher beside the tested one, silently overruling it on block names and keywords. A test fails if anyone turns it back on.

## Evidence

529 tests pass (469 builder, 60 plugin-page-builder), 30/30 tasks, from a clean build.

Stub-verified in **eight** directions — every break failed exactly the intended test and nothing else, restored and proven by empty diff:

| break | test that fired |
| --- | --- |
| target always `root` | stays inside the selected block's own region |
| no deep clone | gives every inserted node its own props |
| nesting keyed on entry id | derives a variation's placement from its block |
| drop the container's half | refuses a block a slot's allow-list does not admit |
| cmdk filter left on | narrows by the tested filter rather than the widget's own |
| no select after insert | selects what it inserted |
| ignore a refused op | does not report an insert the op layer refused |
| offer the whole catalog | offers only what the target admits |

## Verified in a browser, including one thing the unit tests could not see

Driven with Playwright against the playground. The shell opens full-screen with admin chrome suppressed, the rail reports `Insert` enabled and the other six `— coming soon` disabled, the panel renders its search box and placement line, and the empty state reads correctly.

**And the palette is empty, for a reason outside this PR.** `registerCoreBlocks` runs in the plugin's server-side setup, and the engine's registry is module state — so the copy in the admin's *client* bundle starts empty. `allBlocks()` returns nothing, and the panel correctly reports "No blocks can be added here."

The same gap affects the canvas, which is handed no block resolver either and so could not draw an inserted block.

I attempted the fix here and **backed it out**: registering the core blocks at mount made the field render "Unknown field type: blocks", which is a namespace-ownership refusal rather than anything the inserter can settle. Populating the client registry is a distinct change touching how the plugin bootstraps in the browser, it affects the renderer as much as the palette, and it deserves its own review rather than riding in on this one.

So this PR ships the inserter and its wiring; a follow-up makes blocks reach the browser. Worth stating plainly: **until that lands, the panel opens and offers nothing.**
