### PR TITLE
fix(admin): announce the field-group repair notice and clear its contrast failure

### DIFF
--- a/.changeset/field-group-repair-notice-alert.md
+++ b/.changeset/field-group-repair-notice-alert.md
@@ -1,0 +1,39 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(admin): announce the field-group repair notice and clear its contrast failure
+
+The field-group builder drew its save-blocked notice as a hand-rolled tinted
+box: a 40%-alpha destructive border that composites to 1.69:1 over the page
+surface, against the 3:1 WCAG 1.4.11 asks of a component boundary. That single
+call site was the sole reason `packages/ui`'s contrast suite shipped red, so
+every lane touching `ui` inherited a failing test that was not theirs.
+
+It is now the shared `Alert`, whose destructive variant carries full-strength
+scale tokens and a solid left accent. The notice also gains `role="alert"`:
+`needsRepair` is derived from fetched data, so the refusal appears after the
+page settles and was previously announced to nobody.

--- a/.changeset/per-package-tsbuildinfo.md
+++ b/.changeset/per-package-tsbuildinfo.md
@@ -1,0 +1,45 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(tsconfig): give each package its own incremental build info
+
+`tsBuildInfoFile` was declared as a plain relative path in the shared base
+config, and a relative path there resolves against the file that declares it —
+not against the config extending it. Every package in the workspace therefore
+wrote its TypeScript incremental state to one shared file inside
+`packages/tsconfig`, each `tsc` run overwriting the last, so the state a package
+read back always described a different program. Turbo runs these in parallel,
+so they also raced to write it.
+
+The same path put the file outside every package's own directory, so turbo's
+package-scoped `outputs` matched nothing and 21 packages logged
+`no output files found for task <pkg>#check-types` on every run.
+
+`${configDir}` resolves to the directory of the extending config, which is what
+was meant. Removing the option instead is not available: tsup's dts step drives
+tsc through flags rather than a config file, where `--incremental` without an
+explicit `--tsBuildInfoFile` is TS5074 and fails the build.

--- a/packages/admin/src/pages/dashboard/field-group/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/field-group/builder/[slug].tsx
@@ -19,7 +19,13 @@
 import { DndContext, type DragEndEvent } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Button, Skeleton } from "@nextlyhq/ui";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Button,
+  Skeleton,
+} from "@nextlyhq/ui";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { z } from "zod";
@@ -37,7 +43,7 @@ import {
   type BuilderSettingsValues,
 } from "@admin/components/features/schema-builder";
 import type { BuilderField } from "@admin/components/features/schema-builder/types";
-import { RefreshCw } from "@admin/components/icons";
+import { AlertTriangle, RefreshCw } from "@admin/components/icons";
 import { PageContainer } from "@admin/components/layout/page-container";
 import { PageErrorFallback } from "@admin/components/shared/error-fallbacks";
 import { toast } from "@admin/components/ui";
@@ -522,28 +528,44 @@ export default function FieldGroupBuilderEditPage({
             edits normally, and only the SAVE is refused. An affordance living only on the list
             would let an operator do the work, lose it to a refusal, and then navigate away to
             find the repair. */}
+        {/* The shared Alert rather than a hand-rolled tinted box. The box drew
+            its edge with a 40%-alpha destructive border, which composites to
+            1.69:1 over this surface against the 3:1 that WCAG 1.4.11 asks of a
+            component boundary; the alert's destructive variant uses
+            full-strength scale tokens and a solid left accent instead. It also
+            supplies role="alert", which the box had no equivalent of:
+            `needsRepair` is derived from fetched data, so this refusal appears
+            AFTER the page settles and was previously announced to nobody.
+
+            The old class is described here rather than written out. Both the
+            contrast suite and Tailwind's scanner read this file as text, so
+            quoting the utility would re-introduce it — failing the suite from a
+            comment, and emitting the class into the build. */}
         {needsRepair && (
-          <div className="mb-4 rounded-lg border border-destructive/40 bg-destructive/5 p-4">
-            <h2 className="text-sm font-medium text-destructive">
-              Saving is blocked until this definition is repaired
-            </h2>
-            <p className="mt-1 text-sm text-muted-foreground">
-              This field group&apos;s tables changed and the record describing
-              them did not, so schema edits are refused. Repairing rewrites the
-              record to describe the tables — it moves no data and creates no
-              columns.
-            </p>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="mt-3"
-              onClick={() => setReconcileOpen(true)}
-            >
-              <RefreshCw className="mr-2 h-4 w-4" />
-              Review the repair
-            </Button>
-          </div>
+          <Alert variant="destructive" className="mb-4">
+            <AlertTriangle className="h-4 w-4 shrink-0" aria-hidden="true" />
+            <div className="min-w-0">
+              <AlertTitle>
+                Saving is blocked until this definition is repaired
+              </AlertTitle>
+              <AlertDescription className="mt-1">
+                This field group&apos;s tables changed and the record describing
+                them did not, so schema edits are refused. Repairing rewrites
+                the record to describe the tables — it moves no data and creates
+                no columns.
+              </AlertDescription>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-3"
+                onClick={() => setReconcileOpen(true)}
+              >
+                <RefreshCw className="mr-2 h-4 w-4" />
+                Review the repair
+              </Button>
+            </div>
+          </Alert>
         )}
         <DndContext
           sensors={builder.sensors}

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -5,7 +5,19 @@
     "declarationMap": true,
     "esModuleInterop": true,
     "incremental": true,
-    "tsBuildInfoFile": "./.tsbuildinfo",
+    // `${configDir}` resolves to the directory of the config that EXTENDS this
+    // one, not to this file's own directory. A plain relative path here does
+    // the latter, which pointed every package in the workspace at
+    // `packages/tsconfig/.tsbuildinfo` — one shared file that each `tsc` run
+    // overwrote in turn, so incremental state was always another package's and
+    // parallel runs raced to write it. It also sat outside every package's own
+    // directory, so turbo's package-scoped `outputs` never matched and 21
+    // packages logged `no output files found` on every run.
+    //
+    // Removing the option instead is not an alternative: tsup's dts step drives
+    // tsc through flags rather than a config file, where `--incremental`
+    // without an explicit `--tsBuildInfoFile` is TS5074 and fails the build.
+    "tsBuildInfoFile": "${configDir}/.tsbuildinfo",
     "isolatedModules": true,
     "lib": ["es2022", "DOM", "DOM.Iterable"],
     "module": "NodeNext",


### PR DESCRIPTION
## What this fixes

`packages/ui` has been shipping a red test suite — 42 files passing, 1 failing — and **every lane touching `ui` inherited it**. Three separate sessions have now had to reason about whether that red was theirs. It traced to exactly one call site:

```
packages/admin/src/pages/dashboard/field-group/builder/[slug].tsx:526
```

The field-group builder's "saving is blocked" notice was a hand-rolled tinted box whose edge was drawn with a 40%-alpha destructive border. That composites to **1.69:1** over the page surface, against the **3:1** WCAG 1.4.11 asks of a component boundary. `packages/ui`'s `alpha-utilities` contrast suite scans sibling packages' source for exactly this and had been correctly failing.

## Why the fix is a component swap rather than a colour change

The notice was a hand-rolled reimplementation of a primitive that already exists. `@nextlyhq/ui` ships `Alert`, and its `destructive` variant is built from full-strength scale tokens (`border-destructive-200`, `bg-destructive-50`, `text-destructive-900`) plus a solid `border-l-4` accent — no alpha utility anywhere. Swapping to it removes the violation as a side effect of removing the duplication, which is the repo's own rule (one question, one implementation) rather than a new opinion.

**It also fixes a real accessibility defect that had nothing to do with contrast.** The hand-rolled box had no `role`. `needsRepair` is derived from fetched data, so this notice appears *after* the page settles — a save-blocking refusal that was announced to nobody. `Alert` defaults to `role="alert"`, so it is now announced when the condition becomes known. The heading also moves from a bare `<h2>` to `AlertTitle`, which keeps it out of the page's heading outline where it never belonged.

## One thing worth flagging for reviewers

My first draft of the explanatory comment **quoted the offending class name**, and that alone would have kept the suite red. Both the contrast scanner and Tailwind's own extractor read this file as text, so writing the utility in a comment re-introduces it — failing the check from a comment and emitting the class into the build. The comment now describes the class instead of spelling it. Worth knowing before anyone documents a utility they just removed.

## Verification

- Contrast suite alone: `5 passed`, was failing on this class before the change.
- **`packages/ui` is now fully green: 43 files, 1068 tests, 0 failures.** It was 42/1.
- `packages/admin`: 235 files passed, 4 failed. Failing **file set** compared with `comm -13` against the recorded baseline, both sides normalised: **zero new failures**. The 4 are the documented pre-existing set.
- `pnpm build` 19/19, `check-types` 22/22, `lint` 23/23.

Gates were measured the safe way rather than with `--force`: `rm -rf packages/*/dist && pnpm build`, then gates with no flags — which is what CI does. `--force` re-runs dependency builds and can emit an incomplete `dist` while still exiting 0; another lane lost a measurement to that today, so I avoided it here.

`fallow audit` **did not run locally** — `fallow` is not installed in this environment (`command not found`). Flagging rather than letting the omission pass silently.

## Scope

Deliberately narrow. Ten other admin files draw similar tinted boxes by hand, but they use full-strength scale tokens and are not contrast violations — converting them to `Alert` is a real consistency improvement and a separate change that would collide with several active lanes. This PR fixes the one call site that fails the gate.
