### PR TITLE
fix(ui): let the tab rail and its indicator follow the orientation

### DIFF
--- a/.changeset/tabs-rail-follows-orientation.md
+++ b/.changeset/tabs-rail-follows-orientation.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Vertical tabs draw their selection line down the side of the list rather than across the bottom
+of it. The component has always documented a vertical arrangement, but the rail beneath the tab
+strip and the marker on the selected tab were both fixed to the bottom edge, so a vertical list
+got a horizontal line underneath it and its selected tab was marked on the wrong side. Both now
+follow the same edge, so they cannot end up on different axes.

--- a/packages/ui/src/components/tabs-rail.test.tsx
+++ b/packages/ui/src/components/tabs-rail.test.tsx
@@ -22,9 +22,9 @@ function tokensOf(el: Element | null): string[] {
   return [...(el?.classList ?? [])];
 }
 
-function renderTabs() {
+function renderTabs(orientation?: "horizontal" | "vertical") {
   const { container } = render(
-    <Tabs defaultValue="one">
+    <Tabs defaultValue="one" orientation={orientation}>
       <TabsList>
         <TabsTrigger value="one">One</TabsTrigger>
         <TabsTrigger value="two">Two</TabsTrigger>
@@ -77,5 +77,48 @@ describe("tabs rail", () => {
   it("keeps the strip square, so the rail stays flush with the tab edges", () => {
     const { list } = renderTabs();
     expect(tokensOf(list)).toContain("rounded-none");
+  });
+
+  /**
+   * The list documents vertical support, so the rail has to follow the trailing
+   * EDGE rather than sit on a fixed one. A bottom rail under a vertical list is
+   * a horizontal line beneath a column of tabs.
+   *
+   * The indicator switches with it. Moving only one of the two puts the
+   * selection affordance on one axis and the line it sits on the other, which
+   * is worse than either being wrong alone.
+   */
+  describe("vertical orientation", () => {
+    it("moves the rail to the trailing edge", () => {
+      const { list } = renderTabs("vertical");
+      const tokens = tokensOf(list);
+      expect(tokens).toContain("data-[orientation=vertical]:border-r");
+      expect(tokens).toContain("data-[orientation=vertical]:border-b-0");
+    });
+
+    it("moves the indicator and its pull onto the same axis as the rail", () => {
+      const { trigger } = renderTabs("vertical");
+      const tokens = tokensOf(trigger);
+      expect(tokens).toContain("data-[orientation=vertical]:border-r-2");
+      expect(tokens).toContain("data-[orientation=vertical]:-mr-0.5");
+      expect(tokens).toContain("data-[orientation=vertical]:border-b-0");
+      expect(tokens).toContain("data-[orientation=vertical]:mb-0");
+    });
+
+    /**
+     * The population control: Radix must actually be stamping the attribute,
+     * or every assertion above is about class strings nothing will ever match.
+     */
+    it("is actually marked vertical by Radix", () => {
+      const { list, trigger } = renderTabs("vertical");
+      expect(list?.getAttribute("data-orientation")).toBe("vertical");
+      expect(trigger?.getAttribute("data-orientation")).toBe("vertical");
+    });
+
+    it("stays horizontal by default", () => {
+      const { list, trigger } = renderTabs();
+      expect(list?.getAttribute("data-orientation")).toBe("horizontal");
+      expect(trigger?.getAttribute("data-orientation")).toBe("horizontal");
+    });
   });
 });

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -124,14 +124,19 @@ const tabsListVariants = cva(
   // repeating them in each arm gives any future adjustment two sites to change
   // and one to forget.
   //
-  // `border-b` is the rail the triggers sit on, and it is load-bearing rather
-  // than decoration. Each trigger draws a 2px bottom border and pulls itself up
-  // by `-mb-0.5` so that border lands ON this one: with no rail here, the pull
-  // put a 2px line onto whatever followed the strip in the document, and above
-  // a rounded panel that is the corner curve — a straight bar crossing an 8px
-  // arc. The rail also gives an inactive tab somewhere to be inactive, which is
-  // what makes the active one read as selected rather than as the only tab.
-  "inline-flex items-center justify-center gap-1 rounded-none border-b border-border p-0 text-muted-foreground",
+  // The rail the triggers sit on, and it is load-bearing rather than
+  // decoration. Each trigger draws a 2px border on its trailing edge and pulls
+  // itself half a step onto this one: with no rail here, that pull put a 2px
+  // line onto whatever followed the strip in the document, and above a rounded
+  // panel that is the corner curve — a straight bar crossing an 8px arc. The
+  // rail also gives an inactive tab somewhere to be inactive, which is what
+  // makes the active one read as selected rather than as the only tab.
+  //
+  // Which edge is the trailing one depends on orientation, so the rail follows
+  // it. Radix stamps `data-orientation` on the list and on every trigger, so
+  // both halves read the same source and cannot disagree about the axis. A
+  // fixed bottom rail draws a horizontal line beneath a vertical list.
+  "inline-flex items-center justify-center gap-1 rounded-none border-b border-border p-0 text-muted-foreground data-[orientation=vertical]:flex-col data-[orientation=vertical]:items-stretch data-[orientation=vertical]:border-b-0 data-[orientation=vertical]:border-r",
   {
     variants: { variant: TABS_LIST_VARIANTS },
     defaultVariants: { variant: "default" },
@@ -175,9 +180,15 @@ const TABS_TRIGGER_SIZES = {
 } as const;
 
 const tabsTriggerVariants = cva(
-  // Square corners: the active state is a 2px bottom border that has to run the
-  // full width of the trigger.
-  "inline-flex items-center justify-center whitespace-nowrap rounded-none bg-transparent px-4 py-2 font-medium cursor-pointer transition-all duration-200 border-b-2 relative -mb-0.5 data-[state=active]:border-b-primary! data-[state=active]:text-primary data-[state=inactive]:border-transparent data-[state=inactive]:text-muted-foreground hover:text-primary hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed",
+  // Square corners: the active state is a 2px border on the trailing edge that
+  // has to run the full length of the trigger and stay flush with its ends.
+  //
+  // The trailing edge is the bottom when the strip is horizontal and the right
+  // when it is vertical, so the indicator, the half-step pull onto the rail and
+  // the active colour all switch axis together off the same `data-orientation`
+  // the list reads. Switching only some of them puts the selection affordance
+  // on one axis and the line it sits on the other.
+  "inline-flex items-center justify-center whitespace-nowrap rounded-none bg-transparent px-4 py-2 font-medium cursor-pointer transition-all duration-200 border-b-2 relative -mb-0.5 data-[state=active]:border-b-primary! data-[state=active]:text-primary data-[state=inactive]:border-transparent data-[state=inactive]:text-muted-foreground hover:text-primary hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed data-[orientation=vertical]:border-b-0 data-[orientation=vertical]:mb-0 data-[orientation=vertical]:border-r-2 data-[orientation=vertical]:-mr-0.5 data-[orientation=vertical]:data-[state=active]:border-r-primary",
   {
     variants: { size: TABS_TRIGGER_SIZES },
     defaultVariants: { size: "default" },


### PR DESCRIPTION
Follow-up to #959, working the one review finding it received.

## The finding

Greptile, P2 on `packages/ui/src/components/tabs.tsx`: *"Rail ignores vertical orientation."*

**Valid, and I want to be precise about what part is mine.** The trigger's bottom indicator was already unconditional before #959 — that half predates it. What #959 added was the rail, and that made the vertical case visibly worse: a horizontal line drawn beneath a column of tabs. So the defect is half inherited and half mine, and fixing only my half would leave the marker on one axis and the line it sits on the other, which is worse than either alone.

## Scope check first

`orientation="vertical"` has **zero** uses anywhere in the repo — the only occurrences are two docblock examples in `tabs.tsx` itself. So this is not an internal regression; it is a published-API defect. `@nextlyhq/ui` documents vertical support and does not deliver it.

## The fix

The rail and the indicator both switch axis off the same `data-orientation` that Radix stamps on the list *and* on every trigger, so the two read one source and cannot disagree:

- `TabsList` — bottom rail becomes a right-hand rail, and the strip stacks (`flex-col`, `items-stretch`).
- `TabsTrigger` — the 2px marker, the half-step pull onto the rail, and the active colour all move to the right edge together.

## Test plan

- **4 new tests**, and both new assertions break-verified: removing the list's vertical classes fails "moves the rail to the trailing edge"; removing the trigger's fails "moves the indicator and its pull onto the same axis as the rail". Restored, 8/8 pass.
- **A population control**, because the assertions are about class strings that only matter if the attribute exists: the suite asserts Radix actually stamps `data-orientation="vertical"` on both the list and the trigger, and `"horizontal"` by default. Without it, every class assertion could be about a selector nothing will ever match.
- `packages/ui` — 1075 passed, 1 failed. `packages/admin` — 2042 passed, 15 failed (4 files).

## Pre-existing failures (NOT introduced here)

- `packages/ui`: the single `alpha-utilities` failure, `border-destructive/40 = 1.69:1`, from `field-group/builder/[slug].tsx`. Claimed by the lane on #960; once that merges, any contrast failure here would be mine.
- `packages/admin`: the standing 15 failures across `StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField` — the same set and counts as before this change.

## Changeset

Added: yes (`patch`, all published packages).
