### PR TITLE
fix(tsconfig): give each package its own incremental build info

### DIFF
--- a/.changeset/per-package-tsbuildinfo.md
+++ b/.changeset/per-package-tsbuildinfo.md
@@ -1,0 +1,45 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(tsconfig): give each package its own incremental build info
+
+`tsBuildInfoFile` was declared as a plain relative path in the shared base
+config, and a relative path there resolves against the file that declares it —
+not against the config extending it. Every package in the workspace therefore
+wrote its TypeScript incremental state to one shared file inside
+`packages/tsconfig`, each `tsc` run overwriting the last, so the state a package
+read back always described a different program. Turbo runs these in parallel,
+so they also raced to write it.
+
+The same path put the file outside every package's own directory, so turbo's
+package-scoped `outputs` matched nothing and 21 packages logged
+`no output files found for task <pkg>#check-types` on every run.
+
+`${configDir}` resolves to the directory of the extending config, which is what
+was meant. Removing the option instead is not available: tsup's dts step drives
+tsc through flags rather than a config file, where `--incremental` without an
+explicit `--tsBuildInfoFile` is TS5074 and fails the build.

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -5,7 +5,19 @@
     "declarationMap": true,
     "esModuleInterop": true,
     "incremental": true,
-    "tsBuildInfoFile": "./.tsbuildinfo",
+    // `${configDir}` resolves to the directory of the config that EXTENDS this
+    // one, not to this file's own directory. A plain relative path here does
+    // the latter, which pointed every package in the workspace at
+    // `packages/tsconfig/.tsbuildinfo` — one shared file that each `tsc` run
+    // overwrote in turn, so incremental state was always another package's and
+    // parallel runs raced to write it. It also sat outside every package's own
+    // directory, so turbo's package-scoped `outputs` never matched and 21
+    // packages logged `no output files found` on every run.
+    //
+    // Removing the option instead is not an alternative: tsup's dts step drives
+    // tsc through flags rather than a config file, where `--incremental`
+    // without an explicit `--tsBuildInfoFile` is TS5074 and fails the build.
+    "tsBuildInfoFile": "${configDir}/.tsbuildinfo",
     "isolatedModules": true,
     "lib": ["es2022", "DOM", "DOM.Iterable"],
     "module": "NodeNext",


### PR DESCRIPTION
## The defect

`packages/tsconfig/base.json` declared:

```jsonc
"incremental": true,
"tsBuildInfoFile": "./.tsbuildinfo"
```

A relative path in a base config resolves against **the file that declares it**, not against the config extending it. So every package in the workspace wrote its TypeScript incremental state to the *same* file inside `packages/tsconfig`.

Confirmed by asking `tsc` rather than by reading the spec — `npx tsc --showConfig` in `packages/ui` reported:

```
tsBuildInfoFile = ../tsconfig/.tsbuildinfo
```

And confirmed as an actual clobber, not just a shared path:

```
after packages/ui         md5=d0435c39… size=78949
after packages/telemetry  md5=e0685dd3… size=58978   <- overwrote it
```

Three consequences:

1. **Incremental compilation never worked.** The state a package read back always described a different program, so `tsc` discarded it and did a full check every time.
2. **Turbo runs these in parallel**, so multiple `tsc` processes raced to write one file.
3. **Turbo's `outputs` matched nothing.** `outputs: ["**/*.tsbuildinfo"]` is package-scoped and the file lived outside every package, so 21 packages logged `no output files found for task <pkg>#check-types` on every single run — 21 spurious warnings training people to skim past real ones.

## The fix, and why not the obvious one

`${configDir}` (TypeScript 5.5+; this repo is on 5.9.3) resolves to the directory of the **extending** config, which is what was meant all along.

**I tried removing the option first, and it broke the build.** tsup's dts step drives `tsc` through flags rather than a config file, and there `--incremental` without an explicit `--tsBuildInfoFile` is `TS5074`:

```
@nextlyhq/blocks-engine:build: error TS5074: Option '--incremental' can only be
specified using tsconfig, emitting to single file or when option
'--tsBuildInfoFile' is specified.
```

So the option is load-bearing; it just needed to resolve per package. Recorded in the config comment so the next person doesn't repeat the experiment.

## Verification

Measured before and after on the same tree:

| | before | after |
| --- | --- | --- |
| `no output files found` warnings | 21 | **0** |
| per-package `.tsbuildinfo` files | 0 | **21** |
| shared `packages/tsconfig/.tsbuildinfo` | present, clobbered | **absent** |

`tsc --showConfig` now reports `./.tsbuildinfo` per package.

Gates: `pnpm build` 19/19, `check-types` 22/22 (`0 cached, 22 total` — genuinely executed, not replayed), `lint` 23/23.

`.gitignore` already covers the new filenames — verified with `git check-ignore -v`, at the root and in `apps/playground`. `git status` stays clean.

The changeset was **generated from `.changeset/config.json`**, not copied from a neighbour — 24 packages, verified with `comm` against the canonical lockstep group in both directions.

`fallow audit` did not run locally: `fallow` is not installed here (`command not found`).

## Note for the reviewer

This was split out of #960 after I mistakenly pushed both onto one branch. #960's branch was reset back to its own single commit with `--force-with-lease`, so it now carries a `head_ref_force_pushed` event — its stranded-tail screen will report NOT CHECKABLE from here on, and it should be verified by content instead. #960's intended content is exactly one commit, `a217a11ba`.
