### PR TITLE
fix(release): cover every lockstep package in this lane's changesets

### DIFF
--- a/.changeset/absent-text-side-says-so.md
+++ b/.changeset/absent-text-side-says-so.md
@@ -4,6 +4,7 @@
 "@nextlyhq/admin": patch
 "@nextlyhq/admin-css": patch
 "@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
 "@nextlyhq/ui": patch
 "@nextlyhq/adapter-drizzle": patch
 "@nextlyhq/adapter-postgres": patch
@@ -20,6 +21,8 @@
 "@nextlyhq/prettier-config": patch
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
 ---
 
 An added or removed text field showed a blank space on the version it never reached, instead of

--- a/.changeset/version-compare-in-its-own-dialog.md
+++ b/.changeset/version-compare-in-its-own-dialog.md
@@ -4,6 +4,7 @@
 "@nextlyhq/admin": patch
 "@nextlyhq/admin-css": patch
 "@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
 "@nextlyhq/ui": patch
 "@nextlyhq/adapter-drizzle": patch
 "@nextlyhq/adapter-postgres": patch
@@ -20,6 +21,8 @@
 "@nextlyhq/prettier-config": patch
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
 ---
 
 Comparing two versions now opens a dialog sized for a comparison instead of a third mode inside


### PR DESCRIPTION
## What

Both changesets this lane authored list **21 packages against a lockstep group of 24**, omitting `@nextlyhq/blocks-react`, `@nextlyhq/builder` and `@nextlyhq/module-specifiers`. Regenerated from `.changeset/config.json`.

## Why it matters, and why it is not only a CI failure

At release, `changeset version` bumps all 24 — so those three ship a version bump **with no changelog entry**. The failing check is the symptom; the missing changelog is the defect.

`.changeset/version-compare-in-its-own-dialog.md` is what turned #956's `Lint / Typecheck / Test / Build` red after merge. `.changeset/absent-text-side-says-so.md` arrived with the same shortfall in #957.

## How the fix was stranded once already

I pushed this repair to #957 as `df55ff238`. **GitHub was in a partial outage**, its PR object never advanced past `19546b388`, no CI run was ever created for the fix, and #957 merged from the stale head. Confirmed after the fact rather than assumed:

```
git ls-tree origin/main -- .changeset/version-compare-in-its-own-dialog.md   → exists   (control: path resolves)
git grep -F '"@nextlyhq/admin": patch'            origin/main -- <that path>  → 1 hit    (control: search works)
git grep -F '"@nextlyhq/module-specifiers": patch' origin/main -- <that path> → ABSENT   (the fix)
git log --oneline 19546b388..<branch tip>                                     → df55ff238 stranded
```

Both controls matter: without them an absent marker is indistinguishable from a mistyped path.

## Scope, deliberately narrow — and I had the reason wrong

**Two files, both authored by this lane.**

An earlier draft of this description said the many other incomplete changesets on `main` were "worth a deliberate pass by whoever owns the release train." **That advice was wrong and I am retracting it**, after a peer lane measured the population and I reproduced the measurement independently.

416 of 556 changesets are incomplete against the 24-package group. But the cause is **age, not copying**, and the join dates settle it rather than the distribution merely suggesting it:

```
package                       joined lockstep   missing from
@nextlyhq/module-specifiers     2026-08-12          416
@nextlyhq/builder               2026-08-11          381
@nextlyhq/blocks-react          2026-08-05          296
@nextlyhq/plugin-seo            2026-07-27          141
@nextlyhq/blocks-engine         2026-07-24          121
@nextlyhq/admin-css             2026-07-20           69
@nextlyhq/admin                 2026-05-09            0
```

Monotonic in both columns. Each changeset listed the group **as it existed the day it was written**; `@nextlyhq/admin` was there from the start and is missing from none. So a bulk rewrite would retroactively assert that changes from July affected packages that did not exist until August — **falsifying the changelog rather than repairing it.** The right release-time answer is that a package's changelog starts when the package did.

**The genuinely malformed set is 3 files, not 416** — the only ones age cannot explain, each listing a single package:

```
admin-shadcn-standards-p3.md        1/24
admin-tokens-full-color-values.md   1/24
admin-tokens-oklch.md               1/24
```

Not touched here; flagged for whoever owns them.

**Why my two ARE a real defect despite that.** Both were written today and still omit the three newest packages, so age cannot explain them — I copied front matter from a changeset old enough to predate all three. Same symptom as the 416, different cause, and only one of the two causes is worth fixing. Generalising from my instance to the population is exactly the error the retracted paragraph made.

The gate reads only changesets a commit touches:

```
git diff --name-only --diff-filter=ACMRT HEAD^1 HEAD -- '.changeset/*.md'
```

so the historical ones fail nothing — and now there is a second, better reason to leave them alone: most of them were never wrong.

I did generate that repo-wide rewrite by accident while scoping this, and reverted it. Recording the near-miss because the script asked *"which changesets are incomplete"* when the question was *"which changesets are mine"*, and the answer to the first would have been a several-hundred-file diff that made the changelog less true.

## Verification

```
printf '%s\n' <the two files> | node scripts/release/check-changesets.mjs
  → Checked 2 changeset(s): all cover the group.        exit 0
```

Stub-verified earlier in this lane: removing one package from a file makes the checker name that file and exit 1, so its silence is evidence rather than absence.

Content-only change to two markdown files; no code, no tests affected.

## The general form

A changeset's package list is **derivable** from `.changeset/config.json`. Copying it from a neighbouring changeset is a second implementation of one question — it agrees on the day it is written and rots silently the next time the group grows. The three merges that grew this group could not have updated changesets already written.

```
node -e 'const c=require("./.changeset/config.json");
         console.log(c.fixed[0].map(p=>`"${p}": patch`).join("\n"))'
```
