### PR TITLE
fix(plugin-page-builder): register the core blocks in the browser

### DIFF
--- a/packages/builder/src/inserter.test.ts
+++ b/packages/builder/src/inserter.test.ts
@@ -87,11 +87,29 @@ describe("catalogFrom", () => {
     expect(entries.map(e => e.label)).toEqual(["Alpha", "Zulu"]);
   });
 
-  it("falls back to the namespaced name when a block declares no label", () => {
-    const entries = catalog([{ ...base, name: "acme/unlabelled" }]);
+  it("humanises the block name when no label is declared", () => {
+    // Not the raw identity. A palette is read by whoever writes the page, and
+    // an unlabelled block would otherwise present as an internal name.
+    const entries = catalog([
+      { ...base, name: "acme/collection-loop" },
+      { ...base, name: "acme/card" },
+    ]);
 
-    expect(entry(entries, "acme/unlabelled").label).toBe("acme/unlabelled");
-    expect(entry(entries, "acme/unlabelled").category).toBe(UNCATEGORISED);
+    expect(entry(entries, "acme/collection-loop").label).toBe(
+      "Collection loop"
+    );
+    expect(entry(entries, "acme/card").label).toBe("Card");
+    expect(entry(entries, "acme/card").category).toBe(UNCATEGORISED);
+  });
+
+  it("prefers a declared label over the humanised name", () => {
+    // The separating control: both blocks would humanise identically, so only a
+    // declared label distinguishes them.
+    const entries = catalog([
+      { ...base, name: "acme/card", editor: { label: "Fancy Card" } },
+    ]);
+
+    expect(entry(entries, "acme/card").label).toBe("Fancy Card");
   });
 
   it("emits one entry per variation, directly after its block", () => {

--- a/packages/builder/src/inserter.ts
+++ b/packages/builder/src/inserter.ts
@@ -190,9 +190,42 @@ export function catalogFrom(
   return entries;
 }
 
-/** The name an author reads, falling back to the block's namespaced identity. */
+/**
+ * The name an author reads.
+ *
+ * A declared `editor.label` wins. Without one, the namespaced identity is
+ * humanised rather than shown raw: "core/collection-loop" reads as "Collection
+ * loop". Showing the identity verbatim is honest and hostile — a palette is
+ * read by whoever writes the page, not by whoever registered the block, and
+ * every block that has simply not been labelled yet would present as an
+ * internal name.
+ *
+ * Derived rather than stored, because a definition gaining a real label must
+ * override this immediately, and a copy written into the entry at build time
+ * would keep the guess alongside it.
+ */
 function labelOf(definition: AnyBlockDefinition): string {
-  return definition.editor?.label ?? definition.name;
+  const declared = definition.editor?.label;
+  if (declared !== undefined && declared !== "") return declared;
+  return humanise(definition.name);
+}
+
+/**
+ * Turn a namespaced block name into something readable.
+ *
+ * The namespace is dropped because it answers "who shipped this", which a
+ * palette groups by rather than repeats on every row. Separators become spaces
+ * and only the first letter is capitalised — title-casing every word would
+ * render "Collection Loop", which reads like a proper noun for a thing that is
+ * a description.
+ */
+function humanise(name: string): string {
+  const local = name
+    .slice(name.indexOf("/") + 1)
+    .replace(/[-_]+/g, " ")
+    .trim();
+  if (local === "") return name;
+  return local.charAt(0).toUpperCase() + local.slice(1);
 }
 
 /**

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -33,7 +33,12 @@
  * @module @nextlyhq/plugin-page-builder/admin/BlocksField
  */
 
-import type { BlockDocument } from "@nextlyhq/blocks-engine";
+import {
+  hasBlock,
+  registerBlocks,
+  type BlockDocument,
+} from "@nextlyhq/blocks-engine";
+import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
 import {
   BuilderShell,
   Canvas,
@@ -74,6 +79,33 @@ export interface BlocksFieldProps<
  * declared ahead of the panels.
  */
 const AVAILABLE_PANELS = ["insert"] as const;
+
+/** Names the registry attributes these blocks to, for diagnostics. */
+const PLUGIN_SOURCE = "@nextlyhq/plugin-page-builder";
+
+/**
+ * Put the core blocks in the BROWSER's registry.
+ *
+ * The plugin registers them during its own setup, which runs in the server
+ * process. The engine's registry is module state, so the copy loaded into the
+ * admin's client bundle is a different one and starts empty — and everything
+ * the editor asks flows through it: `allBlocks` fills the inserter,
+ * `registryNestingSource` decides what a position accepts, and the renderer
+ * resolves a node's type to something it can draw.
+ *
+ * Registering once, here, rather than handing each of those its own list is
+ * what keeps them agreeing. Given separate lists, the palette could offer a
+ * block the renderer cannot draw and the nesting rule has never heard of — and
+ * an empty registry fails SILENTLY in the permissive direction, because a block
+ * nobody has heard of declares no parent and is therefore allowed everywhere.
+ *
+ * Filtered by `hasBlock` because registration refuses a redefinition, and this
+ * runs again on every hot reload and every remount of the editor.
+ */
+function ensureCoreBlocksRegistered(): void {
+  const missing = coreBlocks.filter(block => !hasBlock(block.name));
+  if (missing.length > 0) registerBlocks(missing, { source: PLUGIN_SOURCE });
+}
 
 /**
  * A stored value that is not a usable document is treated as absent.
@@ -147,6 +179,12 @@ function BlocksEditor({
   onCommit: (value: BlockDocument) => void;
   onClose: () => void;
 }) {
+  // Before anything reads the registry. Inside the component that mounts the
+  // editor rather than at module scope: this file is imported by the field
+  // control, which every entry form holding a blocks field renders whether or
+  // not the editor is ever opened.
+  ensureCoreBlocksRegistered();
+
   const initialDocument = useMemo(
     () => documentFrom(initialValue),
     [initialValue]


### PR DESCRIPTION
The follow-up #958 named. The inserter shipped correct and **inert**: it opened and offered nothing.

## The defect

`registerCoreBlocks` runs during the plugin's setup, which is the SERVER process. The engine's registry is module state, so the copy loaded into the admin's CLIENT bundle is a different one and starts empty. `allBlocks()` returned `[]`, and the panel truthfully reported "No blocks can be added here."

The same gap reached further than the palette. Everything the editor asks flows through that registry:

- `allBlocks` fills the inserter's catalogue
- `registryNestingSource` decides what a position accepts
- the renderer resolves a node's type to something it can draw

**And it failed in the permissive direction, silently.** A block the registry has never heard of declares no `parent`, so `canNest` permits it everywhere — an empty registry does not refuse placements, it allows all of them.

## The fix

Register once, in the browser, at the point the editor mounts. One registration rather than passing each consumer its own list: given separate lists, the palette could offer a block the renderer cannot draw and the nesting rule has never met.

`hasBlock` filters first, because registration refuses a redefinition and this runs again on every hot reload and every remount.

## Also: an unlabelled block is no longer shown as its internal name

Core blocks declare no `editor.label`, so the palette read `core/collection-loop`. It now reads "Collection loop". A declared label still wins outright; this only replaces the fallback, which previously showed the namespaced identity verbatim.

That is honest and hostile — a palette is read by whoever writes the page, not by whoever registered the block. Derived rather than stored, so a definition gaining a real label overrides it immediately.

**Follow-up worth taking in `blocks-react`:** core blocks should declare `editor.label` AND `editor.category` of their own. Until they do, every one of them groups under "other". This change makes that presentable; it does not make it right.

## Verified in a browser, not only in tests

531 tests pass (470 builder, 61 plugin-page-builder), 30/30 tasks from a clean build.

Driven with Playwright against the playground, three consecutive runs after letting the dev server settle:

- the palette populates — `core/accordion`, `core/box`, `core/button`, `core/card`, `core/collection-loop`, `core/columns`, `core/divider` …
- searching `head` narrows to `core/heading`
- **`core/column` is correctly ABSENT at the document root**, because it declares `parent: ["core/columns"]`. That is the nesting rule working in the real application rather than in a fixture.

## One process note, recorded because it nearly cost the fix

I backed this change out TWICE before landing it, both times on a false reading. The probe was sound; my WAIT was not — the first browser run after a rebuild hits Next's compile-on-demand and reports the field missing. Running the same unchanged tree three times gave `true, true, true`, and that is what exposed it.

So two earlier conclusions in #958's description — "registering at mount breaks the field" and "the import breaks the module" — were artifacts, and neither is true. Stated here rather than quietly dropped, because #958 shipped with them written down.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Blocks without custom labels now display clearer, humanized names.
  - Custom editor labels take precedence when provided.
  - Core blocks are automatically registered when needed, improving block availability in the editor.

- **Bug Fixes**
  - Prevented duplicate core block registrations during editor initialization.
  - Preserved uncategorized blocks when displaying the block catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->