### PR TITLE
test(builder): cover the frame inset read

### DIFF
--- a/packages/builder/src/geometry-dom.test.ts
+++ b/packages/builder/src/geometry-dom.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+
+/**
+ * The one DOM read in the frame mapping, and the one it kept getting wrong.
+ *
+ * `geometry.test.ts` covers the arithmetic, which takes plain numbers and needs
+ * no browser. What is only true HERE is which measurements add up to the inset —
+ * and the answer is the whole reason this module exists: the contract was once
+ * documented as `clientLeft`/`clientTop`, three call sites followed that recipe,
+ * and all three were short by the padding.
+ *
+ * So padding is the separating property throughout. A border-only fixture is
+ * satisfied by exactly the implementation this function was written to replace,
+ * which is why no case below leaves padding at zero without saying so.
+ *
+ * @module geometry-dom.test
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { frameInsetOf } from "./geometry-dom";
+
+/**
+ * A frame with known border and padding.
+ *
+ * `clientLeft`/`clientTop` are defined rather than styled: jsdom performs no
+ * layout, so a border declared in CSS leaves both reading 0 and every assertion
+ * would pass on an implementation that ignored borders entirely. Defining them
+ * is what makes the border observable at all here.
+ */
+function frameWith({
+  border,
+  padding,
+}: {
+  border: { left: number; top: number };
+  padding?: string;
+}): HTMLIFrameElement {
+  const frame = document.createElement("iframe");
+  if (padding !== undefined) frame.style.padding = padding;
+  document.body.appendChild(frame);
+  Object.defineProperty(frame, "clientLeft", { value: border.left });
+  Object.defineProperty(frame, "clientTop", { value: border.top });
+  return frame;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("frameInsetOf", () => {
+  it("adds the padding to the border", () => {
+    // THE case. An implementation reading `clientLeft`/`clientTop` alone
+    // answers {left: 3, top: 5} here — which is the defect this module was
+    // introduced to remove, and it is invisible in any zero-padding fixture.
+    const frame = frameWith({
+      border: { left: 3, top: 5 },
+      padding: "7px 0 0 11px",
+    });
+
+    expect(frameInsetOf(frame)).toEqual({ left: 14, top: 12 });
+  });
+
+  it("reports the border alone when there is no padding", () => {
+    // The control for the case above: it pins the border as still being read,
+    // so a function that returned only padding would fail here rather than
+    // passing both.
+    const frame = frameWith({ border: { left: 4, top: 6 }, padding: "0px" });
+
+    expect(frameInsetOf(frame)).toEqual({ left: 4, top: 6 });
+  });
+
+  it("reports the padding alone when there is no border", () => {
+    // The mirror control. Together the three fix both coefficients at 1, which
+    // neither a border-only nor a padding-only reader satisfies.
+    const frame = frameWith({ border: { left: 0, top: 0 }, padding: "9px" });
+
+    expect(frameInsetOf(frame)).toEqual({ left: 9, top: 9 });
+  });
+
+  it("keeps the border when a frame is detached and has no computed style", () => {
+    // A frame outside a document has no view, so padding cannot be resolved.
+    // The border is still readable, and reporting it beats guessing a padding
+    // that would displace every mapped point — but the value must be a NUMBER:
+    // an unparsed `NaN` propagates silently through the mapping and surfaces
+    // later as coordinates that were never meaningful.
+    const frame = document.createElement("iframe");
+    Object.defineProperty(frame, "clientLeft", { value: 2 });
+    Object.defineProperty(frame, "clientTop", { value: 3 });
+
+    const inset = frameInsetOf(frame);
+
+    expect(Number.isFinite(inset.left)).toBe(true);
+    expect(Number.isFinite(inset.top)).toBe(true);
+    expect(inset).toEqual({ left: 2, top: 3 });
+  });
+
+  it("never answers NaN, whatever the padding parses to", () => {
+    // `parseFloat` on a value it cannot read returns NaN, and NaN survives
+    // addition — so a single unreadable padding would poison the inset and
+    // every point mapped through it, with no error anywhere.
+    const frame = frameWith({ border: { left: 1, top: 1 } });
+    frame.style.paddingLeft = "auto";
+    frame.style.paddingTop = "auto";
+
+    const inset = frameInsetOf(frame);
+
+    expect(Number.isFinite(inset.left)).toBe(true);
+    expect(Number.isFinite(inset.top)).toBe(true);
+  });
+});


### PR DESCRIPTION
`frameInsetOf` had **zero test references**. It lost its only exercise when the PoC canvas suite was retired in `c12e43472` — `poc-driver.ts:410` was the sole caller — and nothing replaced it.

Positive control for that absence, because a bare zero is the reassuring direction: the same search finds `frameContentOrigin` at 5 call sites in `geometry.test.ts`, along with `pointToHost`, `pointToCanvas` and `rectToHost`. The search works and the file is discovered. `frameInsetOf` was the one sibling nothing touched.

## Why it slipped, and why it matters more than a typical uncovered helper

Its four siblings are pure arithmetic in `geometry.ts` and are covered there. This one takes a live `HTMLIFrameElement` and reads computed style, so it could not move into that suite — the retired browser harness was the only place it could run.

And it exists specifically to prevent a defect. Its own changeset records that the contract was documented as `clientLeft`/`clientTop`, that three call sites followed that recipe, and that all three were short by the padding — an iframe's nested viewport begins at the CONTENT box, so padding displaces it exactly as a border does. A function written to stop a silent off-by-padding drift, in the package that maps pointer coordinates into the canvas, with nothing exercising it.

## The separating property is padding, in every case

A border-only fixture is satisfied by exactly the implementation this function replaced, so no case leaves padding at zero without saying why. Three cases pin both coefficients at 1 — border with padding, border alone, padding alone — which neither a border-only nor a padding-only reader satisfies.

`clientLeft`/`clientTop` are defined on the fixture rather than styled: jsdom performs no layout, so a CSS border leaves both reading 0 and every assertion would pass on an implementation that ignored borders entirely.

## Stub-verified in both directions

| break | tests that fired |
| --- | --- |
| return the border alone — the original defect | adds the padding to the border; reports the padding alone when there is no border |
| drop the `Number.isFinite` guard — over-application | keeps the border when a frame is detached; never answers NaN |

Restored between each, proven by empty diff. 475 tests pass across 19 files, 26/26 tasks.

The second break is the one worth having: `parseFloat` returns NaN on a value it cannot read, NaN survives addition, and a single unreadable padding would poison the inset and every point mapped through it with no error anywhere.

No changeset — test-only, and nothing a user installs changes.
