### PR TITLE
fix(admin): read a document's history without losing the document

### DIFF
--- a/.changeset/history-panel-is-not-modal.md
+++ b/.changeset/history-panel-is-not-modal.md
@@ -1,0 +1,38 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Opening a document's version history no longer takes the document away. The panel was built on a
+modal surface, so it dimmed the page behind a scrim, trapped focus inside itself and withdrew
+everything else from the accessibility tree — leaving the one thing an editor needs beside a
+version, the document itself, unreachable and unscrollable. It is now a non-modal panel: the page
+stays lit, scrollable and focusable while history is open, and the panel closes from its own
+controls or Escape rather than from any click into the page.
+
+The Sheet primitive gains the same capability for every caller. Its root already accepted Radix's
+modal flag; the scrim is now derived from that one value rather than decided separately by the
+content, so a non-modal sheet cannot paint a scrim over a page it deliberately left interactive.
+Existing sheets are unchanged, because modal remains the default.

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -350,10 +350,20 @@ export function VersionHistorySheet({
   const isEmpty = !list.isLoading && !list.isError && versions.length === 0;
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
+    // Non-modal, and that is the point rather than a detail. A modal panel
+    // scrims the page, traps focus and withdraws everything behind it from the
+    // accessibility tree — so reading a document's history made the document
+    // itself unreachable and unscrollable, which is the one thing an editor
+    // needs beside it. Nothing else about the panel changes.
+    <Sheet open={open} onOpenChange={onOpenChange} modal={false}>
       <SheetContent
         side="right"
         className="w-[480px] sm:max-w-[480px] p-0 flex flex-col"
+        // A non-modal surface closes on outside interaction by default, which
+        // would make the document unusable while history is open: the first
+        // click into the page it now leaves interactive would dismiss the
+        // panel. Closing stays with the explicit controls and Escape.
+        onInteractOutside={event => event.preventDefault()}
       >
         <SheetHeader className="p-4 border-b border-border">
           <div className="flex items-center justify-between gap-2">

--- a/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
@@ -106,6 +106,21 @@ function renderSheet() {
   );
 }
 
+/**
+ * Whether an element is reachable to assistive technology: present, and with no
+ * ancestor withdrawing it from the accessibility tree. A modal surface marks
+ * everything outside itself this way, so this is the property that separates a
+ * panel the document sits beside from one the document hides behind.
+ */
+function reachable(element: Element | null): boolean {
+  if (!element) return false;
+  for (let node: Element | null = element; node; node = node.parentElement) {
+    if (node.getAttribute("aria-hidden") === "true") return false;
+    if (node.hasAttribute("inert")) return false;
+  }
+  return true;
+}
+
 describe("VersionHistorySheet", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -291,6 +306,33 @@ describe("VersionHistorySheet", () => {
     expect(compareDialogMock).toHaveBeenCalledWith(
       expect.objectContaining({ from: 2, to: 3 })
     );
+  });
+
+  it("leaves the document reachable while its history is open", () => {
+    useVersionsMock.mockReturnValue(
+      listState({
+        data: { pages: [{ items: [version(1)], meta: { hasNext: false } }] },
+      })
+    );
+
+    render(
+      <>
+        <input aria-label="Title" defaultValue="the live document" />
+        <VersionHistorySheet
+          open
+          onOpenChange={vi.fn()}
+          scope={scope}
+          fields={fields}
+        />
+      </>
+    );
+
+    // The panel and the document are both on screen, which is the point: an
+    // editor reads a version against what is live. A modal surface withdraws
+    // everything outside itself from the accessibility tree, so the document
+    // being present is not enough — it has to still be reachable.
+    expect(screen.getByText("Version 1")).toBeInTheDocument();
+    expect(reachable(screen.getByLabelText("Title"))).toBe(true);
   });
 
   it("mounts no compare dialog until one is asked for", () => {

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -6,6 +6,24 @@ import * as React from "react";
 
 import { cn } from "../lib/utils";
 import { usePortalContainer } from "../providers/portal-provider";
+import type { SheetProps } from "../types/sheet";
+
+/**
+ * Whether the enclosing sheet is modal, published to its own parts.
+ *
+ * Radix takes `modal` at the root and uses it to decide focus trapping and
+ * whether the rest of the page is withdrawn from the accessibility tree. The
+ * scrim is that same decision expressed visually, and it is rendered a level
+ * down in `SheetContent`. Passing the root's answer down — rather than giving
+ * the content a second prop of its own — keeps one answer to one question: a
+ * caller cannot ask for a non-modal sheet and still get a scrim over the page
+ * it deliberately left interactive.
+ *
+ * Declared above the component doc blocks on purpose. The bundler attaches a
+ * doc comment to the declaration that follows it, so anything inserted between
+ * a tagged comment and its declaration silently steals the tag.
+ */
+const SheetModalContext = React.createContext(true);
 
 // Note: the close icon is not rendered by default here. Consumers should import and render their preferred icon with `SheetClose`.
 
@@ -63,8 +81,14 @@ import { usePortalContainer } from "../providers/portal-provider";
  * @see https://www.radix-ui.com/primitives/docs/components/dialog
  * @public
  */
-
-const Sheet = DialogPrimitive.Root;
+const Sheet = ({ modal = true, children, ...props }: SheetProps) => (
+  <SheetModalContext.Provider value={modal}>
+    <DialogPrimitive.Root modal={modal} {...props}>
+      {children}
+    </DialogPrimitive.Root>
+  </SheetModalContext.Provider>
+);
+Sheet.displayName = "Sheet";
 
 /** @experimental */
 const SheetTrigger = DialogPrimitive.Trigger;
@@ -156,10 +180,14 @@ const SheetContent = React.forwardRef<
   SheetContentProps
 >(({ side = "right", className, children, ...props }, ref) => {
   const portalContainer = usePortalContainer();
+  // Taken from the root rather than from a prop here: the scrim and Radix's
+  // inerting are the same decision, and two places to state it would let a
+  // sheet scrim a page it had left interactive.
+  const modal = React.useContext(SheetModalContext);
 
   return (
     <SheetPortal container={portalContainer}>
-      <SheetOverlay />
+      {modal ? <SheetOverlay /> : null}
       <DialogPrimitive.Content
         ref={ref}
         data-slot="sheet-content"


### PR DESCRIPTION
## What

Reading a document's version history no longer takes the document away. The panel is non-modal: the page stays lit, scrollable and focusable while history is open.

Follow-up to #956 (T-08 step B). The founder's words were "I don't like the off-canvas sheet view" — and off-canvas turned out not to be the problem.

## The diagnosis, measured rather than inferred

`Sheet` is `DialogPrimitive.Root`, so opening it scrims the page, traps focus and withdraws everything behind it from the accessibility tree. Reading that off the primitive establishes the mechanism; this is the observation, taken on the entry editor at 1440x950:

```
                       documentReachable   bodyScrollLocked
history closed              true                false
history open                FALSE               TRUE
```

`documentReachable` = the entry's own `input[name="title"]` exists and has no ancestor carrying `aria-hidden="true"` or `inert`.

So the one thing an editor needs beside a version — the document it belongs to — was unreachable and unscrollable. **Off-canvas is fine; modality was the defect.**

After this change, same probe:

```
history open                true                false
```

Live regions unchanged at 2 total / 2 audible in both states, so nothing new competes for announcements.

## Where the fix lives, and why it is in the primitive

`Sheet` was a bare alias for `DialogPrimitive.Root`, so a caller could already pass `modal={false}` — Radix would stop trapping focus and stop inerting the page. The gap was that `SheetContent` rendered `<SheetOverlay />` unconditionally, so a non-modal sheet still painted a scrim over a page it had deliberately left interactive.

The obvious fix is an `overlay?: boolean` prop beside `modal`. **That is two props that must agree**, which is the drift shape `derived-checks.md` forbids — and I had already been bitten by answering one question in two places earlier today.

Instead `Sheet` becomes a real component that takes `modal`, publishes it on a context, and passes the same value to Radix. `SheetContent` reads it. One question, answered once, where Radix already asks it.

```tsx
const Sheet = ({ modal = true, children, ...props }: SheetProps) => (
  <SheetModalContext.Provider value={modal}>
    <DialogPrimitive.Root modal={modal} {...props}>{children}</DialogPrimitive.Root>
  </SheetModalContext.Provider>
);
```

**`modal` defaults to true, so the other five sheets are unchanged.** The props type stays Radix's own rather than an enumerated subset, so consumers keep `defaultOpen`, `onOpenChange` and anything the primitive gains later — `Sheet` is `@public` and an enumerated wrapper would break for callers rather than for me.

**One behavioural decision worth reviewing.** A non-modal surface closes on outside interaction by default, which would make the document unusable: the first click into the page it just left interactive would dismiss the panel. `onInteractOutside` is prevented, so closing stays with the panel's own controls and Escape.

## Verification

Measured with the cache forced off, since a cached task reports success without running anything:

```
pnpm turbo run build --force                       20 successful / 20 total,  0 cached
pnpm turbo run check-types lint --continue --force 45 successful / 45 total,  0 cached
```

```
packages/ui      44 files / 1076 tests, ZERO failures
packages/admin   4 failed | 237 passed (241 files) · 15 failed | 2054 passed (2069)
                 comm -13 baseline after → empty; the 4 are the documented
                 pre-existing set (StatsCard, BasicsTab, SlugInput, DefaultValueField)
```

### The guard, and why it is the point

The regression this class invites is a CSS fix — widen the panel, hide the scrim — that leaves `DialogPrimitive.Root` modal and looks correct. So the test asserts the property rather than the appearance:

```
leaves the document reachable while its history is open
```

Written red-first against the unfixed code and confirmed failing for the right reason (`expected false to be true`, not a crash). Stub-verified in both directions afterwards:

| break | result |
|---|---|
| consumer stops passing `modal={false}` | FAILS the guard, nothing else |
| primitive stops forwarding `modal` to Radix | FAILS the guard, nothing else |

**The second break passed at first, and that is worth reporting rather than hiding.** `packages/admin` resolves `@nextlyhq/ui` through its `dist`, so editing ui source and running an admin test exercises the previously built artifact — the break never reached the code under test, and the green was about nothing. It fails correctly once `pnpm --filter @nextlyhq/ui... build` runs between the break and the test. Any control that crosses a package boundary here needs that rebuild, or it certifies the old build.

### A tag hazard this change tripped, recorded because the next person will

`Sheet` carries `@public`, and `ui-surface.test.ts` checks that barrel tags reach `dist/index.d.ts`. Declaring the context between the existing doc block and `const Sheet` silently reassigned the tag to the context — the bundler attaches a doc comment to whatever declaration follows it. Caught by that test, which named the cause exactly. The context is now declared above the doc blocks, with a comment saying why.

## Reviewer status

Correcting a note that several docs in this repo still carry: `greptile-apps` **is** reviewing, and found a real P1 on #956. Codex still answers with usage-limit notices and `@nextly-bot` still produces zero reviews.

## Scope

`packages/admin/src/components/features/versions/**` and the Sheet primitive. Confirmed `sheet.tsx` free with the lane closest to `packages/ui` before starting. Does **not** touch the document rail, `EntryForm.tsx`, or any layout: docking history into the existing 320px rail is a possible second step, and the measurement says it would help only above ~1224px, because `@4xl/content` hides that rail at 1200px and below.
