### PR TITLE
fix(admin): put api keys and image sizes on the shared list shell

### DIFF
--- a/.changeset/list-surface-more-conversions.md
+++ b/.changeset/list-surface-more-conversions.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Two more admin lists — API keys and image sizes — use the shared list layout, so their search
+field, column control and spacing match the rest of the admin instead of each carrying their own.
+The image-sizes note about config-defined sizes now sits with the list it describes.

--- a/packages/admin/src/components/features/api-keys/ApiKeyTable.tsx
+++ b/packages/admin/src/components/features/api-keys/ApiKeyTable.tsx
@@ -8,28 +8,16 @@
  * edit and revoke. Revoked keys are read-only (no row click, no actions).
  */
 
-import {
-  Skeleton,
-  Badge,
-  Button,
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@nextlyhq/ui";
+import { Skeleton, Badge } from "@nextlyhq/ui";
 import type React from "react";
 import { useCallback, useMemo, useState, useEffect } from "react";
 
-import { SettingsTableToolbar } from "@admin/components/features/settings";
-import { AlertTriangle, Columns, Edit, Trash2 } from "@admin/components/icons";
-import { SearchBar } from "@admin/components/shared/search-bar";
-import { DataTableView } from "@admin/components/ui/table/data-table";
+import { AlertTriangle, Edit, Trash2 } from "@admin/components/icons";
 import type {
   NextlyColumn,
   RowAction,
 } from "@admin/components/ui/table/data-table";
+import { ListView } from "@admin/components/ui/table/list-view";
 import { PAGINATION } from "@admin/constants/pagination";
 import { usePagination } from "@admin/hooks/usePagination";
 import type { ApiKeyMeta } from "@admin/services/apiKeyApi";
@@ -291,79 +279,47 @@ export const ApiKeyTable: React.FC<ApiKeyTableProps> = ({
   );
 
   return (
-    <div className="space-y-4">
-      <SettingsTableToolbar
-        search={
-          <SearchBar
-            value={search}
-            onChange={setSearch}
-            placeholder="Search API keys by name, description, or role..."
-            isLoading={isLoading}
-            className="w-full"
-          />
-        }
-        columns={
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="md">
-                <Columns className="h-4 w-4" />
-                Columns
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-48">
-              <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              {toggleableColumns.map(col => (
-                <DropdownMenuCheckboxItem
-                  key={col.name}
-                  checked={!hiddenColumns.has(col.name)}
-                  onCheckedChange={() => toggleColumn(col.name)}
-                >
-                  {typeof col.header === "string" ? col.header : col.name}
-                </DropdownMenuCheckboxItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        }
-      />
-
-      {isLoading && data.length === 0 ? (
+    <ListView<ApiKeyMeta>
+      search={{
+        value: search,
+        onChange: setSearch,
+        placeholder: "Search API keys by name, description, or role...",
+        isLoading,
+      }}
+      columnsControl={{
+        columns: toggleableColumns,
+        isColumnVisible: name => !hiddenColumns.has(name),
+        onToggleColumn: toggleColumn,
+      }}
+      skeleton={
         <div className="rounded-lg border border-border bg-card p-4">
           <Skeleton className="h-50 w-full rounded-lg" />
         </div>
-      ) : (
-        <>
-          <DataTableView<ApiKeyMeta>
-            columns={columns}
-            rows={paginatedData}
-            loading={isLoading}
-            onRowClick={key => {
-              // Only active keys are editable; revoked keys are read-only.
-              if (key.isActive) onEdit(key);
-            }}
-            primaryColumn="name"
-            rowActions={rowActions}
-            registryKey="api-keys"
-            ariaLabel="API keys table"
-            emptyMessage="No API keys yet. Create your first key to authenticate programmatic access."
-            // The pager belongs to the table, not beside it. Rendered here it
-            // lands inside the card on desktop and in the column's gap on
-            // mobile --
-            // a decision only this component can make, because only it knows
-            // which of the two views is showing.
-            pagination={{
-              currentPage: page,
-              totalPages: Math.max(1, totalPages),
-              pageSize,
-              pageSizeOptions: PAGINATION.TABLE_PAGE_SIZE_OPTIONS,
-              onPageChange: setPage,
-              onPageSizeChange: setPageSize,
-              totalItems,
-              isLoading,
-            }}
-          />
-        </>
-      )}
-    </div>
+      }
+      columns={columns}
+      rows={paginatedData}
+      loading={isLoading}
+      onRowClick={key => {
+        // Only active keys are editable; revoked keys are read-only.
+        if (key.isActive) onEdit(key);
+      }}
+      primaryColumn="name"
+      rowActions={rowActions}
+      registryKey="api-keys"
+      ariaLabel="API keys table"
+      emptyMessage="No API keys yet. Create your first key to authenticate programmatic access."
+      // Inside the table rather than beside it: only the table knows
+      // which of its two views is showing, so only it can place the pager.
+      pagination={{
+        currentPage: page,
+        totalPages: Math.max(1, totalPages),
+        pageSize,
+        pageSizeOptions: PAGINATION.TABLE_PAGE_SIZE_OPTIONS,
+        onPageChange: setPage,
+        onPageSizeChange: setPageSize,
+        totalItems,
+        isLoading,
+      }}
+    />
   );
 };

--- a/packages/admin/src/components/ui/table/list-view/__tests__/no-hand-rolled-toolbar.test.ts
+++ b/packages/admin/src/components/ui/table/list-view/__tests__/no-hand-rolled-toolbar.test.ts
@@ -29,12 +29,14 @@ const SRC = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../..");
  * only ever shrink, and it is empty when the migration is done.
  */
 const NOT_YET_CONVERTED = [
-  "components/features/api-keys/ApiKeyTable.tsx",
   "pages/dashboard/collection/components/CollectionTable.tsx",
   "pages/dashboard/field-group/components/FieldGroupTable.tsx",
+  // Its LIST is converted; an error branch still renders a search field of its
+  // own, at a fifth width. That branch shows search beside an alert and no
+  // table at all, so converting it is a question about how a failed list
+  // reports itself rather than about the toolbar.
   "pages/dashboard/settings/email-providers/index.tsx",
   "pages/dashboard/settings/email-templates/index.tsx",
-  "pages/dashboard/settings/image-sizes/index.tsx",
   "pages/dashboard/singles/components/SinglesTable.tsx",
 ];
 

--- a/packages/admin/src/pages/dashboard/settings/email-templates/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/email-templates/index.tsx
@@ -12,24 +12,14 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
   Skeleton,
 } from "@nextlyhq/ui";
 import type React from "react";
 import { useState, useCallback, useEffect, useMemo } from "react";
 
-import {
-  SettingsLayout,
-  SettingsTableToolbar,
-} from "@admin/components/features/settings";
+import { SettingsLayout } from "@admin/components/features/settings";
 import {
   AlertTriangle,
-  Columns,
   Copy,
   Edit,
   Eye,
@@ -42,11 +32,11 @@ import { PageErrorFallback } from "@admin/components/shared/error-fallbacks";
 import { QueryErrorBoundary } from "@admin/components/shared/query-error-boundary";
 import { SearchBar } from "@admin/components/shared/search-bar";
 import { toast } from "@admin/components/ui";
-import { DataTableView } from "@admin/components/ui/table/data-table";
 import type {
   NextlyColumn,
   RowAction,
 } from "@admin/components/ui/table/data-table";
+import { ListView } from "@admin/components/ui/table/list-view";
 import { PAGINATION } from "@admin/constants/pagination";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import {
@@ -475,76 +465,49 @@ function EmailTemplateTable() {
   }
 
   return (
-    <div className="space-y-4">
-      <SettingsTableToolbar
-        search={
-          <SearchBar
-            value={search}
-            onChange={setSearch}
-            placeholder="Search templates by name, slug, or subject..."
-            isLoading={isLoading}
-            className="w-full"
-          />
+    <>
+      <ListView<EmailTemplateRecord>
+        search={{
+          value: search,
+          onChange: setSearch,
+          placeholder: "Search templates by name, slug, or subject...",
+          isLoading,
+        }}
+        columnsControl={{
+          columns: toggleableColumns,
+          isColumnVisible: name => !hiddenColumns.has(name),
+          onToggleColumn: toggleColumn,
+        }}
+        skeleton={
+          <div className="rounded-lg border border-border bg-card p-4">
+            <Skeleton className="h-50 w-full rounded-lg" />
+          </div>
         }
-        columns={
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="md" className="bg-background">
-                <Columns className="h-4 w-4" />
-                Columns
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-48">
-              <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              {toggleableColumns.map(col => (
-                <DropdownMenuCheckboxItem
-                  key={col.name}
-                  checked={!hiddenColumns.has(col.name)}
-                  onCheckedChange={() => toggleColumn(col.name)}
-                >
-                  {typeof col.header === "string" ? col.header : col.name}
-                </DropdownMenuCheckboxItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        }
+        columns={columns}
+        rows={paginatedTemplates}
+        loading={isLoading}
+        onRowClick={template => handleEdit(template)}
+        primaryColumn="name"
+        rowActions={rowActions}
+        registryKey="email-templates"
+        ariaLabel="Email templates table"
+        emptyMessage="No email templates found. Create a template to get started."
+        // The table owns the pager, so it is placed for whichever view is
+        // showing. Ungated because this list paginates in memory:
+        // `totalPages` is derived from the filtered rows and floored at one
+        // below, so the pager renders its own single-page state instead of
+        // needing to be hidden.
+        pagination={{
+          currentPage: page,
+          totalPages: Math.max(1, totalPages),
+          pageSize,
+          pageSizeOptions: PAGINATION.TABLE_PAGE_SIZE_OPTIONS,
+          onPageChange: setPage,
+          onPageSizeChange: setPageSize,
+          totalItems,
+          isLoading,
+        }}
       />
-
-      {isLoading && templates.length === 0 ? (
-        <div className="rounded-lg border border-border bg-card p-4">
-          <Skeleton className="h-50 w-full rounded-lg" />
-        </div>
-      ) : (
-        <>
-          <DataTableView<EmailTemplateRecord>
-            columns={columns}
-            rows={paginatedTemplates}
-            loading={isLoading}
-            onRowClick={template => handleEdit(template)}
-            primaryColumn="name"
-            rowActions={rowActions}
-            registryKey="email-templates"
-            ariaLabel="Email templates table"
-            emptyMessage="No email templates found. Create a template to get started."
-            // The table owns the pager, so it is placed for whichever view is
-            // showing. Ungated because this list paginates in memory:
-            // `totalPages` is derived from the filtered rows and floored at one
-            // below, so the pager renders its own single-page state instead of
-            // needing to be hidden.
-            pagination={{
-              currentPage: page,
-              totalPages: Math.max(1, totalPages),
-              pageSize,
-              pageSizeOptions: PAGINATION.TABLE_PAGE_SIZE_OPTIONS,
-              onPageChange: setPage,
-              onPageSizeChange: setPageSize,
-              totalItems,
-              isLoading,
-            }}
-          />
-        </>
-      )}
 
       <TemplateDeleteDialog
         open={deleteDialogOpen}
@@ -559,7 +522,7 @@ function EmailTemplateTable() {
         onOpenChange={setPreviewDialogOpen}
         template={templateToPreview}
       />
-    </div>
+    </>
   );
 }
 

--- a/packages/admin/src/pages/dashboard/settings/image-sizes/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/image-sizes/index.tsx
@@ -8,33 +8,20 @@
  * Shows regeneration status when sizes change.
  */
 
-import {
-  Badge,
-  Button,
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@nextlyhq/ui";
+import { Badge, Button } from "@nextlyhq/ui";
 import * as React from "react";
 
-import {
-  SettingsLayout,
-  SettingsTableToolbar,
-} from "@admin/components/features/settings";
-import { Columns, Edit, Info, Plus, Trash2 } from "@admin/components/icons";
+import { SettingsLayout } from "@admin/components/features/settings";
+import { Edit, Info, Plus, Trash2 } from "@admin/components/icons";
 import { PageContainer } from "@admin/components/layout/page-container";
 import { PageErrorFallback } from "@admin/components/shared/error-fallbacks";
 import { QueryErrorBoundary } from "@admin/components/shared/query-error-boundary";
-import { SearchBar } from "@admin/components/shared/search-bar";
 import { Link } from "@admin/components/ui/link";
-import { DataTableView } from "@admin/components/ui/table/data-table";
 import type {
   NextlyColumn,
   RowAction,
 } from "@admin/components/ui/table/data-table";
+import { ListView } from "@admin/components/ui/table/list-view";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { usePagination } from "@admin/hooks/usePagination";
 import { navigateTo } from "@admin/lib/navigation";
@@ -250,93 +237,65 @@ function ImageSizesContent({
   );
 
   return (
-    <div className="space-y-4">
-      {/* Search Bar & Columns Filter */}
-      <SettingsTableToolbar
-        search={
-          <SearchBar
-            value={search}
-            onChange={setSearch}
-            placeholder="Search image sizes..."
-            className="w-full"
-            isLoading={isLoading}
-          />
-        }
-        columns={
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="md" className="bg-background">
-                <Columns className="h-4 w-4" />
-                Columns
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-48">
-              <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              {toggleableColumns.map(col => (
-                <DropdownMenuCheckboxItem
-                  key={col.name}
-                  checked={!hiddenColumns.has(col.name)}
-                  onCheckedChange={() => toggleColumn(col.name)}
-                >
-                  {typeof col.header === "string" ? col.header : col.name}
-                </DropdownMenuCheckboxItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        }
-      />
-
-      {/* Table */}
-      <DataTableView<ImageSize>
-        columns={columns}
-        rows={paginatedSizes}
-        loading={isLoading}
-        rowHref={size =>
-          buildRoute(ROUTES.SETTINGS_IMAGE_SIZES_EDIT, { id: size.id })
-        }
-        primaryColumn="name"
-        rowActions={rowActions}
-        registryKey="image-sizes"
-        ariaLabel="Image sizes table"
-        emptyMessage={
-          search
-            ? "No image sizes found matching your search."
-            : "No image sizes configured."
-        }
-        // The table owns the pager, so it is placed for whichever view is
-        // showing. This list paginates in memory rather than
-        // over the wire, so the gate counts the filtered rows: a search that
-        // matches nothing should leave no controls behind.
-        pagination={
-          filteredSizes.length > 0
-            ? {
-                currentPage: page,
-                totalPages: Math.max(
-                  1,
-                  Math.ceil(filteredSizes.length / pageSize)
-                ),
-                totalItems: filteredSizes.length,
-                pageSize,
-                onPageChange: setPage,
-                onPageSizeChange: setPageSize,
-                isLoading,
-              }
-            : undefined
-        }
-      />
-
-      {/* Info note about code-defined sizes */}
-      {!isLoading && sizes.some(s => s.isDefault) && (
-        <div className="flex items-start gap-2 text-xs text-muted-foreground px-1">
-          <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-          <span>
-            Sizes marked as <strong>Config</strong> are defined in your
-            nextly.config.ts and cannot be deleted here.
-          </span>
-        </div>
-      )}
-    </div>
+    <ListView<ImageSize>
+      search={{
+        value: search,
+        onChange: setSearch,
+        placeholder: "Search image sizes...",
+        isLoading,
+      }}
+      columnsControl={{
+        columns: toggleableColumns,
+        isColumnVisible: name => !hiddenColumns.has(name),
+        onToggleColumn: toggleColumn,
+      }}
+      slots={{
+        afterList: !isLoading && sizes.some(s => s.isDefault) && (
+          <div className="flex items-start gap-2 text-xs text-muted-foreground px-1">
+            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <span>
+              Sizes marked as <strong>Config</strong> are defined in your
+              nextly.config.ts and cannot be deleted here.
+            </span>
+          </div>
+        ),
+      }}
+      columns={columns}
+      rows={paginatedSizes}
+      loading={isLoading}
+      rowHref={size =>
+        buildRoute(ROUTES.SETTINGS_IMAGE_SIZES_EDIT, { id: size.id })
+      }
+      primaryColumn="name"
+      rowActions={rowActions}
+      registryKey="image-sizes"
+      ariaLabel="Image sizes table"
+      emptyMessage={
+        search
+          ? "No image sizes found matching your search."
+          : "No image sizes configured."
+      }
+      // The table owns the pager, so it is placed for whichever view is
+      // showing. This list paginates in memory rather than
+      // over the wire, so the gate counts the filtered rows: a search that
+      // matches nothing should leave no controls behind.
+      pagination={
+        filteredSizes.length > 0
+          ? {
+              currentPage: page,
+              totalPages: Math.max(
+                1,
+                Math.ceil(filteredSizes.length / pageSize)
+              ),
+              totalItems: filteredSizes.length,
+              pageSize,
+              onPageChange: setPage,
+              onPageSizeChange: setPageSize,
+              isLoading,
+            }
+          : undefined
+      }
+    />
   );
 }
 


### PR DESCRIPTION
Continues T-04. #959 built the shared `ListView` and moved 9 of 16 surfaces onto it; this moves two more and shrinks the ratchet from 7 to 5.

## What changed

**`ApiKeyTable`** and **`settings/image-sizes`** each composed their own toolbar around the shared table — their own search width, and their own copy of the columns dropdown. Those were the fifth and sixth copies of that markup; both are now the shared control.

Two smaller things fell out:

- Both had a `isLoading ? <skeleton> : <table>` branch, so the toolbar disappeared during load and the page jumped when rows arrived. They pass `skeleton` to `ListView` now, which keeps the toolbar mounted through the load.
- The image-sizes note about config-defined sizes was a sibling of the table re-declaring its own spacing. It moves into `slots.afterList`, with the list it describes.

## Why email-templates and email-providers are still in the ratchet

**`email-templates` is converted and still listed, deliberately.** Its list uses `ListView`, but an error branch renders a search field of its own — at `max-w-md`, a fifth width — beside an alert and *no table*. Converting that is a question about how a failed list reports itself, not about the toolbar. `UserTable` already answers it the other way (the failure is a table state, so the list reports it like every other list), and adopting that here changes error-path behaviour, which I did not want to do as an afterthought at the end of a conversion PR.

The guard catches it because the file renders both a table and a `SearchBar`, which is the rule working rather than a false positive.

**`email-providers` is untouched.** It carries a catalog-unavailable alert above its toolbar, so it needs `slots.beforeList` and a decision about whether that alert belongs to the list. Its own change.

So `SettingsTableToolbar` cannot be deleted yet — `email-providers` is its last consumer.

## Test plan

- `no-hand-rolled-toolbar` ratchet: 4/4. The list shrank from 7 to 5, and I let the guard tell me which two had actually gone clean rather than assuming — it named exactly `ApiKeyTable` and `image-sizes`.
- `pnpm --filter @nextlyhq/admin test` — **2053 passed, 15 failed (4 files)**, the standing pre-existing set.
- `check-types` and `lint` both clean (exit 0).

Two mistakes worth recording, since both were caught by gates rather than by reading:

- My import-pruning pass removed `Button` from two files that still used it elsewhere. `check-types` caught it; restored.
- My first close-tag rewrite assumed nothing followed the table inside the wrapper. Both pages had content after it, so the JSX came out unbalanced. `check-types` caught that too.

## Pre-existing failures (NOT introduced here)

`packages/admin`: the standing 15 across `StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField` — same set and counts as on main.

`packages/ui` is untouched by this PR and is currently zero-failure on main.

## Changeset

Added: yes (`patch`, all published packages).
