### PR TITLE
feat(blocks-react): give core blocks the metadata the palette reads

### DIFF
--- a/.changeset/core-block-editor-metadata.md
+++ b/.changeset/core-block-editor-metadata.md
@@ -1,0 +1,23 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+The block palette now reads as names rather than identifiers. Core blocks declare a label, a category and search keywords, so the inserter groups them under Layout, Content, Media and Interactive instead of a single "other" heading, and a search for "picture" finds the image block.

--- a/packages/blocks-react/src/blocks/accordion-item.tsx
+++ b/packages/blocks-react/src/blocks/accordion-item.tsx
@@ -55,6 +55,8 @@ import type { ReactElement } from "react";
 // `ReactNode` so a slot's output can be placed straight into JSX.
 import type { BlockRenderArgs, PageContext } from "../context";
 
+import { INTERACTIVE } from "./categories";
+
 /** This block's registered name, so the tests and its parent name it once. */
 export const ACCORDION_ITEM_BLOCK = "core/accordion-item";
 
@@ -126,6 +128,14 @@ export const accordionItem = defineBlock<AccordionItemProps, PageContext>({
   version: 1,
   description:
     "One section of an accordion: a title that is always visible and children the browser reveals when it is open.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Accordion item",
+    category: INTERACTIVE,
+    keywords: ["disclosure", "panel", "faq"],
+  },
   props: {
     title: { type: "text" },
     open: { type: "checkbox" },

--- a/packages/blocks-react/src/blocks/accordion.tsx
+++ b/packages/blocks-react/src/blocks/accordion.tsx
@@ -62,6 +62,7 @@ import { defineBlock } from "@nextlyhq/blocks-engine";
 import type { PageContext } from "../context";
 
 import { ACCORDION_BLOCK, ACCORDION_ITEM_BLOCK } from "./accordion-item";
+import { INTERACTIVE } from "./categories";
 import { CONTAINER_SUPPORTS, renderContainer } from "./container";
 import type { ContainerProps } from "./container";
 
@@ -99,6 +100,14 @@ export const accordion = defineBlock<ContainerProps, PageContext>({
   version: 1,
   description:
     "A group of disclosure sections. Restricts its slot to core/accordion-item so a stray block cannot render outside every section and stay permanently visible.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Accordion",
+    category: INTERACTIVE,
+    keywords: ["disclosure", "faq", "collapse", "toggle"],
+  },
   props: {
     as: { type: "select", options: ["div", "section", "article"] },
     contained: { type: "checkbox" },

--- a/packages/blocks-react/src/blocks/box.tsx
+++ b/packages/blocks-react/src/blocks/box.tsx
@@ -14,6 +14,7 @@ import { defineBlock } from "@nextlyhq/blocks-engine";
 
 import type { PageContext } from "../context";
 
+import { LAYOUT } from "./categories";
 import { CONTAINER_SUPPORTS, renderContainer } from "./container";
 import type { ContainerProps } from "./container";
 
@@ -26,6 +27,14 @@ export const box = defineBlock<ContainerProps, PageContext>({
   version: 1,
   description:
     "A generic container. Full width with no padding of its own; use display to make it a flex row, a stack, or a grid.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Box",
+    category: LAYOUT,
+    keywords: ["container", "div", "group", "wrapper"],
+  },
   props: {
     as: { type: "select", options: ["div", "article", "aside"] },
     // Declared even though a box is full width by default: a preset differs

--- a/packages/blocks-react/src/blocks/button.tsx
+++ b/packages/blocks-react/src/blocks/button.tsx
@@ -13,6 +13,7 @@ import type { ReactElement } from "react";
 
 import type { BlockRenderArgs, PageContext } from "../context";
 
+import { INTERACTIVE } from "./categories";
 import { oneOf, relFor, text, url } from "./props";
 
 /** The button's HTML behaviour when it is not a link. */
@@ -91,6 +92,14 @@ export const button = defineBlock<ButtonProps, PageContext>({
   version: 1,
   description:
     "A call to action. Renders a link when it has a destination and a button when it does not, so it is operable either way.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Button",
+    category: INTERACTIVE,
+    keywords: ["link", "cta", "call to action"],
+  },
   props: {
     label: { type: "text" },
     href: { type: "url" },

--- a/packages/blocks-react/src/blocks/card.tsx
+++ b/packages/blocks-react/src/blocks/card.tsx
@@ -50,6 +50,7 @@ import { defineBlock } from "@nextlyhq/blocks-engine";
 
 import type { PageContext } from "../context";
 
+import { LAYOUT } from "./categories";
 import { CONTAINER_SUPPORTS, renderContainer } from "./container";
 import type { ContainerProps } from "./container";
 
@@ -104,6 +105,14 @@ export const card = defineBlock<ContainerProps, PageContext>({
   version: 1,
   description:
     "A rounded container that clips its contents, so an image sitting at its top edge follows the corner instead of overhanging it.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Card",
+    category: LAYOUT,
+    keywords: ["panel", "tile", "surface"],
+  },
   props: {
     // `article` is offered rather than defaulted. It is the right element for a
     // card that is independently distributable — a post, a product — and it is

--- a/packages/blocks-react/src/blocks/categories.ts
+++ b/packages/blocks-react/src/blocks/categories.ts
@@ -1,0 +1,60 @@
+/**
+ * The palette's headings, declared once.
+ *
+ * A block's `editor.category` is a free string, so nineteen definitions each
+ * spelling their own would make "interactive" and "Interactive" two headings
+ * with no error anywhere — the inserter groups by the value it is given and has
+ * no vocabulary to check it against.
+ *
+ * These are also the ONE answer to how this library is grouped. `index.ts` used
+ * to carry a second one in comments over `coreBlocks`, which agreed with
+ * nothing enforcing it; that list's comments now describe the ORDERING
+ * constraints they always also encoded — parent before child, so a resolver
+ * built by iterating meets the container first — and the grouping is declared
+ * here, on the blocks themselves, where the palette actually reads it.
+ *
+ * @module blocks/categories
+ */
+
+/**
+ * What holds other blocks and shapes the page.
+ *
+ * Structure with no content of its own: removing one changes where things sit,
+ * never what they say.
+ */
+export const LAYOUT = "layout";
+
+/**
+ * What the page says.
+ *
+ * Includes `core/divider`, which is a semantic thematic break rather than
+ * spacing — `core/spacer` is the layout counterpart, pure space with no
+ * meaning. And `core/collection-loop`, which lives here until there are enough
+ * data-driven blocks to earn a heading of their own: one item under a heading
+ * of its own reads as a mistake rather than as a category.
+ */
+export const CONTENT = "content";
+
+/** Pictures, video and embedded external content. */
+export const MEDIA = "media";
+
+/**
+ * What a visitor operates.
+ *
+ * `core/form` sits here rather than under anything data-driven: it is static
+ * markup that posts to a URL, storing nothing and shipping no JavaScript of its
+ * own. What makes a block interactive is that a visitor acts on it.
+ */
+export const INTERACTIVE = "interactive";
+
+/**
+ * Every category, in the order the palette should offer them.
+ *
+ * Declared rather than derived from the blocks, because the order is an
+ * editorial judgement — layout first because a page starts as structure — and
+ * deriving it from registration order would rearrange the palette whenever an
+ * unrelated plugin loaded first.
+ */
+export const CORE_CATEGORIES = [LAYOUT, CONTENT, MEDIA, INTERACTIVE] as const;
+
+export type CoreCategory = (typeof CORE_CATEGORIES)[number];

--- a/packages/blocks-react/src/blocks/collection-loop.tsx
+++ b/packages/blocks-react/src/blocks/collection-loop.tsx
@@ -27,6 +27,8 @@ import type { ReactElement } from "react";
 
 import type { BlockRenderArgs, PageContext } from "../context";
 
+import { CONTENT } from "./categories";
+
 export interface CollectionLoopProps {
   /** The collection queried. */
   collection?: string;
@@ -141,6 +143,14 @@ export const collectionLoop = defineBlock<CollectionLoopProps, PageContext>({
   version: 1,
   description:
     "Repeats its children once per entry in a collection. Renders its template once while no collection is chosen, and renders empty when the data source cannot be reached.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Collection loop",
+    category: CONTENT,
+    keywords: ["repeat", "query", "entries", "dynamic"],
+  },
   props: {
     collection: { type: "text" },
     limit: { type: "number", min: 1, max: 100 },

--- a/packages/blocks-react/src/blocks/column.tsx
+++ b/packages/blocks-react/src/blocks/column.tsx
@@ -24,6 +24,7 @@ import { defineBlock } from "@nextlyhq/blocks-engine";
 
 import type { PageContext } from "../context";
 
+import { LAYOUT } from "./categories";
 import { CONTAINER_SUPPORTS, renderContainer } from "./container";
 import type { ContainerProps } from "./container";
 
@@ -76,6 +77,14 @@ export const column = defineBlock<ContainerProps, PageContext>({
   version: COLUMN_VERSION,
   description:
     "One column of a core/columns row. A container with an identity, so it can be selected, styled and dropped into.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Column",
+    category: LAYOUT,
+    keywords: ["cell", "track"],
+  },
   props: {
     // Narrower than a box's list: a column is a layout child, and `aside` or
     // `article` inside a row is nearly always a mistake the author meant to

--- a/packages/blocks-react/src/blocks/columns.tsx
+++ b/packages/blocks-react/src/blocks/columns.tsx
@@ -53,6 +53,7 @@ import { defineBlock } from "@nextlyhq/blocks-engine";
 
 import type { PageContext } from "../context";
 
+import { LAYOUT } from "./categories";
 import { COLUMN_BLOCK, COLUMNS_BLOCK } from "./column";
 import { CONTAINER_SUPPORTS, renderContainer } from "./container";
 import type { ContainerProps } from "./container";
@@ -97,6 +98,14 @@ export const columns = defineBlock<ContainerProps, PageContext>({
   version: 1,
   description:
     "A row of columns. Restricts its slot to core/column so each column keeps an identity that can be selected and styled.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Columns",
+    category: LAYOUT,
+    keywords: ["row", "grid", "split", "side by side"],
+  },
   props: {
     as: { type: "select", options: ["div", "section", "article"] },
     contained: { type: "checkbox" },

--- a/packages/blocks-react/src/blocks/divider.tsx
+++ b/packages/blocks-react/src/blocks/divider.tsx
@@ -13,6 +13,8 @@ import type { ReactElement } from "react";
 
 import type { BlockRenderArgs, PageContext } from "../context";
 
+import { CONTENT } from "./categories";
+
 export type DividerProps = Record<string, never>;
 
 export function renderDivider({
@@ -30,6 +32,14 @@ export const divider = defineBlock<DividerProps, PageContext>({
   version: 1,
   description:
     "A thematic break between sections, announced as a separator rather than drawn as a decorative line.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Divider",
+    category: CONTENT,
+    keywords: ["hr", "rule", "separator", "break"],
+  },
   props: {},
   defaultProps: {},
   example: { props: {} },

--- a/packages/blocks-react/src/blocks/editor-metadata.test.ts
+++ b/packages/blocks-react/src/blocks/editor-metadata.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Every core block carries the metadata the palette reads.
+ *
+ * A documented convention with nothing enforcing it is not a control, and this
+ * one had already been broken by the whole library: nineteen blocks shipped
+ * with no `editor` at all, so the inserter grouped them under a single "other"
+ * heading and showed each block's namespaced identity as its name. Nothing
+ * failed, because none of it is required by the type.
+ *
+ * These are also the example every plugin author copies. A first-party library
+ * that omits the three fields teaches the ecosystem that they are optional.
+ *
+ * @module blocks/editor-metadata.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { CORE_CATEGORIES } from "./categories";
+import { coreBlocks } from "./index";
+
+describe("core block editor metadata", () => {
+  it("reads a populated library", () => {
+    // The population, before any verdict. Every assertion below is `.each` over
+    // this list, and an empty list satisfies all of them by having nothing to
+    // contradict — a suite that silently stopped discovering blocks would read
+    // as a clean pass.
+    expect(coreBlocks.length).toBeGreaterThan(15);
+    expect(coreBlocks.map(block => block.name)).toContain("core/heading");
+    expect(coreBlocks.map(block => block.name)).toContain(
+      "core/collection-loop"
+    );
+  });
+
+  it.each(coreBlocks.map(block => [block.name, block] as const))(
+    "%s declares a label, a category and keywords",
+    (name, block) => {
+      const editor = block.editor;
+      expect(editor).toBeDefined();
+
+      // A label the author reads, not the identity. The inserter humanises a
+      // missing one, which is a guess rather than a name someone chose.
+      expect(typeof editor?.label).toBe("string");
+      expect(editor?.label?.length ?? 0).toBeGreaterThan(0);
+      expect(editor?.label).not.toBe(name);
+
+      // Membership in the declared set rather than "is a string": a category is
+      // a free string, so "Interactive" and "interactive" would become two
+      // headings in the palette with no error anywhere.
+      expect(CORE_CATEGORIES).toContain(editor?.category);
+
+      // Keywords are the field nobody notices is missing. Without them a search
+      // matches only the label and the description, so a reader looking for
+      // "picture" finds nothing and reads it as an empty library.
+      expect(Array.isArray(editor?.keywords)).toBe(true);
+      expect(editor?.keywords?.length ?? 0).toBeGreaterThan(0);
+      for (const keyword of editor?.keywords ?? []) {
+        expect(typeof keyword).toBe("string");
+        expect(keyword).toBe(keyword.toLowerCase());
+      }
+    }
+  );
+
+  it("gives every block a distinct label", () => {
+    // Two blocks reading the same in the palette is indistinguishable to an
+    // author, and a per-block check cannot see it: each label is individually
+    // valid. Only comparing the set does.
+    const labels = coreBlocks.map(block => block.editor?.label);
+    expect(new Set(labels).size).toBe(coreBlocks.length);
+  });
+
+  it("uses every declared category, so none is dead", () => {
+    // The other direction. A category nothing claims is a heading the palette
+    // can never draw, which is the same drift as a block naming one that does
+    // not exist — caught here rather than by reading the two lists side by side.
+    const claimed = new Set(coreBlocks.map(block => block.editor?.category));
+    for (const category of CORE_CATEGORIES) {
+      expect(claimed).toContain(category);
+    }
+  });
+});

--- a/packages/blocks-react/src/blocks/embed.tsx
+++ b/packages/blocks-react/src/blocks/embed.tsx
@@ -28,6 +28,7 @@ import type { ReactElement } from "react";
 
 import type { BlockRenderArgs, PageContext } from "../context";
 
+import { MEDIA } from "./categories";
 import { flag, isTrustedOrigin, text, url } from "./props";
 
 /**
@@ -99,6 +100,14 @@ export const embed = defineBlock<EmbedProps, PageContext>({
   version: 1,
   description:
     "Third-party content in a sandboxed iframe, with an accessible name and a referrer policy that does not leak the page's path.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Embed",
+    category: MEDIA,
+    keywords: ["video", "iframe", "youtube", "external"],
+  },
   props: {
     src: { type: "url" },
     title: { type: "text" },

--- a/packages/blocks-react/src/blocks/form.tsx
+++ b/packages/blocks-react/src/blocks/form.tsx
@@ -36,6 +36,7 @@ import type { ReactElement, ReactNode } from "react";
 
 import type { BlockRenderArgs, PageContext } from "../context";
 
+import { INTERACTIVE } from "./categories";
 import { flag, oneOf, text, url } from "./props";
 
 /** The control types a field may declare. */
@@ -225,6 +226,14 @@ export const form = defineBlock<FormProps, PageContext>({
   version: 1,
   description:
     "A plain HTML form that posts to a URL you choose. Stores nothing and ships no JavaScript; the form-builder plugin is the one that collects submissions.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Form",
+    category: INTERACTIVE,
+    keywords: ["contact", "input", "submit", "fields"],
+  },
   props: {
     action: { type: "url" },
     method: { type: "select", options: [...FORM_METHODS] },

--- a/packages/blocks-react/src/blocks/gallery.tsx
+++ b/packages/blocks-react/src/blocks/gallery.tsx
@@ -60,6 +60,7 @@ import { defineBlock } from "@nextlyhq/blocks-engine";
 
 import type { PageContext } from "../context";
 
+import { MEDIA } from "./categories";
 import { CONTAINER_SUPPORTS, renderContainer } from "./container";
 import type { ContainerProps } from "./container";
 
@@ -98,6 +99,14 @@ export const gallery = defineBlock<ContainerProps, PageContext>({
   version: 1,
   description:
     "A reflowing grid of pictures. Restricts its slot to core/image so every item carries alt text and an intrinsic size, and a stray block cannot be laid out as though it were a photograph.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Gallery",
+    category: MEDIA,
+    keywords: ["images", "photos", "grid", "carousel"],
+  },
   props: {
     as: { type: "select", options: ["div", "section", "article"] },
     contained: { type: "checkbox" },

--- a/packages/blocks-react/src/blocks/heading.tsx
+++ b/packages/blocks-react/src/blocks/heading.tsx
@@ -15,6 +15,7 @@ import type { ReactElement } from "react";
 
 import type { BlockRenderArgs, PageContext } from "../context";
 
+import { CONTENT } from "./categories";
 import { oneOf, relFor, text, url } from "./props";
 
 /** The levels a heading may render. */
@@ -73,6 +74,14 @@ export const heading = defineBlock<HeadingProps, PageContext>({
   version: 1,
   description:
     "A section title. The level is chosen by the author, so the page outline stays stable when blocks move.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Heading",
+    category: CONTENT,
+    keywords: ["title", "headline", "h1", "h2"],
+  },
   props: {
     text: { type: "text" },
     level: { type: "select", options: [...HEADING_LEVELS] },

--- a/packages/blocks-react/src/blocks/image.tsx
+++ b/packages/blocks-react/src/blocks/image.tsx
@@ -17,6 +17,7 @@ import type { ReactElement } from "react";
 
 import type { BlockRenderArgs, PageContext } from "../context";
 
+import { MEDIA } from "./categories";
 import { flag, isAuthoredText, oneOf, text, url } from "./props";
 
 /** How the browser should schedule the image. */
@@ -139,6 +140,14 @@ export const image = defineBlock<ImageProps, PageContext>({
   version: 1,
   description:
     "A picture, resolved through the host's media library so its URL, alt text and intrinsic size stay current.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Image",
+    category: MEDIA,
+    keywords: ["picture", "photo", "img", "media"],
+  },
   props: {
     mediaId: { type: "media" },
     src: { type: "url" },

--- a/packages/blocks-react/src/blocks/index.ts
+++ b/packages/blocks-react/src/blocks/index.ts
@@ -107,8 +107,27 @@ export type { CollectionLoopProps } from "./collection-loop";
  * own registration service, and a test can take a subset. Exported as a plain
  * array because that is the shape both of those want.
  */
+/**
+ * The palette's headings and the order they are offered in.
+ *
+ * Re-exported from the library's own entry because a host that registers these
+ * blocks is the same host that ranks their categories, and making it import
+ * from two places to do one thing invites the two to be versioned apart.
+ */
+// Only the ordered list is public. The individual constants are how the block
+// files in this directory spell their own category, which is a relative import
+// — publishing them too would widen the surface by four names no consumer needs
+// and which could then never be renamed.
+export { CORE_CATEGORIES } from "./categories";
+export type { CoreCategory } from "./categories";
+
 export const coreBlocks = [
-  // Layout
+  // The comments below record ORDER, which is load-bearing: a resolver built by
+  // iterating this list must meet a container before the child whose slot names
+  // it. How the library is GROUPED is declared on the blocks themselves, as
+  // `editor.category`, because that is where the palette reads it — a second
+  // grouping here would agree today and drift silently, with nothing checking
+  // either against the other.
   section,
   box,
   // Registered after `columns`, because a row's slot template names the column
@@ -121,20 +140,16 @@ export const coreBlocks = [
   accordion,
   accordionItem,
   spacer,
-  // Typography
   heading,
   paragraph,
   list,
-  // Media and interaction
   image,
   button,
   form,
   // Registered after `image`, the only block its slot allows.
   gallery,
-  // Structure
   divider,
   quote,
   embed,
-  // Dynamic
   collectionLoop,
 ];

--- a/packages/blocks-react/src/blocks/list.tsx
+++ b/packages/blocks-react/src/blocks/list.tsx
@@ -12,6 +12,7 @@ import type { ReactElement } from "react";
 
 import type { BlockRenderArgs, PageContext } from "../context";
 
+import { CONTENT } from "./categories";
 import { number, oneOf, text } from "./props";
 
 export const LIST_KINDS = ["unordered", "ordered"] as const;
@@ -81,6 +82,14 @@ export const list = defineBlock<ListProps, PageContext>({
   version: 1,
   description:
     "An ordered or unordered list of items, rendered as real list elements so its length and positions are announced.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "List",
+    category: CONTENT,
+    keywords: ["bullets", "ordered", "unordered", "items"],
+  },
   props: {
     kind: { type: "select", options: [...LIST_KINDS] },
     items: { type: "array", of: "text" },

--- a/packages/blocks-react/src/blocks/paragraph.tsx
+++ b/packages/blocks-react/src/blocks/paragraph.tsx
@@ -14,6 +14,7 @@ import type { ReactElement } from "react";
 
 import type { BlockRenderArgs, PageContext } from "../context";
 
+import { CONTENT } from "./categories";
 import { text } from "./props";
 
 export interface ParagraphProps {
@@ -37,6 +38,14 @@ export const paragraph = defineBlock<ParagraphProps, PageContext>({
   version: 1,
   description:
     "A paragraph of plain text. Rich formatting lives in the rich-text block, which carries its own editor.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Text",
+    category: CONTENT,
+    keywords: ["paragraph", "copy", "body", "prose"],
+  },
   props: { text: { type: "textarea" } },
   defaultProps: { text: "" },
   // The opening prose is what a search result should quote. Offered whole and

--- a/packages/blocks-react/src/blocks/quote.tsx
+++ b/packages/blocks-react/src/blocks/quote.tsx
@@ -16,6 +16,7 @@ import type { ReactElement } from "react";
 
 import type { BlockRenderArgs, PageContext } from "../context";
 
+import { CONTENT } from "./categories";
 import { text, url } from "./props";
 
 export interface QuoteProps {
@@ -77,6 +78,14 @@ export const quote = defineBlock<QuoteProps, PageContext>({
   version: 1,
   description:
     "Quoted text with an optional attribution, kept outside the quotation so the speaker is not quoted saying their own name.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Quote",
+    category: CONTENT,
+    keywords: ["blockquote", "pull quote", "citation"],
+  },
   props: {
     text: { type: "textarea" },
     attribution: { type: "text" },

--- a/packages/blocks-react/src/blocks/section.tsx
+++ b/packages/blocks-react/src/blocks/section.tsx
@@ -10,6 +10,7 @@ import { defineBlock } from "@nextlyhq/blocks-engine";
 
 import type { PageContext } from "../context";
 
+import { LAYOUT } from "./categories";
 import { CONTAINER_SUPPORTS, renderContainer } from "./container";
 import type { ContainerProps } from "./container";
 
@@ -22,6 +23,14 @@ export const section = defineBlock<ContainerProps, PageContext>({
   version: 1,
   description:
     "A page region. Renders a landmark element, and opts into the site's content width once the site stylesheet defines it.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Section",
+    category: LAYOUT,
+    keywords: ["container", "wrapper", "band", "region"],
+  },
   props: {
     as: { type: "select", options: ["section", "header", "footer", "main"] },
     contained: { type: "checkbox" },

--- a/packages/blocks-react/src/blocks/spacer.tsx
+++ b/packages/blocks-react/src/blocks/spacer.tsx
@@ -17,6 +17,8 @@ import type { ReactElement } from "react";
 
 import type { BlockRenderArgs, PageContext } from "../context";
 
+import { LAYOUT } from "./categories";
+
 export type SpacerProps = Record<string, never>;
 
 export function renderSpacer({
@@ -34,6 +36,14 @@ export const spacer = defineBlock<SpacerProps, PageContext>({
   version: 1,
   description:
     "Deliberate empty space, sized by the style system so it can differ per breakpoint. Hidden from assistive technology.",
+  // Palette metadata. The category is imported rather than spelled here so
+  // nineteen blocks cannot drift into nineteen headings; keywords are what
+  // let a search for a word the description never uses still find this.
+  editor: {
+    label: "Spacer",
+    category: LAYOUT,
+    keywords: ["gap", "space", "whitespace"],
+  },
   props: {},
   defaultProps: {},
   example: { props: {} },

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -299,6 +299,13 @@ describe("the blocks entry", () => {
       "BUTTON_TYPES",
       "CONTAINER_TAGS",
       "CONTENT_WIDTH_CLASS",
+      // Added deliberately: the palette's headings and the order they are
+      // offered in. A host registering these blocks is the same host ranking
+      // their categories, so the ordered list ships from this entry. The four
+      // individual category constants stay internal — the block files reach
+      // them by relative import, and publishing them would add four names no
+      // consumer needs and which could then never be renamed.
+      "CORE_CATEGORIES",
       "FORM_FIELD_TYPES",
       "FORM_METHODS",
       "HEADING_LEVELS",

--- a/packages/builder/src/insert-panel.tsx
+++ b/packages/builder/src/insert-panel.tsx
@@ -76,6 +76,15 @@ export interface InsertPanelProps {
   definitions?: readonly AnyBlockDefinition[];
   /** How nesting is resolved. Defaults to the live registry. */
   nesting?: NestingSource;
+  /**
+   * Category headings to offer first, in order.
+   *
+   * Supplied by the host rather than ranked here: categories are free strings
+   * any plugin may contribute, and a panel that hardcoded an order would rank
+   * the first-party library above whatever a user installed. Unranked
+   * categories still appear, after these.
+   */
+  categoryOrder?: readonly string[];
   /** Notified after a successful insert, with the node that was added. */
   onInsert?: (node: BlockNode) => void;
 }
@@ -91,6 +100,7 @@ export function InsertPanel({
   editor,
   definitions,
   nesting,
+  categoryOrder,
   onInsert,
 }: InsertPanelProps): React.JSX.Element {
   const [query, setQuery] = React.useState("");
@@ -124,7 +134,8 @@ export function InsertPanel({
         // search is a different message from "nothing can go here", and
         // filtering first would collapse them into one.
         groupByCategory(
-          filterEntries(allowedEntries(catalog, point.target, source), query)
+          filterEntries(allowedEntries(catalog, point.target, source), query),
+          categoryOrder
         );
 
   const insert = (entry: InsertEntry) => {

--- a/packages/builder/src/inserter.test.ts
+++ b/packages/builder/src/inserter.test.ts
@@ -278,6 +278,72 @@ describe("groupByCategory", () => {
     ]);
   });
 
+  it("offers preferred categories first, in the order declared", () => {
+    // The separating case. Sorted by label these arrive Accordion(interactive)
+    // then Box(layout), so first-appearance puts "interactive" on top — which
+    // is what the panel actually showed before this existed. A page starts as
+    // structure, so "layout" belongs above it.
+    const entries = catalog([
+      {
+        ...base,
+        name: "acme/accordion",
+        editor: { label: "Accordion", category: "interactive" },
+      },
+      {
+        ...base,
+        name: "acme/box",
+        editor: { label: "Box", category: "layout" },
+      },
+    ]);
+
+    expect(groupByCategory(entries).map(g => g.category)).toEqual([
+      "interactive",
+      "layout",
+    ]);
+    expect(
+      groupByCategory(entries, ["layout", "interactive"]).map(g => g.category)
+    ).toEqual(["layout", "interactive"]);
+  });
+
+  it("keeps a category the preferred list never names", () => {
+    // A plugin shipping its own category must still get a heading. Dropping it
+    // would make its blocks unreachable through the panel that exists to reach
+    // them, and the failure is silent because a shorter list looks tidy.
+    const entries = catalog([
+      {
+        ...base,
+        name: "acme/box",
+        editor: { label: "Box", category: "layout" },
+      },
+      {
+        ...base,
+        name: "acme/chart",
+        editor: { label: "Chart", category: "acme-data" },
+      },
+    ]);
+
+    expect(groupByCategory(entries, ["layout"]).map(g => g.category)).toEqual([
+      "layout",
+      "acme-data",
+    ]);
+  });
+
+  it("ignores a preferred category nothing claims", () => {
+    // The preferred list describes intent, not this catalogue. A heading with
+    // no blocks under it would render as an empty section.
+    const entries = catalog([
+      {
+        ...base,
+        name: "acme/box",
+        editor: { label: "Box", category: "layout" },
+      },
+    ]);
+
+    expect(
+      groupByCategory(entries, ["media", "layout"]).map(g => g.category)
+    ).toEqual(["layout"]);
+  });
+
   it("puts uncategorised blocks under one heading rather than dropping them", () => {
     const entries = catalog([{ ...base, name: "acme/loose" }]);
 

--- a/packages/builder/src/inserter.ts
+++ b/packages/builder/src/inserter.ts
@@ -308,14 +308,22 @@ export interface InsertGroup {
 }
 
 /**
- * Group entries under their categories, preserving the order they arrive in.
+ * Group entries under their categories.
  *
- * First appearance decides category order rather than an alphabetical sort of
- * the headings, so a block and its variations stay adjacent and the sort
- * applied upstream is not undone here by a second ordering rule.
+ * `preferred` names the headings a library wants offered first — a page starts
+ * as structure, so "layout" belongs above "interactive", and neither
+ * first-appearance nor an alphabetical sort produces that. It is a caller's
+ * declaration rather than a constant here, because categories are free strings
+ * contributed by any plugin and this module has no standing to rank them.
+ *
+ * Categories outside `preferred` follow, in first-appearance order. A plugin
+ * that ships an unranked category still gets a heading rather than being hidden
+ * behind a list it was never named in — dropping it would make a block
+ * unreachable through the very panel that exists to reach it.
  */
 export function groupByCategory(
-  entries: readonly InsertEntry[]
+  entries: readonly InsertEntry[],
+  preferred: readonly string[] = []
 ): InsertGroup[] {
   const groups = new Map<string, InsertEntry[]>();
   for (const entry of entries) {
@@ -323,9 +331,18 @@ export function groupByCategory(
     if (bucket === undefined) groups.set(entry.category, [entry]);
     else bucket.push(entry);
   }
-  return [...groups].map(([category, grouped]) => ({
+
+  // Ranked first, in the order declared; then everything else as it arrived.
+  // `preferred` may name categories nothing claims, so it is filtered against
+  // what is actually present rather than trusted to describe this catalogue.
+  const ranked = preferred.filter(category => groups.has(category));
+  const rest = [...groups.keys()].filter(
+    category => !ranked.includes(category)
+  );
+
+  return [...ranked, ...rest].map(category => ({
     category,
-    entries: grouped,
+    entries: groups.get(category) ?? [],
   }));
 }
 

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -216,3 +216,31 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
+
+/*
+ * Rows grow to their content.
+ *
+ * The command primitives size an item for a single line, which clips any label
+ * that wraps — "Collection loop" lost its second line. Labels come from block
+ * authors and cannot be assumed short, and a clipped row is worse than a taller
+ * one: the author reads a truncated name with nothing indicating it was cut.
+ *
+ * `align-items: start` so a two-line label does not drag its description to the
+ * vertical centre, which reads as misalignment against the single-line rows
+ * above and below it.
+ */
+.nx-insert-panel [cmdk-item] {
+  height: auto;
+  min-height: 2.5rem;
+  align-items: start;
+  padding-block: 0.375rem;
+}
+
+/*
+ * The label keeps its own column and never wraps mid-word. A block named
+ * "Collection loop" breaks at the space; one named "Collectionloop" would
+ * otherwise break mid-word and read as two words.
+ */
+.nx-insert-panel__label {
+  overflow-wrap: break-word;
+}

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -38,7 +38,7 @@ import {
   registerBlocks,
   type BlockDocument,
 } from "@nextlyhq/blocks-engine";
-import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
+import { CORE_CATEGORIES, coreBlocks } from "@nextlyhq/blocks-react/blocks";
 import {
   BuilderShell,
   Canvas,
@@ -237,7 +237,9 @@ function BlocksEditor({
         // opened, and a renderer ignoring that argument would draw the inserter
         // under every heading the moment a second panel is listed above.
         renderPanel={panel =>
-          panel === "insert" ? <InsertPanel editor={editor} /> : null
+          panel === "insert" ? (
+            <InsertPanel editor={editor} categoryOrder={CORE_CATEGORIES} />
+          ) : null
         }
       >
         <Canvas


### PR DESCRIPTION
The inserter works; the library it offers did not describe itself. All nineteen core blocks shipped with **no `editor` metadata at all**, so the palette grouped them under a single "other" heading and showed each block's namespaced identity as its name:

```
OTHER
  core/accordion        A group of disclosure sections...
  core/collection-loop  Repeats its children once per entry...
```

Nothing failed, because none of the three fields is required by the type. And these are the example every plugin author copies, so the first-party library was teaching that they are optional.

## One grouping, not two

`index.ts` already carried a grouping in comments over `coreBlocks` — Layout / Typography / Media and interaction / Structure / Dynamic. Adding `editor.category` beside it would have been a **second answer to how this library is grouped**, agreeing on the day it was written and drifting afterwards with nothing checking either against the other.

Those comments also encoded something else that IS load-bearing: ordering, parent before child, so a resolver built by iterating meets a container before the child whose slot names it. So the comments now describe the ordering alone, and the grouping is declared on the blocks where the palette actually reads it.

The categories themselves are declared once in `categories.ts`. A category is a free string: nineteen definitions each spelling their own would make "interactive" and "Interactive" two headings with no error anywhere.

## Where the taxonomy differs from the old comments, deliberately

- **`form` is interactive, not dynamic.** It is static markup that posts to a URL — stores nothing, ships no JavaScript. "Dynamic" should mean data-driven.
- **`divider` is content, not layout.** A semantic thematic break. `core/spacer` is the layout counterpart: pure space, no meaning.
- **`accordion` is interactive**, which is neither the old "Layout" nor data-driven. What makes a block interactive is that a visitor acts on it.
- **`collection-loop` sits in content** until there are enough data blocks to earn a heading. One item under a heading of its own reads as a mistake rather than a category.

## Keywords are the field nobody notices is missing

Without them a search matches only the label and description, so looking for "picture" returned nothing and read as an empty library rather than as absent metadata. `image` now answers to picture, photo, img, media.

## The panel does not rank categories itself

`groupByCategory` takes a preferred order, and the panel takes it as a prop the host supplies. Categories are contributed by any plugin, and a panel with a built-in opinion would rank the first-party library above whatever a user installed. Categories outside the preferred list still get a heading, after the ranked ones — dropping them would make a plugin's blocks unreachable through the panel that exists to reach them.

This also fixes something my own code had wrong: `CORE_CATEGORIES` documented itself as "the order the palette should offer them" and **nothing read it**, so the panel rendered INTERACTIVE above LAYOUT. A page starts as structure.

## Verified in the browser

Palette now reads LAYOUT (Box, Card, Columns, Section, Spacer) then CONTENT (Collection loop, Divider, …), with real names throughout. Two consecutive settled runs.

One defect that only a browser could show: **"Collection loop" was clipped** — the command primitives size a row for a single line. Rows now grow to their content, because labels come from block authors and cannot be assumed short, and a truncated name gives the reader nothing indicating it was cut.

## Guard, so this cannot regress

`editor-metadata.test.ts` asserts every core block declares all three fields, that categories are members of the declared set rather than merely strings, that labels are distinct, and that no declared category is dead. Population asserted first, by membership — an empty list would satisfy every `.each` assertion by having nothing to contradict.

Stub-verified both ways: removing one block's metadata fails that block's case; giving two blocks the same label fails only the set-level test, which is the point — a duplicate label passes every per-block check.

`entry-surface.test.ts` needed updating for the one new export. That is a **deliberate surface addition, not a fix to go green**, and it is annotated as such in the file. I also narrowed what ships: only the ordered list is public, since the four individual constants are reached by relative import inside the directory and publishing them would add four names no consumer needs and which could then never be renamed.

1164 tests pass across the three packages, 32/32 tasks from a clean build.
