### PR TITLE
feat(eslint-plugin): ship design-token rules to plugin authors

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -28,6 +28,7 @@
       "@nextlyhq/plugin-seo",
       "@nextlyhq/plugin-sdk",
       "@nextlyhq/eslint-config",
+      "@nextlyhq/eslint-plugin",
       "@nextlyhq/prettier-config",
       "@nextlyhq/telemetry",
       "@nextlyhq/tsconfig",

--- a/.changeset/eslint-plugin-design-tokens.md
+++ b/.changeset/eslint-plugin-design-tokens.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Add `@nextlyhq/eslint-plugin`: design-token lint rules that plugin authors can run in their own projects.
+
+Nextly's admin is themeable because its surfaces read design tokens, and a surface that reaches past them keeps its light-mode appearance in dark mode. That contract was only enforced inside this repository, so the first-party plugins followed it and plugins built by anyone else had nothing checking them.
+
+The new package ships three rules — `no-palette-classes`, `no-hardcoded-colors` and `no-static-inline-style` — with a `recommended` config bundled in. Install it and extend `nextly.configs.recommended` to get the same checks the admin holds itself to, in your editor and in your CI. A genuine exception is marked in place with a `design-lint-ok: <reason>` comment rather than by disabling a rule.
+
+The repository's own design guard now derives which trees it scans instead of listing them, so a plugin package added later is covered automatically, and it reports what it read so a run that scanned nothing can no longer be mistaken for a clean one. The plugin template's settings page is rebuilt on design tokens, matching the guidance its own comment gives.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -55,6 +55,7 @@ jobs:
             plugin-sdk
             create-nextly-app
             eslint-config
+            eslint-plugin
             prettier-config
             tsconfig
             telemetry

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,6 +45,10 @@ export default [
       // reason: shared eslint-config package's own .js files are not in
       // any tsconfig project; type-aware linting would fail on them
       "packages/eslint-config/**",
+      // reason: same case — the eslint-plugin package ships plain ESM rule
+      // modules with no tsconfig project, and is linted by its own config
+      // (`js.configs.recommended`) through its package `lint` script.
+      "packages/eslint-plugin/**",
       // reason: per-package eslint.config.{js,mjs,ts} files and root-level
       // config files aren't in any tsconfig project; they are meant to be
       // maintained by hand, not linted as TS source

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,15 @@
 import { config } from "@nextlyhq/eslint-config/base";
+import { designTokensConfig } from "@nextlyhq/eslint-config/design-tokens";
 import { reactRules } from "@nextlyhq/eslint-config/react-internal";
 
 import { bareErrorConfig } from "./packages/nextly/eslint-bare-error-rule.js";
+
+// Admin UI shipped by a first-party plugin is held to the same token contract
+// third-party plugins are, since these are the packages authors read as the
+// worked example. `packages/admin` and `packages/ui` are deliberately not here
+// yet: they carry violations that need triage rather than a blanket fix, and
+// enabling the rules before that would fail the build on legitimate code.
+const PLUGIN_UI_FILES = ["packages/plugin-*/src/**/*.{ts,tsx}"];
 
 // Apply the React + react-hooks rule set to React-bearing paths so
 // inline `// eslint-disable-next-line react-hooks/...` directives
@@ -28,6 +36,7 @@ export default [
   // includes lint-staged, the hook that runs before a commit is written. Same reason as the
   // React block above.
   bareErrorConfig("packages/nextly/"),
+  ...designTokensConfig(PLUGIN_UI_FILES),
   {
     ignores: [
       "packages/*/dist/**",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",
+    "@nextlyhq/eslint-plugin": "workspace:*",
     "@aws-sdk/client-s3": "^3.1090.0",
     "@aws-sdk/lib-storage": "^3.1090.0",
     "@changesets/changelog-github": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",
-    "@nextlyhq/eslint-plugin": "workspace:*",
     "@aws-sdk/client-s3": "^3.1090.0",
     "@aws-sdk/lib-storage": "^3.1090.0",
     "@changesets/changelog-github": "^0.5.1",
@@ -91,6 +90,7 @@
     "@commitlint/cli": "^20.1.0",
     "@commitlint/config-conventional": "^20.0.0",
     "@manypkg/get-packages": "^1.1.3",
+    "@nextlyhq/eslint-plugin": "workspace:*",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/packages/eslint-config/design-tokens.js
+++ b/packages/eslint-config/design-tokens.js
@@ -1,0 +1,33 @@
+import nextlyPlugin from "@nextlyhq/eslint-plugin";
+
+/**
+ * The design-token rules, as this repository mounts them.
+ *
+ * The rules themselves live in the published `@nextlyhq/eslint-plugin` so that
+ * plugin authors outside this repository get the same checks. This module is
+ * only the mounting: it exists because ESLint resolves a flat config from the
+ * CWD rather than from the linted file, so a rule written into one package's
+ * config is absent from every invocation that reads a different one — including
+ * lint-staged, which runs from the repository root.
+ *
+ * `files` is supplied by the caller rather than fixed here, because the same
+ * rules apply at different scopes: the root config scopes them by glob, and a
+ * package config that mounts them wants its own tree.
+ *
+ * @param {string[]} files - globs the rules apply to.
+ * @returns {import("eslint").Linter.Config[]}
+ */
+export function designTokensConfig(files) {
+  return [
+    {
+      name: "@nextlyhq/design-tokens",
+      files,
+      plugins: { "@nextlyhq": nextlyPlugin },
+      rules: {
+        "@nextlyhq/no-palette-classes": "error",
+        "@nextlyhq/no-hardcoded-colors": "error",
+        "@nextlyhq/no-static-inline-style": "error",
+      },
+    },
+  ];
+}

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -7,7 +7,8 @@
   "exports": {
     "./base": "./base.js",
     "./next-js": "./next.js",
-    "./react-internal": "./react-internal.js"
+    "./react-internal": "./react-internal.js",
+    "./design-tokens": "./design-tokens.js"
   },
   "scripts": {
     "//": "Config-only package - no build/dev/test scripts needed"
@@ -29,5 +30,8 @@
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "@nextlyhq/eslint-plugin": "workspace:*"
+  }
 }

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,0 +1,125 @@
+# @nextlyhq/eslint-plugin
+
+ESLint rules that keep admin UI on Nextly's design-token system.
+
+Nextly's admin is themeable: colours, spacing and radius come from tokens, and
+every surface that consumes them follows a retheme and flips between light and
+dark for free. A surface that reaches past the tokens does not. These rules catch
+the three ways that happens.
+
+They apply to **any** Nextly plugin, not just the first-party ones — which is why
+they ship as a package rather than living in Nextly's own repository.
+
+## Install
+
+```sh
+npm install --save-dev @nextlyhq/eslint-plugin
+```
+
+Requires ESLint 9 or later (flat config).
+
+## Use
+
+```js
+// eslint.config.mjs
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import nextly from "@nextlyhq/eslint-plugin";
+
+export default tseslint.config(
+  { ignores: ["dist", "node_modules"] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  ...nextly.configs.recommended
+);
+```
+
+Rules can also be enabled one at a time:
+
+```js
+export default [
+  {
+    plugins: { "@nextlyhq": nextly },
+    rules: { "@nextlyhq/no-palette-classes": "error" },
+  },
+];
+```
+
+## Rules
+
+### `no-palette-classes`
+
+A Tailwind palette hue is a fixed colour. It does not move when the theme moves,
+so a surface painted with one keeps its light-mode appearance in dark mode while
+everything around it changes.
+
+```jsx
+// ✗ frozen at the value you typed
+<div className="bg-red-500 text-slate-400" />
+
+// ✓ derives from a token, so a retheme moves it
+<div className="bg-destructive text-muted-foreground" />
+```
+
+The error names the scale to use instead: `success-*`, `warning-*`,
+`destructive-*`, `primary-*`, or a neutral (`foreground`, `muted-foreground`,
+`border`).
+
+### `no-hardcoded-colors`
+
+The same problem in a literal rather than a class.
+
+```jsx
+// ✗
+<div style={{ borderColor: "#e5e7eb" }} />;
+const shadow = "0 1px 2px rgb(12 34 56 / 0.1)";
+
+// ✓
+<div className="border-border" />;
+const shadow =
+  "0 1px 2px color-mix(in oklch, var(--nx-foreground) 10%, transparent)";
+```
+
+Black, white and transparent are exempt: they are mode-invariant, so routing
+them through a themed token would claim a variation that does not exist. So are
+`url(...)` payloads and `placeholder` example values.
+
+### `no-static-inline-style`
+
+An inline style whose every value is a constant is a utility class written the
+long way — it bypasses the spacing and radius scales and does not respond to the
+theme.
+
+```jsx
+// ✗ every value is constant, so a class could have expressed it
+<div style={{ padding: 24, display: "flex" }} />
+
+// ✓
+<div className="flex p-6" />
+
+// ✓ computed at run time — a class cannot express this, and the rule ignores it
+<div style={{ transform: `translateX(${offset}px)` }} />
+```
+
+The rule only reports the all-constant case, so the legitimate use of inline
+style — a value you compute — needs no exemption and no allowlist.
+
+## Exemptions
+
+A genuine exception is marked in place, with a reason, on the line itself or the
+line above:
+
+```jsx
+// design-lint-ok: matches the external brand swatch this embed must sit inside
+<div className="bg-red-500" />
+```
+
+A marked line states what was decided and survives review. Disabling a rule for a
+file or a directory silently exempts everything added to it later, which is why
+the marker is per-line.
+
+## Where the tokens are documented
+
+The full token contract — what each token means, the two CSS entry points, and
+how plugin styles inherit the admin's light/dark scope — is in the
+[plugin UI authoring guide](https://nextlyhq.com/docs/plugins).

--- a/packages/eslint-plugin/eslint.config.js
+++ b/packages/eslint-plugin/eslint.config.js
@@ -1,0 +1,18 @@
+import js from "@eslint/js";
+
+// This package is plain Node ESM tooling with no tsconfig, so it is linted with
+// the non-type-aware rule set (the shared config's `projectService` requires a
+// TS project and would fail to parse these `.js` files) — the same posture the
+// repo takes for its other build-tooling packages.
+export default [
+  { ignores: ["node_modules/**"] },
+  js.configs.recommended,
+  {
+    files: ["**/*.js"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: { console: "readonly", process: "readonly" },
+    },
+  },
+];

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -31,7 +31,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.34.0",
+    "@typescript-eslint/parser": "^8.59.0",
     "eslint": "^9.39.1",
+    "typescript": "^5.9.3",
     "vitest": "^4.1.0"
   },
   "engines": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@nextlyhq/eslint-plugin",
+  "version": "0.0.2-alpha.58",
+  "description": "ESLint rules that keep Nextly admin UI on the design-token system — for first-party packages and for plugins built by anyone else.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nextlyhq/nextly.git",
+    "directory": "packages/eslint-plugin"
+  },
+  "homepage": "https://nextlyhq.com/docs/plugins",
+  "bugs": {
+    "url": "https://github.com/nextlyhq/nextly/issues"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.js",
+    "./vocabulary": "./src/vocabulary.js"
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint ."
+  },
+  "peerDependencies": {
+    "eslint": ">=9.0.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.34.0",
+    "eslint": "^9.39.1",
+    "vitest": "^4.1.0"
+  },
+  "engines": {
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  },
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin",
+    "nextly",
+    "nextly-plugin",
+    "design-tokens"
+  ]
+}

--- a/packages/eslint-plugin/src/__tests__/exemplar-conforms.test.js
+++ b/packages/eslint-plugin/src/__tests__/exemplar-conforms.test.js
@@ -1,0 +1,74 @@
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import { ESLint } from "eslint";
+import tsParser from "@typescript-eslint/parser";
+import { expect, it } from "vitest";
+
+import plugin from "../index.js";
+
+/**
+ * The plugin template is the file every third-party plugin starts from, so it is
+ * held to the rules it demonstrates.
+ *
+ * Checked here rather than through the repository's ESLint run because the root
+ * config ignores `templates/**` — those trees have no tsconfig of their own and
+ * type-aware linting cannot parse them. That exclusion is correct and it leaves
+ * the exemplar ungoverned, which is how it came to contradict its own docblock.
+ * These rules need no type information, so they can be applied directly.
+ */
+const REPO_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../.."
+);
+const TEMPLATE_GLOB = "templates/plugin/src/**/*.{ts,tsx}";
+
+async function lintTemplate() {
+  // `cwd` is the repository root because ESLint treats a path outside its
+  // working directory as ignored, and reports that as "all files are ignored"
+  // rather than as zero violations — which would otherwise have read as a pass.
+  const eslint = new ESLint({
+    cwd: REPO_ROOT,
+    overrideConfigFile: true,
+    overrideConfig: [
+      {
+        files: ["**/*.{ts,tsx}"],
+        languageOptions: {
+          parser: tsParser,
+          parserOptions: {
+            ecmaVersion: 2022,
+            sourceType: "module",
+            ecmaFeatures: { jsx: true },
+          },
+        },
+        plugins: { "@nextlyhq": plugin },
+        rules: {
+          "@nextlyhq/no-palette-classes": "error",
+          "@nextlyhq/no-hardcoded-colors": "error",
+          "@nextlyhq/no-static-inline-style": "error",
+        },
+      },
+    ],
+  });
+  return eslint.lintFiles([TEMPLATE_GLOB]);
+}
+
+it("lints a non-empty set of template files", async () => {
+  const results = await lintTemplate();
+  // Asserted before the verdict below: zero violations across zero files is the
+  // same output as a conforming template, so without this the next assertion
+  // would pass on a path that stopped resolving.
+  expect(results.length).toBeGreaterThan(0);
+  expect(results.some(r => r.filePath.endsWith("SettingsPage.tsx"))).toBe(true);
+});
+
+it("the plugin exemplar obeys the rules it demonstrates", async () => {
+  const results = await lintTemplate();
+  const violations = results.flatMap(result =>
+    result.messages.map(
+      message =>
+        `${result.filePath.split("/templates/")[1]}:${message.line}  ${message.ruleId}  ${message.message}`
+    )
+  );
+  expect(violations).toEqual([]);
+});

--- a/packages/eslint-plugin/src/__tests__/no-hardcoded-colors.test.js
+++ b/packages/eslint-plugin/src/__tests__/no-hardcoded-colors.test.js
@@ -1,0 +1,55 @@
+import rule from "../rules/no-hardcoded-colors.js";
+import { createRuleTester } from "./rule-tester.js";
+
+const ruleTester = createRuleTester();
+
+ruleTester.run("no-hardcoded-colors", rule, {
+  valid: [
+    `const a = "var(--nx-border)";`,
+    `const a = "color-mix(in oklch, var(--nx-primary) 40%, transparent)";`,
+    // Mode-invariant colours are the same in light and dark, so a themed token
+    // would claim a variation that does not exist.
+    `const a = "#fff";`,
+    `const a = "#000000";`,
+    `const a = "rgba(0, 0, 0, 0.5)";`,
+    `const a = "rgb(255,255,255)";`,
+    // A scrim's two-digit alpha on black stays exempt.
+    `const a = "#00000033";`,
+    // A data URI's payload is content, not styling.
+    `const a = "url(data:image/svg+xml;base64,PHN2ZyBmaWxsPScjZmYwMDAwJy8+)";`,
+    // A hex that is not a colour at all.
+    `const a = "commit 1f4b";`,
+    `// design-lint-ok: mirrors a third-party embed's fixed palette
+       const a = "#ff0000";`,
+  ],
+  invalid: [
+    {
+      code: `const a = "#ff0000";`,
+      errors: [{ messageId: "hardcodedColor", data: { literal: "#ff0000" } }],
+    },
+    {
+      code: `const a = { color: "#1a2b3c" };`,
+      errors: 1,
+    },
+    {
+      code: `const a = "rgb(12, 34, 56)";`,
+      errors: [
+        { messageId: "hardcodedColor", data: { literal: "rgb(12, 34, 56)" } },
+      ],
+    },
+    {
+      code: `const a = "hsl(210, 50%, 40%)";`,
+      errors: 1,
+    },
+    {
+      // A non-exempt colour beside an exempt one still reports: stripping the
+      // legitimate pieces must not take the violation with them.
+      code: `const a = "1px solid #ff0000, 0 0 0 rgba(0,0,0,0.2)";`,
+      errors: 1,
+    },
+    {
+      code: "const a = `border: 1px solid #abcdef`;",
+      errors: 1,
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/__tests__/no-palette-classes.test.js
+++ b/packages/eslint-plugin/src/__tests__/no-palette-classes.test.js
@@ -1,0 +1,84 @@
+import rule from "../rules/no-palette-classes.js";
+import { createRuleTester } from "./rule-tester.js";
+
+const ruleTester = createRuleTester();
+
+ruleTester.run("no-palette-classes", rule, {
+  valid: [
+    // Semantic scales and neutral tokens are the point of the system.
+    `const a = <div className="bg-background text-foreground" />;`,
+    `const a = <div className="border-border text-muted-foreground" />;`,
+    `const a = <div className="bg-success-100 text-destructive-600" />;`,
+    // A fraction utility contains a hue substring ("translate-x" ends in
+    // "late-x") and must not be read as one.
+    `const a = <div className="translate-x-1/2 -translate-y-1/2" />;`,
+    // A hue name with no utility prefix styles nothing.
+    `const a = "the red team";`,
+    // A shade with no hue is not a palette utility.
+    `const a = <div className="gap-500" />;`,
+    // An exemption is marked in place, with a reason.
+    `// design-lint-ok: matches an external brand swatch
+       const a = <div className="bg-red-500" />;`,
+  ],
+  invalid: [
+    {
+      code: `const a = <div className="bg-red-500" />;`,
+      errors: [
+        {
+          messageId: "paletteClass",
+          data: { className: "bg-red-500", advice: "use destructive-*" },
+        },
+      ],
+    },
+    {
+      // Assembled through a helper rather than written on the attribute.
+      code: `const a = cn("text-green-600", isOn && "p-2");`,
+      errors: [
+        {
+          messageId: "paletteClass",
+          data: { className: "text-green-600", advice: "use success-*" },
+        },
+      ],
+    },
+    {
+      // A variant prefix precedes the utility.
+      code: `const a = <div className="dark:bg-slate-800" />;`,
+      errors: 1,
+    },
+    {
+      // An opacity suffix follows it.
+      code: `const a = <div className="bg-amber-500/40" />;`,
+      errors: [
+        {
+          messageId: "paletteClass",
+          data: { className: "bg-amber-500/40", advice: "use warning-*" },
+        },
+      ],
+    },
+    {
+      // Inside a template literal, which the line-based guard also reads but
+      // which a naive AST rule that only visits `Literal` would miss.
+      code: "const a = `p-2 ${x} bg-rose-200`;",
+      errors: 1,
+    },
+    {
+      // A neutral hue has no dedicated scale, so the advice is the general form.
+      code: `const a = <div className="text-zinc-400" />;`,
+      errors: [
+        {
+          messageId: "paletteClass",
+          data: {
+            className: "text-zinc-400",
+            advice:
+              "use a semantic scale (success-*/warning-*/destructive-*/primary-*) or a neutral token",
+          },
+        },
+      ],
+    },
+    {
+      // Two in one string are two violations, not one.
+      code: `const a = <div className="bg-red-500 text-blue-300" />;`,
+      errors: 2,
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/__tests__/no-static-inline-style.test.js
+++ b/packages/eslint-plugin/src/__tests__/no-static-inline-style.test.js
@@ -1,0 +1,48 @@
+import rule from "../rules/no-static-inline-style.js";
+import { createRuleTester } from "./rule-tester.js";
+
+const ruleTester = createRuleTester();
+
+ruleTester.run("no-static-inline-style", rule, {
+  valid: [
+    // Computed at run time — a class cannot express it, which is exactly the
+    // case inline style exists for.
+    "const a = ({x}) => <div style={{ transform: `translate(${x}px)` }} />;",
+    `const a = ({x}) => <div style={{ top: x }} />;`,
+    // Mixed: one dynamic value means the object as a whole had to be a style.
+    `const a = ({x}) => <div style={{ padding: 24, top: x }} />;`,
+    // Not an object literal, so there is nothing to convert.
+    `const a = ({s}) => <div style={s} />;`,
+    // A spread carries values this rule cannot see.
+    `const a = ({rest}) => <div style={{ ...rest }} />;`,
+    `const a = ({rest}) => <div style={{ padding: 24, ...rest }} />;`,
+    // Empty styles nothing.
+    `const a = <div style={{}} />;`,
+    // A different attribute entirely.
+    `const a = <div className="p-6" />;`,
+    `// design-lint-ok: the embed's host requires an inline width
+       const a = <div style={{ width: 320 }} />;`,
+  ],
+  invalid: [
+    {
+      // The shape the plugin scaffold shipped.
+      code: `const a = <div style={{ padding: 24 }}>x</div>;`,
+      errors: [{ messageId: "staticInlineStyle" }],
+    },
+    {
+      // A negative number parses as an operator applied to a literal, so a
+      // rule that only accepted `Literal` would let this through.
+      code: `const a = <div style={{ marginTop: -4 }} />;`,
+      errors: [{ messageId: "staticInlineStyle" }],
+    },
+    {
+      code: `const a = <div style={{ display: "flex", gap: 8 }} />;`,
+      errors: [{ messageId: "staticInlineStyle" }],
+    },
+    {
+      // A template literal that interpolates nothing is still a constant.
+      code: "const a = <div style={{ width: `100%` }} />;",
+      errors: [{ messageId: "staticInlineStyle" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/__tests__/rule-tester.js
+++ b/packages/eslint-plugin/src/__tests__/rule-tester.js
@@ -1,0 +1,23 @@
+import { RuleTester } from "eslint";
+import { afterAll, describe, it } from "vitest";
+
+// `RuleTester` discovers its runner from globals. Vitest does not install any
+// unless `globals: true` is set, so without this wiring the tester registers no
+// cases and the suite reports "no tests" — a pass that ran nothing. Injecting
+// vitest's functions keeps the config free of globals while still letting each
+// case appear individually in the report.
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+/** A tester configured for the JSX + modern ESM the admin and plugins are written in. */
+export function createRuleTester() {
+  return new RuleTester({
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      parserOptions: { ecmaFeatures: { jsx: true } },
+    },
+  });
+}

--- a/packages/eslint-plugin/src/exempt.js
+++ b/packages/eslint-plugin/src/exempt.js
@@ -1,0 +1,26 @@
+import { EXEMPTION_MARKER } from "./vocabulary.js";
+
+/**
+ * Whether the line a node sits on carries the exemption marker.
+ *
+ * An exception is marked in place, with a reason, rather than by disabling the
+ * rule for a file or a directory: a marked line states what was decided and
+ * survives review, while a disabled scope silently exempts everything added to
+ * it afterwards.
+ *
+ * The marker is looked for on the node's own line and on the line above, because
+ * a long JSX attribute is commonly preceded by its comment rather than trailed
+ * by one.
+ */
+export function isExempt(sourceCode, node) {
+  const start = node.loc.start.line;
+  return sourceCode
+    .getAllComments()
+    .some(
+      comment =>
+        comment.value.includes(EXEMPTION_MARKER) &&
+        (comment.loc.start.line === start ||
+          comment.loc.end.line === start ||
+          comment.loc.end.line === start - 1)
+    );
+}

--- a/packages/eslint-plugin/src/index.js
+++ b/packages/eslint-plugin/src/index.js
@@ -1,0 +1,54 @@
+import { createRequire } from "node:module";
+
+import noHardcodedColors from "./rules/no-hardcoded-colors.js";
+import noPaletteClasses from "./rules/no-palette-classes.js";
+import noStaticInlineStyle from "./rules/no-static-inline-style.js";
+
+// Read rather than hardcoded: the version is published metadata and a second
+// copy of it drifts the moment the release tooling bumps one and not the other.
+const { version } = createRequire(import.meta.url)("../package.json");
+
+/**
+ * ESLint rules that keep admin UI on Nextly's design-token system.
+ *
+ * Published so the rules reach plugin authors. A guard that runs only in this
+ * repository governs the four first-party plugins and nothing anyone else
+ * builds, which leaves the ecosystem the contract is written for as the only
+ * part of it unenforced.
+ *
+ * Configs ship inside the plugin so a consumer installs one package and extends
+ * one entry, rather than pairing a plugin with a separately versioned config
+ * that can disagree with it.
+ */
+const plugin = {
+  meta: { name: "@nextlyhq/eslint-plugin", version },
+  rules: {
+    "no-palette-classes": noPaletteClasses,
+    "no-hardcoded-colors": noHardcodedColors,
+    "no-static-inline-style": noStaticInlineStyle,
+  },
+  configs: {},
+};
+
+Object.assign(plugin.configs, {
+  /**
+   * Every rule at `error`.
+   *
+   * There is no graduated "strict" tier above this one: each rule marks code
+   * that cannot follow a retheme, so a warning would describe the same defect
+   * while letting it ship.
+   */
+  recommended: [
+    {
+      name: "@nextlyhq/recommended",
+      plugins: { "@nextlyhq": plugin },
+      rules: {
+        "@nextlyhq/no-palette-classes": "error",
+        "@nextlyhq/no-hardcoded-colors": "error",
+        "@nextlyhq/no-static-inline-style": "error",
+      },
+    },
+  ],
+});
+
+export default plugin;

--- a/packages/eslint-plugin/src/rules/no-hardcoded-colors.js
+++ b/packages/eslint-plugin/src/rules/no-hardcoded-colors.js
@@ -1,0 +1,74 @@
+import { isExempt } from "../exempt.js";
+import {
+  createColorLiteralPattern,
+  stripExemptColorPieces,
+} from "../vocabulary.js";
+
+/**
+ * Reject a hardcoded colour where a token belongs.
+ *
+ * A literal colour is frozen at the value someone typed, so it neither follows a
+ * retheme nor flips between light and dark. Tokens are complete OKLCH colours
+ * and can be referenced directly — `var(--nx-border)` — or blended with
+ * `color-mix(...)`.
+ *
+ * Detection runs on text with the legitimate cases removed rather than on the
+ * raw text, so black, white, transparent, `url(...)` payloads and `placeholder`
+ * examples never reach the pattern. Those are mode-invariant or are content, and
+ * routing them through a themed token would claim a variation that does not
+ * exist.
+ */
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Use design tokens instead of hardcoded colour values",
+      url: "https://nextlyhq.com/docs/plugins",
+    },
+    schema: [],
+    messages: {
+      hardcodedColor:
+        "`{{literal}}` is a hardcoded colour — use var(--token) or color-mix(...).",
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+
+    /**
+     * The literal to name in the message.
+     *
+     * Detection deliberately matches only a colour function's opening channel,
+     * which is enough to decide but reads badly in a message, so the whole call
+     * is recovered here. This is presentation only — what counts as a violation
+     * stays in the shared vocabulary.
+     */
+    function display(text) {
+      return (
+        /#[0-9a-fA-F]{3,8}\b|\b(?:rgb|rgba|hsl|hsla)\([^)]*\)?/.exec(
+          text
+        )?.[0] ?? text.trim()
+      );
+    }
+
+    function check(node, text) {
+      if (typeof text !== "string" || text.length === 0) return;
+      const stripped = stripExemptColorPieces(text);
+      if (!createColorLiteralPattern().test(stripped)) return;
+      if (isExempt(sourceCode, node)) return;
+      context.report({
+        node,
+        messageId: "hardcodedColor",
+        data: { literal: display(stripped) },
+      });
+    }
+
+    return {
+      Literal(node) {
+        if (typeof node.value === "string") check(node, node.value);
+      },
+      TemplateElement(node) {
+        check(node, node.value.cooked ?? node.value.raw);
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/src/rules/no-palette-classes.js
+++ b/packages/eslint-plugin/src/rules/no-palette-classes.js
@@ -1,0 +1,60 @@
+import { isExempt } from "../exempt.js";
+import { createPaletteClassPattern, paletteAdvice } from "../vocabulary.js";
+
+/**
+ * Reject a Tailwind palette utility where a semantic scale belongs.
+ *
+ * A palette hue is a fixed colour: it does not move when the theme moves, so an
+ * admin surface painted with one keeps its light-mode appearance in dark mode
+ * while everything around it changes. The semantic scales derive from tokens and
+ * follow the theme, which is the whole reason the token system exists.
+ *
+ * String VALUES are inspected rather than `className` attributes specifically,
+ * because the class list is assembled in too many shapes to enumerate — a bare
+ * attribute, a `cn()` / `clsx()` argument, a variant map, a constant lifted to
+ * module scope. Matching the value catches all of them; the class-list boundary
+ * in the pattern is what keeps prose from matching.
+ */
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Use Nextly's semantic colour scales instead of Tailwind palette utilities",
+      url: "https://nextlyhq.com/docs/plugins",
+    },
+    schema: [],
+    messages: {
+      paletteClass: "`{{className}}` is a fixed palette colour — {{advice}}.",
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+
+    /** Report every palette utility inside one string value. */
+    function check(node, text) {
+      if (typeof text !== "string" || text.length === 0) return;
+      // A fresh pattern per call: a `g`-flagged regex reused across nodes carries
+      // `lastIndex`, so the second node would start scanning mid-string.
+      const pattern = createPaletteClassPattern({ global: true });
+      let match;
+      while ((match = pattern.exec(text)) !== null) {
+        if (isExempt(sourceCode, node)) return;
+        context.report({
+          node,
+          messageId: "paletteClass",
+          data: { className: match[1], advice: paletteAdvice(match[1]) },
+        });
+      }
+    }
+
+    return {
+      Literal(node) {
+        if (typeof node.value === "string") check(node, node.value);
+      },
+      TemplateElement(node) {
+        check(node, node.value.cooked ?? node.value.raw);
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/src/rules/no-static-inline-style.js
+++ b/packages/eslint-plugin/src/rules/no-static-inline-style.js
@@ -1,0 +1,78 @@
+import { isExempt } from "../exempt.js";
+
+/**
+ * Reject a JSX `style` object whose every value is a constant.
+ *
+ * An inline style with only constants is a utility class written the long way:
+ * it bypasses the spacing and colour scales, so it does not move with the theme
+ * and does not respond to density or radius. The same declaration expressed as a
+ * class, or as a `@nextlyhq/ui` component, inherits all of that.
+ *
+ * The rule is deliberately narrow. Inline style is the correct and only tool for
+ * a value computed at run time — a drag transform, a measured offset, a
+ * percentage from data — and those are exactly the cases where a class cannot
+ * express the value. Reporting only the all-constant object separates "could
+ * have been a class" from "had to be a style" without an allowlist to maintain,
+ * because the distinguishing property is in the code rather than in a list of
+ * blessed files.
+ */
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Express constant styling as classes or @nextlyhq/ui components rather than inline style",
+      url: "https://nextlyhq.com/docs/plugins",
+    },
+    schema: [],
+    messages: {
+      staticInlineStyle:
+        "This `style` object is entirely constant — use design-token utility classes or a @nextlyhq/ui component instead.",
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+
+    /**
+     * A value a class could have expressed.
+     *
+     * `UnaryExpression` is included because a negative number parses as an
+     * operator applied to a literal rather than as one — without it,
+     * `marginTop: -4` would read as dynamic and the object would escape.
+     * A template literal counts only when it interpolates nothing, since one
+     * with expressions is computed at run time.
+     */
+    function isStaticValue(node) {
+      if (node.type === "Literal") return true;
+      if (
+        node.type === "UnaryExpression" &&
+        (node.operator === "-" || node.operator === "+")
+      ) {
+        return isStaticValue(node.argument);
+      }
+      if (node.type === "TemplateLiteral") return node.expressions.length === 0;
+      return false;
+    }
+
+    return {
+      JSXAttribute(node) {
+        if (node.name?.name !== "style") return;
+        if (node.value?.type !== "JSXExpressionContainer") return;
+
+        const expression = node.value.expression;
+        if (expression.type !== "ObjectExpression") return;
+        // An empty object styles nothing, so there is no class to prefer.
+        if (expression.properties.length === 0) return;
+
+        const everyValueIsConstant = expression.properties.every(
+          property =>
+            property.type === "Property" && isStaticValue(property.value)
+        );
+        if (!everyValueIsConstant) return;
+        if (isExempt(sourceCode, node)) return;
+
+        context.report({ node, messageId: "staticInlineStyle" });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/src/vocabulary.js
+++ b/packages/eslint-plugin/src/vocabulary.js
@@ -1,0 +1,197 @@
+/**
+ * The design-token vocabulary, defined once and consumed by every guard that
+ * enforces it.
+ *
+ * Two mechanisms enforce this contract and they run in different places: the
+ * ESLint rules in this package run wherever a plugin author lints (their editor,
+ * their CI, and ours), while `scripts/lint-design.mjs` covers CSS and acts as the
+ * repository-wide backstop. Both import this module, so the two can differ in
+ * WHERE they run and never in WHAT they mean. A hue added to one and not the
+ * other is the drift this file exists to make unrepresentable.
+ */
+
+/**
+ * Tailwind's built-in palette hues.
+ *
+ * These ship with the framework whether or not `theme.css` redefines a given
+ * hue, so a palette utility compiles even where no matching `--color-*` scale is
+ * declared. That is why they need naming here rather than being derivable from
+ * the token file: the token file is what they BYPASS.
+ */
+export const PALETTE_HUES = [
+  "slate",
+  "gray",
+  "zinc",
+  "neutral",
+  "stone",
+  "red",
+  "orange",
+  "amber",
+  "yellow",
+  "lime",
+  "green",
+  "emerald",
+  "teal",
+  "cyan",
+  "sky",
+  "blue",
+  "indigo",
+  "violet",
+  "purple",
+  "fuchsia",
+  "pink",
+  "rose",
+];
+
+/**
+ * Shades, longest first.
+ *
+ * The order is load-bearing in the alternation: `50|\d{3}` matches the leading
+ * `50` of `500` and lets the rest through, so a three-digit shade must be
+ * offered before the two-digit one.
+ */
+export const PALETTE_SHADES = [
+  "950",
+  "900",
+  "800",
+  "700",
+  "600",
+  "500",
+  "400",
+  "300",
+  "200",
+  "100",
+  "50",
+];
+
+/** Utility prefixes that take a colour. */
+export const COLOR_UTILS = [
+  "text",
+  "bg",
+  "border",
+  "ring",
+  "ring-offset",
+  "from",
+  "via",
+  "to",
+  "fill",
+  "stroke",
+  "shadow",
+  "outline",
+  "decoration",
+  "accent",
+  "caret",
+  "divide",
+  "placeholder",
+];
+
+/**
+ * The semantic scale that replaced each hue.
+ *
+ * A hue is not a meaning: two hues stood in for "success" here and two for
+ * "destructive", which is how they drift apart. Each scale derives from one
+ * token, so a retheme moves the whole scale at once. Hues with no entry are
+ * neutrals, which take `foreground` / `muted-foreground` / `border` instead.
+ */
+export const HUE_REPLACEMENT = {
+  green: "success-*",
+  emerald: "success-*",
+  red: "destructive-*",
+  rose: "destructive-*",
+  amber: "warning-*",
+  yellow: "warning-*",
+  orange: "warning-*",
+};
+
+/** The inline comment that exempts a line, and the reason it must carry one. */
+export const EXEMPTION_MARKER = "design-lint-ok";
+
+/**
+ * Build the palette-utility pattern.
+ *
+ * A FACTORY rather than a shared constant because a `g`-flagged regex carries
+ * `lastIndex` between calls: one shared instance would skip matches depending on
+ * where the previous caller left off, and the misses would look like clean code.
+ *
+ * The match is anchored on a class-list boundary so `translate-x-1/2` (which
+ * contains "slate-x") and a hue named in prose are not read as utilities.
+ * Variants (`hover:`, `dark:`) and the `!` important marker are allowed to
+ * precede the utility, and an opacity suffix (`/40`) to follow it.
+ */
+export function createPaletteClassPattern({ global = false } = {}) {
+  const utils = COLOR_UTILS.join("|");
+  const hues = PALETTE_HUES.join("|");
+  const shades = PALETTE_SHADES.join("|");
+  return new RegExp(
+    `(?:^|[\\s"'\`{])((?:[a-z-]+:)*!?(?:${utils})-(?:${hues})-(?:${shades})(?:\\/\\d{1,3})?)(?![\\w-])`,
+    global ? "g" : ""
+  );
+}
+
+/**
+ * Build the colour-literal pattern: a hex value, or a colour function whose
+ * channels are literal numbers.
+ *
+ * `rgb(var(--x))` is deliberately NOT matched here — a token wrapped in a colour
+ * function is a different defect with a different fix, and
+ * `createTokenWrapPattern` is what names it.
+ */
+export function createColorLiteralPattern({ global = false } = {}) {
+  return new RegExp(
+    `#[0-9a-fA-F]{3,8}\\b|\\b(?:rgb|rgba|hsl|hsla)\\(\\s*[0-9.]`,
+    global ? "g" : ""
+  );
+}
+
+/**
+ * Build the pattern for a token wrapped in a colour function.
+ *
+ * Tokens are complete OKLCH colours, so `hsl(var(--nx-primary))` expands to
+ * `hsl(oklch(...))`, which is invalid and which the browser drops — the element
+ * silently loses its colour rather than failing loudly.
+ */
+export function createTokenWrapPattern({ global = false } = {}) {
+  return new RegExp(`\\b(?:hsl|hsla|rgb|rgba)\\(\\s*var\\(`, global ? "g" : "");
+}
+
+/**
+ * Advice naming what to use instead, derived from the hue that was matched.
+ *
+ * The message carries the replacement because an error that only says "do not do
+ * this" leaves the reader to guess which of four semantic scales applies, and the
+ * guess is what produced the two-hues-per-meaning drift in the first place.
+ */
+export function paletteAdvice(match) {
+  const hue = new RegExp(`(${PALETTE_HUES.join("|")})`).exec(match)?.[1];
+  const replacement = hue && HUE_REPLACEMENT[hue];
+  if (replacement) return `use ${replacement}`;
+  return "use a semantic scale (success-*/warning-*/destructive-*/primary-*) or a neutral token";
+}
+
+/**
+ * Remove the colour literals that are legitimate everywhere, so what remains is
+ * only the kind a token should have supplied.
+ *
+ * Black, white and transparent are mode-invariant: a scrim or a shadow is the
+ * same colour in light and dark, so routing it through a themed token would
+ * claim a variation that does not exist. `url(...)` payloads and `placeholder`
+ * example values are content rather than styling.
+ */
+export function stripExemptColorPieces(text) {
+  return (
+    text
+      // A hex inside a comment is documentation, not code.
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/url\([^)]*\)/g, "")
+      .replace(/placeholder\s*[:=]\s*["'][^"']*["']/g, "")
+      // black / white, with an optional 2-digit alpha (`#00000033` scrims)
+      .replace(/#(?:ffffff|fff|000000|000)(?:[0-9a-f]{2})?\b/gi, "")
+      .replace(/rgba?\(\s*0\s*[,\s]\s*0\s*[,\s]\s*0[^)]*\)/gi, "")
+      .replace(/rgba?\(\s*255\s*[,\s]\s*255\s*[,\s]\s*255[^)]*\)/gi, "")
+  );
+}
+
+/** Whether a colour literal survives the exemptions above. */
+export function hasNonExemptColorLiteral(text) {
+  return createColorLiteralPattern().test(stripExemptColorPieces(text));
+}

--- a/packages/eslint-plugin/vitest.config.ts
+++ b/packages/eslint-plugin/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/eslint-plugin/vitest.config.ts
+++ b/packages/eslint-plugin/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-  test: {
-    environment: "node",
-  },
-});

--- a/packages/plugin-form-builder/eslint.config.js
+++ b/packages/plugin-form-builder/eslint.config.js
@@ -1,6 +1,8 @@
 import { config } from "@nextlyhq/eslint-config/react-internal";
+import { designTokensConfig } from "@nextlyhq/eslint-config/design-tokens";
 
 export default [
+  ...designTokensConfig(["src/**/*.{ts,tsx}"]),
   ...config,
   {
     ignores: [

--- a/packages/plugin-sdk/eslint.config.js
+++ b/packages/plugin-sdk/eslint.config.js
@@ -1,3 +1,4 @@
 import { config } from "@nextlyhq/eslint-config/base";
+import { designTokensConfig } from "@nextlyhq/eslint-config/design-tokens";
 
 export default [...config];

--- a/packages/plugin-seo/eslint.config.mjs
+++ b/packages/plugin-seo/eslint.config.mjs
@@ -1,6 +1,8 @@
 import { config } from "@nextlyhq/eslint-config/base";
+import { designTokensConfig } from "@nextlyhq/eslint-config/design-tokens";
 
 export default [
+  ...designTokensConfig(["src/**/*.{ts,tsx}"]),
   ...config,
   {
     ignores: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@manypkg/get-packages':
         specifier: ^1.1.3
         version: 1.1.3
+      '@nextlyhq/eslint-plugin':
+        specifier: workspace:*
+        version: link:packages/eslint-plugin
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -1035,6 +1038,18 @@ importers:
         specifier: ^8.59.0
         version: 8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3)
 
+  packages/eslint-plugin:
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.34.0
+        version: 9.39.1
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.1(jiti@2.7.0)
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.10(@types/node@24.10.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/module-specifiers:
     devDependencies:
       '@nextlyhq/eslint-config':
@@ -1191,7 +1206,7 @@ importers:
         version: 8.3.4
       eslint:
         specifier: ^9.39.1
-        version: 9.39.1(jiti@2.6.1)
+        version: 9.39.1(jiti@2.7.0)
       mysql2:
         specifier: ^3.15.0
         version: 3.15.0
@@ -1209,7 +1224,7 @@ importers:
         version: 6.4.1(rollup@4.60.1)(typescript@5.9.3)
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(jiti@2.6.1)(postcss@8.5.23)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.0(jiti@2.7.0)(postcss@8.5.23)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.20.5
         version: 4.20.5
@@ -1218,10 +1233,10 @@ importers:
         version: 5.9.3
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
+        version: 5.1.4(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.0
-        version: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
+        version: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
 
   packages/plugin-form-builder:
     dependencies:
@@ -6980,10 +6995,6 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jiti@2.6.1:
-    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
-    hasBin: true
-
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -10073,11 +10084,6 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.1(jiti@2.6.1))':
-    dependencies:
-      eslint: 9.39.1(jiti@2.6.1)
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.1(jiti@2.7.0))':
     dependencies:
       eslint: 9.39.1(jiti@2.7.0)
@@ -12566,13 +12572,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
+      vite: 7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -13645,47 +13651,6 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.1(jiti@2.6.1):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1))
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.1
-      '@eslint/config-helpers': 0.4.2
-      '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.39.1
-      '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.6
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
-      ajv: 6.15.0
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint-scope: 8.4.0
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      esquery: 1.6.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      minimatch: 10.2.6
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 2.6.1
-    transitivePeerDependencies:
-      - supports-color
-
   eslint@9.39.1(jiti@2.7.0):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.7.0))
@@ -14348,9 +14313,6 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-
-  jiti@2.6.1:
-    optional: true
 
   jiti@2.7.0: {}
 
@@ -15042,11 +15004,11 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.23)(tsx@4.20.5)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.20.5)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      jiti: 2.6.1
+      jiti: 2.7.0
       postcss: 8.5.23
       tsx: 4.20.5
       yaml: 2.8.3
@@ -15901,7 +15863,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.0(jiti@2.6.1)(postcss@8.5.23)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.0(jiti@2.7.0)(postcss@8.5.23)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.12)
       cac: 6.7.14
@@ -15912,7 +15874,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.23)(tsx@4.20.5)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.20.5)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.8.0-beta.0
@@ -16165,13 +16127,13 @@ snapshots:
 
   validate-npm-package-name@5.0.1: {}
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:
-      vite: 7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
+      vite: 7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -16198,7 +16160,7 @@ snapshots:
       - supports-color
       - typescript
 
-  vite@7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3):
+  vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
@@ -16209,7 +16171,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.17
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 2.7.0
       lightningcss: 1.32.0
       terser: 5.44.1
       tsx: 4.20.5
@@ -16266,10 +16228,10 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)):
+  vitest@4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -16286,7 +16248,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
+      vite: 7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1000,6 +1000,10 @@ importers:
         version: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/eslint-config:
+    dependencies:
+      '@nextlyhq/eslint-plugin':
+        specifier: workspace:*
+        version: link:../eslint-plugin
     devDependencies:
       '@eslint/js':
         specifier: ^9.34.0
@@ -1043,9 +1047,15 @@ importers:
       '@eslint/js':
         specifier: ^9.34.0
         version: 9.39.1
+      '@typescript-eslint/parser':
+        specifier: ^8.59.0
+        version: 8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3)
       eslint:
         specifier: ^9.39.1
         version: 9.39.1(jiti@2.7.0)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       vitest:
         specifier: ^4.1.0
         version: 4.1.10(@types/node@24.10.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))

--- a/scripts/lint-design.mjs
+++ b/scripts/lint-design.mjs
@@ -29,56 +29,73 @@
  * A genuine exception gets an inline `design-lint-ok: <reason>` comment rather than
  * silencing the whole check. Run with `pnpm lint:design`.
  */
-import { readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 
-const ROOTS = [
-  "packages/admin/src",
-  "packages/plugin-form-builder/src",
-  "packages/plugin-page-builder/src",
+import {
+  createColorLiteralPattern,
+  createPaletteClassPattern,
+  createTokenWrapPattern,
+  paletteAdvice,
+  stripExemptColorPieces,
+} from "@nextlyhq/eslint-plugin/vocabulary";
+
+/**
+ * The scanned trees, DISCOVERED rather than listed.
+ *
+ * A hardcoded list is complete only against the repository it was written for.
+ * Every plugin package added afterwards is outside it, and the guard then
+ * reports clean on that package in exactly the same words it uses for one it
+ * examined — so the coverage silently stops growing with the repo.
+ *
+ * `templates/plugin` is here because the exemplar every plugin author copies is
+ * held to the contract it teaches. The other templates are deliberately absent:
+ * they are site starters, and a palette colour on someone's own marketing page
+ * is their design decision rather than a theme violation.
+ */
+function deriveRoots() {
+  const roots = [];
+  const add = path => {
+    if (existsSync(path)) roots.push(path);
+  };
+
+  add("packages/admin/src");
   // The shared token source is covered too, so token-consistency bugs (e.g. a
   // shadow that hardcodes a color instead of deriving from its token) can't ship
   // in the file every consumer depends on.
-  "packages/ui/src",
-];
+  add("packages/ui/src");
+  for (const entry of readdirSync("packages", { withFileTypes: true })) {
+    if (entry.isDirectory() && entry.name.startsWith("plugin-")) {
+      add(`packages/${entry.name}/src`);
+    }
+  }
+  add("templates/plugin/src");
+
+  return roots;
+}
 
 // Files whose color literals are page-theme output defaults, not admin UI theming.
 const FILE_ALLOWLIST = ["plugin-page-builder/src/core/style-compiler.ts"];
 
-const PLUGIN_MARKER = "packages/plugin-";
+/**
+ * Whether a file is a plugin surface, which decides the stricter rules.
+ *
+ * Matched on the path SHAPE rather than on a `"packages/plugin-"` substring.
+ * The substring answers "no" for `templates/plugin/src/admin/SettingsPage.tsx`
+ * — the one file the plugin rules most need to reach, since it is what every
+ * third-party plugin is copied from — and it answers no silently, leaving the
+ * exemplar exempt from the contract it demonstrates.
+ */
+const PLUGIN_SURFACE_RE =
+  /(?:^|\/)(?:packages\/plugin-[^/]+|templates\/plugin)\//;
+
 // Admin's reviewed `!important` baseline (see packages/admin/src/styles/globals.css). The
 // guard fails if this grows; lower it when overrides are removed.
 const ADMIN_IMPORTANT_BASELINE = 35;
 
-const TOKEN_WRAP_RE = /\b(?:hsl|hsla|rgb|rgba)\(\s*var\(/;
-const COLOR_LITERAL_RE = /#[0-9a-fA-F]{3,8}\b|\b(?:rgb|rgba|hsl|hsla)\(\s*[0-9.]/;
-
-// Tailwind's built-in palette, which ships with the framework whether or not
-// theme.css redefines a given hue — so `bg-emerald-50` compiles even though no
-// `--color-emerald-*` is declared anywhere here. That is exactly why this needs
-// its own rule.
-const PALETTE_HUES =
-  "slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose";
-const COLOR_UTILS =
-  "text|bg|border|ring|ring-offset|from|via|to|fill|stroke|shadow|outline|decoration|accent|caret|divide|placeholder";
-// Longest shade first: `50|\d{3}` would match `500` as `50` and let it through.
-const PALETTE_SHADES = "950|900|800|700|600|500|400|300|200|100|50";
-// Anchored on a class-list boundary so `translate-x-1/2` (which contains
-// "slate-x") and a prose mention of a colour are not read as utilities.
-const PALETTE_CLASS_RE = new RegExp(
-  `(?:^|[\\s"'\`{])((?:[a-z-]+:)*!?(?:${COLOR_UTILS})-(?:${PALETTE_HUES})-(?:${PALETTE_SHADES})(?:\\/\\d{1,3})?)(?![\\w-])`
-);
-
-/** The token scale that replaced each hue, so the error says what to do next. */
-const HUE_REPLACEMENT = {
-  green: "success-*",
-  emerald: "success-*",
-  red: "destructive-*",
-  rose: "destructive-*",
-  amber: "warning-*",
-  yellow: "warning-*",
-  orange: "warning-*",
-};
+const TOKEN_WRAP_RE = createTokenWrapPattern();
+const COLOR_LITERAL_RE = createColorLiteralPattern();
+const PALETTE_CLASS_RE = createPaletteClassPattern();
 
 /** True for a line that is nothing but a comment — `//`, `/* … *​/`, or a JSDoc `*`. */
 function isCommentLine(line) {
@@ -86,16 +103,9 @@ function isCommentLine(line) {
   return t.startsWith("//") || t.startsWith("*") || t.startsWith("/*");
 }
 
-function paletteAdvice(match) {
-  const hue = new RegExp(`(${PALETTE_HUES})`).exec(match)?.[1];
-  const replacement = hue && HUE_REPLACEMENT[hue];
-  if (replacement) return `use ${replacement}`;
-  return "use a semantic scale (success-*/warning-*/destructive-*/primary-*) or a neutral token";
-}
-
-const listFiles = () =>
+const listFiles = roots =>
   execSync(
-    `find ${ROOTS.join(" ")} -type f \\( -name "*.css" -o -name "*.tsx" -o -name "*.ts" \\)`,
+    `find ${roots.join(" ")} -type f \\( -name "*.css" -o -name "*.tsx" -o -name "*.ts" \\)`,
     { encoding: "utf8" }
   )
     .trim()
@@ -111,24 +121,22 @@ function colorLiteralIsExempt(line, file) {
   // source of truth in theme.css; only these `--color-*` scale definitions are
   // allowed to hardcode. Semantic tokens and shadows must still derive from them.
   if (/--color-[a-z]+-\d+\s*:/.test(line)) return true;
-  let rest = line
-    // strip inline comments (a hex inside `/* … */` is documentation, not code)
-    .replace(/\/\*.*?\*\//g, "")
-    .replace(/url\([^)]*\)/g, "")
-    .replace(/placeholder\s*[:=]\s*["'][^"']*["']/g, "")
-    // black / white, with an optional 2-digit alpha (`#00000033` shadow scrims)
-    .replace(/#(?:ffffff|fff|000000|000)(?:[0-9a-f]{2})?\b/gi, "")
-    .replace(/rgba?\(\s*0\s*[,\s]\s*0\s*[,\s]\s*0[^)]*\)/gi, "")
-    .replace(/rgba?\(\s*255\s*[,\s]\s*255\s*[,\s]\s*255[^)]*\)/gi, "");
-  return !COLOR_LITERAL_RE.test(rest);
+  // The mode-invariant strip is shared with the published ESLint rules, so the
+  // two guards cannot disagree about which literals are legitimate.
+  return !COLOR_LITERAL_RE.test(stripExemptColorPieces(line));
 }
+
+const roots = deriveRoots();
+const files = listFiles(roots);
 
 const violations = [];
 let adminImportant = 0;
+let pluginClassified = 0;
 
-for (const file of listFiles()) {
+for (const file of files) {
   const isCss = file.endsWith(".css");
-  const isPlugin = file.includes(PLUGIN_MARKER);
+  const isPlugin = PLUGIN_SURFACE_RE.test(file);
+  if (isPlugin) pluginClassified += 1;
   // The theme declares the palette scales themselves; it is the one place the
   // hue names are the subject rather than a shortcut past the tokens.
   const isThemeSource = file.endsWith("ui/src/styles/theme.css");
@@ -171,6 +179,33 @@ for (const file of listFiles()) {
   });
 }
 
+/**
+ * What the run actually read, asserted before any verdict is reported.
+ *
+ * A scan whose roots resolved to nothing finds no violations and exits 0, which
+ * is byte-identical to a clean repository. The three populations are reported
+ * separately because they fail independently: roots can resolve while matching
+ * no files, and files can be read while none of them is classified as a plugin
+ * surface — and that last case makes every plugin-only rule inert while the
+ * summary still reads as a pass.
+ */
+const populations = [
+  ["roots", roots.length],
+  ["files", files.length],
+  ["plugin-surface files", pluginClassified],
+];
+const empty = populations.filter(([, count]) => count === 0);
+if (empty.length > 0) {
+  console.error(
+    `\n✖ Design lint could not run: ${empty
+      .map(([label]) => `no ${label}`)
+      .join(", ")}.\n\n` +
+      "  This is not a pass. The guard reports nothing when it reads nothing,\n" +
+      "  so an empty population is a tooling failure rather than a clean tree.\n"
+  );
+  process.exit(1);
+}
+
 if (adminImportant > ADMIN_IMPORTANT_BASELINE) {
   violations.push(
     `admin: ${adminImportant} \`!important\` exceed the reviewed baseline of ${ADMIN_IMPORTANT_BASELINE}. ` +
@@ -188,5 +223,8 @@ if (violations.length) {
 }
 
 console.log(
-  `✓ Design lint passed (admin \`!important\`: ${adminImportant}/${ADMIN_IMPORTANT_BASELINE}).`
+  `✓ Design lint passed — ${files.length} files across ${roots.length} roots ` +
+    `(${pluginClassified} plugin-surface), admin \`!important\`: ` +
+    `${adminImportant}/${ADMIN_IMPORTANT_BASELINE}.`
 );
+console.log(`  roots: ${roots.join(", ")}`);

--- a/scripts/lint-design.mjs
+++ b/scripts/lint-design.mjs
@@ -126,7 +126,29 @@ function colorLiteralIsExempt(line, file) {
   return !COLOR_LITERAL_RE.test(stripExemptColorPieces(line));
 }
 
+/**
+ * Refuse, rather than report, when the run read nothing.
+ *
+ * Separate from the violation list because the two are different outcomes: no
+ * violations is a verdict, and nothing scanned is the absence of one. Reporting
+ * the second as the first is the failure this guard is meant not to have.
+ */
+function refuse(missing) {
+  console.error(
+    `\n✖ Design lint could not run: ${missing.join(", ")}.\n\n` +
+      "  This is not a pass. The guard reports nothing when it reads nothing,\n" +
+      "  so an empty population is a tooling failure rather than a clean tree.\n"
+  );
+  process.exit(1);
+}
+
 const roots = deriveRoots();
+// Checked before `listFiles`, which shells out to `find`: with no paths that
+// command fails and takes the process down before any population is reported,
+// so the refusal below would be unreachable and the operator would see a stack
+// trace instead of the reason.
+if (roots.length === 0) refuse(["no roots"]);
+
 const files = listFiles(roots);
 
 const violations = [];
@@ -189,22 +211,11 @@ for (const file of files) {
  * surface — and that last case makes every plugin-only rule inert while the
  * summary still reads as a pass.
  */
-const populations = [
-  ["roots", roots.length],
+const empty = [
   ["files", files.length],
   ["plugin-surface files", pluginClassified],
-];
-const empty = populations.filter(([, count]) => count === 0);
-if (empty.length > 0) {
-  console.error(
-    `\n✖ Design lint could not run: ${empty
-      .map(([label]) => `no ${label}`)
-      .join(", ")}.\n\n` +
-      "  This is not a pass. The guard reports nothing when it reads nothing,\n" +
-      "  so an empty population is a tooling failure rather than a clean tree.\n"
-  );
-  process.exit(1);
-}
+].filter(([, count]) => count === 0);
+if (empty.length > 0) refuse(empty.map(([label]) => `no ${label}`));
 
 if (adminImportant > ADMIN_IMPORTANT_BASELINE) {
   violations.push(

--- a/templates/plugin/src/admin/SettingsPage.tsx
+++ b/templates/plugin/src/admin/SettingsPage.tsx
@@ -1,13 +1,57 @@
 /**
  * Example plugin settings page, rendered at `/admin/plugins/<slug>` and inside
- * a per-component error boundary (D53). Build your real settings UI here with
- * `@nextlyhq/ui` components.
+ * a per-component error boundary (D53).
+ *
+ * Every class here is a design token utility, so this page follows the admin's
+ * theme and its light/dark modes with no styling work of its own. Build your
+ * real settings UI the same way.
+ *
+ * Third-party plugins are not part of the admin's Tailwind `@source` scan, so
+ * only the curated utilities in `plugin-safelist.css` are guaranteed to be
+ * compiled — layout, spacing, type, and the token-mapped colours used below.
+ * Anything outside that set belongs in the stylesheet your plugin declares as
+ * `adminStyles`, written against the `--nx-*` custom properties.
  */
 export function SettingsPage() {
   return (
-    <div style={{ padding: 24 }}>
-      <h1>Plugin Settings</h1>
-      <p>Settings UI goes here. Edit src/admin/SettingsPage.tsx.</p>
+    <div className="w-full max-w-2xl space-y-6 p-6">
+      <header className="space-y-1">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">
+          Plugin Settings
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Settings UI goes here. Edit{" "}
+          <span className="font-mono text-xs">src/admin/SettingsPage.tsx</span>.
+        </p>
+      </header>
+
+      <section className="space-y-4 rounded-lg border border-border bg-card p-6">
+        <div className="space-y-1">
+          <h2 className="text-sm font-semibold text-foreground">
+            Where to put your fields
+          </h2>
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            Replace this card with your own form. Group related settings under a
+            heading, and keep one save action for the page rather than one per
+            group.
+          </p>
+        </div>
+
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li>
+            Colours come from tokens —{" "}
+            <span className="font-mono text-xs">bg-card</span>,{" "}
+            <span className="font-mono text-xs">text-muted-foreground</span>,{" "}
+            <span className="font-mono text-xs">border-border</span> — never
+            from a fixed palette shade, which would keep its light-mode
+            appearance in dark mode.
+          </li>
+          <li>
+            Spacing and radius come from the same scales the rest of the admin
+            uses, so your page stays aligned with it when those move.
+          </li>
+        </ul>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## What and why

Nextly's admin is themeable because its surfaces read design tokens. A surface that reaches past them keeps its light-mode appearance in dark mode and ignores a retheme. That contract is documented in `plugin-ui-authoring.md`, which calls it *"a contract"* — and then scopes enforcement to *"code that ships in this repo."*

So the four first-party plugins are governed and **nothing anyone else builds is**. `@nextlyhq/eslint-config` carries the repo's conventions and is `private: true`, and `templates/plugin/eslint.config.mjs` is generic `@eslint/js` + `typescript-eslint`. A scaffolded plugin inherits zero design-system enforcement.

**The task premise turned out to be false and is worth stating.** T-02 reads "official plugins should follow the design-token system". Measured on `origin/main` with two positive controls: palette utilities and colour literals across `plugin-form-builder`, `plugin-page-builder`, `plugin-seo` and `plugin-sdk` are **zero**, `lint:design` passes, and it already runs in `ci.yml` and `.husky/pre-push`. They conform. The gap is that nothing reaches plugins we did not write, and that the guard itself had four defects.

## What this changes

**New published package `@nextlyhq/eslint-plugin`** — three AST rules with a `recommended` config bundled in (the `@wordpress/eslint-plugin` / `@shopify/eslint-plugin` shape):

- `no-palette-classes` — a fixed palette hue where a semantic scale belongs; the message names the scale.
- `no-hardcoded-colors` — hex / `rgb()` / `hsl()` literals, with black, white, `url(...)` payloads and `placeholder` examples exempt as mode-invariant.
- `no-static-inline-style` — reports a JSX `style` object **only when every value is a constant**, i.e. when a class could have expressed it. Genuinely computed inline style (a drag transform) is untouched, so there is no allowlist to maintain.

**One vocabulary, two mechanisms.** The hue list, shade list and scale map live in one module that both the ESLint rules and `scripts/lint-design.mjs` import, so the two can differ in *where they run* and never in *what they mean*.

**Four measured defects in the guard, fixed:**

| defect | fix |
|---|---|
| `ROOTS` was a hardcoded list of four, so coverage never grew with the repo | roots derived at run time — now 7, adding `plugin-sdk`, `plugin-seo` and the plugin template |
| `PLUGIN_MARKER` was the substring `"packages/plugin-"`, which answers **no** for `templates/plugin/...` | classified by path shape; the exemplar is now a plugin surface (82 files, up from 76) |
| a run that scanned nothing exited 0, identical to a clean tree | asserts and prints roots / files / plugin-surface, and refuses when any is empty |
| the colour rules could never catch the exemplar's actual defect | `no-static-inline-style` catches it, and a conformance test pins it |

**The exemplar is rebuilt.** `templates/plugin/src/admin/SettingsPage.tsx` was `<div style={{ padding: 24 }}>` with bare `h1`/`p` while its own docblock said to build with `@nextlyhq/ui`. It now uses only utilities from `plugin-safelist.css` — the set that actually compiles for a plugin outside the admin's Tailwind `@source` scan, which is the part a third-party author most needs to know.

## Test plan

Cache forced off throughout; tree built before any lint or type result was believed.

- `pnpm build` — **19/19, 0 cached**
- `pnpm turbo run lint --continue --force` — **24/24**
- `pnpm turbo run check-types --continue --force` — **22/22**
- `pnpm test:scripts` — **492/492**
- `packages/eslint-plugin` — **45/45**
- `pnpm lint:design` — passes, 860 files / 7 roots / 82 plugin-surface, `!important` **35/35 unchanged** (measured before and after the roots rewrite, so the ratchet moving would not be mistaken for a regression)

**Every test break-verified in both directions.** Ten probes, each targeting a specific property rather than "does it report anything", each confirmed to have actually applied before its result was read, and each restored byte-identically:

- hue→scale advice removed → 3 fail · `TemplateElement` visitor removed → 1 · match loop → single match → 1
- black/white exemption removed → 3 fail
- `UnaryExpression` (negative numbers) removed → 1 · `every`→`some` → 2
- `design-lint-ok` marker ignored → 3 fail
- roots empty → refuses · files empty → refuses · classification reverted → 82→76
- exemplar regressed → conformance test fails · its glob pointed nowhere → population assertion fails

**The mounting was verified through both invocation paths.** ESLint resolves a flat config from the CWD, so a rule mounted only in a package config is absent from lint-staged and vice versa. A violation injected into `plugin-form-builder` is reported by the root config **and** by the package config.

## Findings worth reading

**One defect this found in my own guard:** with roots empty, `find` failed and killed the process *before* the population check ran, so the refusal naming the cause was unreachable and an operator would have seen a stack trace. Found by break-verifying the refusal path, fixed in `51336dfb1`.

**Adoption in `packages/admin` is deliberately NOT in this PR, and the count is measured, not guessed:** 14 `no-static-inline-style` and 9 `no-hardcoded-colors`. I checked the colour ones rather than assuming — all 9 are **legitimate**: `EmailTemplateForm.tsx` builds an iframe document for an *email*, where CSS custom properties do not exist, and `color-picker.tsx`'s checkerboard has a docblock explaining it is deliberately theme-independent. Those need `design-lint-ok` exemptions with reasons, which is triage rather than a blanket fix. Rules are mounted for `packages/plugin-*` only, where the count is zero.

**`@nextlyhq/ui` is not in the plugin template's tsup `external` list**, so importing a kit component there would bundle the whole kit into every published plugin. That is why the exemplar uses token utilities rather than components. Worth fixing when the scaffold is next touched.

## Changeset

Added: **yes, patch**, all 25 lockstep packages — **generated from `.changeset/config.json`, not copied**, and `@nextlyhq/eslint-plugin` added to the `fixed` group (the release checker refuses a group that does not match the workspace).

## Pre-existing, not introduced

- Root `package.json` has `dependencies` (`zod`), which sherif warns about. Pre-existing; sherif exits 0.
- `fallow` is not installed locally (`command not found`), so that gate did not run here. CI enforces it.
- `gitleaks` is not installed locally; the pre-commit scan was skipped. CI runs it.

## Needs a maintainer action before the next release

`@nextlyhq/eslint-plugin` is a **new public package**, and `scripts/release/preflight.mjs` will **block the release train** until its name exists on npm with a Trusted Publisher attached. That is by design — a multi-package publish is not atomic, so it refuses rather than stranding the package after the rest goes live. It cannot be done from CI (OIDC cannot make a first publish).

Two steps, both requiring npm credentials I do not have:

1. `node scripts/release/bootstrap-package.mjs @nextlyhq/eslint-plugin --publish`
2. Attach its Trusted Publisher at npmjs.com (repository `nextlyhq/nextly`, workflow `release.yml`, environment `Production`), then add it to `scripts/release/first-publish-acknowledged.json`.

**I deliberately did not add the acknowledgement entry.** That file asserts the Trusted Publisher is configured, and adding it without that being true converts a loud, recoverable block into a publish that 404s mid-train. `@nextlyhq/builder` is the precedent.

## Review status

No bot had reviewed this at the time of writing. `greptile-apps` is reportedly active again; Codex has been returning usage-limit notices and `@nextlyhq-bot` has been silent. Treat quiet threads as unreviewed rather than as a pass. GitHub was in a **major partial outage** while this was pushed, so the branch was verified by `git ls-remote` rather than by the API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added design-token linting to identify palette utility classes, hardcoded colors, and static inline styles.
  * Added recommended configuration options and exemption support for intentional exceptions.
  * Added automated scanning across plugin packages and templates.

* **Documentation**
  * Added installation, configuration, rule guidance, examples, and token contract documentation.

* **Style**
  * Refreshed the plugin settings page with responsive, theme-compatible token-based styling and clearer guidance content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->