### PR TITLE
fix(admin): drop the formatting toolbar on a read-only rich text field

### DIFF
--- a/.changeset/readonly-richtext-drops-its-toolbar.md
+++ b/.changeset/readonly-richtext-drops-its-toolbar.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A read-only rich-text field no longer shows a row of dead formatting buttons. The toolbar was
+rendered and greyed rather than omitted, so every read-only rich-text field carried a band of
+controls that could not be used, and assistive technology found a toolbar with a dozen unusable
+buttons in it. The other structured inputs already drop their controls when the field cannot be
+edited; this one now matches them.

--- a/packages/admin/src/components/features/entries/fields/special/RichTextInput.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextInput.test.tsx
@@ -70,7 +70,13 @@ const queryClient = new QueryClient({
  * `control`, and a locale switch arrives as `form.reset(...)` with another language's
  * value — the exact external-change path the editor must follow.
  */
-function Harness({ initial }: { initial: SerializedEditorState | null }) {
+function Harness({
+  initial,
+  readOnly = false,
+}: {
+  initial: SerializedEditorState | null;
+  readOnly?: boolean;
+}) {
   const form = useForm<{ body: unknown }>({
     defaultValues: { body: initial },
   });
@@ -79,7 +85,12 @@ function Harness({ initial }: { initial: SerializedEditorState | null }) {
     // tooltips, so the harness supplies the same app-level providers the admin does.
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
-        <RichTextInput name="body" field={FIELD} control={form.control} />
+        <RichTextInput
+          name="body"
+          field={FIELD}
+          control={form.control}
+          readOnly={readOnly}
+        />
         <button onClick={() => form.reset({ body: doc("Cuerpo espanol") })}>
           switch-es
         </button>
@@ -142,5 +153,29 @@ describe("RichTextInput — external value sync", () => {
     // The editor is still alive: a follow-up valid value loads normally.
     await userEvent.click(screen.getByText("switch-es"));
     expect(await screen.findByText("Cuerpo espanol")).toBeInTheDocument();
+  });
+});
+
+describe("RichTextInput — read-only", () => {
+  it("offers the formatting toolbar while the field is editable", async () => {
+    render(<Harness initial={doc("Body copy")} />);
+
+    // The control for the negative below: without this, an absent toolbar in
+    // the read-only case would be satisfied by a harness that renders no
+    // toolbar under any circumstances.
+    expect(
+      await screen.findByRole("toolbar", { name: /text formatting/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders no formatting toolbar when the field is read-only", async () => {
+    render(<Harness initial={doc("Body copy")} readOnly />);
+
+    // The content still has to be there — an absent toolbar proves nothing if
+    // the editor failed to mount at all.
+    expect(await screen.findByText("Body copy")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("toolbar", { name: /text formatting/i })
+    ).toBeNull();
   });
 });

--- a/packages/admin/src/components/features/entries/fields/special/RichTextInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextInput.tsx
@@ -381,8 +381,13 @@ export function RichTextInput<TFieldValues extends FieldValues = FieldValues>({
       data-richtext-editor
     >
       <LexicalComposer initialConfig={initialConfig}>
-        {/* Toolbar */}
-        <RichTextToolbar features={field.features} disabled={!isEditable} />
+        {/* Toolbar, omitted rather than disabled when the field cannot be
+            edited. A row of dead controls advertises actions that are not
+            available, costs a band of vertical space on every read-only
+            field, and reaches assistive technology as a toolbar with a dozen
+            unusable buttons. The other structured inputs already drop their
+            controls this way; this one greyed them instead. */}
+        {isEditable ? <RichTextToolbar features={field.features} /> : null}
 
         {/* Main editor area */}
         <div className="relative" ref={setEditorAnchor}>


### PR DESCRIPTION
## What

A read-only rich-text field no longer shows a row of dead formatting buttons.

`RichTextInput` rendered `<RichTextToolbar disabled={!isEditable} />` — present but greyed. It is now omitted entirely when the field cannot be edited.

## Why it is a defect today, not only for versioning

This surfaced while scoping T-08 step C, but it is wrong wherever a rich-text field is read-only:

- a band of vertical space on every read-only field, spent on controls that do nothing
- assistive technology finds a `role="toolbar"` with a dozen unusable buttons in it
- it advertises actions that are not available

**And it was the odd one out.** Measured across all the field inputs, on how each behaves when `readOnly`:

| behaviour | components |
|---|---|
| already **hide** their chrome | Upload, Select, Component, Json, Repeater, CodeMirror |
| only **tint** | the plain inputs — correct, an input box has no chrome to remove |
| rendered **dead chrome** | `RichTextInput` — this one |

## Verification

```
pnpm turbo run build --force                       20 successful / 20 total,  0 cached
pnpm turbo run check-types lint --continue --force 45 successful / 45 total,  0 cached

packages/admin   4 failed | 237 passed (241 files) · 15 failed | 2056 passed (2071)
                 comm -13 baseline after → empty; the 4 are the documented
                 pre-existing set (StatsCard, BasicsTab, SlugInput, DefaultValueField)
```

Two tests, queried **by role and accessible name** rather than by testid, so they would notice a toolbar that lost its labelling as well as one that vanished:

- `offers the formatting toolbar while the field is editable` — the positive control. Without it, an absent toolbar in the read-only case would be satisfied by a harness that renders no toolbar under any circumstances.
- `renders no formatting toolbar when the field is read-only` — and asserts the **content is still present**, because an absent toolbar proves nothing if the editor failed to mount at all.

Stub-verified: rendering the toolbar unconditionally fails the second test and nothing else.

## Scope, and a correction I made mid-change

`RichTextInput` is the toolbar's only caller, so after this change nothing sets `RichTextToolbar`'s `disabled` prop. **I removed it, and then reverted that.**

The removal cascaded: `BlockTypeDropdown`, `FormattingDropdown`, `AlignmentDropdown` and `InsertDropdown` all *require* `disabled`, so dropping it from the toolbar broke `check-types` in four places and would have pulled four more components into a fix about one line. The prop keeps its `false` default and its internal consumers, so nothing is broken by leaving it — it is simply no longer reachable from outside.

Recording it rather than quietly filing it: **the prop is now unreachable and worth removing in a change that owns those four dropdowns.** It is not gated — `fallow dead-code` attributes unused exports, files and dependencies, not unused component props — so this is a tidiness question, not a failing check.

## Context

Part of T-08 step C scoping. The audit result worth knowing on its own: C was estimated in two handoffs as weeks of work across 18 field components, and it is not. `FieldRenderer` already threads `readOnly` through `commonProps` to all 18 types, all 18 inputs already honour it, `EntryFormContent` already accepts it, and `form.reset(snapshot)` already exists for autosave recovery. The plumbing is complete; this was the one real gap in how it presents.
