### PR TITLE
fix(eslint-plugin): catch palette utilities behind arbitrary variants

### DIFF
--- a/.changeset/vocabulary-variant-and-alpha-hex.md
+++ b/.changeset/vocabulary-variant-and-alpha-hex.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Fix two defects in `@nextlyhq/eslint-plugin`'s colour vocabulary.
+
+`no-palette-classes` missed a fixed palette colour placed behind an arbitrary Tailwind variant — `data-[state=open]:bg-red-500`, `supports-[display:grid]:bg-red-500` and the bracket-led `[&>*]:bg-red-500` all reported clean, so a colour that ignores dark mode and retheming passed lint.
+
+`no-hardcoded-colors` rejected the four-digit spelling of the mode-invariant colours it documents as legitimate: `#0000` and `#fff8` were reported as hardcoded, because alpha was only offered on the six-digit forms.

--- a/packages/eslint-plugin/src/__tests__/no-hardcoded-colors.test.js
+++ b/packages/eslint-plugin/src/__tests__/no-hardcoded-colors.test.js
@@ -15,6 +15,12 @@ ruleTester.run("no-hardcoded-colors", rule, {
     `const a = "rgb(255,255,255)";`,
     // A scrim's two-digit alpha on black stays exempt.
     `const a = "#00000033";`,
+    // `#RGB` takes a ONE-digit alpha, so the four-digit spelling of the same
+    // mode-invariant colours is exempt for the same reason the others are.
+    `const a = "#0000";`,
+    `const a = "#fff8";`,
+    `const a = "#ffff";`,
+    `const a = "#0008";`,
     // A data URI's payload is content, not styling.
     `const a = "url(data:image/svg+xml;base64,PHN2ZyBmaWxsPScjZmYwMDAwJy8+)";`,
     // A hex that is not a colour at all.

--- a/packages/eslint-plugin/src/__tests__/no-palette-classes.test.js
+++ b/packages/eslint-plugin/src/__tests__/no-palette-classes.test.js
@@ -22,6 +22,27 @@ ruleTester.run("no-palette-classes", rule, {
   ],
   invalid: [
     {
+      // An ARBITRARY variant carries brackets, an equals sign and a colon of
+      // its own, so a pattern that consumes the variant prefix cannot reach the
+      // utility behind it and reports clean.
+      code: `const a = <div className="data-[state=open]:bg-red-500" />;`,
+      errors: 1,
+    },
+    {
+      code: `const a = <div className="supports-[display:grid]:bg-red-500" />;`,
+      errors: 1,
+    },
+    {
+      // An arbitrary SELECTOR variant, which is bracket-led rather than named.
+      code: `const a = <div className="[&>*]:bg-red-500" />;`,
+      errors: 1,
+    },
+    {
+      // A variant stack ending in the important marker still resolves.
+      code: `const a = <div className="dark:hover:!bg-red-500" />;`,
+      errors: 1,
+    },
+    {
       code: `const a = <div className="bg-red-500" />;`,
       errors: [
         {

--- a/packages/eslint-plugin/src/vocabulary.js
+++ b/packages/eslint-plugin/src/vocabulary.js
@@ -114,16 +114,26 @@ export const EXEMPTION_MARKER = "design-lint-ok";
  * where the previous caller left off, and the misses would look like clean code.
  *
  * The match is anchored on a class-list boundary so `translate-x-1/2` (which
- * contains "slate-x") and a hue named in prose are not read as utilities.
- * Variants (`hover:`, `dark:`) and the `!` important marker are allowed to
- * precede the utility, and an opacity suffix (`/40`) to follow it.
+ * contains "slate-x") and a hue named in prose are not read as utilities. The
+ * `!` important marker may precede the utility and an opacity suffix (`/40`)
+ * may follow it.
+ *
+ * A VARIANT SEPARATOR counts as a boundary, rather than the variants themselves
+ * being matched. Enumerating them cannot be made complete: Tailwind admits
+ * arbitrary variants containing brackets, equals signs and colons of their own —
+ * `data-[state=open]:`, `supports-[display:grid]:`, `[&>*]:` — so a pattern that
+ * consumes the prefix has to model the whole variant grammar, and every shape it
+ * has not met yet reads as clean. Anchoring on the `:` that ends any variant
+ * needs to model none of it. The trade is that the reported class names the
+ * utility rather than the whole expression, which is the part being asked to
+ * change anyway.
  */
 export function createPaletteClassPattern({ global = false } = {}) {
   const utils = COLOR_UTILS.join("|");
   const hues = PALETTE_HUES.join("|");
   const shades = PALETTE_SHADES.join("|");
   return new RegExp(
-    `(?:^|[\\s"'\`{])((?:[a-z-]+:)*!?(?:${utils})-(?:${hues})-(?:${shades})(?:\\/\\d{1,3})?)(?![\\w-])`,
+    `(?:^|[\\s"'\`{:])(!?(?:${utils})-(?:${hues})-(?:${shades})(?:\\/\\d{1,3})?)(?![\\w-])`,
     global ? "g" : ""
   );
 }
@@ -184,8 +194,14 @@ export function stripExemptColorPieces(text) {
       .replace(/\/\*[\s\S]*?\*\//g, "")
       .replace(/url\([^)]*\)/g, "")
       .replace(/placeholder\s*[:=]\s*["'][^"']*["']/g, "")
-      // black / white, with an optional 2-digit alpha (`#00000033` scrims)
-      .replace(/#(?:ffffff|fff|000000|000)(?:[0-9a-f]{2})?\b/gi, "")
+      // Black and white in every hex length CSS accepts, each with its own
+      // alpha form: `#RGB` takes one alpha digit (`#0000`), `#RRGGBB` takes two
+      // (`#00000033`). Offering only the 6-digit pair's alpha rejected `#0000`
+      // and `#fff8` — mode-invariant scrims the rule advertises as legitimate.
+      .replace(
+        /#(?:ffffff(?:[0-9a-f]{2})?|000000(?:[0-9a-f]{2})?|fff[0-9a-f]?|000[0-9a-f]?)\b/gi,
+        ""
+      )
       .replace(/rgba?\(\s*0\s*[,\s]\s*0\s*[,\s]\s*0[^)]*\)/gi, "")
       .replace(/rgba?\(\s*255\s*[,\s]\s*255\s*[,\s]\s*255[^)]*\)/gi, "")
   );


### PR DESCRIPTION
## What and why

Two P1 findings from `greptile-apps` on #970, both **verified empirically before accepting**, both real, and both now on `main` inside a rule other people are meant to install.

### 1. Palette utilities behind an arbitrary variant reported clean

The pattern consumed the variant prefix with `(?:[a-z-]+:)*`, which cannot match a Tailwind *arbitrary* variant — those carry brackets, equals signs and colons of their own. Measured on `main`:

```
bg-red-500                          caught=true
dark:bg-red-500                     caught=true
group-hover:bg-red-500              caught=true
data-[state=open]:bg-red-500        caught=FALSE   <-- reported by greptile
supports-[display:grid]:bg-red-500  caught=FALSE   <-- found by this probe
[&>*]:bg-red-500                    caught=FALSE   <-- found by this probe
```

**The finding was broader than reported**: greptile named one shape, the probe found three. A fixed colour behind any of them passed lint while ignoring dark mode and retheming.

**The fix models none of the variant grammar.** Rather than teaching the pattern about brackets — which is the same enumeration problem one level down, with every unmet shape reading as clean — it anchors on the `:` that *ends* any variant. That cannot have this class of gap, because it never tries to parse what precedes it. The trade is that the reported class names the utility (`bg-red-500`) rather than the whole expression, which is the part being asked to change anyway.

### 2. Four-digit mode-invariant colours were rejected

`#RGB` takes a one-digit alpha and `#RRGGBB` takes two. Only the six-digit pair's alpha was offered, so:

```
#000  #fff  #000000  #ffffff  #00000033   exempt (correct)
#0000  #fff8                              REJECTED (wrong)
```

The rule documents black, white and transparent as legitimate and then failed lint on two spellings of exactly those. Ordering in the new alternation is load-bearing — six-digit forms are offered before three-digit ones, or `#ffffff` matches as `fff` + a stray `f`.

## Test plan

- **8 new tests** (53 total, up from 45), covering all three variant shapes, a variant stack ending in `!`, and all four four-digit forms.
- **Both fixes break-verified**, snapshot-restored and confirmed byte-identical:
  - boundary reverted to the variant-consuming form → **3 fail** (exactly the arbitrary-variant cases; the all-named-variant case still passes, which is correct)
  - hex strip reverted to six-digit-alpha only → **4 fail** (exactly the new four-digit cases)
- **No new false positives from the widened pattern**, which was the risk worth checking: `pnpm lint:design` is unchanged at **860 files / 7 roots / 82 plugin-surface**, `!important` **35/35**, and all four plugin packages lint clean.

## Changeset

Added: **yes, patch**, all **25** lockstep packages — generated from `.changeset/config.json`, not copied.

## Note on the previous PR

#970 merged with these two threads unresolved and its checks queued. `verify-merge.mjs` reports it landed whole (`landed-whole: no-candidates`, merge `83187ff12`), so nothing was stranded — this PR is the follow-up those threads asked for, not a repair of a bad merge.

Also worth knowing for anyone rebasing onto #970: `pnpm lint:design` fails with `ERR_MODULE_NOT_FOUND: Cannot find package '@nextlyhq/eslint-plugin'` in a worktree that has not reinstalled since. It reads as the script being broken; it is a stale install, and `pnpm install --frozen-lockfile` clears it.
