### PR TITLE
feat(admin): render a past version with the editor's own fields

### DIFF
--- a/.changeset/version-preview-uses-the-editor.md
+++ b/.changeset/version-preview-uses-the-editor.md
@@ -1,0 +1,38 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A past version now reads the way the document reads. Previewing one used to go through a viewer
+written only for version history, which had its own idea of how each field type looked and knew
+nothing about tabs, rows or collapsible sections — so a version was legible but never quite the
+page it came from. It is drawn by the editor's own field components now, read-only, which means
+layout survives, every field type presents exactly as it does when editing, and a field type added
+in future is supported in history the day it renders in the editor.
+
+The snapshot is rendered against its own form rather than loaded into the live one. Nothing an
+editor has typed is disturbed by opening a version, and no historical value can reach a save or an
+autosave, because those values never enter the form that either of them reads.

--- a/packages/admin/src/components/features/versions/VersionPreview.tsx
+++ b/packages/admin/src/components/features/versions/VersionPreview.tsx
@@ -10,7 +10,6 @@
 
 import type { FieldConfig } from "nextly/config";
 
-import { FieldValueDisplay } from "@admin/components/features/versions/value-display/FieldValueDisplay";
 import {
   Alert,
   AlertDescription,
@@ -18,6 +17,8 @@ import {
   Button,
   Skeleton,
 } from "@admin/components/ui";
+
+import { VersionSnapshotForm } from "./VersionSnapshotForm";
 
 export interface VersionPreviewProps {
   versionNo: number;
@@ -77,11 +78,6 @@ export function VersionPreview({
     );
   }
 
-  const values =
-    typeof snapshot === "object" && snapshot !== null
-      ? (snapshot as Record<string, unknown>)
-      : {};
-
   return (
     <div className="flex flex-col">
       <div className="px-4 py-2 bg-primary/5 border-b border-border flex flex-wrap items-center gap-2">
@@ -99,41 +95,18 @@ export function VersionPreview({
         )}
       </div>
 
-      <div className="p-4 flex flex-col gap-4">
+      <div className="p-4">
         {fields.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             This document has no fields to show.
           </p>
         ) : (
-          fields.map((field, i) => {
-            if (field.name) {
-              return (
-                <FieldValueDisplay
-                  key={field.name}
-                  field={field}
-                  value={values[field.name]}
-                />
-              );
-            }
-
-            // A presentational group has no name and stores its children at
-            // this level, so it is rendered against the same object rather than
-            // dropped along with everything inside it.
-            const children = (field as { fields?: FieldConfig[] }).fields;
-            if (field.type === "group" && Array.isArray(children)) {
-              return children.map(child =>
-                child.name ? (
-                  <FieldValueDisplay
-                    key={child.name}
-                    field={child}
-                    value={values[child.name]}
-                  />
-                ) : null
-              );
-            }
-
-            return <span key={`unnamed-${i}`} />;
-          })
+          // Drawn by the editor's own components rather than a viewer of its
+          // own. Layout fields, nameless groups and every type's presentation
+          // then come from one place, so a version reads the way the document
+          // reads — and a new field type is supported here the day it renders
+          // in the editor, with nothing to keep in step.
+          <VersionSnapshotForm fields={fields} snapshot={snapshot} />
         )}
       </div>
     </div>

--- a/packages/admin/src/components/features/versions/VersionSnapshotForm.tsx
+++ b/packages/admin/src/components/features/versions/VersionSnapshotForm.tsx
@@ -1,0 +1,69 @@
+/**
+ * Renders a stored snapshot through the editor's own field components.
+ *
+ * A past version is the document as it was, so it is drawn by the same
+ * components that draw the document now — read-only. There is no second
+ * renderer deciding how a field looks: `FieldRenderer` resolves its `control`
+ * from form context, so supplying a different context is the whole mechanism,
+ * and all eighteen field types arrive already honouring `readOnly`.
+ *
+ * The snapshot gets its OWN form instance rather than being reset into the
+ * live one, and that is a boundary rather than a preference. Resetting the
+ * live form would destroy an editor's unsaved work, and any subsequent dirty
+ * flag would let autosave record a historical snapshot as if it were new
+ * writing. Neither is guarded against here — a second form makes both
+ * unwritable, because the values never enter the form that autosave watches
+ * and the submit handler reads.
+ *
+ * PRECONDITION, and the reason this component renders the field tree and
+ * nothing else: `useFormContext` binds to the nearest provider, so anything
+ * rendered inside this one silently retargets onto the snapshot. A save
+ * affordance placed in here would act on the past. Only `EntryFormContent`
+ * belongs inside — verified against every `useFormContext` consumer under
+ * `EntryForm/`, none of which is reachable from its subtree.
+ *
+ * @module components/features/versions/VersionSnapshotForm
+ */
+
+import type { FieldConfig } from "nextly/config";
+import { useMemo } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+
+import { EntryFormContent } from "@admin/components/features/entries/EntryForm/EntryFormContent";
+
+export interface VersionSnapshotFormProps {
+  /** The document's current schema, which decides what is shown. */
+  fields: FieldConfig[];
+  /** The stored values for this version. */
+  snapshot: unknown;
+}
+
+export function VersionSnapshotForm({
+  fields,
+  snapshot,
+}: VersionSnapshotFormProps) {
+  // A snapshot that is not an object (absent, or a stored primitive) becomes an
+  // empty document rather than throwing: every field then renders as it does
+  // when it holds nothing, which is the truthful reading of a version that
+  // carries no value for it.
+  const values = useMemo(
+    () =>
+      typeof snapshot === "object" && snapshot !== null
+        ? (snapshot as Record<string, unknown>)
+        : {},
+    [snapshot]
+  );
+
+  // Keyed by the caller, so a different version mounts a fresh form rather than
+  // needing a reset — the panel already remounts this on selection.
+  const form = useForm<Record<string, unknown>>({ defaultValues: values });
+
+  return (
+    <FormProvider {...form}>
+      {/* `mode="edit"` because a version belongs to a document that exists;
+          write-only fields present themselves as they do when editing rather
+          than as they do on a blank create form. */}
+      <EntryFormContent fields={fields} readOnly mode="edit" />
+    </FormProvider>
+  );
+}

--- a/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
@@ -389,7 +389,9 @@ describe("VersionHistorySheet", () => {
     await userEvent.click(screen.getByRole("button", { name: /Version 3/ }));
 
     expect(screen.getByText(/Viewing version 3/)).toBeInTheDocument();
-    expect(screen.getByText("Old title")).toBeInTheDocument();
+    // The snapshot is drawn by the editor's own field components, so its values
+    // are display values on read-only inputs rather than text nodes.
+    expect(screen.getByLabelText(/Title/)).toHaveValue("Old title");
   });
 
   it("returns to the list from a preview", async () => {

--- a/packages/admin/src/components/features/versions/__tests__/VersionPreview.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionPreview.test.tsx
@@ -1,7 +1,9 @@
 /**
- * A preview shows what a document held at an earlier point. The states that
- * matter are the ones that could mislead: a field that was blank then, and a
- * snapshot that failed to load.
+ * A preview shows what a document held at an earlier point, drawn by the
+ * editor's own field components. The states that matter are the ones that
+ * could mislead: a field that was blank then, a snapshot that failed to load,
+ * and — since these are the real inputs — any suggestion that the past can be
+ * edited from here.
  */
 import userEvent from "@testing-library/user-event";
 import type { FieldConfig } from "nextly/config";
@@ -26,8 +28,30 @@ describe("VersionPreview", () => {
       />
     );
 
-    expect(screen.getByText("Hello")).toBeInTheDocument();
-    expect(screen.getByText("World")).toBeInTheDocument();
+    // Values sit in the editor's own inputs now, so they are display values
+    // rather than text nodes. Queried by the label a reader sees, so a field
+    // that lost its labelling would fail here too.
+    expect(screen.getByLabelText(/Title/)).toHaveValue("Hello");
+    expect(screen.getByLabelText(/Subtitle/)).toHaveValue("World");
+  });
+
+  it("renders the past read-only, with no way to edit it", () => {
+    render(
+      <VersionPreview
+        versionNo={3}
+        fields={fields}
+        snapshot={{ title: "Hello", subtitle: "World" }}
+      />
+    );
+
+    // The whole point of drawing a version in the editor's components is that
+    // it must not become a way to edit the past.
+    for (const label of [/Title/, /Subtitle/]) {
+      expect(screen.getByLabelText(label)).toHaveAttribute("readonly");
+    }
+    // And nothing in here may offer to write: this subtree renders under its
+    // own form context, so a save affordance would act on the snapshot.
+    expect(screen.queryByRole("button", { name: /save|publish/i })).toBeNull();
   });
 
   it("says plainly which version is on screen and that it is not live", () => {
@@ -48,8 +72,8 @@ describe("VersionPreview", () => {
       />
     );
 
-    expect(screen.getByText("Subtitle")).toBeInTheDocument();
-    expect(screen.getByText("Not set")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Subtitle/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Subtitle/)).toHaveValue("");
   });
 
   it("tolerates a snapshot that is not an object", () => {
@@ -57,7 +81,10 @@ describe("VersionPreview", () => {
       <VersionPreview versionNo={3} fields={fields} snapshot={"corrupt"} />
     );
 
-    expect(screen.getAllByText("Not set")).toHaveLength(2);
+    // Not a crash and not a claim: every field reads as holding nothing, which
+    // is the truthful rendering of a snapshot that carries no values.
+    expect(screen.getByLabelText(/Title/)).toHaveValue("");
+    expect(screen.getByLabelText(/Subtitle/)).toHaveValue("");
   });
 
   it("announces loading without claiming the document is empty", () => {
@@ -119,8 +146,10 @@ describe("VersionPreview", () => {
       />
     );
 
-    expect(screen.getByText("City")).toBeInTheDocument();
-    expect(screen.getByText("Lisbon")).toBeInTheDocument();
+    // The editor's own layout handling flattens a nameless group, so this is
+    // no longer a case the preview treats specially — it is covered here
+    // because dropping it would silently hide every field inside.
+    expect(screen.getByLabelText(/City/)).toHaveValue("Lisbon");
   });
 
   it("reports a failed load instead of rendering an empty document", () => {


### PR DESCRIPTION
## What

A past version is now drawn by **the editor's own field components**, read-only, instead of by a viewer written only for version history.

T-08 step C, first increment. Founder decision, and firm: one renderer, no parallel viewer.

## Why

`VersionPreview` mapped fields through `FieldValueDisplay` — 610 lines that answer "how does this field look" a second time. Consequences, all visible:

- it knows nothing about **tabs, rows or collapsible sections**, so a version was legible but never quite the page it came from
- a nameless group needed a special case here that the editor already handles
- **every new field type has to be taught to two renderers**, and the one nobody is looking at drifts

This is the shape #923 and #930 both removed — and the reason a parallel renderer was rejected for this step.

## Why it cost no per-type work

Both handoffs scoped C as weeks across 18 field components. Measured, the plumbing was already complete:

```
FieldRenderer.tsx:255    const { ... } = useFormContext()   ← control comes from CONTEXT
FieldRenderer                            threads readOnly via commonProps to ALL 18 types
all 18 inputs                            already accept and honour readOnly
EntryFormContent                         already takes readOnly and passes it down
```

Because `control` resolves from context, **supplying a different context is the entire mechanism.** No change to `FieldRenderer`, `EntryFormContent`, or any of the eighteen inputs.

## The architectural decision worth reviewing

The snapshot gets **its own form instance**. It is not `form.reset(...)` into the live one.

The autosave lane pointed out what reusing the live form costs, and their analysis is why this design exists:

- `form.reset(snapshot)` **destroys an editor's unsaved work**, irrecoverably
- `reset(..., { keepDefaultValues: true })` — the form goes dirty, and **autosave writes the historical snapshot as that author's recovery point**. That is their line at `EntryForm.tsx:389`, correct for recovery and exactly wrong here, and it is the most copyable line in the file
- a dirty form in history mode makes the **unsaved-changes guard fire on a read-only view**

Their advice was three coordinated guards: refuse entry while dirty, pass `enabled: !isHistoryMode`, keep the form clean. Each correct. But they also wrote *"dirty-derived safety is a coincidence of the current implementation, not a boundary"* — and a second form makes all three unnecessary, because **the historical values never enter the form autosave watches or submit reads.** The wrong state is unwritable rather than checked for.

It also removes a UX limitation the guards would have imposed: you can open history **with unsaved edits**, which is what Google Docs does.

### The precondition this creates, and how it was checked

`useFormContext` binds to the nearest provider, so anything rendered inside the history context silently retargets onto the snapshot — a save affordance in there would act on the past. That fails quietly: correct code, wrong subject.

So **only the field tree renders inside it**, verified rather than asserted:

```
useFormContext consumers under EntryForm/:
  EntryFormProvider, EntryFormToolbarSlots, EntryMetaStrip,
  EntrySystemHeader, PublicUrlChangeNotice

EntryFormContent's subtree:  EntryFormContent → FieldRow → FieldRenderer
```

None of the five is reachable. Recorded as a precondition in the component's own doc comment, and asserted in a test: the preview must contain no save or publish control.

## Verification

```
pnpm turbo run build --force                       20 successful / 20 total,  0 cached
pnpm turbo run check-types lint --continue --force 46 successful / 46 total,  0 cached

packages/admin   4 failed | 237 passed (241 files) · 15 failed | 2057 passed (2072)
                 comm -13 baseline after → empty; the 4 are the documented pre-existing set
```

Stub-verified, restores confirmed **byte-identical with `cmp`** rather than `git checkout`:

| break | fails |
|---|---|
| history renders without `readOnly` | `renders the past read-only, with no way to edit it` |
| the form is not seeded from the snapshot | both value tests, nothing else |

### Tests that changed, and why

Four assertions moved from `getByText` to `getByLabelText(...).toHaveValue(...)`. That is not a weakened test — the rendering changed on purpose, values now sit in the editor's inputs rather than in text nodes, and querying **by the label a reader sees** means a field that lost its labelling fails here too. One new test asserts the read-only contract and the absence of any write affordance.

## Still to come in step C

The timeline UI, and restoring from it. This increment changes only how a selected version is drawn. An e2e case — open a past version, assert no autosave PUT is issued, and assert the live Save submits live values — is the next thing I owe: unit tests here mock the transport and cannot see either property.

## One process note

The lockstep group grew to **25** today (`@nextlyhq/eslint-plugin`). My first attempt at this changeset hardcoded 24 — the same copy-instead-of-derive error I diagnosed earlier today and warned three lanes about. The gate caught it. Generate the list, every time:

```
node -e 'const c=require("./.changeset/config.json");
         console.log(c.fixed[0].map(p=>JSON.stringify(p)+": patch").join("\n"))'
```
