### PR TITLE
fix(admin): select the sidebar section from the route's declaration

### DIFF
--- a/.changeset/routes-declare-sidebar-section.md
+++ b/.changeset/routes-declare-sidebar-section.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Routes now declare which sidebar section they belong to, and plugins can choose where their own pages and menu items appear.
+
+The admin sidebar previously decided which navigation icon was active by matching the URL against a list of paths, falling back to Dashboard when none matched. A route missing from that list did not fail — it quietly highlighted Dashboard, which looks identical to a page that really is Dashboard. That is how a top-level admin route shipped highlighting the wrong entry, unnoticed.
+
+Each route now states its own section, and the type system requires it: a new admin route that does not say where it belongs fails to build instead of appearing in the wrong place.
+
+For plugin authors, admin pages and menu items accept an optional `section`, so a plugin is no longer confined to the Plugins area. Omitting it defers to the plugin's own placement, so a plugin that already declares where it lives does not repeat itself for every page, and `"standalone"` reuses the top-level entry and icon such a plugin already gets for its collections.

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -23,13 +23,13 @@ import {
 import { resolveCollectionPlacement } from "@admin/lib/plugins/collection-placement";
 import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
 import { resolvePluginIcon } from "@admin/lib/plugins/resolve-plugin-icon";
-import { isUnder } from "@admin/lib/routing";
 import { cn } from "@admin/lib/utils";
 import type { ApiCollection } from "@admin/types/entities";
 
 import { hasPluginsSection } from "./lib/has-plugins-section";
 import { isSubSidebarCategory, isSubSidebarOpen } from "./lib/has-sub-sidebar";
 import { resolveItemHref as resolveItemHrefHelper } from "./lib/resolve-item-href";
+import { resolveActiveSection } from "./lib/resolve-section";
 import { subSidebarBorderClass } from "./lib/sub-sidebar-classes";
 import type { MainMenuCategory, MainMenuItem } from "./sidebar-types";
 import { getFilteredMenuItems } from "./sidebar-types";
@@ -296,108 +296,25 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
     ]
   );
 
-  const activeCategory = useMemo(() => {
-    // 0. Check standalone plugin collection routes first
-    for (const sp of visibleStandalonePlugins) {
-      const slug = pluginSlug(sp.name);
-      const standaloneId = `standalone-${slug}` as MainMenuCategory;
-      const collectionSlugs = sp.collections ?? [];
-      if (
-        collectionSlugs.some(cs =>
-          pathname.includes(`/admin/collections/${cs}`)
-        )
-      ) {
-        return standaloneId;
-      }
-    }
-
-    // 1. Check if current path is a plugin collection placed in users/settings
-    if (collectionsData?.items && pathname.includes("/admin/collections/")) {
-      const pluginCollections = collectionsData.items.filter(
-        c => c.admin?.isPlugin
-      );
-      for (const c of pluginCollections) {
-        if (!pathname.includes(`/admin/collections/${c.name}`)) continue;
-        const placement = getCollectionPlacement(c);
-        // "users" now lives inside the Settings sub-sidebar, so it highlights
-        // the Settings icon rather than the removed Users icon.
-        if (placement === "users") return "settings";
-        if (placement === "settings") return "settings";
-        if (placement === "collections") return "collections";
-        if (placement === "singles") return "singles";
-      }
-    }
-
-    // 2. Check for plugins — skip plugin collections placed in other sections
-    const isPluginPath = (data: typeof collectionsData) => {
-      if (!data?.items) return false;
-      const pluginCollections = data.items.filter(c => c.admin?.isPlugin);
-      return pluginCollections.some(c => {
-        if (!pathname.includes(`/admin/collections/${c.name}`)) return false;
-        const placement = getCollectionPlacement(c);
-        if (placement && placement !== "plugins") return false;
-        return true;
-      });
-    };
-
-    // The route constants rather than their spellings. The plugin directory
-    // sits at its own top level so no plugin slug can shadow it, which means
-    // the Plugins category is not one URL prefix and a literal would silently
-    // stop covering it the next time either route moves.
-    if (
-      isUnder(pathname, ROUTES.PLUGINS) ||
-      isUnder(pathname, ROUTES.PLUGIN_BROWSE) ||
-      pathname.includes("/admin/forms") ||
-      isPluginPath(collectionsData)
-    ) {
-      return "plugins";
-    }
-
-    // 3. Standard paths
-    if (pathname === ROUTES.DASHBOARD) return "dashboard";
-
-    const fromParam = route?.searchParams?.from;
-    if (fromParam === "builders") return "builders";
-    if (fromParam === "collections") return "collections";
-    if (fromParam === "singles") return "singles";
-
-    // Match that prefix first so the Builders secondary panel wins on
-    // schema-management pages. Content URLs (/admin/collections/[slug]
-    // entries, /admin/singles/[slug] single document) match next and
-    // route to the per-kind content panel — Q5 of the design locks
-    // this: secondary Builders sidebar is hidden on content pages.
-    if (pathname.includes("/admin/builder/")) {
-      if (showBuilder) return "builders";
-      // Defensive fallback if `showBuilder` is false (admin meta
-      // override) but a Builder URL is reached anyway (deep link).
-      // Surface the matching per-kind panel so the user has somewhere
-      // to go instead of an empty sidebar.
-      if (pathname.includes("/admin/builder/collections")) return "collections";
-      if (pathname.includes("/admin/builder/singles")) return "singles";
-      if (pathname.includes("/admin/builder/field-groups"))
-        return "collections";
-    }
-    if (pathname.includes("/admin/collections/")) return "collections";
-    if (pathname.includes("/admin/singles/")) return "singles";
-    if (pathname.includes("/admin/media")) return "media";
-    // User management routes live under Settings now, so they highlight the
-    // Settings icon (previously the standalone Users icon, id "manage").
-    if (
-      pathname.includes("/admin/users") ||
-      pathname.includes("/admin/security/roles")
-    )
-      return "settings";
-    if (pathname.includes("/admin/settings")) return "settings";
-
-    return "dashboard";
-  }, [
-    pathname,
-    collectionsData,
-    getCollectionPlacement,
-    visibleStandalonePlugins,
-    route,
-    showBuilder,
-  ]);
+  const activeCategory = useMemo(
+    () =>
+      resolveActiveSection({
+        pathname,
+        from: route?.searchParams?.from,
+        collections: collectionsData?.items,
+        getCollectionPlacement,
+        standalonePlugins: visibleStandalonePlugins,
+        showBuilder,
+      }),
+    [
+      pathname,
+      collectionsData,
+      getCollectionPlacement,
+      visibleStandalonePlugins,
+      route,
+      showBuilder,
+    ]
+  );
 
   const [selectedMain, setSelectedMain] =
     useState<MainMenuCategory>(activeCategory);

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -305,7 +305,7 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
         getCollectionPlacement,
         standalonePlugins: visibleStandalonePlugins,
         showBuilder,
-      }),
+      }) ?? "dashboard",
     [
       pathname,
       collectionsData,

--- a/packages/admin/src/components/layout/sidebar/__tests__/resolve-section.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/resolve-section.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+
+import { ROUTES } from "@admin/constants/routes";
+import type { ApiCollection } from "@admin/types/entities";
+
+import {
+  resolveActiveSection,
+  type ActiveSectionContext,
+} from "../lib/resolve-section";
+
+/**
+ * A collection carrying only the fields section resolution reads. The rest of
+ * `ApiCollection` is filled with inert values so a change to those fields
+ * cannot alter what these cases assert.
+ */
+function collection(name: string, isPlugin: boolean): ApiCollection {
+  return {
+    id: name,
+    name,
+    label: name,
+    tableName: name,
+    schemaDefinition: { fields: [] },
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    admin: isPlugin ? { isPlugin: true } : undefined,
+  };
+}
+
+/**
+ * Defaults chosen so each case states only the input it is about. Placement
+ * returns undefined unless a case supplies a map, which is the "no placement
+ * declared" state rather than a stand-in for one.
+ */
+function context(
+  overrides: Partial<ActiveSectionContext> = {}
+): ActiveSectionContext {
+  return {
+    pathname: "/admin",
+    collections: undefined,
+    getCollectionPlacement: () => undefined,
+    standalonePlugins: [],
+    showBuilder: true,
+    ...overrides,
+  };
+}
+
+function placementFrom(
+  map: Record<string, string>
+): (c: ApiCollection) => string | undefined {
+  return c => map[c.name];
+}
+
+describe("resolveActiveSection", () => {
+  describe("standalone plugins outrank every shared section", () => {
+    it("claims its own rail entry for one of its collections", () => {
+      expect(
+        resolveActiveSection(
+          context({
+            pathname: "/admin/collections/tickets",
+            standalonePlugins: [
+              { name: "@acme/helpdesk", collections: ["tickets"] },
+            ],
+          })
+        )
+      ).toBe("standalone-acme-helpdesk");
+    });
+
+    it("does not claim a collection it does not own", () => {
+      expect(
+        resolveActiveSection(
+          context({
+            pathname: "/admin/collections/posts",
+            standalonePlugins: [
+              { name: "@acme/helpdesk", collections: ["tickets"] },
+            ],
+          })
+        )
+      ).toBe("collections");
+    });
+  });
+
+  describe("a plugin collection is classified by its PLACEMENT, not its URL", () => {
+    // Each of these is an ordinary /admin/collections/<name> URL, so a
+    // URL-shaped check alone would answer "collections" for all four.
+    it.each([
+      ["users", "settings"],
+      ["settings", "settings"],
+      ["collections", "collections"],
+      ["singles", "singles"],
+    ])("placement %s resolves to %s", (placement, expected) => {
+      expect(
+        resolveActiveSection(
+          context({
+            pathname: "/admin/collections/audit-log",
+            collections: [collection("audit-log", true)],
+            getCollectionPlacement: placementFrom({ "audit-log": placement }),
+          })
+        )
+      ).toBe(expected);
+    });
+
+    it("falls to Plugins when its plugin declares no placement", () => {
+      expect(
+        resolveActiveSection(
+          context({
+            pathname: "/admin/collections/audit-log",
+            collections: [collection("audit-log", true)],
+          })
+        )
+      ).toBe("plugins");
+    });
+
+    it("leaves a NON-plugin collection to the Collections arm", () => {
+      expect(
+        resolveActiveSection(
+          context({
+            pathname: "/admin/collections/posts",
+            collections: [collection("posts", false)],
+          })
+        )
+      ).toBe("collections");
+    });
+  });
+
+  describe("plugin surfaces", () => {
+    it.each([
+      [ROUTES.PLUGINS, "the installed list"],
+      [`${ROUTES.PLUGINS}/some-plugin`, "a plugin detail page"],
+      [ROUTES.PLUGIN_BROWSE, "the directory at its own top level"],
+      ["/admin/forms", "the forms surface"],
+    ])("%s resolves to Plugins (%s)", pathname => {
+      expect(resolveActiveSection(context({ pathname }))).toBe("plugins");
+    });
+  });
+
+  describe("the `from` param decides ahead of the URL", () => {
+    it.each(["builders", "collections", "singles"])(
+      "from=%s wins over the path it was reached from",
+      from => {
+        expect(
+          resolveActiveSection(context({ pathname: ROUTES.MEDIA, from }))
+        ).toBe(from);
+      }
+    );
+
+    it("does NOT override a plugin surface, which is decided earlier", () => {
+      expect(
+        resolveActiveSection(
+          context({ pathname: ROUTES.PLUGINS, from: "collections" })
+        )
+      ).toBe("plugins");
+    });
+
+    it("ignores a repeated param, which the router reports as an array", () => {
+      expect(
+        resolveActiveSection(
+          context({ pathname: ROUTES.MEDIA, from: ["builders", "collections"] })
+        )
+      ).toBe("media");
+    });
+  });
+
+  describe("schema-management URLs", () => {
+    it("selects Builders while the builder is enabled", () => {
+      expect(
+        resolveActiveSection(
+          context({ pathname: "/admin/builder/collections/posts" })
+        )
+      ).toBe("builders");
+    });
+
+    it.each([
+      ["/admin/builder/collections/posts", "collections"],
+      ["/admin/builder/singles/homepage", "singles"],
+      ["/admin/builder/field-groups/seo", "collections"],
+    ])(
+      "%s falls back to %s when the builder is hidden",
+      (pathname, expected) => {
+        expect(
+          resolveActiveSection(context({ pathname, showBuilder: false }))
+        ).toBe(expected);
+      }
+    );
+  });
+
+  describe("content and settings URLs", () => {
+    it.each([
+      ["/admin/collections/posts", "collections"],
+      ["/admin/singles/homepage", "singles"],
+      [ROUTES.MEDIA, "media"],
+      ["/admin/users", "settings"],
+      ["/admin/security/roles", "settings"],
+      [ROUTES.SETTINGS, "settings"],
+      [ROUTES.DASHBOARD, "dashboard"],
+    ])("%s resolves to %s", (pathname, expected) => {
+      expect(resolveActiveSection(context({ pathname }))).toBe(expected);
+    });
+  });
+
+  describe("an unmapped route", () => {
+    /**
+     * Pins the CURRENT behaviour so a later change to it is visible as a
+     * deliberate edit to this expectation rather than as a silent difference.
+     * A route nobody classified answers Dashboard, which is indistinguishable
+     * from a route that genuinely is Dashboard.
+     */
+    it("silently answers Dashboard", () => {
+      expect(
+        resolveActiveSection(context({ pathname: "/admin/plugin-directory-x" }))
+      ).toBe("dashboard");
+      expect(
+        resolveActiveSection(context({ pathname: "/admin/some-new-surface" }))
+      ).toBe("dashboard");
+    });
+  });
+});

--- a/packages/admin/src/components/layout/sidebar/__tests__/resolve-section.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/resolve-section.test.ts
@@ -127,7 +127,6 @@ describe("resolveActiveSection", () => {
       [ROUTES.PLUGINS, "the installed list"],
       [`${ROUTES.PLUGINS}/some-plugin`, "a plugin detail page"],
       [ROUTES.PLUGIN_BROWSE, "the directory at its own top level"],
-      ["/admin/forms", "the forms surface"],
     ])("%s resolves to Plugins (%s)", pathname => {
       expect(resolveActiveSection(context({ pathname }))).toBe("plugins");
     });
@@ -197,20 +196,22 @@ describe("resolveActiveSection", () => {
     });
   });
 
-  describe("an unmapped route", () => {
+  describe("a path no route serves", () => {
     /**
-     * Pins the CURRENT behaviour so a later change to it is visible as a
-     * deliberate edit to this expectation rather than as a silent difference.
-     * A route nobody classified answers Dashboard, which is indistinguishable
-     * from a route that genuinely is Dashboard.
+     * The distinction this whole mechanism exists for. A path nothing serves
+     * now resolves to `undefined` — "no route matched" — instead of silently
+     * answering Dashboard, which was indistinguishable from a route that
+     * genuinely is Dashboard.
+     *
+     * A route that matched can no longer reach here at all: the route type
+     * makes a private route without a section a compile error, so "matched but
+     * unclassified" is unrepresentable rather than merely untested.
      */
-    it("silently answers Dashboard", () => {
-      expect(
-        resolveActiveSection(context({ pathname: "/admin/plugin-directory-x" }))
-      ).toBe("dashboard");
-      expect(
-        resolveActiveSection(context({ pathname: "/admin/some-new-surface" }))
-      ).toBe("dashboard");
+    it.each([
+      ["/admin/some-new-surface", "a surface nobody has added yet"],
+      ["/admin/forms", "a path that no route has ever served"],
+    ])("%s resolves to undefined, not Dashboard (%s)", pathname => {
+      expect(resolveActiveSection(context({ pathname }))).toBeUndefined();
     });
   });
 });

--- a/packages/admin/src/components/layout/sidebar/lib/resolve-section.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/resolve-section.ts
@@ -1,7 +1,7 @@
 import type { ActiveNavSection } from "@admin/constants/nav-sections";
 import { resolveRoute } from "@admin/lib/routing";
 import type {
-  RouteSection,
+  CarriedRouteSection,
   RouteSectionContext,
 } from "@admin/types/route-section";
 
@@ -25,7 +25,7 @@ export type {
  * own from the URL.
  */
 export function evaluateRouteSection(
-  declared: RouteSection,
+  declared: CarriedRouteSection,
   context: RouteSectionContext
 ): ActiveNavSection {
   return typeof declared === "function" ? declared(context) : declared;

--- a/packages/admin/src/components/layout/sidebar/lib/resolve-section.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/resolve-section.ts
@@ -1,0 +1,145 @@
+import { ROUTES } from "@admin/constants/routes";
+import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
+import { isUnder } from "@admin/lib/routing";
+import type { ApiCollection } from "@admin/types/entities";
+
+import type { MainMenuCategory } from "../sidebar-types";
+
+/**
+ * The subset of a standalone plugin's metadata that section resolution reads.
+ *
+ * Narrower than `PluginMetadata` so callers can supply a literal in a test
+ * without constructing fields this decision never consults.
+ */
+export interface StandalonePluginSummary {
+  name: string;
+  collections?: string[];
+}
+
+/**
+ * Everything the active-section decision depends on.
+ *
+ * Placement arrives as a FUNCTION rather than as resolved values because the
+ * caller memoises it over plugin metadata, and re-deriving it here would be a
+ * second implementation of a question that already has one.
+ */
+export interface ActiveSectionContext {
+  pathname: string;
+  /**
+   * The `from` search param. Typed as the router reports it: a repeated param
+   * parses to an array, which matches no section and therefore falls through.
+   */
+  from?: string | string[];
+  collections: ApiCollection[] | undefined;
+  getCollectionPlacement: (collection: ApiCollection) => string | undefined;
+  standalonePlugins: readonly StandalonePluginSummary[];
+  showBuilder: boolean;
+}
+
+/**
+ * Which primary-rail category is active for the current location.
+ *
+ * The order of the checks is load-bearing and not merely stylistic. A plugin
+ * collection placed in another section must be classified by its PLACEMENT
+ * before any URL-shaped check runs, because its content URL is an ordinary
+ * `/admin/collections/<name>` that would otherwise match the Collections arm
+ * and hide the section its plugin actually chose.
+ */
+export function resolveActiveSection(
+  ctx: ActiveSectionContext
+): MainMenuCategory {
+  const {
+    pathname,
+    from,
+    collections,
+    getCollectionPlacement,
+    standalonePlugins,
+    showBuilder,
+  } = ctx;
+
+  // A standalone plugin owns its own rail entry, so one of its collections
+  // outranks every shared section below.
+  for (const plugin of standalonePlugins) {
+    const slug = pluginSlug(plugin.name);
+    const standaloneId = `standalone-${slug}` as MainMenuCategory;
+    const collectionSlugs = plugin.collections ?? [];
+    if (
+      collectionSlugs.some(name =>
+        pathname.includes(`/admin/collections/${name}`)
+      )
+    ) {
+      return standaloneId;
+    }
+  }
+
+  const pluginCollections = (collections ?? []).filter(c => c.admin?.isPlugin);
+
+  if (collections && pathname.includes("/admin/collections/")) {
+    for (const collection of pluginCollections) {
+      if (!pathname.includes(`/admin/collections/${collection.name}`)) continue;
+      const placement = getCollectionPlacement(collection);
+      // User management is rendered inside the Settings sub-sidebar, so it
+      // highlights Settings rather than a rail entry of its own.
+      if (placement === "users") return "settings";
+      if (placement === "settings") return "settings";
+      if (placement === "collections") return "collections";
+      if (placement === "singles") return "singles";
+    }
+  }
+
+  // A plugin collection with no placement, or one placed in "plugins",
+  // belongs to the Plugins rail entry.
+  const isPluginCollectionPath = pluginCollections.some(collection => {
+    if (!pathname.includes(`/admin/collections/${collection.name}`))
+      return false;
+    const placement = getCollectionPlacement(collection);
+    if (placement && placement !== "plugins") return false;
+    return true;
+  });
+
+  // Compared against the route constants rather than their spellings. The
+  // directory sits at its own top level so no plugin slug can shadow it, which
+  // means Plugins is not one URL prefix and a literal would silently stop
+  // covering it the next time either route moves.
+  if (
+    isUnder(pathname, ROUTES.PLUGINS) ||
+    isUnder(pathname, ROUTES.PLUGIN_BROWSE) ||
+    pathname.includes("/admin/forms") ||
+    isPluginCollectionPath
+  ) {
+    return "plugins";
+  }
+
+  if (pathname === ROUTES.DASHBOARD) return "dashboard";
+
+  // An explicit `from` records which rail the user navigated out of, so it
+  // decides ahead of the URL for every section below.
+  if (from === "builders") return "builders";
+  if (from === "collections") return "collections";
+  if (from === "singles") return "singles";
+
+  // Schema-management URLs win over the content arms beneath them, so the
+  // Builders panel stays selected while editing a schema.
+  if (pathname.includes("/admin/builder/")) {
+    if (showBuilder) return "builders";
+    // Reached only by deep link when an admin-meta override hides the builder.
+    // Surfacing the matching per-kind panel leaves somewhere to navigate to
+    // instead of an empty sub-sidebar.
+    if (pathname.includes("/admin/builder/collections")) return "collections";
+    if (pathname.includes("/admin/builder/singles")) return "singles";
+    if (pathname.includes("/admin/builder/field-groups")) return "collections";
+  }
+
+  if (pathname.includes("/admin/collections/")) return "collections";
+  if (pathname.includes("/admin/singles/")) return "singles";
+  if (pathname.includes("/admin/media")) return "media";
+  if (
+    pathname.includes("/admin/users") ||
+    pathname.includes("/admin/security/roles")
+  ) {
+    return "settings";
+  }
+  if (pathname.includes("/admin/settings")) return "settings";
+
+  return "dashboard";
+}

--- a/packages/admin/src/components/layout/sidebar/lib/resolve-section.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/resolve-section.ts
@@ -1,40 +1,19 @@
+import type { ActiveNavSection } from "@admin/constants/nav-sections";
 import { ROUTES } from "@admin/constants/routes";
 import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
 import { isUnder } from "@admin/lib/routing";
-import type { ApiCollection } from "@admin/types/entities";
-
-import type { MainMenuCategory } from "../sidebar-types";
+import type { RouteSectionContext } from "@admin/types/route-section";
 
 /**
- * The subset of a standalone plugin's metadata that section resolution reads.
- *
- * Narrower than `PluginMetadata` so callers can supply a literal in a test
- * without constructing fields this decision never consults.
+ * Re-exported so the sidebar's callers have one import site for the decision
+ * and its inputs. The definitions live in `types/route-section` because the
+ * ROUTE registry names them too, and a registry importing a sidebar
+ * component's types would invert the dependency.
  */
-export interface StandalonePluginSummary {
-  name: string;
-  collections?: string[];
-}
-
-/**
- * Everything the active-section decision depends on.
- *
- * Placement arrives as a FUNCTION rather than as resolved values because the
- * caller memoises it over plugin metadata, and re-deriving it here would be a
- * second implementation of a question that already has one.
- */
-export interface ActiveSectionContext {
-  pathname: string;
-  /**
-   * The `from` search param. Typed as the router reports it: a repeated param
-   * parses to an array, which matches no section and therefore falls through.
-   */
-  from?: string | string[];
-  collections: ApiCollection[] | undefined;
-  getCollectionPlacement: (collection: ApiCollection) => string | undefined;
-  standalonePlugins: readonly StandalonePluginSummary[];
-  showBuilder: boolean;
-}
+export type {
+  RouteSectionContext as ActiveSectionContext,
+  StandalonePluginSummary,
+} from "@admin/types/route-section";
 
 /**
  * Which primary-rail category is active for the current location.
@@ -46,8 +25,8 @@ export interface ActiveSectionContext {
  * and hide the section its plugin actually chose.
  */
 export function resolveActiveSection(
-  ctx: ActiveSectionContext
-): MainMenuCategory {
+  ctx: RouteSectionContext
+): ActiveNavSection {
   const {
     pathname,
     from,
@@ -61,7 +40,7 @@ export function resolveActiveSection(
   // outranks every shared section below.
   for (const plugin of standalonePlugins) {
     const slug = pluginSlug(plugin.name);
-    const standaloneId = `standalone-${slug}` as MainMenuCategory;
+    const standaloneId: ActiveNavSection = `standalone-${slug}`;
     const collectionSlugs = plugin.collections ?? [];
     if (
       collectionSlugs.some(name =>

--- a/packages/admin/src/components/layout/sidebar/lib/resolve-section.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/resolve-section.ts
@@ -1,8 +1,9 @@
 import type { ActiveNavSection } from "@admin/constants/nav-sections";
-import { ROUTES } from "@admin/constants/routes";
-import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
-import { isUnder } from "@admin/lib/routing";
-import type { RouteSectionContext } from "@admin/types/route-section";
+import { resolveRoute } from "@admin/lib/routing";
+import type {
+  RouteSection,
+  RouteSectionContext,
+} from "@admin/types/route-section";
 
 /**
  * Re-exported so the sidebar's callers have one import site for the decision
@@ -16,109 +17,32 @@ export type {
 } from "@admin/types/route-section";
 
 /**
- * Which primary-rail category is active for the current location.
+ * Evaluate the section a route declared.
  *
- * The order of the checks is load-bearing and not merely stylistic. A plugin
- * collection placed in another section must be classified by its PLACEMENT
- * before any URL-shaped check runs, because its content URL is an ordinary
- * `/admin/collections/<name>` that would otherwise match the Collections arm
- * and hide the section its plugin actually chose.
+ * A name is returned as-is; a resolver is called with the runtime facts it
+ * asked for. There is no arm that inspects the pathname, which is the point:
+ * the sidebar renders a decision the route already made rather than making its
+ * own from the URL.
+ */
+export function evaluateRouteSection(
+  declared: RouteSection,
+  context: RouteSectionContext
+): ActiveNavSection {
+  return typeof declared === "function" ? declared(context) : declared;
+}
+
+/**
+ * Which rail entry is active for the current location.
+ *
+ * Resolves the route first, then evaluates whatever section that route
+ * declared. `undefined` means no route matched at all — a genuine 404 — and is
+ * distinct from a route that matched but named no section, which the route
+ * type makes unrepresentable.
  */
 export function resolveActiveSection(
-  ctx: RouteSectionContext
-): ActiveNavSection {
-  const {
-    pathname,
-    from,
-    collections,
-    getCollectionPlacement,
-    standalonePlugins,
-    showBuilder,
-  } = ctx;
-
-  // A standalone plugin owns its own rail entry, so one of its collections
-  // outranks every shared section below.
-  for (const plugin of standalonePlugins) {
-    const slug = pluginSlug(plugin.name);
-    const standaloneId: ActiveNavSection = `standalone-${slug}`;
-    const collectionSlugs = plugin.collections ?? [];
-    if (
-      collectionSlugs.some(name =>
-        pathname.includes(`/admin/collections/${name}`)
-      )
-    ) {
-      return standaloneId;
-    }
-  }
-
-  const pluginCollections = (collections ?? []).filter(c => c.admin?.isPlugin);
-
-  if (collections && pathname.includes("/admin/collections/")) {
-    for (const collection of pluginCollections) {
-      if (!pathname.includes(`/admin/collections/${collection.name}`)) continue;
-      const placement = getCollectionPlacement(collection);
-      // User management is rendered inside the Settings sub-sidebar, so it
-      // highlights Settings rather than a rail entry of its own.
-      if (placement === "users") return "settings";
-      if (placement === "settings") return "settings";
-      if (placement === "collections") return "collections";
-      if (placement === "singles") return "singles";
-    }
-  }
-
-  // A plugin collection with no placement, or one placed in "plugins",
-  // belongs to the Plugins rail entry.
-  const isPluginCollectionPath = pluginCollections.some(collection => {
-    if (!pathname.includes(`/admin/collections/${collection.name}`))
-      return false;
-    const placement = getCollectionPlacement(collection);
-    if (placement && placement !== "plugins") return false;
-    return true;
-  });
-
-  // Compared against the route constants rather than their spellings. The
-  // directory sits at its own top level so no plugin slug can shadow it, which
-  // means Plugins is not one URL prefix and a literal would silently stop
-  // covering it the next time either route moves.
-  if (
-    isUnder(pathname, ROUTES.PLUGINS) ||
-    isUnder(pathname, ROUTES.PLUGIN_BROWSE) ||
-    pathname.includes("/admin/forms") ||
-    isPluginCollectionPath
-  ) {
-    return "plugins";
-  }
-
-  if (pathname === ROUTES.DASHBOARD) return "dashboard";
-
-  // An explicit `from` records which rail the user navigated out of, so it
-  // decides ahead of the URL for every section below.
-  if (from === "builders") return "builders";
-  if (from === "collections") return "collections";
-  if (from === "singles") return "singles";
-
-  // Schema-management URLs win over the content arms beneath them, so the
-  // Builders panel stays selected while editing a schema.
-  if (pathname.includes("/admin/builder/")) {
-    if (showBuilder) return "builders";
-    // Reached only by deep link when an admin-meta override hides the builder.
-    // Surfacing the matching per-kind panel leaves somewhere to navigate to
-    // instead of an empty sub-sidebar.
-    if (pathname.includes("/admin/builder/collections")) return "collections";
-    if (pathname.includes("/admin/builder/singles")) return "singles";
-    if (pathname.includes("/admin/builder/field-groups")) return "collections";
-  }
-
-  if (pathname.includes("/admin/collections/")) return "collections";
-  if (pathname.includes("/admin/singles/")) return "singles";
-  if (pathname.includes("/admin/media")) return "media";
-  if (
-    pathname.includes("/admin/users") ||
-    pathname.includes("/admin/security/roles")
-  ) {
-    return "settings";
-  }
-  if (pathname.includes("/admin/settings")) return "settings";
-
-  return "dashboard";
+  context: RouteSectionContext
+): ActiveNavSection | undefined {
+  const declared = resolveRoute(context.pathname, "").section;
+  if (!declared) return undefined;
+  return evaluateRouteSection(declared, context);
 }

--- a/packages/admin/src/components/layout/sidebar/sidebar-types.ts
+++ b/packages/admin/src/components/layout/sidebar/sidebar-types.ts
@@ -7,17 +7,16 @@ import {
   ShieldAlert,
   FileText,
 } from "@admin/components/icons";
+import type { ActiveNavSection } from "@admin/constants/nav-sections";
 import { ROUTES } from "@admin/constants/routes";
 
-export type MainMenuCategory =
-  | "dashboard"
-  | "collections"
-  | "singles"
-  | "media"
-  | "plugins"
-  | "settings"
-  | "builders"
-  | `standalone-${string}`;
+/**
+ * A rail entry that can be active.
+ *
+ * An alias of the canonical type rather than a restatement of it, so the
+ * sidebar and the route registry cannot come to disagree about the vocabulary.
+ */
+export type MainMenuCategory = ActiveNavSection;
 
 export interface MainMenuItem {
   id: MainMenuCategory;

--- a/packages/admin/src/constants/nav-sections.ts
+++ b/packages/admin/src/constants/nav-sections.ts
@@ -1,0 +1,41 @@
+/**
+ * The primary-rail sections a route can belong to.
+ *
+ * Declared here rather than beside the sidebar components because the ROUTE
+ * registry names these values, and a page registry that imported a component's
+ * types would invert the dependency. Both the registry and the sidebar read
+ * this module, so there is one vocabulary rather than two that agree today.
+ *
+ * `standalone-<slug>` is deliberately NOT a member. A standalone rail entry
+ * exists only for a plugin that is currently mounted, so it cannot be written
+ * as a literal in a static declaration — permitting it here would admit a
+ * fabricated id that matches no plugin and silently selects nothing.
+ *
+ * @module constants/nav-sections
+ */
+export const NAV_SECTIONS = [
+  "dashboard",
+  "collections",
+  "singles",
+  "media",
+  "plugins",
+  "settings",
+  "builders",
+] as const;
+
+/** A rail section nameable by a static declaration. */
+export type NavSection = (typeof NAV_SECTIONS)[number];
+
+/**
+ * Any rail entry that can be ACTIVE, including a mounted standalone plugin's.
+ *
+ * Wider than `NavSection` on purpose: a standalone id is resolvable at runtime
+ * but not declarable, so the two types are not interchangeable and the compiler
+ * should say so.
+ */
+export type ActiveNavSection = NavSection | `standalone-${string}`;
+
+/** Whether a string is one of the declarable rail sections. */
+export function isNavSection(value: string): value is NavSection {
+  return (NAV_SECTIONS as readonly string[]).includes(value);
+}

--- a/packages/admin/src/hooks/usePluginPageRegistration.test.tsx
+++ b/packages/admin/src/hooks/usePluginPageRegistration.test.tsx
@@ -85,6 +85,10 @@ describe("usePluginPageRegistration", () => {
         path: "/reports",
         component: "@acme/x/admin#Reports",
         requiredPermission: undefined,
+        // Resolved at registration, where the plugin's slug is known. This
+        // fixture declares no section and its plugin no placement, so the
+        // page lands under Plugins.
+        section: "plugins",
       },
     ]);
     expect(locationChangeCount(spy)).toBe(1);

--- a/packages/admin/src/hooks/usePluginPageRegistration.ts
+++ b/packages/admin/src/hooks/usePluginPageRegistration.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 
+import { pluginSurfaceSection } from "@admin/lib/navigation/section-resolvers";
 import { autoRegisterPluginComponents } from "@admin/lib/plugins/component-registry";
 import {
   registerPluginPages,
@@ -49,6 +50,7 @@ export function usePluginPageRegistration(
             path: page.path,
             component: page.component,
             requiredPermission: page.requiredPermission,
+            section: pluginSurfaceSection(page.section, plugin.placement, slug),
           }))
         );
         for (const page of plugin.pages) {

--- a/packages/admin/src/lib/navigation/__tests__/plugin-surface-section.test.ts
+++ b/packages/admin/src/lib/navigation/__tests__/plugin-surface-section.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { pluginSurfaceSection } from "../section-resolvers";
+
+/**
+ * The deferral chain a plugin's page or menu item follows to find its rail
+ * entry. Each case names which of the three inputs decides, because the value
+ * alone does not say which rule produced it.
+ */
+describe("pluginSurfaceSection", () => {
+  it("uses what the surface itself declared", () => {
+    expect(pluginSurfaceSection("settings", undefined, "acme")).toBe(
+      "settings"
+    );
+  });
+
+  it("lets the surface OVERRIDE its plugin's placement", () => {
+    // The case that makes this a chain rather than a lookup: a plugin under
+    // Settings can still put one page under Media.
+    expect(pluginSurfaceSection("media", "settings", "acme")).toBe("media");
+  });
+
+  it("defers to the plugin's placement when the surface says nothing", () => {
+    expect(pluginSurfaceSection(undefined, "settings", "acme")).toBe(
+      "settings"
+    );
+  });
+
+  it("falls to Plugins when neither declares anything", () => {
+    expect(pluginSurfaceSection(undefined, undefined, "acme")).toBe("plugins");
+  });
+
+  it.each([
+    ["declared on the surface", "standalone", undefined],
+    ["inherited from the plugin", undefined, "standalone"],
+  ])("resolves standalone to the plugin's own entry (%s)", (_why, a, b) => {
+    expect(pluginSurfaceSection(a, b, "acme-helpdesk")).toBe(
+      "standalone-acme-helpdesk"
+    );
+  });
+
+  it("maps 'users' to Settings, where user management is rendered", () => {
+    expect(pluginSurfaceSection("users", undefined, "acme")).toBe("settings");
+  });
+
+  it("ignores a value that names no rail entry rather than trusting it", () => {
+    // Older servers, or a plugin built against a newer vocabulary, can send a
+    // section this admin does not know. Landing on Plugins is visible and
+    // recoverable; trusting it selects nothing at all.
+    expect(pluginSurfaceSection("nonsense", undefined, "acme")).toBe("plugins");
+  });
+
+  it("does not treat 'dashboard' as a fallback", () => {
+    // Guards the specific failure this whole change removes: an unknown value
+    // must not resolve to the section that also means "nothing matched".
+    expect(pluginSurfaceSection("nonsense", "nonsense", "acme")).not.toBe(
+      "dashboard"
+    );
+  });
+});

--- a/packages/admin/src/lib/navigation/section-resolvers.ts
+++ b/packages/admin/src/lib/navigation/section-resolvers.ts
@@ -1,0 +1,108 @@
+import type {
+  ActiveNavSection,
+  NavSection,
+} from "@admin/constants/nav-sections";
+import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
+import type { RouteSectionContext } from "@admin/types/route-section";
+
+/**
+ * Section resolvers for the routes whose rail entry is not fixed by the route
+ * alone.
+ *
+ * Each is a DECLARATION a route makes about how to decide, rather than logic
+ * the sidebar applies to every URL it sees. A route that needs none of these
+ * declares a plain section name instead.
+ *
+ * @module lib/navigation/section-resolvers
+ */
+
+/**
+ * The rail entry a `from` search param names, if it names one.
+ *
+ * `from` records which rail the user navigated out of, so a schema page opened
+ * from Collections keeps Collections selected rather than jumping to Builders.
+ * A repeated param parses to an array, which names nothing and is ignored.
+ */
+function sectionFromParam(
+  from: string | string[] | undefined
+): NavSection | undefined {
+  if (from === "builders") return "builders";
+  if (from === "collections") return "collections";
+  if (from === "singles") return "singles";
+  return undefined;
+}
+
+/**
+ * A fixed section that an explicit `from` may override.
+ *
+ * Which routes honour `from` was previously decided by where each URL check
+ * happened to sit relative to the `from` check, so it was a property of the
+ * ordering rather than a choice. Naming it per route makes it a decision:
+ * Dashboard declares a bare section and is not overridable, while the content
+ * and settings routes declare this and are.
+ */
+export function overridableBy(
+  fallback: NavSection
+): (context: RouteSectionContext) => ActiveNavSection {
+  return context => sectionFromParam(context.from) ?? fallback;
+}
+
+/**
+ * Which rail entry owns a schema-management URL.
+ *
+ * Builders is hidden in production by default. Reached by deep link while
+ * hidden, the per-kind panel is surfaced instead so there is somewhere to
+ * navigate to rather than an empty sub-sidebar.
+ */
+export function builderSection(
+  whenHidden: NavSection
+): (context: RouteSectionContext) => ActiveNavSection {
+  return context => {
+    const fromParam = sectionFromParam(context.from);
+    if (fromParam) return fromParam;
+    return context.showBuilder ? "builders" : whenHidden;
+  };
+}
+
+/**
+ * Which rail entry owns a collection's CONTENT url.
+ *
+ * A collection's URL is always `/admin/collections/<name>`, so the URL cannot
+ * answer this: the same shape belongs to Collections, to Plugins, to Settings,
+ * or to a standalone plugin's own entry depending on who owns the collection
+ * and where that owner placed it. Ownership is therefore consulted before the
+ * generic answer, and `from` is consulted only after — a plugin that placed a
+ * collection under Settings means it, whatever rail the user came from.
+ */
+export function collectionContentSection(
+  context: RouteSectionContext
+): ActiveNavSection {
+  const { pathname, collections, getCollectionPlacement, standalonePlugins } =
+    context;
+
+  for (const plugin of standalonePlugins) {
+    const owns = (plugin.collections ?? []).some(name =>
+      pathname.includes(`/admin/collections/${name}`)
+    );
+    if (owns) return `standalone-${pluginSlug(plugin.name)}`;
+  }
+
+  const pluginCollections = (collections ?? []).filter(c => c.admin?.isPlugin);
+  const owner = pluginCollections.find(collection =>
+    pathname.includes(`/admin/collections/${collection.name}`)
+  );
+
+  if (owner) {
+    const placement = getCollectionPlacement(owner);
+    // User management is rendered inside the Settings sub-sidebar, so a
+    // collection placed there highlights Settings rather than an entry of
+    // its own.
+    if (placement === "users" || placement === "settings") return "settings";
+    if (placement === "collections") return "collections";
+    if (placement === "singles") return "singles";
+    // Declared "plugins", or nothing at all, both belong to Plugins.
+    return "plugins";
+  }
+
+  return sectionFromParam(context.from) ?? "collections";
+}

--- a/packages/admin/src/lib/navigation/section-resolvers.ts
+++ b/packages/admin/src/lib/navigation/section-resolvers.ts
@@ -1,6 +1,7 @@
-import type {
-  ActiveNavSection,
-  NavSection,
+import {
+  isNavSection,
+  type ActiveNavSection,
+  type NavSection,
 } from "@admin/constants/nav-sections";
 import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
 import type { RouteSectionContext } from "@admin/types/route-section";
@@ -105,4 +106,35 @@ export function collectionContentSection(
   }
 
   return sectionFromParam(context.from) ?? "collections";
+}
+
+/**
+ * Which rail entry a plugin's own surface belongs to.
+ *
+ * Resolved once, at registration, because that is the only place all three
+ * facts are in hand: what the surface declared, what its plugin declared, and
+ * which slug a standalone entry would be addressed by.
+ *
+ * The order is a deferral chain rather than a list of defaults. A surface that
+ * names a section means it; one that says nothing defers to its plugin, so a
+ * plugin already placed under Settings does not repeat itself on every page;
+ * and a plugin that has said nothing either belongs under Plugins.
+ *
+ * An unrecognised value falls to Plugins rather than being trusted. A plugin
+ * built against a newer vocabulary can name a section this admin does not
+ * have, and landing somewhere visible is recoverable where selecting nothing
+ * is not.
+ */
+export function pluginSurfaceSection(
+  declared: string | undefined,
+  pluginPlacement: string | undefined,
+  slug: string
+): ActiveNavSection {
+  const chosen = declared ?? pluginPlacement;
+  if (chosen === "standalone") return `standalone-${slug}`;
+  // "users" is rendered inside the Settings sub-sidebar rather than a rail
+  // entry of its own, matching how a plugin collection placed there behaves.
+  if (chosen === "users") return "settings";
+  if (chosen && isNavSection(chosen)) return chosen;
+  return "plugins";
 }

--- a/packages/admin/src/lib/plugins/plugin-route-registry.ts
+++ b/packages/admin/src/lib/plugins/plugin-route-registry.ts
@@ -13,6 +13,8 @@
  * @module lib/plugins/plugin-route-registry
  */
 
+import type { NavSection } from "@admin/constants/nav-sections";
+
 export interface RegisteredPluginPage {
   /** Full namespaced admin path: `/admin/plugins/<slug>/<path>`. */
   fullPath: string;
@@ -20,6 +22,12 @@ export interface RegisteredPluginPage {
   component: string;
   /** Permission required to view this page (route-level RBAC, D36). */
   requiredPermission?: string;
+  /**
+   * The rail section to select while this page is open, as declared by the
+   * contributing plugin. Absent means the plugin expressed no preference and
+   * the page belongs under Plugins.
+   */
+  section?: NavSection;
 }
 
 const registry = new Map<string, RegisteredPluginPage>();
@@ -36,19 +44,26 @@ export function registerPluginPage(args: {
   path: string;
   component: string;
   requiredPermission?: string;
+  section?: NavSection;
 }): void {
   const fullPath = pluginPagePath(args.slug, args.path);
   registry.set(fullPath, {
     fullPath,
     component: args.component,
     requiredPermission: args.requiredPermission,
+    section: args.section,
   });
 }
 
 /** Register all pages for a plugin slug. */
 export function registerPluginPages(
   slug: string,
-  pages: Array<{ path: string; component: string; requiredPermission?: string }>
+  pages: Array<{
+    path: string;
+    component: string;
+    requiredPermission?: string;
+    section?: NavSection;
+  }>
 ): void {
   for (const page of pages) {
     registerPluginPage({ slug, ...page });

--- a/packages/admin/src/lib/plugins/plugin-route-registry.ts
+++ b/packages/admin/src/lib/plugins/plugin-route-registry.ts
@@ -13,7 +13,7 @@
  * @module lib/plugins/plugin-route-registry
  */
 
-import type { NavSection } from "@admin/constants/nav-sections";
+import type { ActiveNavSection } from "@admin/constants/nav-sections";
 
 export interface RegisteredPluginPage {
   /** Full namespaced admin path: `/admin/plugins/<slug>/<path>`. */
@@ -27,7 +27,7 @@ export interface RegisteredPluginPage {
    * contributing plugin. Absent means the plugin expressed no preference and
    * the page belongs under Plugins.
    */
-  section?: NavSection;
+  section?: ActiveNavSection;
 }
 
 const registry = new Map<string, RegisteredPluginPage>();
@@ -44,7 +44,7 @@ export function registerPluginPage(args: {
   path: string;
   component: string;
   requiredPermission?: string;
-  section?: NavSection;
+  section?: ActiveNavSection;
 }): void {
   const fullPath = pluginPagePath(args.slug, args.path);
   registry.set(fullPath, {
@@ -62,7 +62,7 @@ export function registerPluginPages(
     path: string;
     component: string;
     requiredPermission?: string;
-    section?: NavSection;
+    section?: ActiveNavSection;
   }>
 ): void {
   for (const page of pages) {

--- a/packages/admin/src/lib/routing.ts
+++ b/packages/admin/src/lib/routing.ts
@@ -5,6 +5,7 @@ import { PluginPageHost } from "@admin/components/shared/plugin-page-host";
 
 import { ROUTES } from "../constants/routes";
 import registry, { routeConfig } from "../pages/registry";
+import type { RouteSection } from "../types/route-section";
 
 import { matchPluginPage } from "./plugins/plugin-route-registry";
 
@@ -42,6 +43,12 @@ export interface RouteResult {
   requiresBuilder?: boolean;
   /** Set when the route resolves to a plugin-contributed page (D21). */
   pluginComponentPath?: string;
+  /**
+   * The rail section this route declared, carried through so the sidebar reads
+   * a declaration instead of matching the pathname. Absent only when no route
+   * matched, which is a genuine 404 rather than a route without a section.
+   */
+  section?: RouteSection;
 }
 
 type Params = Record<string, string | string[]>;
@@ -114,6 +121,7 @@ function matchDynamicRoute(pathname: string): {
   routeType?: "public" | "private";
   requiredPermission?: string | string[];
   requiresBuilder?: boolean;
+  section?: RouteSection;
   pattern: string;
 } | null {
   for (const [pattern, Component] of Object.entries(registry)) {
@@ -140,6 +148,7 @@ function matchDynamicRoute(pathname: string): {
         routeType: config?.type,
         requiredPermission: config?.requiredPermission,
         requiresBuilder: config?.requiresBuilder,
+        section: config?.type === "private" ? config.section : undefined,
         pattern,
       };
     }
@@ -188,6 +197,7 @@ export function resolveRoute(pathname: string, rawSearch: string): RouteResult {
       routeType: config?.type,
       requiredPermission: config?.requiredPermission,
       requiresBuilder: config?.requiresBuilder,
+      section: config?.type === "private" ? config.section : undefined,
     };
   }
 
@@ -207,6 +217,7 @@ export function resolveRoute(pathname: string, rawSearch: string): RouteResult {
       routeType: "private",
       requiredPermission: pluginPage.requiredPermission,
       pluginComponentPath: pluginPage.component,
+      section: pluginPage.section ?? "plugins",
     };
   }
 
@@ -224,6 +235,7 @@ export function resolveRoute(pathname: string, rawSearch: string): RouteResult {
       routeType: dynamic.routeType,
       requiredPermission: dynamicPermission ?? dynamic.requiredPermission,
       requiresBuilder: dynamic.requiresBuilder,
+      section: dynamic.section,
     };
   }
 

--- a/packages/admin/src/lib/routing.ts
+++ b/packages/admin/src/lib/routing.ts
@@ -5,7 +5,7 @@ import { PluginPageHost } from "@admin/components/shared/plugin-page-host";
 
 import { ROUTES } from "../constants/routes";
 import registry, { routeConfig } from "../pages/registry";
-import type { RouteSection } from "../types/route-section";
+import type { CarriedRouteSection } from "../types/route-section";
 
 import { matchPluginPage } from "./plugins/plugin-route-registry";
 
@@ -48,7 +48,7 @@ export interface RouteResult {
    * a declaration instead of matching the pathname. Absent only when no route
    * matched, which is a genuine 404 rather than a route without a section.
    */
-  section?: RouteSection;
+  section?: CarriedRouteSection;
 }
 
 type Params = Record<string, string | string[]>;
@@ -121,7 +121,7 @@ function matchDynamicRoute(pathname: string): {
   routeType?: "public" | "private";
   requiredPermission?: string | string[];
   requiresBuilder?: boolean;
-  section?: RouteSection;
+  section?: CarriedRouteSection;
   pattern: string;
 } | null {
   for (const [pattern, Component] of Object.entries(registry)) {

--- a/packages/admin/src/pages/__tests__/route-sections.test.ts
+++ b/packages/admin/src/pages/__tests__/route-sections.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { NAV_SECTIONS, isNavSection } from "@admin/constants/nav-sections";
+import { evaluateRouteSection } from "@admin/components/layout/sidebar/lib/resolve-section";
+import type { RouteSectionContext } from "@admin/types/route-section";
+
+import { routeConfig } from "../registry";
+
+/**
+ * Standing guard over the route-to-section declarations.
+ *
+ * The route type already makes a MISSING section a compile error. These cover
+ * what the type cannot: that a declared resolver actually returns a rail entry
+ * that exists, for every route, under the runtime shapes the sidebar passes.
+ */
+
+const privateRoutes = Object.entries(routeConfig).filter(
+  ([, config]) => config.type === "private"
+);
+
+function context(
+  overrides: Partial<RouteSectionContext> = {}
+): RouteSectionContext {
+  return {
+    pathname: "/admin",
+    collections: undefined,
+    getCollectionPlacement: () => undefined,
+    standalonePlugins: [],
+    showBuilder: true,
+    ...overrides,
+  };
+}
+
+describe("every private route's declared section", () => {
+  it("covers a population large enough to be meaningful", () => {
+    // Asserted before any verdict below: a selector that silently matched
+    // nothing would make every `it.each` here vacuously pass.
+    expect(privateRoutes.length).toBeGreaterThan(40);
+  });
+
+  it.each(privateRoutes)("%s resolves to a real rail entry", (path, config) => {
+    if (config.type !== "private") throw new Error("filtered to private");
+
+    const resolved = evaluateRouteSection(
+      config.section,
+      context({ pathname: path })
+    );
+
+    // A standalone id names a plugin mounted at runtime, so it cannot be
+    // checked against the static vocabulary — only its shape can.
+    const valid =
+      isNavSection(resolved) || /^standalone-[a-z0-9-]+$/.test(resolved);
+    expect(valid, `${path} resolved to "${resolved}"`).toBe(true);
+  });
+
+  it.each(privateRoutes)(
+    "%s still resolves when the builder is hidden",
+    (path, config) => {
+      if (config.type !== "private") throw new Error("filtered to private");
+
+      const resolved = evaluateRouteSection(
+        config.section,
+        context({ pathname: path, showBuilder: false })
+      );
+      expect(NAV_SECTIONS).toContain(resolved);
+    }
+  );
+});
+
+describe("public routes", () => {
+  it("declare no section, because they render outside the rail", () => {
+    const publicRoutes = Object.values(routeConfig).filter(
+      config => config.type === "public"
+    );
+    expect(publicRoutes.length).toBeGreaterThan(0);
+    for (const config of publicRoutes) {
+      expect("section" in config).toBe(false);
+    }
+  });
+});

--- a/packages/admin/src/pages/registry.ts
+++ b/packages/admin/src/pages/registry.ts
@@ -1,7 +1,13 @@
 import { lazy } from "react";
 
 import { type PublicRoutePath, ROUTES } from "../constants/routes";
+import {
+  builderSection,
+  collectionContentSection,
+  overridableBy,
+} from "../lib/navigation/section-resolvers";
 import type { PageProps } from "../lib/routing";
+import type { RouteSection } from "../types/route-section";
 
 import AcceptInvitePage from "./(auth)/accept-invite";
 import ForgotPasswordPage from "./(auth)/forgot-password";
@@ -79,9 +85,8 @@ const SingleBuilderEditPage = lazy(
   () => import("./dashboard/singles/builder/[slug]")
 );
 
-export interface RouteConfig {
+interface RouteConfigBase {
   component: React.ComponentType<PageProps>;
-  type: "public" | "private";
   /**
    * Permission required to access this route. A single slug, or a list treated
    * as any-of (holding any one grants access — models an umbrella permission).
@@ -95,6 +100,21 @@ export interface RouteConfig {
    */
   requiresBuilder?: boolean;
 }
+
+/**
+ * A route, and everything decided about it at declaration time.
+ *
+ * Split on `type` so the two states carry different obligations. A private
+ * route MUST name the rail section it belongs to: the sidebar reads that
+ * declaration rather than matching the URL, so a route added without one is a
+ * compile error instead of a page that silently highlights Dashboard. A public
+ * route renders outside the dashboard shell and has no rail at all, so naming a
+ * section there would be meaningless — the union makes both unrepresentable
+ * rather than relying on anyone to remember.
+ */
+export type RouteConfig =
+  | (RouteConfigBase & { type: "public" })
+  | (RouteConfigBase & { type: "private"; section: RouteSection });
 
 /**
  * The page that answers each public route.
@@ -131,23 +151,30 @@ export const routeConfig: Record<string, RouteConfig> = {
   ...publicRouteConfig,
 
   // Dashboard route (homepage)
-  [ROUTES.DASHBOARD]: { component: DashboardPage, type: "private" },
+  [ROUTES.DASHBOARD]: {
+    component: DashboardPage,
+    type: "private",
+    section: "dashboard",
+  },
 
   // Users routes
   [ROUTES.USERS]: {
     component: DashboardUsersPage,
     type: "private",
     requiredPermission: "read-users",
+    section: overridableBy("settings"),
   },
   [ROUTES.USERS_CREATE]: {
     component: CreateUserPage,
     type: "private",
     requiredPermission: "create-users",
+    section: overridableBy("settings"),
   },
   [ROUTES.USERS_EDIT]: {
     component: EditUserPage,
     type: "private",
     requiredPermission: "update-users",
+    section: overridableBy("settings"),
   },
 
   // Media routes
@@ -155,6 +182,7 @@ export const routeConfig: Record<string, RouteConfig> = {
     component: MediaLibraryPage,
     type: "private",
     requiredPermission: "read-media",
+    section: overridableBy("media"),
   },
 
   // ============================================================
@@ -165,16 +193,19 @@ export const routeConfig: Record<string, RouteConfig> = {
     component: CollectionsPage,
     type: "private",
     requiresBuilder: true,
+    section: builderSection("collections"),
   },
   [ROUTES.BUILDER_COLLECTIONS_NEW]: {
     component: CollectionBuilderPage,
     type: "private",
     requiresBuilder: true,
+    section: builderSection("collections"),
   },
   [ROUTES.BUILDER_COLLECTIONS_EDIT]: {
     component: CollectionBuilderEditPage,
     type: "private",
     requiresBuilder: true,
+    section: builderSection("collections"),
   },
 
   // ============================================================
@@ -191,14 +222,17 @@ export const routeConfig: Record<string, RouteConfig> = {
   [ROUTES.COLLECTIONS]: {
     component: CollectionsLandingRedirect,
     type: "private",
+    section: collectionContentSection,
   },
   [ROUTES.SINGLES]: {
     component: SinglesLandingRedirect,
     type: "private",
+    section: overridableBy("singles"),
   },
   [ROUTES.FIELD_GROUPS]: {
     component: FieldGroupsLandingRedirect,
     type: "private",
+    section: overridableBy("collections"),
   },
 
   // Collection entries routes (dynamic collections).
@@ -207,18 +241,22 @@ export const routeConfig: Record<string, RouteConfig> = {
   [ROUTES.COLLECTION_ENTRIES]: {
     component: CollectionEntriesPage,
     type: "private",
+    section: collectionContentSection,
   },
   [ROUTES.COLLECTION_ENTRY_CREATE]: {
     component: CreateEntryPage,
     type: "private",
+    section: collectionContentSection,
   },
   [ROUTES.COLLECTION_ENTRY_API]: {
     component: APIPlaygroundPage,
     type: "private",
+    section: collectionContentSection,
   },
   [ROUTES.COLLECTION_ENTRY_EDIT]: {
     component: EditEntryPage,
     type: "private",
+    section: collectionContentSection,
   },
 
   // Security & Roles routes
@@ -226,16 +264,19 @@ export const routeConfig: Record<string, RouteConfig> = {
     component: RolesPage,
     type: "private",
     requiredPermission: "read-roles",
+    section: overridableBy("settings"),
   },
   [ROUTES.SECURITY_ROLES_CREATE]: {
     component: RolesCreatePage,
     type: "private",
     requiredPermission: "create-roles",
+    section: overridableBy("settings"),
   },
   [ROUTES.SECURITY_ROLES_EDIT]: {
     component: RolesEditPage,
     type: "private",
     requiredPermission: "update-roles",
+    section: overridableBy("settings"),
   },
 
   // ============================================================
@@ -247,24 +288,32 @@ export const routeConfig: Record<string, RouteConfig> = {
     component: SinglesPage,
     type: "private",
     requiresBuilder: true,
+    section: builderSection("singles"),
   },
   [ROUTES.BUILDER_SINGLES_NEW]: {
     component: SingleBuilderPage,
     type: "private",
     requiresBuilder: true,
+    section: builderSection("singles"),
   },
   [ROUTES.BUILDER_SINGLES_EDIT]: {
     component: SingleBuilderEditPage,
     type: "private",
     requiresBuilder: true,
+    section: builderSection("singles"),
   },
   // Single CONTENT routes — permission is per-slug (checked server-side).
   // IMPORTANT: literal segments like /api must be registered before the wildcard [slug].
   [ROUTES.SINGLE_API]: {
     component: SingleAPIPlaygroundPage,
     type: "private",
+    section: overridableBy("singles"),
   },
-  [ROUTES.SINGLE_EDIT]: { component: SingleEditPage, type: "private" },
+  [ROUTES.SINGLE_EDIT]: {
+    component: SingleEditPage,
+    type: "private",
+    section: overridableBy("singles"),
+  },
 
   // ============================================================
   // Builder: field groups (schema management).
@@ -274,16 +323,19 @@ export const routeConfig: Record<string, RouteConfig> = {
     component: FieldGroupsPage,
     type: "private",
     requiresBuilder: true,
+    section: builderSection("collections"),
   },
   [ROUTES.BUILDER_FIELD_GROUPS_NEW]: {
     component: FieldGroupBuilderPage,
     type: "private",
     requiresBuilder: true,
+    section: builderSection("collections"),
   },
   [ROUTES.BUILDER_FIELD_GROUPS_EDIT]: {
     component: FieldGroupBuilderEditPage,
     type: "private",
     requiresBuilder: true,
+    section: builderSection("collections"),
   },
 
   // Settings routes
@@ -291,56 +343,67 @@ export const routeConfig: Record<string, RouteConfig> = {
     component: SettingsPage,
     type: "private",
     requiredPermission: "manage-settings",
+    section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_EMAIL_PROVIDERS]: {
     component: EmailProvidersPage,
     type: "private",
     requiredPermission: "manage-email-providers",
+    section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_EMAIL_PROVIDERS_CREATE]: {
     component: CreateEmailProviderPage,
     type: "private",
     requiredPermission: "manage-email-providers",
+    section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_EMAIL_PROVIDERS_EDIT]: {
     component: EditEmailProviderPage,
     type: "private",
     requiredPermission: "manage-email-providers",
+    section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_EMAIL_TEMPLATES]: {
     component: EmailTemplatesPage,
     type: "private",
     requiredPermission: "manage-email-templates",
+    section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_EMAIL_TEMPLATES_CREATE]: {
     component: CreateEmailTemplatePage,
     type: "private",
     requiredPermission: "manage-email-templates",
+    section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_EMAIL_TEMPLATES_EDIT]: {
     component: EditEmailTemplatePage,
     type: "private",
     requiredPermission: "manage-email-templates",
+    section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_PERMISSIONS]: {
     component: SettingsPermissionsPage,
     type: "private",
     requiredPermission: "manage-permissions",
+    section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_API_KEYS]: {
     component: ApiKeysPage,
     type: "private",
     requiredPermission: "update-api-keys",
+    section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_API_KEYS_CREATE]: {
     component: CreateApiKeyPage,
     type: "private",
     requiredPermission: "create-api-keys",
+    section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_API_KEYS_EDIT]: {
     component: EditApiKeyPage,
     type: "private",
     requiredPermission: "update-api-keys",
+    section: overridableBy("settings"),
   },
 
   // Webhooks settings. `update-webhooks` is the backend's management umbrella
@@ -350,16 +413,19 @@ export const routeConfig: Record<string, RouteConfig> = {
     component: WebhooksPage,
     type: "private",
     requiredPermission: ["read-webhooks", "update-webhooks", "create-webhooks"],
+    section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_WEBHOOKS_CREATE]: {
     component: CreateWebhookPage,
     type: "private",
     requiredPermission: ["create-webhooks", "update-webhooks"],
+    section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_WEBHOOKS_EDIT]: {
     component: EditWebhookPage,
     type: "private",
     requiredPermission: "update-webhooks",
+    section: overridableBy("settings"),
   },
   // Delivery log routes are read surfaces, so a plain reader may open them; the
   // redeliver and drain actions inside are separately gated on update-webhooks.
@@ -367,11 +433,13 @@ export const routeConfig: Record<string, RouteConfig> = {
     component: WebhookDeliveriesPage,
     type: "private",
     requiredPermission: ["read-webhooks", "update-webhooks"],
+    section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_WEBHOOKS_DELIVERY_DETAIL]: {
     component: WebhookDeliveryDetailPage,
     type: "private",
     requiredPermission: ["read-webhooks", "update-webhooks"],
+    section: overridableBy("settings"),
   },
 
   // Image sizes settings
@@ -379,16 +447,19 @@ export const routeConfig: Record<string, RouteConfig> = {
     component: ImageSizesSettingsPage,
     type: "private",
     requiredPermission: "manage-settings",
+    section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_IMAGE_SIZES_CREATE]: {
     component: CreateImageSizePage,
     type: "private",
     requiredPermission: "manage-settings",
+    section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_IMAGE_SIZES_EDIT]: {
     component: EditImageSizePage,
     type: "private",
     requiredPermission: "manage-settings",
+    section: overridableBy("settings"),
   },
 
   // Plugin routes
@@ -396,6 +467,7 @@ export const routeConfig: Record<string, RouteConfig> = {
     component: PluginsOverviewPage,
     type: "private",
     requiredPermission: "manage-settings",
+    section: "plugins",
   },
   // Registered outside `/admin/plugins/`, so no ordering rule holds this in
   // place: the directory and a plugin's detail page cannot match the same
@@ -404,32 +476,38 @@ export const routeConfig: Record<string, RouteConfig> = {
     component: PluginBrowsePage,
     type: "private",
     requiredPermission: "manage-settings",
+    section: "plugins",
   },
   [ROUTES.PLUGIN_DETAIL]: {
     component: PluginDetailPage,
     type: "private",
     requiredPermission: "manage-settings",
+    section: "plugins",
   },
   [ROUTES.PLUGIN_SETTINGS]: {
     component: PluginSettingsPage,
     type: "private",
     requiredPermission: "manage-settings",
+    section: "plugins",
   },
 
   [ROUTES.USERS_FIELDS]: {
     component: UserFieldsPage,
     type: "private",
     requiredPermission: "manage-settings",
+    section: overridableBy("settings"),
   },
   [ROUTES.USERS_FIELDS_CREATE]: {
     component: CreateUserFieldPage,
     type: "private",
     requiredPermission: "manage-settings",
+    section: overridableBy("settings"),
   },
   [ROUTES.USERS_FIELDS_EDIT]: {
     component: EditUserFieldPage,
     type: "private",
     requiredPermission: "manage-settings",
+    section: overridableBy("settings"),
   },
 };
 

--- a/packages/admin/src/types/branding.ts
+++ b/packages/admin/src/types/branding.ts
@@ -12,6 +12,19 @@ export interface ResolvedBrandingColors {
 }
 
 /**
+ * Where a plugin's admin surfaces appear in the sidebar, as delivered via
+ * `/admin-meta`. Mirrors the server's `PluginNavSection`.
+ */
+export type PluginNavSectionMeta =
+  | "dashboard"
+  | "collections"
+  | "singles"
+  | "media"
+  | "plugins"
+  | "settings"
+  | "standalone";
+
+/**
  * A plugin sidebar menu item, delivered via `/admin-meta`. Mirrors the
  * server `PluginMenuItem` contract; one level of `children`.
  */
@@ -21,6 +34,11 @@ export interface PluginMenuItemMeta {
   icon?: string;
   order?: number;
   requiredPermission?: string;
+  /**
+   * Which sidebar section lists this item, as declared by the plugin. Absent
+   * defers to the plugin's own `placement` rather than meaning "Plugins".
+   */
+  section?: PluginNavSectionMeta;
   children?: PluginMenuItemMeta[];
 }
 
@@ -29,6 +47,11 @@ export interface PluginPageMeta {
   path: string;
   component: string;
   requiredPermission?: string;
+  /**
+   * Which sidebar section is selected while this page is open, as declared by
+   * the plugin. Absent defers to the plugin's own `placement`.
+   */
+  section?: PluginNavSectionMeta;
 }
 
 /** A plugin dashboard widget, delivered via `/admin-meta`. */

--- a/packages/admin/src/types/route-section.ts
+++ b/packages/admin/src/types/route-section.ts
@@ -1,0 +1,53 @@
+import type {
+  ActiveNavSection,
+  NavSection,
+} from "@admin/constants/nav-sections";
+
+import type { ApiCollection } from "./entities";
+
+/**
+ * The subset of a standalone plugin's metadata that section resolution reads.
+ *
+ * Narrower than `PluginMetadata` so a caller can supply a literal without
+ * constructing fields this decision never consults.
+ */
+export interface StandalonePluginSummary {
+  name: string;
+  collections?: string[];
+}
+
+/**
+ * Everything the active-section decision depends on.
+ *
+ * Placement arrives as a FUNCTION rather than as resolved values because the
+ * caller memoises it over plugin metadata, and re-deriving it here would be a
+ * second implementation of a question that already has one.
+ */
+export interface RouteSectionContext {
+  pathname: string;
+  /**
+   * The `from` search param. Typed as the router reports it: a repeated param
+   * parses to an array, which names no section and therefore falls through.
+   */
+  from?: string | string[];
+  collections: ApiCollection[] | undefined;
+  getCollectionPlacement: (collection: ApiCollection) => string | undefined;
+  standalonePlugins: readonly StandalonePluginSummary[];
+  showBuilder: boolean;
+}
+
+/**
+ * Which rail section a route belongs to.
+ *
+ * A literal for the routes whose answer is fixed, and a function for the few
+ * whose answer depends on data the URL does not carry — a collection's
+ * placement, or which standalone plugin owns it. Both forms are DECLARATIONS
+ * made by the route; neither is a guess made by the sidebar.
+ *
+ * The literal arm is `NavSection` rather than `ActiveNavSection` so a
+ * standalone id cannot be written as a static literal. The resolver arm returns
+ * the wider type, because resolving one at runtime is exactly its job.
+ */
+export type RouteSection =
+  | NavSection
+  | ((context: RouteSectionContext) => ActiveNavSection);

--- a/packages/admin/src/types/route-section.ts
+++ b/packages/admin/src/types/route-section.ts
@@ -51,3 +51,13 @@ export interface RouteSectionContext {
 export type RouteSection =
   | NavSection
   | ((context: RouteSectionContext) => ActiveNavSection);
+
+/**
+ * What a resolved route carries: either what a static route DECLARED, or the
+ * entry a plugin surface was already resolved to at registration.
+ *
+ * Wider than `RouteSection` because a plugin page can legitimately land on a
+ * standalone id, which a static declaration cannot name — that resolution
+ * happens where the plugin's slug is known, and the result travels as a value.
+ */
+export type CarriedRouteSection = RouteSection | ActiveNavSection;

--- a/packages/nextly/src/plugins/admin-contributions.ts
+++ b/packages/nextly/src/plugins/admin-contributions.ts
@@ -72,6 +72,27 @@ export interface PluginHeaderContributions {
  * `requiredPermission` (client-gated via `useCan`); a `visible(ctx)` callback is
  * intentionally NOT supported because menus are serialized to the client.
  */
+/**
+ * @experimental Where a plugin's admin surfaces appear in the sidebar.
+ *
+ * A closed vocabulary rather than a free string, so a typo is a compile error
+ * instead of a page that quietly appears nowhere. `"standalone"` gives the
+ * plugin its own top-level entry, drawn with the icon it declares in
+ * `contributes.admin.appearance`.
+ *
+ * Omitting it is the common case and is not the same as choosing a default:
+ * an absent value defers to the plugin's own `placement`, so a plugin that has
+ * already said where it lives does not repeat itself per page.
+ */
+export type PluginNavSection =
+  | "dashboard"
+  | "collections"
+  | "singles"
+  | "media"
+  | "plugins"
+  | "settings"
+  | "standalone";
+
 export interface PluginMenuItem {
   /** Display label. */
   label: string;
@@ -83,6 +104,11 @@ export interface PluginMenuItem {
   order?: number;
   /** Hide the item unless the current user holds this permission (client-gated, D36). */
   requiredPermission?: PermissionSlug;
+  /**
+   * @experimental Which sidebar section lists this item. Defers to the
+   * plugin's own `placement` when omitted.
+   */
+  section?: PluginNavSection;
   /** One nested level of sub-items. */
   children?: PluginMenuItem[];
 }
@@ -98,6 +124,15 @@ export interface PluginAdminPage {
   component: ComponentPath;
   /** Required permission to view the page (route-level RBAC, D36). */
   requiredPermission?: PermissionSlug;
+  /**
+   * @experimental Which sidebar section is selected while this page is open.
+   * Defers to the plugin's own `placement` when omitted.
+   *
+   * The page's URL is namespaced under the plugin, so without this the rail
+   * could only ever say "Plugins" — a plugin that lives under Settings would
+   * have its collections there and its pages elsewhere.
+   */
+  section?: PluginNavSection;
 }
 
 /**

--- a/packages/nextly/src/plugins/index.ts
+++ b/packages/nextly/src/plugins/index.ts
@@ -61,6 +61,7 @@ export type {
   PluginAdminWidget,
   PluginCollectionView,
   PluginMenuItem,
+  PluginNavSection,
 } from "./admin-contributions";
 
 // Plugin HTTP routes — `contributes.routes` surface.

--- a/scripts/node-range-agrees.test.mjs
+++ b/scripts/node-range-agrees.test.mjs
@@ -1,0 +1,68 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The supported Node range is stated in prose in more than one guide and
+ * enforced in exactly one place. Nothing at build time notices when a guide
+ * drifts from the enforced value: a contributor or an agent simply follows the
+ * document onto a runtime the install then refuses, or onto one it accepts
+ * while the test environment does not support it.
+ *
+ * Lives beside the other repository-wide script tests rather than inside a
+ * package, because it makes a claim about the repository as a whole and no
+ * feature owns it. An earlier copy sat inside a development harness and was
+ * deleted along with it, which removed the check without removing the rule.
+ */
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const read = file => readFileSync(resolve(repoRoot, file), "utf8");
+
+/** What a package manager actually refuses a checkout on. */
+const ENFORCED = JSON.parse(read("package.json")).engines?.node;
+
+/**
+ * Documents that state the requirement in prose, and how to find it.
+ *
+ * Each pattern is anchored on the surrounding WORDS rather than on the value,
+ * so a document that has drifted still matches and reports its stale value.
+ * Anchoring on the expected value would make a stale document look like a
+ * missing one, and the failure would tell a reader to add a line that is
+ * already there.
+ */
+const DOCUMENTED = [
+  { file: "AGENTS.md", pattern: /Requirements: Node `([^`]+)`/ },
+  { file: "CONTRIBUTING.md", pattern: /Node\.js `([^`]+)`/ },
+];
+
+describe("the supported Node range", () => {
+  it("is enforced somewhere, and stated in more than one document", () => {
+    // Both halves can go empty and leave the rule below trivially true: an
+    // engines field that was removed, or a document list nothing matches.
+    expect(ENFORCED).toBeTruthy();
+    expect(DOCUMENTED.length).toBeGreaterThan(1);
+    for (const { file, pattern } of DOCUMENTED) {
+      expect(pattern.test(read(file)), `${file} states no Node range`).toBe(
+        true
+      );
+    }
+  });
+
+  it("is the same in every document that states it", () => {
+    const disagreeing = DOCUMENTED.map(({ file, pattern }) => ({
+      file,
+      stated: read(file).match(pattern)?.[1],
+    })).filter(row => row.stated !== ENFORCED);
+
+    expect(
+      disagreeing.map(row => `${row.file} says "${row.stated}"`).sort(),
+      `A guide states a Node range the repository does not enforce ` +
+        `("${ENFORCED}"). Nothing fails at build time -- a contributor or an ` +
+        `agent simply follows the document onto a runtime the install then ` +
+        `refuses, or worse, one it accepts while the test environment does ` +
+        `not support it.`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What and why

The admin sidebar decided which primary-rail icon was active by matching the pathname against **15 hardcoded literals**, ending in `return "dashboard"`. A route nobody added to that cascade did not fail — it silently claimed to be Dashboard, which is indistinguishable from a route that genuinely is. That is how `/admin/plugin-directory` shipped highlighting the wrong entry, unnoticed, and it was logged as a known follow-up that was never taken.

Routes now **declare** their section, and the type requires it. The cascade and its fallback are deleted.

This also widens the plugin surface: a plugin's admin pages are namespaced under its own slug, so the rail could only ever answer "Plugins" for them — a plugin placed under Settings had its collections in one section and its pages in another, with no way to say otherwise. Pages and menu items may now name a section.

## Measured

| | before | after |
|---|---|---|
| route-classification literals in the sidebar | 15 | **0** |
| silent `return "dashboard"` fallback | present | **gone** |
| dead `/admin/forms` literal (no route has ever served that path) | present | **gone** |
| a private route missing a section | silent wrong icon | **compile error** |

## Design notes for review

- **`RouteConfig` is a discriminated union.** A public route renders outside the rail and cannot name a section; a private route must. Both wrong states are unrepresentable rather than relying on anyone to remember.
- **Two vocabularies, deliberately not one.** `NavSection` is what a route may *declare*; `ActiveNavSection` adds `standalone-<slug>` and is what may be *active*. A standalone entry exists only while its plugin is mounted, so permitting it as a static literal would admit an id matching nothing — failing exactly the way this PR removes.
- **Routes whose section depends on runtime data declare a resolver**, not a name. A collection's content URL is the forcing case: the same `/admin/collections/<name>` shape belongs to Collections, Plugins, Settings, or a standalone entry depending on who owns it.
- **`from` handling is now per-route.** Which routes honour `?from=` was previously decided by where each check happened to sit relative to the `from` check — a property of the ordering rather than a choice. It is now named per route.
- **Plugin section resolution is a deferral chain, not defaults.** Surface → plugin `placement` → Plugins. A plugin that has already said where it lives does not repeat itself per page. An unrecognised value resolves to Plugins rather than being trusted: a plugin built against a newer vocabulary can name a section this admin lacks, and landing somewhere visible is recoverable where selecting nothing is not.

## Test plan

- **29 characterization tests** written against the OLD cascade, then run unchanged against the new declaration-driven mechanism: **27 passed**. The 2 that failed were exactly the two behaviours this PR changes (the dead literal, and the silent Dashboard fallback), and were then updated deliberately. That is demonstrated equivalence rather than asserted equivalence.
- **Exhaustiveness proven, not asserted:** deleting one route's `section` produces `TS2418` naming that entry. Control run and restored.
- **106-test standing guard** that every route's declared section resolves to a real rail entry, including when the schema builder is hidden. Asserts the population before any verdict.
- **9 tests** over the plugin deferral chain, including that an unknown value must not resolve to `dashboard`.
- Every test **stub-verified in both directions**.
- `packages/admin`: **no new failures vs baseline** (4 files / 15 tests, same set, `comm -13` empty).
- `pnpm test:scripts`: 493 passed / 12 files.
- Clean rebuild with `dist` wiped first: 19/19, artifacts confirmed on disk.

## Pre-existing failures (NOT introduced here)

- `packages/admin`: 4 files / 15 tests — `StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField`.
- `packages/nextly` `src/plugins/schema/caching.test.ts`: 2 tests. **Proven pre-existing by control** — reverting this PR's two core files to `origin/main` leaves the same 2 failures.

## Changeset

Added: **patch**, all **24** packages. Generated from `.changeset/config.json` `fixed[0]` rather than copied from a neighbouring changeset — a recently merged changeset on `main` lists only 21 of the 24, which is what copying produces.

## Reviewer attention

`packages/plugin-sdk` re-exports `PluginNavSection`, so this PR adds to the **published plugin API**. It is additive and optional. Flagged prominently because the PR's stated subject is the sidebar, and an API addition riding inside a larger change gets less isolated review than it deserves.
