### PR TITLE
feat(builder): move the selected block with the keyboard

### DIFF
--- a/.changeset/keyboard-block-moves.md
+++ b/.changeset/keyboard-block-moves.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+The selected block can be moved with the keyboard: alt+arrow up and down reorder it, alt+arrow left and right move it out of and into a container. Dragging is not the only way to reorder a page, which WCAG 2.2 requires of any function operated by a drag.

--- a/packages/builder/src/keyboard-moves.test.tsx
+++ b/packages/builder/src/keyboard-moves.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+
+/**
+ * What the wiring adds on top of the rule: that the keys ask for the move the
+ * rule decided, and that the answer reaches the store.
+ *
+ * `keyboard-move.test.ts` already covers where a block lands and what a
+ * direction means. Re-asserting that through a keystroke would test the same
+ * derivation twice while making the failures harder to read, so what is checked
+ * here is the seam — the binding, its guards, and the op passed to `apply`.
+ *
+ * @module keyboard-moves.test
+ */
+import { cleanup, render } from "@testing-library/react";
+import { ShortcutProvider } from "@nextlyhq/ui";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { BlockDocument } from "@nextlyhq/blocks-engine";
+
+import type { EditorState } from "./editor-state";
+import { useBlockKeyboardMoves } from "./keyboard-moves";
+
+// `cleanup`, not an innerHTML wipe. This package does not enable vitest
+// globals, so testing-library registers no cleanup of its own — and clearing
+// the DOM does not UNMOUNT the tree, so every previous case's shortcut layer
+// stays registered against the editor it was given. A later press then fires an
+// earlier test's binding, which is how "nothing is selected" came back with the
+// keystroke consumed.
+afterEach(cleanup);
+
+function documentOf(nodes: BlockDocument["nodes"]): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+}
+
+/** Two top-level blocks, so `up` and `down` both have somewhere to go. */
+function pair(): BlockDocument {
+  return documentOf([
+    { id: "a", type: "acme/text", version: 1, props: {} },
+    { id: "b", type: "acme/text", version: 1, props: {} },
+  ]);
+}
+
+function editorSpy(
+  doc: BlockDocument,
+  selectedId: string | null
+): EditorState & { apply: ReturnType<typeof vi.fn> } {
+  return {
+    document: doc,
+    selectedId,
+    select: vi.fn(),
+    apply: vi.fn(() => doc),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+    undoDepth: 0,
+  } as unknown as EditorState & { apply: ReturnType<typeof vi.fn> };
+}
+
+function Harness({ editor }: { editor: EditorState }) {
+  useBlockKeyboardMoves({ editor });
+  return null;
+}
+
+function mount(editor: EditorState) {
+  render(
+    <ShortcutProvider>
+      <Harness editor={editor} />
+    </ShortcutProvider>
+  );
+}
+
+/**
+ * Press a key on the document, as the shortcut manager listens for it.
+ *
+ * Returns the event so a caller can read `defaultPrevented`, which is how a
+ * binding that DECLINED a keystroke is told apart from one that handled it and
+ * did nothing. Both leave the store untouched.
+ */
+function press(key: string, init: KeyboardEventInit = {}): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  document.dispatchEvent(event);
+  return event;
+}
+
+describe("useBlockKeyboardMoves", () => {
+  it("moves the selected block down, through the store", () => {
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    press("ArrowDown", { altKey: true });
+
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+    const op = editor.apply.mock.calls[0][0];
+    expect(op.kind).toBe("move");
+    expect(op.id).toBe("a");
+    // Index 1: past its sibling. A wiring that passed the selection's own index
+    // would move it to where it already is.
+    expect(op.to).toEqual({ index: 1 });
+  });
+
+  it("moves the selected block up", () => {
+    const editor = editorSpy(pair(), "b");
+    mount(editor);
+
+    press("ArrowUp", { altKey: true });
+
+    expect(editor.apply.mock.calls[0][0].to).toEqual({ index: 0 });
+  });
+
+  it("does nothing when the move has nowhere to go", () => {
+    // The first block cannot move up. A refusal is an ordinary answer, so
+    // nothing reaches the store — and nothing is reported at the author either.
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    press("ArrowUp", { altKey: true });
+
+    expect(editor.apply).not.toHaveBeenCalled();
+  });
+
+  it("passes the keystroke on when nothing is selected", () => {
+    // Not merely "does nothing". A binding that fired and returned early leaves
+    // the store untouched too, and ALSO calls preventDefault — swallowing the
+    // caret movement alt+Arrow performs natively. Only `defaultPrevented`
+    // separates declining a keystroke from consuming it, which is why asserting
+    // the store alone passed with the guard deleted.
+    const editor = editorSpy(pair(), null);
+    mount(editor);
+
+    const event = press("ArrowDown", { altKey: true });
+
+    expect(editor.apply).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("consumes the keystroke when it does move a block", () => {
+    // The control for the case above: it pins `defaultPrevented` as observable
+    // and true on the happy path, so the false there is a real difference
+    // rather than a value this environment never sets.
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    const event = press("ArrowDown", { altKey: true });
+
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("ignores an arrow pressed without alt", () => {
+    // The control for every case above. A binding that fired on a bare arrow
+    // would satisfy all of them while making the arrow keys unusable for
+    // anything else.
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    press("ArrowDown");
+
+    expect(editor.apply).not.toHaveBeenCalled();
+  });
+
+  it("leaves the selection on the block that moved", () => {
+    // What makes a run of presses walk one block across the page instead of
+    // moving a different block each time.
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    press("ArrowDown", { altKey: true });
+
+    expect(editor.select).not.toHaveBeenCalled();
+  });
+
+  it("carries the vacated slot when a block leaves a container", () => {
+    // Outdenting empties the container it leaves. Without `dropSlotIfEmpty` the
+    // slot survives as an empty array, which the page-builder validator
+    // rejects — and a keyboard author meets that far sooner than a pointer one,
+    // moving a single block at a time.
+    const editor = editorSpy(
+      documentOf([
+        {
+          id: "wrap",
+          type: "acme/columns",
+          version: 1,
+          props: {},
+          slots: {
+            children: [
+              { id: "inner", type: "acme/text", version: 1, props: {} },
+            ],
+          },
+        },
+      ]),
+      "inner"
+    );
+    mount(editor);
+
+    press("ArrowLeft", { altKey: true });
+
+    const op = editor.apply.mock.calls[0]?.[0];
+    expect(op?.kind).toBe("move");
+    expect(op?.dropSlotIfEmpty).toEqual({ parentId: "wrap", slot: "children" });
+  });
+});

--- a/packages/builder/src/keyboard-moves.tsx
+++ b/packages/builder/src/keyboard-moves.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+/**
+ * Moving the selected block with the keyboard.
+ *
+ * **This is not a convenience over dragging; it is the accessible way to do the
+ * same job.** WCAG 2.2 adds SC 2.5.7 *Dragging Movements* (AA), which requires
+ * any function operated by a drag to be achievable without one, and SC 2.1.1
+ * *Keyboard* (A) requires it to be operable from a keyboard at all. A canvas
+ * that can only reorder by pointer fails both. Building this first means the
+ * drag path arrives as an enhancement over a working baseline rather than as
+ * the only way in.
+ *
+ * **The rule lives in `keyboard-move`; this is the wiring.** That module decides
+ * where a block lands, what the move means, and which slot it may vacate. Every
+ * decision worth asserting is already made there, without React and without a
+ * DOM. What is only true here is which keys ask for it, when they are allowed
+ * to, and that the answer reaches the one place a document changes.
+ *
+ * @module keyboard-moves
+ */
+
+import { useShortcuts } from "@nextlyhq/ui";
+import * as React from "react";
+
+import type { EditorState } from "./editor-state";
+import { keyboardMovePosition, type MoveDirection } from "./keyboard-move";
+
+/**
+ * The bindings, and why these keys.
+ *
+ * `alt+ArrowUp`/`alt+ArrowDown` is the line-move gesture from VS Code and the
+ * editors that copied it, so it arrives already known rather than needing to be
+ * taught. `alt+ArrowLeft`/`alt+ArrowRight` follows the indent convention every
+ * outliner and list editor shares, and it matches the axis the rule itself
+ * names — `indent` and `outdent` are its own words for the effect.
+ *
+ * Deliberately NOT Gutenberg's `mod+shift+alt+T`/`Y`. A four-key chord for the
+ * commonest structural edit in the editor is undiscoverable and awkward on a
+ * laptop, and the two letters carry no relationship to the direction they move.
+ */
+const MOVE_KEYS: ReadonlyArray<{
+  keys: string;
+  direction: MoveDirection;
+  description: string;
+}> = [
+  {
+    keys: "alt+ArrowUp",
+    direction: "up",
+    description: "Move the selected block up",
+  },
+  {
+    keys: "alt+ArrowDown",
+    direction: "down",
+    description: "Move the selected block down",
+  },
+  {
+    keys: "alt+ArrowRight",
+    direction: "indent",
+    description: "Move the selected block into the container above it",
+  },
+  {
+    keys: "alt+ArrowLeft",
+    direction: "outdent",
+    description: "Move the selected block out of its container",
+  },
+];
+
+export interface BlockKeyboardMovesOptions {
+  /**
+   * The editor whose document these move blocks in.
+   *
+   * The whole state rather than a document and an `apply` separately: the move
+   * is computed against a document and applied through a store, and passing
+   * them apart lets a caller hand a document from one render to an `apply`
+   * bound to another.
+   */
+  editor: EditorState;
+  /**
+   * Whether the bindings are live. Defaults to true.
+   *
+   * A host that mounts the canvas inside something modal turns them off rather
+   * than unmounting the canvas, so the selection survives whatever is over it.
+   */
+  enabled?: boolean;
+}
+
+/**
+ * Register the move bindings for as long as the caller is mounted.
+ *
+ * Returns nothing: there is no state here worth exposing, and a hook that
+ * returned handlers would invite a second caller to wire them to different keys
+ * — which is how one gesture ends up with two answers.
+ */
+export function useBlockKeyboardMoves({
+  editor,
+  enabled = true,
+}: BlockKeyboardMovesOptions): void {
+  // The newest editor, reachable from a binding registered once. The shortcut
+  // layer is deliberately not rebuilt when its bindings change — rebuilding
+  // moves the layer to the top of its depth and silently changes precedence —
+  // so a closure captured at registration would go on applying moves against
+  // the document from that render.
+  const latest = React.useRef(editor);
+  latest.current = editor;
+
+  const bindings = React.useMemo(
+    () =>
+      MOVE_KEYS.map(({ keys, direction, description }) => ({
+        keys,
+        description,
+        // Checked at press time rather than by toggling `enabled`: with nothing
+        // selected the keystroke has no subject, and passing it on lets the
+        // browser do whatever it would have done — which on a text field is
+        // move the caret by word.
+        when: () => latest.current.selectedId !== null,
+        // Not while typing. Alt carries a non-shift modifier, so the manager
+        // would otherwise fire these inside a field, where alt+Arrow is
+        // word-wise caret movement on every platform that has it. An author
+        // editing a heading must be able to move the caret through it.
+        whenTyping: false,
+        run: () => {
+          const editorNow = latest.current;
+          const selectedId = editorNow.selectedId;
+          if (selectedId === null) return;
+
+          const move = keyboardMovePosition(
+            editorNow.document.nodes,
+            selectedId,
+            direction
+          );
+          // `null` is an ordinary answer: the first block cannot move up, and a
+          // top-level block cannot outdent. Refusing quietly is right — a block
+          // at the end of its container has nowhere to go, and saying so would
+          // be an error message for pressing a key that did nothing.
+          if (move === null) return;
+
+          editorNow.apply({
+            kind: "move",
+            id: selectedId,
+            to: move.to,
+            dropSlotIfEmpty: move.dropSlotIfEmpty,
+          });
+          // The selection deliberately does NOT change. The block that moved is
+          // the block still selected, so a second press continues moving the
+          // same block — which is what makes a run of presses walk it across the
+          // page rather than moving a different block each time.
+        },
+      })),
+    []
+  );
+
+  useShortcuts(bindings, { name: "builder-block-moves", enabled });
+}
+
+/**
+ * The bindings as a component, for mounting inside the shell.
+ *
+ * `BuilderShell` provides the shortcut context, so the hook cannot be called by
+ * whatever RENDERS the shell — only by something inside it. A host would
+ * otherwise have to invent a null-returning wrapper of its own, and every host
+ * would invent a slightly different one.
+ *
+ * Renders nothing. It is a place to run a hook, which is the same shape the
+ * command palette already uses for its modal key hold.
+ */
+export function BlockKeyboardMoves({
+  editor,
+  enabled,
+}: BlockKeyboardMovesOptions): null {
+  useBlockKeyboardMoves({ editor, enabled });
+  return null;
+}

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -58,14 +58,6 @@ export { CANVAS_ROOT_CLASS, Canvas, nodeIdFromEvent } from "./canvas";
 export type { CanvasProps } from "./canvas";
 
 /**
- * The editor's document state, published beside the canvas because it is a hook
- * and therefore client-only for the same reason the shell is.
- *
- * It is the ONLY place a document changes: the canvas, the panels, a keyboard
- * handler and an agent all reach the same `apply`, so undo covers every one of
- * them rather than only the path that happened to implement it.
- */
-/**
  * The inserter, behind the same client banner as the shell it fills: it holds
  * search state and composes the command primitives, so it is interactive in its
  * own right.
@@ -83,5 +75,23 @@ export type { CanvasProps } from "./canvas";
 export { InsertPanel } from "./insert-panel";
 export type { InsertPanelProps } from "./insert-panel";
 
+/**
+ * Moving the selected block from the keyboard, behind the same client banner.
+ *
+ * Published as a component as well as a hook because the shell provides the
+ * shortcut context: whatever renders the shell is outside it, so only a child
+ * of the shell can register bindings.
+ */
+export { BlockKeyboardMoves, useBlockKeyboardMoves } from "./keyboard-moves";
+export type { BlockKeyboardMovesOptions } from "./keyboard-moves";
+
+/**
+ * The editor's document state, published beside the canvas because it is a hook
+ * and therefore client-only for the same reason the shell is.
+ *
+ * It is the ONLY place a document changes: the canvas, the panels, a keyboard
+ * handler and an agent all reach the same `apply`, so undo covers every one of
+ * them rather than only the path that happened to implement it.
+ */
 export { MAX_HISTORY, useEditorState } from "./editor-state";
 export type { EditorState, UseEditorStateArgs } from "./editor-state";

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -40,6 +40,7 @@ import {
 } from "@nextlyhq/blocks-engine";
 import { CORE_CATEGORIES, coreBlocks } from "@nextlyhq/blocks-react/blocks";
 import {
+  BlockKeyboardMoves,
   BuilderShell,
   Canvas,
   InsertPanel,
@@ -242,6 +243,12 @@ function BlocksEditor({
           ) : null
         }
       >
+        {/*
+          Inside the shell, which is what provides the shortcut context — a
+          caller rendering the shell is outside it and cannot register bindings.
+          Draws nothing; it exists to run the hook where the context is.
+        */}
+        <BlockKeyboardMoves editor={editor} />
         <Canvas
           document={editor.document}
           siteStyles={siteSheet()}


### PR DESCRIPTION
`keyboard-move.ts` shipped a tested rule for where a block lands and merged with **no consumer**. This connects it.

## Why this lands BEFORE the drag path, not after

**WCAG 2.2 SC 2.5.7 *Dragging Movements* (AA)** requires any function operated by a dragging movement to be achievable without one. **SC 2.1.1 *Keyboard* (A)** requires it to be operable from a keyboard at all. A canvas that can only reorder by pointer fails both.

So keyboard reordering is not a convenience layered over dragging — it is the accessible path that dragging would have needed anyway. Building it first means drag arrives as an enhancement over a working baseline rather than as the only way in.

## The keys, and why these

`alt+ArrowUp` / `alt+ArrowDown` is the line-move gesture from VS Code and the editors that copied it, so it arrives already known rather than needing to be taught. `alt+ArrowLeft` / `alt+ArrowRight` follows the indent convention every outliner shares, and matches the rule's own words for the effect — `indent`, `outdent`.

Deliberately **not** Gutenberg's `mod+shift+alt+T`/`Y`: a four-key chord for the commonest structural edit in the editor, whose two letters carry no relationship to the direction they move.

They do not fire while typing. Alt is a non-shift modifier, so the manager would otherwise run them inside a field — where alt+Arrow is word-wise caret movement on every platform that has it.

## Verified in a browser

Two blocks inserted, the second selected, `alt+ArrowUp` swaps them, `alt+ArrowDown` returns them. Stable across three runs. The round trip is asserted rather than the single move, because one direction happening to match a re-render is not the same as the move working.

## Two things the browser found that the unit tests could not

**The canvas draws no selection.** `selectedId` is declared as a prop, destructured, and then never used — so there is no visual indication of which block is current. The keyboard path reads the editor directly and works regardless, but an author cannot see what they are about to move. Not fixed here; it belongs with the canvas.

**Focus stays in the panel's search field after inserting.** So a block just inserted cannot immediately be moved — the binding correctly declines while a field has focus. Keeping focus there is right for inserting several in a row (Gutenberg does the same), but the author has to click the block first. Worth a deliberate decision rather than an accident.

## The stub-verify caught a defect in my own test

Breaking the `when` guard failed **nothing** — because `run` redundantly re-checks the selection, so the store stayed untouched either way. The guard's real effect is different: a declined keystroke is **passed on**, an accepted one is consumed. `defaultPrevented` is the separating property, and asserting it exposed a second defect — the suite's `afterEach` cleared `document.body.innerHTML` instead of calling testing-library's `cleanup()`, so every previous case's shortcut layer stayed registered against the editor it was given, and a later press fired an earlier test's binding.

Both fixed. With real cleanup, deleting the guard now fails exactly that case.

Breaks verified: dropped guard, dropped `dropSlotIfEmpty`, selecting after the move, and swapping up with down — each failing only the case that names it.

547 tests, 30/30 tasks from a clean build.
