### PR TITLE
fix(admin): follow the selected version, and read its stored shapes

### DIFF
--- a/.changeset/version-snapshot-followups.md
+++ b/.changeset/version-snapshot-followups.md
@@ -1,0 +1,40 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Two defects in how a past version renders, both found in review.
+
+Selecting a second version while the panel stayed open left the previous version's values on screen
+under the new version's heading. The form read its values once when it mounted, and the panel does
+not remount it between selections; it now follows a changed snapshot itself, so the correct
+behaviour belongs to the component rather than to every caller remembering to remount it.
+
+Structured fields could render empty for a version that plainly held something. A snapshot is
+captured from the persisted row, so a JSON-backed field arrives as text on SQLite and as an object
+on Postgres and MySQL, and a boolean arrives in any of four spellings. Those values are now read
+into runtime shapes before the editor sees them, through the same coercion the diff and the value
+kit already use.

--- a/packages/admin/src/components/features/versions/VersionSnapshotForm.tsx
+++ b/packages/admin/src/components/features/versions/VersionSnapshotForm.tsx
@@ -31,6 +31,8 @@ import { FormProvider, useForm } from "react-hook-form";
 
 import { EntryFormContent } from "@admin/components/features/entries/EntryForm/EntryFormContent";
 
+import { snapshotToFormValues } from "./snapshot-to-form-values";
+
 export interface VersionSnapshotFormProps {
   /** The document's current schema, which decides what is shown. */
   fields: FieldConfig[];
@@ -42,21 +44,21 @@ export function VersionSnapshotForm({
   fields,
   snapshot,
 }: VersionSnapshotFormProps) {
-  // A snapshot that is not an object (absent, or a stored primitive) becomes an
-  // empty document rather than throwing: every field then renders as it does
-  // when it holds nothing, which is the truthful reading of a version that
-  // carries no value for it.
+  // Read into runtime shapes before the inputs see them. A snapshot comes from
+  // the persisted row, so a JSON-backed field arrives as text on SQLite and as
+  // an object elsewhere; handing the raw value to a control renders a
+  // structured field empty instead of showing what it held.
   const values = useMemo(
-    () =>
-      typeof snapshot === "object" && snapshot !== null
-        ? (snapshot as Record<string, unknown>)
-        : {},
-    [snapshot]
+    () => snapshotToFormValues(fields, snapshot),
+    [fields, snapshot]
   );
 
-  // Keyed by the caller, so a different version mounts a fresh form rather than
-  // needing a reset — the panel already remounts this on selection.
-  const form = useForm<Record<string, unknown>>({ defaultValues: values });
+  // `values`, not `defaultValues`. `defaultValues` is read once per mounted
+  // form, so selecting a second version while this stays mounted would leave
+  // the previous version's fields under the new version's heading. `values`
+  // reapplies when it changes, which makes the correct behaviour a property of
+  // this component rather than an obligation on every caller to remount it.
+  const form = useForm<Record<string, unknown>>({ values });
 
   return (
     <FormProvider {...form}>

--- a/packages/admin/src/components/features/versions/__tests__/VersionPreview.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionPreview.test.tsx
@@ -168,3 +168,32 @@ describe("VersionPreview", () => {
     expect(screen.queryByText("Not set")).not.toBeInTheDocument();
   });
 });
+
+describe("VersionPreview — switching between versions", () => {
+  it("shows the newly selected version's values, not the previous one's", () => {
+    const { rerender } = render(
+      <VersionPreview
+        versionNo={3}
+        fields={fields}
+        snapshot={{ title: "Third", subtitle: "Older" }}
+      />
+    );
+    expect(screen.getByLabelText(/Title/)).toHaveValue("Third");
+
+    // The panel does not remount this between selections, so the form has to
+    // follow a changed snapshot itself. Left to `defaultValues`, the heading
+    // would advance while the fields stayed on the previous version — which
+    // reads as the new version having those values.
+    rerender(
+      <VersionPreview
+        versionNo={5}
+        fields={fields}
+        snapshot={{ title: "Fifth", subtitle: "Newer" }}
+      />
+    );
+
+    expect(screen.getByText(/Viewing version 5/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Title/)).toHaveValue("Fifth");
+    expect(screen.getByLabelText(/Subtitle/)).toHaveValue("Newer");
+  });
+});

--- a/packages/admin/src/components/features/versions/__tests__/snapshot-to-form-values.test.ts
+++ b/packages/admin/src/components/features/versions/__tests__/snapshot-to-form-values.test.ts
@@ -1,0 +1,76 @@
+/**
+ * A snapshot is captured from the persisted row, so it carries whatever shape
+ * the dialect stored — JSON as text on SQLite, objects elsewhere, and four
+ * spellings of a boolean. These are the readings the editor's inputs need, and
+ * the cases where handing over the raw value would render a field as empty
+ * while it plainly held something.
+ */
+import type { FieldConfig } from "nextly/config";
+import { describe, it, expect } from "vitest";
+
+import { snapshotToFormValues } from "../snapshot-to-form-values";
+
+const field = (name: string, type: string, extra = {}): FieldConfig =>
+  ({ name, type, label: name, ...extra }) as FieldConfig;
+
+describe("snapshotToFormValues", () => {
+  it("parses a JSON-backed value stored as text, as SQLite stores it", () => {
+    const values = snapshotToFormValues([field("tags", "chips")], {
+      tags: '["alpha","beta"]',
+    });
+
+    // Handed over raw, a control expecting a list receives a string and shows
+    // nothing — the field reads as empty while it held two entries.
+    expect(values.tags).toEqual(["alpha", "beta"]);
+  });
+
+  it("leaves an already-parsed value alone, as Postgres and MySQL store it", () => {
+    const values = snapshotToFormValues([field("tags", "chips")], {
+      tags: ["alpha"],
+    });
+
+    expect(values.tags).toEqual(["alpha"]);
+  });
+
+  it("reads every dialect's spelling of a boolean", () => {
+    for (const stored of [true, "true", 1, "1"]) {
+      expect(
+        snapshotToFormValues([field("live", "checkbox")], { live: stored }).live
+      ).toBe(true);
+    }
+    expect(
+      snapshotToFormValues([field("live", "checkbox")], { live: false }).live
+    ).toBe(false);
+  });
+
+  it("omits a field the snapshot has no value for", () => {
+    const values = snapshotToFormValues(
+      [field("title", "text"), field("subtitle", "text")],
+      { title: "Only this" }
+    );
+
+    // Absent rather than null: an explicit null turns a controlled input
+    // uncontrolled, and both render blank, which is the truthful reading.
+    expect(values).toEqual({ title: "Only this" });
+    expect("subtitle" in values).toBe(false);
+  });
+
+  it("reads the children of a nameless container against the same object", () => {
+    const grouped = [
+      { name: "", type: "group", fields: [field("city", "text")] },
+    ] as FieldConfig[];
+
+    // A presentational group stores its children beside it, so dropping it
+    // would hide every field inside from the historical document.
+    expect(snapshotToFormValues(grouped, { city: "Lisbon" })).toEqual({
+      city: "Lisbon",
+    });
+  });
+
+  it("treats a snapshot that is not an object as holding nothing", () => {
+    expect(snapshotToFormValues([field("title", "text")], "corrupt")).toEqual(
+      {}
+    );
+    expect(snapshotToFormValues([field("title", "text")], null)).toEqual({});
+  });
+});

--- a/packages/admin/src/components/features/versions/snapshot-to-form-values.ts
+++ b/packages/admin/src/components/features/versions/snapshot-to-form-values.ts
@@ -1,0 +1,67 @@
+/**
+ * Reads a stored version snapshot into the shape the editor's inputs expect.
+ *
+ * A snapshot is captured from the persisted row rather than from the
+ * deserialized read model, so it carries raw storage shapes: JSON-backed types
+ * arrive as text on SQLite and as objects on Postgres and MySQL, and a boolean
+ * can be `true`, `"true"`, `1` or `"1"`. Handing that straight to a control
+ * that expects a runtime value renders a structured field empty rather than
+ * showing what it held.
+ *
+ * The coercion is `normalizeStoredValue`, which already answers this question
+ * for the diff and the value kit. It is reused rather than reimplemented: its
+ * own header records that three earlier copies disagreed about the fallback,
+ * and a fourth would be the same mistake again.
+ *
+ * @module components/features/versions/snapshot-to-form-values
+ */
+
+import type { FieldConfig } from "nextly/config";
+
+import { normalizeStoredValue } from "./value-display/normalize-stored-value";
+
+/** A layout container: it has children and stores them at its OWN level. */
+function presentationalChildren(field: FieldConfig): FieldConfig[] | null {
+  const children = (field as { fields?: FieldConfig[] }).fields;
+  return !field.name && Array.isArray(children) ? children : null;
+}
+
+/**
+ * Snapshot values keyed the way the form reads them.
+ *
+ * A field the snapshot has no value for is left OUT rather than set to null:
+ * an absent key lets each input apply its own empty representation, where an
+ * explicit null makes a controlled input uncontrolled and reads to React as a
+ * mistake. Both render as blank, which is the truthful reading either way.
+ */
+export function snapshotToFormValues(
+  fields: FieldConfig[],
+  snapshot: unknown
+): Record<string, unknown> {
+  const stored =
+    typeof snapshot === "object" && snapshot !== null
+      ? (snapshot as Record<string, unknown>)
+      : {};
+
+  const values: Record<string, unknown> = {};
+
+  const visit = (list: FieldConfig[]): void => {
+    for (const field of list) {
+      // A nameless container — a tab set, a row, a presentational group —
+      // holds no value of its own and stores its children beside it, so its
+      // children are read against the same object.
+      const children = presentationalChildren(field);
+      if (children) {
+        visit(children);
+        continue;
+      }
+      if (!field.name) continue;
+
+      const normalized = normalizeStoredValue(field, stored[field.name]);
+      if (normalized !== null) values[field.name] = normalized;
+    }
+  };
+
+  visit(fields);
+  return values;
+}


### PR DESCRIPTION
## What

Both `greptile-apps` P1s on #974. **Both were real**, and one of them contradicted a claim in my own doc comment.

## 1 — Selecting a second version showed the first version's values

`useForm({ defaultValues })` reads once per mounted form, and the panel does **not** remount `VersionPreview` between selections — there is no `key` at the call site. So picking version 5 after version 3 advanced the heading while the fields stayed on version 3, which reads as version 5 having held those values. Worse than a blank: a confident wrong answer.

My doc comment asserted *"the panel already remounts this on selection."* I wrote that as a precondition and never checked it. It was false when I wrote it.

**Fix:** `useForm({ values })`, which reapplies when the values change. Chosen over adding `key={versionNo}` at the call site deliberately — a `key` makes correctness an obligation on every present and future caller, and the failure when someone forgets is silent and wrong rather than loud. `values` makes it a property of the component.

## 2 — Structured fields rendered empty for a version that held something

A snapshot is captured from the persisted row, not the deserialized read model. The normalizer's own header says so:

> *"A version snapshot makes this sharper still: it is captured from the persisted row rather than the deserialized read model, so it carries the raw storage shape."*

So a JSON-backed field (`repeater`, `group`, `json`, `chips`, `richText`, any `hasMany`) arrives as **text on SQLite** and as an object on Postgres and MySQL, and a boolean arrives as `true`, `"true"`, `1` or `"1"`. Handed straight to a control expecting a runtime value, a chips field holding two entries renders as nothing.

The old `FieldValueDisplay` path normalized. Mine dropped that when it stopped going through it — a regression I introduced and did not notice, because my fixtures were all plain text.

**Fix:** `snapshotToFormValues` reads each field through `normalizeStoredValue` before the form sees it. **Reused, not reimplemented** — that module's header records that three earlier copies already disagreed about the fallback, and a fourth would be the same mistake.

One deliberate choice inside it: a field the snapshot has no value for is **omitted** rather than set to `null`. An explicit `null` turns a controlled input uncontrolled; both render blank, so omission is the truthful reading without the React complaint.

## Verification

```
pnpm turbo run build --force                       20 successful / 20 total,  0 cached
pnpm turbo run check-types lint --continue --force 46 successful / 46 total,  0 cached

packages/admin   4 failed | 240 passed (244 files) · 15 failed | 2206 passed (2221)
                 comm -13 baseline after → empty; the 4 are the documented pre-existing set
```

Stub-verified, restores confirmed **byte-identical with `cmp`**:

| break | fails |
|---|---|
| back to `defaultValues` | `shows the newly selected version's values, not the previous one's` — nothing else |
| normalization removed | the SQLite-text case and the boolean-spellings case — nothing else |

Seven new tests. The dialect cases are the point: `'["alpha","beta"]'` as SQLite stores it, the parsed array as the other two store it, and all four boolean spellings.

## Note on the review

`greptile-apps` found both, and both were beyond what the existing tests could see — my fixtures were plain strings, which is exactly the shape that hides a normalization regression. Worth recording against the standing claim in several docs here that there is no working automated reviewer: it has now caught three real defects in this lane today, two of them P1.
