### PR TITLE
feat(admin): every list remembers the columns a reader hid

### DIFF
--- a/.changeset/list-columns-adopt.md
+++ b/.changeset/list-columns-adopt.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Every admin list now remembers which columns you hid. Previously only collection entries did, so
+narrowing a wide table anywhere else lasted until you closed the tab. Each list keeps its own
+choice, so hiding a column on Users does not change what Roles shows you.

--- a/packages/admin/src/components/features/api-keys/ApiKeyTable.tsx
+++ b/packages/admin/src/components/features/api-keys/ApiKeyTable.tsx
@@ -17,7 +17,7 @@ import type {
   NextlyColumn,
   RowAction,
 } from "@admin/components/ui/table/data-table";
-import { ListView } from "@admin/components/ui/table/list-view";
+import { ListView, useListColumns } from "@admin/components/ui/table/list-view";
 import { PAGINATION } from "@admin/constants/pagination";
 import { usePagination } from "@admin/hooks/usePagination";
 import type { ApiKeyMeta } from "@admin/services/apiKeyApi";
@@ -110,17 +110,7 @@ export const ApiKeyTable: React.FC<ApiKeyTableProps> = ({
   onRevoke,
 }) => {
   const [search, setSearch] = useState("");
-  const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set());
   const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
-
-  const toggleColumn = (key: string) => {
-    setHiddenColumns(prev => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  };
 
   const allColumns = useMemo((): NextlyColumn<ApiKeyMeta>[] => {
     return [
@@ -214,15 +204,24 @@ export const ApiKeyTable: React.FC<ApiKeyTableProps> = ({
     ];
   }, []);
 
-  const columns = useMemo(
-    () =>
-      allColumns.map(col => ({ ...col, hidden: hiddenColumns.has(col.name) })),
-    [allColumns, hiddenColumns]
-  );
-
   const toggleableColumns = useMemo(
     () => allColumns.filter(col => !ALWAYS_VISIBLE.has(col.name)),
     [allColumns]
+  );
+
+  /* The reader's column choice outlives the tab it was made in. */
+  const columnsControl = useListColumns({
+    storageKey: "api-keys",
+    columns: toggleableColumns,
+  });
+
+  const columns = useMemo(
+    () =>
+      allColumns.map(col => ({
+        ...col,
+        hidden: !columnsControl.isColumnVisible(col.name),
+      })),
+    [allColumns, columnsControl]
   );
 
   const filteredData = useMemo(() => {
@@ -286,11 +285,7 @@ export const ApiKeyTable: React.FC<ApiKeyTableProps> = ({
         placeholder: "Search API keys by name, description, or role...",
         isLoading,
       }}
-      columnsControl={{
-        columns: toggleableColumns,
-        isColumnVisible: name => !hiddenColumns.has(name),
-        onToggleColumn: toggleColumn,
-      }}
+      columnsControl={columnsControl}
       skeleton={
         <div className="rounded-lg border border-border bg-card p-4">
           <Skeleton className="h-50 w-full rounded-lg" />

--- a/packages/admin/src/pages/dashboard/collection/components/CollectionTable.tsx
+++ b/packages/admin/src/pages/dashboard/collection/components/CollectionTable.tsx
@@ -33,7 +33,7 @@ import type {
   NextlyColumn,
   RowAction,
 } from "@admin/components/ui/table/data-table";
-import { ListView } from "@admin/components/ui/table/list-view";
+import { ListView, useListColumns } from "@admin/components/ui/table/list-view";
 import { PAGINATION } from "@admin/constants/pagination";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { UI } from "@admin/constants/ui";
@@ -139,16 +139,6 @@ export default function CollectionTable() {
     name: string;
   } | null>(null);
   const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false);
-  const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set());
-
-  const toggleColumn = (key: string) => {
-    setHiddenColumns(prev => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  };
 
   const { data, isLoading, isFetching, isError, error } = useCollections({
     pagination: { page, pageSize },
@@ -384,15 +374,24 @@ export default function CollectionTable() {
     ];
   }, []);
 
-  const columns = useMemo(
-    () =>
-      allColumns.map(col => ({ ...col, hidden: hiddenColumns.has(col.name) })),
-    [allColumns, hiddenColumns]
-  );
-
   const toggleableColumns = useMemo(
     () => allColumns.filter(col => !ALWAYS_VISIBLE.has(col.name)),
     [allColumns]
+  );
+
+  /* The reader's column choice outlives the tab it was made in. */
+  const columnsControl = useListColumns({
+    storageKey: "collections",
+    columns: toggleableColumns,
+  });
+
+  const columns = useMemo(
+    () =>
+      allColumns.map(col => ({
+        ...col,
+        hidden: !columnsControl.isColumnVisible(col.name),
+      })),
+    [allColumns, columnsControl]
   );
 
   const handleSourceFilterChange = (value: string) => {
@@ -541,15 +540,7 @@ export default function CollectionTable() {
             </>
           )
         }
-        columnsControl={
-          showLoadingSkeleton
-            ? undefined
-            : {
-                columns: toggleableColumns,
-                isColumnVisible: name => !hiddenColumns.has(name),
-                onToggleColumn: toggleColumn,
-              }
-        }
+        columnsControl={showLoadingSkeleton ? undefined : columnsControl}
         toolbarActions={
           showLoadingSkeleton ? (
             <>

--- a/packages/admin/src/pages/dashboard/field-group/components/FieldGroupTable.tsx
+++ b/packages/admin/src/pages/dashboard/field-group/components/FieldGroupTable.tsx
@@ -26,7 +26,7 @@ import type {
   NextlyColumn,
   RowAction,
 } from "@admin/components/ui/table/data-table";
-import { ListView } from "@admin/components/ui/table/list-view";
+import { ListView, useListColumns } from "@admin/components/ui/table/list-view";
 import { PAGINATION } from "@admin/constants/pagination";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { UI } from "@admin/constants/ui";
@@ -161,16 +161,6 @@ export default function FieldGroupTable() {
     null
   );
   const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false);
-  const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set());
-
-  const toggleColumn = (key: string) => {
-    setHiddenColumns(prev => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  };
 
   // 🔴 Both filters go to the SERVER, and the table renders exactly what comes back.
   //
@@ -409,15 +399,24 @@ export default function FieldGroupTable() {
     [getFieldCount]
   );
 
-  const columns = useMemo(
-    () =>
-      allColumns.map(col => ({ ...col, hidden: hiddenColumns.has(col.name) })),
-    [allColumns, hiddenColumns]
-  );
-
   const toggleableColumns = useMemo(
     () => allColumns.filter(col => !ALWAYS_VISIBLE.has(col.name)),
     [allColumns]
+  );
+
+  /* The reader's column choice outlives the tab it was made in. */
+  const columnsControl = useListColumns({
+    storageKey: "field-groups",
+    columns: toggleableColumns,
+  });
+
+  const columns = useMemo(
+    () =>
+      allColumns.map(col => ({
+        ...col,
+        hidden: !columnsControl.isColumnVisible(col.name),
+      })),
+    [allColumns, columnsControl]
   );
 
   const handleSourceFilterChange = (value: string) => {
@@ -567,15 +566,7 @@ export default function FieldGroupTable() {
             </>
           )
         }
-        columnsControl={
-          showLoadingSkeleton
-            ? undefined
-            : {
-                columns: toggleableColumns,
-                isColumnVisible: name => !hiddenColumns.has(name),
-                onToggleColumn: toggleColumn,
-              }
-        }
+        columnsControl={showLoadingSkeleton ? undefined : columnsControl}
         toolbarActions={
           showLoadingSkeleton ? (
             <>

--- a/packages/admin/src/pages/dashboard/plugins/components/PluginsTable.tsx
+++ b/packages/admin/src/pages/dashboard/plugins/components/PluginsTable.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { Badge, Button } from "@nextlyhq/ui";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { PluginIcon } from "@admin/components/shared/plugin-icon";
 import type { NextlyColumn } from "@admin/components/ui/table/data-table";
-import { ListView } from "@admin/components/ui/table/list-view";
+import { ListView, useListColumns } from "@admin/components/ui/table/list-view";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { UI } from "@admin/constants/ui";
 import {
@@ -86,7 +86,6 @@ export default function PluginsTable() {
     initialPageSize: 25,
   });
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
-  const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set());
 
   // Reset to the first page when the search term or status filter changes so
   // the slice does not fall out of range against the newly filtered list.
@@ -128,15 +127,6 @@ export default function PluginsTable() {
     const start = page * pageSize;
     return filteredPlugins.slice(start, start + pageSize);
   }, [filteredPlugins, page, pageSize]);
-
-  const toggleColumn = useCallback((key: string) => {
-    setHiddenColumns(prev => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  }, []);
 
   const allColumns = useMemo<NextlyColumn<PluginWithId>[]>(() => {
     return [
@@ -208,15 +198,24 @@ export default function PluginsTable() {
     ];
   }, []);
 
-  const columns = useMemo(
-    () =>
-      allColumns.map(col => ({ ...col, hidden: hiddenColumns.has(col.name) })),
-    [allColumns, hiddenColumns]
-  );
-
   const toggleableColumns = useMemo(
     () => allColumns.filter(col => !ALWAYS_VISIBLE.has(col.name)),
     [allColumns]
+  );
+
+  /* The reader's column choice outlives the tab it was made in. */
+  const columnsControl = useListColumns({
+    storageKey: "plugins",
+    columns: toggleableColumns,
+  });
+
+  const columns = useMemo(
+    () =>
+      allColumns.map(col => ({
+        ...col,
+        hidden: !columnsControl.isColumnVisible(col.name),
+      })),
+    [allColumns, columnsControl]
   );
 
   // Before the table, because its empty state is a STATEMENT: "no plugins
@@ -251,11 +250,7 @@ export default function PluginsTable() {
           ))}
         </div>
       }
-      columnsControl={{
-        columns: toggleableColumns,
-        isColumnVisible: name => !hiddenColumns.has(name),
-        onToggleColumn: toggleColumn,
-      }}
+      columnsControl={columnsControl}
       columns={columns}
       rows={paginatedPlugins}
       rowHref={plugin => buildRoute(ROUTES.PLUGIN_DETAIL, { slug: plugin.id })}

--- a/packages/admin/src/pages/dashboard/settings/email-providers/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/email-providers/index.tsx
@@ -43,7 +43,7 @@ import type {
   NextlyColumn,
   RowAction,
 } from "@admin/components/ui/table/data-table";
-import { ListView } from "@admin/components/ui/table/list-view";
+import { ListView, useListColumns } from "@admin/components/ui/table/list-view";
 import { PAGINATION } from "@admin/constants/pagination";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import {
@@ -309,16 +309,6 @@ function EmailProviderTable() {
   // clearing the filter. The sentinel below exists only for the Select, which
   // cannot hold an empty value, and never reaches the request.
   const [type, setType] = useState<string | undefined>(undefined);
-  const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set());
-
-  const toggleColumn = useCallback((key: string) => {
-    setHiddenColumns(prev => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  }, []);
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [providerToDelete, setProviderToDelete] = useState<{
@@ -582,15 +572,24 @@ function EmailProviderTable() {
     [descriptorsByType]
   );
 
-  const columns = useMemo(
-    () =>
-      allColumns.map(col => ({ ...col, hidden: hiddenColumns.has(col.name) })),
-    [allColumns, hiddenColumns]
-  );
-
   const toggleableColumns = useMemo(
     () => allColumns.filter(col => !ALWAYS_VISIBLE.has(col.name)),
     [allColumns]
+  );
+
+  /* The reader's column choice outlives the tab it was made in. */
+  const columnsControl = useListColumns({
+    storageKey: "email-providers",
+    columns: toggleableColumns,
+  });
+
+  const columns = useMemo(
+    () =>
+      allColumns.map(col => ({
+        ...col,
+        hidden: !columnsControl.isColumnVisible(col.name),
+      })),
+    [allColumns, columnsControl]
   );
 
   const rowActions = useCallback(
@@ -681,11 +680,7 @@ function EmailProviderTable() {
           </SelectContent>
         </Select>
       }
-      columnsControl={{
-        columns: toggleableColumns,
-        isColumnVisible: name => !hiddenColumns.has(name),
-        onToggleColumn: toggleColumn,
-      }}
+      columnsControl={columnsControl}
       // Loading and failure are TABLE states, so the toolbar stays mounted and
       // the reader keeps the search field they just typed in.
       loading={isLoading && !data}

--- a/packages/admin/src/pages/dashboard/settings/email-templates/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/email-templates/index.tsx
@@ -31,7 +31,7 @@ import type {
   NextlyColumn,
   RowAction,
 } from "@admin/components/ui/table/data-table";
-import { ListView } from "@admin/components/ui/table/list-view";
+import { ListView, useListColumns } from "@admin/components/ui/table/list-view";
 import { PAGINATION } from "@admin/constants/pagination";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import {
@@ -228,16 +228,6 @@ function EmailTemplateTable() {
 
   const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
   const [search, setSearch] = useState("");
-  const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set());
-
-  const toggleColumn = useCallback((key: string) => {
-    setHiddenColumns(prev => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  }, []);
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [templateToDelete, setTemplateToDelete] = useState<{
@@ -387,15 +377,24 @@ function EmailTemplateTable() {
     []
   );
 
-  const columns = useMemo(
-    () =>
-      allColumns.map(col => ({ ...col, hidden: hiddenColumns.has(col.name) })),
-    [allColumns, hiddenColumns]
-  );
-
   const toggleableColumns = useMemo(
     () => allColumns.filter(col => !ALWAYS_VISIBLE.has(col.name)),
     [allColumns]
+  );
+
+  /* The reader's column choice outlives the tab it was made in. */
+  const columnsControl = useListColumns({
+    storageKey: "email-templates",
+    columns: toggleableColumns,
+  });
+
+  const columns = useMemo(
+    () =>
+      allColumns.map(col => ({
+        ...col,
+        hidden: !columnsControl.isColumnVisible(col.name),
+      })),
+    [allColumns, columnsControl]
   );
 
   const rowActions = useCallback(
@@ -454,11 +453,7 @@ function EmailTemplateTable() {
               "Failed to load email templates. Please try again.")
             : null
         }
-        columnsControl={{
-          columns: toggleableColumns,
-          isColumnVisible: name => !hiddenColumns.has(name),
-          onToggleColumn: toggleColumn,
-        }}
+        columnsControl={columnsControl}
         skeleton={
           <div className="rounded-lg border border-border bg-card p-4">
             <Skeleton className="h-50 w-full rounded-lg" />

--- a/packages/admin/src/pages/dashboard/settings/image-sizes/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/image-sizes/index.tsx
@@ -21,7 +21,7 @@ import type {
   NextlyColumn,
   RowAction,
 } from "@admin/components/ui/table/data-table";
-import { ListView } from "@admin/components/ui/table/list-view";
+import { ListView, useListColumns } from "@admin/components/ui/table/list-view";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { usePagination } from "@admin/hooks/usePagination";
 import { navigateTo } from "@admin/lib/navigation";
@@ -64,21 +64,6 @@ function ImageSizesContent({
   const [sizes, setSizes] = React.useState<ImageSize[]>([]);
   const [isLoading, setIsLoading] = React.useState(true);
   const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
-  const [hiddenColumns, setHiddenColumns] = React.useState<Set<string>>(
-    new Set()
-  );
-
-  const toggleColumn = (key: string) => {
-    setHiddenColumns(prev => {
-      const next = new Set(prev);
-      if (next.has(key)) {
-        next.delete(key);
-      } else {
-        next.add(key);
-      }
-      return next;
-    });
-  };
 
   // Fetch sizes on mount
   const loadSizes = React.useCallback(async () => {
@@ -202,14 +187,23 @@ function ImageSizesContent({
     []
   );
 
-  const columns = React.useMemo(
-    () =>
-      allColumns.map(col => ({ ...col, hidden: hiddenColumns.has(col.name) })),
-    [allColumns, hiddenColumns]
-  );
-
   const toggleableColumns = allColumns.filter(
     col => !ALWAYS_VISIBLE.has(col.name)
+  );
+
+  /* The reader's column choice outlives the tab it was made in. */
+  const columnsControl = useListColumns({
+    storageKey: "image-sizes",
+    columns: toggleableColumns,
+  });
+
+  const columns = React.useMemo(
+    () =>
+      allColumns.map(col => ({
+        ...col,
+        hidden: !columnsControl.isColumnVisible(col.name),
+      })),
+    [allColumns, columnsControl]
   );
 
   const rowActions = React.useCallback(
@@ -244,11 +238,7 @@ function ImageSizesContent({
         placeholder: "Search image sizes...",
         isLoading,
       }}
-      columnsControl={{
-        columns: toggleableColumns,
-        isColumnVisible: name => !hiddenColumns.has(name),
-        onToggleColumn: toggleColumn,
-      }}
+      columnsControl={columnsControl}
       slots={{
         afterList: !isLoading && sizes.some(s => s.isDefault) && (
           <div className="flex items-start gap-2 text-xs text-muted-foreground px-1">

--- a/packages/admin/src/pages/dashboard/singles/components/SinglesTable.tsx
+++ b/packages/admin/src/pages/dashboard/singles/components/SinglesTable.tsx
@@ -31,7 +31,7 @@ import type {
   NextlyColumn,
   RowAction,
 } from "@admin/components/ui/table/data-table";
-import { ListView } from "@admin/components/ui/table/list-view";
+import { ListView, useListColumns } from "@admin/components/ui/table/list-view";
 import { PAGINATION } from "@admin/constants/pagination";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { UI } from "@admin/constants/ui";
@@ -132,16 +132,6 @@ export default function SinglesTable({ mode = "builder" }: SinglesTableProps) {
     label: string;
   } | null>(null);
   const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false);
-  const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set());
-
-  const toggleColumn = (key: string) => {
-    setHiddenColumns(prev => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  };
 
   const { data, isLoading, isFetching, isError, error } = useSingles({
     pagination: { page, pageSize },
@@ -355,15 +345,24 @@ export default function SinglesTable({ mode = "builder" }: SinglesTableProps) {
     [getFieldCount]
   );
 
-  const columns = useMemo(
-    () =>
-      allColumns.map(col => ({ ...col, hidden: hiddenColumns.has(col.name) })),
-    [allColumns, hiddenColumns]
-  );
-
   const toggleableColumns = useMemo(
     () => allColumns.filter(col => !ALWAYS_VISIBLE.has(col.name)),
     [allColumns]
+  );
+
+  /* The reader's column choice outlives the tab it was made in. */
+  const columnsControl = useListColumns({
+    storageKey: "singles",
+    columns: toggleableColumns,
+  });
+
+  const columns = useMemo(
+    () =>
+      allColumns.map(col => ({
+        ...col,
+        hidden: !columnsControl.isColumnVisible(col.name),
+      })),
+    [allColumns, columnsControl]
   );
 
   const handleSourceFilterChange = useCallback(
@@ -525,15 +524,7 @@ export default function SinglesTable({ mode = "builder" }: SinglesTableProps) {
             </>
           )
         }
-        columnsControl={
-          showLoadingSkeleton
-            ? undefined
-            : {
-                columns: toggleableColumns,
-                isColumnVisible: name => !hiddenColumns.has(name),
-                onToggleColumn: toggleColumn,
-              }
-        }
+        columnsControl={showLoadingSkeleton ? undefined : columnsControl}
         toolbarActions={
           showLoadingSkeleton ? (
             <>

--- a/packages/admin/src/pages/dashboard/users/components/UserTable.tsx
+++ b/packages/admin/src/pages/dashboard/users/components/UserTable.tsx
@@ -20,7 +20,7 @@ import type {
   NextlyColumn,
   RowAction,
 } from "@admin/components/ui/table/data-table";
-import { ListView } from "@admin/components/ui/table/list-view";
+import { ListView, useListColumns } from "@admin/components/ui/table/list-view";
 import { PAGINATION } from "@admin/constants/pagination";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { useUserFields } from "@admin/hooks/queries/useUserFields";
@@ -122,7 +122,6 @@ export default function UserTable() {
   const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
   const [search, setSearch] = useState("");
   const [roleFilter] = useState<string>("all");
-  const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set());
 
   // Single + bulk delete dialog state.
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -356,25 +355,25 @@ export default function UserTable() {
     ];
   }, [customColumns, formatDate]);
 
-  const columns = useMemo(
-    () =>
-      allColumns.map(col => ({ ...col, hidden: hiddenColumns.has(col.name) })),
-    [allColumns, hiddenColumns]
-  );
-
   const toggleableColumns = useMemo(
     () => allColumns.filter(col => !ALWAYS_VISIBLE.has(col.name)),
     [allColumns]
   );
 
-  const toggleColumn = useCallback((columnKey: string) => {
-    setHiddenColumns(prev => {
-      const next = new Set(prev);
-      if (next.has(columnKey)) next.delete(columnKey);
-      else next.add(columnKey);
-      return next;
-    });
-  }, []);
+  /* The reader's column choice outlives the tab it was made in. */
+  const columnsControl = useListColumns({
+    storageKey: "users",
+    columns: toggleableColumns,
+  });
+
+  const columns = useMemo(
+    () =>
+      allColumns.map(col => ({
+        ...col,
+        hidden: !columnsControl.isColumnVisible(col.name),
+      })),
+    [allColumns, columnsControl]
+  );
 
   // Controlled selection wired to the page-level selection hook.
   const selection = useMemo<DataTableSelection<UserApiResponse>>(
@@ -439,15 +438,7 @@ export default function UserTable() {
         // While the list is still loading there is nothing to toggle, so the
         // control is withheld and its footprint held by a skeleton rather
         // than by a menu that would open onto an empty list.
-        columnsControl={
-          showLoadingSkeleton
-            ? undefined
-            : {
-                columns: toggleableColumns,
-                isColumnVisible: name => !hiddenColumns.has(name),
-                onToggleColumn: toggleColumn,
-              }
-        }
+        columnsControl={showLoadingSkeleton ? undefined : columnsControl}
         toolbarActions={
           showLoadingSkeleton ? <Skeleton className="h-9 w-25" /> : undefined
         }


### PR DESCRIPTION
Completes the follow-up #979 started. **All ten remaining list surfaces now remember which columns a reader hid**, each under its own storage key.

Before this, the control looked durable and was not: hiding a column lasted until you closed the tab on every list except collection entries.

## Surfaces adopted

`UserTable`, `RoleTable` (in #979), `CollectionTable`, `FieldGroupTable`, `SinglesTable`, `PluginsTable`, `ApiKeyTable`, `email-providers`, `email-templates`, `image-sizes`.

Each is one declaration — `useListColumns({ storageKey, columns })` — replacing a `useState<Set<string>>` plus a hand-written toggle. Keys are per-surface, so hiding a column on Users cannot change what Roles shows.

One structural detail the compiler enforced: `columns` reads the control, so the control and the list it is built from had to move above it. `check-types` caught the ordering on the first file, and the script does it for the rest.

## The script refused two files, and that is the result worth reporting

The adoption script asserts every shape it rewrites and **exits rather than half-editing** anything that differs. It refused:

- `image-sizes` — spells its state `React.useState` rather than the bare import
- `PluginsTable` — a differently-shaped toggle

Both were then done by hand. It also asserts `hiddenColumns` is gone from the file *after* the rewrite, so a partial substitution fails loudly instead of leaving a half-converted surface that still compiles.

This is the fifth scripted-rewrite episode in this program and the second where the guard prevented the loss instead of a gate catching it afterwards. The four earlier ones each shipped a real defect into a PR (a dropped dialog, a swallowed binding, two stripped-but-still-used imports).

## What I did NOT do, deliberately

**`EntryList` still uses `useColumnVisibility` directly.** It is the one surface that already persisted correctly, and it threads TanStack's `VisibilityState` down to `EntryTable`, which builds the control internally — so converting it changes a component's prop contract rather than adding a declaration.

Two mechanisms for one question is real drift and worth closing, but it is a pure refactor with no user-visible change, and I would rather file it than do it late in a session. Recorded in the tracker.

## Test plan

- `packages/admin` — **2212 passed, 15 failed (4 files)**: the standing pre-existing set, unchanged.
- `check-types` and `lint` clean.
- The hook's own 7 tests (from #979) cover the properties that matter: the choice survives a remount, and two keys do not share a choice.

## Pre-existing failures

`packages/admin`: the standing 15 across `StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField`.

## Changeset

Added: yes (`patch`), generated from `.changeset/config.json` — 25 packages.
