### PR TITLE
fix(admin): make a plugin's declared section reach the sidebar

### DIFF
--- a/.changeset/plugin-nav-section-reaches-consumers.md
+++ b/.changeset/plugin-nav-section-reaches-consumers.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Plugins can now actually place their sidebar menu items, and the type describing where they go is importable.
+
+The previous release accepted a `section` declaration on menu items and then ignored it: every item was flattened into one list rendered under Plugins, so a plugin placed under Settings had its pages in one panel and its menu items in another. Items are now attributed through the same chain a plugin's pages use — the item's own declaration, then the plugin's placement, then Plugins.
+
+`PluginNavSection`, the type the field is declared with, was also missing from both the `nextly` root and `@nextlyhq/plugin-sdk`, so a plugin author could not import it.

--- a/packages/admin/src/__tests__/plugin-admin-contributions.integration.test.tsx
+++ b/packages/admin/src/__tests__/plugin-admin-contributions.integration.test.tsx
@@ -68,7 +68,7 @@ describe("plugin admin contributions (live render, B4)", () => {
 
     renderWithProviders(
       <SidebarProvider>
-        <PluginMenuItems isActive={() => false} />
+        <PluginMenuItems isActive={() => false} section="plugins" />
       </SidebarProvider>
     );
 

--- a/packages/admin/src/components/features/dashboard/PluginMenuItems.tsx
+++ b/packages/admin/src/components/features/dashboard/PluginMenuItems.tsx
@@ -17,6 +17,7 @@ import {
   SidebarMenuSubItem,
 } from "@admin/components/layout/sidebar";
 import { Link } from "@admin/components/ui/link";
+import type { ActiveNavSection } from "@admin/constants/nav-sections";
 import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { useCurrentUserPermissions } from "@admin/hooks/useCurrentUserPermissions";
 import { resolveVisibleMenuItems } from "@admin/lib/plugins/menu";
@@ -34,6 +35,12 @@ function iconFor(name?: string): React.ElementType {
 
 interface PluginMenuItemsProps {
   isActive: (href?: string) => boolean;
+  /**
+   * Which sidebar group is rendering. Items are attributed to a group through
+   * the plugin deferral chain, so a plugin that placed itself elsewhere has
+   * its items listed there rather than under Plugins.
+   */
+  section: ActiveNavSection;
 }
 
 /**
@@ -42,10 +49,14 @@ interface PluginMenuItemsProps {
  * (super-admin-aware, closed-until-loaded — the `useCan` semantics, D36) and
  * ordered/nested by `resolveVisibleMenuItems`.
  */
-export function PluginMenuItems({ isActive }: PluginMenuItemsProps) {
+export function PluginMenuItems({ isActive, section }: PluginMenuItemsProps) {
   const branding = useBranding();
   const { hasPermission } = useCurrentUserPermissions();
-  const items = resolveVisibleMenuItems(branding?.plugins, hasPermission);
+  const items = resolveVisibleMenuItems(
+    branding?.plugins,
+    hasPermission,
+    section
+  );
 
   if (items.length === 0) return null;
 

--- a/packages/admin/src/components/features/dashboard/SidebarNavigation.tsx
+++ b/packages/admin/src/components/features/dashboard/SidebarNavigation.tsx
@@ -361,6 +361,7 @@ export function SidebarNavigation({
           <SidebarGroupContent>
             <SidebarMenu>
               <DynamicCollectionNav isActive={isActive} search={search} />
+              <PluginMenuItems isActive={isActive} section="collections" />
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
@@ -377,6 +378,7 @@ export function SidebarNavigation({
           <SidebarGroupContent>
             <SidebarMenu>
               <DynamicSingleNav isActive={isActive} search={search} />
+              <PluginMenuItems isActive={isActive} section="singles" />
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
@@ -432,7 +434,7 @@ export function SidebarNavigation({
           <SidebarGroupContent>
             <SidebarMenu>
               <DynamicPluginNav isActive={isActive} search={search} />
-              <PluginMenuItems isActive={isActive} />
+              <PluginMenuItems isActive={isActive} section="plugins" />
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>

--- a/packages/admin/src/lib/plugins/menu.test.ts
+++ b/packages/admin/src/lib/plugins/menu.test.ts
@@ -102,3 +102,57 @@ describe("resolveVisibleMenuItems", () => {
     ).toEqual([]);
   });
 });
+
+describe("resolveVisibleMenuItems — section attribution", () => {
+  const always = () => true;
+
+  const plugins = [
+    {
+      name: "@acme/reports",
+      collections: [],
+      placement: "settings",
+      menu: [
+        { label: "Reports", to: "/r" },
+        { label: "Elsewhere", to: "/e", section: "media" as const },
+      ],
+    },
+    {
+      name: "@acme/plain",
+      collections: [],
+      menu: [{ label: "Plain", to: "/p" }],
+    },
+  ] as unknown as PluginMetadata[];
+
+  it("lists an item under the section its plugin was placed in", () => {
+    // The defect this covers: the field was declarable and nothing read it,
+    // so every item appeared under Plugins whatever it said.
+    expect(
+      resolveVisibleMenuItems(plugins, always, "settings").map(i => i.label)
+    ).toEqual(["Reports"]);
+  });
+
+  it("lets an item OVERRIDE its plugin's placement", () => {
+    expect(
+      resolveVisibleMenuItems(plugins, always, "media").map(i => i.label)
+    ).toEqual(["Elsewhere"]);
+  });
+
+  it("keeps an item whose plugin declared nothing under Plugins", () => {
+    expect(
+      resolveVisibleMenuItems(plugins, always, "plugins").map(i => i.label)
+    ).toEqual(["Plain"]);
+  });
+
+  it("does not list a placed item under Plugins as well", () => {
+    // Appearing in both places is the failure a partition must not have.
+    const underPlugins = resolveVisibleMenuItems(plugins, always, "plugins");
+    expect(underPlugins.map(i => i.label)).not.toContain("Reports");
+    expect(underPlugins.map(i => i.label)).not.toContain("Elsewhere");
+  });
+
+  it("returns every item when no section is named", () => {
+    // Asserts the population the partition is drawn from, so a filter that
+    // dropped everything could not pass the per-section cases vacuously.
+    expect(resolveVisibleMenuItems(plugins, always)).toHaveLength(3);
+  });
+});

--- a/packages/admin/src/lib/plugins/menu.ts
+++ b/packages/admin/src/lib/plugins/menu.ts
@@ -1,3 +1,6 @@
+import type { ActiveNavSection } from "@admin/constants/nav-sections";
+import { pluginSurfaceSection } from "@admin/lib/navigation/section-resolvers";
+import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
 import type { PluginMenuItemMeta, PluginMetadata } from "@admin/types/branding";
 
 const DEFAULT_ORDER = 100;
@@ -27,12 +30,27 @@ function filterAndSort(
  * admin-meta plugin list, RBAC-gated by `can` (typically
  * `useCurrentUserPermissions().hasPermission`, which is super-admin-aware and
  * stays closed until permissions load) and ordered by `order`.
+ *
+ * `section` selects which sidebar group is asking. Each item is attributed
+ * through the same deferral chain a plugin's pages use — the item's own
+ * declaration, then its plugin's placement, then Plugins — so an item and a
+ * page contributed by one plugin cannot disagree about where that plugin
+ * lives. Callers that pass nothing get every item regardless of section.
  */
 export function resolveVisibleMenuItems(
   plugins: PluginMetadata[] | undefined,
-  can: (permission: string) => boolean
+  can: (permission: string) => boolean,
+  section?: ActiveNavSection
 ): PluginMenuItemMeta[] {
   if (!plugins || plugins.length === 0) return [];
-  const all = plugins.flatMap(plugin => plugin.menu ?? []);
+  const all = plugins.flatMap(plugin => {
+    const items = plugin.menu ?? [];
+    if (section === undefined) return items;
+    const slug = pluginSlug(plugin.name);
+    return items.filter(
+      item =>
+        pluginSurfaceSection(item.section, plugin.placement, slug) === section
+    );
+  });
   return filterAndSort(all, can);
 }

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -448,6 +448,7 @@ export {
   type PluginAdminWidget,
   type PluginCollectionView,
   type PluginMenuItem,
+  type PluginNavSection,
 } from "./plugins";
 
 // Value exports for the email provider contract. A plugin calls

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -171,6 +171,7 @@ export type {
   JsonValue,
   PluginAdminContributions,
   PluginAdminPage,
+  PluginNavSection,
   PluginAdminWidget,
   PluginCollectionView,
   PluginMenuItem,


### PR DESCRIPTION
Follow-up to #976, closing both P1 findings Greptile raised there. **Both were real**, and both are the same shape as the defect #976 existed to remove: a declaration that is accepted and then silently does nothing.

## 1. A menu item's `section` was read by nothing

`resolveVisibleMenuItems` flattened every plugin's items into one list, and `SidebarNavigation` rendered that list inside the **Plugins** group only. So a menu item declaring `section: "settings"` was accepted by the type, serialized by the server, and then listed under Plugins anyway.

The visible consequence: a plugin placed under Settings had its **collections** in Settings and its **menu items** in Plugins — the sidebar contradicting itself about where one plugin lives.

Items are now attributed through **the same deferral chain a plugin's pages use** (`pluginSurfaceSection`): the item's own declaration, then its plugin's `placement`, then Plugins. One implementation, so a page and a menu item from one plugin cannot disagree.

`PluginMenuItems` now takes a required `section` prop and is rendered inside the Collections, Singles and Plugins groups. Making it **required** rather than defaulted is deliberate — the compiler found the one existing caller immediately, which a default would have silently left pointing at the wrong group.

## 2. `PluginNavSection` was unreachable from the SDK

It was exported from `packages/nextly/src/plugins/index.ts` and from **neither** the `nextly` root nor `@nextlyhq/plugin-sdk`, so a plugin author could not import the type the field is declared with.

**#976's description claimed plugin-sdk re-exported it. That claim was wrong** — I asserted it without checking, and Greptile caught it. Now exported from both.

## Test plan

- 5 new tests over section attribution, including that a placed item does **not** also appear under Plugins, and one asserting the **unpartitioned population** (3 items) so a filter that dropped everything could not pass the per-section cases vacuously.
- **Stub-verified:** removing the partition fails 4 of 10.
- `check-types` 0, `lint` 0.
- `packages/admin`: **no new failures vs baseline** (4 files / 15 tests, same set).

## Changeset

**patch, 25 packages** — generated from `.changeset/config.json` `fixed[0]`, not copied. Worth noting it is 25 and not 24: `main` added `@nextlyhq/eslint-plugin` to the lockstep group since #976, and generating from config picked that up automatically where copying a neighbour would not have.

## Pre-existing, not introduced

`packages/admin`: 4 files / 15 tests — `StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin menu items are now displayed in the appropriate sidebar section, including Collections, Singles, and Plugins.
  * Added public navigation section types for plugin integrations.

* **Bug Fixes**
  * Corrected plugin menu filtering so items appear only in their assigned section while preserving permission-based visibility.

* **Tests**
  * Added coverage for plugin placement, section overrides, defaults, exclusions, and unrestricted menu resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->