### PR TITLE
feat(builder): show the selected block, and announce a keyboard move

### DIFF
--- a/.changeset/canvas-selection-and-move-announcements.md
+++ b/.changeset/canvas-selection-and-move-announcements.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+The selected block is now outlined on the canvas, and a keyboard move is announced to assistive technology — naming whether the block was reordered or moved into or out of a container, which a keyboard author cannot see.

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -17,11 +17,27 @@
  * @module canvas.test
  */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createElement } from "react";
+
+import { clearBlocks, registerBlocks } from "@nextlyhq/blocks-engine";
 
 import { NODE_ID_ATTRIBUTE } from "@nextlyhq/blocks-react";
 
-import { CANVAS_ROOT_CLASS, nodeIdFromEvent } from "./canvas";
+import {
+  CANVAS_ROOT_CLASS,
+  Canvas,
+  SELECTED_ATTRIBUTE,
+  nodeIdFromEvent,
+} from "./canvas";
 
 // Explicit because this package does not enable vitest globals, and without
 // them testing-library never registers its own cleanup: every render stays
@@ -130,5 +146,114 @@ describe("selection", () => {
 
     fireEvent.click(screen.getByTestId("background"));
     expect(onSelect).toHaveBeenLastCalledWith(null);
+  });
+});
+
+describe("the selected block is marked on its own element", () => {
+  // A minimal registered block rather than the core library: the marking is
+  // about the node attribute the renderer emits, not about what any particular
+  // block draws, and importing `coreBlocks` here would couple a canvas test to
+  // whatever that library ships next.
+  beforeAll(() => {
+    clearBlocks();
+    registerBlocks(
+      [
+        {
+          name: "acme/leaf",
+          version: 1,
+          description: "A block.",
+          example: { props: {} },
+          render: ({ className }: { className: string }) =>
+            createElement("div", { className }),
+        },
+      ] as never,
+      { source: "canvas-test" }
+    );
+  });
+
+  afterAll(clearBlocks);
+
+  /** A canvas over two blocks, with one of them selected. */
+  function renderCanvas(selectedId: string | null) {
+    return render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [
+              { id: "a", type: "acme/leaf", version: 1, props: {} },
+              { id: "b", type: "acme/leaf", version: 1, props: {} },
+            ],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {} } as never}
+        selectedId={selectedId}
+      />
+    );
+  }
+
+  it("marks the selected element and no other", () => {
+    // Both halves. Asserting only that the selected one is marked passes on an
+    // implementation that marks every block, which draws an outline round the
+    // whole page.
+    const { container } = renderCanvas("b");
+
+    const marked = container.querySelectorAll(`[${SELECTED_ATTRIBUTE}]`);
+    expect(marked.length).toBe(1);
+    expect(marked[0]?.getAttribute(NODE_ID_ATTRIBUTE)).toBe("b");
+  });
+
+  it("marks nothing when the selection is empty", () => {
+    const { container } = renderCanvas(null);
+
+    expect(container.querySelectorAll(`[${SELECTED_ATTRIBUTE}]`).length).toBe(
+      0
+    );
+  });
+
+  it("moves the mark when the selection changes", () => {
+    // The stale-mark case: a re-render must CLEAR the previous element as well
+    // as mark the new one, or two blocks read as selected at once.
+    const { container, rerender } = renderCanvas("a");
+    expect(
+      container
+        .querySelector(`[${SELECTED_ATTRIBUTE}]`)
+        ?.getAttribute(NODE_ID_ATTRIBUTE)
+    ).toBe("a");
+
+    rerender(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [
+              { id: "a", type: "acme/leaf", version: 1, props: {} },
+              { id: "b", type: "acme/leaf", version: 1, props: {} },
+            ],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {} } as never}
+        selectedId="b"
+      />
+    );
+
+    const marked = container.querySelectorAll(`[${SELECTED_ATTRIBUTE}]`);
+    expect(marked.length).toBe(1);
+    expect(marked[0]?.getAttribute(NODE_ID_ATTRIBUTE)).toBe("b");
+  });
+
+  it("reports the selected id on the canvas root", () => {
+    // Named apart from the per-element marker on purpose: this carries an id
+    // and that one is a boolean. A caller wanting the answer without walking
+    // the tree reads this.
+    const { container } = renderCanvas("a");
+
+    expect(
+      container
+        .querySelector(`.${CANVAS_ROOT_CLASS}`)
+        ?.getAttribute("data-nx-selected-id")
+    ).toBe("a");
   });
 });

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -33,7 +33,7 @@ import type { BlockDocument } from "@nextlyhq/blocks-engine";
 import { NODE_ID_ATTRIBUTE, PageRenderer } from "@nextlyhq/blocks-react";
 import type { PageRendererProps } from "@nextlyhq/blocks-react";
 import { cn } from "@nextlyhq/ui/utils";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 /**
  * The class marking the canvas root, and the boundary the hit-test stops at.
@@ -44,6 +44,19 @@ import { useCallback, useMemo } from "react";
  * target and climbs.
  */
 export const CANVAS_ROOT_CLASS = "nx-canvas";
+
+/**
+ * Marks the selected block's own element.
+ *
+ * Boolean by presence rather than carrying the id: the element already states
+ * its id through `NODE_ID_ATTRIBUTE`, and repeating it here would be a second
+ * copy that a partial re-mark could leave disagreeing with the first.
+ *
+ * Exported because a host styling the canvas, and a test asserting what is
+ * selected, both need to name it — and a string typed twice is a contract with
+ * no compiler behind it.
+ */
+export const SELECTED_ATTRIBUTE = "data-nx-selected";
 
 /**
  * How a pointer event on the canvas resolves to a node id, or to nothing.
@@ -121,6 +134,7 @@ export function Canvas({
   render,
   className,
 }: CanvasProps) {
+  const root = useRef<HTMLDivElement | null>(null);
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       if (!onSelect) return;
@@ -152,10 +166,43 @@ export function Canvas({
     [render, document, siteStyles]
   );
 
+  // Marked on the rendered element AFTER the renderer has produced it, rather
+  // than asked of `PageRenderer`. Which node an editor considers current is an
+  // editor's concern, and a published route renders the same document without
+  // one — pushing it into the renderer's contract would put editor state in the
+  // component that serves live pages.
+  //
+  // Compared in JavaScript rather than matched with a selector built from the
+  // id. A node id reaches this from stored data, and interpolating it into
+  // `querySelector` makes any character CSS treats specially either throw or,
+  // worse, match something else.
+  useEffect(() => {
+    const container = root.current;
+    if (container === null) return;
+    // `forEach` rather than `for…of`: a `NodeList` is only iterable under a lib
+    // that declares its iterator, and this package compiles without one — so the
+    // loop that reads more naturally does not type-check here.
+    container.querySelectorAll(`[${NODE_ID_ATTRIBUTE}]`).forEach(element => {
+      element.toggleAttribute(
+        SELECTED_ATTRIBUTE,
+        element.getAttribute(NODE_ID_ATTRIBUTE) === selectedId
+      );
+    });
+    // Re-marked whenever the rendered tree changes as well as when the
+    // selection does: a re-render replaces the elements, and an effect keyed on
+    // the selection alone would leave the new tree carrying no marker at all.
+  }, [selectedId, page]);
+
   return (
     <div
+      ref={root}
       className={cn(CANVAS_ROOT_CLASS, className)}
-      data-nx-selected={selectedId ?? undefined}
+      // The id the canvas believes is current, for a caller that wants the
+      // answer without walking the tree. Named apart from the per-element
+      // marker deliberately: one carries an id and the other is a boolean, and
+      // a single name meaning both is the kind of thing that reads correctly
+      // right up until someone writes a selector against the wrong one.
+      data-nx-selected-id={selectedId ?? undefined}
       onClick={handleClick}
     >
       {page}

--- a/packages/builder/src/keyboard-moves.test.tsx
+++ b/packages/builder/src/keyboard-moves.test.tsx
@@ -11,14 +11,14 @@
  *
  * @module keyboard-moves.test
  */
-import { cleanup, render } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { ShortcutProvider } from "@nextlyhq/ui";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { BlockDocument } from "@nextlyhq/blocks-engine";
 
 import type { EditorState } from "./editor-state";
-import { useBlockKeyboardMoves } from "./keyboard-moves";
+import { BlockKeyboardMoves } from "./keyboard-moves";
 
 // `cleanup`, not an innerHTML wipe. This package does not enable vitest
 // globals, so testing-library registers no cleanup of its own — and clearing
@@ -57,15 +57,18 @@ function editorSpy(
   } as unknown as EditorState & { apply: ReturnType<typeof vi.fn> };
 }
 
-function Harness({ editor }: { editor: EditorState }) {
-  useBlockKeyboardMoves({ editor });
-  return null;
-}
-
+/**
+ * Mounts the COMPONENT rather than calling the hook.
+ *
+ * That is what a host renders, and it is the half carrying the live region: a
+ * harness that called the hook and returned null would exercise the bindings
+ * while leaving the announcement untested — which is how the effect the rule
+ * returns went unconsumed in the first place.
+ */
 function mount(editor: EditorState) {
   render(
     <ShortcutProvider>
-      <Harness editor={editor} />
+      <BlockKeyboardMoves editor={editor} />
     </ShortcutProvider>
   );
 }
@@ -84,7 +87,13 @@ function press(key: string, init: KeyboardEventInit = {}): KeyboardEvent {
     cancelable: true,
     ...init,
   });
-  document.dispatchEvent(event);
+  // Wrapped in `act` because the listener is on `document` rather than on a
+  // rendered node: testing-library wraps its own `fireEvent`, but a direct
+  // dispatch is outside that, so a state update the handler makes is not
+  // flushed before the assertion reads the DOM.
+  act(() => {
+    document.dispatchEvent(event);
+  });
   return event;
 }
 
@@ -203,5 +212,106 @@ describe("useBlockKeyboardMoves", () => {
     const op = editor.apply.mock.calls[0]?.[0];
     expect(op?.kind).toBe("move");
     expect(op?.dropSlotIfEmpty).toEqual({ parentId: "wrap", slot: "children" });
+  });
+
+  it("announces the move, naming what the effect was", () => {
+    // A keyboard author cannot see the result, and `keyboardMovePosition`
+    // returns `effect` for exactly this. Dropping it made a reorder and a
+    // change of parent identical to someone not looking at the screen.
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    press("ArrowDown", { altKey: true });
+
+    const region = screen.getByRole("status");
+    expect(region.textContent).toContain("Block moved");
+  });
+
+  it("distinguishes leaving a container from reordering", () => {
+    // The separating case. Both are "the block moved"; only one changes which
+    // block CONTAINS it, and that is the difference a screen reader must carry.
+    const editor = editorSpy(
+      documentOf([
+        {
+          id: "wrap",
+          type: "acme/columns",
+          version: 1,
+          props: {},
+          slots: {
+            children: [
+              { id: "inner", type: "acme/text", version: 1, props: {} },
+            ],
+          },
+        },
+      ]),
+      "inner"
+    );
+    mount(editor);
+
+    press("ArrowLeft", { altKey: true });
+
+    expect(screen.getByRole("status").textContent).toContain(
+      "out of its container"
+    );
+  });
+
+  it("says nothing when the move was refused", () => {
+    // The first block cannot move up. Announcing a move that did not happen is
+    // worse than silence, because it cannot be told from one that did.
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    press("ArrowUp", { altKey: true });
+
+    expect(screen.getByRole("status").textContent).toBe("");
+  });
+
+  it("says nothing when the store refuses the op", () => {
+    // `apply` answering null means the document moved underneath the press.
+    // The rule permitted it; the store did not.
+    const editor = editorSpy(pair(), "a");
+    editor.apply.mockReturnValue(null);
+    mount(editor);
+
+    press("ArrowDown", { altKey: true });
+
+    expect(screen.getByRole("status").textContent).toBe("");
+  });
+
+  it("re-announces a repeated move rather than falling silent", () => {
+    // Two presses of the same direction produce the same sentence, and a live
+    // region does not re-read text that did not change — so the second press
+    // would be silent without something making the value differ.
+    const editor = editorSpy(
+      documentOf([
+        { id: "a", type: "acme/text", version: 1, props: {} },
+        { id: "b", type: "acme/text", version: 1, props: {} },
+        { id: "c", type: "acme/text", version: 1, props: {} },
+      ]),
+      "a"
+    );
+    mount(editor);
+
+    press("ArrowDown", { altKey: true });
+    const first = screen.getByRole("status").textContent;
+    press("ArrowDown", { altKey: true });
+    const second = screen.getByRole("status").textContent;
+
+    expect(first).not.toBe(second);
+    // And both still read as the same sentence to a listener: the difference is
+    // a zero-width space, not different wording.
+    expect(second?.replace(/\u200b/g, "")).toBe(first?.replace(/\u200b/g, ""));
+  });
+
+  it("renders the live region before any move happens", () => {
+    // A region added to the page at the moment it gains text is frequently not
+    // announced at all — the assistive technology has nothing it was already
+    // watching. Present and empty from the first render.
+    mount(editorSpy(pair(), "a"));
+
+    const region = screen.getByRole("status");
+    expect(region).toBeTruthy();
+    expect(region.getAttribute("aria-live")).toBe("polite");
+    expect(region.textContent).toBe("");
   });
 });

--- a/packages/builder/src/keyboard-moves.tsx
+++ b/packages/builder/src/keyboard-moves.tsx
@@ -24,7 +24,11 @@ import { useShortcuts } from "@nextlyhq/ui";
 import * as React from "react";
 
 import type { EditorState } from "./editor-state";
-import { keyboardMovePosition, type MoveDirection } from "./keyboard-move";
+import {
+  keyboardMovePosition,
+  type MoveDirection,
+  type MoveEffect,
+} from "./keyboard-move";
 
 /**
  * The bindings, and why these keys.
@@ -66,6 +70,24 @@ const MOVE_KEYS: ReadonlyArray<{
   },
 ];
 
+/**
+ * What each effect is announced as.
+ *
+ * Derived from the effect the rule already decided rather than inferred here
+ * from the direction pressed. `alt+ArrowLeft` is `outdent` only when there is a
+ * container to leave, and re-deriving it from the keystroke would announce a
+ * move out of a group that never happened.
+ *
+ * Three sentences rather than one, because the three are not the same event to
+ * someone who cannot see the result: reordering keeps a block among its
+ * siblings, while indenting and outdenting change which block CONTAINS it.
+ */
+const EFFECT_ANNOUNCEMENT: Readonly<Record<MoveEffect, string>> = {
+  reorder: "Block moved",
+  indent: "Block moved into the container above it",
+  outdent: "Block moved out of its container",
+};
+
 export interface BlockKeyboardMovesOptions {
   /**
    * The editor whose document these move blocks in.
@@ -95,7 +117,22 @@ export interface BlockKeyboardMovesOptions {
 export function useBlockKeyboardMoves({
   editor,
   enabled = true,
-}: BlockKeyboardMovesOptions): void {
+}: BlockKeyboardMovesOptions): string {
+  // The message a live region reads out. Held as state rather than written to
+  // the DOM directly so React owns the node — a region mutated behind React's
+  // back is reverted by the next render, silently and only sometimes.
+  const [announcement, setAnnouncement] = React.useState("");
+
+  // A move can repeat the previous effect — two presses of alt+ArrowDown are
+  // both "Block moved" — and a live region does not re-announce text that did
+  // not change. The zero-width space alternates the string so each press is a
+  // new value, without changing what is read aloud.
+  const announce = React.useCallback((message: string) => {
+    setAnnouncement(previous =>
+      previous.replace(/\u200b$/, "") === message ? `${message}\u200b` : message
+    );
+  }, []);
+
   // The newest editor, reachable from a binding registered once. The shortcut
   // layer is deliberately not rebuilt when its bindings change — rebuilding
   // moves the layer to the top of its depth and silently changes precedence —
@@ -135,22 +172,33 @@ export function useBlockKeyboardMoves({
           // be an error message for pressing a key that did nothing.
           if (move === null) return;
 
-          editorNow.apply({
+          const applied = editorNow.apply({
             kind: "move",
             id: selectedId,
             to: move.to,
             dropSlotIfEmpty: move.dropSlotIfEmpty,
           });
+          // Announced only once the store has accepted it. A keyboard author
+          // cannot see the result, and the store may refuse — announcing before
+          // it answered would report a move that did not happen, which is worse
+          // than silence because it cannot be told from one that did.
+          //
+          // Refusals stay silent, deliberately. "This block is already first"
+          // on every press at the end of a list is noise an author cannot act
+          // on, and the block not moving is itself the answer.
+          if (applied !== null) announce(EFFECT_ANNOUNCEMENT[move.effect]);
           // The selection deliberately does NOT change. The block that moved is
           // the block still selected, so a second press continues moving the
           // same block — which is what makes a run of presses walk it across the
           // page rather than moving a different block each time.
         },
       })),
-    []
+    [announce]
   );
 
   useShortcuts(bindings, { name: "builder-block-moves", enabled });
+
+  return announcement;
 }
 
 /**
@@ -167,7 +215,20 @@ export function useBlockKeyboardMoves({
 export function BlockKeyboardMoves({
   editor,
   enabled,
-}: BlockKeyboardMovesOptions): null {
-  useBlockKeyboardMoves({ editor, enabled });
-  return null;
+}: BlockKeyboardMovesOptions): React.JSX.Element {
+  const announcement = useBlockKeyboardMoves({ editor, enabled });
+
+  // `polite`, not `assertive`: a move is the author's own action and its result
+  // can wait for a pause. Assertive interrupts whatever is being read, which for
+  // a run of presses means talking over itself.
+  //
+  // The region is present from the first render rather than appearing with its
+  // first message. A live region added to the page at the same moment it gains
+  // text is frequently not announced at all, because the assistive technology
+  // has nothing it was already watching.
+  return (
+    <p aria-live="polite" role="status" className="nx-sr-only">
+      {announcement}
+    </p>
+  );
 }

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -244,3 +244,54 @@
 .nx-insert-panel__label {
   overflow-wrap: break-word;
 }
+
+/*
+ * The selected block.
+ *
+ * `outline` rather than `border`, because an outline is drawn outside the box
+ * model and changes no geometry — a border would move the block by its own
+ * width the moment it was selected, so choosing a block would reflow the page
+ * around it and the author would be editing a layout the visitor never sees.
+ *
+ * A NEGATIVE offset draws the ring just inside the element's edge. Outside it,
+ * a block flush against the canvas edge has its indicator clipped, and adjacent
+ * blocks' rings overlap into what reads as one thick line between them.
+ */
+.nx-canvas [data-nx-selected] {
+  outline: 2px solid var(--nx-primary);
+  outline-offset: -2px;
+}
+
+/*
+ * A block that draws nothing still has to be selectable and visible when it is.
+ * `core/spacer` is deliberate empty space and `core/divider` is a single rule,
+ * so an outline is the only thing distinguishing "selected" from "not there" —
+ * which is why the ring is drawn inside rather than around, and why nothing
+ * here depends on the block having any content of its own.
+ */
+.nx-canvas [data-nx-selected]:empty {
+  min-height: 2px;
+}
+
+/*
+ * Available to assistive technology, absent from the page.
+ *
+ * `display: none` and `visibility: hidden` both remove an element from the
+ * accessibility tree as well as from view, so neither can carry an
+ * announcement. This clips the element to nothing instead, which leaves it
+ * rendered — and a live region has to be rendered to be watched.
+ *
+ * `white-space: nowrap` because a 1px-wide box wraps its text to one character
+ * per line, and some screen readers read the result letter by letter.
+ */
+.nx-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border-width: 0;
+}


### PR DESCRIPTION
Two halves of one gap: **the editor knew what was selected and told nobody.**

## 1. The canvas draws the selection

`canvas.tsx` wrote `data-nx-selected={selectedId}` to the canvas ROOT — where it addresses the selection but cannot style it, since the outline belongs on the block's own element. And nothing read it: `nx-selected` occurred in exactly one place across `packages/builder/src`, `packages/admin/src` and `packages/ui/src` — the line that wrote it.

The mark now lands on the selected element. Two decisions worth the review:

**Compared in JavaScript, not matched with a built selector.** A node id reaches this from stored data, and interpolating it into `querySelector` makes any character CSS treats specially either throw or match something else. The effect iterates and compares.

**`outline` with a negative offset, never `border`.** An outline is drawn outside the box model and changes no geometry; a border would move the block by its own width the moment it was selected, so choosing a block would reflow the page around it and the author would be editing a layout the visitor never sees. The offset draws the ring just inside the edge, so a block flush against the canvas edge is not clipped and adjacent rings do not merge into one thick line.

The root attribute is renamed `data-nx-selected-id`, since one name meaning "an id" on the container and "a boolean" on a child reads correctly right up until someone writes a selector against the wrong one. Nothing consumed it.

## 2. A keyboard move is announced

**Found by @nextly-integrations-38 reviewing #977, and it is the accessibility half of a feature built for accessibility.**

`keyboardMovePosition` returns `effect: "reorder" | "indent" | "outdent"` for exactly one purpose — its own docblock says a keyboard author cannot see the result — and the handler destructured `to` and `dropSlotIfEmpty` and dropped `effect`. There was no live region for moves anywhere in the builder.

The consequence lands on the people the feature exists for: press `alt+ArrowRight`, the block changes PARENT, and a screen-reader user gets **silence** — which is exactly what a refused move already produces, since the handler correctly returns quietly when a move is unavailable. Two opposite outcomes, byte-identical to someone not looking at the screen.

Announced on **success only**, after the store has accepted it: announcing before it answered would report a move that did not happen, which is worse than silence because it cannot be told from one that did. Refusals stay quiet — "this block is already first" on every press at the end of a list is noise an author cannot act on, and the block not moving is itself the answer.

`polite`, not `assertive`: a run of presses would otherwise talk over itself. The region renders empty from the first mount, because a live region added at the same moment it gains text is frequently not announced at all.

**The repeated-move case is the subtle one.** Two presses of `alt+ArrowDown` produce the same sentence, and a live region does not re-read text that did not change — so the second press would be silent. A zero-width space alternates the value without changing what is read aloud.

## Evidence

496 tests in `builder`, 30/30 tasks from a clean build.

Stub-verified, each break failing only the case that names it:

| break | test that fired |
| --- | --- |
| mark every node | marks the selected element and no other (+2) |
| add the mark, never clear it | moves the mark when the selection changes |
| announce before the store answers | says nothing when the store refuses the op |
| one sentence for every effect | distinguishes leaving a container from reordering |
| drop the repeat-distinguishing suffix | re-announces a repeated move rather than falling silent |

Verified in a browser across three settled runs: exactly **one** marked element, the live region present, the outline visible, and the inserter's placement line switching to "Adds after the selected block" — which is the selection reaching a second consumer.

**One defect this found in my own test harness:** it mounted the HOOK and returned null, so the bindings were exercised while the announcement was not. That is how the unconsumed `effect` survived #977's review in the first place. It now mounts the component a host actually renders.
