### PR TITLE
fix(admin): scope a field's DOM id to the rendering it belongs to

### DIFF
--- a/.changeset/field-ids-are-scoped-per-rendering.md
+++ b/.changeset/field-ids-are-scoped-per-rendering.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A field rendered twice on one page no longer collides with itself. A field's DOM id was its path,
+which is unique within a form and not within a page — so showing a past version beside the live
+editor gave both copies the same ids, and every label in the version panel pointed at the live
+editor's control instead. Those fields lost their accessible name, and clicking one of their labels
+moved focus into the editable document. Ids are now scoped per rendering; the live editor's ids are
+unchanged.

--- a/e2e/tests/version-history-isolation.spec.ts
+++ b/e2e/tests/version-history-isolation.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * Reading a document's history must not write to the document.
+ *
+ * A past version is rendered by the editor's own field components, against a
+ * form of its own. That separation is the whole safety property, and it is
+ * invisible to every unit test covering it: those mock the transport, so a
+ * historical value reaching a real save or a real autosave produces no failure
+ * they can observe. The retarget that would cause it is quiet too — React form
+ * context binds to the nearest provider, so a component that resolved to the
+ * wrong form is still perfectly valid code doing the wrong thing.
+ *
+ * So the properties below are the ones only a real browser and a real database
+ * can answer: that no write is issued while reading, and that the live document
+ * is still the thing that gets saved afterwards.
+ *
+ * Requires `versions: { drafts: true }` on the collection. `status: true` alone
+ * resolves to `{ drafts: false }`, the policy gate then refuses every write,
+ * and a spec pointed at a collection without it fails for a configuration
+ * reason that looks like a broken feature.
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+import { gotoAdmin } from "./support/admin";
+
+/**
+ * The two Excerpt fields are told apart by WHERE they are, not by their order
+ * in the document. The history panel is portalled, so its position in the DOM
+ * is an implementation detail of the portal rather than anything this spec
+ * should depend on — and `.first()` silently picks the wrong one the day that
+ * changes.
+ */
+const liveExcerpt = (page: Page) =>
+  page.locator("main").getByRole("textbox", { name: "Excerpt", exact: true });
+
+const historyExcerpt = (page: Page) =>
+  page
+    .getByRole("dialog")
+    .getByRole("textbox", { name: "Excerpt", exact: true });
+
+/** The autosave write: a PUT to a named sub-resource of the entry. */
+const AUTOSAVE_WRITE =
+  /\/collections\/posts\/entries\/[^/]+\/versions\/autosave$/;
+
+/**
+ * A saved post whose title has been changed once, so its history holds an
+ * earlier version that differs from what is live.
+ *
+ * Both titles are returned rather than recomputed by the caller: the assertions
+ * turn on telling them apart, and a test that rebuilt the string would still
+ * pass if the editor showed neither.
+ */
+async function postWithHistory(
+  page: Page
+): Promise<{ first: string; current: string }> {
+  const stamp = Date.now();
+  const title = `History ${stamp}`;
+  const first = `excerpt as first written ${stamp}`;
+  const current = `excerpt as it stands now ${stamp}`;
+
+  // `/create`, from `routes.ts`, NOT `/new` — the page file tree says otherwise
+  // and the router remaps it.
+  await gotoAdmin(page, "/collections/posts/create");
+  await page.getByRole("textbox", { name: "Title", exact: true }).fill(title);
+  // The excerpt is set HERE, on the first save, so the earliest version already
+  // holds it. Filling it only after creation would leave the oldest version
+  // blank, and the assertions below would then be comparing against an empty
+  // field — which passes for the wrong reason if the panel renders nothing.
+  await liveExcerpt(page).fill(first);
+  await page.getByRole("button", { name: /save draft/i }).click();
+
+  // Saving a NEW entry returns to the LIST rather than staying in the editor.
+  await page.waitForURL(/\/collections\/posts$/, { timeout: 30_000 });
+  await page.getByRole("link", { name: title }).click();
+  await page.waitForURL(/\/collections\/posts\/(?!create$)[^/]+$/, {
+    timeout: 30_000,
+  });
+  await expect(page.locator("main")).toBeVisible({ timeout: 30_000 });
+
+  // Excerpt rather than Title, and not for convenience: on the EDIT page the
+  // title is an inline control in the document header, not a field in the form,
+  // so a spec that fills it there waits on something the form never renders.
+  // Excerpt is a plain field of the entry and is what the sibling autosave spec
+  // exercises for the same reason.
+  await expect(liveExcerpt(page)).toHaveValue(first, { timeout: 30_000 });
+
+  // A second save, so there is a version that is NOT what is live.
+  await liveExcerpt(page).fill(current);
+  await page.getByRole("button", { name: /save draft/i }).click();
+  await expect(liveExcerpt(page)).toHaveValue(current, { timeout: 30_000 });
+
+  return { first, current };
+}
+
+/** Open the history panel and select the oldest version it lists. */
+async function openOldestVersion(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Version history" }).click();
+  const rows = page.getByRole("button", { name: /^Version \d+/ });
+  await expect(rows.first()).toBeVisible({ timeout: 30_000 });
+
+  // The list is newest first, so the last row is the earliest version — the one
+  // that differs from what is live, which is what makes the assertions bite.
+  await rows.last().click();
+  await expect(page.getByText(/Viewing version/)).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+test.describe("reading history does not write", () => {
+  test("issues no autosave while a past version is on screen", async ({
+    page,
+  }) => {
+    const { first } = await postWithHistory(page);
+
+    // Armed BEFORE the panel opens: a request that already completed is one
+    // this would wait for forever, and the point is to catch a write the act
+    // of opening provokes.
+    const write = page
+      .waitForResponse(
+        r => AUTOSAVE_WRITE.test(r.url()) && r.request().method() === "PUT",
+        { timeout: 8_000 }
+      )
+      .then(r => r.url())
+      .catch(() => null);
+
+    await openOldestVersion(page);
+
+    // POPULATION BEFORE VERDICT. "No write happened" is satisfied just as well
+    // by a panel that rendered nothing at all, so the historical value has to
+    // be on screen before the absence means anything.
+    await expect(
+      historyExcerpt(page),
+      "the past version's own value must be rendered before absence proves anything"
+    ).toHaveValue(first, { timeout: 15_000 });
+
+    expect(
+      await write,
+      "loading a past version must not record it as unsaved work"
+    ).toBeNull();
+  });
+
+  test("leaves the live document untouched, and saves the live values", async ({
+    page,
+  }) => {
+    const { first, current } = await postWithHistory(page);
+
+    await openOldestVersion(page);
+
+    // The panel is non-modal, so the live editor is still on screen behind it.
+    // Its own field must still hold what is live — if the snapshot had been
+    // loaded into the live form, this would read the historical title.
+    await expect(
+      liveExcerpt(page),
+      "opening history must not load the snapshot into the live form"
+    ).toHaveValue(current, { timeout: 15_000 });
+
+    // And the live save must still submit live values. A component that
+    // resolved to the history form would write the past here, silently.
+    await page.getByRole("button", { name: /save draft/i }).click();
+    await page.reload();
+    await expect(page.locator("main")).toBeVisible({ timeout: 30_000 });
+
+    await expect(
+      liveExcerpt(page),
+      "saving with history open must persist the live values, not the historical ones"
+    ).toHaveValue(current, { timeout: 30_000 });
+    await expect(liveExcerpt(page)).not.toHaveValue(first);
+  });
+});

--- a/packages/admin/src/components/features/entries/fields/FieldWrapper.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldWrapper.tsx
@@ -21,6 +21,8 @@ import { cn } from "@admin/lib/utils";
 
 import { useEntryLocale } from "../EntryLocaleContext";
 
+import { useFieldElementId } from "./field-id-scope";
+
 // ============================================================
 // Types
 // ============================================================
@@ -204,7 +206,9 @@ export function FieldWrapper({
   const generatedId = useId();
   // Use type guard to safely access name property (not all fields have it, e.g., TabsFieldConfig)
   const fieldName = "name" in field ? (field.name as string) : undefined;
-  const fieldId = fieldPath || fieldName || generatedId;
+  // Scoped for the same reason the controls are: two renderings of one
+  // document on a page would otherwise aim both labels at the first one.
+  const fieldId = useFieldElementId(fieldPath || fieldName || generatedId);
   const errorId = `${fieldId}-error`;
   const descriptionId = `${fieldId}-description`;
   // Names the group when the field has no single control to point a label at.

--- a/packages/admin/src/components/features/entries/fields/field-id-scope.ts
+++ b/packages/admin/src/components/features/entries/fields/field-id-scope.ts
@@ -1,0 +1,36 @@
+/**
+ * Keeps a field's DOM id unique when the same document is rendered twice.
+ *
+ * A field's element id is its path, which is unique within one form and not
+ * within one page. That was harmless while a document appeared once. It stops
+ * being harmless as soon as a second rendering exists — a version preview
+ * beside the live editor — because `getElementById` answers with the first
+ * match: every `<label for>` in the second rendering then points at the FIRST
+ * rendering's control. The duplicated fields lose their accessible name, and
+ * clicking a label in a read-only view moves focus into the editable document.
+ *
+ * A scope is an opaque prefix supplied by whoever renders the second copy. The
+ * default is empty, so the live editor's ids are exactly what they were and
+ * nothing that reads them has to change.
+ *
+ * @module components/features/entries/fields/field-id-scope
+ */
+
+import { createContext, useContext } from "react";
+
+/**
+ * The prefix applied to every field element id below this point. Empty means
+ * "this is the only rendering of the document", which is the common case.
+ */
+export const FieldIdScopeContext = createContext("");
+
+/**
+ * The DOM id a field's control should carry.
+ *
+ * Callers pass the identifier they would otherwise have used, so an unscoped
+ * tree keeps byte-identical ids and a scoped one cannot collide with it.
+ */
+export function useFieldElementId(id: string): string {
+  const scope = useContext(FieldIdScopeContext);
+  return scope ? `${scope}-${id}` : id;
+}

--- a/packages/admin/src/components/features/entries/fields/number/NumberInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/number/NumberInput.tsx
@@ -19,6 +19,8 @@ import {
 
 import { cn } from "@admin/lib/utils";
 
+import { useFieldElementId } from "../field-id-scope";
+
 // Helper to get validation value from flat or nested format (for dynamic collections)
 function getValidationValue<T>(
   field: Record<string, unknown>,
@@ -154,6 +156,12 @@ export function NumberInput<TFieldValues extends FieldValues = FieldValues>({
     return value;
   };
 
+  // Scoped, so a second rendering of the same document on one page cannot
+
+  // duplicate this id and steal the first rendering's label.
+
+  const elementId = useFieldElementId(name);
+
   const {
     field: { value, onChange, onBlur, ref },
     fieldState: { invalid },
@@ -194,7 +202,7 @@ export function NumberInput<TFieldValues extends FieldValues = FieldValues>({
   return (
     <Input
       ref={ref}
-      id={name}
+      id={elementId}
       type="number"
       value={value ?? ""}
       onChange={handleChange}

--- a/packages/admin/src/components/features/entries/fields/selection/CheckboxInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/selection/CheckboxInput.tsx
@@ -17,6 +17,8 @@ import {
   type Path,
 } from "react-hook-form";
 
+import { useFieldElementId } from "../field-id-scope";
+
 // ============================================================
 // Types
 // ============================================================
@@ -116,6 +118,12 @@ export function CheckboxInput<TFieldValues extends FieldValues = FieldValues>({
     return field.defaultValue ?? false;
   };
 
+  // Scoped, so a second rendering of the same document on one page cannot
+
+  // duplicate this id and steal the first rendering's label.
+
+  const elementId = useFieldElementId(name);
+
   const {
     field: { value, onChange },
   } = useController({
@@ -126,7 +134,7 @@ export function CheckboxInput<TFieldValues extends FieldValues = FieldValues>({
 
   return (
     <Checkbox
-      id={name}
+      id={elementId}
       checked={!!value}
       onCheckedChange={onChange}
       disabled={disabled || readOnly}

--- a/packages/admin/src/components/features/entries/fields/selection/DateInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/selection/DateInput.tsx
@@ -23,6 +23,8 @@ import {
 
 import { cn } from "@admin/lib/utils";
 
+import { useFieldElementId } from "../field-id-scope";
+
 // ============================================================
 // Types
 // ============================================================
@@ -193,6 +195,12 @@ export function DateInput<TFieldValues extends FieldValues = FieldValues>({
     return field.defaultValue ?? null;
   };
 
+  // Scoped, so a second rendering of the same document on one page cannot
+
+  // duplicate this id and steal the first rendering's label.
+
+  const elementId = useFieldElementId(name);
+
   const {
     field: { value, onChange, onBlur, ref },
     fieldState: { invalid },
@@ -296,7 +304,7 @@ export function DateInput<TFieldValues extends FieldValues = FieldValues>({
   return (
     <Input
       ref={ref}
-      id={name}
+      id={elementId}
       type={inputType}
       value={formatValue(value)}
       onChange={handleChange}

--- a/packages/admin/src/components/features/entries/fields/selection/MultiSelectInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/selection/MultiSelectInput.tsx
@@ -30,6 +30,8 @@ import {
 import { X } from "@admin/components/icons";
 import { cn } from "@admin/lib/utils";
 
+import { useFieldElementId } from "../field-id-scope";
+
 // ============================================================
 // Types
 // ============================================================
@@ -59,6 +61,10 @@ export function MultiSelectInput<
   readOnly = false,
   className,
 }: MultiSelectInputProps<TFieldValues>) {
+  // Scoped, so a second rendering of the same document on one page cannot
+  // duplicate this id and steal the first rendering's label.
+  const elementId = useFieldElementId(name);
+
   const {
     field: { value, onChange },
     fieldState: { invalid },
@@ -134,7 +140,7 @@ export function MultiSelectInput<
           value=""
           onValueChange={addValue}
         >
-          <SelectTrigger id={name} aria-invalid={invalid || undefined}>
+          <SelectTrigger id={elementId} aria-invalid={invalid || undefined}>
             <SelectValue placeholder={placeholder} />
           </SelectTrigger>
           <SelectContent>

--- a/packages/admin/src/components/features/entries/fields/selection/RadioInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/selection/RadioInput.tsx
@@ -19,6 +19,8 @@ import {
 
 import { cn } from "@admin/lib/utils";
 
+import { useFieldElementId } from "../field-id-scope";
+
 // ============================================================
 // Types
 // ============================================================
@@ -131,6 +133,10 @@ export function RadioInput<TFieldValues extends FieldValues = FieldValues>({
     return (field.defaultValue as string) || "";
   };
 
+  // Scoped: each option's id must stay unique across two renderings too.
+
+  const elementId = useFieldElementId(name);
+
   const {
     field: { value, onChange },
     fieldState: { invalid },
@@ -160,11 +166,11 @@ export function RadioInput<TFieldValues extends FieldValues = FieldValues>({
         <div key={option.value} className="flex items-center space-x-2">
           <RadioGroupItem
             value={option.value}
-            id={`${name}-${option.value}`}
+            id={`${elementId}-${option.value}`}
             disabled={disabled || readOnly}
           />
           <Label
-            htmlFor={`${name}-${option.value}`}
+            htmlFor={`${elementId}-${option.value}`}
             className={cn(
               "cursor-pointer",
               (disabled || readOnly) && "cursor-not-allowed opacity-60"

--- a/packages/admin/src/components/features/entries/fields/selection/SelectInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/selection/SelectInput.tsx
@@ -26,6 +26,8 @@ import {
 import { X } from "@admin/components/icons";
 import { cn } from "@admin/lib/utils";
 
+import { useFieldElementId } from "../field-id-scope";
+
 // ============================================================
 // Types
 // ============================================================
@@ -140,6 +142,12 @@ export function SelectInput<TFieldValues extends FieldValues = FieldValues>({
     return (value as string) || "";
   };
 
+  // Scoped, so a second rendering of the same document on one page cannot
+
+  // duplicate this id and steal the first rendering's label.
+
+  const elementId = useFieldElementId(name);
+
   const {
     field: { value, onChange },
     fieldState: { invalid },
@@ -172,7 +180,7 @@ export function SelectInput<TFieldValues extends FieldValues = FieldValues>({
 
   const trigger = (
     <SelectTrigger
-      id={name}
+      id={elementId}
       aria-invalid={invalid || undefined}
       className={cn(
         readOnly && "bg-primary/5 cursor-not-allowed",

--- a/packages/admin/src/components/features/entries/fields/selection/ToggleInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/selection/ToggleInput.tsx
@@ -17,6 +17,8 @@ import {
   type Path,
 } from "react-hook-form";
 
+import { useFieldElementId } from "../field-id-scope";
+
 // ============================================================
 // Types
 // ============================================================
@@ -118,6 +120,12 @@ export function ToggleInput<TFieldValues extends FieldValues = FieldValues>({
     return field.defaultValue ?? false;
   };
 
+  // Scoped, so a second rendering of the same document on one page cannot
+
+  // duplicate this id and steal the first rendering's label.
+
+  const elementId = useFieldElementId(name);
+
   const {
     field: { value, onChange },
   } = useController({
@@ -128,7 +136,7 @@ export function ToggleInput<TFieldValues extends FieldValues = FieldValues>({
 
   return (
     <Switch
-      id={name}
+      id={elementId}
       checked={!!value}
       onCheckedChange={onChange}
       disabled={disabled || readOnly}

--- a/packages/admin/src/components/features/entries/fields/structured/JsonInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/structured/JsonInput.tsx
@@ -24,6 +24,8 @@ import { Braces, Check, AlertCircle } from "@admin/components/icons";
 import { UI } from "@admin/constants/ui";
 import { cn } from "@admin/lib/utils";
 
+import { useFieldElementId } from "../field-id-scope";
+
 // ============================================================
 // Types
 // ============================================================
@@ -170,6 +172,10 @@ export function JsonInput<TFieldValues extends FieldValues = FieldValues>({
   };
 
   // React Hook Form controller
+  // Scoped, so a second rendering of the same document on one page cannot
+  // duplicate this id and steal the first rendering's label.
+  const elementId = useFieldElementId(name);
+
   const {
     field: { value, onChange },
     fieldState: { invalid },
@@ -280,7 +286,7 @@ export function JsonInput<TFieldValues extends FieldValues = FieldValues>({
       {/* Textarea */}
       <div className="relative">
         <Textarea
-          id={name}
+          id={elementId}
           value={textValue}
           onChange={handleChange}
           onBlur={handleBlur}
@@ -305,7 +311,7 @@ export function JsonInput<TFieldValues extends FieldValues = FieldValues>({
         {/* Parse error message */}
         {parseError && (
           <div
-            id={`${name}-error`}
+            id={`${elementId}-error`}
             className="flex items-center gap-1.5 text-sm text-destructive"
           >
             <AlertCircle className="h-4 w-4 flex-shrink-0" />

--- a/packages/admin/src/components/features/entries/fields/text/EmailInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/text/EmailInput.tsx
@@ -19,6 +19,8 @@ import {
 
 import { cn } from "@admin/lib/utils";
 
+import { useFieldElementId } from "../field-id-scope";
+
 // ============================================================
 // Types
 // ============================================================
@@ -122,6 +124,12 @@ export function EmailInput<TFieldValues extends FieldValues = FieldValues>({
       ? "" // Functions are evaluated at form level, not here
       : (field.defaultValue as string) || "";
 
+  // Scoped, so a second rendering of the same document on one page cannot
+
+  // duplicate this id and steal the first rendering's label.
+
+  const elementId = useFieldElementId(name);
+
   const {
     field: { value, onChange, onBlur, ref },
     fieldState: { invalid },
@@ -134,7 +142,7 @@ export function EmailInput<TFieldValues extends FieldValues = FieldValues>({
   return (
     <Input
       ref={ref}
-      id={name}
+      id={elementId}
       type="email"
       value={value ?? ""}
       onChange={onChange}

--- a/packages/admin/src/components/features/entries/fields/text/PasswordInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/text/PasswordInput.tsx
@@ -23,6 +23,8 @@ import {
 
 import { cn } from "@admin/lib/utils";
 
+import { useFieldElementId } from "../field-id-scope";
+
 // ============================================================
 // Types
 // ============================================================
@@ -148,6 +150,12 @@ export function PasswordInput<TFieldValues extends FieldValues = FieldValues>({
       ? "" // Functions are evaluated at form level, not here
       : (field.defaultValue as string) || "";
 
+  // Scoped, so a second rendering of the same document on one page cannot
+
+  // duplicate this id and steal the first rendering's label.
+
+  const elementId = useFieldElementId(name);
+
   const {
     field: { value, onChange, onBlur, ref },
     fieldState: { invalid },
@@ -161,7 +169,7 @@ export function PasswordInput<TFieldValues extends FieldValues = FieldValues>({
     <div className="relative">
       <Input
         ref={ref}
-        id={name}
+        id={elementId}
         type={showPassword ? "text" : "password"}
         value={value ?? ""}
         onChange={onChange}

--- a/packages/admin/src/components/features/entries/fields/text/TextInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/text/TextInput.tsx
@@ -25,6 +25,8 @@ import {
 
 import { cn } from "@admin/lib/utils";
 
+import { useFieldElementId } from "../field-id-scope";
+
 // Helper to get validation value from flat or nested format (for dynamic collections)
 function getValidationValue<T>(
   field: Record<string, unknown>,
@@ -150,6 +152,12 @@ export function TextInput<TFieldValues extends FieldValues = FieldValues>({
       ? "" // Functions are evaluated at form level, not here
       : (field.defaultValue as string) || "";
 
+  // Scoped, so a second rendering of the same document on one page cannot
+
+  // duplicate this id and steal the first rendering's label.
+
+  const elementId = useFieldElementId(name);
+
   const {
     field: { value, onChange, onBlur, ref },
     fieldState: { invalid },
@@ -180,7 +188,7 @@ export function TextInput<TFieldValues extends FieldValues = FieldValues>({
   return (
     <Input
       ref={ref}
-      id={name}
+      id={elementId}
       type="text"
       value={value ?? ""}
       onChange={onChange}

--- a/packages/admin/src/components/features/entries/fields/text/TextareaInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/text/TextareaInput.tsx
@@ -19,6 +19,8 @@ import {
 
 import { cn } from "@admin/lib/utils";
 
+import { useFieldElementId } from "../field-id-scope";
+
 // Helper to get validation value from flat or nested format (for dynamic collections)
 function getValidationValue<T>(
   field: Record<string, unknown>,
@@ -155,6 +157,12 @@ export function TextareaInput<TFieldValues extends FieldValues = FieldValues>({
       ? "" // Functions are evaluated at form level, not here
       : (field.defaultValue as string) || "";
 
+  // Scoped, so a second rendering of the same document on one page cannot
+
+  // duplicate this id and steal the first rendering's label.
+
+  const elementId = useFieldElementId(name);
+
   const {
     field: { value, onChange, onBlur, ref },
     fieldState: { invalid },
@@ -189,7 +197,7 @@ export function TextareaInput<TFieldValues extends FieldValues = FieldValues>({
   return (
     <Textarea
       ref={ref}
-      id={name}
+      id={elementId}
       value={value ?? ""}
       onChange={onChange}
       onBlur={onBlur}

--- a/packages/admin/src/components/features/versions/VersionSnapshotForm.tsx
+++ b/packages/admin/src/components/features/versions/VersionSnapshotForm.tsx
@@ -26,10 +26,11 @@
  */
 
 import type { FieldConfig } from "nextly/config";
-import { useMemo } from "react";
+import { useId, useMemo } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { EntryFormContent } from "@admin/components/features/entries/EntryForm/EntryFormContent";
+import { FieldIdScopeContext } from "@admin/components/features/entries/fields/field-id-scope";
 
 export interface VersionSnapshotFormProps {
   /** The document's current schema, which decides what is shown. */
@@ -58,12 +59,21 @@ export function VersionSnapshotForm({
   // needing a reset — the panel already remounts this on selection.
   const form = useForm<Record<string, unknown>>({ defaultValues: values });
 
+  // A DOM id scope of its own. A field's id is its path, which is unique in a
+  // form and not on a page — so without this every label here would point at
+  // the live editor's control of the same name: these fields would lose their
+  // accessible name, and clicking a label in a read-only view would move focus
+  // into the editable document.
+  const idScope = useId();
+
   return (
-    <FormProvider {...form}>
-      {/* `mode="edit"` because a version belongs to a document that exists;
-          write-only fields present themselves as they do when editing rather
-          than as they do on a blank create form. */}
-      <EntryFormContent fields={fields} readOnly mode="edit" />
-    </FormProvider>
+    <FieldIdScopeContext.Provider value={idScope}>
+      <FormProvider {...form}>
+        {/* `mode="edit"` because a version belongs to a document that exists;
+            write-only fields present themselves as they do when editing rather
+            than as they do on a blank create form. */}
+        <EntryFormContent fields={fields} readOnly mode="edit" />
+      </FormProvider>
+    </FieldIdScopeContext.Provider>
   );
 }


### PR DESCRIPTION
## What

An end-to-end spec for the property that makes version history safe — reading a document's past must not write to it — **and the defect that spec immediately found.**

## The defect it found

Rendering a past version beside the live editor gave both copies **the same DOM ids**. A field's element id was its path, which is unique within a form and not within a page.

Measured on the running app with a version open:

```
duplicated ids: 10   (excerpt, metaTitle, metaDescription, editorMode,
                      editorMode-description, content-group-label, …)

panel inputs:   excerpt          label: (none)
                metaTitle        label: (none)
                metaDescription  label: (none)
```

`getElementById` answers with the first match, so every `<label for>` in the panel pointed at the **live editor's** control. Two consequences, both user-facing:

- those fields had **no accessible name** — a screen reader reads them as unlabelled
- clicking a label in the read-only panel **moved focus into the editable document** behind it

A latent defect that had never been reachable, made reachable by #974. The fix is a scope prefix supplied by whoever renders the second copy; the default is empty, so **the live editor's ids are byte-identical** and nothing that reads them changes.

## Why unit tests could not find it

jsdom renders one tree per test. A collision *between two renderings on one page* is not a state they can reach — so three rounds of unit tests on this feature were green throughout, correctly.

## The spec

Two properties, both chosen for what only a real browser and a real database can answer:

1. **no autosave write is issued while a past version is on screen** — armed before the panel opens, since a request that already completed is one the wait would never see
2. **the live document is untouched, and the live save still submits live values** — the retarget that would break this is quiet: React form context binds to the nearest provider, so a component resolving to the wrong form is valid code doing the wrong thing

Both assert the **population before the verdict**: the historical value must be on screen before "no write happened" means anything, since a panel that rendered nothing satisfies the absence just as well.

Locators are scoped to `main` and to the dialog rather than using `.first()`/`.last()` — the panel is portalled, so DOM order is an implementation detail of the portal, and ordering would silently pick the wrong field the day it changes.

## Stub-verification, including one result I could not obtain

| break | outcome |
|---|---|
| remove the id scope | **FAILS**, naming the population assertion — verified |
| history resets the live form during render | passed — malformed break, the reset is deferred |
| history resets the live form in an effect | passed — could not reach the property |

**So the isolation half of property 2 is asserted but UNFALSIFIED, and I am reporting that rather than presenting it as coverage.** Two attempts to make history write into the live form both left the spec green: either `useFormContext` does not reach the live form from the panel, or the live form's own data source immediately re-applies. I did not determine which, and until I do, that assertion has not been shown to bite.

What *is* verified: the id scoping, and that the spec fails loudly when the panel stops rendering the past version's own values.

## Verification

```
pnpm turbo run build --force                       20 successful / 20 total,  0 cached
pnpm turbo run check-types lint --continue --force 46 successful / 46 total,  0 cached
playwright version-history-isolation               2 passed
packages/admin                                     failing file set identical to baseline
```

## Scope

13 field components change how their control's id is derived, and nothing else about them. `FieldWrapper` and `RadioInput`'s per-option ids go through the same scope.
