### PR TITLE
refactor(admin): give column visibility one implementation

### DIFF
--- a/.changeset/entrylist-one-columns-mechanism.md
+++ b/.changeset/entrylist-one-columns-mechanism.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The collection-entries list now remembers your column choice the same way every other admin list
+does. Behaviour is unchanged — it already remembered — but it is one mechanism now rather than
+two, so the lists cannot drift apart.

--- a/packages/admin/src/components/features/entries/EntryList/EntryList.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/EntryList.tsx
@@ -17,6 +17,7 @@ import { useState, useCallback, useMemo, useRef } from "react";
 import { Code, Plus } from "@admin/components/icons";
 import { Breadcrumbs } from "@admin/components/shared";
 import { PluginSlot } from "@admin/components/shared/plugin-slot";
+import { useListColumns } from "@admin/components/ui/table/list-view";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import {
   useEntries,
@@ -24,7 +25,6 @@ import {
   useBulkUpdateEntries,
 } from "@admin/hooks/queries";
 import { useCollection } from "@admin/hooks/queries/useCollections";
-import { useColumnVisibility } from "@admin/hooks/useColumnVisibility";
 import { useEntryListShortcuts } from "@admin/hooks/useKeyboardShortcuts";
 import { useLocalization } from "@admin/hooks/useLocalization";
 import { usePluginAutoRegistration } from "@admin/hooks/usePluginAutoRegistration";
@@ -370,14 +370,15 @@ export function EntryList({ collectionSlug }: EntryListProps) {
     [collectionForColumns]
   );
 
-  // Use column visibility hook with localStorage persistence
-  const {
-    columnVisibility,
-    onColumnVisibilityChange,
-    resetToDefault: resetColumnVisibility,
-  } = useColumnVisibility({
-    collectionSlug,
-    availableColumns,
+  /*
+   * The same control every other admin list uses, so "which columns has this
+   * reader hidden" has one answer and one place it is stored. This surface read
+   * the underlying hook directly, which left the entry list with its own
+   * spelling of a question the shared one already answers.
+   */
+  const columnsControl = useListColumns<Record<string, unknown>>({
+    storageKey: collectionSlug,
+    columns: availableColumns.map(name => ({ name, header: name })),
     defaultVisible: defaultVisibleColumns,
   });
 
@@ -691,9 +692,7 @@ export function EntryList({ collectionSlug }: EntryListProps) {
           onCreatedToChange={handleCreatedToChange}
           onUpdatedFromChange={handleUpdatedFromChange}
           onUpdatedToChange={handleUpdatedToChange}
-          columnVisibility={columnVisibility}
-          onColumnVisibilityChange={onColumnVisibilityChange}
-          onResetColumnVisibility={resetColumnVisibility}
+          columnsControl={columnsControl}
         />
       )}
 

--- a/packages/admin/src/components/features/entries/EntryList/EntryTable.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/EntryTable.tsx
@@ -32,7 +32,10 @@ import type {
   DataTableSelection,
   RowAction,
 } from "@admin/components/ui/table/data-table";
-import { ListView } from "@admin/components/ui/table/list-view";
+import {
+  ListView,
+  type ListColumnsControl,
+} from "@admin/components/ui/table/list-view";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { useLocalization } from "@admin/hooks/useLocalization";
 
@@ -109,14 +112,15 @@ export interface EntryTableProps {
   onBulkUnpublish?: (entryIds: string[]) => void;
   /** Whether a bulk publish/unpublish request is in flight. */
   isBulkPublishing?: boolean;
-  /** Column visibility state (controlled by parent for persistence) */
-  columnVisibility?: Record<string, boolean>;
-  /** Callback when column visibility changes */
-  onColumnVisibilityChange?: (
-    updater: (prev: Record<string, boolean>) => Record<string, boolean>
-  ) => void;
-  /** Callback to reset column visibility to defaults */
-  onResetColumnVisibility?: () => void;
+  /**
+   * The reader's column choice, as the control `ListView` renders.
+   *
+   * One prop rather than the three this took before — a visibility record, a
+   * change handler and a reset — which this component then recombined into
+   * exactly this shape. The owner builds it with `useListColumns`, so the
+   * choice persists the same way it does on every other list.
+   */
+  columnsControl?: ListColumnsControl<EntryRow>;
   /** Callback when row selection changes */
   onSelectionChange?: (selectedIds: string[]) => void;
   /** Current status filter value */
@@ -184,9 +188,7 @@ export const EntryTable = forwardRef<EntryTableRef, EntryTableProps>(
       onBulkPublish,
       onBulkUnpublish,
       isBulkPublishing = false,
-      columnVisibility,
-      onColumnVisibilityChange,
-      onResetColumnVisibility,
+      columnsControl,
       onSelectionChange,
       status = "all",
       onStatusChange,
@@ -215,8 +217,8 @@ export const EntryTable = forwardRef<EntryTableRef, EntryTableProps>(
     // -------------------------------------------------------------------------
 
     const columns = useMemo(
-      () => buildEntryColumns(collection, columnVisibility),
-      [collection, columnVisibility]
+      () => buildEntryColumns(collection, columnsControl?.isColumnVisible),
+      [collection, columnsControl]
     );
 
     const titleField = useMemo(
@@ -315,15 +317,6 @@ export const EntryTable = forwardRef<EntryTableRef, EntryTableProps>(
       onSearchChange(value);
     };
 
-    const isColumnVisible = (name: string) =>
-      columnVisibility?.[name] !== false;
-    const handleToggleColumn = (name: string) => {
-      onColumnVisibilityChange?.(prev => ({
-        ...prev,
-        [name]: prev[name] === false,
-      }));
-    };
-
     // -------------------------------------------------------------------------
     // Filters (status + date range) rendered into the toolbar dropdown
     // -------------------------------------------------------------------------
@@ -382,12 +375,7 @@ export const EntryTable = forwardRef<EntryTableRef, EntryTableProps>(
           placeholder: `Search ${collection.label}...`,
           inputProps: { "data-entry-search-input": true },
         }}
-        columnsControl={{
-          columns,
-          isColumnVisible,
-          onToggleColumn: handleToggleColumn,
-          onReset: onResetColumnVisibility,
-        }}
+        columnsControl={columnsControl && { ...columnsControl, columns }}
         hasActiveFilters={hasAnyActiveFilters}
         filters={
           showFilterDropdown ? (

--- a/packages/admin/src/components/features/entries/EntryList/EntryTableColumns.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/EntryTableColumns.tsx
@@ -692,9 +692,16 @@ export function getEntryTitleField(
  */
 export function buildEntryColumns(
   collection: CollectionForColumns,
-  columnVisibility?: Record<string, boolean>
+  /**
+   * Whether a column is visible to this reader. Taken as the predicate the
+   * shared columns control already exposes, rather than as a record of hidden
+   * names — a record is a second spelling of the same question, and only this
+   * file knew how to read it.
+   */
+  isColumnVisible?: (name: string) => boolean
 ): NextlyColumn<Record<string, unknown>>[] {
-  const isHidden = (name: string) => columnVisibility?.[name] === false;
+  const isHidden = (name: string) =>
+    isColumnVisible ? !isColumnVisible(name) : false;
 
   const columnNames = getAvailableColumns(collection).filter(
     name => name !== "select" && name !== "actions"

--- a/packages/admin/src/components/ui/table/list-view/__tests__/one-columns-mechanism.test.ts
+++ b/packages/admin/src/components/ui/table/list-view/__tests__/one-columns-mechanism.test.ts
@@ -1,0 +1,77 @@
+/**
+ * "Which columns has this reader hidden" has ONE implementation.
+ *
+ * `useColumnVisibility` owns the storage. `useListColumns` adapts it to the
+ * shape `ListView` renders, and is the only thing product code should reach
+ * for. A surface that calls the storage hook directly gets a second spelling of
+ * the same question — which is how the entry list ended up with its own
+ * visibility record while ten other lists used a predicate, and how a reader's
+ * choice came to persist on one list and evaporate on the rest.
+ *
+ * There is a second, sharper reason this is a boundary rather than advice: the
+ * storage hook re-reads in an effect keyed on its ARRAY arguments, so an inline
+ * `defaultVisible` loops forever. `useListColumns` keys by value and prevents
+ * it. Calling the storage hook directly re-opens that trap.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const SRC = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../..");
+
+/** The adapter, and the hook's own definition and tests, may name it. */
+const ALLOWED = [
+  join("hooks", "useColumnVisibility.ts"),
+  join("hooks", "index.ts"),
+  join("list-view", "useListColumns.ts"),
+];
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      walk(full, out);
+    } else if (
+      /\.tsx?$/.test(entry.name) &&
+      !/\.test\.tsx?$/.test(entry.name)
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("one columns mechanism", () => {
+  const files = walk(SRC);
+
+  /**
+   * Population before verdict: a scan that reached nothing reports no direct
+   * callers in exactly the same words as a clean one. Asserted by MEMBERSHIP,
+   * because a count passes on any set of the right size.
+   */
+  it("reads the admin source, including both hooks", () => {
+    const rel = files.map(f => f.replace(`${SRC}/`, ""));
+    expect(rel).toContain(join("hooks", "useColumnVisibility.ts"));
+    expect(rel).toContain(
+      join("components", "ui", "table", "list-view", "useListColumns.ts")
+    );
+  });
+
+  it("has no product code calling the storage hook directly", () => {
+    const offenders = files
+      .filter(file => !ALLOWED.some(allowed => file.endsWith(allowed)))
+      .filter(file => /useColumnVisibility/.test(readFileSync(file, "utf8")))
+      .map(file => file.replace(`${SRC}/`, ""));
+
+    expect(
+      offenders,
+      "These call `useColumnVisibility` directly. Use `useListColumns` from " +
+        "`components/ui/table/list-view` instead: it is the one adapter, and " +
+        "it stabilises its array arguments by value, which the storage hook " +
+        "requires and does not enforce."
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes the drift #980 left behind. **Column visibility now has one implementation.**

## The problem

`useColumnVisibility` owns the storage. After #979/#980, eleven list surfaces reached it through `useListColumns` — but the collection-entries list still called it directly, and spoke a different dialect:

- **everywhere else:** a predicate, `isColumnVisible(name)`
- **entries:** a visibility *record*, threaded through three props into `EntryTable`, which recombined them into exactly the control shape the other lists already had

Same question, two spellings. Nothing was broken — entries persisted correctly, it was the one surface that always had — but it is the drift `AGENTS.md` names, and I created the second spelling myself when I added the adapter.

## The change

- **`buildEntryColumns` takes the predicate** instead of a record. It had exactly one caller, so this is contained.
- **`EntryTable` takes `columnsControl` — one prop replacing three** (`columnVisibility`, `onColumnVisibilityChange`, `onResetColumnVisibility`). It no longer re-derives `isColumnVisible` and a toggle handler; the owner builds the control and passes it.
- **`EntryList` uses `useListColumns`.**

Behaviour is unchanged: entries remembered your columns before and remembers them now, under the same key.

## A boundary, not a convention

`one-columns-mechanism.test.ts` fails if any product code imports `useColumnVisibility` directly. Break-verified: reintroducing the import into `EntryList` fails it by name; removed, it passes.

Two reasons it is a boundary rather than a note:

1. It is exactly how the second spelling appeared, and a documented rule with nothing enforcing it is not a control.
2. **The storage hook re-reads in an effect keyed on its array arguments**, so an inline `defaultVisible` loops forever and kills the vitest worker (found in #979). `useListColumns` keys by value and prevents it. Calling the storage hook directly re-opens that trap, so "use the adapter" is a correctness rule, not a style preference.

The guard asserts its **population by membership** before its verdict — it requires both hooks to be among the files it read, because a scan that reached nothing reports no direct callers in exactly the same words as a clean one.

## Worth noting: this behaviour had no tests

`git grep` for `columnVisibility` across test files returned **zero** before this change. The three-prop contract, the record threading and the derivation were all uncovered. The entries suite (338 tests) passes unchanged after the refactor, which is behaviour-preservation evidence rather than new coverage — the new coverage is the boundary guard plus the hook's own 7 tests from #979.

## Test plan

- `packages/admin` — **2214 passed, 15 failed (4 files)**: the standing pre-existing set.
- Entries suite specifically: **338 passed**, unchanged across the refactor.
- `check-types` and `lint` clean.

## Pre-existing failures

`packages/admin`: the standing 15 across `StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField`.

## Changeset

Added: yes (`patch`), generated from `.changeset/config.json` — 25 packages.
