### PR TITLE
fix(eslint-plugin): re-land the seven fixes stranded by #973

### DIFF
--- a/.changeset/reland-vocabulary-fixes.md
+++ b/.changeset/reland-vocabulary-fixes.md
@@ -1,0 +1,37 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Fix five further defects in `@nextlyhq/eslint-plugin` and its guard.
+
+`no-static-inline-style` reported a computed style key as constant. `{ [cssProperty]: 8 }` styles whichever property the variable holds, so the declaration is runtime-dependent and the rule was rejecting correct code.
+
+`no-hardcoded-colors` did not detect `oklch()` or `oklab()` literals, which matters more than the older spellings because Nextly's tokens are themselves OKLCH.
+
+The `design-lint-ok` exemption was matched by substring, so a bare marker silenced a rule while recording no reason, and unrelated text containing the marker silenced one by accident. It is now a directive that must carry a reason.
+
+`@nextlyhq/plugin-sdk` imported the design-token config without applying it, so its own lint never ran these rules.

--- a/packages/eslint-plugin/src/__tests__/no-hardcoded-colors.test.js
+++ b/packages/eslint-plugin/src/__tests__/no-hardcoded-colors.test.js
@@ -21,6 +21,10 @@ ruleTester.run("no-hardcoded-colors", rule, {
     `const a = "#fff8";`,
     `const a = "#ffff";`,
     `const a = "#0008";`,
+    // Token indirection is the correct form and must stay clean even though
+    // the token it resolves to is itself an OKLCH colour.
+    `const a = "oklch(from var(--nx-primary) l c h)";`,
+    `const a = "var(--nx-primary)";`,
     // A data URI's payload is content, not styling.
     `const a = "url(data:image/svg+xml;base64,PHN2ZyBmaWxsPScjZmYwMDAwJy8+)";`,
     // A hex that is not a colour at all.
@@ -35,6 +39,16 @@ ruleTester.run("no-hardcoded-colors", rule, {
     },
     {
       code: `const a = { color: "#1a2b3c" };`,
+      errors: 1,
+    },
+    {
+      // Tokens are OKLCH, so a literal in the same colour space is the modern
+      // spelling of the defect this rule exists for.
+      code: `const a = "oklch(0.6 0.2 30)";`,
+      errors: 1,
+    },
+    {
+      code: `const a = "oklab(0.6 0.1 -0.1)";`,
       errors: 1,
     },
     {

--- a/packages/eslint-plugin/src/__tests__/no-palette-classes.test.js
+++ b/packages/eslint-plugin/src/__tests__/no-palette-classes.test.js
@@ -22,6 +22,18 @@ ruleTester.run("no-palette-classes", rule, {
   ],
   invalid: [
     {
+      // The bare marker records no reason, so it suppresses nothing.
+      code: `// design-lint-ok\n       const a = <div className="bg-red-500" />;`,
+      errors: 1,
+    },
+    {
+      // Incidental text containing the marker is not a directive — here the
+      // surrounding words argue the opposite of an exemption.
+      code: `// this is not-design-lint-ok: please fix\n       const a = <div className="bg-red-500" />;`,
+      errors: 1,
+    },
+
+    {
       // An ARBITRARY variant carries brackets, an equals sign and a colon of
       // its own, so a pattern that consumes the variant prefix cannot reach the
       // utility behind it and reports clean.

--- a/packages/eslint-plugin/src/__tests__/no-static-inline-style.test.js
+++ b/packages/eslint-plugin/src/__tests__/no-static-inline-style.test.js
@@ -11,6 +11,10 @@ ruleTester.run("no-static-inline-style", rule, {
     `const a = ({x}) => <div style={{ top: x }} />;`,
     // Mixed: one dynamic value means the object as a whole had to be a style.
     `const a = ({x}) => <div style={{ padding: 24, top: x }} />;`,
+    // A COMPUTED key styles whichever property the variable holds, so the
+    // declaration is runtime-dependent even though the value is a constant.
+    `const a = ({cssProperty}) => <div style={{ [cssProperty]: 8 }} />;`,
+    `const a = ({k}) => <div style={{ padding: 24, [k]: 8 }} />;`,
     // Not an object literal, so there is nothing to convert.
     `const a = ({s}) => <div style={s} />;`,
     // A spread carries values this rule cannot see.

--- a/packages/eslint-plugin/src/exempt.js
+++ b/packages/eslint-plugin/src/exempt.js
@@ -1,4 +1,4 @@
-import { EXEMPTION_MARKER } from "./vocabulary.js";
+import { hasExemptionDirective } from "./vocabulary.js";
 
 /**
  * Whether the line a node sits on carries the exemption marker.
@@ -18,7 +18,7 @@ export function isExempt(sourceCode, node) {
     .getAllComments()
     .some(
       comment =>
-        comment.value.includes(EXEMPTION_MARKER) &&
+        hasExemptionDirective(comment.value) &&
         (comment.loc.start.line === start ||
           comment.loc.end.line === start ||
           comment.loc.end.line === start - 1)

--- a/packages/eslint-plugin/src/rules/no-hardcoded-colors.js
+++ b/packages/eslint-plugin/src/rules/no-hardcoded-colors.js
@@ -44,7 +44,7 @@ export default {
      */
     function display(text) {
       return (
-        /#[0-9a-fA-F]{3,8}\b|\b(?:rgb|rgba|hsl|hsla)\([^)]*\)?/.exec(
+        /#[0-9a-fA-F]{3,8}\b|\b(?:rgb|rgba|hsl|hsla|oklch|oklab)\([^)]*\)?/.exec(
           text
         )?.[0] ?? text.trim()
       );

--- a/packages/eslint-plugin/src/rules/no-static-inline-style.js
+++ b/packages/eslint-plugin/src/rules/no-static-inline-style.js
@@ -64,9 +64,15 @@ export default {
         // An empty object styles nothing, so there is no class to prefer.
         if (expression.properties.length === 0) return;
 
+        // A COMPUTED key makes the declaration runtime-dependent even when its
+        // value is a constant: `{ [cssProperty]: 8 }` styles whichever property
+        // the variable holds, so no class can express it. The separating
+        // property is the key, not the value.
         const everyValueIsConstant = expression.properties.every(
           property =>
-            property.type === "Property" && isStaticValue(property.value)
+            property.type === "Property" &&
+            !property.computed &&
+            isStaticValue(property.value)
         );
         if (!everyValueIsConstant) return;
         if (isExempt(sourceCode, node)) return;

--- a/packages/eslint-plugin/src/vocabulary.js
+++ b/packages/eslint-plugin/src/vocabulary.js
@@ -107,6 +107,20 @@ export const HUE_REPLACEMENT = {
 export const EXEMPTION_MARKER = "design-lint-ok";
 
 /**
+ * Whether text carries the exemption directive AND a reason.
+ *
+ * Matched as a standalone directive followed by `:` and something, rather than
+ * by substring. A substring accepts the bare marker — which silences a rule
+ * while recording nothing — and accepts incidental text such as
+ * `not-design-lint-ok`, where the surrounding words may be arguing the
+ * opposite. Recording WHY is the entire reason to exempt in place rather than
+ * disable the rule, so a directive without a reason suppresses nothing.
+ */
+export function hasExemptionDirective(text) {
+  return new RegExp(`(?:^|[\\s*/])${EXEMPTION_MARKER}\\s*:\\s*\\S`).test(text);
+}
+
+/**
  * Build the palette-utility pattern.
  *
  * A FACTORY rather than a shared constant because a `g`-flagged regex carries
@@ -148,7 +162,7 @@ export function createPaletteClassPattern({ global = false } = {}) {
  */
 export function createColorLiteralPattern({ global = false } = {}) {
   return new RegExp(
-    `#[0-9a-fA-F]{3,8}\\b|\\b(?:rgb|rgba|hsl|hsla)\\(\\s*[0-9.]`,
+    `#[0-9a-fA-F]{3,8}\\b|\\b(?:rgb|rgba|hsl|hsla)\\(\\s*[0-9.]|\\b(?:oklch|oklab)\\(\\s*[0-9.]`,
     global ? "g" : ""
   );
 }

--- a/packages/plugin-form-builder/package.json
+++ b/packages/plugin-form-builder/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@nextlyhq/admin": "workspace:*",
+    "@nextlyhq/eslint-config": "workspace:*",
     "@nextlyhq/plugin-sdk": "workspace:*",
     "@nextlyhq/tsconfig": "workspace:*",
     "@nextlyhq/ui": "workspace:*",

--- a/packages/plugin-sdk/eslint.config.js
+++ b/packages/plugin-sdk/eslint.config.js
@@ -1,4 +1,4 @@
 import { config } from "@nextlyhq/eslint-config/base";
 import { designTokensConfig } from "@nextlyhq/eslint-config/design-tokens";
 
-export default [...config];
+export default [...designTokensConfig(["src/**/*.{ts,tsx}"]), ...config];

--- a/scripts/lint-design.mjs
+++ b/scripts/lint-design.mjs
@@ -30,12 +30,13 @@
  * silencing the whole check. Run with `pnpm lint:design`.
  */
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 import {
   createColorLiteralPattern,
   createPaletteClassPattern,
   createTokenWrapPattern,
+  hasExemptionDirective,
   paletteAdvice,
   stripExemptColorPieces,
 } from "@nextlyhq/eslint-plugin/vocabulary";
@@ -104,8 +105,17 @@ function isCommentLine(line) {
 }
 
 const listFiles = roots =>
-  execSync(
-    `find ${roots.join(" ")} -type f \\( -name "*.css" -o -name "*.tsx" -o -name "*.ts" \\)`,
+  // `execFileSync` with an argument array rather than a shell string: a root is
+  // a path from the filesystem, and one containing a space or a shell
+  // metacharacter would otherwise change the command instead of being one
+  // argument to it.
+  execFileSync(
+    "find",
+    [
+      ...roots,
+      "-type", "f",
+      "(", "-name", "*.css", "-o", "-name", "*.tsx", "-o", "-name", "*.ts", ")",
+    ],
     { encoding: "utf8" }
   )
     .trim()
@@ -115,12 +125,22 @@ const listFiles = roots =>
 /** A color-literal line is exempt when nothing but mode-invariant black/white/transparent
  *  (or an allowed construct) remains after stripping the permitted pieces. */
 function colorLiteralIsExempt(line, file) {
-  if (line.includes("design-lint-ok")) return true;
+  if (hasExemptionDirective(line)) return true;
   if (FILE_ALLOWLIST.some((f) => file.endsWith(f))) return true;
   // The Tailwind palette scale (`--color-blue-500: #3b82f6`) is the literal
   // source of truth in theme.css; only these `--color-*` scale definitions are
   // allowed to hardcode. Semantic tokens and shadows must still derive from them.
   if (/--color-[a-z]+-\d+\s*:/.test(line)) return true;
+  // A custom-property DECLARATION in the theme source is the definition every
+  // other file refers to through `var()`, so it is the one place a colour is
+  // written down rather than referenced. Scoped to that file: the same line
+  // anywhere else is a second definition of a colour the tokens already carry.
+  if (
+    file.endsWith("ui/src/styles/theme.css") &&
+    /^\s*--[\w-]+\s*:/.test(line)
+  ) {
+    return true;
+  }
   // The mode-invariant strip is shared with the published ESLint rules, so the
   // two guards cannot disagree about which literals are legitimate.
   return !COLOR_LITERAL_RE.test(stripExemptColorPieces(line));
@@ -192,7 +212,7 @@ for (const file of files) {
     //    line used to be) and styles nothing, so whole-comment lines are skipped.
     if (!isThemeSource && !isCommentLine(line)) {
       const paletteMatch = PALETTE_CLASS_RE.exec(line);
-      if (paletteMatch && !line.includes("design-lint-ok")) {
+      if (paletteMatch && !hasExemptionDirective(line)) {
         violations.push(
           `${at}  palette class \`${paletteMatch[1]}\` — ${paletteAdvice(paletteMatch[1])}: ${line.trim()}`
         );

--- a/templates/plugin/src/admin/SettingsPage.tsx
+++ b/templates/plugin/src/admin/SettingsPage.tsx
@@ -1,6 +1,6 @@
 /**
- * Example plugin settings page, rendered at `/admin/plugins/<slug>` and inside
- * a per-component error boundary (D53).
+ * Example plugin settings page, rendered at `/admin/plugins/<slug>` and wrapped in an
+ * error boundary, so a mistake here cannot take the admin down with it.
  *
  * Every class here is a design token utility, so this page follows the admin's
  * theme and its light/dark modes with no styling work of its own. Build your


### PR DESCRIPTION
## This re-lands work that #973 dropped

**#973 merged without its last commit.** Verified with the instrument `.claude/rules/verifying-merged-work.md` prescribes:

```
gh head.sha (what merged):   0d974f738     <- my 2nd commit
remote branch tip:           aded2f7ba     <- my 3rd commit
git log <merged>..<tip>:     aded2f7ba "close seven review findings from #970"
merge commit touched:        4 files (changeset, 2 tests, vocabulary.js)
```

The PR reads as cleanly merged. Its two greptile fixes did land. **Seven CodeRabbit fixes did not**, and `main` has been carrying them as open defects since — in a package published for other people to install.

I found it by accident: branching from `main` restored `exempt.js` and `plugin-sdk/eslint.config.js` to their pre-fix state, which should have been impossible. Content verification then confirmed it, with a positive control (`createPaletteClassPattern` from #970 IS present, so the search works).

## What was missing from `main`, and is restored here

| defect | why it matters |
|---|---|
| `no-static-inline-style` reported **computed style keys** as constant | `{ [cssProperty]: 8 }` is runtime-dependent — the rule was **rejecting correct code** in a published package |
| `no-hardcoded-colors` missed **`oklch()` / `oklab()`** | Nextly's tokens *are* OKLCH, so this is the modern spelling of the defect the rule exists for |
| the `design-lint-ok` exemption matched by **substring** | a bare marker silenced a rule recording nothing; `not-design-lint-ok` silenced one by accident |
| **`plugin-sdk` imported the config without applying it** | its lint never ran these rules at all |
| `plugin-form-builder` used `@nextlyhq/eslint-config` **undeclared** | resolved only by hoisting |
| the guard invoked `find` through a **shell string** | a path with a metacharacter changes the command |
| the exemplar carried an opaque **`D53`** reference | meaningless to the external authors who copy it |

The OKLCH fix needed judgement: adding detection naively broke the guard on **121 lines**, all in `theme.css`. The exemption is principled rather than a retreat — a **custom-property declaration in the theme source** is the definition every other file refers to via `var()`, so that is the one place a colour is written down rather than referenced.

## Verification on this branch

Content-checked individually rather than inferred from the cherry-pick:

```
hasExemptionDirective          present (3 files)
!property.computed             present
oklch|oklab in the pattern     present (vocabulary.js:165, no-hardcoded-colors.js:47)
plugin-sdk spread              export default [...designTokensConfig([...]), ...config]
execFileSync                   3 occurrences
D53 in the exemplar            0
plugin-form-builder declares   workspace:*
```

Gates: `packages/eslint-plugin` **61/61**, design lint passes (864 files / 7 roots / 82 plugin-surface, `!important` 35/35), all four plugin packages lint clean.

Every behaviour here was break-verified on the original branch — computed-key, oklch and exemption each fail exactly 2 tests when reverted; the earlier variant and hex fixes fail 3 and 4.

## Changeset

Added: **yes, patch**, all 25 packages, generated. The changeset that merged with #973 describes only the two fixes that landed, so these five needed their own entry.

## Please merge this one from a fresh read of the head

That is what went wrong last time: the merge was computed against a head that was one commit stale. `--match-head-commit e56dddb31` would refuse rather than repeat it.
