### PR TITLE
chore(release): acknowledge the eslint-plugin trusted publisher

### DIFF
--- a/scripts/release/first-publish-acknowledged.json
+++ b/scripts/release/first-publish-acknowledged.json
@@ -18,5 +18,5 @@
     "Once a package has published a real version the entry stops doing anything and",
     "preflight will say so; remove it then."
   ],
-  "packages": ["@nextlyhq/builder"]
+  "packages": ["@nextlyhq/builder", "@nextlyhq/eslint-plugin"]
 }


### PR DESCRIPTION
Adds `@nextlyhq/eslint-plugin` to `scripts/release/first-publish-acknowledged.json`.

**This currently blocks every release, not just this package.** `preflight.mjs` refuses to start a release while any package under `packages/` carries only its bootstrap placeholder and is missing from this list — that is deliberate, because a multi-package publish is not atomic and would otherwise strand the package after the rest of the train is live.

The maintainer has confirmed the Trusted Publisher is attached (repository `nextlyhq/nextly`, workflow `release.yml`, environment `Production`).

**Why the confirmation is the evidence:** npm does not expose trusted-publisher configuration publicly. I checked — the packument carries no such field, and the attestations endpoint returns 404 for `@nextlyhq/eslint-plugin@0.0.0` because that placeholder was hand-published rather than published from CI. The endpoint itself works: `@nextlyhq/plugin-sdk@0.0.2-alpha.58` returns 200. So the 404 is expected and says nothing either way, and this entry records the maintainer's attestation.

No changeset: `scripts/release/**` is tooling, not a published package.