### PR TITLE
fix(ui): let a theme restyle the selected tab's underline

### DIFF
--- a/.changeset/tabs-indicator-themeable.md
+++ b/.changeset/tabs-indicator-themeable.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The line under the selected tab now follows the theme. It was marked so that nothing could
+override it, which made it the one piece of admin colour a retheme could not reach.

--- a/packages/ui/src/components/__tests__/tabs-variants.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-variants.test.ts
@@ -186,7 +186,13 @@ describe("what a variant is allowed to change", () => {
     const trigger = classesOf(tabsTriggerVariants());
     expect(trigger).toContain("rounded-none");
     expect(trigger).toContain("border-b-2");
-    expect(trigger).toContain("data-[state=active]:border-b-primary!");
+    expect(trigger).toContain("data-[state=active]:border-b-primary");
+
+    // Unmarked, deliberately. The colour of the line under the selected tab is
+    // the token system's to decide, and an important-marked utility is the one
+    // thing a theme cannot override — so marking it would make this the single
+    // line in the admin that ignores a retheme.
+    expect(trigger).not.toContain("data-[state=active]:border-b-primary!");
     expect(classesOf(tabsListVariants())).toContain("rounded-none");
   });
 });

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -183,12 +183,19 @@ const tabsTriggerVariants = cva(
   // Square corners: the active state is a 2px border on the trailing edge that
   // has to run the full length of the trigger and stay flush with its ends.
   //
+  // The active colour is NOT important-marked. Nothing inside this component
+  // competes for it — the inactive arm is mutually exclusive with the active
+  // one — so the only thing an `!` could win against is a caller's class, which
+  // is precisely what a theme supplies. Marking it made the one line under
+  // every selected tab the one line a theme could not restyle, and the failure
+  // read as "the theme did not apply here" rather than as an opt-out.
+  //
   // The trailing edge is the bottom when the strip is horizontal and the right
   // when it is vertical, so the indicator, the half-step pull onto the rail and
   // the active colour all switch axis together off the same `data-orientation`
   // the list reads. Switching only some of them puts the selection affordance
   // on one axis and the line it sits on the other.
-  "inline-flex items-center justify-center whitespace-nowrap rounded-none bg-transparent px-4 py-2 font-medium cursor-pointer transition-all duration-200 border-b-2 relative -mb-0.5 data-[state=active]:border-b-primary! data-[state=active]:text-primary data-[state=inactive]:border-transparent data-[state=inactive]:text-muted-foreground hover:text-primary hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed data-[orientation=vertical]:border-b-0 data-[orientation=vertical]:mb-0 data-[orientation=vertical]:border-r-2 data-[orientation=vertical]:-mr-0.5 data-[orientation=vertical]:data-[state=active]:border-r-primary",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-none bg-transparent px-4 py-2 font-medium cursor-pointer transition-all duration-200 border-b-2 relative -mb-0.5 data-[state=active]:border-b-primary data-[state=active]:text-primary data-[state=inactive]:border-transparent data-[state=inactive]:text-muted-foreground hover:text-primary hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed data-[orientation=vertical]:border-b-0 data-[orientation=vertical]:mb-0 data-[orientation=vertical]:border-r-2 data-[orientation=vertical]:-mr-0.5 data-[orientation=vertical]:data-[state=active]:border-r-primary",
   {
     variants: { size: TABS_TRIGGER_SIZES },
     defaultVariants: { size: "default" },
@@ -203,8 +210,8 @@ const tabsTriggerVariants = cva(
  * - Padding: 6px 16px (px-4 py-2)
  * - Font: text-sm (14px), font-medium (500)
  * - Transition: 150ms (design system standard)
- * - Active state: blue text with blue bottom  border border-border (2px)
- * - Hover: blue text with blue bottom  border border-border
+ * - Active state: the accent colour on the text and on the 2px trailing border
+ * - Hover: the same accent, so the target reads before it is chosen
  * - Gmail-inspired clean underline style
  *
  * Accessibility:


### PR DESCRIPTION
A defect that has been passed between three lanes without anyone taking it. I am in this file — I added the tab rail in #959/#962 — so it is cheapest here.

## The defect

`main` shipped `data-[state=active]:border-b-primary!` on `TabsTrigger`: an **important-marked colour in a shared primitive**.

Nothing inside the component competes for that property. The inactive arm (`data-[state=inactive]:border-transparent`) is mutually exclusive with the active one, so there is no internal conflict for the mark to resolve. **The only thing it could win against is a caller's class — which is exactly what a theme supplies.**

So it made the line under every selected tab the one piece of admin colour a retheme could not reach, and the failure reads as *"the theme did not apply here"* rather than *"this component opted out"*. That distinction is the reason PR #721's indicator lock was reverted; this is the same shape that survived it.

## The argument that settles it

The vertical variant I added in #962 — `data-[orientation=vertical]:data-[state=active]:border-r-primary` — was **never marked**. So the two axes already disagreed about whether the indicator is overridable: horizontal locked, vertical themeable, same component, same decision. That is not a defensible state to leave, and unmarking is the half that matches the token system.

## What changed

- the `!` is gone from the active border colour
- a comment records *why* it is unmarked, so the next person does not restore it as a fix
- the pinning test in `tabs-variants.test.ts` now asserts the class is present **and** that the marked spelling is absent, so this cannot silently come back

Also repairs a doc line a past sweep substituted into, which left *"blue bottom  border border-border (2px)"* — a double space and a sentence that no longer parses, in the block a plugin author reads.

## Test plan

- `packages/ui` — **1076 passed, 0 failed.** The existing pin failed first (it asserted the marked spelling), which is the guard working; updated to assert the property rather than the old string, and it now fails in both directions.
- `packages/admin` — **2217 passed, 15 failed (4 files)**: the standing pre-existing set. Tabs are shared, so admin was run deliberately.
- `check-types` and `lint` clean on both.

## Not swept, deliberately

`badge.tsx` and `checkbox.tsx` still carry important-marked colours (`border-border!`, `border-primary!`, `border-destructive!`). Same defect class, but each may have an internal conflict this one did not — the reasoning above turns on nothing else competing for the property, and I have not checked that for those two. Sweeping them on the strength of this one's argument is how a correct fix becomes a regression. Filed, not fixed.

## Changeset

Added: yes (`patch`), generated from `.changeset/config.json` — 25 packages.
