### PR TITLE
fix(admin): point a JSON field's error description at the node that carries it

### DIFF
--- a/.changeset/json-error-describedby.md
+++ b/.changeset/json-error-describedby.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A JSON field's parse error is announced again. Scoping field ids moved the error node without
+moving the reference to it, so in a version preview the control described an element that did not
+exist — and a dangling description reaches assistive technology as no description at all, which is
+worse than the plain error it replaced.

--- a/packages/admin/src/components/features/entries/fields/structured/JsonInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/structured/JsonInput.tsx
@@ -294,7 +294,7 @@ export function JsonInput<TFieldValues extends FieldValues = FieldValues>({
           readOnly={readOnly}
           placeholder={field.admin?.placeholder ?? "{\n  \n}"}
           aria-invalid={invalid || parseError !== null || undefined}
-          aria-describedby={parseError ? `${name}-error` : undefined}
+          aria-describedby={parseError ? `${elementId}-error` : undefined}
           className={cn(
             "font-mono text-sm resize-y",
             "min-h-[100px]",

--- a/packages/admin/src/components/features/entries/fields/structured/__tests__/JsonInput.describedby.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/structured/__tests__/JsonInput.describedby.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * A control's `aria-describedby` must name an element that exists.
+ *
+ * This is the failure that scoping field ids can introduce and that nothing
+ * else would notice: the description node and the reference to it are written
+ * in two places, so moving one silently leaves the other pointing at nothing.
+ * A dangling description reaches assistive technology as no description at
+ * all — strictly worse than the plain error it was meant to announce, because
+ * the visible text is there and the announcement is not.
+ *
+ * Asserted by RESOLVING the reference rather than by comparing it to an
+ * expected string: a test that hard-codes the id passes just as happily when
+ * both sides move together to something wrong.
+ */
+import userEvent from "@testing-library/user-event";
+import type { JSONFieldConfig } from "nextly/config";
+import { useForm } from "react-hook-form";
+import { describe, it, expect } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+import { FieldIdScopeContext } from "../../field-id-scope";
+import { JsonInput } from "../JsonInput";
+
+const FIELD = {
+  name: "payload",
+  type: "json",
+  label: "Payload",
+} as JSONFieldConfig;
+
+function Harness({ scope }: { scope: string }) {
+  const form = useForm<{ payload: unknown }>({
+    defaultValues: { payload: {} },
+  });
+  return (
+    <FieldIdScopeContext.Provider value={scope}>
+      <JsonInput name="payload" field={FIELD} control={form.control} />
+    </FieldIdScopeContext.Provider>
+  );
+}
+
+/** The element a control's description points at, or null when it dangles. */
+function describedNode(control: Element): Element | null {
+  const id = control.getAttribute("aria-describedby");
+  return id ? document.getElementById(id) : null;
+}
+
+describe("JsonInput — the parse error is reachable from the control", () => {
+  it("points at a node that exists, in a scoped rendering", async () => {
+    // A scoped rendering is where the two ids can diverge: the description node
+    // takes the scope and a hard-coded reference does not.
+    render(<Harness scope="history-1" />);
+
+    // Queried by role alone: the visible label is supplied by `FieldWrapper`,
+    // which is not part of this unit — and the property under test is the
+    // description reference, not the labelling.
+    const control = await screen.findByRole("textbox");
+    // The parse error is a state the editor types into, not one a stored value
+    // arrives in — an invalid default never round-trips through the parser.
+    await userEvent.clear(control);
+    await userEvent.type(control, "{{ not json");
+
+    // POPULATION BEFORE VERDICT: a control with no description at all would
+    // satisfy "the reference does not dangle" vacuously.
+    expect(
+      control.getAttribute("aria-describedby"),
+      "a parse error must be announced at all"
+    ).toBeTruthy();
+    expect(
+      describedNode(control),
+      "the description must name an element that exists"
+    ).not.toBeNull();
+  });
+
+  it("points at a node that exists in an unscoped rendering too", async () => {
+    render(<Harness scope="" />);
+
+    const control = await screen.findByRole("textbox");
+    await userEvent.clear(control);
+    await userEvent.type(control, "{{ not json");
+    expect(control.getAttribute("aria-describedby")).toBeTruthy();
+    expect(describedNode(control)).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## What

`greptile-apps`' P2 on #984. Correct, and a defect I introduced in that PR.

Scoping the field ids moved the JSON parse-error node's id to `${elementId}-error`, but the textarea's `aria-describedby` still named `${name}-error`. In a **scoped** rendering — a version preview beside the live editor — the control therefore described an element that does not exist.

A dangling description reaches assistive technology as **no description at all**, which is worse than the plain error it replaced: the text is visible on screen and silent to a screen reader.

## How it slipped through

My change to those 13 field components was scripted, and the script rewrote every `id=` it found. `aria-describedby` is the *reference* to an id, spelled differently, and the script never looked for it. One survivor across the tree, confirmed by searching for the shape rather than re-reading the diff:

```
git grep -nE 'aria-describedby=\{`\$\{name\}|id=\{`\$\{name\}' .../fields/
  → (empty after this change)
```

## The test

Asserts the reference **resolves**, rather than comparing it to an expected string:

```ts
const id = control.getAttribute("aria-describedby");
return id ? document.getElementById(id) : null;
```

A test that hard-codes the id passes just as happily when both sides move together to something wrong. It also asserts the description exists at all first — population before verdict, since a control with no description satisfies "does not dangle" vacuously.

The parse error is typed rather than supplied as a default value: an invalid stored value never round-trips through the parser, so a fixture that sets one never reaches the state under test.

## Stub-verified

Reintroducing the dangling reference fails **only the scoped test**, and correctly leaves the unscoped one green — unscoped, the two ids are the same string and cannot diverge. Restore confirmed byte-identical with `cmp`.

```
admin check-types + lint --force   clean
JsonInput.describedby              2 passed
```
