### PR TITLE
fix(ui): let an outline badge show the border colour it is given

### DIFF
--- a/.changeset/badge-outline-border.md
+++ b/.changeset/badge-outline-border.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Outline badges now show the border colour they are given. Seven places in the admin ask one for a
+specific colour — a green edge on an enabled plugin, red and blue on submission states — and every
+one was quietly drawn in the default grey instead. The enabled-plugin pill in particular asked for
+a stronger green so its edge stays visible against the background, and did not get it.

--- a/packages/ui/src/components/badge-outline-border.test.tsx
+++ b/packages/ui/src/components/badge-outline-border.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+/**
+ * An outline badge's border colour belongs to whoever renders it.
+ *
+ * The variant used to mark its border colour important, so a caller asking for
+ * a different one lost silently: the class was present in the list and the
+ * marked declaration still won in the cascade. Seven call sites were affected,
+ * including a status pill carrying a stated 3:1 contrast reason for the colour
+ * it asks for.
+ */
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Badge } from "./badge";
+
+function borderClassesOf(node: Element | null): string[] {
+  return [...(node?.classList ?? [])].filter(c => c.includes("border"));
+}
+
+describe("outline badge border colour", () => {
+  it("is not important-marked, so a caller's colour can win", () => {
+    const { container } = render(<Badge variant="outline">x</Badge>);
+    const marked = borderClassesOf(container.firstElementChild).filter(c =>
+      c.endsWith("!")
+    );
+    expect(
+      marked,
+      "An important-marked border colour cannot be overridden by the caller " +
+        "or by a theme, and the base sets no border colour for it to resolve " +
+        "against — so the only thing it wins against is deliberate intent."
+    ).toEqual([]);
+  });
+
+  it("still draws a default border when the caller asks for nothing", () => {
+    const { container } = render(<Badge variant="outline">x</Badge>);
+    expect(borderClassesOf(container.firstElementChild)).toContain(
+      "border-border"
+    );
+  });
+});

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -47,8 +47,16 @@ const badgeVariants = cva(
           "bg-warning-100 text-warning-700 dark:bg-warning-900 dark:text-warning-100",
         destructive:
           "bg-destructive-100 text-destructive-700 dark:bg-destructive-900 dark:text-destructive-100",
+        /*
+         * The border colour is NOT important-marked. The base sets no border
+         * colour, so nothing inside this component competes for it — the only
+         * thing a mark could win against is the caller's own class. Seven
+         * outline badges pass one, including a status pill whose comment gives
+         * a 3:1 contrast reason for the colour it asks for, and every one of
+         * them was being overridden without any sign that it had been.
+         */
         outline:
-          "border border-border! bg-transparent text-foreground dark:text-muted-foreground dark:border-border!",
+          "border border-border bg-transparent text-foreground dark:text-muted-foreground dark:border-border",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
Follow-up to #988, which removed an important-marked colour from `TabsTrigger`. I filed `badge` and `checkbox` as "same class, unverified" and deliberately did not sweep them. Checking each individually was the right call: **one is a live defect, the other is correct as-is.**

## badge: a real defect, not a styling preference

`badge`'s `outline` variant carried `border border-border! … dark:border-border!`.

Nothing inside the component competes for that property — **the base string sets no border colour at all** — so the only thing the mark could win against is the caller's own class.

**Seven outline badges pass one**, measured by scanning whole JSX elements:

```
schema-builder/SafeChangeConfirmDialog.tsx   border-success-*
plugins/components/PluginsTable.tsx          border-success
plugin-form-builder … (5 sites)              border-border, border-destructive, border-primary
```

And they were all losing. Probed by rendering the component rather than reasoning about `tailwind-merge`:

```
<Badge variant="outline" className="border-success">
→ "border border-border! dark:border-border! border-success"
```

`tailwind-merge` keeps both (the important form is a different group), and `!important` then wins the cascade. **So the caller's class sits in the list looking applied while the marked declaration decides the pixel** — the worst version of this failure, because inspecting the element shows the class you asked for.

`PluginsTable`'s enabled pill is the one that matters: its comment says *"Full-strength success border so the enabled pill's boundary is perceivable at the 3:1 UI minimum."* It was rendering the default grey. That makes this a **contrast defect**, not a theming nicety.

## checkbox: left marked, deliberately

`checkbox` keeps `focus:border-primary!`, `focus-visible:border-primary!`, `aria-invalid:focus:border-destructive!` and `aria-invalid:focus-visible:border-destructive!`.

**There the marks are load-bearing.** That component sets border colour in five places — `border-control-border` (base), `data-[state=checked]:border-primary`, `aria-invalid:border-destructive`, plus the focus states — and those states genuinely **co-occur**: a checkbox can be checked, focused and invalid at once, so `aria-invalid:focus:border-destructive` has to beat `focus:border-primary`. The marks resolve a real internal conflict rather than overruling a caller.

This is exactly the distinction #988's reasoning turned on, and it is why sweeping on that PR's argument would have been a regression.

## Test plan

- **2 new tests**, break-verified: restoring the mark fails both.
- `packages/ui` — **1078 passed, 0 failed.**
- `packages/admin` — **2219 passed, 15 failed (4 files)**: the standing pre-existing set. `Badge` is used widely, so admin was run deliberately.
- `check-types` and `lint` clean on both.

The probe that produced the evidence above was a throwaway; the committed test asserts the property (no important-marked border on the variant) rather than the string.

## Pre-existing failures

`packages/admin`: the standing 15 across `StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField`.

## Changeset

Added: yes (`patch`), generated from `.changeset/config.json` — 25 packages.
