### PR TITLE
feat(builder): delete a block, and make undo reachable

### DIFF
--- a/.changeset/delete-and-undo.md
+++ b/.changeset/delete-and-undo.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+A block can now be deleted with Delete or Backspace, and any edit undone with Ctrl+Z or Cmd+Z and redone with Shift+Z or Y. The editor could add and reorder blocks but not remove them, and its undo history had no way to be invoked.

--- a/packages/builder/src/delete-block.test.ts
+++ b/packages/builder/src/delete-block.test.ts
@@ -1,0 +1,138 @@
+/**
+ * What deleting the selected block takes with it, and where it leaves the
+ * author.
+ *
+ * Selection is what these mostly assert. Removing the node is one op and the
+ * store already covers it; deciding what an author is looking at afterwards is
+ * a judgement with four outcomes, and every one of them renders as "a canvas
+ * with one fewer block" — so none of it is separable in a component test.
+ *
+ * @module delete-block.test
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BlockDocument, BlockNode } from "@nextlyhq/blocks-engine";
+
+import { blockDeletion } from "./delete-block";
+
+function documentOf(nodes: BlockNode[]): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+}
+
+function leaf(id: string): BlockNode {
+  return { id, type: "acme/text", version: 1, props: {} } as BlockNode;
+}
+
+function box(id: string, children: BlockNode[]): BlockNode {
+  return {
+    id,
+    type: "acme/box",
+    version: 1,
+    props: {},
+    slots: { children },
+  } as BlockNode;
+}
+
+describe("blockDeletion", () => {
+  it("names the block and its type", () => {
+    const deletion = blockDeletion(documentOf([leaf("a"), leaf("b")]), "b");
+
+    expect(deletion?.id).toBe("b");
+    // The type travels so a caller can say WHAT was deleted. Recovering it
+    // afterwards is impossible: the node is gone by then.
+    expect(deletion?.type).toBe("acme/text");
+  });
+
+  it("selects the next sibling, so a repeated delete moves forward", () => {
+    // THE case. Selecting the previous sibling here would answer "a" — a block
+    // the author has already passed and approved — so a second press would
+    // destroy work behind them. Forward is what every list-deletion surface
+    // does, and it is what makes a run of presses clear a section.
+    const deletion = blockDeletion(
+      documentOf([leaf("a"), leaf("b"), leaf("c")]),
+      "b"
+    );
+
+    expect(deletion?.nextSelection).toBe("c");
+  });
+
+  it("falls back to the previous sibling when the block was last", () => {
+    // The separating case for the rule above: with nothing after it, the
+    // author stays in the same container rather than losing their place.
+    const deletion = blockDeletion(documentOf([leaf("a"), leaf("b")]), "b");
+
+    expect(deletion?.nextSelection).toBe("a");
+  });
+
+  it("falls to the parent when the block was an only child", () => {
+    // The container is where the author was working, and it is the nearest
+    // thing that still exists.
+    const deletion = blockDeletion(
+      documentOf([box("wrap", [leaf("only")])]),
+      "only"
+    );
+
+    expect(deletion?.nextSelection).toBe("wrap");
+  });
+
+  it("clears the selection only when nothing is left", () => {
+    // The one case with genuinely nowhere to be. Asserting the other three
+    // above is what stops this becoming the answer for all of them.
+    const deletion = blockDeletion(documentOf([leaf("only")]), "only");
+
+    expect(deletion?.nextSelection).toBeNull();
+  });
+
+  it("names the slot it may empty, so an undo can restore it", () => {
+    const deletion = blockDeletion(
+      documentOf([box("wrap", [leaf("only")])]),
+      "only"
+    );
+
+    expect(deletion?.dropSlotIfEmpty).toEqual({
+      parentId: "wrap",
+      slot: "children",
+    });
+  });
+
+  it("names no slot for a top-level block", () => {
+    // The control: a deletion that always carried a slot address would ask the
+    // store to tidy a container that does not exist.
+    const deletion = blockDeletion(documentOf([leaf("a"), leaf("b")]), "a");
+
+    expect(deletion?.dropSlotIfEmpty).toBeUndefined();
+  });
+
+  it("counts what goes with a container, at every depth", () => {
+    // A collapsed section looks exactly like an empty one, so the count is the
+    // only thing telling an author what they are about to lose. Nested rather
+    // than flat on purpose: counting immediate children alone would answer 1
+    // here and be wrong by two.
+    const deletion = blockDeletion(
+      documentOf([box("wrap", [leaf("x"), box("inner", [leaf("y")])])]),
+      "wrap"
+    );
+
+    expect(deletion?.descendantCount).toBe(3);
+  });
+
+  it("counts nothing for a leaf", () => {
+    const deletion = blockDeletion(documentOf([leaf("a")]), "a");
+
+    expect(deletion?.descendantCount).toBe(0);
+  });
+
+  it("refuses when nothing is selected", () => {
+    expect(blockDeletion(documentOf([leaf("a")]), null)).toBeNull();
+  });
+
+  it("refuses an id the document no longer holds", () => {
+    // A stale selection after an undo, or one made against a document that has
+    // since been replaced.
+    expect(blockDeletion(documentOf([leaf("a")]), "gone")).toBeNull();
+  });
+
+  it("is empty-document safe", () => {
+    expect(blockDeletion(documentOf([]), "a")).toBeNull();
+  });
+});

--- a/packages/builder/src/delete-block.ts
+++ b/packages/builder/src/delete-block.ts
@@ -1,0 +1,157 @@
+/**
+ * Deleting the selected block: what it takes with it, and where the author is
+ * left.
+ *
+ * Pure, and separate from the keys that ask for it, for the reason every other
+ * rule in this package is: none of it needs React, and all of it is worth
+ * asserting. A component test in jsdom cannot tell a correct
+ * where-does-selection-go answer from a plausible wrong one, because both
+ * render a canvas with one fewer block.
+ *
+ * **Selection is the whole difficulty.** Removing a node is one op; deciding
+ * what an author is looking at afterwards is a judgement, and getting it wrong
+ * is felt hardest by the keyboard-only author this axis exists for. Clearing
+ * the selection is safe and costs them their place — they must find the canvas
+ * again and re-select before they can do anything else, after an action they
+ * took deliberately.
+ *
+ * @module delete-block
+ */
+
+import {
+  countNodes,
+  locateNode,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+
+import type { SlotAddress } from "./ops";
+
+/** A deletion, with everything a caller needs to describe and apply it. */
+export interface BlockDeletion {
+  /** The node to remove. */
+  readonly id: string;
+  /** The block type, for naming what was removed. */
+  readonly type: string;
+  /**
+   * The slot the block is vacating, when removing it may empty one.
+   *
+   * A request rather than a command: the store drops the slot only if it is
+   * actually empty afterwards. Without it, deleting the last child of a
+   * container leaves an empty slot the page-builder validator rejects.
+   */
+  readonly dropSlotIfEmpty?: SlotAddress;
+  /**
+   * What to select once the block is gone.
+   *
+   * Carried with the deletion rather than recomputed after applying it. Once the
+   * node is removed there is nothing left to derive a neighbour FROM, so a
+   * caller asking afterwards would be asking a document that no longer contains
+   * the subject.
+   */
+  readonly nextSelection: string | null;
+  /**
+   * How many blocks go with it, not counting the block itself.
+   *
+   * A container takes its children, and that is not visible from the block an
+   * author has selected — a collapsed section looks exactly like an empty one.
+   * Carried so the deletion can be STATED rather than gated behind a
+   * confirmation: undo covers it, and a prompt on every delete is friction
+   * people learn to click through without reading.
+   */
+  readonly descendantCount: number;
+}
+
+/**
+ * Where the author is left after a block is removed.
+ *
+ * **Next sibling first, and the case that decides it is REPEATED deletion** —
+ * which is what clearing a section actually is. From `[a, b, c]` with `b`
+ * selected: choosing the previous sibling selects `a`, so a second press
+ * destroys a block the author already passed and approved. Choosing the next
+ * selects `c`, so a second press continues forward through what they were
+ * heading toward. One gesture eats work behind you; the other does not.
+ *
+ * Gutenberg selects the previous block, for a reason that does not transfer:
+ * its Backspace is a text-merge — you delete at the START of a block and carry
+ * on typing in the one before it, so the caret must travel backward. A canvas
+ * with an explicit delete key is list management rather than text editing, and
+ * every list-deletion surface people already use — file managers, mail
+ * clients, task lists — moves forward.
+ *
+ * Then the previous sibling, when the block was last. Then the parent, when it
+ * was an only child: the container is where the author was working, and one
+ * more press deletes it, which is a coherent next action rather than a dead
+ * end.
+ *
+ * `null` only at the top level with nothing left, which is the one case with
+ * genuinely nowhere to be.
+ */
+function selectionAfter(
+  siblings: readonly BlockNode[],
+  index: number,
+  parent: BlockNode | undefined
+): string | null {
+  const next = siblings[index + 1];
+  if (next !== undefined) return next.id;
+  const previous = siblings[index - 1];
+  if (previous !== undefined) return previous.id;
+  return parent?.id ?? null;
+}
+
+/** The list a located node actually sits in, or undefined when it has none. */
+function siblingsOf(
+  nodes: BlockNode[],
+  parent: BlockNode | undefined,
+  slot: string | undefined
+): BlockNode[] | undefined {
+  if (parent === undefined) return nodes;
+  if (slot === undefined) return undefined;
+  return parent.slots?.[slot];
+}
+
+/**
+ * Describe deleting the selected block, or `null` when there is nothing to
+ * delete.
+ *
+ * `null` for an absent selection and for an id the document no longer holds —
+ * a stale id after an undo, or a selection made against a document that has
+ * since been replaced. Both mean the same thing to a caller: there is no
+ * deletion to perform, so nothing should be applied or announced.
+ *
+ * **A returned deletion is not permission.** Validity and locking belong to the
+ * store, so a caller must handle a refusal rather than assume this will apply.
+ */
+export function blockDeletion(
+  document: BlockDocument,
+  selectedId: string | null
+): BlockDeletion | null {
+  if (selectedId === null) return null;
+
+  const here = locateNode(document.nodes, selectedId);
+  if (here === undefined) return null;
+
+  const siblings = siblingsOf(document.nodes, here.parent, here.slot);
+  if (siblings === undefined) return null;
+
+  const node = siblings[here.index];
+  if (node === undefined) return null;
+
+  // The subtree's own size, less the node itself. `countNodes` walks slots, so
+  // this is every descendant at any depth rather than the immediate children —
+  // which is what actually disappears.
+  const descendantCount = countNodes([node]) - 1;
+
+  const dropSlotIfEmpty =
+    here.parent !== undefined && here.slot !== undefined
+      ? { parentId: here.parent.id, slot: here.slot }
+      : undefined;
+
+  return {
+    id: selectedId,
+    type: node.type,
+    ...(dropSlotIfEmpty === undefined ? {} : { dropSlotIfEmpty }),
+    nextSelection: selectionAfter(siblings, here.index, here.parent),
+    descendantCount,
+  };
+}

--- a/packages/builder/src/keyboard-actions.test.tsx
+++ b/packages/builder/src/keyboard-actions.test.tsx
@@ -9,16 +9,20 @@
  * derivation twice while making the failures harder to read, so what is checked
  * here is the seam — the binding, its guards, and the op passed to `apply`.
  *
- * @module keyboard-moves.test
+ * @module keyboard-actions.test
  */
 import { act, cleanup, render, screen } from "@testing-library/react";
 import { ShortcutProvider } from "@nextlyhq/ui";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { BlockDocument } from "@nextlyhq/blocks-engine";
+import {
+  clearBlocks,
+  registerBlocks,
+  type BlockDocument,
+} from "@nextlyhq/blocks-engine";
 
 import type { EditorState } from "./editor-state";
-import { BlockKeyboardMoves } from "./keyboard-moves";
+import { BlockKeyboardActions } from "./keyboard-actions";
 
 // `cleanup`, not an innerHTML wipe. This package does not enable vitest
 // globals, so testing-library registers no cleanup of its own — and clearing
@@ -68,7 +72,7 @@ function editorSpy(
 function mount(editor: EditorState) {
   render(
     <ShortcutProvider>
-      <BlockKeyboardMoves editor={editor} />
+      <BlockKeyboardActions editor={editor} />
     </ShortcutProvider>
   );
 }
@@ -97,7 +101,7 @@ function press(key: string, init: KeyboardEventInit = {}): KeyboardEvent {
   return event;
 }
 
-describe("useBlockKeyboardMoves", () => {
+describe("useBlockKeyboardActions", () => {
   it("moves the selected block down, through the store", () => {
     const editor = editorSpy(pair(), "a");
     mount(editor);
@@ -313,5 +317,180 @@ describe("useBlockKeyboardMoves", () => {
     expect(region).toBeTruthy();
     expect(region.getAttribute("aria-live")).toBe("polite");
     expect(region.textContent).toBe("");
+  });
+
+  it("deletes the selected block through the store", () => {
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    press("Delete");
+
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+    const op = editor.apply.mock.calls[0][0];
+    expect(op.kind).toBe("remove");
+    expect(op.id).toBe("a");
+  });
+
+  it("deletes on Backspace as well", () => {
+    // Most people reach for Backspace. Binding only Delete leaves half the
+    // authors pressing a key that does nothing.
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    press("Backspace");
+
+    expect(editor.apply.mock.calls[0][0].kind).toBe("remove");
+  });
+
+  it("moves the selection forward, not backward", () => {
+    // The repeated-delete case: selecting the PREVIOUS sibling would put the
+    // author on a block they already approved, so a second press destroys work
+    // behind them.
+    const editor = editorSpy(
+      documentOf([
+        { id: "a", type: "acme/text", version: 1, props: {} },
+        { id: "b", type: "acme/text", version: 1, props: {} },
+        { id: "c", type: "acme/text", version: 1, props: {} },
+      ]),
+      "b"
+    );
+    mount(editor);
+
+    press("Delete");
+
+    expect(editor.select).toHaveBeenCalledWith("c");
+  });
+
+  it("does not move the selection when the store refuses", () => {
+    // Moving it first would leave the author pointed at a neighbour while the
+    // block they asked to delete is still on the page.
+    const editor = editorSpy(pair(), "a");
+    editor.apply.mockReturnValue(null);
+    mount(editor);
+
+    press("Delete");
+
+    expect(editor.select).not.toHaveBeenCalled();
+    expect(screen.getByRole("status").textContent).toBe("");
+  });
+
+  it("announces what was deleted and how to get it back", () => {
+    // A screen-reader user cannot see an undo control, so the announcement is
+    // the only place the recovery path exists for them.
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    press("Delete");
+
+    const said = screen.getByRole("status").textContent ?? "";
+    // The type, because this fixture registers no block and so has no label.
+    // The labelled case is asserted below.
+    expect(said).toContain("acme/text deleted");
+    expect(said).toContain("Undo");
+  });
+
+  it("says how many blocks a container takes with it", () => {
+    // A collapsed section looks exactly like an empty one, so the count is the
+    // only thing telling an author what they just lost.
+    const editor = editorSpy(
+      documentOf([
+        {
+          id: "wrap",
+          type: "acme/box",
+          version: 1,
+          props: {},
+          slots: {
+            children: [
+              { id: "x", type: "acme/text", version: 1, props: {} },
+              { id: "y", type: "acme/text", version: 1, props: {} },
+            ],
+          },
+        },
+      ]),
+      "wrap"
+    );
+    mount(editor);
+
+    press("Delete");
+
+    expect(screen.getByRole("status").textContent).toContain("2 blocks inside");
+  });
+
+  // `ctrlKey`, not `metaKey`: the manager resolves `mod` from the platform, and
+  // this environment is not macOS — so a Command press here matches nothing and
+  // would report the binding as missing when it is the fixture that is wrong.
+  it("undoes, and says so", () => {
+    const editor = editorSpy(pair(), "a");
+    (editor as { canUndo: boolean }).canUndo = true;
+    mount(editor);
+
+    press("z", { ctrlKey: true });
+
+    expect(editor.undo).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("status").textContent).toContain("Undone");
+  });
+
+  it("does not undo when there is nothing to undo", () => {
+    // `canUndo` is false on the spy by default. A binding that fired regardless
+    // would call into an empty history on every press.
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    press("z", { ctrlKey: true });
+
+    expect(editor.undo).not.toHaveBeenCalled();
+  });
+
+  it("redoes on both the mac and windows spellings", () => {
+    const editor = editorSpy(pair(), "a");
+    (editor as { canRedo: boolean }).canRedo = true;
+    mount(editor);
+
+    press("z", { ctrlKey: true, shiftKey: true });
+    press("y", { ctrlKey: true });
+
+    expect(editor.redo).toHaveBeenCalledTimes(2);
+  });
+
+  it("undoes with no selection", () => {
+    // Undo acts on the document's history rather than on whatever is selected,
+    // and the commonest thing to undo is a deletion — which leaves a different
+    // block selected than the one the edit touched.
+    const editor = editorSpy(pair(), null);
+    (editor as { canUndo: boolean }).canUndo = true;
+    mount(editor);
+
+    press("z", { ctrlKey: true });
+
+    expect(editor.undo).toHaveBeenCalledTimes(1);
+  });
+
+  it("names the block by its label when it has one", () => {
+    // An author who inserted "Divider" from the palette should hear "Divider
+    // deleted" — the identifier is what the registry calls it, the label is
+    // what they were shown.
+    clearBlocks();
+    registerBlocks(
+      [
+        {
+          name: "acme/text",
+          version: 1,
+          description: "A block.",
+          example: { props: {} },
+          render: () => null,
+          editor: { label: "Paragraph" },
+        },
+      ] as never,
+      { source: "keyboard-actions-test" }
+    );
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    press("Delete");
+
+    expect(screen.getByRole("status").textContent).toContain(
+      "Paragraph deleted"
+    );
+    clearBlocks();
   });
 });

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -17,12 +17,14 @@
  * DOM. What is only true here is which keys ask for it, when they are allowed
  * to, and that the answer reaches the one place a document changes.
  *
- * @module keyboard-moves
+ * @module keyboard-actions
  */
 
+import { getBlock } from "@nextlyhq/blocks-engine";
 import { useShortcuts } from "@nextlyhq/ui";
 import * as React from "react";
 
+import { blockDeletion } from "./delete-block";
 import type { EditorState } from "./editor-state";
 import {
   keyboardMovePosition,
@@ -88,7 +90,39 @@ const EFFECT_ANNOUNCEMENT: Readonly<Record<MoveEffect, string>> = {
   outdent: "Block moved out of its container",
 };
 
-export interface BlockKeyboardMovesOptions {
+/**
+ * How a deletion is announced.
+ *
+ * Names what went AND how to get it back. A screen-reader user cannot see an
+ * undo control, so for them the announcement is the only place the recovery
+ * path exists — and a container takes its children with it, which is invisible
+ * from the block they had selected: a collapsed section looks exactly like an
+ * empty one.
+ *
+ * The count is stated rather than prompted for. A confirmation on every delete
+ * is friction people learn to click through, so it stops being a decision and
+ * becomes a keystroke — protecting nobody while costing everybody. That trade
+ * only holds because undo is reachable, which is why these ship together.
+ */
+function deletionAnnouncement(type: string, descendants: number): string {
+  // The block's own label, falling back to its type. An author who inserted
+  // "Divider" from the palette should hear "Divider deleted", not
+  // "core/divider deleted" — the identifier is what the registry calls it, and
+  // the label is what they were shown. Resolved here rather than carried on the
+  // deletion, because the deletion is a document fact and the wording is a
+  // presentation one.
+  const name = getBlock(type)?.editor?.label ?? type;
+  const what =
+    descendants === 0
+      ? `${name} deleted`
+      : `${name} deleted, with ${descendants} ${descendants === 1 ? "block" : "blocks"} inside`;
+  return `${what}. Undo with ${UNDO_KEYS_SPOKEN}.`;
+}
+
+/** How the undo shortcut is READ ALOUD, which is not how it is parsed. */
+const UNDO_KEYS_SPOKEN = "Control or Command Z";
+
+export interface BlockKeyboardActionsOptions {
   /**
    * The editor whose document these move blocks in.
    *
@@ -114,10 +148,10 @@ export interface BlockKeyboardMovesOptions {
  * returned handlers would invite a second caller to wire them to different keys
  * — which is how one gesture ends up with two answers.
  */
-export function useBlockKeyboardMoves({
+export function useBlockKeyboardActions({
   editor,
   enabled = true,
-}: BlockKeyboardMovesOptions): string {
+}: BlockKeyboardActionsOptions): string {
   // The message a live region reads out. Held as state rather than written to
   // the DOM directly so React owns the node — a region mutated behind React's
   // back is reverted by the next render, silently and only sometimes.
@@ -140,6 +174,28 @@ export function useBlockKeyboardMoves({
   // the document from that render.
   const latest = React.useRef(editor);
   latest.current = editor;
+
+  const deleteSelected = React.useCallback(() => {
+    const editorNow = latest.current;
+    const deletion = blockDeletion(editorNow.document, editorNow.selectedId);
+    // `null` means there is nothing to delete — no selection, or an id the
+    // document no longer holds after an undo. Nothing is applied and nothing is
+    // said, because there is no event to report.
+    if (deletion === null) return;
+
+    const applied = editorNow.apply({
+      kind: "remove",
+      id: deletion.id,
+      dropSlotIfEmpty: deletion.dropSlotIfEmpty,
+    });
+    if (applied === null) return;
+
+    // Selection moved only after the store accepted the removal. Moving it
+    // first would leave the author pointed at a neighbour while the block they
+    // asked to delete is still there.
+    editorNow.select(deletion.nextSelection);
+    announce(deletionAnnouncement(deletion.type, deletion.descendantCount));
+  }, [announce]);
 
   const bindings = React.useMemo(
     () =>
@@ -196,7 +252,71 @@ export function useBlockKeyboardMoves({
     [announce]
   );
 
-  useShortcuts(bindings, { name: "builder-block-moves", enabled });
+  const editing = React.useMemo(
+    () => [
+      {
+        // Both keys. Delete is the explicit one; Backspace is what most people
+        // reach for, and binding only one leaves half the authors pressing a
+        // key that does nothing.
+        keys: "Delete",
+        description: "Delete the selected block",
+        when: () => latest.current.selectedId !== null,
+        // Not while typing, and for a sharper reason than the moves: alt+Arrow
+        // in a field is caret movement, but Backspace is the most destructive
+        // key a text field has. A binding that fired there would eat the
+        // author's characters instead of their block.
+        whenTyping: false,
+        run: () => deleteSelected(),
+      },
+      {
+        keys: "Backspace",
+        description: "Delete the selected block",
+        when: () => latest.current.selectedId !== null,
+        whenTyping: false,
+        run: () => deleteSelected(),
+      },
+      {
+        keys: "mod+z",
+        description: "Undo the last change",
+        // No selection required: undo acts on the document's history, not on
+        // whatever happens to be selected — and the commonest thing to undo is
+        // a deletion, which leaves a different block selected than the one the
+        // edit touched.
+        when: () => latest.current.canUndo,
+        run: () => {
+          latest.current.undo();
+          announce("Undone");
+        },
+      },
+      {
+        // Both spellings: `mod+shift+z` is the convention on macOS and in most
+        // editors, `mod+y` is the Windows one. Neither is wrong and authors
+        // arrive with whichever they learned.
+        keys: "mod+shift+z",
+        description: "Redo the last undone change",
+        when: () => latest.current.canRedo,
+        run: () => {
+          latest.current.redo();
+          announce("Redone");
+        },
+      },
+      {
+        keys: "mod+y",
+        description: "Redo the last undone change",
+        when: () => latest.current.canRedo,
+        run: () => {
+          latest.current.redo();
+          announce("Redone");
+        },
+      },
+    ],
+    [announce, deleteSelected]
+  );
+
+  useShortcuts([...bindings, ...editing], {
+    name: "builder-block-actions",
+    enabled,
+  });
 
   return announcement;
 }
@@ -212,11 +332,11 @@ export function useBlockKeyboardMoves({
  * Renders nothing. It is a place to run a hook, which is the same shape the
  * command palette already uses for its modal key hold.
  */
-export function BlockKeyboardMoves({
+export function BlockKeyboardActions({
   editor,
   enabled,
-}: BlockKeyboardMovesOptions): React.JSX.Element {
-  const announcement = useBlockKeyboardMoves({ editor, enabled });
+}: BlockKeyboardActionsOptions): React.JSX.Element {
+  const announcement = useBlockKeyboardActions({ editor, enabled });
 
   // `polite`, not `assertive`: a move is the author's own action and its result
   // can wait for a pause. Assertive interrupts whatever is being read, which for

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -76,14 +76,22 @@ export { InsertPanel } from "./insert-panel";
 export type { InsertPanelProps } from "./insert-panel";
 
 /**
- * Moving the selected block from the keyboard, behind the same client banner.
+ * The editor's keyboard actions — moving, deleting, undoing — behind the same
+ * client banner.
+ *
+ * ONE component rather than a set, because they share a live region: two
+ * regions announcing the same author's actions read them twice, and a listener
+ * has no way to tell which to believe.
  *
  * Published as a component as well as a hook because the shell provides the
  * shortcut context: whatever renders the shell is outside it, so only a child
  * of the shell can register bindings.
  */
-export { BlockKeyboardMoves, useBlockKeyboardMoves } from "./keyboard-moves";
-export type { BlockKeyboardMovesOptions } from "./keyboard-moves";
+export {
+  BlockKeyboardActions,
+  useBlockKeyboardActions,
+} from "./keyboard-actions";
+export type { BlockKeyboardActionsOptions } from "./keyboard-actions";
 
 /**
  * The editor's document state, published beside the canvas because it is a hook

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -40,7 +40,7 @@ import {
 } from "@nextlyhq/blocks-engine";
 import { CORE_CATEGORIES, coreBlocks } from "@nextlyhq/blocks-react/blocks";
 import {
-  BlockKeyboardMoves,
+  BlockKeyboardActions,
   BuilderShell,
   Canvas,
   InsertPanel,
@@ -248,7 +248,7 @@ function BlocksEditor({
           caller rendering the shell is outside it and cannot register bindings.
           Draws nothing; it exists to run the hook where the context is.
         */}
-        <BlockKeyboardMoves editor={editor} />
+        <BlockKeyboardActions editor={editor} />
         <Canvas
           document={editor.document}
           siteStyles={siteSheet()}


### PR DESCRIPTION
Measured on `main` before choosing this over drag:

| op | store implements | any UI issues it |
| --- | --- | --- |
| `insert` | yes | yes |
| `move` | yes | yes |
| **`remove`** | yes | **nothing** |
| **`update`** | yes | **nothing** |

A block could be added and reordered and **never removed** — a one-way door, where the only exit from a wrong insert was discarding the editing session. That beats drag on value, and `dragSensors.ts` does not exist yet, so drag is also the larger piece.

## Undo lands with it, because it was in the same state

My first draft argued no confirmation was needed since "undo covers it". **@nextly-integrations-38 checked that claim rather than accepting it, and it was false.** Every keyboard binding in the builder was `F6`, four `alt+Arrow`, and a `mod+b` test fixture. No `mod+z`. Zero callers of `undo()` outside the module defining it. Verified independently here, with `.apply({` at 3 call sites as the control that the search was not blind.

So undo was in exactly the state `remove` was: implemented, tested, unreachable. Shipping delete against it would have moved the one-way door one layer down and made it worse — the content would already be gone. They are one change because delete's design depends on undo existing.

## Deleting selects the NEXT sibling, and that is 38's call

The case that decides it is a **repeated** delete, which is what clearing a section is:

```
[a, b, c]   select b, delete

previous  ->  selects a.  Press again -> a, already approved, is destroyed.
next      ->  selects c.  Press again -> continues forward.
```

Gutenberg selects the previous block for a reason that does not transfer: its Backspace is a text-merge, so the caret must travel backward into the block you continue typing in. A canvas with an explicit delete key is list management, and inheriting the selection rule without the text model inherits the wrong half. Every list-deletion surface people already use moves forward.

Falls back to the previous sibling when the block was last, then to the parent when it was an only child — which leaves the author inside the container they were working in and makes the now-empty container deletable with one more press.

## No confirmation; announce instead

A prompt on every delete is friction people learn to click through, so it stops being a decision and becomes a keystroke — protecting nobody while costing everybody. What a container takes with it is **stated**: a collapsed section looks exactly like an empty one, so the count is the only thing telling an author what they lost.

The announcement names the recovery path, because a screen-reader user cannot see an undo control — for them it is the only place that path exists. It reuses the live region #983 added rather than inventing a second, which is also why this module was renamed from `keyboard-moves` to `keyboard-actions`: two regions announcing one author's actions read them twice.

Backspace and Delete both, neither while typing — and the reason differs from `alt+Arrow`'s. That one is excluded because alt+Arrow is word-wise caret movement; Backspace because it is the most destructive key a text field has.

## Evidence

519 tests in `builder`, 30/30 tasks from a clean build.

Stub-verified, each break failing only what names it:

| break | tests that fired |
| --- | --- |
| previous sibling instead of next | selects the next sibling (+ the wiring's own case) |
| select before the store accepts | does not move the selection when the store refuses |
| count immediate children only | counts what goes with a container, at every depth |
| undo without checking `canUndo` | does not undo when there is nothing to undo |

Browser-verified across three settled runs: two blocks, Delete removes one and announces **"Divider deleted. Undo with Control or Command Z."**, Cmd+Z restores it and announces "Undone".

**Two things the browser taught that the unit tests could not.** The announcement first read `core/divider deleted` — the identifier the registry uses, not the label the author was shown in the palette; it now resolves the label. And undo appeared broken until I pressed **Cmd**: `mod` resolves per platform, so the unit tests press Ctrl because jsdom is not macOS while a real browser here wants Command. Same binding, two spellings, and pressing the wrong one reports a working feature as missing.
