### PR TITLE
fix(root): record plugin-form-builder's eslint-config dependency in the lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1272,6 +1272,9 @@ importers:
       '@nextlyhq/admin':
         specifier: workspace:*
         version: link:../admin
+      '@nextlyhq/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
       '@nextlyhq/plugin-sdk':
         specifier: workspace:*
         version: link:../plugin-sdk


### PR DESCRIPTION
## `main` refuses a frozen install

`packages/plugin-form-builder/package.json` declares `@nextlyhq/eslint-config: workspace:*`; `pnpm-lock.yaml` does not carry it. So:

```
pnpm install --frozen-lockfile
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with packages/plugin-form-builder/package.json
```

`ci.yml` installs that way in **six** places, and pnpm defaults `frozen-lockfile` to true in CI regardless of the flag — so every job that installs is affected. Introduced by `1f66dfdb4`, which added the dependency without regenerating the lockfile.

I found this because my own `--frozen-lockfile` refused on a fresh checkout of `main`; it is not specific to my machine.

## Fix

`pnpm install --lockfile-only`. The diff is **3 lines** — the one missing entry, with every other resolution untouched:

```
+      '@nextlyhq/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
```

## Verification — before/after control

| | `pnpm install --frozen-lockfile` |
|---|---|
| before | exit **1**, `ERR_PNPM_OUTDATED_LOCKFILE` |
| after | exit **0**, no drift |

Then, on the fixed tree with `dist` wiped first: `pnpm build` → **19/19 successful, 616 artifacts on disk** (checked as files, not as a "build succeeded" line).

## Note on CI's current colour

Every recent `main` commit has its `Integration` and `Lint / Typecheck / Test / Build` jobs **`queued`**, repo-wide, so there is no red to point at yet. That is not evidence the problem is absent — a queued job has reported nothing. The lockfile drift is reproducible locally and independent of any CI verdict.

## Changeset

**Skipped deliberately.** No published package's contents change — the diff is `pnpm-lock.yaml` only.
