### PR TITLE
fix(builder): insert a block an author can see

### DIFF
--- a/.changeset/insert-visible-content.md
+++ b/.changeset/insert-visible-content.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Inserting a block now adds one you can see. Blocks were inserted with their defaults, which are deliberately empty, so a new heading rendered as an empty element with no height and the page looked unchanged.

--- a/packages/builder/src/inserter.test.ts
+++ b/packages/builder/src/inserter.test.ts
@@ -138,6 +138,28 @@ describe("catalogFrom", () => {
     expect(entry(entries, "acme/card").variationName).toBeUndefined();
   });
 
+  it("inserts the block's worked example, not its empty defaults", () => {
+    // THE case an author sees. A block's defaults are deliberately blank —
+    // `core/heading` defaults to `text: ""` — so inserting them renders an
+    // empty element with no height and nothing to read: the block is added and
+    // the page looks unchanged.
+    const entries = catalog([
+      {
+        ...base,
+        name: "acme/heading",
+        defaultProps: { text: "", level: "h2" },
+        example: { props: { text: "A section title" } },
+      },
+    ]);
+
+    expect(entry(entries, "acme/heading").props).toEqual({
+      // From the example: real content.
+      text: "A section title",
+      // From the defaults: the example says nothing about it, so it survives.
+      level: "h2",
+    });
+  });
+
   it("overlays a variation's props onto the block's defaults", () => {
     const entries = catalog([
       {

--- a/packages/builder/src/inserter.ts
+++ b/packages/builder/src/inserter.ts
@@ -145,10 +145,28 @@ export function catalogFrom(
     const editor = definition.editor;
     const category = editor?.category ?? UNCATEGORISED;
     const keywords = editor?.keywords ?? [];
-    // `defaultProps` is the block's own object. Spreading here means the entry
-    // owns its copy, so the clone taken at insert time cannot reach back into
-    // the definition — and two inserts of one entry cannot share substructure.
-    const defaults = { ...(definition.defaultProps ?? {}) };
+    // The block's DEFAULTS, overlaid by its EXAMPLE.
+    //
+    // Defaults alone are what an author was getting, and they are deliberately
+    // empty: `core/heading` defaults to `text: ""`, `core/text` to `text: ""`,
+    // `core/button` to `label: ""`. Inserting those renders an empty `<h2>` —
+    // an element with no height and nothing to read — so the block was added
+    // and the page looked unchanged. An author cannot edit what they cannot
+    // find, and cannot tell it from the insert having failed.
+    //
+    // `example` is the right source and needs no new contract: the engine
+    // REQUIRES it on every definition, describing it as a worked instance, so
+    // every block already carries one and a third-party block gets this for
+    // free. Defaults stay underneath it, because an example states what is
+    // worth showing rather than every prop — `core/image` illustrates a `src`
+    // while its `loading: "lazy"` default still applies.
+    //
+    // Spread rather than referenced, so the entry owns its copy and the clone
+    // taken at insert time cannot reach back into the definition.
+    const defaults = {
+      ...(definition.defaultProps ?? {}),
+      ...(definition.example?.props ?? {}),
+    };
 
     entries.push({
       id: definition.name,


### PR DESCRIPTION
**Reported by the founder: "when I click on a block, it just adds a black line on the canvas."** That is exactly what was happening, and it is my defect from the inserter.

## What the canvas actually contained

Inserting a Heading produced this:

```html
<h2 class="nx-pb-… nx-bt-core--heading" data-nx-node="ef348fdd-…"></h2>
```

An empty `<h2>`. Canvas visible text: `""`.

The "black line" was the **selection outline** from #983, drawn on an element zero pixels tall — the CSS even gives an empty selected block a 2px minimum height so it can be seen at all. So the one visible trace of an insert was the indicator saying "something is selected here", over nothing.

## The cause

`catalogFrom` built each entry's props from `defaultProps`, and those are deliberately blank:

| block | `defaultProps` | `example.props` |
| --- | --- | --- |
| `core/heading` | `{ text: "", level: "h2" }` | `{ text: "A section title", level: "h2" }` |
| `core/text` | `{ text: "" }` | `{ text: "A paragraph of text." }` |
| `core/button` | `{ label: "", type: "button" }` | `{ label: "Get started", href: "/signup" }` |
| `core/image` | `{ alt: "", loading: "lazy" }` | `{ src: "/example.jpg", alt: "An example image" }` |

Defaults are the block's resting state, not something worth putting on a page. Every block ships real content and the inserter was reading the wrong field.

## Why `example`, rather than a new field

It needs no new contract. The engine REQUIRES `example` on every definition and documents it as a worked instance, so every block already carries one — including third-party blocks, which get this for free rather than having to adopt something.

Defaults stay underneath it. An example states what is worth showing rather than every prop, so `core/image` illustrates a `src` while its `loading: "lazy"` default still applies.

## Verified in the browser

Inserted a Heading, a Quote and a Button. Canvas visible text, which was `""` before:

```
A section title
Simplicity is the soul of efficiency.
Austin Freeman
Get started
```

520 tests, 30/30 tasks from a clean build.

Stub-verified in both directions, which matters here because the two wrong answers fail differently:

| break | tests that fired |
| --- | --- |
| defaults only — the bug that shipped | inserts the block's worked example, not its empty defaults |
| example only, defaults dropped | that case, plus the variation overlay and the deep-clone case |

## One thing this does not fix, worth stating

A block whose example names an asset inserts that reference — `core/image` arrives pointing at `/example.jpg`, which a host will not have. A broken image is still better than an invisible block, because the author can see it and act on it, but the right answer is a block rendering its own empty state when it has no source. That belongs with the block rather than with the inserter.
