### PR TITLE
feat(admin): hold the admin and the kit to the design-token rules

### DIFF
--- a/.changeset/admin-adopts-design-token-rules.md
+++ b/.changeset/admin-adopts-design-token-rules.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The admin and `@nextlyhq/ui` now enforce the same design-token rules shipped to plugin authors.
+
+Twelve inline styles became utility classes, so those surfaces follow the theme and the spacing scale rather than fixed values. The page-builder drop indicator was painted a fixed `deepskyblue` that ignored light and dark mode entirely; it now uses the primary token.
+
+The email preview's palette is named in one place and documented as deliberately literal — mail clients do not resolve CSS custom properties, so a preview built from admin tokens would show authors something recipients never receive.
+
+A `design-lint-ok` exemption now annotates the construct it precedes rather than a single line, so a multi-line declaration needs its reason recorded once. The reach is bounded and cannot extend past a function.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,12 +4,17 @@ import { reactRules } from "@nextlyhq/eslint-config/react-internal";
 
 import { bareErrorConfig } from "./packages/nextly/eslint-bare-error-rule.js";
 
-// Admin UI shipped by a first-party plugin is held to the same token contract
-// third-party plugins are, since these are the packages authors read as the
-// worked example. `packages/admin` and `packages/ui` are deliberately not here
-// yet: they carry violations that need triage rather than a blanket fix, and
-// enabling the rules before that would fail the build on legitimate code.
-const PLUGIN_UI_FILES = ["packages/plugin-*/src/**/*.{ts,tsx}"];
+// Every surface that paints admin chrome is held to the token contract: the
+// first-party plugins, the admin itself, and the kit they both draw from.
+// Anything genuinely outside it — an email preview that mail clients render, a
+// colour picker whose subject IS the colour — carries a `design-lint-ok`
+// directive naming the reason, rather than being excluded here where the
+// exclusion would silently cover whatever is added next.
+const ADMIN_UI_FILES = [
+  "packages/plugin-*/src/**/*.{ts,tsx}",
+  "packages/admin/src/**/*.{ts,tsx}",
+  "packages/ui/src/**/*.{ts,tsx}",
+];
 
 // Apply the React + react-hooks rule set to React-bearing paths so
 // inline `// eslint-disable-next-line react-hooks/...` directives
@@ -36,7 +41,7 @@ export default [
   // includes lint-staged, the hook that runs before a commit is written. Same reason as the
   // React block above.
   bareErrorConfig("packages/nextly/"),
-  ...designTokensConfig(PLUGIN_UI_FILES),
+  ...designTokensConfig(ADMIN_UI_FILES),
   {
     ignores: [
       "packages/*/dist/**",

--- a/packages/admin/eslint.config.js
+++ b/packages/admin/eslint.config.js
@@ -1,6 +1,8 @@
+import { designTokensConfig } from "@nextlyhq/eslint-config/design-tokens";
 import { config } from "@nextlyhq/eslint-config/react-internal";
 
 export default [
+  ...designTokensConfig(["src/**/*.{ts,tsx}"]),
   ...config,
   {
     ignores: [

--- a/packages/admin/src/components/features/content/SortableFieldsTable.tsx
+++ b/packages/admin/src/components/features/content/SortableFieldsTable.tsx
@@ -54,12 +54,11 @@ function SortableFieldRow({
     >
       <td className="px-6 py-4 whitespace-nowrap text-sm">
         <span
-          className="cursor-grab flex items-center select-none"
+          className="flex cursor-grab items-center touch-none select-none"
           {...attributes}
           {...listeners}
           tabIndex={0}
           aria-label="Drag handle"
-          style={{ touchAction: "none" }}
         >
           <svg
             width="16"

--- a/packages/admin/src/components/features/entries/fields/special/DraggableBlockMenuPlugin.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/DraggableBlockMenuPlugin.tsx
@@ -121,15 +121,13 @@ export function DraggableBlockMenuPlugin({
       menuComponent={
         <div
           ref={menuRef}
+          // design-lint-ok: the two properties carry different durations in one
+          // declaration, which a utility cannot express without changing them.
           style={{
-            position: "absolute",
-            left: 0,
-            top: 0,
-            willChange: "transform",
             transition:
               "transform 140ms ease-in-out, opacity 160ms ease-in-out",
           }}
-          className="flex items-center gap-0.5 rounded-md p-[2px_1px] z-10"
+          className="absolute top-0 left-0 z-10 flex items-center gap-0.5 rounded-md p-[2px_1px] will-change-transform"
         >
           <button
             type="button"
@@ -148,16 +146,9 @@ export function DraggableBlockMenuPlugin({
       targetLineComponent={
         <div
           ref={targetLineRef}
-          style={{
-            position: "absolute",
-            left: 0,
-            top: 0,
-            willChange: "transform",
-            height: "4px",
-            backgroundColor: "deepskyblue",
-            borderRadius: "4px",
-          }}
-          className="pointer-events-none"
+          // `deepskyblue` was a fixed colour that ignored the theme; the drop
+          // indicator now takes the primary token like every other affordance.
+          className="pointer-events-none absolute top-0 left-0 h-1 rounded bg-primary will-change-transform"
         />
       }
     />

--- a/packages/admin/src/components/features/entries/fields/special/TableActionMenuPlugin.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/TableActionMenuPlugin.tsx
@@ -296,7 +296,7 @@ export function TableActionMenuPlugin({
       <div style={separatorStyle} />
 
       <ActionButton
-        label={<Trash2 style={{ width: "13px", height: "13px" }} />}
+        label={<Trash2 className="h-[13px] w-[13px]" />}
         title="Delete entire table"
         onClick={deleteTable}
         destructive

--- a/packages/admin/src/components/features/entries/fields/special/VideoNode.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/VideoNode.tsx
@@ -177,8 +177,7 @@ function VideoComponent({
       <figure className="my-4 relative group">
         <div
           // Square corners: embedded media renders full-bleed in the document flow.
-          className="relative w-full overflow-hidden rounded-none"
-          style={{ paddingBottom: "56.25%" }}
+          className="relative aspect-video w-full overflow-hidden rounded-none"
         >
           <iframe
             src={embedUrl}

--- a/packages/admin/src/components/features/media-library/MediaListView/index.tsx
+++ b/packages/admin/src/components/features/media-library/MediaListView/index.tsx
@@ -146,8 +146,7 @@ export function MediaListView({
                   <img
                     src={item.thumbnailUrl ?? item.url}
                     alt={item.altText || item.originalFilename}
-                    className="block max-h-full max-w-full"
-                    style={{ objectFit: "contain" }}
+                    className="block max-h-full max-w-full object-contain"
                     loading="lazy"
                   />
                 ) : (

--- a/packages/admin/src/components/features/schema-builder/RestartOverlay.tsx
+++ b/packages/admin/src/components/features/schema-builder/RestartOverlay.tsx
@@ -26,18 +26,9 @@ export function RestartOverlay() {
       <div className="text-center text-white">
         {/* Pulsing dots animation */}
         <div className="mb-4 flex items-center justify-center gap-1.5">
-          <span
-            className="inline-block h-2 w-2 rounded-full bg-white animate-pulse"
-            style={{ animationDelay: "0s" }}
-          />
-          <span
-            className="inline-block h-2 w-2 rounded-full bg-white animate-pulse"
-            style={{ animationDelay: "0.2s" }}
-          />
-          <span
-            className="inline-block h-2 w-2 rounded-full bg-white animate-pulse"
-            style={{ animationDelay: "0.4s" }}
-          />
+          <span className="inline-block h-2 w-2 rounded-full bg-white animate-pulse [animation-delay:0s]" />
+          <span className="inline-block h-2 w-2 rounded-full bg-white animate-pulse [animation-delay:0.2s]" />
+          <span className="inline-block h-2 w-2 rounded-full bg-white animate-pulse [animation-delay:0.4s]" />
         </div>
 
         <p className="text-sm font-medium">{statusMessage}</p>

--- a/packages/admin/src/components/features/settings/EmailTemplateForm.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm.tsx
@@ -82,6 +82,34 @@ import type {
 } from "@admin/services/emailTemplateApi";
 import type { Media } from "@admin/types/media";
 
+/**
+ * The preview iframe's own palette.
+ *
+ * An email is rendered by mail clients, which do not resolve CSS custom
+ * properties, so a preview that reads the admin's tokens would show the author
+ * something their recipients will never see. These are the email's colours, not
+ * the admin's, which is why they are literal — and why they are named here once
+ * rather than spelled out at each interpolation.
+ *
+ * design-lint-ok: an email cannot resolve `var(--nx-*)`; see above.
+ */
+const PREVIEW_PALETTE = {
+  dark: {
+    text: "#e5e7eb",
+    background: "#0b0b0f",
+    page: "#0b0b0f",
+  },
+  light: {
+    text: "#111827",
+    background: "#ffffff",
+    page: "#f3f4f6",
+  },
+  /** Placeholder copy shown when there is nothing to preview. */
+  muted: "#9ca3af",
+  /** The sample body injected into a layout row's `{{content}}` slot. */
+  sample: "#71717a",
+} as const;
+
 // CodeMirror reaches for browser globals on import, so it loads on demand
 // rather than during SSR.
 const CodeMirrorEditor = lazy(() =>
@@ -459,12 +487,16 @@ function PreviewPane({
     const dark = theme === "dark";
     if (format === "text") {
       return `<!doctype html><html><body style="margin:0;padding:16px;font-family:ui-monospace,monospace;font-size:13px;white-space:pre-wrap;color:${
-        dark ? "#e5e7eb" : "#111827"
+        dark ? PREVIEW_PALETTE.dark.text : PREVIEW_PALETTE.light.text
       };background:${
-        dark ? "#0b0b0f" : "#ffffff"
+        dark
+          ? PREVIEW_PALETTE.dark.background
+          : PREVIEW_PALETTE.light.background
       }">${escapeHtmlValue(text || "(no plain-text content)")}</body></html>`;
     }
-    const pageBg = dark ? "#0b0b0f" : "#f3f4f6";
+    const pageBg = dark
+      ? PREVIEW_PALETTE.dark.page
+      : PREVIEW_PALETTE.light.page;
     // A <meta color-scheme> can't drive `@media (prefers-color-scheme: dark)`
     // (that follows the OS), so rewrite the email's own dark-mode query to
     // force it on/off deterministically with the toggle. Emails without a
@@ -480,7 +512,7 @@ function PreviewPane({
       dark ? "dark" : "light"
     }"><style>html,body{margin:0}body{background:${pageBg};padding:16px}</style></head><body>${
       themedHtml ||
-      "<p style='font-family:sans-serif;color:#9ca3af'>Nothing to preview yet.</p>"
+      `<p style='font-family:sans-serif;color:${PREVIEW_PALETTE.muted}'>Nothing to preview yet.</p>`
     }</body></html>`;
   }, [html, text, theme, format]);
 
@@ -1496,8 +1528,7 @@ export function EmailTemplateForm({
       const [before, after] = splitLayout(htmlContent ?? "");
       const head = interpolate(before, sampleData, false);
       const tail = interpolate(after, sampleData, false);
-      const sampleBody =
-        '<p style="color:#71717a;font-style:italic;">Your email content appears here.</p>';
+      const sampleBody = `<p style="color:${PREVIEW_PALETTE.sample};font-style:italic;">Your email content appears here.</p>`;
       return `${head}${sampleBody}${tail}`;
     }
 

--- a/packages/admin/src/components/shared/charts/Sparkline.tsx
+++ b/packages/admin/src/components/shared/charts/Sparkline.tsx
@@ -55,6 +55,8 @@ export const Sparkline: React.FC<SparklineProps> = ({
         strokeLinecap="round"
         strokeLinejoin="round"
         className="text-primary transition-all duration-700 ease-in-out"
+        // design-lint-ok: stroke-dash geometry has no utility, and the animation
+        // names a keyframe declared in this component's own <style> block.
         style={{
           strokeDasharray: 400,
           strokeDashoffset: 400,

--- a/packages/admin/src/pages/dashboard/singles/builder/components/DragOverlayContent.tsx
+++ b/packages/admin/src/pages/dashboard/singles/builder/components/DragOverlayContent.tsx
@@ -65,10 +65,7 @@ export function DragOverlayContent({ data }: DragOverlayContentProps) {
   const isRequired = field.validation?.required;
 
   return (
-    <div
-      className="flex items-center gap-4 py-3 px-4 bg-background  border border-border rounded-lg shadow-lg cursor-grabbing"
-      style={{ minWidth: 320 }}
-    >
+    <div className="flex items-center gap-4 py-3 px-4 bg-background  border border-border rounded-lg shadow-lg min-w-80 cursor-grabbing">
       {/* Drag handle */}
       <div className="p-1.5 shrink-0">
         {/* Muted foreground to match the reorder handle on the real row. */}

--- a/packages/admin/src/pages/dashboard/users/fields/index.tsx
+++ b/packages/admin/src/pages/dashboard/users/fields/index.tsx
@@ -361,12 +361,11 @@ function SortableFieldRow({
       <TableCell className="whitespace-nowrap text-base">
         <div className="flex items-center gap-2">
           <span
-            className="cursor-grab text-muted-foreground hover:text-foreground shrink-0"
+            className="shrink-0 cursor-grab touch-none text-muted-foreground hover:text-foreground"
             {...attributes}
             {...listeners}
             tabIndex={0}
             aria-label="Drag to reorder"
-            style={{ touchAction: "none" }}
             onClick={e => e.stopPropagation()}
           >
             <GripVertical className="h-4 w-4" />

--- a/packages/eslint-plugin/src/__tests__/no-hardcoded-colors.test.js
+++ b/packages/eslint-plugin/src/__tests__/no-hardcoded-colors.test.js
@@ -31,8 +31,25 @@ ruleTester.run("no-hardcoded-colors", rule, {
     `const a = "commit 1f4b";`,
     `// design-lint-ok: mirrors a third-party embed's fixed palette
        const a = "#ff0000";`,
+    // A directive annotates the CONSTRUCT it precedes, so a named palette does
+    // not need the reason repeated on every line inside it.
+    `// design-lint-ok: an email client cannot resolve custom properties
+     const palette = {
+       text: "#e5e7eb",
+       background: "#0b0b0f",
+       muted: "#9ca3af",
+     };`,
+    // A trailing directive on the violation's own line.
+    `const a = "#ff0000"; // design-lint-ok: matches an external embed`,
   ],
   invalid: [
+    {
+      // The reach is BOUNDED: a directive above a function does not exempt
+      // everything inside it, which would be a blanket disable by another name.
+      code: `// design-lint-ok: blanket attempt
+             function paint() { return "#ff0000"; }`,
+      errors: 1,
+    },
     {
       code: `const a = "#ff0000";`,
       errors: [{ messageId: "hardcodedColor", data: { literal: "#ff0000" } }],

--- a/packages/eslint-plugin/src/exempt.js
+++ b/packages/eslint-plugin/src/exempt.js
@@ -1,26 +1,58 @@
 import { hasExemptionDirective } from "./vocabulary.js";
 
 /**
- * Whether the line a node sits on carries the exemption marker.
+ * Nodes a directive may not reach past.
+ *
+ * Without a ceiling, a comment above a component would exempt every violation
+ * inside it — the "disabled scope silently exempts whatever is added later"
+ * failure this mechanism exists to avoid, reintroduced by the back door. A
+ * directive annotates a declaration, an element or an attribute; it does not
+ * annotate a function or a module.
+ */
+const EXEMPTION_CEILING = new Set([
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "ArrowFunctionExpression",
+  "ClassBody",
+  "Program",
+]);
+
+/**
+ * Whether a `design-lint-ok` directive annotates this node or the construct
+ * containing it.
  *
  * An exception is marked in place, with a reason, rather than by disabling the
  * rule for a file or a directory: a marked line states what was decided and
  * survives review, while a disabled scope silently exempts everything added to
  * it afterwards.
  *
- * The marker is looked for on the node's own line and on the line above, because
- * a long JSX attribute is commonly preceded by its comment rather than trailed
- * by one.
+ * Resolved by walking the node's ancestors and asking whether a directive
+ * immediately PRECEDES any of them, rather than by comparing line numbers. Line
+ * matching cannot annotate a construct that spans lines — a named palette
+ * object, or a multi-property style — so the directive had to be repeated on
+ * every line inside it, which is precisely the noise that makes a reader reach
+ * for a blanket disable instead. The walk stops at {@link EXEMPTION_CEILING} so
+ * the reach stays bounded to the thing the comment sits above.
  */
 export function isExempt(sourceCode, node) {
-  const start = node.loc.start.line;
+  for (let current = node; current; current = current.parent) {
+    if (EXEMPTION_CEILING.has(current.type)) break;
+
+    const before = sourceCode.getCommentsBefore(current);
+    if (before.some(comment => hasExemptionDirective(comment.value))) {
+      return true;
+    }
+  }
+
+  // A trailing directive on the node's own line, which reads naturally for a
+  // short violation: `color: "#fff", // design-lint-ok: <reason>`.
+  const line = node.loc.start.line;
   return sourceCode
     .getAllComments()
     .some(
       comment =>
         hasExemptionDirective(comment.value) &&
-        (comment.loc.start.line === start ||
-          comment.loc.end.line === start ||
-          comment.loc.end.line === start - 1)
+        comment.loc.start.line === line &&
+        comment.range[0] > node.range[0]
     );
 }

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -118,6 +118,8 @@ const SLIDER = "h-3 w-full cursor-pointer appearance-none rounded-full";
  * Fixed greys, deliberately, where the rest of this package uses theme tokens:
  * this is the standard rendering of "nothing here", and a chequerboard that
  * changed colour with the theme would read as part of the colour being edited.
+ *
+ * design-lint-ok: fixed greys are the point here; see above.
  */
 const CHECKERBOARD = "repeating-conic-gradient(#c8c8c8 0% 25%, #ffffff 0% 50%)";
 
@@ -320,6 +322,8 @@ export function ColorPicker<TValue = string>({
           commit({ ...hsva, h: hueAt(+event.target.value / (HUE_MAX + 1)) })
         }
         className={SLIDER}
+        // design-lint-ok: the hue strip renders the colour wheel itself, so its
+        // stops are the control's data rather than theming.
         style={{
           backgroundImage:
             "linear-gradient(to right, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00)",


### PR DESCRIPTION
## The product now enforces on itself what it ships to others

#970 published design-token rules for plugin authors and mounted them for `packages/plugin-*`. The admin — the thing those plugins render inside — was exempt. This closes that.

`packages/admin/src/**` and `packages/ui/src/**` are now in scope, in both the root config (lint-staged) and each package's own config (`pnpm lint`).

**Result: 22 violations → 0**, across 778 files. Fourteen were fixed, eight were exempted with written reasons, and one was a genuine bug.

## The bug the rules caught

`DraggableBlockMenuPlugin.tsx` painted the page-builder's drop indicator `backgroundColor: "deepskyblue"` — a fixed colour that ignores light and dark mode entirely. It now takes the primary token, like every other affordance.

**My rule did not catch it.** `no-hardcoded-colors` detects hex, `rgb()`, `hsl()`, `oklch()` and `oklab()`, but **not CSS named colours**. I found it by reading the file the inline-style rule flagged for a different reason. Filed as a follow-up rather than fixed here: a blanket named-colour check would flag prose like "the red team", so the precise version keys on a colour-valued style property and is its own change.

## What was fixed rather than exempted

| site | was | now |
|---|---|---|
| 2 drag handles | `touchAction: "none"` | `touch-none` |
| media thumbnail | `objectFit: "contain"` | `object-contain` |
| video embed | `paddingBottom: "56.25%"` | `aspect-video` |
| drag overlay | `minWidth: 320` | `min-w-80` |
| table action icon | `width/height: "13px"` | `h-[13px] w-[13px]` |
| restart overlay ×3 | `animationDelay` | `[animation-delay:…]` |
| drop indicator | absolute/size/radius + `deepskyblue` | classes + `bg-primary` |

The video one is a real improvement rather than a translation: `56.25%` bottom padding is the pre-`aspect-ratio` hack, and `aspect-video` says what it means.

## What was exempted, and why each is genuine

- **Email preview palette (7 findings).** An email is rendered by mail clients, which do not resolve CSS custom properties — a preview built from admin tokens would show authors something recipients never see. The colours are now **named once** in `PREVIEW_PALETTE` with the reason recorded there, rather than spelled out at seven interpolations.
- **Colour picker (2).** The chequerboard and the hue strip: the colours *are* the control's data. The chequerboard already carried a docblock explaining this; it now carries the directive too.
- **Sparkline (1).** Stroke-dash geometry has no utility, and the animation names a keyframe declared in the component's own `<style>` block.
- **Drag menu transition (1).** Two properties with different durations in one declaration, which a utility cannot express without changing the timing.

## A mechanism fix that adoption forced

`isExempt` matched a comment to a **line**, so it could not annotate anything spanning lines — the named palette above needed the reason repeated seven times, which is exactly the noise that makes a blanket disable the easier path.

A directive now annotates **the construct it precedes**, resolved by walking ancestors. The reach is **bounded** by a ceiling (function, class body, module) so it cannot become a blanket disable by another name. Three controls, all passing:

```
unexempted violation still caught          → reported ✓
directive above a FUNCTION                 → still reported ✓ (ceiling holds)
directive above a DECLARATION              → whole body exempt ✓
```

## Test plan

- **64 rule tests** (up from 61); 3 new cover the exemption semantics including the bounded-reach case.
- Gates, cache forced off: build **19/19**, lint **24/24**, check-types **22/22**, `test:scripts` **494/494**, `packages/ui` **1078/1078**.
- **`packages/admin`: zero new test failures.** Compared failing FILE SETS with `comm -13` against `origin/main` measured in the same tree — identical, and the 4 files match the documented baseline **by name** (`StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField`), not merely by count.
- Rules verified to actually fire in `admin` and `ui` **individually**, through both the package and root invocation paths — not generalised from one package, which is how a dead mount shipped in #970.

## Stated limit: no visual verification

**Playwright MCP is not available in this session**, so I have not looked at these surfaces in a browser. That matters because the changes are UI-facing, so here is what I am relying on instead:

- Ten of the twelve conversions are documented CSS equivalences (`touch-none` → `touch-action: none`, `object-contain` → `object-fit: contain`, `min-w-80` → `min-width: 20rem` = 320px, `aspect-video` → `16/9`).
- **One change is deliberately visible**: the drop indicator moves from `deepskyblue` to the primary token. That is the point of it.
- **One is worth a human glance**: `aspect-video` replaces a padding hack on the video embed. The absolutely-positioned iframe inside is unaffected, but a rendered check would be better than my reasoning.

If you want, point me at a way to run Playwright and I will verify before this merges.
