### PR TITLE
feat(admin): make reading a version read-only, and actionable from the banner

### DIFF
--- a/.changeset/history-is-read-only-and-actionable.md
+++ b/.changeset/history-is-read-only-and-actionable.md
@@ -1,0 +1,37 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Reading a past version is now read-only all the way through, and can be acted on from where it is
+read. The save controls stand down while a version is on screen — they act on the live document,
+which is not what is being read — and restoring is offered from the banner over the version itself.
+
+Three things that stayed editable are fixed with it. The title and the slug are part of the
+document, so they lock with the rest of it rather than quietly changing the live entry from a
+historical page. The set of fields a version shows is now decided by that version's own values, so
+a document whose layout has changed since is not shown through today's layout. And returning to the
+live document clears the panel's selection too, so no row stays marked as the version on screen.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -20,10 +20,12 @@ import { useCallback, useMemo, useState } from "react";
 
 import {
   DocumentHistoryContext,
+  type RestoreAffordance,
   type ViewedVersion,
 } from "@admin/components/features/versions/document-history-context";
 import { HistoricalDocumentBanner } from "@admin/components/features/versions/HistoricalDocumentBanner";
 import { historyEnabledFrom } from "@admin/components/features/versions/history-enabled";
+import { snapshotToFormValues } from "@admin/components/features/versions/snapshot-to-form-values";
 import { VersionSnapshotForm } from "@admin/components/features/versions/VersionSnapshotForm";
 import { Alert, AlertDescription, Skeleton } from "@admin/components/ui";
 import { useBranding } from "@admin/context/providers/BrandingProvider";
@@ -317,10 +319,31 @@ export function EntryForm({
   const [viewingVersion, setViewingVersion] = useState<ViewedVersion | null>(
     null
   );
+  // Published by the history panel while it is mounted, so the banner can
+  // offer restoring without a second copy of the permission or the mutation.
+  const [restoreAffordance, setRestoreAffordance] =
+    useState<RestoreAffordance | null>(null);
   const documentHistory = useMemo(
-    () => ({ viewing: viewingVersion, setViewing: setViewingVersion }),
-    [viewingVersion]
+    () => ({
+      viewing: viewingVersion,
+      setViewing: setViewingVersion,
+      restore: restoreAffordance,
+      setRestore: setRestoreAffordance,
+    }),
+    [viewingVersion, restoreAffordance]
   );
+
+  // Which fields a version HAD, decided by that version's own values. The
+  // takeover layout is value-driven, so computing it from the live entry would
+  // show today's layout over yesterday's document — omitting fields the version
+  // stored, or offering fields it never had.
+  const historicalFields = useMemo(() => {
+    if (!viewingVersion) return null;
+    return computeMainFields(allFields, {
+      takeoverTypes,
+      values: snapshotToFormValues(allFields, viewingVersion.snapshot),
+    });
+  }, [viewingVersion, allFields, takeoverTypes]);
 
   // Whether this collection has Draft/Published status enabled at the meta
   // level. When true, the system header splits into Save Draft + Publish/Update
@@ -599,7 +622,13 @@ export function EntryForm({
                     <HistoricalDocumentBanner
                       versionNo={viewingVersion.versionNo}
                       locale={viewingVersion.locale}
-                      onReturnToCurrent={() => setViewingVersion(null)}
+                      // Routed through the panel when one is mounted, so its
+                      // selection clears with the shared state. The direct
+                      // fallback keeps the banner working without a panel.
+                      onReturnToCurrent={
+                        restoreAffordance?.returnToCurrent ??
+                        (() => setViewingVersion(null))
+                      }
                     />
                   ) : null}
                   <EntryMetaStrip
@@ -654,7 +683,7 @@ export function EntryForm({
                         </div>
                       ) : (
                         <VersionSnapshotForm
-                          fields={mainFields}
+                          fields={historicalFields ?? mainFields}
                           snapshot={viewingVersion.snapshot}
                         />
                       )}

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -12,6 +12,7 @@ import { isFieldLocalized, type FieldConfig } from "nextly/config";
 import { useEffect, useRef, useState } from "react";
 import { useFormContext } from "react-hook-form";
 
+import { useDocumentHistory } from "@admin/components/features/versions/document-history-context";
 import { VersionHistorySheet } from "@admin/components/features/versions/VersionHistorySheet";
 import {
   Code,
@@ -277,6 +278,10 @@ export function EntrySystemHeader({
   const [unpublishOpen, setUnpublishOpen] = useState(false);
   const [discardDraftOpen, setDiscardDraftOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
+  // True while the document area is showing a past version rather than the
+  // live document.
+  const { viewing: viewingVersion } = useDocumentHistory();
+  const isReadingHistory = viewingVersion !== null;
 
   // Both collections and singles authorize a document write as `update-{slug}`.
   const canUpdateDocument = useCan(`update-${collectionSlug}`);
@@ -310,7 +315,10 @@ export function EntrySystemHeader({
     (titleField as { label?: string } | undefined)?.label ?? "Title";
 
   const { ref: rhfRef, ...rhfRegister } = form.register(titleName, {
-    required: !lockIdentity && titleRequired ? "Title is required" : false,
+    required:
+      !lockIdentity && !isReadingHistory && titleRequired
+        ? "Title is required"
+        : false,
   });
 
   // the title input bypasses FieldWrapper, so apply the same per-field RTL rule here —
@@ -378,7 +386,11 @@ export function EntrySystemHeader({
           placeholder="Untitled"
           aria-label={titleLabel}
           disabled={isSubmitting}
-          readOnly={lockIdentity}
+          // The title is part of the document, so reading a past version locks
+          // it with everything else. Left editable it would mutate the LIVE
+          // document while the banner says the page cannot be edited — and go
+          // to autosave as unsaved work nobody typed on purpose.
+          readOnly={lockIdentity || isReadingHistory}
           // RTL for a translatable title edited in an RTL language.
           {...(titleRtl ? { dir: "rtl" as const } : {})}
           className={cn(
@@ -484,7 +496,12 @@ export function EntrySystemHeader({
                 localeCount: counts.total,
               })}
         />
-        {hasStatus && isPublishedEdit ? (
+        {/* No save affordances while a past version is on screen. They act on
+            the live document, which is not what is being read — an editor
+            offered "Save" over a historical page has been invited to make a
+            decision about something they cannot see. Restoring is offered
+            instead, from the banner over the version itself. */}
+        {isReadingHistory ? null : hasStatus && isPublishedEdit ? (
           <>
             <Button
               type="button"

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -14,7 +14,7 @@
  * @module components/features/versions/VersionHistorySheet
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   Alert,
@@ -179,7 +179,7 @@ export function VersionHistorySheet({
   // Hand the chosen version to the document area, and take it back whenever
   // nothing is chosen — including when the panel closes, so dismissing it never
   // strands the editor on a version it can no longer see the list for.
-  const { setViewing } = useDocumentHistory();
+  const { setViewing, setRestore } = useDocumentHistory();
   const viewedSnapshot = detail.data?.snapshot;
   const viewedLocale = detail.data?.locale ?? null;
   const viewedLoading = detail.isLoading;
@@ -216,6 +216,24 @@ export function VersionHistorySheet({
     if (!open) return;
     return () => setViewing(null);
   }, [open, setViewing]);
+
+  // Restoring is offered from the banner in the document, which is where the
+  // reader is looking — but it stays THIS component's mutation, guarded by
+  // this component's confirmation. Only the trigger travels.
+  const requestRestore = useCallback(() => setConfirmingRestore(true), []);
+  // Clears this panel's own selection as well as the shared one, so the list
+  // stops marking a row active for a version that is no longer on screen.
+  const returnToCurrent = useCallback(() => setSelected(null), []);
+  useEffect(() => {
+    if (!open || selected === null) {
+      setRestore(null);
+      return;
+    }
+    setRestore({ canRestore, request: requestRestore, returnToCurrent });
+    // Withdrawn on unmount as well as on close: a banner left holding a
+    // trigger into an unmounted panel would open a dialog nothing renders.
+    return () => setRestore(null);
+  }, [open, selected, canRestore, requestRestore, returnToCurrent, setRestore]);
 
   const restore = useRestoreVersion({
     scope,

--- a/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
@@ -382,7 +382,14 @@ describe("VersionHistorySheet", () => {
 
     const setViewing = vi.fn();
     render(
-      <DocumentHistoryContext.Provider value={{ viewing: null, setViewing }}>
+      <DocumentHistoryContext.Provider
+        value={{
+          viewing: null,
+          setViewing,
+          restore: null,
+          setRestore: vi.fn(),
+        }}
+      >
         <VersionHistorySheet open onOpenChange={vi.fn()} scope={scope} />
       </DocumentHistoryContext.Provider>
     );
@@ -635,5 +642,73 @@ describe("VersionHistorySheet — renaming", () => {
     expect(
       screen.getAllByRole("button", { name: /name version/i }).length
     ).toBeGreaterThan(0);
+  });
+});
+
+describe("VersionHistorySheet — what it publishes to the document", () => {
+  function renderWithDocument(canRestore = true) {
+    const setViewing = vi.fn();
+    const setRestore = vi.fn();
+    render(
+      <DocumentHistoryContext.Provider
+        value={{ viewing: null, setViewing, restore: null, setRestore }}
+      >
+        <VersionHistorySheet
+          open
+          onOpenChange={vi.fn()}
+          scope={scope}
+          canRestore={canRestore}
+        />
+      </DocumentHistoryContext.Provider>
+    );
+    return { setViewing, setRestore };
+  }
+
+  beforeEach(() => {
+    useVersionsMock.mockReturnValue(
+      listState({
+        data: { pages: [{ items: [version(3)], meta: { hasNext: false } }] },
+      })
+    );
+    useVersionMock.mockReturnValue(
+      detailState({ data: { snapshot: { title: "Old" }, locale: null } })
+    );
+  });
+
+  it("offers restoring to the document only when the caller may write", async () => {
+    const { setRestore } = renderWithDocument(false);
+    await userEvent.click(screen.getByRole("button", { name: /Version 3/ }));
+
+    await waitFor(() =>
+      expect(setRestore).toHaveBeenCalledWith(
+        expect.objectContaining({ canRestore: false })
+      )
+    );
+  });
+
+  it("returns to the live document THROUGH the panel, clearing its own row", async () => {
+    const { setRestore } = renderWithDocument();
+    await userEvent.click(screen.getByRole("button", { name: /Version 3/ }));
+
+    await waitFor(() => expect(setRestore).toHaveBeenCalled());
+    const published = setRestore.mock.calls.at(-1)?.[0] as {
+      returnToCurrent: () => void;
+    };
+
+    // The banner cannot clear this panel's selection itself, so it asks. Going
+    // back must leave no row marked active for a version off screen.
+    expect(screen.getByRole("button", { name: /Version 3/ })).toHaveAttribute(
+      "aria-current",
+      "true"
+    );
+    // ONLY the published callback — clicking "Back to history" as well would
+    // clear the selection by itself and the assertion would pass whether or not
+    // `returnToCurrent` does anything.
+    published.returnToCurrent();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Version 3/ })
+      ).not.toHaveAttribute("aria-current", "true")
+    );
   });
 });

--- a/packages/admin/src/components/features/versions/document-history-context.tsx
+++ b/packages/admin/src/components/features/versions/document-history-context.tsx
@@ -34,10 +34,35 @@ export interface ViewedVersion {
   error: Error | null;
 }
 
+/**
+ * Restoring, offered by the panel that owns the mutation and its confirmation.
+ *
+ * Published rather than reimplemented beside the banner: a second restore path
+ * would be a second answer to "may this caller write, and what happens when
+ * they do" — and the panel already holds the permission, the mutation and the
+ * dialog that guards it.
+ */
+export interface RestoreAffordance {
+  /** Whether this caller may write the document at all. */
+  canRestore: boolean;
+  /** Opens the panel's confirmation for the version currently on screen. */
+  request: () => void;
+  /**
+   * Returns to the live document THROUGH the panel, so its own selection is
+   * cleared with the shared one. Clearing only the shared state would leave a
+   * row marked active for a version no longer on screen, with restore and
+   * compare still aimed at it, and clicking that row again a no-op.
+   */
+  returnToCurrent: () => void;
+}
+
 export interface DocumentHistoryValue {
   /** The version on screen in place of the live document, or null for live. */
   viewing: ViewedVersion | null;
   setViewing: (viewing: ViewedVersion | null) => void;
+  /** Present only while the history panel is mounted to provide it. */
+  restore: RestoreAffordance | null;
+  setRestore: (restore: RestoreAffordance | null) => void;
 }
 
 /**
@@ -48,6 +73,8 @@ export interface DocumentHistoryValue {
 export const DocumentHistoryContext = createContext<DocumentHistoryValue>({
   viewing: null,
   setViewing: () => {},
+  restore: null,
+  setRestore: () => {},
 });
 
 export function useDocumentHistory(): DocumentHistoryValue {


### PR DESCRIPTION
## What

Reading a past version is now read-only **all the way through**, and can be acted on from where it is read.

Closes the two pieces I deferred from #994, plus the three P1s `greptile-apps` raised on it — all four are the same question: *what is still live while you are reading the past.*

## Save controls stand down

They act on the live document, which is not what is on screen. An editor offered **Save** over a historical page has been invited to decide about something they cannot see.

**Restoring is offered from the banner instead**, over the version itself. The mutation and its confirmation stay in the panel that owns them; only the *trigger* travels, published through the shared history state. A second restore path would be a second answer to who may write and what happens when they do.

## The three review findings, all real

**Title and slug stayed editable** (P1). Both sit outside the field tree, so replacing the fields left them live — editing either changed the **live** entry from a page saying it cannot be edited, and fed autosave work nobody meant to do. Both now lock with everything else, through the `lockIdentity` / `lockSlug` props they already had.

**The field set was computed from live values** (P1). The takeover layout is value-driven, so `computeMainFields(allFields, { takeoverTypes, values })` with *live* values showed today's layout over yesterday's document — omitting fields the version stored. It is now computed from that version's own values, through the same normalisation the form gets.

**Returning left the panel's selection stale** (P1). The banner cleared only the shared state, so a row stayed marked active for a version off screen, restore and compare kept targeting it, and clicking that row again was a no-op.

### The first fix for that last one was wrong, and the way it failed is the useful part

I first had the panel *watch* the shared state and clear its selection when it went null. That broke six existing tests instantly — because the context's default value is `viewing: null` with a no-op setter, so **without a provider the panel deselected itself the moment anything was chosen.**

A default that makes the wrong state representable. The fix is the same shape as restore: the banner **asks** the panel to return, through a published `returnToCurrent`, so the panel keeps owning its own selection. A direct fallback keeps the banner working where no panel is mounted.

## Verification

```
pnpm turbo run build --force                       20 successful / 20 total,  0 cached
pnpm turbo run check-types lint --continue --force 46 successful / 46 total,  0 cached
playwright version-history-isolation               2 passed
packages/admin   4 failed | 242 passed (246 files)  — failing file set identical to baseline
```

Two new tests on what the panel publishes. The second was **passing for the wrong reason** on its first draft — it clicked "Back to history" *and* called the published callback, so it would have passed whether or not the callback did anything. With the click removed, making `returnToCurrent` inert fails it and nothing else. Restore confirmed byte-identical with `cmp`.
