### PR TITLE
feat(builder): edit the selected block's props

### DIFF
--- a/.changeset/block-inspector.md
+++ b/.changeset/block-inspector.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+The selected block can now be edited. An inspector reads the props a block declares and draws a control for each, so a heading inserted from the palette can be given its real text instead of staying at the example the palette supplied.

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+/**
+ * The inspector: editing the selected block's props.
+ *
+ * Draws what `inspector` decides and decides nothing itself — which props a
+ * block exposes, in what order, and the patch that changes one all live there,
+ * where they can be asserted without a DOM.
+ *
+ * **Text commits on blur, not on every keystroke.** Undo is built from op
+ * inverses, so an op per character would make one undo remove one letter, and
+ * a sentence would take a sentence's worth of presses to take back. Committing
+ * on blur keeps an edit to a field one entry in the history, which is what an
+ * author means by "undo that change". The cost is that the canvas updates when
+ * focus leaves the field rather than as you type; live preview needs the store
+ * to coalesce consecutive updates to one node and prop, which it does not do
+ * yet.
+ *
+ * Discrete controls — a checkbox, a select — commit immediately. There is no
+ * typing to coalesce, and waiting for blur on a checkbox would leave the canvas
+ * disagreeing with a control the author has already changed.
+ *
+ * @module inspector-panel
+ */
+
+import { findNode } from "@nextlyhq/blocks-engine";
+import {
+  Checkbox,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+} from "@nextlyhq/ui";
+import * as React from "react";
+
+import type { EditorState } from "./editor-state";
+import { inspectSelection, propPatch, type EditableProp } from "./inspector";
+
+export interface InspectorPanelProps {
+  /**
+   * The editor whose selected block this edits.
+   *
+   * The whole state rather than a document and an `apply` separately: a patch is
+   * built from the node in a particular document, and passing them apart lets a
+   * caller hand a node from one render to an `apply` bound to another — which
+   * writes a merged props object assembled from a stale node.
+   */
+  editor: EditorState;
+}
+
+/** A prop name as a human reads it: `backgroundColor` becomes "Background color". */
+function labelFor(name: string): string {
+  const spaced = name
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[-_]+/g, " ")
+    .trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
+}
+
+export function InspectorPanel({
+  editor,
+}: InspectorPanelProps): React.JSX.Element {
+  // Recomputed each render rather than memoised: an inspection is only valid
+  // against the document it was read from, and an edit anywhere changes both
+  // the document and the values shown.
+  const inspection = inspectSelection(editor.document, editor.selectedId);
+
+  const commit = React.useCallback(
+    (name: string, value: unknown) => {
+      const id = editor.selectedId;
+      if (id === null) return;
+      // Read the node at commit time rather than closing over one. A field
+      // committing on blur can fire after another edit has already replaced the
+      // node, and patching from the older copy would resurrect its props.
+      const node = findNode(editor.document.nodes, id);
+      if (node === undefined) return;
+      editor.apply({ kind: "update", id, patch: propPatch(node, name, value) });
+    },
+    [editor]
+  );
+
+  if (inspection === null) {
+    return (
+      <div className="nx-inspector" data-empty="no-selection">
+        <p className="nx-inspector__note">Select a block to edit it.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="nx-inspector">
+      <h2 className="nx-inspector__title">{inspection.label}</h2>
+      {inspection.props.length === 0 ? (
+        <p className="nx-inspector__note">
+          This block has no editable properties.
+        </p>
+      ) : (
+        <div className="nx-inspector__fields">
+          {inspection.props.map(prop => (
+            <PropField
+              // Keyed by node AND prop: a bare prop name would let React reuse
+              // one block's field for the next block's same-named prop, so the
+              // input would keep the previous block's uncommitted text.
+              key={`${inspection.nodeId}:${prop.name}`}
+              prop={prop}
+              onCommit={commit}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PropField({
+  prop,
+  onCommit,
+}: {
+  prop: EditableProp;
+  onCommit: (name: string, value: unknown) => void;
+}): React.JSX.Element {
+  const id = `nx-prop-${prop.name}`;
+
+  if (!prop.supported) {
+    return (
+      <div className="nx-inspector__field" data-unsupported="">
+        <Label htmlFor={id}>{labelFor(prop.name)}</Label>
+        {/*
+          Listed rather than omitted. A block declaring a prop this panel cannot
+          draw is still a block with that prop, and hiding it presents an
+          incomplete block as a complete one — an author would conclude the
+          field does not exist rather than that it is edited elsewhere.
+        */}
+        <p className="nx-inspector__note">
+          Not editable here ({prop.schema.type}).
+        </p>
+      </div>
+    );
+  }
+
+  if (prop.schema.type === "checkbox") {
+    return (
+      <div className="nx-inspector__field nx-inspector__field--inline">
+        <Checkbox
+          id={id}
+          checked={prop.value === true}
+          onCheckedChange={checked => onCommit(prop.name, checked === true)}
+        />
+        <Label htmlFor={id}>{labelFor(prop.name)}</Label>
+      </div>
+    );
+  }
+
+  if (prop.schema.type === "select") {
+    return (
+      <div className="nx-inspector__field">
+        <Label htmlFor={id}>{labelFor(prop.name)}</Label>
+        <Select
+          value={typeof prop.value === "string" ? prop.value : undefined}
+          onValueChange={next => onCommit(prop.name, next)}
+        >
+          <SelectTrigger id={id}>
+            <SelectValue placeholder="Choose" />
+          </SelectTrigger>
+          <SelectContent>
+            {prop.options.map(option => (
+              <SelectItem key={option} value={option}>
+                {option}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    );
+  }
+
+  return <TextishField id={id} prop={prop} onCommit={onCommit} />;
+}
+
+/** A prop's value as editable text, or empty when it is not representable. */
+function storedText(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
+/**
+ * A field the author types into: text, textarea, url, number.
+ *
+ * Holds its own value while focused so typing is responsive, and reports it on
+ * blur. Reading straight from the node would make every keystroke a document
+ * edit; reporting only on blur without local state would make the field refuse
+ * to show what was typed.
+ */
+function TextishField({
+  id,
+  prop,
+  onCommit,
+}: {
+  id: string;
+  prop: EditableProp;
+  onCommit: (name: string, value: unknown) => void;
+}): React.JSX.Element {
+  // Only a primitive becomes text. `String({})` is "[object Object]", and a
+  // field showing that would COMMIT it on blur — turning a prop the panel
+  // cannot represent into a string that permanently replaces it. An
+  // unrepresentable value shows empty and, because `send` compares against
+  // this, an untouched field writes nothing.
+  const stored = storedText(prop.value);
+  const [draft, setDraft] = React.useState(stored);
+
+  // The stored value wins whenever it changes underneath the field — an undo,
+  // an edit from the canvas, a different block selected into the same slot.
+  // Without this the input would go on showing a value the document no longer
+  // has.
+  React.useEffect(() => {
+    setDraft(stored);
+  }, [stored]);
+
+  const send = () => {
+    if (draft === stored) return;
+    if (prop.schema.type === "number") {
+      const parsed = Number(draft);
+      // A number field that cannot parse reverts rather than writing NaN, which
+      // survives JSON as `null` and reaches the renderer as a missing prop.
+      if (draft.trim() === "" || Number.isNaN(parsed)) {
+        setDraft(stored);
+        return;
+      }
+      onCommit(prop.name, parsed);
+      return;
+    }
+    onCommit(prop.name, draft);
+  };
+
+  const shared = {
+    id,
+    value: draft,
+    onBlur: send,
+    onChange: (
+      event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+    ) => setDraft(event.target.value),
+  };
+
+  return (
+    <div className="nx-inspector__field">
+      <Label htmlFor={id}>{labelFor(prop.name)}</Label>
+      {prop.schema.type === "textarea" ? (
+        <Textarea {...shared} rows={3} />
+      ) : (
+        <Input
+          {...shared}
+          type={prop.schema.type === "number" ? "number" : "text"}
+          inputMode={prop.schema.type === "url" ? "url" : undefined}
+          // Enter commits as well as blur. A single-line field is where an
+          // author expects Enter to mean "done", and waiting for them to click
+          // elsewhere leaves the canvas stale after a deliberate action.
+          onKeyDown={event => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              send();
+            }
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/builder/src/inspector.test.ts
+++ b/packages/builder/src/inspector.test.ts
@@ -1,0 +1,223 @@
+/**
+ * What the selected block exposes for editing, and the patch that changes it.
+ *
+ * Driven through the real registry, because which props a block declares is
+ * exactly what a stub would restate — and a stub that agreed today would keep
+ * agreeing after the registry changed what a definition means.
+ *
+ * @module inspector.test
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  clearBlocks,
+  registerBlocks,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+
+import { inspectSelection, propPatch, SUPPORTED_PROP_TYPES } from "./inspector";
+
+const base = {
+  version: 1,
+  description: "A block.",
+  example: { props: {} },
+  render: () => null,
+};
+
+afterEach(clearBlocks);
+
+function documentOf(nodes: BlockNode[]): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+}
+
+/** Register a heading-like block and put one instance in a document. */
+function withHeading(props: Record<string, unknown> = {}) {
+  registerBlocks(
+    [
+      {
+        ...base,
+        name: "acme/heading",
+        editor: { label: "Heading" },
+        props: {
+          text: { type: "text" },
+          level: { type: "select", options: ["h1", "h2", "h3"] },
+          anchor: { type: "url" },
+        },
+      },
+    ] as never,
+    { source: "inspector-test" }
+  );
+  return documentOf([
+    { id: "a", type: "acme/heading", version: 1, props } as BlockNode,
+  ]);
+}
+
+describe("inspectSelection", () => {
+  it("titles the panel with the block's label", () => {
+    const inspection = inspectSelection(withHeading(), "a");
+
+    // The label, not the namespaced identity — the same name the palette
+    // offered. An author who inserted "Heading" should be editing "Heading".
+    expect(inspection?.label).toBe("Heading");
+    expect(inspection?.blockName).toBe("acme/heading");
+  });
+
+  it("lists props in the order the block declares them", () => {
+    // Declaration order rather than alphabetical: a block author writes a
+    // heading before its level, and sorting rearranges a form somebody
+    // designed. Alphabetical here would be anchor, level, text.
+    const inspection = inspectSelection(withHeading(), "a");
+
+    expect(inspection?.props.map(p => p.name)).toEqual([
+      "text",
+      "level",
+      "anchor",
+    ]);
+  });
+
+  it("carries each prop's current value", () => {
+    const inspection = inspectSelection(withHeading({ text: "Hello" }), "a");
+
+    expect(inspection?.props.find(p => p.name === "text")?.value).toBe("Hello");
+    // Absent rather than defaulted: what the node holds is what the control
+    // shows, and inventing a value here would write it back on the first edit.
+    expect(
+      inspection?.props.find(p => p.name === "anchor")?.value
+    ).toBeUndefined();
+  });
+
+  it("carries a select's options", () => {
+    const inspection = inspectSelection(withHeading(), "a");
+
+    expect(inspection?.props.find(p => p.name === "level")?.options).toEqual([
+      "h1",
+      "h2",
+      "h3",
+    ]);
+  });
+
+  it("marks a prop it cannot draw as unsupported, and keeps it", () => {
+    // Kept rather than dropped. A block declaring a prop the panel cannot draw
+    // is still a block with that prop, and hiding it presents an incomplete
+    // block as complete — the author concludes the field does not exist.
+    registerBlocks(
+      [
+        {
+          ...base,
+          name: "acme/gallery",
+          props: {
+            caption: { type: "text" },
+            images: { type: "array" },
+          },
+        },
+      ] as never,
+      { source: "inspector-test" }
+    );
+    const inspection = inspectSelection(
+      documentOf([
+        { id: "g", type: "acme/gallery", version: 1, props: {} } as BlockNode,
+      ]),
+      "g"
+    );
+
+    expect(inspection?.props.map(p => p.name)).toEqual(["caption", "images"]);
+    expect(inspection?.props.find(p => p.name === "caption")?.supported).toBe(
+      true
+    );
+    expect(inspection?.props.find(p => p.name === "images")?.supported).toBe(
+      false
+    );
+  });
+
+  it("supports exactly the declared set", () => {
+    // The set is named rather than inferred from what a switch happens to
+    // handle, so this pins the two together: a type added to one and not the
+    // other is what makes an unsupported prop fall through silently.
+    expect([...SUPPORTED_PROP_TYPES]).toEqual([
+      "text",
+      "textarea",
+      "url",
+      "number",
+      "checkbox",
+      "select",
+    ]);
+  });
+
+  it("refuses with no selection, a stale id, or an unregistered block", () => {
+    const document = withHeading();
+
+    expect(inspectSelection(document, null)).toBeNull();
+    expect(inspectSelection(document, "gone")).toBeNull();
+
+    // Unregistered: its props have no schemas, so every control would be
+    // guessed from the stored value's runtime type — a text box for a number,
+    // silently rewriting it on save.
+    clearBlocks();
+    expect(inspectSelection(document, "a")).toBeNull();
+  });
+
+  it("reports a block with no declared props as having none", () => {
+    // Distinct from refusing: the block is known and simply exposes nothing.
+    // The panel says so rather than showing an empty column.
+    registerBlocks([{ ...base, name: "acme/divider" }] as never, {
+      source: "inspector-test",
+    });
+    const inspection = inspectSelection(
+      documentOf([
+        { id: "d", type: "acme/divider", version: 1, props: {} } as BlockNode,
+      ]),
+      "d"
+    );
+
+    expect(inspection).not.toBeNull();
+    expect(inspection?.props).toEqual([]);
+  });
+});
+
+describe("propPatch", () => {
+  it("carries every other prop through", () => {
+    // THE case. `updateNode` merges at the top level, so a patch holding only
+    // the edited key REPLACES the props object and drops the rest — editing a
+    // heading's text would silently discard its level.
+    const node = {
+      id: "a",
+      type: "acme/heading",
+      version: 1,
+      props: { text: "Old", level: "h2" },
+    } as BlockNode;
+
+    expect(propPatch(node, "text", "New")).toEqual({
+      props: { text: "New", level: "h2" },
+    });
+  });
+
+  it("adds a prop the node did not have", () => {
+    const node = {
+      id: "a",
+      type: "acme/heading",
+      version: 1,
+      props: { text: "Hi" },
+    } as BlockNode;
+
+    expect(propPatch(node, "level", "h3")).toEqual({
+      props: { text: "Hi", level: "h3" },
+    });
+  });
+
+  it("does not mutate the node it was given", () => {
+    // The patch is applied by the store against its own copy; mutating here
+    // would edit the document outside the op layer, and undo would have no
+    // inverse for it.
+    const node = {
+      id: "a",
+      type: "acme/heading",
+      version: 1,
+      props: { text: "Old" },
+    } as BlockNode;
+
+    propPatch(node, "text", "New");
+
+    expect(node.props.text).toBe("Old");
+  });
+});

--- a/packages/builder/src/inspector.ts
+++ b/packages/builder/src/inspector.ts
@@ -1,0 +1,157 @@
+/**
+ * What the selected block exposes for editing, and the patch that changes it.
+ *
+ * Pure, for the reason every rule in this package is: which controls a block
+ * offers, in what order, carrying which values, is derivation — and a component
+ * test in jsdom cannot separate a correct answer from a plausible wrong one,
+ * because both render a column of inputs.
+ *
+ * **A block declares its own editable surface.** `props` on the definition maps
+ * each prop name to a `PropSchema`, and the schema's `type` decides the
+ * control. Nothing here holds a list of which blocks have which fields: a
+ * third-party block gets an inspector by declaring its props, exactly as a
+ * first-party one does.
+ *
+ * @module inspector
+ */
+
+import {
+  getBlock,
+  findNode,
+  type BlockDocument,
+  type BlockNode,
+  type PropSchema,
+} from "@nextlyhq/blocks-engine";
+
+import type { NodePatch } from "./ops";
+
+/**
+ * The prop types this inspector can draw a control for.
+ *
+ * Named as a set rather than inferred from what the switch happens to handle,
+ * so an unsupported prop is a KNOWN gap rather than a silent fallthrough. A
+ * block declaring `type: "array"` still appears in the panel — the author is
+ * told the prop exists and is not editable here — because omitting it entirely
+ * would present an incomplete block as a complete one.
+ */
+export const SUPPORTED_PROP_TYPES = [
+  "text",
+  "textarea",
+  "url",
+  "number",
+  "checkbox",
+  "select",
+] as const;
+
+export type SupportedPropType = (typeof SUPPORTED_PROP_TYPES)[number];
+
+/** One editable prop, with everything a control needs to draw itself. */
+export interface EditableProp {
+  readonly name: string;
+  readonly schema: PropSchema;
+  /** The node's current value, which may be absent. */
+  readonly value: unknown;
+  /**
+   * Whether this inspector can draw a control for it.
+   *
+   * Carried rather than recomputed by the panel: the panel would have to repeat
+   * the membership test, and the two would disagree the first time this set
+   * gained a member.
+   */
+  readonly supported: boolean;
+  /** The options a `select` offers, empty for every other type. */
+  readonly options: readonly string[];
+}
+
+/** The selected block, as something to edit. */
+export interface BlockInspection {
+  readonly nodeId: string;
+  readonly blockName: string;
+  /** What to title the panel: the block's label, or its name. */
+  readonly label: string;
+  /**
+   * Props in the order the definition declares them.
+   *
+   * Declaration order rather than alphabetical: a block author writes a heading
+   * before its level and a button before its destination, and sorting that into
+   * alphabetical order rearranges a form somebody designed.
+   */
+  readonly props: readonly EditableProp[];
+}
+
+/** Read a schema's `options`, which is untyped by construction. */
+function optionsOf(schema: PropSchema): readonly string[] {
+  const declared = schema.options;
+  if (!Array.isArray(declared)) return [];
+  return declared.filter(
+    (option): option is string => typeof option === "string"
+  );
+}
+
+/**
+ * Describe the selected block for editing, or `null` when there is nothing to
+ * edit.
+ *
+ * `null` for no selection, for an id the document no longer holds, and for a
+ * block the registry does not know — the last because an unregistered block's
+ * props have no schemas, so every control would have to be guessed from the
+ * stored value's runtime type. Guessing produces a text box for a number and
+ * silently rewrites the value on save.
+ */
+export function inspectSelection(
+  document: BlockDocument,
+  selectedId: string | null
+): BlockInspection | null {
+  if (selectedId === null) return null;
+
+  const node = findNode(document.nodes, selectedId);
+  if (node === undefined) return null;
+
+  const definition = getBlock(node.type);
+  if (definition === undefined) return null;
+
+  const declared = definition.props ?? {};
+  const props = Object.entries(declared).flatMap<EditableProp>(
+    ([name, schema]) => {
+      if (schema === undefined) return [];
+      return [
+        {
+          name,
+          schema,
+          value: node.props[name],
+          supported: (SUPPORTED_PROP_TYPES as readonly string[]).includes(
+            schema.type
+          ),
+          options: optionsOf(schema),
+        },
+      ];
+    }
+  );
+
+  return {
+    nodeId: node.id,
+    blockName: node.type,
+    label: definition.editor?.label ?? node.type,
+    props,
+  };
+}
+
+/**
+ * The patch that sets one prop.
+ *
+ * **The whole props object, not the one key.** `updateNode` merges at the top
+ * level — `{ ...node, ...patch }` — so a patch carrying `{ props: { text } }`
+ * REPLACES the node's props and drops every other one. Editing a heading's text
+ * would silently discard its level.
+ *
+ * Built here rather than in the panel so that fact is stated once. A caller
+ * assembling its own patch has to know a merge rule that is two files away, and
+ * the failure is silent: the edit works and the other props are gone.
+ */
+export function propPatch(
+  node: BlockNode,
+  name: string,
+  value: unknown
+): NodePatch {
+  return { props: { ...node.props, [name]: value } };
+}

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -72,6 +72,18 @@ export type { CanvasProps } from "./canvas";
  * is the second implementation of the nesting rule that the engine exists to
  * prevent.
  */
+/**
+ * The inspector, behind the same client banner: it holds draft field state and
+ * writes through the store.
+ *
+ * The derivations it draws from are not re-exported beside it, for the reason
+ * the inserter's are not — which props a block exposes is the editor's answer,
+ * and publishing it invites a host to build a second inspector that disagrees
+ * with this one about the merge rule for a patch.
+ */
+export { InspectorPanel } from "./inspector-panel";
+export type { InspectorPanelProps } from "./inspector-panel";
+
 export { InsertPanel } from "./insert-panel";
 export type { InsertPanelProps } from "./insert-panel";
 

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -295,3 +295,69 @@
   white-space: nowrap;
   border-width: 0;
 }
+
+/*
+ * The inspector.
+ *
+ * Scrolls inside its own region rather than growing: the shell fixes the
+ * region's size, and a block with many props would otherwise push the shell's
+ * layout instead of its own.
+ */
+.nx-inspector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 0;
+  height: 100%;
+  overflow-y: auto;
+  padding: 0.75rem;
+  color: var(--nx-builder-text, var(--nx-foreground));
+  background: var(--nx-builder-surface, var(--nx-background));
+}
+
+.nx-inspector__title {
+  margin: 0;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--nx-muted-foreground);
+}
+
+.nx-inspector__note {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--nx-muted-foreground);
+}
+
+.nx-inspector__fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+.nx-inspector__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+/*
+ * A checkbox reads as one line with its label beside it rather than stacked
+ * above it: the control is small enough that a label on its own line separates
+ * the two further than they belong.
+ */
+.nx-inspector__field--inline {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/*
+ * A prop the panel cannot draw is dimmed rather than hidden — present, and
+ * visibly not one of the things an author can change here.
+ */
+.nx-inspector__field[data-unsupported] {
+  opacity: 0.7;
+}

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -44,6 +44,7 @@ import {
   BuilderShell,
   Canvas,
   InsertPanel,
+  InspectorPanel,
   useEditorState,
 } from "@nextlyhq/builder/shell";
 import { useSuppressAdminChrome } from "@nextlyhq/plugin-sdk/admin";
@@ -233,6 +234,11 @@ function BlocksEditor({
       <BuilderShell
         onExit={done}
         availablePanels={AVAILABLE_PANELS}
+        // The shell owns the region; this fills it. Rendered unconditionally
+        // rather than only when something is selected, because the panel states
+        // "select a block to edit it" — a region that appears and disappears
+        // with the selection makes the canvas resize on every click.
+        inspector={<InspectorPanel editor={editor} />}
         // Switched on the panel id rather than rendering the inserter for
         // whatever the rail reports open. The shell asks for the panel it
         // opened, and a renderer ignoring that argument would draw the inserter


### PR DESCRIPTION
Measured on `main` before starting:

| op | store implements | any UI issues it |
| --- | --- | --- |
| `insert` | yes | yes |
| `move` | yes | yes |
| `remove` | yes | yes |
| **`update`** | yes | **nothing** |

A page could be assembled, rearranged and pruned — and never **changed**. Every block stayed at the example content the palette inserted, so an author's own words could not reach the page. That is the last of the four ops to get a consumer.

## A block declares its own editable surface

`props` on the definition maps each name to a `PropSchema`, and the schema's `type` picks the control. Nothing here holds a list of which blocks have which fields, so a third-party block gets an inspector by declaring its props exactly as a first-party one does.

The vocabulary across the core library, which decided the scope:

| type | declarations |
| --- | --- |
| `text` | 16 |
| `select` | 15 |
| `checkbox` | 10 |
| `url` | 6 |
| `array` | 3 |
| `textarea` | 2 |
| `number` | 2 |
| `media` | 1 |

Six types cover 51 of 55. `array` and `media` need dedicated UI and are **listed and marked**, not hidden — a block declaring a prop this panel cannot draw is still a block with that prop, and omitting it would present an incomplete block as a complete one.

## Two decisions worth the review

**Text commits on blur; discrete controls commit at once.** Undo is built from op inverses, so an op per keystroke would make one undo remove one letter and a sentence take a sentence's worth of presses to take back. A checkbox has no typing to coalesce, and waiting for blur there would leave the canvas disagreeing with a control the author already changed. The cost is stated in the module: live preview needs the store to coalesce consecutive updates to one node and prop, which it does not do yet.

**A patch carries the whole props object.** `updateNode` merges at the top level — `{ ...node, ...patch }` — so a patch holding only the edited key REPLACES props and drops the rest. Editing a heading's text would silently discard its level. `propPatch` states that once, rather than leaving every call site to know a merge rule two files away.

## Evidence

531 tests in `builder`, 30/30 tasks from a clean build.

Stub-verified, each break failing only what names it:

| break | tests that fired |
| --- | --- |
| patch only the edited key | carries every other prop through; adds a prop the node did not have |
| drop unsupported props instead of listing them | marks a prop it cannot draw as unsupported, and keeps it |
| sort props alphabetically | lists props in the order the block declares them |
| inspect an unregistered block by guessing | refuses with no selection, a stale id, or an unregistered block |

Browser-verified: inserted a Heading, inspector titles **HEADING** and lists `Text, Level, Href, Target, Rel` in declaration order; typing into Text and pressing Enter changed the canvas to "My real heading".

**One defect the lint caught that a test would not have.** `String(prop.value)` on an object yields `"[object Object]"` — and the field would have **committed** that on blur, permanently replacing a prop the panel cannot represent. Only primitives become text now; anything else shows empty and, because the commit compares against that, an untouched field writes nothing.
