### PR TITLE
fix(admin): connect the banner's restore trigger, and cover the wiring

### DIFF
--- a/.changeset/banner-restore-is-reachable.md
+++ b/.changeset/banner-restore-is-reachable.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Restoring a version is now offered from the historical-document banner: the entry form passes its restore handler through, so an authorised reader sees the action beside the version they are reading rather than nowhere at all.

--- a/e2e/tests/version-history-isolation.spec.ts
+++ b/e2e/tests/version-history-isolation.spec.ts
@@ -145,6 +145,15 @@ test.describe("reading history does not write", () => {
     // The document is showing the past.
     await expect(documentExcerpt(page)).toHaveValue(first, { timeout: 15_000 });
 
+    // Restoring is offered from the banner, over the version being read. This
+    // is a wiring assertion and belongs here rather than in a unit test: the
+    // panel publishes the trigger and the banner consumes it, so a component
+    // test of either half passes while the two are not connected.
+    await expect(
+      page.getByRole("button", { name: /restore this version/i }),
+      "an authorised reader must be offered restore from the banner"
+    ).toBeVisible({ timeout: 15_000 });
+
     // Returning must restore what is LIVE, unchanged. Had the snapshot been
     // loaded into the live form rather than rendered against one of its own,
     // the editor would come back holding the historical text — and a save from

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -629,6 +629,19 @@ export function EntryForm({
                         restoreAffordance?.returnToCurrent ??
                         (() => setViewingVersion(null))
                       }
+                      // Offered only when the panel says this caller may write.
+                      onRestore={
+                        restoreAffordance?.canRestore
+                          ? restoreAffordance.request
+                          : undefined
+                      }
+                      // And only once the version is actually on screen:
+                      // restoring from a skeleton, or from a failed read, is a
+                      // decision made without having seen what is being chosen.
+                      restoreDisabled={
+                        viewingVersion.isLoading ||
+                        viewingVersion.error !== null
+                      }
                     />
                   ) : null}
                   <EntryMetaStrip

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -587,23 +587,13 @@ export function VersionHistorySheet({
                   Compare with current
                 </Button>
               ) : null}
-              {/* Available only once the snapshot is on screen: restoring is
-                  offered from the preview so the choice is made having seen
-                  what the version holds, which a skeleton or an error is not. */}
-              {canRestore ? (
-                <Button
-                  size="sm"
-                  onClick={() => setConfirmingRestore(true)}
-                  disabled={
-                    restore.isPending ||
-                    detail.isLoading ||
-                    Boolean(detail.error) ||
-                    detail.data === undefined
-                  }
-                >
-                  Restore this version
-                </Button>
-              ) : null}
+              {/* Restoring is offered in the BANNER over the version being
+                  read, not here. The panel only ever offered it while a
+                  version was selected, which is exactly when the banner is on
+                  screen — so a button here would be a second control with the
+                  same label, and the further one from what it acts on. This
+                  component still owns the mutation and its confirmation; the
+                  banner holds the trigger. */}
             </>
           ) : null}
           <Button

--- a/packages/admin/src/components/features/versions/__tests__/HistoricalDocumentBanner.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/HistoricalDocumentBanner.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * The banner is the only thing on a historical page that says it is historical,
+ * and the only way off it. What matters is that it names the version, offers
+ * the way back unconditionally, and offers restoring only when restoring is a
+ * decision the reader is in a position to make.
+ */
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+import { HistoricalDocumentBanner } from "../HistoricalDocumentBanner";
+
+describe("HistoricalDocumentBanner", () => {
+  it("names the version and says it is not live", () => {
+    render(
+      <HistoricalDocumentBanner versionNo={7} onReturnToCurrent={vi.fn()} />
+    );
+
+    expect(screen.getByText("Version 7")).toBeInTheDocument();
+    expect(screen.getByText(/not what is live/)).toBeInTheDocument();
+  });
+
+  it("names the locale a version was captured in", () => {
+    render(
+      <HistoricalDocumentBanner
+        versionNo={7}
+        locale="de"
+        onReturnToCurrent={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(/\(de\)/)).toBeInTheDocument();
+  });
+
+  it("always offers the way back", async () => {
+    const onReturnToCurrent = vi.fn();
+    render(
+      <HistoricalDocumentBanner
+        versionNo={7}
+        onReturnToCurrent={onReturnToCurrent}
+      />
+    );
+
+    // Offered even without restore: a reader who may not write still has to be
+    // able to leave a page that cannot be edited.
+    await userEvent.click(
+      screen.getByRole("button", { name: /back to current/i })
+    );
+    expect(onReturnToCurrent).toHaveBeenCalled();
+  });
+
+  it("offers restoring only when a handler is supplied", () => {
+    const { unmount } = render(
+      <HistoricalDocumentBanner versionNo={7} onReturnToCurrent={vi.fn()} />
+    );
+    expect(
+      screen.queryByRole("button", { name: /restore this version/i })
+    ).toBeNull();
+    unmount();
+
+    render(
+      <HistoricalDocumentBanner
+        versionNo={7}
+        onReturnToCurrent={vi.fn()}
+        onRestore={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole("button", { name: /restore this version/i })
+    ).toBeInTheDocument();
+  });
+
+  it("holds restoring back until the version is actually on screen", () => {
+    // Restoring writes the live document. Choosing it from a skeleton, or from
+    // a version that failed to load, is a decision made without having seen
+    // what is being chosen.
+    const onRestore = vi.fn();
+    render(
+      <HistoricalDocumentBanner
+        versionNo={7}
+        onReturnToCurrent={vi.fn()}
+        onRestore={onRestore}
+        restoreDisabled
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /restore this version/i })
+    ).toBeDisabled();
+    // The way back stays available: being unable to restore is not being
+    // trapped on the page.
+    expect(
+      screen.getByRole("button", { name: /back to current/i })
+    ).toBeEnabled();
+  });
+});

--- a/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
@@ -117,6 +117,38 @@ function reachable(element: Element | null): boolean {
   return true;
 }
 
+/**
+ * Renders the panel with a document context and returns a reader for what it
+ * publishes. The restore TRIGGER lives in the banner now, so a test that wants
+ * to exercise restoring asks the panel for it rather than clicking a control
+ * this component no longer renders.
+ */
+function renderPublishing(props: Record<string, unknown> = {}) {
+  const setRestore = vi.fn();
+  const setViewing = vi.fn();
+  render(
+    <DocumentHistoryContext.Provider
+      value={{ viewing: null, setViewing, restore: null, setRestore }}
+    >
+      <VersionHistorySheet
+        open
+        onOpenChange={vi.fn()}
+        scope={scope}
+        {...props}
+      />
+    </DocumentHistoryContext.Provider>
+  );
+  const published = () =>
+    setRestore.mock.calls.at(-1)?.[0] as
+      | {
+          canRestore: boolean;
+          request: () => void;
+          returnToCurrent: () => void;
+        }
+      | undefined;
+  return { setRestore, setViewing, published };
+}
+
 describe("VersionHistorySheet", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -428,7 +460,7 @@ describe("VersionHistorySheet", () => {
     ).toBeInTheDocument();
   });
 
-  it("offers restore only to a caller who may write the document", async () => {
+  it("publishes whether the caller may restore, rather than rendering a button", async () => {
     useVersionsMock.mockReturnValue(
       listState({
         data: { pages: [{ items: [version(3)], meta: { hasNext: false } }] },
@@ -436,31 +468,19 @@ describe("VersionHistorySheet", () => {
     );
     useVersionMock.mockReturnValue(detailState({ data: { snapshot: {} } }));
 
-    const { unmount } = render(
-      <VersionHistorySheet open onOpenChange={vi.fn()} scope={scope} />
-    );
+    const { published } = renderPublishing({ canRestore: true });
     await userEvent.click(screen.getByRole("button", { name: /Version 3/ }));
+
+    // The control is in the banner over the version; this panel supplies the
+    // permission and the trigger.
+    await waitFor(() => expect(published()?.canRestore).toBe(true));
     expect(
       screen.queryByRole("button", { name: /Restore this version/ })
-    ).not.toBeInTheDocument();
-    unmount();
-
-    render(
-      <VersionHistorySheet
-        open
-        onOpenChange={vi.fn()}
-        scope={scope}
-        canRestore
-      />
-    );
-    await userEvent.click(screen.getByRole("button", { name: /Version 3/ }));
-    expect(
-      screen.getByRole("button", { name: /Restore this version/ })
-    ).toBeInTheDocument();
+    ).toBeNull();
   });
 
-  it("confirms before restoring rather than writing on the first click", async () => {
-    // Restore writes the live document, so a single misclick must not do it.
+  it("confirms before restoring rather than writing on the first request", async () => {
+    // Restore writes the live document, so triggering it must not do it.
     useVersionsMock.mockReturnValue(
       listState({
         data: { pages: [{ items: [version(3)], meta: { hasNext: false } }] },
@@ -468,22 +488,14 @@ describe("VersionHistorySheet", () => {
     );
     useVersionMock.mockReturnValue(detailState({ data: { snapshot: {} } }));
 
-    render(
-      <VersionHistorySheet
-        open
-        onOpenChange={vi.fn()}
-        scope={scope}
-        canRestore
-      />
-    );
-
+    const { published } = renderPublishing({ canRestore: true });
     await userEvent.click(screen.getByRole("button", { name: /Version 3/ }));
-    await userEvent.click(
-      screen.getByRole("button", { name: /Restore this version/ })
-    );
+    await waitFor(() => expect(published()).toBeDefined());
+
+    published()!.request();
 
     expect(mutateMock).not.toHaveBeenCalled();
-    expect(screen.getByText(/Restore version 3\?/)).toBeInTheDocument();
+    expect(await screen.findByText(/Restore version 3\?/)).toBeInTheDocument();
   });
 
   it("tells the editor when a restore was refused", async () => {
@@ -517,44 +529,9 @@ describe("VersionHistorySheet", () => {
     await waitFor(() => expect(toastErrorMock).toHaveBeenCalled());
   });
 
-  it("does not offer restore until the version is on screen", async () => {
-    // Restore is offered from the preview so the choice follows seeing what the
-    // version holds; a skeleton or an error is not that.
-    useVersionsMock.mockReturnValue(
-      listState({
-        data: { pages: [{ items: [version(3)], meta: { hasNext: false } }] },
-      })
-    );
-    useVersionMock.mockReturnValue(detailState({ isLoading: true }));
-
-    const { unmount } = render(
-      <VersionHistorySheet
-        open
-        onOpenChange={vi.fn()}
-        scope={scope}
-        canRestore
-      />
-    );
-    await userEvent.click(screen.getByRole("button", { name: /Version 3/ }));
-    expect(
-      screen.getByRole("button", { name: /Restore this version/ })
-    ).toBeDisabled();
-    unmount();
-
-    useVersionMock.mockReturnValue(detailState({ data: { snapshot: {} } }));
-    render(
-      <VersionHistorySheet
-        open
-        onOpenChange={vi.fn()}
-        scope={scope}
-        canRestore
-      />
-    );
-    await userEvent.click(screen.getByRole("button", { name: /Version 3/ }));
-    expect(
-      screen.getByRole("button", { name: /Restore this version/ })
-    ).toBeEnabled();
-  });
+  // Whether restore is offered before the version has finished loading is now
+  // the banner's decision (`restoreDisabled`), because the banner is where the
+  // control is. Covered by HistoricalDocumentBanner's own suite.
 
   it("warns from the live document's status, not the version's", async () => {
     // The selected version's status describes the past; whether this change is
@@ -568,22 +545,17 @@ describe("VersionHistorySheet", () => {
       detailState({ data: { snapshot: {}, status: "draft" } })
     );
 
-    render(
-      <VersionHistorySheet
-        open
-        onOpenChange={vi.fn()}
-        scope={scope}
-        canRestore
-        liveStatus="published"
-      />
-    );
-
+    const { published } = renderPublishing({
+      canRestore: true,
+      liveStatus: "published",
+    });
     await userEvent.click(screen.getByRole("button", { name: /Version 3/ }));
-    await userEvent.click(
-      screen.getByRole("button", { name: /Restore this version/ })
-    );
+    await waitFor(() => expect(published()).toBeDefined());
+    published()!.request();
 
-    expect(screen.getByText(/the document is published/)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/the document is published/)
+    ).toBeInTheDocument();
   });
 
   it("does not query while closed", () => {


### PR DESCRIPTION
Recovers work that #996 merged without: the merge ran from a stale head, so
`021b99eb8` never reached `main`. Verified by content against the merge commit
`b0f20cc7e` with positive controls — the markers are present at the branch head
and absent from the merge, and `HistoricalDocumentBanner.test.tsx` is missing
from the merged tree entirely.

## What this restores

- **The banner's restore trigger was never connected.** `EntryForm` rendered
  `HistoricalDocumentBanner` without `onRestore`, so "Restore this version"
  never appeared for anyone. The prop and its `restoreDisabled` companion are
  passed through now.
- **The panel's own restore button is removed.** It offered restore exactly
  when the banner does, so it was redundant, and two identically-labelled
  buttons made every query for it ambiguous.
- **Coverage for the wiring**, which is what would have caught it: the e2e
  asserts an authorised reader is offered restore from the banner, and
  `HistoricalDocumentBanner.test.tsx` adds five tests over the banner's own
  contract.
- Four sheet tests retargeted through the published trigger via a
  `renderPublishing()` helper.

## Verification

- `pnpm build` 19/19, `check-types` + `lint` 46/46 with `--force`, 0 cached
- versions suite 14 files / 188 tests, `HistoricalDocumentBanner.test.tsx`
  confirmed in the run by membership
- full admin suite 4 failed / 243 passed (247 files); the failing set matches
  the documented baseline exactly by membership (StatsCard, BasicsTab,
  SlugInput, DefaultValueField), no extras
- comment convention exit 0 across 3879 of 3903 source files
- the e2e assertion was stub-verified by deleting the `onRestore` prop: 1
  failed, 1 passed, restore byte-identical via `cmp`

## Pre-existing red on `main`, not from this branch

`Lint / Typecheck / Test / Build` is failing on `main` because
`packages/plugin-sdk/src/plugin-surface.test.ts` holds a stale export snapshot —
`PluginNavSection`, `AdminChromeLayer`, `ValidationNumberField` and
`ValidationNumberFieldProps` were added without updating it. It was already
failing on `3744d81c2` (the merge before this lane's), and neither #996 nor this
branch touches any plugin-sdk file.
