### PR TITLE
feat(builder): put a block inside the container it was aimed at

### DIFF
--- a/.changeset/insert-into-container.md
+++ b/.changeset/insert-into-container.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Selecting an empty container and inserting now puts the block inside it. Every insert landed as a sibling before, so a container could be added and never filled, and the panel says which of the two placements it will use.

--- a/packages/builder/src/insert-panel.tsx
+++ b/packages/builder/src/insert-panel.tsx
@@ -26,6 +26,7 @@
 
 import {
   allBlocks,
+  getBlock,
   registryNestingSource,
   type AnyBlockDefinition,
   type BlockNode,
@@ -49,6 +50,8 @@ import {
   groupByCategory,
   insertionPointFor,
   nodeForEntry,
+  type InsertionPoint,
+  type SlotSource,
   type InsertEntry,
 } from "./inserter";
 
@@ -90,10 +93,32 @@ export interface InsertPanelProps {
 }
 
 /** Sentence describing where the next insert will land. */
-function placementLabel(kind: "after-selection" | "document-end"): string {
-  return kind === "after-selection"
+function placementLabel(point: InsertionPoint, label?: string): string {
+  if (point.kind === "inside-selection") {
+    // Names the container, because "inside" is only meaningful if the author
+    // knows what it is inside OF — and this is the one placement that differs
+    // from what selecting a block usually implies.
+    return `Adds inside ${label ?? "the selected block"}`;
+  }
+  return point.kind === "after-selection"
     ? "Adds after the selected block"
     : "Adds at the end of the page";
+}
+
+/**
+ * The registry as a slot source.
+ *
+ * Reads the DEFINITION's declared slots rather than the node's, because a
+ * container inserted from the palette has no `slots` key until something is put
+ * in it — which is precisely the container that needs filling.
+ */
+function registrySlotSource(): SlotSource {
+  return {
+    slotsOf: type => {
+      const declared = getBlock(type)?.slots;
+      return declared === undefined ? undefined : Object.keys(declared);
+    },
+  };
 }
 
 export function InsertPanel({
@@ -119,7 +144,12 @@ export function InsertPanel({
   // read from, and an undo or a remote edit can move it without the selection
   // changing — a memo keyed on the selection alone would keep a position whose
   // index no longer names the same place.
-  const point = insertionPointFor(editor.document, editor.selectedId);
+  const slotSource = React.useMemo(registrySlotSource, []);
+  const point = insertionPointFor(
+    editor.document,
+    editor.selectedId,
+    slotSource
+  );
 
   // Computed on every render rather than memoised. `insertionPointFor` builds a
   // fresh target each call, so a memo keyed on it could never hit — it would
@@ -173,7 +203,14 @@ export function InsertPanel({
           placeholder="Search blocks"
         />
         <p className="nx-insert-panel__placement" aria-live="polite">
-          {placementLabel(point.kind)}
+          {placementLabel(
+            point,
+            point.kind === "inside-selection"
+              ? getBlock(
+                  point.target.at === "slot" ? point.target.parentType : ""
+                )?.editor?.label
+              : undefined
+          )}
         </p>
         <CommandList>
           <CommandEmpty>

--- a/packages/builder/src/inserter.test.ts
+++ b/packages/builder/src/inserter.test.ts
@@ -21,6 +21,7 @@ import {
 
 import {
   UNCATEGORISED,
+  type SlotSource,
   allowedEntries,
   catalogFrom,
   entryAllowedAt,
@@ -546,6 +547,11 @@ describe("entryAllowedAt and allowedEntries", () => {
   });
 });
 
+/** A slot source over a fixed map, standing in for the registry. */
+function slotsFor(map: Record<string, readonly string[]>): SlotSource {
+  return { slotsOf: type => map[type] };
+}
+
 describe("insertionPointFor", () => {
   it("appends at the end of the document when nothing is selected", () => {
     const document = documentOf([
@@ -609,6 +615,81 @@ describe("insertionPointFor", () => {
 
     expect(insertionPointFor(document, "gone")?.kind).toBe("document-end");
     expect(insertionPointFor(document, "gone")?.at).toEqual({ index: 1 });
+  });
+
+  it("places into an EMPTY container rather than beside it", () => {
+    // THE case. Without this a container can be inserted and never filled:
+    // every insert lands as a sibling, so a columns block arrives empty and
+    // stays empty, and every container in the library is decorative.
+    const document = documentOf([
+      { id: "wrap", type: "acme/columns", version: 1, props: {} },
+    ]);
+
+    expect(
+      insertionPointFor(
+        document,
+        "wrap",
+        slotsFor({ "acme/columns": ["children"] })
+      )
+    ).toEqual({
+      kind: "inside-selection",
+      at: { parentId: "wrap", slot: "children", index: 0 },
+      target: { at: "slot", parentType: "acme/columns", slot: "children" },
+    });
+  });
+
+  it("places BESIDE a container that already holds something", () => {
+    // The separating case, and what keeps a sibling reachable at all. A
+    // container the author has filled takes a sibling; adding a third child is
+    // done by selecting the second and inserting after it.
+    const document = documentOf([
+      {
+        id: "wrap",
+        type: "acme/columns",
+        version: 1,
+        props: {},
+        slots: {
+          children: [{ id: "kid", type: "acme/text", version: 1, props: {} }],
+        },
+      },
+    ]);
+
+    expect(
+      insertionPointFor(
+        document,
+        "wrap",
+        slotsFor({ "acme/columns": ["children"] })
+      )?.kind
+    ).toBe("after-selection");
+  });
+
+  it("reads the DEFINITION's slots, not the node's", () => {
+    // A container inserted from the palette carries no `slots` key at all, so a
+    // rule asking the node whether it is a container answers "no" for exactly
+    // the empty ones that need filling. Same node as the first case; without a
+    // source it can only be a sibling.
+    const document = documentOf([
+      { id: "wrap", type: "acme/columns", version: 1, props: {} },
+    ]);
+
+    expect(insertionPointFor(document, "wrap")?.kind).toBe("after-selection");
+  });
+
+  it("places beside a leaf, whatever the source says", () => {
+    // The control: a block declaring no slots is not a container, so the rule
+    // must not claim one. Without it, a source answering for every type would
+    // send every insert inside its own selection.
+    const document = documentOf([
+      { id: "a", type: "acme/text", version: 1, props: {} },
+    ]);
+
+    expect(
+      insertionPointFor(
+        document,
+        "a",
+        slotsFor({ "acme/columns": ["children"] })
+      )?.kind
+    ).toBe("after-selection");
   });
 
   it("is empty-document safe", () => {

--- a/packages/builder/src/inserter.ts
+++ b/packages/builder/src/inserter.ts
@@ -28,6 +28,7 @@ import {
   canBeRoot,
   canNest,
   canNestInSlot,
+  findNode,
   locateNode,
   makeNode,
   type AnyBlockDefinition,
@@ -98,6 +99,23 @@ export interface InsertEntry {
   readonly props: Readonly<Record<string, unknown>>;
 }
 
+/**
+ * How a caller answers for a block's declared child regions.
+ *
+ * Deliberately NOT a registry, matching `NestingSource`: resolving a type to
+ * its definition differs per caller, and a one-method source lets each supply
+ * its own resolution while sharing the rule applied to the result.
+ *
+ * The NODE cannot answer this. A container inserted from the palette carries no
+ * `slots` key at all — `makeNode` writes one only when children are supplied —
+ * so asking the node whether it is a container answers "no" for every empty
+ * one, which is exactly the case that needs filling.
+ */
+export interface SlotSource {
+  /** The names of the child regions this block type declares, in order. */
+  slotsOf(type: string): readonly string[] | undefined;
+}
+
 /** Where an insert would land, as the nesting rule needs to see it. */
 export type InsertTarget =
   | { readonly at: "root" }
@@ -115,7 +133,7 @@ export type InsertTarget =
  * the same question a second time and could answer differently.
  */
 export interface InsertionPoint {
-  readonly kind: "after-selection" | "document-end";
+  readonly kind: "after-selection" | "document-end" | "inside-selection";
   readonly at: OpPosition;
   readonly target: InsertTarget;
 }
@@ -384,7 +402,8 @@ export function groupByCategory(
  */
 export function insertionPointFor(
   document: BlockDocument,
-  selectedId: string | null
+  selectedId: string | null,
+  slots?: SlotSource
 ): InsertionPoint | null {
   const end: InsertionPoint = {
     kind: "document-end",
@@ -395,6 +414,34 @@ export function insertionPointFor(
 
   const location = locateNode(document.nodes, selectedId);
   if (location === undefined) return end;
+
+  // An EMPTY container takes the block instead of standing beside it.
+  //
+  // Without this a container can be inserted and never filled: every insert
+  // lands as a sibling, so `core/columns` arrives empty and stays empty, and
+  // the seven container blocks in the library are decorative. Selecting an
+  // empty container and adding a block means putting it IN there — there is no
+  // other reading of the gesture.
+  //
+  // Only when empty, which is what keeps a sibling reachable. A container the
+  // author has already filled takes a sibling instead, and adding a third child
+  // to it is done by selecting the second and inserting after that — so both
+  // placements stay available without a second affordance to discover.
+  const selected = findNode(document.nodes, selectedId);
+  const declared =
+    selected === undefined ? undefined : slots?.slotsOf(selected.type);
+  const firstSlot = declared?.[0];
+  if (
+    selected !== undefined &&
+    firstSlot !== undefined &&
+    (selected.slots?.[firstSlot]?.length ?? 0) === 0
+  ) {
+    return {
+      kind: "inside-selection",
+      at: { parentId: selected.id, slot: firstSlot, index: 0 },
+      target: { at: "slot", parentType: selected.type, slot: firstSlot },
+    };
+  }
 
   let after: OpPosition;
   try {


### PR DESCRIPTION
Confirmed in a browser before fixing, rather than inferred from the code: insert a Columns, then insert a Heading, and the canvas tree is **two siblings at root** with the Columns empty.

`insertionPointFor` always returned a sibling position after the selection. There was no branch targeting a selected container's slot, so a container could be inserted and never filled — and the seven container blocks in the library (section, box, columns, column, card, accordion, gallery) were decorative.

## Only when the container is EMPTY

That is what keeps a sibling reachable. A container already holding something takes a sibling instead, and adding a third child is done by selecting the second and inserting after it. Both placements stay available without a second affordance to discover, and neither requires an in-canvas appender that does not exist yet.

Selecting an empty container and adding a block has no other reading of the gesture.

## The node cannot answer whether it is a container

A container inserted from the palette carries **no `slots` key at all** — `makeNode` writes one only when children are supplied — so asking the node answers "no" for exactly the empty ones that need filling.

So the rule asks a `SlotSource` for the DEFINITION's declared regions, mirroring how the engine hands out `NestingSource`: not a registry, one method, each caller supplying its own resolution while sharing the rule applied to the result.

## Verified in the browser, and the nesting rule is visibly doing its job

Three settled runs. Inserting Columns, then Column, then Heading:

```
canvas tree: Columns
               └─ Column
                    └─ Heading
```

Two things worth reading from that run:

- the placement line reads **"Adds inside Columns"**, then **"Adds inside Column"** — the panel names the container, because "inside" is only meaningful if the author knows what it is inside of
- inside Columns the palette offered **exactly one entry, "Column"** — `core/columns` restricts its slot to `core/column`, and the same run confirms an earlier Heading attempt was correctly refused

That is `canNestInSlot` filtering a real palette against a real registry, which no fixture had shown before.

## Evidence

535 tests in `builder`, 30/30 tasks from a clean build.

Stub-verified, each break failing only what names it:

| break | test that fired |
| --- | --- |
| never place inside — the bug that shipped | places into an EMPTY container rather than beside it |
| place inside even when the container is full | places BESIDE a container that already holds something |
| read the NODE's slots instead of the definition's | places into an EMPTY container rather than beside it |

The third is the one worth having: it fails for the reason the `SlotSource` exists, and a reader who assumed the node knew its own slots would have written exactly that code.
