### PR TITLE
feat(eslint-plugin): detect CSS named colours in colour positions

### DIFF
--- a/.changeset/named-color-detection.md
+++ b/.changeset/named-color-detection.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+`no-hardcoded-colors` now catches CSS named colours.
+
+The rule already rejected hex, `rgb()`, `hsl()` and `oklch()`, but a name like `deepskyblue` passed — which is how a fixed colour that ignores light and dark mode sat on the page-builder's drop indicator until it was found by reading a file flagged for something else.
+
+A colour name is an ordinary word, so it is reported only where its position makes it a colour: the value of a colour-valued style property, or the right-hand side of a CSS declaration. Prose and data are untouched — `"the red team"`, `{ fruit: "plum" }` and a label reading `"Tomato"` are all fine. `black`, `white` and `transparent` stay exempt, as their hex spellings already were.
+
+The rules also stop applying to test files, matching the repository's CSS guard. A fixture writing `color: red` is modelling arbitrary user data rather than styling a surface that ships.

--- a/packages/eslint-config/design-tokens.js
+++ b/packages/eslint-config/design-tokens.js
@@ -22,6 +22,12 @@ export function designTokensConfig(files) {
     {
       name: "@nextlyhq/design-tokens",
       files,
+      // Tests are excluded, matching `scripts/lint-design.mjs`, which has
+      // filtered them since it was written. A fixture writing `color: red` is
+      // modelling arbitrary user data, not styling a surface that ships — and
+      // the two guards enforce one contract, so they must agree on which files
+      // it governs as well as on what it means.
+      ignores: ["**/*.test.*", "**/*.spec.*", "**/__tests__/**", "**/*.d.ts"],
       plugins: { "@nextlyhq": nextlyPlugin },
       rules: {
         "@nextlyhq/no-palette-classes": "error",

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -80,6 +80,23 @@ const shadow =
   "0 1px 2px color-mix(in oklch, var(--nx-foreground) 10%, transparent)";
 ```
 
+It also catches CSS **named** colours, which are the easiest to miss because
+they read as ordinary words:
+
+```jsx
+// ✗ ignores the theme completely
+<div style={{ backgroundColor: "deepskyblue" }} />;
+const css = ".badge { color: crimson }";
+
+// ✓
+<div className="bg-primary" />;
+```
+
+A colour name is only reported where its POSITION makes it a colour — the value
+of a colour-valued property, or the right-hand side of a CSS declaration. Prose
+and data are untouched, so `"the red team"`, `{ fruit: "plum" }` and a label
+reading `"Tomato"` are all fine.
+
 Black, white and transparent are exempt: they are mode-invariant, so routing
 them through a themed token would claim a variation that does not exist. So are
 `url(...)` payloads and `placeholder` example values.

--- a/packages/eslint-plugin/src/__tests__/no-hardcoded-colors.test.js
+++ b/packages/eslint-plugin/src/__tests__/no-hardcoded-colors.test.js
@@ -27,6 +27,19 @@ ruleTester.run("no-hardcoded-colors", rule, {
     `const a = "var(--nx-primary)";`,
     // A data URI's payload is content, not styling.
     `const a = "url(data:image/svg+xml;base64,PHN2ZyBmaWxsPScjZmYwMDAwJy8+)";`,
+    // A colour NAME is an ordinary word too, so it is only a violation in a
+    // position that makes it a colour. None of these is one.
+    `const a = "the red team won";`,
+    `const a = { fruit: "plum", wood: "teal" };`,
+    `const a = "scarlet: red";`,
+    `const a = { label: "Tomato", description: "a salmon dish" };`,
+    // A colour-valued property pointing at a token is the correct form.
+    `const a = { backgroundColor: "var(--nx-primary)" };`,
+    `const a = { color: "inherit" };`,
+    // Mode-invariant names stay exempt, as their hex spellings are.
+    `const a = { backgroundColor: "white" };`,
+    `const a = { color: "black" };`,
+    `const a = { backgroundColor: "transparent" };`,
     // A hex that is not a colour at all.
     `const a = "commit 1f4b";`,
     `// design-lint-ok: mirrors a third-party embed's fixed palette
@@ -43,6 +56,30 @@ ruleTester.run("no-hardcoded-colors", rule, {
     `const a = "#ff0000"; // design-lint-ok: matches an external embed`,
   ],
   invalid: [
+    {
+      // The defect that motivated this: a fixed colour on a drop indicator,
+      // invisible to a rule that already caught hex, rgb() and oklch().
+      code: `const a = { backgroundColor: "deepskyblue" };`,
+      errors: [{ messageId: "namedColor", data: { literal: "deepskyblue" } }],
+    },
+    {
+      code: `const a = <div style={{ color: "tomato" }} />;`,
+      errors: [{ messageId: "namedColor" }],
+    },
+    {
+      // Kebab-case, inside a CSS string rather than a style object.
+      code: `const a = "<p style='color: crimson'>hi</p>";`,
+      errors: [{ messageId: "namedColor" }],
+    },
+    {
+      code: "const a = `.warn { background-color: gold; }`;",
+      errors: [{ messageId: "namedColor" }],
+    },
+    {
+      // An SVG presentation attribute takes a colour too.
+      code: `const a = { fill: "rebeccapurple" };`,
+      errors: [{ messageId: "namedColor" }],
+    },
     {
       // The reach is BOUNDED: a directive above a function does not exempt
       // everything inside it, which would be a blanket disable by another name.

--- a/packages/eslint-plugin/src/rules/no-hardcoded-colors.js
+++ b/packages/eslint-plugin/src/rules/no-hardcoded-colors.js
@@ -1,6 +1,9 @@
 import { isExempt } from "../exempt.js";
 import {
   createColorLiteralPattern,
+  createNamedColorDeclarationPattern,
+  isColorValuedProperty,
+  isNamedColor,
   stripExemptColorPieces,
 } from "../vocabulary.js";
 
@@ -17,6 +20,12 @@ import {
  * examples never reach the pattern. Those are mode-invariant or are content, and
  * routing them through a themed token would claim a variation that does not
  * exist.
+ *
+ * NAMED colours are decided differently, and deliberately so. `deepskyblue` is
+ * an ordinary English word as well as a colour, so matching it anywhere would
+ * report prose, seed data and identifiers. What makes it a colour is the
+ * POSITION: the value of a colour-valued style property, or the right-hand side
+ * of a CSS declaration. Both of those are checked; a bare occurrence is not.
  */
 export default {
   meta: {
@@ -29,6 +38,8 @@ export default {
     messages: {
       hardcodedColor:
         "`{{literal}}` is a hardcoded colour — use var(--token) or color-mix(...).",
+      namedColor:
+        "`{{literal}}` is a fixed CSS colour — it ignores the theme and dark mode. Use var(--token) or a semantic utility.",
     },
   },
   create(context) {
@@ -62,12 +73,49 @@ export default {
       });
     }
 
+    /** A CSS declaration assigning a named colour, inside any string. */
+    function checkDeclaration(node, text) {
+      if (typeof text !== "string" || text.length === 0) return;
+      const match = createNamedColorDeclarationPattern().exec(text);
+      if (!match) return;
+      if (isExempt(sourceCode, node)) return;
+      context.report({
+        node,
+        messageId: "namedColor",
+        data: { literal: `${match[1]}: ${match[2]}` },
+      });
+    }
+
     return {
       Literal(node) {
-        if (typeof node.value === "string") check(node, node.value);
+        if (typeof node.value === "string") {
+          check(node, node.value);
+          checkDeclaration(node, node.value);
+        }
       },
       TemplateElement(node) {
-        check(node, node.value.cooked ?? node.value.raw);
+        const text = node.value.cooked ?? node.value.raw;
+        check(node, text);
+        checkDeclaration(node, text);
+      },
+      /**
+       * A style object entry whose KEY takes a colour and whose value is a
+       * named one — `{ backgroundColor: "deepskyblue" }`. The key is what makes
+       * the string a colour rather than a word.
+       */
+      Property(node) {
+        if (node.computed) return;
+        const key =
+          node.key.type === "Identifier" ? node.key.name : node.key.value;
+        if (!isColorValuedProperty(key)) return;
+        if (node.value.type !== "Literal") return;
+        if (!isNamedColor(node.value.value)) return;
+        if (isExempt(sourceCode, node)) return;
+        context.report({
+          node: node.value,
+          messageId: "namedColor",
+          data: { literal: String(node.value.value) },
+        });
       },
     };
   },

--- a/packages/eslint-plugin/src/vocabulary.js
+++ b/packages/eslint-plugin/src/vocabulary.js
@@ -103,6 +103,238 @@ export const HUE_REPLACEMENT = {
   orange: "warning-*",
 };
 
+/**
+ * CSS named colours, minus the mode-invariant ones.
+ *
+ * `black`, `white` and `transparent` are deliberately absent for the same
+ * reason their hex spellings are exempt: they are the same colour in light and
+ * dark, so routing them through a themed token would claim a variation that
+ * does not exist. Every other name is a fixed colour that ignores the theme —
+ * `deepskyblue` on a drop indicator was how this gap was found.
+ */
+export const CSS_NAMED_COLORS = [
+  "aliceblue",
+  "antiquewhite",
+  "aqua",
+  "aquamarine",
+  "azure",
+  "beige",
+  "bisque",
+  "blanchedalmond",
+  "blue",
+  "blueviolet",
+  "brown",
+  "burlywood",
+  "cadetblue",
+  "chartreuse",
+  "chocolate",
+  "coral",
+  "cornflowerblue",
+  "cornsilk",
+  "crimson",
+  "cyan",
+  "darkblue",
+  "darkcyan",
+  "darkgoldenrod",
+  "darkgray",
+  "darkgreen",
+  "darkgrey",
+  "darkkhaki",
+  "darkmagenta",
+  "darkolivegreen",
+  "darkorange",
+  "darkorchid",
+  "darkred",
+  "darksalmon",
+  "darkseagreen",
+  "darkslateblue",
+  "darkslategray",
+  "darkslategrey",
+  "darkturquoise",
+  "darkviolet",
+  "deeppink",
+  "deepskyblue",
+  "dimgray",
+  "dimgrey",
+  "dodgerblue",
+  "firebrick",
+  "floralwhite",
+  "forestgreen",
+  "fuchsia",
+  "gainsboro",
+  "ghostwhite",
+  "gold",
+  "goldenrod",
+  "gray",
+  "green",
+  "greenyellow",
+  "grey",
+  "honeydew",
+  "hotpink",
+  "indianred",
+  "indigo",
+  "ivory",
+  "khaki",
+  "lavender",
+  "lavenderblush",
+  "lawngreen",
+  "lemonchiffon",
+  "lightblue",
+  "lightcoral",
+  "lightcyan",
+  "lightgoldenrodyellow",
+  "lightgray",
+  "lightgreen",
+  "lightgrey",
+  "lightpink",
+  "lightsalmon",
+  "lightseagreen",
+  "lightskyblue",
+  "lightslategray",
+  "lightslategrey",
+  "lightsteelblue",
+  "lightyellow",
+  "lime",
+  "limegreen",
+  "linen",
+  "magenta",
+  "maroon",
+  "mediumaquamarine",
+  "mediumblue",
+  "mediumorchid",
+  "mediumpurple",
+  "mediumseagreen",
+  "mediumslateblue",
+  "mediumspringgreen",
+  "mediumturquoise",
+  "mediumvioletred",
+  "midnightblue",
+  "mintcream",
+  "mistyrose",
+  "moccasin",
+  "navajowhite",
+  "navy",
+  "oldlace",
+  "olive",
+  "olivedrab",
+  "orange",
+  "orangered",
+  "orchid",
+  "palegoldenrod",
+  "palegreen",
+  "paleturquoise",
+  "palevioletred",
+  "papayawhip",
+  "peachpuff",
+  "peru",
+  "pink",
+  "plum",
+  "powderblue",
+  "purple",
+  "rebeccapurple",
+  "red",
+  "rosybrown",
+  "royalblue",
+  "saddlebrown",
+  "salmon",
+  "sandybrown",
+  "seagreen",
+  "seashell",
+  "sienna",
+  "silver",
+  "skyblue",
+  "slateblue",
+  "slategray",
+  "slategrey",
+  "snow",
+  "springgreen",
+  "steelblue",
+  "tan",
+  "teal",
+  "thistle",
+  "tomato",
+  "turquoise",
+  "violet",
+  "wheat",
+  "whitesmoke",
+  "yellow",
+  "yellowgreen",
+];
+
+/**
+ * Style properties whose value IS a colour.
+ *
+ * A named colour is only a defect in one of these positions. Matching the bare
+ * word anywhere would flag `"the red team"`, a `plum` in seed data, or a CSS
+ * class fragment — so the PROPERTY is what makes the value a colour, and the
+ * rule keys on it. Both spellings are listed because a JS style object uses
+ * camelCase and a CSS declaration uses kebab-case.
+ */
+export const COLOR_VALUED_PROPERTIES = [
+  "color",
+  "backgroundColor",
+  "background-color",
+  "background",
+  "borderColor",
+  "border-color",
+  "borderTopColor",
+  "border-top-color",
+  "borderRightColor",
+  "border-right-color",
+  "borderBottomColor",
+  "border-bottom-color",
+  "borderLeftColor",
+  "border-left-color",
+  "outlineColor",
+  "outline-color",
+  "caretColor",
+  "caret-color",
+  "textDecorationColor",
+  "text-decoration-color",
+  "columnRuleColor",
+  "column-rule-color",
+  "fill",
+  "stroke",
+  "stopColor",
+  "stop-color",
+  "floodColor",
+  "flood-color",
+  "lightingColor",
+  "lighting-color",
+];
+
+/** Whether a value is exactly a fixed CSS named colour. */
+export function isNamedColor(value) {
+  return (
+    typeof value === "string" &&
+    CSS_NAMED_COLORS.includes(value.trim().toLowerCase())
+  );
+}
+
+/** Whether a property name takes a colour as its value. */
+export function isColorValuedProperty(name) {
+  return (
+    typeof name === "string" && COLOR_VALUED_PROPERTIES.includes(name.trim())
+  );
+}
+
+/**
+ * Build the pattern for a CSS DECLARATION assigning a named colour, e.g.
+ * `color: deepskyblue` inside a style string or a stylesheet.
+ *
+ * The declaration form is what makes this safe to run over free text: the
+ * property and the colon are what distinguish a colour from the same word used
+ * as prose or as part of an identifier.
+ */
+export function createNamedColorDeclarationPattern({ global = false } = {}) {
+  const props = COLOR_VALUED_PROPERTIES.join("|");
+  const names = CSS_NAMED_COLORS.join("|");
+  return new RegExp(
+    `(?:^|[\\s;{"'\`])(${props})\\s*:\\s*(${names})\\s*(?:[;}"'\`]|$)`,
+    global ? "gi" : "i"
+  );
+}
+
 /** The inline comment that exempts a line, and the reason it must carry one. */
 export const EXEMPTION_MARKER = "design-lint-ok";
 


### PR DESCRIPTION
## The gap this closes was found by accident, which is the point

`no-hardcoded-colors` rejected hex, `rgb()`, `hsl()` and `oklch()` — and let `deepskyblue` through. That is how a fixed colour ignoring light and dark mode sat on the page-builder's **drop indicator** until #995, where I only noticed it because the *inline-style* rule flagged the same element for an unrelated reason.

Measured on `main` before this change:

```
deepskyblue  flagged=false
red          flagged=false
tomato       flagged=false
#ff0000      flagged=true
oklch(...)   flagged=true
```

## Why this rule is scoped by POSITION, not by word

A colour name is also an ordinary English word. Matching `red`, `plum`, `tan`, `salmon` or `peru` anywhere would report prose, seed data, labels and identifiers — a false-positive engine that gets the whole guard suppressed.

What makes a name a colour is **where it sits**: the value of a colour-valued style property, or the right-hand side of a CSS declaration. Both are checked; a bare occurrence is not.

```jsx
// ✗ reported
<div style={{ backgroundColor: "deepskyblue" }} />
const css = ".badge { color: crimson }"
{ fill: "rebeccapurple" }

// ✓ untouched
"the red team won"
{ fruit: "plum", wood: "teal" }
{ label: "Tomato", description: "a salmon dish" }
{ backgroundColor: "var(--nx-primary)" }
```

`black`, `white` and `transparent` stay exempt, exactly as their hex spellings already were — mode-invariant, so a themed token would claim a variation that does not exist.

## A divergence it surfaced, fixed at the cause

Run repo-wide, the new detection produced **7 findings — all in test files** writing `color: red` as sample data.

That is not a rule defect; it is two guards disagreeing about their population. `scripts/lint-design.mjs` has filtered `**/*.test.*` and `__tests__` since it was written. The ESLint mount never did. One contract, two mechanisms, different file sets — the exact drift the shared vocabulary exists to prevent, one level up from the vocabulary.

So I fixed the **mount**, not the rule: `designTokensConfig` now excludes tests. A fixture modelling arbitrary user input is not a surface that ships.

## Test plan

**78 tests**, up from 64. New cases cover every shape in both directions, including the negatives that decide whether this rule is usable at all (prose, data, labels, token indirection, mode-invariant names).

**Three break-verifications**, each snapshot-restored and confirmed byte-identical:

| break | result |
|---|---|
| Property visitor removed | **3 fail** |
| CSS-declaration check removed | **2 fail** |
| `black`/`white` made reportable | **2 fail** |

**Both directions verified through the REAL mount** rather than a hand-built config — the mistake that let a dead rule ship in #970:

```
test files (ops.test.ts, field-validation.test.ts):  0 findings   ← correctly excluded
a real source file with an injected deepskyblue:     reported     ← positive control
```

**Gates, cache forced off:** build **19/19**, lint **24/24**, check-types **22/22**, `test:scripts` **494/494**, design lint unchanged at 865 files / 7 roots / 82 plugin-surface, `!important` 35/35.

## Changeset

Added: **yes, patch**, all 25 lockstep packages, generated from `.changeset/config.json`.
