### PR TITLE
fix(admin): require a version to be on screen before acting on it

### DIFF
--- a/.changeset/version-must-be-on-screen.md
+++ b/.changeset/version-must-be-on-screen.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Reading a past version now waits for the snapshot to arrive before showing it or offering to restore it. A version read that has not returned reports neither progress nor failure, which previously rendered an empty document as though it were the version and enabled restore for a version nobody had seen.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -333,6 +333,19 @@ export function EntryForm({
     [viewingVersion, restoreAffordance]
   );
 
+  // One question — is the chosen version actually on screen? — answered once,
+  // because the document body and the restore affordance must never disagree
+  // about it. A read that has not returned leaves `isLoading` false with no
+  // error and no snapshot: the query is disabled whenever the scope is not yet
+  // addressable, and a paused one reports the same. Deciding from `isLoading`
+  // alone would render an empty document as though it were the version, and
+  // offer to restore what nobody has seen.
+  const versionOnScreen =
+    viewingVersion !== null &&
+    viewingVersion.error === null &&
+    !viewingVersion.isLoading &&
+    viewingVersion.snapshot !== undefined;
+
   // Which fields a version HAD, decided by that version's own values. The
   // takeover layout is value-driven, so computing it from the live entry would
   // show today's layout over yesterday's document — omitting fields the version
@@ -638,10 +651,7 @@ export function EntryForm({
                       // And only once the version is actually on screen:
                       // restoring from a skeleton, or from a failed read, is a
                       // decision made without having seen what is being chosen.
-                      restoreDisabled={
-                        viewingVersion.isLoading ||
-                        viewingVersion.error !== null
-                      }
+                      restoreDisabled={!versionOnScreen}
                     />
                   ) : null}
                   <EntryMetaStrip
@@ -682,7 +692,7 @@ export function EntryForm({
                             This version could not be loaded.
                           </AlertDescription>
                         </Alert>
-                      ) : viewingVersion.isLoading ? (
+                      ) : !versionOnScreen ? (
                         <div className="flex flex-col gap-4" aria-busy="true">
                           <span className="sr-only" role="status">
                             Loading version {viewingVersion.versionNo}

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntryForm.version-on-screen.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntryForm.version-on-screen.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * What the document area and the banner do while a chosen version has not
+ * arrived.
+ *
+ * `isLoading` is false for a query that was never started as well as for one
+ * that has finished, so it cannot stand for "the snapshot is here": the version
+ * read is disabled until the scope is addressable, and a paused one reports the
+ * same. Both consumers are asserted in one test on purpose — the defect was
+ * that they disagreed, rendering an empty document as the version while
+ * offering to restore it, so covering either alone would leave the other free
+ * to drift.
+ */
+import { useEffect } from "react";
+import { describe, it, expect, vi } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+import { useDocumentHistory } from "@admin/components/features/versions/document-history-context";
+import type { ViewedVersion } from "@admin/components/features/versions/document-history-context";
+
+const { viewed } = vi.hoisted(() => ({
+  viewed: { current: null as ViewedVersion | null },
+}));
+
+// The header is where the history panel normally mounts and publishes both the
+// chosen version and the restore affordance. Standing in for it lets a test
+// name the arrival state directly, which no fixture of the real panel can.
+vi.mock("../EntrySystemHeader", () => ({
+  EntrySystemHeader: () => {
+    const { setViewing, setRestore } = useDocumentHistory();
+    useEffect(() => {
+      setViewing(viewed.current);
+      setRestore({
+        canRestore: true,
+        request: vi.fn(),
+        returnToCurrent: vi.fn(),
+      });
+    }, [setViewing, setRestore]);
+    return null;
+  },
+}));
+
+vi.mock("@admin/hooks/useLocalization", () => ({
+  useLocalization: () => ({
+    enabled: false,
+    locales: [],
+    defaultLocale: "en",
+    fallback: true,
+    getLocale: () => undefined,
+  }),
+}));
+
+vi.mock("../../../versions/VersionSnapshotForm", () => ({
+  VersionSnapshotForm: () => <div data-testid="snapshot-form" />,
+}));
+
+import { EntryForm } from "../EntryForm";
+
+const collection = {
+  name: "posts",
+  label: "Posts",
+  fields: [{ name: "title", type: "text", label: "Title" }],
+} as never;
+
+const entry = { id: "e1", title: "Hello" } as never;
+
+function renderViewing(version: ViewedVersion) {
+  viewed.current = version;
+  return render(
+    <EntryForm collection={collection} entry={entry} mode="edit" />
+  );
+}
+
+describe("EntryForm — a version has to be on screen before it can be acted on", () => {
+  it("shows the snapshot and offers restore once the read has returned", () => {
+    // The positive control. Without it the assertions below are satisfied by a
+    // document area that renders nothing under any circumstances.
+    renderViewing({
+      versionNo: 7,
+      snapshot: { title: "as it was" },
+      locale: null,
+      isLoading: false,
+      error: null,
+    });
+
+    expect(screen.getByTestId("snapshot-form")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /restore this version/i })
+    ).toBeEnabled();
+  });
+
+  it("holds both back when the read has not returned, though nothing is loading or failed", () => {
+    renderViewing({
+      versionNo: 7,
+      // No snapshot, and the query reports neither progress nor failure —
+      // which is what a disabled or paused read looks like.
+      snapshot: undefined,
+      locale: null,
+      isLoading: false,
+      error: null,
+    });
+
+    // An absent snapshot must not render as an empty version.
+    expect(screen.queryByTestId("snapshot-form")).toBeNull();
+    expect(screen.getByText(/loading version 7/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /restore this version/i })
+    ).toBeDisabled();
+  });
+});


### PR DESCRIPTION
Fixes the P1 Greptile raised on #999, which merged before it was addressed.

## The finding, and the half it did not name

`restoreDisabled` was `isLoading || error !== null`. A version read that has
**not returned** reports `isLoading` false with `error` null and no snapshot, so
that predicate enabled restore for a version nobody had seen.

The same state has a second consumer, and it was wrong in the same way: the
document branch fell through to `VersionSnapshotForm` with an undefined
snapshot, rendering an **empty document as though it were the version** — which
is the exact claim the neighbouring error branch already refuses to make
("a failed read must not render as an empty document: that is a different and
wrong claim about the version").

Neither state is hypothetical. `useVersion` declares
`enabled: enabled && versionNo !== null && isAddressable(scope)`, so the query is
disabled whenever the scope is not yet addressable, and a paused query reports
the same triple. `VersionDetail` types `snapshot` as required, so
`snapshot === undefined` means precisely "the read has not returned" — which is
what `ViewedVersion`'s own doc comment already said, while no consumer asked.

## The fix

One derived answer, `versionOnScreen`, consumed by both sites. Patching only
`restoreDisabled` would have left the empty-document half live and the two
consumers free to drift again — the repository's rule is that a narrower view is
derived from the richer one, never computed alongside it.

## Verification

- `pnpm build` 19/19; `check-types` + `lint` 46/46 with `--force`, 0 cached
- new `EntryForm.version-on-screen.test.tsx`, 2 tests, asserting both consumers
  in one test because the defect was that they disagreed
- the first test is a **positive control**: without it the negative assertions
  are satisfied by a document area that renders nothing at all
- **stub-verified** — replacing the arrival term with `true` fails the arrival
  test while the positive control stays green (1 failed, 1 passed); restore
  confirmed byte-identical with `cmp`
- full admin suite 4 failed / 244 passed (248 files); failing set matches the
  documented baseline by membership (StatsCard, BasicsTab, SlugInput,
  DefaultValueField), no extras. File count 247 → 248 and tests +2 are exactly
  this addition
- comment convention exit 0; fallow clean on 3 changed files
