### PR TITLE
fix(create-nextly-app): declare the UI kit as a plugin peer dependency

### DIFF
--- a/.changeset/plugin-template-ui-peer.md
+++ b/.changeset/plugin-template-ui-peer.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A scaffolded plugin no longer bundles a copy of `@nextlyhq/ui`.
+
+The UI kit is supplied by the host admin at run time, but the plugin template declared it only as a devDependency — and tsup externalises peer dependencies while bundling dev ones, so the entire kit was inlined into every published plugin. It is now declared as a peer, matching the first-party plugins, and named in the template's externals.

--- a/packages/create-nextly-app/src/__tests__/scaffold-plugin.test.ts
+++ b/packages/create-nextly-app/src/__tests__/scaffold-plugin.test.ts
@@ -77,6 +77,15 @@ describe("scaffold --template plugin (D44/D45 smoke test)", () => {
     expect(pkg.files).toEqual(["dist"]);
     expect(pkg.keywords).toContain("nextly-plugin");
     expect(pkg.scripts.dev).toContain("next dev dev");
+
+    // The UI kit is a HOST peer, not a bundled dependency. tsup externalises
+    // peers automatically and bundles devDependencies, so declaring it only as
+    // a devDependency ships a second copy of the whole kit inside every
+    // published plugin.
+    expect(pkg.peerDependencies["@nextlyhq/ui"]).toBeTruthy();
+
+    const tsup = await readFile(path.join(target, "tsup.config.ts"), "utf-8");
+    expect(tsup).toContain('"@nextlyhq/ui"');
     // The native-build allowlist lives in pnpm-workspace.yaml, NOT the package.json
     // `pnpm` field (pnpm 11 ignores that field). Without this, `pnpm install` aborts
     // on better-sqlite3 (the dev playground's native dep) with ERR_PNPM_IGNORED_BUILDS.

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -1289,6 +1289,11 @@ async function generatePluginPackageJson(
     nextly: range("nextly"),
     "@nextlyhq/admin": range("@nextlyhq/admin"),
     "@nextlyhq/plugin-sdk": range("@nextlyhq/plugin-sdk"),
+    // The UI kit is supplied by the host admin at run time, so a plugin must
+    // declare it rather than carry a copy. As a devDependency alone, tsup
+    // treats it as bundleable and inlines the whole kit into the published
+    // plugin — first-party plugins declare it as a peer for this reason.
+    "@nextlyhq/ui": range("@nextlyhq/ui"),
     react: PINNED_VERSIONS.react,
     "react-dom": PINNED_VERSIONS["react-dom"],
   };

--- a/scripts/release/first-publish-acknowledged.json
+++ b/scripts/release/first-publish-acknowledged.json
@@ -18,5 +18,5 @@
     "Once a package has published a real version the entry stops doing anything and",
     "preflight will say so; remove it then."
   ],
-  "packages": ["@nextlyhq/builder", "@nextlyhq/eslint-plugin"]
+  "packages": ["@nextlyhq/eslint-plugin"]
 }

--- a/templates/plugin/tsup.config.ts
+++ b/templates/plugin/tsup.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "tsup";
 
 // Builds the publishable plugin. `dev/` is NOT an entry — it never ships.
-// nextly / admin / react are peers, kept external.
+// nextly / admin / sdk / ui / react are peers, kept external: bundling one
+// would ship a second copy of code the host already provides.
 export default defineConfig({
   entry: ["src/index.ts", "src/admin/index.ts"],
   format: ["esm"],
@@ -13,6 +14,7 @@ export default defineConfig({
     "nextly",
     "@nextlyhq/admin",
     "@nextlyhq/plugin-sdk",
+    "@nextlyhq/ui",
     "react",
     "react-dom",
   ],


### PR DESCRIPTION
## Three closers from the T-02 lane, two of which turned out to be real

### 1. A scaffolded plugin bundled a copy of `@nextlyhq/ui`

The UI kit is supplied by the **host admin** at run time. The plugin template declared it only under `devDependencies` — and **tsup externalises peer dependencies while bundling dev ones**, so the entire kit was inlined into every published plugin.

The first-party precedent settles the shape: `plugin-form-builder` declares `"@nextlyhq/ui": "workspace:^"` as a **peer** and carries no explicit `external` list at all, because tsup already keeps peers out. The scaffold now does the same, and the template names it in `external` as well.

This was masked: the exemplar deliberately uses safelisted token utilities rather than kit components (third-party plugins are outside the admin's Tailwind `@source` scan), so nobody would hit it until they followed the docblock's advice to build with `@nextlyhq/ui`.

### 2. A dead first-publish acknowledgement

`preflight` reported it itself:

```
Acknowledgements no longer needed (these have published real versions):
  @nextlyhq/builder — remove from first-publish-acknowledged.json
```

Confirmed against the registry — `@nextlyhq/builder` has `alpha: 0.0.2-alpha.58`, a real version, so the entry no longer does anything. The file's own comment says to remove entries once they stop mattering. `@nextlyhq/eslint-plugin` stays, because it still carries only its `0.0.0` placeholder.

### 3. `packages/plugin-redirects` — no change, and the reason is the finding

I had flagged this as a possible packaging defect: a published-looking package name whose directory held only `dist/` and `node_modules/`. Measured on `origin/main`:

```
tracked files under packages/plugin-redirects:  0
tracked references to "plugin-redirects":       0
```

The package does not exist and **nothing references it**. What I saw earlier was stale build output in a different checkout — local cruft, not a repository issue. Recorded here rather than silently dropped, because the original flag is in the tracker and the next person deserves the disposal rather than the suspicion.

## Test plan

- **New assertions** in `scaffold-plugin.test.ts`: the generated manifest declares `@nextlyhq/ui` as a peer, and the shipped `tsup.config.ts` names it.
- **Break-verified**: removing the peer declaration fails the test (1 failed / 1), restored byte-identical.
- **`preflight` re-run**: the "no longer needed" line is gone and all 20 packages still classify as ready to publish, so removing the entry changed nothing else.
- Gates, cache forced off: lint **24/24**, check-types **22/22**, `test:scripts` **494/494**.

## Changeset

Added: **yes, patch**, all 25 lockstep packages, generated from `.changeset/config.json`.
