### PR TITLE
feat(admin): give the entry header a language row and reachable language actions

### DIFF
--- a/.changeset/entry-header-language-row.md
+++ b/.changeset/entry-header-language-row.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The entry editor's language tools are now visible, reachable, and legible.
+
+In a localized collection, the document title was invisible: the language strip shared its header row and squeezed the title input to zero width at every screen size. The title now has its own row, with languages on a row of their own beneath it.
+
+One segmented control shows every language with its state (published, translated, draft, or not translated — carried by shape and text, never colour alone) and switches between them; it replaces the separate dropdown and pill row that both switched languages. A Languages menu in the header offers Copy from and Publish all languages at every screen width — previously those lived only in a side panel that disappears on smaller screens — along with a legend for the language states.
+
+Creating an entry now says which language it will be created in. The "Shared across languages" badge appears only while editing a non-default language, where it matters. If a language fails to load, the editor offers the way back to the default language instead of only an exit.

--- a/apps/playground/nextly.config.ts
+++ b/apps/playground/nextly.config.ts
@@ -27,6 +27,7 @@ import { formBuilderPlugin } from "@nextlyhq/plugin-form-builder";
 import { pageBuilder } from "@nextlyhq/plugin-page-builder";
 import { defineConfig } from "nextly/config";
 
+import { Authors } from "./src/collections/authors";
 import { BlockPages } from "./src/collections/block-pages";
 import { Categories } from "./src/collections/categories";
 import { Posts } from "./src/collections/posts";
@@ -78,7 +79,10 @@ export default defineConfig({
     // Untranslated fields fall back to another locale's value on read (default true).
     fallback: true,
   },
-  collections: [Posts, Categories, Tags, BlockPages],
+  // Authors is the localized collection, registered so the i18n admin surfaces
+  // (language row, copy-from, publish-all, list translation status) are
+  // exercised in development rather than existing only in code.
+  collections: [Posts, Categories, Tags, BlockPages, Authors],
   singles: [Homepage, LandingPage, SiteSettings],
   fieldGroups: [Seo],
   // Dev-harness plugins: page builder and form builder are what a contributor

--- a/packages/admin/src/components/features/entries/CopyFromLanguageDialog.tsx
+++ b/packages/admin/src/components/features/entries/CopyFromLanguageDialog.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+/**
+ * CopyFromLanguageDialog — the confirm step of copy-from-language, rendered by
+ * whichever surface triggered it.
+ *
+ * The dialog is its own component (rather than living inside one trigger)
+ * because two surfaces offer the action and the warning must read identically
+ * from both: what gets overwritten, what is untouched, and that nothing is
+ * saved until the form is.
+ *
+ * @module components/features/entries/CopyFromLanguageDialog
+ */
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@nextlyhq/ui";
+
+import type { CopyFromLanguage } from "./useCopyFromLanguage";
+
+export function CopyFromLanguageDialog({ copy }: { copy: CopyFromLanguage }) {
+  const { pending, pendingLabel, activeLabel, busy } = copy;
+  return (
+    <AlertDialog
+      open={pending !== null}
+      onOpenChange={open => {
+        if (!open) copy.cancel();
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Copy from {pendingLabel}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This fills {activeLabel}&rsquo;s translatable fields with{" "}
+            {pendingLabel}&rsquo;s values, overwriting anything already entered
+            for {activeLabel}. Shared fields are untouched. Nothing is saved
+            until you save the form, so you can review or discard first.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={busy}
+            onClick={e => {
+              e.preventDefault();
+              void copy.confirm();
+            }}
+          >
+            {busy ? "Copying…" : `Copy from ${pendingLabel}`}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/admin/src/components/features/entries/CopyFromLanguageMenu.tsx
+++ b/packages/admin/src/components/features/entries/CopyFromLanguageMenu.tsx
@@ -1,27 +1,20 @@
+"use client";
+
 /**
- * CopyFromLanguageMenu — seed the current language from another (i18n M7, spec §10).
+ * CopyFromLanguageMenu — the document rail's trigger for copy-from-language.
  *
- * Translators shouldn't start from a blank form. This control copies another language's values into
- * the *translatable* fields of the language being edited, so translation starts from filled content.
- * Per the spec it is **explicit** (a deliberate menu action), **field-scoped** (only translatable
- * fields, never shared ones), **reversible** (it fills the form but does not save — discard to
- * revert), and it **warns before overwriting** any values the current language already has.
+ * The logic lives in `useCopyFromLanguage` and the warning in
+ * `CopyFromLanguageDialog`, because the header's Languages menu offers the
+ * same action: one implementation, two triggers. This component is only the
+ * rail's button-and-menu shape around them.
  *
- * Renders nothing unless localization is on, the collection is localized, the entry exists, and
- * there is more than one language — so non-localized editors are unchanged.
+ * Renders nothing when the action does not apply, so non-localized editors
+ * are unchanged.
  *
  * @module components/features/entries/CopyFromLanguageMenu
  */
 
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
   Button,
   DropdownMenu,
   DropdownMenuContent,
@@ -29,100 +22,15 @@ import {
   DropdownMenuTrigger,
 } from "@nextlyhq/ui";
 import { Languages } from "lucide-react";
-import { useState } from "react";
-import { useFormContext } from "react-hook-form";
 
-import { toast } from "@admin/components/ui";
-import { useLocalization } from "@admin/hooks/useLocalization";
-import { entryApi } from "@admin/services/entryApi";
+import { CopyFromLanguageDialog } from "./CopyFromLanguageDialog";
+import { useCopyFromLanguage } from "./useCopyFromLanguage";
 
-import { useEntryLocale } from "./EntryLocaleContext";
-
-/** True when a value counts as "present" (would be overwritten). Mirrors the blank=empty rule. */
-function isPresent(value: unknown): boolean {
-  if (value === null || value === undefined) return false;
-  if (typeof value === "string") return value.trim() !== "";
-  return true;
-}
-
-/**
- * Pick the translatable field values to copy from a source entry: only the named localized fields
- * that actually have a value in the source (so absent source fields don't blank the target).
- */
-export function pickLocalizedValues(
-  source: Record<string, unknown>,
-  localizedFieldNames: string[]
-): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  for (const name of localizedFieldNames) {
-    if (isPresent(source[name])) out[name] = source[name];
-  }
-  return out;
-}
+export { pickLocalizedValues } from "./useCopyFromLanguage";
 
 export function CopyFromLanguageMenu() {
-  const { enabled, locales, defaultLocale, getLocale } = useLocalization();
-  const {
-    locale,
-    collectionLocalized,
-    collectionSlug,
-    entryId,
-    localizedFieldNames,
-  } = useEntryLocale();
-  const form = useFormContext();
-
-  const [pending, setPending] = useState<string | null>(null);
-  const [busy, setBusy] = useState(false);
-
-  const active = locale ?? defaultLocale;
-  const sources = locales.filter(l => l.code !== active);
-
-  // Nothing to copy from / not applicable → render nothing.
-  if (
-    !enabled ||
-    !collectionLocalized ||
-    !collectionSlug ||
-    !entryId ||
-    !localizedFieldNames ||
-    localizedFieldNames.length === 0 ||
-    sources.length === 0
-  ) {
-    return null;
-  }
-
-  const activeLabel = getLocale(active)?.label ?? active;
-  const pendingLabel = pending ? (getLocale(pending)?.label ?? pending) : "";
-
-  async function applyCopy(sourceCode: string) {
-    setBusy(true);
-    try {
-      // Fetch the source language's raw values (no fallback — copy what that language actually has).
-      const source = (await entryApi.findByID(collectionSlug!, entryId!, {
-        locale: sourceCode,
-        fallbackLocale: "none",
-        depth: 0,
-      })) as unknown as Record<string, unknown>;
-
-      const patch = pickLocalizedValues(source, localizedFieldNames!);
-      const count = Object.keys(patch).length;
-      if (count === 0) {
-        toast.info(`${pendingLabel} has no content to copy.`);
-        return;
-      }
-      // Fill the form (dirty, so the user can review then save — or discard to revert).
-      for (const [name, value] of Object.entries(patch)) {
-        form.setValue(name, value, { shouldDirty: true, shouldValidate: true });
-      }
-      toast.success(
-        `Copied ${count} field${count === 1 ? "" : "s"} from ${pendingLabel}. Review, then save.`
-      );
-    } catch {
-      toast.error(`Couldn't copy from ${pendingLabel}.`);
-    } finally {
-      setBusy(false);
-      setPending(null);
-    }
-  }
+  const copy = useCopyFromLanguage();
+  if (!copy.available) return null;
 
   return (
     <>
@@ -140,10 +48,10 @@ export function CopyFromLanguageMenu() {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          {sources.map(l => (
+          {copy.sources.map(l => (
             <DropdownMenuItem
               key={l.code}
-              onClick={() => setPending(l.code)}
+              onClick={() => copy.requestCopy(l.code)}
               {...(l.rtl ? { dir: "rtl" as const } : {})}
             >
               {l.label}
@@ -151,37 +59,7 @@ export function CopyFromLanguageMenu() {
           ))}
         </DropdownMenuContent>
       </DropdownMenu>
-
-      <AlertDialog
-        open={pending !== null}
-        onOpenChange={open => {
-          if (!open && !busy) setPending(null);
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Copy from {pendingLabel}?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This fills {activeLabel}&rsquo;s translatable fields with{" "}
-              {pendingLabel}&rsquo;s values, overwriting anything already
-              entered for {activeLabel}. Shared fields are untouched. Nothing is
-              saved until you save the form, so you can review or discard first.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={busy}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              disabled={busy}
-              onClick={e => {
-                e.preventDefault();
-                if (pending) void applyCopy(pending);
-              }}
-            >
-              {busy ? "Copying…" : `Copy from ${pendingLabel}`}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <CopyFromLanguageDialog copy={copy} />
     </>
   );
 }

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -33,8 +33,9 @@ import { useLocalization } from "@admin/hooks/useLocalization";
 import { cn } from "@admin/lib/utils";
 
 import { useEntryLocale } from "../EntryLocaleContext";
-import { LanguageSwitcher } from "../LanguageSwitcher";
-import { TranslationStatus, translationCounts } from "../TranslationStatus";
+import { LanguageControl } from "../LanguageControl";
+import { LanguagesMenu } from "../LanguagesMenu";
+import { translationCounts } from "../TranslationStatus";
 
 import { AutoSaveIndicator } from "./AutoSaveIndicator";
 import { DiscardDraftConfirmDialog } from "./DiscardDraftConfirmDialog";
@@ -261,7 +262,13 @@ export function EntrySystemHeader({
   const entryLocale = useEntryLocale();
   // The default language is edited with `locale === undefined`, and its status
   // can live on the companion, so resolve it to read the right lifecycle.
-  const { defaultLocale, locales } = useLocalization();
+  const {
+    enabled: localizationEnabled,
+    defaultLocale,
+    locales,
+    getLocale,
+  } = useLocalization();
+  const defaultLocaleLabel = getLocale(defaultLocale)?.label ?? defaultLocale;
   // Present only when the entry was fetched with `?translation-status=1` on a
   // localized collection; undefined otherwise, which both consumers below
   // treat as "nothing to report" rather than as zero progress.
@@ -373,73 +380,55 @@ export function EntrySystemHeader({
       : ((entry?.slug as string | undefined) ?? null);
 
   return (
-    <div className="px-6 py-3 border-b border-border flex items-center gap-3 sticky top-0 z-30 bg-background">
-      {/* Title input — borderless, 19px, autofocus on create */}
-      <div className="flex-1 min-w-0">
-        <input
-          {...rhfRegister}
-          ref={el => {
-            rhfRef(el);
-            inputRef.current = el;
-          }}
-          type="text"
-          placeholder="Untitled"
-          aria-label={titleLabel}
-          disabled={isSubmitting}
-          // The title is part of the document, so reading a past version locks
-          // it with everything else. Left editable it would mutate the LIVE
-          // document while the banner says the page cannot be edited — and go
-          // to autosave as unsaved work nobody typed on purpose.
-          readOnly={lockIdentity || isReadingHistory}
-          // RTL for a translatable title edited in an RTL language.
-          {...(titleRtl ? { dir: "rtl" as const } : {})}
-          className={cn(
-            "w-full text-xl font-semibold tracking-tight text-foreground",
-            "bg-transparent outline-none placeholder:text-muted-foreground",
-            isSubmitting && "opacity-60 cursor-not-allowed",
-            lockIdentity && "cursor-default text-foreground/80"
-          )}
-        />
-      </div>
+    <div className="sticky top-0 z-30 bg-background border-b border-border">
+      <div className="px-6 py-3 flex items-center gap-3">
+        {/* Title input — borderless, 19px, autofocus on create */}
+        <div className="flex-1 min-w-0">
+          <input
+            {...rhfRegister}
+            ref={el => {
+              rhfRef(el);
+              inputRef.current = el;
+            }}
+            type="text"
+            placeholder="Untitled"
+            aria-label={titleLabel}
+            disabled={isSubmitting}
+            // The title is part of the document, so reading a past version locks
+            // it with everything else. Left editable it would mutate the LIVE
+            // document while the banner says the page cannot be edited — and go
+            // to autosave as unsaved work nobody typed on purpose.
+            readOnly={lockIdentity || isReadingHistory}
+            // RTL for a translatable title edited in an RTL language.
+            {...(titleRtl ? { dir: "rtl" as const } : {})}
+            className={cn(
+              "w-full text-xl font-semibold tracking-tight text-foreground",
+              "bg-transparent outline-none placeholder:text-muted-foreground",
+              isSubmitting && "opacity-60 cursor-not-allowed",
+              lockIdentity && "cursor-default text-foreground/80"
+            )}
+          />
+        </div>
 
-      {/* Action cluster — right-aligned */}
-      <div className="flex items-center gap-1.5 shrink-0">
-        {toolbarSlot}
-        {/* A document only has history once it has been saved, and rendering a
+        {/* Action cluster — right-aligned */}
+        <div className="flex items-center gap-1.5 shrink-0">
+          {toolbarSlot}
+          {/* A document only has history once it has been saved, and rendering a
             snapshot needs the schema, so both are required to offer this. */}
-        {showEditMenuItems && historyFields && historyEnabled !== false ? (
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="px-2"
-            aria-label="Version history"
-            title="Version history"
-            onClick={() => setHistoryOpen(true)}
-          >
-            <History className="h-4 w-4" />
-          </Button>
-        ) : null}
-        {/* i18n M7: content-language switcher. Renders only when a change handler is wired AND
-            localization is configured (the component self-hides otherwise). */}
-        {onLocaleChange && (
-          <LanguageSwitcher value={locale} onChange={onLocaleChange} />
-        )}
-        {/* Beside the switcher rather than in the document rail: the switcher
-            answers "which language am I editing" and this answers "what state
-            is every other language in", which is the same question continued.
-            Splitting them across two panels made the reader assemble one fact
-            from two places. Self-hides when localization is off. */}
-        <TranslationStatus
-          {...(entryTranslations === undefined
-            ? {}
-            : { translations: entryTranslations })}
-          {...(locale === undefined ? {} : { activeLocale: locale })}
-          {...(onLocaleChange === undefined
-            ? {}
-            : { onSelect: onLocaleChange })}
-        />
-        {/* Directly left of the submit cluster, which is where an author looks
+          {showEditMenuItems && historyFields && historyEnabled !== false ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="px-2"
+              aria-label="Version history"
+              title="Version history"
+              onClick={() => setHistoryOpen(true)}
+            >
+              <History className="h-4 w-4" />
+            </Button>
+          ) : null}
+          {/* Directly left of the submit cluster, which is where an author looks
             for it: checking how something reads is part of deciding to publish
             it, not a document-management action like Duplicate or Delete. The
             `sm` size is the band's, so it lines up with Save beside it rather
@@ -449,17 +438,17 @@ export function EntrySystemHeader({
             minting a link and opening a preview both act on what is already
             saved, so a submit in flight is a race with them and not merely a
             busy form. */}
-        <PreviewActions
-          size="sm"
-          isPreviewAvailable={isPreviewAvailable}
-          {...(onPreview === undefined ? {} : { onPreview })}
-          {...(previewLabel === undefined ? {} : { previewLabel })}
-          isLinkAvailable={isLinkAvailable}
-          {...(onCopyLink === undefined ? {} : { onCopyLink })}
-          isCopyingLink={isCopyingLink}
-          disabled={isSubmitting}
-        />
-        {/* Sits with the actions rather than beside the title: it reports on
+          <PreviewActions
+            size="sm"
+            isPreviewAvailable={isPreviewAvailable}
+            {...(onPreview === undefined ? {} : { onPreview })}
+            {...(previewLabel === undefined ? {} : { previewLabel })}
+            isLinkAvailable={isLinkAvailable}
+            {...(onCopyLink === undefined ? {} : { onCopyLink })}
+            isCopyingLink={isCopyingLink}
+            disabled={isSubmitting}
+          />
+          {/* Sits with the actions rather than beside the title: it reports on
             the same work the save buttons act on, and reads as status for that
             cluster.
 
@@ -470,251 +459,304 @@ export function EntrySystemHeader({
             edit to a saved entry the status is still idle and no recovery point
             exists yet, which is exactly when the reader most wants to be told
             their change is not stored. */}
-        {autosaveEnabled ? (
-          <AutoSaveIndicator
-            lastSavedAt={autosaveLastSavedAt}
-            isSaving={autosaveStatus === "saving"}
-            isDirty={isDirty}
-          />
-        ) : null}
-        {/* The spoken half of the same information. `AutoSaveIndicator` reports
+          {autosaveEnabled ? (
+            <AutoSaveIndicator
+              lastSavedAt={autosaveLastSavedAt}
+              isSaving={autosaveStatus === "saving"}
+              isDirty={isDirty}
+            />
+          ) : null}
+          {/* The spoken half of the same information. `AutoSaveIndicator` reports
             visually only — it carries no live region — so an author using a
             screen reader was never told whether their work had been stored.
             This is rendered unconditionally rather than beside the indicator's
             own condition, because a live region has to be PRESENT BEFORE the
             text it will announce changes: mounting a region and populating it
             in the same commit is not reliably announced. */}
-        <DocumentStatusLive
-          autosaveEnabled={autosaveEnabled}
-          isSaving={autosaveStatus === "saving"}
-          isDirty={isDirty}
-          lastSavedAt={autosaveLastSavedAt}
-          {...(entryTranslations === undefined
-            ? {}
-            : {
-                translatedCount: counts.translated,
-                localeCount: counts.total,
-              })}
-        />
-        {/* No save affordances while a past version is on screen. They act on
+          <DocumentStatusLive
+            autosaveEnabled={autosaveEnabled}
+            isSaving={autosaveStatus === "saving"}
+            isDirty={isDirty}
+            lastSavedAt={autosaveLastSavedAt}
+            {...(entryTranslations === undefined
+              ? {}
+              : {
+                  translatedCount: counts.translated,
+                  localeCount: counts.total,
+                })}
+          />
+          {/* No save affordances while a past version is on screen. They act on
             the live document, which is not what is being read — an editor
             offered "Save" over a historical page has been invited to make a
             decision about something they cannot see. Restoring is offered
             instead, from the banner over the version itself. */}
-        {isReadingHistory ? null : hasStatus && isPublishedEdit ? (
-          <>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={isSubmitting || isInvalid || !isDirty}
-              // On a drafts-enabled collection a save on a published entry
-              // stores a working draft (live untouched); otherwise it re-asserts
-              // published, keeping the lifecycle unchanged.
-              onClick={draftsEnabled ? onSaveWorkingDraft : onSaveChanges}
-              data-status={
-                draftsEnabled ? "save-working-draft" : "save-changes"
-              }
-            >
-              {isSubmitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-              {draftsEnabled ? "Save" : "Save changes"}
-            </Button>
-            {/* Promote the pending working draft to live. Shown only when one
-                exists — a fully-published entry has nothing to promote. */}
-            {hasWorkingDraft && canPublishDocument && (
+          {isReadingHistory ? null : hasStatus && isPublishedEdit ? (
+            <>
               <Button
                 type="button"
+                variant="outline"
+                size="sm"
+                disabled={isSubmitting || isInvalid || !isDirty}
+                // On a drafts-enabled collection a save on a published entry
+                // stores a working draft (live untouched); otherwise it re-asserts
+                // published, keeping the lifecycle unchanged.
+                onClick={draftsEnabled ? onSaveWorkingDraft : onSaveChanges}
+                data-status={
+                  draftsEnabled ? "save-working-draft" : "save-changes"
+                }
+              >
+                {isSubmitting && (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                )}
+                {draftsEnabled ? "Save" : "Save changes"}
+              </Button>
+              {/* Promote the pending working draft to live. Shown only when one
+                exists — a fully-published entry has nothing to promote. */}
+              {hasWorkingDraft && canPublishDocument && (
+                <Button
+                  type="button"
+                  size="sm"
+                  disabled={isSubmitting || isInvalid}
+                  onClick={onPublish}
+                  data-status="published"
+                >
+                  {isSubmitting ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Globe className="h-3.5 w-3.5" />
+                  )}
+                  Publish
+                </Button>
+              )}
+              {canUnpublishDocument && (
+                <Button
+                  type="button"
+                  // Keep Publish the sole primary action when a draft is pending;
+                  // otherwise Unpublish stays the primary (published-only) action.
+                  variant={hasWorkingDraft ? "outline" : "default"}
+                  size="sm"
+                  disabled={isSubmitting}
+                  onClick={() => setUnpublishOpen(true)}
+                  data-status="unpublish"
+                >
+                  <EyeOff className="h-3.5 w-3.5" />
+                  Unpublish
+                </Button>
+              )}
+            </>
+          ) : hasStatus ? (
+            <>
+              <Button
+                type="button"
+                variant="outline"
                 size="sm"
                 disabled={isSubmitting || isInvalid}
-                onClick={onPublish}
-                data-status="published"
+                onClick={onSaveDraft}
+                data-status="draft"
               >
-                {isSubmitting ? (
+                {isSubmitting && (
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                ) : (
-                  <Globe className="h-3.5 w-3.5" />
                 )}
-                Publish
+                Save Draft
               </Button>
-            )}
-            {canUnpublishDocument && (
-              <Button
-                type="button"
-                // Keep Publish the sole primary action when a draft is pending;
-                // otherwise Unpublish stays the primary (published-only) action.
-                variant={hasWorkingDraft ? "outline" : "default"}
-                size="sm"
-                disabled={isSubmitting}
-                onClick={() => setUnpublishOpen(true)}
-                data-status="unpublish"
-              >
-                <EyeOff className="h-3.5 w-3.5" />
-                Unpublish
-              </Button>
-            )}
-          </>
-        ) : hasStatus ? (
-          <>
+              {canPublishDocument && (
+                <Button
+                  type="button"
+                  size="sm"
+                  disabled={isSubmitting || isInvalid}
+                  onClick={onPublish}
+                  data-status="published"
+                >
+                  {isSubmitting ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Globe className="h-3.5 w-3.5" />
+                  )}
+                  Publish
+                </Button>
+              )}
+            </>
+          ) : (
             <Button
-              type="button"
-              variant="outline"
+              type="submit"
+              form={formId}
               size="sm"
               disabled={isSubmitting || isInvalid}
-              onClick={onSaveDraft}
-              data-status="draft"
             >
-              {isSubmitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-              Save Draft
-            </Button>
-            {canPublishDocument && (
-              <Button
-                type="button"
-                size="sm"
-                disabled={isSubmitting || isInvalid}
-                onClick={onPublish}
-                data-status="published"
-              >
-                {isSubmitting ? (
+              {isSubmitting ? (
+                <>
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                ) : (
-                  <Globe className="h-3.5 w-3.5" />
-                )}
-                Publish
-              </Button>
-            )}
-          </>
-        ) : (
-          <Button
-            type="submit"
-            form={formId}
-            size="sm"
-            disabled={isSubmitting || isInvalid}
-          >
-            {isSubmitting ? (
-              <>
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                Saving…
-              </>
-            ) : mode === "create" ? (
-              "Create"
-            ) : (
-              "Save"
-            )}
-          </Button>
-        )}
+                  Saving…
+                </>
+              ) : mode === "create" ? (
+                "Create"
+              ) : (
+                "Save"
+              )}
+            </Button>
+          )}
 
-        {/* Single consolidated More menu — hidden entirely in create mode.
+          {/* Single consolidated More menu — hidden entirely in create mode.
             Why: in create mode the entry doesn't exist server-side yet, so
             Duplicate / Show JSON / View API / Delete have nothing to act on,
             and Discard changes is redundant with navigating away. Once the
             entry is persisted (mode === "edit"), the full action set
             appears. Resolves item 11 of 07-admin-bugs-feedback (PR-8). */}
-        {showEditMenuItems && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
+          {showEditMenuItems && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="px-2"
+                  aria-label="More actions"
+                >
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {showDiscardDraft && (
+                  <DropdownMenuItem
+                    onClick={() => setDiscardDraftOpen(true)}
+                    disabled={isSubmitting}
+                  >
+                    <RotateCcw className="h-3.5 w-3.5" />
+                    Discard draft
+                  </DropdownMenuItem>
+                )}
+                {isDirty && onCancel && (
+                  <DropdownMenuItem onClick={onCancel} disabled={isSubmitting}>
+                    <RotateCcw className="h-3.5 w-3.5" />
+                    Discard changes
+                  </DropdownMenuItem>
+                )}
+                {onDuplicate && (
+                  <>
+                    {(showDiscardDraft || (isDirty && onCancel)) && (
+                      <DropdownMenuSeparator />
+                    )}
+                    <DropdownMenuItem
+                      onClick={onDuplicate}
+                      disabled={isSubmitting}
+                    >
+                      <Copy className="h-3.5 w-3.5" />
+                      Duplicate
+                    </DropdownMenuItem>
+                  </>
+                )}
+                {showJson && (
+                  <ShowJSONDialog
+                    scope={scope}
+                    collectionSlug={collectionSlug}
+                    /* Why: collection scope needs the entry id to build
+                     /api/collections/{slug}/entries/{id}; single scope is
+                     keyed only by slug so entryId is unused. The outer
+                     showEditMenuItems gate guarantees entry?.id exists
+                     for the collection branch. */
+                    entryId={scope === "single" ? undefined : entry.id}
+                    trigger={
+                      <DropdownMenuItem onSelect={e => e.preventDefault()}>
+                        <Code className="h-3.5 w-3.5" />
+                        Show JSON
+                      </DropdownMenuItem>
+                    }
+                  />
+                )}
+                {onViewApi && (
+                  <DropdownMenuItem onClick={onViewApi}>
+                    <Code className="h-3.5 w-3.5" />
+                    View API response
+                  </DropdownMenuItem>
+                )}
+                {onDelete && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      onClick={onDelete}
+                      disabled={isSubmitting}
+                      className="text-destructive focus:text-destructive"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                      Delete
+                    </DropdownMenuItem>
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+
+          {/* Rail toggle — far right, separated by a thin divider */}
+          {onToggleRail && (
+            <>
+              <span className="w-px h-5 bg-border mx-1" />
               <Button
                 type="button"
                 variant="outline"
                 size="sm"
                 className="px-2"
-                aria-label="More actions"
+                onClick={onToggleRail}
+                aria-label={isRailCollapsed ? "Show rail" : "Hide rail"}
+                aria-pressed={isRailCollapsed}
               >
-                <MoreHorizontal className="h-4 w-4" />
+                {isRailCollapsed ? (
+                  <PanelRightClose className="h-4 w-4" />
+                ) : (
+                  <PanelRight className="h-4 w-4" />
+                )}
               </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {showDiscardDraft && (
-                <DropdownMenuItem
-                  onClick={() => setDiscardDraftOpen(true)}
-                  disabled={isSubmitting}
-                >
-                  <RotateCcw className="h-3.5 w-3.5" />
-                  Discard draft
-                </DropdownMenuItem>
-              )}
-              {isDirty && onCancel && (
-                <DropdownMenuItem onClick={onCancel} disabled={isSubmitting}>
-                  <RotateCcw className="h-3.5 w-3.5" />
-                  Discard changes
-                </DropdownMenuItem>
-              )}
-              {onDuplicate && (
-                <>
-                  {(showDiscardDraft || (isDirty && onCancel)) && (
-                    <DropdownMenuSeparator />
-                  )}
-                  <DropdownMenuItem
-                    onClick={onDuplicate}
-                    disabled={isSubmitting}
-                  >
-                    <Copy className="h-3.5 w-3.5" />
-                    Duplicate
-                  </DropdownMenuItem>
-                </>
-              )}
-              {showJson && (
-                <ShowJSONDialog
-                  scope={scope}
-                  collectionSlug={collectionSlug}
-                  /* Why: collection scope needs the entry id to build
-                     /api/collections/{slug}/entries/{id}; single scope is
-                     keyed only by slug so entryId is unused. The outer
-                     showEditMenuItems gate guarantees entry?.id exists
-                     for the collection branch. */
-                  entryId={scope === "single" ? undefined : entry.id}
-                  trigger={
-                    <DropdownMenuItem onSelect={e => e.preventDefault()}>
-                      <Code className="h-3.5 w-3.5" />
-                      Show JSON
-                    </DropdownMenuItem>
-                  }
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* The language row. Its own row rather than the action cluster: sharing
+          one flex row starved the title input to zero width in a localized
+          collection, since the cluster is shrink-0 and the strip is the widest
+          thing in it. Rendered only when localization applies, so
+          non-localized editors keep a single-row header.
+
+          While a past version is on screen, switching language or running a
+          language action would act on the live document under a banner saying
+          the page cannot be edited — so both are withheld, and only there. */}
+      {localizationEnabled && (mode === "create" || onLocaleChange) && (
+        <div className="px-6 py-2 border-t border-border flex items-center gap-3 flex-wrap">
+          {mode === "create" ? (
+            <span className="text-xs text-muted-foreground inline-flex items-center gap-1.5">
+              <Globe className="h-3.5 w-3.5" aria-hidden="true" />
+              Creating in {defaultLocaleLabel} — other languages can be added
+              after the first save
+            </span>
+          ) : (
+            <>
+              {onLocaleChange && (
+                <LanguageControl
+                  {...(entryTranslations === undefined
+                    ? {}
+                    : { translations: entryTranslations })}
+                  {...(locale === undefined ? {} : { activeLocale: locale })}
+                  onSelect={onLocaleChange}
+                  disabled={isReadingHistory}
                 />
               )}
-              {onViewApi && (
-                <DropdownMenuItem onClick={onViewApi}>
-                  <Code className="h-3.5 w-3.5" />
-                  View API response
-                </DropdownMenuItem>
+              {counts.total > 0 && counts.translated < counts.total && (
+                <span className="text-xs text-muted-foreground whitespace-nowrap tabular-nums">
+                  {counts.total - counts.translated}{" "}
+                  {counts.total - counts.translated === 1
+                    ? "language"
+                    : "languages"}{" "}
+                  untranslated
+                </span>
               )}
-              {onDelete && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={onDelete}
-                    disabled={isSubmitting}
-                    className="text-destructive focus:text-destructive"
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                    Delete
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
-
-        {/* Rail toggle — far right, separated by a thin divider */}
-        {onToggleRail && (
-          <>
-            <span className="w-px h-5 bg-border mx-1" />
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="px-2"
-              onClick={onToggleRail}
-              aria-label={isRailCollapsed ? "Show rail" : "Hide rail"}
-              aria-pressed={isRailCollapsed}
-            >
-              {isRailCollapsed ? (
-                <PanelRightClose className="h-4 w-4" />
-              ) : (
-                <PanelRight className="h-4 w-4" />
-              )}
-            </Button>
-          </>
-        )}
-      </div>
+            </>
+          )}
+          <span className="flex-1" />
+          <LanguagesMenu
+            hasStatus={hasStatus}
+            actionsDisabled={isReadingHistory || mode === "create"}
+          />
+        </div>
+      )}
 
       {/* Why: render the confirm modal at the component root so it's
           mounted regardless of which button matrix branch fired. The

--- a/packages/admin/src/components/features/entries/LanguageControl.tsx
+++ b/packages/admin/src/components/features/entries/LanguageControl.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+/**
+ * LanguageControl — one control that answers "which language am I editing" and
+ * "what state is every language in", together.
+ *
+ * The header previously answered those with two adjacent controls: a dropdown
+ * that switched and a row of pills that showed state (and also switched). One
+ * question, two affordances. This is a single segmented control: each segment
+ * is a language, its dot is that language's state, and pressing it switches.
+ *
+ * State is never colour alone. Each dot's SHAPE differs per state (filled /
+ * half-filled / outline), the segment carries the language's label as text,
+ * and the accessible name spells the state out.
+ *
+ * Renders nothing when localization is off or a change handler is not wired,
+ * so non-localized editors are unchanged.
+ *
+ * @module components/features/entries/LanguageControl
+ */
+
+import { useLocalization } from "@admin/hooks/useLocalization";
+import { cn } from "@admin/lib/utils";
+
+import type { LocaleTranslationMeta } from "./LanguageStatusPills";
+
+export type LanguageState = "missing" | "draft" | "translated" | "published";
+
+/** Resolve a locale's display state from its translation meta. */
+export function languageState(
+  meta: LocaleTranslationMeta | undefined
+): LanguageState {
+  if (!meta || !meta.translated) return "missing";
+  if (meta.status === "published") return "published";
+  if (meta.status === "draft") return "draft";
+  return "translated";
+}
+
+export const LANGUAGE_STATE_LABEL: Record<LanguageState, string> = {
+  missing: "not translated",
+  draft: "draft",
+  translated: "translated",
+  published: "published",
+};
+
+/**
+ * The dot encodes state by shape first: filled (published), filled in the
+ * positive scale (translated), half-filled (draft), outline (missing). Colour
+ * comes from the semantic scales only.
+ */
+export function StateDot({ state }: { state: LanguageState }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "inline-block size-2 rounded-full shrink-0",
+        state === "published" && "bg-foreground",
+        state === "translated" && "bg-success-600 dark:bg-success-400",
+        state === "draft" &&
+          "border-[1.5px] border-foreground/70 [background:linear-gradient(90deg,currentColor_50%,transparent_50%)] text-foreground/70",
+        state === "missing" && "border-[1.5px] border-muted-foreground/60"
+      )}
+    />
+  );
+}
+
+export interface LanguageControlProps {
+  /** The entry's `_translations` map, keyed by locale code. Absent → all dots read "missing". */
+  translations?: Record<string, LocaleTranslationMeta>;
+  /** The active editing locale (undefined = the app default). */
+  activeLocale?: string;
+  /** Called with the newly selected locale code. */
+  onSelect: (code: string) => void;
+  /**
+   * Disables switching (e.g. while a past version is on screen, where changing
+   * the document under the history banner would be disorienting). The states
+   * stay readable; only the interaction is withheld.
+   */
+  disabled?: boolean;
+  className?: string;
+}
+
+export function LanguageControl({
+  translations,
+  activeLocale,
+  onSelect,
+  disabled = false,
+  className,
+}: LanguageControlProps) {
+  const { enabled, locales, defaultLocale } = useLocalization();
+  if (!enabled || locales.length < 2) return null;
+
+  const active = activeLocale ?? defaultLocale;
+
+  return (
+    <div
+      role="group"
+      aria-label="Content language"
+      className={cn(
+        "inline-flex items-stretch rounded-md border border-border overflow-hidden",
+        className
+      )}
+    >
+      {locales.map((locale, index) => {
+        const state = languageState(translations?.[locale.code]);
+        const isActive = locale.code === active;
+        return (
+          <button
+            key={locale.code}
+            type="button"
+            onClick={() => onSelect(locale.code)}
+            disabled={disabled}
+            aria-pressed={isActive}
+            aria-label={`${locale.label} — ${LANGUAGE_STATE_LABEL[state]}${
+              locale.code === defaultLocale ? " (default)" : ""
+            }`}
+            title={`${locale.label} — ${LANGUAGE_STATE_LABEL[state]}`}
+            className={cn(
+              "inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
+              index > 0 && "border-l border-border",
+              isActive
+                ? "bg-muted text-foreground"
+                : "text-muted-foreground hover:text-foreground",
+              disabled && "opacity-60 cursor-default"
+            )}
+          >
+            <StateDot state={state} />
+            {locale.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/entries/LanguagesMenu.tsx
+++ b/packages/admin/src/components/features/entries/LanguagesMenu.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+/**
+ * LanguagesMenu — the header's always-reachable home for language actions.
+ *
+ * Copy-from and publish-all previously lived only in the document rail, which
+ * hides on narrower content widths — taking the two most important
+ * translation actions with it. This menu sits in the header at every width.
+ * The rail keeps its triggers; both consume the same hooks, so there is one
+ * implementation of each action however many places offer it.
+ *
+ * The menu also carries the legend for the language states, beside the
+ * actions that change them — the states were previously decodable only
+ * through tooltips.
+ *
+ * Renders nothing when localization is off or nothing in it applies, so
+ * non-localized editors are unchanged.
+ *
+ * @module components/features/entries/LanguagesMenu
+ */
+
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@nextlyhq/ui";
+import { Globe } from "lucide-react";
+
+import { useLocalization } from "@admin/hooks/useLocalization";
+
+import { CopyFromLanguageDialog } from "./CopyFromLanguageDialog";
+import {
+  LANGUAGE_STATE_LABEL,
+  StateDot,
+  type LanguageState,
+} from "./LanguageControl";
+import { useCopyFromLanguage } from "./useCopyFromLanguage";
+import { usePublishAllLanguages } from "./usePublishAllLanguages";
+
+const LEGEND_STATES: readonly LanguageState[] = [
+  "published",
+  "translated",
+  "draft",
+  "missing",
+];
+
+export interface LanguagesMenuProps {
+  /** Whether the collection has the Draft/Published lifecycle. */
+  hasStatus?: boolean;
+  /**
+   * Withholds the mutating actions (e.g. while a past version is on screen,
+   * where nothing in the header may write the live document). The menu still
+   * opens so the legend stays readable.
+   */
+  actionsDisabled?: boolean;
+}
+
+export function LanguagesMenu({
+  hasStatus,
+  actionsDisabled = false,
+}: LanguagesMenuProps) {
+  const { enabled } = useLocalization();
+  const copy = useCopyFromLanguage();
+  const publish = usePublishAllLanguages(
+    hasStatus === undefined ? {} : { hasStatus }
+  );
+
+  // Without localization there is nothing to put in the menu; with it, the
+  // legend alone justifies rendering even when no action applies yet (a new
+  // entry has no id, so copy-from and publish-all are both unavailable).
+  if (!enabled) return null;
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            aria-label="Language actions"
+          >
+            <Globe className="h-3.5 w-3.5" />
+            <span>Languages</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="min-w-52">
+          {copy.available && (
+            <>
+              <DropdownMenuLabel className="text-xs text-muted-foreground">
+                Copy into {copy.activeLabel}
+              </DropdownMenuLabel>
+              {copy.sources.map(l => (
+                <DropdownMenuItem
+                  key={l.code}
+                  disabled={actionsDisabled}
+                  onClick={() => copy.requestCopy(l.code)}
+                >
+                  Copy from {l.label}…
+                </DropdownMenuItem>
+              ))}
+            </>
+          )}
+          {publish.available && (
+            <DropdownMenuItem
+              disabled={actionsDisabled || publish.pending}
+              onClick={publish.publishAll}
+            >
+              {publish.pending ? "Publishing…" : "Publish all languages"}
+            </DropdownMenuItem>
+          )}
+          {(copy.available || publish.available) && <DropdownMenuSeparator />}
+          <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+            <span className="block mb-1 font-medium">Language states</span>
+            {LEGEND_STATES.map(state => (
+              <span key={state} className="flex items-center gap-1.5 py-0.5">
+                <StateDot state={state} />
+                {LANGUAGE_STATE_LABEL[state]}
+              </span>
+            ))}
+          </DropdownMenuLabel>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <CopyFromLanguageDialog copy={copy} />
+    </>
+  );
+}

--- a/packages/admin/src/components/features/entries/PublishAllLanguagesButton.tsx
+++ b/packages/admin/src/components/features/entries/PublishAllLanguagesButton.tsx
@@ -1,10 +1,13 @@
+"use client";
+
 /**
- * PublishAllLanguagesButton — publish every language of an entry at once (i18n M7, spec §10).
+ * PublishAllLanguagesButton — the document rail's trigger for publishing every
+ * language at once.
  *
- * The spec's default publish behavior for localized+draft collections: one click publishes all
- * languages together (per-language publish stays available via the normal locale-scoped Save/Publish).
- * Atomic on the server. Renders nothing unless localization is on, the collection is localized and
- * has drafts, and the entry exists — so non-localized editors are unchanged.
+ * Gating and the mutation live in `usePublishAllLanguages`, shared with the
+ * header's Languages menu: one availability rule, two triggers. Renders
+ * nothing when the action does not apply, so non-localized editors are
+ * unchanged.
  *
  * @module components/features/entries/PublishAllLanguagesButton
  */
@@ -12,11 +15,7 @@
 import { Button } from "@nextlyhq/ui";
 import { Globe } from "lucide-react";
 
-import { usePublishAllLocales } from "@admin/hooks/queries/usePublishAllLocales";
-import { useCan } from "@admin/hooks/useCan";
-import { useLocalization } from "@admin/hooks/useLocalization";
-
-import { useEntryLocale } from "./EntryLocaleContext";
+import { usePublishAllLanguages } from "./usePublishAllLanguages";
 
 export interface PublishAllLanguagesButtonProps {
   /** Whether the collection has the Draft/Published lifecycle (per-language publish applies). */
@@ -26,28 +25,10 @@ export interface PublishAllLanguagesButtonProps {
 export function PublishAllLanguagesButton({
   hasStatus,
 }: PublishAllLanguagesButtonProps) {
-  const { enabled, locales } = useLocalization();
-  const { collectionLocalized, collectionSlug, entryId } = useEntryLocale();
-  const publishAll = usePublishAllLocales({
-    collectionSlug: collectionSlug ?? "",
-  });
-  // Publishing every language is a publish, so it owes the same permission the
-  // header Publish button does. Without this an author holding only
-  // `update-<slug>` could publish all languages from the sidebar, bypassing the
-  // header gate. Empty slug matches no permission, keeping the hook unconditional.
-  const canPublish = useCan(`publish-${collectionSlug ?? ""}`);
-
-  if (
-    !enabled ||
-    !hasStatus ||
-    !collectionLocalized ||
-    !collectionSlug ||
-    !entryId ||
-    locales.length < 2 ||
-    !canPublish
-  ) {
-    return null;
-  }
+  const publish = usePublishAllLanguages(
+    hasStatus === undefined ? {} : { hasStatus }
+  );
+  if (!publish.available) return null;
 
   return (
     <Button
@@ -55,11 +36,11 @@ export function PublishAllLanguagesButton({
       variant="outline"
       size="sm"
       className="gap-1.5"
-      disabled={publishAll.isPending}
-      onClick={() => publishAll.mutate(entryId)}
+      disabled={publish.pending}
+      onClick={publish.publishAll}
     >
       <Globe className="h-3.5 w-3.5" />
-      {publishAll.isPending ? "Publishing…" : "Publish all languages"}
+      {publish.pending ? "Publishing…" : "Publish all languages"}
     </Button>
   );
 }

--- a/packages/admin/src/components/features/entries/__tests__/LanguageControl.test.tsx
+++ b/packages/admin/src/components/features/entries/__tests__/LanguageControl.test.tsx
@@ -1,0 +1,113 @@
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+import { LanguageControl, languageState } from "../LanguageControl";
+
+const useBranding = vi.fn();
+vi.mock("@admin/context/providers/BrandingProvider", () => ({
+  useBranding: () => useBranding(),
+}));
+
+const LOCALES = {
+  defaultLocale: "en",
+  fallback: true,
+  locales: [
+    { code: "en", label: "English", rtl: false, fallbackLocale: [] },
+    { code: "de", label: "German", rtl: false, fallbackLocale: [] },
+    { code: "ar", label: "Arabic", rtl: true, fallbackLocale: [] },
+  ],
+};
+
+const TRANSLATIONS = {
+  en: { translated: true, status: "published" },
+  de: { translated: true, status: "draft" },
+  ar: { translated: false },
+};
+
+describe("languageState", () => {
+  it("resolves each state from the translation meta", () => {
+    expect(languageState(undefined)).toBe("missing");
+    expect(languageState({ translated: false })).toBe("missing");
+    expect(languageState({ translated: true, status: "draft" })).toBe("draft");
+    expect(languageState({ translated: true, status: "published" })).toBe(
+      "published"
+    );
+    expect(languageState({ translated: true })).toBe("translated");
+  });
+});
+
+describe("LanguageControl", () => {
+  beforeEach(() => useBranding.mockReset());
+
+  it("renders nothing when localization is not configured", () => {
+    useBranding.mockReturnValue({ locales: undefined });
+    const { container } = render(
+      <LanguageControl translations={TRANSLATIONS} onSelect={() => {}} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders one pressable segment per language, state in the accessible name", () => {
+    useBranding.mockReturnValue({ locales: LOCALES });
+    render(
+      <LanguageControl
+        translations={TRANSLATIONS}
+        activeLocale="en"
+        onSelect={() => {}}
+      />
+    );
+    // The name carries language AND state, so neither is colour-only.
+    expect(
+      screen.getByRole("button", { name: "English — published (default)" })
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.getByRole("button", { name: "German — draft" })
+    ).toHaveAttribute("aria-pressed", "false");
+    expect(
+      screen.getByRole("button", { name: "Arabic — not translated" })
+    ).toBeInTheDocument();
+  });
+
+  it("treats an ABSENT translations map as every language missing, not as nothing to render", () => {
+    // The map only arrives with `?translation-status=1`; before it does, the
+    // switcher must still switch.
+    useBranding.mockReturnValue({ locales: LOCALES });
+    render(<LanguageControl onSelect={() => {}} />);
+    expect(
+      screen.getByRole("button", { name: "German — not translated" })
+    ).toBeInTheDocument();
+  });
+
+  it("switches on press", async () => {
+    useBranding.mockReturnValue({ locales: LOCALES });
+    const onSelect = vi.fn();
+    render(
+      <LanguageControl
+        translations={TRANSLATIONS}
+        activeLocale="en"
+        onSelect={onSelect}
+      />
+    );
+    await userEvent.click(screen.getByRole("button", { name: /German/ }));
+    expect(onSelect).toHaveBeenCalledWith("de");
+  });
+
+  it("withholds switching while disabled, keeping the states readable", async () => {
+    useBranding.mockReturnValue({ locales: LOCALES });
+    const onSelect = vi.fn();
+    render(
+      <LanguageControl
+        translations={TRANSLATIONS}
+        activeLocale="en"
+        onSelect={onSelect}
+        disabled
+      />
+    );
+    const german = screen.getByRole("button", { name: /German/ });
+    expect(german).toBeDisabled();
+    await userEvent.click(german);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/admin/src/components/features/entries/__tests__/LanguagesMenu.test.tsx
+++ b/packages/admin/src/components/features/entries/__tests__/LanguagesMenu.test.tsx
@@ -1,0 +1,123 @@
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+import { LanguagesMenu } from "../LanguagesMenu";
+
+const useBranding = vi.fn();
+vi.mock("@admin/context/providers/BrandingProvider", () => ({
+  useBranding: () => useBranding(),
+}));
+
+// The menu is a composition surface: the copy and publish behaviours have
+// their own implementations (and the rail's tests exercise the same hooks),
+// so these tests pin what the MENU decides — what it offers, and when it
+// withholds — with the hooks replaced by their contracts.
+const copyState = vi.fn();
+vi.mock("../useCopyFromLanguage", () => ({
+  useCopyFromLanguage: () => copyState(),
+}));
+const publishState = vi.fn();
+vi.mock("../usePublishAllLanguages", () => ({
+  usePublishAllLanguages: () => publishState(),
+}));
+vi.mock("../CopyFromLanguageDialog", () => ({
+  CopyFromLanguageDialog: () => null,
+}));
+
+const LOCALES = {
+  defaultLocale: "en",
+  fallback: true,
+  locales: [
+    { code: "en", label: "English", rtl: false, fallbackLocale: [] },
+    { code: "de", label: "German", rtl: false, fallbackLocale: [] },
+  ],
+};
+
+const COPY_IDLE = {
+  available: true,
+  sources: [{ code: "en", label: "English", rtl: false }],
+  activeLabel: "German",
+  pendingLabel: "",
+  pending: null,
+  busy: false,
+  requestCopy: vi.fn(),
+  cancel: vi.fn(),
+  confirm: vi.fn(),
+};
+const PUBLISH_IDLE = { available: true, pending: false, publishAll: vi.fn() };
+
+describe("LanguagesMenu", () => {
+  beforeEach(() => {
+    useBranding.mockReset();
+    copyState.mockReturnValue(COPY_IDLE);
+    publishState.mockReturnValue(PUBLISH_IDLE);
+  });
+
+  it("renders nothing when localization is not configured", () => {
+    useBranding.mockReturnValue({ locales: undefined });
+    const { container } = render(<LanguagesMenu hasStatus />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("offers the actions and the legend from one always-present trigger", async () => {
+    useBranding.mockReturnValue({ locales: LOCALES });
+    render(<LanguagesMenu hasStatus />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Language actions" })
+    );
+    expect(
+      screen.getByRole("menuitem", { name: "Copy from English…" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Publish all languages" })
+    ).toBeInTheDocument();
+    // The legend decodes every state in text, not tooltip-only.
+    expect(screen.getByText("not translated")).toBeInTheDocument();
+    expect(screen.getByText("published")).toBeInTheDocument();
+  });
+
+  it("keeps the legend when no action applies (a new, unsaved entry)", async () => {
+    useBranding.mockReturnValue({ locales: LOCALES });
+    copyState.mockReturnValue({ ...COPY_IDLE, available: false });
+    publishState.mockReturnValue({ ...PUBLISH_IDLE, available: false });
+    render(<LanguagesMenu hasStatus />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Language actions" })
+    );
+    expect(screen.queryByRole("menuitem")).not.toBeInTheDocument();
+    expect(screen.getByText("Language states")).toBeInTheDocument();
+  });
+
+  it("withholds the mutations while actions are disabled, keeping the legend readable", async () => {
+    // Reading a past version: nothing in the header may write the live
+    // document, so both actions are withheld rather than hidden.
+    useBranding.mockReturnValue({ locales: LOCALES });
+    render(<LanguagesMenu hasStatus actionsDisabled />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Language actions" })
+    );
+    expect(
+      screen.getByRole("menuitem", { name: "Copy from English…" })
+    ).toHaveAttribute("aria-disabled", "true");
+    expect(
+      screen.getByRole("menuitem", { name: "Publish all languages" })
+    ).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByText("Language states")).toBeInTheDocument();
+  });
+
+  it("routes a copy request to the shared implementation", async () => {
+    useBranding.mockReturnValue({ locales: LOCALES });
+    const requestCopy = vi.fn();
+    copyState.mockReturnValue({ ...COPY_IDLE, requestCopy });
+    render(<LanguagesMenu hasStatus />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Language actions" })
+    );
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: "Copy from English…" })
+    );
+    expect(requestCopy).toHaveBeenCalledWith("en");
+  });
+});

--- a/packages/admin/src/components/features/entries/fields/FieldWrapper.rtl.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldWrapper.rtl.test.tsx
@@ -102,13 +102,29 @@ describe("FieldWrapper shared-across-languages affordance", () => {
   // on the old short text would make the two NEGATIVE assertions pass for the
   // wrong reason, since an exact query for "Shared" no longer matches the
   // element that is now rendered either.
-  it("marks a shared field in a multilingual collection", () => {
-    renderField(numberField, { collectionLocalized: true });
+  it("marks a shared field while editing a non-default language", () => {
+    renderField(numberField, {
+      collectionLocalized: true,
+      isNonDefaultLocale: true,
+    });
     expect(screen.getByText("Shared across languages")).toBeInTheDocument();
   });
 
+  it("stays quiet on the DEFAULT language, where every field behaves normally", () => {
+    // The consequence the badge warns about — edits reaching other languages —
+    // only exists once another language is the one being edited, so the badge
+    // on the ordinary editing path was noise.
+    renderField(numberField, { collectionLocalized: true });
+    expect(
+      screen.queryByText("Shared across languages")
+    ).not.toBeInTheDocument();
+  });
+
   it("does NOT mark a translatable field", () => {
-    renderField(textField, { collectionLocalized: true });
+    renderField(textField, {
+      collectionLocalized: true,
+      isNonDefaultLocale: true,
+    });
     expect(
       screen.queryByText("Shared across languages")
     ).not.toBeInTheDocument();

--- a/packages/admin/src/components/features/entries/fields/FieldWrapper.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldWrapper.tsx
@@ -265,8 +265,15 @@ export function FieldWrapper({
   // Subtle marker on shared fields in a multilingual collection: their value applies to every
   // language and has no per-language draft state (spec §7), so editing one changes all — surface
   // it so editors aren't surprised. Only meaningful for real (named) data fields.
+  //
+  // Only while editing a NON-default language: on the default language every
+  // field behaves normally and the distinction has no consequence yet, so the
+  // badge on every shared field was noise on the ordinary editing path. The
+  // surprise it guards against — "editing this changes other languages too" —
+  // only exists once another language is the one being edited.
   const sharedHint =
     entryLocale.collectionLocalized &&
+    entryLocale.isNonDefaultLocale &&
     !isLocalizedField &&
     fieldName != null ? (
       // The whole fact is written out rather than abbreviated to "Shared"

--- a/packages/admin/src/components/features/entries/useCopyFromLanguage.ts
+++ b/packages/admin/src/components/features/entries/useCopyFromLanguage.ts
@@ -1,0 +1,153 @@
+"use client";
+
+/**
+ * useCopyFromLanguage — the one implementation of "seed this language from
+ * another", shared by every surface that offers it.
+ *
+ * The action renders in more than one place (the document rail, the header's
+ * Languages menu), and two copies of the fill logic would agree today and
+ * drift silently. The hook owns gating, the pending/confirm handshake and the
+ * copy itself; surfaces own only their trigger.
+ *
+ * The contract is unchanged from the original control: explicit (a deliberate
+ * action), field-scoped (translatable fields only, absent source fields never
+ * blank the target), reversible (fills the form without saving), and it warns
+ * before overwriting via the confirm step.
+ *
+ * @module components/features/entries/useCopyFromLanguage
+ */
+
+import { useState } from "react";
+import { useFormContext } from "react-hook-form";
+
+import { toast } from "@admin/components/ui";
+import { useLocalization } from "@admin/hooks/useLocalization";
+import { entryApi } from "@admin/services/entryApi";
+
+import { useEntryLocale } from "./EntryLocaleContext";
+
+/** True when a value counts as "present" (would be overwritten). Mirrors the blank=empty rule. */
+function isPresent(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim() !== "";
+  return true;
+}
+
+/**
+ * Pick the translatable field values to copy from a source entry: only the named localized fields
+ * that actually have a value in the source (so absent source fields don't blank the target).
+ */
+export function pickLocalizedValues(
+  source: Record<string, unknown>,
+  localizedFieldNames: string[]
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const name of localizedFieldNames) {
+    if (isPresent(source[name])) out[name] = source[name];
+  }
+  return out;
+}
+
+export interface CopyFromLanguageSource {
+  code: string;
+  label: string;
+  rtl: boolean;
+}
+
+export interface CopyFromLanguage {
+  /** Whether the action applies here at all; surfaces render nothing when false. */
+  available: boolean;
+  /** Languages that can be copied from (every locale except the active one). */
+  sources: CopyFromLanguageSource[];
+  /** Label of the language being edited (the copy target). */
+  activeLabel: string;
+  /** Label of the source awaiting confirmation, or "" when none is pending. */
+  pendingLabel: string;
+  /** Locale code awaiting confirmation, or null. */
+  pending: string | null;
+  /** True while a confirmed copy is fetching and filling. */
+  busy: boolean;
+  /** Ask to copy from a source; opens the confirm step. */
+  requestCopy: (code: string) => void;
+  /** Dismiss the confirm step without copying. */
+  cancel: () => void;
+  /** Run the pending copy. */
+  confirm: () => Promise<void>;
+}
+
+export function useCopyFromLanguage(): CopyFromLanguage {
+  const { enabled, locales, defaultLocale, getLocale } = useLocalization();
+  const {
+    locale,
+    collectionLocalized,
+    collectionSlug,
+    entryId,
+    localizedFieldNames,
+  } = useEntryLocale();
+  const form = useFormContext();
+
+  const [pending, setPending] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const active = locale ?? defaultLocale;
+  const sources = locales.filter(l => l.code !== active);
+
+  const available =
+    enabled &&
+    collectionLocalized &&
+    !!collectionSlug &&
+    !!entryId &&
+    !!localizedFieldNames &&
+    localizedFieldNames.length > 0 &&
+    sources.length > 0 &&
+    !!form;
+
+  const activeLabel = getLocale(active)?.label ?? active;
+  const pendingLabel = pending ? (getLocale(pending)?.label ?? pending) : "";
+
+  async function confirm(): Promise<void> {
+    if (!pending || !available) return;
+    setBusy(true);
+    try {
+      // Fetch the source language's raw values (no fallback — copy what that language actually has).
+      const source = (await entryApi.findByID(collectionSlug, entryId, {
+        locale: pending,
+        fallbackLocale: "none",
+        depth: 0,
+      })) as unknown as Record<string, unknown>;
+
+      const patch = pickLocalizedValues(source, localizedFieldNames);
+      const count = Object.keys(patch).length;
+      if (count === 0) {
+        toast.info(`${pendingLabel} has no content to copy.`);
+        return;
+      }
+      // Fill the form (dirty, so the user can review then save — or discard to revert).
+      for (const [name, value] of Object.entries(patch)) {
+        form.setValue(name, value, { shouldDirty: true, shouldValidate: true });
+      }
+      toast.success(
+        `Copied ${count} field${count === 1 ? "" : "s"} from ${pendingLabel}. Review, then save.`
+      );
+    } catch {
+      toast.error(`Couldn't copy from ${pendingLabel}.`);
+    } finally {
+      setBusy(false);
+      setPending(null);
+    }
+  }
+
+  return {
+    available,
+    sources,
+    activeLabel,
+    pendingLabel,
+    pending,
+    busy,
+    requestCopy: setPending,
+    cancel: () => {
+      if (!busy) setPending(null);
+    },
+    confirm,
+  };
+}

--- a/packages/admin/src/components/features/entries/usePublishAllLanguages.ts
+++ b/packages/admin/src/components/features/entries/usePublishAllLanguages.ts
@@ -1,0 +1,62 @@
+"use client";
+
+/**
+ * usePublishAllLanguages — gating and action for "publish every language",
+ * shared by every surface that offers it.
+ *
+ * The action renders in the document rail and in the header's Languages menu;
+ * the availability rule (localized draft collection, saved entry, several
+ * languages, publish permission) must be one implementation or the two
+ * surfaces drift into disagreeing about who may publish.
+ *
+ * @module components/features/entries/usePublishAllLanguages
+ */
+
+import { usePublishAllLocales } from "@admin/hooks/queries/usePublishAllLocales";
+import { useCan } from "@admin/hooks/useCan";
+import { useLocalization } from "@admin/hooks/useLocalization";
+
+import { useEntryLocale } from "./EntryLocaleContext";
+
+export interface PublishAllLanguages {
+  /** Whether the action applies here at all; surfaces render nothing when false. */
+  available: boolean;
+  /** True while the publish is in flight. */
+  pending: boolean;
+  /** Publish every language of the current entry. */
+  publishAll: () => void;
+}
+
+export function usePublishAllLanguages({
+  hasStatus,
+}: {
+  /** Whether the collection has the Draft/Published lifecycle. */
+  hasStatus?: boolean;
+}): PublishAllLanguages {
+  const { enabled, locales } = useLocalization();
+  const { collectionLocalized, collectionSlug, entryId } = useEntryLocale();
+  const mutation = usePublishAllLocales({
+    collectionSlug: collectionSlug ?? "",
+  });
+  // Publishing every language is a publish, so it owes the same permission the
+  // header Publish button does. Empty slug matches no permission, keeping the
+  // hook unconditional.
+  const canPublish = useCan(`publish-${collectionSlug ?? ""}`);
+
+  const available =
+    enabled &&
+    !!hasStatus &&
+    collectionLocalized &&
+    !!collectionSlug &&
+    !!entryId &&
+    locales.length >= 2 &&
+    canPublish;
+
+  return {
+    available,
+    pending: mutation.isPending,
+    publishAll: () => {
+      if (entryId) mutation.mutate(entryId);
+    },
+  };
+}

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
@@ -320,10 +320,20 @@ export default function EditEntryPage({
             No entry ID was specified in the URL.
           </AlertDescription>
         </Alert>
-        <div className="mt-6">
+        <div className="mt-6 flex items-center gap-2">
           <Link href={buildRoute(ROUTES.COLLECTION_ENTRIES, { slug })}>
             <Button variant="outline">← Back to {slug}</Button>
           </Link>
+          {/* A failed load while a non-default language is active is usually a
+              failure of THAT fetch, and the default language is still likely to
+              load — so offer the way back to it instead of stranding the
+              editor with only an exit. Resetting the locale re-keys the query,
+              which is the retry. */}
+          {locale !== undefined && (
+            <Button variant="outline" onClick={() => setLocale(undefined)}>
+              Back to the default language
+            </Button>
+          )}
         </div>
       </PageContainer>
     );


### PR DESCRIPTION
Stage A of the founder-approved multilingual UX plan (audit + design options: the T-07 artifact; staged direction: repairs → language panel → list columns → translation mode). This PR is the repairs.

## The two P1s, measured before and after

**1. The document title rendered at `width: 0` in localized collections — at every viewport width.** The language strip shared the title's flex row; the `shrink-0` strip starved the `flex-1` title completely. Measured on the live playground: `titleW: 0` at 1200 AND 1512 before; **227px (1512), 171px (1200), 210px (Arabic active)** after. The strip now lives on its own row.

**2. Copy-from and Publish-all were unreachable on ordinary laptops.** They existed only in the 320px document rail, which hides below 896px content width. Measured at 1200px viewport: rail `w=0`, and previously no other surface. Now: a **Languages menu in the header**, measured visible (`126px`) at exactly the width where the rail is hidden. Rail keeps its triggers; both surfaces consume one implementation (`useCopyFromLanguage`, `usePublishAllLanguages`) so they cannot drift.

## Also in this stage

- **One segmented `LanguageControl`** replaces the switcher-dropdown + pills pair that both switched languages. State is dot **shape** + text label + accessible name (`"German — draft"`), never colour alone; colours come from semantic scales only.
- **The legend exists** — in the Languages menu, beside the actions. Previously tooltip-only.
- **Create mode names its language** ("Creating in English — other languages can be added after the first save").
- **`Shared across languages` badge only while editing a non-default language** — on the default path it stated a fact with no consequence yet, on every shared field.
- **A failed load with a non-default language active** offers "Back to the default language" (re-keys the query = retry) instead of only an exit.
- **The playground registers `Authors`** — the only localized collection existed on disk unregistered, so every i18n admin surface was dark in development.
- **Singles inherit the row automatically** (they render `EntrySystemHeader`); their provider intentionally omits `entryId`/`collectionSlug`, so the entries-only actions self-gate off and the menu degrades to legend-only. True singles copy-from/publish-all is Stage B's data seam, deliberately.

## The version-history constraint, honoured

While a past version is on screen (`isReadingHistory`), nothing in this header may write the live document: language switching is disabled and the menu's mutating actions are withheld (legend stays readable). Same gate the title/save affordances already carry.

## Test plan

- **14 new tests** (`LanguageControl` 6, `LanguagesMenu` 5, badge-gating updates 3), every one **stub-verified in both directions** — six deliberate breaks (state resolution, disabled gate, select wiring, menu disabled gate, availability gate, request routing), each failed as intended, each restore verified by copy-compare.
- FieldWrapper's badge tests updated to the new contract, including a new case pinning default-language quietness.
- Full admin suite: **no new failures vs baseline** (4 files / 15 tests, same set, `comm -13` empty).
- `check-types` 0 · `lint` 0 (design-token rules active).
- **Browser-verified on the live playground**: title widths above; segmented control switches (Arabic: `aria-pressed=true`, RTL applied per-field, inline source hint present, no error); create notice renders; both P1 measurements taken at the rail-hidden width.

## Pre-existing failures (not introduced)

`packages/admin`: 4 files / 15 tests — `StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField`.

## Changeset

Added: **patch, 25 packages**, generated from `.changeset/config.json` `fixed[0]`.
