### PR TITLE
test(root): cover the design-lint guard and split its rules apart

### DIFF
--- a/scripts/lint-design.mjs
+++ b/scripts/lint-design.mjs
@@ -54,7 +54,7 @@ import {
  * they are site starters, and a palette colour on someone's own marketing page
  * is their design decision rather than a theme violation.
  */
-function deriveRoots() {
+export function deriveRoots() {
   const roots = [];
   const add = path => {
     if (existsSync(path)) roots.push(path);
@@ -90,6 +90,11 @@ const FILE_ALLOWLIST = ["plugin-page-builder/src/core/style-compiler.ts"];
 const PLUGIN_SURFACE_RE =
   /(?:^|\/)(?:packages\/plugin-[^/]+|templates\/plugin)\//;
 
+/** Whether this path is a plugin surface, and so subject to the stricter rules. */
+export function isPluginSurface(file) {
+  return PLUGIN_SURFACE_RE.test(file);
+}
+
 // Admin's reviewed `!important` baseline (see packages/admin/src/styles/globals.css). The
 // guard fails if this grows; lower it when overrides are removed.
 const ADMIN_IMPORTANT_BASELINE = 35;
@@ -99,7 +104,7 @@ const COLOR_LITERAL_RE = createColorLiteralPattern();
 const PALETTE_CLASS_RE = createPaletteClassPattern();
 
 /** True for a line that is nothing but a comment — `//`, `/* … *​/`, or a JSDoc `*`. */
-function isCommentLine(line) {
+export function isCommentLine(line) {
   const t = line.trim();
   return t.startsWith("//") || t.startsWith("*") || t.startsWith("/*");
 }
@@ -124,7 +129,7 @@ const listFiles = roots =>
 
 /** A color-literal line is exempt when nothing but mode-invariant black/white/transparent
  *  (or an allowed construct) remains after stripping the permitted pieces. */
-function colorLiteralIsExempt(line, file) {
+export function colorLiteralIsExempt(line, file) {
   if (hasExemptionDirective(line)) return true;
   if (FILE_ALLOWLIST.some((f) => file.endsWith(f))) return true;
   // The Tailwind palette scale (`--color-blue-500: #3b82f6`) is the literal
@@ -162,42 +167,61 @@ function refuse(missing) {
   process.exit(1);
 }
 
-const roots = deriveRoots();
-// Checked before `listFiles`, which shells out to `find`: with no paths that
-// command fails and takes the process down before any population is reported,
-// so the refusal below would be unreachable and the operator would see a stack
-// trace instead of the reason.
-if (roots.length === 0) refuse(["no roots"]);
+/**
+ * The four rules, each as its own decision so the reason a line is reported is
+ * separable from the loop that visits lines. Each returns the violation text,
+ * or `null` when the line is clean under that rule.
+ */
+export function tokenWrapViolation(at, line) {
+  if (!TOKEN_WRAP_RE.test(line)) return null;
+  return `${at}  token wrapped in color fn — use var(--token): ${line.trim()}`;
+}
 
-const files = listFiles(roots);
+export function colorLiteralViolation(at, line, file, { isCss, isPlugin }) {
+  if (!isCss && !isPlugin) return null;
+  if (!COLOR_LITERAL_RE.test(line)) return null;
+  if (colorLiteralIsExempt(line, file)) return null;
+  return `${at}  hardcoded color — use var(--token)/color-mix: ${line.trim()}`;
+}
 
-const violations = [];
-let adminImportant = 0;
-let pluginClassified = 0;
+export function paletteViolation(at, line, { isThemeSource }) {
+  if (isThemeSource || isCommentLine(line)) return null;
+  const match = PALETTE_CLASS_RE.exec(line);
+  if (!match || hasExemptionDirective(line)) return null;
+  return `${at}  palette class \`${match[1]}\` — ${paletteAdvice(match[1])}: ${line.trim()}`;
+}
 
-for (const file of files) {
+/**
+ * Audit one file's source.
+ *
+ * Takes the SOURCE rather than reading it, so the rules can be exercised
+ * without a fixture on disk — the reason this was previously untestable was
+ * that the only way to reach it was to run the whole scan.
+ *
+ * `!important` is counted rather than reported outside a plugin, because the
+ * admin carries a reviewed baseline that this returns for the caller to ratchet.
+ */
+export function auditFile(file, source) {
   const isCss = file.endsWith(".css");
-  const isPlugin = PLUGIN_SURFACE_RE.test(file);
-  if (isPlugin) pluginClassified += 1;
+  const isPlugin = isPluginSurface(file);
   // The theme declares the palette scales themselves; it is the one place the
   // hue names are the subject rather than a shortcut past the tokens.
   const isThemeSource = file.endsWith("ui/src/styles/theme.css");
-  const lines = readFileSync(file, "utf8").split("\n");
 
-  lines.forEach((line, i) => {
-    const at = `${file}:${i + 1}`;
+  const violations = [];
+  let adminImportant = 0;
 
-    // 1. token wrapped in a color function — everywhere.
-    if (TOKEN_WRAP_RE.test(line)) {
-      violations.push(`${at}  token wrapped in color fn — use var(--token): ${line.trim()}`);
+  source.split("\n").forEach((line, index) => {
+    const at = `${file}:${index + 1}`;
+
+    for (const found of [
+      tokenWrapViolation(at, line),
+      colorLiteralViolation(at, line, file, { isCss, isPlugin }),
+      paletteViolation(at, line, { isThemeSource }),
+    ]) {
+      if (found) violations.push(found);
     }
 
-    // 2. hardcoded color literal — CSS files (any package) or plugin source.
-    if ((isCss || isPlugin) && COLOR_LITERAL_RE.test(line) && !colorLiteralIsExempt(line, file)) {
-      violations.push(`${at}  hardcoded color — use var(--token)/color-mix: ${line.trim()}`);
-    }
-
-    // 3. !important — banned in plugins; baseline-capped in admin.
     if (line.includes("!important")) {
       if (isPlugin) {
         violations.push(`${at}  !important not allowed in plugins: ${line.trim()}`);
@@ -205,38 +229,56 @@ for (const file of files) {
         adminImportant += 1;
       }
     }
-
-    // 4. Tailwind palette utility — every package, every file type. The theme
-    //    defines its own `--color-{hue}-*` scales, so skip the file that owns them.
-    //    A comment naming a hue is prose (a JSDoc example, a note about what a
-    //    line used to be) and styles nothing, so whole-comment lines are skipped.
-    if (!isThemeSource && !isCommentLine(line)) {
-      const paletteMatch = PALETTE_CLASS_RE.exec(line);
-      if (paletteMatch && !hasExemptionDirective(line)) {
-        violations.push(
-          `${at}  palette class \`${paletteMatch[1]}\` — ${paletteAdvice(paletteMatch[1])}: ${line.trim()}`
-        );
-      }
-    }
   });
+
+  return { violations, adminImportant, isPlugin };
 }
 
 /**
- * What the run actually read, asserted before any verdict is reported.
- *
- * A scan whose roots resolved to nothing finds no violations and exits 0, which
- * is byte-identical to a clean repository. The three populations are reported
- * separately because they fail independently: roots can resolve while matching
- * no files, and files can be read while none of them is classified as a plugin
- * surface — and that last case makes every plugin-only rule inert while the
- * summary still reads as a pass.
+ * The populations whose emptiness means the run could not look, rather than
+ * that it looked and found nothing. Returned rather than printed so the caller
+ * decides, and so a test can ask without catching `process.exit`.
  */
-const empty = [
-  ["files", files.length],
-  ["plugin-surface files", pluginClassified],
-].filter(([, count]) => count === 0);
-if (empty.length > 0) refuse(empty.map(([label]) => `no ${label}`));
+export function emptyPopulations({ files, pluginClassified }) {
+  return [
+    ["files", files],
+    ["plugin-surface files", pluginClassified],
+  ]
+    .filter(([, count]) => count === 0)
+    .map(([label]) => `no ${label}`);
+}
 
+function main() {
+  const roots = deriveRoots();
+  // Checked before `listFiles`, which shells out to `find`: with no paths that
+  // command fails and takes the process down before any population is reported,
+  // so the refusal below would be unreachable and the operator would see a
+  // stack trace instead of the reason.
+  if (roots.length === 0) refuse(["no roots"]);
+
+  const files = listFiles(roots);
+
+  const violations = [];
+  let adminImportant = 0;
+  let pluginClassified = 0;
+
+  for (const file of files) {
+    const result = auditFile(file, readFileSync(file, "utf8"));
+    violations.push(...result.violations);
+    adminImportant += result.adminImportant;
+    if (result.isPlugin) pluginClassified += 1;
+  }
+
+  const empty = emptyPopulations({
+    files: files.length,
+    pluginClassified,
+  });
+  if (empty.length > 0) refuse(empty);
+
+  report({ roots, files, violations, adminImportant, pluginClassified });
+}
+
+function report({ roots, files, violations, adminImportant, pluginClassified }) {
 if (adminImportant > ADMIN_IMPORTANT_BASELINE) {
   violations.push(
     `admin: ${adminImportant} \`!important\` exceed the reviewed baseline of ${ADMIN_IMPORTANT_BASELINE}. ` +
@@ -259,3 +301,14 @@ console.log(
     `${adminImportant}/${ADMIN_IMPORTANT_BASELINE}.`
 );
 console.log(`  roots: ${roots.join(", ")}`);
+}
+
+// Runs only when invoked directly, so importing this module for tests does not
+// scan the repository or call `process.exit`. Matched on the script NAME rather
+// than by comparing `import.meta.url` to `process.argv[1]`: that comparison is
+// sensitive to how the path was resolved — a symlinked prefix breaks it, and
+// resolving with `realpathSync` breaks the opposite case, because
+// `--preserve-symlinks-main` is settable through `NODE_OPTIONS`.
+if (process.argv[1] && process.argv[1].endsWith("lint-design.mjs")) {
+  main();
+}

--- a/scripts/lint-design.test.mjs
+++ b/scripts/lint-design.test.mjs
@@ -1,0 +1,179 @@
+/**
+ * Controls for the design-system lint guard.
+ *
+ * The guard had no tests. That mattered more than an ordinary coverage gap,
+ * because it is the check every other surface relies on to notice a hardcoded
+ * colour — and its own failure mode is silence: a scan that reads nothing
+ * reports exactly what a clean repository reports.
+ *
+ * The rules are exercised through the exported decisions rather than by running
+ * the whole scan, so a case can be stated as one line of source and one
+ * expectation. The scan itself is covered at the end by running the real
+ * script, which is the only way to assert the entry guard and the summary.
+ */
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+import {
+  auditFile,
+  colorLiteralIsExempt,
+  colorLiteralViolation,
+  deriveRoots,
+  emptyPopulations,
+  isCommentLine,
+  isPluginSurface,
+  paletteViolation,
+  tokenWrapViolation,
+} from "./lint-design.mjs";
+
+describe("isPluginSurface", () => {
+  it("recognises a plugin package and the plugin template", () => {
+    expect(isPluginSurface("packages/plugin-form-builder/src/admin/X.tsx")).toBe(true);
+    expect(isPluginSurface("packages/plugin-seo/src/index.ts")).toBe(true);
+    expect(isPluginSurface("templates/plugin/src/admin/SettingsPage.tsx")).toBe(true);
+  });
+
+  it("does not classify the admin, the kit, or a package that merely contains the word", () => {
+    expect(isPluginSurface("packages/admin/src/x.tsx")).toBe(false);
+    expect(isPluginSurface("packages/ui/src/x.tsx")).toBe(false);
+    // `packages/eslint-plugin` contains "plugin" and is tooling, not a surface.
+    expect(isPluginSurface("packages/eslint-plugin/src/index.js")).toBe(false);
+    // The other templates are site starters, deliberately out of scope.
+    expect(isPluginSurface("templates/blog/src/app/page.tsx")).toBe(false);
+  });
+});
+
+describe("isCommentLine", () => {
+  it("is true only for a line that is nothing but a comment", () => {
+    expect(isCommentLine("  // a note")).toBe(true);
+    expect(isCommentLine("   * jsdoc continuation")).toBe(true);
+    expect(isCommentLine("/* opening */")).toBe(true);
+    expect(isCommentLine('const a = "x"; // trailing')).toBe(false);
+    expect(isCommentLine("")).toBe(false);
+  });
+});
+
+describe("colorLiteralIsExempt", () => {
+  const file = "packages/plugin-seo/src/x.ts";
+
+  it("exempts a marked line, but only with a reason", () => {
+    expect(colorLiteralIsExempt('a: "#ff0000" // design-lint-ok: brand swatch', file)).toBe(true);
+    expect(colorLiteralIsExempt('a: "#ff0000" // design-lint-ok', file)).toBe(false);
+  });
+
+  it("exempts mode-invariant colours and content, not real ones", () => {
+    expect(colorLiteralIsExempt('a: "#fff"', file)).toBe(true);
+    expect(colorLiteralIsExempt('a: "#00000033"', file)).toBe(true);
+    expect(colorLiteralIsExempt('a: "rgba(0,0,0,.5)"', file)).toBe(true);
+    expect(colorLiteralIsExempt('a: "#1a2b3c"', file)).toBe(false);
+  });
+
+  it("exempts a token DECLARATION in the theme source only", () => {
+    const theme = "packages/ui/src/styles/theme.css";
+    expect(colorLiteralIsExempt("  --nx-primary: oklch(0.6 0.2 30);", theme)).toBe(true);
+    // The same line anywhere else is a second definition of a themed colour.
+    expect(colorLiteralIsExempt("  --nx-primary: oklch(0.6 0.2 30);", file)).toBe(false);
+  });
+
+  it("exempts the Tailwind palette scale wherever it is declared", () => {
+    expect(colorLiteralIsExempt("  --color-blue-500: #3b82f6;", file)).toBe(true);
+  });
+});
+
+describe("the individual rules", () => {
+  it("tokenWrapViolation reports a token wrapped in a colour function", () => {
+    expect(tokenWrapViolation("f:1", "color: hsl(var(--nx-primary));")).toContain("token wrapped");
+    expect(tokenWrapViolation("f:1", "color: var(--nx-primary);")).toBeNull();
+  });
+
+  it("colorLiteralViolation applies to CSS and plugin source, not admin tsx", () => {
+    const line = 'const a = "#1a2b3c";';
+    expect(colorLiteralViolation("f:1", line, "a.css", { isCss: true, isPlugin: false })).toContain("hardcoded color");
+    expect(colorLiteralViolation("f:1", line, "p.ts", { isCss: false, isPlugin: true })).toContain("hardcoded color");
+    expect(colorLiteralViolation("f:1", line, "a.tsx", { isCss: false, isPlugin: false })).toBeNull();
+  });
+
+  it("paletteViolation names the replacement scale, and skips prose and the theme", () => {
+    const found = paletteViolation("f:1", '<div className="bg-red-500" />', { isThemeSource: false });
+    expect(found).toContain("destructive-*");
+    // A hue named in a whole-line comment styles nothing.
+    expect(paletteViolation("f:1", "// we used bg-red-500 here once", { isThemeSource: false })).toBeNull();
+    // The theme file is where the scales are declared.
+    expect(paletteViolation("f:1", '"bg-red-500"', { isThemeSource: true })).toBeNull();
+    // A marked exception with a reason.
+    expect(
+      paletteViolation("f:1", '"bg-red-500" // design-lint-ok: external brand', { isThemeSource: false })
+    ).toBeNull();
+  });
+});
+
+describe("auditFile", () => {
+  it("reports across rules and returns the plugin classification", () => {
+    const result = auditFile(
+      "packages/plugin-seo/src/x.ts",
+      ['const a = "#1a2b3c";', 'const b = "bg-red-500";'].join("\n")
+    );
+    expect(result.isPlugin).toBe(true);
+    expect(result.violations).toHaveLength(2);
+    expect(result.violations[0]).toContain(":1");
+    expect(result.violations[1]).toContain(":2");
+  });
+
+  it("BANS !important in a plugin and COUNTS it in the admin", () => {
+    const plugin = auditFile("packages/plugin-seo/src/x.ts", ".a { color: red !important; }");
+    expect(plugin.violations.some(v => v.includes("!important not allowed"))).toBe(true);
+    expect(plugin.adminImportant).toBe(0);
+
+    const admin = auditFile("packages/admin/src/styles/globals.css", ".a { color: red !important; }");
+    expect(admin.violations.some(v => v.includes("!important not allowed"))).toBe(false);
+    expect(admin.adminImportant).toBe(1);
+  });
+
+  it("is clean on token-driven source", () => {
+    const result = auditFile(
+      "packages/admin/src/x.tsx",
+      '<div className="bg-background text-muted-foreground" />'
+    );
+    expect(result.violations).toEqual([]);
+  });
+});
+
+describe("emptyPopulations", () => {
+  it("names each population that would make the run blind", () => {
+    expect(emptyPopulations({ files: 0, pluginClassified: 0 })).toEqual([
+      "no files",
+      "no plugin-surface files",
+    ]);
+    // Files read but nothing classified: every plugin-only rule is inert while
+    // the summary would still read as a pass.
+    expect(emptyPopulations({ files: 10, pluginClassified: 0 })).toEqual([
+      "no plugin-surface files",
+    ]);
+    expect(emptyPopulations({ files: 10, pluginClassified: 2 })).toEqual([]);
+  });
+});
+
+describe("deriveRoots", () => {
+  it("discovers every plugin package rather than naming a fixed list", () => {
+    const roots = deriveRoots();
+    expect(roots).toContain("packages/admin/src");
+    expect(roots).toContain("packages/ui/src");
+    expect(roots).toContain("templates/plugin/src");
+    // Discovered, not listed: these are exactly the packages a hardcoded list
+    // was missing before the roots were derived.
+    expect(roots).toContain("packages/plugin-sdk/src");
+    expect(roots).toContain("packages/plugin-seo/src");
+  });
+});
+
+describe("the script as a whole", () => {
+  it("runs, passes on this repository, and prints the population it read", () => {
+    const out = execFileSync("node", ["scripts/lint-design.mjs"], { encoding: "utf8" });
+    expect(out).toContain("Design lint passed");
+    // The population is part of the output on purpose: a scan that read nothing
+    // must not be indistinguishable from a clean tree.
+    expect(out).toMatch(/\d+ files across \d+ roots/);
+    expect(out).toMatch(/\(\d+ plugin-surface\)/);
+    expect(out).toContain("roots:");
+  });
+});


### PR DESCRIPTION
## The guard everything relies on had no tests

`scripts/lint-design.mjs` is what stops a hardcoded colour reaching `main`. It had **zero** coverage — and its failure mode is silence: a scan that reads nothing prints what a clean repository prints.

The hygiene gate had already noticed the shape of the problem, scoring the per-line loop at **CRAP 156** (cyclomatic 12, 35 lines, no coverage). CRAP combines complexity with coverage, so it was reporting exactly this: the most branch-dense function in the file was the one nothing exercised.

## What changed

**The four rules are now four decisions.** Each returns the violation text or `null`, so the reason a line is reported is separable from the loop that visits lines:

```
tokenWrapViolation       3 lines
colorLiteralViolation    5 lines
paletteViolation         5 lines
auditFile               31 lines   (was one arrow carrying all four)
```

**`auditFile` takes the SOURCE rather than reading it.** That is what made this untestable before: the only way to reach the rules was to run the whole scan against the real repository. A case is now one line of input and one expectation.

**The entry runs only when the script is invoked directly.** Matched on the script name rather than by comparing `import.meta.url` to `process.argv[1]` — that comparison is sensitive to how the path was resolved, and this repository has already been bitten by it in both directions: a symlinked prefix breaks the raw comparison, and `realpathSync` breaks the opposite case because `--preserve-symlinks-main` is settable through `NODE_OPTIONS`.

Verified both modes: running it prints the same summary as before (`870 files across 7 roots (82 plugin-surface)`), and importing it scans nothing and exits nothing.

## 16 tests, every one break-verified

Each probe reverts one decision and requires the intended failure; all restored byte-identical afterwards:

| break | result |
|---|---|
| plugin classification back to a `"packages/plugin-"` substring | **1 fail** |
| theme-source declaration exemption removed | **2 fail** |
| comment-line skip removed from the palette rule | **1 fail** |
| `!important` plugin/admin split collapsed | **1 fail** |
| empty populations never reported | **1 fail** |

The theme-source probe failing **two** tests is worth noting: the unit test and the end-to-end run both caught it, because removing that exemption makes the real scan report 121 violations in `theme.css` and exit 1. The end-to-end test is doing real work rather than restating the units.

The cases were chosen to cover the traps this guard has actually had:

- **`packages/eslint-plugin` must NOT classify as a plugin surface** — it contains the word and is tooling. The substring form this replaced got `templates/plugin` wrong in the other direction.
- **A directive without a reason exempts nothing** — the bare marker is not a directive.
- **A token declaration is exempt in `theme.css` and nowhere else** — that file is where a colour is written down; the same line elsewhere is a second definition.
- **`emptyPopulations` reports "files read, nothing classified"** — the case that makes every plugin-only rule inert while the summary still reads as a pass.

## Test plan

- `pnpm test:scripts`: **510 passed**, up from 494.
- `node scripts/lint-design.mjs`: unchanged output, exit 0.
- Comment-convention gate: clean, allowlist unchanged at 402.
- Gates, cache forced off: lint **24/24**, check-types **22/22**.

## Changeset

**None** — `scripts/` is repository tooling, not a published package, and this is a test-and-refactor change with no user-facing behaviour. Per `AGENTS.md`, test-only and tooling-only PRs get no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved design-system linting with more consistent validation and clearer scan reporting.
  * Design checks now run reliably when invoked directly without affecting imports or other tooling.

* **Tests**
  * Added comprehensive automated coverage for design rules, exemptions, file scanning, root discovery, and execution results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->