### PR TITLE
fix(admin): stop reporting a failed plugin list as an unknown field type

### DIFF
--- a/.changeset/plugin-fields-survive-a-failed-plugin-list.md
+++ b/.changeset/plugin-fields-survive-a-failed-plugin-list.md
@@ -18,6 +18,7 @@
 "@nextlyhq/plugin-seo": patch
 "@nextlyhq/plugin-sdk": patch
 "@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
 "@nextlyhq/prettier-config": patch
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch

--- a/.changeset/plugin-fields-survive-a-failed-plugin-list.md
+++ b/.changeset/plugin-fields-survive-a-failed-plugin-list.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Plugin-contributed fields no longer report themselves as an unknown field type when the list of
+installed plugins fails to load. The list arrives from a session-gated request, and a failed one
+left it empty — which looked exactly like a project with no plugins installed, so a correctly
+installed plugin's field rendered a red "Unknown field type" error. Reloading usually fixed it,
+which made it look like an intermittent fault in the plugin rather than a failed request. The
+field now says the plugin list is unavailable and to reload, and a field whose editor is still
+loading shows a loading state rather than an error.

--- a/packages/admin/src/components/features/entries/fields/FieldRenderer.fieldtype.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldRenderer.fieldtype.test.tsx
@@ -23,6 +23,13 @@ import {
  */
 let pluginsPending = false;
 
+/**
+ * Whether the plugin list NEVER answered. Distinct from `pluginsPending`
+ * because the two are different facts and only one of them ends: a request in
+ * flight resolves, a failed one does not.
+ */
+let pluginsUnavailable = false;
+
 vi.mock("@admin/context/providers/BrandingProvider", () => ({
   useBranding: () => ({
     plugins: [
@@ -35,7 +42,7 @@ vi.mock("@admin/context/providers/BrandingProvider", () => ({
   }),
   useBrandingStatus: () => ({
     isPending: pluginsPending,
-    isUnavailable: false,
+    isUnavailable: pluginsUnavailable,
     isBrandingUnavailable: false,
   }),
 }));
@@ -44,6 +51,7 @@ afterEach(() => {
   clearRegistry();
   vi.restoreAllMocks();
   pluginsPending = false;
+  pluginsUnavailable = false;
 });
 
 function Form({ children }: { children: ReactNode }) {
@@ -87,6 +95,52 @@ describe("FieldRenderer custom field types (C7/D16)", () => {
       </Form>
     );
     expect(screen.queryByText(/unknown field type/i)).not.toBeInTheDocument();
+  });
+
+  it("does not call a type unknown when the plugin list never arrived", () => {
+    // THE case behind a bug that read as an intermittent fault in the page
+    // builder. A failed request leaves `branding` undefined, which is the same
+    // value as a project with no plugins — so the field reported "Unknown field
+    // type" and blamed a correctly-installed plugin for a fetch that failed.
+    // A reload retries and usually succeeds, which is what made it look
+    // intermittent.
+    pluginsUnavailable = true;
+    render(
+      <Form>
+        <FieldRenderer field={field("blocks")} />
+      </Form>
+    );
+    expect(screen.queryByText(/unknown field type/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/could not be loaded/i)).toBeInTheDocument();
+  });
+
+  it("shows the loading editor while the list is still in flight", () => {
+    // The POSITIVE CONTROL for the case below. Without it, asserting that the
+    // failed state shows no loading editor would be satisfied by a renderer
+    // that never shows one at all — and the selector being wrong looks exactly
+    // the same as the behaviour being right.
+    pluginsPending = true;
+    render(
+      <Form>
+        <FieldRenderer field={field("blocks")} />
+      </Form>
+    );
+    expect(screen.getByText(/loading editor/i)).toBeInTheDocument();
+  });
+
+  it("says the list is unavailable rather than loading forever", () => {
+    // A loading state says something is coming. The request is issued with
+    // `retry: false`, so after it fails nothing is coming, and folding this
+    // state into the loading one would leave the field pretending to load for
+    // as long as the server stays unreachable.
+    pluginsUnavailable = true;
+    render(
+      <Form>
+        <FieldRenderer field={field("blocks")} />
+      </Form>
+    );
+    expect(screen.getByText(/could not be loaded/i)).toBeInTheDocument();
+    expect(screen.queryByText(/loading editor/i)).not.toBeInTheDocument();
   });
 
   it("still reports an unknown type once the list has ARRIVED without it", () => {

--- a/packages/admin/src/components/features/entries/fields/FieldRenderer.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldRenderer.tsx
@@ -37,11 +37,8 @@ import { lazy, Suspense, useState, useEffect } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 
 import { PluginSlot } from "@admin/components/shared/plugin-slot";
-import {
-  useBranding,
-  useBrandingStatus,
-} from "@admin/context/providers/BrandingProvider";
 import { evaluateCondition } from "@admin/lib/builder/condition-evaluator";
+import { usePluginFieldType } from "@admin/lib/plugins/plugin-field-type";
 
 import { FieldWrapper } from "./FieldWrapper";
 import { UploadInput } from "./media/UploadInput";
@@ -254,8 +251,6 @@ export function FieldRenderer({
     control,
   } = useFormContext();
 
-  // C7/D16 — plugin-registered custom field types, delivered via /admin-meta.
-  const branding = useBranding();
   /*
    * The plugin list arrives from the SESSION-GATED half of admin-meta, so it is
    * absent for a moment on every load — and a field whose type lives in a
@@ -266,7 +261,7 @@ export function FieldRenderer({
    * would say so has not come back. Only the first is a fact about the project;
    * treating the second as one reports a correctly-configured field as broken.
    */
-  const { isPending: pluginsPending } = useBrandingStatus();
+  const pluginFieldType = usePluginFieldType(field.type);
 
   // Determine if field should be read-only or disabled
   // Cast to any to handle fields that don't have readOnly/disabled in their admin options
@@ -354,11 +349,14 @@ export function FieldRenderer({
   // This is deliberately a STRUCTURAL question rather than a check against the
   // field's type name: an override leaves the type untouched while replacing
   // the component entirely, so no list of composite type names can see it.
+  //
+  // Derived from the one lookup above rather than scanning the plugin list a
+  // second time. Two scans of one list for one fact agree today and drift the
+  // first time either changes what it matches.
   const hasPluginEditor =
     Boolean(adminOptions?.component) ||
-    (branding?.plugins ?? [])
-      .flatMap(p => p.fieldTypes ?? [])
-      .some(ft => ft.type === (field.type as string));
+    (pluginFieldType.status === "ready" &&
+      pluginFieldType.component !== undefined);
 
   return (
     <FieldWrapper
@@ -553,26 +551,45 @@ export function FieldRenderer({
       // Unknown Type
       // =========================================
       default: {
-        // C7/D16 — a plugin-registered custom field type renders via its
-        // contributed editor component (PluginSlot isolates it, D53).
-        const customComponent = (branding?.plugins ?? [])
-          .flatMap(p => p.fieldTypes ?? [])
-          .find(ft => ft.type === fieldType)?.component;
-        if (customComponent) {
+        /*
+         * C7/D16 — a plugin-registered custom field type renders via its
+         * contributed editor component (PluginSlot isolates it, D53).
+         *
+         * The lookup reports whether the plugin list can answer at all, so the
+         * "unknown type" sentence below is reachable only from a list that
+         * actually arrived. Reading `branding.plugins` here instead would make
+         * a failed request indistinguishable from a project with no plugins.
+         */
+        if (pluginFieldType.status === "loading") return <EditorSkeleton />;
+        if (pluginFieldType.status === "unavailable") {
+          /*
+           * A THIRD state, not a slower version of the skeleton above.
+           *
+           * A skeleton says something is coming. The request is issued with
+           * `retry: false`, so once it has failed nothing is coming and a
+           * skeleton would leave the field pretending to load for as long as
+           * the server stays unreachable. Falling through to "unknown field
+           * type" is worse still: it blames the field for a request that
+           * failed, so a correctly-installed plugin reads as a broken
+           * configuration.
+           */
+          return (
+            <div className="rounded-lg border border-border bg-muted/50 p-4 text-center">
+              <p className="text-sm text-muted-foreground">
+                This field could not be loaded because the list of installed
+                plugins is unavailable. Reload the page to try again.
+              </p>
+            </div>
+          );
+        }
+        if (pluginFieldType.component) {
           return (
             <PluginSlot
-              path={customComponent}
+              path={pluginFieldType.component}
               props={{ ...commonProps, field }}
             />
           );
         }
-        /*
-         * The list that would name this type has not answered yet, so nothing
-         * is known about it. Reporting it as unknown here states a conclusion
-         * the data does not support, and it is the WRONG one for every
-         * plugin-contributed field on the page.
-         */
-        if (pluginsPending) return <EditorSkeleton />;
         return (
           <div className="rounded-lg  border border-destructive bg-destructive/10 p-4 text-center">
             <p className="text-sm text-destructive">

--- a/packages/admin/src/components/features/users/UserCustomFields.tsx
+++ b/packages/admin/src/components/features/users/UserCustomFields.tsx
@@ -42,8 +42,8 @@ import { EmailInput } from "@admin/components/features/entries/fields/text/Email
 import { TextareaInput } from "@admin/components/features/entries/fields/text/TextareaInput";
 import { TextInput } from "@admin/components/features/entries/fields/text/TextInput";
 import { PluginSlot } from "@admin/components/shared/plugin-slot";
-import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { useUserFields } from "@admin/hooks/queries/useUserFields";
+import { usePluginFieldType } from "@admin/lib/plugins/plugin-field-type";
 import type { UserFieldDefinitionRecord } from "@admin/services/userFieldsApi";
 
 // ============================================================================
@@ -267,7 +267,7 @@ function UserFieldInput({
   error,
   disabled,
 }: UserFieldInputProps) {
-  const branding = useBranding();
+  const pluginFieldType = usePluginFieldType(fieldConfig.type);
   const isCheckbox = fieldConfig.type === "checkbox";
 
   return (
@@ -360,9 +360,27 @@ function UserFieldInput({
             </p>
           </div>
         );
-        const customComponent = (branding.plugins ?? [])
-          .flatMap(plugin => plugin.fieldTypes ?? [])
-          .find(fieldType => fieldType.type === fieldConfig.type)?.component;
+        /*
+         * The plugin list has three states and only one supports the sentence
+         * above. Reading it directly made "Unsupported field type" the answer
+         * while the list was still in flight AND when it had failed outright,
+         * so a correctly-installed plugin field read as a broken one on every
+         * load and stayed that way whenever the request did not come back.
+         */
+        if (pluginFieldType.status === "loading") {
+          return <Skeleton className="h-10 w-full" />;
+        }
+        if (pluginFieldType.status === "unavailable") {
+          return (
+            <div className="rounded-md border border-border bg-muted/50 p-3 text-center">
+              <p className="text-sm text-muted-foreground">
+                This field could not be loaded because the list of installed
+                plugins is unavailable. Reload the page to try again.
+              </p>
+            </div>
+          );
+        }
+        const customComponent = pluginFieldType.component;
         if (customComponent) {
           return (
             <PluginSlot

--- a/packages/admin/src/lib/plugins/__tests__/plugin-field-type.test.tsx
+++ b/packages/admin/src/lib/plugins/__tests__/plugin-field-type.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Which editor a plugin contributes for a field type, and whether that answer
+ * is knowable yet.
+ *
+ * The property under test is not "does it find the component" — a plain lookup
+ * does that. It is that the two states which CANNOT support a conclusion are
+ * reported as themselves rather than as an empty result, because an empty
+ * result is what every caller turned into "no plugin contributes this type".
+ *
+ * @module lib/plugins/plugin-field-type.test
+ */
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { usePluginFieldType } from "@admin/lib/plugins/plugin-field-type";
+
+/** What the provider reports, mutable so each state can be driven. */
+let branding: { plugins?: unknown[] } = {};
+let status = {
+  isPending: false,
+  isUnavailable: false,
+  isBrandingUnavailable: false,
+};
+
+vi.mock("@admin/context/providers/BrandingProvider", () => ({
+  useBranding: () => branding,
+  useBrandingStatus: () => status,
+}));
+
+afterEach(() => {
+  branding = {};
+  status = {
+    isPending: false,
+    isUnavailable: false,
+    isBrandingUnavailable: false,
+  };
+});
+
+/** A settled list that contributes an editor for `rating`. */
+function withRating() {
+  branding = {
+    plugins: [
+      {
+        name: "@acme/p",
+        fieldTypes: [{ type: "rating", component: "@acme/p/admin#Rating" }],
+      },
+    ],
+  };
+}
+
+describe("usePluginFieldType", () => {
+  it("reports the contributed component once the list has arrived", () => {
+    withRating();
+
+    const { result } = renderHook(() => usePluginFieldType("rating"));
+
+    expect(result.current).toEqual({
+      status: "ready",
+      component: "@acme/p/admin#Rating",
+    });
+  });
+
+  it("reports a type no plugin contributes as READY with no component", () => {
+    // The control for every case below. This is the only state in which
+    // "unknown field type" is a true statement, and without it the assertions
+    // about `loading` and `unavailable` would pass just as well against a hook
+    // that never reported `ready` at all.
+    withRating();
+
+    const { result } = renderHook(() => usePluginFieldType("nothing-has-this"));
+
+    expect(result.current).toEqual({ status: "ready", component: undefined });
+  });
+
+  it("reports a list still in flight as LOADING, not as an empty answer", () => {
+    status = { ...status, isPending: true };
+
+    const { result } = renderHook(() => usePluginFieldType("rating"));
+
+    expect(result.current).toEqual({ status: "loading" });
+  });
+
+  it("reports a list that never arrived as UNAVAILABLE, not as an empty answer", () => {
+    // THE case. `useBranding()` returns `{}` when nothing arrived, so a failed
+    // request and a project with no plugins are the same value — and a caller
+    // reading it cannot tell "there is no such plugin" from "I could not ask".
+    status = { ...status, isUnavailable: true };
+
+    const { result } = renderHook(() => usePluginFieldType("rating"));
+
+    expect(result.current).toEqual({ status: "unavailable" });
+  });
+
+  it("prefers LOADING over unavailable while both are set", () => {
+    // A request in flight has not failed. Reporting it as unavailable would
+    // show a permanent error for the moment every load passes through, and the
+    // provider can carry both flags while the two halves settle.
+    status = { ...status, isPending: true, isUnavailable: true };
+
+    const { result } = renderHook(() => usePluginFieldType("rating"));
+
+    expect(result.current).toEqual({ status: "loading" });
+  });
+
+  it("reports READY with no component for a settled EMPTY list", () => {
+    // A project that genuinely installs no plugins. Distinguished from the two
+    // states above only by the status flags, which is exactly why they travel.
+    branding = {};
+
+    const { result } = renderHook(() => usePluginFieldType("rating"));
+
+    expect(result.current).toEqual({ status: "ready", component: undefined });
+  });
+
+  it("ignores a plugin that contributes no field types", () => {
+    branding = { plugins: [{ name: "@acme/other" }] };
+
+    const { result } = renderHook(() => usePluginFieldType("rating"));
+
+    expect(result.current).toEqual({ status: "ready", component: undefined });
+  });
+});

--- a/packages/admin/src/lib/plugins/plugin-field-type.ts
+++ b/packages/admin/src/lib/plugins/plugin-field-type.ts
@@ -1,0 +1,76 @@
+/**
+ * Which editor a plugin contributes for a field type, and whether that answer
+ * is knowable yet.
+ *
+ * The plugin list arrives from the session-gated half of `/admin-meta`, so it
+ * has three states and only one of them supports a conclusion:
+ *
+ * - it has not answered yet;
+ * - it never answered, so absence proves nothing;
+ * - it answered, and this type is either in it or genuinely is not.
+ *
+ * `useBranding()` collapses all three into one value. It returns `{}` when
+ * nothing has arrived, so `branding.plugins ?? []` is an empty list whether the
+ * project has no plugins, the request is in flight, or the request failed —
+ * and every caller that reads it is one line away from reporting "no plugin
+ * contributes this type" as a fact about the project.
+ *
+ * That failure is not hypothetical and it is not cosmetic. Both surfaces that
+ * looked a type up this way rendered a red error naming the field's type when
+ * the request had merely failed, so a correctly-installed plugin read as a
+ * broken configuration — and because a reload retries and usually succeeds, it
+ * presented as an intermittent bug in the plugin rather than as a failed fetch.
+ *
+ * **A discriminated union rather than a documented rule.** `types/branding.ts`
+ * already tells callers to consult `useBrandingStatus()` before concluding
+ * anything from a plugin being missing, and both callers did not. A rule with
+ * nothing enforcing it is not a control: here the component is unreachable
+ * without narrowing `status` first, so the two states that cannot support a
+ * conclusion have to be handled to get at the one that can.
+ *
+ * @module lib/plugins/plugin-field-type
+ */
+
+import {
+  useBranding,
+  useBrandingStatus,
+} from "@admin/context/providers/BrandingProvider";
+
+/**
+ * What is known about a field type's contributed editor.
+ *
+ * `ready` carries `component: undefined` for a type no installed plugin
+ * contributes, which is the ONLY state in which "unknown field type" is a true
+ * statement. The other two members exist so that sentence cannot be reached
+ * from a list that never arrived.
+ */
+export type PluginFieldTypeLookup =
+  | { readonly status: "loading" }
+  | { readonly status: "unavailable" }
+  | { readonly status: "ready"; readonly component: string | undefined };
+
+/**
+ * The editor component path a plugin contributes for `type`.
+ *
+ * Not memoised. The lookup is a scan of a handful of plugins for one string,
+ * and a `useMemo` keyed on `branding.plugins` would rerun on every identity
+ * change of that array anyway — so it would add a dependency to keep correct
+ * in exchange for nothing measurable.
+ */
+export function usePluginFieldType(type: string): PluginFieldTypeLookup {
+  const branding = useBranding();
+  const { isPending, isUnavailable } = useBrandingStatus();
+
+  // Pending first. A request that is still in flight has not failed, and
+  // reporting it as unavailable would show a permanent error for the moment
+  // every load passes through.
+  if (isPending) return { status: "loading" };
+  if (isUnavailable) return { status: "unavailable" };
+
+  return {
+    status: "ready",
+    component: (branding.plugins ?? [])
+      .flatMap(plugin => plugin.fieldTypes ?? [])
+      .find(contributed => contributed.type === type)?.component,
+  };
+}


### PR DESCRIPTION
The founder reported hitting **"Unknown field type: blocks"** constantly in the admin, with a reload usually clearing it. This is that bug. It is not specific to the page builder — it affects every plugin-contributed field type.

## What was actually happening

The plugin list arrives from the **session-gated** half of `/admin-meta`, and `useBranding()` returns `{}` until it does. So `branding.plugins ?? []` is an empty list in three different situations:

| situation | what the code concluded |
| --- | --- |
| the project installs no plugins | "no plugin contributes this type" ✅ |
| the request is still in flight | "no plugin contributes this type" ❌ |
| the request **failed** | "no plugin contributes this type" ❌ |

Only the first supports that conclusion. The other two are *"I could not ask"* being reported as *"there is nothing"* — the distinction `derived-checks.md` in this repo is about.

`FieldRenderer` guarded the in-flight case (`isPending` → skeleton) and not the failed one. `UserCustomFields` guarded **neither**, so it misreported during the moment every load passes through as well.

The result: a correctly installed plugin's field rendered a red error naming its own type. A reload retries and usually succeeds, which is exactly why it presented as an intermittent fault in the plugin rather than a failed fetch. I saw a 401 on an admin API in the dev-server log during one occurrence.

## The fix is a boundary, not a check

`types/branding.ts:228` already tells callers to consult `useBrandingStatus()` before concluding anything from a plugin being missing. **Both callers did not.** AGENTS.md: *a documented rule with nothing enforcing it is not a control.*

So `usePluginFieldType(type)` returns a discriminated union:

```ts
| { status: "loading" }
| { status: "unavailable" }
| { status: "ready"; component: string | undefined }
```

The component is unreachable without narrowing past the two states that cannot support a conclusion. A future caller inherits that for free instead of being expected to remember the rule.

**`unavailable` is its own state, not folded into the loading skeleton.** A skeleton says something is coming; the query is issued with `retry: false`, so once it has failed nothing is — sharing the branch would leave the field pretending to load for as long as the server stays unreachable. That is the same bug one step along. (Thanks to the lane that pushed back on my first draft, which did exactly that.)

`FieldRenderer` also derives `hasPluginEditor` from the same lookup now, rather than scanning the plugin list a second time for the same fact.

## Tests

14, across the hook and the consumer. Every state stub-verified — broken one at a time, intended tests confirmed failing, restored, restore confirmed by diff:

- remove `unavailable` → 3 fail
- remove `loading` → 4 fail
- check `unavailable` before `loading` → 1 fails (the precedence case)

The consumer test carries a **positive control** asserting the loading state *does* render "Loading editor…", because my first version asserted a skeleton was absent using a selector that matched nothing — it passed by absence, which is the trap this repo documents.

## Baseline

`packages/admin` has 15 pre-existing failures in `dashboard/StatsCard`, `schema-builder/builder-settings-modal/{BasicsTab,SlugInput}` and `schema-builder/field-editor-sheet/DefaultValueField`. **None imports anything this PR touches** — verified by reading their imports, with a positive control proving the search finds a real import when one exists. 2240 pass.
