### PR TITLE
fix(admin): raise the untranslated language dot to 3:1 contrast

### DIFF
--- a/.changeset/language-dot-contrast.md
+++ b/.changeset/language-dot-contrast.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The "not translated" language dot drew its outline with `border-muted-foreground/60`, which composites to 2.87:1 against the page surface and misses the 3:1 a non-text UI boundary needs. The outline is the only thing that renders that dot, so nothing else carried the state. It now uses the token at full strength, reaching 7.55:1 while staying visually quieter than the draft dot beside it.

--- a/packages/admin/src/components/features/entries/LanguageControl.tsx
+++ b/packages/admin/src/components/features/entries/LanguageControl.tsx
@@ -58,7 +58,11 @@ export function StateDot({ state }: { state: LanguageState }) {
         state === "translated" && "bg-success-600 dark:bg-success-400",
         state === "draft" &&
           "border-[1.5px] border-foreground/70 [background:linear-gradient(90deg,currentColor_50%,transparent_50%)] text-foreground/70",
-        state === "missing" && "border-[1.5px] border-muted-foreground/60"
+        // Full strength rather than an alpha: the outline is the only thing
+        // that renders this dot, so it is a UI boundary held to 3:1. At /60 it
+        // measured 2.87:1 on the page surface; the token itself reaches 7.55:1
+        // and stays quieter than the draft dot above it.
+        state === "missing" && "border-[1.5px] border-muted-foreground"
       )}
     />
   );


### PR DESCRIPTION
## What

The "not translated" language dot drew its outline with `border-muted-foreground/60`. Composited over the page surface that resolves to **2.87:1**, below the **3:1** WCAG 1.4.11 requires of a non-text UI boundary. `packages/ui`'s alpha-utility contrast suite catches it, so `Lint / Typecheck / Test / Build` is currently failing on `main` and on every open PR that GitHub tests as a merge commit.

Introduced by 269f495b1 (#1005, entry-header language row). Not noticed there because the suite scans sibling packages' source, so the failure surfaces in `@nextlyhq/ui#test` rather than in admin's own job.

## Why full strength rather than a higher alpha

Measured against the same resolver the suite uses:

| candidate | worst-mode ratio | |
|---|---|---|
| `border-muted-foreground/60` | 2.87:1 | current, fails |
| `border-muted-foreground/70` | 3.58:1 | passes, thin margin |
| **`border-muted-foreground`** | **7.55:1** | taken |
| `border-foreground/70` | 8.41:1 | what the sibling *draft* dot uses |

`/70` clears the bar by 0.58 and would be a constant tuned to sit just past a threshold. The suite's own message recommends a full-strength semantic token, and at 7.55:1 the dot still reads quieter than the draft dot beside it, so the visual hierarchy across the four states is unchanged.

The dot is `aria-hidden`, but 1.4.11 is about sighted perception and the outline is the only thing that renders this state — nothing else carries it, so it is not a decorative exception and does not belong in `ALLOWED_DECORATIVE`.

## Verification

- `packages/ui` alpha-utility suite: **5 passed** with the fix; break-verified by restoring `/60`, which reproduces `border-muted-foreground/60 = 2.87:1 (needs 3:1)` exactly as CI reports it.
- `@nextlyhq/admin` `lint` exit 0, `check-types` exit 0 (after building workspace deps, so the earlier unresolved-`@nextlyhq/ui` errors were a missing dist rather than this change).