### PR TITLE
feat(builder): layers panel and ancestor breadcrumb

### DIFF
--- a/.changeset/canvas-click-selects-again.md
+++ b/.changeset/canvas-click-selects-again.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Clicking a block on the page-builder canvas selects it again. A drag took control of the pointer
+as soon as the mouse went down, which made the browser report every click as landing on the canvas
+background rather than on a block — so clicking a block cleared the selection instead of setting
+it. The canvas now takes control only once a drag has actually started.

--- a/.changeset/layers-panel-and-breadcrumb.md
+++ b/.changeset/layers-panel-and-breadcrumb.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The page builder has a layers panel and an ancestor breadcrumb. The panel shows the page as a
+tree, so a block the canvas cannot show — an empty container, or one hidden at the current screen
+size — can still be found and selected, and a search narrows the tree to what matches while keeping
+the containers around it. Selecting a block anywhere reveals it in the tree and shows the trail of
+containers holding it, and each step of that trail selects the container it names. Blocks that are
+locked, hidden at some screen sizes, or shown conditionally say so on their row.

--- a/packages/builder/src/breadcrumb.test.tsx
+++ b/packages/builder/src/breadcrumb.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+
+/**
+ * The ancestor breadcrumb.
+ *
+ * The trail itself comes from `pathTo`, which is asserted in `layers.test.ts`
+ * without a DOM. What is only true here is what the component does with it:
+ * which crumb is marked current, that every crumb changes the selection, and
+ * that an empty path renders nothing rather than an empty bar.
+ *
+ * @module breadcrumb.test
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import * as React from "react";
+
+import {
+  clearBlocks,
+  hasBlock,
+  registerBlocks,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+
+import { SelectionBreadcrumb } from "./breadcrumb";
+import { useEditorState, type EditorState } from "./editor-state";
+
+afterEach(() => {
+  cleanup();
+  clearBlocks();
+});
+
+const base = {
+  version: 1,
+  description: "A block.",
+  example: { props: {} },
+  render: () => null,
+};
+
+function register() {
+  if (hasBlock("core/heading")) return;
+  registerBlocks(
+    [
+      { ...base, name: "core/heading", editor: { label: "Heading" } },
+      {
+        ...base,
+        name: "core/box",
+        editor: { label: "Box" },
+        slots: { children: {} },
+      },
+    ] as never,
+    { source: "breadcrumb-test" }
+  );
+}
+
+function node(
+  id: string,
+  type: string,
+  extra: Partial<BlockNode> = {}
+): BlockNode {
+  return { id, type, version: 1, props: {}, ...extra } as BlockNode;
+}
+
+/** A heading two containers deep, so the trail has three crumbs. */
+function documentOf(): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      node("outer", "core/box", {
+        name: "Section",
+        slots: {
+          children: [
+            node("inner", "core/box", {
+              slots: { children: [node("leaf", "core/heading")] },
+            }),
+          ],
+        },
+      }),
+    ],
+  } as BlockDocument;
+}
+
+let editorRef: EditorState | null = null;
+
+function Host(): React.JSX.Element {
+  const editor = useEditorState({ initialDocument: documentOf() });
+  editorRef = editor;
+  return <SelectionBreadcrumb editor={editor} />;
+}
+
+function crumbs(): string[] {
+  return screen.queryAllByRole("button").map(b => b.textContent ?? "");
+}
+
+describe("SelectionBreadcrumb", () => {
+  it("reads outermost first and ends with the selected block", () => {
+    register();
+    render(<Host />);
+    React.act(() => {
+      editorRef?.select("leaf");
+    });
+
+    // The instance name where the author gave one, the block's name otherwise —
+    // the same rule the palette and the layers panel use.
+    expect(crumbs()).toEqual(["Section", "Box", "Heading"]);
+  });
+
+  it("marks the last crumb as the current position, and only the last", () => {
+    register();
+    render(<Host />);
+    React.act(() => {
+      editorRef?.select("leaf");
+    });
+
+    const marked = screen
+      .getAllByRole("button")
+      .map(b => b.getAttribute("aria-current"));
+
+    expect(marked).toEqual([null, null, "true"]);
+  });
+
+  it("selects the ancestor a crumb names", () => {
+    // The reason the trail is buttons rather than text. A full-width container
+    // is almost entirely covered by its own children, so reaching it on the
+    // canvas means finding a margin.
+    register();
+    render(<Host />);
+    React.act(() => {
+      editorRef?.select("leaf");
+    });
+
+    React.act(() => {
+      fireEvent.click(screen.getAllByRole("button")[0] as HTMLElement);
+    });
+
+    expect(editorRef?.selectedId).toBe("outer");
+  });
+
+  it("renders nothing at all when there is no selection", () => {
+    // Nothing rather than an empty bar: a bar would reserve height for a trail
+    // that is not there, so clearing a selection would resize the canvas.
+    register();
+    const { container } = render(<Host />);
+
+    expect(crumbs()).toEqual([]);
+    expect(container.querySelector(".nx-breadcrumb")).toBeNull();
+  });
+
+  it("renders nothing for a selection the document no longer holds", () => {
+    // Routine rather than exotic: an undo can remove the selected node while
+    // the selection stands, and a partial trail would name ancestors of a block
+    // that is gone.
+    register();
+    render(<Host />);
+    React.act(() => {
+      editorRef?.select("leaf");
+    });
+    expect(crumbs()).toHaveLength(3);
+
+    React.act(() => {
+      editorRef?.apply({ kind: "remove", id: "outer" });
+    });
+
+    expect(crumbs()).toEqual([]);
+  });
+});

--- a/packages/builder/src/breadcrumb.tsx
+++ b/packages/builder/src/breadcrumb.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * The ancestor breadcrumb: where the selected block sits, and one click to each
+ * container holding it.
+ *
+ * The canvas answers "what does this look like" and the layers panel answers
+ * "what is the whole page". Neither answers the question an author has while
+ * editing one block — what am I inside — and that question is why selecting a
+ * parent is otherwise a hunt: the outer container of a full-width section has
+ * almost no pixels that are not covered by its own children, so clicking it on
+ * the canvas is a game of finding a margin.
+ *
+ * **Reads the same tree the layers panel does.** `pathTo` is the one
+ * implementation of "which blocks contain this one", so the trail and the
+ * panel's highlight cannot name different ancestors — and the labels match the
+ * palette's, because they come from the same rule.
+ *
+ * **A list of buttons, not a `<nav>`.** The WAI-ARIA breadcrumb pattern
+ * describes navigation between pages; this moves a selection inside one
+ * document and navigates nowhere. Announcing it as site navigation would send
+ * a screen-reader user looking for links that do not exist, so it is a labelled
+ * list whose items are buttons.
+ *
+ * @module breadcrumb
+ */
+
+import { ChevronRight } from "lucide-react";
+import type * as React from "react";
+
+import type { EditorState } from "./editor-state";
+import { pathTo } from "./layers";
+
+export interface SelectionBreadcrumbProps {
+  /** The editor whose selection this describes and changes. */
+  editor: EditorState;
+}
+
+export function SelectionBreadcrumb({
+  editor,
+}: SelectionBreadcrumbProps): React.JSX.Element | null {
+  const path = pathTo(editor.document, editor.selectedId);
+
+  /*
+   * Nothing selected, or a selection the document no longer holds.
+   *
+   * Renders NOTHING rather than an empty bar. The bar would reserve height for
+   * a trail that is not there, so the canvas would resize every time a
+   * selection was cleared — and an undo that removes the selected node clears
+   * it, which is a routine action rather than an edge case.
+   */
+  if (path.length === 0) return null;
+
+  return (
+    <ol className="nx-breadcrumb" aria-label="Selected block's ancestors">
+      {path.map((node, index) => {
+        const isCurrent = index === path.length - 1;
+        return (
+          <li className="nx-breadcrumb__item" key={node.id}>
+            {index > 0 ? (
+              <ChevronRight
+                className="nx-breadcrumb__separator"
+                size={12}
+                aria-hidden="true"
+              />
+            ) : null}
+            <button
+              type="button"
+              className="nx-breadcrumb__crumb"
+              // The last crumb IS the selection, so it is rendered as the
+              // current position rather than as a way to reach it. Left
+              // clickable and marked current: pressing it is harmless, and
+              // disabling it would take the trail's end out of the tab order
+              // for no gain.
+              aria-current={isCurrent ? "true" : undefined}
+              onClick={() => editor.select(node.id)}
+            >
+              {node.label}
+            </button>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/packages/builder/src/canvas-drag.test.tsx
+++ b/packages/builder/src/canvas-drag.test.tsx
@@ -37,7 +37,11 @@ import { registrySlotSource } from "./inserter";
 afterEach(() => {
   cleanup();
   clearBlocks();
+  captured = [];
 });
+
+/** Pointer ids the canvas has taken capture of, newest last. */
+let captured: number[] = [];
 
 beforeAll(() => {
   // Absent from jsdom entirely. Without them the first pointerdown throws and
@@ -46,7 +50,9 @@ beforeAll(() => {
     string,
     unknown
   >;
-  element.setPointerCapture = function setPointerCapture(): void {};
+  element.setPointerCapture = function setPointerCapture(id: number): void {
+    captured.push(id);
+  };
   element.releasePointerCapture = function releasePointerCapture(): void {};
   element.hasPointerCapture = function hasPointerCapture(): boolean {
     return true;
@@ -203,6 +209,42 @@ describe("useCanvasDrag", () => {
 
     expect(indicator(container)).toBeNull();
     expect(editorRef?.undoDepth).toBe(before);
+  });
+
+  it("does not capture the pointer for a press that stays a click", () => {
+    /*
+     * The mechanism behind a regression that made every canvas click CLEAR the
+     * selection instead of setting it.
+     *
+     * Capture retargets later pointer events to the capturing element, and the
+     * browser derives a click's target from where the press and the release
+     * landed — so capturing on `pointerdown` made every click report the canvas
+     * ROOT as its target, and the canvas read "no block above this target" as a
+     * click on the background.
+     *
+     * jsdom implements no capture retargeting and synthesises no click from a
+     * press, so the SYMPTOM cannot be reproduced here. When capture is taken is
+     * observable, and it is what the defect actually was.
+     */
+    const { container, root } = renderThree();
+
+    press(root, blockElement(container, "a"), 200, 50);
+    moveTo(root, 201, 51);
+    release(root, 201, 51);
+
+    expect(captured).toEqual([]);
+  });
+
+  it("captures the pointer once the drag activates", () => {
+    // The positive control, and the reason capture exists at all: a drag may
+    // leave the canvas and has to keep receiving moves. Without this, "never
+    // captures" would also pass on a canvas that never captures.
+    const { container, root } = renderThree();
+
+    press(root, blockElement(container, "a"), 200, 50);
+    moveTo(root, 200, 250);
+
+    expect(captured).toEqual([1]);
   });
 
   it("shows an indicator once the pointer has travelled far enough", () => {

--- a/packages/builder/src/canvas-drag.tsx
+++ b/packages/builder/src/canvas-drag.tsx
@@ -234,10 +234,7 @@ export function useCanvasDrag({
         switchState: NO_TARGET,
         targets: new Map(),
       };
-      // Capture on the ROOT, so a pointer that leaves the canvas keeps
-      // delivering. Without it a drag that wanders outside simply stops
-      // reporting, and the gesture ends wherever the pointer happened to exit.
-      root.setPointerCapture(event.pointerId);
+      // NOT captured here. See the activation branch in `onPointerMove`.
     },
     []
   );
@@ -257,6 +254,25 @@ export function useCanvasDrag({
         );
         if (travelled < activationPx) return;
         drag.active = true;
+        /*
+         * Capture the pointer HERE rather than on the press, so that a press
+         * which stays a click never captures at all.
+         *
+         * Capture retargets every later pointer event to the capturing element,
+         * and the browser derives a `click`'s target from where the press and
+         * the release landed — so capturing on `pointerdown` makes every click
+         * on the canvas report the CANVAS ROOT as its target. The canvas
+         * resolves a click by walking up from the target to the nearest block,
+         * finds none above the root, and reads that as "the author clicked the
+         * background": selecting a block by clicking it cleared the selection
+         * instead.
+         *
+         * A drag needs capture because it may leave the canvas and must keep
+         * receiving moves. A click does not, and until the pointer has travelled
+         * far enough there is no way to tell which one this is — so the capture
+         * waits for the answer.
+         */
+        event.currentTarget.setPointerCapture(event.pointerId);
         // Selecting on activation rather than on press: a press that turns out
         // to be a click is handled by the canvas's own click handler, and
         // selecting here as well would run the same decision twice.

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -213,3 +213,22 @@ export {
   type TargetId,
   type TargetSwitchState,
 } from "./target-switch";
+
+/**
+ * @experimental The document as a structure: the layers tree, the path to a
+ * block, and what a search leaves standing.
+ *
+ * From this entry rather than from `/shell`, because none of it touches React.
+ * A host that wants an outline of a stored document — a summary, an export, an
+ * agent describing a page — needs the tree without needing an editor.
+ */
+export {
+  ancestorIds,
+  filterLayers,
+  layerLabel,
+  layersOf,
+  pathTo,
+  type LayerNode,
+  type LayerSearch,
+} from "./layers";
+export { blockLabel } from "./inserter";

--- a/packages/builder/src/inserter.ts
+++ b/packages/builder/src/inserter.ts
@@ -241,6 +241,15 @@ export function catalogFrom(
  * override this immediately, and a copy written into the entry at build time
  * would keep the guess alongside it.
  */
+export function blockLabel(type: string): string {
+  const definition = getBlock(type);
+  // An unregistered type still has to read as something. Humanising its
+  // identity is the same fallback a registered-but-unlabelled block gets, so a
+  // block that disappears from the registry does not change what it is called
+  // in the middle of an editing session.
+  return definition === undefined ? humanise(type) : labelOf(definition);
+}
+
 function labelOf(definition: AnyBlockDefinition): string {
   const declared = definition.editor?.label;
   if (declared !== undefined && declared !== "") return declared;

--- a/packages/builder/src/inspector.ts
+++ b/packages/builder/src/inspector.ts
@@ -23,6 +23,7 @@ import {
   type PropSchema,
 } from "@nextlyhq/blocks-engine";
 
+import { blockLabel } from "./inserter";
 import type { NodePatch } from "./ops";
 
 /**
@@ -131,7 +132,11 @@ export function inspectSelection(
   return {
     nodeId: node.id,
     blockName: node.type,
-    label: definition.editor?.label ?? node.type,
+    // The same name the palette offered and the layers panel shows. Reading
+    // `editor.label ?? node.type` here instead was a second rule that agreed
+    // only for blocks which declare a label: an unlabelled third-party block
+    // was "Collection loop" in the palette and `acme/collection-loop` here.
+    label: blockLabel(node.type),
     props,
   };
 }

--- a/packages/builder/src/keyboard-actions.test.tsx
+++ b/packages/builder/src/keyboard-actions.test.tsx
@@ -383,9 +383,13 @@ describe("useBlockKeyboardActions", () => {
     press("Delete");
 
     const said = screen.getByRole("status").textContent ?? "";
-    // The type, because this fixture registers no block and so has no label.
-    // The labelled case is asserted below.
-    expect(said).toContain("acme/text deleted");
+    // The HUMANISED name, because this fixture registers no block and so has no
+    // declared label. An unlabelled block is named the same way here as in the
+    // palette and the layers panel — announcing `acme/text` while both of those
+    // read "Text" would give one block two names inside one editor, and the
+    // announcement is the only one of the three a screen-reader user hears.
+    // The declared-label case is asserted below.
+    expect(said).toContain("Text deleted");
     expect(said).toContain("Undo");
   });
 

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -20,12 +20,12 @@
  * @module keyboard-actions
  */
 
-import { getBlock } from "@nextlyhq/blocks-engine";
 import { useShortcuts } from "@nextlyhq/ui";
 import * as React from "react";
 
 import { blockDeletion } from "./delete-block";
 import type { EditorState } from "./editor-state";
+import { blockLabel } from "./inserter";
 import {
   keyboardMovePosition,
   type MoveDirection,
@@ -111,7 +111,7 @@ function deletionAnnouncement(type: string, descendants: number): string {
   // the label is what they were shown. Resolved here rather than carried on the
   // deletion, because the deletion is a document fact and the wording is a
   // presentation one.
-  const name = getBlock(type)?.editor?.label ?? type;
+  const name = blockLabel(type);
   const what =
     descendants === 0
       ? `${name} deleted`

--- a/packages/builder/src/layers-panel.test.tsx
+++ b/packages/builder/src/layers-panel.test.tsx
@@ -1,0 +1,290 @@
+// @vitest-environment jsdom
+
+/**
+ * The layers panel, driven through a host that renders it against a real editor.
+ *
+ * What is only true HERE is the part `layers.ts` cannot decide: which branches
+ * are open, and who is allowed to close them. The tree, its labels and its
+ * filter are asserted there, without a DOM.
+ *
+ * The expansion rules are the reason this file exists. Each of the three things
+ * that open a branch — the author, a selection, a search — is correct alone and
+ * wrong when they share one derived set, and the failure is not visible from
+ * either module's own tests.
+ *
+ * @module layers-panel.test
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import * as React from "react";
+
+import {
+  clearBlocks,
+  hasBlock,
+  registerBlocks,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+
+import { LayersPanel } from "./layers-panel";
+import { useEditorState, type EditorState } from "./editor-state";
+
+afterEach(() => {
+  cleanup();
+  clearBlocks();
+});
+
+beforeAll(() => {
+  // The tree virtualizes, so it measures its scroll container and observes
+  // resizes. jsdom provides neither, and without them the render throws before
+  // any assertion runs.
+  const element = window.Element.prototype as unknown as Record<
+    string,
+    unknown
+  >;
+  element.scrollIntoView = function scrollIntoView(): void {};
+  (window as unknown as Record<string, unknown>).ResizeObserver =
+    class ResizeObserver {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    };
+  // Every element reports zero size in jsdom, and a virtualizer told its
+  // viewport is zero pixels tall renders no rows at all — so the panel would
+  // be empty for a reason that has nothing to do with the panel.
+  Object.defineProperty(window.HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    value: 800,
+  });
+  Object.defineProperty(window.HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    value: 800,
+  });
+});
+
+const base = {
+  version: 1,
+  description: "A block.",
+  example: { props: {} },
+  render: () => null,
+};
+
+function register() {
+  if (hasBlock("core/heading")) return;
+  registerBlocks(
+    [
+      { ...base, name: "core/heading", editor: { label: "Heading" } },
+      {
+        ...base,
+        name: "core/box",
+        editor: { label: "Box" },
+        slots: { children: {} },
+      },
+    ] as never,
+    { source: "layers-panel-test" }
+  );
+}
+
+function node(
+  id: string,
+  type: string,
+  extra: Partial<BlockNode> = {}
+): BlockNode {
+  return { id, type, version: 1, props: {}, ...extra } as BlockNode;
+}
+
+/** A box holding a heading, plus a sibling heading at the top level. */
+function nestedDocument(): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      node("box", "core/box", {
+        name: "Hero",
+        slots: { children: [node("inner", "core/heading", { name: "Title" })] },
+      }),
+      node("loose", "core/heading", { name: "Footnote" }),
+    ],
+  } as BlockDocument;
+}
+
+let editorRef: EditorState | null = null;
+
+function Host({ document }: { document: BlockDocument }): React.JSX.Element {
+  const editor = useEditorState({ initialDocument: document });
+  editorRef = editor;
+  return <LayersPanel editor={editor} />;
+}
+
+function renderPanel(document: BlockDocument = nestedDocument()) {
+  register();
+  return render(<Host document={document} />);
+}
+
+/** The rows currently on screen, by their accessible name. */
+function rows(): string[] {
+  return screen
+    .queryAllByRole("treeitem")
+    .map(element => element.textContent ?? "");
+}
+
+describe("LayersPanel", () => {
+  it("shows the top level, and hides what is inside a collapsed block", () => {
+    // The precondition for everything below. An assertion that a nested row is
+    // ABSENT is satisfied by a panel that renders nothing at all, so the rows
+    // that must be present are asserted first.
+    renderPanel();
+
+    expect(rows().some(text => text.includes("Hero"))).toBe(true);
+    expect(rows().some(text => text.includes("Footnote"))).toBe(true);
+    expect(rows().some(text => text.includes("Title"))).toBe(false);
+  });
+
+  it("opens a selection's ancestors so a canvas click is visible here", () => {
+    // A block selected on the canvas inside a collapsed container would
+    // otherwise be highlighted in a tree showing none of it, which reads as the
+    // panel ignoring the click.
+    renderPanel();
+
+    React.act(() => {
+      editorRef?.select("inner");
+    });
+
+    expect(rows().some(text => text.includes("Title"))).toBe(true);
+  });
+
+  it("lets the author close a branch the SELECTION opened", () => {
+    // THE case. Merging the selection's ancestors into the expanded set at
+    // render makes this impossible: the author collapses the branch, the next
+    // render puts it straight back, and an ancestor of the selected block can
+    // never be closed.
+    renderPanel();
+    React.act(() => {
+      editorRef?.select("inner");
+    });
+    expect(rows().some(text => text.includes("Title"))).toBe(true);
+
+    // Two presses, which is what a keyboard user does. The tab stop follows the
+    // SELECTION, so the first Left climbs from the selected child to its parent
+    // — the APG move for a row with no children — and the second collapses it.
+    // One press would leave the branch open and the test would be asserting
+    // that the wrong row did nothing.
+    const tree = screen.getByRole("tree");
+    React.act(() => {
+      fireEvent.keyDown(tree, { key: "ArrowLeft" });
+    });
+    React.act(() => {
+      fireEvent.keyDown(tree, { key: "ArrowLeft" });
+    });
+
+    expect(rows().some(text => text.includes("Title"))).toBe(false);
+  });
+
+  it("selects the editor's node when a row is chosen", () => {
+    renderPanel();
+
+    const footnote = screen
+      .getAllByRole("treeitem")
+      .find(element => (element.textContent ?? "").includes("Footnote"));
+    if (footnote === undefined) throw new Error("the Footnote row is missing");
+    React.act(() => {
+      fireEvent.click(footnote);
+    });
+
+    expect(editorRef?.selectedId).toBe("loose");
+  });
+
+  it("reveals a buried match while searching, and hides it again after", () => {
+    // Search is a way of LOOKING. Storing the branches it opens would leave the
+    // tree rearranged by a query the author has already cleared.
+    renderPanel();
+    const search = screen.getByLabelText("Search layers");
+
+    React.act(() => {
+      fireEvent.change(search, { target: { value: "Title" } });
+    });
+    expect(rows().some(text => text.includes("Title"))).toBe(true);
+
+    React.act(() => {
+      fireEvent.change(search, { target: { value: "" } });
+    });
+    expect(rows().some(text => text.includes("Title"))).toBe(false);
+  });
+
+  it("does not bake a search's branches into what the author has open", () => {
+    // The case the test above CANNOT reach. The temporary branches are dropped
+    // when the tree reports a new expanded set, and it only reports one when the
+    // author toggles something — so a search followed by no interaction never
+    // exercises the filter at all. Here the author collapses an unrelated branch
+    // during the search, which is what makes the tree report, and the assertion
+    // is that clearing the query still closes what only the search had opened.
+    renderPanel();
+    const search = screen.getByLabelText("Search layers");
+
+    React.act(() => {
+      fireEvent.change(search, { target: { value: "Title" } });
+    });
+    expect(rows().some(text => text.includes("Title"))).toBe(true);
+
+    // Any author-driven expansion change while the query stands.
+    const tree = screen.getByRole("tree");
+    React.act(() => {
+      fireEvent.keyDown(tree, { key: "*" });
+    });
+
+    React.act(() => {
+      fireEvent.change(search, { target: { value: "" } });
+    });
+
+    expect(rows().some(text => text.includes("Title"))).toBe(false);
+  });
+
+  it("says so when nothing matches, rather than showing an empty tree", () => {
+    renderPanel();
+
+    React.act(() => {
+      fireEvent.change(screen.getByLabelText("Search layers"), {
+        target: { value: "zzzz" },
+      });
+    });
+
+    // `getByText` throws when absent, so reaching the assertion is the
+    // evidence; the assertion pins that it is the panel note rather than a row.
+    expect(screen.getByText(/no blocks match/i).className).toContain(
+      "nx-layers-panel__note"
+    );
+  });
+
+  it("names a locked block as locked, in text rather than by an icon alone", () => {
+    // An icon with no accessible name announces as an image called nothing, so
+    // the badge ships the word and clips it visually.
+    render(
+      <Host
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [node("a", "core/heading", { locked: true })],
+          } as BlockDocument
+        }
+      />
+    );
+    register();
+
+    expect(screen.getAllByRole("treeitem")[0]?.textContent ?? "").toMatch(
+      /locked/i
+    );
+  });
+
+  it("points an empty document at the panel that fills it", () => {
+    renderPanel({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [],
+    } as BlockDocument);
+
+    expect(screen.getByText(/no blocks yet/i).className).toContain(
+      "nx-layers-panel__note"
+    );
+  });
+});

--- a/packages/builder/src/layers-panel.tsx
+++ b/packages/builder/src/layers-panel.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+/**
+ * The layers panel: the page as a tree, and the way to reach a block the canvas
+ * cannot show.
+ *
+ * Decides nothing about the tree itself — `layers.ts` derives it, filters it and
+ * says what has to open. This draws what that returns and owns one thing the
+ * pure module cannot: which branches are expanded, which is state rather than
+ * derivation.
+ *
+ * **The tree is `@nextlyhq/ui`'s `TreeView`, not one built here.** That
+ * component exists for this control and says so: virtualized so a document of a
+ * few thousand blocks costs a window rather than a tree, and flat
+ * `role="treeitem"` rows carrying `aria-level`/`aria-setsize`/`aria-posinset`
+ * because virtualization makes the nested `role="group"` markup impossible to
+ * build. It also brings the APG keyboard model and typeahead. Reimplementing
+ * any of that here would be a second answer to a question the design system has
+ * already answered, and the accessibility half is the half that would rot.
+ *
+ * ## Three things open a branch, and they are not the same kind of thing
+ *
+ * The author clicks a twisty; a selection made on the canvas sits inside
+ * collapsed containers; a search finds a match that is buried. Treating all
+ * three as one derived union looks right and makes an ancestor of the selected
+ * block IMPOSSIBLE TO CLOSE — the author collapses it, the next render puts it
+ * straight back.
+ *
+ * So they are split by how long they should last. A selection opens its
+ * ancestors ONCE, into the author's own set, and the author may close them
+ * again. A search opens its matches' ancestors only while the query stands, so
+ * clearing it returns the tree to what the author had open. Only the author's
+ * set is stored.
+ *
+ * @module layers-panel
+ */
+
+import { Input, TreeView, type TreeNode } from "@nextlyhq/ui";
+import { EyeOff, Lock, SlidersHorizontal } from "lucide-react";
+import * as React from "react";
+
+import type { EditorState } from "./editor-state";
+import { ancestorIds, filterLayers, layersOf, type LayerNode } from "./layers";
+
+export interface LayersPanelProps {
+  /** The editor whose document this shows and whose selection it drives. */
+  editor: EditorState;
+}
+
+/** One badge: an icon nobody has to see, and a word every reader gets. */
+function Badge({
+  icon,
+  text,
+}: {
+  icon: React.ReactNode;
+  text: string;
+}): React.JSX.Element {
+  return (
+    <span className="nx-layer-row__badge">
+      {/*
+        The icon is decorative and the word is the fact. A title attribute would
+        reach a pointer and nothing else, and an icon alone announces as an
+        image with no name — so the text ships and is clipped visually.
+      */}
+      <span aria-hidden="true">{icon}</span>
+      <span className="nx-sr-only">{text}</span>
+    </span>
+  );
+}
+
+/** A layer as a row: its name, and what is true about it. */
+function rowOf(node: LayerNode): TreeNode {
+  return {
+    id: node.id,
+    // `textValue` carries the NAME alone even though the label renders badges
+    // beside it. Typeahead matches what an author would type, and a row whose
+    // searchable text included "Locked" would be reachable by typing a word
+    // that is not its name.
+    textValue: node.label,
+    label: (
+      <span className="nx-layer-row">
+        <span className="nx-layer-row__label">{node.label}</span>
+        {node.locked ? <Badge icon={<Lock size={12} />} text="Locked" /> : null}
+        {node.breakpointHidden ? (
+          <Badge
+            icon={<EyeOff size={12} />}
+            text="Hidden at some screen sizes"
+          />
+        ) : null}
+        {node.conditional ? (
+          <Badge
+            icon={<SlidersHorizontal size={12} />}
+            text="Shown conditionally"
+          />
+        ) : null}
+      </span>
+    ),
+    children: node.children.map(rowOf),
+  };
+}
+
+export function LayersPanel({ editor }: LayersPanelProps): React.JSX.Element {
+  const [query, setQuery] = React.useState("");
+  const [opened, setOpened] = React.useState<readonly string[]>([]);
+
+  // Recomputed each render rather than memoised. The tree is only valid against
+  // the document it was read from, and every edit replaces that document — a
+  // memo would need the document as its key and would therefore never hit.
+  const tree = layersOf(editor.document);
+  const search = filterLayers(tree, query);
+
+  /*
+   * The document, read at effect time rather than depended on.
+   *
+   * The effect below must run when the SELECTION moves and not when the
+   * document changes. Listing the document as a dependency would re-open the
+   * selected block's ancestors after every edit, so a branch the author closed
+   * would spring back open the next time they typed in the inspector.
+   */
+  const documentRef = React.useRef(editor.document);
+  documentRef.current = editor.document;
+
+  /*
+   * A selection made elsewhere opens its ancestors ONCE.
+   *
+   * Written into state rather than merged into the expanded set at render.
+   * Derived, it could not be undone: the author collapses a branch, the union
+   * puts it straight back, and an ancestor of the selected block becomes
+   * impossible to close.
+   */
+  React.useEffect(() => {
+    const needed = ancestorIds(documentRef.current, editor.selectedId);
+    if (needed.length === 0) return;
+    setOpened(previous => {
+      const missing = needed.filter(id => !previous.includes(id));
+      // Returning the same array when nothing is missing is what stops this
+      // effect re-rendering forever: a new array every run is a new state value.
+      return missing.length === 0 ? previous : [...previous, ...missing];
+    });
+  }, [editor.selectedId]);
+
+  /*
+   * Search reveals TEMPORARILY, so its branches are unioned at render and never
+   * stored. Clearing the query returns the tree to what the author had open,
+   * which is what makes searching feel like looking rather than like editing.
+   */
+  const expandedIds = React.useMemo(
+    () => [...new Set([...opened, ...search.expand])],
+    [opened, search.expand]
+  );
+
+  const nodes = React.useMemo(() => search.roots.map(rowOf), [search.roots]);
+
+  return (
+    <div className="nx-layers-panel">
+      <div className="nx-layers-panel__search">
+        <Input
+          value={query}
+          onChange={event => setQuery(event.target.value)}
+          placeholder="Search layers"
+          aria-label="Search layers"
+        />
+      </div>
+
+      {tree.length === 0 ? (
+        <p className="nx-layers-panel__note">
+          This page has no blocks yet. Add one from the Insert panel.
+        </p>
+      ) : nodes.length === 0 ? (
+        <p className="nx-layers-panel__note">No blocks match “{query}”.</p>
+      ) : (
+        <TreeView
+          className="nx-layers-panel__tree"
+          aria-label="Layers"
+          nodes={nodes}
+          selectedId={editor.selectedId}
+          onSelectedChange={editor.select}
+          expandedIds={expandedIds}
+          // The tree reports the whole next set, which during a search includes
+          // branches only the search opened. Those are dropped before storing,
+          // so clearing the query collapses them again instead of baking a
+          // temporary reveal into what the author has open.
+          onExpandedChange={next =>
+            setOpened(next.filter(id => !search.expand.includes(id)))
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/builder/src/layers.test.ts
+++ b/packages/builder/src/layers.test.ts
@@ -1,0 +1,297 @@
+/**
+ * The document as a structure an author can see.
+ *
+ * Driven through the real registry, because what a block is CALLED comes from
+ * it — a stub would restate the label rule and keep agreeing after the registry
+ * changed what a definition means.
+ *
+ * @module layers.test
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  clearBlocks,
+  hasBlock,
+  registerBlocks,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+
+import {
+  ancestorIds,
+  filterLayers,
+  layerLabel,
+  layersOf,
+  pathTo,
+} from "./layers";
+
+const base = {
+  version: 1,
+  description: "A block.",
+  example: { props: {} },
+  render: () => null,
+};
+
+afterEach(clearBlocks);
+
+/**
+ * Registers the fixture blocks, and may be called more than once in a test.
+ *
+ * Registration refuses a redefinition, so a helper that builds a document by
+ * calling this would throw the second time a test needed one.
+ */
+function register() {
+  if (hasBlock("core/heading")) return;
+  registerBlocks(
+    [
+      { ...base, name: "core/heading", editor: { label: "Heading" } },
+      { ...base, name: "core/text", editor: { label: "Text" } },
+      {
+        ...base,
+        name: "core/box",
+        editor: { label: "Box" },
+        slots: { children: {} },
+      },
+      // No `editor.label`, so its name has to be humanised rather than shown
+      // raw. This is the block that separates the shared label rule from the
+      // weaker `?? node.type` one.
+      { ...base, name: "acme/collection-loop", slots: { children: {} } },
+    ] as never,
+    { source: "layers-test" }
+  );
+}
+
+function node(
+  id: string,
+  type: string,
+  extra: Partial<BlockNode> = {}
+): BlockNode {
+  return { id, type, version: 1, props: {}, ...extra } as BlockNode;
+}
+
+function documentOf(nodes: BlockNode[]): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+}
+
+describe("layerLabel", () => {
+  it("prefers the instance name the author wrote", () => {
+    register();
+    expect(layerLabel(node("a", "core/heading", { name: "Page title" }))).toBe(
+      "Page title"
+    );
+  });
+
+  it("falls back to the block's name, humanised", () => {
+    // THE case for sharing one label rule. `editor.label ?? node.type` would
+    // put `acme/collection-loop` on the row while the palette offered
+    // "Collection loop" — the same block under two names in one editor.
+    register();
+    expect(layerLabel(node("a", "acme/collection-loop"))).toBe(
+      "Collection loop"
+    );
+    expect(layerLabel(node("b", "core/heading"))).toBe("Heading");
+  });
+
+  it("ignores a name that is only whitespace", () => {
+    // A blank row cannot be told from its neighbours and cannot be typed to,
+    // so an empty name is not a name.
+    register();
+    expect(layerLabel(node("a", "core/heading", { name: "   " }))).toBe(
+      "Heading"
+    );
+  });
+});
+
+describe("layersOf", () => {
+  it("nests children under the block that holds them", () => {
+    register();
+    const tree = layersOf(
+      documentOf([
+        node("box", "core/box", {
+          slots: { children: [node("h", "core/heading")] },
+        }),
+      ])
+    );
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0]?.id).toBe("box");
+    expect(tree[0]?.children.map(c => c.id)).toEqual(["h"]);
+  });
+
+  it("reports the badges as three separate facts", () => {
+    // Not one "hidden" flag. A block hidden on mobile is fully present on
+    // desktop, and a conditional block's presence depends on an entry the
+    // editor cannot evaluate — so collapsing these into an eye would state an
+    // answer nothing here knows.
+    register();
+    const tree = layersOf(
+      documentOf([
+        node("a", "core/heading", { locked: true }),
+        node("b", "core/heading", {
+          visibility: { devices: { mobile: false, desktop: true } },
+        }),
+        node("c", "core/heading", {
+          visibility: { conditions: [[{ field: "status", op: "eq" }]] },
+        }),
+      ])
+    );
+
+    expect(
+      tree.map(n => [n.locked, n.breakpointHidden, n.conditional])
+    ).toEqual([
+      [true, false, false],
+      [false, true, false],
+      [false, false, true],
+    ]);
+  });
+
+  it("does not call a node breakpoint-hidden when every breakpoint shows it", () => {
+    // The control for the case above: `devices` being PRESENT is not the same
+    // as a breakpoint being off, and an assertion satisfied by the key existing
+    // would pass on a node that is visible everywhere.
+    register();
+    const tree = layersOf(
+      documentOf([
+        node("a", "core/heading", {
+          visibility: { devices: { mobile: true, desktop: true } },
+        }),
+      ])
+    );
+
+    expect(tree[0]?.breakpointHidden).toBe(false);
+  });
+
+  it("treats an empty condition group as no condition", () => {
+    register();
+    const tree = layersOf(
+      documentOf([
+        node("a", "core/heading", { visibility: { conditions: [] } }),
+      ])
+    );
+
+    expect(tree[0]?.conditional).toBe(false);
+  });
+
+  it("flattens children across slots in document order", () => {
+    // Every container in the catalogue declares exactly one slot today, so this
+    // pins the behaviour for the block that will eventually declare two: the
+    // run is flat and follows the order the document was written in, rather
+    // than an alphabetical rearrangement of the region names.
+    register();
+    const tree = layersOf(
+      documentOf([
+        node("box", "core/box", {
+          slots: {
+            zebra: [node("z", "core/heading")],
+            alpha: [node("a", "core/text")],
+          },
+        }),
+      ])
+    );
+
+    expect(tree[0]?.children.map(c => c.id)).toEqual(["z", "a"]);
+  });
+});
+
+describe("pathTo and ancestorIds", () => {
+  function nested() {
+    register();
+    return documentOf([
+      node("outer", "core/box", {
+        slots: {
+          children: [
+            node("inner", "core/box", {
+              slots: { children: [node("leaf", "core/heading")] },
+            }),
+          ],
+        },
+      }),
+    ]);
+  }
+
+  it("reads outermost first and ends with the node itself", () => {
+    expect(pathTo(nested(), "leaf").map(n => n.id)).toEqual([
+      "outer",
+      "inner",
+      "leaf",
+    ]);
+  });
+
+  it("reports nothing for no selection or a node the document lost", () => {
+    // Routine rather than exotic: an undo can remove the selected node while
+    // the selection stands, and a breadcrumb drawing a broken trail there is
+    // worse than one drawing nothing.
+    expect(pathTo(nested(), null)).toEqual([]);
+    expect(pathTo(nested(), "gone")).toEqual([]);
+  });
+
+  it("gives the ancestors WITHOUT the node, which is what has to open", () => {
+    // Expanding the node itself would open a branch the author did not ask for
+    // — selecting a container should reveal where it sits, not its contents.
+    expect(ancestorIds(nested(), "leaf")).toEqual(["outer", "inner"]);
+    expect(ancestorIds(nested(), "outer")).toEqual([]);
+  });
+});
+
+describe("filterLayers", () => {
+  function tree() {
+    register();
+    return layersOf(
+      documentOf([
+        node("box", "core/box", {
+          slots: {
+            children: [
+              node("h", "core/heading", { name: "Welcome" }),
+              node("t", "core/text"),
+            ],
+          },
+        }),
+        node("other", "core/heading", { name: "Footer" }),
+      ])
+    );
+  }
+
+  it("returns the tree unchanged for an empty query", () => {
+    // The panel renders with no query, and treating that as "match nothing"
+    // would show an empty panel on open.
+    const roots = tree();
+    expect(filterLayers(roots, "  ").roots).toBe(roots);
+  });
+
+  it("keeps a match's ancestors even when they do not match", () => {
+    // THE case. Dropping them would present "Welcome" as a top-level block and
+    // lose the nesting this panel exists to show.
+    const result = filterLayers(tree(), "welcome");
+
+    expect(result.roots.map(n => n.id)).toEqual(["box"]);
+    expect(result.roots[0]?.children.map(n => n.id)).toEqual(["h"]);
+  });
+
+  it("names the ancestors that have to open, and not the matches", () => {
+    // A node kept because of a descendant is collapsed and hides the match; a
+    // node that matched is already visible where it stands.
+    expect(filterLayers(tree(), "welcome").expand).toEqual(["box"]);
+  });
+
+  it("keeps a matching container's whole subtree", () => {
+    // Searching for a container asks what is inside it. Pruning its children
+    // would answer a narrower question than the one typed.
+    const result = filterLayers(tree(), "box");
+
+    expect(result.roots.map(n => n.id)).toEqual(["box"]);
+    expect(result.roots[0]?.children.map(n => n.id)).toEqual(["h", "t"]);
+    expect(result.expand).toEqual([]);
+  });
+
+  it("matches the block type as well as the label", () => {
+    // An author who knows a block as `core/text` — from the docs, or from an
+    // agent's output — should not have to guess the panel's wording.
+    const result = filterLayers(tree(), "core/text");
+
+    expect(result.roots[0]?.children.map(n => n.id)).toEqual(["t"]);
+  });
+
+  it("returns nothing when nothing matches", () => {
+    expect(filterLayers(tree(), "zzz").roots).toEqual([]);
+  });
+});

--- a/packages/builder/src/layers.ts
+++ b/packages/builder/src/layers.ts
@@ -1,0 +1,221 @@
+/**
+ * The document as a structure an author can see: the layers tree, the path to
+ * the selected block, and what a search leaves standing.
+ *
+ * The canvas shows a page. It does not show that the heading is inside a box
+ * which is inside a section, and it cannot show a block that renders nothing —
+ * an empty container is a couple of pixels, and a block hidden at the current
+ * breakpoint is not there at all. Those are exactly the blocks an author loses.
+ * This module is the other view of the same document.
+ *
+ * **One tree, two consumers.** The layers panel draws it and the breadcrumb
+ * walks it, so both take their labels, their nesting and their badges from
+ * here. Computed separately they would agree until the first time either
+ * changed what it matched, and the disagreement would be silent: a breadcrumb
+ * naming one ancestor while the panel highlights another.
+ *
+ * ## Children are flattened across slots, and that is measured rather than
+ * assumed
+ *
+ * A block may declare several named child regions. Every container in the core
+ * library declares exactly ONE, always called `children` — measured across the
+ * catalogue, 9 containers with one slot and none with more. So a flat tree
+ * describes the document faithfully today, and slot rows would add a level of
+ * nesting to every tree in order to name a distinction no block currently
+ * makes.
+ *
+ * **The limit that leaves, stated because it is not visible from the output:** a
+ * block declaring two slots renders its children in one flat run here, so an
+ * author could not tell which region a child sits in. That block does not exist
+ * yet; when one does, this is the module that grows slot rows.
+ *
+ * Pure, and it takes a document rather than a registry lookup per row, so the
+ * tree can be asserted without React and without a DOM.
+ *
+ * @module layers
+ */
+
+import type { BlockDocument, BlockNode } from "@nextlyhq/blocks-engine";
+
+import { blockLabel } from "./inserter";
+
+/**
+ * One block, as a row in the tree.
+ *
+ * Badges are FACTS about the node rather than switches. `locked` is a boolean
+ * the engine defines; the two visibility flags are not, and conflating them
+ * into one "hidden" is the mistake this shape exists to prevent — see
+ * {@link LayerNode.conditional}.
+ */
+export interface LayerNode {
+  readonly id: string;
+  readonly type: string;
+  /** The instance name if the author gave one, otherwise the block's name. */
+  readonly label: string;
+  /** The author has asked the editor not to move or delete this block. */
+  readonly locked: boolean;
+  /**
+   * The block declares conditions, so whether it appears depends on the entry.
+   *
+   * NOT "hidden". Conditions are predicates over an entry's fields evaluated at
+   * render time, so the editor cannot know the answer — showing an eye here
+   * would state one. What is knowable, and worth showing, is that this block's
+   * presence is conditional at all.
+   */
+  readonly conditional: boolean;
+  /**
+   * The block is hidden at one or more breakpoints.
+   *
+   * Also not "hidden", for a different reason: visibility is per breakpoint, so
+   * a block hidden on mobile is fully present on desktop. A single eye would
+   * have to pick one of those to be true about.
+   */
+  readonly breakpointHidden: boolean;
+  readonly children: readonly LayerNode[];
+}
+
+/** Whether any breakpoint switches this node off. */
+function hiddenAtSomeBreakpoint(node: BlockNode): boolean {
+  const devices = node.visibility?.devices;
+  if (devices === undefined) return false;
+  return Object.values(devices).some(visible => visible === false);
+}
+
+/** Whether the node carries any condition at all. */
+function hasConditions(node: BlockNode): boolean {
+  const groups = node.visibility?.conditions;
+  if (!Array.isArray(groups)) return false;
+  return groups.some(group => Array.isArray(group) && group.length > 0);
+}
+
+/**
+ * The name an author reads for one block.
+ *
+ * An instance name wins, because it is the only part an author wrote. It is
+ * trimmed and an empty one is ignored: a name of spaces would render a blank
+ * row that cannot be typed to and cannot be told from its neighbours.
+ */
+export function layerLabel(node: BlockNode): string {
+  const named = node.name?.trim();
+  return named !== undefined && named !== "" ? named : blockLabel(node.type);
+}
+
+/** The document as a tree of rows. */
+export function layersOf(document: BlockDocument): LayerNode[] {
+  const walk = (nodes: readonly BlockNode[]): LayerNode[] =>
+    nodes.map(node => ({
+      id: node.id,
+      type: node.type,
+      label: layerLabel(node),
+      locked: node.locked === true,
+      conditional: hasConditions(node),
+      breakpointHidden: hiddenAtSomeBreakpoint(node),
+      // Declaration order across every slot the node holds. `Object.values`
+      // preserves insertion order for string keys, which is the order the
+      // document was written in — so the tree matches the document rather than
+      // an alphabetical rearrangement of its regions.
+      children: walk(Object.values(node.slots ?? {}).flat()),
+    }));
+
+  return walk(document.nodes);
+}
+
+/**
+ * The ancestors of a node, outermost first, ending with the node itself.
+ *
+ * Empty when nothing is selected or the id is not in the document — which the
+ * breadcrumb draws as nothing rather than as a broken trail, and which happens
+ * routinely: an undo can remove the selected node while the selection stands.
+ */
+export function pathTo(
+  document: BlockDocument,
+  id: string | null
+): LayerNode[] {
+  if (id === null) return [];
+
+  const find = (nodes: readonly LayerNode[]): LayerNode[] => {
+    for (const node of nodes) {
+      if (node.id === id) return [node];
+      const below = find(node.children);
+      if (below.length > 0) return [node, ...below];
+    }
+    return [];
+  };
+
+  return find(layersOf(document));
+}
+
+/**
+ * Every ancestor id on the way to a node, excluding the node itself.
+ *
+ * What the panel must expand for a selection made elsewhere to be visible. A
+ * block selected on the canvas inside three collapsed containers is otherwise
+ * highlighted in a tree that shows none of it, which reads as the panel
+ * ignoring the click.
+ */
+export function ancestorIds(
+  document: BlockDocument,
+  id: string | null
+): string[] {
+  return pathTo(document, id)
+    .slice(0, -1)
+    .map(node => node.id);
+}
+
+/** What a search left standing, and what has to open for it to be visible. */
+export interface LayerSearch {
+  readonly roots: readonly LayerNode[];
+  /** Ids to expand so every match is on screen. */
+  readonly expand: readonly string[];
+}
+
+/** Whether a row itself answers the query. */
+function matches(node: LayerNode, needle: string): boolean {
+  // The type as well as the label, because an author who knows a block as
+  // `core/heading` — from documentation, or from an agent's output — should not
+  // have to guess what it is called in the panel.
+  return (
+    node.label.toLowerCase().includes(needle) ||
+    node.type.toLowerCase().includes(needle)
+  );
+}
+
+/**
+ * Narrow the tree to what matches, keeping the ancestors of every match.
+ *
+ * A match's ancestors are KEPT even when they do not match themselves, because
+ * a tree that dropped them would present matches as top-level blocks and lose
+ * the one thing this panel exists to show. A matching node keeps its whole
+ * subtree, so searching for a container still shows what is inside it.
+ *
+ * An empty or whitespace-only query returns the tree unchanged rather than
+ * nothing — the panel renders with no query, and treating that as "match
+ * nothing" would show an empty panel on open.
+ */
+export function filterLayers(
+  roots: readonly LayerNode[],
+  query: string
+): LayerSearch {
+  const needle = query.trim().toLowerCase();
+  if (needle === "") return { roots, expand: [] };
+
+  const expand: string[] = [];
+
+  const prune = (nodes: readonly LayerNode[]): LayerNode[] =>
+    nodes.flatMap(node => {
+      if (matches(node, needle)) {
+        // Kept whole. Its descendants are the contents of a thing the author
+        // asked for, and hiding them would answer a narrower question than the
+        // one they typed.
+        return [node];
+      }
+      const children = prune(node.children);
+      if (children.length === 0) return [];
+      // Only a node kept BECAUSE of a descendant needs opening; a node that
+      // matched is visible where it stands.
+      expand.push(node.id);
+      return [{ ...node, children }];
+    });
+
+  return { roots: prune(roots), expand };
+}

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -137,3 +137,19 @@ export type {
   DropIndicatorProps,
   UseCanvasDragOptions,
 } from "./canvas-drag";
+
+/**
+ * The layers panel and the ancestor breadcrumb, behind the same client banner.
+ *
+ * Together because they answer one question from two directions — where does
+ * this block sit — and they read the SAME tree to answer it, so shipping one
+ * without the other would leave a host able to show a trail the panel could
+ * contradict.
+ *
+ * The tree they draw is derived in `layers`, which is plain functions over a
+ * document and ships from the root entry.
+ */
+export { LayersPanel } from "./layers-panel";
+export type { LayersPanelProps } from "./layers-panel";
+export { SelectionBreadcrumb } from "./breadcrumb";
+export type { SelectionBreadcrumbProps } from "./breadcrumb";

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -428,3 +428,128 @@
   width: 2px;
   transform: translateX(-1px);
 }
+
+/*
+ * The layers panel: a search field above a tree that takes the rest of the
+ * height.
+ *
+ * A column with `min-height: 0` so the tree can scroll. Without it the tree's
+ * own overflow never engages — a flex child's default minimum size is its
+ * content, so a tall tree grows the panel instead of scrolling inside it, and
+ * the search field is pushed off the top.
+ */
+.nx-layers-panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+  gap: 0.5rem;
+  padding: 0.75rem;
+}
+
+.nx-layers-panel__search {
+  flex: none;
+}
+
+.nx-layers-panel__tree {
+  flex: 1;
+  min-height: 0;
+}
+
+.nx-layers-panel__note {
+  margin: 0;
+  padding: 0.5rem 0.25rem;
+  font-size: 0.8125rem;
+  color: var(--nx-builder-text-muted);
+}
+
+/*
+ * One row: the name takes the space, the badges keep theirs.
+ *
+ * The name truncates rather than wrapping, because the tree's rows are a fixed
+ * height that the virtualizer depends on — a wrapped label would overflow its
+ * row and overlap the next one.
+ */
+.nx-layer-row {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  min-width: 0;
+  width: 100%;
+}
+
+.nx-layer-row__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/*
+ * A badge states a fact about the block, so it is dimmer than the name without
+ * being decoration.
+ *
+ * `--nx-builder-text-muted` rather than an opacity on the text colour: an
+ * alpha-blended foreground has a contrast ratio that depends on whatever is
+ * behind it, which changes between the panel and a selected row. The token is
+ * the value the design system already checks.
+ */
+.nx-layer-row__badge {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  color: var(--nx-builder-text-muted);
+}
+
+/*
+ * The ancestor breadcrumb, along the bottom bar.
+ *
+ * Scrolls horizontally rather than wrapping: the bar is a fixed-height strip,
+ * and a deep selection would otherwise grow it and shrink the canvas every time
+ * an author selected something nested.
+ */
+.nx-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.125rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  min-width: 0;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.nx-breadcrumb__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.125rem;
+}
+
+.nx-breadcrumb__separator {
+  flex: none;
+  color: var(--nx-builder-text-muted);
+}
+
+.nx-breadcrumb__crumb {
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--nx-builder-text-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.nx-breadcrumb__crumb:hover {
+  color: var(--nx-builder-text);
+}
+
+/*
+ * The current crumb is the selection, so it reads at full strength. Colour
+ * alone does not carry it — the `aria-current` attribute is what a screen
+ * reader announces, and this rule is the visual half of the same fact.
+ */
+.nx-breadcrumb__crumb[aria-current] {
+  color: var(--nx-builder-text);
+  font-weight: 500;
+}

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -48,6 +48,8 @@ import {
   DropIndicator,
   InsertPanel,
   InspectorPanel,
+  LayersPanel,
+  SelectionBreadcrumb,
   useCanvasDrag,
   useEditorState,
 } from "@nextlyhq/builder/shell";
@@ -77,14 +79,14 @@ export interface BlocksFieldProps<
 /**
  * Every left panel the editor can fill today.
  *
- * The inserter only; layers and the rest are not built. The shell draws all
+ * The inserter and the layers tree; the rest are not built. The shell draws all
  * seven regardless and disables the ones nothing fills, so the rail describes
  * the editor's shape while never opening a region with nothing in it. Listing a
  * panel here that renders nothing would reserve space and shrink the canvas to
  * show it, which is why this grows one entry at a time rather than being
  * declared ahead of the panels.
  */
-const AVAILABLE_PANELS = ["insert"] as const;
+const AVAILABLE_PANELS = ["insert", "layers"] as const;
 
 /** Names the registry attributes these blocks to, for diagnostics. */
 const PLUGIN_SOURCE = "@nextlyhq/plugin-page-builder";
@@ -260,11 +262,19 @@ function BlocksEditor({
         // whatever the rail reports open. The shell asks for the panel it
         // opened, and a renderer ignoring that argument would draw the inserter
         // under every heading the moment a second panel is listed above.
-        renderPanel={panel =>
-          panel === "insert" ? (
-            <InsertPanel editor={editor} categoryOrder={CORE_CATEGORIES} />
-          ) : null
-        }
+        // The trail sits in the bottom bar, which the shell owns. Passed as a
+        // slot rather than rendered beside the canvas so it cannot overlap the
+        // page an author is editing.
+        breadcrumb={<SelectionBreadcrumb editor={editor} />}
+        renderPanel={panel => {
+          if (panel === "insert") {
+            return (
+              <InsertPanel editor={editor} categoryOrder={CORE_CATEGORIES} />
+            );
+          }
+          if (panel === "layers") return <LayersPanel editor={editor} />;
+          return null;
+        }}
       >
         {/*
           Inside the shell, which is what provides the shortcut context — a


### PR DESCRIPTION
Plan 04 **B-13** (layers panel) and the navigation half of **B-16** (ancestor breadcrumb).

> **Stacked on #1012.** That branch is merged in here, because click-to-select was broken on `main` and without it the panel cannot be verified at all. Merge #1012 first; this diff then reduces to the layers work.

## Why this, now

The editor can insert, select, move, delete, undo and edit. It could not show an author **the structure of their page** — and structure is exactly where blocks get lost: an empty container is a couple of pixels, and a block hidden at the current breakpoint is not on the canvas at all.

## The tree is `@nextlyhq/ui`'s `TreeView`, not one written here

F7 shipped it and its own docblock says it exists for this control. It is virtualized, and its flat `role="treeitem"` rows carry `aria-level`/`aria-setsize`/`aria-posinset` **because** virtualization makes the nested `role="group"` markup impossible to build — only a window is in the DOM. It also brings the APG keyboard model, roving tabindex and typeahead. Reimplementing that here would have put the accessibility half in the place it would rot.

## Decisions, each from a measurement

**Children are flattened across slots.** Measured across the catalogue: **9 containers declare exactly one slot, none declares more.** So a flat tree is faithful today, and slot rows would add a level of nesting to name a distinction no block currently makes. The limit is stated in the module — a two-slot block would show its children in one run, and this is where slot rows grow.

**Badges are three facts, not one eye.** `locked` is a boolean the engine defines. Visibility is *not*: it is `conditions` evaluated against an entry the editor cannot see, plus a per-breakpoint map where a block hidden on mobile is fully present on desktop. A single eye icon would have to state an answer nothing here knows, so the row reports *locked*, *hidden at some screen sizes* and *shown conditionally* separately — each as clipped text beside an `aria-hidden` icon, because an icon alone announces as an image with no name.

**Expansion is split by how long it should last.** Three things want to open a branch: the author, a selection made on the canvas, a search. Deriving all three as one union reads correctly and makes an ancestor of the selected block **impossible to close** — the author collapses it, the next render puts it straight back. So a selection opens its ancestors *once*, into the author's own set; a search opens its matches' ancestors only while the query stands. Only the author's set is stored.

**One label rule.** `blockLabel` replaces the inspector's `editor.label ?? node.type`, which agreed only for blocks that declare a label — an unlabelled third-party block was "Collection loop" in the palette and `acme/collection-loop` in the inspector. This also changes a delete announcement for an unlabelled block from `acme/text` to "Text"; that test now records the decision and why.

## Verified in a browser

```
rail: ["Insert","Layers"]                       tree present: 1
rows: Box (level 1) · Text (level 1)            — collapsed, Heading hidden
click the nested Heading on the canvas →
rows: Box (level 1, expanded) · Heading (level 2, SELECTED) · Text (level 1)
breadcrumb: ["Box","Heading"]
search "Head" → Box (expanded) · Heading        clear → Text returns
click the first crumb → selection moves to the container
pageerrors: []
```

## Tests

606 in `@nextlyhq/builder` (was 575), 61 in `plugin-page-builder`, 30/30 tasks. Every rule stub-verified — broken one at a time, intended tests confirmed failing, restored, restore confirmed by diff: 5 for the tree model, 3 for the expansion rules, 4 for the breadcrumb.

**One of those breaks moved nothing**, which is a finding rather than a pass: dropping the search-branch filter changed no result, because the filter only runs when the author toggles a branch and no test toggled one during a search. The property was uncovered. The test that reaches it is in this PR, and re-running the same break now fails it.

## Not in this PR, deliberately

Rename, the lock **toggle**, and the 2.5.7 move menus. The lock toggle needs `node.locked` to be honoured by delete and keyboard-move too — today **only drag reads it** — and shipping a switch whose effect is half-wired is worse than shipping none. That is a coherent "locking works" PR of its own.

## Note for whoever reviews the chrome

`packages/builder/src/**` is outside the three design-token ESLint rules, outside `lint-design.mjs`, and outside the alpha-contrast suite's scanned directories. **Nothing would catch a sub-3:1 border in this panel.** The new styles therefore use only the existing `--nx-builder-*` tokens, which alias the vetted admin palette, and add no opacity-modified colours — an alpha-blended foreground's contrast depends on whatever is behind it, which is what broke `main` earlier today. That coverage gap is worth closing separately.
