### PR TITLE
fix(plugin-page-builder): budget the registration test for a cold import

### DIFF
--- a/packages/plugin-page-builder/src/admin/registration.test.ts
+++ b/packages/plugin-page-builder/src/admin/registration.test.ts
@@ -37,30 +37,49 @@ vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
 }));
 
 describe("the admin entry's component registration", () => {
-  it("registers the exact specifier the blocks field declares", async () => {
-    // Imported for its side effect, after the mock is in place.
-    await import("./index");
+  // Both cases `await import("./index")`, so their cost is dominated by
+  // TRANSFORMING that module graph rather than by the assertions, which run in
+  // roughly 300ms locally. The graph is this package's whole client entry, and
+  // in CI it is transformed cold while parallel workers compete for the same
+  // machine — so the budget scales with the runner's load rather than with
+  // anything either test controls. Vitest's 5s default was never chosen for
+  // that shape and timed out on five separate branches in one morning. Stated
+  // explicitly, so a loaded runner reads as a loaded runner rather than as this
+  // registration breaking.
+  const IMPORT_GRAPH_BUDGET_MS = 30_000;
 
-    // The specifier, not merely "something was registered" — a map with one
-    // unrelated entry satisfies a count and leaves the field unresolvable.
-    expect(Object.keys(registered)).toContain(BLOCKS_FIELD_COMPONENT);
-    expect(registered[BLOCKS_FIELD_COMPONENT]).toBeTypeOf("function");
-  });
+  it(
+    "registers the exact specifier the blocks field declares",
+    async () => {
+      // Imported for its side effect, after the mock is in place.
+      await import("./index");
 
-  it("registers nothing it does not export, so no specifier dangles", async () => {
-    await import("./index");
-    const entry = await import("./index");
+      // The specifier, not merely "something was registered" — a map with one
+      // unrelated entry satisfies a count and leaves the field unresolvable.
+      expect(Object.keys(registered)).toContain(BLOCKS_FIELD_COMPONENT);
+      expect(registered[BLOCKS_FIELD_COMPONENT]).toBeTypeOf("function");
+    },
+    IMPORT_GRAPH_BUDGET_MS
+  );
 
-    // Every registered path must name an export of this module. A registration
-    // pointing at a component that was deleted resolves to `undefined` and
-    // renders blank, which is the same failure from the other direction.
-    for (const path of Object.keys(registered)) {
-      const name = path.split("#")[1];
-      expect(name, `${path} has no #ComponentName`).toBeTruthy();
-      expect(
-        entry,
-        `${path} names an export this module does not have`
-      ).toHaveProperty(name as string);
-    }
-  });
+  it(
+    "registers nothing it does not export, so no specifier dangles",
+    async () => {
+      await import("./index");
+      const entry = await import("./index");
+
+      // Every registered path must name an export of this module. A registration
+      // pointing at a component that was deleted resolves to `undefined` and
+      // renders blank, which is the same failure from the other direction.
+      for (const path of Object.keys(registered)) {
+        const name = path.split("#")[1];
+        expect(name, `${path} has no #ComponentName`).toBeTruthy();
+        expect(
+          entry,
+          `${path} names an export this module does not have`
+        ).toHaveProperty(name as string);
+      }
+    },
+    IMPORT_GRAPH_BUDGET_MS
+  );
 });


### PR DESCRIPTION
## The failure

    FAIL src/admin/registration.test.ts > registers the exact specifier the blocks field declares
    Error: Test timed out in 5000ms.

## It is repo-wide, not one branch's

Sampling the last 8 failed `ci.yml` runs, this test appears in the failure log of **five separate branches** in one morning:

    feat/scaffold-design-token-lint      hits=5
    feat/t07-language-panel              hits=5
    fix/language-dot-contrast            hits=5
    changeset-release/main               hits=2
    test/lint-design-coverage            hits=2

None of those diffs touches `plugin-page-builder`. It has blocked #981 twice and rode along on a Version PR.

## Why 5000ms is the wrong budget

Locally the file runs **2/2 in ~300ms of test time** (3 runs: 333ms, 286ms, 266ms), so it is not marginal in isolation.

Both cases do `await import("./index")`. That is this package's entire client entry, and the cost is dominated by **transforming that module graph**, not by the assertions. Locally the graph is warm (~146ms import). In CI it is transformed cold while parallel vitest workers compete for the same runner, so the wall-clock scales with the machine's load rather than with anything either test controls.

5000ms is vitest's default. It was never chosen for this shape.

## Why an explicit budget rather than a retry or a mock

The repo already has precedent for exactly this reasoning — `packages/ui/src/styles/contrast/__tests__/alpha-utilities.test.ts` gives its whole-monorepo `grep` `60_000` with a comment saying the budget is I/O rather than work the test controls. Same argument, same remedy.

Mocking the import away would delete the assertion's subject: this file exists because a string specifier is not a type-checked reference, and it once caught an entry that exported a component without registering it while every other test stayed green. The import IS the test.

30s is generous against a ~0.5s local run while still failing a genuine hang.

## Verification

- **Break-verified that the budget is wired, not merely present**: with `IMPORT_GRAPH_BUDGET_MS = 1` both cases fail with `Test timed out in 1ms`; at 30_000 both pass. So the third argument is honoured rather than ignored.
- `2 passed (2)` on the branch.

## No changeset

Test-only, and test files are not in the built package, so no shipped behaviour changes and there is nothing to write a changelog entry about. `check-changesets.mjs` validates a changeset's completeness but does not require one. Say so if you would rather it carried one.