### PR TITLE
fix(admin): let the toolbar yield before the document title does

### DIFF
--- a/.changeset/toolbar-yields-before-the-title.md
+++ b/.changeset/toolbar-yields-before-the-title.md
@@ -1,0 +1,45 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The document header's title input no longer collapses.
+
+The title was a `flex-1` beside an action cluster that never shrank, so it got
+whatever was left: measured on `main`, `row - 598px`, which is 34px in a
+1280-wide window and 0 at 900. It reproduced on non-localized collections too,
+so this was general header behaviour rather than anything about translations.
+
+Actions now yield before the title does. As the toolbar narrows, supporting
+labels (preview, copy link) drop to their icons, then publish and unpublish do;
+the primary Save never collapses, and the title keeps a readable floor. A
+collapsed label becomes `sr-only` rather than being removed, so every control
+keeps the accessible name it had at full width.
+
+The queries read the toolbar's own width rather than the viewport's, because the
+document rail is 320px wide and hides at its own breakpoint — one window width
+produces two different toolbar widths, and only the toolbar knows how much room
+the toolbar has.

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -43,6 +43,7 @@ import { DocumentStatusLive } from "./DocumentStatusLive";
 import { effectiveEntryStatus } from "./entry-address";
 import { PreviewActions } from "./PreviewActions";
 import { ShowJSONDialog } from "./ShowJSONDialog";
+import { TOOLBAR_CONTAINER, ToolbarLabel } from "./toolbar-density";
 import { UnpublishConfirmDialog } from "./UnpublishConfirmDialog";
 import type { EntryData, EntryFormMode } from "./useEntryForm";
 
@@ -381,9 +382,16 @@ export function EntrySystemHeader({
 
   return (
     <div className="sticky top-0 z-30 bg-background border-b border-border">
-      <div className="px-6 py-3 flex items-center gap-3">
-        {/* Title input — borderless, 19px, autofocus on create */}
-        <div className="flex-1 min-w-0">
+      <div
+        className={cn(TOOLBAR_CONTAINER, "px-6 py-3 flex items-center gap-3")}
+      >
+        {/* Title input — borderless, 19px, autofocus on create.
+
+          The floor is the point: as a bare `flex-1 min-w-0` beside a cluster
+          that never shrank, the title was whatever was left over, and at common
+          window widths that was nothing. It now keeps a readable minimum and the
+          actions collapse around it (see `toolbar-density`). */}
+        <div className="flex-1 min-w-[10rem]">
           <input
             {...rhfRegister}
             ref={el => {
@@ -518,6 +526,7 @@ export function EntrySystemHeader({
                   size="sm"
                   disabled={isSubmitting || isInvalid}
                   onClick={onPublish}
+                  title="Publish"
                   data-status="published"
                 >
                   {isSubmitting ? (
@@ -525,7 +534,7 @@ export function EntrySystemHeader({
                   ) : (
                     <Globe className="h-3.5 w-3.5" />
                   )}
-                  Publish
+                  <ToolbarLabel priority="lifecycle">Publish</ToolbarLabel>
                 </Button>
               )}
               {canUnpublishDocument && (
@@ -537,10 +546,11 @@ export function EntrySystemHeader({
                   size="sm"
                   disabled={isSubmitting}
                   onClick={() => setUnpublishOpen(true)}
+                  title="Unpublish"
                   data-status="unpublish"
                 >
                   <EyeOff className="h-3.5 w-3.5" />
-                  Unpublish
+                  <ToolbarLabel priority="lifecycle">Unpublish</ToolbarLabel>
                 </Button>
               )}
             </>
@@ -565,6 +575,7 @@ export function EntrySystemHeader({
                   size="sm"
                   disabled={isSubmitting || isInvalid}
                   onClick={onPublish}
+                  title="Publish"
                   data-status="published"
                 >
                   {isSubmitting ? (
@@ -572,7 +583,7 @@ export function EntrySystemHeader({
                   ) : (
                     <Globe className="h-3.5 w-3.5" />
                   )}
-                  Publish
+                  <ToolbarLabel priority="lifecycle">Publish</ToolbarLabel>
                 </Button>
               )}
             </>

--- a/packages/admin/src/components/features/entries/EntryForm/PreviewActions.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/PreviewActions.tsx
@@ -32,6 +32,8 @@ import {
   DropdownMenuTrigger,
 } from "@admin/components/ui";
 
+import { ToolbarLabel } from "./toolbar-density";
+
 export interface PreviewActionsProps {
   /** Whether the collection has a preview URL configured. */
   isPreviewAvailable?: boolean;
@@ -110,9 +112,10 @@ export function PreviewActions({
         size={size}
         onClick={startPreview}
         disabled={disabled}
+        title={previewLabel}
       >
         <Eye className="h-4 w-4" />
-        {previewLabel}
+        <ToolbarLabel priority="secondary">{previewLabel}</ToolbarLabel>
       </Button>
     );
   }
@@ -125,13 +128,14 @@ export function PreviewActions({
         size={size}
         onClick={onCopyLink}
         disabled={disabled || isCopyingLink}
+        title={COPY_LABEL}
       >
         {isCopyingLink ? (
           <Loader2 className="h-4 w-4 animate-spin" />
         ) : (
           <Link2 className="h-4 w-4" />
         )}
-        {COPY_LABEL}
+        <ToolbarLabel priority="secondary">{COPY_LABEL}</ToolbarLabel>
       </Button>
     );
   }
@@ -148,13 +152,14 @@ export function PreviewActions({
           // says so: a control labelled only "Preview" that opens a list is a
           // different promise than the one it keeps.
           aria-label={`${previewLabel} options`}
+          title={`${previewLabel} options`}
         >
           {isCopyingLink ? (
             <Loader2 className="h-4 w-4 animate-spin" />
           ) : (
             <Eye className="h-4 w-4" />
           )}
-          {previewLabel}
+          <ToolbarLabel priority="secondary">{previewLabel}</ToolbarLabel>
           <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
         </Button>
       </DropdownMenuTrigger>

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/toolbar-density.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/toolbar-density.test.tsx
@@ -1,0 +1,86 @@
+// The toolbar's collapse rules.
+//
+// jsdom evaluates no CSS, so these cannot assert that a label is visually
+// hidden at a given width — that is measured in a real browser. What they CAN
+// pin is the part that would silently break the mechanism: which container the
+// queries name, that a collapsed label keeps its text (so the control keeps its
+// accessible name), and that the primary action was never given a way to
+// collapse at all.
+import { describe, it, expect } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+import {
+  TOOLBAR_CONTAINER,
+  ToolbarLabel,
+  type ToolbarLabelPriority,
+} from "../toolbar-density";
+
+describe("TOOLBAR_CONTAINER", () => {
+  it("names the container the labels query against", () => {
+    // The labels use `.../toolbar:` variants. If this class stops declaring a
+    // container called `toolbar`, every query silently stops matching and each
+    // label stays at full width — the exact defect this module was built to
+    // fix, returning with no error anywhere.
+    expect(TOOLBAR_CONTAINER).toBe("@container/toolbar");
+  });
+});
+
+describe("ToolbarLabel", () => {
+  const priorities: ToolbarLabelPriority[] = ["secondary", "lifecycle"];
+
+  it.each(priorities)(
+    "keeps %s label text in the accessible tree",
+    priority => {
+      // `sr-only` hides the pixels and keeps the text. A label REMOVED at
+      // narrow widths would leave an icon-only button with no name, which is
+      // the failure mode this approach exists to avoid.
+      //
+      // Deliberately NO `title` on this button, though the real ones carry one:
+      // with a title present the accessible name comes from the attribute and
+      // this assertion passes even when the label renders nothing at all. The
+      // label's own text has to be the only thing that can satisfy it.
+      render(
+        <button type="button">
+          <ToolbarLabel priority={priority}>Unpublish</ToolbarLabel>
+        </button>
+      );
+      expect(
+        screen.getByRole("button", { name: "Unpublish" })
+      ).toBeInTheDocument();
+    }
+  );
+
+  it("collapses a secondary label before a lifecycle one", () => {
+    // Ordering is the whole design: supporting actions give up their words
+    // first, and publish/unpublish hold theirs longer. Equal thresholds would
+    // read as working while making the priority meaningless.
+    const { container: secondary } = render(
+      <ToolbarLabel priority="secondary">a</ToolbarLabel>
+    );
+    const { container: lifecycle } = render(
+      <ToolbarLabel priority="lifecycle">b</ToolbarLabel>
+    );
+    const cls = (c: HTMLElement) => c.firstElementChild?.className ?? "";
+
+    expect(cls(secondary)).toContain("/toolbar:sr-only");
+    expect(cls(lifecycle)).toContain("/toolbar:sr-only");
+    // Tailwind's `@max-*` scale ascends, so the secondary label's breakpoint
+    // must be the LARGER one for it to collapse first.
+    const rank = ["xs", "sm", "md", "lg", "xl", "2xl", "3xl", "4xl", "5xl"];
+    const stepOf = (c: string) =>
+      rank.indexOf(c.replace(/^@max-/, "").replace(/\/toolbar:sr-only$/, ""));
+    expect(stepOf(cls(secondary))).toBeGreaterThan(stepOf(cls(lifecycle)));
+  });
+
+  it("passes extra classes through without dropping the collapse rule", () => {
+    const { container } = render(
+      <ToolbarLabel priority="secondary" className="ml-1">
+        x
+      </ToolbarLabel>
+    );
+    const cls = container.firstElementChild?.className ?? "";
+    expect(cls).toContain("ml-1");
+    expect(cls).toContain("sr-only");
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryForm/toolbar-density.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/toolbar-density.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+/**
+ * toolbar-density — how the document toolbar gives up width as it narrows.
+ *
+ * The header row holds a title that should grow and a cluster of actions that
+ * should not shrink. With nothing yielding, the title is simply whatever is
+ * left: measured on `main`, it came to `row - 598px`, which is 34px at a
+ * 1280-wide window and 0 at 900. The document's own name, in the field an
+ * author types it into, disappeared before any action did.
+ *
+ * So the actions yield first, in priority order — the standard toolbar answer:
+ * a label drops to its icon before the control drops out, and the primary
+ * action never gives up anything.
+ *
+ * Two properties make this safe to do in CSS alone:
+ *
+ * - The query is on the TOOLBAR'S OWN width, not the viewport and not the
+ *   content column. Those disagree here — the rail is 320px wide and hides at
+ *   its own breakpoint, so one viewport width produces two different row
+ *   widths. Only the row knows how much room the row has.
+ * - A collapsed label becomes `sr-only` rather than being removed, so the
+ *   control keeps its accessible name. The button reads identically to a screen
+ *   reader at every width; only the pixels go.
+ *
+ * @module components/features/entries/EntryForm/toolbar-density
+ */
+
+import type { ReactNode } from "react";
+
+import { cn } from "@admin/lib/utils";
+
+/**
+ * Marks an element as the toolbar whose width the labels below respond to.
+ *
+ * Exported rather than written inline so the container and the queries against
+ * it cannot drift apart: a renamed container with the labels left behind fails
+ * silently, because a container query with no matching container simply never
+ * matches and every label stays at full width.
+ */
+export const TOOLBAR_CONTAINER = "@container/toolbar";
+
+/**
+ * How early a label gives up its width.
+ *
+ * - `secondary` — supporting actions (preview, share a link). First to go, at
+ *   48rem, because they are the ones an author is least often reaching for
+ *   while typing a title.
+ * - `lifecycle` — publish and unpublish. Held longer, to 42rem: these change
+ *   what readers can see, so their words are worth more room than a preview's.
+ *
+ * The primary action (Save / Create) is deliberately absent. It never collapses
+ * at any width — a toolbar that hides the thing it exists for has optimised the
+ * wrong side.
+ */
+export type ToolbarLabelPriority = "secondary" | "lifecycle";
+
+/**
+ * Thresholds are read against the toolbar's CONTENT box, which is 48px narrower
+ * than the row (`px-6`). They were chosen by measuring the widest cluster the
+ * editor actually builds — a localized, publishable, previewable entry — and
+ * requiring that the title keep its floor without the row overflowing:
+ *
+ *   cluster + title-floor + padding + gap <= row
+ *
+ * At a 632px row that leaves 412px for the cluster, and the localized cluster
+ * is 442px until publish gives up its word.
+ */
+const COLLAPSE_AT: Record<ToolbarLabelPriority, string> = {
+  secondary: "@max-3xl/toolbar:sr-only",
+  lifecycle: "@max-2xl/toolbar:sr-only",
+};
+
+export interface ToolbarLabelProps {
+  priority: ToolbarLabelPriority;
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * A control's words, which step aside for its icon when the toolbar is tight.
+ *
+ * Wrap the TEXT, never the icon: the icon is what remains, and a control that
+ * collapses to nothing has been hidden rather than condensed. Give any button
+ * using this a `title` too, so a sighted reader can still name it once the
+ * label is only spoken.
+ */
+export function ToolbarLabel({
+  priority,
+  children,
+  className,
+}: ToolbarLabelProps) {
+  return (
+    <span className={cn(COLLAPSE_AT[priority], className)}>{children}</span>
+  );
+}


### PR DESCRIPTION
## The defect

The document title input collapses to nothing at common window widths, on **every** collection.

It was a `flex-1` beside an action cluster marked `shrink-0`, so it received whatever was left. Measured on `main`, the relationship is exact:

```
title width = row width − 598px
```

| viewport | rail | row | **title** |
|---|---|---|---|
| 1512 | open | 864 | 266 |
| 1440 | open | 792 | 194 |
| 1366 | open | 718 | 120 |
| **1280** | open | 632 | **34** |
| 1200 | hidden | 808 | 210 |
| **1024** | hidden | 632 | **34** |
| **900** | open | 580 | **0** |

Not an edge case: 1280 and 1366 are ordinary laptop widths. The rail toggling at 1200 is what makes the sequence look non-monotonic — it returns 320px to the row.

**It reproduces on a non-localized collection** (Posts: 34px at 1280), so this is general header behaviour, not an i18n surface. That control is what moved it out of the T-07 lane and into its own PR.

## The fix

Actions yield before the title does — the standard priority-toolbar answer, done in CSS.

```
wide    [Title...............] [⏱] [Copy shareable link] [Save changes] [Unpublish] [⋯] [▤]
medium  [Title...............] [⏱] [🔗] [Save changes] [Unpublish] [⋯] [▤]
narrow  [Title...............] [⏱] [🔗] [Save changes] [👁] [⋯] [▤]
```

`toolbar-density` owns the container name and both thresholds, so the row and the labels cannot drift apart — a renamed container with the queries left behind fails *silently*, since a container query with no matching container simply never matches.

Two decisions worth calling out:

**The queries read the toolbar's own width**, not the viewport's and not the content column's. Those genuinely disagree here: the rail is 320px and hides at its own breakpoint, so one window width produces two different toolbar widths. Only the row knows what the row has.

**A collapsed label becomes `sr-only`, never removed.** The control keeps the accessible name it had at full width. Verified in the browser — at 1280, "Copy shareable link" is 185px → 50px with its accessible name unchanged, and `Save changes` holds 125px at every width because the primary action never collapses.

## Measured after

Both a localized (Authors) and a non-localized (Posts) collection, twelve widths from 1512 to 720, plus a single:

- title stays between **160 and 346px** — 24/24 measurements pass
- the row **never overflows** at any width
- worst cases: Posts 1280 `34 → 224`, Authors 1024 `0 → 202`, Authors 900 `0 → 160`
- the wide case is untouched: Authors 1512 stays 227px with every label intact

Also verified: `sr-only` genuinely applies (`position: absolute`, 1×1px, `clip: inset(50%)`), and — because `PreviewActions` is also used in the embedded form footer, which has no toolbar container — that a label with **no** container ancestor stays fully visible even in a 200px host. The safe default holds, so the embedded form is unaffected.

## Tests

`toolbar-density.test.tsx` pins what would silently break the mechanism: the container name, that a collapsed label keeps its text, and that secondary collapses before lifecycle. jsdom evaluates no CSS, so it deliberately does not claim to test visual collapse — that is the browser measurement above, and the file says so.

All three stub-verified. One of them caught a flaw in my own test first: the accessible-name assertion originally passed with the label removed entirely, because the button's `title` supplied the name. The test now omits `title` so the label's own text is the only thing that can satisfy it.

Gates: `check-types` 0, `lint` 0, admin suite 252 files / 2266 tests with no new failures against the pre-existing 4-file baseline.
