### PR TITLE
fix(admin): wrap the document header instead of overflowing it on a phone

### DIFF
--- a/.changeset/toolbar-wraps-on-phones.md
+++ b/.changeset/toolbar-wraps-on-phones.md
@@ -1,0 +1,39 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The document header no longer overflows on a phone.
+
+Collapsing labels recovered enough width for the title down to about 540px, and
+below that there is simply not enough room for a title and a row of controls
+side by side: even with every label already reduced to its icon the cluster
+needs around 370px, against 294px of usable width on a 390px screen.
+
+So below 32rem the header wraps instead. The title takes its own line and the
+controls sit beneath it, wrapping among themselves rather than running off the
+edge. Nothing is hidden and nothing is clipped; the header is taller on a phone,
+which is the dimension a phone has to spare.

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -381,9 +381,24 @@ export function EntrySystemHeader({
       : ((entry?.slug as string | undefined) ?? null);
 
   return (
-    <div className="sticky top-0 z-30 bg-background border-b border-border">
+    <div
+      className={cn(
+        TOOLBAR_CONTAINER,
+        "sticky top-0 z-30 bg-background border-b border-border"
+      )}
+    >
+      {/* The row WRAPS on a phone rather than overflowing. Even with every label
+        collapsed the cluster needs about 370px, which does not fit beside a
+        title on a 390px screen — so below that the title takes its own line and
+        the actions sit beneath it, which is what vertical space is for.
+
+        The container declaration sits on the PARENT because an element cannot
+        query its own width, and this row now responds to that width itself. */}
       <div
-        className={cn(TOOLBAR_CONTAINER, "px-6 py-3 flex items-center gap-3")}
+        className={cn(
+          "px-6 py-3 flex items-center gap-3",
+          "@max-lg/toolbar:flex-wrap @max-lg/toolbar:gap-y-2"
+        )}
       >
         {/* Title input — borderless, 19px, autofocus on create.
 
@@ -391,7 +406,7 @@ export function EntrySystemHeader({
           that never shrank, the title was whatever was left over, and at common
           window widths that was nothing. It now keeps a readable minimum and the
           actions collapse around it (see `toolbar-density`). */}
-        <div className="flex-1 min-w-[10rem]">
+        <div className="flex-1 min-w-[10rem] @max-lg/toolbar:basis-full">
           <input
             {...rhfRegister}
             ref={el => {
@@ -419,7 +434,22 @@ export function EntrySystemHeader({
         </div>
 
         {/* Action cluster — right-aligned */}
-        <div className="flex items-center gap-1.5 shrink-0">
+        {/* Wraps on a phone for the same reason the row does: with every label
+          already collapsed the controls still need more width than the screen
+          has, and a cluster that cannot wrap pushes them off the edge instead.
+
+          `basis-full` is what makes the wrap real. Sized to its content the
+          cluster is always exactly as wide as its widest possible line, so
+          `flex-wrap` alone had nothing to wrap against; taking the whole line
+          first gives it a width to break inside. Right-aligned so the wrapped
+          controls still read as one group. */}
+        <div
+          className={cn(
+            "flex items-center gap-1.5 shrink-0",
+            "@max-lg/toolbar:basis-full @max-lg/toolbar:min-w-0",
+            "@max-lg/toolbar:flex-wrap @max-lg/toolbar:justify-end @max-lg/toolbar:gap-y-2"
+          )}
+        >
           {toolbarSlot}
           {/* A document only has history once it has been saved, and rendering a
             snapshot needs the schema, so both are required to offer this. */}


### PR DESCRIPTION
Follow-up to #1015, addressing the review finding left on it.

## The finding, and what was actually true

Greptile flagged a P1 on #1015: the new 10rem title floor combines with the non-wrapping cluster and overflows at mobile widths.

The overflow is real. The attribution is not — so I measured both arms on the same fixture, same widths, CSS rebuilt each time:

| viewport | before #1015 | after #1015 |
|---|---|---|
| 900 | title 0, needs 613px — **overflows** | title 160, needs 580px — fits |
| 640 | title 0, needs 613px — **overflows** | title 162, needs 592px — fits |
| 390 | title 0, needs 613px — **overflows** | title 160, needs 566px — **overflows** |

The header already overflowed on phones before #1015, and by more. #1015 removed it at 900 and 640 and reduced it at 390. It did not introduce it.

But the finding points at something real that #1015 left unfixed, so this fixes it.

## Why no arrangement fits

At 390px the row has 342px, of which 294px is usable after padding. With every label already collapsed to its icon the cluster still needs ~370px:

```
[⏱ 34] [🔗 50] [Save changes 125] [👁 48] [⋯ 34] [▤ 34] + gaps = 370
```

There is no side-by-side layout that fits a title beside that. So below 32rem the header wraps: the title takes its own line, the controls sit beneath it and wrap among themselves. Taller on a phone, which is the dimension a phone has to spare, and nothing is hidden or clipped.

## Two things that were not obvious

**The container declaration moved to the sticky wrapper.** An element cannot query its own width, and the row now has to respond to that width itself.

**`basis-full` on the cluster is what makes its wrap real.** My first attempt added `flex-wrap` to the cluster and changed nothing — measured, still overflowing at 430 and below. A flex item sized to its content is always exactly as wide as its widest possible line, so `flex-wrap` had nothing to break against. Taking the whole line first gives it a width to wrap inside.

## Verified

Three document kinds (localized collection, non-localized collection, single) × nine widths from 1512 to 320 — **27/27 pass**: title ≥ 150px, row never overflows, page never scrolls sideways.

The checker itself was wrong the first time and reported 27/27 *failures* on passing data — an escaped-quote mismatch in the grep. It now carries a positive control asserting it both accepts `ok:true` and rejects `ok:false`, run before the sweep.

Header height on the wrapped tier: 96px at 540, 140px at 430 and below. 60px everywhere above, unchanged.

Gates: `check-types` 0, `lint` 0, `EntryForm` suite 152 passed.
