### PR TITLE
feat(builder): name and lock a block from the inspector

### DIFF
--- a/.changeset/name-and-lock-a-block.md
+++ b/.changeset/name-and-lock-a-block.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Blocks can be named and locked from the page builder inspector. A name replaces the block type
+wherever the editor refers to that block — the layers panel, the ancestor breadcrumb and the
+spoken announcements — so a page with six headings no longer presents six identical rows. The lock
+checkbox sets the flag the editor already honours, so locking a block from here immediately stops
+it being moved or deleted. Clearing a name or releasing a lock removes the field rather than
+storing an empty value.

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+
+/**
+ * The inspector, driven through a host that renders it against a real editor.
+ *
+ * `inspector.ts` decides which controls a block offers and what op each edit
+ * produces, and asserts that without a DOM. What is only true HERE is the
+ * wiring: that an edit reaches `editor.apply` at the moment it should, and that
+ * a field showing a stored value follows that value when something else changes
+ * it.
+ *
+ * **Scoped to the identity fields.** `inspector-panel.tsx` had no test file at
+ * all before this one, so the prop controls below it remain uncovered — stated
+ * rather than implied, because a file that exists reads as a file that covers
+ * the module.
+ *
+ * @module inspector-panel.test
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+
+import {
+  clearBlocks,
+  hasBlock,
+  registerBlocks,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+
+import { InspectorPanel } from "./inspector-panel";
+import type { EditorState } from "./editor-state";
+
+afterEach(() => {
+  cleanup();
+  clearBlocks();
+});
+
+beforeAll(() => {
+  // Radix measures and scrolls; jsdom provides neither, and a missing one
+  // throws during render rather than failing an assertion.
+  const element = window.Element.prototype as unknown as Record<
+    string,
+    unknown
+  >;
+  element.scrollIntoView = function scrollIntoView(): void {};
+  (window as unknown as Record<string, unknown>).ResizeObserver =
+    class ResizeObserver {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    };
+});
+
+function register() {
+  if (hasBlock("acme/heading")) return;
+  registerBlocks(
+    [
+      {
+        name: "acme/heading",
+        version: 1,
+        description: "A heading.",
+        example: { props: {} },
+        editor: { label: "Heading" },
+        props: { text: { type: "text" } },
+        render: () => null,
+      },
+    ] as never,
+    { source: "inspector-panel-test" }
+  );
+}
+
+function documentOf(node: Partial<BlockNode>): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      { id: "a", type: "acme/heading", version: 1, props: {}, ...node },
+    ] as BlockNode[],
+  } as BlockDocument;
+}
+
+function editorFor(
+  document: BlockDocument
+): EditorState & { apply: ReturnType<typeof vi.fn> } {
+  return {
+    document,
+    selectedId: "a",
+    select: vi.fn(),
+    apply: vi.fn(() => document),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+    undoDepth: 0,
+  } as unknown as EditorState & { apply: ReturnType<typeof vi.fn> };
+}
+
+function mount(node: Partial<BlockNode> = {}) {
+  register();
+  const editor = editorFor(documentOf(node));
+  render(<InspectorPanel editor={editor} />);
+  return editor;
+}
+
+describe("InspectorPanel identity fields", () => {
+  it("shows the block's stored name and lock", () => {
+    mount({ name: "Hero title", locked: true });
+
+    expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe(
+      "Hero title"
+    );
+    // `data-state` rather than a `toBeChecked` matcher: this package does not
+    // register jest-dom, and the property form of that matcher is a no-op that
+    // reads as an assertion — it was in this test until it threw.
+    expect(
+      screen.getByLabelText("Lock this block").getAttribute("data-state")
+    ).toBe("checked");
+  });
+
+  it("renames on blur, through the store", () => {
+    // Through `editor.apply` rather than around it, so the rename is on the undo
+    // stack with every other edit.
+    const editor = mount();
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Hero title" },
+    });
+    expect(editor.apply).not.toHaveBeenCalled(); // not on every keystroke
+    fireEvent.blur(screen.getByLabelText("Name"));
+
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: { name: "Hero title" },
+    });
+  });
+
+  it("does not write when the name is unchanged", () => {
+    // Blur fires whenever focus leaves, including when an author clicks into
+    // the field and straight out of it. Writing there would put an op with no
+    // effect on the undo stack, so one press of undo would appear to do nothing.
+    const editor = mount({ name: "Hero title" });
+
+    fireEvent.blur(screen.getByLabelText("Name"));
+
+    expect(editor.apply).not.toHaveBeenCalled();
+  });
+
+  it("clears the name by unsetting the field", () => {
+    const editor = mount({ name: "Hero title" });
+
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "" } });
+    fireEvent.blur(screen.getByLabelText("Name"));
+
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: {},
+      unset: ["name"],
+    });
+  });
+
+  it("locks immediately, with no blur to wait for", () => {
+    // There is nothing to coalesce in a checkbox, and waiting would leave the
+    // canvas disagreeing with a control the author has already changed.
+    const editor = mount();
+
+    fireEvent.click(screen.getByLabelText("Lock this block"));
+
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: { locked: true },
+    });
+  });
+
+  it("unlocks by unsetting rather than storing false", () => {
+    const editor = mount({ locked: true });
+
+    fireEvent.click(screen.getByLabelText("Lock this block"));
+
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: {},
+      unset: ["locked"],
+    });
+  });
+
+  it("says nothing about identity when there is no selection", () => {
+    // The control for every case above: they would all pass against a panel
+    // that rendered the fields unconditionally, and this is the state the
+    // inspector spends most of its time in.
+    register();
+    const editor = editorFor(documentOf({}));
+    render(
+      <InspectorPanel
+        editor={{ ...editor, selectedId: null } as unknown as EditorState}
+      />
+    );
+
+    expect(screen.queryByLabelText("Name")).toBeNull();
+    expect(screen.queryByLabelText("Lock this block")).toBeNull();
+  });
+});

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -38,7 +38,14 @@ import {
 import * as React from "react";
 
 import type { EditorState } from "./editor-state";
-import { inspectSelection, propPatch, type EditableProp } from "./inspector";
+import {
+  inspectSelection,
+  lockOp,
+  propPatch,
+  renameOp,
+  type BlockIdentity,
+  type EditableProp,
+} from "./inspector";
 
 export interface InspectorPanelProps {
   /**
@@ -94,6 +101,24 @@ export function InspectorPanel({
   return (
     <div className="nx-inspector">
       <h2 className="nx-inspector__title">{inspection.label}</h2>
+
+      {/*
+        What the block IS, above what it holds.
+        
+        First because it answers "which block am I looking at" — a page with six
+        headings gives an author six identical inspector titles, and the name is
+        the only thing that tells them apart. Both fields are also the two the
+        layers panel already shows, so this is where that display gets a writer.
+      */}
+      <IdentityFields
+        // Keyed by node so the name input does not carry an uncommitted edit
+        // across a selection change, exactly as the prop fields are.
+        key={`${inspection.nodeId}:identity`}
+        nodeId={inspection.nodeId}
+        identity={inspection.identity}
+        editor={editor}
+      />
+
       {inspection.props.length === 0 ? (
         <p className="nx-inspector__note">
           This block has no editable properties.
@@ -112,6 +137,73 @@ export function InspectorPanel({
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * The block's own name and its lock.
+ *
+ * Applied through `editor.apply` like every other edit, so both are covered by
+ * undo — a rename an author regrets is one press away, and a lock is not a
+ * setting that sits outside the history everything else is in.
+ */
+function IdentityFields({
+  nodeId,
+  identity,
+  editor,
+}: {
+  nodeId: string;
+  identity: BlockIdentity;
+  editor: EditorState;
+}): React.JSX.Element {
+  const [draft, setDraft] = React.useState(identity.name);
+
+  // The stored name wins whenever it changes underneath the field — an undo, or
+  // a rename applied from somewhere else. Without this the input would go on
+  // showing a name the document no longer has.
+  React.useEffect(() => {
+    setDraft(identity.name);
+  }, [identity.name]);
+
+  const commitName = () => {
+    if (draft.trim() === identity.name) return;
+    editor.apply(renameOp(nodeId, draft));
+  };
+
+  return (
+    <div className="nx-inspector__fields nx-inspector__identity">
+      <div className="nx-inspector__field">
+        <Label htmlFor="nx-block-name">Name</Label>
+        <Input
+          id="nx-block-name"
+          value={draft}
+          placeholder="Unnamed"
+          onChange={event => setDraft(event.target.value)}
+          // Committed on blur and on Enter, matching the text props below: an
+          // op per keystroke would make one undo remove one letter.
+          onBlur={commitName}
+          onKeyDown={event => {
+            if (event.key !== "Enter") return;
+            event.preventDefault();
+            commitName();
+          }}
+        />
+      </div>
+
+      <div className="nx-inspector__field nx-inspector__field--inline">
+        <Checkbox
+          id="nx-block-locked"
+          checked={identity.locked}
+          // Immediately, with no blur to wait for. There is nothing to coalesce
+          // in a checkbox, and waiting would leave the canvas disagreeing with a
+          // control the author has already changed.
+          onCheckedChange={checked =>
+            editor.apply(lockOp(nodeId, checked === true))
+          }
+        />
+        <Label htmlFor="nx-block-locked">Lock this block</Label>
+      </div>
     </div>
   );
 }

--- a/packages/builder/src/inspector.test.ts
+++ b/packages/builder/src/inspector.test.ts
@@ -16,7 +16,13 @@ import {
   type BlockNode,
 } from "@nextlyhq/blocks-engine";
 
-import { inspectSelection, propPatch, SUPPORTED_PROP_TYPES } from "./inspector";
+import {
+  inspectSelection,
+  lockOp,
+  propPatch,
+  renameOp,
+  SUPPORTED_PROP_TYPES,
+} from "./inspector";
 
 const base = {
   version: 1,
@@ -219,5 +225,91 @@ describe("propPatch", () => {
     propPatch(node, "text", "New");
 
     expect(node.props.text).toBe("Old");
+  });
+});
+
+describe("block identity", () => {
+  it("reports the author's name and the lock, and their absence", () => {
+    // Both fields are optional and absent on every document written before they
+    // existed, so "absent" is the common case rather than the edge one.
+    const named = inspectSelection(withHeading(), "a");
+    expect(named?.identity).toEqual({ name: "", locked: false });
+  });
+
+  it("carries a name and a lock the node does have", () => {
+    registerBlocks(
+      [{ ...base, name: "acme/thing", editor: { label: "Thing" } }] as never,
+      { source: "inspector-test" }
+    );
+    const inspection = inspectSelection(
+      documentOf([
+        {
+          id: "t",
+          type: "acme/thing",
+          version: 1,
+          props: {},
+          name: "Hero title",
+          locked: true,
+        } as BlockNode,
+      ]),
+      "t"
+    );
+
+    expect(inspection?.identity).toEqual({ name: "Hero title", locked: true });
+  });
+});
+
+describe("renameOp", () => {
+  it("sets a trimmed name", () => {
+    expect(renameOp("a", "  Hero title  ")).toEqual({
+      kind: "update",
+      id: "a",
+      patch: { name: "Hero title" },
+    });
+  });
+
+  it("UNSETS the field for an empty name rather than storing one", () => {
+    // THE case. `""` stored is a second spelling of "no name": absent is what
+    // the optional field already means, and `layerLabel` would have to know
+    // about both to avoid rendering a blank row.
+    expect(renameOp("a", "")).toEqual({
+      kind: "update",
+      id: "a",
+      patch: {},
+      unset: ["name"],
+    });
+  });
+
+  it("treats a name of only spaces as no name", () => {
+    // The same thing wearing a disguise: it passes a non-empty check, renders
+    // as nothing, and cannot be reached by the layers panel's typeahead.
+    expect(renameOp("a", "   ")).toEqual({
+      kind: "update",
+      id: "a",
+      patch: {},
+      unset: ["name"],
+    });
+  });
+});
+
+describe("lockOp", () => {
+  it("locks by setting the flag", () => {
+    expect(lockOp("a", true)).toEqual({
+      kind: "update",
+      id: "a",
+      patch: { locked: true },
+    });
+  });
+
+  it("UNSETS on release rather than storing false", () => {
+    // `locked` is absent on every node in every document written so far, so
+    // storing `false` would make an unlock a WRITE to every block an author
+    // touches, adding a field that means what its absence already meant.
+    expect(lockOp("a", false)).toEqual({
+      kind: "update",
+      id: "a",
+      patch: {},
+      unset: ["locked"],
+    });
   });
 });

--- a/packages/builder/src/inspector.ts
+++ b/packages/builder/src/inspector.ts
@@ -24,7 +24,7 @@ import {
 } from "@nextlyhq/blocks-engine";
 
 import { blockLabel } from "./inserter";
-import type { NodePatch } from "./ops";
+import type { BuilderOp, NodePatch } from "./ops";
 
 /**
  * The prop types this inspector can draw a control for.
@@ -64,10 +64,27 @@ export interface EditableProp {
   readonly options: readonly string[];
 }
 
+/**
+ * What a block is, as distinct from what it holds.
+ *
+ * `name` and `locked` are fields on the NODE rather than entries in `props`, so
+ * no `PropSchema` describes them and the prop loop below cannot reach them.
+ * They are also the two the layers panel already displays — and until this
+ * existed, nothing in the editor could set either, so the panel showed
+ * information the editor had no way to produce.
+ */
+export interface BlockIdentity {
+  /** The author's own name for this instance, empty when they have not given one. */
+  readonly name: string;
+  readonly locked: boolean;
+}
+
 /** The selected block, as something to edit. */
 export interface BlockInspection {
   readonly nodeId: string;
   readonly blockName: string;
+  /** What the block IS, beside what it holds. */
+  readonly identity: BlockIdentity;
   /** What to title the panel: the block's label, or its name. */
   readonly label: string;
   /**
@@ -132,6 +149,7 @@ export function inspectSelection(
   return {
     nodeId: node.id,
     blockName: node.type,
+    identity: { name: node.name ?? "", locked: node.locked === true },
     // The same name the palette offered and the layers panel shows. Reading
     // `editor.label ?? node.type` here instead was a second rule that agreed
     // only for blocks which declare a label: an unlabelled third-party block
@@ -159,4 +177,38 @@ export function propPatch(
   value: unknown
 ): NodePatch {
   return { props: { ...node.props, [name]: value } };
+}
+
+/**
+ * The op that names a block, or takes its name away.
+ *
+ * An empty name UNSETS the field rather than storing `""`. The field is
+ * optional, so absent is what "no name" already means everywhere else — a
+ * stored empty string would be a second spelling of the same state, and
+ * `layerLabel` would have to know about both to avoid rendering a blank row.
+ *
+ * Trimmed, because a name of spaces is the same thing wearing a disguise: it
+ * satisfies a non-empty check, renders as nothing, and cannot be typed to in
+ * the layers panel's typeahead.
+ */
+export function renameOp(id: string, name: string): BuilderOp {
+  const trimmed = name.trim();
+  return trimmed === ""
+    ? { kind: "update", id, patch: {}, unset: ["name"] }
+    : { kind: "update", id, patch: { name: trimmed } };
+}
+
+/**
+ * The op that locks a block, or releases it.
+ *
+ * Unlocking UNSETS rather than storing `false`, for the reason above and one
+ * more: `locked` is absent on every node in every document written so far, so
+ * storing `false` on release would make an unlock a WRITE to every block an
+ * author ever touched, and the documents would grow a field that means what
+ * their absence already meant.
+ */
+export function lockOp(id: string, locked: boolean): BuilderOp {
+  return locked
+    ? { kind: "update", id, patch: { locked: true } }
+    : { kind: "update", id, patch: {}, unset: ["locked"] };
 }

--- a/packages/builder/src/keyboard-actions.test.tsx
+++ b/packages/builder/src/keyboard-actions.test.tsx
@@ -453,6 +453,55 @@ describe("useBlockKeyboardActions", () => {
     expect(said).toContain("Undo");
   });
 
+  it("names a block by the name its author gave it", () => {
+    // The layers panel and the breadcrumb both show the instance name, so the
+    // one surface a screen-reader user HEARS must not be the only one still
+    // calling the block by its type.
+    const editor = editorSpy(
+      documentOf([
+        {
+          id: "a",
+          type: "acme/text",
+          version: 1,
+          props: {},
+          name: "Hero title",
+        },
+        { id: "b", type: "acme/text", version: 1, props: {} },
+      ] as BlockDocument["nodes"]),
+      "a"
+    );
+    mount(editor);
+
+    press("Delete");
+
+    expect(screen.getByRole("status").textContent ?? "").toContain(
+      "Hero title deleted"
+    );
+  });
+
+  it("names a LOCKED block by its author's name too", () => {
+    const editor = editorSpy(
+      documentOf([
+        {
+          id: "a",
+          type: "acme/text",
+          version: 1,
+          props: {},
+          name: "Hero title",
+          locked: true,
+        },
+      ] as BlockDocument["nodes"]),
+      "a"
+    );
+    mount(editor);
+
+    press("Delete");
+
+    expect(screen.getByRole("status").textContent ?? "").toContain(
+      "Hero title is locked"
+    );
+  });
+
   it("refuses to delete a locked block, and says why", () => {
     /*
      * A lock is a POLICY refusal, so it is announced where a structural one is

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -20,17 +20,18 @@
  * @module keyboard-actions
  */
 
+import { findNode } from "@nextlyhq/blocks-engine";
 import { useShortcuts } from "@nextlyhq/ui";
 import * as React from "react";
 
 import { blockDeletion } from "./delete-block";
 import type { EditorState } from "./editor-state";
-import { blockLabel } from "./inserter";
 import {
   keyboardMovePosition,
   type MoveDirection,
   type MoveEffect,
 } from "./keyboard-move";
+import { layerLabel } from "./layers";
 import { lockBlockingDelete, lockBlockingMove } from "./locking";
 
 /**
@@ -105,14 +106,16 @@ const EFFECT_ANNOUNCEMENT: Readonly<Record<MoveEffect, string>> = {
  * becomes a keystroke — protecting nobody while costing everybody. That trade
  * only holds because undo is reachable, which is why these ship together.
  */
-function deletionAnnouncement(type: string, descendants: number): string {
-  // The block's own label, falling back to its type. An author who inserted
-  // "Divider" from the palette should hear "Divider deleted", not
-  // "core/divider deleted" — the identifier is what the registry calls it, and
-  // the label is what they were shown. Resolved here rather than carried on the
-  // deletion, because the deletion is a document fact and the wording is a
-  // presentation one.
-  const name = blockLabel(type);
+/**
+ * @param name - what to CALL the block, already resolved by the caller.
+ *
+ * A resolved name rather than a type, so the one rule that decides what a block
+ * is called lives in `layerLabel` and this only phrases it. Taking a type and
+ * resolving here would put a second resolution in the one surface a
+ * screen-reader user hears — and it would have to reach for `blockLabel`, which
+ * knows nothing about the name the author gave this instance.
+ */
+function deletionAnnouncement(name: string, descendants: number): string {
   const what =
     descendants === 0
       ? `${name} deleted`
@@ -203,8 +206,8 @@ export function useBlockKeyboardActions({
     if (blocked !== undefined) {
       announce(
         blocked.id === deletion.id
-          ? `${blockLabel(blocked.type)} is locked. Unlock it to delete it.`
-          : `This block contains ${blockLabel(blocked.type)}, which is locked. Unlock it to delete.`
+          ? `${layerLabel(blocked)} is locked. Unlock it to delete it.`
+          : `This block contains ${layerLabel(blocked)}, which is locked. Unlock it to delete.`
       );
       return;
     }
@@ -220,7 +223,20 @@ export function useBlockKeyboardActions({
     // first would leave the author pointed at a neighbour while the block they
     // asked to delete is still there.
     editorNow.select(deletion.nextSelection);
-    announce(deletionAnnouncement(deletion.type, deletion.descendantCount));
+    /*
+     * Named the way the layers panel and the breadcrumb name it.
+     *
+     * `blockLabel(type)` would say "Heading" for a block the author called
+     * "Hero title", so the one surface a screen-reader user hears would be the
+     * only one using a different name for the same block.
+     */
+    const removed = findNode(editorNow.document.nodes, deletion.id);
+    announce(
+      deletionAnnouncement(
+        removed === undefined ? deletion.type : layerLabel(removed),
+        deletion.descendantCount
+      )
+    );
   }, [announce]);
 
   const bindings = React.useMemo(
@@ -250,7 +266,7 @@ export function useBlockKeyboardActions({
           const lockedNode = lockBlockingMove(editorNow.document, selectedId);
           if (lockedNode !== undefined) {
             announce(
-              `${blockLabel(lockedNode.type)} is locked. Unlock it to move it.`
+              `${layerLabel(lockedNode)} is locked. Unlock it to move it.`
             );
             return;
           }

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -553,3 +553,17 @@
   color: var(--nx-builder-text);
   font-weight: 500;
 }
+
+/*
+ * The block's own identity, separated from its properties by a rule.
+ *
+ * A divider rather than a heading: the section holds two fields and a heading
+ * above them would be as tall as the fields themselves. The separation matters
+ * because the two groups answer different questions — what this block IS, and
+ * what it HOLDS — and without a break they read as one list in which "Name"
+ * looks like another prop.
+ */
+.nx-inspector__identity {
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--nx-builder-border);
+}


### PR DESCRIPTION
The layers panel **displays** a block's name and its lock. Nothing in the editor could **set** either — so the panel showed information the editor had no way to produce. This is the writer for both, and it completes the loop #1013 and #1016 started.

## Where they live, and why not the layers row

Plan 04's B-13 says "explicit-gesture rename; hover eye+lock", which reads as controls in the row. I put them in the **inspector** instead:

- A control inside a `role="treeitem"` complicates the roving-tabindex model `TreeView` owns, and that component's accessibility is the half most likely to rot if fought.
- The inspector already answers "change the selected block", and these *are* block-level properties.
- The panel reflects the result immediately anyway, because it reads the same document. Gutenberg puts block name and lock in the inspector for the same reason.

## Clearing UNSETS rather than storing a falsy value

Both fields are optional, so absent is already what "no name" and "not locked" mean everywhere else. Storing `""` or `false` would create **two spellings of one state**, and `layerLabel` would have to know about both to avoid rendering a blank row.

Releasing a lock by writing `false` has a second cost: `locked` is absent on every node in every document written so far, so an unlock would become a **write to every block an author ever touches**, adding a field that means what its absence already meant.

A name is trimmed — a name of spaces passes a non-empty check, renders as nothing, and cannot be reached by the panel's typeahead.

## A drift I reintroduced this morning and have now removed

The announcements were still calling a block by its **type** while the panel and breadcrumb used the name its author gave it:

```
layers:       "Hero title"
breadcrumb:   "Hero title"
announcement: "Heading is locked. Unlock it to move it."     ← the only one out of step
```

That is exactly the drift `blockLabel` was extracted to remove, reappearing one layer up — and the announcement is the **one surface a screen-reader user hears**. `deletionAnnouncement` now takes a resolved name rather than a type, so the rule stays in `layerLabel` instead of gaining a second resolution inside the phrasing.

## Verified end to end

```
rename in the inspector  →  layers ["Hero title","Text"]   breadcrumb ["Hero title"]
lock in the inspector    →  layers ["Hero titleLocked","Text"]
alt+Down  → refused | "Hero title is locked. Unlock it to move it."
Delete    → refused | "Hero title is locked. Unlock it to delete it."
unlock    → moves again | "Block moved"
pageerrors: []
```

## Tests

636 in `@nextlyhq/builder` (was 620), 61 in `plugin-page-builder`, 30/30 tasks. Four stub-verifications on the unset and trim rules, each failing exactly its intended tests.

**`inspector-panel.tsx` had no test file at all.** This adds one, **scoped to the identity fields and saying so in its header** — the prop controls below remain uncovered, and a file that exists otherwise reads as a file that covers the module.

One thing worth flagging from writing it: my first version of the "shows the stored lock" case contained `expect(...).toBeChecked;` — the property form, which asserts nothing. It threw because this package does not register jest-dom, which is the only reason I noticed. A no-op assertion that happened to be valid syntax would have shipped as coverage.
