### PR TITLE
fix(admin): make the toolbar thresholds carry the rows' padding

### DIFF
--- a/.changeset/toolbar-thresholds-carry-the-padding.md
+++ b/.changeset/toolbar-thresholds-carry-the-padding.md
@@ -1,0 +1,41 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The document header's labels collapse at the width they were calibrated for.
+
+The density thresholds were measured against the toolbar row, which carries its
+own horizontal padding. The container they are queried against then moved to the
+header's sticky wrapper, which has none — so each query saw a box 48px wider
+than the space actually available, and every label held on 48px longer than
+intended.
+
+The effect was measurable rather than theoretical: at a 792px row the labels
+stayed at full width, leaving the title pinned to its minimum with no slack,
+where collapsing them gives it 290px.
+
+The thresholds now carry that padding explicitly.

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/toolbar-density.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/toolbar-density.test.tsx
@@ -65,12 +65,36 @@ describe("ToolbarLabel", () => {
 
     expect(cls(secondary)).toContain("/toolbar:sr-only");
     expect(cls(lifecycle)).toContain("/toolbar:sr-only");
-    // Tailwind's `@max-*` scale ascends, so the secondary label's breakpoint
-    // must be the LARGER one for it to collapse first.
-    const rank = ["xs", "sm", "md", "lg", "xl", "2xl", "3xl", "4xl", "5xl"];
-    const stepOf = (c: string) =>
-      rank.indexOf(c.replace(/^@max-/, "").replace(/\/toolbar:sr-only$/, ""));
-    expect(stepOf(cls(secondary))).toBeGreaterThan(stepOf(cls(lifecycle)));
+
+    // Compared as WIDTHS rather than as positions on Tailwind's named scale.
+    // The thresholds are deliberately arbitrary values — they carry the rows'
+    // horizontal padding, which no named step accounts for — so a rank lookup
+    // over `sm`/`md`/`lg` cannot read them and would report a false ordering.
+    const remOf = (c: string) => {
+      const arbitrary = /@max-\[(\d+(?:\.\d+)?)rem\]/.exec(c);
+      if (arbitrary) return Number(arbitrary[1]);
+      const named: Record<string, number> = {
+        xs: 20,
+        sm: 24,
+        md: 28,
+        lg: 32,
+        xl: 36,
+        "2xl": 42,
+        "3xl": 48,
+        "4xl": 56,
+        "5xl": 64,
+      };
+      const step = /@max-([a-z0-9]+)\//.exec(c)?.[1] ?? "";
+      const value = named[step];
+      if (value === undefined) {
+        throw new Error(`unreadable toolbar threshold: ${c}`);
+      }
+      return value;
+    };
+
+    // `@max-*` applies BELOW its value, so the label that collapses first is the
+    // one with the LARGER threshold.
+    expect(remOf(cls(secondary))).toBeGreaterThan(remOf(cls(lifecycle)));
   });
 
   it("passes extra classes through without dropping the collapse rule", () => {

--- a/packages/admin/src/components/features/entries/EntryForm/toolbar-density.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/toolbar-density.tsx
@@ -43,11 +43,11 @@ export const TOOLBAR_CONTAINER = "@container/toolbar";
 /**
  * How early a label gives up its width.
  *
- * - `secondary` — supporting actions (preview, share a link). First to go, at
- *   48rem, because they are the ones an author is least often reaching for
- *   while typing a title.
- * - `lifecycle` — publish and unpublish. Held longer, to 42rem: these change
- *   what readers can see, so their words are worth more room than a preview's.
+ * - `secondary` — supporting actions (preview, share a link). First to go,
+ *   because they are the ones an author is least often reaching for while
+ *   typing a title.
+ * - `lifecycle` — publish and unpublish. Held longer: these change what readers
+ *   can see, so their words are worth more room than a preview's.
  *
  * The primary action (Save / Create) is deliberately absent. It never collapses
  * at any width — a toolbar that hides the thing it exists for has optimised the
@@ -56,19 +56,31 @@ export const TOOLBAR_CONTAINER = "@container/toolbar";
 export type ToolbarLabelPriority = "secondary" | "lifecycle";
 
 /**
- * Thresholds are read against the toolbar's CONTENT box, which is 48px narrower
- * than the row (`px-6`). They were chosen by measuring the widest cluster the
- * editor actually builds — a localized, publishable, previewable entry — and
- * requiring that the title keep its floor without the row overflowing:
+ * Thresholds are the ROW'S OUTER width, and the arbitrary values are the reason
+ * this note exists rather than a tidy `@max-3xl`.
+ *
+ * The container is declared on the header's sticky wrapper, which has no
+ * padding of its own, so a query against it measures the row's full width. The
+ * rows carry `px-6` themselves — they must, because the language row's top
+ * border has to span the header rather than sit inset — so the space actually
+ * available to the title and the actions is 48px less than what the query sees.
+ *
+ * These numbers therefore carry that 48px explicitly. They were chosen by
+ * measuring the widest cluster the editor builds — a localized, publishable,
+ * previewable entry — and requiring the title to keep its floor without the row
+ * overflowing:
  *
  *   cluster + title-floor + padding + gap <= row
  *
- * At a 632px row that leaves 412px for the cluster, and the localized cluster
- * is 442px until publish gives up its word.
+ * A round `3rem`-smaller threshold reads tidier and is wrong by exactly the
+ * padding: at a 792px row it leaves the labels at full width, the title pinned
+ * to its 10rem floor, and the row with no slack at all.
  */
 const COLLAPSE_AT: Record<ToolbarLabelPriority, string> = {
-  secondary: "@max-3xl/toolbar:sr-only",
-  lifecycle: "@max-2xl/toolbar:sr-only",
+  // 48rem of usable width + 3rem of padding.
+  secondary: "@max-[51rem]/toolbar:sr-only",
+  // 42rem of usable width + 3rem of padding.
+  lifecycle: "@max-[45rem]/toolbar:sr-only",
 };
 
 export interface ToolbarLabelProps {


### PR DESCRIPTION
Follow-up to #1017, addressing the review finding left on it. Greptile was right.

## The finding

Moving `TOOLBAR_CONTAINER` to the unpadded sticky wrapper made the label-density queries measure a box 48px wider than the padded row they were calibrated against, so labels collapse later than intended.

## Confirmed by measurement, not by reading

Swept 30 widths on `main` hunting the worst case. It was the title pinned to its 10rem floor at a **792px row** — a width with plenty of room — with the cluster still at full 577px width because the secondary threshold had not yet fired.

| viewport | row | cluster | title |
|---|---|---|---|
| 1470 | 822 | 577 (full labels) | 185 |
| **1440** | **792** | **577 — should have collapsed** | **160 (floor)** |

After: at that same 792px row the cluster collapses to 442 and the title gets **290px**.

| viewport | row | cluster | title |
|---|---|---|---|
| 1470 | 822 | 577 (correctly above threshold) | 185 |
| 1440 | 792 | 442 | **290** |
| 1410 | 762 | 442 | 260 |
| 1380 | 732 | 442 | 230 |

Re-swept 34 widths from 1500 to 320: **no overflow anywhere**, and the narrowest title is now 160px at a 582px row — a width where the floor is the right answer — instead of at 792px, where it was not.

## Why the thresholds carry the padding instead of the container carrying it

The obvious repair is to move `px-6` onto the container so the two boxes agree. That is wrong here: the language row beneath shares the same wrapper, and its top border has to span the header rather than sit inset 24px on each side.

So the rows keep their padding and the thresholds carry it — `48rem + 3rem` and `42rem + 3rem`. That is why these are arbitrary values rather than a tidy `@max-3xl`, and the module now says so in as many words, because the next reader's instinct will be to "clean them up" and that would reintroduce exactly this bug.

## Test repair

The ordering test ranked thresholds against Tailwind's named scale (`sm`/`md`/`lg`), so it could not read an arbitrary value at all — it would have ranked `@max-[51rem]` as `-1` and reported a false ordering. It now compares the widths themselves and **throws** on a threshold it cannot parse rather than silently ranking it last.

Both stub-verified: inverting the order fails it, and an unreadable threshold fails it.

Gates: `check-types` 0, `lint` 0, toolbar suite 5 passed.
