### PR TITLE
feat(builder): duplicate a block

### DIFF
--- a/.changeset/duplicate-a-block.md
+++ b/.changeset/duplicate-a-block.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A block can be duplicated in the page builder with Cmd/Ctrl+D. The copy lands immediately after the
+original, in the same container, and becomes the selected block so the next edit goes to the copy
+rather than to the block it came from. A named block's copy is suffixed, so two of them can be told
+apart in the layers panel. The whole block is copied, including everything inside a container, and
+one undo removes it.

--- a/packages/builder/src/duplicate-block.test.ts
+++ b/packages/builder/src/duplicate-block.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Duplicating a block: the copy, and where it goes.
+ *
+ * The fixture that separates a correct duplication from a plausible one is a
+ * CONTAINER holding children. A copy that re-ids only the top node passes every
+ * single-block case and then gives the document two nodes sharing each child's
+ * id — after which an edit aimed at the copy lands on the original, silently,
+ * because every op addresses by id and takes the first match.
+ *
+ * @module duplicate-block.test
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  clearBlocks,
+  hasBlock,
+  registerBlocks,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+
+import { blockDuplication, COPY_SUFFIX } from "./duplicate-block";
+
+const base = {
+  version: 1,
+  description: "A block.",
+  example: { props: {} },
+  render: () => null,
+};
+
+afterEach(clearBlocks);
+
+function register() {
+  if (hasBlock("acme/heading")) return;
+  registerBlocks(
+    [
+      { ...base, name: "acme/heading", editor: { label: "Heading" } },
+      {
+        ...base,
+        name: "acme/box",
+        editor: { label: "Box" },
+        slots: { children: {} },
+      },
+    ] as never,
+    { source: "duplicate-test" }
+  );
+}
+
+function node(
+  id: string,
+  type: string,
+  extra: Partial<BlockNode> = {}
+): BlockNode {
+  return { id, type, version: 1, props: {}, ...extra } as BlockNode;
+}
+
+function documentOf(nodes: BlockNode[]): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+}
+
+/** Every id in a subtree, so uniqueness can be asserted rather than sampled. */
+function idsOf(node: BlockNode): string[] {
+  return [
+    node.id,
+    ...Object.values(node.slots ?? {})
+      .flat()
+      .flatMap(idsOf),
+  ];
+}
+
+describe("blockDuplication", () => {
+  it("places the copy immediately after the original", () => {
+    // Not at the end of the page. An author duplicating a card is building a row
+    // of them, and a copy appended elsewhere is one they then have to find.
+    register();
+    const document = documentOf([
+      node("a", "acme/heading"),
+      node("b", "acme/heading"),
+    ]);
+
+    expect(blockDuplication(document, "a")?.at).toEqual({ index: 1 });
+  });
+
+  it("keeps the copy in the original's parent and slot", () => {
+    register();
+    const document = documentOf([
+      node("box", "acme/box", {
+        slots: { children: [node("kid", "acme/heading")] },
+      }),
+    ]);
+
+    expect(blockDuplication(document, "kid")?.at).toEqual({
+      parentId: "box",
+      slot: "children",
+      index: 1,
+    });
+  });
+
+  it("re-ids the WHOLE subtree, not just the node", () => {
+    // THE case. Ids are the only thing this editor addresses by, so a copy that
+    // kept a child's id would give one id two nodes — and every op afterwards
+    // reaches whichever the walk finds first.
+    register();
+    const document = documentOf([
+      node("box", "acme/box", {
+        slots: {
+          children: [
+            node("kid", "acme/heading"),
+            node("box2", "acme/box", {
+              slots: { children: [node("deep", "acme/heading")] },
+            }),
+          ],
+        },
+      }),
+    ]);
+
+    const copy = blockDuplication(document, "box")?.node;
+    if (copy === undefined) throw new Error("expected a duplication");
+
+    const original = ["box", "kid", "box2", "deep"];
+    const copied = idsOf(copy);
+
+    // Same shape — the control, without which "no shared ids" would pass on a
+    // copy that dropped its children entirely.
+    expect(copied).toHaveLength(original.length);
+    expect(copied.filter(id => original.includes(id))).toEqual([]);
+    expect(new Set(copied).size).toBe(copied.length);
+  });
+
+  it("drops the DOM id, which two elements must not share", () => {
+    // `cssId` and `attributes.id` both become an HTML `id`, and two elements
+    // carrying one breaks every `getElementById` and every in-page anchor.
+    register();
+    const document = documentOf([
+      node("a", "acme/heading", {
+        cssId: "hero",
+        attributes: { id: "hero", "data-keep": "yes" },
+      }),
+    ]);
+
+    const copy = blockDuplication(document, "a")?.node;
+
+    expect(copy?.cssId).toBeUndefined();
+    expect(copy?.attributes).toEqual({ "data-keep": "yes" });
+  });
+
+  it("suffixes a name the author gave", () => {
+    // Two rows reading "Hero title" in the layers panel is the confusion naming
+    // exists to remove.
+    register();
+    const document = documentOf([
+      node("a", "acme/heading", { name: "Hero title" }),
+    ]);
+
+    expect(blockDuplication(document, "a")?.node.name).toBe(
+      `Hero title${COPY_SUFFIX}`
+    );
+  });
+
+  it("leaves an UNNAMED block's copy unnamed", () => {
+    // Inventing "Heading copy" would put a name on a block whose author never
+    // gave it one, and two rows reading "Heading" are what an author expects
+    // from two headings.
+    register();
+    const document = documentOf([node("a", "acme/heading")]);
+
+    expect(blockDuplication(document, "a")?.node.name).toBeUndefined();
+  });
+
+  it("carries the lock, so the copy is not quietly different", () => {
+    register();
+    const document = documentOf([node("a", "acme/heading", { locked: true })]);
+
+    expect(blockDuplication(document, "a")?.node.locked).toBe(true);
+  });
+
+  it("names the block for an announcement, by the author's name where there is one", () => {
+    register();
+    expect(
+      blockDuplication(
+        documentOf([node("a", "acme/heading", { name: "Hero title" })]),
+        "a"
+      )?.label
+    ).toBe("Hero title");
+    expect(
+      blockDuplication(documentOf([node("b", "acme/heading")]), "b")?.label
+    ).toBe("Heading");
+  });
+
+  it("refuses with no selection or an id the document lost", () => {
+    // An undo removing the selected node while the selection stands is routine,
+    // not exotic.
+    register();
+    const document = documentOf([node("a", "acme/heading")]);
+
+    expect(blockDuplication(document, null)).toBeNull();
+    expect(blockDuplication(document, "gone")).toBeNull();
+  });
+
+  it("copies props rather than sharing them", () => {
+    // A shallow copy would leave both blocks pointing at one props object, so
+    // editing the copy would change the original with nothing to show for it.
+    register();
+    const document = documentOf([
+      node("a", "acme/heading", { props: { text: "Hello" } }),
+    ]);
+
+    const copy = blockDuplication(document, "a")?.node;
+    const original = document.nodes[0];
+
+    expect(copy?.props).toEqual({ text: "Hello" });
+    expect(copy?.props).not.toBe(original?.props);
+  });
+});

--- a/packages/builder/src/duplicate-block.ts
+++ b/packages/builder/src/duplicate-block.ts
@@ -1,0 +1,124 @@
+/**
+ * Duplicating a block: the copy, and where it goes.
+ *
+ * The most-reached-for verb in a page builder after inserting one. An author
+ * builds a card the way they want it and then wants three of them, and without
+ * this the only route is to insert a fresh block and redo every property by
+ * hand — which is also how the second card ends up subtly different from the
+ * first.
+ *
+ * ## The copy is made by the ENGINE, not here
+ *
+ * `reidSubtree` mints a fresh id for the node and for everything inside it.
+ * That is not a detail: ids are the only thing this editor addresses by, so a
+ * copy that kept them would give one id two nodes, and every op afterwards
+ * would reach whichever the walk found first — an edit to the copy landing on
+ * the original, silently.
+ *
+ * It also drops `cssId` and any `attributes.id`, because those become DOM ids
+ * and two elements carrying one id is invalid HTML that breaks every
+ * `getElementById` and every in-page anchor. Both rules belong to what a COPY
+ * is rather than to what this command does, and restating either here would be
+ * a second opinion about the same question.
+ *
+ * ## What this decides, because the engine deliberately does not
+ *
+ * **Where it goes** — immediately after the original, in the same parent and
+ * slot. An author duplicating a card is building a row of them, and a copy
+ * appended to the end of the page is one they then have to go and find.
+ *
+ * **What it is called.** A name the author typed is theirs, and two rows
+ * reading "Hero title" in the layers panel is exactly the confusion naming
+ * exists to remove — so a named block's copy is suffixed. An UNNAMED block's
+ * copy stays unnamed: it shows its block's label, two rows reading "Heading"
+ * are what an author expects from two headings, and inventing "Heading copy"
+ * would put a name on a block whose author never gave it one.
+ *
+ * **The lock travels.** `locked` is copied because it is part of the block
+ * being duplicated, and a copy that quietly differed from its original in one
+ * field would be a worse surprise than one that matches. The copy is announced,
+ * and the layers panel shows the badge, so the author is not left wondering why
+ * the new block will not move.
+ *
+ * @module duplicate-block
+ */
+
+import {
+  findNode,
+  locateNode,
+  reidSubtree,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+
+import { layerLabel } from "./layers";
+import { positionOf, type OpPosition } from "./ops";
+
+/** The suffix that keeps two copies of a named block apart. */
+export const COPY_SUFFIX = " copy";
+
+/** A duplication, ready to apply. */
+export interface BlockDuplication {
+  /** The re-id'd copy, with its name adjusted. */
+  readonly node: BlockNode;
+  /** Immediately after the original, in the same parent and slot. */
+  readonly at: OpPosition;
+  /** What to call the block in an announcement. */
+  readonly label: string;
+}
+
+/**
+ * The copy's name.
+ *
+ * Suffixed only when the author gave one. Repeated duplication produces "Hero
+ * title copy copy" rather than counting, which is honest about what happened
+ * and needs no scan of the document to find the highest number — a count would
+ * have to decide what to do about a name the author had since edited, and there
+ * is no answer to that which is not a guess.
+ */
+function copyName(node: BlockNode): string | undefined {
+  const named = node.name?.trim();
+  if (named === undefined || named === "") return undefined;
+  return `${named}${COPY_SUFFIX}`;
+}
+
+/**
+ * What duplicating the selected block would do, or `null` when it cannot.
+ *
+ * `null` for no selection and for an id the document no longer holds — which an
+ * undo produces routinely — and for a node whose parent has no named slot,
+ * because that is a position the op vocabulary cannot express and therefore one
+ * an insert could not be undone from.
+ */
+export function blockDuplication(
+  document: BlockDocument,
+  selectedId: string | null
+): BlockDuplication | null {
+  if (selectedId === null) return null;
+
+  const original = findNode(document.nodes, selectedId);
+  if (original === undefined) return null;
+
+  const location = locateNode(document.nodes, selectedId);
+  if (location === undefined) return null;
+
+  let at: OpPosition;
+  try {
+    const here = positionOf(location);
+    at = { ...here, index: here.index + 1 };
+  } catch {
+    // `positionOf` refuses a parent with no named slot. That refusal is about
+    // the selected node's surroundings rather than anything the author did, so
+    // it is reported as "no answer" rather than raised at them — the same
+    // reading the inserter gives it.
+    return null;
+  }
+
+  const copy = reidSubtree(original);
+  const name = copyName(original);
+  return {
+    node: name === undefined ? copy : { ...copy, name },
+    at,
+    label: layerLabel(original),
+  };
+}

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -243,3 +243,17 @@ export { blockLabel } from "./inserter";
  * a container is refused by a lock anywhere inside it, while moving one is not.
  */
 export { isLocked, lockBlockingDelete, lockBlockingMove } from "./locking";
+
+/**
+ * @experimental Duplicating a block: the copy, and where it goes.
+ *
+ * From this entry because it is a plain function over a document. An agent
+ * asked to "make three of these" needs the same copy the editor makes — one
+ * that re-ids the whole subtree and drops the DOM id — and a second
+ * implementation would produce a document with two nodes sharing an id.
+ */
+export {
+  blockDuplication,
+  COPY_SUFFIX,
+  type BlockDuplication,
+} from "./duplicate-block";

--- a/packages/builder/src/keyboard-actions.test.tsx
+++ b/packages/builder/src/keyboard-actions.test.tsx
@@ -453,6 +453,92 @@ describe("useBlockKeyboardActions", () => {
     expect(said).toContain("Undo");
   });
 
+  it("duplicates the selected block through the store", () => {
+    // `ctrlKey`, not `metaKey`. The binding is declared as `mod`, which the
+    // shortcut manager resolves per platform — and jsdom is not macOS, so it
+    // resolves to Control here while a real browser on this machine wants
+    // Command. A test pressing Meta simply never fires the binding, and reads
+    // as the command being unwired.
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    press("d", { ctrlKey: true });
+
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+    const op = editor.apply.mock.calls[0][0];
+    expect(op.kind).toBe("insert");
+    // Immediately after the original, not at the end of the page.
+    expect(op.at).toEqual({ index: 1 });
+  });
+
+  it("gives the copy a different id from the original", () => {
+    // Ids are the only thing the editor addresses by, so a copy that kept one
+    // would send every later edit to whichever node the walk found first.
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    press("d", { ctrlKey: true });
+
+    expect(editor.apply.mock.calls[0][0].node.id).not.toBe("a");
+  });
+
+  it("selects the copy, not the original", () => {
+    // The copy is the block the author is now working on — they duplicated it
+    // in order to change it — and leaving the original selected would send the
+    // next edit to the wrong one of two identical blocks.
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    press("d", { ctrlKey: true });
+
+    const copyId = editor.apply.mock.calls[0][0].node.id;
+    expect(editor.select).toHaveBeenCalledWith(copyId);
+  });
+
+  it("announces the duplication and the way back", () => {
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    press("d", { ctrlKey: true });
+
+    const said = screen.getByRole("status").textContent ?? "";
+    expect(said).toMatch(/duplicated/i);
+    expect(said).toContain("Undo");
+  });
+
+  it("DUPLICATES a locked block rather than refusing", () => {
+    /*
+     * The engine's rule is that the command layer must not let an author move
+     * or DELETE a locked node. Duplicating does neither — the original stays
+     * exactly where it is — so refusing would read as cautious and would mean
+     * an author could not take a copy of the block they had most deliberately
+     * protected.
+     */
+    const editor = editorSpy(
+      documentOf([
+        { id: "a", type: "acme/text", version: 1, props: {}, locked: true },
+      ] as BlockDocument["nodes"]),
+      "a"
+    );
+    mount(editor);
+
+    press("d", { ctrlKey: true });
+
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+    expect(editor.apply.mock.calls[0][0].kind).toBe("insert");
+  });
+
+  it("does nothing with no selection", () => {
+    // The control for every case above: they would all pass against a binding
+    // that fired unconditionally.
+    const editor = editorSpy(pair(), null);
+    mount(editor);
+
+    press("d", { ctrlKey: true });
+
+    expect(editor.apply).not.toHaveBeenCalled();
+  });
+
   it("names a block by the name its author gave it", () => {
     // The layers panel and the breadcrumb both show the instance name, so the
     // one surface a screen-reader user HEARS must not be the only one still

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -25,6 +25,7 @@ import { useShortcuts } from "@nextlyhq/ui";
 import * as React from "react";
 
 import { blockDeletion } from "./delete-block";
+import { blockDuplication } from "./duplicate-block";
 import type { EditorState } from "./editor-state";
 import {
   keyboardMovePosition,
@@ -239,6 +240,40 @@ export function useBlockKeyboardActions({
     );
   }, [announce]);
 
+  const duplicateSelected = React.useCallback(() => {
+    const editorNow = latest.current;
+    const duplication = blockDuplication(
+      editorNow.document,
+      editorNow.selectedId
+    );
+    // `null` means there is nothing to duplicate, or a position the op
+    // vocabulary cannot express. Nothing is applied and nothing is said,
+    // because there is no event to report.
+    if (duplication === null) return;
+
+    /*
+     * A lock does NOT stop a duplication.
+     *
+     * The engine's rule is that the command layer must not let an author move
+     * or delete a locked node, and duplicating does neither — the original
+     * stays exactly where it is, untouched. Refusing here would read as
+     * cautious and would mean an author could not take a copy of the one block
+     * they had most deliberately protected.
+     */
+    const applied = editorNow.apply({
+      kind: "insert",
+      node: duplication.node,
+      at: duplication.at,
+    });
+    if (applied === null) return;
+
+    // Selection follows the copy. It is the block the author is now working on
+    // — they duplicated it to change it — and leaving the original selected
+    // would send the next edit to the wrong one of two identical blocks.
+    editorNow.select(duplication.node.id);
+    announce(`${duplication.label} duplicated. Undo with ${UNDO_KEYS_SPOKEN}.`);
+  }, [announce]);
+
   const bindings = React.useMemo(
     () =>
       MOVE_KEYS.map(({ keys, direction, description }) => ({
@@ -323,6 +358,24 @@ export function useBlockKeyboardActions({
         run: () => deleteSelected(),
       },
       {
+        /*
+         * `mod+d`, which is what a duplicating editor binds nearly everywhere —
+         * Figma, Sketch and every canvas tool an author is likely to arrive
+         * from. The browser's own `mod+d` bookmarks the page, and taking it is
+         * the deliberate trade: inside a full-screen editor a bookmark is not
+         * what the keystroke means, and the shortcut manager prevents the
+         * default so the dialog does not appear over the canvas.
+         */
+        keys: "mod+d",
+        description: "Duplicate the selected block",
+        when: () => latest.current.selectedId !== null,
+        // Not while typing. `mod+d` in a text field is a browser action rather
+        // than an editing one, but an author mid-sentence is not asking for a
+        // block, and the manager cannot tell the two apart without this.
+        whenTyping: false,
+        run: () => duplicateSelected(),
+      },
+      {
         keys: "Backspace",
         description: "Delete the selected block",
         when: () => latest.current.selectedId !== null,
@@ -364,7 +417,7 @@ export function useBlockKeyboardActions({
         },
       },
     ],
-    [announce, deleteSelected]
+    [announce, deleteSelected, duplicateSelected]
   );
 
   useShortcuts([...bindings, ...editing], {


### PR DESCRIPTION
The verb an author reaches for most after inserting one, and it **was absent** — measured: zero occurrences in `packages/builder`, and no copy, paste or clipboard either. Building a row of cards meant inserting a fresh block and redoing every property by hand, which is also how the second card ends up subtly different from the first.

## The copy is made by the engine, and that matters more than it looks

`reidSubtree` mints a fresh id for the node **and everything inside it**. Ids are the only thing this editor addresses by, so a copy that kept them would give one id two nodes — and every later op would reach whichever the walk found first. An edit aimed at the copy would land on the original, silently.

It also drops `cssId` and any `attributes.id`, because both become a DOM `id`, and two elements sharing one is invalid HTML that breaks `getElementById` and every in-page anchor. I would not have thought of the second. Both rules belong to what a **copy is** rather than to what this command does, so restating either here would have been a second opinion about the same question.

I checked it was exported from the engine's entry before using it — that is the #946 lesson, where a function existed, was tested, and was absent from `dist`.

## What this decides, because the engine deliberately does not

**Where it goes** — immediately after the original, in the same parent and slot. An author duplicating a card is building a row of them; a copy appended to the end of the page is one they then have to find.

**What it is called** — a name the author typed gets suffixed, because two rows reading "Hero title" in the layers panel is exactly the confusion naming exists to remove. An **unnamed** block's copy stays unnamed: inventing "Heading copy" would put a name on a block whose author never gave it one, and two rows reading "Heading" are what anyone expects from two headings.

Repeated duplication gives "Hero title copy copy" rather than counting. Counting would have to decide what to do about a name the author had since edited, and there is no answer to that which is not a guess.

**A lock does NOT refuse a duplication.** The engine's rule is that the command layer must not let an author *move or delete* a locked node — duplicating does neither, and the original is untouched. Refusing would read as cautious and would mean an author could not take a copy of the block they had most deliberately protected. The lock travels with the copy, so it does not quietly differ from its original.

**Selection follows the copy**, because that is the block the author is now working on — they duplicated it in order to change it — and leaving the original selected would send the next edit to the wrong one of two identical blocks.

## Verified end to end

```
before      : 1 block
after mod+d : 2 blocks     ids unique: true
said        : "Hero title duplicated. Undo with Control or Command Z."
selected    : the COPY
layers      : ["Hero title", "Hero title copy"]
after undo  : 1 block          ← one press, not two
pageerrors  : []
```

## Tests

652 in `@nextlyhq/builder` (was 636), 61 in `plugin-page-builder`, 30/30 tasks. Five stub-verifications, each failing exactly its intended tests.

The subtree test asserts **shape before uniqueness** — `copied.length === original.length` first — because "no shared ids" is satisfied perfectly by a copy that dropped its children entirely.

## A note for the next person writing a shortcut test

My first version pressed `metaKey` and every case failed, reading exactly like the command being unwired. `mod` resolves per platform: jsdom is not macOS so it resolves to **Control**, while a real browser on this machine wants **Command**. The test now says so at the first use, since the failure mode is silent and misleading.
