### PR TITLE
fix(root): build the workspace on every dev:app, not only when a sentinel is empty

### DIFF
--- a/scripts/dev-doctor.mjs
+++ b/scripts/dev-doctor.mjs
@@ -75,6 +75,21 @@ export async function checkEnvFile(envPath) {
 // seed step. Using packages/nextly/dist as the sentinel because it is the
 // last package built in the turbo graph -- if it exists, the whole
 // dependency chain compiled.
+/**
+ * Whether the workspace has EVER been built.
+ *
+ * One sentinel, and the claim is narrowed to what one sentinel can support.
+ * This detects a workspace nobody has built; it cannot detect a `dist` that is
+ * STALE, PARTIAL, or missing in a package other than the sentinel's — and the
+ * failures that actually happen are those. `packages/builder/dist` going absent
+ * leaves this reporting ok while the admin renders blank, because the page
+ * builder's stylesheet `@import`s a file from it.
+ *
+ * `dev:app` therefore does not gate its build on this any more; it builds every
+ * time and lets turbo's hashing answer the currency question, which a directory
+ * listing cannot. This stays for `dev:doctor`, where a human is asking what is
+ * wrong and "nothing has been built" is worth saying plainly.
+ */
 export async function checkBuildArtifacts(nextlyRoot) {
   const sentinel = path.join(nextlyRoot, "packages", "nextly", "dist");
   try {

--- a/scripts/dev-doctor.test.mjs
+++ b/scripts/dev-doctor.test.mjs
@@ -1,0 +1,93 @@
+/**
+ * The dev doctor's build-artifacts check, and the limit of what it can say.
+ *
+ * The check existed untested while `dev:app` gated its build on it, and the
+ * gate could not see the case that kept breaking: a `dist` missing in a package
+ * OTHER than the sentinel's. These cases pin what it does answer and, more
+ * usefully, assert the blind spot rather than leaving it to be rediscovered —
+ * because a check whose limits are undocumented reads as one with none.
+ *
+ * @module dev-doctor.test
+ */
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { checkBuildArtifacts } from "./dev-doctor.mjs";
+
+const made = [];
+
+afterEach(async () => {
+  for (const dir of made.splice(0)) await rm(dir, { recursive: true, force: true });
+});
+
+/** A throwaway workspace root, with whichever package dists are named. */
+async function workspace(dists = {}) {
+  const root = await mkdtemp(path.join(tmpdir(), "nextly-doctor-"));
+  made.push(root);
+  for (const [pkg, files] of Object.entries(dists)) {
+    const dir = path.join(root, "packages", pkg, "dist");
+    await mkdir(dir, { recursive: true });
+    for (const file of files) await writeFile(path.join(dir, file), "x");
+  }
+  return root;
+}
+
+describe("checkBuildArtifacts", () => {
+  it("reports a workspace nobody has built", async () => {
+    const root = await workspace();
+
+    const result = await checkBuildArtifacts(root);
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/missing/i);
+  });
+
+  it("reports an EMPTY dist as unbuilt", async () => {
+    // Distinct from absent: a `rimraf dist` that ran without the build that
+    // follows it leaves the directory there and empty.
+    const root = await workspace({ nextly: [] });
+
+    expect((await checkBuildArtifacts(root)).ok).toBe(false);
+  });
+
+  it("passes once the sentinel package has output", async () => {
+    // The control. Without it every assertion above would be satisfied by a
+    // check that reported failure unconditionally.
+    const root = await workspace({ nextly: ["index.mjs"] });
+
+    expect((await checkBuildArtifacts(root)).ok).toBe(true);
+  });
+
+  it("CANNOT see a dist missing from another package", async () => {
+    /*
+     * The blind spot, asserted as a DELTA rather than as a state.
+     *
+     * Checking `ok === true` on a workspace with no builder output would be the
+     * same assertion as the control above and would demonstrate nothing. What
+     * shows the insensitivity is that removing the output changes NOTHING about
+     * the answer: the check reports ok before and after, while the thing that
+     * renders the admin blank has appeared in between.
+     *
+     * `packages/builder/dist` absent is that thing — the page builder's
+     * stylesheet `@import`s a file from it — and this is why `dev:app` no
+     * longer gates its build on this result.
+     */
+    const root = await workspace({
+      nextly: ["index.mjs"],
+      builder: ["builder-chrome.css"],
+    });
+    const withOutput = await checkBuildArtifacts(root);
+
+    await rm(path.join(root, "packages", "builder", "dist"), {
+      recursive: true,
+      force: true,
+    });
+    const withoutOutput = await checkBuildArtifacts(root);
+
+    expect(withOutput.ok).toBe(true);
+    // The answer did not move, which is the finding.
+    expect(withoutOutput.ok).toBe(true);
+  });
+});

--- a/scripts/dev-playground.mjs
+++ b/scripts/dev-playground.mjs
@@ -159,35 +159,50 @@ async function main() {
     );
   }
 
-  // Auto-build workspace packages if the doctor flagged missing dist.
-  // The seed sub-process (and the runtime itself) imports compiled dist
-  // artifacts, so a fresh clone without `pnpm build` crashes seed and
-  // produces HTTP 500s in /admin. Turbo's cache makes this a no-op on
-  // subsequent runs once dist exists, so the cost is paid once.
-  if (!results.buildArtifacts.ok) {
-    console.log(
-      "[nextly] First boot detected (no built dist outputs). " +
-        "Running `pnpm turbo build --filter='./packages/*'`..."
+  /*
+   * Build the workspace before starting, every time.
+   *
+   * This used to run only when the doctor reported missing artifacts, and that
+   * gate could not see the case it most needed to: the doctor checks ONE
+   * sentinel directory — `packages/nextly/dist` — for being non-empty. A
+   * `packages/builder/dist` that is stale, partial or absent entirely leaves
+   * that sentinel untouched, so the build was skipped and `next dev` started
+   * against whatever happened to be on disk.
+   *
+   * The failure that produces does not look like a missing build. The page
+   * builder's stylesheet `@import`s `@nextlyhq/builder/styles.css`, which
+   * resolves through that package's export map into `dist`; when the file is
+   * not there the import throws a CssSyntaxError naming
+   * `plugin-page-builder/dist/styles/editor.css`, and the WHOLE ADMIN renders
+   * blank. Two sessions lost time to it in one day, neither of them looking at
+   * the package that was actually unbuilt.
+   *
+   * Running unconditionally replaces a proxy — does one directory exist — with
+   * the question that matters: is every package's output current for its
+   * inputs. Turbo already answers that by hashing, so a workspace that is
+   * already built costs a cache lookup: measured at ~430ms with 19 of 19 tasks
+   * cached, against a blank admin whose error names the wrong package.
+   */
+  console.log("[nextly] Building workspace packages (cached when current)...");
+  const buildExit = await runChild(
+    "pnpm",
+    ["turbo", "build", "--filter=./packages/*"],
+    NEXTLY_ROOT
+  );
+  if (buildExit !== 0) {
+    console.error(
+      `[nextly] ✗ build exited ${buildExit}. ` +
+        `Aborting — fix the build first, then re-run \`pnpm dev:app\`.`
     );
-    const buildExit = await runChild(
-      "pnpm",
-      ["turbo", "build", "--filter=./packages/*"],
-      NEXTLY_ROOT
-    );
-    if (buildExit !== 0) {
-      console.error(
-        `[nextly] ✗ build exited ${buildExit}. ` +
-          `Aborting — fix the build first, then re-run \`pnpm dev:app\`.`
-      );
-      process.exit(buildExit);
-    }
-    // Re-run doctor to refresh the buildArtifacts result.
-    ({ ok, results } = await runAllChecks({
-      nextlyRoot: NEXTLY_ROOT,
-      envPath,
-      port,
-    }));
+    process.exit(buildExit);
   }
+  // Re-run the checks against what the build produced, so anything downstream
+  // of the artifacts is judged on the current ones.
+  ({ ok, results } = await runAllChecks({
+    nextlyRoot: NEXTLY_ROOT,
+    envPath,
+    port,
+  }));
 
   if (!ok) {
     for (const [name, r] of Object.entries(results)) {


### PR DESCRIPTION
A blank admin whose error names the wrong package. Two sessions lost time to this today, neither looking at the package that was actually unbuilt.

## What was happening

`dev:app` gated its build on the doctor's `buildArtifacts` check. That check reads **one sentinel directory** — `packages/nextly/dist` — for being non-empty. A `packages/builder/dist` that is stale, partial or **absent entirely** leaves the sentinel untouched, so the build was skipped and `next dev` started against whatever happened to be on disk.

The resulting failure looks nothing like a missing build. The page builder's stylesheet `@import`s `@nextlyhq/builder/styles.css`, which resolves through that package's export map into `dist`. With the file absent the import throws a **CssSyntaxError naming `plugin-page-builder/dist/styles/editor.css`** — a different package from the one that is unbuilt — and the whole admin renders blank.

AGENTS.md already documents this trap in general terms: *"Stale build output — `dist` EXISTS but predates a source or export-map change. An existence check on the directory says 'built' and is wrong."* This is that, plus a one-package sentinel standing in for a twenty-package workspace.

## Measured, before and after

Same condition both runs: `packages/builder/dist` removed, sentinel intact.

```
BEFORE   rebuild: no      dist: 0 files     admin: 500     CssSyntaxError: 2
AFTER    rebuild: yes     dist: 17 files    admin: 200     CssSyntaxError: 0
```

The "before" run is the current `main` code restored into place deliberately, so the failure is demonstrated rather than described.

## The fix

Build every time and let turbo answer. That replaces a proxy — *does one directory exist* — with the question that matters: **is every package's output current for its inputs**. Turbo answers it by hashing, so an already-built workspace costs a cache lookup: **~430ms with 19 of 19 tasks cached**, against a blank admin.

## The doctor keeps its check, with an honest claim

`dev:doctor` is a human asking what is wrong, and "nothing has been built" is worth saying plainly. But its docblock now states what one sentinel can support: it detects a workspace nobody has built, and **cannot** detect a `dist` that is stale, partial, or missing in another package.

**It had no tests.** The four added assert what it does answer and — more usefully — the blind spot **as a delta**: removing another package's output does not move the answer. Asserting the state instead would have been the same assertion as the control beside it and would have demonstrated nothing.

## Scope

`scripts/` only, not published, so **no changeset**. `pnpm test:scripts`: 514 tests, 14 files, all passing.
