### PR TITLE
fix(admin): ask before leaving an entry editor with unsaved changes

### DIFF
--- a/.changeset/leaving-a-dirty-editor-asks-first.md
+++ b/.changeset/leaving-a-dirty-editor-asks-first.md
@@ -1,0 +1,43 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Leaving an entry editor with unsaved changes now asks first.
+
+The admin ships an unsaved-changes guard — dialog, history interception,
+back/forward handling, `beforeunload` — and nothing has ever mounted it. It has
+been present since the first commit, exported through a barrel no consumer
+imports, and touched since only by two theme passes that restyled a dialog which
+never appeared. So navigating away from a half-written entry discarded it in
+silence.
+
+It is mounted now for the entry editor, and an action that has already asked the
+question — Discard changes — says so rather than being asked it twice.
+
+Not yet mounted for singles: an untouched single reports itself dirty on load,
+so the guard would question a document nobody had edited. That is recorded as
+its own defect rather than worked around here.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -70,6 +70,7 @@ import { EntryMetaStrip } from "./EntryMetaStrip";
 import { EntrySystemHeader } from "./EntrySystemHeader";
 import { FormErrorSummary } from "./FormErrorSummary";
 import { PublicUrlChangeNotice } from "./PublicUrlChangeNotice";
+import { UnsavedChangesGuard } from "./UnsavedChangesGuard";
 import {
   useEntryForm,
   getCollectionFields,
@@ -558,25 +559,30 @@ export function EntryForm({
   // and (optional) right rail. No breadcrumbs, no DocumentTabs, no separate
   // page title h1; the title input lives inside EntrySystemHeader.
   return (
-    <EntryLocaleProvider value={localeCtx}>
-      <DocumentHistoryContext.Provider value={documentHistory}>
-        <EntryFormContextProvider
-          entryId={entry?.id}
-          collectionSlug={collection.name}
-          isCreateMode={mode === "create"}
-        >
-          <div className={cn("space-y-0", className)}>
-            <EntryFormProvider form={form} onSubmit={handleSubmit}>
-              <FormErrorSummary
-                errors={errors}
-                submitCount={submitCount}
-                className="mx-6 mt-3"
-              />
+    // Standalone only. An embedded editor lives in a modal, where leaving is
+    // closing the dialog rather than a history move — and a modal opened FROM
+    // this editor would mount a second interceptor over this one, so two
+    // dialogs would answer one navigation.
+    <UnsavedChangesGuard isDirty={isDirty} disabled={isSubmitting}>
+      <EntryLocaleProvider value={localeCtx}>
+        <DocumentHistoryContext.Provider value={documentHistory}>
+          <EntryFormContextProvider
+            entryId={entry?.id}
+            collectionSlug={collection.name}
+            isCreateMode={mode === "create"}
+          >
+            <div className={cn("space-y-0", className)}>
+              <EntryFormProvider form={form} onSubmit={handleSubmit}>
+                <FormErrorSummary
+                  errors={errors}
+                  submitCount={submitCount}
+                  className="mx-6 mt-3"
+                />
 
-              <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-m-8">
-                {/* Main column */}
-                <div className="flex-1 min-w-0 flex flex-col">
-                  {/* Why: the parent flex's @4xl/content:-m-8 already cancels
+                <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-m-8">
+                  {/* Main column */}
+                  <div className="flex-1 min-w-0 flex flex-col">
+                    {/* Why: the parent flex's @4xl/content:-m-8 already cancels
                   PageContainer's px-8 padding so the form runs edge-to-edge
                   once the panel is wide enough. Wrapping the system
                   header / meta strip in another -mx-8 doubled the negative
@@ -584,210 +590,210 @@ export function EntryForm({
                   each side — clipping the title's first character on the
                   left and the rail toggle / right-edge buttons on the right.
                   Letting them fill the Main column naturally fixes that. */}
-                  <EntrySystemHeader
-                    mode={mode}
-                    titleField={titleField}
-                    hasStatus={hasStatus}
-                    draftsEnabled={collection.draftsEnabled === true}
-                    isSubmitting={isSubmitting}
-                    isDirty={isDirty}
-                    autosaveEnabled={autosaveScope !== null}
-                    autosaveStatus={autosave.status}
-                    autosaveLastSavedAt={autosave.lastSavedAt}
-                    entry={entry}
-                    collectionSlug={collection.name}
-                    historyFields={getCollectionFields(collection)}
-                    historyEnabled={historyEnabledFrom(collection)}
-                    locale={locale}
-                    onLocaleChange={onLocaleChange}
-                    localized={collection.localized === true}
-                    // Withheld while the language is unknown as well as while
-                    // the entry is unsaved: a link minted without a resolvable
-                    // locale is either refused by the mint route or, if the claim
-                    // were dropped to avoid that, a grant over every translation.
-                    isLinkAvailable={
-                      savedEntryId !== "" && linkLocale.kind !== "unresolved"
-                    }
-                    {...(savedEntryId === ""
-                      ? {}
-                      : {
-                          onCopyLink: () => {
-                            previewLink.mutate();
-                          },
-                        })}
-                    isCopyingLink={previewLink.isPending}
-                    toolbarSlot={
-                      <EntryFormToolbarSlots
-                        context="collection"
-                        controllerField={controllerNames[0]}
-                      />
-                    }
-                    onSaveDraft={() => {
-                      void handleSubmit(undefined, "save-draft");
-                    }}
-                    onPublish={() => {
-                      void handleSubmit(undefined, "publish");
-                    }}
-                    onSaveChanges={() => {
-                      void handleSubmit(undefined, "save-changes");
-                    }}
-                    onSaveWorkingDraft={() => {
-                      void handleSubmit(undefined, "save-working-draft");
-                    }}
-                    onUnpublish={() => {
-                      void handleSubmit(undefined, "unpublish");
-                    }}
-                    onCancel={handleCancel}
-                    onDelete={handleDelete}
-                    onDiscardWorkingDraft={handleDiscardWorkingDraft}
-                    isRailCollapsed={railCollapsed}
-                    onToggleRail={mode === "edit" ? toggleRail : undefined}
-                  />
-                  {/* Above the fields and below the header: the reader sees
+                    <EntrySystemHeader
+                      mode={mode}
+                      titleField={titleField}
+                      hasStatus={hasStatus}
+                      draftsEnabled={collection.draftsEnabled === true}
+                      isSubmitting={isSubmitting}
+                      isDirty={isDirty}
+                      autosaveEnabled={autosaveScope !== null}
+                      autosaveStatus={autosave.status}
+                      autosaveLastSavedAt={autosave.lastSavedAt}
+                      entry={entry}
+                      collectionSlug={collection.name}
+                      historyFields={getCollectionFields(collection)}
+                      historyEnabled={historyEnabledFrom(collection)}
+                      locale={locale}
+                      onLocaleChange={onLocaleChange}
+                      localized={collection.localized === true}
+                      // Withheld while the language is unknown as well as while
+                      // the entry is unsaved: a link minted without a resolvable
+                      // locale is either refused by the mint route or, if the claim
+                      // were dropped to avoid that, a grant over every translation.
+                      isLinkAvailable={
+                        savedEntryId !== "" && linkLocale.kind !== "unresolved"
+                      }
+                      {...(savedEntryId === ""
+                        ? {}
+                        : {
+                            onCopyLink: () => {
+                              previewLink.mutate();
+                            },
+                          })}
+                      isCopyingLink={previewLink.isPending}
+                      toolbarSlot={
+                        <EntryFormToolbarSlots
+                          context="collection"
+                          controllerField={controllerNames[0]}
+                        />
+                      }
+                      onSaveDraft={() => {
+                        void handleSubmit(undefined, "save-draft");
+                      }}
+                      onPublish={() => {
+                        void handleSubmit(undefined, "publish");
+                      }}
+                      onSaveChanges={() => {
+                        void handleSubmit(undefined, "save-changes");
+                      }}
+                      onSaveWorkingDraft={() => {
+                        void handleSubmit(undefined, "save-working-draft");
+                      }}
+                      onUnpublish={() => {
+                        void handleSubmit(undefined, "unpublish");
+                      }}
+                      onCancel={handleCancel}
+                      onDelete={handleDelete}
+                      onDiscardWorkingDraft={handleDiscardWorkingDraft}
+                      isRailCollapsed={railCollapsed}
+                      onToggleRail={mode === "edit" ? toggleRail : undefined}
+                    />
+                    {/* Above the fields and below the header: the reader sees
                     the document it refers to without the offer covering it. */}
-                  {recovery.offer ? (
-                    <AutosaveRecoveryBanner
-                      savedAt={recovery.offer.savedAt}
-                      onRestore={restoreRecovery}
-                      onDismiss={recovery.dismiss}
-                    />
-                  ) : null}
-                  {viewingVersion ? (
-                    <HistoricalDocumentBanner
-                      versionNo={viewingVersion.versionNo}
-                      locale={viewingVersion.locale}
-                      // Routed through the panel when one is mounted, so its
-                      // selection clears with the shared state. The direct
-                      // fallback keeps the banner working without a panel.
-                      onReturnToCurrent={
-                        restoreAffordance?.returnToCurrent ??
-                        (() => setViewingVersion(null))
+                    {recovery.offer ? (
+                      <AutosaveRecoveryBanner
+                        savedAt={recovery.offer.savedAt}
+                        onRestore={restoreRecovery}
+                        onDismiss={recovery.dismiss}
+                      />
+                    ) : null}
+                    {viewingVersion ? (
+                      <HistoricalDocumentBanner
+                        versionNo={viewingVersion.versionNo}
+                        locale={viewingVersion.locale}
+                        // Routed through the panel when one is mounted, so its
+                        // selection clears with the shared state. The direct
+                        // fallback keeps the banner working without a panel.
+                        onReturnToCurrent={
+                          restoreAffordance?.returnToCurrent ??
+                          (() => setViewingVersion(null))
+                        }
+                        // Offered only when the panel says this caller may write.
+                        onRestore={
+                          restoreAffordance?.canRestore
+                            ? restoreAffordance.request
+                            : undefined
+                        }
+                        // And only once the version is actually on screen:
+                        // restoring from a skeleton, or from a failed read, is a
+                        // decision made without having seen what is being chosen.
+                        restoreDisabled={!versionOnScreen}
+                      />
+                    ) : null}
+                    <EntryMetaStrip
+                      slugField={slugField}
+                      hasStatus={hasStatus}
+                      // The pill reports the language being edited, matching the header's submit
+                      // affordances. Reading the main row instead would show "Published" beside a
+                      // Publish button whenever a translation lags its default language.
+                      status={
+                        effectiveEntryStatus(entry, locale, defaultLocale) ??
+                        "draft"
                       }
-                      // Offered only when the panel says this caller may write.
-                      onRestore={
-                        restoreAffordance?.canRestore
-                          ? restoreAffordance.request
-                          : undefined
+                      hasWorkingDraft={
+                        (
+                          entry as
+                            | { _isWorkingDraft?: boolean }
+                            | null
+                            | undefined
+                        )?._isWorkingDraft === true
                       }
-                      // And only once the version is actually on screen:
-                      // restoring from a skeleton, or from a failed read, is a
-                      // decision made without having seen what is being chosen.
-                      restoreDisabled={!versionOnScreen}
+                      isRailCollapsed={railCollapsed}
+                      hasPublicAddress={hasPublicAddress}
                     />
-                  ) : null}
-                  <EntryMetaStrip
-                    slugField={slugField}
-                    hasStatus={hasStatus}
-                    // The pill reports the language being edited, matching the header's submit
-                    // affordances. Reading the main row instead would show "Published" beside a
-                    // Publish button whenever a translation lags its default language.
-                    status={
-                      effectiveEntryStatus(entry, locale, defaultLocale) ??
-                      "draft"
-                    }
-                    hasWorkingDraft={
-                      (
-                        entry as
-                          | { _isWorkingDraft?: boolean }
-                          | null
-                          | undefined
-                      )?._isWorkingDraft === true
-                    }
-                    isRailCollapsed={railCollapsed}
-                    hasPublicAddress={hasPublicAddress}
-                  />
 
-                  {/* The language panel, inline. Its rail mount is
+                    {/* The language panel, inline. Its rail mount is
                       `hidden @4xl/content:flex`, so this is the exact
                       complement: shown only where the rail is not. When the
                       rail cannot carry it at all — create mode, or the author
                       collapsed it — the panel renders unconditionally instead,
                       because "the actions live in the rail" is precisely the
                       failure this stage removes. */}
-                  {localizationEnabled && (
-                    <div
-                      className={cn(
-                        "px-6 pt-4",
-                        mode === "edit" &&
-                          !railCollapsed &&
-                          "@4xl/content:hidden"
-                      )}
-                    >
-                      <LanguagePanel
-                        {...(entry?._translations === undefined
-                          ? {}
-                          : {
-                              translations: entry._translations as Record<
-                                string,
-                                { translated: boolean; status?: string }
-                              >,
-                            })}
-                        {...(locale === undefined
-                          ? {}
-                          : { activeLocale: locale })}
-                        {...(onLocaleChange === undefined
-                          ? {}
-                          : { onSelect: onLocaleChange })}
-                        hasStatus={hasStatus}
-                        actionsDisabled={viewingVersion !== null}
-                      />
-                    </div>
-                  )}
+                    {localizationEnabled && (
+                      <div
+                        className={cn(
+                          "px-6 pt-4",
+                          mode === "edit" &&
+                            !railCollapsed &&
+                            "@4xl/content:hidden"
+                        )}
+                      >
+                        <LanguagePanel
+                          {...(entry?._translations === undefined
+                            ? {}
+                            : {
+                                translations: entry._translations as Record<
+                                  string,
+                                  { translated: boolean; status?: string }
+                                >,
+                              })}
+                          {...(locale === undefined
+                            ? {}
+                            : { activeLocale: locale })}
+                          {...(onLocaleChange === undefined
+                            ? {}
+                            : { onSelect: onLocaleChange })}
+                          hasStatus={hasStatus}
+                          actionsDisabled={viewingVersion !== null}
+                        />
+                      </div>
+                    )}
 
-                  {/* Reading a past version replaces the document rather than
+                    {/* Reading a past version replaces the document rather than
                     opening beside it: the question an editor is asking is how
                     this page read then, and that is answered by the page. The
                     live form stays mounted underneath — the historical values
                     are rendered against a form of their own, so nothing typed
                     here is disturbed and nothing historical can reach a save. */}
-                  {viewingVersion ? (
-                    <div className="@4xl/content:p-8 pt-6">
-                      {viewingVersion.error ? (
-                        // A failed read must not render as an empty document:
-                        // that is a different and wrong claim about the version.
-                        <Alert variant="destructive">
-                          <AlertDescription>
-                            This version could not be loaded.
-                          </AlertDescription>
-                        </Alert>
-                      ) : !versionOnScreen ? (
-                        <div className="flex flex-col gap-4" aria-busy="true">
-                          <span className="sr-only" role="status">
-                            Loading version {viewingVersion.versionNo}
-                          </span>
-                          {[0, 1, 2, 3].map(i => (
-                            <div key={i} className="flex flex-col gap-1">
-                              <Skeleton className="h-3 w-24" />
-                              <Skeleton className="h-9 w-full" />
-                            </div>
-                          ))}
-                        </div>
-                      ) : (
-                        <VersionSnapshotForm
-                          fields={historicalFields ?? mainFields}
-                          snapshot={viewingVersion.snapshot}
-                        />
-                      )}
-                    </div>
-                  ) : (
-                    mainFields.length > 0 && (
+                    {viewingVersion ? (
                       <div className="@4xl/content:p-8 pt-6">
-                        {/* Forward the form mode: in edit mode a blank password
+                        {viewingVersion.error ? (
+                          // A failed read must not render as an empty document:
+                          // that is a different and wrong claim about the version.
+                          <Alert variant="destructive">
+                            <AlertDescription>
+                              This version could not be loaded.
+                            </AlertDescription>
+                          </Alert>
+                        ) : !versionOnScreen ? (
+                          <div className="flex flex-col gap-4" aria-busy="true">
+                            <span className="sr-only" role="status">
+                              Loading version {viewingVersion.versionNo}
+                            </span>
+                            {[0, 1, 2, 3].map(i => (
+                              <div key={i} className="flex flex-col gap-1">
+                                <Skeleton className="h-3 w-24" />
+                                <Skeleton className="h-9 w-full" />
+                              </div>
+                            ))}
+                          </div>
+                        ) : (
+                          <VersionSnapshotForm
+                            fields={historicalFields ?? mainFields}
+                            snapshot={viewingVersion.snapshot}
+                          />
+                        )}
+                      </div>
+                    ) : (
+                      mainFields.length > 0 && (
+                        <div className="@4xl/content:p-8 pt-6">
+                          {/* Forward the form mode: in edit mode a blank password
                       field means "keep the current password" rather than a
                       required-field violation (see note on the layout form
                       above). */}
-                        <EntryFormContent
-                          fields={mainFields}
-                          disabled={isSubmitting}
-                          withCard
-                          mode={mode}
-                        />
-                      </div>
-                    )
-                  )}
-                </div>
+                          <EntryFormContent
+                            fields={mainFields}
+                            disabled={isSubmitting}
+                            withCard
+                            mode={mode}
+                          />
+                        </div>
+                      )
+                    )}
+                  </div>
 
-                {/* Rail (collapsible). Width 320px. Hidden until the content panel
+                  {/* Rail (collapsible). Width 320px. Hidden until the content panel
                 is wide enough (@4xl) to fit it beside the main column, until a
                 future mobile sheet ships.
 
@@ -796,28 +802,29 @@ export function EntryForm({
                 nothing to show. Rendering it anyway left an empty 320px
                 strip down the right side of the page, which reads as a
                 failed load rather than as an absence. */}
-                {mode === "edit" && !railCollapsed && (
-                  <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
-                    <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
-                      <EntryFormSidebar
-                        mode={mode}
-                        entry={entry}
-                        hasStatus={hasStatus}
-                        {...(locale === undefined ? {} : { locale })}
-                        {...(onLocaleChange === undefined
-                          ? {}
-                          : { onLocaleChange })}
-                        actionsDisabled={viewingVersion !== null}
-                        isDirty={isDirty}
-                      />
+                  {mode === "edit" && !railCollapsed && (
+                    <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
+                      <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
+                        <EntryFormSidebar
+                          mode={mode}
+                          entry={entry}
+                          hasStatus={hasStatus}
+                          {...(locale === undefined ? {} : { locale })}
+                          {...(onLocaleChange === undefined
+                            ? {}
+                            : { onLocaleChange })}
+                          actionsDisabled={viewingVersion !== null}
+                          isDirty={isDirty}
+                        />
+                      </div>
                     </div>
-                  </div>
-                )}
-              </div>
-            </EntryFormProvider>
-          </div>
-        </EntryFormContextProvider>
-      </DocumentHistoryContext.Provider>
-    </EntryLocaleProvider>
+                  )}
+                </div>
+              </EntryFormProvider>
+            </div>
+          </EntryFormContextProvider>
+        </DocumentHistoryContext.Provider>
+      </EntryLocaleProvider>
+    </UnsavedChangesGuard>
   );
 }

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -45,6 +45,7 @@ import { PreviewActions } from "./PreviewActions";
 import { ShowJSONDialog } from "./ShowJSONDialog";
 import { TOOLBAR_CONTAINER, ToolbarLabel } from "./toolbar-density";
 import { UnpublishConfirmDialog } from "./UnpublishConfirmDialog";
+import { useLeaveWithoutWarning } from "./UnsavedChangesGuard";
 import type { EntryData, EntryFormMode } from "./useEntryForm";
 
 // into one component. The title input lives in the action-bar row (autofocus
@@ -293,6 +294,9 @@ export function EntrySystemHeader({
   const isReadingHistory = viewingVersion !== null;
 
   // Both collections and singles authorize a document write as `update-{slug}`.
+  // Read here, inside the guard this header renders under, so a deliberate
+  // discard can say so before it navigates.
+  const leaveWithoutWarning = useLeaveWithoutWarning();
   const canUpdateDocument = useCan(`update-${collectionSlug}`);
 
   // Publishing is its own permission, distinct from editing. Without it the
@@ -668,7 +672,16 @@ export function EntrySystemHeader({
                   </DropdownMenuItem>
                 )}
                 {isDirty && onCancel && (
-                  <DropdownMenuItem onClick={onCancel} disabled={isSubmitting}>
+                  <DropdownMenuItem
+                    // Says so before leaving: this action IS the answer to the
+                    // unsaved-changes question, so being asked it again reads as
+                    // a warning rather than as the confirmation just given.
+                    onClick={() => {
+                      leaveWithoutWarning();
+                      onCancel();
+                    }}
+                    disabled={isSubmitting}
+                  >
                     <RotateCcw className="h-3.5 w-3.5" />
                     Discard changes
                   </DropdownMenuItem>

--- a/packages/admin/src/components/features/entries/EntryForm/UnsavedChangesGuard.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/UnsavedChangesGuard.tsx
@@ -21,9 +21,25 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@nextlyhq/ui";
-import type { ReactNode } from "react";
+import { createContext, useContext, type ReactNode } from "react";
 
 import { useUnsavedChanges } from "@admin/hooks/useUnsavedChanges";
+
+/**
+ * Lets a descendant say "this leave is deliberate" without the guard having to
+ * be threaded through as a prop. Defaults to a no-op, so a form rendered
+ * outside a guard — an embedded editor in a modal — calls it harmlessly.
+ */
+const LeaveWithoutWarningContext = createContext<() => void>(() => {});
+
+/**
+ * The escape for an action that has already asked the question: discarding
+ * changes, or leaving after a save. See `useUnsavedChanges` for why intent has
+ * to be stated rather than read off `isDirty`.
+ */
+export function useLeaveWithoutWarning(): () => void {
+  return useContext(LeaveWithoutWarningContext);
+}
 
 // ============================================================================
 // Types
@@ -105,14 +121,15 @@ export function UnsavedChangesGuard({
   disabled = false,
   children,
 }: UnsavedChangesGuardProps) {
-  const { showDialog, confirmLeave, cancelLeave } = useUnsavedChanges({
-    isDirty,
-    onConfirmLeave: onDiscard,
-    disabled,
-  });
+  const { showDialog, confirmLeave, cancelLeave, leaveWithoutWarning } =
+    useUnsavedChanges({
+      isDirty,
+      onConfirmLeave: onDiscard,
+      disabled,
+    });
 
   return (
-    <>
+    <LeaveWithoutWarningContext.Provider value={leaveWithoutWarning}>
       {children}
 
       <AlertDialog
@@ -145,6 +162,6 @@ export function UnsavedChangesGuard({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </>
+    </LeaveWithoutWarningContext.Provider>
   );
 }

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/UnsavedChangesGuard.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/UnsavedChangesGuard.test.tsx
@@ -1,0 +1,147 @@
+// The guard that stops a dirty editor being navigated away from.
+//
+// It had never been mounted — present since the initial commit, exported
+// through a barrel nothing imported — so nothing here is a regression test for
+// behaviour that once worked. These pin the contract now that it is live, and
+// the ones that matter most are the NEGATIVE cases: a guard that fires on a
+// clean form is worse than no guard, because it gets removed.
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+import {
+  UnsavedChangesGuard,
+  useLeaveWithoutWarning,
+} from "../UnsavedChangesGuard";
+
+/** Navigates the way the admin's own router does — by pushing history. */
+function GoElsewhere() {
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        window.history.pushState(null, "", "/admin/somewhere-else")
+      }
+    >
+      go
+    </button>
+  );
+}
+
+/** A control that has already asked the question itself. */
+function DeliberateLeave() {
+  const leaveWithoutWarning = useLeaveWithoutWarning();
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        leaveWithoutWarning();
+        window.history.pushState(null, "", "/admin/somewhere-else");
+      }}
+    >
+      discard and go
+    </button>
+  );
+}
+
+const START = "/admin/collections/posts/1";
+
+describe("UnsavedChangesGuard", () => {
+  beforeEach(() => {
+    window.history.pushState(null, "", START);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("lets a clean editor leave without a word", async () => {
+    // The case that decides whether this guard survives contact with users.
+    render(
+      <UnsavedChangesGuard isDirty={false}>
+        <GoElsewhere />
+      </UnsavedChangesGuard>
+    );
+    await userEvent.click(screen.getByRole("button", { name: "go" }));
+    expect(window.location.pathname).toBe("/admin/somewhere-else");
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
+  it("stops a dirty editor and asks", async () => {
+    render(
+      <UnsavedChangesGuard isDirty>
+        <GoElsewhere />
+      </UnsavedChangesGuard>
+    );
+    await userEvent.click(screen.getByRole("button", { name: "go" }));
+    // Blocked: the URL must not have moved, or the work is already gone and
+    // the dialog is asking about something that already happened.
+    expect(window.location.pathname).toBe(START);
+    expect(await screen.findByRole("alertdialog")).toBeInTheDocument();
+  });
+
+  it("keeps the editor in place when the author chooses to stay", async () => {
+    render(
+      <UnsavedChangesGuard isDirty>
+        <GoElsewhere />
+      </UnsavedChangesGuard>
+    );
+    await userEvent.click(screen.getByRole("button", { name: "go" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /keep editing/i })
+    );
+    expect(window.location.pathname).toBe(START);
+  });
+
+  it("completes the navigation the author confirmed", async () => {
+    const onDiscard = vi.fn();
+    render(
+      <UnsavedChangesGuard isDirty onDiscard={onDiscard}>
+        <GoElsewhere />
+      </UnsavedChangesGuard>
+    );
+    await userEvent.click(screen.getByRole("button", { name: "go" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /discard/i })
+    );
+    expect(window.location.pathname).toBe("/admin/somewhere-else");
+    expect(onDiscard).toHaveBeenCalled();
+  });
+
+  it("does not ask again when the action already did", async () => {
+    // "Discard changes" IS the answer to this dialog's question. Asking it
+    // again reads as a warning rather than as the confirmation just given.
+    render(
+      <UnsavedChangesGuard isDirty>
+        <DeliberateLeave />
+      </UnsavedChangesGuard>
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "discard and go" })
+    );
+    expect(window.location.pathname).toBe("/admin/somewhere-else");
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
+  it("withholds nothing while disabled, so a submit in flight can navigate", async () => {
+    render(
+      <UnsavedChangesGuard isDirty disabled>
+        <GoElsewhere />
+      </UnsavedChangesGuard>
+    );
+    await userEvent.click(screen.getByRole("button", { name: "go" }));
+    expect(window.location.pathname).toBe("/admin/somewhere-else");
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+});
+
+describe("useLeaveWithoutWarning outside a guard", () => {
+  it("is a no-op rather than a crash", async () => {
+    // An embedded editor renders in a modal, with no guard above it.
+    render(<DeliberateLeave />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "discard and go" })
+    );
+    expect(window.location.pathname).toBe("/admin/somewhere-else");
+  });
+});

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -657,6 +657,8 @@ export function SingleForm({
   }, [recovery, form]);
 
   return (
+    // A single is only ever edited standalone, so there is no embedded case to
+    // exclude the way the entry editor has.
     <EntryLocaleProvider value={localeCtx}>
       <div className={cn("space-y-0", className)}>
         <EntryFormProvider form={form} onSubmit={handleSubmit}>

--- a/packages/admin/src/hooks/useUnsavedChanges.ts
+++ b/packages/admin/src/hooks/useUnsavedChanges.ts
@@ -63,6 +63,19 @@ export interface UseUnsavedChangesReturn {
    * Whether navigation is currently blocked.
    */
   isBlocked: boolean;
+
+  /**
+   * Declare that the navigation about to happen is deliberate, so it is not
+   * questioned.
+   *
+   * For the cases where the author has ALREADY answered this dialog's question
+   * by choosing the action — discarding changes, or leaving after a save. Those
+   * reset the form and navigate in the same breath, and the reset cannot reach
+   * this hook before the navigation does: the interceptor reads `isDirty` from
+   * the render that registered it, which is still the dirty one. So the intent
+   * is stated rather than inferred from state that has not caught up.
+   */
+  leaveWithoutWarning: () => void;
 }
 
 interface PendingNavigation {
@@ -171,6 +184,17 @@ export function useUnsavedChanges({
       }, 100);
     }
   }, [onConfirmLeave]);
+
+  // Deliberate leave: suppress the next interception. The window is generous
+  // because the caller navigates on the next tick or two (a form reset, a
+  // mutation settling), and it closes itself so a suppression can never leak
+  // into a later navigation the author did not ask for.
+  const leaveWithoutWarning = useCallback(() => {
+    isNavigating.current = true;
+    setTimeout(() => {
+      isNavigating.current = false;
+    }, 500);
+  }, []);
 
   // Cancel leaving - stay on page
   const cancelLeave = useCallback(() => {
@@ -368,5 +392,6 @@ export function useUnsavedChanges({
     confirmLeave,
     cancelLeave,
     isBlocked,
+    leaveWithoutWarning,
   };
 }


### PR DESCRIPTION
## A shipped safety feature has never been switched on

The admin contains a complete unsaved-changes guard: the dialog, history interception for `pushState`/`replaceState`, back/forward handling, `beforeunload`. **Nothing has ever mounted it.**

```
$ fallow dead-code --trace UnsavedChangesGuard.tsx:UnsavedChangesGuard
  UNUSED UnsavedChangesGuard
  Reason: Re-exported through 1 barrel(s) but no consumer imports it through the barrel
```

Present since the initial commit, and touched since only by two theme passes that restyled a dialog which never rendered.

So this was true in the shipped product, measured in the browser:

1. Type into an entry title → `"Amina Khalid DIRTY"`
2. Navigate to another collection
3. **No dialog. URL moved. Work gone.**

I found it while investigating a narrower version of the same thing: switching content language on a dirty entry destroys unsaved edits silently — no warning, and no autosave recovery point either. That one matters to me particularly because Stage A/B made language switching far more reachable, so I increased exposure to it.

## What this does

Mounts the guard on the standalone entry editor.

**Not the embedded one.** That lives in a modal, where leaving is closing the dialog rather than a history move — and a modal opened *from* this editor would stack a second interceptor over the first, so two dialogs would answer one navigation.

**Discard changes is exempt, and has to be.** It is already the author answering this dialog's question; being asked again reads as a warning rather than as the confirmation just given.

Resetting the form first does *not* achieve that, and I tried it: the reset cannot reach the guard before the navigation does, because the interceptor reads `isDirty` from the render that registered it. Measured — the double prompt still appeared. So the intent is **declared** via `useLeaveWithoutWarning()` rather than inferred from state that has not caught up. That escape closes itself after 500ms, so a suppression can never leak into a later navigation.

I also got the placement wrong first time and caught it: `useEntryForm` runs *above* the guard it renders, so reading the context there returns the default no-op. The consumer has to be inside the provider, which the header is.

## Deliberately NOT mounted on singles

An untouched single already reports `isDirty === true` on load — visible today as a "Not saved" indicator and an enabled Save button on a document nobody has touched. Probed: `isDirty: true` with `dirtyFields: {}`.

The guard would therefore question a document with no changes. **A guard that fires on a clean form is worse than no guard, because it gets removed.** That is a pre-existing defect in `SingleForm`, unrelated to this change, and it is recorded as its own item rather than papered over here.

## Verified in the browser (entries)

| case | result |
|---|---|
| clean form → navigate | no prompt, navigates |
| untouched **create** form → navigate | no prompt, navigates |
| dirty → navigate | **blocked**, prompt shown, edit intact |
| Keep Editing | stays put, edit intact |
| Discard (dialog) | navigates |
| explicit "Discard changes" | navigates, **no second prompt** |
| clean single → navigate | no prompt (guard correctly not mounted) |

7 tests, all stub-verified. Reverting the hook to its dead state fails three; neutering the escape fails the fourth. The negative cases are the ones that matter, so they are the ones I wrote first.

Gates: `check-types` 0, `lint` 0, admin suite 254 files / 2293 tests, no new failures against the pre-existing 4-file baseline.

## Still open, deliberately

The **language switch** itself still discards work without asking, because it is not navigation at all — it is component state, so the guard cannot see it. Fixing that properly means making the editor's language URL-addressable so a switch becomes a history move the guard already understands. That is the next PR, and it also unblocks click-to-open from the list's language dots.
