### PR TITLE
feat(builder): add a floating toolbar to the selected block

### DIFF
--- a/.changeset/builder-block-toolbar.md
+++ b/.changeset/builder-block-toolbar.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The page builder gains a floating toolbar on the selected block: select its container, move it up or down, duplicate it, or delete it. These actions existed only as keyboard shortcuts before, so they were undiscoverable without reading a shortcut list. Unavailable actions stay in place and explain why, and a press still announces to screen readers through the same live region the keyboard uses.

--- a/packages/builder/src/block-toolbar.test.tsx
+++ b/packages/builder/src/block-toolbar.test.tsx
@@ -1,0 +1,299 @@
+// @vitest-environment jsdom
+
+/**
+ * The toolbar's wiring, which is the half `toolbar-actions.test.ts` cannot see.
+ *
+ * That file already decides which buttons appear and whether each is available.
+ * What is only true HERE is that a press reaches the same verb a keystroke
+ * reaches, that the bar is reachable from a keyboard, and — the case this
+ * component is most likely to break — that pressing a button does not clear the
+ * selection it acts on.
+ *
+ * **That last one is a REGRESSION class, not a hypothetical.** The canvas
+ * treats a click that resolves to no block as a click on the background and
+ * clears the selection, and the bar is rendered inside the canvas root. The
+ * first version of the drag layer broke click-to-select in exactly this shape
+ * and shipped, so the case is asserted against a real `Canvas` rather than
+ * against a stub that could not exhibit it.
+ *
+ * @module block-toolbar.test
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { ShortcutProvider } from "@nextlyhq/ui";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+
+import {
+  clearBlocks,
+  hasBlock,
+  registerBlocks,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+
+import { BlockToolbar } from "./block-toolbar";
+import { Canvas } from "./canvas";
+import type { EditorState } from "./editor-state";
+import { BlockKeyboardActions } from "./keyboard-actions";
+
+afterEach(() => {
+  cleanup();
+  clearBlocks();
+});
+
+function register() {
+  if (hasBlock("acme/leaf")) return;
+  registerBlocks(
+    [
+      {
+        name: "acme/leaf",
+        version: 1,
+        description: "A leaf.",
+        example: { props: {} },
+        editor: { label: "Leaf" },
+        render: () => React.createElement("p", null, "leaf"),
+      },
+    ] as never,
+    { source: "block-toolbar-test" }
+  );
+}
+
+function documentOf(nodes: BlockNode[]): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+}
+
+/** Two blocks, so `up` and `down` each have a case that is available. */
+function pair(extra: Partial<BlockNode> = {}): BlockDocument {
+  return documentOf([
+    {
+      id: "a",
+      type: "acme/leaf",
+      version: 1,
+      props: {},
+      ...extra,
+    } as BlockNode,
+    { id: "b", type: "acme/leaf", version: 1, props: {} } as BlockNode,
+  ]);
+}
+
+function editorSpy(
+  doc: BlockDocument,
+  selectedId: string | null
+): EditorState & {
+  apply: ReturnType<typeof vi.fn>;
+  select: ReturnType<typeof vi.fn>;
+} {
+  return {
+    document: doc,
+    selectedId,
+    select: vi.fn(),
+    apply: vi.fn(() => doc),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+    undoDepth: 0,
+  } as unknown as EditorState & {
+    apply: ReturnType<typeof vi.fn>;
+    select: ReturnType<typeof vi.fn>;
+  };
+}
+
+/**
+ * The bar in the composition a host actually renders.
+ *
+ * A real `Canvas`, not a bare div. The bar measures against the SELECTED
+ * BLOCK'S element and hides itself when it cannot find one, so a harness
+ * without rendered blocks tests a permanently hidden toolbar — which is how the
+ * first draft of these cases came back unable to find a single button.
+ */
+function mount(editor: EditorState, props: { hidden?: boolean } = {}) {
+  return render(
+    <ShortcutProvider>
+      <BlockKeyboardActions editor={editor}>
+        <Canvas
+          document={editor.document}
+          siteStyles={{ css: "", classes: {} } as never}
+          selectedId={editor.selectedId}
+          onSelect={editor.select}
+          overlay={<BlockToolbar editor={editor} {...props} />}
+        />
+      </BlockKeyboardActions>
+    </ShortcutProvider>
+  );
+}
+
+describe("BlockToolbar", () => {
+  it("draws nothing with no selection", () => {
+    register();
+    mount(editorSpy(pair(), null));
+
+    expect(screen.queryByRole("toolbar")).toBeNull();
+  });
+
+  it("draws nothing while the host says a gesture is in flight", () => {
+    // A bar drawn during a drag sits over the canvas the author is aiming at,
+    // and names a block that is in the middle of moving.
+    register();
+    mount(editorSpy(pair(), "a"), { hidden: true });
+
+    expect(screen.queryByRole("toolbar")).toBeNull();
+  });
+
+  it("offers the five verbs, named", () => {
+    register();
+    mount(editorSpy(pair(), "a"));
+
+    expect(
+      screen.getAllByRole("button").map(b => b.getAttribute("aria-label"))
+    ).toEqual(["Select parent", "Move up", "Move down", "Duplicate", "Delete"]);
+  });
+
+  it("presses the SAME verb the keystroke presses", () => {
+    // Through `editor.apply` with the op duplicate produces, rather than
+    // through an op this component composed. A toolbar that built its own would
+    // pass a test asserting only that something was applied.
+    register();
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    fireEvent.click(screen.getByLabelText("Duplicate"));
+
+    expect(editor.apply).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "insert", at: { index: 1 } })
+    );
+    // Selection follows the copy, which is the keyboard duplicate's behaviour
+    // and therefore has to be this one's.
+    expect(editor.select).toHaveBeenCalled();
+  });
+
+  it("moves the selection down through the store", () => {
+    register();
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    fireEvent.click(screen.getByLabelText("Move down"));
+
+    expect(editor.apply).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "move", id: "a" })
+    );
+  });
+
+  it("passes a dimmed press to the verb, which refuses it and says why", () => {
+    /*
+     * The bar deliberately does not guard the press itself. Every verb already
+     * refuses what it cannot do, and a lock refusal ANNOUNCES — so a dimmed
+     * Delete pressed by a keyboard author explains itself instead of doing
+     * nothing. A guard in the bar would swallow exactly that sentence.
+     *
+     * Both halves are asserted. "Nothing was applied" alone would pass against
+     * a bar that ignored the press entirely, which is the design this one
+     * rejected.
+     */
+    register();
+    const editor = editorSpy(pair({ locked: true }), "a");
+    mount(editor);
+
+    fireEvent.click(screen.getByLabelText("Delete"));
+
+    expect(editor.apply).not.toHaveBeenCalled();
+    expect(screen.getByRole("status").textContent).toBe(
+      "Leaf is locked. Unlock it to delete it."
+    );
+  });
+
+  it("keeps an unavailable button FOCUSABLE, and says why", () => {
+    // The reason is the information. `disabled` would take the button out of
+    // the tab sequence and take the reason with it, so the author most in need
+    // of the sentence is the one who would never receive it.
+    register();
+    const editor = editorSpy(pair({ locked: true }), "a");
+    mount(editor);
+
+    const remove = screen.getByLabelText("Delete");
+    expect(remove.getAttribute("aria-disabled")).toBe("true");
+    expect(remove.hasAttribute("disabled")).toBe(false);
+
+    const describedBy = remove.getAttribute("aria-describedby");
+    expect(describedBy).not.toBeNull();
+    expect(document.getElementById(describedBy ?? "")?.textContent).toBe(
+      "This block is locked."
+    );
+  });
+
+  it("is ONE tab stop, with arrows moving inside it", () => {
+    // The WAI-ARIA toolbar pattern. Five separate tab stops would put four
+    // extra presses between the canvas and whatever follows it.
+    register();
+    mount(editorSpy(pair(), "a"));
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.map(b => b.getAttribute("tabindex"))).toEqual([
+      "0",
+      "-1",
+      "-1",
+      "-1",
+      "-1",
+    ]);
+
+    fireEvent.keyDown(screen.getByRole("toolbar"), { key: "ArrowRight" });
+    expect(document.activeElement).toBe(buttons[1]);
+
+    // Wrapping, so Delete is one press from Select parent rather than four.
+    fireEvent.keyDown(screen.getByRole("toolbar"), { key: "ArrowLeft" });
+    fireEvent.keyDown(screen.getByRole("toolbar"), { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(buttons[4]);
+  });
+
+  it("refuses to render without the verbs above it", () => {
+    // Loudly. A toolbar that rendered its buttons and did nothing on every
+    // press looks like a broken editor rather than a missing wrapper, and it
+    // would reach a person before it reached a developer.
+    register();
+    const quiet = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(() =>
+        render(<BlockToolbar editor={editorSpy(pair(), "a")} />)
+      ).toThrow(/BlockKeyboardActions/);
+    } finally {
+      quiet.mockRestore();
+    }
+  });
+});
+
+describe("a press on the toolbar and the canvas's own click handling", () => {
+  it("does NOT clear the selection the bar acts on", () => {
+    /*
+     * Against a real `Canvas`, because the fault lives in the interaction
+     * between the two: the canvas reads a click that resolves to no block as a
+     * click on the background and clears the selection, and the bar is rendered
+     * INSIDE the canvas root. A stubbed canvas cannot exhibit it, and the
+     * equivalent defect shipped once already in the drag layer.
+     */
+    register();
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    fireEvent.click(screen.getByLabelText("Duplicate"));
+
+    // `select` IS called — duplicate moves the selection to the copy — so the
+    // assertion is that it was never called with null, which is the value a
+    // background click sends.
+    expect(editor.select).not.toHaveBeenCalledWith(null);
+  });
+
+  it("still clears the selection for a click on the page background", () => {
+    // The control. Without it the case above passes against a canvas that had
+    // stopped clearing the selection at all, which would be a different bug
+    // with the same green.
+    register();
+    const editor = editorSpy(pair(), "a");
+    const { container } = mount(editor);
+
+    const root = container.querySelector(".nx-canvas");
+    if (root === null) throw new Error("expected a canvas root");
+    fireEvent.click(root);
+
+    expect(editor.select).toHaveBeenCalledWith(null);
+  });
+});

--- a/packages/builder/src/block-toolbar.tsx
+++ b/packages/builder/src/block-toolbar.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+/**
+ * The floating toolbar: the structural verbs, at the block they act on.
+ *
+ * Every action here already existed and was reachable only by keystroke —
+ * alt+Arrow to move, mod+D to duplicate, Delete to remove. An author who has
+ * not read a shortcut list has no way to discover that this editor can
+ * duplicate a block at all, so for most of the people using it those verbs were
+ * effectively absent. This is B-16's pointer half; the breadcrumb in the bottom
+ * bar is the other.
+ *
+ * ## It presses the SAME verbs the keys do
+ *
+ * The callbacks come from `useBlockActionsContext`, which is the set
+ * `BlockKeyboardActions` binds. Nothing here applies an op. A toolbar with its
+ * own ops would be a second answer to "what does duplicate do", and the two
+ * would drift — the author meets that as a button and a keystroke that disagree,
+ * long after either was written. It is also why the announcements are right
+ * without this module containing one: the verbs announce into the single live
+ * region that component owns.
+ *
+ * ## Why it is drawn in the canvas overlay
+ *
+ * The bar is positioned in the canvas's own CONTENT coordinates, which means
+ * scrolling the canvas carries it along with the block at no cost — there is no
+ * scroll listener here, and there is no frame on which the bar and the block it
+ * names disagree. That is the same reason the drop indicator lives there.
+ *
+ * ## Disabled, not hidden; and still focusable
+ *
+ * A bar whose buttons come and go changes width and order as the selection
+ * moves, so the control an author is aiming at has moved by the time they
+ * arrive. Unavailable actions stay in place, dimmed.
+ *
+ * They also stay REACHABLE, through `aria-disabled` rather than the `disabled`
+ * attribute. A disabled button is removed from the tab sequence, and the reason
+ * it is disabled — "Caption inside this block is locked" — is precisely what a
+ * keyboard or screen-reader author needs and would then never receive. The
+ * press is refused in the handler instead.
+ *
+ * @module block-toolbar
+ */
+
+import { NODE_ID_ATTRIBUTE } from "@nextlyhq/blocks-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  Copy,
+  CornerLeftUp,
+  Trash2,
+  type LucideIcon,
+} from "lucide-react";
+import * as React from "react";
+
+import { CANVAS_ROOT_CLASS, CHROME_ATTRIBUTE } from "./canvas";
+import type { EditorState } from "./editor-state";
+import { canvasContentRect } from "./geometry-dom";
+import { useBlockActionsContext } from "./keyboard-actions";
+import {
+  toolbarActions,
+  toolbarPlacement,
+  toolbarShortcut,
+  type ToolbarAction,
+  type ToolbarActionId,
+  type ToolbarPlacement,
+} from "./toolbar-actions";
+
+const ICONS: Record<ToolbarActionId, LucideIcon> = {
+  "select-parent": CornerLeftUp,
+  "move-up": ArrowUp,
+  "move-down": ArrowDown,
+  duplicate: Copy,
+  delete: Trash2,
+};
+
+export interface BlockToolbarProps {
+  /** The editor whose selection this acts on. */
+  editor: EditorState;
+  /**
+   * Suppress the bar, for a host that is mid-gesture.
+   *
+   * A drag is the case this exists for: the bar would sit over the canvas while
+   * the author is aiming at it, and it names a block that is in the middle of
+   * moving. Rendering nothing is right rather than hiding with CSS, because a
+   * hidden bar would still be in the tab order.
+   */
+  hidden?: boolean;
+}
+
+/**
+ * The selected block's element, found by comparing ids rather than by selector.
+ *
+ * A node id reaches this from stored data, and interpolating it into
+ * `querySelector` makes any character CSS treats specially either throw or,
+ * worse, match something else. The canvas resolves the same question the same
+ * way for the same reason.
+ *
+ * Deliberately NOT the `data-nx-selected` marker the canvas writes. That marker
+ * is applied in a passive effect, and this measurement runs in a layout effect
+ * of a DESCENDANT — so on the render where the selection changes, the marker is
+ * still on the previously selected element. The bar would spend one frame
+ * measuring the wrong block, which is visible as a jump.
+ */
+function selectedElement(root: HTMLElement, id: string): Element | null {
+  let found: Element | null = null;
+  // `forEach` rather than `for…of`: a `NodeList` is only iterable under a lib
+  // that declares its iterator, and this package compiles without one.
+  root.querySelectorAll(`[${NODE_ID_ATTRIBUTE}]`).forEach(element => {
+    if (found === null && element.getAttribute(NODE_ID_ATTRIBUTE) === id) {
+      found = element;
+    }
+  });
+  return found;
+}
+
+export function BlockToolbar({
+  editor,
+  hidden = false,
+}: BlockToolbarProps): React.JSX.Element | null {
+  const verbs = useBlockActionsContext();
+  const bar = React.useRef<HTMLDivElement | null>(null);
+  const [placement, setPlacement] = React.useState<ToolbarPlacement | null>(
+    null
+  );
+
+  const { document, selectedId } = editor;
+  const actions = React.useMemo(
+    () => toolbarActions(document, selectedId),
+    [document, selectedId]
+  );
+
+  /*
+   * Which button holds the tab stop, per the WAI-ARIA toolbar pattern: one stop
+   * for the whole bar, arrows to move within it.
+   *
+   * Held as an index rather than an id so it survives a selection change to a
+   * block whose actions differ, and reset below when the selection moves —
+   * otherwise the stop would sit on whichever button happened to be there for
+   * the last block.
+   */
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  React.useEffect(() => {
+    setActiveIndex(0);
+  }, [selectedId]);
+
+  /*
+   * Measure after the DOM has the block but before the browser paints, so the
+   * bar never appears at a stale position first.
+   *
+   * Re-run on the document as well as the selection: an edit can resize the
+   * selected block — that is most of what the inspector does — and a bar keyed
+   * on the selection alone would stay where the block used to end.
+   */
+  const measure = React.useCallback(() => {
+    const element = bar.current;
+    if (element === null || selectedId === null) {
+      setPlacement(null);
+      return;
+    }
+    const root = element.closest(`.${CANVAS_ROOT_CLASS}`);
+    if (!(root instanceof HTMLElement)) {
+      setPlacement(null);
+      return;
+    }
+    const block = selectedElement(root, selectedId);
+    if (block === null) {
+      setPlacement(null);
+      return;
+    }
+    // The bar's own size, through the same measurement the block goes through.
+    // Its position is discarded — what is wanted is width and height — but a
+    // second way of reading a rectangle is exactly what `geometry-dom` exists
+    // to prevent, and a bar measured one way against a block measured another
+    // is a disagreement that only shows up at a scroll offset.
+    const size = canvasContentRect(element, root);
+    setPlacement(
+      toolbarPlacement(
+        canvasContentRect(block, root),
+        { width: size.width, height: size.height },
+        // The root's own box rather than its scroll extent. `scrollWidth` and
+        // `scrollHeight` are the CONTENT's size, so a long page would report a
+        // height of several thousand and the clamp would let the bar sit far
+        // outside what the author can see.
+        canvasContentRect(root, root)
+      )
+    );
+  }, [selectedId]);
+
+  React.useLayoutEffect(() => {
+    if (hidden) return;
+    measure();
+  }, [measure, hidden, document, actions]);
+
+  /*
+   * Re-measure when the block changes size for a reason no render reports — an
+   * image finishing, a webfont swapping, the panels being resized around the
+   * canvas. Without this the bar sits at the position the block had while it
+   * was still loading, which is the state most pages spend their first second
+   * in.
+   */
+  React.useEffect(() => {
+    if (hidden || selectedId === null) return;
+    const element = bar.current;
+    const root = element?.closest(`.${CANVAS_ROOT_CLASS}`);
+    if (!(root instanceof HTMLElement)) return;
+    const block = selectedElement(root, selectedId);
+    if (block === null) return;
+
+    // Absent in jsdom unless a test supplies one, and absent in older browsers.
+    // A missing observer costs a re-measure, not correctness — every render
+    // path above still measures.
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => measure());
+    observer.observe(block);
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, [measure, hidden, selectedId, document]);
+
+  const focusAt = React.useCallback((index: number) => {
+    setActiveIndex(index);
+    const buttons = bar.current?.querySelectorAll("button");
+    const target = buttons?.[index];
+    if (target instanceof HTMLElement) target.focus();
+  }, []);
+
+  const onKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const count = actions.length;
+      if (count === 0) return;
+      // Wrapping, which the toolbar pattern lists as the common choice: the bar
+      // is five buttons, and stopping at the ends makes reaching Delete from
+      // Select parent four presses instead of one.
+      if (event.key === "ArrowRight") {
+        focusAt((activeIndex + 1) % count);
+      } else if (event.key === "ArrowLeft") {
+        focusAt((activeIndex - 1 + count) % count);
+      } else if (event.key === "Home") {
+        focusAt(0);
+      } else if (event.key === "End") {
+        focusAt(count - 1);
+      } else {
+        return;
+      }
+      // Only for the keys handled above. Returning first leaves Tab, Escape and
+      // every shortcut the shell binds to reach their own handlers.
+      event.preventDefault();
+    },
+    [actions.length, activeIndex, focusAt]
+  );
+
+  /*
+   * A press is passed on WHATEVER the action's availability says.
+   *
+   * Every verb already refuses what it cannot do — a first block will not move
+   * up, a locked one will not be deleted — so a guard here would refuse a
+   * second time and could only ever disagree with the first. It would also cost
+   * something real: a lock refusal ANNOUNCES itself, so a dimmed Delete pressed
+   * by a keyboard author says "Caption is locked. Unlock it to delete it."
+   * rather than nothing at all. That sentence is the reason the button stays
+   * pressable, and swallowing the press here would take it away.
+   */
+  const run = React.useCallback(
+    (action: ToolbarAction) => {
+      if (action.id === "select-parent") verbs.selectParent();
+      else if (action.id === "move-up") verbs.move("up");
+      else if (action.id === "move-down") verbs.move("down");
+      else if (action.id === "duplicate") verbs.duplicate();
+      else verbs.delete();
+    },
+    [verbs]
+  );
+
+  if (hidden || actions.length === 0) return null;
+
+  return (
+    <div
+      ref={bar}
+      className="nx-block-toolbar"
+      // Marked as chrome so a press here is not read as a click on the page
+      // background, which would clear the very selection this bar acts on.
+      {...{ [CHROME_ATTRIBUTE]: "" }}
+      role="toolbar"
+      aria-orientation="horizontal"
+      aria-label="Block actions"
+      data-side={placement?.side}
+      // Kept out of sight rather than unmounted until the first measurement.
+      // The bar has to be in the DOM to be measured at all, and mounting it at
+      // a default position would show it in the wrong place for one frame.
+      style={
+        placement === null
+          ? { visibility: "hidden" }
+          : { left: placement.x, top: placement.y }
+      }
+      onKeyDown={onKeyDown}
+    >
+      {actions.map((action, index) => {
+        const Icon = ICONS[action.id];
+        const shortcut = toolbarShortcut(action.id);
+        const describedBy =
+          action.reason === undefined
+            ? undefined
+            : `nx-toolbar-reason-${action.id}`;
+        return (
+          <button
+            key={action.id}
+            type="button"
+            className="nx-block-toolbar__button"
+            // The name is the verb alone. Voice control activates a control by
+            // its name, so folding the reason into it would make "click delete"
+            // stop matching the button called Delete.
+            aria-label={action.label}
+            aria-disabled={action.enabled ? undefined : true}
+            aria-describedby={describedBy}
+            // The description twice over: `title` for a pointer, and a hidden
+            // span for anything that reads the accessible description. `title`
+            // alone never reaches a keyboard author, who is exactly the person
+            // the reason is for.
+            title={
+              action.reason ??
+              (shortcut === undefined
+                ? action.label
+                : `${action.label} (${shortcut})`)
+            }
+            tabIndex={index === activeIndex ? 0 : -1}
+            onFocus={() => setActiveIndex(index)}
+            onClick={() => run(action)}
+          >
+            <Icon size={16} aria-hidden="true" />
+            {describedBy === undefined ? null : (
+              <span id={describedBy} className="nx-sr-only">
+                {action.reason}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -61,6 +61,30 @@ export const CANVAS_ROOT_CLASS = "nx-canvas";
 export const SELECTED_ATTRIBUTE = "data-nx-selected";
 
 /**
+ * Marks editor chrome drawn over the page, which is not part of the page.
+ *
+ * A click on the canvas background CLEARS the selection, and the overlay sits
+ * inside the canvas root — so without this a press on any control drawn over
+ * the page resolves to "no node" and deselects the very block that control
+ * acts on. The floating toolbar would run its action and then watch itself
+ * disappear.
+ *
+ * An attribute rather than each overlay calling `stopPropagation`: the rule
+ * belongs to what chrome IS, and the version where every new overlay has to
+ * remember it is the version where the next one does not. The drop indicator
+ * needs no marker only because it takes no pointer events at all.
+ */
+export const CHROME_ATTRIBUTE = "data-nx-chrome";
+
+/** Whether an event started inside editor chrome rather than inside the page. */
+function isChrome(target: EventTarget | null): boolean {
+  return (
+    target instanceof Element &&
+    target.closest(`[${CHROME_ATTRIBUTE}]`) !== null
+  );
+}
+
+/**
  * How a pointer event on the canvas resolves to a node id, or to nothing.
  *
  * `closest` rather than reading the target directly: a click lands on whatever
@@ -160,6 +184,10 @@ export function Canvas({
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       if (!onSelect) return;
+      // Chrome is not the page. Pressing a button drawn over the canvas is not
+      // a click on the background, and treating it as one would deselect the
+      // block that button acts on.
+      if (isChrome(event.target)) return;
       // A click on the canvas background resolves to null, which CLEARS the
       // selection rather than being ignored. Ignoring it leaves an inspector
       // showing a node the author believes they have deselected.

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -257,3 +257,22 @@ export {
   COPY_SUFFIX,
   type BlockDuplication,
 } from "./duplicate-block";
+
+/**
+ * @experimental What the floating toolbar offers, and where it sits.
+ *
+ * From this entry because both halves are plain functions. The action list is
+ * the same set of questions an agent asks before proposing a structural edit —
+ * whether this block can move, whether a lock forbids removing it — answered by
+ * the rules the editor itself uses rather than by a second reading of them.
+ */
+export {
+  TOOLBAR_GAP_PX,
+  toolbarActions,
+  toolbarPlacement,
+  toolbarShortcut,
+  type ToolbarAction,
+  type ToolbarActionId,
+  type ToolbarPlacement,
+  type ToolbarSize,
+} from "./toolbar-actions";

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -32,7 +32,7 @@ import {
   type MoveDirection,
   type MoveEffect,
 } from "./keyboard-move";
-import { layerLabel } from "./layers";
+import { layerLabel, pathTo } from "./layers";
 import { lockBlockingDelete, lockBlockingMove } from "./locking";
 
 /**
@@ -127,6 +127,58 @@ function deletionAnnouncement(name: string, descendants: number): string {
 /** How the undo shortcut is READ ALOUD, which is not how it is parsed. */
 const UNDO_KEYS_SPOKEN = "Control or Command Z";
 
+/**
+ * The structural verbs, as callables.
+ *
+ * Published so a POINTER surface can press exactly what a keystroke presses.
+ * The floating toolbar offers the same five actions, and a toolbar that applied
+ * its own ops would be a second answer to "what does duplicate do" — which an
+ * author meets as two buttons that disagree, months after the second one was
+ * written.
+ *
+ * Every one is silent when it has no subject, so a caller may press any of them
+ * without first asking whether it applies. `toolbarActions` answers that
+ * separately, for drawing a control as unavailable rather than for guarding the
+ * call.
+ */
+export interface BlockActions {
+  /** Move the selection one step in `direction`, lock permitting. */
+  readonly move: (direction: MoveDirection) => void;
+  /** Delete the selection and everything inside it, lock permitting. */
+  readonly delete: () => void;
+  /** Copy the selection in beside itself and select the copy. */
+  readonly duplicate: () => void;
+  /** Select the container holding the selection. */
+  readonly selectParent: () => void;
+}
+
+/**
+ * The verbs, for a surface rendered under {@link BlockKeyboardActions}.
+ *
+ * `null` until a provider is above it, which {@link useBlockActionsContext}
+ * turns into a thrown error rather than a silently inert toolbar.
+ */
+const BlockActionsContext = React.createContext<BlockActions | null>(null);
+
+/**
+ * The verbs from the nearest {@link BlockKeyboardActions}.
+ *
+ * Throws when there is none. A toolbar without them would render its buttons
+ * and do nothing on every press, which looks like a broken editor rather than
+ * like a missing wrapper — and it would reach a person before it reached a
+ * developer.
+ */
+export function useBlockActionsContext(): BlockActions {
+  const actions = React.useContext(BlockActionsContext);
+  if (actions === null) {
+    throw new Error(
+      "[@nextlyhq/builder] Block actions are only available inside " +
+        "<BlockKeyboardActions>. Render it as an ancestor of whatever uses them."
+    );
+  }
+  return actions;
+}
+
 export interface BlockKeyboardActionsOptions {
   /**
    * The editor whose document these move blocks in.
@@ -146,17 +198,32 @@ export interface BlockKeyboardActionsOptions {
   enabled?: boolean;
 }
 
+/** What the hook hands back: the region's text, and the verbs behind the keys. */
+export interface BlockKeyboardActionsResult {
+  /** The live region's current text. Owned by one region and one only. */
+  readonly announcement: string;
+  /** The same verbs the keystrokes run, for a pointer surface to press. */
+  readonly actions: BlockActions;
+}
+
 /**
  * Register the move bindings for as long as the caller is mounted.
  *
- * Returns nothing: there is no state here worth exposing, and a hook that
- * returned handlers would invite a second caller to wire them to different keys
- * — which is how one gesture ends up with two answers.
+ * The verbs come back as well as the announcement, and the reason is the one
+ * this hook's earlier note argued against: a returned handler could be bound to
+ * a second set of keys. What settles it is that the alternative is worse. The
+ * toolbar needs the same five verbs AND the same live region, and a surface
+ * that reimplemented either would produce two answers to one gesture — a second
+ * region that talks over the first, or a button whose op drifts from its
+ * keystroke's. Sharing them is what keeps there being one of each.
+ *
+ * The keys stay this module's alone: nothing here is bindable by a caller, and
+ * {@link BlockKeyboardActions} is the only supported way to reach the verbs.
  */
 export function useBlockKeyboardActions({
   editor,
   enabled = true,
-}: BlockKeyboardActionsOptions): string {
+}: BlockKeyboardActionsOptions): BlockKeyboardActionsResult {
   // The message a live region reads out. Held as state rather than written to
   // the DOM directly so React owns the node — a region mutated behind React's
   // back is reverted by the next render, silently and only sometimes.
@@ -274,6 +341,71 @@ export function useBlockKeyboardActions({
     announce(`${duplication.label} duplicated. Undo with ${UNDO_KEYS_SPOKEN}.`);
   }, [announce]);
 
+  const moveSelected = React.useCallback(
+    (direction: MoveDirection) => {
+      const editorNow = latest.current;
+      const selectedId = editorNow.selectedId;
+      if (selectedId === null) return;
+
+      // Only the node itself, never its subtree: moving a container leaves
+      // a locked child in the same slot at the same index, so the lock is
+      // not violated and refusing would let one locked caption freeze the
+      // whole section around it.
+      const lockedNode = lockBlockingMove(editorNow.document, selectedId);
+      if (lockedNode !== undefined) {
+        announce(`${layerLabel(lockedNode)} is locked. Unlock it to move it.`);
+        return;
+      }
+
+      const move = keyboardMovePosition(
+        editorNow.document.nodes,
+        selectedId,
+        direction
+      );
+      // `null` is an ordinary answer: the first block cannot move up, and a
+      // top-level block cannot outdent. Refusing quietly is right — a block
+      // at the end of its container has nowhere to go, and saying so would
+      // be an error message for pressing a key that did nothing.
+      if (move === null) return;
+
+      const applied = editorNow.apply({
+        kind: "move",
+        id: selectedId,
+        to: move.to,
+        dropSlotIfEmpty: move.dropSlotIfEmpty,
+      });
+      // Announced only once the store has accepted it. A keyboard author
+      // cannot see the result, and the store may refuse — announcing before
+      // it answered would report a move that did not happen, which is worse
+      // than silence because it cannot be told from one that did.
+      //
+      // Refusals stay silent, deliberately. "This block is already first"
+      // on every press at the end of a list is noise an author cannot act
+      // on, and the block not moving is itself the answer.
+      if (applied !== null) announce(EFFECT_ANNOUNCEMENT[move.effect]);
+      // The selection deliberately does NOT change. The block that moved is
+      // the block still selected, so a second press continues moving the
+      // same block — which is what makes a run of presses walk it across the
+    },
+    [announce]
+  );
+
+  /**
+   * Select the container holding the selection.
+   *
+   * Reads the same trail the breadcrumb draws, so "the parent" cannot mean one
+   * block here and another there. Silent when there is no container: a
+   * top-level block has none, and saying so on every press would be an error
+   * message for a control that is already disabled.
+   */
+  const selectParent = React.useCallback(() => {
+    const editorNow = latest.current;
+    const path = pathTo(editorNow.document, editorNow.selectedId);
+    const parent = path[path.length - 2];
+    if (parent === undefined) return;
+    editorNow.select(parent.id);
+  }, []);
+
   const bindings = React.useMemo(
     () =>
       MOVE_KEYS.map(({ keys, direction, description }) => ({
@@ -289,56 +421,9 @@ export function useBlockKeyboardActions({
         // word-wise caret movement on every platform that has it. An author
         // editing a heading must be able to move the caret through it.
         whenTyping: false,
-        run: () => {
-          const editorNow = latest.current;
-          const selectedId = editorNow.selectedId;
-          if (selectedId === null) return;
-
-          // Only the node itself, never its subtree: moving a container leaves
-          // a locked child in the same slot at the same index, so the lock is
-          // not violated and refusing would let one locked caption freeze the
-          // whole section around it.
-          const lockedNode = lockBlockingMove(editorNow.document, selectedId);
-          if (lockedNode !== undefined) {
-            announce(
-              `${layerLabel(lockedNode)} is locked. Unlock it to move it.`
-            );
-            return;
-          }
-
-          const move = keyboardMovePosition(
-            editorNow.document.nodes,
-            selectedId,
-            direction
-          );
-          // `null` is an ordinary answer: the first block cannot move up, and a
-          // top-level block cannot outdent. Refusing quietly is right — a block
-          // at the end of its container has nowhere to go, and saying so would
-          // be an error message for pressing a key that did nothing.
-          if (move === null) return;
-
-          const applied = editorNow.apply({
-            kind: "move",
-            id: selectedId,
-            to: move.to,
-            dropSlotIfEmpty: move.dropSlotIfEmpty,
-          });
-          // Announced only once the store has accepted it. A keyboard author
-          // cannot see the result, and the store may refuse — announcing before
-          // it answered would report a move that did not happen, which is worse
-          // than silence because it cannot be told from one that did.
-          //
-          // Refusals stay silent, deliberately. "This block is already first"
-          // on every press at the end of a list is noise an author cannot act
-          // on, and the block not moving is itself the answer.
-          if (applied !== null) announce(EFFECT_ANNOUNCEMENT[move.effect]);
-          // The selection deliberately does NOT change. The block that moved is
-          // the block still selected, so a second press continues moving the
-          // same block — which is what makes a run of presses walk it across the
-          // page rather than moving a different block each time.
-        },
+        run: () => moveSelected(direction),
       })),
-    [announce]
+    [moveSelected]
   );
 
   const editing = React.useMemo(
@@ -425,7 +510,17 @@ export function useBlockKeyboardActions({
     enabled,
   });
 
-  return announcement;
+  const actions = React.useMemo<BlockActions>(
+    () => ({
+      move: moveSelected,
+      delete: deleteSelected,
+      duplicate: duplicateSelected,
+      selectParent,
+    }),
+    [moveSelected, deleteSelected, duplicateSelected, selectParent]
+  );
+
+  return { announcement, actions };
 }
 
 /**
@@ -436,14 +531,25 @@ export function useBlockKeyboardActions({
  * otherwise have to invent a null-returning wrapper of its own, and every host
  * would invent a slightly different one.
  *
- * Renders nothing. It is a place to run a hook, which is the same shape the
- * command palette already uses for its modal key hold.
+ * Renders the live region, and publishes the verbs to whatever it wraps. Both
+ * belong to the same mount deliberately: a toolbar reachable without the region
+ * could act without announcing, and a keyboard author would meet a button that
+ * changes the page and says nothing.
+ *
+ * `children` is optional. A host that wants only the keystrokes passes none and
+ * gets exactly what this rendered before.
  */
 export function BlockKeyboardActions({
   editor,
   enabled,
-}: BlockKeyboardActionsOptions): React.JSX.Element {
-  const announcement = useBlockKeyboardActions({ editor, enabled });
+  children,
+}: BlockKeyboardActionsOptions & {
+  readonly children?: React.ReactNode;
+}): React.JSX.Element {
+  const { announcement, actions } = useBlockKeyboardActions({
+    editor,
+    enabled,
+  });
 
   // `polite`, not `assertive`: a move is the author's own action and its result
   // can wait for a pause. Assertive interrupts whatever is being read, which for
@@ -454,8 +560,11 @@ export function BlockKeyboardActions({
   // text is frequently not announced at all, because the assistive technology
   // has nothing it was already watching.
   return (
-    <p aria-live="polite" role="status" className="nx-sr-only">
-      {announcement}
-    </p>
+    <BlockActionsContext.Provider value={actions}>
+      <p aria-live="polite" role="status" className="nx-sr-only">
+        {announcement}
+      </p>
+      {children}
+    </BlockActionsContext.Provider>
   );
 }

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -101,9 +101,25 @@ export type { InsertPanelProps } from "./insert-panel";
  */
 export {
   BlockKeyboardActions,
+  useBlockActionsContext,
   useBlockKeyboardActions,
 } from "./keyboard-actions";
-export type { BlockKeyboardActionsOptions } from "./keyboard-actions";
+export type {
+  BlockActions,
+  BlockKeyboardActionsOptions,
+  BlockKeyboardActionsResult,
+} from "./keyboard-actions";
+
+/**
+ * The floating toolbar, from this entry because it is a client component and
+ * because it only works below `BlockKeyboardActions`.
+ *
+ * It presses the verbs that component publishes rather than applying ops of its
+ * own, which is what keeps one gesture having one answer — and what lets both
+ * the button and the keystroke announce into the single live region.
+ */
+export { BlockToolbar } from "./block-toolbar";
+export type { BlockToolbarProps } from "./block-toolbar";
 
 /**
  * The editor's document state, published beside the canvas because it is a hook

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -567,3 +567,77 @@
   padding-bottom: 0.75rem;
   border-bottom: 1px solid var(--nx-builder-border);
 }
+
+/*
+ * The floating block toolbar.
+ *
+ * Positioned in the canvas's own content coordinates, like the drop indicator
+ * and for the same reason: the coordinates the component computes are the ones
+ * `left` and `top` consume, so scrolling the canvas carries the bar along with
+ * the block it names and there is no frame on which the two disagree.
+ *
+ * Above the indicator in the stack. They are never both on screen — the bar
+ * unmounts for the duration of a drag — but a z-index that depended on that
+ * staying true would fail silently the first time it stopped being true.
+ */
+.nx-block-toolbar {
+  position: absolute;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  gap: 0.125rem;
+  padding: 0.125rem;
+  border: 1px solid var(--nx-builder-border);
+  border-radius: 0.375rem;
+  background: var(--nx-builder-surface-raised);
+  /*
+   * The elevation is drawn in the border's own colour rather than in a
+   * translucent black. An alpha-blended shadow's contrast depends on whatever
+   * the page happens to render behind it, and the page here is the author's —
+   * so the one value that would need checking is the one value this component
+   * cannot know.
+   */
+  box-shadow: 0 1px 3px var(--nx-builder-border);
+}
+
+/*
+ * 1.75rem is 28px, over the 24px floor WCAG 2.2 SC 2.5.8 sets for a target.
+ * The icons are 16px, so the remainder is the hit area rather than padding
+ * around a smaller one.
+ */
+.nx-block-toolbar__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: none;
+  border-radius: 0.25rem;
+  background: none;
+  color: var(--nx-builder-text);
+  cursor: pointer;
+}
+
+.nx-block-toolbar__button:hover {
+  background: var(--nx-builder-surface);
+}
+
+.nx-block-toolbar__button:focus-visible {
+  outline: 2px solid var(--nx-builder-accent);
+  outline-offset: -2px;
+}
+
+/*
+ * `aria-disabled`, never the `disabled` attribute — the button stays focusable
+ * so the reason it is unavailable can be read. The styling therefore has to
+ * carry what `:disabled` would have: no hover response, and a pointer that says
+ * the press will not land.
+ */
+.nx-block-toolbar__button[aria-disabled="true"] {
+  color: var(--nx-builder-text-muted);
+  cursor: not-allowed;
+}
+
+.nx-block-toolbar__button[aria-disabled="true"]:hover {
+  background: none;
+}

--- a/packages/builder/src/toolbar-actions.test.ts
+++ b/packages/builder/src/toolbar-actions.test.ts
@@ -1,0 +1,281 @@
+/**
+ * The toolbar's decisions, without a DOM.
+ *
+ * Two properties matter more than the rest and are asserted with controls
+ * beside them. **A lock stops a move and a delete but not a duplicate**, and
+ * **a lock INSIDE a block stops the delete without stopping the move** — those
+ * two together are what separates "the toolbar asks the lock rules" from "the
+ * toolbar reads `node.locked`", and only the second case can tell them apart.
+ *
+ * The placement cases exist here rather than in the component because every
+ * rectangle jsdom reports is zero: a placement computed during render is a
+ * placement no component test can see fail.
+ *
+ * @module toolbar-actions.test
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BlockDocument, BlockNode } from "@nextlyhq/blocks-engine";
+
+import {
+  TOOLBAR_GAP_PX,
+  toolbarActions,
+  toolbarPlacement,
+  toolbarShortcut,
+  type ToolbarAction,
+  type ToolbarActionId,
+} from "./toolbar-actions";
+
+function node(
+  id: string,
+  type = "acme/heading",
+  extra: Partial<BlockNode> = {}
+): BlockNode {
+  return { id, type, version: 1, props: {}, ...extra } as BlockNode;
+}
+
+function documentOf(nodes: BlockNode[]): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+}
+
+function box(
+  id: string,
+  children: BlockNode[],
+  extra: Partial<BlockNode> = {}
+) {
+  return node(id, "acme/box", { slots: { children }, ...extra });
+}
+
+function actionOf(
+  actions: ToolbarAction[],
+  id: ToolbarActionId
+): ToolbarAction {
+  const found = actions.find(action => action.id === id);
+  if (found === undefined) throw new Error(`no ${id} action`);
+  return found;
+}
+
+describe("toolbarActions", () => {
+  it("offers nothing without a selection", () => {
+    expect(toolbarActions(documentOf([node("a")]), null)).toEqual([]);
+  });
+
+  it("offers nothing for an id the document no longer holds", () => {
+    // An undo that removes the selected node while the selection stands is
+    // routine. The bar is drawn against an element, and there is none.
+    expect(toolbarActions(documentOf([node("a")]), "gone")).toEqual([]);
+  });
+
+  it("draws the same buttons in the same order whatever is selected", () => {
+    // The bar keeping one shape is what lets an author aim at a button before
+    // the selection has finished changing. A set that varied would move the
+    // control they were reaching for.
+    const document = documentOf([box("outer", [node("kid")]), node("last")]);
+    const expected: ToolbarActionId[] = [
+      "select-parent",
+      "move-up",
+      "move-down",
+      "duplicate",
+      "delete",
+    ];
+
+    for (const id of ["outer", "kid", "last"]) {
+      expect(toolbarActions(document, id).map(a => a.id)).toEqual(expected);
+    }
+  });
+
+  it("cannot select a parent from the top level, and can from inside one", () => {
+    const document = documentOf([box("outer", [node("kid")])]);
+
+    expect(
+      actionOf(toolbarActions(document, "outer"), "select-parent").enabled
+    ).toBe(false);
+    expect(
+      actionOf(toolbarActions(document, "kid"), "select-parent").enabled
+    ).toBe(true);
+  });
+
+  it("refuses the move that would leave the container", () => {
+    const document = documentOf([node("a"), node("b"), node("c")]);
+
+    expect(actionOf(toolbarActions(document, "a"), "move-up").enabled).toBe(
+      false
+    );
+    expect(actionOf(toolbarActions(document, "a"), "move-down").enabled).toBe(
+      true
+    );
+    expect(actionOf(toolbarActions(document, "c"), "move-up").enabled).toBe(
+      true
+    );
+    expect(actionOf(toolbarActions(document, "c"), "move-down").enabled).toBe(
+      false
+    );
+  });
+
+  it("says nothing about a move that is merely at the end of its container", () => {
+    // A fact about the page the author can see. Explaining it on every
+    // selection is noise, and it would train them to ignore the one reason that
+    // does need reading.
+    const document = documentOf([node("a"), node("b")]);
+
+    expect(
+      actionOf(toolbarActions(document, "a"), "move-up").reason
+    ).toBeUndefined();
+  });
+
+  it("a lock stops the move and the delete, and says why", () => {
+    const document = documentOf([
+      node("a", "acme/heading", { locked: true }),
+      node("b"),
+    ]);
+    const actions = toolbarActions(document, "a");
+
+    expect(actionOf(actions, "move-down").enabled).toBe(false);
+    expect(actionOf(actions, "move-down").reason).toBe("This block is locked.");
+    expect(actionOf(actions, "delete").enabled).toBe(false);
+    expect(actionOf(actions, "delete").reason).toBe("This block is locked.");
+  });
+
+  it("a lock does NOT stop a duplicate", () => {
+    // Duplicating neither moves nor removes the original. Refusing would mean
+    // an author could not copy the one block they had most deliberately
+    // protected — and the keyboard duplicate already reads it this way.
+    const document = documentOf([node("a", "acme/heading", { locked: true })]);
+
+    expect(actionOf(toolbarActions(document, "a"), "duplicate").enabled).toBe(
+      true
+    );
+  });
+
+  it("a lock INSIDE a block stops its delete but not its move", () => {
+    // THE case that separates asking the two lock rules from reading
+    // `node.locked` once: delete destroys the subtree, a move carries it
+    // intact. Both halves are asserted, so a toolbar that used one answer for
+    // both fails here whichever answer it picked.
+    const document = documentOf([
+      box("outer", [node("kid", "acme/heading", { locked: true })]),
+      node("after"),
+    ]);
+    const actions = toolbarActions(document, "outer");
+
+    expect(actionOf(actions, "move-down").enabled).toBe(true);
+    expect(actionOf(actions, "delete").enabled).toBe(false);
+    expect(actionOf(actions, "delete").reason).toBe(
+      "Heading inside this block is locked."
+    );
+  });
+
+  it("names an inner lock by the author's name for it", () => {
+    // Through the one label rule, so the toolbar cannot call a block something
+    // the layers panel does not.
+    const document = documentOf([
+      box("outer", [
+        node("kid", "acme/heading", { locked: true, name: "Caption" }),
+      ]),
+    ]);
+
+    expect(actionOf(toolbarActions(document, "outer"), "delete").reason).toBe(
+      "Caption inside this block is locked."
+    );
+  });
+
+  it("offers duplicate and delete for an ordinary block", () => {
+    // The control for the refusal cases above: they would all pass against a
+    // toolbar that disabled everything.
+    const document = documentOf([node("a")]);
+    const actions = toolbarActions(document, "a");
+
+    expect(actionOf(actions, "duplicate").enabled).toBe(true);
+    expect(actionOf(actions, "delete").enabled).toBe(true);
+    expect(actionOf(actions, "delete").reason).toBeUndefined();
+  });
+});
+
+describe("toolbarShortcut", () => {
+  it("names a keystroke only where one exists", () => {
+    expect(toolbarShortcut("duplicate")).toBe("Ctrl+D");
+    expect(toolbarShortcut("move-up")).toBe("Alt+Up");
+    // Selecting the parent has no binding, and inventing one in a tooltip would
+    // teach a keystroke that does nothing.
+    expect(toolbarShortcut("select-parent")).toBeUndefined();
+  });
+});
+
+describe("toolbarPlacement", () => {
+  const bar = { width: 200, height: 32 };
+  const canvas = { width: 1000, height: 800 };
+
+  it("sits above the block, clear of it by the gap", () => {
+    const at = toolbarPlacement(
+      { x: 40, y: 300, width: 500, height: 100 },
+      bar,
+      canvas
+    );
+
+    expect(at.side).toBe("above");
+    expect(at.y).toBe(300 - 32 - TOOLBAR_GAP_PX);
+  });
+
+  it("aligns to the block's leading edge", () => {
+    // Not centred: a centred bar moves whenever the block's width changes,
+    // which is exactly what an author is doing while editing its padding.
+    expect(
+      toolbarPlacement({ x: 40, y: 300, width: 500, height: 100 }, bar, canvas)
+        .x
+    ).toBe(40);
+    expect(
+      toolbarPlacement({ x: 40, y: 300, width: 900, height: 100 }, bar, canvas)
+        .x
+    ).toBe(40);
+  });
+
+  it("flips below when there is no room above", () => {
+    // The first block on a page. Clamping to the canvas top instead would draw
+    // the bar ON the block rather than beside it.
+    const at = toolbarPlacement(
+      { x: 0, y: 10, width: 500, height: 100 },
+      bar,
+      canvas
+    );
+
+    expect(at.side).toBe("below");
+    expect(at.y).toBe(10 + 100 + TOOLBAR_GAP_PX);
+  });
+
+  it("stays above for a block at the BOTTOM of a tall canvas", () => {
+    // The control for the flip: a rule that flipped on any overflow would move
+    // the bar for a block that had plenty of room above it.
+    expect(
+      toolbarPlacement({ x: 0, y: 700, width: 500, height: 100 }, bar, canvas)
+        .side
+    ).toBe("above");
+  });
+
+  it("slides back in from the right edge", () => {
+    const at = toolbarPlacement(
+      { x: 950, y: 300, width: 40, height: 20 },
+      bar,
+      canvas
+    );
+
+    expect(at.x).toBe(1000 - 200);
+  });
+
+  it("slides back in from a negative left edge", () => {
+    expect(
+      toolbarPlacement({ x: -30, y: 300, width: 200, height: 20 }, bar, canvas)
+        .x
+    ).toBe(0);
+  });
+
+  it("keeps the FIRST buttons visible when the bar is wider than the canvas", () => {
+    // No position satisfies both edges. Clamping to the right would push the
+    // leading buttons off-screen, and those are the ones an author reaches for.
+    expect(
+      toolbarPlacement({ x: 40, y: 300, width: 100, height: 20 }, bar, {
+        width: 120,
+        height: 800,
+      }).x
+    ).toBe(0);
+  });
+});

--- a/packages/builder/src/toolbar-actions.ts
+++ b/packages/builder/src/toolbar-actions.ts
@@ -1,0 +1,240 @@
+/**
+ * What the floating toolbar offers for the selected block, and where it sits.
+ *
+ * The structural verbs — select the container, move up, move down, duplicate,
+ * delete — exist already and are reachable only by keystroke. An author who has
+ * never read a shortcut list has no way to discover that this editor can
+ * duplicate a block at all, so the verbs are effectively absent for most of the
+ * people using them. This module is the half of that fix which can be decided
+ * without a DOM.
+ *
+ * ## Two questions, both pure
+ *
+ * **Which actions, and can they run.** Every answer is delegated: whether a
+ * move is possible is `keyboardMovePosition`, whether a lock forbids it is
+ * `lockBlockingMove` and `lockBlockingDelete`, whether a duplicate has a
+ * position is `blockDuplication`. Nothing here re-derives any of those, because
+ * a toolbar that decided for itself would eventually disagree with the
+ * keystroke that does the same thing — and the author would meet the
+ * disagreement as a button that looks available and does nothing.
+ *
+ * **Where the bar goes.** Above the block, falling back to below it, clamped
+ * into the canvas. Separated from the rendering so the placement rules can be
+ * asserted at sizes a jsdom test cannot produce: every rectangle in jsdom is
+ * zero, so a placement computed inside a component is a placement no test can
+ * see.
+ *
+ * ## Why a disabled button rather than a hidden one
+ *
+ * A toolbar whose buttons come and go changes width and order as the selection
+ * moves, so the control an author is aiming at is somewhere else by the time
+ * they arrive. Disabled buttons keep the bar one shape, and the reason is
+ * carried with the action so the surface can say why rather than leaving the
+ * author to guess.
+ *
+ * @module toolbar-actions
+ */
+
+import type { BlockDocument, BlockNode } from "@nextlyhq/blocks-engine";
+
+import { blockDeletion } from "./delete-block";
+import { blockDuplication } from "./duplicate-block";
+import type { Rect } from "./geometry";
+import { keyboardMovePosition } from "./keyboard-move";
+import { layerLabel, pathTo } from "./layers";
+import { lockBlockingDelete, lockBlockingMove } from "./locking";
+
+/** The verbs the bar offers, in the order it draws them. */
+export type ToolbarActionId =
+  | "select-parent"
+  | "move-up"
+  | "move-down"
+  | "duplicate"
+  | "delete";
+
+/** One button's worth of decision. */
+export interface ToolbarAction {
+  readonly id: ToolbarActionId;
+  /**
+   * The accessible name, which is also the tooltip.
+   *
+   * Fixed per verb rather than naming the block: the bar is drawn against the
+   * block it acts on, so "Duplicate" is unambiguous there, and a name that grew
+   * with the block's would reflow the bar on every selection.
+   */
+  readonly label: string;
+  /** Whether pressing it would do anything. */
+  readonly enabled: boolean;
+  /**
+   * Why it is disabled, phrased for an author, or `undefined` when enabled.
+   *
+   * Only ever set for a reason an author can act on. "This block is at the top
+   * of its container" is a fact about the page they can see and is left unsaid;
+   * a lock is the opposite, because nothing on the canvas explains it and the
+   * remedy is one field away.
+   */
+  readonly reason?: string;
+}
+
+/** The keystroke that does the same thing, for the tooltip. */
+const SHORTCUTS: Record<ToolbarActionId, string | undefined> = {
+  "select-parent": undefined,
+  "move-up": "Alt+Up",
+  "move-down": "Alt+Down",
+  duplicate: "Ctrl+D",
+  delete: "Delete",
+};
+
+/**
+ * The shortcut hint for an action, or `undefined` where there is no keystroke.
+ *
+ * Stated as Ctrl rather than resolved per platform. The hint is a pointer to
+ * the shortcut list rather than a contract, and a hint that read "Cmd+D" on a
+ * Mac would have to be produced at render time from a platform check — which is
+ * a second place that decides what the key IS, and the first place is the
+ * shortcut manager.
+ */
+export function toolbarShortcut(id: ToolbarActionId): string | undefined {
+  return SHORTCUTS[id];
+}
+
+/**
+ * What a lock refusal says.
+ *
+ * Names the block only when it is not the selected one. "Caption inside this
+ * block is locked" sends an author somewhere to look; repeating the selected
+ * block's own name back at them while the bar is drawn against it does not.
+ */
+function lockedBy(locked: BlockNode, selectedId: string): string {
+  return locked.id === selectedId
+    ? "This block is locked."
+    : `${layerLabel(locked)} inside this block is locked.`;
+}
+
+/**
+ * The toolbar's buttons for the current selection, or `[]` when there is none.
+ *
+ * `[]` also covers a selected id the document no longer holds, which an undo
+ * produces routinely — the bar is drawn against an element, and there is no
+ * element for a node that is gone.
+ */
+export function toolbarActions(
+  document: BlockDocument,
+  selectedId: string | null
+): ToolbarAction[] {
+  if (selectedId === null) return [];
+
+  const path = pathTo(document, selectedId);
+  if (path.length === 0) return [];
+
+  const moveLock = lockBlockingMove(document, selectedId);
+  const deleteLock = lockBlockingDelete(document, selectedId);
+
+  const canMove = (direction: "up" | "down"): boolean =>
+    keyboardMovePosition(document.nodes, selectedId, direction) !== null;
+
+  const move = (
+    id: "move-up" | "move-down",
+    label: string,
+    direction: "up" | "down"
+  ): ToolbarAction =>
+    moveLock === undefined
+      ? { id, label, enabled: canMove(direction) }
+      : {
+          id,
+          label,
+          enabled: false,
+          reason: lockedBy(moveLock, selectedId),
+        };
+
+  return [
+    {
+      id: "select-parent",
+      label: "Select parent",
+      // The path always ends at the selection itself, so a length of one means
+      // a top-level block with no container to step out to.
+      enabled: path.length > 1,
+    },
+    move("move-up", "Move up", "up"),
+    move("move-down", "Move down", "down"),
+    {
+      id: "duplicate",
+      label: "Duplicate",
+      // A lock deliberately does not stop this. Duplicating neither moves nor
+      // removes the original, and refusing would mean an author could not take
+      // a copy of the one block they had most deliberately protected — the same
+      // reading the keyboard duplicate takes.
+      enabled: blockDuplication(document, selectedId) !== null,
+    },
+    deleteLock === undefined
+      ? {
+          id: "delete",
+          label: "Delete",
+          enabled: blockDeletion(document, selectedId) !== null,
+        }
+      : {
+          id: "delete",
+          label: "Delete",
+          enabled: false,
+          reason: lockedBy(deleteLock, selectedId),
+        },
+  ];
+}
+
+/** How big the bar measured, in canvas content pixels. */
+export interface ToolbarSize {
+  readonly width: number;
+  readonly height: number;
+}
+
+/** Where the bar is drawn, and which side of the block it landed on. */
+export interface ToolbarPlacement {
+  readonly x: number;
+  readonly y: number;
+  readonly side: "above" | "below";
+}
+
+/** The gap between the bar and the block it names, in pixels. */
+export const TOOLBAR_GAP_PX = 6;
+
+/**
+ * Where to draw the bar for a block, in the canvas's own content coordinates.
+ *
+ * **Above by default, below when there is no room.** Above keeps the bar off
+ * the block's own content, which is what an author is looking at; the first
+ * block on a page has nothing above it, and a bar clamped to the canvas top
+ * would sit ON that block instead of beside it.
+ *
+ * **Left-aligned to the block, never centred.** A centred bar moves whenever
+ * the block's width changes — which happens while an author is editing its
+ * padding — so the button they are reaching for slides out from under the
+ * pointer. The leading edge is the one part of a block that stays put.
+ *
+ * **Clamped horizontally, never vertically.** A bar pushed off the right edge
+ * is unreachable, so it slides back in. Vertical overflow is handled by the
+ * side flip above rather than by clamping, because a clamped bar overlaps the
+ * block and a flipped one does not.
+ */
+export function toolbarPlacement(
+  block: Rect,
+  toolbar: ToolbarSize,
+  canvas: ToolbarSize,
+  gap: number = TOOLBAR_GAP_PX
+): ToolbarPlacement {
+  const above = block.y - toolbar.height - gap;
+  const below = block.y + block.height + gap;
+
+  // Below only when above would leave the canvas. A block near the BOTTOM keeps
+  // the bar above it, where it is still visible — flipping there would push it
+  // under the fold for no gain.
+  const side: "above" | "below" = above >= 0 ? "above" : "below";
+
+  // The clamp is skipped when the bar is wider than the canvas, because there
+  // is no position that satisfies both edges and clamping would silently choose
+  // the right one — leaving the first buttons, which are the ones an author
+  // reaches for, off-screen.
+  const maxX = canvas.width - toolbar.width;
+  const x = maxX <= 0 ? 0 : Math.min(Math.max(block.x, 0), maxX);
+
+  return { x, y: side === "above" ? above : below, side };
+}

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -43,6 +43,7 @@ import { CORE_CATEGORIES, coreBlocks } from "@nextlyhq/blocks-react/blocks";
 import { registrySlotSource } from "@nextlyhq/builder";
 import {
   BlockKeyboardActions,
+  BlockToolbar,
   BuilderShell,
   Canvas,
   DropIndicator,
@@ -279,21 +280,35 @@ function BlocksEditor({
         {/*
           Inside the shell, which is what provides the shortcut context — a
           caller rendering the shell is outside it and cannot register bindings.
-          Draws nothing; it exists to run the hook where the context is.
+          It draws the live region and publishes the structural verbs to what it
+          wraps, which is how the toolbar presses exactly what the keys press.
         */}
-        <BlockKeyboardActions editor={editor} />
-        <Canvas
-          document={editor.document}
-          siteStyles={siteSheet()}
-          selectedId={editor.selectedId}
-          onSelect={editor.select}
-          dragHandlers={drag.handlers}
-          // The indicator is the only chrome drawn over the page today. It goes
-          // through the canvas rather than beside it because it is positioned in
-          // the canvas's own content coordinates, which the canvas root is what
-          // establishes.
-          overlay={<DropIndicator target={drag.target} />}
-        />
+        <BlockKeyboardActions editor={editor}>
+          <Canvas
+            document={editor.document}
+            siteStyles={siteSheet()}
+            selectedId={editor.selectedId}
+            onSelect={editor.select}
+            dragHandlers={drag.handlers}
+            // Both pieces of chrome go through the canvas rather than beside it,
+            // because both are positioned in the canvas's own content
+            // coordinates and the canvas root is what establishes them.
+            overlay={
+              <>
+                <DropIndicator target={drag.target} />
+                {/*
+                  Suppressed for the duration of a drag. The bar would otherwise
+                  sit over the canvas the author is aiming at, naming a block
+                  that is in the middle of moving.
+                */}
+                <BlockToolbar
+                  editor={editor}
+                  hidden={drag.draggingId !== null}
+                />
+              </>
+            }
+          />
+        </BlockKeyboardActions>
       </BuilderShell>
     </div>
   );


### PR DESCRIPTION
Completes **B-16**. The breadcrumb half shipped in #1013; this is the toolbar half.

## Why

Select parent, move up, move down, duplicate and delete all existed already — and every one of them was reachable **only by keystroke**. An author who has not read a shortcut list has no way to discover that this editor can duplicate a block at all, so for most of the people using it those verbs were effectively absent.

## The design decisions worth arguing with

**It presses the same verbs the keys press.** `BlockKeyboardActions` now publishes them to whatever it wraps, and the toolbar consumes them. Nothing in the toolbar applies an op. A bar with its own ops would be a second answer to "what does duplicate do", and the two would drift — the author meets that as a button and a keystroke that disagree, long after either was written. It is also why the announcements are right without the toolbar containing one: the verbs announce into the single live region that component already owns.

**Unavailable actions stay in place, and stay focusable.** `aria-disabled`, never the `disabled` attribute. A disabled button leaves the tab sequence, and the reason it is disabled — "Caption inside this block is locked" — is precisely what a keyboard or screen-reader author needs and would then never receive. Hiding them instead would change the bar's width and order as the selection moves, so the control an author is aiming at has moved by the time they arrive.

**A dimmed press is passed on rather than swallowed.** This started as a guard in the toolbar. Stub-verification showed removing the guard moved no test result — every verb already refuses what it cannot do — so the guard was dead code that could only ever *disagree* with the rule beside it. Removing it is also strictly better behaviour: a lock refusal **announces**, so a dimmed Delete pressed by a keyboard author now says *"Caption is locked. Unlock it to delete it."* instead of nothing.

**A lock stops a move and a delete but not a duplicate**, and **a lock inside a block stops its delete without stopping its move**. Both come from `lockBlockingMove` / `lockBlockingDelete` rather than from reading `node.locked`, and the second case is the one that can tell the two apart.

**The insertion point is a line, the toolbar is a rectangle — but both live in canvas content coordinates.** Scrolling carries the bar with its block at no cost; there is no scroll listener and no frame on which the two disagree.

## One change outside the toolbar

`canvas.tsx` learns that editor chrome drawn over the page is not the page (`data-nx-chrome`). Without it, a press on any overlay control resolves to "no node", which the canvas reads as a background click and uses to **clear the very selection that control acts on** — the toolbar would run its action and then watch itself disappear. An attribute rather than each overlay calling `stopPropagation`, because the rule belongs to what chrome *is*, and the version where every new overlay has to remember it is the version where the next one does not.

## Accessibility

- WAI-ARIA toolbar pattern: `role="toolbar"`, one tab stop, arrows within, Home/End, wrapping.
- SC 2.5.7 and 2.1.1 unaffected — the keyboard path is unchanged and is what this presses.
- SC 2.5.8: 28px targets, over the 24px floor.
- Every colour is a `--nx-builder-*` token aliasing the vetted admin palette. Zero literals, zero opacity-modified colours — `packages/builder/src` is outside `lint-design.mjs`'s roots and outside the contrast suite, so nothing would have caught a bad one.

## Verified

**In a browser** (playground, `:3123`, auth control asserted first — `h1` reads "Welcome, Dev"):

- Duplicate creates the copy, selection follows it, `Name` reads "Kid copy", and **the selection is not cleared**.
- Action states update live: after duplicating, Move up flips to enabled and Move down to disabled; after Move up, they swap back.
- Locking flips Move down and Delete to disabled while **Duplicate stays enabled**.
- Pressing the dimmed Delete announces *"Kid copy is locked. Unlock it to delete it."* and deletes nothing.
- Select parent moves to the Section and then correctly disables itself at top level.
- Roving tabindex: arrows move, End jumps, wrapping works, exactly one tab stop in the bar.
- Background click clears the selection and the bar disappears; clicking a block brings both back.
- The bar hides for the duration of a drag, the drop indicator shows, and the bar returns after.

**In tests**: 682 in `packages/builder` (up from 652), 61 in `plugin-page-builder`, types and lint clean on both. Every new test stub-verified in both directions.

## Known, not fixed here

For a block near the canvas top the bar flips below it and therefore overlaps the following block. That is the standard trade for this pattern and the flip is the correct half of it — clamping to the canvas top instead would draw the bar *on* the selected block.

A pre-existing console error in the autosave-recovery lane (`["autosave-recovery","collection","pages",…]` returning undefined) is visible in the editor and is untouched by this change.
