### PR TITLE
fix(admin): stop a single reporting itself edited before anyone types

### DIFF
--- a/.changeset/single-is-not-dirty-on-arrival.md
+++ b/.changeset/single-is-not-dirty-on-arrival.md
@@ -1,0 +1,43 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A single no longer reports itself edited before anyone has typed.
+
+A structural field stored as `null` — a component or group, `seo: null` in the
+playground — was taken verbatim as the form's default. Its inputs then
+materialise the shape as they register, so the form's values could never equal
+its defaults and the document was dirty from the moment it loaded. Visible as a
+permanent "Not saved" indicator and an always-enabled Save button.
+
+A stored null for a non-repeatable component or group now falls through to the
+structural default, which is the shape the form will actually hold. Fixed in the
+entry editor too, where the same code carries the same latent defect and only
+avoided it because those documents omit the key rather than storing null.
+
+With that gone, the unsaved-changes guard is mounted for singles as well: leaving
+a single with real edits now asks first, and leaving an untouched one does not.

--- a/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
@@ -358,8 +358,21 @@ function getDefaultValues(
     const existingValue =
       existingData?.[fieldName] ?? existingData?.[toSnakeCase(fieldName)];
 
+    // A STORED NULL for a structural field is not a value to keep. The field's
+    // own inputs materialise the shape as they register — `seo: null` becomes
+    // `{ metaTitle: null, ... }` the moment its sub-fields mount — so taking the
+    // null verbatim guarantees the form's values can never equal its defaults,
+    // and the document reports itself edited before anyone has typed. Fall
+    // through to the structural default instead, which is the shape the form
+    // will actually hold.
+    const isStructural = field.type === "component" || field.type === "group";
+    const isRepeatable =
+      (field as { repeatable?: boolean }).repeatable === true;
+    const nullStructural =
+      existingValue === null && isStructural && !isRepeatable;
+
     // Use existing value if available
-    if (existingValue !== undefined) {
+    if (existingValue !== undefined && !nullStructural) {
       // Coerce checkbox values to boolean — the database may store/return
       // them as strings ("true"/"false") or integers (0/1).
       const fieldType = field.type as string;

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -40,6 +40,7 @@ import { EntryFormToolbarSlots } from "@admin/components/features/entries/EntryF
 import { EntryMetaStrip } from "@admin/components/features/entries/EntryForm/EntryMetaStrip";
 import { EntrySystemHeader } from "@admin/components/features/entries/EntryForm/EntrySystemHeader";
 import { FormErrorSummary } from "@admin/components/features/entries/EntryForm/FormErrorSummary";
+import { UnsavedChangesGuard } from "@admin/components/features/entries/EntryForm/UnsavedChangesGuard";
 import {
   mapIntentToPayload,
   passwordFieldNames,
@@ -179,8 +180,21 @@ function getDefaultValues(
     const existingValue =
       existingData?.[fieldName] ?? existingData?.[toSnakeCase(fieldName)];
 
+    // A STORED NULL for a structural field is not a value to keep. The field's
+    // own inputs materialise the shape as they register — `seo: null` becomes
+    // `{ metaTitle: null, ... }` the moment its sub-fields mount — so taking the
+    // null verbatim guarantees the form's values can never equal its defaults,
+    // and the document reports itself edited before anyone has typed. Fall
+    // through to the structural default instead, which is the shape the form
+    // will actually hold.
+    const isStructural = field.type === "component" || field.type === "group";
+    const isRepeatable =
+      (field as { repeatable?: boolean }).repeatable === true;
+    const nullStructural =
+      existingValue === null && isStructural && !isRepeatable;
+
     // Use existing value if available
-    if (existingValue !== undefined) {
+    if (existingValue !== undefined && !nullStructural) {
       // Coerce checkbox values to boolean — the database may store/return
       // them as strings ("true"/"false") or integers (0/1).
       const fieldType = field.type as string;
@@ -657,151 +671,155 @@ export function SingleForm({
   }, [recovery, form]);
 
   return (
-    // A single is only ever edited standalone, so there is no embedded case to
-    // exclude the way the entry editor has.
-    <EntryLocaleProvider value={localeCtx}>
-      <div className={cn("space-y-0", className)}>
-        <EntryFormProvider form={form} onSubmit={handleSubmit}>
-          <FormErrorSummary
-            errors={errors}
-            submitCount={submitCount}
-            className="mx-6 mt-3"
-          />
+    // A single is only ever edited standalone, so unlike the entry editor there
+    // is no embedded case to exclude.
+    <UnsavedChangesGuard isDirty={isDirty} disabled={isSubmitting}>
+      <EntryLocaleProvider value={localeCtx}>
+        <div className={cn("space-y-0", className)}>
+          <EntryFormProvider form={form} onSubmit={handleSubmit}>
+            <FormErrorSummary
+              errors={errors}
+              submitCount={submitCount}
+              className="mx-6 mt-3"
+            />
 
-          <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-m-8">
-            {/* Main column */}
-            <div className="flex-1 min-w-0 flex flex-col">
-              {/* Why: same fix as EntryForm — the parent flex's @4xl/content:-m-8
+            <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-m-8">
+              {/* Main column */}
+              <div className="flex-1 min-w-0 flex flex-col">
+                {/* Why: same fix as EntryForm — the parent flex's @4xl/content:-m-8
                 already cancels PageContainer's px-8, so wrapping the header / meta
                 strip in another -mx-8 was double-negative and pushed them
                 past the page edges. */}
-              <EntrySystemHeader
-                autosaveEnabled={autosaveScope !== null}
-                autosaveStatus={autosave.status}
-                autosaveLastSavedAt={autosave.lastSavedAt}
-                mode="edit"
-                titleField={titleField}
-                historyFields={schema.fields}
-                historyEnabled={historyEnabledFrom(schema)}
-                hasStatus={hasStatus}
-                isSubmitting={isSubmitting}
-                isDirty={isDirty}
-                entry={entryLike}
-                collectionSlug={schema.slug}
-                /* i18n: forward the active locale + switch handler so a localized single shows
+                <EntrySystemHeader
+                  autosaveEnabled={autosaveScope !== null}
+                  autosaveStatus={autosave.status}
+                  autosaveLastSavedAt={autosave.lastSavedAt}
+                  mode="edit"
+                  titleField={titleField}
+                  historyFields={schema.fields}
+                  historyEnabled={historyEnabledFrom(schema)}
+                  hasStatus={hasStatus}
+                  isSubmitting={isSubmitting}
+                  isDirty={isDirty}
+                  entry={entryLike}
+                  collectionSlug={schema.slug}
+                  /* i18n: forward the active locale + switch handler so a localized single shows
                    the primary header language switcher (the sidebar pills are unavailable when
                    the rail is collapsed or on narrow layouts). The switcher self-hides when the
                    single isn't localized / localization isn't configured. */
-                locale={locale}
-                onLocaleChange={onLocaleChange}
-                localized={schema.localized === true}
-                toolbarSlot={
-                  <EntryFormToolbarSlots
-                    context="single"
-                    controllerField={controllerNames[0]}
-                  />
-                }
-                onSaveDraft={() => {
-                  void handleSubmit(undefined, "save-draft");
-                }}
-                onPublish={() => {
-                  void handleSubmit(undefined, "publish");
-                }}
-                onSaveChanges={() => {
-                  void handleSubmit(undefined, "save-changes");
-                }}
-                onUnpublish={() => {
-                  void handleSubmit(undefined, "unpublish");
-                }}
-                onCancel={handleCancel}
-                onViewApi={onViewApi}
-                /* Why: Singles share the Show JSON dialog with collections,
+                  locale={locale}
+                  onLocaleChange={onLocaleChange}
+                  localized={schema.localized === true}
+                  toolbarSlot={
+                    <EntryFormToolbarSlots
+                      context="single"
+                      controllerField={controllerNames[0]}
+                    />
+                  }
+                  onSaveDraft={() => {
+                    void handleSubmit(undefined, "save-draft");
+                  }}
+                  onPublish={() => {
+                    void handleSubmit(undefined, "publish");
+                  }}
+                  onSaveChanges={() => {
+                    void handleSubmit(undefined, "save-changes");
+                  }}
+                  onUnpublish={() => {
+                    void handleSubmit(undefined, "unpublish");
+                  }}
+                  onCancel={handleCancel}
+                  onViewApi={onViewApi}
+                  /* Why: Singles share the Show JSON dialog with collections,
                  but at the /api/singles/{slug} URL pattern. Passing
                  `scope="single"` routes the dialog through singleApi
                  instead of entryApi. */
-                scope="single"
-                lockIdentity
-                isRailCollapsed={railCollapsed}
-                onToggleRail={toggleRail}
-              />
-              <EntryMetaStrip
-                slugField={slugField}
-                hasStatus={hasStatus}
-                status={documentStatus}
-                isRailCollapsed={railCollapsed}
-                lockSlug
-              />
+                  scope="single"
+                  lockIdentity
+                  isRailCollapsed={railCollapsed}
+                  onToggleRail={toggleRail}
+                />
+                <EntryMetaStrip
+                  slugField={slugField}
+                  hasStatus={hasStatus}
+                  status={documentStatus}
+                  isRailCollapsed={railCollapsed}
+                  lockSlug
+                />
 
-              {/* Inside the main column, below the header, matching the entry
+                {/* Inside the main column, below the header, matching the entry
                   editor. Placed above the flex row it sat UNDER the sticky
                   header, which intercepted pointer events: the offer was
                   visible and its buttons were not clickable. */}
-              {recovery.offer ? (
-                <AutosaveRecoveryBanner
-                  savedAt={recovery.offer.savedAt}
-                  onRestore={restoreRecovery}
-                  onDismiss={recovery.dismiss}
-                  className="mx-6 mt-3"
-                />
-              ) : null}
+                {recovery.offer ? (
+                  <AutosaveRecoveryBanner
+                    savedAt={recovery.offer.savedAt}
+                    onRestore={restoreRecovery}
+                    onDismiss={recovery.dismiss}
+                    className="mx-6 mt-3"
+                  />
+                ) : null}
 
-              {/* The language panel, inline. The rail that otherwise carries it
+                {/* The language panel, inline. The rail that otherwise carries it
                   is `hidden @4xl/content:flex`, so this is the exact
                   complement: shown only where the rail is not, and rendered
                   unconditionally once the author collapses the rail. Without
                   it a single loses its language workflow entirely at narrow
                   widths, which is the failure this panel exists to remove. */}
-              {localizationEnabled && (
-                <div
-                  className={cn(
-                    "px-6 pt-4",
-                    !railCollapsed && "@4xl/content:hidden"
-                  )}
-                >
-                  <LanguagePanel
-                    {...(singleTranslations === undefined
-                      ? {}
-                      : { translations: singleTranslations })}
-                    {...(locale === undefined ? {} : { activeLocale: locale })}
-                    {...(onLocaleChange === undefined
-                      ? {}
-                      : { onSelect: onLocaleChange })}
-                    hasStatus={hasStatus}
-                  />
-                </div>
-              )}
+                {localizationEnabled && (
+                  <div
+                    className={cn(
+                      "px-6 pt-4",
+                      !railCollapsed && "@4xl/content:hidden"
+                    )}
+                  >
+                    <LanguagePanel
+                      {...(singleTranslations === undefined
+                        ? {}
+                        : { translations: singleTranslations })}
+                      {...(locale === undefined
+                        ? {}
+                        : { activeLocale: locale })}
+                      {...(onLocaleChange === undefined
+                        ? {}
+                        : { onSelect: onLocaleChange })}
+                      hasStatus={hasStatus}
+                    />
+                  </div>
+                )}
 
-              {mainFields.length > 0 && (
-                <div className="@4xl/content:p-8 pt-6">
-                  <EntryFormContent
-                    fields={mainFields}
-                    disabled={isSubmitting}
-                    withCard
-                  />
+                {mainFields.length > 0 && (
+                  <div className="@4xl/content:p-8 pt-6">
+                    <EntryFormContent
+                      fields={mainFields}
+                      disabled={isSubmitting}
+                      withCard
+                    />
+                  </div>
+                )}
+              </div>
+
+              {/* Rail (collapsible). Same shape and width as collections. */}
+              {!railCollapsed && (
+                <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
+                  <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
+                    <EntryFormSidebar
+                      mode="edit"
+                      entry={entryLike}
+                      hasStatus={hasStatus}
+                      isDirty={isDirty}
+                      {...(locale === undefined ? {} : { locale })}
+                      {...(onLocaleChange === undefined
+                        ? {}
+                        : { onLocaleChange })}
+                    />
+                  </div>
                 </div>
               )}
             </div>
-
-            {/* Rail (collapsible). Same shape and width as collections. */}
-            {!railCollapsed && (
-              <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
-                <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
-                  <EntryFormSidebar
-                    mode="edit"
-                    entry={entryLike}
-                    hasStatus={hasStatus}
-                    isDirty={isDirty}
-                    {...(locale === undefined ? {} : { locale })}
-                    {...(onLocaleChange === undefined
-                      ? {}
-                      : { onLocaleChange })}
-                  />
-                </div>
-              </div>
-            )}
-          </div>
-        </EntryFormProvider>
-      </div>
-    </EntryLocaleProvider>
+          </EntryFormProvider>
+        </div>
+      </EntryLocaleProvider>
+    </UnsavedChangesGuard>
   );
 }


### PR DESCRIPTION
Follow-up to #1024, which mounted the unsaved-changes guard on entries but **deliberately not on singles** — because a single already reported itself dirty on load, and a guard that fires on a clean form is worse than no guard.

This removes that blocker and mounts it.

## What was wrong

An untouched single arrived with `isDirty: true` and `dirtyFields: {}`. That combination is the shape of *values disagreeing with their defaults without anyone touching a field*, so I probed which key differed:

```
{ key: "seo", def: "null", cur: "{\"metaTitle\":null,\"metaDescription\":null…" }
```

A structural field stored as `null` was taken verbatim as the form's default. Its own inputs then materialise the shape as they register, so the values can never equal the defaults and the document reports itself edited on arrival.

Visible until now as a permanent **"Not saved"** indicator and a Save button enabled over a document with nothing to save.

## The fix

A stored `null` for a non-repeatable component or group falls through to the structural default — the shape the form will actually hold.

**Applied to the entry editor too.** The defect is latent there rather than absent: `useEntryForm` carries a second copy of the same logic, and entries escape it only because their documents omit the key instead of storing null. Leaving it would mean an entry with a stored null prompting about unsaved changes it does not have — which matters more now that the guard is live on entries.

## What this does *not* fix, and why

That the two forms carry **two copies of `getDefaultValues`** is the larger problem. Measured: 152 and 198 lines, 22 divergences. They have already drifted in ways with user-visible consequences — the entry version honours a developer's `defaultValue` for `richText`, `json` and `chips`; the singles version does not.

Reconciling them means judging each divergence against the entry editor, the most-used surface in the admin. That is its own PR, not something to do alongside a bug fix. Filed rather than bundled.

## Verified in the browser

| case | before | after |
|---|---|---|
| single on load | `isDirty: true`, "Not saved" shown | `isDirty: false`, no indicator |
| untouched single → navigate | (guard not mounted) | no prompt, navigates |
| single with a real edit → navigate | (guard not mounted) | **blocked**, prompt shown |
| Keep Editing | — | stays put |
| entry with a component field → navigate | no prompt | no prompt (unchanged) |

Gates run against a **freshly built dependency tree** rather than whatever `dist` happened to be lying around — `pnpm turbo build --filter=@nextlyhq/admin^...` to completion first, then `check-types` and `lint` as separate commands. `check-types` depends on `^check-types` and `lint` on nothing, so neither builds a workspace dependency: a missing `dist` invents errors that belong to nobody, and a stale one lets both gates pass over source that was never compiled.

`check-types` 0, `lint` 0, admin suite 254 files / 2293 tests, no new failures against the pre-existing 4-file baseline.
