### PR TITLE
feat(admin): address the editor's content language in the URL

### DIFF
--- a/.changeset/editor-language-in-the-url.md
+++ b/.changeset/editor-language-in-the-url.md
@@ -1,0 +1,43 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The content language an editor is open in now lives in the URL.
+
+`?locale=de` makes the language linkable, survives a reload, and comes back with
+the browser's back button. An unconfigured value falls back to the default
+rather than being sent to the API.
+
+It also stops a language switch from silently discarding unsaved work. Switching
+refetches the document, so the edits go — and as component state that happened
+with nothing able to ask first. As a URL it is a navigation, which the
+unsaved-changes guard already understands, so it asks. The guard now compares
+the query as well as the path, because here the query is part of where you are
+rather than decoration on it.
+
+A language mark in the entry list opens that row in that language, which is the
+same act as being sent a link to it.

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/UnsavedChangesGuard.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/UnsavedChangesGuard.test.tsx
@@ -123,6 +123,54 @@ describe("UnsavedChangesGuard", () => {
     expect(screen.queryByRole("alertdialog")).toBeNull();
   });
 
+  it("treats a change of QUERY as leaving, because here it is", async () => {
+    // The editor addresses its content language as `?locale=`, and switching
+    // language refetches the document and discards unsaved edits exactly as
+    // leaving the page would. Comparing paths alone read that as "same place,
+    // let it through", and the work went without anything asking.
+    function SwitchLanguage() {
+      return (
+        <button
+          type="button"
+          onClick={() =>
+            window.history.pushState(null, "", `${START}?locale=de`)
+          }
+        >
+          switch
+        </button>
+      );
+    }
+    render(
+      <UnsavedChangesGuard isDirty>
+        <SwitchLanguage />
+      </UnsavedChangesGuard>
+    );
+    await userEvent.click(screen.getByRole("button", { name: "switch" }));
+    expect(window.location.search).toBe("");
+    expect(await screen.findByRole("alertdialog")).toBeInTheDocument();
+  });
+
+  it("lets a hash through, because it moves within the page rather than off it", async () => {
+    function JumpToSection() {
+      return (
+        <button
+          type="button"
+          onClick={() => window.history.pushState(null, "", `${START}#fields`)}
+        >
+          jump
+        </button>
+      );
+    }
+    render(
+      <UnsavedChangesGuard isDirty>
+        <JumpToSection />
+      </UnsavedChangesGuard>
+    );
+    await userEvent.click(screen.getByRole("button", { name: "jump" }));
+    expect(window.location.hash).toBe("#fields");
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
   it("withholds nothing while disabled, so a submit in flight can navigate", async () => {
     render(
       <UnsavedChangesGuard isDirty disabled>

--- a/packages/admin/src/components/features/entries/EntryList/EntryList.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/EntryList.tsx
@@ -19,13 +19,13 @@ import { Breadcrumbs } from "@admin/components/shared";
 import { PluginSlot } from "@admin/components/shared/plugin-slot";
 import { useListColumns } from "@admin/components/ui/table/list-view";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
+import { LOCALE_PARAM } from "@admin/constants/search-params";
 import {
   useEntries,
   useBulkDeleteEntries,
   useBulkUpdateEntries,
 } from "@admin/hooks/queries";
 import { useCollection } from "@admin/hooks/queries/useCollections";
-import { LOCALE_PARAM } from "@admin/hooks/useEditorLocale";
 import { useEntryListShortcuts } from "@admin/hooks/useKeyboardShortcuts";
 import { useLocalization } from "@admin/hooks/useLocalization";
 import { usePluginAutoRegistration } from "@admin/hooks/usePluginAutoRegistration";
@@ -33,7 +33,7 @@ import { useSearchParams } from "@admin/hooks/useSearchParams";
 import type { ListResponse } from "@admin/lib/api/response-types";
 import { navigateTo } from "@admin/lib/navigation";
 import type { InjectionPointProps } from "@admin/lib/plugins/component-registry";
-import { getSearchParam } from "@admin/lib/routing";
+import { getSearchParam } from "@admin/lib/search-params";
 import type { Entry } from "@admin/types/collection";
 import type { ApiCollection } from "@admin/types/entities";
 

--- a/packages/admin/src/components/features/entries/EntryList/EntryList.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/EntryList.tsx
@@ -25,6 +25,7 @@ import {
   useBulkUpdateEntries,
 } from "@admin/hooks/queries";
 import { useCollection } from "@admin/hooks/queries/useCollections";
+import { LOCALE_PARAM } from "@admin/hooks/useEditorLocale";
 import { useEntryListShortcuts } from "@admin/hooks/useKeyboardShortcuts";
 import { useLocalization } from "@admin/hooks/useLocalization";
 import { usePluginAutoRegistration } from "@admin/hooks/usePluginAutoRegistration";
@@ -399,12 +400,18 @@ export function EntryList({ collectionSlug }: EntryListProps) {
   // ---------------------------------------------------------------------------
 
   const handleEdit = useCallback(
-    (entryId: string) => {
+    (entryId: string, locale?: string) => {
+      const path = buildRoute(ROUTES.COLLECTION_ENTRY_EDIT, {
+        slug: collectionSlug,
+        id: entryId,
+      });
+      // The language rides in the URL because that is where the editor reads
+      // it. Opening a row "in Arabic" from the list is the same act as being
+      // sent a link to the Arabic copy, and both arrive the same way.
       navigateTo(
-        buildRoute(ROUTES.COLLECTION_ENTRY_EDIT, {
-          slug: collectionSlug,
-          id: entryId,
-        })
+        locale
+          ? `${path}?${new URLSearchParams({ [LOCALE_PARAM]: locale }).toString()}`
+          : path
       );
     },
     [collectionSlug]

--- a/packages/admin/src/components/features/entries/EntryList/EntryTable.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/EntryTable.tsx
@@ -95,7 +95,8 @@ export interface EntryTableProps {
   /** Callback when search query changes */
   onSearchChange: (search: string) => void;
   /** Callback when edit action is triggered */
-  onEdit: (entryId: string) => void;
+  /** Open a row. `locale` opens it in that content language. */
+  onEdit: (entryId: string, locale?: string) => void;
   /** Callback when delete action is triggered */
   onDelete: (entryId: string) => void;
   /** Callback for bulk delete operation */
@@ -217,8 +218,11 @@ export const EntryTable = forwardRef<EntryTableRef, EntryTableProps>(
     // -------------------------------------------------------------------------
 
     const columns = useMemo(
-      () => buildEntryColumns(collection, columnsControl?.isColumnVisible),
-      [collection, columnsControl]
+      () =>
+        buildEntryColumns(collection, columnsControl?.isColumnVisible, {
+          openInLocale: (entryId, locale) => onEdit(entryId, locale),
+        }),
+      [collection, columnsControl, onEdit]
     );
 
     const titleField = useMemo(

--- a/packages/admin/src/components/features/entries/EntryList/EntryTableColumns.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/EntryTableColumns.tsx
@@ -340,6 +340,11 @@ export function getEntryTitleField(
  * renders selection and the row-action menu itself. Column visibility is
  * applied by marking columns `hidden` from the passed visibility map.
  */
+export interface EntryColumnActions {
+  /** Open a row in a given content language. Absent leaves the marks inert. */
+  openInLocale?: (entryId: string, locale: string) => void;
+}
+
 export function buildEntryColumns(
   collection: CollectionForColumns,
   /**
@@ -348,7 +353,8 @@ export function buildEntryColumns(
    * names — a record is a second spelling of the same question, and only this
    * file knew how to read it.
    */
-  isColumnVisible?: (name: string) => boolean
+  isColumnVisible?: (name: string) => boolean,
+  actions?: EntryColumnActions
 ): NextlyColumn<Record<string, unknown>>[] {
   const isHidden = (name: string) =>
     isColumnVisible ? !isColumnVisible(name) : false;
@@ -380,6 +386,12 @@ export function buildEntryColumns(
                   | Record<string, { translated: boolean; status?: string }>
                   | undefined
               }
+              {...(actions?.openInLocale && typeof row.id === "string"
+                ? {
+                    onOpenLocale: (locale: string) =>
+                      actions.openInLocale?.(row.id as string, locale),
+                  }
+                : {})}
             />
           ),
         });

--- a/packages/admin/src/constants/search-params.ts
+++ b/packages/admin/src/constants/search-params.ts
@@ -1,0 +1,15 @@
+/**
+ * Query keys the admin addresses its own state by.
+ *
+ * They live here, in a module that imports nothing, because the readers and the
+ * writers of a key sit on opposite sides of the app — the entry list writes the
+ * editor's language, the editor reads it — and a key defined next to either one
+ * drags that side's imports into the other. `lib/routing` in particular pulls in
+ * the page registry, and therefore every page, so a hook that reached for a
+ * constant there closed a cycle back onto itself.
+ *
+ * @module constants/search-params
+ */
+
+/** The editor's active content language. Absent means the app default. */
+export const LOCALE_PARAM = "locale";

--- a/packages/admin/src/hooks/__tests__/useEditorLocale.test.ts
+++ b/packages/admin/src/hooks/__tests__/useEditorLocale.test.ts
@@ -1,34 +1,98 @@
-// The editor's language state, and the seed that has to survive a switch.
+// The editor's language, and the seed a switch can carry with it.
 //
-// The pairing is the whole point: a switch refetches the document and tears the
-// editor's subtree down, so a seed recorded inside it is gone before anything
-// can act on it. These tests pin the rules that make the pair safe to carry —
-// a seed never outlives the switch that asked for it, and returning to the
-// default abandons it.
+// The language lives in the URL and the seed does not, and that split is the
+// thing worth pinning: the language is where you are — linkable, reloadable,
+// reachable with the back button, and visible to the unsaved-changes guard as a
+// navigation. The seed is a one-shot intent consumed on arrival, which in a URL
+// would survive a reload and be carried into any link the author shared.
 import { renderHook, act } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { useEditorLocale } from "../useEditorLocale";
 
+const useBranding = vi.fn();
+vi.mock("@admin/context/providers/BrandingProvider", () => ({
+  useBranding: () => useBranding(),
+}));
+
+const LOCALES = {
+  defaultLocale: "en",
+  fallback: true,
+  locales: [
+    { code: "en", label: "English", rtl: false, fallbackLocale: [] },
+    { code: "de", label: "German", rtl: false, fallbackLocale: [] },
+    { code: "fr", label: "French", rtl: false, fallbackLocale: [] },
+  ],
+};
+
+const AT = "/admin/collections/posts/1";
+const go = (search = "") =>
+  window.history.replaceState(null, "", `${AT}${search}`);
+
 describe("useEditorLocale", () => {
+  beforeEach(() => {
+    useBranding.mockReturnValue({ locales: LOCALES });
+    go();
+  });
+
   it("starts on the app default, with nothing to seed", () => {
     const { result } = renderHook(() => useEditorLocale());
     expect(result.current.locale).toBeUndefined();
     expect(result.current.seedFromLocale).toBeUndefined();
   });
 
+  it("reads the language out of the URL", () => {
+    go("?locale=de");
+    const { result } = renderHook(() => useEditorLocale());
+    expect(result.current.locale).toBe("de");
+  });
+
+  it("ignores a language the app does not configure", () => {
+    // A hand-edited or stale link would otherwise be sent to the API, which
+    // answers for a language that does not exist. The default is a usable
+    // answer; an error the reader cannot act on is not.
+    go("?locale=zz");
+    const { result } = renderHook(() => useEditorLocale());
+    expect(result.current.locale).toBeUndefined();
+  });
+
+  it("puts the language in the URL when it changes", () => {
+    const { result } = renderHook(() => useEditorLocale());
+    act(() => result.current.changeLocale("de"));
+    expect(window.location.search).toBe("?locale=de");
+  });
+
+  it("leaves the rest of the query alone", () => {
+    // The list's filter lives in the same query string.
+    go("?where=%7B%7D&page=2");
+    const { result } = renderHook(() => useEditorLocale());
+    act(() => result.current.changeLocale("fr"));
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get("locale")).toBe("fr");
+    expect(params.get("where")).toBe("{}");
+    expect(params.get("page")).toBe("2");
+  });
+
+  it("returns to the default by removing the parameter, not by naming it", () => {
+    // The default is the ABSENCE of a choice, so the URL says nothing rather
+    // than saying "en" — otherwise two URLs mean the same document.
+    go("?locale=de");
+    const { result } = renderHook(() => useEditorLocale());
+    act(() => result.current.resetLocale());
+    expect(window.location.search).toBe("");
+  });
+
   it("carries the seed alongside the language it was asked for", () => {
     const { result } = renderHook(() => useEditorLocale());
     act(() => result.current.changeLocale("de", { seedFrom: "en" }));
-    expect(result.current.locale).toBe("de");
+    expect(window.location.search).toBe("?locale=de");
     expect(result.current.seedFromLocale).toBe("en");
   });
 
-  it("switches without a seed when none was asked for", () => {
+  it("keeps the seed OUT of the URL", () => {
     const { result } = renderHook(() => useEditorLocale());
-    act(() => result.current.changeLocale("de"));
-    expect(result.current.locale).toBe("de");
-    expect(result.current.seedFromLocale).toBeUndefined();
+    act(() => result.current.changeLocale("de", { seedFrom: "en" }));
+    expect(window.location.search).not.toContain("seed");
   });
 
   it("drops a previous seed on the next plain switch", () => {
@@ -37,11 +101,11 @@ describe("useEditorLocale", () => {
     const { result } = renderHook(() => useEditorLocale());
     act(() => result.current.changeLocale("de", { seedFrom: "en" }));
     act(() => result.current.changeLocale("fr"));
-    expect(result.current.locale).toBe("fr");
     expect(result.current.seedFromLocale).toBeUndefined();
   });
 
   it("clears the seed once the editor has offered it, keeping the language", () => {
+    go("?locale=de");
     const { result } = renderHook(() => useEditorLocale());
     act(() => result.current.changeLocale("de", { seedFrom: "en" }));
     act(() => result.current.clearSeed());
@@ -50,12 +114,10 @@ describe("useEditorLocale", () => {
   });
 
   it("abandons a pending seed when returning to the default language", () => {
-    // The seed names a target that is no longer being edited, so acting on it
-    // would fill the default language from a copy meant for another one.
     const { result } = renderHook(() => useEditorLocale());
     act(() => result.current.changeLocale("de", { seedFrom: "en" }));
     act(() => result.current.resetLocale());
-    expect(result.current.locale).toBeUndefined();
     expect(result.current.seedFromLocale).toBeUndefined();
+    expect(result.current.locale).toBeUndefined();
   });
 });

--- a/packages/admin/src/hooks/useEditorLocale.ts
+++ b/packages/admin/src/hooks/useEditorLocale.ts
@@ -15,10 +15,25 @@
  * written and drift silently, and the drift would show up as a button that
  * quietly does nothing.
  *
+ * The language lives in the URL rather than in component state, which makes it
+ * three things it was not: linkable (a colleague can be sent the German copy),
+ * durable across a reload, and reachable with the back button. It also makes a
+ * switch a NAVIGATION, which is what lets the unsaved-changes guard see it —
+ * changing language refetches the document and discards unsaved edits, and as
+ * pure state that happened without anything being able to ask first.
+ *
  * @module hooks/useEditorLocale
  */
 
 import { useCallback, useState } from "react";
+
+import { useLocalization } from "@admin/hooks/useLocalization";
+import { useSearchParams } from "@admin/hooks/useSearchParams";
+import { setSearchParam } from "@admin/lib/navigation";
+import { getSearchParam } from "@admin/lib/routing";
+
+/** The query key the editor's content language is addressed by. */
+export const LOCALE_PARAM = "locale";
 
 export interface EditorLocale {
   /** Active content language. `undefined` = the app default, resolved by the backend. */
@@ -41,7 +56,23 @@ export interface EditorLocale {
 }
 
 export function useEditorLocale(): EditorLocale {
-  const [locale, setLocale] = useState<string | undefined>(undefined);
+  const searchParams = useSearchParams();
+  const { locales } = useLocalization();
+
+  // Only a CONFIGURED language is honoured. A hand-edited or stale `?locale=`
+  // would otherwise be sent to the API, which answers for a language the app
+  // does not have — so an unknown one reads as the default rather than as an
+  // error the reader cannot act on.
+  const requested = getSearchParam(searchParams, LOCALE_PARAM);
+  const locale =
+    requested && locales.some(l => l.code === requested)
+      ? requested
+      : undefined;
+
+  // The seed stays in component state deliberately. It is a one-shot intent
+  // consumed on arrival, not a property of the page: in the URL it would
+  // survive a reload and re-offer a copy the author asked for once, and it
+  // would be carried into any link they shared.
   const [seedFromLocale, setSeedFromLocale] = useState<string | undefined>(
     undefined
   );
@@ -51,8 +82,8 @@ export function useEditorLocale(): EditorLocale {
   // asked for two languages ago.
   const changeLocale = useCallback(
     (code: string, options?: { seedFrom?: string }) => {
-      setLocale(code);
       setSeedFromLocale(options?.seedFrom);
+      setSearchParam(LOCALE_PARAM, code);
     },
     []
   );
@@ -60,8 +91,8 @@ export function useEditorLocale(): EditorLocale {
   // Drops the seed too: a pending copy names a target language that is no
   // longer the one being edited.
   const resetLocale = useCallback(() => {
-    setLocale(undefined);
     setSeedFromLocale(undefined);
+    setSearchParam(LOCALE_PARAM, null);
   }, []);
 
   const clearSeed = useCallback(() => setSeedFromLocale(undefined), []);

--- a/packages/admin/src/hooks/useEditorLocale.ts
+++ b/packages/admin/src/hooks/useEditorLocale.ts
@@ -27,13 +27,10 @@
 
 import { useCallback, useState } from "react";
 
+import { LOCALE_PARAM } from "@admin/constants/search-params";
 import { useLocalization } from "@admin/hooks/useLocalization";
 import { useSearchParams } from "@admin/hooks/useSearchParams";
 import { setSearchParam } from "@admin/lib/navigation";
-import { getSearchParam } from "@admin/lib/routing";
-
-/** The query key the editor's content language is addressed by. */
-export const LOCALE_PARAM = "locale";
 
 export interface EditorLocale {
   /** Active content language. `undefined` = the app default, resolved by the backend. */
@@ -63,7 +60,11 @@ export function useEditorLocale(): EditorLocale {
   // would otherwise be sent to the API, which answers for a language the app
   // does not have — so an unknown one reads as the default rather than as an
   // error the reader cannot act on.
-  const requested = getSearchParam(searchParams, LOCALE_PARAM);
+  // Read straight off the parsed params rather than through `lib/routing`'s
+  // helper: that module imports the page registry, so reaching into it from a
+  // hook every page uses closes a cycle.
+  const raw = searchParams[LOCALE_PARAM];
+  const requested = (Array.isArray(raw) ? raw[0] : raw) ?? null;
   const locale =
     requested && locales.some(l => l.code === requested)
       ? requested

--- a/packages/admin/src/hooks/useSearchParams.ts
+++ b/packages/admin/src/hooks/useSearchParams.ts
@@ -2,7 +2,7 @@
 
 import { useMemo, useSyncExternalStore } from "react";
 
-import { parseSearchParams, type SearchParams } from "@admin/lib/routing";
+import { parseSearchParams, type SearchParams } from "@admin/lib/search-params";
 
 /**
  * Subscribe to the signals that change the URL without a document load:

--- a/packages/admin/src/hooks/useUnsavedChanges.ts
+++ b/packages/admin/src/hooks/useUnsavedChanges.ts
@@ -78,6 +78,33 @@ export interface UseUnsavedChangesReturn {
   leaveWithoutWarning: () => void;
 }
 
+/**
+ * Whether a history write moves the reader somewhere else.
+ *
+ * Compares the QUERY as well as the path, because in this admin the query is
+ * part of where you are rather than decoration on it: the entry editor
+ * addresses its content language as `?locale=`, and switching language
+ * refetches the document and discards unsaved edits exactly as leaving the page
+ * would. Comparing paths alone reported that as "same place, let it through",
+ * and the work went without anything asking.
+ *
+ * The hash is deliberately excluded. It moves within a page rather than off it.
+ */
+function movesElsewhere(url: string | URL | null | undefined): boolean {
+  if (url === undefined || url === null) return false;
+  try {
+    const next = new URL(url.toString(), window.location.origin);
+    return (
+      next.pathname !== window.location.pathname ||
+      next.search !== window.location.search
+    );
+  } catch {
+    // An unparseable target is not something to silently allow past a guard
+    // whose whole job is to stop unnoticed leaves.
+    return true;
+  }
+}
+
 interface PendingNavigation {
   type: "pushState" | "replaceState" | "popstate";
   args?: [data: unknown, unused: string, url?: string | URL | null];
@@ -245,14 +272,8 @@ export function useUnsavedChanges({
         return originalPushState.current!.apply(this, [data, unused, url]);
       }
 
-      // Check if navigating to a different path
-      const currentPath = window.location.pathname;
-      const newPath = url
-        ? new URL(url.toString(), window.location.origin).pathname
-        : currentPath;
-
-      if (currentPath === newPath) {
-        // Same path, allow (might be query string change)
+      if (!movesElsewhere(url)) {
+        // Staying put — a hash, or a rewrite of the same address.
         return originalPushState.current!.apply(this, [data, unused, url]);
       }
 
@@ -289,14 +310,8 @@ export function useUnsavedChanges({
         return originalReplaceState.current!.apply(this, [data, unused, url]);
       }
 
-      // Check if navigating to a different path
-      const currentPath = window.location.pathname;
-      const newPath = url
-        ? new URL(url.toString(), window.location.origin).pathname
-        : currentPath;
-
-      if (currentPath === newPath) {
-        // Same path, allow
+      if (!movesElsewhere(url)) {
+        // Staying put — a hash, or a rewrite of the same address.
         return originalReplaceState.current!.apply(this, [data, unused, url]);
       }
 

--- a/packages/admin/src/lib/__tests__/navigation.search-param.test.ts
+++ b/packages/admin/src/lib/__tests__/navigation.search-param.test.ts
@@ -1,0 +1,73 @@
+// `setSearchParam` — the writer the admin did not have.
+//
+// The query was already read as state here (the entry list takes its filter
+// from `?where=`), but nothing wrote one, so anything that belonged in the URL
+// was kept in component state instead. These pin the properties that make it
+// safe to put state there: the rest of the query survives, an unchanged write
+// does nothing, and the default is a history entry the reader can undo.
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { setSearchParam } from "../navigation";
+
+const AT = "/admin/collections/posts/1";
+
+describe("setSearchParam", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", AT);
+  });
+
+  it("adds a parameter without disturbing the path", () => {
+    setSearchParam("locale", "de");
+    expect(window.location.pathname).toBe(AT);
+    expect(window.location.search).toBe("?locale=de");
+  });
+
+  it("keeps every other parameter", () => {
+    // The list's filter and page live in the same query string, and losing them
+    // on a language switch would silently reset what the reader was looking at.
+    window.history.replaceState(null, "", `${AT}?where=%7B%7D&page=3`);
+    setSearchParam("locale", "fr");
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get("where")).toBe("{}");
+    expect(params.get("page")).toBe("3");
+    expect(params.get("locale")).toBe("fr");
+  });
+
+  it("removes the parameter when given null", () => {
+    window.history.replaceState(null, "", `${AT}?locale=de&page=2`);
+    setSearchParam("locale", null);
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get("locale")).toBeNull();
+    expect(params.get("page")).toBe("2");
+  });
+
+  it("does nothing when the value is already set", () => {
+    // A component that writes the parameter it just read would otherwise fill
+    // the history with copies of one page, and the back button would appear
+    // stuck.
+    window.history.replaceState(null, "", `${AT}?locale=de`);
+    const before = window.history.length;
+    setSearchParam("locale", "de");
+    expect(window.history.length).toBe(before);
+    expect(window.location.search).toBe("?locale=de");
+  });
+
+  it("pushes by default, so the reader can go back", () => {
+    const before = window.history.length;
+    setSearchParam("locale", "de");
+    expect(window.history.length).toBeGreaterThan(before);
+  });
+
+  it("replaces when asked, for a correction rather than a move", () => {
+    const before = window.history.length;
+    setSearchParam("locale", "de", { replace: true });
+    expect(window.history.length).toBe(before);
+    expect(window.location.search).toBe("?locale=de");
+  });
+
+  it("preserves the hash", () => {
+    window.history.replaceState(null, "", `${AT}#section`);
+    setSearchParam("locale", "de");
+    expect(window.location.hash).toBe("#section");
+  });
+});

--- a/packages/admin/src/lib/navigation.ts
+++ b/packages/admin/src/lib/navigation.ts
@@ -56,3 +56,46 @@ export function replaceTo(path: string): void {
     }
   }
 }
+
+/**
+ * Set or clear one query parameter on the CURRENT path, leaving the rest of the
+ * query and the path untouched.
+ *
+ * The admin already reads state out of the query — the entry list takes its
+ * filter from `?where=` — but nothing wrote one, so state that belonged in the
+ * URL was kept in component state instead and could not be linked to, restored
+ * on reload, or reached with the back button.
+ *
+ * `navigateTo` is not the tool for this. It compares only `window.location.pathname`
+ * against its argument, so asking it to change a parameter on the page you are
+ * already on is either skipped outright or works by the accident of the compared
+ * strings differing once a `?` is involved.
+ *
+ * Pushes by default: changing one of these is a move the reader can undo with
+ * the back button. Pass `replace` for a parameter that corrects the current
+ * entry rather than making a new one.
+ *
+ * No-ops when the value is already set, so a component that writes the
+ * parameter it just read does not fill the history with copies of one page.
+ */
+export function setSearchParam(
+  key: string,
+  value: string | null,
+  options?: { replace?: boolean }
+): void {
+  try {
+    const url = new URL(window.location.href);
+    const current = url.searchParams.get(key);
+    if (current === value) return;
+    if (value === null) url.searchParams.delete(key);
+    else url.searchParams.set(key, value);
+
+    const next = `${url.pathname}${url.search}${url.hash}`;
+    // The patched history methods in `useRouter` dispatch "locationchange"
+    // themselves, so nothing is dispatched here.
+    if (options?.replace) window.history.replaceState(null, "", next);
+    else window.history.pushState(null, "", next);
+  } catch (error) {
+    console.error("Failed to set search param:", error);
+  }
+}

--- a/packages/admin/src/lib/routing.ts
+++ b/packages/admin/src/lib/routing.ts
@@ -8,6 +8,7 @@ import registry, { routeConfig } from "../pages/registry";
 import type { CarriedRouteSection } from "../types/route-section";
 
 import { matchPluginPage } from "./plugins/plugin-route-registry";
+import { parseSearchParams } from "./search-params";
 
 /**
  * Whether `pathname` is `base` or sits beneath it.
@@ -52,36 +53,16 @@ export interface RouteResult {
 }
 
 type Params = Record<string, string | string[]>;
-export type SearchParams = Record<string, string | string[] | undefined>;
 
-// Parse URL search parameters
-export function parseSearchParams(search: string): SearchParams {
-  const usp = new URLSearchParams(search);
-  const out: SearchParams = {};
-  for (const key of Array.from(new Set(Array.from(usp.keys())))) {
-    const values = usp.getAll(key);
-    out[key] =
-      values.length === 0
-        ? undefined
-        : values.length === 1
-          ? values[0]
-          : values;
-  }
-  return out;
-}
-
-/**
- * Read a single search-param value, mirroring `URLSearchParams.get()`: the
- * first value when a key is repeated, and `null` when it is absent.
- */
-export function getSearchParam(
-  params: SearchParams,
-  key: string
-): string | null {
-  const value = params[key];
-  if (Array.isArray(value)) return value[0] ?? null;
-  return value ?? null;
-}
+// Query-string parsing lives in `lib/search-params`, which imports nothing:
+// this module imports the page registry, and therefore every page, so the
+// helpers were unreachable from a hook without closing a cycle. Re-exported
+// here so existing callers keep working.
+export {
+  getSearchParam,
+  parseSearchParams,
+  type SearchParams,
+} from "./search-params";
 
 // Normalize Next.js App Router patterns
 function normalizePattern(pattern: string): string {

--- a/packages/admin/src/lib/search-params.ts
+++ b/packages/admin/src/lib/search-params.ts
@@ -1,0 +1,43 @@
+/**
+ * Reading a URL's query string.
+ *
+ * Separate from `lib/routing` on purpose. Routing resolves a path against the
+ * page registry, so it imports every page in the admin — and these helpers are
+ * used BY pages and by the hooks pages call, which closed a cycle back onto
+ * itself through a module none of them actually needed. Parsing a query string
+ * has nothing to do with knowing what routes exist, so it lives where anything
+ * can reach it.
+ *
+ * @module lib/search-params
+ */
+
+export type SearchParams = Record<string, string | string[] | undefined>;
+
+/** Parse a URL search string into a plain record, keeping repeated keys as arrays. */
+export function parseSearchParams(search: string): SearchParams {
+  const usp = new URLSearchParams(search);
+  const out: SearchParams = {};
+  for (const key of Array.from(new Set(Array.from(usp.keys())))) {
+    const values = usp.getAll(key);
+    out[key] =
+      values.length === 0
+        ? undefined
+        : values.length === 1
+          ? values[0]
+          : values;
+  }
+  return out;
+}
+
+/**
+ * Read a single search-param value, mirroring `URLSearchParams.get()`: the
+ * first value when a key is repeated, and `null` when it is absent.
+ */
+export function getSearchParam(
+  params: SearchParams,
+  key: string
+): string | null {
+  const value = params[key];
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}


### PR DESCRIPTION
Completes the T-07 arc that #1024 started, and closes the language half of the data loss it found.

## The language is now a place

`?locale=de`. It is linkable, survives a reload, and comes back with the browser's back button. An unconfigured value falls back to the default rather than being sent to an API that has no answer for it.

## But the reason to do it now is not the linking

Switching language refetches the document and discards unsaved edits. As component state that happened with **nothing able to ask first** — measured before this change: an edited title, switch language, gone, no dialog and no recovery point.

As a URL it is a **navigation**, which the guard mounted in #1024 already understands.

So `useUnsavedChanges` now compares the **query** as well as the path. In this admin the query is part of where you are rather than decoration on it, and the old pathname-only comparison read a language switch as *"same place, let it through"* — the comment there even said `// Same path, allow (might be query string change)`. A hash is still allowed, because it moves within a page rather than off it.

## `setSearchParam` is the writer the admin did not have

The query was already read as state here — the entry list takes its filter from `?where=` — but nothing wrote one, so anything belonging in the URL stayed in component state.

`navigateTo` is not that tool: it compares only `window.location.pathname` against its argument, so changing a parameter on the page you are already on is either skipped outright or works by the accident of the two strings differing once a `?` is involved.

**The seed a switch can carry stays out of the URL**, deliberately. It is a one-shot intent consumed on arrival; in the URL it would survive a reload and be carried into any link the author shared.

With an address to link to, a language mark in the entry list opens that row in that language — the click-to-open that #1023 shipped inert.

## A cycle the gate caught, and the fix for it

`fallow audit` came back **fail**: 2 circular dependencies introduced. `useEditorLocale` → `useSearchParams` → `lib/routing` → `pages/registry` → the entry page → back to `useEditorLocale`.

`lib/routing` resolves a path against the page registry, so it imports every page in the admin. Anything a page uses could not reach a query-string helper without closing a loop.

Parsing a query string has nothing to do with knowing what routes exist, so those three names move to `lib/search-params`, which imports nothing; `lib/routing` re-exports them so callers are unchanged. That also closes **a cycle that pre-dates this branch**, through `EntryList`. Fifteen remain, all through `useRouter`, none of them mine. Verdict now **pass**, `dead_code_introduced: 0`.

The locale key moved to `constants/search-params` for the same reason from the other side: the list writes it and the editor reads it, so defining it beside either drags that side's imports into the other.

## Verified in the browser

| | result |
|---|---|
| switch language | URL becomes `?locale=es`, editor in Spanish |
| reload that URL | still Spanish |
| `?locale=zz` | falls back to English |
| back button | returns to the previous language |
| **dirty + switch language** | **blocked, asked, edit intact** |
| Arabic mark in the list | opens the row at `?locale=ar`, editing Arabic |

## Tests

27 across three files, all stub-verified: reverting the guard to pathname-only fails the query test; making the writer drop the rest of the query fails four; accepting an unconfigured locale fails the fallback test.

Gates run after building dependencies to completion as a separate command: `check-types` 0, `lint` 0, admin suite 255 files / 2307 tests, no new failures against the pre-existing 4-file baseline.

## Note

Escape from a dirty entry editor is **correctly guarded** — I measured it independently after a cross-lane report suggested otherwise, and the report was withdrawn. What remains from that thread is separate and not in this PR: a page-builder blocks change reaches the form but does not mark it dirty, so Escape leaves without asking. Same family as #1026 in the opposite direction — that one could never equal its default, this one always does.
