### PR TITLE
fix(builder): drop the platform-wrong keystroke hint and hold the roving stop at focus

### DIFF
--- a/.changeset/builder-toolbar-hint-and-roving-stop.md
+++ b/.changeset/builder-toolbar-hint-and-roving-stop.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The page builder toolbar no longer shows a keyboard hint that named the wrong modifier on macOS, and its arrow-key navigation no longer jumps backwards after an action that moves the selection.

--- a/packages/builder/src/block-toolbar.test.tsx
+++ b/packages/builder/src/block-toolbar.test.tsx
@@ -107,8 +107,8 @@ function editorSpy(
  * without rendered blocks tests a permanently hidden toolbar — which is how the
  * first draft of these cases came back unable to find a single button.
  */
-function mount(editor: EditorState, props: { hidden?: boolean } = {}) {
-  return render(
+function tree(editor: EditorState, props: { hidden?: boolean }) {
+  return (
     <ShortcutProvider>
       <BlockKeyboardActions editor={editor}>
         <Canvas
@@ -121,6 +121,16 @@ function mount(editor: EditorState, props: { hidden?: boolean } = {}) {
       </BlockKeyboardActions>
     </ShortcutProvider>
   );
+}
+
+function mount(editor: EditorState, props: { hidden?: boolean } = {}) {
+  const result = render(tree(editor, props));
+  return {
+    ...result,
+    /** Re-render with the selection moved, as a verb that changes it does. */
+    reselect: (id: string) =>
+      result.rerender(tree({ ...editor, selectedId: id }, props)),
+  };
 }
 
 describe("BlockToolbar", () => {
@@ -243,6 +253,46 @@ describe("BlockToolbar", () => {
     fireEvent.keyDown(screen.getByRole("toolbar"), { key: "ArrowLeft" });
     fireEvent.keyDown(screen.getByRole("toolbar"), { key: "ArrowLeft" });
     expect(document.activeElement).toBe(buttons[4]);
+  });
+
+  it("keeps the roving stop where FOCUS is when the selection moves", () => {
+    /*
+     * Duplicate and Select parent both change the selection while the author's
+     * focus is still on the button they pressed. Resetting the stop to 0 there
+     * would put the roving index and the caret on different buttons, and the
+     * next arrow press would jump backwards from where the author is looking.
+     */
+    register();
+    const editor = editorSpy(pair(), "a");
+    const { reselect } = mount(editor);
+    const buttons = screen.getAllByRole("button");
+
+    buttons[3]?.focus(); // Duplicate
+    reselect("b"); // as duplicating does: selection follows the copy
+
+    fireEvent.keyDown(screen.getByRole("toolbar"), { key: "ArrowRight" });
+
+    // Delete, the button after the focused one — not Move up, which is where a
+    // stop reset to 0 would have sent it.
+    expect(document.activeElement).toBe(buttons[4]);
+  });
+
+  it("DOES reset the stop when focus is outside the bar", () => {
+    // The control. Without it the case above passes against a bar that never
+    // reset the stop at all, which would strand it on a button belonging to a
+    // block the author has moved on from.
+    register();
+    const editor = editorSpy(pair(), "a");
+    const { reselect } = mount(editor);
+    const buttons = screen.getAllByRole("button");
+
+    buttons[3]?.focus();
+    (window.document.activeElement as HTMLElement | null)?.blur();
+    reselect("b");
+
+    fireEvent.keyDown(screen.getByRole("toolbar"), { key: "ArrowRight" });
+
+    expect(document.activeElement).toBe(buttons[1]);
   });
 
   it("refuses to render without the verbs above it", () => {

--- a/packages/builder/src/block-toolbar.tsx
+++ b/packages/builder/src/block-toolbar.tsx
@@ -60,7 +60,6 @@ import { useBlockActionsContext } from "./keyboard-actions";
 import {
   toolbarActions,
   toolbarPlacement,
-  toolbarShortcut,
   type ToolbarAction,
   type ToolbarActionId,
   type ToolbarPlacement,
@@ -141,6 +140,20 @@ export function BlockToolbar({
    */
   const [activeIndex, setActiveIndex] = React.useState(0);
   React.useEffect(() => {
+    /*
+     * Only when focus is elsewhere.
+     *
+     * Duplicate and Select parent both CHANGE the selection, and an author who
+     * pressed one of them with the keyboard still has focus on that button.
+     * Resetting the stop to 0 there would leave the roving index and the caret
+     * on different buttons, so the next arrow press would jump backwards from
+     * where the author is looking. When the bar holds focus, `onFocus` has
+     * already put the index where the caret is.
+     */
+    const element = bar.current;
+    if (element !== null && element.contains(window.document.activeElement)) {
+      return;
+    }
     setActiveIndex(0);
   }, [selectedId]);
 
@@ -296,7 +309,6 @@ export function BlockToolbar({
     >
       {actions.map((action, index) => {
         const Icon = ICONS[action.id];
-        const shortcut = toolbarShortcut(action.id);
         const describedBy =
           action.reason === undefined
             ? undefined
@@ -312,16 +324,23 @@ export function BlockToolbar({
             aria-label={action.label}
             aria-disabled={action.enabled ? undefined : true}
             aria-describedby={describedBy}
-            // The description twice over: `title` for a pointer, and a hidden
-            // span for anything that reads the accessible description. `title`
-            // alone never reaches a keyboard author, who is exactly the person
-            // the reason is for.
-            title={
-              action.reason ??
-              (shortcut === undefined
-                ? action.label
-                : `${action.label} (${shortcut})`)
-            }
+            /*
+             * The description twice over: `title` for a pointer, and a hidden
+             * span for anything that reads the accessible description. `title`
+             * alone never reaches a keyboard author, who is exactly the person
+             * the reason is for.
+             *
+             * No keystroke hint, deliberately. Every binding here is spelled
+             * `mod`, which the shortcut manager resolves to Command on Apple
+             * platforms and Control everywhere else — so any fixed string is
+             * wrong on one of them, and "Ctrl+D" on a Mac teaches a keystroke
+             * that does nothing. The manager's own `detectApplePlatform` is the
+             * one rule that answers this, and it is not on `@nextlyhq/ui`'s
+             * public entry; spelling the platform a second time here would let
+             * a tooltip disagree with the binding it describes. The hint
+             * returns when that export does.
+             */
+            title={action.reason ?? action.label}
             tabIndex={index === activeIndex ? 0 : -1}
             onFocus={() => setActiveIndex(index)}
             onClick={() => run(action)}

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -270,7 +270,6 @@ export {
   TOOLBAR_GAP_PX,
   toolbarActions,
   toolbarPlacement,
-  toolbarShortcut,
   type ToolbarAction,
   type ToolbarActionId,
   type ToolbarPlacement,

--- a/packages/builder/src/toolbar-actions.test.ts
+++ b/packages/builder/src/toolbar-actions.test.ts
@@ -21,7 +21,6 @@ import {
   TOOLBAR_GAP_PX,
   toolbarActions,
   toolbarPlacement,
-  toolbarShortcut,
   type ToolbarAction,
   type ToolbarActionId,
 } from "./toolbar-actions";
@@ -188,16 +187,6 @@ describe("toolbarActions", () => {
     expect(actionOf(actions, "duplicate").enabled).toBe(true);
     expect(actionOf(actions, "delete").enabled).toBe(true);
     expect(actionOf(actions, "delete").reason).toBeUndefined();
-  });
-});
-
-describe("toolbarShortcut", () => {
-  it("names a keystroke only where one exists", () => {
-    expect(toolbarShortcut("duplicate")).toBe("Ctrl+D");
-    expect(toolbarShortcut("move-up")).toBe("Alt+Up");
-    // Selecting the parent has no binding, and inventing one in a tooltip would
-    // teach a keystroke that does nothing.
-    expect(toolbarShortcut("select-parent")).toBeUndefined();
   });
 });
 

--- a/packages/builder/src/toolbar-actions.ts
+++ b/packages/builder/src/toolbar-actions.ts
@@ -76,28 +76,6 @@ export interface ToolbarAction {
   readonly reason?: string;
 }
 
-/** The keystroke that does the same thing, for the tooltip. */
-const SHORTCUTS: Record<ToolbarActionId, string | undefined> = {
-  "select-parent": undefined,
-  "move-up": "Alt+Up",
-  "move-down": "Alt+Down",
-  duplicate: "Ctrl+D",
-  delete: "Delete",
-};
-
-/**
- * The shortcut hint for an action, or `undefined` where there is no keystroke.
- *
- * Stated as Ctrl rather than resolved per platform. The hint is a pointer to
- * the shortcut list rather than a contract, and a hint that read "Cmd+D" on a
- * Mac would have to be produced at render time from a platform check — which is
- * a second place that decides what the key IS, and the first place is the
- * shortcut manager.
- */
-export function toolbarShortcut(id: ToolbarActionId): string | undefined {
-  return SHORTCUTS[id];
-}
-
 /**
  * What a lock refusal says.
  *


### PR DESCRIPTION
Two defects in #1025, found by reviewing my own diff after both review bots hit their usage limits and never ran on it.

**These fixes existed before #1025 merged but did not make it in.** #1025 was merged at `09:04:44Z` on head `17c181a32`; I pushed the fixes at `10:03` on `ce4a06158`, after the merge, so they were stranded on a branch nobody would look at again. That sequencing was my error — I kept working on a PR without re-checking whether it was still open. This recovers them by cherry-pick onto current `main`.

## 1. The tooltip taught a keystroke that does nothing on macOS

It showed `Ctrl+D`. The binding is spelled `mod`, and `key-spec.ts` resolves `mod` to **Command on Apple platforms**, Control elsewhere. So on a Mac the tooltip named a keystroke that does nothing, for the one action an author is most likely to try to learn.

The original justification — that resolving per platform would be "a second place that decides what the key is" — conflated two different jobs: which key the BINDING is (the shortcut manager's), and how to SPELL it for a human (a display concern). Getting the second wrong is not excused by owning the first.

The right rule already exists: `detectApplePlatform` in `packages/ui/src/lib/shortcuts/key-spec.ts`. It is **not on `@nextlyhq/ui`'s public entry**, so `packages/builder` cannot reach it, and spelling the platform a second time here would let a tooltip disagree with the binding it describes. So the hint is removed rather than guessed, with a comment recording what would bring it back. The tooltip keeps the action name and, when unavailable, the reason — which is the load-bearing content.

For context, not fixed here: the admin hardcodes `⌘` in `RequestBar.tsx`, which is wrong on Windows and Linux for the same underlying reason.

## 2. The roving tab stop fought the caret

The stop reset to the first button whenever the selection moved. But **Duplicate and Select parent both move the selection while the author's focus is still on the button they pressed** — so the roving index and the caret ended up on different buttons, and the next arrow press jumped backwards from where the author was looking.

Now the reset is skipped while the bar contains focus, where `onFocus` has already put the index in the right place.

## Verified

Both fixes stub-verified in both directions, each caught by exactly the test whose name claims it:

- reset unconditionally again → *"keeps the roving stop where FOCUS is when the selection moves"* fails.
- never reset → *"DOES reset the stop when focus is outside the bar"* fails.

The second test is the control for the first: without it, the fix would pass against a bar that had simply stopped resetting the stop at all, stranding it on a button belonging to a block the author has moved on from.

`packages/builder`: 683 tests, types and lint clean. Built to completion first, then gated as separate commands — `check-types` depends on `^check-types` and `lint` on nothing, so neither builds what it reads.
