### PR TITLE
fix(builder): claim Escape for the editor instead of the page behind it

### DIFF
--- a/.changeset/builder-claims-escape.md
+++ b/.changeset/builder-claims-escape.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Pressing Escape in the page builder no longer navigates away from the entry and discards unsaved block edits. The editor now claims the key: it clears the block selection, leaves a text field to handle its own dismissal, and stands aside only for an open dialog.

--- a/packages/builder/src/canvas-escape.test.ts
+++ b/packages/builder/src/canvas-escape.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+/**
+ * Who owns Escape, decided without a keyboard.
+ *
+ * The property that matters is not "Escape deselects" — it is that the editor
+ * CONSUMES the key in every state except an open modal. A rule that declined it
+ * in any other case would let the keystroke reach the entry form's "cancel and
+ * go back", which discards the author's uncommitted blocks, so the cases below
+ * are written to catch a rule that stands down too readily.
+ *
+ * @module canvas-escape.test
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { escapeOutcome, isTextEntry, modalIsOpen } from "./canvas-escape";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function mount(html: string): HTMLElement {
+  document.body.innerHTML = html;
+  const first = document.body.firstElementChild;
+  if (!(first instanceof HTMLElement)) throw new Error("expected an element");
+  return first;
+}
+
+describe("modalIsOpen", () => {
+  it("sees an open dialog", () => {
+    mount('<div role="dialog" data-state="open"></div>');
+    expect(modalIsOpen(document)).toBe(true);
+  });
+
+  it("ignores a CLOSED dialog left in the document", () => {
+    // The dialog primitive keeps a closed dialog mounted. A rule that matched
+    // the role alone would hand Escape to a component that is not on screen,
+    // and the canvas would stop deselecting for the rest of the session.
+    mount('<div role="dialog" data-state="closed"></div>');
+    expect(modalIsOpen(document)).toBe(false);
+  });
+
+  it("answers false with no document at all", () => {
+    // A server render has no DOM, and the editor's bindings are registered
+    // before the first paint.
+    expect(modalIsOpen(undefined)).toBe(false);
+  });
+});
+
+describe("isTextEntry", () => {
+  it("recognises the things people type into", () => {
+    expect(isTextEntry(mount("<textarea></textarea>"))).toBe(true);
+    expect(isTextEntry(mount('<input type="text" />'))).toBe(true);
+    expect(isTextEntry(mount('<input type="search" />'))).toBe(true);
+    // No `type` at all is a text input.
+    expect(isTextEntry(mount("<input />"))).toBe(true);
+    const editable = mount('<div contenteditable="true"></div>');
+    expect(isTextEntry(editable)).toBe(true);
+  });
+
+  it("follows editability down to the node the caret is actually in", () => {
+    /*
+     * Where the first version of this was wrong. A rich-text editor puts focus
+     * on the inner node holding the caret, not on the element carrying the
+     * attribute, so reading it off the focused element answers "no" for most of
+     * the time someone is typing. `isContentEditable` would have covered this
+     * in a browser and silently answered false in jsdom, so the case would have
+     * looked tested and not been.
+     */
+    const editable = mount(
+      '<div contenteditable="true"><p><span id="deep">x</span></p></div>'
+    );
+
+    expect(isTextEntry(editable.querySelector("#deep"))).toBe(true);
+  });
+
+  it("does not count an explicitly NON-editable region", () => {
+    expect(isTextEntry(mount('<div contenteditable="false"></div>'))).toBe(
+      false
+    );
+  });
+
+  it("does NOT count inputs nobody types into", () => {
+    // The control. Without it "is it an input" would pass every case above
+    // while making Escape inert over a checkbox, which is an ordinary
+    // deselect.
+    expect(isTextEntry(mount('<input type="checkbox" />'))).toBe(false);
+    expect(isTextEntry(mount('<input type="radio" />'))).toBe(false);
+    expect(isTextEntry(mount('<input type="button" />'))).toBe(false);
+  });
+
+  it("answers false for a plain element and for nothing", () => {
+    expect(isTextEntry(mount("<div></div>"))).toBe(false);
+    expect(isTextEntry(null)).toBe(false);
+  });
+});
+
+describe("escapeOutcome", () => {
+  it("defers to an open modal, which is dismissing on the same key", () => {
+    mount('<div role="dialog" data-state="open"></div>');
+    expect(escapeOutcome(document)).toBe("defer-to-modal");
+  });
+
+  it("leaves the key to a field, without releasing it to the page", () => {
+    const field = mount('<input type="text" />') as HTMLInputElement;
+    field.focus();
+    expect(escapeOutcome(document)).toBe("leave-to-field");
+  });
+
+  it("claims the key whenever nothing else is", () => {
+    /*
+     * Note what is NOT a parameter: the selection. There may be nothing to
+     * deselect, and the editor still owns the key — which is precisely the
+     * state an author is in after clicking canvas background, one click away
+     * from any block. A rule written around what Escape ACHIEVES would release
+     * it there, and the keystroke would reach the entry form's cancel and take
+     * every uncommitted block edit with it.
+     */
+    expect(escapeOutcome(document)).toBe("deselect");
+  });
+
+  it("prefers the modal over a field inside it", () => {
+    // A palette is a dialog containing a search input, so both conditions hold
+    // at once and the order they are asked in decides. The modal wins: its own
+    // Escape closes it, and consuming the key for the canvas would strand it
+    // open.
+    const dialog = mount(
+      '<div role="dialog" data-state="open"><input type="text" /></div>'
+    );
+    const field = dialog.querySelector("input");
+    field?.focus();
+
+    expect(escapeOutcome(document)).toBe("defer-to-modal");
+  });
+});

--- a/packages/builder/src/canvas-escape.ts
+++ b/packages/builder/src/canvas-escape.ts
@@ -1,0 +1,126 @@
+/**
+ * Who owns Escape while the editor is on screen.
+ *
+ * The page builder mounts as a full-screen surface INSIDE an entry form, and
+ * the admin binds Escape on that form to "cancel and go back". Both use the
+ * same shortcut manager, so with nothing claiming Escape for the editor the
+ * form's binding wins by default — and an author who pressed Escape over a
+ * canvas full of work was navigated away from the entry entirely, discarding
+ * every block edit made since the editor was opened. Nothing warned them,
+ * because the form was never told the document had changed.
+ *
+ * ## Why this is a PRIORITY question, not a depth one
+ *
+ * The shell renders its own `ShortcutProvider`, which the manager resolves to
+ * the parent's manager when it sits on the same target — so the editor's
+ * layers and the host page's layers are in ONE stack, ordered by
+ * `(priority, depth, sequence)`. Depth cannot settle it: the editor's provider
+ * takes the parent's depth rather than adding to it, and the host decides how
+ * deeply its own shortcuts are scoped, so any depth chosen here can be tied or
+ * beaten by a host that nests one scope further. `sequence` — which layer
+ * registered later — happens to favour the editor today because the form is on
+ * screen before the editor opens, but the manager's own documentation calls
+ * equal-depth ordering incidental and says to express real requirements as
+ * precedence. So this is precedence, deliberately.
+ *
+ * ## The editor claims it; a MODAL still outranks the editor
+ *
+ * Escape's meaning is "dismiss the innermost thing", which is why a rule that
+ * simply took the key for the canvas would be wrong: with the command palette
+ * open, Escape belongs to the palette. Rather than couple to that one
+ * component, the claim stands down whenever an open dialog is in the document.
+ * Any modal a host adds inherits the same deference, and there is no list to
+ * keep in step with the components.
+ *
+ * @module canvas-escape
+ */
+
+/** The priority that puts the editor's claim above a host page's bindings. */
+export const CANVAS_ESCAPE_PRIORITY = 1;
+
+/**
+ * Whether a modal is open, and therefore owns Escape.
+ *
+ * Read from the DOM rather than from editor state, because the components that
+ * matter — the command palette today, whatever a host mounts tomorrow — portal
+ * to the body and are outside every React tree this could subscribe to. The
+ * attribute pair is what the dialog primitive already publishes, so this reads
+ * a contract rather than a convention.
+ */
+export function modalIsOpen(root: Document | undefined): boolean {
+  if (root === undefined) return false;
+  return root.querySelector('[role="dialog"][data-state="open"]') !== null;
+}
+
+/**
+ * Whether focus is somewhere that Escape means something else.
+ *
+ * A field's own dismissal — closing a combobox, abandoning an IME composition,
+ * reverting an edit in progress — is what Escape means while typing, and
+ * clearing the canvas selection out from under it would answer a question the
+ * author did not ask.
+ *
+ * The claim is still made in that case, and that is the point: standing down
+ * would let the keystroke fall through to the form's "cancel and go back",
+ * which is the data loss this module exists to stop. So the answer here decides
+ * what Escape DOES, never whether the editor consumes it.
+ */
+export function isTextEntry(element: Element | null): boolean {
+  if (element === null) return false;
+  if (element instanceof HTMLTextAreaElement) return true;
+  /*
+   * `closest`, not `isContentEditable`.
+   *
+   * Editability is INHERITED, and a rich-text editor puts focus on whichever
+   * inner node the caret is in rather than on the element carrying the
+   * attribute — so reading the attribute off the focused element alone answers
+   * "no" for most of the time an author is actually typing. `closest` follows
+   * the inheritance the same way the browser does.
+   */
+  if (element.closest('[contenteditable=""], [contenteditable="true"]')) {
+    return true;
+  }
+  if (!(element instanceof HTMLInputElement)) return false;
+  // Buttons, checkboxes and radios are inputs that nobody types into, and
+  // Escape over one of those is an ordinary "clear the selection".
+  return !NON_TEXT_INPUT_TYPES.has(element.type);
+}
+
+const NON_TEXT_INPUT_TYPES: ReadonlySet<string> = new Set([
+  "button",
+  "checkbox",
+  "color",
+  "file",
+  "image",
+  "radio",
+  "range",
+  "reset",
+  "submit",
+]);
+
+/** What pressing Escape over the editor should do. */
+export type EscapeOutcome = "defer-to-modal" | "leave-to-field" | "deselect";
+
+/**
+ * The whole rule, as one decision a test can make without a keyboard.
+ *
+ * `"leave-to-field"` and `"deselect"` are both CONSUMED by the editor; they
+ * differ only in what happens afterwards. Only `"defer-to-modal"` declines the
+ * key, and it declines to something that is itself dismissing on Escape.
+ *
+ * **The selection is deliberately not an input.** This answers who OWNS the
+ * key, and the editor owns it whether or not a block is selected — an editor
+ * that released Escape once the canvas happened to have nothing selected would
+ * lose the author's work in exactly the state a click on background produces.
+ * Whether there is anything to deselect is the caller's question, asked after
+ * this one.
+ */
+export function escapeOutcome(root: Document | undefined): EscapeOutcome {
+  if (modalIsOpen(root)) return "defer-to-modal";
+  if (isTextEntry(root?.activeElement ?? null)) return "leave-to-field";
+  // Deselecting with nothing selected is a no-op that still consumes the key —
+  // which is the whole point. An editor that let Escape through once the canvas
+  // happened to have no selection would lose the author's work in exactly the
+  // state where they had clicked away from a block before pressing it.
+  return "deselect";
+}

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -259,6 +259,22 @@ export {
 } from "./duplicate-block";
 
 /**
+ * @experimental Who owns Escape while the editor is on screen.
+ *
+ * From this entry because the rule is a plain function over the DOM and a
+ * selection. A host embedding the editor beside its own Escape handling needs
+ * the same answer the editor uses, and a second reading of it is how the two
+ * end up both claiming the key or both releasing it.
+ */
+export {
+  CANVAS_ESCAPE_PRIORITY,
+  escapeOutcome,
+  isTextEntry,
+  modalIsOpen,
+  type EscapeOutcome,
+} from "./canvas-escape";
+
+/**
  * @experimental What the floating toolbar offers, and where it sits.
  *
  * From this entry because both halves are plain functions. The action list is

--- a/packages/builder/src/keyboard-actions.test.tsx
+++ b/packages/builder/src/keyboard-actions.test.tsx
@@ -12,7 +12,7 @@
  * @module keyboard-actions.test
  */
 import { act, cleanup, render, screen } from "@testing-library/react";
-import { ShortcutProvider } from "@nextlyhq/ui";
+import { ShortcutProvider, useShortcuts } from "@nextlyhq/ui";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -84,7 +84,21 @@ function mount(editor: EditorState) {
  * binding that DECLINED a keystroke is told apart from one that handled it and
  * did nothing. Both leave the store untouched.
  */
-function press(key: string, init: KeyboardEventInit = {}): KeyboardEvent {
+function press(
+  key: string,
+  init: KeyboardEventInit = {},
+  /**
+   * Where the keystroke starts, defaulting to the document.
+   *
+   * It matters for any binding whose behaviour depends on whether the user is
+   * TYPING: the manager reads that from the event's target, not from
+   * `document.activeElement`. A test that focuses a field and then dispatches
+   * on the document has moved the focus and told the manager nothing, so a
+   * `whenTyping` rule is exercised by neither value — which is exactly how the
+   * first version of the field case below passed against both settings.
+   */
+  target: EventTarget = window.document
+): KeyboardEvent {
   const event = new KeyboardEvent("keydown", {
     key,
     bubbles: true,
@@ -96,7 +110,7 @@ function press(key: string, init: KeyboardEventInit = {}): KeyboardEvent {
   // dispatch is outside that, so a state update the handler makes is not
   // flushed before the assertion reads the DOM.
   act(() => {
-    document.dispatchEvent(event);
+    target.dispatchEvent(event);
   });
   return event;
 }
@@ -777,5 +791,220 @@ describe("useBlockKeyboardActions", () => {
       "Paragraph deleted"
     );
     clearBlocks();
+  });
+});
+
+describe("Escape belongs to the editor, not to the page behind it", () => {
+  /*
+   * The regression this exists for: the admin binds Escape on the entry form to
+   * "cancel and go back", both sets of bindings live in ONE shortcut stack, and
+   * with nothing claiming the key here an author pressing Escape over the canvas
+   * was navigated away from the entry — discarding every block edit the builder
+   * had not yet committed, with no prompt, because the form was never told the
+   * document had changed.
+   *
+   * The harness registers a competing layer at the host's precedence and asserts
+   * it never runs. Asserting only that the selection cleared would pass against
+   * an editor that cleared it AND let the key through.
+   */
+  function mountWithHostEscape(editor: EditorState) {
+    const hostCancel = vi.fn();
+    function HostBindings(): null {
+      useShortcuts(
+        [{ keys: "Escape", description: "Cancel", run: hostCancel }],
+        {
+          name: "test-entry-form",
+        }
+      );
+      return null;
+    }
+    render(
+      <ShortcutProvider>
+        <HostBindings />
+        <BlockKeyboardActions editor={editor} />
+      </ShortcutProvider>
+    );
+    return hostCancel;
+  }
+
+  it("clears the selection and does NOT reach the page's cancel", () => {
+    const editor = editorSpy(pair(), "a");
+    const hostCancel = mountWithHostEscape(editor);
+
+    press("Escape");
+
+    expect(editor.select).toHaveBeenCalledWith(null);
+    expect(hostCancel).not.toHaveBeenCalled();
+  });
+
+  it("holds the key even with NOTHING selected", () => {
+    /*
+     * THE case, and the one a rule written around what Escape ACHIEVES would
+     * get wrong. With no selection there is nothing to clear, so an editor that
+     * only claimed the key when it had work to do would release it here — and
+     * this is exactly the state an author is in after clicking canvas
+     * background, one click away from any block.
+     */
+    const editor = editorSpy(pair(), null);
+    const hostCancel = mountWithHostEscape(editor);
+
+    press("Escape");
+
+    expect(hostCancel).not.toHaveBeenCalled();
+  });
+
+  it("wins even when the host's layer registers LAST", () => {
+    /*
+     * What makes the claim PRECEDENCE rather than luck.
+     *
+     * At equal priority the manager orders layers by depth and then by which
+     * registered later, and "later" wins. Every other case here mounts the host
+     * first, so the editor would come out on top from mount order alone — and
+     * removing the priority entirely left them all green, which is how this gap
+     * was found. Reversing the mount order takes that accident away: only the
+     * declared priority can decide it now.
+     *
+     * This is not a contrived arrangement. The shell renders its own provider,
+     * which resolves to the host's manager and INHERITS its depth rather than
+     * adding to it, so the two sets of bindings genuinely sit at one level and
+     * their order is whatever mounting happened to produce.
+     */
+    const editor = editorSpy(pair(), "a");
+    const hostCancel = vi.fn();
+    function HostBindings(): null {
+      useShortcuts(
+        [{ keys: "Escape", description: "Cancel", run: hostCancel }],
+        { name: "test-entry-form" }
+      );
+      return null;
+    }
+    render(
+      <ShortcutProvider>
+        <BlockKeyboardActions editor={editor} />
+        <HostBindings />
+      </ShortcutProvider>
+    );
+
+    press("Escape");
+
+    expect(hostCancel).not.toHaveBeenCalled();
+    expect(editor.select).toHaveBeenCalledWith(null);
+  });
+
+  it("stands down while a modal is open, which dismisses on the same key", () => {
+    // Escape means "dismiss the innermost thing". A rule that simply took the
+    // key for the canvas would strand an open palette, and the author would
+    // press Escape at a dialog and watch the page behind it change instead.
+    const editor = editorSpy(pair(), "a");
+    const dialog = window.document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("data-state", "open");
+    window.document.body.append(dialog);
+    try {
+      render(
+        <ShortcutProvider>
+          <BlockKeyboardActions editor={editor} />
+        </ShortcutProvider>
+      );
+
+      const event = press("Escape");
+
+      /*
+       * `defaultPrevented`, not "the selection did not change".
+       *
+       * The selection is unchanged either way — a rule that consumed the key
+       * and then declined to act on it leaves exactly the same store — so that
+       * assertion cannot tell deference from a handler that took the key and
+       * did nothing. Only one of those lets the dialog close, and stubbing the
+       * deference away moved no result until this asserted the consumption.
+       */
+      expect(event.defaultPrevented).toBe(false);
+      expect(editor.select).not.toHaveBeenCalled();
+    } finally {
+      dialog.remove();
+    }
+  });
+
+  it("control: it DOES consume the key with no modal open", () => {
+    // Without this, the case above passes against an editor that had stopped
+    // claiming Escape at all — which is the defect, not the fix.
+    const editor = editorSpy(pair(), "a");
+    render(
+      <ShortcutProvider>
+        <BlockKeyboardActions editor={editor} />
+      </ShortcutProvider>
+    );
+
+    expect(press("Escape").defaultPrevented).toBe(true);
+  });
+
+  it("holds the key from INSIDE a text field, where the inspector lives", () => {
+    /*
+     * The same data loss through a different door, and the one a reasonable
+     * instinct opens. Escape normally "stays out of fields" — it is how a
+     * combobox or an IME composition is dismissed — so declining it there looks
+     * like good manners. It is not: declining releases the key to the entry
+     * form's cancel, and the inspector an author types a block's name into is
+     * full of fields. So the editor consumes it wherever focus is; what focus
+     * changes is what the key DOES.
+     */
+    const editor = editorSpy(pair(), "a");
+    const hostCancel = vi.fn();
+    function HostBindings(): null {
+      useShortcuts(
+        [{ keys: "Escape", description: "Cancel", run: hostCancel }],
+        { name: "test-entry-form" }
+      );
+      return null;
+    }
+    render(
+      <ShortcutProvider>
+        <HostBindings />
+        <BlockKeyboardActions editor={editor} />
+      </ShortcutProvider>
+    );
+
+    const field = window.document.createElement("input");
+    field.type = "text";
+    window.document.body.append(field);
+    field.focus();
+    try {
+      // FROM the field, as a real keystroke arrives — see `press`.
+      const event = press("Escape", {}, field);
+
+      expect(hostCancel).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(true);
+      // And it does NOT clear the selection out from under the field, which is
+      // the half that makes consuming it acceptable rather than rude.
+      expect(editor.select).not.toHaveBeenCalled();
+    } finally {
+      field.remove();
+    }
+  });
+
+  it("control: the host's Escape DOES fire without the editor mounted", () => {
+    /*
+     * Without this, both cases above would pass against a harness whose host
+     * layer never worked — which would prove nothing about the editor at all.
+     */
+    const hostCancel = vi.fn();
+    function HostOnly(): null {
+      useShortcuts(
+        [{ keys: "Escape", description: "Cancel", run: hostCancel }],
+        {
+          name: "test-entry-form",
+        }
+      );
+      return null;
+    }
+    render(
+      <ShortcutProvider>
+        <HostOnly />
+      </ShortcutProvider>
+    );
+
+    press("Escape");
+
+    expect(hostCancel).toHaveBeenCalled();
   });
 });

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -24,6 +24,7 @@ import { findNode } from "@nextlyhq/blocks-engine";
 import { useShortcuts } from "@nextlyhq/ui";
 import * as React from "react";
 
+import { CANVAS_ESCAPE_PRIORITY, escapeOutcome } from "./canvas-escape";
 import { blockDeletion } from "./delete-block";
 import { blockDuplication } from "./duplicate-block";
 import type { EditorState } from "./editor-state";
@@ -509,6 +510,53 @@ export function useBlockKeyboardActions({
     name: "builder-block-actions",
     enabled,
   });
+
+  /*
+   * Escape, claimed for the editor and registered as its OWN layer.
+   *
+   * Separate from the block actions above because it needs a precedence they
+   * must not have. The host page binds Escape to "cancel and go back", and both
+   * sets are in one stack — so without a claim here the form's binding took the
+   * key and navigated away from the entry, discarding every uncommitted block
+   * edit. Raising the whole block-actions layer instead would put Delete and
+   * `mod+d` above the command palette's modal hold, so a keystroke aimed at the
+   * palette would edit the canvas behind it.
+   *
+   * `whenTyping` is left at its default, which is TRUE for Escape. That is not
+   * incidental: standing down inside a field would drop the key straight back
+   * to the form's cancel, and the inspector is full of fields. What focus in a
+   * field changes is what the key DOES, never who consumes it — see
+   * `canvas-escape`.
+   */
+  useShortcuts(
+    [
+      {
+        keys: "Escape",
+        description: "Clear the block selection",
+        // The one case the editor declines. `when` rather than a branch in
+        // `run`, because declining has to leave the key UNCONSUMED for the
+        // dialog to receive it, and a binding that runs has already taken it.
+        when: () =>
+          escapeOutcome(
+            typeof document === "undefined" ? undefined : document
+          ) !== "defer-to-modal",
+        run: () => {
+          const editorNow = latest.current;
+          const outcome = escapeOutcome(
+            typeof document === "undefined" ? undefined : document
+          );
+          if (outcome !== "deselect") return;
+          if (editorNow.selectedId === null) return;
+          editorNow.select(null);
+        },
+      },
+    ],
+    {
+      name: "builder-canvas-escape",
+      enabled,
+      priority: CANVAS_ESCAPE_PRIORITY,
+    }
+  );
 
   const actions = React.useMemo<BlockActions>(
     () => ({


### PR DESCRIPTION
Closes **B-11**, and it is a **P1 data-loss fix** rather than the polish item the plan filed it as.

## The bug

Open the page builder, duplicate a block, press Escape. The editor closes, the route jumps from `/admin/collections/pages/<id>` back to `/admin/collections/pages`, and **the block is gone.** No prompt, no save.

Measured in a browser, with the control that rules out "nothing persists without Save": leaving via **Exit editor** commits correctly and keeps the block. Only Escape lost it.

## Why it happened, which is the part worth reviewing

The admin binds Escape on the entry form to "cancel and go back" (`useEntryFormShortcuts`). Both it and the builder use the same `useShortcuts` manager — and `BuilderShell` renders its own `ShortcutProvider`, which the manager resolves to **the parent's manager** when it sits on the same target, taking `parent.depth` rather than adding to it. So the two sets of bindings are in **one stack at one depth**, and with nothing claiming Escape for the editor the form's binding took it.

The unsaved-changes guard could not help: `BlocksField` commits the document to the form only on exit, deliberately, so the form was never dirty and had nothing to question.

## The design

**Precedence, not mount order.** At equal priority the manager orders by `sequence` — which layer registered later — and that favours the editor today only because the form is on screen before the editor opens. The manager's own docs call equal-depth ordering incidental and say to express real requirements as precedence, so this declares `priority`.

**Its own layer.** Raising the existing block-actions layer instead would lift `Delete` and `mod+d` above the command palette's modal hold, so a keystroke aimed at the palette would edit the canvas behind it.

**A modal still outranks the editor.** Escape means "dismiss the innermost thing". Rather than couple to the palette, the claim stands down whenever an open dialog is in the document, so any modal a host adds inherits the same deference.

**`whenTyping` stays at its default of true**, which is the non-obvious half. Declining Escape inside a field looks like good manners — it is how a combobox or an IME composition is dismissed — but declining releases the key to the form's cancel, and the inspector is full of fields. So focus in a field changes what the key *does*, never who consumes it.

**The selection is not an input to the rule.** The editor owns Escape whether or not a block is selected; an editor that released it once the canvas happened to have nothing selected would lose work in exactly the state a background click produces.

## Verified in a browser

Playground on `:3123`, auth control asserted first (`h1` reads "Welcome, Dev"):

- Duplicate a block, press Escape → **URL unchanged, editor still open, both blocks intact**, selection cleared, toolbar gone.
- Press Escape again with nothing selected → still no navigation, blocks intact.
- Press Escape from inside a text field → still no navigation.
- `Cmd+K` opens the palette, Escape **closes the palette** and leaves the canvas and URL untouched.
- Regression controls: `Cmd+D` still duplicates (2 → 3), `Cmd+Z` still undoes (3 → 2), and Escape mid-drag still abandons the drag without closing the editor.

## Verified in tests

`packages/builder`: **701 tests**, types and lint clean. Six mechanisms stub-verified, and **three of the six were found uncovered by stubbing and needed new tests**:

- Dropping `priority` moved no result, because the harness mounted the host layer first and mount order was doing the work. Fixed by a case that registers the host layer **last**, which only precedence can win.
- Dropping the modal deference moved no result, because the assertion read the selection — unchanged either way. Fixed by asserting `defaultPrevented`, which is the only thing that distinguishes deferring from consuming-and-doing-nothing.
- Setting `whenTyping: false` moved no result, because `press()` dispatched on `document` while the test merely focused a field — the manager reads typing from the event target. Fixed by dispatching from the field, as a real keystroke does.

## Not fixed here, found on the way

The form's `mod+s` "Save entry" binding is at default priority and still fires from inside the builder. Because the builder commits only on exit, that saves the **last committed** document rather than what is on the canvas. Not data loss — the author can save again after exiting — but it is silently stale, and it is the same root shape as this bug. Worth its own issue.
