### PR TITLE
chore(plugin-page-builder): drop the dnd-kit dependencies nothing imports

### DIFF
--- a/.changeset/drop-dead-dnd-kit-deps.md
+++ b/.changeset/drop-dead-dnd-kit-deps.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Installing the page builder plugin no longer pulls in @dnd-kit/dom and @dnd-kit/react. Neither was imported by any code; they were left behind when the canvas drag shipped on its own implementation.

--- a/packages/plugin-page-builder/package.json
+++ b/packages/plugin-page-builder/package.json
@@ -48,8 +48,6 @@
     "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "dependencies": {
-    "@dnd-kit/dom": "0.5.0",
-    "@dnd-kit/react": "0.5.0",
     "@nextlyhq/blocks-engine": "workspace:*",
     "@nextlyhq/blocks-react": "workspace:*",
     "css-tree": "^2.3.1",
@@ -69,7 +67,6 @@
     "react-hook-form": ">=7.0.0"
   },
   "devDependencies": {
-    "@dnd-kit/abstract": "0.5.0",
     "@nextlyhq/admin": "workspace:*",
     "@nextlyhq/builder": "workspace:*",
     "@nextlyhq/plugin-sdk": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1329,12 +1329,6 @@ importers:
 
   packages/plugin-page-builder:
     dependencies:
-      '@dnd-kit/dom':
-        specifier: 0.5.0
-        version: 0.5.0
-      '@dnd-kit/react':
-        specifier: 0.5.0
-        version: 0.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@nextlyhq/blocks-engine':
         specifier: workspace:*
         version: link:../blocks-engine
@@ -1351,9 +1345,6 @@ importers:
         specifier: ^16.2.12
         version: 16.2.12(@babel/core@7.29.7)(@playwright/test@1.61.1)(@types/node@20.19.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     devDependencies:
-      '@dnd-kit/abstract':
-        specifier: 0.5.0
-        version: 0.5.0
       '@nextlyhq/admin':
         specifier: workspace:*
         version: link:../admin
@@ -2325,16 +2316,10 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@dnd-kit/abstract@0.5.0':
-    resolution: {integrity: sha512-hi13iMJgjPX/KDYVKg5VeDIhmYiV6buc9bAX+tCLYf4QdyYjPbsXjn2sPo6m7fQ6SGJBEFgHJ2PemeKDUbwBaA==}
-
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
     peerDependencies:
       react: '>=16.8.0'
-
-  '@dnd-kit/collision@0.5.0':
-    resolution: {integrity: sha512-xUqRn3lS7oqLkT0AnnHS/STh/Czvwe1UapZFYiLbsUGxopMsQd4teaPCzPouOThoMdGEe+dHWjfqJl6t9iG4mQ==}
 
   '@dnd-kit/core@6.3.1':
     resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
@@ -2342,26 +2327,11 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@dnd-kit/dom@0.5.0':
-    resolution: {integrity: sha512-f2xFJp5SYQ8EW/Fbtaa8iBb66hpkWc7qa8vU826KW11/tb44sH+AisZnGtwOOTWTQ0GraqBDr5ixTErww+eKXw==}
-
-  '@dnd-kit/geometry@0.5.0':
-    resolution: {integrity: sha512-ubHQS1CiSDH8ssYH2xG5BnpwPSFP1tStXXjug7/Ba6qnQdu/EUH47l6QXKIksQnnanfVfDf0aGeevRxgZlj28A==}
-
-  '@dnd-kit/react@0.5.0':
-    resolution: {integrity: sha512-abQPLI8lmfVE+v/n+pqy5WFxrw6T2Yg0UQZsL78dp5DKci7dKTVDjvLWqvass+XTFtzJmsZEjk1NdqE6xG8Jiw==}
-    peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-
   '@dnd-kit/sortable@10.0.0':
     resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
     peerDependencies:
       '@dnd-kit/core': ^6.3.0
       react: '>=16.8.0'
-
-  '@dnd-kit/state@0.5.0':
-    resolution: {integrity: sha512-y7XbabQqjF58Lk8YmDQuR8l6QjN+Kh4qlGEjUvHuIeasLk1QP+9L5diXS98VMxQIivyMmUtX2//f+3N7qPJX4w==}
 
   '@dnd-kit/utilities@3.2.2':
     resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
@@ -3623,9 +3593,6 @@ packages:
 
   '@posthog/core@1.25.2':
     resolution: {integrity: sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==}
-
-  '@preact/signals-core@1.12.1':
-    resolution: {integrity: sha512-BwbTXpj+9QutoZLQvbttRg5x3l5468qaV2kufh+51yha1c53ep5dY4kTuZR35+3pAZxpfQerGJiQqg34ZNZ6uA==}
 
   '@preact/signals-core@1.14.4':
     resolution: {integrity: sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==}
@@ -9852,21 +9819,9 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@dnd-kit/abstract@0.5.0':
-    dependencies:
-      '@dnd-kit/geometry': 0.5.0
-      '@dnd-kit/state': 0.5.0
-      tslib: 2.8.1
-
   '@dnd-kit/accessibility@3.1.1(react@19.2.0)':
     dependencies:
       react: 19.2.0
-      tslib: 2.8.1
-
-  '@dnd-kit/collision@0.5.0':
-    dependencies:
-      '@dnd-kit/abstract': 0.5.0
-      '@dnd-kit/geometry': 0.5.0
       tslib: 2.8.1
 
   '@dnd-kit/core@6.3.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
@@ -9877,38 +9832,11 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       tslib: 2.8.1
 
-  '@dnd-kit/dom@0.5.0':
-    dependencies:
-      '@dnd-kit/abstract': 0.5.0
-      '@dnd-kit/collision': 0.5.0
-      '@dnd-kit/geometry': 0.5.0
-      '@dnd-kit/state': 0.5.0
-      tslib: 2.8.1
-
-  '@dnd-kit/geometry@0.5.0':
-    dependencies:
-      '@dnd-kit/state': 0.5.0
-      tslib: 2.8.1
-
-  '@dnd-kit/react@0.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@dnd-kit/abstract': 0.5.0
-      '@dnd-kit/dom': 0.5.0
-      '@dnd-kit/state': 0.5.0
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      tslib: 2.8.1
-
   '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@dnd-kit/utilities': 3.2.2(react@19.2.0)
       react: 19.2.0
-      tslib: 2.8.1
-
-  '@dnd-kit/state@0.5.0':
-    dependencies:
-      '@preact/signals-core': 1.12.1
       tslib: 2.8.1
 
   '@dnd-kit/utilities@3.2.2(react@19.2.0)':
@@ -10985,8 +10913,6 @@ snapshots:
   '@polka/url@1.0.0-next.29': {}
 
   '@posthog/core@1.25.2': {}
-
-  '@preact/signals-core@1.12.1': {}
 
   '@preact/signals-core@1.14.4': {}
 


### PR DESCRIPTION
`@nextlyhq/plugin-page-builder` declared `@dnd-kit/dom` and `@dnd-kit/react` in **`dependencies`**, plus `@dnd-kit/abstract` in devDependencies. Nothing imports any of them.

They are left over from the dnd-kit spike. That spike was discharged and the canvas drag shipped in #1007 on its own region-and-line model instead — but the declarations stayed, so every install of this plugin has been downloading two runtime packages it never loads.

Surfaced by the Fallow audit on #1025, which reports them as `unused-dependency` (major). Nothing else in that report belongs to this lane; the rest is pre-existing and untouched here.

## Absence verified with a positive control

An absence claim is only as good as the proof the search could have found something:

| query | files |
| --- | --- |
| `@nextlyhq/blocks-engine` in `packages/plugin-page-builder/src` (**positive control**) | 17 |
| `@dnd-kit/dom` across all workspace source | **0** |
| `@dnd-kit/react` across all workspace source | **0** |
| `@dnd-kit/abstract` across all workspace source | **0** |

Searched with `git grep` over `*.ts,tsx,mts,cts,js,mjs`, because the shell's `grep` here is `ugrep`, which classifies some files as binary and skips them silently. The only remaining mentions of "dnd-kit" anywhere in the package are CHANGELOG prose and the `package.json` lines this PR removes.

`@dnd-kit/core` in `packages/admin` is a **different package** and is genuinely used by `SortableFieldsTable`; it is untouched.

## Verified

**Runtime, in a browser** (playground on `:3123`, auth control asserted first — `h1` reads "Welcome, Dev"), because a dependency removal is exactly the change whose failure is a runtime resolution error rather than a build one. After `pnpm install` and a full rebuild with the packages gone:

- the page builder opens and renders its blocks;
- click-to-select works;
- **dragging still works** — the drop indicator appears mid-gesture, which is the specific thing a reader will worry about when they see "dnd-kit removed";
- the only console error is the pre-existing `["autosave-recovery","collection","pages",…]` one, which is unrelated and present on main.

**Gates**: `plugin-page-builder` 61 tests, types and lint clean; workspace build green. `sherif` reports 0 errors — its 2 warnings are pre-existing and concern the root `package.json` and a phantom `packages/node_modules`, neither touched here.
