### PR TITLE
feat(builder): mount the editor's command palette

### DIFF
--- a/.changeset/mount-builder-command-palette.md
+++ b/.changeset/mount-builder-command-palette.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The page builder now has a working command palette. Pressing Cmd+K (Ctrl+K) in the editor lists what you can do to the selected block, plus undo, redo and closing the editor, searchable by name. The palette existed but was never mounted, so the shortcut opened the admin palette instead.

--- a/packages/builder/src/builder-commands.test.ts
+++ b/packages/builder/src/builder-commands.test.ts
@@ -1,0 +1,132 @@
+/**
+ * The palette's command list.
+ *
+ * The property worth defending is that availability is DERIVED from
+ * `toolbarActions` rather than re-decided here. A palette that answered "can
+ * this move" for itself would eventually offer a command the toolbar shows as
+ * unavailable, and the author would meet the disagreement as a row that runs
+ * and does nothing.
+ *
+ * @module builder-commands.test
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { BlockDocument, BlockNode } from "@nextlyhq/blocks-engine";
+
+import { builderCommands, type CommandVerbs } from "./builder-commands";
+
+function node(id: string, extra: Partial<BlockNode> = {}): BlockNode {
+  return {
+    id,
+    type: "acme/heading",
+    version: 1,
+    props: {},
+    ...extra,
+  } as BlockNode;
+}
+
+function documentOf(nodes: BlockNode[]): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+}
+
+function verbs(): CommandVerbs & Record<string, ReturnType<typeof vi.fn>> {
+  return {
+    move: vi.fn(),
+    delete: vi.fn(),
+    duplicate: vi.fn(),
+    selectParent: vi.fn(),
+  } as unknown as CommandVerbs & Record<string, ReturnType<typeof vi.fn>>;
+}
+
+function build(over: Partial<Parameters<typeof builderCommands>[0]> = {}) {
+  return builderCommands({
+    document: documentOf([node("a"), node("b")]),
+    selectedId: "a",
+    verbs: verbs(),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+    ...over,
+  });
+}
+
+describe("builderCommands", () => {
+  it("offers no block commands without a selection", () => {
+    expect(build({ selectedId: null }).map(c => c.id)).toEqual([]);
+  });
+
+  it("omits a block verb the toolbar would show as unavailable", () => {
+    // `a` is first, so it cannot move up. Derived rather than re-decided: this
+    // is the same answer the toolbar gives, from the same call.
+    const ids = build({ selectedId: "a" }).map(c => c.id);
+
+    expect(ids).toContain("block.move-down");
+    expect(ids).not.toContain("block.move-up");
+  });
+
+  it("omits what a LOCK forbids while keeping what it does not", () => {
+    // The case that separates deriving from re-deciding. A lock stops moving
+    // and deleting but NOT duplicating, and only a rule that asked
+    // `toolbarActions` gets all three right at once.
+    const ids = build({
+      document: documentOf([node("a", { locked: true }), node("b")]),
+      selectedId: "a",
+    }).map(c => c.id);
+
+    expect(ids).toContain("block.duplicate");
+    expect(ids).not.toContain("block.move-down");
+    expect(ids).not.toContain("block.delete");
+  });
+
+  it("runs the verb the command names", () => {
+    const spies = verbs();
+    const commands = build({ selectedId: "a", verbs: spies });
+
+    commands.find(c => c.id === "block.duplicate")?.run();
+    expect(spies.duplicate).toHaveBeenCalled();
+
+    commands.find(c => c.id === "block.move-down")?.run();
+    expect(spies.move).toHaveBeenCalledWith("down");
+  });
+
+  it("offers undo and redo only when there is something to undo or redo", () => {
+    expect(
+      build({ canUndo: false, canRedo: false }).map(c => c.id)
+    ).not.toContain("history.undo");
+    expect(build({ canUndo: true }).map(c => c.id)).toContain("history.undo");
+    expect(build({ canRedo: true }).map(c => c.id)).toContain("history.redo");
+  });
+
+  it("offers a way out only when the host has somewhere to go", () => {
+    // Embedded in a form that is already on screen there is nowhere to close
+    // to, and a command that does nothing is worse than an absent one.
+    expect(build().map(c => c.id)).not.toContain("editor.exit");
+    expect(build({ onExit: vi.fn() }).map(c => c.id)).toContain("editor.exit");
+  });
+
+  it("gives every command a unique id, which the palette keys selection on", () => {
+    // Two rows sharing an id are both marked selected and Enter runs the first
+    // whichever the author chose — a defect the palette's own contract calls
+    // out and cannot defend against itself.
+    const ids = build({
+      selectedId: "b",
+      canUndo: true,
+      canRedo: true,
+      onExit: vi.fn(),
+    }).map(c => c.id);
+
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids.length).toBeGreaterThan(4);
+  });
+
+  it("names its subject, because a palette row has no block beside it", () => {
+    // "Duplicate" is unambiguous on a toolbar button drawn at the block. In a
+    // searched list it is not, so the label carries the noun and the keyword
+    // carries the short word people actually type.
+    const duplicate = build().find(c => c.id === "block.duplicate");
+
+    expect(duplicate?.label).toBe("Duplicate block");
+    expect(duplicate?.keywords).toContain("duplicate");
+  });
+});

--- a/packages/builder/src/builder-commands.ts
+++ b/packages/builder/src/builder-commands.ts
@@ -1,0 +1,169 @@
+/**
+ * What the editor's command palette can run.
+ *
+ * The palette is the third way to reach the same verbs, after the keystrokes
+ * and the floating toolbar, and it is the one that answers "what can this
+ * editor even do". A toolbar shows five icons at the block; a palette lists
+ * every action by NAME, which is what someone who has never used this editor
+ * searches with.
+ *
+ * ## Availability comes from the toolbar's rule, not a second one
+ *
+ * Whether a block can move, whether a lock forbids deleting it — every one of
+ * those questions is already answered by `toolbarActions`, and asking them a
+ * second time here is how a palette ends up offering a command that the button
+ * beside it shows as unavailable. So the block verbs are DERIVED from that
+ * list: same order, same enabling, same reasons.
+ *
+ * ## Why the labels differ from the toolbar's
+ *
+ * A toolbar button sits on the block it acts on, so "Duplicate" is unambiguous
+ * there. A palette row is read in a list with no such context, so it names its
+ * subject: "Duplicate block". The keywords carry the shorter word, so searching
+ * "duplicate" still finds it.
+ *
+ * @module builder-commands
+ */
+
+import type { BlockDocument } from "@nextlyhq/blocks-engine";
+
+import type { BuilderCommand } from "./command-palette";
+import { toolbarActions, type ToolbarActionId } from "./toolbar-actions";
+
+/** The verbs a palette command needs, as `BlockKeyboardActions` publishes them. */
+export interface CommandVerbs {
+  readonly move: (direction: "up" | "down") => void;
+  readonly delete: () => void;
+  readonly duplicate: () => void;
+  readonly selectParent: () => void;
+}
+
+/** Everything the command list is built from. */
+export interface BuilderCommandsInput {
+  readonly document: BlockDocument;
+  readonly selectedId: string | null;
+  readonly verbs: CommandVerbs;
+  readonly undo: () => void;
+  readonly redo: () => void;
+  readonly canUndo: boolean;
+  readonly canRedo: boolean;
+  /**
+   * Leaving the editor, when the host has somewhere to go.
+   *
+   * Optional for the same reason the shell's exit affordance is: the editor
+   * mounts both standalone and embedded in a form that is already on screen,
+   * and a palette offering "Close the editor" where nothing closes is a command
+   * that does nothing.
+   */
+  readonly onExit?: () => void;
+}
+
+/** How each block verb is named and found in a list with no block beside it. */
+const BLOCK_COMMAND_COPY: Record<
+  ToolbarActionId,
+  { label: string; keywords: readonly string[] }
+> = {
+  "select-parent": {
+    label: "Select parent block",
+    keywords: ["parent", "container", "up", "outer", "enclosing"],
+  },
+  "move-up": {
+    label: "Move block up",
+    keywords: ["move", "up", "before", "earlier", "reorder"],
+  },
+  "move-down": {
+    label: "Move block down",
+    keywords: ["move", "down", "after", "later", "reorder"],
+  },
+  duplicate: {
+    label: "Duplicate block",
+    keywords: ["duplicate", "copy", "clone", "repeat"],
+  },
+  delete: {
+    label: "Delete block",
+    keywords: ["delete", "remove", "destroy", "clear"],
+  },
+};
+
+/** The group the block verbs are listed under. */
+export const BLOCK_GROUP = "Block";
+/** The group undo and redo are listed under. */
+export const HISTORY_GROUP = "History";
+/** The group leaving the editor is listed under. */
+export const EDITOR_GROUP = "Editor";
+
+/**
+ * The palette's commands for the current state.
+ *
+ * Unavailable commands are OMITTED rather than listed and disabled, which is
+ * the opposite of what the toolbar does — and deliberately. A toolbar keeps one
+ * shape so the control an author is aiming at does not move; a palette is
+ * searched rather than aimed at, and a row that matches the search and then
+ * refuses to run is worse there than one that was never offered.
+ */
+export function builderCommands({
+  document,
+  selectedId,
+  verbs,
+  undo,
+  redo,
+  canUndo,
+  canRedo,
+  onExit,
+}: BuilderCommandsInput): BuilderCommand[] {
+  const run: Record<ToolbarActionId, () => void> = {
+    "select-parent": verbs.selectParent,
+    "move-up": () => verbs.move("up"),
+    "move-down": () => verbs.move("down"),
+    duplicate: verbs.duplicate,
+    delete: verbs.delete,
+  };
+
+  const blockCommands = toolbarActions(document, selectedId)
+    .filter(action => action.enabled)
+    .map(action => {
+      const copy = BLOCK_COMMAND_COPY[action.id];
+      return {
+        id: `block.${action.id}`,
+        label: copy.label,
+        group: BLOCK_GROUP,
+        keywords: copy.keywords,
+        run: run[action.id],
+      };
+    });
+
+  const history: BuilderCommand[] = [];
+  if (canUndo) {
+    history.push({
+      id: "history.undo",
+      label: "Undo",
+      group: HISTORY_GROUP,
+      keywords: ["undo", "revert", "back"],
+      run: undo,
+    });
+  }
+  if (canRedo) {
+    history.push({
+      id: "history.redo",
+      label: "Redo",
+      group: HISTORY_GROUP,
+      keywords: ["redo", "again", "forward"],
+      run: redo,
+    });
+  }
+
+  const editor: BuilderCommand[] =
+    onExit === undefined
+      ? []
+      : [
+          {
+            id: "editor.exit",
+            label: "Close the editor",
+            group: EDITOR_GROUP,
+            keywords: ["close", "exit", "leave", "done", "back"],
+            run: onExit,
+          },
+        ];
+
+  return [...blockCommands, ...history, ...editor];
+}

--- a/packages/builder/src/editor-command-palette.tsx
+++ b/packages/builder/src/editor-command-palette.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+/**
+ * The editor's command palette, assembled and mounted.
+ *
+ * `CommandPalette` is the surface and `builderCommands` is the list; this is
+ * the one piece that knows both, and it exists so a host does not have to.
+ * Mounting the palette otherwise means reaching into the verbs context,
+ * rebuilding the command array on the right renders, and knowing that the
+ * palette must sit inside `BlockKeyboardActions` — three things every host
+ * would have to get right, and would get right differently.
+ *
+ * **It was the missing piece.** `CommandPalette` shipped and was tested and was
+ * exported, and no host ever mounted it — so the editor advertised a command
+ * palette that no author could open. Pressing `mod+k` in the admin opens
+ * `@nextlyhq/admin`'s palette instead, which is the reason the gap survived a
+ * browser check: something opens, so the feature looks present.
+ *
+ * @module editor-command-palette
+ */
+
+import * as React from "react";
+
+import { builderCommands } from "./builder-commands";
+import { CommandPalette } from "./command-palette";
+import type { EditorState } from "./editor-state";
+import { useBlockActionsContext } from "./keyboard-actions";
+
+export interface EditorCommandPaletteProps {
+  /** The editor whose state the commands read and change. */
+  editor: EditorState;
+  /**
+   * Leaving the editor, when the host has somewhere to go.
+   *
+   * Omitted where there is nowhere — the editor embedded in a form that is
+   * already on screen — and the palette then offers no way out rather than a
+   * command that does nothing. Passed to `builderCommands`, which makes the
+   * same distinction the shell's exit affordance does.
+   */
+  onExit?: () => void;
+}
+
+export function EditorCommandPalette({
+  editor,
+  onExit,
+}: EditorCommandPaletteProps): React.JSX.Element {
+  const verbs = useBlockActionsContext();
+
+  /*
+   * Rebuilt when what it OFFERS could have changed, which is the document, the
+   * selection and the history's two flags.
+   *
+   * `editor` as a whole would be the obvious dependency and is the wrong one:
+   * the store hands back a fresh object on every render, so the list would be
+   * rebuilt on every frame of a panel drag — and `CommandPalette` keys its rows
+   * on identity, so a list rebuilt mid-search is a list that loses the row the
+   * author had highlighted.
+   */
+  const commands = React.useMemo(
+    () =>
+      builderCommands({
+        document: editor.document,
+        selectedId: editor.selectedId,
+        verbs,
+        undo: editor.undo,
+        redo: editor.redo,
+        canUndo: editor.canUndo,
+        canRedo: editor.canRedo,
+        onExit,
+      }),
+    [
+      editor.document,
+      editor.selectedId,
+      editor.undo,
+      editor.redo,
+      editor.canUndo,
+      editor.canRedo,
+      verbs,
+      onExit,
+    ]
+  );
+
+  return <CommandPalette commands={commands} />;
+}

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -259,6 +259,23 @@ export {
 } from "./duplicate-block";
 
 /**
+ * @experimental The palette's command list, as a plain function over state.
+ *
+ * From this entry because a host assembling its own palette — or an agent
+ * enumerating what the editor can do right now — needs the same list the editor
+ * offers, and availability derived from a second reading of the lock and move
+ * rules is how the two come to disagree.
+ */
+export {
+  BLOCK_GROUP,
+  EDITOR_GROUP,
+  HISTORY_GROUP,
+  builderCommands,
+  type BuilderCommandsInput,
+  type CommandVerbs,
+} from "./builder-commands";
+
+/**
  * @experimental Who owns Escape while the editor is on screen.
  *
  * From this entry because the rule is a plain function over the DOM and a

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -118,6 +118,16 @@ export type {
  * own, which is what keeps one gesture having one answer — and what lets both
  * the button and the keystroke announce into the single live region.
  */
+/**
+ * The command palette, assembled and mounted for the editor.
+ *
+ * From this entry because it is a client component and because it only works
+ * below `BlockKeyboardActions`, whose verbs it runs. A host that wants to build
+ * its own list uses `CommandPalette` with `builderCommands` instead.
+ */
+export { EditorCommandPalette } from "./editor-command-palette";
+export type { EditorCommandPaletteProps } from "./editor-command-palette";
+
 export { BlockToolbar } from "./block-toolbar";
 export type { BlockToolbarProps } from "./block-toolbar";
 

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -44,6 +44,7 @@ import { registrySlotSource } from "@nextlyhq/builder";
 import {
   BlockKeyboardActions,
   BlockToolbar,
+  EditorCommandPalette,
   BuilderShell,
   Canvas,
   DropIndicator,
@@ -284,6 +285,17 @@ function BlocksEditor({
           wraps, which is how the toolbar presses exactly what the keys press.
         */}
         <BlockKeyboardActions editor={editor}>
+          {/*
+            Inside the verbs provider, which is what lets the palette run
+            exactly what the keystrokes and the toolbar run.
+
+            `onExit` is the SAME handler the shell's exit button gets, so
+            leaving through the palette commits the document exactly as leaving
+            through the button does. Passing a different one — or omitting it
+            while the button exists — would give the editor two ways out that
+            behave differently.
+          */}
+          <EditorCommandPalette editor={editor} onExit={done} />
           <Canvas
             document={editor.document}
             siteStyles={siteSheet()}


### PR DESCRIPTION
Closes **B-17**, which the tracker recorded as ✅ and which was not delivered.

`CommandPalette` was written, tested and exported from `shell.ts` — and **no host ever mounted it**. The editor advertised a command palette no author could open.

**Why that survived a browser check**: pressing `mod+k` in the admin *does* open a palette — `@nextlyhq/admin`'s, mounted globally in the playground layout. Something opens, so the feature looks present. Verifying that a feature works is not verifying that *this* implementation is the one running.

Found by auditing which builder surfaces the one host actually mounts, prompted by the admin lane losing two shipped features to the same shape in one session.

## What it offers

Block verbs for the current selection, plus undo, redo, and closing the editor — searchable by name and by synonym.

**Availability is derived from `toolbarActions`, not re-decided.** Whether a block can move, whether a lock forbids deleting it — those are already answered, and asking again is how a palette comes to offer a verb the toolbar beside it shows as unavailable. The lock case is the one that proves it: a lock stops moving and deleting but **not** duplicating, and only a list that asks the shared rule gets all three right at once.

**Unavailable commands are omitted, not disabled** — the opposite of the toolbar, deliberately. A toolbar is *aimed at*, so it must keep one shape or the control moves out from under the pointer. A palette is *searched*, and a row that matches the query and then refuses to run is worse than one that was never offered.

**Labels name their subject.** "Duplicate" is unambiguous on a button drawn at the block; in a searched list it is not, so the row reads "Duplicate block" and carries "duplicate", "copy", "clone" as keywords.

**The exit command takes the same handler the shell's exit button takes**, so leaving through the palette commits the document exactly as leaving through the button does.

## A precedence change I tried and reverted — worth knowing

Both palettes bind `mod+k` on the same manager, so which one answers is decided by `(priority, depth, sequence)`. I first raised the builder opener's `priority` to beat the admin's.

**An existing test refuted it.** A host modal registers `useShortcuts([], { blocking: true })` inside a `ShortcutScope` — **priority 0, deeper depth**. Since `priority` sorts *above* `depth`, any raised priority beats a modal hold too, and the palette would open over a dialog that already owns the keyboard. Depth cannot express it either: making the opener deeper beats the admin's palette *and* ties the modal's scope.

So priority is the wrong instrument for "above the page, below any modal", and the opener's original design — host depth, no priority — is correct. Reverted in full; `command-palette.tsx` is untouched by this PR.

**The residual, stated rather than hidden:** with both at equal precedence, the builder's palette wins by mount order because it mounts later. Verified in a browser, but it is incidental by the manager's own account. The clean fix is for the admin's global palette to stand down while admin chrome is suppressed — one line in a package this lane does not own, and that lane's session has ended. Filed as a follow-up rather than reached into.

## Verified in a browser

Playground on `:3123`, auth control asserted first (`h1` reads "Welcome, Dev"):

- **Control** — outside the editor, `Cmd+K` lists `Dashboard`, `Users`, `Roles & Permissions`: the admin's palette, as it should be.
- **Inside the editor**, `Cmd+K` lists `Select parent block`, `Duplicate block`, `Delete block`, `Close the editor`. `Move block up`/`down` are correctly absent — the selected block is an only child.
- Running **Duplicate block** duplicates it (1 → 2) and closes the palette.
- The list then updates live: `Move block up` appears (the copy now has a sibling above it), `Undo` appears (`canUndo` flipped), `Move block down` stays absent (the copy is last).
- **Escape closes the palette and the canvas selection survives** — the modal deference added in #1030 working in the real composition.
- Searching **"copy"** returns **"Duplicate block"**, so the synonyms reach commands whose label does not contain the query.

## Verified in tests

`packages/builder`: **710 tests**, types and lint clean; `plugin-page-builder` green. Three stubs, each caught by the test whose name claims it: dropping the `enabled` filter, offering undo unconditionally, and collapsing the command ids to one.

## Not in this PR

`BreakpointDialog` is the other dark surface and I am **not** mounting it. It is not unwired by oversight: `siteBreakpoints()` in `plugin-page-builder` returns an empty set and says why — *"Empty because this plugin has nowhere to store them yet."* Mounting it means building site-level breakpoint storage, which is a feature with a schema decision, not a wiring task. The error is the plan recording it as shipped.
