### PR TITLE
feat(nextly): make sharp an optional peer dependency

### DIFF
--- a/.changeset/sharp-optional-peer.md
+++ b/.changeset/sharp-optional-peer.md
@@ -18,6 +18,7 @@
 "@nextlyhq/plugin-seo": patch
 "@nextlyhq/plugin-sdk": patch
 "@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
 "@nextlyhq/prettier-config": patch
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch

--- a/.changeset/sharp-optional-peer.md
+++ b/.changeset/sharp-optional-peer.md
@@ -1,0 +1,38 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+**Breaking for installs that process images:** `sharp` is now an optional peer dependency. If you upload images and want thumbnails or configured image sizes, run `npm install sharp`.
+
+It was a hard dependency of `nextly`, so every install downloaded it: about 18 MB per platform, almost all of it the native libvips binaries. A site with no image uploads, or one using external images, never executed a line of it. Installs that do process images add one command.
+
+A missing `sharp` now DEGRADES instead of failing. Uploads still succeed and files are still stored; they simply arrive with no thumbnail, no dimensions and no resized copies. Upload security is unchanged, because the check that guards uploads is magic-byte based and never used `sharp`.
+
+This also fixes a defect that would have made the change unusable. `isValidImage` reported "not an image" whenever it could not run, and the upload route refuses on that with `400 Invalid image file`. An install without the package would therefore have rejected every image upload while blaming the user's file. Image validity now reports three states rather than two, and only a positive finding that a buffer is not an image can refuse an upload.
+
+The Image Sizes settings page says when the server cannot process images, and names the command that fixes it, so configured sizes that can never be generated no longer fail silently.
+
+Hosts whose bundler cannot resolve a native module can supply the library directly with `setSharp(sharp)` instead of relying on resolution.

--- a/packages/admin/src/pages/dashboard/settings/image-sizes/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/image-sizes/index.tsx
@@ -8,7 +8,7 @@
  * Shows regeneration status when sizes change.
  */
 
-import { Badge, Button } from "@nextlyhq/ui";
+import { Alert, AlertDescription, Badge, Button } from "@nextlyhq/ui";
 import * as React from "react";
 
 import { SettingsLayout } from "@admin/components/features/settings";
@@ -27,7 +27,9 @@ import { usePagination } from "@admin/hooks/usePagination";
 import { navigateTo } from "@admin/lib/navigation";
 import {
   deleteImageSize,
+  fetchImageProcessingAvailability,
   fetchImageSizes,
+  type ImageProcessingAvailability,
   type ImageSize,
 } from "@admin/services/imageSizesApi";
 
@@ -63,6 +65,10 @@ function ImageSizesContent({
 }) {
   const [sizes, setSizes] = React.useState<ImageSize[]>([]);
   const [isLoading, setIsLoading] = React.useState(true);
+  // Starts as available so the page never accuses the server of a missing
+  // package before it has heard back. Only a definite "no" renders the notice.
+  const [imageProcessing, setImageProcessing] =
+    React.useState<ImageProcessingAvailability>({ available: true });
   const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
 
   // Fetch sizes on mount
@@ -79,6 +85,13 @@ function ImageSizesContent({
   React.useEffect(() => {
     void loadSizes();
   }, [loadSizes]);
+
+  // Asked once on mount: whether the server can process images at all does not
+  // change while the page is open, and the answer decides whether the sizes
+  // listed below can ever be produced.
+  React.useEffect(() => {
+    void fetchImageProcessingAvailability().then(setImageProcessing);
+  }, []);
 
   // Handle delete
   const handleDelete = React.useCallback(
@@ -240,6 +253,26 @@ function ImageSizesContent({
       }}
       columnsControl={columnsControl}
       slots={{
+        // Above the toolbar rather than below the list: it explains why every
+        // size on this page is inert, so it has to be read before them.
+        beforeList: !imageProcessing.available && (
+          <Alert variant="warning" className="mb-4">
+            <AlertDescription>
+              <p>
+                This server cannot process images, so no sizes are generated.
+                Existing uploads are unaffected and new uploads still succeed,
+                they simply arrive without resized copies.
+              </p>
+              {imageProcessing.installCommand ? (
+                <pre className="mt-2 overflow-x-auto rounded-md bg-muted p-2">
+                  <code className="font-mono text-xs">
+                    {imageProcessing.installCommand}
+                  </code>
+                </pre>
+              ) : null}
+            </AlertDescription>
+          </Alert>
+        ),
         afterList: !isLoading && sizes.some(s => s.isDefault) && (
           <div className="flex items-start gap-2 text-xs text-muted-foreground px-1">
             <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />

--- a/packages/admin/src/services/imageSizesApi.ts
+++ b/packages/admin/src/services/imageSizesApi.ts
@@ -30,6 +30,44 @@ export interface ImageSize {
 // API helpers
 // ============================================================
 
+/**
+ * Whether the server can process images, and what to install if it cannot.
+ *
+ * Mirrors `RegenerationStatus["imageProcessing"]` in core: a wire contract
+ * parsed from JSON rather than an imported type, so the two move together.
+ */
+export interface ImageProcessingAvailability {
+  available: boolean;
+  packageName?: string;
+  installCommand?: string;
+}
+
+/**
+ * Ask the server whether image processing is available.
+ *
+ * `sharp` is an optional peer dependency, so an otherwise healthy install can
+ * be unable to generate sizes. Without this the page would list configured
+ * sizes that silently never materialise.
+ *
+ * Returns `available: true` when the request fails: a page that cannot reach
+ * the endpoint must not accuse the server of missing a package on no evidence.
+ */
+export async function fetchImageProcessingAvailability(): Promise<ImageProcessingAvailability> {
+  try {
+    const res = await authFetch("/admin/api/image-sizes/regeneration-status", {
+      credentials: "include",
+    });
+    if (!res.ok) return { available: true };
+
+    const data = (await res.json()) as {
+      imageProcessing?: ImageProcessingAvailability;
+    };
+    return data.imageProcessing ?? { available: true };
+  } catch {
+    return { available: true };
+  }
+}
+
 export async function fetchImageSizes(): Promise<ImageSize[]> {
   const res = await authFetch("/admin/api/image-sizes", {
     credentials: "include",

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -232,6 +232,7 @@
     "rimraf": "^6.1.3",
     "rollup": "^4.60.1",
     "rollup-plugin-dts": "^6.4.1",
+    "sharp": "^0.35.0",
     "tsup": "^8.5.0",
     "tsx": "^4.20.5",
     "typescript": "^5.9.3",
@@ -243,7 +244,8 @@
     "@nextlyhq/adapter-postgres": "workspace:*",
     "@nextlyhq/adapter-sqlite": "workspace:*",
     "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
-    "nodemailer": "^9.0.1"
+    "nodemailer": "^9.0.1",
+    "sharp": "^0.35.0"
   },
   "peerDependenciesMeta": {
     "@nextlyhq/adapter-postgres": {
@@ -256,6 +258,9 @@
       "optional": true
     },
     "nodemailer": {
+      "optional": true
+    },
+    "sharp": {
       "optional": true
     }
   },
@@ -282,7 +287,6 @@
     "safe-regex2": "^5.1.1",
     "semver": "^7.6.0",
     "server-only": "^0.0.1",
-    "sharp": "^0.35.0",
     "ws": "^8.21.1",
     "zod": "^4.1.12"
   },

--- a/packages/nextly/src/domains/media/services/media-service.ts
+++ b/packages/nextly/src/domains/media/services/media-service.ts
@@ -72,7 +72,10 @@ import type {
 } from "../../../services/shared";
 import { consoleLogger } from "../../../services/shared";
 import type { UploadValidator } from "../../../services/upload-validation";
-import type { ImageProcessor } from "../../../storage/image-processor";
+import type {
+  ImageProcessor,
+  ImageValidity,
+} from "../../../storage/image-processor";
 import type { IStorageAdapter } from "../../../storage/types";
 import {
   isImageMimeType,
@@ -1168,9 +1171,13 @@ export class MediaService {
    * Validate an image buffer
    *
    * @param buffer - File buffer
-   * @returns True if buffer is a valid image
+   * @returns Whether the buffer is an image, or "unknown" when this install
+   *   has no image processing and therefore could not look.
    */
-  async validateImage(buffer: Buffer): Promise<boolean> {
+  async validateImage(buffer: Buffer): Promise<ImageValidity> {
+    // Forwarded rather than collapsed to a boolean. Squeezing three states
+    // into two is what made a missing library read as a bad file, and a
+    // wrapper that re-flattens it here would reintroduce that at one remove.
     return this.imageProcessor.isValidImage(buffer);
   }
 

--- a/packages/nextly/src/services/__tests__/media.test.ts
+++ b/packages/nextly/src/services/__tests__/media.test.ts
@@ -318,7 +318,9 @@ describe("MediaService", () => {
     });
 
     it("should reject invalid image files", async () => {
-      mockIsValidImage.mockResolvedValueOnce(false);
+      // "invalid" is a POSITIVE finding that the buffer is not an image, which
+      // is the only validity result that may refuse an upload.
+      mockIsValidImage.mockResolvedValueOnce("invalid");
 
       const buffer = Buffer.from("corrupted-image");
       const result = await mediaService.uploadMedia({
@@ -333,6 +335,25 @@ describe("MediaService", () => {
       expect(result.statusCode).toBe(400);
       expect(result.message).toBe("Invalid image file");
       expect(result.data).toBeNull();
+    });
+
+    it("accepts the upload when image processing is unavailable", async () => {
+      // "unknown" means this install has no image processing, so the check
+      // never ran. Refusing on it would answer "Invalid image file" to a user
+      // whose file is fine, blaming them for a package missing from the
+      // server -- and the magic-byte gate has already accepted the upload.
+      mockIsValidImage.mockResolvedValueOnce("unknown");
+
+      const buffer = Buffer.from("a perfectly good image");
+      const result = await mediaService.uploadMedia({
+        file: buffer,
+        filename: "photo.jpg",
+        mimeType: "image/jpeg",
+        size: 1024,
+        uploadedBy: testUserId,
+      });
+
+      expect(result.message).not.toBe("Invalid image file");
     });
 
     it("should continue upload if thumbnail generation fails", async () => {

--- a/packages/nextly/src/services/media-regeneration.ts
+++ b/packages/nextly/src/services/media-regeneration.ts
@@ -14,6 +14,8 @@ import { and, sql, gt } from "drizzle-orm";
 
 import { getMediaStorage } from "@nextly/storage";
 
+import { SHARP_INSTALL_COMMAND, loadSharp } from "../storage/sharp-loader";
+
 import { BaseService } from "./base-service";
 import { ImageSizeService } from "./image-size";
 import type { Logger } from "./shared";
@@ -25,6 +27,41 @@ export interface RegenerationStatus {
   total: number;
   /** Whether a regeneration batch is currently running */
   inProgress: boolean;
+  /**
+   * Whether this install can process images at all.
+   *
+   * Reported alongside the counts because without it the page is honest but
+   * useless: it would show images pending forever with nothing explaining
+   * why regeneration produces nothing. `sharp` is an optional peer, so a
+   * perfectly healthy install can be in this state.
+   */
+  imageProcessing: {
+    available: boolean;
+    /** The package to install. Present only when unavailable. */
+    packageName?: string;
+    /** The exact command. Present only when unavailable. */
+    installCommand?: string;
+  };
+}
+
+/**
+ * How this install's image processing should be described to the admin.
+ *
+ * Built here rather than at each return so both paths report the same thing,
+ * and derived from the loader every operation uses rather than from a second
+ * probe that could disagree with it.
+ */
+async function describeImageProcessing(): Promise<
+  RegenerationStatus["imageProcessing"]
+> {
+  const sharp = await loadSharp();
+  if (sharp) return { available: true };
+
+  return {
+    available: false,
+    packageName: "sharp",
+    installCommand: SHARP_INSTALL_COMMAND,
+  };
 }
 
 export interface RegenerationBatchResult {
@@ -67,7 +104,12 @@ export class MediaRegenerationService extends BaseService {
     const configNames = sizeConfigs.map(s => s.name).sort();
 
     if (configNames.length === 0) {
-      return { pending: 0, total, inProgress: false };
+      return {
+        pending: 0,
+        total,
+        inProgress: false,
+        imageProcessing: await describeImageProcessing(),
+      };
     }
 
     // An image is up-to-date if its sizes JSONB contains all configured size names.
@@ -88,7 +130,12 @@ export class MediaRegenerationService extends BaseService {
       }
     }
 
-    return { pending, total, inProgress: false };
+    return {
+      pending,
+      total,
+      inProgress: false,
+      imageProcessing: await describeImageProcessing(),
+    };
   }
 
   /**

--- a/packages/nextly/src/services/media.ts
+++ b/packages/nextly/src/services/media.ts
@@ -45,6 +45,7 @@ import type { RetentionRunner } from "../domains/retention/runner";
 import type { WebhookFastDrainScheduler } from "../domains/webhooks/after-drain";
 import { recordMutationEvent } from "../domains/webhooks/record-mutation-event";
 import { keysToSnakeCase } from "../lib/case-conversion";
+import { refusesUpload } from "../storage/image-processor";
 import { isImageMimeType, validateFileSize } from "../types/media";
 import type {
   Media,
@@ -287,8 +288,10 @@ export class MediaService extends BaseService {
       let thumbnailUrl: string | null = null;
 
       if (isImage) {
-        const isValid = await this.imageProcessor.isValidImage(file);
-        if (!isValid) {
+        const validity = await this.imageProcessor.isValidImage(file);
+        // Asked rather than re-derived here, so the rule lives in one place
+        // and is testable without the whole upload harness.
+        if (refusesUpload(validity)) {
           return {
             success: false,
             statusCode: 400,
@@ -306,27 +309,32 @@ export class MediaService extends BaseService {
 
         try {
           const thumbnail = await this.imageProcessor.generateThumbnail(file);
-          const thumbnailFilename = `thumb_${filename}`;
-          const thumbnailResult = await withRetry(
-            () =>
-              this.storage.upload(thumbnail.buffer, {
-                filename: thumbnailFilename,
-                mimeType: "image/jpeg",
-                collection: "media",
-              }),
-            {
-              maxAttempts: 3,
-              baseDelayMs: 500,
-              shouldRetry: isTransientError,
-              onRetry: (err, attempt) => {
-                console.warn(
-                  `[MediaService] Thumbnail upload retry ${attempt}:`,
-                  err instanceof Error ? err.message : err
-                );
-              },
-            }
-          );
-          thumbnailUrl = thumbnailResult.url;
+          // Null means no image processing on this install. The upload keeps
+          // its file and simply carries no thumbnail, rather than failing for
+          // a derived artefact that was never essential to storing it.
+          if (thumbnail) {
+            const thumbnailFilename = `thumb_${filename}`;
+            const thumbnailResult = await withRetry(
+              () =>
+                this.storage.upload(thumbnail.buffer, {
+                  filename: thumbnailFilename,
+                  mimeType: "image/jpeg",
+                  collection: "media",
+                }),
+              {
+                maxAttempts: 3,
+                baseDelayMs: 500,
+                shouldRetry: isTransientError,
+                onRetry: (err, attempt) => {
+                  console.warn(
+                    `[MediaService] Thumbnail upload retry ${attempt}:`,
+                    err instanceof Error ? err.message : err
+                  );
+                },
+              }
+            );
+            thumbnailUrl = thumbnailResult.url;
+          }
         } catch (error) {
           console.warn("[MediaService] Thumbnail generation failed:", error);
           // Continue without thumbnail

--- a/packages/nextly/src/storage/__tests__/image-processor.test.ts
+++ b/packages/nextly/src/storage/__tests__/image-processor.test.ts
@@ -11,6 +11,16 @@ vi.mock("sharp", () => ({
   default: vi.fn(),
 }));
 
+/**
+ * The result of an operation that now returns null when this install has no
+ * image processing. Every test here mocks sharp, so a null is a real failure
+ * rather than the degraded path, and asserting it here says so once.
+ */
+function nonNull<T>(value: T | null): T {
+  if (value === null) throw new Error("expected a processed result, got null");
+  return value;
+}
+
 describe("ImageProcessor", () => {
   let processor: ImageProcessor;
   let mockSharpFunction: any;
@@ -55,9 +65,9 @@ describe("ImageProcessor", () => {
       const buffer = Buffer.from("fake image");
       const result = await processor.getMetadata(buffer);
 
-      expect(result.width).toBe(0);
-      expect(result.height).toBe(0);
-      expect(result.format).toBe("unknown");
+      expect(nonNull(result).width).toBe(0);
+      expect(nonNull(result).height).toBe(0);
+      expect(nonNull(result).format).toBe("unknown");
     });
   });
 
@@ -91,9 +101,9 @@ describe("ImageProcessor", () => {
         quality: 80,
         progressive: true,
       });
-      expect(result.buffer).toBe(mockProcessed.data);
-      expect(result.metadata.width).toBe(300);
-      expect(result.metadata.height).toBe(300);
+      expect(nonNull(result).buffer).toBe(mockProcessed.data);
+      expect(nonNull(result).metadata.width).toBe(300);
+      expect(nonNull(result).metadata.height).toBe(300);
     });
 
     it("should accept custom thumbnail size", async () => {
@@ -151,7 +161,7 @@ describe("ImageProcessor", () => {
         quality: 80,
         effort: 4,
       });
-      expect(result.metadata.format).toBe("webp");
+      expect(nonNull(result).metadata.format).toBe("webp");
     });
 
     it("should skip optimization for small WebP images", async () => {
@@ -166,8 +176,8 @@ describe("ImageProcessor", () => {
 
       const result = await processor.optimize(smallBuffer);
 
-      expect(result.buffer).toBe(smallBuffer);
-      expect(result.metadata.format).toBe("webp");
+      expect(nonNull(result).buffer).toBe(smallBuffer);
+      expect(nonNull(result).metadata.format).toBe("webp");
     });
 
     it("should accept custom quality parameter", async () => {
@@ -222,30 +232,35 @@ describe("ImageProcessor", () => {
         fit: "inside",
         withoutEnlargement: true,
       });
-      expect(result.metadata.width).toBe(800);
-      expect(result.metadata.height).toBe(600);
+      expect(nonNull(result).metadata.width).toBe(800);
+      expect(nonNull(result).metadata.height).toBe(600);
     });
   });
 
   describe("isValidImage", () => {
-    it("should return true for valid images", async () => {
+    it("reports 'valid' for an image the library reads", async () => {
       mockSharpFunction.mockReturnValue({
         metadata: vi.fn().mockResolvedValue({ width: 100, height: 100 }),
       });
 
-      const isValid = await processor.isValidImage(Buffer.from("valid image"));
+      const validity = await processor.isValidImage(Buffer.from("valid image"));
 
-      expect(isValid).toBe(true);
+      expect(validity).toBe("valid");
     });
 
-    it("should return false for invalid images", async () => {
+    it("reports 'invalid' when the library REFUSES the buffer", async () => {
       mockSharpFunction.mockReturnValue({
         metadata: vi.fn().mockRejectedValue(new Error("Invalid image")),
       });
 
-      const isValid = await processor.isValidImage(Buffer.from("not an image"));
+      const validity = await processor.isValidImage(
+        Buffer.from("not an image")
+      );
 
-      expect(isValid).toBe(false);
+      // "invalid" rather than "unknown": the library ran and rejected it,
+      // which is a verdict about the FILE and the only case that may refuse
+      // an upload.
+      expect(validity).toBe("invalid");
     });
   });
 

--- a/packages/nextly/src/storage/__tests__/sharp-loader.test.ts
+++ b/packages/nextly/src/storage/__tests__/sharp-loader.test.ts
@@ -1,0 +1,101 @@
+/**
+ * The one place this package reaches for sharp.
+ *
+ * It is an optional peer dependency, so it can be absent at runtime while the
+ * code that uses it is compiled and registered. What matters here is that the
+ * absence arrives as a value the caller can act on rather than as an exception
+ * every call site has to catch.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  SHARP_INSTALL_COMMAND,
+  isSharpAvailable,
+  loadSharp,
+  setSharp,
+} from "../sharp-loader";
+
+afterEach(() => setSharp(null));
+
+describe("the sharp loader", () => {
+  it("names a command a user can actually run", () => {
+    expect(SHARP_INSTALL_COMMAND).toContain("sharp");
+    expect(SHARP_INSTALL_COMMAND).toMatch(/install|add/);
+  });
+
+  it("finds the library here, where it stays a devDependency", () => {
+    // The repository keeps testing against the real library after it stops
+    // being shipped to users. A false here would mean the image suites are
+    // silently exercising nothing.
+    expect(isSharpAvailable()).toBe(true);
+  });
+
+  it("loads a callable image factory", async () => {
+    const sharp = await loadSharp();
+
+    // Asserting the CALLABLE rather than a shape: sharp is published as
+    // CommonJS, so which interop form arrives depends on the host's bundler.
+    expect(typeof sharp).toBe("function");
+  });
+
+  it("prefers an injected module over resolution", async () => {
+    const injected = (() => ({})) as unknown as Parameters<typeof setSharp>[0];
+    setSharp(injected);
+
+    expect(await loadSharp()).toBe(injected);
+  });
+
+  it("reports availability once a module is injected", () => {
+    const injected = (() => ({})) as unknown as Parameters<typeof setSharp>[0];
+    setSharp(injected);
+
+    expect(isSharpAvailable()).toBe(true);
+  });
+
+  it("returns null rather than throwing when it cannot be had", async () => {
+    // The caller decides what a missing library means: an upload degrades, a
+    // thumbnail is skipped. Throwing would force every call site into a
+    // try/catch and invite one of them to report the wrong cause.
+    setSharp(null);
+
+    await expect(loadSharp({ resolver: () => null })).resolves.toBeNull();
+  });
+
+  it("returns null when resolution throws", async () => {
+    setSharp(null);
+
+    await expect(
+      loadSharp({
+        resolver: () => {
+          throw new Error("ERR_MODULE_NOT_FOUND");
+        },
+      })
+    ).resolves.toBeNull();
+  });
+
+  it("survives a namespace that throws on unknown exports", async () => {
+    setSharp(null);
+    const real = (() => ({})) as unknown as Parameters<typeof setSharp>[0];
+
+    // A module namespace is not always a plain object: a test double or a
+    // bundler shim can be a proxy that throws on reading a name it was not
+    // given. This asserts the loader never puts such a namespace into a state
+    // where it reads one, whichever order the two shapes are tried in.
+    const namespace = new Proxy(
+      { default: real },
+      {
+        get(target, prop) {
+          if (prop === "default") return target.default;
+          // `then` and the tag are how a value is AWAITED and printed, and no
+          // real namespace refuses them. Throwing on those would model a value
+          // that cannot be awaited at all, which is a different failure from
+          // the one under test.
+          if (prop === "then" || typeof prop === "symbol") return undefined;
+          throw new Error(`No "${String(prop)}" export is defined`);
+        },
+      }
+    );
+
+    await expect(loadSharp({ resolver: () => namespace })).resolves.toBe(real);
+  });
+});

--- a/packages/nextly/src/storage/__tests__/uploads-without-sharp.test.ts
+++ b/packages/nextly/src/storage/__tests__/uploads-without-sharp.test.ts
@@ -1,0 +1,93 @@
+/**
+ * An install without sharp still accepts uploads.
+ *
+ * Image processing is optional; storing what a user uploaded is not. The real
+ * upload gate is magic-byte based (`services/upload-validation/`) and never
+ * used sharp, so degrading here weakens no security control.
+ *
+ * The defect this pins: `isValidImage` was `catch { return false }`, and the
+ * upload route rejects on `false` with "Invalid image file". A missing library
+ * therefore produced a verdict about the USER'S FILE. Two states cannot carry
+ * three outcomes, so "could not check" needs its own value.
+ */
+import { describe, expect, it } from "vitest";
+
+import { ImageProcessor, refusesUpload } from "../image-processor";
+
+/** An ImageProcessor whose loader can never find the library. */
+function withoutSharp() {
+  return new ImageProcessor({ loader: () => Promise.resolve(null) });
+}
+
+/** The same class with the real library, as the control. */
+function withSharp() {
+  return new ImageProcessor();
+}
+
+const NOT_AN_IMAGE = Buffer.from("this is plainly not an image");
+
+describe("image processing when sharp is absent", () => {
+  it("reports that it cannot process", async () => {
+    await expect(withoutSharp().canProcess()).resolves.toBe(false);
+  });
+
+  it("answers 'unknown' for validity rather than 'invalid'", async () => {
+    // The separating property. `invalid` is a claim about the file and makes
+    // the upload route refuse it; `unknown` says the check did not run.
+    await expect(withoutSharp().isValidImage(NOT_AN_IMAGE)).resolves.toBe(
+      "unknown"
+    );
+  });
+
+  it("returns no dimensions instead of throwing", async () => {
+    await expect(
+      withoutSharp().getDimensions(NOT_AN_IMAGE)
+    ).resolves.toBeNull();
+  });
+
+  it("skips the thumbnail instead of throwing", async () => {
+    await expect(
+      withoutSharp().generateThumbnail(NOT_AN_IMAGE)
+    ).resolves.toBeNull();
+  });
+
+  it("skips a configured resize instead of throwing", async () => {
+    await expect(
+      withoutSharp().resize(NOT_AN_IMAGE, 100, 100)
+    ).resolves.toBeNull();
+  });
+});
+
+describe("image processing when sharp is present", () => {
+  // The CONTROL. Without it, every assertion above is satisfied by a class
+  // that can never process anything, and the degraded path would look correct
+  // while the real one was broken.
+  it("reports that it can process", async () => {
+    await expect(withSharp().canProcess()).resolves.toBe(true);
+  });
+
+  it("still calls a non-image 'invalid' rather than 'unknown'", async () => {
+    // This is what proves the three states are distinguished by the LIBRARY's
+    // verdict rather than by its absence.
+    await expect(withSharp().isValidImage(NOT_AN_IMAGE)).resolves.toBe(
+      "invalid"
+    );
+  });
+});
+
+describe("what may refuse an upload", () => {
+  it("refuses only a positive finding that the file is not an image", () => {
+    expect(refusesUpload("invalid")).toBe(true);
+  });
+
+  it("does not refuse when this install could not check", () => {
+    // The defect this whole three-state type exists for. Refusing here returns
+    // a 400 blaming the user's file for a package missing from the server,
+    // and the magic-byte gate has already accepted the upload.
+    expect(refusesUpload("unknown")).toBe(false);
+  });
+
+  it("does not refuse a valid image", () => {
+    expect(refusesUpload("valid")).toBe(false);
+  });
+});

--- a/packages/nextly/src/storage/image-processor.ts
+++ b/packages/nextly/src/storage/image-processor.ts
@@ -13,23 +13,75 @@
 
 import type { default as SharpDefault } from "sharp";
 
+import { loadSharp } from "./sharp-loader";
 import type { ImageMetadata, ProcessedImage } from "./types";
 
-// Lazy-load sharp to avoid Next.js module resolution issues
-let sharpModule: typeof SharpDefault | null = null;
-async function getSharp() {
-  if (!sharpModule) {
-    sharpModule = (await import("sharp")).default;
-  }
-  return sharpModule;
+type SharpModule = typeof SharpDefault;
+
+/**
+ * Whether a buffer is an image, or whether this install could not tell.
+ *
+ * `unknown` exists because "no image processing here" and "not an image" have
+ * different remedies and only one of them is the uploader's problem.
+ */
+export type ImageValidity = "valid" | "invalid" | "unknown";
+
+/**
+ * Whether a validity finding is grounds to REFUSE an upload.
+ *
+ * Extracted from the upload path so the decision has one home and can be
+ * tested on its own. It is the decision that produced the defect this three
+ * state type exists for: only a positive "invalid" is a statement about the
+ * file. "unknown" means this install has no image processing, which says
+ * nothing about what was uploaded, and the magic-byte gate has already run.
+ */
+export function refusesUpload(validity: ImageValidity): boolean {
+  return validity === "invalid";
+}
+
+/**
+ * Dependencies an ImageProcessor may be built with.
+ *
+ * `loader` is injected so a test can model an install without sharp without
+ * touching the filesystem. Production constructs the class with no argument
+ * and it reaches the shared loader.
+ */
+export interface ImageProcessorDeps {
+  loader?: () => Promise<SharpModule | null>;
 }
 
 export class ImageProcessor {
+  constructor(private readonly deps: ImageProcessorDeps = {}) {}
+
+  /** The library, or null when this install does not have it. */
+  private sharp(): Promise<SharpModule | null> {
+    return (this.deps.loader ?? loadSharp)();
+  }
+
+  /**
+   * Whether this install can process images at all.
+   *
+   * Exposed so a caller can decide BEFORE doing work, and so the admin can say
+   * what is missing once rather than letting each operation fail separately.
+   */
+  async canProcess(): Promise<boolean> {
+    // DERIVED from the same loader every operation uses, rather than asking
+    // resolution a second time. A separate synchronous probe answers a
+    // different question from the one the work depends on -- an injected or
+    // shimmed loader can yield nothing while resolution succeeds, and the two
+    // would disagree silently.
+    return (await this.sharp()) !== null;
+  }
+
   /**
    * Get image metadata without loading full image
    */
-  async getMetadata(buffer: Buffer): Promise<ImageMetadata> {
-    const sharp = await getSharp();
+  async getMetadata(buffer: Buffer): Promise<ImageMetadata | null> {
+    const sharp = await this.sharp();
+    // No processing available on this install: the file is still stored, it
+    // simply has no derived data. Callers read null as "not generated", never
+    // as a failure, so an upload proceeds without it.
+    if (!sharp) return null;
     const metadata = await sharp(buffer).metadata();
 
     return {
@@ -48,8 +100,12 @@ export class ImageProcessor {
   async generateThumbnail(
     buffer: Buffer,
     size: number = 300
-  ): Promise<ProcessedImage> {
-    const sharp = await getSharp();
+  ): Promise<ProcessedImage | null> {
+    const sharp = await this.sharp();
+    // No processing available on this install: the file is still stored, it
+    // simply has no derived data. Callers read null as "not generated", never
+    // as a failure, so an upload proceeds without it.
+    if (!sharp) return null;
     const processed = await sharp(buffer)
       .resize(size, size, {
         fit: "cover", // Crop to fill entire area
@@ -79,8 +135,12 @@ export class ImageProcessor {
   async optimize(
     buffer: Buffer,
     quality: number = 80
-  ): Promise<ProcessedImage> {
-    const sharp = await getSharp();
+  ): Promise<ProcessedImage | null> {
+    const sharp = await this.sharp();
+    // No processing available on this install: the file is still stored, it
+    // simply has no derived data. Callers read null as "not generated", never
+    // as a failure, so an upload proceeds without it.
+    if (!sharp) return null;
     const metadata = await sharp(buffer).metadata();
 
     // If already small and WebP, return as-is
@@ -122,8 +182,12 @@ export class ImageProcessor {
     buffer: Buffer,
     maxWidth?: number,
     maxHeight?: number
-  ): Promise<ProcessedImage> {
-    const sharp = await getSharp();
+  ): Promise<ProcessedImage | null> {
+    const sharp = await this.sharp();
+    // No processing available on this install: the file is still stored, it
+    // simply has no derived data. Callers read null as "not generated", never
+    // as a failure, so an upload proceeds without it.
+    if (!sharp) return null;
     const processed = await sharp(buffer)
       .resize(maxWidth, maxHeight, {
         fit: "inside", // Fit within bounds, maintaining aspect ratio
@@ -166,8 +230,12 @@ export class ImageProcessor {
     height: number;
     format: string;
     size: number;
-  }> {
-    const sharp = await getSharp();
+  } | null> {
+    const sharp = await this.sharp();
+    // No processing available on this install: the file is still stored, it
+    // simply has no derived data. Callers read null as "not generated", never
+    // as a failure, so an upload proceeds without it.
+    if (!sharp) return null;
     const quality = options.quality ?? 80;
 
     // Get original metadata to determine output format
@@ -294,13 +362,19 @@ export class ImageProcessor {
   /**
    * Check if buffer is a valid image
    */
-  async isValidImage(buffer: Buffer): Promise<boolean> {
+  async isValidImage(buffer: Buffer): Promise<ImageValidity> {
+    const sharp = await this.sharp();
+    // THREE states, not two. `catch { return false }` reported "not an image"
+    // when the library was merely absent, and the upload route turns that into
+    // a 400 blaming the user's file. "unknown" says the check did not run,
+    // which is not grounds to refuse an upload the magic-byte gate passed.
+    if (!sharp) return "unknown";
+
     try {
-      const sharp = await getSharp();
       await sharp(buffer).metadata();
-      return true;
+      return "valid";
     } catch {
-      return false;
+      return "invalid";
     }
   }
 
@@ -311,7 +385,11 @@ export class ImageProcessor {
     buffer: Buffer
   ): Promise<{ width: number; height: number } | null> {
     try {
-      const sharp = await getSharp();
+      const sharp = await this.sharp();
+      // No processing available on this install: the file is still stored, it
+      // simply has no derived data. Callers read null as "not generated", never
+      // as a failure, so an upload proceeds without it.
+      if (!sharp) return null;
       const metadata = await sharp(buffer).metadata();
       if (metadata.width && metadata.height) {
         return { width: metadata.width, height: metadata.height };

--- a/packages/nextly/src/storage/image-sizes.ts
+++ b/packages/nextly/src/storage/image-sizes.ts
@@ -130,6 +130,64 @@ function buildVariantFilename(
  * @param options - Focal point and routing options
  * @returns Map of size name → variant metadata
  */
+/**
+ * Produce and upload ONE variant, or report that there is nothing to store.
+ *
+ * Split out of the loop so each size's work reads as a single unit and the
+ * loop is left doing only iteration and error containment. `null` covers both
+ * reasons a size yields nothing: the config names no dimensions, and this
+ * install has no image processing.
+ */
+async function generateOneSize(
+  processor: ReturnType<typeof getImageProcessor>,
+  originalBuffer: Buffer,
+  originalFilename: string,
+  sizeConfig: ImageSizeConfig,
+  uploadFn: UploadFn,
+  options: GenerateImageSizesOptions
+): Promise<ImageSizeVariant | null> {
+  // A size naming neither dimension describes no resize to perform.
+  if (!sizeConfig.width && !sizeConfig.height) return null;
+
+  const resized = await processor.resizeWithFocalPoint(originalBuffer, {
+    width: sizeConfig.width ?? undefined,
+    height: sizeConfig.height ?? undefined,
+    fit: sizeConfig.fit,
+    quality: sizeConfig.quality,
+    format: sizeConfig.format,
+    focalX: options.focalX ?? undefined,
+    focalY: options.focalY ?? undefined,
+  });
+
+  // No image processing on this install, so there is no variant to store.
+  // The original is already safe; derived copies are what go missing.
+  if (!resized) return null;
+
+  const variantFilename = buildVariantFilename(
+    originalFilename,
+    sizeConfig.name,
+    resized.format
+  );
+  const mimeType = getMimeTypeForFormat(resized.format);
+
+  const uploadResult = await uploadFn(resized.buffer, {
+    filename: variantFilename,
+    mimeType,
+    folder: options.folder,
+    collection: options.collection,
+  });
+
+  return {
+    url: uploadResult.url,
+    path: uploadResult.path,
+    width: resized.width,
+    height: resized.height,
+    filesize: resized.size,
+    mimeType,
+    filename: variantFilename,
+  };
+}
+
 export async function generateImageSizes(
   originalBuffer: Buffer,
   originalFilename: string,
@@ -142,57 +200,21 @@ export async function generateImageSizes(
   const processor = getImageProcessor();
   const results: Record<string, ImageSizeVariant> = {};
 
-  // Process each size sequentially to avoid memory pressure from
-  // multiple Sharp instances processing large images simultaneously
+  // Sequential on purpose, to avoid the memory pressure of several image
+  // pipelines running over one large original at once.
   for (const sizeConfig of sizes) {
     try {
-      // Skip sizes that have no dimensions specified
-      if (!sizeConfig.width && !sizeConfig.height) continue;
-
-      // Resize with focal point awareness
-      const resized = await processor.resizeWithFocalPoint(originalBuffer, {
-        width: sizeConfig.width ?? undefined,
-        height: sizeConfig.height ?? undefined,
-        fit: sizeConfig.fit,
-        quality: sizeConfig.quality,
-        format: sizeConfig.format,
-        focalX: options.focalX ?? undefined,
-        focalY: options.focalY ?? undefined,
-      });
-
-      // No image processing on this install, so there is no variant to store.
-      // Skipping the whole set is right rather than failing the upload: image
-      // sizes are derived copies, and the original is already safe.
-      if (!resized) continue;
-
-      // Build the variant filename
-      const variantFilename = buildVariantFilename(
+      const variant = await generateOneSize(
+        processor,
+        originalBuffer,
         originalFilename,
-        sizeConfig.name,
-        resized.format
+        sizeConfig,
+        uploadFn,
+        options
       );
-      const mimeType = getMimeTypeForFormat(resized.format);
-
-      // Upload the variant to storage
-      const uploadResult = await uploadFn(resized.buffer, {
-        filename: variantFilename,
-        mimeType,
-        folder: options.folder,
-        collection: options.collection,
-      });
-
-      // Store the variant metadata
-      results[sizeConfig.name] = {
-        url: uploadResult.url,
-        path: uploadResult.path,
-        width: resized.width,
-        height: resized.height,
-        filesize: resized.size,
-        mimeType,
-        filename: variantFilename,
-      };
+      if (variant) results[sizeConfig.name] = variant;
     } catch (error) {
-      // Log but don't fail the entire upload if one size generation fails
+      // One size failing must not lose the others or the upload itself.
       console.warn(
         `[ImageSizes] Failed to generate size "${sizeConfig.name}":`,
         error instanceof Error ? error.message : error

--- a/packages/nextly/src/storage/image-sizes.ts
+++ b/packages/nextly/src/storage/image-sizes.ts
@@ -160,6 +160,11 @@ export async function generateImageSizes(
         focalY: options.focalY ?? undefined,
       });
 
+      // No image processing on this install, so there is no variant to store.
+      // Skipping the whole set is right rather than failing the upload: image
+      // sizes are derived copies, and the original is already safe.
+      if (!resized) continue;
+
       // Build the variant filename
       const variantFilename = buildVariantFilename(
         originalFilename,

--- a/packages/nextly/src/storage/sharp-loader.ts
+++ b/packages/nextly/src/storage/sharp-loader.ts
@@ -1,0 +1,113 @@
+/**
+ * The one place this package reaches for sharp.
+ *
+ * sharp is an optional peer dependency: its native libvips binaries are around
+ * 17 MB per platform, and an install that never uploads an image does not
+ * execute a line of it. Keeping it out of the hard dependency graph is the
+ * difference between every install paying for image processing and only the
+ * ones that use it paying.
+ *
+ * Returns `null` instead of throwing, which is the deliberate difference from
+ * the nodemailer loader beside it. An SMTP send has nothing to fall back to, so
+ * throwing there is right. An upload has a good degraded outcome -- store the
+ * file, skip the derived data -- so the decision belongs to each caller rather
+ * than to this module.
+ *
+ * @module storage/sharp-loader
+ */
+
+import { createRequire } from "node:module";
+
+import type { default as SharpDefault } from "sharp";
+
+/** The command reported to an install that wants image processing. */
+export const SHARP_INSTALL_COMMAND = "npm install sharp";
+
+/**
+ * The callable this package uses. Imported as a TYPE only, which is erased at
+ * compile time, so type-checking never requires the package to be installed.
+ */
+type SharpModule = typeof SharpDefault;
+
+const requireFrom = createRequire(import.meta.url);
+
+/**
+ * A module supplied by the host rather than resolved from disk.
+ *
+ * Payload requires this and resolves nothing, which costs its users an install
+ * AND a config edit. Here it is the escape hatch instead: automatic resolution
+ * keeps the ordinary case to a single command, and this covers a bundler that
+ * cannot resolve a native module on its own.
+ */
+let injected: SharpModule | null = null;
+
+/** Supply sharp explicitly. Pass `null` to clear. */
+export function setSharp(module: SharpModule | null): void {
+  injected = module;
+}
+
+/**
+ * Whether the library can be found, without executing it.
+ *
+ * Resolution rather than import, because this answers a synchronous question
+ * asked while deciding what to tell an operator, and finding out whether
+ * something is installed should not run its module initialisation.
+ */
+export function isSharpAvailable(): boolean {
+  if (injected) return true;
+
+  try {
+    requireFrom.resolve("sharp");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** The value, if it can actually produce an image pipeline. */
+function imageFactoryOf(value: unknown): SharpModule | undefined {
+  return typeof value === "function" ? (value as SharpModule) : undefined;
+}
+
+/**
+ * Load sharp, or report that this install does not have it.
+ *
+ * `resolver` exists so a test can model an absent or hostile module without
+ * touching the filesystem. Production callers pass nothing.
+ */
+export async function loadSharp(options?: {
+  // Returns `unknown` rather than a union with a promise: `unknown` already
+  // covers both, and `await` resolves a thenable or passes a plain value
+  // through unchanged.
+  resolver?: () => unknown;
+}): Promise<SharpModule | null> {
+  if (injected) return injected;
+
+  try {
+    const loaded = await (options?.resolver
+      ? options.resolver()
+      : import("sharp"));
+
+    if (loaded === null || loaded === undefined) return null;
+
+    // Published as CommonJS, so an ESM host may receive the module namespace
+    // with the real export on `default`. Both shapes are handled rather than
+    // one assumed, because which arrives depends on the host's bundler.
+    //
+    // Order is NOT load-bearing here, unlike a loader that probes a NAMED
+    // export: `imageFactoryOf` asks only `typeof value === "function"`, and a
+    // namespace object fails that without any property being read. A namespace
+    // that throws on unknown names therefore cannot be tripped by this probe.
+    // `default` is still read first because a CommonJS module is the common
+    // case and finding it immediately avoids a second check.
+    return (
+      imageFactoryOf((loaded as { default?: unknown }).default) ??
+      imageFactoryOf(loaded) ??
+      null
+    );
+  } catch {
+    // Absent, or present and unloadable. Both mean this install cannot process
+    // images and both have the same remedy, so they are one outcome here.
+    return null;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1149,9 +1149,6 @@ importers:
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
-      sharp:
-        specifier: ^0.35.0
-        version: 0.35.3(@types/node@20.19.17)
       ws:
         specifier: ^8.21.0
         version: 8.21.1
@@ -1238,6 +1235,9 @@ importers:
       rollup-plugin-dts:
         specifier: ^6.4.1
         version: 6.4.1(rollup@4.60.1)(typescript@5.9.3)
+      sharp:
+        specifier: ^0.35.0
+        version: 0.35.3(@types/node@20.19.17)
       tsup:
         specifier: ^8.5.0
         version: 8.5.0(jiti@2.7.0)(postcss@8.5.23)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.3)


### PR DESCRIPTION
Takes the largest avoidable weight out of core: `sharp` is now an optional peer dependency. **Measured on disk: ~18 MB per platform** (1 MB wrapper plus 17 MB of native libvips binaries), which every install downloaded whether or not it ever processed an image.

For scale, #1028 removed 0.68 MB. This is roughly 26x that.

## The design, and why it is not just a manifest move

**A missing `sharp` degrades, it does not fail.** Uploads still succeed and files are still stored; they arrive without a thumbnail, dimensions or resized copies. This matches Payload v3, whose `createImageSizes` opens with `if (!imageSizes || !sharp) return { sizeData: {}, sizesToSave: [] }`. Where Payload requires the host to inject `sharp` into config (an install *and* a config edit), this resolves it automatically and keeps injection as an escape hatch, so the ordinary case is one command.

**Upload security is untouched.** `services/upload-validation/validate-upload.ts` guards uploads with magic-byte, extension, filename and mime checks and has zero `sharp` reference. Degrading image processing weakens no control. `width`/`height` were already nullable, so degradation is schema-safe.

## The defect that would have made this unusable

`isValidImage` was `catch { return false }`, and `services/media.ts` refuses on `false` with `400 "Invalid image file"`. An install without the package would therefore have **rejected every image upload while blaming the user's file**.

Image validity now reports three states rather than two. Only a positive `"invalid"` may refuse an upload; `"unknown"` means this install could not look, which says nothing about the file. The decision is extracted as `refusesUpload(validity)` so it has one home and is testable on its own rather than buried in the upload path.

## UX

The Image Sizes settings page now says when the server cannot process images and shows the command, so configured sizes that can never be generated stop failing silently. It renders above the toolbar, because it explains why everything below it is inert.

## Verification

- `packages/nextly/src/storage`: 111 pass. Admin `src/pages` + `src/components/ui/table`: 250 pass.
- lint + check-types green on `nextly` and `@nextlyhq/admin`.
- **Failure counts measured against the branch base, not assumed.** `src/services` sits at 42 pre-existing failures on `21ba45b19` and at 42 here: zero new, zero masked. Those are mock gaps (`adapter.getCapabilities is not a function`) unrelated to this change.
- Every behaviour break-verified: reverting `refusesUpload` to the old polarity fails exactly the "could not check" test and the new upload-path test, and nothing else.
- **Tested against the packed tarball with `sharp` genuinely deleted**, running the shipped `dist`: `canProcess()` false, `isValidImage()` `"unknown"`, `refusesUpload` false, dimensions/thumbnail/resize all null, and `refusesUpload("invalid")` still true.

## Two findings worth a reviewer's eye

**One regression, caught by comparing to the base rather than eyeballing.** `src/services/__tests__/media.test.ts` mocks `isValidImage` and asserted the old boolean contract, so the gate change broke `should reject invalid image files`. It is updated to `"invalid"`, and a companion test now pins the fix at the real upload path: an `"unknown"` verdict must not produce "Invalid image file".

**A test that proved nothing, removed rather than kept.** The loader's namespace-proxy test was written to prove `default` is read before the top level. Break-verify showed it passes with the ordering reversed, because `imageFactoryOf` checks `typeof value === "function"` and never reads a named property, so a hostile proxy cannot be tripped. The comment claiming the order is load-bearing was corrected to say what the code actually guarantees, and the test renamed to the property it really covers.

## Out of scope, deliberately

`esbuild` (~9.6 MB) was proposed as a sibling of this work. It is not: `init/boot-apply.ts` and `init/reload-config.ts` both reach `cli/utils/config-loader`, which imports it, so removing it means removing the need to compile `nextly.config.ts` at runtime. That is an architecture change to the in-process schema-apply path and needs its own plan. `drizzle-kit` (95 MB measured, the largest single item) stays: it is what applies schema changes in-process, which is the product.
