### PR TITLE
feat(builder): add the selection grammar a multi-block selection needs

### DIFF
--- a/.changeset/builder-selection-model.md
+++ b/.changeset/builder-selection-model.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The page builder gains the rules a multi-block selection needs: click to replace, mod-click to add or remove, shift-click to select a run. Published as plain functions so a host or an agent reads a selection the same way the editor does.

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -259,6 +259,25 @@ export {
 } from "./duplicate-block";
 
 /**
+ * @experimental What "the selection" is once it can hold more than one block.
+ *
+ * From this entry because every part of it is a plain function over a document.
+ * A host, an agent, or a surface answering "what is selected" needs the same
+ * normalisation the editor uses — a second reading would let one of them act on
+ * a container AND something inside it, which deletes the child twice.
+ */
+export {
+  EMPTY_SELECTION,
+  applySelection,
+  documentOrder,
+  normalizeSelection,
+  pruneSelection,
+  rangeBetween,
+  type Selection,
+  type SelectionMode,
+} from "./selection";
+
+/**
  * @experimental The palette's command list, as a plain function over state.
  *
  * From this entry because a host assembling its own palette — or an agent

--- a/packages/builder/src/selection.test.ts
+++ b/packages/builder/src/selection.test.ts
@@ -1,0 +1,293 @@
+/**
+ * The selection grammar.
+ *
+ * Three properties carry the module and each has a control beside it, because
+ * each has a plausible implementation that satisfies the obvious case and fails
+ * the real one:
+ *
+ * - **outermost normalisation** — a set holding a container and its child must
+ *   collapse, or deleting it removes the child twice;
+ * - **document order** — asserted to agree with `layersOf`, so there is one
+ *   VERIFIED definition of order rather than two implementations of it;
+ * - **the range at the shared level** — a run must never span two slots or two
+ *   containers, however close the indices look.
+ *
+ * @module selection.test
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BlockDocument, BlockNode } from "@nextlyhq/blocks-engine";
+
+import { layersOf, type LayerNode } from "./layers";
+import {
+  EMPTY_SELECTION,
+  applySelection,
+  documentOrder,
+  normalizeSelection,
+  pruneSelection,
+  rangeBetween,
+  type Selection,
+} from "./selection";
+
+function node(id: string, slots?: Record<string, BlockNode[]>): BlockNode {
+  return {
+    id,
+    type: slots ? "acme/box" : "acme/leaf",
+    version: 1,
+    props: {},
+    ...(slots ? { slots } : {}),
+  } as BlockNode;
+}
+
+function documentOf(nodes: BlockNode[]): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+}
+
+/**
+ * Two sections, each holding three leaves, plus a two-slot container.
+ *
+ * The two-slot container is the fixture that separates "same parent" from "same
+ * LIST": `x1` and `y1` share a parent and are in different slots, so no run
+ * spans them.
+ */
+function tree(): BlockDocument {
+  return documentOf([
+    node("s1", { children: [node("a"), node("b"), node("c")] }),
+    node("s2", { children: [node("d"), node("e"), node("f")] }),
+    node("two", { left: [node("x1"), node("x2")], right: [node("y1")] }),
+  ]);
+}
+
+function selection(ids: string[], primary: string | null): Selection {
+  return { ids, primary };
+}
+
+describe("documentOrder", () => {
+  it("reads parents before children and slots in declaration order", () => {
+    expect(documentOrder(tree())).toEqual([
+      "s1",
+      "a",
+      "b",
+      "c",
+      "s2",
+      "d",
+      "e",
+      "f",
+      "two",
+      "x1",
+      "x2",
+      "y1",
+    ]);
+  });
+
+  it("agrees with the layers panel's order", () => {
+    // The two are separate walks on purpose — this one skips the label and
+    // badge work the panel does — so the guarantee that they cannot disagree
+    // has to be asserted rather than assumed.
+    const flatten = (rows: readonly LayerNode[]): string[] =>
+      rows.flatMap(row => [row.id, ...flatten(row.children)]);
+
+    expect(documentOrder(tree())).toEqual(flatten(layersOf(tree())));
+  });
+});
+
+describe("normalizeSelection", () => {
+  it("drops a child whose ancestor is also selected", () => {
+    // THE case. Deleting a set holding both would remove `a` with `s1` and then
+    // again from a document that no longer has it.
+    expect(normalizeSelection(tree(), ["s1", "a"])).toEqual(["s1"]);
+  });
+
+  it("drops a DEEP descendant, not merely a direct child", () => {
+    const deep = documentOf([
+      node("outer", { children: [node("mid", { children: [node("leaf")] })] }),
+    ]);
+
+    expect(normalizeSelection(deep, ["outer", "leaf"])).toEqual(["outer"]);
+  });
+
+  it("keeps siblings, which is the control", () => {
+    // Without this, "collapse everything to one id" would pass every case
+    // above.
+    expect(normalizeSelection(tree(), ["b", "a"])).toEqual(["a", "b"]);
+  });
+
+  it("returns document order however the ids arrive", () => {
+    expect(normalizeSelection(tree(), ["f", "a", "d"])).toEqual([
+      "a",
+      "d",
+      "f",
+    ]);
+  });
+
+  it("drops ids the document no longer holds", () => {
+    // An undo that removes selected blocks is routine, not exotic.
+    expect(normalizeSelection(tree(), ["a", "gone"])).toEqual(["a"]);
+  });
+});
+
+describe("rangeBetween", () => {
+  it("selects the run between two siblings, in either direction", () => {
+    expect(rangeBetween(tree(), "a", "c")).toEqual(["a", "b", "c"]);
+    expect(rangeBetween(tree(), "c", "a")).toEqual(["a", "b", "c"]);
+  });
+
+  it("selects at the level where the two paths diverge", () => {
+    // `a` is in s1 and `e` is in s2, so there is no run of siblings spanning
+    // them. The answer is the run at the level that does contain both.
+    expect(rangeBetween(tree(), "a", "e")).toEqual(["s1", "s2"]);
+  });
+
+  it("never spans two SLOTS of one parent", () => {
+    // `x1` and `y1` share a parent and are in different slots. A run across
+    // them is not contiguous however close the indices look, and a rule keyed
+    // on "same parent" rather than "same list" would return one.
+    expect(rangeBetween(tree(), "x1", "y1")).toEqual([]);
+  });
+
+  it("answers with the OUTER block when one contains the other", () => {
+    expect(rangeBetween(tree(), "s1", "b")).toEqual(["s1"]);
+    expect(rangeBetween(tree(), "b", "s1")).toEqual(["s1"]);
+  });
+
+  it("answers with nothing for an id the document lost", () => {
+    expect(rangeBetween(tree(), "a", "gone")).toEqual([]);
+  });
+});
+
+describe("applySelection", () => {
+  it("replaces on a plain click", () => {
+    expect(applySelection(tree(), selection(["a", "b"], "a"), "e")).toEqual({
+      ids: ["e"],
+      primary: "e",
+    });
+  });
+
+  it("clears on a click that hit no block", () => {
+    expect(
+      applySelection(tree(), selection(["a"], "a"), null, "toggle")
+    ).toEqual(EMPTY_SELECTION);
+  });
+
+  it("ignores a target the document does not hold", () => {
+    // Rather than clearing. A stale id is not an instruction to deselect, and
+    // treating it as one loses a selection for a reason the author cannot see.
+    const current = selection(["a"], "a");
+    expect(applySelection(tree(), current, "gone")).toBe(current);
+  });
+
+  it("toggles a block in, and makes it primary", () => {
+    // Primary follows the block just pointed at: it is the one the author
+    // expects the inspector to describe.
+    expect(
+      applySelection(tree(), selection(["a"], "a"), "c", "toggle")
+    ).toEqual({ ids: ["a", "c"], primary: "c" });
+  });
+
+  it("toggles a block out, and hands primary to what is left", () => {
+    // A set with members but no primary would leave the inspector blank while
+    // the canvas still drew outlines.
+    const next = applySelection(
+      tree(),
+      selection(["a", "c"], "c"),
+      "c",
+      "toggle"
+    );
+
+    expect(next.ids).toEqual(["a"]);
+    expect(next.primary).toBe("a");
+  });
+
+  it("hands primary to the FIRST survivor when more than one remains", () => {
+    /*
+     * The case that pins an otherwise arbitrary choice. With one survivor every
+     * rule agrees, so a test using two is the only one that can distinguish
+     * "first in document order" from "nearest to what was removed" — and an
+     * earlier version chose the latter with nothing able to tell.
+     */
+    const next = applySelection(
+      tree(),
+      selection(["a", "b", "c"], "b"),
+      "b",
+      "toggle"
+    );
+
+    expect(next.ids).toEqual(["a", "c"]);
+    expect(next.primary).toBe("a");
+  });
+
+  it("toggling the last block out empties the selection", () => {
+    expect(
+      applySelection(tree(), selection(["a"], "a"), "a", "toggle")
+    ).toEqual(EMPTY_SELECTION);
+  });
+
+  it("toggling a container in absorbs its selected children", () => {
+    const next = applySelection(
+      tree(),
+      selection(["a", "b"], "b"),
+      "s1",
+      "toggle"
+    );
+
+    expect(next.ids).toEqual(["s1"]);
+    // Primary was `s1` — the block pointed at — and it survives normalisation.
+    expect(next.primary).toBe("s1");
+  });
+
+  it("extends from the primary, replacing rather than growing", () => {
+    // Shift-click means "the selection is now anchor-to-here" in every list
+    // this grammar comes from. Growing would make a corrected aim additive.
+    const next = applySelection(tree(), selection(["a"], "a"), "c", "extend");
+
+    expect(next.ids).toEqual(["a", "b", "c"]);
+    // The anchor stays primary, so a run of shift-clicks re-aims from one end.
+    expect(next.primary).toBe("a");
+  });
+
+  it("a second extend re-aims from the same anchor", () => {
+    const first = applySelection(tree(), selection(["a"], "a"), "c", "extend");
+    const second = applySelection(tree(), first, "b", "extend");
+
+    expect(second.ids).toEqual(["a", "b"]);
+    expect(second.primary).toBe("a");
+  });
+
+  it("extending with nothing selected behaves as a plain click", () => {
+    expect(applySelection(tree(), EMPTY_SELECTION, "b", "extend")).toEqual({
+      ids: ["b"],
+      primary: "b",
+    });
+  });
+
+  it("extending across slots selects the target alone rather than nothing", () => {
+    // `rangeBetween` answers `[]` here, and a selection that emptied itself on
+    // a shift-click would read as the gesture being broken.
+    const next = applySelection(
+      tree(),
+      selection(["x1"], "x1"),
+      "y1",
+      "extend"
+    );
+
+    expect(next.ids).toEqual(["y1"]);
+    expect(next.primary).toBe("y1");
+  });
+});
+
+describe("pruneSelection", () => {
+  it("drops what an edit removed and keeps a valid primary", () => {
+    const after = documentOf([node("s1", { children: [node("a")] })]);
+
+    expect(pruneSelection(after, selection(["a", "e"], "e"))).toEqual({
+      ids: ["a"],
+      primary: "a",
+    });
+  });
+
+  it("empties when nothing survives", () => {
+    expect(
+      pruneSelection(documentOf([node("z")]), selection(["a"], "a"))
+    ).toEqual(EMPTY_SELECTION);
+  });
+});

--- a/packages/builder/src/selection.ts
+++ b/packages/builder/src/selection.ts
@@ -1,0 +1,297 @@
+/**
+ * What "the selection" is once it can hold more than one block.
+ *
+ * A page builder that can only ever act on one block makes every repetitive
+ * job — deleting six cards, locking a whole section's children, moving a run of
+ * blocks — a sequence of identical single edits. This module is the grammar for
+ * the alternative, decided without a DOM.
+ *
+ * ## A SET plus a PRIMARY, not a set alone
+ *
+ * The selection is an ordered set of ids AND one primary id. The primary is the
+ * block the inspector edits, the block the breadcrumb traces, and the anchor a
+ * range extends from. Modelling the set alone would leave every one of those
+ * surfaces inventing "which of these did the author mean" separately, and they
+ * would each pick a different answer — the first in document order, the last
+ * clicked, the deepest. It is also what lets the existing single-selection
+ * surfaces keep working unchanged: `primary` IS the old `selectedId`, with a
+ * name that says what it means.
+ *
+ * ## Document order, always
+ *
+ * The set is kept in document order rather than click order. Every consumer
+ * that acts on a selection — delete, duplicate, an announcement counting what
+ * is in it — either needs that order or is indifferent to it, and a set that
+ * remembered clicks would make "delete the selection" produce a different
+ * document depending on which block the author happened to click first.
+ *
+ * ## Outermost only
+ *
+ * A selection holding a container AND something inside it is normalised to the
+ * container. This is not tidiness: deleting such a set would remove the child
+ * twice, the second time from a document that no longer has it, and duplicating
+ * it would produce the child both inside the copied container and beside it.
+ * The engine already reads nesting this way — `lockBlockingDelete` walks
+ * outermost-first for the same reason.
+ *
+ * ## The three gestures, which are the platform's and not ours
+ *
+ * Plain click REPLACES, `mod`-click TOGGLES, shift-click EXTENDS. That is the
+ * grammar of every file manager, every list view and every design tool people
+ * arrive already knowing, and inventing a fourth would be a thing to teach for
+ * no gain.
+ *
+ * @module selection
+ */
+
+import { type BlockDocument, type BlockNode } from "@nextlyhq/blocks-engine";
+
+/** How a gesture changes the selection. */
+export type SelectionMode = "replace" | "toggle" | "extend";
+
+/** The selection: what is in it, and which one the surfaces answer for. */
+export interface Selection {
+  /** Every selected id, in document order, outermost only. */
+  readonly ids: readonly string[];
+  /**
+   * The block the inspector edits and a range extends from, or `null`.
+   *
+   * Always a member of `ids` when `ids` is non-empty, which callers may rely
+   * on: a primary outside the set would make the inspector edit a block the
+   * canvas does not show as selected.
+   */
+  readonly primary: string | null;
+}
+
+/** Nothing selected. */
+export const EMPTY_SELECTION: Selection = { ids: [], primary: null };
+
+/**
+ * Every id in the document, in the order a reader meets them.
+ *
+ * Deliberately a walk of its own rather than a flatten of `layersOf`, which
+ * would compute a label, a lock badge and two style predicates per node on
+ * every click. `selection.test` asserts this agrees with `layersOf`'s order, so
+ * there is one VERIFIED definition of document order rather than one shared
+ * implementation of it.
+ */
+export function documentOrder(document: BlockDocument): string[] {
+  const out: string[] = [];
+  const walk = (nodes: readonly BlockNode[]): void => {
+    for (const node of nodes) {
+      out.push(node.id);
+      for (const children of Object.values(node.slots ?? {})) walk(children);
+    }
+  };
+  walk(document.nodes);
+  return out;
+}
+
+/** The ids from the root down to `id`, inclusive, or `[]` when it is absent. */
+function pathOf(document: BlockDocument, id: string): string[] {
+  const find = (nodes: readonly BlockNode[], trail: string[]): string[] => {
+    for (const node of nodes) {
+      const here = [...trail, node.id];
+      if (node.id === id) return here;
+      for (const children of Object.values(node.slots ?? {})) {
+        const found = find(children, here);
+        if (found.length > 0) return found;
+      }
+    }
+    return [];
+  };
+  return find(document.nodes, []);
+}
+
+/**
+ * The set with anything that has an ancestor in it removed, in document order.
+ *
+ * Ids the document no longer holds are dropped too, which an undo produces
+ * routinely — a selection outliving its blocks is the normal case, not an edge
+ * one.
+ */
+export function normalizeSelection(
+  document: BlockDocument,
+  ids: readonly string[]
+): string[] {
+  const paths = new Map<string, string[]>();
+  for (const id of ids) {
+    const path = pathOf(document, id);
+    if (path.length > 0) paths.set(id, path);
+  }
+
+  const kept = [...paths.keys()].filter(id => {
+    const path = paths.get(id) ?? [];
+    // Every entry but the last is an ancestor. If the set holds one of them,
+    // this node travels with it and listing it as well would act on it twice.
+    return !path.slice(0, -1).some(ancestor => paths.has(ancestor));
+  });
+
+  const order = documentOrder(document);
+  return kept.sort((a, b) => order.indexOf(a) - order.indexOf(b));
+}
+
+/**
+ * The sibling run between two blocks, at the deepest level they share.
+ *
+ * Shift-clicking a block inside another section does NOT select across the two
+ * containers, because there is no run of siblings spanning them. It selects the
+ * run at the level where the two paths diverge — the sections themselves — so
+ * the gesture always answers with something contiguous.
+ *
+ * `[]` when either id is absent, and the OUTER one alone when one contains the
+ * other: a range from a container to something inside it is the container.
+ */
+export function rangeBetween(
+  document: BlockDocument,
+  anchorId: string,
+  targetId: string
+): string[] {
+  const anchor = pathOf(document, anchorId);
+  const target = pathOf(document, targetId);
+  if (anchor.length === 0 || target.length === 0) return [];
+
+  let shared = 0;
+  while (
+    shared < anchor.length &&
+    shared < target.length &&
+    anchor[shared] === target[shared]
+  ) {
+    shared += 1;
+  }
+
+  // One is on the other's path, so they are not siblings at any level.
+  if (shared === anchor.length) return [anchorId];
+  if (shared === target.length) return [targetId];
+
+  const from = anchor[shared];
+  const to = target[shared];
+  if (from === undefined || to === undefined) return [];
+
+  const parentId = shared === 0 ? undefined : anchor[shared - 1];
+  const siblings = siblingRunOf(document, parentId, from, to);
+  return siblings;
+}
+
+/** The contiguous run of siblings from `from` to `to`, whichever comes first. */
+function siblingRunOf(
+  document: BlockDocument,
+  parentId: string | undefined,
+  from: string,
+  to: string
+): string[] {
+  const lists =
+    parentId === undefined ? [document.nodes] : slotListsOf(document, parentId);
+
+  for (const list of lists) {
+    const ids = list.map(node => node.id);
+    const a = ids.indexOf(from);
+    const b = ids.indexOf(to);
+    // BOTH in the same list. A parent's slots are separate lists, and a run
+    // spanning two of them is not contiguous however close the indices look.
+    if (a === -1 || b === -1) continue;
+    return ids.slice(Math.min(a, b), Math.max(a, b) + 1);
+  }
+  return [];
+}
+
+/** Each of a parent's slots, as its own list. */
+function slotListsOf(document: BlockDocument, parentId: string): BlockNode[][] {
+  const find = (nodes: readonly BlockNode[]): BlockNode[][] | undefined => {
+    for (const node of nodes) {
+      if (node.id === parentId) return Object.values(node.slots ?? {});
+      for (const children of Object.values(node.slots ?? {})) {
+        const found = find(children);
+        if (found !== undefined) return found;
+      }
+    }
+    return undefined;
+  };
+  return find(document.nodes) ?? [];
+}
+
+/**
+ * The selection after a gesture on `targetId`.
+ *
+ * `null` clears it, whatever the mode: a click on canvas background has no
+ * subject to toggle or extend to.
+ */
+export function applySelection(
+  document: BlockDocument,
+  current: Selection,
+  targetId: string | null,
+  mode: SelectionMode = "replace"
+): Selection {
+  if (targetId === null) return EMPTY_SELECTION;
+  if (pathOf(document, targetId).length === 0) return current;
+
+  if (mode === "toggle") {
+    const has = current.ids.includes(targetId);
+    const next = has
+      ? current.ids.filter(id => id !== targetId)
+      : [...current.ids, targetId];
+    const ids = normalizeSelection(document, next);
+    if (ids.length === 0) return EMPTY_SELECTION;
+    /*
+     * Adding makes the NEW block primary: it is the one the author just pointed
+     * at and the one they expect the inspector to describe. Removing keeps the
+     * primary it had, which the guard below corrects when the block removed WAS
+     * the primary — it hands it to the first survivor in document order.
+     *
+     * First rather than nearest, deliberately. The set is ordered by the
+     * document, so "the first one still selected" is a position the author can
+     * see; "the one next to what you just removed" is a rule they would have to
+     * be told. An earlier version chose the last survivor and no test could
+     * tell the two apart, which is how the arbitrariness was found.
+     */
+    const primary = has ? current.primary : targetId;
+    return {
+      ids,
+      primary: primary !== null && ids.includes(primary) ? primary : ids[0],
+    };
+  }
+
+  if (mode === "extend" && current.primary !== null) {
+    const run = rangeBetween(document, current.primary, targetId);
+    if (run.length === 0) return { ids: [targetId], primary: targetId };
+    /*
+     * The run REPLACES rather than unions with what was selected.
+     *
+     * Shift-click in every list this grammar comes from means "the selection is
+     * now anchor-to-here". Unioning would make a second shift-click grow the
+     * selection instead of redefining it, so an author correcting their aim
+     * would have to clear and start again.
+     *
+     * The anchor stays primary, which is what makes a run of shift-clicks
+     * re-aim from the same end rather than walking the anchor along.
+     */
+    const ids = normalizeSelection(document, run);
+    return {
+      ids,
+      primary: ids.includes(current.primary)
+        ? current.primary
+        : (ids[0] ?? null),
+    };
+  }
+
+  return { ids: [targetId], primary: targetId };
+}
+
+/**
+ * The selection with anything the document has lost dropped.
+ *
+ * Called after an edit rather than on read, so a surface never renders against
+ * ids that are gone. An undo removing selected blocks is routine.
+ */
+export function pruneSelection(
+  document: BlockDocument,
+  selection: Selection
+): Selection {
+  const ids = normalizeSelection(document, selection.ids);
+  if (ids.length === 0) return EMPTY_SELECTION;
+  const primary =
+    selection.primary !== null && ids.includes(selection.primary)
+      ? selection.primary
+      : (ids[0] ?? null);
+  return { ids, primary };
+}


### PR DESCRIPTION
**Step 1 of 4 toward B-10.** Rules only — nothing is wired, and the editor still selects one block at a time. Opened separately because the model is where the decisions are, and reviewing it next to a canvas rewrite would bury them.

## The plan

1. **This PR** — the selection model, pure and tested.
2. `EditorState` carries the set; canvas marks all; the click grammar is wired.
3. Operations on a set — delete, duplicate, lock — through the existing command layer.
4. Surfaces — layers multi-highlight, toolbar for N blocks, inspector "N selected".

## The decision that makes this incremental

**A selection is an ordered SET plus one PRIMARY.** The primary is the block the inspector edits, the block the breadcrumb traces, and the anchor a range extends from.

Modelling the set alone would leave each of those surfaces deciding which member the author meant — first in document order, last clicked, deepest — and they would each pick differently. It is also what keeps the migration additive: **`primary` IS the existing `selectedId`**, with a name that says what it means. Fourteen modules read `selectedId` today; none of them has to change to be correct.

## Rules worth arguing with

**Outermost only.** A set holding a container AND something inside it normalises to the container. Not tidiness: deleting such a set removes the child once with its parent and again from a document that no longer has it, and duplicating it puts the child both inside the copy and beside it. The engine already reads nesting this way — `lockBlockingDelete` walks outermost-first for the same reason.

**Document order, not click order.** Every consumer either needs that order or is indifferent to it, and a set that remembered clicks would make "delete the selection" produce a different document depending on which block was clicked first.

**A range is the run at the level where two paths diverge.** Shift-clicking a block inside another section selects the sections between them, because no run of siblings spans two containers. And a run never spans two SLOTS of one parent — that is not contiguous however close the indices look, which is why the fixture has a two-slot container.

**Shift-click replaces rather than grows.** That is what shift-click means in every list this grammar comes from; growing would make a corrected aim additive. The anchor stays primary, so a run of shift-clicks re-aims from one end instead of walking the anchor along.

**A stale target is ignored, not treated as a deselect.** An id the document no longer holds is not an instruction to clear, and treating it as one loses a selection for a reason the author cannot see.

## Verified

26 tests; `packages/builder` **736 total**, types and lint clean.

**Eight stubs.** Six were caught by exactly the test whose name claims the property. The two that were not are the interesting part:

- **Two stubs silently failed to apply** — prettier had rewrapped the expressions I was matching on, so `replace` matched nothing and the suite stayed green. That reads exactly like "the test does not catch this". Both were redone with an assertion that the edit landed; one then failed as expected.
- **One stub survived a correctly-applied edit**, and that was a real finding: the primary-handoff branch and the guard below it only differ when two or more blocks remain, and no test covered that. The branch chose the *last* survivor for no defensible reason. **Removed it** — the guard hands primary to the first survivor in document order, which is a position the author can see — and added the two-survivor case that pins the choice. Re-stubbed to confirm it now fails on "last".

`documentOrder` is a walk of its own rather than a flatten of `layersOf`, which would compute a label, a lock badge and two style predicates per node on every click. A test asserts the two orders agree, so there is one *verified* definition rather than one shared implementation.
