### PR TITLE
fix(nextly): store a configuration JSON can only carry as text

### DIFF
--- a/.changeset/config-coercion-not-loss.md
+++ b/.changeset/config-coercion-not-loss.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+An email provider whose parser returns a value JSON can only carry as text now has it stored in that form, instead of the save being refused.
+
+The stored configuration is defined as its serialisation, so a `Date` becoming an ISO string is a coercion and is accepted. A parser returning a value that would LOSE data is still refused, and the message now names the field that would be lost rather than describing the rule in the abstract: a key JSON drops, an array's named properties, or a `Map` or `Set` whose entries serialisation cannot see at all.
+
+A parser that returns a different value each time it reads the same input is still refused, because stored credentials would not survive a read. That comparison is now structural, so a parser that rebuilds its output field by field is no longer refused for changing the order of its own fields.

--- a/packages/nextly/src/domains/email/__tests__/configuration-loss.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/configuration-loss.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Telling COERCION apart from LOSS in a stored provider configuration.
+ *
+ * The stored configuration is its serialisation, and the founder's decision is
+ * that a value JSON can only carry as text is coerced SILENTLY rather than
+ * refused: a `Date` becoming an ISO string keeps the information, and the DX
+ * wrinkle is accepted deliberately.
+ *
+ * Nothing in that decision permits LOSS, and loss is what the old guard was
+ * really catching alongside the coercion. It arrives in two shapes that need
+ * different questions:
+ *
+ *   - a KEY disappears, because JSON drops `undefined` values and an array's
+ *     named properties;
+ *   - a key SURVIVES while its content vanishes, because a `Map` or a `Set`
+ *     holds its data somewhere JSON cannot see and serialises to `{}`.
+ *
+ * A single comparison cannot separate the three. Refusing everything that
+ * changes is the old behaviour; accepting everything that serialises is the
+ * candidate that failed. This module answers only "was anything lost".
+ */
+import { describe, expect, it } from "vitest";
+
+import { findConfigurationLoss } from "../configuration-loss";
+
+/** What the column will hold for a given parsed value. */
+function serialised(value: unknown): unknown {
+  return JSON.parse(JSON.stringify(value));
+}
+
+/** The answer for a value, as the service asks it. */
+function lossIn(value: unknown): string | null {
+  return findConfigurationLoss(value, serialised(value));
+}
+
+describe("values that are COERCED, and must be accepted", () => {
+  it("accepts a Date, which JSON carries as text", () => {
+    // The decision's own example. The information survives; only the type
+    // does not, and that cost was taken deliberately.
+    expect(lossIn({ apiKey: "k", issuedAt: new Date(0) })).toBeNull();
+  });
+
+  it("accepts a Date nested inside an object", () => {
+    expect(lossIn({ a: { issuedAt: new Date(0) } })).toBeNull();
+  });
+
+  it("accepts a Date nested inside an array", () => {
+    expect(lossIn({ stamps: [new Date(0)] })).toBeNull();
+  });
+
+  it("accepts a plain configuration unchanged", () => {
+    expect(lossIn({ apiKey: "k", port: 587, secure: true })).toBeNull();
+  });
+
+  it("accepts an array of scalars", () => {
+    expect(lossIn({ scopes: ["send", "read"] })).toBeNull();
+  });
+
+  it("accepts a genuinely empty object", () => {
+    // The control for the exotic-object rule below: `{}` serialising to `{}`
+    // has lost nothing, and a rule that cannot tell it from a Map would
+    // refuse a legitimate empty configuration.
+    expect(lossIn({ headers: {} })).toBeNull();
+  });
+
+  it("accepts a nested empty array", () => {
+    expect(lossIn({ scopes: [] })).toBeNull();
+  });
+});
+
+describe("KEYS that disappear, which must be refused", () => {
+  it("refuses an undefined-valued key, which JSON drops", () => {
+    expect(lossIn({ apiKey: "k", label: undefined })).toMatch(/label/);
+  });
+
+  it("refuses a plain object whose toJSON discards its fields", () => {
+    const headers = { token: "ops", toJSON: () => ({}) };
+    expect(lossIn({ apiKey: "k", headers })).toMatch(/headers/);
+  });
+
+  it("refuses an array carrying named properties JSON cannot keep", () => {
+    const scopes = Object.assign(["send"], { region: "eu" });
+    expect(lossIn({ apiKey: "k", scopes })).toMatch(/scopes/);
+  });
+
+  it("names the PATH to the loss, not just that there was one", () => {
+    // The message reaches an author who has to find the field. A bare "this
+    // configuration loses data" makes them search their own parser.
+    expect(lossIn({ outer: { inner: { gone: undefined } } })).toMatch(
+      /outer\.inner\.gone/
+    );
+  });
+});
+
+describe("CONTENT that vanishes while its key survives", () => {
+  it("refuses a Map, whose entries JSON cannot see", () => {
+    // `headers` exists on both sides, so a key comparison passes it. What is
+    // lost is inside a value that reports no own enumerable keys at all.
+    expect(lossIn({ apiKey: "k", headers: new Map([["x", "y"]]) })).toMatch(
+      /headers/
+    );
+  });
+
+  it("refuses a Set", () => {
+    expect(lossIn({ apiKey: "k", tags: new Set(["primary"]) })).toMatch(/tags/);
+  });
+
+  it("refuses a Set reached through an array", () => {
+    expect(
+      lossIn({ routes: [{ region: "eu", tags: new Set(["primary"]) }] })
+    ).toMatch(/routes/);
+  });
+
+  it("refuses a class instance carrying its data privately", () => {
+    class Credential {
+      readonly #secret: string;
+      constructor(secret: string) {
+        this.#secret = secret;
+      }
+      reveal() {
+        return this.#secret;
+      }
+    }
+
+    expect(lossIn({ cred: new Credential("s") })).toMatch(/cred/);
+  });
+});

--- a/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
@@ -149,17 +149,24 @@ describe("a configuration whose parse is not a fixed point", () => {
     );
   });
 
-  // JSON carries no `Date`, so the column holds a string and the adapter is
-  // handed a shape this provider's own parser just rejected.
-  it("refuses a parser returning a value JSON cannot carry", async () => {
+  // The stored configuration IS its serialisation, so a value JSON can only
+  // carry as text is COERCED rather than refused. The cost is deliberate: the
+  // adapter is handed an ISO string where the parser returned a `Date`. That
+  // is a real DX wrinkle, taken in exchange for a rule that stops producing
+  // refusals for values nobody needed to be warned about.
+  it("stores the serialised form of a value JSON cannot carry", async () => {
     register("dated", input => ({
       apiKey: String((input as { apiKey: unknown }).apiKey),
       issuedAt: new Date(0),
     }));
 
-    await expect(write("dated", { apiKey: "k" })).rejects.toThrow(
-      /parsing what would be saved does not return what was saved/
-    );
+    const provider = await write("dated", { apiKey: "k" });
+
+    const stored = await service.getProviderDecrypted(provider.id);
+    expect(stored.configuration).toEqual({
+      apiKey: "k",
+      issuedAt: "1970-01-01T00:00:00.000Z",
+    });
   });
 
   // The same property reached by throwing rather than by returning something
@@ -186,7 +193,7 @@ describe("a configuration whose parse is not a fixed point", () => {
     }));
 
     await expect(write("optional", { apiKey: "k" })).rejects.toThrow(
-      /parsing what would be saved does not return what was saved/
+      /loses .* when written as JSON/
     );
   });
 
@@ -248,7 +255,11 @@ describe("a configuration whose parse is not a fixed point", () => {
   // A PASS-THROUGH parser: it accepts both the typed value and its JSON form,
   // so re-parsing agrees with itself while the value actually stored lost its
   // type. The Date test above recreates the Date and cannot see this.
-  it("refuses a pass-through parser whose value loses type in the column", async () => {
+  // The SAME coercion reached by a parser that passes its input through on the
+  // second call rather than rebuilding it. Accepted for the same reason, and
+  // kept as its own case because the two parsers differ in shape while the
+  // decision about them does not.
+  it("stores a coerced value a pass-through parser accepts back", async () => {
     register("passthrough-date", input => {
       const value = input as { apiKey: unknown; issuedAt?: unknown };
       return value.issuedAt === undefined
@@ -256,9 +267,13 @@ describe("a configuration whose parse is not a fixed point", () => {
         : (value as object);
     });
 
-    await expect(write("passthrough-date", { apiKey: "k" })).rejects.toThrow(
-      /parsing what would be saved does not return what was saved|cannot be written as JSON/
-    );
+    const provider = await write("passthrough-date", { apiKey: "k" });
+
+    const stored = await service.getProviderDecrypted(provider.id);
+    expect(stored.configuration).toEqual({
+      apiKey: "k",
+      issuedAt: "1970-01-01T00:00:00.000Z",
+    });
   });
 
   // A root `toJSON` returning undefined makes JSON.stringify return undefined
@@ -331,7 +346,7 @@ describe("a configuration whose parse is not a fixed point", () => {
     }));
 
     await expect(write("mapped", { apiKey: "k" })).rejects.toThrow(
-      /parsing what would be saved does not return what was saved/
+      /loses .* when written as JSON/
     );
   });
 
@@ -344,7 +359,7 @@ describe("a configuration whose parse is not a fixed point", () => {
     }));
 
     await expect(write("nested-set", { apiKey: "k" })).rejects.toThrow(
-      /parsing what would be saved does not return what was saved/
+      /loses .* when written as JSON/
     );
   });
 
@@ -357,7 +372,7 @@ describe("a configuration whose parse is not a fixed point", () => {
     }));
 
     await expect(write("self-emptying", { apiKey: "k" })).rejects.toThrow(
-      /parsing what would be saved does not return what was saved/
+      /loses .* when written as JSON/
     );
   });
 
@@ -370,7 +385,7 @@ describe("a configuration whose parse is not a fixed point", () => {
     }));
 
     await expect(write("named-array", { apiKey: "k" })).rejects.toThrow(
-      /parsing what would be saved does not return what was saved/
+      /loses .* when written as JSON/
     );
   });
 

--- a/packages/nextly/src/domains/email/configuration-loss.ts
+++ b/packages/nextly/src/domains/email/configuration-loss.ts
@@ -1,0 +1,98 @@
+/**
+ * Whether serialising a parsed configuration LOST anything.
+ *
+ * The stored configuration is its serialisation, so a value JSON can only
+ * carry as text is COERCED rather than refused: a `Date` becoming an ISO
+ * string keeps the information, and that cost is deliberate.
+ *
+ * Loss is a different thing and is not permitted, because it corrupts a
+ * configuration rather than restyling it. It arrives in two shapes, and one
+ * question cannot answer both:
+ *
+ *   - a KEY disappears. JSON drops an `undefined` value and an array's named
+ *     properties, so `{ label: undefined }` and `Object.assign([], {region})`
+ *     reach the column smaller than they left.
+ *   - the key SURVIVES and its CONTENT vanishes. A `Map`, a `Set` or a class
+ *     instance keeps its data somewhere `JSON.stringify` cannot reach, so it
+ *     serialises to `{}` while reporting no own enumerable keys to compare.
+ *
+ * Separating those from coercion is the whole job. Refusing everything that
+ * changes shape is the old guard, which refused the `Date` this decision
+ * accepts; accepting everything that serialises misses both shapes above.
+ *
+ * @module domains/email/configuration-loss
+ */
+
+/**
+ * Whether a value keeps its data in its OWN enumerable properties.
+ *
+ * This is the property that decides whether serialisation can see everything
+ * a value holds, and it is asked structurally rather than by constructor name:
+ * a plain object and an array expose their contents as own properties, while
+ * a `Map`, a `Set` or a class with private fields does not, whatever it is
+ * called. A null-prototype object counts, because its data is still its own
+ * properties.
+ */
+function keepsDataInOwnProperties(value: object): boolean {
+  if (Array.isArray(value)) return true;
+  const proto = Object.getPrototypeOf(value) as object | null;
+  return proto === Object.prototype || proto === null;
+}
+
+/** A readable path to the field that lost something. */
+function join(path: string, key: string): string {
+  return path === "" ? key : `${path}.${key}`;
+}
+
+/**
+ * The first thing serialisation lost, as a path, or null when nothing was.
+ *
+ * `parsed` is what `parseConfig` returned; `stored` is what the column will
+ * hold, which the caller obtains by serialising and re-parsing rather than by
+ * inspecting. Comparing those two is what makes the question answerable at
+ * all: the loss is only visible across that boundary.
+ */
+export function findConfigurationLoss(
+  parsed: unknown,
+  stored: unknown,
+  path = ""
+): string | null {
+  // A primitive on the parsed side cannot have lost anything: it had no parts.
+  if (parsed === null || typeof parsed !== "object") return null;
+
+  // COERCION, and the case this module exists to permit. An object that
+  // serialises to a primitive was flattened rather than emptied -- a `Date`
+  // becoming its ISO string is the example the decision names. The
+  // information survives in a form the column can hold, so this is where the
+  // walk stops rather than where it complains.
+  if (stored === null || typeof stored !== "object") return null;
+
+  // CONTENT LOSS. The value holds data somewhere serialisation cannot reach,
+  // and it still produced an object, so nothing downstream will notice. Asked
+  // before the key comparison because such a value reports no own keys at
+  // all: comparing key sets would find `{}` against `{}` and pass it.
+  if (!keepsDataInOwnProperties(parsed)) {
+    return path === "" ? "the configuration" : path;
+  }
+
+  // KEY LOSS, recursively. Every own enumerable key on the parsed side must
+  // survive into the stored form. A function-valued key is exempt: JSON drops
+  // it by design and no configuration can carry behaviour into a column, so
+  // reporting it would refuse the ordinary `toJSON` idiom rather than the
+  // discarding one -- which is caught anyway by the keys it discards.
+  const storedRecord = stored as Record<string, unknown>;
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof value === "function") continue;
+
+    if (!(key in storedRecord)) return join(path, key);
+
+    const deeper = findConfigurationLoss(
+      value,
+      storedRecord[key],
+      join(path, key)
+    );
+    if (deeper !== null) return deeper;
+  }
+
+  return null;
+}

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -37,6 +37,7 @@ import { encrypt, decrypt } from "../../../utils/encryption";
 // Pull adapter type into a normal `import type` declaration so the return
 // signature on createAdapterFromProvider satisfies consistent-type-imports.
 import { affectedRowCount } from "../../auth/services/auth-service";
+import { findConfigurationLoss } from "../configuration-loss";
 import {
   isRecognisedMessageId,
   mailboxOf,
@@ -173,6 +174,72 @@ interface ProviderTransaction {
   insert(table: EmailProvidersTable): {
     values(data: Record<string, unknown>): Promise<unknown>;
   };
+}
+
+/**
+ * Refuse a configuration that serialisation would LOSE part of.
+ *
+ * The stored configuration is its serialisation, so a value JSON can only
+ * carry as text is COERCED and accepted: a `Date` becoming an ISO string keeps
+ * the information, and that cost is deliberate. Loss is different and is
+ * refused, because it corrupts a configuration rather than restyling it.
+ *
+ * Its own function because it answers its own question. Comparing the two
+ * object graphs cannot separate loss from coercion, which is what the old
+ * guard did and why it refused the `Date`.
+ */
+function assertNothingLost(
+  type: string,
+  parsed: Record<string, unknown>,
+  stored: unknown
+): void {
+  const lost = findConfigurationLoss(parsed, stored);
+  if (lost === null) return;
+
+  throw new NextlyError({
+    code: "BUSINESS_RULE_VIOLATION",
+    publicMessage: `Email provider "${type}" parsed its configuration into a value that loses ${lost} when written as JSON, so what is read back would not be what was validated. Return only what JSON can carry from \`parseConfig\`.`,
+    logContext: {
+      reason: "email-provider-configuration-loses-data",
+      type,
+      lost,
+    },
+  });
+}
+
+/**
+ * Refuse a parser that does not return what it was given.
+ *
+ * This is what catches a parser that DERIVES -- one base64-encoding on every
+ * pass, so each read yields a different credential from the one stored and the
+ * row decays rather than merely changing type.
+ *
+ * Compared in the JSON domain and STRUCTURALLY: both sides are parsed objects
+ * rather than strings, so field ORDER is not a difference. A parser that
+ * rebuilds its output field by field is an ordinary thing to write and must
+ * not be refused for it.
+ */
+function assertParseIsAFixedPoint(
+  type: string,
+  reparsed: unknown,
+  expected: unknown
+): void {
+  let reserialised: unknown;
+  try {
+    reserialised = JSON.parse(JSON.stringify(reparsed) ?? "null");
+  } catch {
+    // A re-parse that cannot itself be serialised cannot be compared, and a
+    // value that will not survive the column is what this refuses anyway.
+    reserialised = undefined;
+  }
+
+  if (isDeepStrictEqual(reserialised, expected)) return;
+
+  throw new NextlyError({
+    code: "BUSINESS_RULE_VIOLATION",
+    publicMessage: `Email provider "${type}" cannot store this configuration, because parsing what would be saved does not return what was saved. Its \`parseConfig\` must accept its own output unchanged -- derive values in \`createAdapter\` instead.`,
+    logContext: { reason: "email-provider-parse-not-a-fixed-point", type },
+  });
 }
 
 export class EmailProviderService extends BaseService {
@@ -383,27 +450,8 @@ export class EmailProviderService extends BaseService {
       // Left as one outcome: both mean the row could not be read back.
       reparsed = undefined;
     }
-    // TWO properties, and each misses what the other catches.
-    //
-    // The parsed value must SURVIVE the round trip: a `Date`, a `Map`, an
-    // `Infinity` or a class instance is written as something else, and a
-    // pass-through parser that accepts both forms then agrees with itself
-    // while the adapter receives an ISO string where a `Date` was returned.
-    // Re-parsing alone cannot see that, because both sides of it are already
-    // past the column.
-    //
-    // And re-parsing the stored form must RETURN it, which is what catches a
-    // parser that derives rather than one that loses a type.
-    if (
-      !isDeepStrictEqual(stored, unchanged) ||
-      !isDeepStrictEqual(reparsed, unchanged)
-    ) {
-      throw new NextlyError({
-        code: "BUSINESS_RULE_VIOLATION",
-        publicMessage: `Email provider "${type}" cannot store this configuration, because parsing what would be saved does not return what was saved. Its \`parseConfig\` must accept its own output unchanged -- derive values in \`createAdapter\` instead, and return only what JSON can carry.`,
-        logContext: { reason: "email-provider-parse-not-a-fixed-point", type },
-      });
-    }
+    assertNothingLost(type, stored, roundTripped);
+    assertParseIsAFixedPoint(type, reparsed, unchanged);
 
     // The VALIDATED form, not the object it was derived from. `encryptConfiguration`
     // serialises again, and returning the original would mean the value written


### PR DESCRIPTION
Completes the email lane. This is the last open item from the 2026-08-10 provider audit, and the one whose own task file recorded a proposed fix that **does not work**.

## The decision this implements

Founder, 2026-08-14: *store what JSON can carry, silently.* A parser returning a `Date` should have it coerced to an ISO string rather than have the whole save refused. The accepted cost is stated in the task file: the adapter is handed a string where the author's type says `Date`.

## Why the task file's own proposal was wrong

It suggested comparing `JSON.stringify(reparsed)` against the stored string. I implemented that in the previous lane and **7 of the suite's tests failed, in both directions**, so it was reverted and the measurement recorded. This PR starts from that measurement.

The missing distinction, which neither the old guard nor the proposal made:

- **COERCION** keeps the information in a form the column can hold. A `Date` becomes its ISO string. The decision accepts this.
- **LOSS** removes information. A key JSON drops, or a value whose entries serialisation cannot see at all. Nothing in the decision permits it, and it corrupts a configuration rather than restyling it.

The old guard refused both. The proposed comparison accepts both, and additionally refuses a harmless field reorder because string equality is order-sensitive.

## What loss actually looks like, measured against the 19 existing tests

It arrives in two shapes that need different questions, which is why one comparison could never separate them:

- **A key disappears.** `{ label: undefined }`, an array carrying named properties, a `toJSON` that discards fields. Caught by recursive key survival.
- **The key survives and the content vanishes.** A `Map`, a `Set` or a class with private fields holds its data where `JSON.stringify` cannot reach, so it serialises to `{}` while reporting no own enumerable keys to compare. A key-set check passes it. Caught by asking whether a value keeps its data in its own enumerable properties.

That second question is asked structurally rather than by constructor name: a plain object and an array expose their contents as own properties; a `Map` does not, whatever it is called.

## Changes

`findConfigurationLoss` is a new module with its own tests, so the rule is testable directly rather than only through a service that needs a database. The two verification steps in `storableConfiguration` are extracted into named assertions, one per question.

Behaviour, stated as the tests now read it:
- a `Date` is stored as its ISO string (2 cases, previously refused)
- loss is still refused, and the message now **names the field** that would be lost
- a deriving parser is still refused, compared structurally so field order is not a difference

## Verification

- `packages/nextly/src/domains/email`: **595 pass**, 45 files. The suite's own 19 round-trip cases all pass, 5 still refusing and 2 flipped per the decision.
- lint + check-types green; fallow `pass` with all four introduced counts at zero.
- **Every rule break-verified independently.** Removing the exotic-object guard fails exactly the 4 content-loss tests; removing key survival fails exactly the 4 key-loss tests; refusing coercion fails exactly the 3 `Date` tests; removing the fixed-point check fails exactly the 3 derivation tests. Each break moved only its own cases.
- The changeset is generated from `.changeset/config.json`, not copied from another changeset. That is what produced the 24-of-25 failure on the last PR.

## One finding worth a reviewer's eye

Tests 3 and 10 of the existing suite are the **same shape** — both parsers return a `Date`, both produce identical JSON on reparse. Test 10 was named `refuses a pass-through parser whose value loses type in the column`, and its own comment describes the adapter receiving an ISO string where a `Date` was returned. That is precisely the cost the founder accepted, so the decision flips both, not just the one the task file named. Reading the task file alone would have left test 10 refusing a case the decision permits.
