### PR TITLE
feat(builder): hold more than one block selected on the canvas

### DIFF
--- a/.changeset/builder-multi-select-wiring.md
+++ b/.changeset/builder-multi-select-wiring.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The page builder canvas now holds more than one block selected. Click replaces the selection, Cmd or Ctrl click adds and removes a block, and Shift click selects a run. The block the inspector is editing is drawn at full strength so it stays clear which one the panels describe.

--- a/packages/builder/src/block-toolbar.test.tsx
+++ b/packages/builder/src/block-toolbar.test.tsx
@@ -344,6 +344,8 @@ describe("a press on the toolbar and the canvas's own click handling", () => {
     if (root === null) throw new Error("expected a canvas root");
     fireEvent.click(root);
 
-    expect(editor.select).toHaveBeenCalledWith(null);
+    // With the gesture, which the canvas now reports alongside the id: a plain
+    // click on background is a "replace" with nothing to replace it with.
+    expect(editor.select).toHaveBeenCalledWith(null, "replace");
   });
 });

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -257,3 +257,181 @@ describe("the selected block is marked on its own element", () => {
     ).toBe("a");
   });
 });
+
+describe("a selection with more than one block in it", () => {
+  /*
+   * Registered here as well as in the describe above, because that one scopes
+   * its registration to itself. A `beforeAll` inside a describe does not reach
+   * a sibling, and the first version of these cases rendered nothing at all —
+   * every assertion came back an empty NodeList, which reads as the canvas
+   * marking nothing rather than as an unregistered block type.
+   */
+  beforeAll(() => {
+    clearBlocks();
+    registerBlocks(
+      [
+        {
+          name: "acme/leaf",
+          version: 1,
+          description: "A block.",
+          example: { props: {} },
+          render: ({ className }: { className: string }) =>
+            createElement("div", { className }),
+        },
+      ] as never,
+      { source: "canvas-multi-test" }
+    );
+  });
+
+  afterAll(clearBlocks);
+
+  function multi(selectedIds: readonly string[], primary: string | null) {
+    return render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [
+              { id: "a", type: "acme/leaf", version: 1, props: {} },
+              { id: "b", type: "acme/leaf", version: 1, props: {} },
+              { id: "c", type: "acme/leaf", version: 1, props: {} },
+            ],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {} } as never}
+        selectedId={primary}
+        selectedIds={selectedIds}
+      />
+    );
+  }
+
+  it("marks every selected block, not only the primary", () => {
+    const { container } = multi(["a", "c"], "a");
+
+    expect(
+      Array.from(container.querySelectorAll(`[${SELECTED_ATTRIBUTE}]`)).map(e =>
+        e.getAttribute(NODE_ID_ATTRIBUTE)
+      )
+    ).toEqual(["a", "c"]);
+  });
+
+  it("names WHICH member the panels answer for", () => {
+    // Without this a multi-selection would draw three identical outlines and
+    // the author would have no way to tell which block the inspector is
+    // editing.
+    const { container } = multi(["a", "c"], "c");
+    const marked = Array.from(
+      container.querySelectorAll(`[${SELECTED_ATTRIBUTE}]`)
+    );
+
+    expect(
+      marked.map(e => [
+        e.getAttribute(NODE_ID_ATTRIBUTE),
+        e.getAttribute(SELECTED_ATTRIBUTE),
+      ])
+    ).toEqual([
+      ["a", ""],
+      ["c", "primary"],
+    ]);
+  });
+
+  it("marks nothing outside the set, which is the control", () => {
+    // Without it, "mark everything" would pass both cases above.
+    const { container } = multi(["a"], "a");
+
+    expect(container.querySelectorAll(`[${SELECTED_ATTRIBUTE}]`).length).toBe(
+      1
+    );
+  });
+
+  it("falls back to the primary alone for a caller that passes no set", () => {
+    // Every existing host. The canvas must not decide what a selection IS, so
+    // it marks exactly what it was told and no more.
+    const { container } = render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [
+              { id: "a", type: "acme/leaf", version: 1, props: {} },
+              { id: "b", type: "acme/leaf", version: 1, props: {} },
+            ],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {} } as never}
+        selectedId="b"
+      />
+    );
+
+    const marked = Array.from(
+      container.querySelectorAll(`[${SELECTED_ATTRIBUTE}]`)
+    );
+    expect(marked.map(e => e.getAttribute(NODE_ID_ATTRIBUTE))).toEqual(["b"]);
+    expect(marked[0]?.getAttribute(SELECTED_ATTRIBUTE)).toBe("primary");
+  });
+});
+
+describe("the gesture a click's modifiers meant", () => {
+  /*
+   * Registered here as well as in the describe above, because that one scopes
+   * its registration to itself. A `beforeAll` inside a describe does not reach
+   * a sibling, and the first version of these cases rendered nothing at all —
+   * every assertion came back an empty NodeList, which reads as the canvas
+   * marking nothing rather than as an unregistered block type.
+   */
+  beforeAll(() => {
+    clearBlocks();
+    registerBlocks(
+      [
+        {
+          name: "acme/leaf",
+          version: 1,
+          description: "A block.",
+          example: { props: {} },
+          render: ({ className }: { className: string }) =>
+            createElement("div", { className }),
+        },
+      ] as never,
+      { source: "canvas-multi-test" }
+    );
+  });
+
+  afterAll(clearBlocks);
+
+  function clickable(onSelect: (id: string | null, mode: string) => void) {
+    return render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {} } as never}
+        onSelect={onSelect as never}
+      />
+    );
+  }
+
+  it("reports the mode alongside the id", () => {
+    // The mode travels with the id because only the event knows it: a caller
+    // reading modifiers off a later render's event would read a different
+    // click.
+    const onSelect = vi.fn();
+    const { container } = clickable(onSelect);
+    const block = container.querySelector(`[${NODE_ID_ATTRIBUTE}]`);
+    if (block === null) throw new Error("expected a rendered block");
+
+    fireEvent.click(block, { metaKey: true });
+    expect(onSelect).toHaveBeenCalledWith("a", "toggle");
+
+    fireEvent.click(block, { shiftKey: true });
+    expect(onSelect).toHaveBeenCalledWith("a", "extend");
+
+    fireEvent.click(block);
+    expect(onSelect).toHaveBeenCalledWith("a", "replace");
+  });
+});

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -36,6 +36,7 @@ import { cn } from "@nextlyhq/ui/utils";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import type { CanvasDragHandlers } from "./canvas-drag";
+import { selectionModeFor, type SelectionMode } from "./selection";
 
 /**
  * The class marking the canvas root, and the boundary the hit-test stops at.
@@ -129,10 +130,32 @@ export interface CanvasProps {
    * the module docblock for why this one is not optional.
    */
   siteStyles: NonNullable<PageRendererProps["siteStyles"]>;
-  /** The selected node's id, or null when the selection is empty. */
+  /**
+   * The PRIMARY selected node's id, or null when the selection is empty.
+   *
+   * The one the inspector edits. Marked `data-nx-selected="primary"` so a
+   * multi-block selection can show which member the panels answer for — with
+   * one block selected there is nothing to distinguish and the distinction
+   * costs nothing.
+   */
   selectedId?: string | null;
-  /** Raised with the clicked node's id, or null when the click hit no node. */
-  onSelect?: (id: string | null) => void;
+  /**
+   * Every selected id. Defaults to the primary alone.
+   *
+   * A separate prop rather than derived from `selectedId`, because the canvas
+   * must not decide what a selection IS — `selection.ts` does, and a canvas
+   * that reconstructed the set from one id would silently disagree with it the
+   * moment there were two.
+   */
+  selectedIds?: readonly string[];
+  /**
+   * Raised with the clicked node's id and the gesture its modifiers meant, or
+   * null when the click hit no node.
+   *
+   * The MODE travels with the id because only the event knows it, and a caller
+   * reading modifiers off a later render's event would read a different click.
+   */
+  onSelect?: (id: string | null, mode: SelectionMode) => void;
   /**
    * Everything else the renderer needs, passed through untouched.
    *
@@ -174,6 +197,7 @@ export function Canvas({
   document,
   siteStyles,
   selectedId = null,
+  selectedIds,
   onSelect,
   render,
   className,
@@ -181,6 +205,15 @@ export function Canvas({
   overlay,
 }: CanvasProps) {
   const root = useRef<HTMLDivElement | null>(null);
+
+  /*
+   * What to mark. The primary alone when a host has not adopted the set yet,
+   * which keeps every existing caller correct without a change.
+   */
+  const marked = useMemo(
+    () => selectedIds ?? (selectedId === null ? [] : [selectedId]),
+    [selectedIds, selectedId]
+  );
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       if (!onSelect) return;
@@ -191,7 +224,7 @@ export function Canvas({
       // A click on the canvas background resolves to null, which CLEARS the
       // selection rather than being ignored. Ignoring it leaves an inspector
       // showing a node the author believes they have deselected.
-      onSelect(nodeIdFromEvent(event.target));
+      onSelect(nodeIdFromEvent(event.target), selectionModeFor(event));
     },
     [onSelect]
   );
@@ -233,15 +266,24 @@ export function Canvas({
     // that declares its iterator, and this package compiles without one — so the
     // loop that reads more naturally does not type-check here.
     container.querySelectorAll(`[${NODE_ID_ATTRIBUTE}]`).forEach(element => {
-      element.toggleAttribute(
+      const id = element.getAttribute(NODE_ID_ATTRIBUTE);
+      const isSelected = id !== null && marked.includes(id);
+      if (!isSelected) {
+        element.removeAttribute(SELECTED_ATTRIBUTE);
+        return;
+      }
+      // The VALUE carries which member the panels answer for. A boolean
+      // attribute could not, and a second attribute for the primary would be a
+      // state where a block is primary without being selected.
+      element.setAttribute(
         SELECTED_ATTRIBUTE,
-        element.getAttribute(NODE_ID_ATTRIBUTE) === selectedId
+        id === selectedId ? "primary" : ""
       );
     });
     // Re-marked whenever the rendered tree changes as well as when the
     // selection does: a re-render replaces the elements, and an effect keyed on
     // the selection alone would leave the new tree carrying no marker at all.
-  }, [selectedId, page]);
+  }, [selectedId, marked, page]);
 
   return (
     <div

--- a/packages/builder/src/editor-state.ts
+++ b/packages/builder/src/editor-state.ts
@@ -31,6 +31,13 @@ import type { BlockDocument, DocumentLimits } from "@nextlyhq/blocks-engine";
 import { useCallback, useMemo, useRef, useState } from "react";
 
 import { applyOp, type BuilderOp } from "./ops";
+import {
+  EMPTY_SELECTION,
+  applySelection,
+  pruneSelection,
+  type BlockSelection,
+  type SelectionMode,
+} from "./selection";
 
 /** How deep the undo history goes before the oldest step is dropped. */
 export const MAX_HISTORY = 100;
@@ -40,8 +47,16 @@ export interface EditorState {
   document: BlockDocument;
   /** The selected node's id, or null when nothing is selected. */
   selectedId: string | null;
+  /**
+   * Everything selected, in document order, with the primary named.
+   *
+   * `selectedId` IS `selection.primary`, derived rather than stored twice: the
+   * two disagreeing would put an outline on one block and the inspector on
+   * another, and there is no render in which that is what an author meant.
+   */
+  selection: BlockSelection;
   /** Select a node, or clear the selection with null. */
-  select: (id: string | null) => void;
+  select: (id: string | null, mode?: SelectionMode) => void;
   /**
    * Apply an edit. Returns the applied op's outcome, or null when the op was
    * refused — a caller that needs to know whether its edit landed can ask,
@@ -84,7 +99,7 @@ export function useEditorState({
   limits,
 }: UseEditorStateArgs): EditorState {
   const [document, setDocument] = useState<BlockDocument>(initialDocument);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selection, setSelection] = useState<BlockSelection>(EMPTY_SELECTION);
 
   const undoStack = useRef<BuilderOp[]>([]);
   const redoStack = useRef<BuilderOp[]>([]);
@@ -142,9 +157,7 @@ export function useEditorState({
       // NEW document whether the id is still there, rather than by inspecting
       // the op — an op that removes a container removes its subtree too, and
       // the op names only the container.
-      setSelectedId(current =>
-        current !== null && !hasNode(applied.document, current) ? null : current
-      );
+      setSelection(current => pruneSelection(applied.document, current));
 
       return applied.document;
     },
@@ -171,12 +184,31 @@ export function useEditorState({
     run(op, "undo");
   }, [run]);
 
-  const select = useCallback((id: string | null) => setSelectedId(id), []);
+  /*
+   * The document is read from a REF rather than closed over.
+   *
+   * A gesture is handled by whatever handler the last render bound, and the
+   * selection rules need the document that is current when the click lands —
+   * not the one that was current when the handler was made. Closing over it
+   * would resolve a range against a stale tree, which is a wrong selection
+   * rather than a missing one.
+   */
+  const latestDocument = useRef(document);
+  latestDocument.current = document;
+
+  const select = useCallback(
+    (id: string | null, mode: SelectionMode = "replace") =>
+      setSelection(current =>
+        applySelection(latestDocument.current, current, id, mode)
+      ),
+    []
+  );
 
   return useMemo(
     () => ({
       document,
-      selectedId,
+      selectedId: selection.primary,
+      selection,
       select,
       apply,
       undo,
@@ -185,27 +217,6 @@ export function useEditorState({
       canRedo: depths.redo > 0,
       undoDepth: depths.undo,
     }),
-    [document, selectedId, select, apply, undo, redo, depths]
+    [document, selection, select, apply, undo, redo, depths]
   );
-}
-
-/**
- * Whether a node id is anywhere in the document.
- *
- * An explicit walk rather than the engine's tree helpers, because this asks the
- * cheapest possible question — presence — and stops at the first hit. The
- * helpers that find a node also compute its path and parent, which nothing here
- * reads.
- */
-function hasNode(doc: BlockDocument, id: string): boolean {
-  const stack = [...doc.nodes];
-  while (stack.length > 0) {
-    const node = stack.pop();
-    if (node === undefined) continue;
-    if (node.id === id) return true;
-    if (node.slots !== undefined) {
-      for (const children of Object.values(node.slots)) stack.push(...children);
-    }
-  }
-  return false;
 }

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -273,7 +273,7 @@ export {
   normalizeSelection,
   pruneSelection,
   rangeBetween,
-  type Selection,
+  type BlockSelection,
   type SelectionMode,
 } from "./selection";
 

--- a/packages/builder/src/selection.test.ts
+++ b/packages/builder/src/selection.test.ts
@@ -26,7 +26,8 @@ import {
   normalizeSelection,
   pruneSelection,
   rangeBetween,
-  type Selection,
+  selectionModeFor,
+  type BlockSelection,
 } from "./selection";
 
 function node(id: string, slots?: Record<string, BlockNode[]>): BlockNode {
@@ -58,7 +59,7 @@ function tree(): BlockDocument {
   ]);
 }
 
-function selection(ids: string[], primary: string | null): Selection {
+function selection(ids: string[], primary: string | null): BlockSelection {
   return { ids, primary };
 }
 
@@ -152,6 +153,33 @@ describe("rangeBetween", () => {
 
   it("answers with nothing for an id the document lost", () => {
     expect(rangeBetween(tree(), "a", "gone")).toEqual([]);
+  });
+});
+
+describe("selectionModeFor", () => {
+  const none = { shiftKey: false, metaKey: false, ctrlKey: false };
+
+  it("reads a plain click as replace", () => {
+    expect(selectionModeFor(none)).toBe("replace");
+  });
+
+  it("reads either platform's toggle modifier", () => {
+    // Both, deliberately: a Mac author presses Command and a Windows author
+    // presses Control, and neither ever presses the other's.
+    expect(selectionModeFor({ ...none, metaKey: true })).toBe("toggle");
+    expect(selectionModeFor({ ...none, ctrlKey: true })).toBe("toggle");
+  });
+
+  it("reads shift as extend", () => {
+    expect(selectionModeFor({ ...none, shiftKey: true })).toBe("extend");
+  });
+
+  it("prefers extend when both are held", () => {
+    // A slip, not a third gesture. Extending is the one whose result is visible
+    // and undone by a plain click.
+    expect(
+      selectionModeFor({ shiftKey: true, metaKey: true, ctrlKey: true })
+    ).toBe("extend");
   });
 });
 

--- a/packages/builder/src/selection.ts
+++ b/packages/builder/src/selection.ts
@@ -50,7 +50,7 @@ import { type BlockDocument, type BlockNode } from "@nextlyhq/blocks-engine";
 export type SelectionMode = "replace" | "toggle" | "extend";
 
 /** The selection: what is in it, and which one the surfaces answer for. */
-export interface Selection {
+export interface BlockSelection {
   /** Every selected id, in document order, outermost only. */
   readonly ids: readonly string[];
   /**
@@ -63,8 +63,36 @@ export interface Selection {
   readonly primary: string | null;
 }
 
+/** The modifier keys a pointer gesture carried. */
+export interface SelectionModifiers {
+  readonly shiftKey: boolean;
+  readonly metaKey: boolean;
+  readonly ctrlKey: boolean;
+}
+
+/**
+ * Which gesture a click's modifiers mean.
+ *
+ * **Shift outranks the toggle modifier**, because a shift+mod click is a slip
+ * rather than a third gesture, and extending is the one whose result an author
+ * can see and undo with a plain click.
+ *
+ * **Both Meta and Control toggle.** Resolving the platform would be the
+ * apparently-correct thing and is not available: the shortcut manager's
+ * `detectApplePlatform` is not on `@nextlyhq/ui`'s public entry, and spelling
+ * the platform a second time here would let this disagree with the keystrokes.
+ * Accepting either is what every web application does, and it is right rather
+ * than merely convenient — a Mac author presses Command, a Windows author
+ * presses Control, and neither ever presses the other's.
+ */
+export function selectionModeFor(modifiers: SelectionModifiers): SelectionMode {
+  if (modifiers.shiftKey) return "extend";
+  if (modifiers.metaKey || modifiers.ctrlKey) return "toggle";
+  return "replace";
+}
+
 /** Nothing selected. */
-export const EMPTY_SELECTION: Selection = { ids: [], primary: null };
+export const EMPTY_SELECTION: BlockSelection = { ids: [], primary: null };
 
 /**
  * Every id in the document, in the order a reader meets them.
@@ -226,9 +254,9 @@ function slotListsOf(document: BlockDocument, parentId: string): BlockNode[][] {
  */
 function toggled(
   document: BlockDocument,
-  current: Selection,
+  current: BlockSelection,
   targetId: string
-): Selection {
+): BlockSelection {
   const has = current.ids.includes(targetId);
   const ids = normalizeSelection(
     document,
@@ -251,9 +279,9 @@ function toggled(
  */
 function extended(
   document: BlockDocument,
-  current: Selection,
+  current: BlockSelection,
   targetId: string
-): Selection {
+): BlockSelection {
   if (current.primary === null) return replaced(targetId);
   const run = rangeBetween(document, current.primary, targetId);
   // No contiguous run reaches the target — across two slots of one parent, for
@@ -264,7 +292,7 @@ function extended(
 }
 
 /** One block, selected on its own. */
-function replaced(targetId: string): Selection {
+function replaced(targetId: string): BlockSelection {
   return { ids: [targetId], primary: targetId };
 }
 
@@ -284,7 +312,7 @@ function replaced(targetId: string): Selection {
 function withPrimary(
   ids: readonly string[],
   preferred: string | null
-): Selection {
+): BlockSelection {
   if (ids.length === 0) return EMPTY_SELECTION;
   return {
     ids,
@@ -308,10 +336,10 @@ function withPrimary(
  */
 export function applySelection(
   document: BlockDocument,
-  current: Selection,
+  current: BlockSelection,
   targetId: string | null,
   mode: SelectionMode = "replace"
-): Selection {
+): BlockSelection {
   if (targetId === null) return EMPTY_SELECTION;
   if (pathOf(document, targetId).length === 0) return current;
 
@@ -328,8 +356,8 @@ export function applySelection(
  */
 export function pruneSelection(
   document: BlockDocument,
-  selection: Selection
-): Selection {
+  selection: BlockSelection
+): BlockSelection {
   const ids = normalizeSelection(document, selection.ids);
   if (ids.length === 0) return EMPTY_SELECTION;
   const primary =

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -263,6 +263,23 @@
 }
 
 /*
+ * The rest of a multi-block selection.
+ *
+ * Thinner rather than a different colour. Colour would have to mean something,
+ * and there is no second meaning here — every one of these blocks is selected
+ * and an action applies to all of them. What the author needs to see is which
+ * one the inspector is describing, and weight says that without implying two
+ * kinds of selected.
+ *
+ * With one block selected this rule matches nothing: a lone selection is always
+ * the primary, so nothing changes for the case the editor spends most of its
+ * time in.
+ */
+.nx-canvas [data-nx-selected=""] {
+  outline-width: 1px;
+}
+
+/*
  * A block that draws nothing still has to be selectable and visible when it is.
  * `core/spacer` is deliberate empty space and `core/divider` is a single rule,
  * so an outline is the only thing distinguishing "selected" from "not there" —

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -300,6 +300,7 @@ function BlocksEditor({
             document={editor.document}
             siteStyles={siteSheet()}
             selectedId={editor.selectedId}
+            selectedIds={editor.selection.ids}
             onSelect={editor.select}
             dragHandlers={drag.handlers}
             // Both pieces of chrome go through the canvas rather than beside it,


### PR DESCRIPTION
**Step 2 of 4 for B-10.** #1036 added the rules; this makes the editor hold a selection and the canvas report gestures. First step with behaviour an author can see, so it is verified in a browser.

## The decision that keeps this small

**`selectedId` is DERIVED from `selection.primary`, not stored beside it.** The two disagreeing would put an outline on one block and the inspector on another, and there is no render in which that is what an author meant. It is also what keeps the **thirteen other modules** that read `selectedId` correct without touching them — the toolbar, the breadcrumb, the layers panel, the inspector, the command list and the keyboard verbs all still ask "which block?" and still get one.

## The marker carries a value now

`data-nx-selected` reads `"primary"` on the block the panels answer for and `""` on the rest. A boolean attribute could not say which member is primary, and a *second* attribute for it would make "primary but not selected" representable.

Visually the primary keeps the 2px outline and the rest drop to 1px. Weight rather than colour, because colour would have to mean something and there is no second meaning — every one of those blocks is selected and an action applies to all of them. With one block selected the secondary rule matches nothing, so the case the editor spends most of its time in is byte-identical.

## A rename, and why it is worth the churn one day later

`Selection` → **`BlockSelection`**. `Selection` is a DOM global — the browser's text selection — and in a package this full of DOM code the short name reads as that one. This was not theoretical: TypeScript silently resolved my type to the global while an import was missing, and reported `Property 'primary' does not exist on type 'Selection'`. One day old, `@experimental`, no external consumers.

## Two other decisions

**Both Meta and Control toggle.** Resolving the platform would be the apparently-correct thing and is unavailable — the shortcut manager's `detectApplePlatform` is not on `@nextlyhq/ui`'s public entry, and spelling the platform a second time here would let the pointer grammar disagree with the keystrokes. Accepting either is right rather than merely convenient: a Mac author presses Command, a Windows author presses Control, and neither presses the other's.

**The document is read from a ref inside `select`.** A range must resolve against the tree that is current when the click lands, not the one that was current when the handler was bound. Closing over it gives a *wrong* selection rather than a missing one.

## Verified in a browser

Playground on `:3123`, auth control asserted first. Fixture: `box` containing `kid`, and a sibling `tail`.

| gesture | result |
| --- | --- |
| click `kid` | `kid:primary` |
| Cmd+click `tail` | `kid:(secondary)`, `tail:primary` |
| Cmd+click `tail` again | `kid:primary` — toggled out, primary handed back |
| **Cmd+click `box`, the PARENT of selected `kid`** | **`box:primary` alone** — outermost normalisation, live |
| click `tail` | `tail:primary` — replaces |
| Escape | nothing selected |
| click `box`, Shift+click `tail` | `box:primary`, `tail:(secondary)` — anchor stays primary |
| computed outlines | `box 2px`, `tail 1px` |

**Regression controls:** the toolbar still appears, the inspector still follows the primary (`Kid`), `Cmd+D` still duplicates and `Cmd+Z` still undoes. Console has exactly **one** error-level line — the pre-existing `["autosave-recovery",…]` one, present on main.

## Verified in tests

`packages/builder` **746 tests**, `plugin-page-builder` 61, types and lint clean on both.

New canvas cases include the control that a "mark everything" implementation would fail, and the case that a host passing no set still gets exactly its primary marked.

## Two process notes

An existing test caught the `onSelect` signature change rather than my noticing it — it asserted `select` was called with `null` and now the gesture travels alongside. Updated to assert the new contract.

`plugin-page-builder`'s `check-types` failed once against a **stale `packages/builder/dist`** after I edited the builder without rebuilding — the cross-package gate reads `dist`, not source. Rebuilt and re-ran; that is why the gate order matters.

Fallow's `new-only` gate returns **`verdict: pass`** with `complexity_introduced: 0`. It reports one advisory styling finding, marked `warn` and `inherited styling debt from ba93cf1425b7` — unlike #1036's, which was error-severity and genuinely mine.
