### PR TITLE
feat(builder): apply several ops as one atomic action

### DIFF
--- a/.changeset/builder-atomic-op-groups.md
+++ b/.changeset/builder-atomic-op-groups.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The page builder can now make several changes as one action, so an edit that touches more than one block takes a single undo to reverse and either happens completely or not at all.

--- a/packages/builder/src/editor-state.test.ts
+++ b/packages/builder/src/editor-state.test.ts
@@ -210,3 +210,152 @@ describe("selection", () => {
     expect(result.current.selectedId).toBe("a");
   });
 });
+
+describe("applying several ops as one action", () => {
+  /** Three top-level blocks, so a group can act on more than one of them. */
+  function three() {
+    return renderHook(() =>
+      useEditorState({
+        initialDocument: doc([node("a"), node("b"), node("c")]),
+      })
+    );
+  }
+
+  it("applies every op in the group", () => {
+    const { result } = three();
+
+    act(() => {
+      result.current.applyAll([
+        { kind: "remove", id: "a" },
+        { kind: "remove", id: "c" },
+      ]);
+    });
+
+    expect(ids(result.current.document)).toEqual(["b"]);
+  });
+
+  it("costs ONE undo, not one per op", () => {
+    /*
+     * The property the whole change exists for. "Delete these two" is one thing
+     * an author did, and two presses to take it back reads as the history being
+     * wrong rather than as a design.
+     */
+    const { result } = three();
+
+    act(() => {
+      result.current.applyAll([
+        { kind: "remove", id: "a" },
+        { kind: "remove", id: "c" },
+      ]);
+    });
+    expect(result.current.undoDepth).toBe(1);
+
+    act(() => result.current.undo());
+
+    expect(ids(result.current.document)).toEqual(["a", "b", "c"]);
+    expect(result.current.undoDepth).toBe(0);
+  });
+
+  it("redoes the whole group as one action too", () => {
+    const { result } = three();
+
+    act(() => {
+      result.current.applyAll([
+        { kind: "remove", id: "a" },
+        { kind: "remove", id: "c" },
+      ]);
+    });
+    act(() => result.current.undo());
+    act(() => result.current.redo());
+
+    expect(ids(result.current.document)).toEqual(["b"]);
+    expect(result.current.undoDepth).toBe(1);
+  });
+
+  it("commits NOTHING when any op in the group is refused", () => {
+    /*
+     * Atomicity, and the case that separates a group from a loop of applies.
+     * Removing four of six blocks because the fifth was refused leaves a
+     * document the author never asked for and that no single undo can leave.
+     */
+    const { result } = three();
+
+    let returned: unknown;
+    act(() => {
+      returned = result.current.applyAll([
+        { kind: "remove", id: "a" },
+        { kind: "remove", id: "does-not-exist" },
+      ]);
+    });
+
+    expect(returned).toBeNull();
+    expect(ids(result.current.document)).toEqual(["a", "b", "c"]);
+    // And no history either — a group that changed nothing must not be
+    // undoable, or one press of undo would appear to do nothing.
+    expect(result.current.undoDepth).toBe(0);
+  });
+
+  it("records nothing for an empty group", () => {
+    /*
+     * A delete with an empty selection. An entry here would be an undo that
+     * appears to do nothing, which reads as the history being broken.
+     *
+     * Asserted by making a REAL edit afterwards, not by reading `undoDepth`
+     * straight after the empty call. The empty case returns before the depth
+     * is published, so a stack corrupted by it stays invisible until something
+     * else republishes — which is exactly what a later edit does, and is how a
+     * stub that pushed an empty entry passed this test in its first form.
+     */
+    const { result } = three();
+
+    act(() => {
+      result.current.applyAll([]);
+    });
+    expect(ids(result.current.document)).toEqual(["a", "b", "c"]);
+
+    act(() => {
+      result.current.apply({ kind: "remove", id: "b" });
+    });
+
+    expect(result.current.undoDepth).toBe(1);
+
+    act(() => result.current.undo());
+
+    expect(ids(result.current.document)).toEqual(["a", "b", "c"]);
+    expect(result.current.canUndo).toBe(false);
+  });
+
+  it("undoes a group in reverse, so each inverse meets the tree it expects", () => {
+    /*
+     * The ordering case. Two inserts at fixed indices only reverse correctly
+     * when the LAST one is undone first — applied in collection order the first
+     * inverse would meet a document the second insert had already shifted.
+     */
+    const { result } = three();
+
+    act(() => {
+      result.current.applyAll([
+        { kind: "insert", node: node("x"), at: { index: 0 } },
+        { kind: "insert", node: node("y"), at: { index: 2 } },
+      ]);
+    });
+    expect(ids(result.current.document)).toEqual(["x", "a", "y", "b", "c"]);
+
+    act(() => result.current.undo());
+
+    expect(ids(result.current.document)).toEqual(["a", "b", "c"]);
+  });
+
+  it("a single apply is still one undo, which is the control", () => {
+    // Without this, "one entry per group" would pass against a store that had
+    // stopped recording single edits at all.
+    const { result } = three();
+
+    act(() => {
+      result.current.apply({ kind: "remove", id: "b" });
+    });
+
+    expect(result.current.undoDepth).toBe(1);
+    expect(ids(result.current.document)).toEqual(["a", "c"]);
+  });
+});

--- a/packages/builder/src/editor-state.ts
+++ b/packages/builder/src/editor-state.ts
@@ -63,6 +63,18 @@ export interface EditorState {
    * rather than comparing documents afterwards.
    */
   apply: (op: BuilderOp) => BlockDocument | null;
+  /**
+   * Apply several ops as ONE action, or nothing at all.
+   *
+   * For an edit whose subject is a multi-block selection. Atomic — a group that
+   * failed halfway would leave a document the author never asked for — and it
+   * costs exactly one undo, because "delete these six" is one thing an author
+   * did and six presses to take it back would read as the history being wrong.
+   *
+   * Returns the new document, or `null` when any op was refused and nothing was
+   * committed.
+   */
+  applyAll: (ops: readonly BuilderOp[]) => BlockDocument | null;
   undo: () => void;
   redo: () => void;
   canUndo: boolean;
@@ -101,8 +113,8 @@ export function useEditorState({
   const [document, setDocument] = useState<BlockDocument>(initialDocument);
   const [selection, setSelection] = useState<BlockSelection>(EMPTY_SELECTION);
 
-  const undoStack = useRef<BuilderOp[]>([]);
-  const redoStack = useRef<BuilderOp[]>([]);
+  const undoStack = useRef<BuilderOp[][]>([]);
+  const redoStack = useRef<BuilderOp[][]>([]);
   // Mirrors the stack lengths so the flags below are STATE and re-render when
   // they change. Reading `undoStack.current.length` directly would leave an
   // undo button disabled after the first edit, because a ref mutation does not
@@ -118,17 +130,59 @@ export function useEditorState({
    * a refused op does, which is nothing at all: no state change, no history
    * entry, and the caller told.
    */
+  /**
+   * Apply a GROUP of ops as one action.
+   *
+   * ## Atomic, and that is the point
+   *
+   * Every op is folded onto a WORKING document and nothing is committed until
+   * all of them have succeeded. A group that failed halfway would leave the
+   * document in a state the author never asked for and no single undo could
+   * leave — deleting four of six blocks because the fifth was locked is worse
+   * than deleting none.
+   *
+   * ## One group, one undo
+   *
+   * The inverses are collected in REVERSE order and pushed as a single stack
+   * entry. Undo granularity belongs to the history rather than to the document
+   * format: the op vocabulary stays four flat kinds, which matters because ops
+   * are persisted in a `json()` column and a nested "batch" op would make every
+   * reader of that column understand recursion.
+   *
+   * A single op is a group of one, so there is one code path rather than a fast
+   * path and a batch path that can drift.
+   */
   const run = useCallback(
-    (op: BuilderOp, into: "undo" | "redo" | "new"): BlockDocument | null => {
-      let applied;
-      try {
-        applied = applyOp(document, op, limits);
-      } catch {
-        // A refused op is an ordinary outcome, not a crash: an insert past a
-        // cap, a move onto a node that no longer exists, an update to a node a
-        // concurrent edit removed. The caller decides what to say about it.
-        return null;
+    (
+      ops: readonly BuilderOp[],
+      into: "undo" | "redo" | "new"
+    ): BlockDocument | null => {
+      // Nothing to do, and nothing to record. An empty group must NOT push an
+      // entry: that would be an undo that appears to do nothing, which reads as
+      // the history being broken.
+      if (ops.length === 0) return document;
+
+      let working = document;
+      const inverses: BuilderOp[] = [];
+      for (const op of ops) {
+        let applied;
+        try {
+          applied = applyOp(working, op, limits);
+        } catch {
+          // A refused op is an ordinary outcome, not a crash: an insert past a
+          // cap, a move onto a node that no longer exists, an update to a node
+          // a concurrent edit removed. The caller decides what to say about it.
+          // Nothing is committed — see the atomicity note above.
+          return null;
+        }
+        working = applied.document;
+        // Front, so undoing the group runs the LAST op's inverse first. Applied
+        // in the order they were collected, each inverse would meet a document
+        // the later ops had already changed.
+        inverses.unshift(applied.inverse);
       }
+
+      const applied = { document: working, inverse: inverses };
 
       if (into === "new") {
         undoStack.current.push(applied.inverse);
@@ -164,24 +218,29 @@ export function useEditorState({
     [document, limits]
   );
 
-  const apply = useCallback((op: BuilderOp) => run(op, "new"), [run]);
+  const apply = useCallback((op: BuilderOp) => run([op], "new"), [run]);
+
+  const applyAll = useCallback(
+    (ops: readonly BuilderOp[]) => run(ops, "new"),
+    [run]
+  );
 
   const undo = useCallback(() => {
-    const op = undoStack.current.pop();
-    if (op === undefined) return;
+    const group = undoStack.current.pop();
+    if (group === undefined) return;
     // Popped before running, and NOT pushed back on failure. A refused undo
     // means the inverse no longer applies to this document, so keeping it would
     // leave a step that fails every time it is reached — an undo button that
     // does nothing and never clears.
     setDepths(d => ({ ...d, undo: undoStack.current.length }));
-    run(op, "redo");
+    run(group, "redo");
   }, [run]);
 
   const redo = useCallback(() => {
-    const op = redoStack.current.pop();
-    if (op === undefined) return;
+    const group = redoStack.current.pop();
+    if (group === undefined) return;
     setDepths(d => ({ ...d, redo: redoStack.current.length }));
-    run(op, "undo");
+    run(group, "undo");
   }, [run]);
 
   /*
@@ -211,12 +270,13 @@ export function useEditorState({
       selection,
       select,
       apply,
+      applyAll,
       undo,
       redo,
       canUndo: depths.undo > 0,
       canRedo: depths.redo > 0,
       undoDepth: depths.undo,
     }),
-    [document, selection, select, apply, undo, redo, depths]
+    [document, selection, select, apply, applyAll, undo, redo, depths]
   );
 }


### PR DESCRIPTION
**Step 3a of B-10.** Wiring delete, duplicate and lock to a multi-block selection turned out to be blocked on something the store could not do, so this is that thing on its own.

## The blocker

The undo stack held **one entry per op**. Deleting six selected blocks would have cost six presses of undo to reverse — and "delete these six" is one thing the author did. Six presses reads as the history being wrong rather than as a design.

## The decision: group in the HISTORY, not in the op format

The obvious alternative is a `{ kind: "batch", ops: [...] }` op. Rejected, because **ops are persisted** — the tracker records that they live in a `json()` column — so a nested op would make every reader of that column understand recursion, forever, to solve a problem that only exists while an author is pressing undo.

Undo granularity is a history concern. So the op vocabulary stays four flat kinds and the *stack* holds groups. That is the same split ProseMirror makes between flat steps and grouped transactions.

**A single op is a group of one.** `apply(op)` is `run([op])`, so there is one code path rather than a fast path and a batch path that drift. All 746 existing tests pass untouched, which is the evidence that the single-edit behaviour is unchanged rather than re-implemented.

## Atomic, and that is the point

Every op folds onto a working document; nothing is committed until all of them succeed. Deleting four of six blocks because the fifth was refused leaves a document the author never asked for and that **no single undo can leave** — the partial state is not on the history at all.

## Inverses are collected front-first

So undo runs the *last* op's inverse first. Applied in collection order, each inverse would meet a document the later ops had already changed. The test that pins this uses two inserts at fixed indices, which is the case where the two orders actually differ.

## Verified

`packages/builder` **753 tests**, `plugin-page-builder` 61, types and lint clean on both. Fallow's `new-only` gate checked **before** opening: `verdict: pass`, everything `introduced: 0`.

Four-part stub loop:

| stub | outcome |
| --- | --- |
| control, none applied | green |
| commit the partial work instead of nothing | fails `commits NOTHING when any op in the group is refused` **and** the pre-existing `returns null and changes NOTHING when the op is refused` |
| collect inverses in applied order | fails `undoes a group in reverse, so each inverse meets the tree it expects` |
| record an entry for an empty group | fails `records nothing for an empty group` |

**The last one needed the test rewritten before it caught anything.** My first version read `undoDepth` straight after the empty call — but the empty case returns *before* the depth is published, so a corrupted stack stayed invisible and the stub passed. The test now makes a real edit afterwards, which republishes the depth and exposes the stale entry. That is the third time a stub has found a test measuring the wrong thing rather than the code being wrong.

## Next

3b wires delete, duplicate and lock onto the selection through `applyAll`, which is now a one-line change per verb instead of a design question.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for applying multiple editor operations as a single grouped change.
  * Grouped changes can be undone or redone in one step.
  * Failed grouped operations are rolled back atomically without committing partial changes.

* **Bug Fixes**
  * Preserved consistent single-step undo and redo behavior for individual edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->