### PR TITLE
feat(builder): delete and duplicate every selected block as one action

### DIFF
--- a/.changeset/builder-selection-operations.md
+++ b/.changeset/builder-selection-operations.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Delete and duplicate now act on every selected block at once in the page builder, as a single action that one undo reverses. A locked block in the selection stops the whole delete and says which one.

--- a/packages/builder/src/block-toolbar.test.tsx
+++ b/packages/builder/src/block-toolbar.test.tsx
@@ -86,8 +86,15 @@ function editorSpy(
   return {
     document: doc,
     selectedId,
+    // The set the structural verbs read. Derived from the primary so every case
+    // here keeps describing one selected block, which is what they assert.
+    selection: {
+      ids: selectedId === null ? [] : [selectedId],
+      primary: selectedId,
+    },
     select: vi.fn(),
     apply: vi.fn(() => doc),
+    applyAll: vi.fn(() => doc),
     undo: vi.fn(),
     redo: vi.fn(),
     canUndo: false,
@@ -169,9 +176,11 @@ describe("BlockToolbar", () => {
 
     fireEvent.click(screen.getByLabelText("Duplicate"));
 
-    expect(editor.apply).toHaveBeenCalledWith(
-      expect.objectContaining({ kind: "insert", at: { index: 1 } })
-    );
+    // A group, because the verbs plan across the selection and one block is a
+    // selection of one.
+    expect(editor.applyAll).toHaveBeenCalledWith([
+      expect.objectContaining({ kind: "insert", at: { index: 1 } }),
+    ]);
     // Selection follows the copy, which is the keyboard duplicate's behaviour
     // and therefore has to be this one's.
     expect(editor.select).toHaveBeenCalled();
@@ -206,7 +215,7 @@ describe("BlockToolbar", () => {
 
     fireEvent.click(screen.getByLabelText("Delete"));
 
-    expect(editor.apply).not.toHaveBeenCalled();
+    expect(editor.applyAll).not.toHaveBeenCalled();
     expect(screen.getByRole("status").textContent).toBe(
       "Leaf is locked. Unlock it to delete it."
     );

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -259,6 +259,25 @@ export {
 } from "./duplicate-block";
 
 /**
+ * @experimental Delete, duplicate and lock across a whole selection.
+ *
+ * From this entry because each is a plain function returning ops. An agent
+ * asked to "remove these six" needs the same plan the editor makes — including
+ * that one lock refuses the whole group, and that copies must be planned in
+ * reverse so each lands beside its own original.
+ */
+export {
+  isRefusal,
+  selectionDeletion,
+  selectionDuplication,
+  selectionLock,
+  type SelectionDuplication,
+  type SelectionEdit,
+  type SelectionPlan,
+  type SelectionRefusal,
+} from "./selection-ops";
+
+/**
  * @experimental What "the selection" is once it can hold more than one block.
  *
  * From this entry because every part of it is a plain function over a document.

--- a/packages/builder/src/keyboard-actions.test.tsx
+++ b/packages/builder/src/keyboard-actions.test.tsx
@@ -44,21 +44,32 @@ function pair(): BlockDocument {
   ]);
 }
 
-function editorSpy(
-  doc: BlockDocument,
-  selectedId: string | null
-): EditorState & { apply: ReturnType<typeof vi.fn> } {
+type EditorSpy = EditorState & {
+  apply: ReturnType<typeof vi.fn>;
+  applyAll: ReturnType<typeof vi.fn>;
+  select: ReturnType<typeof vi.fn>;
+};
+
+function editorSpy(doc: BlockDocument, selectedId: string | null): EditorSpy {
   return {
     document: doc,
     selectedId,
+    // The set the structural verbs now read. Derived from the primary here so
+    // every existing case keeps describing one selected block, which is what
+    // they were written to describe.
+    selection: {
+      ids: selectedId === null ? [] : [selectedId],
+      primary: selectedId,
+    },
     select: vi.fn(),
     apply: vi.fn(() => doc),
+    applyAll: vi.fn(() => doc),
     undo: vi.fn(),
     redo: vi.fn(),
     canUndo: false,
     canRedo: false,
     undoDepth: 0,
-  } as unknown as EditorState & { apply: ReturnType<typeof vi.fn> };
+  } as unknown as EditorSpy;
 }
 
 /**
@@ -399,8 +410,8 @@ describe("useBlockKeyboardActions", () => {
 
     press("Delete");
 
-    expect(editor.apply).toHaveBeenCalledTimes(1);
-    const op = editor.apply.mock.calls[0][0];
+    expect(editor.applyAll).toHaveBeenCalledTimes(1);
+    const op = editor.applyAll.mock.calls[0][0][0];
     expect(op.kind).toBe("remove");
     expect(op.id).toBe("a");
   });
@@ -413,7 +424,7 @@ describe("useBlockKeyboardActions", () => {
 
     press("Backspace");
 
-    expect(editor.apply.mock.calls[0][0].kind).toBe("remove");
+    expect(editor.applyAll.mock.calls[0][0][0].kind).toBe("remove");
   });
 
   it("moves the selection forward, not backward", () => {
@@ -439,7 +450,7 @@ describe("useBlockKeyboardActions", () => {
     // Moving it first would leave the author pointed at a neighbour while the
     // block they asked to delete is still on the page.
     const editor = editorSpy(pair(), "a");
-    editor.apply.mockReturnValue(null);
+    editor.applyAll.mockReturnValue(null);
     mount(editor);
 
     press("Delete");
@@ -478,8 +489,8 @@ describe("useBlockKeyboardActions", () => {
 
     press("d", { ctrlKey: true });
 
-    expect(editor.apply).toHaveBeenCalledTimes(1);
-    const op = editor.apply.mock.calls[0][0];
+    expect(editor.applyAll).toHaveBeenCalledTimes(1);
+    const op = editor.applyAll.mock.calls[0][0][0];
     expect(op.kind).toBe("insert");
     // Immediately after the original, not at the end of the page.
     expect(op.at).toEqual({ index: 1 });
@@ -493,7 +504,7 @@ describe("useBlockKeyboardActions", () => {
 
     press("d", { ctrlKey: true });
 
-    expect(editor.apply.mock.calls[0][0].node.id).not.toBe("a");
+    expect(editor.applyAll.mock.calls[0][0][0].node.id).not.toBe("a");
   });
 
   it("selects the copy, not the original", () => {
@@ -505,8 +516,10 @@ describe("useBlockKeyboardActions", () => {
 
     press("d", { ctrlKey: true });
 
-    const copyId = editor.apply.mock.calls[0][0].node.id;
-    expect(editor.select).toHaveBeenCalledWith(copyId);
+    const copyId = editor.applyAll.mock.calls[0][0][0].node.id;
+    // Through the same grammar a click uses, so there is no second way to build
+    // a selection: one replace, then a toggle per further copy.
+    expect(editor.select).toHaveBeenCalledWith(copyId, "replace");
   });
 
   it("announces the duplication and the way back", () => {
@@ -538,8 +551,8 @@ describe("useBlockKeyboardActions", () => {
 
     press("d", { ctrlKey: true });
 
-    expect(editor.apply).toHaveBeenCalledTimes(1);
-    expect(editor.apply.mock.calls[0][0].kind).toBe("insert");
+    expect(editor.applyAll).toHaveBeenCalledTimes(1);
+    expect(editor.applyAll.mock.calls[0][0][0].kind).toBe("insert");
   });
 
   it("does nothing with no selection", () => {
@@ -550,7 +563,7 @@ describe("useBlockKeyboardActions", () => {
 
     press("d", { ctrlKey: true });
 
-    expect(editor.apply).not.toHaveBeenCalled();
+    expect(editor.applyAll).not.toHaveBeenCalled();
   });
 
   it("names a block by the name its author gave it", () => {
@@ -620,7 +633,7 @@ describe("useBlockKeyboardActions", () => {
 
     press("Delete");
 
-    expect(editor.apply).not.toHaveBeenCalled();
+    expect(editor.applyAll).not.toHaveBeenCalled();
     expect(screen.getByRole("status").textContent ?? "").toMatch(
       /is locked\. unlock it to delete it/i
     );
@@ -656,7 +669,7 @@ describe("useBlockKeyboardActions", () => {
 
     press("Delete");
 
-    expect(editor.apply).not.toHaveBeenCalled();
+    expect(editor.applyAll).not.toHaveBeenCalled();
     expect(screen.getByRole("status").textContent ?? "").toMatch(
       /contains .*which is locked/i
     );
@@ -683,9 +696,11 @@ describe("useBlockKeyboardActions", () => {
 
     press("Delete");
 
-    expect(editor.apply).toHaveBeenCalledWith(
-      expect.objectContaining({ kind: "remove", id: "wrap" })
-    );
+    // A GROUP now, even for one block: the verbs plan across the selection and
+    // a single block is a selection of one.
+    expect(editor.applyAll).toHaveBeenCalledWith([
+      expect.objectContaining({ kind: "remove", id: "wrap" }),
+    ]);
   });
 
   it("says how many blocks a container takes with it", () => {
@@ -791,6 +806,96 @@ describe("useBlockKeyboardActions", () => {
       "Paragraph deleted"
     );
     clearBlocks();
+  });
+});
+
+describe("the verbs act on the WHOLE selection", () => {
+  /** An editor with three top-level blocks and two of them selected. */
+  function twoSelected() {
+    return {
+      ...editorSpy(
+        documentOf([
+          { id: "a", type: "acme/text", version: 1, props: {} },
+          { id: "b", type: "acme/text", version: 1, props: {} },
+          { id: "c", type: "acme/text", version: 1, props: {} },
+        ]),
+        "a"
+      ),
+      selection: { ids: ["a", "c"], primary: "a" },
+    } as ReturnType<typeof editorSpy>;
+  }
+
+  it("deletes every selected block in ONE group", () => {
+    // One group, so one undo. Two separate applies would cost two presses to
+    // take back something the author did once.
+    const editor = twoSelected();
+    mount(editor);
+
+    press("Delete");
+
+    expect(editor.applyAll).toHaveBeenCalledTimes(1);
+    expect(
+      editor.applyAll.mock.calls[0][0].map((op: { id: string }) => op.id)
+    ).toEqual(["a", "c"]);
+  });
+
+  it("counts the blocks in what it says, rather than naming one", () => {
+    // "Hero title deleted" would be wrong and confusing when three went.
+    const editor = twoSelected();
+    mount(editor);
+
+    press("Delete");
+
+    expect(screen.getByRole("status").textContent).toContain(
+      "2 blocks deleted"
+    );
+  });
+
+  it("duplicates every selected block and selects the copies", () => {
+    const editor = twoSelected();
+    mount(editor);
+
+    press("d", { ctrlKey: true });
+
+    expect(editor.applyAll).toHaveBeenCalledTimes(1);
+    expect(editor.applyAll.mock.calls[0][0]).toHaveLength(2);
+    // One replace then one toggle: the copies become the selection through the
+    // same grammar a click uses.
+    expect(editor.select).toHaveBeenCalledWith(expect.any(String), "replace");
+    expect(editor.select).toHaveBeenCalledWith(expect.any(String), "toggle");
+  });
+
+  it("refuses the whole delete when ONE selected block is locked", () => {
+    /*
+     * Atomic: there is no half-done delete to fall back to. Silently skipping
+     * the locked one would leave an author who selected two blocks looking at
+     * one they did not notice surviving.
+     */
+    const editor = {
+      ...editorSpy(
+        documentOf([
+          { id: "a", type: "acme/text", version: 1, props: {} },
+          {
+            id: "c",
+            type: "acme/text",
+            version: 1,
+            props: {},
+            locked: true,
+            name: "Pinned",
+          },
+        ] as never),
+        "a"
+      ),
+      selection: { ids: ["a", "c"], primary: "a" },
+    } as ReturnType<typeof editorSpy>;
+    mount(editor);
+
+    press("Delete");
+
+    expect(editor.applyAll).not.toHaveBeenCalled();
+    expect(screen.getByRole("status").textContent).toBe(
+      "Pinned is locked. Unlock it to delete it."
+    );
   });
 });
 

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -20,13 +20,10 @@
  * @module keyboard-actions
  */
 
-import { findNode } from "@nextlyhq/blocks-engine";
 import { useShortcuts } from "@nextlyhq/ui";
 import * as React from "react";
 
 import { CANVAS_ESCAPE_PRIORITY, escapeOutcome } from "./canvas-escape";
-import { blockDeletion } from "./delete-block";
-import { blockDuplication } from "./duplicate-block";
 import type { EditorState } from "./editor-state";
 import {
   keyboardMovePosition,
@@ -34,7 +31,12 @@ import {
   type MoveEffect,
 } from "./keyboard-move";
 import { layerLabel, pathTo } from "./layers";
-import { lockBlockingDelete, lockBlockingMove } from "./locking";
+import { lockBlockingMove } from "./locking";
+import {
+  isRefusal,
+  selectionDeletion,
+  selectionDuplication,
+} from "./selection-ops";
 
 /**
  * The bindings, and why these keys.
@@ -250,96 +252,67 @@ export function useBlockKeyboardActions({
 
   const deleteSelected = React.useCallback(() => {
     const editorNow = latest.current;
-    const deletion = blockDeletion(editorNow.document, editorNow.selectedId);
-    // `null` means there is nothing to delete — no selection, or an id the
-    // document no longer holds after an undo. Nothing is applied and nothing is
-    // said, because there is no event to report.
-    if (deletion === null) return;
+    const plan = selectionDeletion(editorNow.document, editorNow.selection.ids);
+    // `null` means there is nothing to delete — no selection, or ids an undo
+    // has since removed. Nothing is applied and nothing is said, because there
+    // is no event to report.
+    if (plan === null) return;
 
     /*
      * A lock is a POLICY refusal, so it is announced where a structural one is
-     * not.
-     *
-     * The moves below stay silent when a block simply has nowhere to go — that
-     * is a fact about the document an author can see, and saying it on every
-     * press at the end of a list is noise. A lock is the opposite: nothing about
-     * the page explains why the key did nothing, the remedy is one the author
-     * can act on, and a keyboard user has no badge to look at.
-     *
-     * The subtree is checked, not just the node. Deleting a container destroys
-     * what is inside it, so an author who locked a caption and then removed its
-     * section would lose the thing they locked through an action aimed at
-     * something else.
+     * not. Nothing about the page explains why the key did nothing, the remedy
+     * is one the author can act on, and a keyboard user has no badge to look
+     * at. ONE lock refuses the whole group, because the group is atomic and
+     * there is no half-done delete to fall back to.
      */
-    const blocked = lockBlockingDelete(editorNow.document, deletion.id);
-    if (blocked !== undefined) {
-      announce(
-        blocked.id === deletion.id
-          ? `${layerLabel(blocked)} is locked. Unlock it to delete it.`
-          : `This block contains ${layerLabel(blocked)}, which is locked. Unlock it to delete.`
-      );
+    if (isRefusal(plan)) {
+      announce(plan.reason);
       return;
     }
 
-    const applied = editorNow.apply({
-      kind: "remove",
-      id: deletion.id,
-      dropSlotIfEmpty: deletion.dropSlotIfEmpty,
-    });
-    if (applied === null) return;
+    if (editorNow.applyAll(plan.ops) === null) return;
 
-    // Selection moved only after the store accepted the removal. Moving it
-    // first would leave the author pointed at a neighbour while the block they
-    // asked to delete is still there.
-    editorNow.select(deletion.nextSelection);
-    /*
-     * Named the way the layers panel and the breadcrumb name it.
-     *
-     * `blockLabel(type)` would say "Heading" for a block the author called
-     * "Hero title", so the one surface a screen-reader user hears would be the
-     * only one using a different name for the same block.
-     */
-    const removed = findNode(editorNow.document.nodes, deletion.id);
-    announce(
-      deletionAnnouncement(
-        removed === undefined ? deletion.type : layerLabel(removed),
-        deletion.descendantCount
-      )
-    );
+    // Moved only after the store accepted the removal. Moving it first would
+    // leave the author pointed at a neighbour while the blocks they asked to
+    // delete are still there.
+    editorNow.select(plan.nextSelection);
+    announce(deletionAnnouncement(plan.subject, plan.descendants));
   }, [announce]);
 
   const duplicateSelected = React.useCallback(() => {
     const editorNow = latest.current;
-    const duplication = blockDuplication(
+    const plan = selectionDuplication(
       editorNow.document,
-      editorNow.selectedId
+      editorNow.selection.ids
     );
     // `null` means there is nothing to duplicate, or a position the op
-    // vocabulary cannot express. Nothing is applied and nothing is said,
-    // because there is no event to report.
-    if (duplication === null) return;
+    // vocabulary cannot express. Nothing is applied and nothing is said.
+    if (plan === null) return;
 
     /*
-     * A lock does NOT stop a duplication.
-     *
-     * The engine's rule is that the command layer must not let an author move
-     * or delete a locked node, and duplicating does neither — the original
-     * stays exactly where it is, untouched. Refusing here would read as
-     * cautious and would mean an author could not take a copy of the one block
-     * they had most deliberately protected.
+     * A lock does NOT stop a duplication. The command layer must not let an
+     * author move or delete a locked node, and duplicating does neither — the
+     * originals stay exactly where they are. Refusing would mean an author
+     * could not take copies of the blocks they had most deliberately protected.
      */
-    const applied = editorNow.apply({
-      kind: "insert",
-      node: duplication.node,
-      at: duplication.at,
-    });
-    if (applied === null) return;
+    if (editorNow.applyAll(plan.ops) === null) return;
 
-    // Selection follows the copy. It is the block the author is now working on
-    // — they duplicated it to change it — and leaving the original selected
-    // would send the next edit to the wrong one of two identical blocks.
-    editorNow.select(duplication.node.id);
-    announce(`${duplication.label} duplicated. Undo with ${UNDO_KEYS_SPOKEN}.`);
+    /*
+     * Selection follows the copies: they are what the author is now working on,
+     * and leaving the originals selected would send the next edit to the wrong
+     * half of two identical runs.
+     *
+     * Built through the same grammar a click uses — one replace then toggles —
+     * rather than by writing a selection object directly, so there is no second
+     * way to construct one and no second place that has to remember the
+     * outermost rule.
+     */
+    const [first, ...rest] = plan.newIds;
+    if (first !== undefined) {
+      editorNow.select(first, "replace");
+      for (const id of rest) editorNow.select(id, "toggle");
+    }
+    announce(`${plan.subject} duplicated. Undo with ${UNDO_KEYS_SPOKEN}.`);
   }, [announce]);
 
   const moveSelected = React.useCallback(

--- a/packages/builder/src/selection-ops.test.ts
+++ b/packages/builder/src/selection-ops.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Delete, duplicate and lock across a selection.
+ *
+ * The case this file exists for is **duplicate order**. Every other property
+ * here is the single-block rule asked more than once, and those rules have
+ * their own tests; what is only true when there is a GROUP is that inserting
+ * each copy beside its original shifts the positions still to be used, so the
+ * plan is only correct in reverse.
+ *
+ * The order is asserted by APPLYING the ops rather than by reading them, since
+ * a plan that looks right and lands wrong is the entire failure mode.
+ *
+ * @module selection-ops.test
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  clearBlocks,
+  hasBlock,
+  registerBlocks,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+
+import { applyOp, type BuilderOp } from "./ops";
+import {
+  isRefusal,
+  selectionDeletion,
+  selectionDuplication,
+  selectionLock,
+} from "./selection-ops";
+
+afterEach(clearBlocks);
+
+function register() {
+  if (hasBlock("acme/leaf")) return;
+  const base = {
+    version: 1,
+    description: "A block.",
+    example: { props: {} },
+    render: () => null,
+  };
+  registerBlocks(
+    [
+      { ...base, name: "acme/leaf", editor: { label: "Leaf" } },
+      {
+        ...base,
+        name: "acme/box",
+        editor: { label: "Box" },
+        slots: { children: {} },
+      },
+    ] as never,
+    { source: "selection-ops-test" }
+  );
+}
+
+function node(id: string, extra: Partial<BlockNode> = {}): BlockNode {
+  return {
+    id,
+    type: "acme/leaf",
+    version: 1,
+    props: {},
+    ...extra,
+  } as BlockNode;
+}
+
+function documentOf(nodes: BlockNode[]): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+}
+
+/** Apply a planned group the way the store does, and report the top-level ids. */
+function afterApplying(
+  document: BlockDocument,
+  ops: readonly BuilderOp[]
+): string[] {
+  let working = document;
+  for (const op of ops) working = applyOp(working, op).document;
+  return working.nodes.map(n => n.id);
+}
+
+describe("selectionDeletion", () => {
+  it("plans nothing for an empty selection", () => {
+    register();
+    expect(selectionDeletion(documentOf([node("a")]), [])).toBeNull();
+  });
+
+  it("removes every selected block", () => {
+    register();
+    const document = documentOf([node("a"), node("b"), node("c")]);
+    const plan = selectionDeletion(document, ["a", "c"]);
+    if (plan === null || isRefusal(plan)) throw new Error("expected a plan");
+
+    expect(afterApplying(document, plan.ops)).toEqual(["b"]);
+  });
+
+  it("refuses the WHOLE group when any block is locked", () => {
+    /*
+     * Follows from the group being atomic rather than from a separate policy:
+     * there is no half-done delete to fall back to. Silently skipping the
+     * locked one would leave an author who selected three blocks looking at one
+     * they did not notice surviving.
+     */
+    register();
+    const document = documentOf([
+      node("a"),
+      node("b", { locked: true, name: "Pinned" }),
+    ]);
+
+    const plan = selectionDeletion(document, ["a", "b"]);
+
+    expect(isRefusal(plan)).toBe(true);
+    expect(isRefusal(plan) ? plan.reason : "").toBe(
+      "Pinned is locked. Unlock it to delete it."
+    );
+  });
+
+  it("refuses for a lock INSIDE a selected container, naming it", () => {
+    register();
+    const document = documentOf([
+      node("box", {
+        type: "acme/box",
+        slots: { children: [node("kid", { locked: true, name: "Caption" })] },
+      } as Partial<BlockNode>),
+    ]);
+
+    const plan = selectionDeletion(document, ["box"]);
+
+    expect(isRefusal(plan) ? plan.reason : "").toBe(
+      "The selection contains Caption, which is locked. Unlock it to delete."
+    );
+  });
+
+  it("names one block by its own name and several by a count", () => {
+    register();
+    const document = documentOf([node("a", { name: "Hero" }), node("b")]);
+
+    const one = selectionDeletion(document, ["a"]);
+    const two = selectionDeletion(document, ["a", "b"]);
+
+    expect(!isRefusal(one) && one !== null ? one.subject : "").toBe("Hero");
+    expect(!isRefusal(two) && two !== null ? two.subject : "").toBe("2 blocks");
+  });
+});
+
+describe("selectionDuplication", () => {
+  it("puts every copy immediately after its own original", () => {
+    /*
+     * THE case. Each insert shifts every later sibling along, so a plan built
+     * in document order computes the second copy's position against a document
+     * the first copy has already changed — and the second lands in the wrong
+     * place. Asserted by APPLYING the ops, because a plan that reads correctly
+     * and lands wrongly is the whole failure mode.
+     */
+    register();
+    const document = documentOf([node("a"), node("b"), node("c")]);
+    const plan = selectionDuplication(document, ["a", "b", "c"]);
+    if (plan === null) throw new Error("expected a plan");
+
+    const after = afterApplying(document, plan.ops);
+
+    // Six blocks, and every copy sits directly after the block it came from.
+    expect(after).toHaveLength(6);
+    expect(after[0]).toBe("a");
+    expect(after[2]).toBe("b");
+    expect(after[4]).toBe("c");
+    expect(after[1]).toBe(plan.newIds[0]);
+    expect(after[3]).toBe(plan.newIds[1]);
+    expect(after[5]).toBe(plan.newIds[2]);
+  });
+
+  it("reports the copies in DOCUMENT order though it plans in reverse", () => {
+    // A caller selecting the copies afterwards wants them the way a reader
+    // meets them, not the way they were planned.
+    register();
+    const document = documentOf([node("a"), node("b")]);
+    const plan = selectionDuplication(document, ["a", "b"]);
+    if (plan === null) throw new Error("expected a plan");
+
+    const after = afterApplying(document, plan.ops);
+
+    expect(after.indexOf(plan.newIds[0] ?? "")).toBeLessThan(
+      after.indexOf(plan.newIds[1] ?? "")
+    );
+  });
+
+  it("is NOT refused by a lock, and the copies carry it", () => {
+    // Duplicating neither moves nor removes the original. Refusing would mean
+    // an author could not copy the blocks they had most deliberately protected.
+    register();
+    const document = documentOf([node("a", { locked: true })]);
+
+    const plan = selectionDuplication(document, ["a"]);
+
+    expect(plan).not.toBeNull();
+    expect(plan?.ops).toHaveLength(1);
+  });
+
+  it("plans nothing for an empty selection", () => {
+    register();
+    expect(selectionDuplication(documentOf([node("a")]), [])).toBeNull();
+  });
+});
+
+describe("selectionLock", () => {
+  it("locks every selected block", () => {
+    register();
+    const document = documentOf([node("a"), node("b")]);
+
+    const plan = selectionLock(document, ["a", "b"], true);
+
+    expect(plan?.ops).toEqual([
+      { kind: "update", id: "a", patch: { locked: true } },
+      { kind: "update", id: "b", patch: { locked: true } },
+    ]);
+  });
+
+  it("unlocks by UNSETTING rather than storing false", () => {
+    // `false` would be a second spelling of a state the absent field already
+    // means, and the two would have to be kept in step forever.
+    register();
+    const document = documentOf([node("a", { locked: true })]);
+
+    expect(selectionLock(document, ["a"], false)?.ops).toEqual([
+      { kind: "update", id: "a", patch: {}, unset: ["locked"] },
+    ]);
+  });
+});
+
+describe("normalisation applies to all three", () => {
+  it("acts on the container once, not on it AND its selected child", () => {
+    /*
+     * The control that the shared rule is actually being asked. Without it a
+     * delete would remove the child with its parent and then again from a
+     * document that no longer has it — which the atomic group turns into a
+     * refusal of the whole edit rather than a partial one.
+     */
+    register();
+    const document = documentOf([
+      node("box", {
+        type: "acme/box",
+        slots: { children: [node("kid")] },
+      } as Partial<BlockNode>),
+    ]);
+
+    const deletion = selectionDeletion(document, ["box", "kid"]);
+    const duplication = selectionDuplication(document, ["box", "kid"]);
+    const lock = selectionLock(document, ["box", "kid"], true);
+
+    expect(
+      !isRefusal(deletion) && deletion !== null ? deletion.ops : []
+    ).toHaveLength(1);
+    expect(duplication?.ops).toHaveLength(1);
+    expect(lock?.ops).toHaveLength(1);
+  });
+});

--- a/packages/builder/src/selection-ops.ts
+++ b/packages/builder/src/selection-ops.ts
@@ -113,13 +113,17 @@ function findIn(
  * locked one would leave an author who selected six blocks looking at one they
  * did not notice surviving.
  */
-export function selectionDeletion(
+/**
+ * The lock that stops this group being deleted, phrased, or `null`.
+ *
+ * Scanned across the WHOLE group before anything is planned, because the group
+ * is atomic: the answer is all or nothing, so it has to be known before the
+ * first op exists.
+ */
+function lockRefusal(
   document: BlockDocument,
-  selectedIds: readonly string[]
-): SelectionPlan {
-  const ids = normalizeSelection(document, selectedIds);
-  if (ids.length === 0) return null;
-
+  ids: readonly string[]
+): SelectionRefusal | null {
   for (const id of ids) {
     const blocked = lockBlockingDelete(document, id);
     if (blocked === undefined) continue;
@@ -131,11 +135,23 @@ export function selectionDeletion(
           : `The selection contains ${name}, which is locked. Unlock it to delete.`,
     };
   }
+  return null;
+}
 
+/** The removals themselves, with what the announcement and the selection need. */
+function removals(
+  document: BlockDocument,
+  ids: readonly string[]
+): {
+  ops: BuilderOp[];
+  descendants: number;
+  nextSelection: string | null;
+} {
   const ops: BuilderOp[] = [];
   const candidates: string[] = [];
   const removing = new Set(ids);
   let descendants = 0;
+
   for (const id of ids) {
     const deletion = blockDeletion(document, id);
     // `null` means the document no longer holds it, which `normalizeSelection`
@@ -158,12 +174,36 @@ export function selectionDeletion(
     });
   }
 
+  return { ops, descendants, nextSelection: candidates[0] ?? null };
+}
+
+/**
+ * Removing every selected block.
+ *
+ * **One lock refuses the WHOLE group**, and that follows from the group being
+ * atomic rather than being a separate policy: there is no half-done delete to
+ * fall back to, so the choice is all or nothing, and silently skipping the
+ * locked one would leave an author who selected six blocks looking at one they
+ * did not notice surviving.
+ */
+export function selectionDeletion(
+  document: BlockDocument,
+  selectedIds: readonly string[]
+): SelectionPlan {
+  const ids = normalizeSelection(document, selectedIds);
+  if (ids.length === 0) return null;
+
+  const refusal = lockRefusal(document, ids);
+  if (refusal !== null) return refusal;
+
+  const { ops, descendants, nextSelection } = removals(document, ids);
   if (ops.length === 0) return null;
+
   return {
     ops,
     count: ids.length,
     descendants,
-    nextSelection: candidates[0] ?? null,
+    nextSelection,
     subject: subjectOf(document, ids),
   };
 }

--- a/packages/builder/src/selection-ops.ts
+++ b/packages/builder/src/selection-ops.ts
@@ -1,0 +1,236 @@
+/**
+ * Delete, duplicate and lock, for a selection that may hold more than one block.
+ *
+ * Each verb is planned as a GROUP of ops that the store applies atomically, so
+ * an edit across six blocks costs one undo and either happens completely or not
+ * at all.
+ *
+ * ## Every rule is the single-block one, asked repeatedly
+ *
+ * `blockDeletion`, `blockDuplication` and `lockOp` already decide what removing
+ * or copying ONE block means, including what a lock forbids and where a copy
+ * goes. Nothing here re-decides any of that. A second implementation would
+ * eventually disagree with the toolbar and the keyboard, which act on one block
+ * through those same functions.
+ *
+ * ## Order is load-bearing, and only for duplicate
+ *
+ * **Duplicating runs in REVERSE document order.** Each copy is inserted
+ * immediately after its original, and inserting shifts every later sibling
+ * along — so planning `[a, b, c]` forwards computes b's position against a
+ * document that a's copy has already changed, and the second copy lands in the
+ * wrong place. Reversed, every insert happens after the positions still to be
+ * used, and each one is correct when it applies.
+ *
+ * **Deleting does not care**, and that is worth stating so nobody "fixes" it:
+ * a remove addresses a node by id, ids do not move, and the op layer derives
+ * each inverse from the document it was applied to. Both orders round-trip.
+ * Document order is used anyway, so a group is deterministic.
+ *
+ * @module selection-ops
+ */
+
+import { type BlockDocument, type BlockNode } from "@nextlyhq/blocks-engine";
+
+import { blockDeletion } from "./delete-block";
+import { blockDuplication } from "./duplicate-block";
+import { lockOp } from "./inspector";
+import { layerLabel } from "./layers";
+import { lockBlockingDelete } from "./locking";
+import type { BuilderOp } from "./ops";
+import { normalizeSelection } from "./selection";
+
+/** A planned group, with what to say about it. */
+export interface SelectionEdit {
+  /** The ops, in the order they must apply. */
+  readonly ops: readonly BuilderOp[];
+  /** How many blocks the author selected, for phrasing. */
+  readonly count: number;
+  /**
+   * How many blocks travel INSIDE the selected ones, across the whole group.
+   *
+   * Reported because a container takes its children with it and that is
+   * invisible from the block an author had selected — a collapsed section looks
+   * exactly like an empty one. Summed across the group rather than per block,
+   * since the announcement describes one action.
+   */
+  readonly descendants: number;
+  /**
+   * What to select once the group is gone, or `null` when nothing is left.
+   *
+   * A delete that left nothing selected would drop the author out of the
+   * inspector and the toolbar for a reason they did not ask for. Taken from the
+   * single-block rule's own `nextSelection`, skipping any candidate that is
+   * itself being deleted — with a run of siblings removed together, most of
+   * them name each other.
+   */
+  readonly nextSelection: string | null;
+  /** What to call the subject: the block's name, or "3 blocks". */
+  readonly subject: string;
+}
+
+/** What stopped an edit, phrased for an author. */
+export interface SelectionRefusal {
+  readonly reason: string;
+}
+
+/** Either a plan or the reason there is none. */
+export type SelectionPlan = SelectionEdit | SelectionRefusal | null;
+
+/** Whether a plan can be applied. */
+export function isRefusal(plan: SelectionPlan): plan is SelectionRefusal {
+  return plan !== null && "reason" in plan;
+}
+
+/** "Hero title", or "3 blocks" once there is more than one. */
+function subjectOf(document: BlockDocument, ids: readonly string[]): string {
+  if (ids.length !== 1) return `${ids.length} blocks`;
+  const only = ids[0];
+  const node = only === undefined ? undefined : findIn(document.nodes, only);
+  return node === undefined ? "1 block" : layerLabel(node);
+}
+
+function findIn(
+  nodes: readonly BlockNode[],
+  id: string
+): BlockNode | undefined {
+  for (const node of nodes) {
+    if (node.id === id) return node;
+    for (const children of Object.values(node.slots ?? {})) {
+      const found = findIn(children, id);
+      if (found !== undefined) return found;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Removing every selected block.
+ *
+ * **One lock refuses the WHOLE group**, and that follows from the group being
+ * atomic rather than being a separate policy: there is no half-done delete to
+ * fall back to, so the choice is all or nothing, and silently skipping the
+ * locked one would leave an author who selected six blocks looking at one they
+ * did not notice surviving.
+ */
+export function selectionDeletion(
+  document: BlockDocument,
+  selectedIds: readonly string[]
+): SelectionPlan {
+  const ids = normalizeSelection(document, selectedIds);
+  if (ids.length === 0) return null;
+
+  for (const id of ids) {
+    const blocked = lockBlockingDelete(document, id);
+    if (blocked === undefined) continue;
+    const name = layerLabel(blocked);
+    return {
+      reason:
+        blocked.id === id
+          ? `${name} is locked. Unlock it to delete it.`
+          : `The selection contains ${name}, which is locked. Unlock it to delete.`,
+    };
+  }
+
+  const ops: BuilderOp[] = [];
+  const candidates: string[] = [];
+  const removing = new Set(ids);
+  let descendants = 0;
+  for (const id of ids) {
+    const deletion = blockDeletion(document, id);
+    // `null` means the document no longer holds it, which `normalizeSelection`
+    // has already excluded — so this is unreachable rather than tolerated, and
+    // skipping is the safe reading if it ever is not.
+    if (deletion === null) continue;
+    descendants += deletion.descendantCount;
+    if (
+      deletion.nextSelection !== null &&
+      !removing.has(deletion.nextSelection)
+    ) {
+      candidates.push(deletion.nextSelection);
+    }
+    ops.push({
+      kind: "remove",
+      id: deletion.id,
+      ...(deletion.dropSlotIfEmpty === undefined
+        ? {}
+        : { dropSlotIfEmpty: deletion.dropSlotIfEmpty }),
+    });
+  }
+
+  if (ops.length === 0) return null;
+  return {
+    ops,
+    count: ids.length,
+    descendants,
+    nextSelection: candidates[0] ?? null,
+    subject: subjectOf(document, ids),
+  };
+}
+
+/** A duplication, with the ids the copies will have. */
+export interface SelectionDuplication extends SelectionEdit {
+  /** The copies, in document order, for selecting them afterwards. */
+  readonly newIds: readonly string[];
+}
+
+/**
+ * Copying every selected block, each beside its original.
+ *
+ * A lock does NOT refuse this: duplicating neither moves nor removes the
+ * original, and refusing would mean an author could not copy the blocks they
+ * had most deliberately protected. The copies carry the lock, as they do for a
+ * single block.
+ */
+export function selectionDuplication(
+  document: BlockDocument,
+  selectedIds: readonly string[]
+): SelectionDuplication | null {
+  const ids = normalizeSelection(document, selectedIds);
+  if (ids.length === 0) return null;
+
+  const ops: BuilderOp[] = [];
+  const newIds: string[] = [];
+  // Reversed — see the module docblock. Forwards, the second copy's position is
+  // computed against a document the first copy has already shifted.
+  for (const id of [...ids].reverse()) {
+    const duplication = blockDuplication(document, id);
+    if (duplication === null) continue;
+    ops.push({ kind: "insert", node: duplication.node, at: duplication.at });
+    // Unshifted, so the ids come back in document order even though the ops go
+    // out in reverse. A caller selecting the copies wants them the way a reader
+    // meets them, not the way they were planned.
+    newIds.unshift(duplication.node.id);
+  }
+
+  if (ops.length === 0) return null;
+  return {
+    ops,
+    newIds,
+    count: ids.length,
+    descendants: 0,
+    nextSelection: null,
+    subject: subjectOf(document, ids),
+  };
+}
+
+/**
+ * Locking or unlocking every selected block.
+ *
+ * Order-independent: each op addresses one node and changes only its own flag.
+ */
+export function selectionLock(
+  document: BlockDocument,
+  selectedIds: readonly string[],
+  locked: boolean
+): SelectionEdit | null {
+  const ids = normalizeSelection(document, selectedIds);
+  if (ids.length === 0) return null;
+  return {
+    ops: ids.map(id => lockOp(id, locked)),
+    count: ids.length,
+    descendants: 0,
+    nextSelection: null,
+    subject: subjectOf(document, ids),
+  };
+}


### PR DESCRIPTION
**Step 3b of B-10.** Delete and duplicate now act on every selected block, planned as one group that #1041's `applyAll` applies atomically.

## The one thing that had to be right

**Duplicating runs in REVERSE document order.** Each copy is inserted immediately after its original, and inserting shifts every later sibling along — so planning `[a, b, c]` forwards computes b's position against a document a's copy has already changed, and the second copy lands in the wrong place.

**Deleting does not care**, and the module says so explicitly, so nobody later makes the two "consistent": a remove addresses a node by id, ids do not move, and the op layer derives each inverse from the document it was applied to. Both orders round-trip. Document order is used anyway, for determinism.

The test asserts this by **applying** the ops, not by reading them — a plan that looks right and lands wrong is the entire failure mode.

## One lock refuses the whole delete

That follows from the group being atomic rather than from a separate policy: there is no half-done delete to fall back to, so the choice is all or nothing. Silently skipping the locked one would leave an author who selected six blocks looking at one they did not notice surviving.

## Everything else is the single-block rule, asked repeatedly

`blockDeletion`, `blockDuplication` and `lockOp` already decide what a lock forbids and where a copy goes. Nothing here re-decides any of that — the toolbar and the keyboard reach those same functions for one block, and a second implementation would drift from them.

The copies become the selection through **the same grammar a click uses** — one `replace` then a `toggle` each — rather than by writing a selection object directly. So there is no second way to construct a selection and no second place that has to remember the outermost rule.

## Verified in a browser

Playground `:3123`, auth control asserted first.

| step | result |
| --- | --- |
| select `kid`, Cmd+click `tail` | both selected |
| `Cmd+D` | `box, kid, COPY, tail, COPY` — **each copy immediately after its own original** |
| live region | "2 blocks duplicated. Undo with Control or Command Z." |
| **one `Cmd+Z`** | **both copies gone** |
| one `Cmd+Shift+Z` | both back |
| select the two copies, `Delete` | exactly those two removed; "2 blocks deleted" |
| lock `tail`, select `kid`+`tail`, `Delete` | **nothing deleted**; "Tail is locked. Unlock it to delete it." |

Console has exactly one error-level line — the pre-existing `["autosave-recovery",…]` one.

## Verified in tests

`packages/builder` **769 tests**, `plugin-page-builder` 61, types and lint clean. Four-part stub loop, each caught by the test that names the property: duplicating in document order, skipping the locked block, dropping normalisation, and reporting copies in planned order.

## Two things the work itself caught

**A regression I introduced and a test found:** my first rewrite of `deleteSelected` dropped `nextSelection`, so a delete left nothing selected. Restored, and generalised — the group takes the first `nextSelection` that is not itself being deleted, since a run of siblings removed together mostly name each other.

**A lost announcement, found because a linter said a function was unused.** `deletionAnnouncement` went dead when I inlined the phrasing, which had quietly dropped "…, with 5 blocks inside" — the part that tells a screen-reader author a container took its children. The plan now carries the descendant total across the group and the original phrasing is back.

## Gate

Fallow's `new-only` gate flagged `selectionDeletion` at high complexity — **caught before opening the PR this time**, unlike #1036. Split into its lock scan and its removals; the gate now returns `verdict: pass` with everything `introduced: 0`.
