### PR TITLE
fix(plugin-page-builder): stop offering the editor on a read-only document

### DIFF
--- a/.changeset/blocks-field-honours-readonly.md
+++ b/.changeset/blocks-field-honours-readonly.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Reading a past version of a document no longer offers a way to open the page builder on it. The blocks field now honours the read-only and disabled states the admin passes to every field, so a historical view shows what the field holds without an editor whose changes would be written into the snapshot.

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -76,6 +76,25 @@ export interface BlocksFieldProps<
   name: Path<TFieldValues>;
   /** React Hook Form control the entry form owns. */
   control: Control<TFieldValues>;
+  /**
+   * The document is being READ, not edited, so no way in is offered.
+   *
+   * The admin passes this to every field through one `commonProps`, and a field
+   * that ignores it does not merely look wrong: this one opened a full-screen
+   * editor bound to whichever form was nearest, which in a version-history view
+   * is the SNAPSHOT'S. Committing there writes into a past version of the
+   * document — `VersionSnapshotForm` states that as impossible in its own
+   * docblock, and nothing was enforcing it.
+   */
+  readOnly?: boolean;
+  /**
+   * The field is unavailable — no permission, or a form mid-submit.
+   *
+   * Accepted alongside `readOnly` because the admin sets the two independently,
+   * and a field honouring one of them is a field that is wrong half the time.
+   * Both mean the same thing here: there is no way in.
+   */
+  disabled?: boolean;
 }
 
 /**
@@ -139,14 +158,51 @@ export function documentFrom(value: unknown): BlockDocument {
     : emptyBlockDocument();
 }
 
+/**
+ * Whether this field may be edited at all.
+ *
+ * Exported and tested apart from the render for the same reason `documentFrom`
+ * is: this package has no DOM harness, and the rule is worth pinning on its own
+ * because getting it wrong is not cosmetic. A blocks field that ignored
+ * `readOnly` offered a full-screen editor from inside a version-history view,
+ * bound to the SNAPSHOT'S form — so committing wrote into a past version of the
+ * document.
+ *
+ * Both flags mean the same thing here. The admin sets them independently —
+ * `readOnly` for a document being read, `disabled` for no permission or a form
+ * mid-submit — and a field honouring one of them is a field that is wrong half
+ * the time.
+ */
+export function canEditBlocks(options: {
+  readOnly?: boolean;
+  disabled?: boolean;
+}): boolean {
+  return options.readOnly !== true && options.disabled !== true;
+}
+
 export function BlocksField<TFieldValues extends FieldValues = FieldValues>({
   name,
   control,
+  readOnly = false,
+  disabled = false,
 }: BlocksFieldProps<TFieldValues>) {
   const [open, setOpen] = useState(false);
   const { field } = useController({ name, control });
 
-  return open ? (
+  const editable = canEditBlocks({ readOnly, disabled });
+
+  /*
+   * Closed if the form becomes read-only while the editor is up.
+   *
+   * Not a hypothetical: a permission can be revoked and a form can start
+   * submitting under an open editor. Rendering the summary instead of the
+   * editor from that render on is not enough on its own — the state has to go
+   * back too, or reopening later would show an editor seeded from a value the
+   * author has not seen since.
+   */
+  if (open && !editable) setOpen(false);
+
+  return open && editable ? (
     <BlocksEditor
       // Remounted per opening: the editor seeds its own history from the value
       // it opened with, and a key change is what discards a previous session's
@@ -159,15 +215,25 @@ export function BlocksField<TFieldValues extends FieldValues = FieldValues>({
   ) : (
     <div className="flex flex-col gap-3">
       <BlocksSummary name={name} control={control} />
-      <div>
-        <button
-          type="button"
-          onClick={() => setOpen(true)}
-          className="inline-flex h-9 items-center rounded-md border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        >
-          Edit blocks
-        </button>
-      </div>
+      {/*
+        No button at all rather than a disabled one.
+        
+        A disabled control says "you could do this, but not now", which is the
+        wrong sentence for a document that cannot be edited at all — and the
+        summary above already says what the field holds. An affordance that
+        cannot ever act here is one an author spends attention on.
+      */}
+      {editable ? (
+        <div>
+          <button
+            type="button"
+            onClick={() => setOpen(true)}
+            className="inline-flex h-9 items-center rounded-md border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            Edit blocks
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/packages/plugin-page-builder/src/admin/blocks-field-document.test.ts
+++ b/packages/plugin-page-builder/src/admin/blocks-field-document.test.ts
@@ -9,7 +9,7 @@
 import { DOCUMENT_FORMAT_VERSION } from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
 
-import { documentFrom } from "./BlocksField";
+import { canEditBlocks, documentFrom } from "./BlocksField";
 
 describe("documentFrom", () => {
   it("keeps a document that already has nodes", () => {
@@ -52,5 +52,39 @@ describe("documentFrom", () => {
     const fresh = documentFrom(null);
     expect(fresh.formatVersion).toBe(DOCUMENT_FORMAT_VERSION);
     expect(typeof fresh.kind).toBe("string");
+  });
+});
+
+describe("canEditBlocks", () => {
+  /*
+   * The rule that decides whether a way INTO the editor is offered at all.
+   *
+   * Not cosmetic. Before this, `readOnly` arrived from the admin's shared
+   * `commonProps` and was dropped on the floor — so a version-history view,
+   * which renders the whole document read-only, still showed an enabled "Edit
+   * blocks" button. Opening it mounted a full-screen editor bound to whichever
+   * form was nearest, which there is the SNAPSHOT'S: committing wrote into a
+   * past version of the document. `VersionSnapshotForm`'s own docblock states
+   * that as impossible.
+   */
+  it("allows editing when neither flag is set", () => {
+    // The control. Without it, "always false" would satisfy every case below
+    // and no author could ever open the editor.
+    expect(canEditBlocks({})).toBe(true);
+    expect(canEditBlocks({ readOnly: false, disabled: false })).toBe(true);
+  });
+
+  it("refuses when the document is being READ", () => {
+    expect(canEditBlocks({ readOnly: true })).toBe(false);
+  });
+
+  it("refuses when the field is DISABLED", () => {
+    // Independently of `readOnly`: the admin sets the two for different
+    // reasons, and honouring one of them is being wrong half the time.
+    expect(canEditBlocks({ disabled: true })).toBe(false);
+  });
+
+  it("refuses when both are set", () => {
+    expect(canEditBlocks({ readOnly: true, disabled: true })).toBe(false);
   });
 });


### PR DESCRIPTION
**A user reading a past version of a document was handed a live, full-screen block editor. Everything they did in it was silently discarded.**

> **Severity corrected after this PR was opened.** It first said "data integrity" and "commits write into the historical snapshot". **That was wrong and is withdrawn.** The write lands on the snapshot form's in-memory state and nothing persists it — I verified this myself rather than accepting the correction: `VersionSnapshotForm` builds a local `useForm({ values })`, contains no `handleSubmit`, `onSubmit`, `mutate`, Save or Publish, and never returns the form; and `EntryForm.tsx:762` passes `actionsDisabled={viewingVersion !== null}`, so the live form's Save and Publish are off while a version is on screen. Positive control: the search does reach that file — 4 `useForm` hits.
>
> So this is **not** corruption. It is a misleading affordance on a screen that says "you are reading a past version", and the cost is an author's work vanishing without a word. Worth fixing, worth fixing this way, but rank it accordingly.

Found and reproduced by the admin lane. I verified their three static claims independently on `main` @ `4e5692379` before changing anything, then reproduced the fixed behaviour in a browser.

## The mechanism

`FieldRenderer.tsx:317` puts `readOnly: isReadOnly` and `disabled: isDisabled` into one `commonProps` and passes it to **every** input, plugin slots included. `BlocksFieldProps` declared only `{ name, control }` — so both arrived and were dropped on the floor. Measured: `git grep -c "readOnly\|disabled"` in that file returned **0**.

The closed state then rendered an **unconditional** "Edit blocks" button. Opening it mounted the editor with `onCommit={field.onChange}`, bound to whichever form context is nearest — which in a version-history view is the **snapshot's**.

`VersionSnapshotForm`'s own docblock states the precondition: *"A save affordance placed in here would act on the past."* It was written down and nothing enforced it.

## The fix

`readOnly` and `disabled` are accepted and honoured. **Both**, because the admin sets them independently — one for a document being read, one for no permission or a form mid-submit — and a field honouring only one is wrong half the time.

**No button at all rather than a disabled one.** A disabled control says "you could do this, but not now", which is the wrong sentence for a document that cannot be edited; the summary above it already says what the field holds. An affordance that can never act is one an author spends attention on.

**The open state is reset if the form becomes read-only under it.** Rendering the summary from that render on is not enough by itself — reopening later would show an editor seeded from a value the author has not seen since. Not hypothetical: a permission can be revoked, and a form starts submitting, while an editor is up.

## Verified in a browser

Playground `:3123`, auth control asserted first (`h1` reads "Welcome, Dev").

| view | result |
| --- | --- |
| live entry (**control**) | one "Edit blocks", `disabled=false` — unchanged |
| version history → Version 1 | page reports "reading a past version"; **zero** "Edit blocks" buttons |
| same historical view | blocks summary still reads "3 blocks" — the field says what it holds |
| same historical view | no `.nx-canvas` mounted |

The summary check is the negative control: this had to be *the button withheld*, not *the field vanishing*.

**A control I got wrong first, and replaced.** My initial structural check grepped for `onClick={() => setOpen(true)}` and expected zero — but the button still exists, it is merely gated, so that check could not tell gated from ungated. Replaced with two that can: the button is no longer a direct sibling of the summary (0), it now sits inside the `editable` guard (1), and the editor branch is gated too (1).

## Tests

The rule is extracted as `canEditBlocks` and tested, including the control that neither flag set still permits editing — without which "always false" would satisfy every other case and no author could ever open the editor.

**Stated plainly: there is no DOM test.** This package has no jsdom or testing-library, and adding a harness for one fix would put a lockfile change and new dev dependencies into a P1. Worth doing as its own change if you want field-level render tests here; the browser verification above is what covers it today.

`plugin-page-builder`: 65 tests, types and lint clean. Fallow `new-only`: `verdict: pass`, everything `introduced: 0`.

## The other half, and a correction to how I described it

I originally wrote that the admin lane's `ReadOnlyDocumentForm` would "make the write impossible" via `useForm({ disabled: true })`. **That route does not work**, and they measured it with a positive control: with `disabled: true`, a `useController(...).field.onChange("WRITTEN")` still sets the value. RHF's `disabled` disables registered *inputs*; it does not make values immutable to a programmatic write.

What is actually true is three layers, and only the third is a boundary:

- **`readOnly`** — a contract each field honours. Works, and now blocks honours it. Depends on the participant, so not a boundary.
- **`disabled`** — defence in depth for registered inputs. Real, but does not stop a programmatic write.
- **Isolation** — nothing outside the component can reach that form. It is built inside, never returned, and no save affordance sits in its provider. That is what makes a stray write unable to reach storage, and it was already true before either of us touched anything.

So removing the affordance is the half that changes what a user experiences. The other half adds a layer and writes the limit down so nobody mistakes `disabled` for a guarantee.
