### PR TITLE
feat(nextly): make esbuild an optional peer dependency

### DIFF
--- a/.changeset/esbuild-optional-peer.md
+++ b/.changeset/esbuild-optional-peer.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+**Breaking for existing projects:** `esbuild` is now an optional peer dependency. Run `npm install --save-dev esbuild` in your project. Newly scaffolded projects already declare it.
+
+It was a hard dependency of `nextly`, so every install downloaded roughly 9.6 MB for tooling that exists to compile `nextly.config.ts`. Nothing that serves a request needs it. Three things do: development, where the dev server re-reads the config; the `nextly` CLI; and production only when `db.runMigrationsOnBoot` is switched on, which is opt-in and off by default. A production deployment installing without dev dependencies no longer downloads it at all.
+
+When it is missing, reading the config now names the package, the exact command, and what needs it, instead of failing with a module-not-found from three different call paths.
+
+With this, `nextly` carries 20 runtime dependencies. `nodemailer`, `sharp` and `esbuild` have all moved to optional peers, which together removes roughly 28 MB per platform from an install that uses none of them.

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -986,6 +986,11 @@ const PINNED_VERSIONS: Record<string, string> = {
   "@tailwindcss/postcss": "^4",
   tailwindcss: "^4",
   eslint: "^9",
+  // Compiles `nextly.config.ts` so the dev server and the CLI can read it.
+  // An optional peer of `nextly` rather than a dependency, because nothing
+  // that serves a request needs it: a production install omitting dev
+  // dependencies never downloads it.
+  esbuild: "^0.28.1",
 };
 
 /**
@@ -1196,6 +1201,10 @@ export async function generatePackageJson(
     tailwindcss: PINNED_VERSIONS.tailwindcss,
     eslint: PINNED_VERSIONS.eslint,
     "eslint-config-next": runtimeVersions["eslint-config-next"],
+    // Declared HERE rather than inherited: `nextly` takes esbuild as an
+    // optional peer, so nothing installs it on a project's behalf. Without it
+    // the dev server cannot read `nextly.config.ts`.
+    esbuild: PINNED_VERSIONS.esbuild,
   };
 
   // Read from the project that was just assembled, so the generated script can only name a

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -225,6 +225,7 @@
     "acorn": "^8.15.0",
     "acorn-walk": "^8.3.4",
     "better-sqlite3": "^12.5.0",
+    "esbuild": "^0.28.1",
     "eslint": "^9.39.1",
     "mysql2": "^3.15.0",
     "nodemailer": "^9.0.1",
@@ -243,18 +244,22 @@
     "@nextlyhq/adapter-mysql": "workspace:*",
     "@nextlyhq/adapter-postgres": "workspace:*",
     "@nextlyhq/adapter-sqlite": "workspace:*",
+    "esbuild": "^0.28.1",
     "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "nodemailer": "^9.0.1",
     "sharp": "^0.35.0"
   },
   "peerDependenciesMeta": {
-    "@nextlyhq/adapter-postgres": {
-      "optional": true
-    },
     "@nextlyhq/adapter-mysql": {
       "optional": true
     },
+    "@nextlyhq/adapter-postgres": {
+      "optional": true
+    },
     "@nextlyhq/adapter-sqlite": {
+      "optional": true
+    },
+    "esbuild": {
       "optional": true
     },
     "nodemailer": {
@@ -279,7 +284,6 @@
     "dotenv": "^17.2.2",
     "drizzle-kit": "1.0.0-rc.4",
     "drizzle-orm": "1.0.0-rc.4",
-    "esbuild": "^0.28.1",
     "file-type": "^21",
     "isomorphic-dompurify": "^2",
     "jose": "^6.2.2",

--- a/packages/nextly/src/cli/utils/__tests__/esbuild-loader.test.ts
+++ b/packages/nextly/src/cli/utils/__tests__/esbuild-loader.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The one place this package reaches for esbuild.
+ *
+ * esbuild is ~9.6 MB and exists to compile the user's `nextly.config.ts`.
+ * Three things need it, and none of them is serving a request:
+ *
+ *   - development, where boot-apply and the HMR listener re-read the config;
+ *   - the CLI (`nextly migrate` and friends);
+ *   - production ONLY when `db.runMigrationsOnBoot` is switched on, which is
+ *     opt-in and off by default.
+ *
+ * So an ordinary production install downloads it and never executes a line.
+ * Making it optional is what this loader is for, and the absence has to arrive
+ * as an instruction rather than as a module-not-found from three call paths.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  ESBUILD_INSTALL_COMMAND,
+  isEsbuildAvailable,
+  loadEsbuild,
+} from "../esbuild-loader";
+
+describe("the esbuild loader", () => {
+  it("names a command a user can run", () => {
+    expect(ESBUILD_INSTALL_COMMAND).toContain("esbuild");
+    expect(ESBUILD_INSTALL_COMMAND).toMatch(/install|add/);
+  });
+
+  it("finds the library here, where it stays a devDependency", () => {
+    expect(isEsbuildAvailable()).toBe(true);
+  });
+
+  it("loads a module exposing build", async () => {
+    const esbuild = await loadEsbuild();
+
+    // The CALLABLE this package uses, rather than a shape: esbuild ships both
+    // CommonJS and ESM, so which interop form arrives depends on the host.
+    expect(typeof esbuild.build).toBe("function");
+  });
+
+  it("explains what to install when it cannot be had", async () => {
+    // Throws rather than returning null, unlike the sharp loader beside it.
+    // Compiling the config is not optional for the caller that asks: there is
+    // no degraded outcome, so the decision does not belong to each call site.
+    await expect(
+      loadEsbuild({
+        resolver: () => {
+          throw new Error("ERR_MODULE_NOT_FOUND");
+        },
+      })
+    ).rejects.toThrow(/esbuild/);
+  });
+
+  it("names the exact command in the message it throws", async () => {
+    await expect(loadEsbuild({ resolver: () => null })).rejects.toThrow(
+      /npm install (--save-dev|-D) esbuild/
+    );
+  });
+
+  it("reads the CommonJS default when that is what arrives", async () => {
+    const real = { build: () => ({}) };
+
+    await expect(
+      loadEsbuild({ resolver: () => ({ default: real }) })
+    ).resolves.toBe(real);
+  });
+});

--- a/packages/nextly/src/cli/utils/config-bundler.ts
+++ b/packages/nextly/src/cli/utils/config-bundler.ts
@@ -50,17 +50,18 @@ import { mkdir, rm } from "node:fs/promises";
 import { dirname, join, basename, extname } from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { build, type Plugin } from "esbuild";
+import type { Plugin } from "esbuild";
+
+import { loadEsbuild } from "./esbuild-loader";
 
 // Turbopack-bypass: the Function constructor body is a string — Turbopack's
 // static analyzer never sees the `import(path)` call inside it, so it
 // cannot emit "Cannot find module as expression is too dynamic". At runtime
 // the returned function performs a real dynamic ESM import.
 // eslint-disable-next-line @typescript-eslint/no-implied-eval
-const opaqueImport = new Function(
-  "path",
-  "return import(path)"
-) as (path: string) => Promise<unknown>;
+const opaqueImport = new Function("path", "return import(path)") as (
+  path: string
+) => Promise<unknown>;
 
 export interface BundleConfigResult {
   // The default-or-namespace export of the compiled config module.
@@ -135,6 +136,12 @@ export async function bundleAndRequire(
   };
 
   try {
+    // Loaded per call rather than held at module scope: this is the optional
+    // peer, and a module-level handle would have to resolve at import time,
+    // which is exactly what an optional dependency cannot promise. A
+    // production install that never compiles a config never reaches this.
+    const { build } = await loadEsbuild();
+
     const result = await build({
       entryPoints: [filepath],
       bundle: true,

--- a/packages/nextly/src/cli/utils/esbuild-loader.ts
+++ b/packages/nextly/src/cli/utils/esbuild-loader.ts
@@ -1,0 +1,125 @@
+/**
+ * The one place this package reaches for esbuild.
+ *
+ * esbuild is around 9.6 MB and exists here for exactly one job: compiling the
+ * user's `nextly.config.ts` so it can be imported. Three things need that, and
+ * none of them is serving a request:
+ *
+ *   - DEVELOPMENT, where boot-apply and the HMR listener re-read the config;
+ *   - the CLI, where `nextly migrate` and its siblings load it;
+ *   - PRODUCTION only when `db.runMigrationsOnBoot` is switched on, which is
+ *     opt-in and off by default.
+ *
+ * An ordinary production install therefore downloads it and never executes a
+ * line, which is what makes it an optional peer rather than a dependency.
+ *
+ * This THROWS where the sharp loader returns null, and the difference is the
+ * caller rather than a preference: an upload has a good degraded outcome, and
+ * a configuration that cannot be compiled has none. There is nothing for a
+ * call site to decide, so the decision is not handed to it.
+ *
+ * @module cli/utils/esbuild-loader
+ */
+
+import { createRequire } from "node:module";
+
+import { NextlyError } from "../../errors";
+
+/**
+ * The command reported to an install that is missing it.
+ *
+ * `--save-dev`, because nothing that serves a request needs esbuild: it is
+ * build and development tooling, and a production deployment installing with
+ * `--omit=dev` is the case this whole change exists to make cheaper.
+ */
+export const ESBUILD_INSTALL_COMMAND = "npm install --save-dev esbuild";
+
+/**
+ * The subset of esbuild this package uses.
+ *
+ * Declared structurally and narrowed to what the one call site reads, rather
+ * than imported wholesale: the type import is erased at compile time, so a
+ * consuming install can type-check without the package present. `metafile` is
+ * optional because esbuild only produces it when asked, and the caller already
+ * treats its absence as "no dependencies to report".
+ */
+export interface EsbuildBuildResult {
+  metafile?: { inputs: Record<string, unknown> };
+}
+
+export interface EsbuildModule {
+  build: (options: unknown) => Promise<EsbuildBuildResult>;
+}
+
+const requireFrom = createRequire(import.meta.url);
+
+/**
+ * Whether the library can be found, without executing it.
+ *
+ * Resolution rather than import, so asking the question does not run a third
+ * party's module initialisation. Used to warn BEFORE work begins rather than
+ * to decide whether to attempt it.
+ */
+export function isEsbuildAvailable(): boolean {
+  try {
+    requireFrom.resolve("esbuild");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** The value, if it can actually build. */
+function builderOf(value: unknown): EsbuildModule | undefined {
+  const candidate = value as EsbuildModule | undefined;
+  return typeof candidate?.build === "function" ? candidate : undefined;
+}
+
+/**
+ * Load esbuild, or explain precisely what to install and why.
+ *
+ * `resolver` exists so a test can model an absent or hostile module without
+ * touching the filesystem. Production callers pass nothing.
+ */
+export async function loadEsbuild(options?: {
+  resolver?: () => unknown;
+}): Promise<EsbuildModule> {
+  let loaded: unknown;
+
+  try {
+    loaded = await (options?.resolver ? options.resolver() : import("esbuild"));
+  } catch (cause) {
+    throw esbuildUnavailable(cause);
+  }
+
+  // `default` is read first for the same reason as the other loaders here: a
+  // module namespace is not always a plain object, and a proxy that throws on
+  // an unknown name turns a good CommonJS default into "missing" when the top
+  // level is probed first.
+  const esbuild =
+    builderOf((loaded as { default?: unknown })?.default) ?? builderOf(loaded);
+
+  if (!esbuild) throw esbuildUnavailable("esbuild exposed no build function");
+
+  return esbuild;
+}
+
+/**
+ * The one refusal this module reports, however it got there.
+ *
+ * Says what needs it as well as what to run: a reader who never asked for a
+ * TypeScript config would otherwise have no idea why a bundler is involved.
+ */
+function esbuildUnavailable(cause: unknown): NextlyError {
+  return new NextlyError({
+    code: "NEXTLY_CONFIG_TOOLING_UNAVAILABLE",
+    publicMessage:
+      `Reading "nextly.config.ts" needs the "esbuild" package, which is not installed. ` +
+      `Run "${ESBUILD_INSTALL_COMMAND}" and try again. ` +
+      `It is needed for development, for the nextly CLI, and in production only when "db.runMigrationsOnBoot" is enabled.`,
+    logContext: {
+      reason: "esbuild-unavailable",
+      cause: cause instanceof Error ? cause.message : String(cause),
+    },
+  });
+}

--- a/packages/nextly/src/errors/error-codes.ts
+++ b/packages/nextly/src/errors/error-codes.ts
@@ -86,6 +86,11 @@ export const NEXTLY_ERROR_STATUS = {
   // nothing is broken, the install simply cannot carry it out yet, and the
   // remedy is one command on the server rather than a change by the caller.
   NEXTLY_EMAIL_TRANSPORT_UNAVAILABLE: 503,
+  // The tooling that compiles `nextly.config.ts` is an optional peer the host
+  // has not installed. 503 rather than 500 for the same reason as the mail
+  // transport above: nothing is broken and the request is not malformed, the
+  // install simply cannot carry it out until one command is run.
+  NEXTLY_CONFIG_TOOLING_UNAVAILABLE: 503,
 } as const;
 
 export type NextlyErrorCode = keyof typeof NEXTLY_ERROR_STATUS;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1122,9 +1122,6 @@ importers:
       drizzle-orm:
         specifier: 1.0.0-rc.4
         version: 1.0.0-rc.4(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.5.0)(effect@3.21.2)(mysql2@3.15.0)(pg@8.16.3)(zod@4.1.12)
-      esbuild:
-        specifier: '>=0.25.0'
-        version: 0.28.1
       file-type:
         specifier: ^21
         version: 21.3.4
@@ -1214,6 +1211,9 @@ importers:
       acorn-walk:
         specifier: ^8.3.4
         version: 8.3.4
+      esbuild:
+        specifier: '>=0.25.0'
+        version: 0.28.1
       eslint:
         specifier: ^9.39.1
         version: 9.39.1(jiti@2.7.0)


### PR DESCRIPTION
Removes the last large avoidable dependency from core. `esbuild` is ~9.6 MB and exists for exactly one job: compiling the user's `nextly.config.ts`.

With this, `nextly` carries **20 runtime dependencies**, down from 22. `nodemailer`, `sharp` and `esbuild` are now all optional peers, which together removes roughly **28 MB per platform** from an install that uses none of them.

## Correcting my own earlier claim

When I deferred this from the `sharp` PR I wrote that esbuild "is reached at RUNTIME… removing it means removing the need to compile `nextly.config.ts` at runtime, which is an architecture change." That was too pessimistic, and the research says so precisely. Three things reach it, and none is serving a request:

| Path | Gate | Reachable in a serving install? |
|---|---|---|
| `init/boot-apply.ts` | `if (process.env.NODE_ENV !== "development") return;` (line 42) | no |
| `init/reload-config.ts` (HMR) | `hmr-listener.ts:36-37` returns early on `production` and `test` | no |
| `init/prod-migrations.ts` → `cli/commands/migrate.ts` | `if (process.env.NODE_ENV !== "production") return;` **and** `db.runMigrationsOnBoot !== true` | only when opted in |
| the `nextly` CLI | n/a | dev/CI tooling |

So it IS production-reachable, which is why an optional peer rather than a plain removal, but only behind a flag that is off by default. An ordinary production deployment downloads 9.6 MB and never executes a line of it.

## Changes

`esbuild-loader.ts` is the single place this package reaches for it, mirroring the loaders added for `nodemailer` and `sharp`. `config-bundler.ts` consumes it; the `Plugin` type import stays and is erased at compile time, so type-checking never needs the package present.

It **throws** where the sharp loader returns `null`, and that difference is the caller rather than a preference: an upload has a good degraded outcome and a configuration that cannot be compiled has none, so there is nothing for a call site to decide.

Scaffolded projects now declare `esbuild` in `devDependencies`. It was previously inherited transitively through `nextly`; nothing installs it on a project's behalf any more, and without it the dev server cannot read the config.

## Verification

- `packages/nextly/src/cli`: 137 pass. **5 failures, identical to the baseline measured on `main`** — migration-file grouping, unrelated to config loading. Zero new, zero masked.
- `create-nextly-app`: 248 pass.
- lint, check-types, `lint:design`, `lint:workspace` all clean; fallow `pass` with every introduced count at zero.
- **Tested against the packed tarball with `esbuild` deleted**, through the real public path rather than internals: `loadConfig()` on a project with a `nextly.config.ts` throws `NEXTLY_CONFIG_TOOLING_UNAVAILABLE` naming the package, the exact command, and what needs it. Confirmed the shipped `dist` now carries `import("esbuild")` dynamically with no static import left.

## One thing the local gates caught that CI would have

`pnpm lint:workspace` rejected the push: `peerDependencies should be ordered alphabetically`. I had appended `esbuild` rather than inserting it. Fixed by sorting, and worth noting the hook did its job before the branch left the machine.
