### PR TITLE
feat(builder): make the toolbar and inspector answer for a selection

### DIFF
--- a/.changeset/builder-surfaces-for-selection.md
+++ b/.changeset/builder-surfaces-for-selection.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The page builder toolbar and inspector now answer for a whole selection. The toolbar sits over everything selected and offers the actions that apply to all of them; the inspector says how many blocks are selected and can lock or unlock them together, showing a mixed state when only some are locked.

--- a/packages/builder/src/block-toolbar.tsx
+++ b/packages/builder/src/block-toolbar.tsx
@@ -55,11 +55,13 @@ import * as React from "react";
 
 import { CANVAS_ROOT_CLASS, CHROME_ATTRIBUTE } from "./canvas";
 import type { EditorState } from "./editor-state";
+import type { Rect } from "./geometry";
 import { canvasContentRect } from "./geometry-dom";
 import { useBlockActionsContext } from "./keyboard-actions";
 import {
   toolbarActions,
   toolbarPlacement,
+  unionRect,
   type ToolbarAction,
   type ToolbarActionId,
   type ToolbarPlacement,
@@ -124,9 +126,10 @@ export function BlockToolbar({
   );
 
   const { document, selectedId } = editor;
+  const selectedIds = editor.selection.ids;
   const actions = React.useMemo(
-    () => toolbarActions(document, selectedId),
-    [document, selectedId]
+    () => toolbarActions(document, selectedId, selectedIds),
+    [document, selectedId, selectedIds]
   );
 
   /*
@@ -176,8 +179,20 @@ export function BlockToolbar({
       setPlacement(null);
       return;
     }
-    const block = selectedElement(root, selectedId);
-    if (block === null) {
+    /*
+     * Anchored to the UNION of everything selected, not to the primary.
+     *
+     * With two blocks selected at opposite ends of a page, a bar drawn at one
+     * of them describes an action about to happen to the other, which the
+     * author cannot see. The union is the shape the selection occupies.
+     */
+    const rects: Rect[] = [];
+    for (const id of selectedIds) {
+      const element = selectedElement(root, id);
+      if (element !== null) rects.push(canvasContentRect(element, root));
+    }
+    const block = unionRect(rects);
+    if (block === undefined) {
       setPlacement(null);
       return;
     }
@@ -189,7 +204,7 @@ export function BlockToolbar({
     const size = canvasContentRect(element, root);
     setPlacement(
       toolbarPlacement(
-        canvasContentRect(block, root),
+        block,
         { width: size.width, height: size.height },
         // The root's own box rather than its scroll extent. `scrollWidth` and
         // `scrollHeight` are the CONTENT's size, so a long page would report a
@@ -198,7 +213,7 @@ export function BlockToolbar({
         canvasContentRect(root, root)
       )
     );
-  }, [selectedId]);
+  }, [selectedId, selectedIds]);
 
   React.useLayoutEffect(() => {
     if (hidden) return;
@@ -217,18 +232,27 @@ export function BlockToolbar({
     const element = bar.current;
     const root = element?.closest(`.${CANVAS_ROOT_CLASS}`);
     if (!(root instanceof HTMLElement)) return;
-    const block = selectedElement(root, selectedId);
-    if (block === null) return;
-
     // Absent in jsdom unless a test supplies one, and absent in older browsers.
     // A missing observer costs a re-measure, not correctness — every render
     // path above still measures.
     if (typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(() => measure());
-    observer.observe(block);
+
+    /*
+     * EVERY selected block, not only the primary.
+     *
+     * The bar is anchored to the union of them all, so any one of them changing
+     * size moves where it belongs. Watching the primary alone would leave the
+     * bar stale whenever a secondary block reflowed — which is most of what
+     * happens while an image loads or a webfont swaps.
+     */
+    for (const id of selectedIds) {
+      const block = selectedElement(root, id);
+      if (block !== null) observer.observe(block);
+    }
     observer.observe(root);
     return () => observer.disconnect();
-  }, [measure, hidden, selectedId, document]);
+  }, [measure, hidden, selectedId, selectedIds, document]);
 
   const focusAt = React.useCallback((index: number) => {
     setActiveIndex(index);

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -245,6 +245,16 @@ export { blockLabel } from "./inserter";
 export { isLocked, lockBlockingDelete, lockBlockingMove } from "./locking";
 
 /**
+ * @experimental How a lock reads across a whole selection.
+ *
+ * From this entry because it is a plain function over a document, and because
+ * anything showing a lock for several blocks needs the same THREE answers the
+ * inspector uses. A surface that collapsed "some of these" into on or off would
+ * tell an author something false about half of what they selected.
+ */
+export { lockStateOf, type LockState } from "./inspector";
+
+/**
  * @experimental Duplicating a block: the copy, and where it goes.
  *
  * From this entry because it is a plain function over a document. An agent
@@ -341,6 +351,7 @@ export {
   TOOLBAR_GAP_PX,
   toolbarActions,
   toolbarPlacement,
+  unionRect,
   type ToolbarAction,
   type ToolbarActionId,
   type ToolbarPlacement,

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -86,6 +86,8 @@ function editorFor(
   return {
     document,
     selectedId: "a",
+    selection: { ids: ["a"], primary: "a" },
+    applyAll: vi.fn(() => document),
     select: vi.fn(),
     apply: vi.fn(() => document),
     undo: vi.fn(),
@@ -202,5 +204,99 @@ describe("InspectorPanel identity fields", () => {
 
     expect(screen.queryByLabelText("Name")).toBeNull();
     expect(screen.queryByLabelText("Lock this block")).toBeNull();
+  });
+});
+
+describe("InspectorPanel with several blocks selected", () => {
+  function manyEditor(locks: readonly boolean[]) {
+    register();
+    const document = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: locks.map((locked, i) => ({
+        id: String(i),
+        type: "acme/heading",
+        version: 1,
+        props: {},
+        ...(locked ? { locked: true } : {}),
+      })),
+    } as unknown as BlockDocument;
+    const editor = {
+      ...editorFor(document),
+      selectedId: "0",
+      selection: { ids: locks.map((_, i) => String(i)), primary: "0" },
+    } as unknown as EditorState & {
+      applyAll: ReturnType<typeof vi.fn>;
+    };
+    render(<InspectorPanel editor={editor} />);
+    return editor;
+  }
+
+  it("says how many, rather than describing one of them", () => {
+    /*
+     * Showing the primary's name and props while three blocks are selected
+     * would describe one block on a screen where the canvas outlines three and
+     * the toolbar's delete removes all of them.
+     */
+    manyEditor([false, false, false]);
+
+    expect(screen.getByText("3 blocks selected")).toBeDefined();
+    expect(screen.queryByLabelText("Name")).toBeNull();
+  });
+
+  it("shows the lock as MIXED when only some are locked", () => {
+    // A real third state. `checked` or unchecked here would tell the author
+    // something false about half of what they selected.
+    manyEditor([true, false]);
+
+    const box = screen.getByRole("checkbox", { name: /lock these blocks/i });
+    expect(box.getAttribute("aria-checked")).toBe("mixed");
+    expect((box as HTMLInputElement).indeterminate).toBe(true);
+  });
+
+  it("shows it as checked when they are ALL locked, which is the control", () => {
+    // Without this, "always mixed" would satisfy the case above.
+    manyEditor([true, true]);
+
+    const box = screen.getByRole("checkbox", { name: /lock these blocks/i });
+    expect(box.getAttribute("aria-checked")).toBe("true");
+    expect((box as HTMLInputElement).indeterminate).toBe(false);
+  });
+
+  it("LOCKS everything on the first press from mixed", () => {
+    /*
+     * Rather than unlocking. Unlocking from mixed is a first press that appears
+     * to do nothing to the blocks that were already unlocked, and every file
+     * manager and design tool resolves it this way.
+     */
+    const editor = manyEditor([true, false]);
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: /lock these blocks/i })
+    );
+
+    /*
+     * ONLY the block that changes. The already-locked one is omitted, because
+     * `applyOp` refuses an update writing what a node already holds and the
+     * group is atomic — planning it would abort the whole edit and lock
+     * nothing. That is what the editor actually did until a browser run caught
+     * it; this suite passed throughout, because the spy never ran the ops.
+     */
+    expect(editor.applyAll).toHaveBeenCalledWith([
+      { kind: "update", id: "1", patch: { locked: true } },
+    ]);
+  });
+
+  it("unlocks everything when they are all locked", () => {
+    const editor = manyEditor([true, true]);
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: /lock these blocks/i })
+    );
+
+    expect(editor.applyAll).toHaveBeenCalledWith([
+      { kind: "update", id: "0", patch: {}, unset: ["locked"] },
+      { kind: "update", id: "1", patch: {}, unset: ["locked"] },
+    ]);
   });
 });

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -41,11 +41,14 @@ import type { EditorState } from "./editor-state";
 import {
   inspectSelection,
   lockOp,
+  lockStateOf,
   propPatch,
   renameOp,
   type BlockIdentity,
   type EditableProp,
+  type LockState,
 } from "./inspector";
+import { selectionLock } from "./selection-ops";
 
 export interface InspectorPanelProps {
   /**
@@ -89,6 +92,29 @@ export function InspectorPanel({
     },
     [editor]
   );
+
+  /*
+   * Several blocks selected: a different panel, not a thinner one.
+   *
+   * Showing the primary's name and props while six blocks are selected would
+   * describe one block and act on one block, on a screen where the canvas shows
+   * six outlined and the toolbar's delete removes all of them. The two surfaces
+   * would be answering different questions with the same words.
+   *
+   * Per-property batch editing — one field showing "Mixed" and writing to every
+   * block — is Plan 05's batch edit and is deliberately not here. What IS here
+   * is the one property that is well defined across any set today, because it
+   * is a flag rather than a value: the lock.
+   */
+  if (editor.selection.ids.length > 1) {
+    return (
+      <ManyBlocksPanel
+        editor={editor}
+        count={editor.selection.ids.length}
+        lock={lockStateOf(editor.document, editor.selection.ids)}
+      />
+    );
+  }
 
   if (inspection === null) {
     return (
@@ -362,6 +388,68 @@ function TextishField({
           }}
         />
       )}
+    </div>
+  );
+}
+
+/**
+ * The inspector when several blocks are selected.
+ *
+ * Says how many, and offers the one control that is well defined across a set:
+ * the lock. A tri-state checkbox rather than a two-state one, because "some of
+ * these are locked" is a real state and showing it as either on or off tells
+ * the author something false about half of their selection.
+ *
+ * From `mixed`, the first press LOCKS everything. The alternative — unlocking —
+ * is a first press that appears to do nothing to the blocks that were already
+ * unlocked, and every file manager and design tool resolves it the same way.
+ */
+function ManyBlocksPanel({
+  editor,
+  count,
+  lock,
+}: {
+  editor: EditorState;
+  count: number;
+  lock: LockState;
+}): React.JSX.Element {
+  const plan = selectionLock(
+    editor.document,
+    editor.selection.ids,
+    // Mixed locks; locked unlocks; unlocked locks.
+    lock !== "locked"
+  );
+
+  return (
+    <div className="nx-inspector" data-selection="many">
+      <h2 className="nx-inspector__title">{count} blocks selected</h2>
+
+      <div className="nx-inspector__identity">
+        <label className="nx-inspector__check">
+          <input
+            type="checkbox"
+            checked={lock === "locked"}
+            // `indeterminate` is a DOM property with no HTML attribute, so it
+            // is set through a ref rather than declared. `aria-checked` carries
+            // the same fact to assistive technology, which reads the attribute
+            // and never the property.
+            ref={element => {
+              if (element !== null) element.indeterminate = lock === "mixed";
+            }}
+            aria-checked={lock === "mixed" ? "mixed" : lock === "locked"}
+            onChange={() => {
+              if (plan === null) return;
+              editor.applyAll(plan.ops);
+            }}
+          />
+          Lock these blocks
+        </label>
+      </div>
+
+      <p className="nx-inspector__note">
+        Editing properties across several blocks is not available yet. Select
+        one block to edit what it holds.
+      </p>
     </div>
   );
 }

--- a/packages/builder/src/inspector.test.ts
+++ b/packages/builder/src/inspector.test.ts
@@ -22,6 +22,7 @@ import {
   propPatch,
   renameOp,
   SUPPORTED_PROP_TYPES,
+  lockStateOf,
 } from "./inspector";
 
 const base = {
@@ -311,5 +312,49 @@ describe("lockOp", () => {
       patch: {},
       unset: ["locked"],
     });
+  });
+});
+
+describe("lockStateOf", () => {
+  /*
+   * `mixed` is a real third state. A checkbox showing on or off for a set where
+   * only some blocks are locked tells the author something false about half of
+   * what they selected, and ARIA models exactly this as `aria-checked="mixed"`.
+   */
+  function docWith(locks: readonly boolean[]) {
+    return {
+      formatVersion: 1,
+      kind: "page",
+      nodes: locks.map((locked, i) => ({
+        id: String(i),
+        type: "acme/leaf",
+        version: 1,
+        props: {},
+        ...(locked ? { locked: true } : {}),
+      })),
+    } as never;
+  }
+
+  it("reads all-locked and all-unlocked", () => {
+    expect(lockStateOf(docWith([true, true]), ["0", "1"])).toBe("locked");
+    expect(lockStateOf(docWith([false, false]), ["0", "1"])).toBe("unlocked");
+  });
+
+  it("reads MIXED when only some are locked", () => {
+    expect(lockStateOf(docWith([true, false]), ["0", "1"])).toBe("mixed");
+  });
+
+  it("skips ids the document lost rather than counting them unlocked", () => {
+    /*
+     * An undo removing a selected block is routine. Counting the missing one as
+     * unlocked would report `mixed` for a set that is entirely locked — the
+     * author would see an indeterminate checkbox describing a state that does
+     * not exist.
+     */
+    expect(lockStateOf(docWith([true]), ["0", "gone"])).toBe("locked");
+  });
+
+  it("reads an empty set as unlocked", () => {
+    expect(lockStateOf(docWith([]), [])).toBe("unlocked");
   });
 });

--- a/packages/builder/src/inspector.ts
+++ b/packages/builder/src/inspector.ts
@@ -107,6 +107,43 @@ function optionsOf(schema: PropSchema): readonly string[] {
 }
 
 /**
+ * How a lock reads across a whole selection.
+ *
+ * `"mixed"` is a real third state, not a rounding of the other two: some
+ * selected blocks are locked and some are not, and a checkbox showing either
+ * on or off there would tell the author something false about half of what
+ * they have selected. ARIA models it as `aria-checked="mixed"`, and the first
+ * click from mixed LOCKS everything — the reading every file manager and design
+ * tool gives it, because the alternative is a first click that appears to do
+ * nothing to half the selection.
+ */
+export type LockState = "locked" | "unlocked" | "mixed";
+
+/**
+ * The lock across a set.
+ *
+ * Ids the document no longer holds are skipped rather than counted as
+ * unlocked. An undo removing a selected block is routine, and counting a
+ * missing one as unlocked would report `mixed` for a set that is entirely
+ * locked.
+ */
+export function lockStateOf(
+  document: BlockDocument,
+  ids: readonly string[]
+): LockState {
+  let locked = 0;
+  let seen = 0;
+  for (const id of ids) {
+    const node = findNode(document.nodes, id);
+    if (node === undefined) continue;
+    seen += 1;
+    if (node.locked === true) locked += 1;
+  }
+  if (seen === 0 || locked === 0) return "unlocked";
+  return locked === seen ? "locked" : "mixed";
+}
+
+/**
  * Describe the selected block for editing, or `null` when there is nothing to
  * edit.
  *

--- a/packages/builder/src/selection-ops.test.ts
+++ b/packages/builder/src/selection-ops.test.ts
@@ -202,6 +202,40 @@ describe("selectionDuplication", () => {
 });
 
 describe("selectionLock", () => {
+  it("plans only the blocks the change would ACTUALLY move", () => {
+    /*
+     * The defect a browser found and these tests did not.
+     *
+     * `applyOp` refuses an update that writes what a node already holds — "a
+     * history entry for it would undo to no visible effect" — and a group is
+     * atomic, so ONE already-locked block aborted the whole edit and locked
+     * nothing. Locking a mixed selection is the ordinary case and every one of
+     * them contains such a block.
+     *
+     * Asserted by APPLYING, not by reading the ops. The earlier version of this
+     * suite checked the array's shape, which is exactly why it passed while the
+     * editor did nothing.
+     */
+    register();
+    const document = documentOf([node("a", { locked: true }), node("b")]);
+    const plan = selectionLock(document, ["a", "b"], true);
+    if (plan === null) throw new Error("expected a plan");
+
+    let working = document;
+    for (const op of plan.ops) working = applyOp(working, op).document;
+
+    expect(working.nodes.map(n => n.locked === true)).toEqual([true, true]);
+  });
+
+  it("plans nothing when every block already holds the target state", () => {
+    // Not an empty group, which would be a no-op the store records nothing for
+    // — `null` says there is no edit, which is what a caller needs to know.
+    register();
+    const document = documentOf([node("a", { locked: true })]);
+
+    expect(selectionLock(document, ["a"], true)).toBeNull();
+  });
+
   it("locks every selected block", () => {
     register();
     const document = documentOf([node("a"), node("b")]);

--- a/packages/builder/src/selection-ops.ts
+++ b/packages/builder/src/selection-ops.ts
@@ -266,8 +266,29 @@ export function selectionLock(
 ): SelectionEdit | null {
   const ids = normalizeSelection(document, selectedIds);
   if (ids.length === 0) return null;
+
+  /*
+   * Only the blocks this would actually change.
+   *
+   * `applyOp` REFUSES an update that writes what a node already holds — "a
+   * history entry for it would undo to no visible effect" — and a group is
+   * applied atomically, so a single already-locked block would abort the whole
+   * edit and lock nothing. That is not hypothetical: locking a MIXED selection
+   * is the ordinary case, and every one of them contains a block already in the
+   * target state.
+   *
+   * Filtering here rather than loosening the op layer, because that rule is
+   * right: an op that changes nothing does not belong on the undo stack. What
+   * was wrong was planning one.
+   */
+  const changing = ids.filter(id => {
+    const node = findIn(document.nodes, id);
+    return node !== undefined && (node.locked === true) !== locked;
+  });
+  if (changing.length === 0) return null;
+
   return {
-    ops: ids.map(id => lockOp(id, locked)),
+    ops: changing.map(id => lockOp(id, locked)),
     count: ids.length,
     descendants: 0,
     nextSelection: null,

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -658,3 +658,17 @@
 .nx-block-toolbar__button[aria-disabled="true"]:hover {
   background: none;
 }
+
+/*
+ * The inspector's checkbox row, for a control that has a label beside it rather
+ * than above it. A checkbox and its words are one target, which is why the
+ * label wraps the input instead of pointing at it.
+ */
+.nx-inspector__check {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--nx-builder-text);
+  cursor: pointer;
+}

--- a/packages/builder/src/toolbar-actions.test.ts
+++ b/packages/builder/src/toolbar-actions.test.ts
@@ -21,6 +21,7 @@ import {
   TOOLBAR_GAP_PX,
   toolbarActions,
   toolbarPlacement,
+  unionRect,
   type ToolbarAction,
   type ToolbarActionId,
 } from "./toolbar-actions";
@@ -266,5 +267,102 @@ describe("toolbarPlacement", () => {
         height: 800,
       }).x
     ).toBe(0);
+  });
+});
+
+describe("unionRect", () => {
+  it("is the rectangle itself for one", () => {
+    expect(unionRect([{ x: 10, y: 20, width: 30, height: 40 }])).toEqual({
+      x: 10,
+      y: 20,
+      width: 30,
+      height: 40,
+    });
+  });
+
+  it("spans two rectangles that do not touch", () => {
+    // What a bar anchors to once a selection can hold blocks at opposite ends
+    // of a page. Anchoring at one of them would describe an action about to
+    // happen to a block the author cannot see.
+    expect(
+      unionRect([
+        { x: 0, y: 0, width: 10, height: 10 },
+        { x: 100, y: 200, width: 20, height: 5 },
+      ])
+    ).toEqual({ x: 0, y: 0, width: 120, height: 205 });
+  });
+
+  it("is unaffected by the order they arrive in", () => {
+    const a = { x: 50, y: 5, width: 10, height: 10 };
+    const b = { x: 0, y: 40, width: 10, height: 10 };
+
+    expect(unionRect([a, b])).toEqual(unionRect([b, a]));
+  });
+
+  it("answers with nothing for an empty selection", () => {
+    expect(unionRect([])).toBeUndefined();
+  });
+});
+
+describe("toolbarActions for MORE than one block", () => {
+  it("keeps duplicate and delete, which repeat cleanly", () => {
+    const document = documentOf([node("a"), node("b")]);
+    const actions = toolbarActions(document, "a", ["a", "b"]);
+
+    expect(actionOf(actions, "duplicate").enabled).toBe(true);
+    expect(actionOf(actions, "delete").enabled).toBe(true);
+  });
+
+  it("withdraws move and select-parent, which do not", () => {
+    /*
+     * A set spread across two containers has no shared list to move within, and
+     * "the parent" of blocks with different parents is not a block. Offering
+     * either would invent an answer to a question the author did not ask.
+     */
+    const document = documentOf([node("a"), node("b")]);
+    const actions = toolbarActions(document, "a", ["a", "b"]);
+
+    for (const id of ["move-up", "move-down", "select-parent"] as const) {
+      expect(actionOf(actions, id).enabled).toBe(false);
+      expect(actionOf(actions, id).reason).toBe(
+        "Only one block at a time. 2 are selected."
+      );
+    }
+  });
+
+  it("keeps the same five buttons in the same order", () => {
+    // A control that vanished when a second block was selected would move every
+    // button after it, so the one an author was aiming at is somewhere else by
+    // the time they arrive.
+    const document = documentOf([node("a"), node("b")]);
+
+    expect(toolbarActions(document, "a", ["a", "b"]).map(x => x.id)).toEqual(
+      toolbarActions(document, "a").map(x => x.id)
+    );
+  });
+
+  it("ONE lock refuses the whole delete, and names it", () => {
+    const document = documentOf([
+      node("a"),
+      node("b", "acme/heading", { locked: true, name: "Pinned" }),
+    ]);
+    const actions = toolbarActions(document, "a", ["a", "b"]);
+
+    expect(actionOf(actions, "delete").enabled).toBe(false);
+    expect(actionOf(actions, "delete").reason).toBe(
+      "Pinned is locked. Unlock it to delete."
+    );
+    // Still duplicable: the originals stay where they are.
+    expect(actionOf(actions, "duplicate").enabled).toBe(true);
+  });
+
+  it("answers exactly as before for a set of ONE, which is the control", () => {
+    // Without this, the multi branch could be taken for every selection and
+    // every single-block case above would still pass.
+    const document = documentOf([node("a"), node("b")]);
+
+    expect(toolbarActions(document, "a", ["a"])).toEqual(
+      toolbarActions(document, "a")
+    );
   });
 });

--- a/packages/builder/src/toolbar-actions.ts
+++ b/packages/builder/src/toolbar-actions.ts
@@ -90,6 +90,57 @@ function lockedBy(locked: BlockNode, selectedId: string): string {
 }
 
 /**
+ * The bar for a selection holding more than one block.
+ *
+ * **Duplicate and delete keep their meaning; move and select-parent lose it.**
+ * Copying six blocks is six copies each beside its own original, and removing
+ * six is removing six — both are the single-block verb repeated, which is
+ * exactly what `selection-ops` plans. Moving is not: a set spread across two
+ * containers has no shared list to move within, and "the parent" of blocks with
+ * different parents is not a block. Offering either would mean inventing an
+ * answer to a question the author did not ask.
+ *
+ * The bar keeps its five buttons and its one shape rather than shrinking to
+ * two. A control that vanishes when a second block is selected moves every
+ * button after it, so the one an author was aiming at is somewhere else by the
+ * time they arrive — the same reason unavailable actions are dimmed rather than
+ * hidden with a single block.
+ */
+function manyBlockActions(
+  document: BlockDocument,
+  ids: readonly string[]
+): ToolbarAction[] {
+  const many = `Only one block at a time. ${ids.length} are selected.`;
+  const deleteLock = ids
+    .map(id => lockBlockingDelete(document, id))
+    .find(node => node !== undefined);
+
+  return [
+    {
+      id: "select-parent",
+      label: "Select parent",
+      enabled: false,
+      reason: many,
+    },
+    { id: "move-up", label: "Move up", enabled: false, reason: many },
+    { id: "move-down", label: "Move down", enabled: false, reason: many },
+    // A lock never stops a duplication, for a set as for one block: the
+    // originals stay where they are.
+    { id: "duplicate", label: "Duplicate", enabled: true },
+    deleteLock === undefined
+      ? { id: "delete", label: "Delete", enabled: true }
+      : {
+          id: "delete",
+          label: "Delete",
+          enabled: false,
+          // ONE lock refuses the whole delete, because the group is applied
+          // atomically and there is no half-done delete to fall back to.
+          reason: `${layerLabel(deleteLock)} is locked. Unlock it to delete.`,
+        },
+  ];
+}
+
+/**
  * The toolbar's buttons for the current selection, or `[]` when there is none.
  *
  * `[]` also covers a selected id the document no longer holds, which an undo
@@ -98,12 +149,23 @@ function lockedBy(locked: BlockNode, selectedId: string): string {
  */
 export function toolbarActions(
   document: BlockDocument,
-  selectedId: string | null
+  selectedId: string | null,
+  /**
+   * Every selected id. Defaults to the primary alone.
+   *
+   * Optional so a caller with one block — the command palette, a host that has
+   * not adopted the set — keeps the same answer it had. What changes for a
+   * SET is which verbs are well defined, not which rules decide them.
+   */
+  selectedIds?: readonly string[]
 ): ToolbarAction[] {
   if (selectedId === null) return [];
 
   const path = pathTo(document, selectedId);
   if (path.length === 0) return [];
+
+  const ids = selectedIds ?? [selectedId];
+  if (ids.length > 1) return manyBlockActions(document, ids);
 
   const moveLock = lockBlockingMove(document, selectedId);
   const deleteLock = lockBlockingDelete(document, selectedId);
@@ -157,6 +219,34 @@ export function toolbarActions(
           reason: lockedBy(deleteLock, selectedId),
         },
   ];
+}
+
+/**
+ * The smallest rectangle containing all of them, or `undefined` for none.
+ *
+ * What a floating bar anchors to once a selection can hold several blocks. The
+ * PRIMARY's rectangle would be the easy choice and is the wrong one: with two
+ * blocks selected at opposite ends of a page, a bar drawn at one of them
+ * describes an action that is about to happen to both, and the author cannot
+ * see the other. The union is the shape the selection actually occupies.
+ */
+export function unionRect(rects: readonly Rect[]): Rect | undefined {
+  const [first, ...rest] = rects;
+  if (first === undefined) return undefined;
+
+  let left = first.x;
+  let top = first.y;
+  let right = first.x + first.width;
+  let bottom = first.y + first.height;
+
+  for (const rect of rest) {
+    left = Math.min(left, rect.x);
+    top = Math.min(top, rect.y);
+    right = Math.max(right, rect.x + rect.width);
+    bottom = Math.max(bottom, rect.y + rect.height);
+  }
+
+  return { x: left, y: top, width: right - left, height: bottom - top };
 }
 
 /** How big the bar measured, in canvas content pixels. */


### PR DESCRIPTION
**Step 4a of B-10.** The toolbar and inspector now answer for a whole selection instead of describing one block while the canvas outlines several.

**The layers panel is deliberately not here.** `TreeView` is single-select by contract — `selectedId?: string | null`, `onSelectedChange?: (id: string) => void`, no `selectedIds` and no modifiers. That change belongs in `packages/ui`; the lane that owns it has confirmed the file is free and agreed I make it, so it lands next.

## The toolbar

**Anchored to the UNION of every selected rectangle, not to the primary.** With two blocks selected at opposite ends of a page, a bar drawn at one of them describes an action about to happen to a block the author cannot see. The `ResizeObserver` watches every selected block for the same reason — the primary alone would leave the bar stale whenever a secondary reflowed, which is most of what happens while an image loads.

**Duplicate and delete keep their meaning; move and select-parent lose it.** A set spread across two containers has no shared list to move within, and "the parent" of blocks with different parents is not a block. Offering either would invent an answer to a question the author did not ask. The bar keeps all five buttons in the same order, for the same reason unavailable actions are dimmed rather than hidden with one block.

## The inspector

Says **how many** blocks are selected rather than describing one of them. Per-property batch editing — a field showing "Mixed" and writing to every block — is Plan 05's, and this PR does not pretend to it.

What *is* here is the one property well defined across any set today, because it is a flag rather than a value: **the lock, as a tri-state**. "Some of these are locked" is a real state, and showing it as on or off tells the author something false about half their selection. ARIA models it as `aria-checked="mixed"`, with `indeterminate` set through a ref since it is a DOM property with no HTML attribute. **From mixed, the first press locks** — unlocking would be a press that appears to do nothing to the blocks that were already unlocked.

## The defect a browser found and the tests did not

The tri-state worked, and pressing it from **mixed** did nothing at all.

`applyOp` deliberately refuses an update that writes what a node already holds — *"a history entry for it would undo to no visible effect."* That is a good rule. But a group is **atomic**, so a single already-locked block aborted the whole edit and locked nothing. Locking a mixed selection is the ordinary case, and every one of them contains such a block.

**Why the suite missed it:** `selectionLock`'s tests asserted the shape of the ops array; the duplicate tests asserted by *applying* the ops. That asymmetry is exactly the gap. The unit test for the panel used a spy `applyAll` that never ran a real op, so it passed while the editor did nothing.

Fixed in `selectionLock` — it plans only the blocks a change would actually move — rather than by loosening the op layer, because that rule is right: an op that changes nothing does not belong on the undo stack. What was wrong was planning one. The new test **applies** the ops and asserts both blocks end locked; stubbing the filter away fails it.

One of my own tests had encoded the buggy behaviour and is corrected, with a comment saying so.

## Verified in a browser

Playground `:3123`, auth control asserted first.

| step | result |
| --- | --- |
| one block selected (**control**) | inspector titled "Heading" with a Name field; all five buttons |
| Cmd+click a second | "2 blocks selected", no Name field; select-parent/move-up/move-down off, duplicate/delete on |
| lock one of the two | checkbox reads `aria-checked="mixed"`, `indeterminate=true` |
| press once from mixed | `aria-checked="true"`, `indeterminate=false`, **both blocks locked** |
| toolbar position | bar top 102 against a union spanning 48–96, i.e. below the union by the 6px gap |
| delete with one locked | refused, "Kid is locked. Unlock it to delete." |

Console: one error-level line, the pre-existing `["autosave-recovery",…]`; zero beyond it.

## Gate and style

`packages/builder` **789 tests**, `plugin-page-builder` 65, types and lint clean. Fallow `new-only` checked before opening: `verdict: pass`, everything `introduced: 0`.

No new colour. Secondary selection is a weight difference only — 2px primary, 1px secondary.

> **A justification I gave for that, and am withdrawing.** This section first said the weight-only rule "sidesteps a contrast hazard where a foreground on a tinted background renders far below what the suite reports". **That hazard is not real**, and I repeated it without checking. Verified myself after its author retracted it:
> - the cited defect splits by variant — light is `bg-success-50` (solid) with `text-success-700`, dark is `bg-success-950/40` with `text-success-300`. The failing pair was one variant's text against the other's background, which never renders.
> - the contrast suite **does** composite tints: `ink-utilities.test.ts:268` blends `compositeOver(applyOpacity(fill, tint.alpha), base)` and measures ink against the blend.
>
> So a tint here would have been measured, not unmeasurable. **The weight-only rule stays** — it reads at any contrast, does not depend on a colour a themer can move, and needs no acceptance entry — but it stays because it is the better design, not because of a hazard that does not exist.
>
> One real gap did come out of it and is not fixed here: `ink-utilities.test.ts` scans `["packages/admin/src", "packages/ui/src"]` only, so `packages/builder/src` is outside it. `tree-view.tsx` in the next PR **is** measured; the builder chrome is not.
