### PR TITLE
feat(admin): show the source language beside the one being translated

### DIFF
--- a/.changeset/translation-mode.md
+++ b/.changeset/translation-mode.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Translating a document now shows the source language beside the one being edited. A translator working a non-default language could previously see the source only as an inline hint under each field, and that hint could render a string or a number and nothing else — so a richText body, a relationship or a chips list had no source text on screen at all, silently. The new mode renders the source through the editor's own field components, so whatever a field can draw the source shows.
+
+The language pair lives in the URL (`?locale=es&translate=en`), which makes it linkable, reload-safe and reachable with the back button, and makes entering or leaving it a navigation the unsaved-changes guard can see. While the mode is on the admin's navigation, sub-sidebar, header and page frame step aside, and the mode renders its own way back — the suppression layer grants the navigation rail only to a surface that says it can be left.
+
+The source pane is read-only and shows only the translatable fields: a shared field holds the same value in both languages, so putting it there would fill half the screen with a copy of what is already in the other pane.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -46,12 +46,12 @@ import {
 } from "@admin/lib/builder/takeoverLayout";
 import { cn } from "@admin/lib/utils";
 
-import {
-  collectionSourceFetcher,
-  localizedFieldNamesOf,
-} from "../entry-locale-source";
+import { collectionSourceFetcher } from "../entry-locale-source";
 import { EntryLocaleProvider } from "../EntryLocaleContext";
 import { LanguagePanel } from "../LanguagePanel";
+import { TranslationPanes } from "../TranslationMode/TranslationPanes";
+import { useTranslationSource } from "../TranslationMode/useTranslationSource";
+import { useEntryLocaleContext } from "../useEntryLocaleContext";
 
 import { AutosaveRecoveryBanner } from "./AutosaveRecoveryBanner";
 import {
@@ -130,6 +130,24 @@ export interface EntryFormProps {
    */
   embedded?: boolean;
   /** Additional CSS classes for the form container */
+  /**
+   * i18n: translation mode — the language being translated FROM, the source
+   * document read at it, and the way in and out.
+   *
+   * One prop rather than four, because they are one concept and always travel
+   * together: three of them are meaningless without `from`, and a form given
+   * some of them is in a state the page cannot produce.
+   */
+  translation?: {
+    /** The source language, or absent when the mode is off. */
+    from?: string | undefined;
+    /** The source document's values, read at `from`. */
+    sourceDocument?: Record<string, unknown> | undefined;
+    /** Enter the mode, reading the source from the named language. */
+    onEnter?: (source: string) => void;
+    /** Leave the mode, keeping the language being edited. */
+    onExit?: () => void;
+  };
   className?: string;
 }
 
@@ -224,6 +242,7 @@ export function EntryForm({
   seedFromLocale,
   onSeedHandled,
   sourceValues,
+  translation,
   embedded = false,
   className,
 }: EntryFormProps) {
@@ -280,49 +299,36 @@ export function EntryForm({
     };
   }, [entry?.id, collection.slug, collection.name, publishAllEntryLocales]);
 
-  const localeCtx = useMemo(() => {
-    const collectionLocalized = collection.localized === true;
-    const collectionSlug = collection.slug ?? collection.name;
-    const entryId = entry?.id ?? undefined;
-    return {
-      locale,
-      // `locale` is undefined while editing the implicit default language, so
-      // resolve the default explicitly — otherwise a default-locale that is RTL
-      // would render its translatable fields left-to-right until explicitly picked.
-      rtl: getLocale(locale ?? defaultLocale)?.rtl ?? false,
-      collectionLocalized,
-      isNonDefaultLocale:
-        !!locale && !!defaultLocale && locale !== defaultLocale,
-      sourceValues,
-      onLocaleChange,
-      seedFromLocale,
-      onSeedHandled,
-      collectionSlug,
-      entryId,
-      // The translatable-field set, for the field-scoped copy-from-language action.
-      localizedFieldNames: localizedFieldNamesOf(
-        getCollectionFields(collection),
-        collectionLocalized
-      ),
-      // Copy-from-language reads its source THROUGH this seam instead of
-      // addressing the document itself, so one implementation serves entries
-      // and singles alike — a single has no collection slug or entry id and
-      // could otherwise never offer the action at all.
-      fetchSourceValues: collectionSourceFetcher(collectionSlug, entryId),
-      publishAllLanguages,
-    };
-  }, [
+  const translationMode = useTranslationSource({
+    fields: getCollectionFields(collection),
+    documentLocalized: collection.localized === true,
+    translation,
     locale,
-    getLocale,
     defaultLocale,
-    collection,
+    getLocale,
+  });
+
+  const collectionSlug = collection.slug ?? collection.name;
+  const localeCtx = useEntryLocaleContext({
+    locale,
+    defaultLocale,
+    getLocale,
+    documentLocalized: collection.localized === true,
+    fields: getCollectionFields(collection),
     sourceValues,
+    inTranslationMode: translationMode.active,
     onLocaleChange,
     seedFromLocale,
     onSeedHandled,
-    entry?.id,
+    onEnterTranslationMode: translationMode.onEnter,
+    collectionSlug,
+    entryId: entry?.id ?? undefined,
+    fetchSourceValues: collectionSourceFetcher(
+      collectionSlug,
+      entry?.id ?? undefined
+    ),
     publishAllLanguages,
-  ]);
+  });
 
   // Get all fields. Title and slug are extracted as system fields rendered in
   // their own header card (this PR keeps the existing title/slug special-case;
@@ -590,23 +596,28 @@ export function EntryForm({
     <UnsavedChangesGuard isDirty={isDirty} disabled={isSubmitting}>
       <EntryLocaleProvider value={localeCtx}>
         <DocumentHistoryContext.Provider value={documentHistory}>
-          <EntryFormContextProvider
-            entryId={entry?.id}
-            collectionSlug={collection.name}
-            isCreateMode={mode === "create"}
+          {/* Renders its child alone when there is no source — see the module. */}
+          <TranslationPanes
+            source={translationMode.source}
+            onExit={translationMode.onExit}
           >
-            <div className={cn("space-y-0", className)}>
-              <EntryFormProvider form={form} onSubmit={handleSubmit}>
-                <FormErrorSummary
-                  errors={errors}
-                  submitCount={submitCount}
-                  className="mx-6 mt-3"
-                />
+            <EntryFormContextProvider
+              entryId={entry?.id}
+              collectionSlug={collection.name}
+              isCreateMode={mode === "create"}
+            >
+              <div className={cn("space-y-0", className)}>
+                <EntryFormProvider form={form} onSubmit={handleSubmit}>
+                  <FormErrorSummary
+                    errors={errors}
+                    submitCount={submitCount}
+                    className="mx-6 mt-3"
+                  />
 
-                <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-m-8">
-                  {/* Main column */}
-                  <div className="flex-1 min-w-0 flex flex-col">
-                    {/* Why: the parent flex's @4xl/content:-m-8 already cancels
+                  <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-m-8">
+                    {/* Main column */}
+                    <div className="flex-1 min-w-0 flex flex-col">
+                      {/* Why: the parent flex's @4xl/content:-m-8 already cancels
                   PageContainer's px-8 padding so the form runs edge-to-edge
                   once the panel is wide enough. Wrapping the system
                   header / meta strip in another -mx-8 doubled the negative
@@ -614,210 +625,214 @@ export function EntryForm({
                   each side — clipping the title's first character on the
                   left and the rail toggle / right-edge buttons on the right.
                   Letting them fill the Main column naturally fixes that. */}
-                    <EntrySystemHeader
-                      mode={mode}
-                      titleField={titleField}
-                      hasStatus={hasStatus}
-                      draftsEnabled={collection.draftsEnabled === true}
-                      isSubmitting={isSubmitting}
-                      isDirty={isDirty}
-                      autosaveEnabled={autosaveScope !== null}
-                      autosaveStatus={autosave.status}
-                      autosaveLastSavedAt={autosave.lastSavedAt}
-                      entry={entry}
-                      collectionSlug={collection.name}
-                      historyFields={getCollectionFields(collection)}
-                      historyEnabled={historyEnabledFrom(collection)}
-                      locale={locale}
-                      onLocaleChange={onLocaleChange}
-                      localized={collection.localized === true}
-                      // Withheld while the language is unknown as well as while
-                      // the entry is unsaved: a link minted without a resolvable
-                      // locale is either refused by the mint route or, if the claim
-                      // were dropped to avoid that, a grant over every translation.
-                      isLinkAvailable={
-                        savedEntryId !== "" && linkLocale.kind !== "unresolved"
-                      }
-                      {...(savedEntryId === ""
-                        ? {}
-                        : {
-                            onCopyLink: () => {
-                              previewLink.mutate();
-                            },
-                          })}
-                      isCopyingLink={previewLink.isPending}
-                      toolbarSlot={
-                        <EntryFormToolbarSlots
-                          context="collection"
-                          controllerField={controllerNames[0]}
-                        />
-                      }
-                      onSaveDraft={() => {
-                        void handleSubmit(undefined, "save-draft");
-                      }}
-                      onPublish={() => {
-                        void handleSubmit(undefined, "publish");
-                      }}
-                      onSaveChanges={() => {
-                        void handleSubmit(undefined, "save-changes");
-                      }}
-                      onSaveWorkingDraft={() => {
-                        void handleSubmit(undefined, "save-working-draft");
-                      }}
-                      onUnpublish={() => {
-                        void handleSubmit(undefined, "unpublish");
-                      }}
-                      onCancel={handleCancel}
-                      onDelete={handleDelete}
-                      onDiscardWorkingDraft={handleDiscardWorkingDraft}
-                      isRailCollapsed={railCollapsed}
-                      onToggleRail={mode === "edit" ? toggleRail : undefined}
-                    />
-                    {/* Above the fields and below the header: the reader sees
+                      <EntrySystemHeader
+                        mode={mode}
+                        titleField={titleField}
+                        hasStatus={hasStatus}
+                        draftsEnabled={collection.draftsEnabled === true}
+                        isSubmitting={isSubmitting}
+                        isDirty={isDirty}
+                        autosaveEnabled={autosaveScope !== null}
+                        autosaveStatus={autosave.status}
+                        autosaveLastSavedAt={autosave.lastSavedAt}
+                        entry={entry}
+                        collectionSlug={collection.name}
+                        historyFields={getCollectionFields(collection)}
+                        historyEnabled={historyEnabledFrom(collection)}
+                        locale={locale}
+                        onLocaleChange={onLocaleChange}
+                        localized={collection.localized === true}
+                        // Withheld while the language is unknown as well as while
+                        // the entry is unsaved: a link minted without a resolvable
+                        // locale is either refused by the mint route or, if the claim
+                        // were dropped to avoid that, a grant over every translation.
+                        isLinkAvailable={
+                          savedEntryId !== "" &&
+                          linkLocale.kind !== "unresolved"
+                        }
+                        {...(savedEntryId === ""
+                          ? {}
+                          : {
+                              onCopyLink: () => {
+                                previewLink.mutate();
+                              },
+                            })}
+                        isCopyingLink={previewLink.isPending}
+                        toolbarSlot={
+                          <EntryFormToolbarSlots
+                            context="collection"
+                            controllerField={controllerNames[0]}
+                          />
+                        }
+                        onSaveDraft={() => {
+                          void handleSubmit(undefined, "save-draft");
+                        }}
+                        onPublish={() => {
+                          void handleSubmit(undefined, "publish");
+                        }}
+                        onSaveChanges={() => {
+                          void handleSubmit(undefined, "save-changes");
+                        }}
+                        onSaveWorkingDraft={() => {
+                          void handleSubmit(undefined, "save-working-draft");
+                        }}
+                        onUnpublish={() => {
+                          void handleSubmit(undefined, "unpublish");
+                        }}
+                        onCancel={handleCancel}
+                        onDelete={handleDelete}
+                        onDiscardWorkingDraft={handleDiscardWorkingDraft}
+                        isRailCollapsed={railCollapsed}
+                        onToggleRail={mode === "edit" ? toggleRail : undefined}
+                      />
+                      {/* Above the fields and below the header: the reader sees
                     the document it refers to without the offer covering it. */}
-                    {recovery.offer ? (
-                      <AutosaveRecoveryBanner
-                        savedAt={recovery.offer.savedAt}
-                        onRestore={restoreRecovery}
-                        onDismiss={recovery.dismiss}
-                      />
-                    ) : null}
-                    {viewingVersion ? (
-                      <HistoricalDocumentBanner
-                        versionNo={viewingVersion.versionNo}
-                        locale={viewingVersion.locale}
-                        // Routed through the panel when one is mounted, so its
-                        // selection clears with the shared state. The direct
-                        // fallback keeps the banner working without a panel.
-                        onReturnToCurrent={
-                          restoreAffordance?.returnToCurrent ??
-                          (() => setViewingVersion(null))
+                      {recovery.offer ? (
+                        <AutosaveRecoveryBanner
+                          savedAt={recovery.offer.savedAt}
+                          onRestore={restoreRecovery}
+                          onDismiss={recovery.dismiss}
+                        />
+                      ) : null}
+                      {viewingVersion ? (
+                        <HistoricalDocumentBanner
+                          versionNo={viewingVersion.versionNo}
+                          locale={viewingVersion.locale}
+                          // Routed through the panel when one is mounted, so its
+                          // selection clears with the shared state. The direct
+                          // fallback keeps the banner working without a panel.
+                          onReturnToCurrent={
+                            restoreAffordance?.returnToCurrent ??
+                            (() => setViewingVersion(null))
+                          }
+                          // Offered only when the panel says this caller may write.
+                          onRestore={
+                            restoreAffordance?.canRestore
+                              ? restoreAffordance.request
+                              : undefined
+                          }
+                          // And only once the version is actually on screen:
+                          // restoring from a skeleton, or from a failed read, is a
+                          // decision made without having seen what is being chosen.
+                          restoreDisabled={!versionOnScreen}
+                        />
+                      ) : null}
+                      <EntryMetaStrip
+                        slugField={slugField}
+                        hasStatus={hasStatus}
+                        // The pill reports the language being edited, matching the header's submit
+                        // affordances. Reading the main row instead would show "Published" beside a
+                        // Publish button whenever a translation lags its default language.
+                        status={
+                          effectiveEntryStatus(entry, locale, defaultLocale) ??
+                          "draft"
                         }
-                        // Offered only when the panel says this caller may write.
-                        onRestore={
-                          restoreAffordance?.canRestore
-                            ? restoreAffordance.request
-                            : undefined
+                        hasWorkingDraft={
+                          (
+                            entry as
+                              | { _isWorkingDraft?: boolean }
+                              | null
+                              | undefined
+                          )?._isWorkingDraft === true
                         }
-                        // And only once the version is actually on screen:
-                        // restoring from a skeleton, or from a failed read, is a
-                        // decision made without having seen what is being chosen.
-                        restoreDisabled={!versionOnScreen}
+                        isRailCollapsed={railCollapsed}
+                        hasPublicAddress={hasPublicAddress}
                       />
-                    ) : null}
-                    <EntryMetaStrip
-                      slugField={slugField}
-                      hasStatus={hasStatus}
-                      // The pill reports the language being edited, matching the header's submit
-                      // affordances. Reading the main row instead would show "Published" beside a
-                      // Publish button whenever a translation lags its default language.
-                      status={
-                        effectiveEntryStatus(entry, locale, defaultLocale) ??
-                        "draft"
-                      }
-                      hasWorkingDraft={
-                        (
-                          entry as
-                            | { _isWorkingDraft?: boolean }
-                            | null
-                            | undefined
-                        )?._isWorkingDraft === true
-                      }
-                      isRailCollapsed={railCollapsed}
-                      hasPublicAddress={hasPublicAddress}
-                    />
 
-                    {/* The language panel, inline. Its rail mount is
+                      {/* The language panel, inline. Its rail mount is
                       `hidden @4xl/content:flex`, so this is the exact
                       complement: shown only where the rail is not. When the
                       rail cannot carry it at all — create mode, or the author
                       collapsed it — the panel renders unconditionally instead,
                       because "the actions live in the rail" is precisely the
                       failure this stage removes. */}
-                    {localizationEnabled && (
-                      <div
-                        className={cn(
-                          "px-6 pt-4",
-                          mode === "edit" &&
-                            !railCollapsed &&
-                            "@4xl/content:hidden"
-                        )}
-                      >
-                        <LanguagePanel
-                          {...(entry?._translations === undefined
-                            ? {}
-                            : {
-                                translations: entry._translations as Record<
-                                  string,
-                                  { translated: boolean; status?: string }
-                                >,
-                              })}
-                          {...(locale === undefined
-                            ? {}
-                            : { activeLocale: locale })}
-                          {...(onLocaleChange === undefined
-                            ? {}
-                            : { onSelect: onLocaleChange })}
-                          hasStatus={hasStatus}
-                          actionsDisabled={viewingVersion !== null}
-                        />
-                      </div>
-                    )}
+                      {localizationEnabled && (
+                        <div
+                          className={cn(
+                            "px-6 pt-4",
+                            mode === "edit" &&
+                              !railCollapsed &&
+                              "@4xl/content:hidden"
+                          )}
+                        >
+                          <LanguagePanel
+                            {...(entry?._translations === undefined
+                              ? {}
+                              : {
+                                  translations: entry._translations as Record<
+                                    string,
+                                    { translated: boolean; status?: string }
+                                  >,
+                                })}
+                            {...(locale === undefined
+                              ? {}
+                              : { activeLocale: locale })}
+                            {...(onLocaleChange === undefined
+                              ? {}
+                              : { onSelect: onLocaleChange })}
+                            hasStatus={hasStatus}
+                            actionsDisabled={viewingVersion !== null}
+                          />
+                        </div>
+                      )}
 
-                    {/* Reading a past version replaces the document rather than
+                      {/* Reading a past version replaces the document rather than
                     opening beside it: the question an editor is asking is how
                     this page read then, and that is answered by the page. The
                     live form stays mounted underneath — the historical values
                     are rendered against a form of their own, so nothing typed
                     here is disturbed and nothing historical can reach a save. */}
-                    {viewingVersion ? (
-                      <div className="@4xl/content:p-8 pt-6">
-                        {viewingVersion.error ? (
-                          // A failed read must not render as an empty document:
-                          // that is a different and wrong claim about the version.
-                          <Alert variant="destructive">
-                            <AlertDescription>
-                              This version could not be loaded.
-                            </AlertDescription>
-                          </Alert>
-                        ) : !versionOnScreen ? (
-                          <div className="flex flex-col gap-4" aria-busy="true">
-                            <span className="sr-only" role="status">
-                              Loading version {viewingVersion.versionNo}
-                            </span>
-                            {[0, 1, 2, 3].map(i => (
-                              <div key={i} className="flex flex-col gap-1">
-                                <Skeleton className="h-3 w-24" />
-                                <Skeleton className="h-9 w-full" />
-                              </div>
-                            ))}
-                          </div>
-                        ) : (
-                          <VersionSnapshotForm
-                            fields={historicalFields ?? mainFields}
-                            snapshot={viewingVersion.snapshot}
-                          />
-                        )}
-                      </div>
-                    ) : (
-                      mainFields.length > 0 && (
+                      {viewingVersion ? (
                         <div className="@4xl/content:p-8 pt-6">
-                          {/* Forward the form mode: in edit mode a blank password
+                          {viewingVersion.error ? (
+                            // A failed read must not render as an empty document:
+                            // that is a different and wrong claim about the version.
+                            <Alert variant="destructive">
+                              <AlertDescription>
+                                This version could not be loaded.
+                              </AlertDescription>
+                            </Alert>
+                          ) : !versionOnScreen ? (
+                            <div
+                              className="flex flex-col gap-4"
+                              aria-busy="true"
+                            >
+                              <span className="sr-only" role="status">
+                                Loading version {viewingVersion.versionNo}
+                              </span>
+                              {[0, 1, 2, 3].map(i => (
+                                <div key={i} className="flex flex-col gap-1">
+                                  <Skeleton className="h-3 w-24" />
+                                  <Skeleton className="h-9 w-full" />
+                                </div>
+                              ))}
+                            </div>
+                          ) : (
+                            <VersionSnapshotForm
+                              fields={historicalFields ?? mainFields}
+                              snapshot={viewingVersion.snapshot}
+                            />
+                          )}
+                        </div>
+                      ) : (
+                        mainFields.length > 0 && (
+                          <div className="@4xl/content:p-8 pt-6">
+                            {/* Forward the form mode: in edit mode a blank password
                       field means "keep the current password" rather than a
                       required-field violation (see note on the layout form
                       above). */}
-                          <EntryFormContent
-                            fields={mainFields}
-                            disabled={isSubmitting}
-                            withCard
-                            mode={mode}
-                          />
-                        </div>
-                      )
-                    )}
-                  </div>
+                            <EntryFormContent
+                              fields={mainFields}
+                              disabled={isSubmitting}
+                              withCard
+                              mode={mode}
+                            />
+                          </div>
+                        )
+                      )}
+                    </div>
 
-                  {/* Rail (collapsible). Width 320px. Hidden until the content panel
+                    {/* Rail (collapsible). Width 320px. Hidden until the content panel
                 is wide enough (@4xl) to fit it beside the main column, until a
                 future mobile sheet ships.
 
@@ -826,27 +841,28 @@ export function EntryForm({
                 nothing to show. Rendering it anyway left an empty 320px
                 strip down the right side of the page, which reads as a
                 failed load rather than as an absence. */}
-                  {mode === "edit" && !railCollapsed && (
-                    <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
-                      <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
-                        <EntryFormSidebar
-                          mode={mode}
-                          entry={entry}
-                          hasStatus={hasStatus}
-                          {...(locale === undefined ? {} : { locale })}
-                          {...(onLocaleChange === undefined
-                            ? {}
-                            : { onLocaleChange })}
-                          actionsDisabled={viewingVersion !== null}
-                          isDirty={isDirty}
-                        />
+                    {mode === "edit" && !railCollapsed && (
+                      <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
+                        <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
+                          <EntryFormSidebar
+                            mode={mode}
+                            entry={entry}
+                            hasStatus={hasStatus}
+                            {...(locale === undefined ? {} : { locale })}
+                            {...(onLocaleChange === undefined
+                              ? {}
+                              : { onLocaleChange })}
+                            actionsDisabled={viewingVersion !== null}
+                            isDirty={isDirty}
+                          />
+                        </div>
                       </div>
-                    </div>
-                  )}
-                </div>
-              </EntryFormProvider>
-            </div>
-          </EntryFormContextProvider>
+                    )}
+                  </div>
+                </EntryFormProvider>
+              </div>
+            </EntryFormContextProvider>
+          </TranslationPanes>
         </DocumentHistoryContext.Provider>
       </EntryLocaleProvider>
     </UnsavedChangesGuard>

--- a/packages/admin/src/components/features/entries/EntryForm/ReadOnlyDocumentForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/ReadOnlyDocumentForm.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+/**
+ * A document rendered through the editor's own field components, not editable.
+ *
+ * Two surfaces need this and want it for the same reason: a past version is the
+ * document as it was, and a translation source is the document in another
+ * language. Neither is a different KIND of thing from the document being
+ * edited, so neither gets a second renderer deciding how a field looks —
+ * `FieldRenderer` resolves its `control` from form context, so supplying a
+ * different context is the whole mechanism, and every field type already
+ * honours `readOnly`.
+ *
+ * ## Three layers, and only the third is a boundary
+ *
+ * Worth stating precisely, because the obvious reading of this file is that the
+ * `disabled` below makes the document unwritable, and it does not.
+ *
+ * 1. **`readOnly` is a CONTRACT**, honoured by each field component. Every core
+ *    type honours it. It is not a boundary: it depends on the participant, and a
+ *    participant has already failed — `plugin-page-builder`'s blocks field
+ *    declared only `{ name, control }`, dropped the flag, and offered a live
+ *    "Edit blocks" button on a past version until #1043 fixed it.
+ * 2. **`disabled` is defence in depth** for registered inputs. It does NOT stop
+ *    a programmatic write: measured against RHF 7.66, a `field.onChange` through
+ *    `useController` lands on a `disabled: true` form exactly as it does on an
+ *    enabled one. `ReadOnlyDocumentForm.boundary.test.tsx` records that, with a
+ *    control, so nobody reads this line as a guarantee.
+ * 3. **Isolation is the boundary.** The form is constructed here, never
+ *    returned, and no save affordance is rendered inside its provider — so a
+ *    stray write has nowhere to go. Nothing outside can read these values, and
+ *    that is what makes a field component's misbehaviour harmless rather than
+ *    merely unlikely.
+ *
+ * ## The precondition callers have to respect
+ *
+ * Layer 3 is the one a caller can break, and breaking it is not obvious:
+ * `useFormContext` binds to the NEAREST provider, so a save control placed
+ * inside this component would submit THIS document rather than the one being
+ * edited. Only a field tree belongs inside.
+ *
+ * @module components/features/entries/EntryForm/ReadOnlyDocumentForm
+ */
+
+import type { FieldConfig } from "nextly/config";
+import { useId } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+
+import { FieldIdScopeContext } from "@admin/components/features/entries/fields/field-id-scope";
+
+import { EntryFormContent } from "./EntryFormContent";
+
+export interface ReadOnlyDocumentFormProps {
+  /** The schema that decides what is shown, and in what order. */
+  fields: FieldConfig[];
+  /**
+   * The values, ALREADY in the shape the form's inputs read.
+   *
+   * Deliberately not normalised here, because the two callers start from
+   * different shapes and only they know which: a version snapshot comes from
+   * the persisted row (`snapshotToFormValues`), and a translation source comes
+   * from the read model (`getDefaultValues`). A normaliser chosen here would be
+   * wrong for one of them, and wrong quietly — a JSON-backed field renders
+   * blank rather than erroring.
+   */
+  values: Record<string, unknown>;
+  /**
+   * Form mode. `"edit"` by default: both callers show a document that exists,
+   * so write-only fields such as password present themselves as they do when
+   * editing rather than as they do on a blank create form.
+   */
+  mode?: "create" | "edit";
+  className?: string;
+}
+
+export function ReadOnlyDocumentForm({
+  fields,
+  values,
+  mode = "edit",
+  className,
+}: ReadOnlyDocumentFormProps) {
+  // `values`, not `defaultValues`. `defaultValues` is read once per mounted
+  // form, so changing which document this shows — a second version, a different
+  // source language — while it stays mounted would leave the previous one's
+  // fields under the new one's heading. `values` reapplies when it changes,
+  // which makes the correct behaviour a property of this component rather than
+  // an obligation on every caller to remount it.
+  //
+  // `disabled` is layer 2 above: it disables the registered inputs, which is
+  // worth having, and it is not what stops a write.
+  const form = useForm<Record<string, unknown>>({ values, disabled: true });
+
+  // A DOM id scope of its own. A field's id is its path, which is unique in a
+  // form and not on a page — so without this every label here would point at
+  // the live editor's control of the same name: these fields would lose their
+  // accessible name, and clicking a label in a read-only view would move focus
+  // into the editable document.
+  const idScope = useId();
+
+  return (
+    <FieldIdScopeContext.Provider value={idScope}>
+      <FormProvider {...form}>
+        <EntryFormContent
+          fields={fields}
+          readOnly
+          mode={mode}
+          {...(className === undefined ? {} : { className })}
+        />
+      </FormProvider>
+    </FieldIdScopeContext.Provider>
+  );
+}

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/ReadOnlyDocumentForm.boundary.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/ReadOnlyDocumentForm.boundary.test.tsx
@@ -1,0 +1,95 @@
+// What `disabled` on a read-only document form does and does NOT do.
+//
+// This file exists because the opposite was assumed. `ReadOnlyDocumentForm`
+// passes `disabled: true`, and the obvious reading is that the document is then
+// unwritable — so a later reader stops looking for a real boundary. It is not:
+// measured against RHF 7.66, a programmatic write through the exact path a field
+// component uses (`useController(...).field.onChange`) lands on a disabled form
+// exactly as it lands on an enabled one.
+//
+// The path is chosen deliberately. `plugin-page-builder`'s blocks field declared
+// only `{ name, control }` and dropped the `readOnly` FieldRenderer passes it,
+// rendering a live editor whose commit is `field.onChange` on whichever form
+// context is nearest — which on a past version was the snapshot's. #1043 fixed
+// that field; this asserts what the FORM does, which is what covers the next one.
+//
+// What actually keeps a stray write harmless is ISOLATION: the form is built
+// inside the component, never returned, and no save affordance sits in its
+// provider.
+
+import { render, screen, act } from "@testing-library/react";
+import {
+  useForm,
+  useController,
+  FormProvider,
+  type Control,
+} from "react-hook-form";
+import { describe, it, expect } from "vitest";
+
+/**
+ * Stands in for a field component that ignores `readOnly` — the shape the blocks
+ * field had before #1043, and the shape any third-party field may still have. It
+ * takes only the two props such a component declares, and writes through the
+ * controller, which is the path a plugin editor's commit takes.
+ */
+function IgnoresReadOnly({
+  name,
+  control,
+}: {
+  name: string;
+  control: Control<Record<string, unknown>>;
+}) {
+  const { field } = useController({ name, control });
+  return (
+    <>
+      <span data-testid="value">{String(field.value ?? "")}</span>
+      <button type="button" onClick={() => field.onChange("WRITTEN")}>
+        Commit
+      </button>
+    </>
+  );
+}
+
+/** Mirrors `ReadOnlyDocumentForm`'s form construction, without its field tree. */
+function Harness({ disabled }: { disabled: boolean }) {
+  const form = useForm<Record<string, unknown>>({
+    values: { body: "original" },
+    disabled,
+  });
+  return (
+    <FormProvider {...form}>
+      <IgnoresReadOnly name="body" control={form.control} />
+      <span data-testid="form-value">{String(form.watch("body") ?? "")}</span>
+    </FormProvider>
+  );
+}
+
+describe("ReadOnlyDocumentForm's write boundary", () => {
+  it("POSITIVE CONTROL: the same write DOES land on a form that is not disabled", async () => {
+    // Without this the test below passes on a harness that never wired the
+    // button up at all, which is the same green as a working boundary.
+    render(<Harness disabled={false} />);
+    expect(screen.getByTestId("form-value")).toHaveTextContent("original");
+
+    await act(async () => {
+      screen.getByRole("button", { name: "Commit" }).click();
+    });
+
+    expect(screen.getByTestId("form-value")).toHaveTextContent("WRITTEN");
+  });
+
+  it("does NOT refuse a programmatic write when the form is disabled", async () => {
+    // The recorded limit, not a wish. If a future RHF makes `disabled` block
+    // this, THIS test fails — and that failure is the signal to promote
+    // `disabled` to a real boundary in the docblock, rather than something to
+    // "fix" by loosening the assertion.
+    render(<Harness disabled />);
+    expect(screen.getByTestId("form-value")).toHaveTextContent("original");
+
+    await act(async () => {
+      screen.getByRole("button", { name: "Commit" }).click();
+    });
+
+    expect(screen.getByTestId("form-value")).toHaveTextContent("WRITTEN");
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryLocaleContext.tsx
+++ b/packages/admin/src/components/features/entries/EntryLocaleContext.tsx
@@ -78,6 +78,16 @@ export interface EntryLocaleContextValue {
    * Absent means the surface cannot publish every language, and the action does
    * not offer itself.
    */
+  /**
+   * Enter translation mode, reading the source from the named language.
+   *
+   * A seam for the same reason the others are: the URL state belongs to the
+   * page, and the control that offers the action sits several levels below it.
+   * Absent means the surface cannot enter the mode, so the action does not offer
+   * itself — which keeps it off a create form and off any editor that has not
+   * been taught to render the panes.
+   */
+  onEnterTranslationMode?: (source: string) => void;
   publishAllLanguages?: {
     /**
      * The slug whose `publish-{slug}` permission this owes. The permission

--- a/packages/admin/src/components/features/entries/LanguagePanel.tsx
+++ b/packages/admin/src/components/features/entries/LanguagePanel.tsx
@@ -186,7 +186,8 @@ export function LanguagePanel({
   className,
 }: LanguagePanelProps) {
   const { enabled, locales, defaultLocale } = useLocalization();
-  const { collectionLocalized } = useEntryLocale();
+  const { collectionLocalized, isNonDefaultLocale, onEnterTranslationMode } =
+    useEntryLocale();
   const copy = useCopyFromLanguage();
   const publish = usePublishAllLanguages(
     hasStatus === undefined ? {} : { hasStatus }
@@ -221,6 +222,25 @@ export function LanguagePanel({
           {counts.translated} of {counts.total} translated
         </span>
         <span className="flex-1" />
+        {/* Offered only while a NON-default language is being edited, because
+            that is the only time there is a translation to do: the default is
+            the language everything else is translated FROM, so pairing it with
+            itself is the one arrangement the mode cannot show. The source is the
+            default language — the overwhelmingly common pairing, and the URL
+            carries the source explicitly so a different one is addressable
+            without this control needing to grow a picker. */}
+        {onEnterTranslationMode && isNonDefaultLocale && defaultLocale && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 px-2 text-xs"
+            disabled={actionsDisabled}
+            onClick={() => onEnterTranslationMode(defaultLocale)}
+          >
+            Translate
+          </Button>
+        )}
         {publish.available && (
           <Button
             type="button"

--- a/packages/admin/src/components/features/entries/TranslationMode/SourceDocumentPane.tsx
+++ b/packages/admin/src/components/features/entries/TranslationMode/SourceDocumentPane.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+/**
+ * The source-language half of translation mode.
+ *
+ * Renders the source document through the editor's own field components,
+ * read-only, so whatever a field can draw the source shows. That is the whole
+ * argument for the pane over the inline hint it supersedes: the hint could only
+ * render a `string` or a `number` (`FieldWrapper.tsx`), so a translator working a
+ * richText field, a relationship or a chips list had no source text on screen at
+ * all — silently, because a field with nothing to show and a field whose type the
+ * hint could not handle looked identical.
+ *
+ * ## Only the translatable fields
+ *
+ * The pane shows the fields the translator is working on, not the document. A
+ * shared field holds the same value in both languages, so putting it here would
+ * fill half the screen with a copy of what is already in the other pane, and
+ * push the fields that DO differ off it.
+ *
+ * @module components/features/entries/TranslationMode/SourceDocumentPane
+ */
+
+import type { FieldConfig } from "nextly/config";
+
+import { ReadOnlyDocumentForm } from "@admin/components/features/entries/EntryForm/ReadOnlyDocumentForm";
+
+export interface SourcePaneDocument {
+  /** The source language's code, for the pane's writing direction. */
+  sourceLocale: string;
+  /** Human label for the source language, as configured. */
+  sourceLabel: string;
+  /** Human label for the language being edited, for the mode bar. */
+  targetLabel: string;
+  /** Whether the source language is written right-to-left. */
+  rtl: boolean;
+  /** The translatable fields, in the document's own order. */
+  fields: FieldConfig[];
+  /** The source document's values, in the shape the form's inputs read. */
+  values: Record<string, unknown>;
+}
+
+export function SourceDocumentPane({ source }: { source: SourcePaneDocument }) {
+  return (
+    <div
+      // A SOLID token, not an alpha tint of one. `text-muted-foreground` is
+      // designed against `bg-muted`, so the pair is checkable; over
+      // `bg-muted/30` the text sits on a composite of muted and whatever is
+      // behind it, which the repo's contrast suite cannot see — it measures a
+      // foreground against the solid page token and reports a pass that
+      // describes a background the user is not looking at.
+      className="@container/content h-full overflow-y-auto bg-muted"
+      // The pane's own direction, from the SOURCE language. Translation mode is
+      // the one place two directions are on screen at once — an English source
+      // beside an Arabic target — so direction cannot be a property of the
+      // document the way `EntryLocaleContext.rtl` treats it.
+      dir={source.rtl ? "rtl" : "ltr"}
+    >
+      <div className="flex items-center gap-2 border-b border-border px-6 py-3">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Source
+        </span>
+        <span className="text-sm font-medium text-foreground">
+          {source.sourceLabel}
+        </span>
+      </div>
+      <div className="px-6 py-4">
+        {source.fields.length === 0 ? (
+          // Said rather than left blank. A localized document whose translatable
+          // set is empty is a real configuration — every field shared — and an
+          // empty pane reads as a failed load.
+          <p className="text-sm text-muted-foreground">
+            This document has no translatable fields, so there is no source text
+            to show.
+          </p>
+        ) : (
+          <ReadOnlyDocumentForm fields={source.fields} values={source.values} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/entries/TranslationMode/SourceDocumentPane.tsx
+++ b/packages/admin/src/components/features/entries/TranslationMode/SourceDocumentPane.tsx
@@ -43,12 +43,13 @@ export interface SourcePaneDocument {
 export function SourceDocumentPane({ source }: { source: SourcePaneDocument }) {
   return (
     <div
-      // A SOLID token, not an alpha tint of one. `text-muted-foreground` is
-      // designed against `bg-muted`, so the pair is checkable; over
-      // `bg-muted/30` the text sits on a composite of muted and whatever is
-      // behind it, which the repo's contrast suite cannot see — it measures a
-      // foreground against the solid page token and reports a pass that
-      // describes a background the user is not looking at.
+      // A SOLID token rather than an alpha tint of one. `text-muted-foreground`
+      // is the foreground `bg-muted` is designed against, so the pair is one the
+      // contrast suite checks by NAME; over `bg-muted/30` the same text is
+      // measured against a computed blend instead. Both are covered — the ink
+      // suite composites a translucent fill over its surface — so this is a
+      // legibility-of-intent choice, not a contrast fix. The solid surface is
+      // also what makes this half read as the one that cannot be edited.
       className="@container/content h-full overflow-y-auto bg-muted"
       // The pane's own direction, from the SOURCE language. Translation mode is
       // the one place two directions are on screen at once — an English source

--- a/packages/admin/src/components/features/entries/TranslationMode/TranslationPanes.tsx
+++ b/packages/admin/src/components/features/entries/TranslationMode/TranslationPanes.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+/**
+ * Translation mode: the language being edited, beside the language it is being
+ * translated from.
+ *
+ * A WRAPPER rather than a second editor. The document being edited stays exactly
+ * the form it already was — same RHF context, same unsaved-changes guard, same
+ * autosave, same save intent — and this puts a read-only source beside it. The
+ * alternative, a route of its own, would duplicate every one of those and the
+ * guard would have to learn a second address.
+ *
+ * Inactive it renders `children` and nothing else: no wrapper element, no
+ * suppression request, no extra DOM. A document with no source to show is the
+ * ordinary editor, unchanged, and that has to be true structurally rather than
+ * by the styles happening to agree.
+ *
+ * The source pane is a SIBLING of `children` rather than inside it, so it never
+ * joins the target's form context — which matters because `useFormContext`
+ * binds to the nearest provider, and a source rendered inside the target's form
+ * would read and write the document being edited.
+ *
+ * ## Why this component owns the chrome request
+ *
+ * `useSuppressAdminChrome` grants `primaryRail` — the whole of the admin's
+ * navigation — only to a request carrying `canExit: true`, per REQUEST, and the
+ * rail is otherwise the only way out. So the component that takes the rail is
+ * the component that must render the way back, and keeping both here means the
+ * invariant cannot be broken by a caller that forgets: there is no arrangement
+ * of props that suppresses the rail without also rendering Exit.
+ *
+ * @module components/features/entries/TranslationMode/TranslationPanes
+ */
+
+import { useSuppressAdminChrome } from "@admin/components/layout/ChromeSuppression";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@admin/components/ui";
+import { cn } from "@admin/lib/utils";
+
+import { SourceDocumentPane } from "./SourceDocumentPane";
+import type { SourcePaneDocument } from "./SourceDocumentPane";
+
+export interface TranslationPanesProps {
+  /**
+   * The source to show, or undefined to render `children` alone.
+   *
+   * Undefined is the ordinary editor. It covers every reason there is no source
+   * — mode off, an unconfigured language in the URL, a source that is the
+   * language already being edited — because none of them is a different screen.
+   */
+  source: SourcePaneDocument | undefined;
+  /**
+   * Leave the mode, keeping the language being edited.
+   *
+   * Optional so a caller that cannot leave — a test harness, a surface still
+   * being wired — needs no placeholder of its own. It defaults to a no-op HERE
+   * rather than at each call site, which is what keeps `canExit: true` honest:
+   * the exit is always rendered, so the rail is never surrendered to a surface
+   * with no button at all.
+   */
+  onExit?: (() => void) | undefined;
+  /** The editor. Rendered in the target pane when the mode is on. */
+  children: React.ReactNode;
+}
+
+export function TranslationPanes({
+  source,
+  onExit = () => {},
+  children,
+}: TranslationPanesProps) {
+  return source ? (
+    <ActivePanes source={source} onExit={onExit}>
+      {children}
+    </ActivePanes>
+  ) : (
+    <>{children}</>
+  );
+}
+
+/**
+ * The mode itself, mounted only while there is a source.
+ *
+ * A separate component so the chrome request below runs only when the mode is
+ * on. Calling the hook from the wrapper above would ask the admin to hide its
+ * navigation for every localized document, in the mode or not — the same reason
+ * `BlocksField` splits its editor out from its control.
+ */
+function ActivePanes({
+  source,
+  onExit,
+  children,
+}: {
+  source: SourcePaneDocument;
+  onExit: () => void;
+  children: React.ReactNode;
+}) {
+  // `documentSidebar` is deliberately absent: this asks for the admin's
+  // furniture, and the editor's own rail is the document's, collapsed through
+  // the form's own control rather than taken away from underneath it.
+  useSuppressAdminChrome({
+    layers: ["primaryRail", "subSidebar", "header", "pageFrame"],
+    canExit: true,
+  });
+
+  return (
+    <div className="flex h-dvh flex-col">
+      <ModeBar source={source} onExit={onExit} />
+      {/* Sizes are PERCENTAGE STRINGS, and that is load-bearing rather than a
+          style choice: this library reads a bare number as PIXELS, so
+          `defaultSize={40}` is a 40-pixel pane. A layout in pixels is also
+          wrong on the next monitor, where a relative one survives a resize.
+
+          Source LEFT because it is read first and the target is where the work
+          happens — the pane ORDER is reading order for the SCREEN, not for
+          either language, so an RTL target does not move it. */}
+      <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
+        <ResizablePanel id="translation-source" minSize="25%" defaultSize="40%">
+          <SourceDocumentPane source={source} />
+        </ResizablePanel>
+        <ResizableHandle withGrip />
+        <ResizablePanel id="translation-target" minSize="30%">
+          {/* A container of its own, and this is the whole of the editor's
+              layout adaptation. `@container/content` is declared on the
+              dashboard's `<main>`, which stays full-page width — so without
+              this every `@4xl/content:` query inside the editor measures the
+              PAGE while rendering into half of it, and the 320px document rail
+              is laid out beside a main column that no longer has room for it.
+              Naming the container here makes those queries measure the PANE, so
+              the editor responds exactly as it already does at a narrow window:
+              the rail hides and its language panel takes over inline. No
+              translation-mode branch anywhere in the form. */}
+          <div className="@container/content h-full overflow-y-auto">
+            {children}
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  );
+}
+
+/**
+ * The one strip of chrome the mode owns: what is being translated, and the way
+ * out.
+ *
+ * Save and Publish are deliberately NOT here. They belong to the document being
+ * edited and already live in its own header, inside the target pane — moving
+ * them up here would put a save control outside the form it saves, and the
+ * suppression request above is what makes this bar the only furniture left.
+ */
+function ModeBar({
+  source,
+  onExit,
+}: {
+  source: SourcePaneDocument;
+  onExit: () => void;
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-3 border-b border-border bg-background px-4 py-2">
+      <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        Translating
+      </span>
+      <span className="text-sm font-medium text-foreground">
+        {source.targetLabel}
+      </span>
+      <span className="text-xs text-muted-foreground">from</span>
+      <span className="text-sm font-medium text-foreground">
+        {source.sourceLabel}
+      </span>
+      <span className="flex-1" />
+      <button
+        type="button"
+        onClick={onExit}
+        className={cn(
+          "inline-flex h-8 items-center rounded-md border border-border bg-background px-3",
+          "text-xs font-medium text-foreground transition-colors",
+          "hover:bg-accent hover:text-accent-foreground",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        )}
+      >
+        Exit translation mode
+      </button>
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/entries/TranslationMode/__tests__/TranslationPanes.test.tsx
+++ b/packages/admin/src/components/features/entries/TranslationMode/__tests__/TranslationPanes.test.tsx
@@ -1,0 +1,128 @@
+// Translation mode's two structural promises.
+//
+// INACTIVE it must be nothing at all — not a wrapper that happens to look
+// transparent. Every localized document renders through this component, so a
+// stray element or a stray chrome request here changes the ordinary editor for
+// everyone.
+//
+// ACTIVE it must render its own way out, because it takes the admin's
+// navigation rail. `useSuppressAdminChrome` grants `primaryRail` only to a
+// request carrying `canExit: true`, and that flag is an assertion the component
+// makes about itself — nothing checks that an exit is really on screen. This
+// file is that check.
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { TranslationPanes } from "../TranslationPanes";
+import type { SourcePaneDocument } from "../SourceDocumentPane";
+
+const { suppress } = vi.hoisted(() => ({ suppress: vi.fn() }));
+vi.mock("@admin/components/layout/ChromeSuppression", () => ({
+  useSuppressAdminChrome: (o: unknown) => suppress(o),
+}));
+// The source pane renders a whole field tree through the editor's components;
+// this file is about the WRAPPER, so it is stubbed to a marker.
+vi.mock("../SourceDocumentPane", () => ({
+  SourceDocumentPane: ({ source }: { source: SourcePaneDocument }) => (
+    <div data-testid="source-pane">{source.sourceLabel}</div>
+  ),
+}));
+
+const SOURCE: SourcePaneDocument = {
+  sourceLocale: "en",
+  sourceLabel: "English",
+  targetLabel: "Spanish",
+  rtl: false,
+  fields: [],
+  values: {},
+};
+
+describe("TranslationPanes", () => {
+  beforeEach(() => suppress.mockReset());
+
+  it("renders its child ALONE when there is no source", () => {
+    const { container } = render(
+      <TranslationPanes source={undefined} onExit={() => {}}>
+        <p>the editor</p>
+      </TranslationPanes>
+    );
+
+    expect(screen.getByText("the editor")).toBeInTheDocument();
+    // The structural claim: the child is the container's only element. A
+    // wrapper div would satisfy "the editor is on screen" while changing the
+    // layout of every localized document that is NOT in the mode.
+    expect(container.firstElementChild?.tagName).toBe("P");
+    expect(container.childElementCount).toBe(1);
+    expect(screen.queryByTestId("source-pane")).not.toBeInTheDocument();
+  });
+
+  it("asks for no chrome suppression when there is no source", () => {
+    render(
+      <TranslationPanes source={undefined} onExit={() => {}}>
+        <p>the editor</p>
+      </TranslationPanes>
+    );
+    expect(suppress).not.toHaveBeenCalled();
+  });
+
+  it("shows the source beside the editor when there is one", () => {
+    render(
+      <TranslationPanes source={SOURCE} onExit={() => {}}>
+        <p>the editor</p>
+      </TranslationPanes>
+    );
+
+    expect(screen.getByTestId("source-pane")).toHaveTextContent("English");
+    expect(screen.getByText("the editor")).toBeInTheDocument();
+  });
+
+  it("renders a way out whenever it takes the navigation rail", () => {
+    // The two halves are asserted TOGETHER on purpose. `canExit: true` is a
+    // claim the component makes about itself, and the suppression layer trusts
+    // it — so an exit that stopped rendering would strand an author full-screen
+    // with the rail already surrendered, and no test of either half alone
+    // would notice.
+    render(
+      <TranslationPanes source={SOURCE} onExit={() => {}}>
+        <p>the editor</p>
+      </TranslationPanes>
+    );
+
+    const request = suppress.mock.calls[0]?.[0] as {
+      layers: string[];
+      canExit: boolean;
+    };
+    expect(request.layers).toContain("primaryRail");
+    expect(request.canExit).toBe(true);
+    expect(
+      screen.getByRole("button", { name: /exit translation mode/i })
+    ).toBeInTheDocument();
+  });
+
+  it("leaves the mode when the exit is used", async () => {
+    const onExit = vi.fn();
+    render(
+      <TranslationPanes source={SOURCE} onExit={onExit}>
+        <p>the editor</p>
+      </TranslationPanes>
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /exit translation mode/i })
+    );
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("names both languages, so the pairing is readable without the URL", () => {
+    render(
+      <TranslationPanes source={SOURCE} onExit={() => {}}>
+        <p>the editor</p>
+      </TranslationPanes>
+    );
+    const bar = screen.getByText(/translating/i).parentElement;
+    expect(bar).toHaveTextContent("Spanish");
+    expect(bar).toHaveTextContent("English");
+  });
+});

--- a/packages/admin/src/components/features/entries/TranslationMode/__tests__/useTranslationSource.test.ts
+++ b/packages/admin/src/components/features/entries/TranslationMode/__tests__/useTranslationSource.test.ts
@@ -1,0 +1,110 @@
+// What the source pane is given, for a source document that exists.
+//
+// The interesting rule is WHICH fields reach the pane: only the translatable
+// ones. A shared field holds the same value in both languages, so showing it
+// would fill half the screen with a copy of what is in the other pane — and
+// push the fields that actually differ off it.
+
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+
+import { useTranslationSource } from "../useTranslationSource";
+
+const LOCALES: Record<string, { label: string; rtl: boolean }> = {
+  en: { label: "English", rtl: false },
+  ar: { label: "Arabic", rtl: true },
+};
+const getLocale = (code: string | undefined) =>
+  code === undefined ? undefined : LOCALES[code];
+
+/** `localized` is explicit per field so the smart per-type default is not in play. */
+const FIELDS = [
+  { name: "headline", type: "text", localized: true },
+  { name: "body", type: "textarea", localized: true },
+  { name: "campaign", type: "text", localized: false },
+] as never[];
+
+/** The view the hook returns; `over` patches the inputs one case at a time. */
+function viewFor(over: Record<string, unknown> = {}) {
+  const { translation, ...rest } = {
+    translation: {
+      from: "en",
+      sourceDocument: { headline: "Hi", body: "There", campaign: "autumn" },
+    },
+    fields: FIELDS,
+    documentLocalized: true,
+    locale: "ar",
+    defaultLocale: "en",
+    getLocale,
+    ...over,
+  } as never as Record<string, unknown>;
+  return renderHook(() =>
+    useTranslationSource({ translation, ...rest } as never)
+  ).result.current;
+}
+
+/** The source pane's document, which is what most cases below are about. */
+function sourceFor(over: Record<string, unknown> = {}) {
+  return viewFor(over).source;
+}
+
+describe("useTranslationSource", () => {
+  it("is undefined when no source language is named", () => {
+    expect(sourceFor({ translation: {} })).toBeUndefined();
+  });
+
+  it("is undefined until the source document has arrived", () => {
+    // Distinct from the case above: the mode is on and the fetch is in flight.
+    // A pane rendered from an absent document would show every field blank,
+    // which reads as "nothing to translate from" rather than "still loading".
+    expect(sourceFor({ translation: { from: "en" } })).toBeUndefined();
+  });
+
+  it("passes only the TRANSLATABLE fields to the pane", () => {
+    const source = sourceFor();
+    expect(source?.fields.map(f => (f as { name: string }).name)).toEqual([
+      "headline",
+      "body",
+    ]);
+  });
+
+  it("carries only the translatable values, keyed as the form reads them", () => {
+    const source = sourceFor();
+    expect(source?.values).toEqual({ headline: "Hi", body: "There" });
+    // The negative half: a shared field must not ride along in the values even
+    // though the source document has it.
+    expect(source?.values).not.toHaveProperty("campaign");
+  });
+
+  it("takes its writing direction from the SOURCE, not the target", () => {
+    // The target here is Arabic and the source English. Reading direction off
+    // the document — which is what the rest of the editor does — would render
+    // an English source right-to-left.
+    expect(sourceFor()?.rtl).toBe(false);
+    expect(
+      sourceFor({
+        translation: { from: "ar", sourceDocument: { headline: "Hi" } },
+        locale: "en",
+      })?.rtl
+    ).toBe(true);
+  });
+
+  it("labels both languages for the mode bar", () => {
+    const source = sourceFor();
+    expect(source?.sourceLabel).toBe("English");
+    expect(source?.targetLabel).toBe("Arabic");
+  });
+
+  it("falls back to the code when a language has no label", () => {
+    const source = sourceFor({ getLocale: () => undefined });
+    expect(source?.sourceLabel).toBe("en");
+    expect(source?.targetLabel).toBe("ar");
+  });
+
+  it("treats every field as translatable-eligible only when the document is", () => {
+    // The document switch wins over the per-field flag: a non-localized
+    // document has no translatable fields at all, so the pane says so rather
+    // than showing a source that cannot differ.
+    expect(sourceFor({ documentLocalized: false })?.fields).toEqual([]);
+  });
+});

--- a/packages/admin/src/components/features/entries/TranslationMode/useTranslationSource.ts
+++ b/packages/admin/src/components/features/entries/TranslationMode/useTranslationSource.ts
@@ -1,0 +1,137 @@
+"use client";
+
+/**
+ * What translation mode shows on its source side, assembled the same way for
+ * both editors.
+ *
+ * The entry editor and the single editor differ in how they ADDRESS a document
+ * — a collection slug and an id, or a slug alone — and in nothing else that
+ * matters here. Both hold a field list, a localization flag, the language being
+ * edited and a source document, and both have to turn those into the same pane.
+ * Two copies would agree the day they were written and drift the moment one
+ * learned something about which fields belong on screen, which is the kind of
+ * drift a reader cannot see: the pane would simply show a different set of
+ * fields on one editor.
+ *
+ * @module components/features/entries/TranslationMode/useTranslationSource
+ */
+
+import type { FieldConfig } from "nextly/config";
+import { useMemo } from "react";
+
+import { localizedFieldNamesOf } from "@admin/components/features/entries/entry-locale-source";
+import { getDefaultValues } from "@admin/lib/form/default-values";
+
+import type { SourcePaneDocument } from "./SourceDocumentPane";
+
+/** What an editor is handed about translation mode, straight from its page. */
+export interface TranslationModeProps {
+  from?: string | undefined;
+  sourceDocument?: Record<string, unknown> | undefined;
+  onEnter?: ((source: string) => void) | undefined;
+  onExit?: (() => void) | undefined;
+}
+
+/** What an editor needs to render it, with every absent case already resolved. */
+export interface TranslationModeView {
+  /** The source pane's document, or undefined when the mode is off. */
+  source: SourcePaneDocument | undefined;
+  /** Whether the mode is on, which withholds the inline hint and the enter action. */
+  active: boolean;
+  /** Offered only while the mode is OFF, so it cannot re-enter itself. */
+  onEnter: ((source: string) => void) | undefined;
+  onExit: (() => void) | undefined;
+}
+
+export interface TranslationSourceInput {
+  /** The document's full field list. */
+  fields: FieldConfig[];
+  /** The document's master localization switch. */
+  documentLocalized: boolean;
+  /** The page's translation-mode props, undefined on an editor without them. */
+  translation: TranslationModeProps | undefined;
+  /** The language being edited. `undefined` = the app default. */
+  locale: string | undefined;
+  /** The app default, which is what `undefined` above resolves to. */
+  defaultLocale: string | undefined;
+  /** Resolves a configured language's label and writing direction. */
+  getLocale: (
+    code: string | undefined
+  ) => { label?: string; rtl?: boolean } | undefined;
+}
+
+/**
+ * A configured language's human label, falling back to its own code.
+ *
+ * Its own function because the fallback chain is the bulk of this module's
+ * branching and none of it is interesting: a language the app configures always
+ * has a label, so every branch here describes a misconfiguration rather than a
+ * case worth reading inline.
+ */
+function labelFor(
+  getLocale: TranslationSourceInput["getLocale"],
+  code: string | undefined,
+  fallback: string
+): string {
+  return getLocale(code)?.label ?? code ?? fallback;
+}
+
+export function useTranslationSource({
+  fields,
+  documentLocalized,
+  translation,
+  locale,
+  defaultLocale,
+  getLocale,
+}: TranslationSourceInput): TranslationModeView {
+  const translateFrom = translation?.from;
+  const sourceDocument = translation?.sourceDocument;
+
+  const source = useMemo(() => {
+    if (!translateFrom || !sourceDocument) return undefined;
+
+    // Only the TRANSLATABLE fields. A shared field holds the same value in both
+    // languages, so putting it in the source pane would fill half the screen
+    // with a copy of what is already in the other one — and push the fields that
+    // DO differ off it.
+    const translatable = new Set(
+      localizedFieldNamesOf(fields, documentLocalized)
+    );
+    const paneFields = fields.filter(
+      f => "name" in f && !!f.name && translatable.has(f.name)
+    );
+
+    const target = locale ?? defaultLocale;
+    return {
+      sourceLocale: translateFrom,
+      sourceLabel: labelFor(getLocale, translateFrom, translateFrom),
+      targetLabel: labelFor(getLocale, target, ""),
+      rtl: getLocale(translateFrom)?.rtl ?? false,
+      fields: paneFields,
+      // The same normaliser the live editor uses to seed itself from an API
+      // document — snake_case fallbacks, chips arriving as JSON strings, a
+      // structural null materialised. A second one here would disagree with the
+      // target pane about what the document says.
+      values: getDefaultValues(paneFields, sourceDocument),
+    };
+  }, [
+    fields,
+    documentLocalized,
+    translateFrom,
+    sourceDocument,
+    locale,
+    defaultLocale,
+    getLocale,
+  ]);
+
+  // `active` is the SOURCE's presence, not the param's. A named language whose
+  // document has not arrived yet is not a mode the editor can show, and treating
+  // it as active would withhold the inline hint while showing no pane — a blank
+  // half-screen where the source used to be.
+  return {
+    source,
+    active: source !== undefined,
+    onEnter: source === undefined ? translation?.onEnter : undefined,
+    onExit: translation?.onExit,
+  };
+}

--- a/packages/admin/src/components/features/entries/useEntryLocaleContext.ts
+++ b/packages/admin/src/components/features/entries/useEntryLocaleContext.ts
@@ -1,0 +1,130 @@
+"use client";
+
+/**
+ * The content-locale context both document editors provide, assembled once.
+ *
+ * The entry editor and the single editor built this object separately and
+ * almost identically, and the differences were the accidents of addressing
+ * rather than decisions: an entry has a collection slug and an id, a single has
+ * neither. Everything else — how the writing direction resolves, what counts as
+ * a non-default language, which fields are translatable, what is withheld while
+ * translation mode is on — is the same question twice.
+ *
+ * Two copies of it had already gone wrong once. Copy-from-language gated on
+ * `collectionSlug && entryId`, which made the action collection-only by accident
+ * of addressing rather than by intent, so a single could never offer it; the
+ * repair was to make the source READ the seam. This module is the same repair
+ * applied to the object itself, so the next rule added here cannot reach one
+ * editor and miss the other.
+ *
+ * @module components/features/entries/useEntryLocaleContext
+ */
+
+import type { FieldConfig } from "nextly/config";
+import { useMemo } from "react";
+
+import { localizedFieldNamesOf } from "./entry-locale-source";
+import type { EntryLocaleContextValue } from "./EntryLocaleContext";
+
+export interface EntryLocaleContextInput {
+  /** The active content language. `undefined` = the app default. */
+  locale: string | undefined;
+  /** The app default, which is what `undefined` above resolves to. */
+  defaultLocale: string | undefined;
+  /** Resolves a configured language's writing direction. */
+  getLocale: (code: string | undefined) => { rtl?: boolean } | undefined;
+  /** The document's master localization switch. */
+  documentLocalized: boolean;
+  /** The document's full field list, for the translatable-field set. */
+  fields: FieldConfig[];
+  /** Source-language values for the inline hint. */
+  sourceValues: Record<string, unknown> | undefined;
+  /** Whether translation mode is on, which withholds two of the values below. */
+  inTranslationMode: boolean;
+  onLocaleChange: EntryLocaleContextValue["onLocaleChange"];
+  seedFromLocale: string | undefined;
+  onSeedHandled: (() => void) | undefined;
+  onEnterTranslationMode: ((source: string) => void) | undefined;
+  /** How THIS editor reads another language — the seam that differs. */
+  fetchSourceValues: EntryLocaleContextValue["fetchSourceValues"];
+  publishAllLanguages: EntryLocaleContextValue["publishAllLanguages"];
+  /** Entry-only addressing; a single supplies neither. */
+  collectionSlug?: string | undefined;
+  entryId?: string | undefined;
+}
+
+export function useEntryLocaleContext(
+  input: EntryLocaleContextInput
+): EntryLocaleContextValue {
+  const {
+    locale,
+    defaultLocale,
+    getLocale,
+    documentLocalized,
+    fields,
+    sourceValues,
+    inTranslationMode,
+    onLocaleChange,
+    seedFromLocale,
+    onSeedHandled,
+    onEnterTranslationMode,
+    fetchSourceValues,
+    publishAllLanguages,
+    collectionSlug,
+    entryId,
+  } = input;
+
+  return useMemo(
+    () => ({
+      locale,
+      // `locale` is undefined while editing the implicit default language, so
+      // resolve the default explicitly — otherwise a default language that is
+      // RTL renders its translatable fields left-to-right until it is picked by
+      // hand.
+      rtl: getLocale(locale ?? defaultLocale)?.rtl ?? false,
+      collectionLocalized: documentLocalized,
+      isNonDefaultLocale:
+        !!locale && !!defaultLocale && locale !== defaultLocale,
+      // Withheld while translation mode is on: the inline hint and the source
+      // pane answer the same question, and with both on the source text appears
+      // three times on one screen. The pane is the better answer — it renders
+      // every field type, where the hint could only render a string or a number.
+      sourceValues: inTranslationMode ? undefined : sourceValues,
+      // Withheld for the same reason in the other direction: the action must not
+      // offer to enter a mode the author is already in.
+      onEnterTranslationMode: inTranslationMode
+        ? undefined
+        : onEnterTranslationMode,
+      onLocaleChange,
+      seedFromLocale,
+      onSeedHandled,
+      collectionSlug,
+      entryId,
+      /** The translatable-field set, for the field-scoped copy-from action. */
+      localizedFieldNames: localizedFieldNamesOf(fields, documentLocalized),
+      // Copy-from-language reads its source THROUGH this seam instead of
+      // addressing the document itself, so one implementation serves entries and
+      // singles alike — a single has no collection slug or entry id and could
+      // otherwise never offer the action at all.
+      fetchSourceValues,
+      publishAllLanguages,
+    }),
+    [
+      locale,
+      defaultLocale,
+      getLocale,
+      documentLocalized,
+      fields,
+      sourceValues,
+      inTranslationMode,
+      onLocaleChange,
+      seedFromLocale,
+      onSeedHandled,
+      onEnterTranslationMode,
+      fetchSourceValues,
+      publishAllLanguages,
+      collectionSlug,
+      entryId,
+    ]
+  );
+}

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -28,10 +28,7 @@ import { useEffect, useMemo, useCallback, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-import {
-  localizedFieldNamesOf,
-  singleSourceFetcher,
-} from "@admin/components/features/entries/entry-locale-source";
+import { singleSourceFetcher } from "@admin/components/features/entries/entry-locale-source";
 import { AutosaveRecoveryBanner } from "@admin/components/features/entries/EntryForm/AutosaveRecoveryBanner";
 import { EntryFormContent } from "@admin/components/features/entries/EntryForm/EntryFormContent";
 import { EntryFormProvider } from "@admin/components/features/entries/EntryForm/EntryFormProvider";
@@ -47,11 +44,11 @@ import {
   type EntryFormIntent,
 } from "@admin/components/features/entries/EntryForm/useEntryForm";
 import { useRailCollapsed } from "@admin/components/features/entries/EntryForm/useRailCollapsed";
-import {
-  EntryLocaleProvider,
-  type EntryLocaleContextValue,
-} from "@admin/components/features/entries/EntryLocaleContext";
+import { EntryLocaleProvider } from "@admin/components/features/entries/EntryLocaleContext";
 import { LanguagePanel } from "@admin/components/features/entries/LanguagePanel";
+import { TranslationPanes } from "@admin/components/features/entries/TranslationMode/TranslationPanes";
+import { useTranslationSource } from "@admin/components/features/entries/TranslationMode/useTranslationSource";
+import { useEntryLocaleContext } from "@admin/components/features/entries/useEntryLocaleContext";
 import { historyEnabledFrom } from "@admin/components/features/versions/history-enabled";
 import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { usePublishAllSingleLocales } from "@admin/hooks/queries/usePublishAllSingleLocales";
@@ -149,6 +146,24 @@ export interface SingleFormProps {
   seedFromLocale?: string;
   /** Clears that seed once it has been offered. */
   onSeedHandled?: () => void;
+  /**
+   * i18n: translation mode — the language being translated FROM, the source
+   * document read at it, and the way in and out.
+   *
+   * One prop rather than four, because they are one concept and always travel
+   * together: three of them are meaningless without `from`, and a form given
+   * some of them is in a state the page cannot produce.
+   */
+  translation?: {
+    /** The source language, or absent when the mode is off. */
+    from?: string | undefined;
+    /** The source document's values, read at `from`. */
+    sourceDocument?: Record<string, unknown> | undefined;
+    /** Enter the mode, reading the source from the named language. */
+    onEnter?: (source: string) => void;
+    /** Leave the mode, keeping the language being edited. */
+    onExit?: () => void;
+  };
   /** Additional CSS classes */
   className?: string;
 }
@@ -215,6 +230,7 @@ export function SingleForm({
   onLocaleChange,
   seedFromLocale,
   onSeedHandled,
+  translation,
   sourceValues,
   className,
 }: SingleFormProps) {
@@ -444,48 +460,36 @@ export function SingleForm({
     slug: schema.slug,
   });
 
-  const localeCtx: EntryLocaleContextValue = useMemo(
-    () => ({
-      locale,
-      // Resolve the default explicitly: `locale` is undefined while editing the
-      // implicit default language, so reading it alone would render an RTL
-      // default language left-to-right until it was picked by hand.
-      rtl: getLocale(locale ?? defaultLocale)?.rtl ?? false,
-      collectionLocalized: schema.localized === true,
-      isNonDefaultLocale:
-        !!locale && !!defaultLocale && locale !== defaultLocale,
-      sourceValues,
-      onLocaleChange,
-      seedFromLocale,
-      onSeedHandled,
-      // The translatable-field set, for the field-scoped copy-from-language action.
-      localizedFieldNames: localizedFieldNamesOf(
-        schema.fields,
-        schema.localized === true
-      ),
-      // A single is addressed by its slug alone, so it supplies its own read.
-      fetchSourceValues: singleSourceFetcher(schema.slug),
-      // And its own publish-every-language action, for the same reason.
-      publishAllLanguages: {
-        slug: schema.slug,
-        publish: () => publishAllSingleLanguages.mutate(),
-        pending: publishAllSingleLanguages.isPending,
-      },
-    }),
-    [
-      locale,
-      getLocale,
-      defaultLocale,
-      schema.localized,
-      schema.fields,
-      schema.slug,
-      sourceValues,
-      onLocaleChange,
-      seedFromLocale,
-      onSeedHandled,
-      publishAllSingleLanguages,
-    ]
-  );
+  const translationMode = useTranslationSource({
+    fields: schema.fields,
+    documentLocalized: schema.localized === true,
+    translation,
+    locale,
+    defaultLocale,
+    getLocale,
+  });
+
+  const localeCtx = useEntryLocaleContext({
+    locale,
+    defaultLocale,
+    getLocale,
+    documentLocalized: schema.localized === true,
+    fields: schema.fields,
+    sourceValues,
+    inTranslationMode: translationMode.active,
+    onLocaleChange,
+    seedFromLocale,
+    onSeedHandled,
+    onEnterTranslationMode: translationMode.onEnter,
+    // A single is addressed by its slug alone, so it supplies its own read and
+    // no entry addressing at all.
+    fetchSourceValues: singleSourceFetcher(schema.slug),
+    publishAllLanguages: {
+      slug: schema.slug,
+      publish: () => publishAllSingleLanguages.mutate(),
+      pending: publishAllSingleLanguages.isPending,
+    },
+  });
 
   // Recovery points for this author, the same mechanism the entry editor uses.
   // A Single always exists once its schema does, so unlike an entry there is no
@@ -521,150 +525,156 @@ export function SingleForm({
     // is no embedded case to exclude.
     <UnsavedChangesGuard isDirty={isDirty} disabled={isSubmitting}>
       <EntryLocaleProvider value={localeCtx}>
-        <div className={cn("space-y-0", className)}>
-          <EntryFormProvider form={form} onSubmit={handleSubmit}>
-            <FormErrorSummary
-              errors={errors}
-              submitCount={submitCount}
-              className="mx-6 mt-3"
-            />
+        {/* Renders its child alone when there is no source — see the module. */}
+        <TranslationPanes
+          source={translationMode.source}
+          onExit={translationMode.onExit}
+        >
+          <div className={cn("space-y-0", className)}>
+            <EntryFormProvider form={form} onSubmit={handleSubmit}>
+              <FormErrorSummary
+                errors={errors}
+                submitCount={submitCount}
+                className="mx-6 mt-3"
+              />
 
-            <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-m-8">
-              {/* Main column */}
-              <div className="flex-1 min-w-0 flex flex-col">
-                {/* Why: same fix as EntryForm — the parent flex's @4xl/content:-m-8
+              <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-m-8">
+                {/* Main column */}
+                <div className="flex-1 min-w-0 flex flex-col">
+                  {/* Why: same fix as EntryForm — the parent flex's @4xl/content:-m-8
                 already cancels PageContainer's px-8, so wrapping the header / meta
                 strip in another -mx-8 was double-negative and pushed them
                 past the page edges. */}
-                <EntrySystemHeader
-                  autosaveEnabled={autosaveScope !== null}
-                  autosaveStatus={autosave.status}
-                  autosaveLastSavedAt={autosave.lastSavedAt}
-                  mode="edit"
-                  titleField={titleField}
-                  historyFields={schema.fields}
-                  historyEnabled={historyEnabledFrom(schema)}
-                  hasStatus={hasStatus}
-                  isSubmitting={isSubmitting}
-                  isDirty={isDirty}
-                  entry={entryLike}
-                  collectionSlug={schema.slug}
-                  /* i18n: forward the active locale + switch handler so a localized single shows
+                  <EntrySystemHeader
+                    autosaveEnabled={autosaveScope !== null}
+                    autosaveStatus={autosave.status}
+                    autosaveLastSavedAt={autosave.lastSavedAt}
+                    mode="edit"
+                    titleField={titleField}
+                    historyFields={schema.fields}
+                    historyEnabled={historyEnabledFrom(schema)}
+                    hasStatus={hasStatus}
+                    isSubmitting={isSubmitting}
+                    isDirty={isDirty}
+                    entry={entryLike}
+                    collectionSlug={schema.slug}
+                    /* i18n: forward the active locale + switch handler so a localized single shows
                    the primary header language switcher (the sidebar pills are unavailable when
                    the rail is collapsed or on narrow layouts). The switcher self-hides when the
                    single isn't localized / localization isn't configured. */
-                  locale={locale}
-                  onLocaleChange={onLocaleChange}
-                  localized={schema.localized === true}
-                  toolbarSlot={
-                    <EntryFormToolbarSlots
-                      context="single"
-                      controllerField={controllerNames[0]}
-                    />
-                  }
-                  onSaveDraft={() => {
-                    void handleSubmit(undefined, "save-draft");
-                  }}
-                  onPublish={() => {
-                    void handleSubmit(undefined, "publish");
-                  }}
-                  onSaveChanges={() => {
-                    void handleSubmit(undefined, "save-changes");
-                  }}
-                  onUnpublish={() => {
-                    void handleSubmit(undefined, "unpublish");
-                  }}
-                  onCancel={handleCancel}
-                  onViewApi={onViewApi}
-                  /* Why: Singles share the Show JSON dialog with collections,
+                    locale={locale}
+                    onLocaleChange={onLocaleChange}
+                    localized={schema.localized === true}
+                    toolbarSlot={
+                      <EntryFormToolbarSlots
+                        context="single"
+                        controllerField={controllerNames[0]}
+                      />
+                    }
+                    onSaveDraft={() => {
+                      void handleSubmit(undefined, "save-draft");
+                    }}
+                    onPublish={() => {
+                      void handleSubmit(undefined, "publish");
+                    }}
+                    onSaveChanges={() => {
+                      void handleSubmit(undefined, "save-changes");
+                    }}
+                    onUnpublish={() => {
+                      void handleSubmit(undefined, "unpublish");
+                    }}
+                    onCancel={handleCancel}
+                    onViewApi={onViewApi}
+                    /* Why: Singles share the Show JSON dialog with collections,
                  but at the /api/singles/{slug} URL pattern. Passing
                  `scope="single"` routes the dialog through singleApi
                  instead of entryApi. */
-                  scope="single"
-                  lockIdentity
-                  isRailCollapsed={railCollapsed}
-                  onToggleRail={toggleRail}
-                />
-                <EntryMetaStrip
-                  slugField={slugField}
-                  hasStatus={hasStatus}
-                  status={documentStatus}
-                  isRailCollapsed={railCollapsed}
-                  lockSlug
-                />
+                    scope="single"
+                    lockIdentity
+                    isRailCollapsed={railCollapsed}
+                    onToggleRail={toggleRail}
+                  />
+                  <EntryMetaStrip
+                    slugField={slugField}
+                    hasStatus={hasStatus}
+                    status={documentStatus}
+                    isRailCollapsed={railCollapsed}
+                    lockSlug
+                  />
 
-                {/* Inside the main column, below the header, matching the entry
+                  {/* Inside the main column, below the header, matching the entry
                   editor. Placed above the flex row it sat UNDER the sticky
                   header, which intercepted pointer events: the offer was
                   visible and its buttons were not clickable. */}
-                {recovery.offer ? (
-                  <AutosaveRecoveryBanner
-                    savedAt={recovery.offer.savedAt}
-                    onRestore={restoreRecovery}
-                    onDismiss={recovery.dismiss}
-                    className="mx-6 mt-3"
-                  />
-                ) : null}
+                  {recovery.offer ? (
+                    <AutosaveRecoveryBanner
+                      savedAt={recovery.offer.savedAt}
+                      onRestore={restoreRecovery}
+                      onDismiss={recovery.dismiss}
+                      className="mx-6 mt-3"
+                    />
+                  ) : null}
 
-                {/* The language panel, inline. The rail that otherwise carries it
+                  {/* The language panel, inline. The rail that otherwise carries it
                   is `hidden @4xl/content:flex`, so this is the exact
                   complement: shown only where the rail is not, and rendered
                   unconditionally once the author collapses the rail. Without
                   it a single loses its language workflow entirely at narrow
                   widths, which is the failure this panel exists to remove. */}
-                {localizationEnabled && (
-                  <div
-                    className={cn(
-                      "px-6 pt-4",
-                      !railCollapsed && "@4xl/content:hidden"
-                    )}
-                  >
-                    <LanguagePanel
-                      {...(singleTranslations === undefined
-                        ? {}
-                        : { translations: singleTranslations })}
-                      {...(locale === undefined
-                        ? {}
-                        : { activeLocale: locale })}
-                      {...(onLocaleChange === undefined
-                        ? {}
-                        : { onSelect: onLocaleChange })}
-                      hasStatus={hasStatus}
-                    />
-                  </div>
-                )}
+                  {localizationEnabled && (
+                    <div
+                      className={cn(
+                        "px-6 pt-4",
+                        !railCollapsed && "@4xl/content:hidden"
+                      )}
+                    >
+                      <LanguagePanel
+                        {...(singleTranslations === undefined
+                          ? {}
+                          : { translations: singleTranslations })}
+                        {...(locale === undefined
+                          ? {}
+                          : { activeLocale: locale })}
+                        {...(onLocaleChange === undefined
+                          ? {}
+                          : { onSelect: onLocaleChange })}
+                        hasStatus={hasStatus}
+                      />
+                    </div>
+                  )}
 
-                {mainFields.length > 0 && (
-                  <div className="@4xl/content:p-8 pt-6">
-                    <EntryFormContent
-                      fields={mainFields}
-                      disabled={isSubmitting}
-                      withCard
-                    />
+                  {mainFields.length > 0 && (
+                    <div className="@4xl/content:p-8 pt-6">
+                      <EntryFormContent
+                        fields={mainFields}
+                        disabled={isSubmitting}
+                        withCard
+                      />
+                    </div>
+                  )}
+                </div>
+
+                {/* Rail (collapsible). Same shape and width as collections. */}
+                {!railCollapsed && (
+                  <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
+                    <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
+                      <EntryFormSidebar
+                        mode="edit"
+                        entry={entryLike}
+                        hasStatus={hasStatus}
+                        isDirty={isDirty}
+                        {...(locale === undefined ? {} : { locale })}
+                        {...(onLocaleChange === undefined
+                          ? {}
+                          : { onLocaleChange })}
+                      />
+                    </div>
                   </div>
                 )}
               </div>
-
-              {/* Rail (collapsible). Same shape and width as collections. */}
-              {!railCollapsed && (
-                <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
-                  <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
-                    <EntryFormSidebar
-                      mode="edit"
-                      entry={entryLike}
-                      hasStatus={hasStatus}
-                      isDirty={isDirty}
-                      {...(locale === undefined ? {} : { locale })}
-                      {...(onLocaleChange === undefined
-                        ? {}
-                        : { onLocaleChange })}
-                    />
-                  </div>
-                </div>
-              )}
-            </div>
-          </EntryFormProvider>
-        </div>
+            </EntryFormProvider>
+          </div>
+        </TranslationPanes>
       </EntryLocaleProvider>
     </UnsavedChangesGuard>
   );

--- a/packages/admin/src/components/ui/index.ts
+++ b/packages/admin/src/components/ui/index.ts
@@ -13,6 +13,19 @@ export { Checkbox } from "@nextlyhq/ui";
 export { Label } from "@nextlyhq/ui";
 export { RadioGroup, RadioGroupItem } from "@nextlyhq/ui";
 export { Switch } from "@nextlyhq/ui";
+/**
+ * The resizable split, for translation mode's source|target panes.
+ *
+ * Marked `@experimental` in `@nextlyhq/ui` because nothing imported it — the kit
+ * graduates a surface once a consumer exists, and the admin is now that
+ * consumer. Re-exported here rather than imported directly at the call site so
+ * the admin has one place that says which kit primitives it depends on.
+ */
+export {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@nextlyhq/ui";
 export { Textarea } from "@nextlyhq/ui";
 export {
   Select,

--- a/packages/admin/src/constants/search-params.ts
+++ b/packages/admin/src/constants/search-params.ts
@@ -13,3 +13,15 @@
 
 /** The editor's active content language. Absent means the app default. */
 export const LOCALE_PARAM = "locale";
+
+/**
+ * The language translation mode reads its SOURCE from. Absent means the mode is
+ * off.
+ *
+ * A language rather than a boolean, so the pairing is in the URL: a translator
+ * working German from Spanish is a different screen from German from English,
+ * and a `?translate=1` that implied the default language could not express it.
+ * It also makes the mode linkable the way `LOCALE_PARAM` made the target
+ * linkable — a reviewer can be sent the exact pair.
+ */
+export const TRANSLATE_PARAM = "translate";

--- a/packages/admin/src/hooks/__tests__/useTranslationMode.test.ts
+++ b/packages/admin/src/hooks/__tests__/useTranslationMode.test.ts
@@ -1,0 +1,102 @@
+// Which `?translate=` values put the editor into translation mode, and which
+// resolve to "no source".
+//
+// Four inputs resolve to undefined and they are NOT interchangeable in the URL —
+// absent, unconfigured, equal to the target, and equal to the target's implicit
+// default. Each is a URL a user can arrive with, and each has to land on the
+// ordinary editor rather than on a pane showing the document beside itself.
+
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { resolveConfiguredLocale } from "../useLocaleParam";
+import { useTranslationMode } from "../useTranslationMode";
+
+const { params, setSearchParam } = vi.hoisted(() => ({
+  params: { current: {} as Record<string, string | undefined> },
+  setSearchParam: vi.fn(),
+}));
+
+vi.mock("@admin/hooks/useSearchParams", () => ({
+  useSearchParams: () => params.current,
+}));
+vi.mock("@admin/hooks/useLocalization", () => ({
+  useLocalization: () => ({
+    locales: [{ code: "en" }, { code: "es" }, { code: "ar" }],
+  }),
+}));
+vi.mock("@admin/lib/navigation", () => ({
+  setSearchParam: (...args: unknown[]) => setSearchParam(...args),
+}));
+
+function modeFor(
+  translate: string | undefined,
+  activeLocale: string | undefined,
+  defaultLocale: string | undefined = "en"
+) {
+  params.current = translate === undefined ? {} : { translate };
+  return renderHook(() => useTranslationMode({ activeLocale, defaultLocale }))
+    .result.current;
+}
+
+describe("resolveConfiguredLocale", () => {
+  const locales = [{ code: "en" }, { code: "es" }];
+
+  it("honours a configured code", () => {
+    expect(resolveConfiguredLocale("es", locales)).toBe("es");
+  });
+
+  it("rejects a code the app does not configure", () => {
+    // A hand-edited or stale URL must not be sent to the API, which would
+    // answer for a language the app does not have.
+    expect(resolveConfiguredLocale("de", locales)).toBeUndefined();
+  });
+
+  it("treats an absent value as absent", () => {
+    expect(resolveConfiguredLocale(null, locales)).toBeUndefined();
+  });
+});
+
+describe("useTranslationMode", () => {
+  beforeEach(() => setSearchParam.mockReset());
+
+  it("is off when no source is named", () => {
+    expect(modeFor(undefined, "es").translateFrom).toBeUndefined();
+  });
+
+  it("is on for a configured source that differs from the target", () => {
+    expect(modeFor("en", "es").translateFrom).toBe("en");
+  });
+
+  it("is off for a source the app does not configure", () => {
+    expect(modeFor("de", "es").translateFrom).toBeUndefined();
+  });
+
+  it("is off when the source IS the target", () => {
+    // Reached by an ordinary action: enter the mode, then switch the target to
+    // the language you were translating from.
+    expect(modeFor("es", "es").translateFrom).toBeUndefined();
+  });
+
+  it("is off when the source is the target's IMPLICIT default", () => {
+    // The same collision spelled differently: an absent `?locale=` means the
+    // default, so `?translate=en` on an English-default app pairs English with
+    // itself. Resolving only the explicit value would miss this.
+    expect(modeFor("en", undefined, "en").translateFrom).toBeUndefined();
+  });
+
+  it("still resolves a real pair when the target is implicit", () => {
+    // The negative control for the case above: it must not switch the mode off
+    // for every implicit target, only for the one that collides.
+    expect(modeFor("es", undefined, "en").translateFrom).toBe("es");
+  });
+
+  it("writes the source to the URL on enter, and clears it on exit", () => {
+    const mode = modeFor(undefined, "es");
+    mode.enterTranslationMode("en");
+    expect(setSearchParam).toHaveBeenCalledWith("translate", "en");
+
+    mode.exitTranslationMode();
+    expect(setSearchParam).toHaveBeenLastCalledWith("translate", null);
+  });
+});

--- a/packages/admin/src/hooks/useEditorLocale.ts
+++ b/packages/admin/src/hooks/useEditorLocale.ts
@@ -28,8 +28,7 @@
 import { useCallback, useState } from "react";
 
 import { LOCALE_PARAM } from "@admin/constants/search-params";
-import { useLocalization } from "@admin/hooks/useLocalization";
-import { useSearchParams } from "@admin/hooks/useSearchParams";
+import { useLocaleParam } from "@admin/hooks/useLocaleParam";
 import { setSearchParam } from "@admin/lib/navigation";
 
 export interface EditorLocale {
@@ -53,22 +52,10 @@ export interface EditorLocale {
 }
 
 export function useEditorLocale(): EditorLocale {
-  const searchParams = useSearchParams();
-  const { locales } = useLocalization();
-
-  // Only a CONFIGURED language is honoured. A hand-edited or stale `?locale=`
-  // would otherwise be sent to the API, which answers for a language the app
-  // does not have — so an unknown one reads as the default rather than as an
-  // error the reader cannot act on.
-  // Read straight off the parsed params rather than through `lib/routing`'s
-  // helper: that module imports the page registry, so reaching into it from a
-  // hook every page uses closes a cycle.
-  const raw = searchParams[LOCALE_PARAM];
-  const requested = (Array.isArray(raw) ? raw[0] : raw) ?? null;
-  const locale =
-    requested && locales.some(l => l.code === requested)
-      ? requested
-      : undefined;
+  // Only a CONFIGURED language is honoured, and translation mode's source param
+  // owes the same rule — see `useLocaleParam`, which is where it lives so the
+  // two cannot come to disagree.
+  const locale = useLocaleParam(LOCALE_PARAM);
 
   // The seed stays in component state deliberately. It is a one-shot intent
   // consumed on arrival, not a property of the page: in the URL it would

--- a/packages/admin/src/hooks/useLocaleParam.ts
+++ b/packages/admin/src/hooks/useLocaleParam.ts
@@ -1,0 +1,50 @@
+"use client";
+
+/**
+ * Reading a content language out of the URL, honouring only languages the app
+ * actually has.
+ *
+ * The editor addresses two languages by query param — the one being edited
+ * (`?locale=`) and, in translation mode, the one being translated FROM
+ * (`?translate=`) — and both owe the same rule: a hand-edited or stale code is
+ * not sent to the API, which would answer for a language the app does not have.
+ * An unknown code reads as absent rather than as an error the reader cannot act
+ * on, because there is nothing for them to do about a URL they did not write.
+ *
+ * One implementation rather than two. The rule is three lines, which is exactly
+ * the size at which a second copy gets written and then drifts — and the drift
+ * would show up as one param accepting a language the other rejects, on the same
+ * screen.
+ *
+ * @module hooks/useLocaleParam
+ */
+
+import { useLocalization } from "@admin/hooks/useLocalization";
+import { useSearchParams } from "@admin/hooks/useSearchParams";
+import { getSearchParam } from "@admin/lib/search-params";
+
+/**
+ * The requested code if the app configures it, otherwise undefined.
+ *
+ * Pure, so the rule can be tested without a router or a branding provider.
+ */
+export function resolveConfiguredLocale(
+  requested: string | null,
+  locales: readonly { code: string }[]
+): string | undefined {
+  if (!requested) return undefined;
+  return locales.some(l => l.code === requested) ? requested : undefined;
+}
+
+/**
+ * Read one query param as a configured content language.
+ *
+ * Reads straight off the parsed params rather than through `lib/routing`'s
+ * helper: that module imports the page registry, so reaching into it from a
+ * hook every page uses closes a cycle.
+ */
+export function useLocaleParam(param: string): string | undefined {
+  const searchParams = useSearchParams();
+  const { locales } = useLocalization();
+  return resolveConfiguredLocale(getSearchParam(searchParams, param), locales);
+}

--- a/packages/admin/src/hooks/useTranslationMode.ts
+++ b/packages/admin/src/hooks/useTranslationMode.ts
@@ -1,0 +1,75 @@
+"use client";
+
+/**
+ * useTranslationMode — whether the editor is showing a source language beside
+ * the one being edited, and which language that is.
+ *
+ * In the URL, alongside `?locale=`, for the reasons that put the language there
+ * (#1027): the pair is linkable, survives a reload, and is reachable with the
+ * back button. Entering and leaving the mode is then a NAVIGATION, which is what
+ * lets the unsaved-changes guard see it — and the guard already compares search
+ * as well as pathname, so it does not need teaching.
+ *
+ * Deliberately NOT folded into `useEditorLocale`. That hook exists to hold the
+ * active language and its one-shot seed together, because they cannot be held
+ * apart; a view mode is a third thing, wanted by fewer callers, and adding it
+ * there would make every consumer of the language re-render when the mode
+ * changes.
+ *
+ * @module hooks/useTranslationMode
+ */
+
+import { useCallback } from "react";
+
+import { TRANSLATE_PARAM } from "@admin/constants/search-params";
+import { useLocaleParam } from "@admin/hooks/useLocaleParam";
+import { setSearchParam } from "@admin/lib/navigation";
+
+export interface TranslationMode {
+  /**
+   * The language being translated FROM, or undefined when the mode is off.
+   *
+   * Undefined covers four cases that are all "no source to show", and none of
+   * them is worth surfacing to the reader: the param is absent, it names a
+   * language the app does not configure, it names the language already being
+   * edited, or the app has no localization at all.
+   */
+  translateFrom: string | undefined;
+  /** Show `source` beside the language being edited. */
+  enterTranslationMode: (source: string) => void;
+  /** Return to the ordinary single-pane editor, keeping the active language. */
+  exitTranslationMode: () => void;
+}
+
+export function useTranslationMode({
+  activeLocale,
+  defaultLocale,
+}: {
+  /** The language being edited. `undefined` = the app default. */
+  activeLocale: string | undefined;
+  /** The app default, which is what `undefined` above resolves to. */
+  defaultLocale: string | undefined;
+}): TranslationMode {
+  const requested = useLocaleParam(TRANSLATE_PARAM);
+
+  // A source that IS the target is not a source. It arises from an ordinary
+  // action — entering the mode and then switching the target to the language you
+  // were translating from — so it has to resolve to "mode off" rather than to a
+  // pane showing the document beside itself. Resolved through `defaultLocale`
+  // because an absent `?locale=` means the default, so `?locale=` unset with
+  // `?translate=en` on an English-default app is the same collision spelled
+  // differently.
+  const target = activeLocale ?? defaultLocale;
+  const translateFrom =
+    requested !== undefined && requested !== target ? requested : undefined;
+
+  const enterTranslationMode = useCallback((source: string) => {
+    setSearchParam(TRANSLATE_PARAM, source);
+  }, []);
+
+  const exitTranslationMode = useCallback(() => {
+    setSearchParam(TRANSLATE_PARAM, null);
+  }, []);
+
+  return { translateFrom, enterTranslationMode, exitTranslationMode };
+}

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
@@ -32,6 +32,7 @@ import { useEntry } from "@admin/hooks/queries/useEntry";
 import { useEditorLocale } from "@admin/hooks/useEditorLocale";
 import { useLocalization } from "@admin/hooks/useLocalization";
 import { usePluginAutoRegistration } from "@admin/hooks/usePluginAutoRegistration";
+import { useTranslationMode } from "@admin/hooks/useTranslationMode";
 import { navigateTo } from "@admin/lib/navigation";
 import {
   getComponent,
@@ -275,12 +276,16 @@ export default function EditEntryPage({
   // the primary fetch above (same cache key) and needs no source copy.
   const isNonDefaultLocale =
     !!locale && !!defaultLocale && locale !== defaultLocale;
+  const { translateFrom, enterTranslationMode, exitTranslationMode } =
+    useTranslationMode({ activeLocale: locale, defaultLocale });
+  // The language the source is read AT. Translation mode names it explicitly;
+  // otherwise the inline hint's source has always been the app default.
   const { data: sourceEntry } = useEntry({
     collectionSlug: slug || "",
     entryId: id,
     depth: 2,
-    locale: defaultLocale,
-    enabled: isNonDefaultLocale,
+    locale: translateFrom ?? defaultLocale,
+    enabled: isNonDefaultLocale || !!translateFrom,
   });
 
   // Auto-register plugin components when collection is loaded
@@ -510,6 +515,12 @@ export default function EditEntryPage({
           {...(seedFromLocale === undefined ? {} : { seedFromLocale })}
           onSeedHandled={clearSeed}
           sourceValues={sourceEntry}
+          translation={{
+            from: translateFrom,
+            sourceDocument: sourceEntry,
+            onEnter: enterTranslationMode,
+            onExit: exitTranslationMode,
+          }}
           onSuccess={handleSuccess}
           onDelete={handleDelete}
           onCancel={handleCancel}

--- a/packages/admin/src/pages/dashboard/singles/[slug]/index.tsx
+++ b/packages/admin/src/pages/dashboard/singles/[slug]/index.tsx
@@ -36,6 +36,7 @@ import {
 } from "@admin/hooks/queries/useSingles";
 import { useEditorLocale } from "@admin/hooks/useEditorLocale";
 import { useLocalization } from "@admin/hooks/useLocalization";
+import { useTranslationMode } from "@admin/hooks/useTranslationMode";
 import { navigateTo } from "@admin/lib/navigation";
 
 // ============================================================================
@@ -185,14 +186,29 @@ export default function SingleEditPage({
     translationStatus: localizationEnabled,
   });
 
-  // i18n: while translating a non-default language, also load the default-language document so the
-  // editor can show the source text inline on each translatable field. Gated so it only fires when
-  // actually translating another language.
+  // i18n: while translating another language, also load the SOURCE document so
+  // the editor can show its text — inline on each translatable field, and in
+  // translation mode's source pane.
   const isNonDefaultLocale =
     !!locale && !!defaultLocale && locale !== defaultLocale;
+  const { translateFrom, enterTranslationMode, exitTranslationMode } =
+    useTranslationMode({
+      activeLocale: locale,
+      defaultLocale,
+    });
+  // The language the source is read AT. Translation mode names it explicitly;
+  // otherwise the inline hint's source has always been the app default.
+  const sourceLocale = translateFrom ?? defaultLocale;
   const { data: sourceDoc } = useSingleDocument(slug, {
-    locale: defaultLocale,
-    queryOptions: { enabled: isNonDefaultLocale && !!slug },
+    locale: sourceLocale,
+    // No fallback, matching `entry-locale-source.ts`'s SOURCE_READ. With
+    // fallback on, an untranslated SOURCE field resolves to yet another
+    // language's text — which would be presented as this language's source and
+    // copied into the target as if it were a translation.
+    fallbackLocale: "none",
+    queryOptions: {
+      enabled: (isNonDefaultLocale || !!translateFrom) && !!slug,
+    },
   });
 
   // Update mutation — routes the save to the active language's companion row.
@@ -318,6 +334,12 @@ export default function SingleEditPage({
           {...(seedFromLocale === undefined ? {} : { seedFromLocale })}
           onSeedHandled={clearSeed}
           sourceValues={isNonDefaultLocale ? sourceDoc : undefined}
+          translation={{
+            from: translateFrom,
+            sourceDocument: sourceDoc,
+            onEnter: enterTranslationMode,
+            onExit: exitTranslationMode,
+          }}
           // collections, so the page route owns navigation. Breadcrumbs and
           // DocumentTabs (Edit / API) are removed; the API view is reachable
           // via the consolidated dropdown in the system header.


### PR DESCRIPTION
## What

**T-07 Stage C-1** — translating a document now shows the source language beside the one being edited.

A translator working a non-default language could previously see the source only as an inline hint under each field, and [`FieldWrapper.tsx`](packages/admin/src/components/features/entries/fields/FieldWrapper.tsx) could render that hint for a `string` or a `number` and **nothing else**. A richText body, a relationship or a chips list had no source text on screen at all — silently, because a field with nothing to show and a field whose type the hint could not handle looked identical. That is audit finding #9, and this retires it by construction rather than by extending a ladder of type checks: the source pane renders through the editor's own field components, so whatever a field can draw, the source shows.

## How it behaves

- **The pair is in the URL** — `?locale=es&translate=en`, beside the language `#1027` already put there. Linkable, reload-safe, back-button-reachable, and entering or leaving is a navigation the unsaved-changes guard already sees.
- **Four URLs resolve to "no source"** and all land on the ordinary editor: absent, a language the app does not configure, a source equal to the target, and a source equal to the target's *implicit* default (`?translate=en` with no `?locale=` on an English-default app).
- **The chrome steps aside** while the mode is on — navigation, sub-sidebar, header, page frame — and the mode renders its own way back. The suppression layer grants the navigation rail only to a request carrying `canExit: true`, so the component that takes the rail is the one that owns the exit; a test asserts both halves together, because neither alone would notice an exit that stopped rendering.
- **The source pane is read-only and shows only the translatable fields.** A shared field holds the same value in both languages, so putting it there would fill half the screen with a copy of what is already in the other pane.
- **The inline hint is withheld while the mode is on.** Both answer the same question, and with both the source text appeared three times on one screen.

## The layout adaptation is one line

`@container/content` is declared on the dashboard's `<main>`, which stays full-page width — so inside a half-width pane every `@4xl/content:` query in the editor still measured the **page**, and the 320px document rail was laid out beside a main column with no room for it (clipped rail, clipped title). Naming the container on the target pane makes those queries measure the pane, and the editor then responds exactly as it already does at a narrow window: the rail hides and its language panel takes over inline. **No translation-mode branch anywhere in the form.**

## Shared rather than duplicated

Doing this on both editors surfaced two copies worth collapsing, and `fallow` attributed both:

- **`useEntryLocaleContext`** — the two forms built the locale context separately and almost identically. The differences were accidents of addressing (an entry has a slug and an id, a single has neither), and that exact split had already caused a bug: copy-from gated on `collectionSlug && entryId`, so a single could never offer it.
- **`ReadOnlyDocumentForm`** — a document rendered read-only through the editor's own components, for the translation source now and available to the version snapshot.

## One measured negative result, recorded rather than assumed

`ReadOnlyDocumentForm` passes `disabled: true`, and the obvious reading is that the document is then unwritable. **It is not.** Measured against RHF 7.66, with a positive control proving the harness writes:

| form | write via `useController(...).field.onChange` | result |
|---|---|---|
| `disabled: false` (control) | `onChange("WRITTEN")` | value becomes `WRITTEN` |
| `disabled: true` | same call | value becomes **`WRITTEN`** |

So the docblock states three layers and names only the third a boundary: `readOnly` is a **contract** each field honours (one did not — #1043), `disabled` is **defence in depth** for registered inputs, and **isolation** — the form built inside, never returned, no save affordance in its provider — is what makes a stray write harmless. `ReadOnlyDocumentForm.boundary.test.tsx` asserts the limit, so a future reader cannot mistake the flag for a guarantee; if RHF ever changes it, that test fails and says so.

## Verified in the running admin

Both editors, on a healthy server, after the final refactor: mode on, chrome suppressed, English source read-only beside editable Spanish, `Translate` correctly withheld while in the mode, Exit restoring the admin with `?locale=` preserved. Screenshots taken at each step; the first revealed the container-query clipping described above.

The source pane uses a **solid** `bg-muted` rather than an alpha tint. I originally changed this on a contrast finding from the token lane which they have since **retracted and corrected** — the ink suite does composite a translucent fill over its surface, and `bg-muted/30` measured 7.42:1 (light) and 8.04:1 (dark), comfortably passing. So this is not a contrast fix. It stays because `text-muted-foreground` is the foreground `bg-muted` is designed against, which makes the pair one the suite checks by name rather than by computed blend, and because a solid surface is what makes this half read as the one that cannot be edited. The code comment says exactly that.

## Testing

- **28 new tests** across the mode hook, the source hook and the panes. Every one break-verified with a **control run** (suite green, no break applied), an asserted anchor, the **right** test failing, and a verified restore — 14 breaks, each caught by exactly the test that names its property.
- `admin` suite: 15 failing across the 4 documented baseline files — **unchanged**.
- `fallow audit`: **pass**, zero introduced dead code, duplication, complexity and styling.
