### PR TITLE
feat(ui): let the tree view hold more than one selected row

### DIFF
--- a/.changeset/tree-view-multi-select.md
+++ b/.changeset/tree-view-multi-select.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The tree view can show more than one row selected, and the page builder layers panel now highlights everything the canvas does. Rows can be added to the selection with Cmd or Ctrl click and a run selected with Shift click, from the keyboard as well as the pointer.

--- a/packages/builder/src/layers-panel.tsx
+++ b/packages/builder/src/layers-panel.tsx
@@ -174,6 +174,14 @@ export function LayersPanel({ editor }: LayersPanelProps): React.JSX.Element {
           aria-label="Layers"
           nodes={nodes}
           selectedId={editor.selectedId}
+          // The panel shows what the canvas shows. Passing only the primary
+          // would leave two surfaces disagreeing about what is selected, on a
+          // screen where a delete acts on all of it.
+          selectedIds={editor.selection.ids}
+          // The tree's three gestures ARE the editor's three gestures: it
+          // reports which one a row's modifiers meant and the store's own rules
+          // decide what that does. A panel translating them itself would be a
+          // second grammar to keep in step.
           onSelectedChange={editor.select}
           expandedIds={expandedIds}
           // The tree reports the whole next set, which during a search includes

--- a/packages/ui/src/components/tree-view.test.tsx
+++ b/packages/ui/src/components/tree-view.test.tsx
@@ -262,7 +262,8 @@ describe("moving through it with the keyboard", () => {
     expect(onSelectedChange).not.toHaveBeenCalled();
 
     fireEvent.keyDown(tree, { key: "Enter" });
-    expect(onSelectedChange).toHaveBeenCalledWith("header");
+    // The gesture travels with the id now; a plain Enter is a replace.
+    expect(onSelectedChange).toHaveBeenCalledWith("header", "replace");
   });
 
   it("types ahead to a row further down", () => {
@@ -412,5 +413,105 @@ describe("virtualization", () => {
     // 500 rows at 28px. A height of only the rendered window would make the scrollbar claim the
     // tree is a fraction of its real length.
     expect(screen.getByRole("tree").style.height).toBe("14000px");
+  });
+});
+
+describe("a tree holding more than one selected row", () => {
+  function multi(props: Partial<React.ComponentProps<typeof TreeView>>) {
+    return render(
+      <TreeView
+        aria-label="Blocks"
+        nodes={[
+          { id: "a", label: "A" },
+          { id: "b", label: "B" },
+          { id: "c", label: "C" },
+        ]}
+        {...props}
+      />
+    );
+  }
+
+  it("marks every selected row, not only the primary", () => {
+    const { container } = multi({ selectedId: "a", selectedIds: ["a", "c"] });
+
+    expect(
+      Array.from(container.querySelectorAll('[role="treeitem"]')).map(row => [
+        row.textContent,
+        row.getAttribute("aria-selected"),
+      ])
+    ).toEqual([
+      ["A", "true"],
+      ["B", "false"],
+      ["C", "true"],
+    ]);
+  });
+
+  it("announces itself as multi-selectable ONLY when a set is supplied", () => {
+    /*
+     * The control that matters most here. A single-select tree claiming to be
+     * multi-selectable is wrong in a way a screen-reader user ACTS on — they
+     * would look for a selection gesture the tree does not have — so it is
+     * worse than the gap it would be closing.
+     */
+    const withSet = multi({ selectedId: "a", selectedIds: ["a"] });
+    expect(
+      withSet.container
+        .querySelector('[role="tree"]')
+        ?.getAttribute("aria-multiselectable")
+    ).toBe("true");
+
+    cleanup();
+
+    const withoutSet = multi({ selectedId: "a" });
+    expect(
+      withoutSet.container
+        .querySelector('[role="tree"]')
+        ?.getAttribute("aria-multiselectable")
+    ).toBeNull();
+  });
+
+  it("selects exactly the primary when no set is supplied, which is the control", () => {
+    // Without this, "existing callers keep working" is a claim rather than a
+    // check — every other case here passes a set.
+    const { container } = multi({ selectedId: "b" });
+
+    expect(
+      Array.from(container.querySelectorAll('[role="treeitem"]')).map(row =>
+        row.getAttribute("aria-selected")
+      )
+    ).toEqual(["false", "true", "false"]);
+  });
+
+  it("reports the gesture a click's modifiers meant", () => {
+    const onSelectedChange = vi.fn();
+    const { container } = multi({ selectedId: "a", onSelectedChange });
+    const second = container.querySelectorAll('[role="treeitem"]')[1];
+    if (second === undefined) throw new Error("expected a second row");
+
+    fireEvent.click(second, { metaKey: true });
+    expect(onSelectedChange).toHaveBeenCalledWith("b", "toggle");
+
+    fireEvent.click(second, { shiftKey: true });
+    expect(onSelectedChange).toHaveBeenCalledWith("b", "extend");
+
+    fireEvent.click(second);
+    expect(onSelectedChange).toHaveBeenCalledWith("b", "replace");
+  });
+
+  it("gives the KEYBOARD the same three gestures", () => {
+    /*
+     * WCAG 2.2 SC 2.1.1. A tree that could only build a multi-row selection by
+     * clicking would make the one capability this change adds mouse-only.
+     */
+    const onSelectedChange = vi.fn();
+    const { container } = multi({ selectedId: "a", onSelectedChange });
+    const tree = container.querySelector('[role="tree"]');
+    if (tree === null) throw new Error("expected a tree");
+
+    fireEvent.keyDown(tree, { key: " ", ctrlKey: true });
+    expect(onSelectedChange).toHaveBeenCalledWith("a", "toggle");
+
+    fireEvent.keyDown(tree, { key: "Enter", shiftKey: true });
+    expect(onSelectedChange).toHaveBeenCalledWith("a", "extend");
   });
 });

--- a/packages/ui/src/components/tree-view.tsx
+++ b/packages/ui/src/components/tree-view.tsx
@@ -191,6 +191,57 @@ function useControllable<T>(
   ];
 }
 
+/**
+ * Which gesture a row's modifiers meant.
+ *
+ * Named by the same three words the rest of the system uses, so a caller maps
+ * them onto its own selection rules without translating. Both Meta and Control
+ * mean toggle: a Mac author presses Command and a Windows author presses
+ * Control, and neither ever presses the other's.
+ *
+ * Shift outranks the toggle modifier — a shift+mod click is a slip rather than
+ * a fourth gesture, and extending is the one whose result is visible and undone
+ * by a plain click.
+ *
+ * @experimental
+ */
+export type TreeSelectionMode = "replace" | "toggle" | "extend";
+
+/**
+ * Read the gesture from the event that carried it.
+ *
+ * @experimental
+ */
+export function treeSelectionMode(modifiers: {
+  shiftKey: boolean;
+  metaKey: boolean;
+  ctrlKey: boolean;
+}): TreeSelectionMode {
+  if (modifiers.shiftKey) return "extend";
+  if (modifiers.metaKey || modifiers.ctrlKey) return "toggle";
+  return "replace";
+}
+
+/**
+ * Whether a row is in the selection at all.
+ *
+ * A helper rather than an expression inside the render, so the multi-select
+ * branch is one call there instead of a condition — a small edit to a large
+ * function is what pushes it across a complexity threshold.
+ *
+ * `selectedIds` when the caller owns a set, the single id otherwise, so a
+ * caller that has not adopted the set keeps exactly the behaviour it had.
+ *
+ * @experimental
+ */
+export function isRowSelected(
+  id: string,
+  primary: string | null | undefined,
+  selectedIds: readonly string[] | undefined
+): boolean {
+  return selectedIds === undefined ? primary === id : selectedIds.includes(id);
+}
+
 /** @experimental */
 export interface TreeViewProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, "onSelect"> {
@@ -202,12 +253,27 @@ export interface TreeViewProps
   defaultExpandedIds?: readonly string[];
   /** Called with the full next set whenever a branch opens or closes. */
   onExpandedChange?: (ids: string[]) => void;
-  /** The selected node id, if the caller owns it. */
+  /**
+   * The selected node id, if the caller owns it.
+   *
+   * With `selectedIds` also supplied this is the PRIMARY — the row a detail
+   * panel answers for. Drawn at a heavier weight so a reader can tell which
+   * member of a multi-row selection the rest of the screen describes.
+   */
   selectedId?: string | null;
+  /**
+   * Every selected id, when the caller holds more than one.
+   *
+   * Additive: omit it and the tree behaves exactly as it did. Supplying it also
+   * makes the tree announce itself as `aria-multiselectable`, which is why it
+   * is a separate prop rather than inferred — a single-select tree claiming to
+   * be multi-selectable is wrong in a way a screen-reader user acts on.
+   */
+  selectedIds?: readonly string[];
   /** Which id starts selected when the caller does not own selection. */
   defaultSelectedId?: string | null;
   /** Called when a row is chosen, by pointer or by Enter. */
-  onSelectedChange?: (id: string) => void;
+  onSelectedChange?: (id: string, mode: TreeSelectionMode) => void;
   /**
    * Names the tree for a screen reader. One of this or `aria-labelledby` is required: a tree
    * announced only as "tree" tells a user nothing about which one they are in.
@@ -228,6 +294,7 @@ const TreeView = React.forwardRef<HTMLDivElement, TreeViewProps>(
       defaultExpandedIds,
       onExpandedChange,
       selectedId,
+      selectedIds,
       defaultSelectedId,
       onSelectedChange,
       className,
@@ -298,9 +365,12 @@ const TreeView = React.forwardRef<HTMLDivElement, TreeViewProps>(
       commitExpanded(next);
     };
 
-    const choose = (id: string): void => {
+    const choose = (id: string, mode: TreeSelectionMode = "replace"): void => {
+      // The uncontrolled fallback tracks the PRIMARY only. A caller wanting a
+      // set owns it; inventing a default set here would give an uncontrolled
+      // tree a selection its caller never sees.
       if (selectedId === undefined) setSelected(id);
-      onSelectedChange?.(id);
+      onSelectedChange?.(id, mode);
     };
 
     /**
@@ -412,7 +482,16 @@ const TreeView = React.forwardRef<HTMLDivElement, TreeViewProps>(
         case "Enter":
         case " ":
           event.preventDefault();
-          if (row.node.disabled !== true) choose(row.node.id);
+          /*
+           * The same three gestures the pointer has, so multi-select is not a
+           * mouse-only capability. WCAG 2.2 SC 2.1.1 asks that everything
+           * reachable by pointer be reachable from a keyboard, and the APG's
+           * multi-select tree pattern names Ctrl+Space for toggle and Shift for
+           * extend — which is what these modifiers resolve to.
+           */
+          if (row.node.disabled !== true) {
+            choose(row.node.id, treeSelectionMode(event));
+          }
           return;
         case "*": {
           event.preventDefault();
@@ -485,6 +564,8 @@ const TreeView = React.forwardRef<HTMLDivElement, TreeViewProps>(
           // container around it. Left outside, a caller who names the tree with
           // `aria-labelledby` gets a tree with no accessible name at all — the label sits on a
           // plain div and the role element is announced as an unlabelled tree.
+          // Only when the caller actually holds a set — see `selectedIds`.
+          aria-multiselectable={selectedIds === undefined ? undefined : true}
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledBy}
           aria-describedby={ariaDescribedBy}
@@ -494,7 +575,14 @@ const TreeView = React.forwardRef<HTMLDivElement, TreeViewProps>(
           {virtualItems.map(item => {
             const row = rows[item.index];
             if (row === undefined) return null;
-            const isSelected = selected === row.node.id;
+            const isSelected = isRowSelected(
+              row.node.id,
+              selected,
+              selectedIds
+            );
+            // Which member the rest of the screen answers for. With no set
+            // supplied every selected row is the primary, so nothing changes.
+            const isPrimary = selected === row.node.id;
             return (
               <div
                 key={row.node.id}
@@ -512,10 +600,10 @@ const TreeView = React.forwardRef<HTMLDivElement, TreeViewProps>(
                 // than stopping at every node in it.
                 tabIndex={item.index === tabStopIndex ? 0 : -1}
                 onFocus={() => setActiveId(row.node.id)}
-                onClick={() => {
+                onClick={event => {
                   if (row.node.disabled === true) return;
                   setActiveId(row.node.id);
-                  choose(row.node.id);
+                  choose(row.node.id, treeSelectionMode(event));
                 }}
                 className={cn(
                   "absolute left-0 flex w-full select-none items-center gap-1 rounded-sm pr-2 text-sm outline-none",
@@ -523,7 +611,12 @@ const TreeView = React.forwardRef<HTMLDivElement, TreeViewProps>(
                   row.node.disabled === true
                     ? "pointer-events-none opacity-50"
                     : "cursor-pointer",
-                  isSelected ? "bg-muted text-foreground" : "hover:bg-muted/50"
+                  isSelected ? "bg-muted text-foreground" : "hover:bg-muted/50",
+                  // WEIGHT, not a second colour. Every row here is selected and
+                  // an action applies to all of them; what a reader needs is
+                  // which one the detail panel describes, and a second colour
+                  // would have to mean a second kind of selected.
+                  isSelected && isPrimary && "font-medium"
                 )}
                 style={{
                   height: item.size,


### PR DESCRIPTION
**Step 4b of B-10, and the last piece of it.** The layers panel now shows what the canvas shows.

`TreeView` was single-select by contract — `selectedId?: string | null`, `onSelectedChange?: (id: string) => void`, no set and no modifiers — so the panel could highlight only one row while the canvas outlined several and the toolbar's delete acted on all of them. Two surfaces answering different questions with the same words.

The lane that owns `packages/ui` confirmed the file was free and asked that I make the change rather than hand over a spec, on the grounds that a translation step between the rule and its use is how two surfaces end up with two answers.

## Additive by construction

`selectedIds` sits **alongside** `selectedId`, which becomes the PRIMARY — the row a detail panel answers for. Omit the set and the tree behaves exactly as it did. That claim is only a claim until something checks it, so there is a case that passes **no** `selectedIds` at all and asserts exactly one row selected.

`onSelectedChange` gains the gesture as a second argument, which is source-compatible: a handler taking one parameter still satisfies it.

## `aria-multiselectable` only when a set is supplied

The detail worth arguing about. A single-select tree announcing itself as multi-selectable is **worse than the gap it closes** — it is wrong in a way a screen-reader user acts on, sending them looking for a selection gesture the tree does not have. So the attribute is present only when the caller actually holds a set, and a test asserts its absence otherwise.

## The keyboard gets the same three gestures

Otherwise multi-select would be a mouse-only capability, which fails WCAG 2.2 SC 2.1.1 for the one thing this change adds. `Ctrl+Space` toggles and `Shift+Enter` extends, which is the APG multi-select tree pattern.

## Primary is a WEIGHT, not a colour

Every row in the selection is selected and an action applies to all of them; what a reader needs is which one the detail panel describes. A second colour would have to mean a second kind of selected. Same rule as the canvas, where primary keeps a 2px outline and the rest drop to 1px.

## Verified

Three stubs, each caught by the test that names the property: announcing multi-selectable unconditionally, marking only the primary, and a keyboard that always replaces.

`packages/ui` **1083 tests**, `packages/builder` 789, `plugin-page-builder` 65, types and lint clean across all three. Fallow `new-only`: `verdict: pass`, everything `introduced: 0`.

**Not verified in a browser.** The session ended before I could run the layers panel through the playground. Every other PR in this B-10 series was browser-verified and this one is not — the gates are green and the unit coverage is there, but a reviewer should know the difference. The specific things worth clicking: mod-click and shift-click on layer rows, and that the panel's highlight matches the canvas after each.

## One correction carried in from a merged PR

`packages/ui/src/components/**` is inside the contrast suite's scanned roots, so an alpha utility here would be measured. An earlier claim that the suite could not see a tint over a tinted background was **retracted by its author and verified retracted by me** — `ink-utilities.test.ts:268` composites with `compositeOver(applyOpacity(fill, alpha), base)`. The weight-only rule above stays because it is the better design, not because a tint was unmeasurable.
