### PR TITLE
feat(admin): report translation progress and fill one field from the source

### DIFF
--- a/.changeset/translation-workflow.md
+++ b/.changeset/translation-workflow.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Translation mode now reports progress and can fill a single field from the source. A translator sees how many of this language's fields are done, counted as they type rather than from what was last saved, and each translatable field offers "Use source" where the source has text — for the lines that are the same in both languages, a name, a URL, a product term. The document-level copy still exists for seeding a whole language; this is the grain the side-by-side view makes possible.
+
+Also fixes two layout defects found by measuring rather than looking. The editor cancels its page container's padding with a negative margin, and inside a translation pane there was no padding to cancel — so its layout was 64px wider than the pane it sat in and the document rail was drawn past the right edge. And a language row in the 320px rail put its label, badges, state and two buttons on one unshrinkable line, which left an untranslated right-to-left language's "Open" button 38px outside the row, unreachable by pointer; that one was not new, and happened on the ordinary editor too.

--- a/packages/admin/src/components/features/entries/CompletenessMeter.tsx
+++ b/packages/admin/src/components/features/entries/CompletenessMeter.tsx
@@ -1,0 +1,35 @@
+/**
+ * How far along a set of translations is, as a bar.
+ *
+ * Two surfaces show one: the language panel counts LANGUAGES against the stored
+ * translation map, and translation mode counts FIELDS against the form's live
+ * values. Different questions, same drawing — and a second copy of the drawing
+ * would drift in height, colour or rounding while both claimed to mean the same
+ * thing.
+ *
+ * `aria-hidden` deliberately: every caller states the same figure in words
+ * beside it, and a bar announced as well would say it twice.
+ *
+ * @module components/features/entries/CompletenessMeter
+ */
+
+export function CompletenessMeter({
+  translated,
+  total,
+}: {
+  translated: number;
+  total: number;
+}) {
+  if (total === 0) return null;
+  return (
+    <span
+      aria-hidden="true"
+      className="inline-flex h-1.5 w-16 overflow-hidden rounded-sm bg-muted"
+    >
+      <span
+        className="block bg-foreground"
+        style={{ width: `${(translated / total) * 100}%` }}
+      />
+    </span>
+  );
+}

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -600,6 +600,7 @@ export function EntryForm({
           <TranslationPanes
             source={translationMode.source}
             onExit={translationMode.onExit}
+            control={form.control}
           >
             <EntryFormContextProvider
               entryId={entry?.id}

--- a/packages/admin/src/components/features/entries/LanguagePanel.tsx
+++ b/packages/admin/src/components/features/entries/LanguagePanel.tsx
@@ -29,6 +29,7 @@ import { Button } from "@nextlyhq/ui";
 import { useLocalization } from "@admin/hooks/useLocalization";
 import { cn } from "@admin/lib/utils";
 
+import { CompletenessMeter } from "./CompletenessMeter";
 import { CopyFromLanguageDialog } from "./CopyFromLanguageDialog";
 import { useEntryLocale } from "./EntryLocaleContext";
 import {
@@ -68,27 +69,6 @@ export interface LanguagePanelProps {
  * The completeness meter. `aria-hidden` because the count beside it states the
  * same fact in words — a reader would otherwise hear the progress twice.
  */
-function CompletenessMeter({
-  translated,
-  total,
-}: {
-  translated: number;
-  total: number;
-}) {
-  if (total === 0) return null;
-  return (
-    <span
-      aria-hidden="true"
-      className="inline-flex h-1.5 w-16 overflow-hidden rounded-sm bg-muted"
-    >
-      <span
-        className="block bg-foreground"
-        style={{ width: `${(translated / total) * 100}%` }}
-      />
-    </span>
-  );
-}
-
 function LanguageRow({
   code,
   label,
@@ -114,26 +94,42 @@ function LanguageRow({
 }) {
   return (
     <li className="flex items-center gap-2 px-3 py-2 border-b border-border last:border-b-0">
-      <StateDot state={state} />
-      <span className="text-sm font-medium">{label}</span>
-      {isDefault && (
-        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
-          default
+      {/* The describing half SHRINKS and the acting half does not. This row
+          lives in a 320px rail, and with a long label, a `default`/`rtl` badge
+          and a state to report there is not always room for both buttons —
+          measured, the "Open" of an untranslated RTL language sat 38px past the
+          row's own right edge, unreachable by pointer. Truncating the state text
+          costs nothing that is not said elsewhere: the dot encodes it by SHAPE,
+          and the language button's accessible name carries it in words. */}
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <StateDot state={state} />
+        {/* The language NAME does not yield. It is the row's identity, and a
+            flex row that shrinks everything proportionally turned "Arabic" into
+            "A…" — which names nothing — while the state beside it still read in
+            full. The state text below is the one thing that gives way. */}
+        <span className="shrink-0 whitespace-nowrap text-sm font-medium">
+          {label}
         </span>
-      )}
-      {rtl && (
-        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
-          rtl
+        {isDefault && (
+          <span className="shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
+            default
+          </span>
+        )}
+        {rtl && (
+          <span className="shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
+            rtl
+          </span>
+        )}
+        <span className="min-w-0 truncate text-xs text-muted-foreground">
+          {LANGUAGE_STATE_LABEL[state]}
         </span>
-      )}
-      <span className="text-xs text-muted-foreground">
-        {LANGUAGE_STATE_LABEL[state]}
-      </span>
-      <span className="flex-1" />
+      </div>
       {isActive ? (
-        <span className="text-xs text-muted-foreground">editing now</span>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          editing now
+        </span>
       ) : (
-        <>
+        <div className="flex shrink-0 items-center gap-1.5">
           {/* Offered only where it is the useful next step: a language with
               nothing in it. Seeding one that already has content is the
               overwrite the confirm step exists to warn about, and it stays
@@ -171,7 +167,7 @@ function LanguageRow({
               Open
             </Button>
           )}
-        </>
+        </div>
       )}
     </li>
   );

--- a/packages/admin/src/components/features/entries/TranslationMode/TranslationFieldContext.tsx
+++ b/packages/admin/src/components/features/entries/TranslationMode/TranslationFieldContext.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+/**
+ * The source text a single field can be filled from, for the fields being
+ * translated.
+ *
+ * Separate from `EntryLocaleContext` deliberately, and the reason is
+ * structural rather than tidiness. Both panes sit inside the locale context —
+ * the source pane needs the writing direction and the translatable-field set
+ * as much as the target does — so a per-field "use the source" offered from
+ * there would appear on the SOURCE fields too, where it means nothing and where
+ * the form it would write to is the read-only one.
+ *
+ * This is provided around the target pane alone. The source pane is a sibling,
+ * so it reads the default and offers nothing: the mistake is unrepresentable
+ * rather than guarded against.
+ *
+ * @module components/features/entries/TranslationMode/TranslationFieldContext
+ */
+
+import { createContext, useContext } from "react";
+
+export interface TranslationFieldContextValue {
+  /**
+   * The source document's values, keyed by field name.
+   *
+   * Absent outside translation mode and inside the source pane, which is what
+   * makes both "no source to offer" without either having to know why.
+   */
+  sourceValues?: Record<string, unknown>;
+  /** The source language's label, for naming the action after what it does. */
+  sourceLabel?: string;
+}
+
+const TranslationFieldContext = createContext<TranslationFieldContextValue>({});
+
+export const TranslationFieldProvider = TranslationFieldContext.Provider;
+
+/** What a field can offer to fill itself from; empty outside translation mode. */
+export function useTranslationField(): TranslationFieldContextValue {
+  return useContext(TranslationFieldContext);
+}

--- a/packages/admin/src/components/features/entries/TranslationMode/TranslationPanes.tsx
+++ b/packages/admin/src/components/features/entries/TranslationMode/TranslationPanes.tsx
@@ -32,6 +32,8 @@
  * @module components/features/entries/TranslationMode/TranslationPanes
  */
 
+import type { Control, FieldValues } from "react-hook-form";
+
 import { useSuppressAdminChrome } from "@admin/components/layout/ChromeSuppression";
 import {
   ResizableHandle,
@@ -42,6 +44,8 @@ import { cn } from "@admin/lib/utils";
 
 import { SourceDocumentPane } from "./SourceDocumentPane";
 import type { SourcePaneDocument } from "./SourceDocumentPane";
+import { TranslationFieldProvider } from "./TranslationFieldContext";
+import { TranslationProgress } from "./TranslationProgress";
 
 export interface TranslationPanesProps {
   /**
@@ -64,15 +68,26 @@ export interface TranslationPanesProps {
   onExit?: (() => void) | undefined;
   /** The editor. Rendered in the target pane when the mode is on. */
   children: React.ReactNode;
+  /**
+   * The target form's control, so the bar can report how far along this
+   * language is as the translator types.
+   *
+   * The control rather than a rendered node: both editors were assembling the
+   * same progress element at the call site, derivation and all. Reading a form
+   * here is safe — the bar must contain nothing that WRITES, which is a
+   * different rule and one `useWatch` does not break.
+   */
+  control?: Control<FieldValues> | undefined;
 }
 
 export function TranslationPanes({
   source,
   onExit = () => {},
   children,
+  control,
 }: TranslationPanesProps) {
   return source ? (
-    <ActivePanes source={source} onExit={onExit}>
+    <ActivePanes source={source} onExit={onExit} control={control}>
       {children}
     </ActivePanes>
   ) : (
@@ -92,10 +107,12 @@ function ActivePanes({
   source,
   onExit,
   children,
+  control,
 }: {
   source: SourcePaneDocument;
   onExit: () => void;
   children: React.ReactNode;
+  control?: Control<FieldValues> | undefined;
 }) {
   // `documentSidebar` is deliberately absent: this asks for the admin's
   // furniture, and the editor's own rail is the document's, collapsed through
@@ -107,7 +124,7 @@ function ActivePanes({
 
   return (
     <div className="flex h-dvh flex-col">
-      <ModeBar source={source} onExit={onExit} />
+      <ModeBar source={source} onExit={onExit} control={control} />
       {/* Sizes are PERCENTAGE STRINGS, and that is load-bearing rather than a
           style choice: this library reads a bare number as PIXELS, so
           `defaultSize={40}` is a 40-pixel pane. A layout in pixels is also
@@ -133,7 +150,30 @@ function ActivePanes({
               the rail hides and its language panel takes over inline. No
               translation-mode branch anywhere in the form. */}
           <div className="@container/content h-full overflow-y-auto">
-            {children}
+            {/* The pane stands in for `PageContainer`, so it owes the same
+                horizontal padding. The editor cancels that padding itself at
+                `@4xl` with `-m-8` to run edge-to-edge — a negative margin with
+                nothing to cancel makes its layout 64px WIDER than the pane, so
+                the document rail is laid out past the right edge and clipped.
+                Measured before this: a 921px pane holding a 985px row.
+
+                On an INNER element, deliberately: the container is declared
+                above, and an element cannot query itself — padding written up
+                there would resolve against the page and reintroduce exactly the
+                mismatch this fixes. */}
+            {/* The per-field source, provided around the TARGET alone. The
+                source pane is a sibling, so its own fields read the default and
+                offer nothing — a field cannot fill itself from itself. */}
+            <TranslationFieldProvider
+              value={{
+                sourceValues: source.values,
+                sourceLabel: source.sourceLabel,
+              }}
+            >
+              <div className="px-4 @sm/content:px-6 @2xl/content:px-8">
+                {children}
+              </div>
+            </TranslationFieldProvider>
           </div>
         </ResizablePanel>
       </ResizablePanelGroup>
@@ -153,9 +193,11 @@ function ActivePanes({
 function ModeBar({
   source,
   onExit,
+  control,
 }: {
   source: SourcePaneDocument;
   onExit: () => void;
+  control?: Control<FieldValues> | undefined;
 }) {
   return (
     <div className="flex shrink-0 items-center gap-3 border-b border-border bg-background px-4 py-2">
@@ -170,6 +212,9 @@ function ModeBar({
         {source.sourceLabel}
       </span>
       <span className="flex-1" />
+      {control && (
+        <TranslationProgress control={control} fields={source.fields} />
+      )}
       <button
         type="button"
         onClick={onExit}

--- a/packages/admin/src/components/features/entries/TranslationMode/TranslationProgress.tsx
+++ b/packages/admin/src/components/features/entries/TranslationMode/TranslationProgress.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * How much of THIS language is done, counted as the translator types.
+ *
+ * Field-level, not document-level. The language panel already answers "how many
+ * languages are translated" from the backend's stored map; that number cannot
+ * move while someone is working, because it describes what was last saved. A
+ * translator part-way through a document needs the other question, and it can
+ * only be answered from the form's live values.
+ *
+ * ## Why it takes a `control` instead of reading form context
+ *
+ * It renders in the mode bar, which is OUTSIDE the target pane and therefore
+ * outside the form's provider — deliberately, since the bar must not contain
+ * anything that writes. `useWatch` accepts an explicit control, so this
+ * subscribes to the translatable fields directly and re-renders ONLY itself.
+ * Watching from the form component instead would re-render the whole editor on
+ * every keystroke.
+ *
+ * @module components/features/entries/TranslationMode/TranslationProgress
+ */
+
+import type { FieldConfig } from "nextly/config";
+import { useWatch, type Control, type FieldValues } from "react-hook-form";
+
+import { CompletenessMeter } from "../CompletenessMeter";
+import { fieldTranslationCounts } from "../translation-meta";
+
+export interface TranslationProgressProps {
+  /** The target form's control, passed rather than read from context. */
+  control: Control<FieldValues>;
+  /**
+   * The translatable fields, in document order.
+   *
+   * Takes the FIELDS and derives their names here rather than taking names,
+   * because both editors would otherwise write the same three-line derivation
+   * at the call site — which is exactly what they did, and what `fallow`
+   * attributed as a clone.
+   */
+  fields: readonly FieldConfig[];
+}
+
+export function TranslationProgress({
+  control,
+  fields,
+}: TranslationProgressProps) {
+  const fieldNames = fields
+    .map(f => ("name" in f ? f.name : undefined))
+    .filter((n): n is string => !!n);
+
+  // Named fields only. A bare `useWatch({ control })` subscribes to the whole
+  // form, which would re-render this on every keystroke in a shared field that
+  // has nothing to do with the count.
+  const values = useWatch({
+    control,
+    name: fieldNames,
+  }) as unknown[];
+
+  const byName: Record<string, unknown> = {};
+  fieldNames.forEach((name, i) => {
+    byName[name] = values?.[i];
+  });
+  const { translated, total } = fieldTranslationCounts(fieldNames, byName);
+
+  // A document whose every field is shared has nothing to report, and a "0 of 0"
+  // reads as work outstanding rather than as a document with no fields to
+  // translate.
+  if (total === 0) return null;
+
+  return (
+    <span
+      className="flex items-center gap-2 text-xs text-muted-foreground"
+      // One live region rather than a chatty one per field: a screen-reader user
+      // typing gets the running total, not an announcement per keystroke.
+      role="status"
+      aria-live="polite"
+    >
+      <CompletenessMeter translated={translated} total={total} />
+      <span className="tabular-nums">
+        {translated} of {total} fields translated
+      </span>
+    </span>
+  );
+}

--- a/packages/admin/src/components/features/entries/TranslationMode/UseSourceButton.tsx
+++ b/packages/admin/src/components/features/entries/TranslationMode/UseSourceButton.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * Fill ONE field from the source language.
+ *
+ * The document-level copy already exists (`useCopyFromLanguage`) and is the
+ * wrong grain for this screen: it fills every translatable field at once behind
+ * a confirm step, because it is offered where the source is not on display and
+ * an author cannot see what they are about to overwrite. Here the source IS on
+ * display, immediately beside the field, and the useful gesture is "this one" —
+ * a name, a URL, a line that is the same in both languages.
+ *
+ * No confirm step, for the same reason: the author can see both values, the
+ * action names the field it fills, and nothing is saved. Undo is the form's
+ * own — the field is dirty until they save, and the unsaved-changes guard
+ * already covers leaving.
+ *
+ * Renders nothing at all unless the field is being translated AND the source
+ * actually holds something. An empty source is not a fill worth offering, and a
+ * button that blanks the target is the opposite of the intent.
+ *
+ * @module components/features/entries/TranslationMode/UseSourceButton
+ */
+
+import { useFormContext } from "react-hook-form";
+
+import { isFieldTranslated } from "../translation-meta";
+
+import { useTranslationField } from "./TranslationFieldContext";
+
+export function UseSourceButton({
+  fieldName,
+  fieldLabel,
+}: {
+  /** The form path this fills — the field's own name. */
+  fieldName: string;
+  /** For the accessible name, so several of these are told apart. */
+  fieldLabel: string;
+}) {
+  const { sourceValues, sourceLabel } = useTranslationField();
+  // Reads the TARGET form, because this renders inside the target pane. The
+  // source pane is outside this context entirely, so there is no arrangement in
+  // which this writes the wrong document.
+  const form = useFormContext();
+
+  const value = sourceValues?.[fieldName];
+  if (!sourceValues || !isFieldTranslated(value)) return null;
+
+  return (
+    <button
+      type="button"
+      className="text-xs font-medium text-muted-foreground underline underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:rounded-sm"
+      // Named for the field it acts on. Read out of context — a screen reader
+      // listing this form's controls — a dozen buttons all saying "Use source"
+      // name no field at all.
+      aria-label={`Use the ${sourceLabel ?? "source"} text for ${fieldLabel}`}
+      onClick={() => {
+        // `shouldDirty` so the form knows there is something to save, and the
+        // unsaved-changes guard sees it; `shouldValidate` so a filled field
+        // stops reporting the error it had while empty.
+        form.setValue(fieldName, value, {
+          shouldDirty: true,
+          shouldValidate: true,
+        });
+      }}
+    >
+      Use source
+    </button>
+  );
+}

--- a/packages/admin/src/components/features/entries/TranslationMode/__tests__/UseSourceButton.test.tsx
+++ b/packages/admin/src/components/features/entries/TranslationMode/__tests__/UseSourceButton.test.tsx
@@ -1,0 +1,110 @@
+// Filling one field from the source language.
+//
+// The cases that matter are the ones where it must NOT appear: outside
+// translation mode, and on the source pane's own fields — where the form it
+// would write to is the read-only one and "use the source" means filling a
+// field from itself. Both are absences, so each is asserted against a positive
+// control in the same file rather than on its own.
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, it, expect } from "vitest";
+
+import { TranslationFieldProvider } from "../TranslationFieldContext";
+import { UseSourceButton } from "../UseSourceButton";
+
+/** Renders the button inside a form, optionally inside the source context. */
+function setup(
+  source:
+    | { sourceValues?: Record<string, unknown>; sourceLabel?: string }
+    | undefined,
+  fieldName = "headline"
+) {
+  const seen: { values?: Record<string, unknown> } = {};
+
+  function Harness() {
+    const form = useForm<Record<string, unknown>>({
+      defaultValues: { headline: "" },
+    });
+    seen.values = form.watch();
+    const button = (
+      <UseSourceButton fieldName={fieldName} fieldLabel="Headline" />
+    );
+    return (
+      <FormProvider {...form}>
+        <span data-testid="value">{String(form.watch(fieldName) ?? "")}</span>
+        <span data-testid="dirty">{String(form.formState.isDirty)}</span>
+        {source ? (
+          <TranslationFieldProvider value={source}>
+            {button}
+          </TranslationFieldProvider>
+        ) : (
+          button
+        )}
+      </FormProvider>
+    );
+  }
+
+  render(<Harness />);
+  return seen;
+}
+
+const SOURCE = {
+  sourceValues: { headline: "Autumn release is live" },
+  sourceLabel: "English",
+};
+
+describe("UseSourceButton", () => {
+  it("POSITIVE CONTROL: offers itself when there is a source to use", () => {
+    // Without this the absence cases below pass on a component that never
+    // renders under any circumstances.
+    setup(SOURCE);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("renders nothing outside translation mode", () => {
+    // No provider at all — which is every ordinary edit of a document.
+    setup(undefined);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing on the source pane's own fields", () => {
+    // The source pane is a SIBLING of the target, so it is outside the provider
+    // and reads the empty default. This is that shape.
+    setup({});
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the source field is empty", () => {
+    // A fill that blanks the target is the opposite of the intent, so a source
+    // holding nothing offers nothing.
+    setup({ sourceValues: { headline: "   " }, sourceLabel: "English" });
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("fills the field, and marks the form dirty so the work can be saved", async () => {
+    setup(SOURCE);
+    expect(screen.getByTestId("value")).toHaveTextContent("");
+    expect(screen.getByTestId("dirty")).toHaveTextContent("false");
+
+    await userEvent.click(screen.getByRole("button"));
+
+    expect(screen.getByTestId("value")).toHaveTextContent(
+      "Autumn release is live"
+    );
+    // Without `shouldDirty` the fill is invisible to Save and to the
+    // unsaved-changes guard: the author would fill a field, navigate away, and
+    // lose it with nothing having asked.
+    expect(screen.getByTestId("dirty")).toHaveTextContent("true");
+  });
+
+  it("names the language AND the field, so several are told apart", () => {
+    setup(SOURCE);
+    expect(
+      screen.getByRole("button", {
+        name: "Use the English text for Headline",
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/entries/__tests__/translation-meta.fields.test.ts
+++ b/packages/admin/src/components/features/entries/__tests__/translation-meta.fields.test.ts
@@ -1,0 +1,70 @@
+// Counting FIELDS rather than languages.
+//
+// The document-level count reads the backend's stored `_translations` map and
+// therefore describes what was last saved. This one reads the form's live
+// values, so it moves while someone is typing — two different questions, and
+// the cases below are the ones where a shared implementation would get one of
+// them wrong.
+
+import { describe, it, expect } from "vitest";
+
+import { fieldTranslationCounts, isFieldTranslated } from "../translation-meta";
+
+describe("isFieldTranslated", () => {
+  it("counts real text", () => {
+    expect(isFieldTranslated("hola")).toBe(true);
+  });
+
+  it("does not count blank or whitespace", () => {
+    // Whitespace-only is what an author leaves behind after clearing a field.
+    // Counting it done would report a document finished that is not.
+    expect(isFieldTranslated("")).toBe(false);
+    expect(isFieldTranslated("   ")).toBe(false);
+    expect(isFieldTranslated(null)).toBe(false);
+    expect(isFieldTranslated(undefined)).toBe(false);
+  });
+
+  it("counts a non-empty list and not an empty one", () => {
+    // A chips field translated to nothing is untranslated; `[]` is truthy, so
+    // the ordinary presence check gets this backwards.
+    expect(isFieldTranslated(["uno"])).toBe(true);
+    expect(isFieldTranslated([])).toBe(false);
+  });
+
+  it("counts a structural value, and a falsy-but-real one", () => {
+    // `0` and `false` are values a translator can legitimately have set, and a
+    // truthiness test would report both as outstanding work forever.
+    expect(isFieldTranslated({ nodes: [] })).toBe(true);
+    expect(isFieldTranslated(0)).toBe(true);
+    expect(isFieldTranslated(false)).toBe(true);
+  });
+});
+
+describe("fieldTranslationCounts", () => {
+  it("counts only the fields it was given", () => {
+    // The denominator is the TRANSLATABLE set, not the document. A shared field
+    // carrying a value would otherwise inflate the count with work nobody did.
+    const counts = fieldTranslationCounts(["a", "b"], {
+      a: "hecho",
+      b: "",
+      campaign: "autumn",
+    });
+    expect(counts).toEqual({ translated: 1, total: 2 });
+  });
+
+  it("reports nothing outstanding for a document with no translatable fields", () => {
+    expect(fieldTranslationCounts([], { a: "x" })).toEqual({
+      translated: 0,
+      total: 0,
+    });
+  });
+
+  it("treats absent values as untranslated rather than erroring", () => {
+    // A field added to the schema after this language was last written has no
+    // entry at all, which is untranslated rather than a crash.
+    expect(fieldTranslationCounts(["a", "b"], undefined)).toEqual({
+      translated: 0,
+      total: 2,
+    });
+  });
+});

--- a/packages/admin/src/components/features/entries/fields/FieldWrapper.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldWrapper.tsx
@@ -20,6 +20,7 @@ import { useLabelLandingCheck } from "@admin/lib/forms/label-landing";
 import { cn } from "@admin/lib/utils";
 
 import { useEntryLocale } from "../EntryLocaleContext";
+import { UseSourceButton } from "../TranslationMode/UseSourceButton";
 
 import { useFieldElementId } from "./field-id-scope";
 
@@ -309,6 +310,15 @@ export function FieldWrapper({
     </p>
   ) : null;
 
+  // In translation mode the source is already on screen in its own pane, so the
+  // field offers the ACTION rather than repeating the text: fill this one field
+  // from the source. Renders nothing outside the mode, and nothing on the source
+  // pane's own fields — that pane sits outside the context this reads.
+  const useSourceAction =
+    isLocalizedField && fieldName != null ? (
+      <UseSourceButton fieldName={fieldName} fieldLabel={label} />
+    ) : null;
+
   // Don't render if hidden
   if (isHidden) {
     return null;
@@ -443,6 +453,10 @@ export function FieldWrapper({
           Below the input it read as a footnote about the field rather than as
           the text being translated. */}
       {sourceHint}
+
+      {useSourceAction && (
+        <div className="flex justify-end">{useSourceAction}</div>
+      )}
 
       {/* Input (children) */}
       {children}

--- a/packages/admin/src/components/features/entries/translation-meta.ts
+++ b/packages/admin/src/components/features/entries/translation-meta.ts
@@ -100,3 +100,43 @@ export const LANGUAGE_STATE_LABEL: Record<LanguageState, string> = {
   translated: "translated",
   published: "published",
 };
+
+/**
+ * Whether ONE field carries a translation.
+ *
+ * Blank-is-empty, matching what copy-from-language already treats as "present"
+ * and what the backend treats as untranslated — a field holding only whitespace
+ * has not been translated, and reporting it done would inflate every count that
+ * uses this.
+ *
+ * Deliberately structural rather than a comparison against the source: a
+ * translation that legitimately matches its source (a product name, a URL) is
+ * still a translation, and flagging it as outstanding would send a translator
+ * back to work that is finished.
+ */
+export function isFieldTranslated(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim() !== "";
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+/**
+ * How far along ONE language's fields are, for the pair on screen.
+ *
+ * The document-level {@link translationCounts} answers "how many LANGUAGES",
+ * read off the backend's `_translations` map. This answers "how many FIELDS",
+ * read off the form's live values — so it moves as the translator types, which
+ * the stored map cannot do. Two different questions, deliberately not one
+ * function with a mode flag.
+ */
+export function fieldTranslationCounts(
+  fieldNames: readonly string[],
+  values: Record<string, unknown> | undefined
+): { translated: number; total: number } {
+  let translated = 0;
+  for (const name of fieldNames) {
+    if (isFieldTranslated(values?.[name])) translated += 1;
+  }
+  return { translated, total: fieldNames.length };
+}

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -529,6 +529,7 @@ export function SingleForm({
         <TranslationPanes
           source={translationMode.source}
           onExit={translationMode.onExit}
+          control={form.control}
         >
           <div className={cn("space-y-0", className)}>
             <EntryFormProvider form={form} onSubmit={handleSubmit}>


### PR DESCRIPTION
## What

**T-07 Stage C-2 and C-3.** Translation mode now reports progress and can fill a single field from the source, and two layout defects are fixed.

## Per-field workflow (C-3)

- **"Use source"** on each translatable field, where the source actually holds something. This is the grain the side-by-side view makes possible: `useCopyFromLanguage` fills every field at once behind a confirm step, because it is offered where the source is *not* on display and an author cannot see what they are about to overwrite. Here they can, so it needs no confirm — and nothing is saved, so the form's own undo applies.
- **Live progress** in the mode bar — `2 of 2 fields translated`, counted from the form's values rather than the stored `_translations` map. The document-level count describes what was last saved and cannot move while someone is working; this is the other question and it needs the live values.

**The context is provided around the TARGET pane alone.** The source pane is a sibling, so its fields read the empty default and offer nothing — a field cannot offer to fill itself from itself. That is structural rather than a guard, and it is what the absence tests assert.

## Two layout defects, both found by measuring rather than looking (C-2)

**The editor ran 64px past its pane.** `PageContainer` applies `px-4 @sm/content:px-6 @2xl/content:px-8`, and the editor cancels it at `@4xl` with `-m-8` to run edge-to-edge. Inside a translation pane there is no `PageContainer` — `pageFrame` is suppressed — so the negative margin had nothing to cancel and the 320px document rail was laid out past the right edge. Measured: a **921px pane holding a 985px row**. The pane now supplies the padding it stands in for, on an *inner* element, because the container is declared on the outer one and an element cannot query itself.

**A language row pushed its own button out of reach.** In the 320px rail, label + `default`/`rtl` badges + state + two buttons on one unshrinkable flex line left an untranslated RTL language's "Open" **38px past the row's right edge**, unreachable by pointer. **Not new** — it reproduced with translation mode off, on the ordinary editor. Fixed by splitting the row into a shrinking describing half and a fixed acting half.

The first fix's own correction is worth noting: truncating the whole describing half turned "Arabic" into "A…". The language name is the row's identity, so it no longer yields; the state text is the one thing that gives way, and it is already carried in the language button's accessible name and in the dot's shape.

## Shared rather than duplicated

`CompletenessMeter` was inside `LanguagePanel`; both the language count and the field count draw the same bar, so it moved to its own module. `fallow` attributed a clone of the progress element assembled at each call site — `TranslationPanes` now takes the form's `control` and derives it once.

## Testing

- **13 new tests**, break-verified: control run green, anchors asserted, 7 breaks each caught by exactly the test naming its property, restore verified identical.
- Verified in the running admin on **both** editors: entry and single, mode on, chrome suppressed, per-field action labelled `Use the English text for Biography`, progress moving live (cleared a field → `1 of 2`, clicked Use source → filled → `2 of 2`, Save enabled).
- `admin` suite: 15 failing across the 4 documented baseline files — **unchanged**.
- `fallow audit`: **pass**, zero introduced in every category.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live translation progress indicators for language panels and translation forms.
  * Added a “Use source” action to copy source text into translated fields.
  * Added accessible translation status feedback and source-language context.
  * Improved language-row layouts for narrow screens, including label truncation and accessible actions.

* **Tests**
  * Added coverage for source-text copying, translation detection, and translation progress calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->