### PR TITLE
fix(admin): keep a null document instead of dropping it to undefined

### DIFF
--- a/.changeset/fetcher-null-document.md
+++ b/.changeset/fetcher-null-document.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A read that legitimately answers "this does not exist" no longer arrives as `undefined` in the admin. The shared HTTP client treated a `null` JSON document as an absent body, so an endpoint answering `200 application/json` with `null` — which is what asking for an autosave recovery point does when the author has none — came back with nothing, and React Query rejected it with "Query data cannot be undefined" on every entry and single editor load. The client now returns the `null` the server sent, and tells it apart from a body that could not be parsed, which had been indistinguishable because both were caught to the same value.

--- a/packages/admin/src/lib/api/fetcher.response-shape.test.ts
+++ b/packages/admin/src/lib/api/fetcher.response-shape.test.ts
@@ -1,0 +1,98 @@
+// What the shared fetcher makes of each response shape.
+//
+// This boundary had no tests, and the defect it shipped is the reason the file
+// exists: a `200 application/json` body of `null` — which is what a read
+// answers when the thing legitimately does not exist — came back as `undefined`,
+// so react-query rejected it with "Query data cannot be undefined" on every
+// editor load. The query had answered correctly; the client threw the answer
+// away.
+//
+// The cases below are the ones that must stay TOLD APART, which is the property
+// a single falsy check cannot hold.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetcher } from "./fetcher";
+
+/** A response with a JSON content-type and the given raw body text. */
+function jsonResponse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  globalThis.fetch = originalFetch;
+});
+
+function respondWith(res: Response) {
+  (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+    res
+  );
+}
+
+describe("fetcher response shapes", () => {
+  it("returns a null DOCUMENT as null, not undefined", () => {
+    // The regression. `GET .../versions/autosave` answers exactly this when an
+    // author has no recovery point.
+    respondWith(jsonResponse("null"));
+    return expect(fetcher("/anything")).resolves.toBeNull();
+  });
+
+  it("POSITIVE CONTROL: an ordinary object still comes back whole", async () => {
+    // Without this, "returns null" would pass on a fetcher that returned null
+    // for everything.
+    respondWith(jsonResponse('{"id":"a","title":"t"}'));
+    await expect(fetcher("/anything")).resolves.toEqual({
+      id: "a",
+      title: "t",
+    });
+  });
+
+  it("returns an array body whole", async () => {
+    respondWith(jsonResponse('[{"id":"a"}]'));
+    await expect(fetcher("/anything")).resolves.toEqual([{ id: "a" }]);
+  });
+
+  it("returns undefined when the body cannot be parsed", async () => {
+    // The case `null` used to be indistinguishable from. The server claimed
+    // JSON and did not send it, which is not an answer of `null` — and a caller
+    // that treats the two the same reports a broken endpoint as an empty one.
+    respondWith(jsonResponse("<!DOCTYPE html><html>"));
+    await expect(fetcher("/anything")).resolves.toBeUndefined();
+  });
+
+  it("returns undefined for a body that is not JSON at all", async () => {
+    respondWith(
+      new Response("hello", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      })
+    );
+    await expect(fetcher("/anything")).resolves.toBeUndefined();
+  });
+
+  it("returns undefined for a no-content status", async () => {
+    // Asserts the OUTCOME callers depend on, and does NOT isolate the 204
+    // branch: an empty body fails to parse anyway, so this stays green with
+    // that branch disabled — verified. Said here rather than left to read as
+    // coverage it does not provide. The branch cannot be isolated from the test
+    // side, because the Response constructor refuses a 204 carrying a body.
+    respondWith(new Response(null, { status: 204 }));
+    await expect(fetcher("/anything")).resolves.toBeUndefined();
+  });
+
+  it("returns undefined for a bare scalar body", async () => {
+    // Unchanged behaviour, asserted so the null fix is not read as licence to
+    // start returning scalars. Nothing in this admin answers with one.
+    respondWith(jsonResponse("42"));
+    await expect(fetcher("/anything")).resolves.toBeUndefined();
+  });
+});

--- a/packages/admin/src/lib/api/fetcher.ts
+++ b/packages/admin/src/lib/api/fetcher.ts
@@ -56,6 +56,9 @@ type ApiErrorResult = {
 
 export type ApiResult<T> = ApiSuccess<T> | ApiErrorResult;
 
+/** Distinguishes "the body could not be parsed" from a body that IS `null`. */
+const PARSE_FAILED = Symbol("fetcher.parse-failed");
+
 export async function fetcher<T = unknown>(
   path: string,
   options: RequestInit = {},
@@ -118,9 +121,30 @@ export async function fetcher<T = unknown>(
     return undefined as T;
   }
 
-  const json = await res.json().catch(() => null);
+  // A sentinel rather than `null` for the parse failure, because `null` is a
+  // value the server can legitimately SEND. Catching to `null` conflated the
+  // two, and the branch below then had no way to tell "the body could not be
+  // read" from "the document is null".
+  const json = await res.json().catch(() => PARSE_FAILED);
 
-  if (!json || typeof json !== "object") {
+  if (json === PARSE_FAILED) {
+    return undefined as T;
+  }
+
+  // `null` is a DOCUMENT, not an absent body — the answer a read gives when the
+  // thing legitimately does not exist. `GET .../versions/autosave` returns
+  // exactly that, `200 application/json` with `null`, when an author has no
+  // recovery point; collapsing it to `undefined` lost the distinction and left
+  // react-query throwing "Query data cannot be undefined" on every editor load,
+  // for a query that had answered correctly.
+  if (json === null) {
+    return null as T;
+  }
+
+  // Any other non-object body — a bare string, a number — is still undefined.
+  // No endpoint in this admin answers with one, so this stays as it was rather
+  // than inventing a meaning for a shape nothing sends.
+  if (typeof json !== "object") {
     return undefined as T;
   }
 


### PR DESCRIPTION
## The defect

Every entry and single editor load logs this, on `main` today:

    [ERROR] Query data cannot be undefined. Please make sure to return a value
    other than undefined from your query function.
    Affected query key: ["autosave-recovery","single","homepage","601b234d-..."]

**The query answered correctly and the client threw the answer away.** Measured against a healthy dev server:

    GET /admin/api/singles/announcement/versions/autosave
      200  application/json  body: null        ← "this author has no recovery point"

`fetcher.ts` then ran `if (!json || typeof json !== "object") return undefined`, so a `null` **document** was treated as an absent body.

Reported by the page-builder lane while browser-verifying #1047, and independently visible in my own session. Not theirs and not mine — pre-existing on `e8ff9f841`, and it reproduces on the ordinary editors, not only inside the builder.

## Two things were conflated, and both mattered

**`null` the document vs. no body.** `null` is the answer a read gives when the thing legitimately does not exist, and `versionApi.getAutosave` is already typed `Promise<AutosaveDetail | null>` — the type was true and the client was not. Callers then had to special-case a value their own types said they would never receive.

**`null` the document vs. a parse failure.** The old code caught a failed `res.json()` to `null`, so a server that claims JSON and sends none was indistinguishable from one that sends `null`. A caller told those are the same reports a broken endpoint as an empty one. A sentinel separates them.

## Scope

Deliberately narrow. A bare scalar body (`42`, `"x"`) still returns `undefined` — nothing in this admin answers with one, and inventing a meaning for a shape nothing sends is how the next ambiguity gets built in. Asserted, so the null fix is not read as licence.

The behaviour change is `null` where callers previously got `undefined`. Both are falsy, so `if (!data)` call sites are unaffected; what changes is that React Query now accepts the answer.

## Testing

**This boundary had no tests at all** — a shared HTTP client used by every query in the admin. It has seven now, covering each response shape that must stay told apart, break-verified with a control run: restoring the original `!json` check fails exactly the null-document test, catching the parse failure to `null` fails exactly the parse test, and removing the scalar guard fails exactly the scalar test.

One honest limit is recorded in the file rather than left to read as coverage: the 204 case asserts the outcome callers depend on but does **not** isolate the 204 branch — an empty body fails to parse anyway, so it stays green with that branch disabled (verified). It cannot be isolated from the test side, because the `Response` constructor refuses a 204 carrying a body.

`admin` suite: 15 failing across the 4 documented baseline files, unchanged. `fallow audit`: pass.
