### PR TITLE
fix(ui): scan the plugins and builder for unreadable ink

### DIFF
--- a/.changeset/ink-scan-reaches-the-plugins.md
+++ b/.changeset/ink-scan-reaches-the-plugins.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The ink-contrast scan now reads the first-party plugins and the builder, not only the admin and the kit. Those three packages paint admin chrome with the same ink utilities and carried 230 of them, measured by nothing — so a token that is unreadable on a surface it lands on could ship there while the same mistake in the admin failed CI.
+
+It found one: the conditional-logic notice drew its text with the base warning token, which measures 4.37:1 once its own 10% fill composites over the page container, short of the 4.5:1 text needs. It now uses the 600 shade, which holds 5.13:1 at its worst surface in either mode.

--- a/packages/plugin-form-builder/src/admin/components/builder/ConditionalLogicEditor.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/ConditionalLogicEditor.tsx
@@ -388,7 +388,11 @@ export function ConditionalLogicEditor({
             </Button>
           ) : (
             // Full-strength warning border so this notice boundary is perceivable over its tinted fill.
-            <p className="mt-4 text-center text-xs text-warning font-medium bg-warning/10 p-2 rounded-none border border-warning">
+            // The 600 shade rather than the base token: the base measures 4.37:1
+            // once its own 10% fill composites over the page container, short of
+            // the 4.5:1 text needs. The 600 shade holds 5.13:1 at its worst
+            // surface in either mode.
+            <p className="mt-4 text-center text-xs text-warning-600 font-medium bg-warning/10 p-2 rounded-none border border-warning">
               Add more fields to the form to create conditions.
             </p>
           )}

--- a/packages/ui/src/styles/contrast/__tests__/ink-utilities.test.ts
+++ b/packages/ui/src/styles/contrast/__tests__/ink-utilities.test.ts
@@ -47,7 +47,19 @@ const { light, dark } = parseThemeTokens(themeCss);
 const scale = parseThemeScale(themeCss);
 
 /** Packages whose components render inside the admin shell. */
-const SCANNED = ["packages/admin/src", "packages/ui/src"];
+const SCANNED = [
+  "packages/admin/src",
+  "packages/ui/src",
+  // The first-party plugins and the builder paint admin chrome with the same
+  // ink utilities and were outside this scan, so a token misused as ink there
+  // was measured by nothing. Between them they carry 230 ink utilities and 41
+  // tinted fills. The builder keeps its own `--nx-builder-*` namespace, which
+  // this scan does not care about: it resolves whatever the utility names and
+  // measures the result.
+  "packages/plugin-form-builder/src",
+  "packages/plugin-page-builder/src",
+  "packages/builder/src",
+];
 const EXTENSIONS = new Set([".tsx", ".ts", ".jsx", ".js"]);
 
 /**


### PR DESCRIPTION
## What

`ink-utilities.test.ts` resolves every ink utility a component paints — `text-*`, `ring-*`, `decoration-*`, `caret-*`, `placeholder-*` — against every surface it can land on, in both modes, compositing any translucent fill over each. It scanned `["packages/admin/src", "packages/ui/src"]`.

Three packages that paint the same admin chrome were outside it:

    packages/plugin-form-builder/src   165 ink utilities, 38 tinted fills
    packages/builder/src                46 ink utilities,  1 tinted fill
    packages/plugin-page-builder/src    19 ink utilities,  2 tinted fills

So an ink token unreadable on a surface it lands on could ship there, while the identical mistake in `packages/admin` failed CI. This adds those three roots.

The builder keeps its own `--nx-builder-*` namespace. This scan does not care: it resolves whatever the utility names and measures the result.

## What it found

One, in the conditional-logic notice:

    text-warning = 4.37:1 on --nx-page-background (light), needs 4.5:1
    ConditionalLogicEditor.tsx:391

The base `warning` token is fine on the page at 5.00:1 and fails only once **its own 10% fill** composites over the page container — the element is `text-warning` on `bg-warning/10`. Fixed by moving to the 600 shade.

Candidates measured across all six surfaces in both modes before choosing:

| ink | worst ratio | where |
|---|---|---|
| `text-warning` | 4.37 | light, page-background — **fails** |
| **`text-warning-600`** | **5.13** | light, page-background — passes everywhere |
| `text-warning-700` | 3.38 | dark, page-background — fails |

`warning-600` is also the admin's most common warning ink (8 uses), so this is the house shade rather than a number tuned to clear a bar.

**The trade, stated rather than buried:** light goes 4.37 → 5.13 and crosses the threshold; dark goes 6.60 → 5.36 and loses headroom while staying well above 4.5. One token that holds in both modes beats a light/dark pair.

## Blast radius

One class on one `<p>`. Four of the five added lines in that file are a comment.

The other changed file is a **test** — `packages/ui` publishes only `dist`, and `__tests__` is not an entry point, so it ships nothing.

## Verification

**Break-verified in both directions, including the control that matters:**

- Revert the ink token → the suite fails with the exact message above.
- Keep the defect but remove the three new roots → the suite **passes** (14/14). That is what proves the coverage addition is doing the work rather than something incidental.
- Every probe restored from a `cp` snapshot and confirmed byte-identical with `diff -q`.

**Verified in the running admin, both themes**, on a form with a single field (the state that renders the notice):

- light — computed `color(srgb 0.5816 0.294979 -0.193003)`, class `text-warning-600`
- dark — computed `color(srgb 0.86446 0.557825 0.0395599)`, with `.nextly-admin.dark` asserted present rather than assumed, since the admin scopes dark there and not on `html`
- before/after captured in each mode via HMR; the difference is a slightly deeper amber, which is the intent — this is a legibility fix, not a restyle

**Gates, cache forced off:**

    build         19/19
    lint          24/24
    check-types   22/22
    lint:design   915 files across 8 roots
    test:scripts  516 passed
    packages/ui   45 files / 1078 tests, 0 failing
    plugin-form-builder  20 files / 89 tests, 0 failing
    packages/admin  4 files / 15 tests failing — file set IDENTICAL to the documented
                    pre-existing baseline (StatsCard, BasicsTab, SlugInput, DefaultValueField)

## Note for the page-builder lane

From this landing, an ink token misused in `packages/builder/src` fails CI rather than shipping silently. Measured before proposing it: that tree passes today, and the only finding was in `plugin-form-builder`. The lane has been told ahead of time so an in-flight PR does not meet a new gate mid-review.

## Not in this PR

An earlier draft of this work chased a much larger claim — that no suite composited tinted backgrounds at all, and that ~412 call sites were unmeasured. **That was wrong and is withdrawn.** `ink-utilities.test.ts` has always composited (`compositeOver(applyOpacity(fill, tint.alpha ?? 1), base)`), and `accepted.ts` already carries entries keyed on `bgAlpha`/`bgOver` with measured ratios. The gap was only ever which packages it read, which is what this changes.
