### PR TITLE
feat(builder): move a whole selection one step at a time

### DIFF
--- a/.changeset/multi-block-move.md
+++ b/.changeset/multi-block-move.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Move several selected blocks at once. The page editor's toolbar and its alt+arrow shortcuts now reorder a whole selection that shares a container, as one step per block and one undo for the group, where they previously refused any selection larger than one. A selection spread across two containers still refuses, and now says why.

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -281,8 +281,11 @@ export {
   selectionDeletion,
   selectionDuplication,
   selectionLock,
+  selectionMove,
   type SelectionDuplication,
   type SelectionEdit,
+  type SelectionMove,
+  type SelectionMovePlan,
   type SelectionPlan,
   type SelectionRefusal,
 } from "./selection-ops";

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -36,6 +36,7 @@ import {
   isRefusal,
   selectionDeletion,
   selectionDuplication,
+  selectionMove,
 } from "./selection-ops";
 
 /**
@@ -315,8 +316,55 @@ export function useBlockKeyboardActions({
     announce(`${plan.subject} duplicated. Undo with ${UNDO_KEYS_SPOKEN}.`);
   }, [announce]);
 
+  /**
+   * Reordering a selection that holds more than one block.
+   *
+   * Only `up` and `down`. Depth is the other axis, and a set does not have one
+   * answer for it: `indent` appends to the container above, so two blocks
+   * indenting together would arrive in an order neither of them was in.
+   *
+   * Returns whether it handled the press, so the single-block path below stays
+   * exactly as it was for the case it already served.
+   */
+  const moveSet = React.useCallback(
+    (direction: MoveDirection): boolean => {
+      const editorNow = latest.current;
+      const ids = editorNow.selection.ids;
+      if (ids.length <= 1 || (direction !== "up" && direction !== "down")) {
+        return false;
+      }
+
+      const plan = selectionMove(editorNow.document, ids, direction);
+      // A set at the edge of its container, exactly as one block there: the
+      // press did nothing and that is the answer. Handled either way, because
+      // falling through would move the PRIMARY alone and break the set apart.
+      if (plan === null) return true;
+
+      /*
+       * A lock and a split selection are both POLICY refusals, so both are
+       * announced where a structural one is not. Nothing on the page explains
+       * why the key did nothing, and a keyboard author has no dimmed button to
+       * look at.
+       */
+      if (isRefusal(plan)) {
+        announce(plan.reason);
+        return true;
+      }
+
+      if (editorNow.applyAll(plan.ops) !== null) {
+        announce(`${plan.subject} moved.`);
+      }
+      // The selection deliberately does not change, for the same reason it does
+      // not for one block: a run of presses walks the same set across the list.
+      return true;
+    },
+    [announce]
+  );
+
   const moveSelected = React.useCallback(
     (direction: MoveDirection) => {
+      if (moveSet(direction)) return;
+
       const editorNow = latest.current;
       const selectedId = editorNow.selectedId;
       if (selectedId === null) return;
@@ -361,7 +409,7 @@ export function useBlockKeyboardActions({
       // the block still selected, so a second press continues moving the
       // same block — which is what makes a run of presses walk it across the
     },
-    [announce]
+    [announce, moveSet]
   );
 
   /**

--- a/packages/builder/src/selection-move.test.ts
+++ b/packages/builder/src/selection-move.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Moving a selection that holds more than one block.
+ *
+ * Nearly every assertion here APPLIES the planned ops and reads the resulting
+ * document, rather than inspecting the ops themselves. A plan that looks right
+ * and lands wrong is the whole failure mode: `move` is remove-then-reinsert, so
+ * an index is interpreted against a list the earlier ops have already changed,
+ * and an op array can be perfectly shaped while the order it applies in puts
+ * the blocks somewhere nobody asked for.
+ *
+ * @module selection-move.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { type BlockDocument, type BlockNode } from "@nextlyhq/blocks-engine";
+
+import { applyOp } from "./ops";
+import { isRefusal, selectionMove } from "./selection-ops";
+
+function documentOf(nodes: BlockNode[]): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+}
+
+function leaf(id: string): BlockNode {
+  return { id, type: "acme/text", version: 1, props: {} } as BlockNode;
+}
+
+function box(id: string, children: BlockNode[]): BlockNode {
+  return {
+    id,
+    type: "acme/box",
+    version: 1,
+    props: {},
+    slots: { children },
+  } as BlockNode;
+}
+
+/** The document a plan produces, by applying every op in the order given. */
+function afterMoving(
+  document: BlockDocument,
+  ids: string[],
+  direction: "up" | "down"
+): BlockDocument {
+  const plan = selectionMove(document, ids, direction);
+  if (plan === null || isRefusal(plan)) {
+    throw new Error("expected a plan, got a refusal");
+  }
+  let current = document;
+  for (const op of plan.ops) current = applyOp(current, op).document;
+  return current;
+}
+
+/** Top-level ids, in order, so an assertion reads like the canvas. */
+function order(document: BlockDocument): string[] {
+  return document.nodes.map(node => node.id);
+}
+
+/** The ids inside a container's `children` slot, in order. */
+function childrenOf(document: BlockDocument, id: string): string[] {
+  const parent = document.nodes.find(node => node.id === id);
+  return (parent?.slots?.children ?? []).map(child => child.id);
+}
+
+describe("selectionMove", () => {
+  it("moves a contiguous run up, keeping the blocks in their own order", () => {
+    const document = documentOf([leaf("a"), leaf("b"), leaf("c"), leaf("d")]);
+
+    expect(order(afterMoving(document, ["b", "c"], "up"))).toEqual([
+      "b",
+      "c",
+      "a",
+      "d",
+    ]);
+  });
+
+  it("moves a contiguous run down", () => {
+    const document = documentOf([leaf("a"), leaf("b"), leaf("c"), leaf("d")]);
+
+    expect(order(afterMoving(document, ["b", "c"], "down"))).toEqual([
+      "a",
+      "d",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("moves a NON-contiguous selection, each block one step", () => {
+    // THE ordering case. Both selected blocks step one place, and the gap
+    // between them is preserved — which is what makes the move reversible.
+    const document = documentOf([leaf("a"), leaf("b"), leaf("c"), leaf("d")]);
+
+    expect(order(afterMoving(document, ["b", "d"], "up"))).toEqual([
+      "b",
+      "a",
+      "d",
+      "c",
+    ]);
+  });
+
+  it("is undone by the opposite direction, which is why an edge refuses", () => {
+    // The inverse is the property the whole-group refusal exists to protect,
+    // so it is asserted rather than argued.
+    const document = documentOf([leaf("a"), leaf("b"), leaf("c"), leaf("d")]);
+    const moved = afterMoving(document, ["b", "d"], "up");
+
+    expect(order(afterMoving(moved, ["b", "d"], "down"))).toEqual(
+      order(document)
+    );
+  });
+
+  it("accepts the order the plan gives, not merely the ops it names", () => {
+    // A guard on the guard: applying the SAME ops in the reverse order must
+    // produce something different, or these tests would pass on a planner that
+    // ignored ordering entirely.
+    const document = documentOf([leaf("a"), leaf("b"), leaf("c"), leaf("d")]);
+    const plan = selectionMove(document, ["b", "c"], "up");
+    if (plan === null || isRefusal(plan)) throw new Error("expected a plan");
+
+    let current = document;
+    for (const op of [...plan.ops].reverse()) {
+      current = applyOp(current, op).document;
+    }
+
+    expect(order(current)).not.toEqual(["b", "c", "a", "d"]);
+  });
+
+  it("refuses the whole group when one block is at the edge", () => {
+    // Silent rather than phrased: a set that cannot go further has said so by
+    // not going, exactly as one block at the end of a list does.
+    const document = documentOf([leaf("a"), leaf("b"), leaf("c")]);
+
+    expect(selectionMove(document, ["a", "c"], "up")).toBeNull();
+  });
+
+  it("refuses a selection spread across two containers, with a reason", () => {
+    // Phrased, because nothing on the page shows that the selection straddles
+    // a boundary — unlike an edge, which the author can see.
+    const document = documentOf([
+      box("outer", [leaf("inside")]),
+      leaf("beside"),
+    ]);
+
+    const plan = selectionMove(document, ["inside", "beside"], "down");
+
+    expect(isRefusal(plan)).toBe(true);
+    expect(isRefusal(plan) ? plan.reason : "").toContain(
+      "different containers"
+    );
+  });
+
+  it("moves siblings INSIDE a slot, not only at the top level", () => {
+    const document = documentOf([
+      box("outer", [leaf("one"), leaf("two"), leaf("three")]),
+    ]);
+
+    const moved = afterMoving(document, ["two", "three"], "up");
+
+    expect(childrenOf(moved, "outer")).toEqual(["two", "three", "one"]);
+  });
+
+  it("refuses when a selected block is locked, naming it", () => {
+    const locked = { ...leaf("b"), locked: true } as BlockNode;
+    const document = documentOf([leaf("a"), locked, leaf("c")]);
+
+    const plan = selectionMove(document, ["b", "c"], "up");
+
+    expect(isRefusal(plan)).toBe(true);
+    expect(isRefusal(plan) ? plan.reason : "").toContain("locked");
+  });
+
+  it("collapses a container and its own child to the container", () => {
+    // The outermost rule, applied before anything is planned: selecting a box
+    // and something inside it is a selection of the box, so this is an
+    // ordinary single-block move rather than a split-container refusal.
+    const document = documentOf([
+      leaf("first"),
+      box("outer", [leaf("inside")]),
+    ]);
+
+    const moved = afterMoving(document, ["outer", "inside"], "up");
+
+    expect(order(moved)).toEqual(["outer", "first"]);
+    expect(childrenOf(moved, "outer")).toEqual(["inside"]);
+  });
+
+  it("counts the blocks and names them for an announcement", () => {
+    const document = documentOf([leaf("a"), leaf("b"), leaf("c")]);
+
+    const plan = selectionMove(document, ["b", "c"], "up");
+    if (plan === null || isRefusal(plan)) throw new Error("expected a plan");
+
+    expect(plan.count).toBe(2);
+    expect(plan.subject).toBe("2 blocks");
+  });
+
+  it("answers null for a selection the document no longer holds", () => {
+    const document = documentOf([leaf("a"), leaf("b")]);
+
+    expect(selectionMove(document, ["gone", "missing"], "up")).toBeNull();
+  });
+});

--- a/packages/builder/src/selection-ops.ts
+++ b/packages/builder/src/selection-ops.ts
@@ -13,7 +13,7 @@
  * eventually disagree with the toolbar and the keyboard, which act on one block
  * through those same functions.
  *
- * ## Order is load-bearing, and only for duplicate
+ * ## Order is load-bearing, and differently for each verb
  *
  * **Duplicating runs in REVERSE document order.** Each copy is inserted
  * immediately after its original, and inserting shifts every later sibling
@@ -21,6 +21,14 @@
  * document that a's copy has already changed, and the second copy lands in the
  * wrong place. Reversed, every insert happens after the positions still to be
  * used, and each one is correct when it applies.
+ *
+ * **Moving runs TOWARDS the edge it is heading for**: ascending for `up`,
+ * descending for `down`. A move vacates the index it leaves, so the block
+ * nearest the destination has to go first — planning `up` from the bottom of
+ * the run would step a block into a place its neighbour has not left yet.
+ * Taken in the right order, each move swaps a pair of adjacent positions that
+ * no later move in the group addresses, so every target computed against the
+ * original document is still correct when it applies.
  *
  * **Deleting does not care**, and that is worth stating so nobody "fixes" it:
  * a remove addresses a node by id, ids do not move, and the op layer derives
@@ -30,13 +38,18 @@
  * @module selection-ops
  */
 
-import { type BlockDocument, type BlockNode } from "@nextlyhq/blocks-engine";
+import {
+  locateNode,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
 
 import { blockDeletion } from "./delete-block";
 import { blockDuplication } from "./duplicate-block";
 import { lockOp } from "./inspector";
+import { keyboardMovePosition } from "./keyboard-move";
 import { layerLabel } from "./layers";
-import { lockBlockingDelete } from "./locking";
+import { lockBlockingDelete, lockBlockingMove } from "./locking";
 import type { BuilderOp } from "./ops";
 import { normalizeSelection } from "./selection";
 
@@ -77,8 +90,17 @@ export interface SelectionRefusal {
 /** Either a plan or the reason there is none. */
 export type SelectionPlan = SelectionEdit | SelectionRefusal | null;
 
-/** Whether a plan can be applied. */
-export function isRefusal(plan: SelectionPlan): plan is SelectionRefusal {
+/**
+ * Whether a plan can be applied.
+ *
+ * Accepts any planned edit rather than only a {@link SelectionPlan}, because
+ * every verb here answers with the same three-way shape and a caller should not
+ * need a different guard per verb. The `reason` field is what separates a
+ * refusal, and only a refusal carries one.
+ */
+export function isRefusal(
+  plan: SelectionEdit | SelectionMove | SelectionRefusal | null
+): plan is SelectionRefusal {
   return plan !== null && "reason" in plan;
 }
 
@@ -294,4 +316,141 @@ export function selectionLock(
     nextSelection: null,
     subject: subjectOf(document, ids),
   };
+}
+
+/** A planned reorder, with what to say about it. */
+export interface SelectionMove {
+  /** The moves, in the order they must apply. */
+  readonly ops: readonly BuilderOp[];
+  /** How many blocks the author selected, for phrasing. */
+  readonly count: number;
+  /** What to call the subject: the block's name, or "3 blocks". */
+  readonly subject: string;
+}
+
+/** Either a reorder, the reason there is none, or `null` for nothing to say. */
+export type SelectionMovePlan = SelectionMove | SelectionRefusal | null;
+
+/**
+ * Blocks that do not share one sibling list cannot travel together.
+ *
+ * Phrased as the remedy rather than the rule. "Different containers" describes
+ * the document; selecting within one container is the thing an author can do
+ * about it.
+ */
+const SPLIT_REFUSAL: SelectionRefusal = {
+  reason:
+    "These blocks sit in different containers. Move blocks that share one.",
+};
+
+/**
+ * The lock that stops this group being moved, phrased, or `null`.
+ *
+ * Separate from the deletion refusal because the verb reaches the author: a
+ * lock that forbids moving is not the same sentence as one that forbids
+ * deleting, and `lockBlockingMove` and `lockBlockingDelete` do not answer alike
+ * either — a locked child blocks a delete while the parent around it may still
+ * be reordered.
+ */
+function moveLockRefusal(
+  document: BlockDocument,
+  ids: readonly string[]
+): SelectionRefusal | null {
+  for (const id of ids) {
+    const blocked = lockBlockingMove(document, id);
+    if (blocked === undefined) continue;
+    const name = layerLabel(blocked);
+    return {
+      reason:
+        blocked.id === id
+          ? `${name} is locked. Unlock it to move it.`
+          : `The selection contains ${name}, which is locked. Unlock it to move.`,
+    };
+  }
+  return null;
+}
+
+/** Where each selected block sits, once they all sit in ONE list. */
+interface SharedRun {
+  /** The selected blocks, sorted by their index in that list. */
+  readonly places: readonly { readonly id: string; readonly index: number }[];
+}
+
+/**
+ * The selection as positions in a single sibling list, or `null`.
+ *
+ * `null` means they do not all share one list — the case a move has no answer
+ * for. Two blocks in different containers have no common order to step
+ * through, and "one step up" would mean a different distance for each.
+ */
+function sharedRun(
+  document: BlockDocument,
+  ids: readonly string[]
+): SharedRun | null {
+  const places: { id: string; index: number }[] = [];
+  let container: string | undefined;
+
+  for (const id of ids) {
+    const at = locateNode(document.nodes, id);
+    if (at === undefined) return null;
+    // Parent and slot together, because one parent's two slots are two lists.
+    // The separator is a space, which an id cannot contain, so no pair of
+    // distinct containers can collide into a single key.
+    const key = `${at.parent?.id ?? ""} ${at.slot ?? ""}`;
+    if (container === undefined) container = key;
+    else if (container !== key) return null;
+    places.push({ id, index: at.index });
+  }
+
+  if (places.length === 0) return null;
+  places.sort((left, right) => left.index - right.index);
+  return { places };
+}
+
+/**
+ * Moving every selected block one step, keeping their order and their spacing.
+ *
+ * **A set moves only within one container.** Duplicate and delete are the
+ * single-block verb repeated and need nothing of each other; a move is a step
+ * through a list, so blocks in different lists are not doing the same thing.
+ * That is a refusal an author is told about, because nothing on the page says
+ * the selection straddles a boundary.
+ *
+ * **One block at the edge refuses the WHOLE group**, like a lock. Letting the
+ * others move would close the gaps between them, and the set would come back
+ * differently arranged than it went, so `up` would no longer be undone by
+ * `down`. Preserving that inverse is what the two move axes exist to protect,
+ * and a group edit is where it is easiest to lose.
+ *
+ * **Every position is the single-block rule's**, asked once per block. Nothing
+ * here re-decides what one step means.
+ */
+export function selectionMove(
+  document: BlockDocument,
+  selectedIds: readonly string[],
+  direction: "up" | "down"
+): SelectionMovePlan {
+  const ids = normalizeSelection(document, selectedIds);
+  if (ids.length === 0) return null;
+
+  const refusal = moveLockRefusal(document, ids);
+  if (refusal !== null) return refusal;
+
+  const run = sharedRun(document, ids);
+  if (run === null) return SPLIT_REFUSAL;
+
+  // Towards the destination first, so each block steps into an index its
+  // neighbour has already left.
+  const order = direction === "up" ? run.places : [...run.places].reverse();
+
+  const ops: BuilderOp[] = [];
+  for (const place of order) {
+    const step = keyboardMovePosition(document.nodes, place.id, direction);
+    // At the edge of the container. Silent, like the single-block move: a
+    // selection that cannot go further has said so by not going.
+    if (step === null) return null;
+    ops.push({ kind: "move", id: place.id, to: step.to });
+  }
+
+  return { ops, count: ids.length, subject: subjectOf(document, ids) };
 }

--- a/packages/builder/src/toolbar-actions.test.ts
+++ b/packages/builder/src/toolbar-actions.test.ts
@@ -313,21 +313,49 @@ describe("toolbarActions for MORE than one block", () => {
     expect(actionOf(actions, "delete").enabled).toBe(true);
   });
 
-  it("withdraws move and select-parent, which do not", () => {
-    /*
-     * A set spread across two containers has no shared list to move within, and
-     * "the parent" of blocks with different parents is not a block. Offering
-     * either would invent an answer to a question the author did not ask.
-     */
+  it("withdraws select-parent, which has no answer for a set", () => {
+    // "The parent" of blocks with different parents is not a block, so there is
+    // nothing for this to select and it does not invent one.
     const document = documentOf([node("a"), node("b")]);
     const actions = toolbarActions(document, "a", ["a", "b"]);
 
-    for (const id of ["move-up", "move-down", "select-parent"] as const) {
-      expect(actionOf(actions, id).enabled).toBe(false);
-      expect(actionOf(actions, id).reason).toBe(
-        "Only one block at a time. 2 are selected."
-      );
-    }
+    expect(actionOf(actions, "select-parent").enabled).toBe(false);
+    expect(actionOf(actions, "select-parent").reason).toBe(
+      "Only one block at a time. 2 are selected."
+    );
+  });
+
+  it("offers move to a set that shares one container", () => {
+    // Two blocks in the same list have a shared order to step through, so one
+    // step for each is well defined. `a` is first, so only down is available.
+    const document = documentOf([node("a"), node("b"), node("c")]);
+    const actions = toolbarActions(document, "a", ["a", "b"]);
+
+    expect(actionOf(actions, "move-down").enabled).toBe(true);
+    // Dimmed WITHOUT a reason at the edge, exactly as one block at the end of
+    // its list is: a step with nowhere to go needs no explaining.
+    expect(actionOf(actions, "move-up").enabled).toBe(false);
+    expect(actionOf(actions, "move-up").reason).toBeUndefined();
+  });
+
+  it("explains a move refused because the set straddles two containers", () => {
+    // Unlike an edge, nothing on the page shows that the selection spans a
+    // boundary, so this refusal carries a reason.
+    const document = documentOf([node("a"), node("b"), node("c")]);
+    const withChild = {
+      ...document,
+      nodes: [
+        { ...document.nodes[0], slots: { children: [node("inside")] } },
+        document.nodes[1],
+      ],
+    } as typeof document;
+
+    const actions = toolbarActions(withChild, "inside", ["inside", "b"]);
+
+    expect(actionOf(actions, "move-up").enabled).toBe(false);
+    expect(actionOf(actions, "move-up").reason).toContain(
+      "different containers"
+    );
   });
 
   it("keeps the same five buttons in the same order", () => {

--- a/packages/builder/src/toolbar-actions.ts
+++ b/packages/builder/src/toolbar-actions.ts
@@ -43,6 +43,7 @@ import type { Rect } from "./geometry";
 import { keyboardMovePosition } from "./keyboard-move";
 import { layerLabel, pathTo } from "./layers";
 import { lockBlockingDelete, lockBlockingMove } from "./locking";
+import { isRefusal, selectionMove } from "./selection-ops";
 
 /** The verbs the bar offers, in the order it draws them. */
 export type ToolbarActionId =
@@ -90,20 +91,49 @@ function lockedBy(locked: BlockNode, selectedId: string): string {
 }
 
 /**
+ * Whether a set can move one step, and what to say when it cannot.
+ *
+ * The plan itself is the answer: `selectionMove` already decides that a set
+ * straddling two containers has nowhere to go and that one block at the edge
+ * holds the rest, and asking it here keeps the bar agreeing with the keyboard
+ * rather than testing those rules a second time.
+ *
+ * `null` is the edge of the container, which is dimmed WITHOUT a reason —
+ * exactly as a single block at the end of its list is. Nothing needs saying
+ * about a step that has nowhere to go.
+ */
+function moveAction(
+  document: BlockDocument,
+  ids: readonly string[],
+  id: "move-up" | "move-down",
+  label: string,
+  direction: "up" | "down"
+): ToolbarAction {
+  const plan = selectionMove(document, ids, direction);
+  if (plan === null) return { id, label, enabled: false };
+  if (isRefusal(plan))
+    return { id, label, enabled: false, reason: plan.reason };
+  return { id, label, enabled: true };
+}
+
+/**
  * The bar for a selection holding more than one block.
  *
- * **Duplicate and delete keep their meaning; move and select-parent lose it.**
- * Copying six blocks is six copies each beside its own original, and removing
- * six is removing six — both are the single-block verb repeated, which is
- * exactly what `selection-ops` plans. Moving is not: a set spread across two
- * containers has no shared list to move within, and "the parent" of blocks with
- * different parents is not a block. Offering either would mean inventing an
- * answer to a question the author did not ask.
+ * **Duplicate, delete and move keep their meaning; select-parent loses it.**
+ * Copying six blocks is six copies each beside its own original, removing six
+ * is removing six, and moving six that share a list is one step for each — all
+ * three are the single-block verb repeated, which is what `selection-ops`
+ * plans. "The parent" of blocks with different parents is not a block, so
+ * select-parent has no answer to give and does not invent one.
  *
- * The bar keeps its five buttons and its one shape rather than shrinking to
- * two. A control that vanishes when a second block is selected moves every
- * button after it, so the one an author was aiming at is somewhere else by the
- * time they arrive — the same reason unavailable actions are dimmed rather than
+ * Move is offered but not always available: a set spread across two containers
+ * has no shared list to step through, and that refusal carries a reason because
+ * nothing on the page shows that the selection straddles a boundary.
+ *
+ * The bar keeps its five buttons and its one shape rather than shrinking. A
+ * control that vanishes when a second block is selected moves every button
+ * after it, so the one an author was aiming at is somewhere else by the time
+ * they arrive — the same reason unavailable actions are dimmed rather than
  * hidden with a single block.
  */
 function manyBlockActions(
@@ -122,8 +152,8 @@ function manyBlockActions(
       enabled: false,
       reason: many,
     },
-    { id: "move-up", label: "Move up", enabled: false, reason: many },
-    { id: "move-down", label: "Move down", enabled: false, reason: many },
+    moveAction(document, ids, "move-up", "Move up", "up"),
+    moveAction(document, ids, "move-down", "Move down", "down"),
     // A lock never stops a duplication, for a set as for one block: the
     // originals stay where they are.
     { id: "duplicate", label: "Duplicate", enabled: true },


### PR DESCRIPTION
Multi-select could delete and duplicate a set, but not move one: the toolbar
withdrew both move buttons with "Only one block at a time." That was the last
obvious hole in the feature, and it is closed for blocks that share a container.

## What a set-move means

**One step for each block, keeping their order and their spacing.** Blocks in
one sibling list have a shared order to step through, so this is the
single-block rule asked once per block — `keyboardMovePosition` still decides
every position, and nothing here re-derives it.

**Blocks in different containers still refuse, and now say why.** Two blocks in
different lists are not doing the same thing when they "move down", and one step
would mean a different distance for each. Unlike an edge, nothing on the page
shows that a selection straddles a boundary, so that refusal carries a reason
while an edge stays silent — the same split the single-block toolbar already
makes between a lock and the end of a list.

**One block at the edge refuses the WHOLE group**, like a lock does. Letting the
others move would close the gaps between them, so the set would come back
arranged differently than it went and `up` would no longer be undone by `down`.
Preserving that inverse is what the two move axes exist to protect, and a group
edit is the easiest place to lose it.

## Ordering is load-bearing, and differently again

`duplicate` plans in REVERSE, `delete` does not care, and move needs a third
answer: **towards the edge it is heading for** — ascending for `up`, descending
for `down`. A move vacates the index it leaves, so the block nearest the
destination goes first. The module docblock said ordering mattered "only for
duplicate"; that sentence is no longer true and has been rewritten rather than
left to mislead.

Worth recording, because it decides which test is load-bearing: ordering only
matters for a CONTIGUOUS run. Separated blocks do not interfere, so a
non-contiguous fixture produces the same document under either order — measured,
not assumed. `moves a contiguous run down` is the test that separates a correct
planner from one that ignores ordering.

## Verification

**Tests: 803 pass in `packages/builder`, up from 789.** Twelve new, and they
assert by APPLYING the planned ops and reading the resulting document rather
than inspecting the op array — a plan that looks right and lands wrong is the
whole failure mode here, since `move` is remove-then-reinsert and each index is
interpreted against a list the earlier ops have already changed. One of them
applies the same ops in REVERSE and requires a different result, so these
cannot pass on a planner that ignores order.

Break-verified, control run green first, each stub restored and the restore
confirmed byte-identical against a copy kept outside the repository:

| stub | test that failed |
|---|---|
| ordering reversal removed | `moves a contiguous run down` |
| shared-container check removed | `refuses a selection spread across two containers` |
| lock refusal removed | `refuses when a selected block is locked` |

Each stub failed exactly the test naming its property, and nothing else.

**Verified in a browser**, on the `homepage` single's real editor at 1680px, with
the seeded document asserted present before each step:

- two top-level siblings selected, Move up → `[sec, hd, txt] → [hd, txt, sec]`;
  both moved one step, order kept, selection kept
- **one undo reversed the whole group**, which is the atomicity claim
- `alt+ArrowUp` produced the identical result and announced "2 blocks moved."
  in the builder's own live region — there are three `[role=status]` nodes on
  that page, so the announcement was read from the right one rather than the
  first
- two children INSIDE a section, Move down → `[one, two, three] → [three, one,
  two]`, and Move down then correctly refused at the edge
- a nested child plus a top-level block → both move buttons `aria-disabled`
  (never `disabled`, so the reason stays reachable) carrying "These blocks sit
  in different containers. Move blocks that share one."

## Accessibility

The pointer and keyboard paths land in the same function, so the toolbar, the
command palette and `alt+ArrowUp`/`alt+ArrowDown` cannot disagree — WCAG 2.2 SC
2.1.1 is met by construction here rather than by a second listener. Refusals an
author cannot see are announced; refusals they can see are not.

Depth is deliberately still single-block. `indent` appends to the container
above, so two blocks indenting together would arrive in an order neither of them
was in — that needs its own answer and does not get an invented one here.