### PR TITLE
fix(admin): offer the source fill on horizontal fields too

### DIFF
--- a/.changeset/source-fill-horizontal.md
+++ b/.changeset/source-fill-horizontal.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A localized checkbox in translation mode now offers to take its source value, not just show it. The field wrapper renders checkboxes through a separate horizontal layout, and that branch showed the source text without the action beside it — so the one field type that uses it could see what the source said and had no way to use it.

--- a/packages/admin/src/components/features/entries/fields/FieldWrapper.source-fill.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldWrapper.source-fill.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * FieldWrapper — the source-fill action, in BOTH layouts.
+ *
+ * The wrapper has two render branches, vertical and horizontal, and the
+ * horizontal one exists for checkboxes. It already rendered the source HINT and
+ * did not render the ACTION, so a localized checkbox showed its source text and
+ * offered no way to take it — the two branches disagreeing rather than a
+ * decision about checkboxes. Only `password` can never be localized, so a schema
+ * author declaring `localized: true` on a checkbox is a supported thing to do.
+ *
+ * Each layout is asserted against the other, so a fix applied to one branch and
+ * forgotten in the other fails here rather than shipping.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+
+import {
+  EntryLocaleProvider,
+  type EntryLocaleContextValue,
+} from "../EntryLocaleContext";
+import { TranslationFieldProvider } from "../TranslationMode/TranslationFieldContext";
+
+import { FieldWrapper } from "./FieldWrapper";
+
+/** Localized explicitly: a checkbox is shared by default, and may be declared otherwise. */
+const checkboxField = {
+  name: "featured",
+  type: "checkbox",
+  label: "Featured",
+  localized: true,
+} as never;
+const textField = {
+  name: "title",
+  type: "text",
+  label: "Title",
+  localized: true,
+} as never;
+
+function renderField({
+  field,
+  horizontal,
+  source,
+}: {
+  field: unknown;
+  horizontal: boolean;
+  source?: Record<string, unknown>;
+}) {
+  const locale: EntryLocaleContextValue = {
+    rtl: false,
+    collectionLocalized: true,
+    isNonDefaultLocale: true,
+  };
+
+  function Harness() {
+    const form = useForm<Record<string, unknown>>({
+      defaultValues: { featured: false, title: "" },
+    });
+    return (
+      <FormProvider {...form}>
+        <EntryLocaleProvider value={locale}>
+          <TranslationFieldProvider
+            value={
+              source ? { sourceValues: source, sourceLabel: "English" } : {}
+            }
+          >
+            <FieldWrapper field={field as never} horizontal={horizontal}>
+              <input data-testid="control" />
+            </FieldWrapper>
+          </TranslationFieldProvider>
+        </EntryLocaleProvider>
+      </FormProvider>
+    );
+  }
+
+  return render(<Harness />);
+}
+
+describe("FieldWrapper source-fill", () => {
+  it("offers the action on a localized field in the VERTICAL layout", () => {
+    renderField({
+      field: textField,
+      horizontal: false,
+      source: { title: "Hi" },
+    });
+    expect(
+      screen.getByRole("button", { name: /use the english text for title/i })
+    ).toBeInTheDocument();
+  });
+
+  it("offers the action on a localized field in the HORIZONTAL layout", () => {
+    // The branch checkboxes take. It rendered the source hint and not the
+    // action, so the field said what the source was and gave no way to use it.
+    renderField({
+      field: checkboxField,
+      horizontal: true,
+      source: { featured: true },
+    });
+    expect(
+      screen.getByRole("button", { name: /use the english text for featured/i })
+    ).toBeInTheDocument();
+  });
+
+  it("offers nothing in EITHER layout when there is no source", () => {
+    // The negative control for both branches at once: without it, "the action
+    // renders" would pass on a wrapper that renders it unconditionally.
+    for (const horizontal of [false, true]) {
+      const { unmount } = renderField({
+        field: horizontal ? checkboxField : textField,
+        horizontal,
+      });
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it("offers nothing on a SHARED field, in either layout", () => {
+    // A shared field holds one value for every language, so there is no source
+    // to take — the action would write the value onto itself.
+    const shared = { name: "price", type: "number", label: "Price" } as never;
+    for (const horizontal of [false, true]) {
+      const { unmount } = renderField({
+        field: shared,
+        horizontal,
+        source: { price: 10 },
+      });
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+      unmount();
+    }
+  });
+});

--- a/packages/admin/src/components/features/entries/fields/FieldWrapper.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldWrapper.tsx
@@ -378,6 +378,16 @@ export function FieldWrapper({
           {/* show the default-language source hint in the horizontal
               (checkbox) layout too — it was only rendered in the vertical layout. */}
           {sourceHint}
+
+          {/* And the source-fill action beside it, for the same reason. A
+              checkbox is not localized by default, but only `password` can
+              NEVER be — so a schema author who declares `localized: true` on one
+              gets a field that showed its source and offered no way to take it,
+              which is the layout branch disagreeing with itself rather than a
+              decision about checkboxes. */}
+          {useSourceAction && (
+            <div className="flex justify-end">{useSourceAction}</div>
+          )}
         </div>
       </div>
     );


### PR DESCRIPTION
## What

A localized checkbox in translation mode showed its source text and offered no way to take it.

`FieldWrapper` has two render branches. The horizontal one exists for checkboxes, and it already rendered the source **hint** — added deliberately, with a comment saying so — but not the source-fill **action** added in #1048. So the one field type that uses that branch could see what the source said and could not use it.

Not a decision about checkboxes: only `password` is in `NEVER_LOCALIZABLE`, so a schema author declaring `localized: true` on a checkbox is doing something supported. It was the two layout branches disagreeing.

Reported by CodeRabbit on #1048 — the one unresolved thread on that PR — and verified against merged `main` before fixing rather than taken on trust.

## Testing

Four tests, and they are written so **each layout is asserted against the other**: a fix applied to one branch and forgotten in the other fails here rather than shipping, which is exactly how this defect arrived.

Break-verified with a control run:

| break | caught by |
|---|---|
| horizontal action removed (the original bug) | *offers the action … in the HORIZONTAL layout* |
| vertical action removed | *offers the action … in the VERTICAL layout* |
| offered on shared fields too | *offers nothing on a SHARED field, in either layout* |

Both negative cases cover both branches in one test, so neither can regress unnoticed.

`admin` suite: 15 failing across the 4 documented baseline files, unchanged. `fallow audit`: pass, zero introduced.
