### PR TITLE
fix(ui): leave Alt to the host in the tree view

### DIFF
--- a/.changeset/tree-view-leaves-alt-to-the-host.md
+++ b/.changeset/tree-view-leaves-alt-to-the-host.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Let a host keep its Alt shortcuts while the layers tree has focus. Reordering blocks with alt+arrow did nothing when focus sat in the page editor's layers panel, because the tree read the arrow key without checking modifiers and moved its own focus instead.

--- a/packages/ui/src/components/tree-view.test.tsx
+++ b/packages/ui/src/components/tree-view.test.tsx
@@ -296,6 +296,88 @@ describe("moving through it with the keyboard", () => {
   });
 });
 
+describe("Alt is left to the host", () => {
+  it("does not move focus on alt+ArrowDown, and does not consume the event", () => {
+    /*
+     * A host binding `alt+ArrowDown` — reordering the selected block, in the
+     * page editor — otherwise loses it exactly where an author is most likely
+     * to press it. The switch reads `event.key`, and `ArrowDown` is
+     * `ArrowDown` whatever modifiers are held, so the row took focus and
+     * called `preventDefault` instead.
+     */
+    render(
+      <TreeView
+        aria-label="Layers"
+        nodes={[
+          { id: "a", label: "A" },
+          { id: "b", label: "B" },
+        ]}
+      />
+    );
+    const tree = screen.getByRole("tree");
+
+    focusRow("A");
+    const handled = fireEvent.keyDown(tree, {
+      key: "ArrowDown",
+      altKey: true,
+    });
+
+    // Focus stays put: navigation did not happen.
+    expect(document.activeElement?.textContent).toContain("A");
+    // And the event was NOT cancelled, so it goes on bubbling to the host.
+    // `fireEvent` returns false only when something called preventDefault.
+    expect(handled).toBe(true);
+  });
+
+  it("still navigates on a BARE ArrowDown, which is the control", () => {
+    // Without this, the assertion above passes on a tree that ignores every
+    // arrow key — including the ones it is supposed to handle.
+    render(
+      <TreeView
+        aria-label="Layers"
+        nodes={[
+          { id: "a", label: "A" },
+          { id: "b", label: "B" },
+        ]}
+      />
+    );
+    const tree = screen.getByRole("tree");
+
+    focusRow("A");
+    const handled = fireEvent.keyDown(tree, { key: "ArrowDown" });
+
+    expect(document.activeElement?.textContent).toContain("B");
+    expect(handled).toBe(false);
+  });
+
+  it("leaves alt+ArrowRight alone rather than expanding a branch", () => {
+    // The host binds all four directions; Right and Left are its indent and
+    // outdent, and expanding here would answer a gesture meant for the editor.
+    render(
+      <TreeView
+        aria-label="Layers"
+        nodes={[
+          {
+            id: "section",
+            label: "Section",
+            children: [{ id: "kid", label: "Kid" }],
+          },
+        ]}
+      />
+    );
+    const tree = screen.getByRole("tree");
+
+    focusRow("Section");
+    fireEvent.keyDown(tree, { key: "ArrowRight", altKey: true });
+
+    expect(screen.queryByText("Kid")).toBeNull();
+    // Control: the same key without Alt does expand, so the assertion above is
+    // about the modifier rather than about the branch being unopenable.
+    fireEvent.keyDown(tree, { key: "ArrowRight" });
+    expect(screen.getByText("Kid")).toBeTruthy();
+  });
+});
+
 describe("arrow keys stay inside the hierarchy", () => {
   it("does not leave the branch when an expanded one has nothing to enter", () => {
     // An empty array marks a branch, so Right on an already-open empty one has nowhere to go. A

--- a/packages/ui/src/components/tree-view.tsx
+++ b/packages/ui/src/components/tree-view.tsx
@@ -413,6 +413,22 @@ const TreeView = React.forwardRef<HTMLDivElement, TreeViewProps>(
       const row = rows[index];
       if (row === undefined) return;
 
+      /*
+       * Alt belongs to the HOST, so nothing here claims it.
+       *
+       * The tree pattern uses bare arrows to move, Shift to extend and Ctrl to
+       * toggle; Alt appears nowhere in it, which leaves the chord free for
+       * whatever embeds the tree. A host that binds one — `alt+ArrowUp` to
+       * reorder, say — otherwise loses it exactly where the author is most
+       * likely to press it, because the switch below reads `event.key` and
+       * `ArrowUp` is `ArrowUp` whatever modifiers are down. The row then takes
+       * focus, calls `preventDefault`, and the host's binding never fires.
+       *
+       * Returning WITHOUT `preventDefault` is the whole point: the event has to
+       * go on bubbling for the host to see it.
+       */
+      if (event.altKey) return;
+
       switch (event.key) {
         case "ArrowDown":
           event.preventDefault();


### PR DESCRIPTION
The move shortcuts shipped in #1051 did nothing when focus sat in the layers
panel — which is exactly where an author leaves focus after clicking a layer to
select it.

## The cause

`tree-view.tsx`'s keydown handler switches on `event.key`, and `ArrowUp` is
`ArrowUp` whatever modifiers are held. So the row took focus and called
`preventDefault()`, and the host's `alt+ArrowUp` binding never fired.

All four directions are affected, because the page editor binds all four:
`alt+ArrowUp`/`alt+ArrowDown` reorder, `alt+ArrowRight`/`alt+ArrowLeft` indent
and outdent. With focus in the panel, the tree answered every one of them —
navigating or expanding instead.

## The fix

One early return: **Alt belongs to the host, so nothing in the tree claims it.**

Alt appears nowhere in the APG tree pattern — that pattern uses bare arrows to
move, Shift to extend and Ctrl to toggle — so the chord is free for whatever
embeds the control. Returning WITHOUT `preventDefault()` is the load-bearing
half: the event has to go on bubbling for the host to see it.

## Verification

**Found in a browser, and the fix confirmed there**, on the `homepage` single at
1680px with the precondition asserted each time (`document.activeElement` really
is a `treeitem` before the keystroke — the whole defect is about where focus is,
so a probe that did not check it would prove nothing).

| | before | after |
|---|---|---|
| `alt+ArrowUp`, focus in panel | focus moved row 1 → row 0, block unmoved | block moves, "Block moved" announced |
| same, focus on `body` | block moves | block moves |
| two rows selected, `alt+ArrowDown` from the panel | nothing | `[hd, sec, txt]` → `[txt, hd, sec]`, "2 blocks moved." |

Focus follows the row that moved rather than the position — after the move the
active row is still "Heading", now at index 0, and the panel order matches the
canvas.

That second row is the control: the identical keystroke already worked with
focus outside the tree, which is what identified the tree as the thing
swallowing it rather than the shortcut being broken.

**Tests: 1086 pass in `packages/ui`**, three new. Break-verified — control run
green, then the guard removed:

| stub | failed |
|---|---|
| `if (event.altKey) return;` removed | `does not move focus on alt+ArrowDown, and does not consume the event` |
| | `leaves alt+ArrowRight alone rather than expanding a branch` |

Restore confirmed byte-identical against a copy kept outside the repository.

**Each new test carries its own control**, because "the tree ignored the key" is
satisfied by a tree that ignores every key: a bare `ArrowDown` must still
navigate and return `false` from `fireEvent` (something called
`preventDefault`), and a bare `ArrowRight` must still expand the branch that
`alt+ArrowRight` left alone. Both controls stayed green under the stub, so the
two failures above are about the modifier rather than about arrows generally.

`packages/builder` stays at 803 passing.

## Accessibility

This is the WCAG 2.2 SC 2.1.1 half of #1051 actually being reachable. The
keyboard path existed and was unreachable from the surface a keyboard user
navigates with, which is indistinguishable from not existing.