### PR TITLE
fix(admin): keep contributed field types in the form's schema

### DIFF
--- a/.changeset/contributed-fields-survive-save.md
+++ b/.changeset/contributed-fields-survive-save.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Stop dropping plugin-contributed field types from every save. A field declared with `pluginField()` — the page builder's blocks field, and any type a plugin adds — was stripped from the request body by the form's validation schema, so edits to it were silently discarded in both the entry and single editors.

--- a/packages/admin/src/lib/field-validation.contributed-fields.test.ts
+++ b/packages/admin/src/lib/field-validation.contributed-fields.test.ts
@@ -1,0 +1,95 @@
+/**
+ * A contributed field type survives the form's schema.
+ *
+ * The editors submit the RESOLVER'S OUTPUT, not the form's raw values, and the
+ * resolver is built from `generateClientSchema`. That shape is a `z.object`,
+ * which strips keys it has no entry for — so a field type the admin cannot name
+ * was removed from the payload after the author had edited it, on every save,
+ * with no error anywhere. `pluginField()` exists precisely to declare types core
+ * does not know, so this reached every contributed field in both editors.
+ *
+ * These cases are written against an INVENTED type rather than against `blocks`.
+ * Naming a real plugin's type would pass again the moment someone added it to a
+ * list, which is the repair this is guarding against.
+ *
+ * @module lib/field-validation.contributed-fields.test
+ */
+import type { FieldConfig } from "nextly/config";
+import { describe, expect, it } from "vitest";
+
+import { generateClientSchema } from "./field-validation";
+
+/** A type the admin has never heard of, as a plugin would contribute one. */
+function contributed(name: string, type = "acme/spatial-map"): FieldConfig {
+  return { type, name } as unknown as FieldConfig;
+}
+
+describe("a contributed field type reaches the server", () => {
+  it("keeps an unknown field's value through the parse", () => {
+    const schema = generateClientSchema([contributed("layout")]);
+
+    const parsed = schema.safeParse({
+      layout: { formatVersion: 1, nodes: [] },
+    });
+
+    expect(parsed.success).toBe(true);
+    // THE case. `success` alone passes on a schema that stripped the key and
+    // then validated the empty object happily, which is exactly the defect.
+    expect(parsed.success && parsed.data).toHaveProperty("layout");
+  });
+
+  it("preserves the value itself, not merely the key", () => {
+    const schema = generateClientSchema([contributed("layout")]);
+    const document = { formatVersion: 1, kind: "page", nodes: [{ id: "a" }] };
+
+    const parsed = schema.safeParse({ layout: document });
+
+    expect(parsed.success && parsed.data.layout).toEqual(document);
+  });
+
+  it("keeps a contributed field beside built-in ones", () => {
+    // The control that separates "unknown types survive" from "this schema
+    // passes everything through": `title` is a built-in and must still be
+    // validated, so a fix that swapped the object for a passthrough would keep
+    // the first two cases green and fail this one.
+    const schema = generateClientSchema([
+      { type: "text", name: "title", required: true } as unknown as FieldConfig,
+      contributed("layout"),
+    ]);
+
+    const both = schema.safeParse({ layout: { nodes: [] }, title: "Homepage" });
+    expect(both.success).toBe(true);
+    expect(both.success && both.data).toHaveProperty("layout");
+
+    const missingTitle = schema.safeParse({ layout: { nodes: [] }, title: "" });
+    expect(missingTitle.success).toBe(false);
+  });
+});
+
+describe("the boundary the fix draws", () => {
+  it("keeps SEVERAL contributed types, not one privileged one", () => {
+    const schema = generateClientSchema([
+      contributed("layout", "acme/spatial-map"),
+      contributed("chart", "othervendor/chart"),
+    ]);
+
+    const parsed = schema.safeParse({ layout: { a: 1 }, chart: { b: 2 } });
+
+    expect(parsed.success && parsed.data).toHaveProperty("layout");
+    expect(parsed.success && parsed.data).toHaveProperty("chart");
+  });
+
+  it("still drops a key no field declares", () => {
+    // The other half of the boundary: fields are kept because they were
+    // DECLARED, not because anything present is welcome. A stray key would
+    // otherwise ride along into the request body.
+    const schema = generateClientSchema([contributed("layout")]);
+
+    const parsed = schema.safeParse({
+      layout: {},
+      strayKey: "should not pass",
+    });
+
+    expect(parsed.success && parsed.data).not.toHaveProperty("strayKey");
+  });
+});

--- a/packages/admin/src/lib/field-validation.ts
+++ b/packages/admin/src/lib/field-validation.ts
@@ -48,7 +48,6 @@ import {
   isRepeaterField,
   isGroupField,
   isJSONField,
-  isDataField,
 } from "nextly/config";
 import { z } from "zod";
 
@@ -259,14 +258,45 @@ export async function validateFieldValue(
 // ============================================================
 
 /**
- * Extract all data fields from a field array.
- * Filters to only include fields that store data.
+ * Whether a field carries a value in the FORM.
+ *
+ * Deliberately not `isDataField`. That guard answers a different question —
+ * "does core generate a database column for this type?" — by testing membership
+ * of a closed list of built-in types. The two questions had the same answer for
+ * as long as every field type was built in, and stopped having it the moment
+ * `pluginField()` allowed a type outside that union: a contributed field stores
+ * data and appears in the form, and core's list cannot name it, because not
+ * naming it is what makes it contributed.
+ *
+ * Asking the wrong one here is not a missing validator. The shape this feeds is
+ * a `z.object`, which STRIPS keys it has no entry for, and the resolver's output
+ * is what the editors submit — so a field absent from this list is absent from
+ * the request body, and its edits are silently dropped on every save.
+ *
+ * A name is the whole test, and it stays the whole test. Core's own
+ * `ALL_FIELD_TYPES` is exactly `DATA_FIELD_TYPES`, so there is no named
+ * presentational type to exclude; anything carrying a name carries a value.
+ * That is a boundary rather than a list — a type nobody has written yet passes
+ * it, which is the property a list of known types can never have.
+ */
+function carriesFormValue(field: FieldConfig): boolean {
+  const named = field as { name?: unknown };
+  return typeof named.name === "string" && named.name.length > 0;
+}
+
+/**
+ * Extract every field that carries a value, for the form's schema.
+ *
+ * An unrecognised type is kept rather than dropped: `fieldToZodSchema` already
+ * ends in `z.unknown()`, which passes a present value through untouched, so a
+ * contributed field validates as permissively as the admin can honestly manage
+ * and reaches the server intact. The server holds the authoritative rule for it.
  */
 function extractDataFields(fields: FieldConfig[]): ExtractedField[] {
   const result: ExtractedField[] = [];
 
   for (const field of fields) {
-    if (isDataField(field)) {
+    if (carriesFormValue(field)) {
       result.push(field as ExtractedField);
     }
   }


### PR DESCRIPTION
Every field type a plugin contributes was **stripped from the request body on
save**, in both the entry and single editors. Nothing errored; the edits were
simply discarded.

Diagnosed by the translation lane and handed over — the chain below is theirs,
re-measured by me before acting on it.

## The chain

1. The editors submit `handleSubmit`'s argument, which is the **resolver's parsed
   output**, not the form's raw values (`SingleForm.tsx:280`,
   `useEntryForm.ts:426` — both `zodResolver`, neither passing `raw`).
2. That resolver is built by `generateClientSchema`, whose shape comes from
   `extractDataFields`.
3. `extractDataFields` kept only fields passing core's `isDataField`, which tests
   membership of `DATA_FIELD_TYPES` — **18 built-in types**.
4. `pluginField()` exists precisely to declare a type outside that closed union,
   so no contributed field was ever on the list.
5. `generateClientSchema` returns `z.object(shape)`, which **strips keys it has
   no entry for**.

So the value reached the form, survived until submit, and was removed on the way
out.

## The fix, and why it is not a list

`extractDataFields` was asking core's question — *"does core generate a database
column for this type?"* — where the admin needs its own: *"does this field carry
a value in the form?"*

Those had the same answer for exactly as long as every field type was built in,
and stopped having it the moment `pluginField()` allowed one that is not. The
admin now asks its own question, and a name is the whole test: core's
`ALL_FIELD_TYPES` is literally `[...DATA_FIELD_TYPES]`, so there is no named
presentational type to exclude.

That is a boundary rather than a list — **a type nobody has written yet passes
it**, which is the property a list of known types can never have. Adding `blocks`
to the list would have fixed the page builder and left every other plugin
broken, once per plugin, forever.

`fieldToZodSchema` already ended in `z.unknown()` ("Unknown field type - accept
anything"), which passes a present value through untouched. The defect was that
a contributed field never reached that arm. The server keeps the authoritative
rule for the value; the admin now declines to invent one.

## Verification

**Verified in a browser, against the DATABASE rather than the response** — the
same sequence that failed before:

| | before | after |
|---|---|---|
| PATCH body | `{"slug","title"}` | `{"slug","title","layout":{…full document…}}` |
| stored blocks | unchanged, while `updatedAt` moved | `[hd-beta, sec-alpha, txt-four]`, matching the canvas |

Reading the stored row is the point: the request succeeded in both cases, so
"the save returned 200" never separated them.

**Tests: 5 new, break-verified.** Written against an INVENTED type
(`acme/spatial-map`) rather than against `blocks`, so a future "fix" that adds a
name to a list fails them.

The first stub I wrote was **malformed** and is worth recording: it referenced
`DATA_FIELD_TYPES`, which is `undefined` at runtime there, so all five tests died
with a `TypeError` and proved nothing — uniform red reading as full coverage. The
second stub restored the genuine original (`isDataField`) and gave the right
shape: **4 failed, 1 passed**, the survivor being the boundary control that must
hold either way.

Each case carries its own control, because "the value survived" is also
satisfied by a schema that passes everything:

- a built-in `title` must still be **rejected** when empty, so swapping the
  object for a `.passthrough()` fails that case;
- a key no field declares must still be **dropped**, so the fix widens what is
  declared rather than what is accepted.

`packages/admin`: **2,385 tests, 15 failing — identical to `origin/main` without
this change**, measured by restoring the base file and running the same four
files. Those four (`StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField`)
are a pre-existing baseline and are untouched here.

## Two things found while verifying, neither fixed here

**Singles autosave answers 403.** Once the block value started reaching the form,
`PUT .../versions/autosave` began firing and being refused. Independent of this
change: a title-only payload to the same endpoint answers 403 too.

**`mod+s` inside the builder still sends no request at all.** A different defect
in the builder's own shortcut layer, and mine to chase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form validation to preserve values from contributed and other recognized custom fields.
  * Custom fields now coexist correctly with built-in validation.
  * Undeclared stray fields continue to be excluded from generated validation schemas.

* **Tests**
  * Added coverage for contributed fields, multiple custom field types, and unknown field values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->