### PR TITLE
feat(builder): scroll the canvas while a drag rests near its edge

### DIFF
--- a/.changeset/canvas-autoscroll.md
+++ b/.changeset/canvas-autoscroll.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Scroll the page editor's canvas while a block is dragged near its edge. On a page taller than the window, a block could not be moved anywhere outside the visible band at all, because the position it would land at never came on screen.

--- a/packages/builder/src/autoscroll.test.ts
+++ b/packages/builder/src/autoscroll.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The autoscroll speed curve.
+ *
+ * Asserted here rather than through the drag, because every rectangle in jsdom
+ * is zero: a curve computed inside a component is a curve no test can see. These
+ * cases feed the function the coordinates a real canvas would produce.
+ *
+ * @module autoscroll.test
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  AUTOSCROLL_MAX_STEP_PX,
+  AUTOSCROLL_ZONE_PX,
+  autoscrollStep,
+} from "./autoscroll";
+
+/** A canvas 600px tall, sitting 100px down the viewport. */
+const TOP = 100;
+const BOTTOM = 700;
+
+function step(pointerY: number): number {
+  return autoscrollStep(pointerY, TOP, BOTTOM);
+}
+
+describe("autoscrollStep", () => {
+  it("does not scroll while the pointer is away from both edges", () => {
+    expect(step(400)).toBe(0);
+  });
+
+  it("scrolls UP near the top and DOWN near the bottom", () => {
+    // The sign carries the direction, so a caller adding it to `scrollTop`
+    // needs no branch of its own.
+    expect(step(TOP + 10)).toBeLessThan(0);
+    expect(step(BOTTOM - 10)).toBeGreaterThan(0);
+  });
+
+  it("does nothing at the band's inner boundary, and moves just inside it", () => {
+    // THE case for a proportional curve. A constant speed would jump from
+    // nothing to full at this line, and the author would have no slow end.
+    expect(step(TOP + AUTOSCROLL_ZONE_PX)).toBe(0);
+    expect(Math.abs(step(TOP + AUTOSCROLL_ZONE_PX - 1))).toBeGreaterThan(0);
+  });
+
+  it("speeds up the deeper into the band the pointer goes", () => {
+    const shallow = Math.abs(step(TOP + 50));
+    const middle = Math.abs(step(TOP + 30));
+    const deep = Math.abs(step(TOP + 5));
+
+    expect(middle).toBeGreaterThan(shallow);
+    expect(deep).toBeGreaterThan(middle);
+  });
+
+  it("reaches full speed at the rim", () => {
+    expect(step(TOP)).toBeCloseTo(-AUTOSCROLL_MAX_STEP_PX);
+    expect(step(BOTTOM)).toBeCloseTo(AUTOSCROLL_MAX_STEP_PX);
+  });
+
+  it("clamps past the edge instead of accelerating without bound", () => {
+    // A drag captures the pointer, so it reports positions from outside the
+    // container. Letting those scale would make the speed depend on how far
+    // outside the window a hand happens to be.
+    expect(step(TOP - 500)).toBeCloseTo(-AUTOSCROLL_MAX_STEP_PX);
+    expect(step(BOTTOM + 500)).toBeCloseTo(AUTOSCROLL_MAX_STEP_PX);
+  });
+
+  it("is symmetric: the same depth scrolls at the same rate either way", () => {
+    expect(Math.abs(step(TOP + 12))).toBeCloseTo(Math.abs(step(BOTTOM - 12)));
+  });
+});
+
+describe("a container too short for two full bands", () => {
+  /** 80px tall — shorter than twice the 64px band. */
+  const SHORT_TOP = 0;
+  const SHORT_BOTTOM = 80;
+
+  function shortStep(pointerY: number): number {
+    return autoscrollStep(pointerY, SHORT_TOP, SHORT_BOTTOM);
+  }
+
+  it("keeps a still point in the middle rather than scrolling both ways", () => {
+    // Without shrinking the band, the midpoint sits inside BOTH, and whichever
+    // is tested first wins — a canvas that scrolls in whichever direction the
+    // code happened to check.
+    expect(shortStep(40)).toBe(0);
+  });
+
+  it("still scrolls each way from its own half", () => {
+    // The control: shrinking the band must not disable the feature on a short
+    // container, only stop the two halves overlapping.
+    expect(shortStep(5)).toBeLessThan(0);
+    expect(shortStep(75)).toBeGreaterThan(0);
+  });
+});
+
+describe("degenerate inputs", () => {
+  it("answers 0 for a container with no height", () => {
+    // A collapsed panel has no inside, so no position within it is near an
+    // edge. Dividing by that height is what this avoids.
+    expect(autoscrollStep(100, 300, 300)).toBe(0);
+    expect(autoscrollStep(100, 400, 300)).toBe(0);
+  });
+
+  it("answers 0 when the band or the speed is switched off", () => {
+    expect(autoscrollStep(TOP, TOP, BOTTOM, 0)).toBe(0);
+    expect(autoscrollStep(TOP, TOP, BOTTOM, AUTOSCROLL_ZONE_PX, 0)).toBe(0);
+  });
+});

--- a/packages/builder/src/autoscroll.ts
+++ b/packages/builder/src/autoscroll.ts
@@ -1,0 +1,96 @@
+/**
+ * How fast the canvas scrolls while a drag rests near its edge.
+ *
+ * A page is taller than the canvas shows, and a drag can only drop where it can
+ * point. Without this, a block cannot be moved to anywhere outside the visible
+ * band at all — not slowly, not awkwardly, not at all — because the position it
+ * would be dropped at never comes on screen. Every drag surface solves it the
+ * same way, and the part worth getting right is the SPEED CURVE rather than the
+ * plumbing.
+ *
+ * **Proportional, not constant.** A fixed speed forces a choice between one that
+ * is too slow to cross a long page and one that overshoots a target near the
+ * edge. Ramping from nothing at the band's inner boundary to full speed at the
+ * rim gives both: the author controls the rate by how far in they push, so a
+ * long haul and a one-line nudge are the same gesture at different depths.
+ *
+ * **Pure, and in client coordinates.** No DOM, no timers, no element. The caller
+ * owns the frame loop and the scrolling; this decides only how far this frame
+ * should move. That split is what lets the curve be asserted at sizes and
+ * positions a jsdom test cannot produce, since every rectangle there is zero.
+ *
+ * @module autoscroll
+ */
+
+/** How deep the band at each edge reaches, in CSS pixels. */
+export const AUTOSCROLL_ZONE_PX = 64;
+
+/**
+ * The most one frame may scroll, in CSS pixels.
+ *
+ * At 60fps this is a little over 1,000px per second at the rim — brisk enough to
+ * cross a long page without waiting, and slow enough that releasing within a few
+ * frames of the intended block is still accurate.
+ */
+export const AUTOSCROLL_MAX_STEP_PX = 18;
+
+/**
+ * How far the canvas should scroll this frame, in CSS pixels.
+ *
+ * Negative scrolls towards the top of the document, positive towards the bottom,
+ * and `0` means the pointer is in the middle where nothing should move.
+ *
+ * **Past the edge behaves like the edge.** A drag captures the pointer, so it
+ * goes on reporting positions after it has left the container entirely. Those
+ * arrive as coordinates beyond `top` or `bottom`, and letting them scale would
+ * make the speed depend on how far outside the window the author's hand happens
+ * to be — unbounded, and not a distance they can judge. Clamped, leaving the
+ * container simply means "as fast as this goes".
+ *
+ * **A short container cannot scroll both ways at once.** When the two bands
+ * would overlap — a canvas less than twice the band deep — the effective band
+ * shrinks to half the height, so the midpoint stays a place where nothing moves.
+ * Without that, the same pointer sits inside both bands and whichever is tested
+ * first wins, which reads as a canvas that scrolls in whichever direction the
+ * code happened to check.
+ *
+ * @param pointerY - the pointer's client Y
+ * @param top - the container's client top edge
+ * @param bottom - the container's client bottom edge
+ * @param zone - how deep the band reaches from each edge
+ * @param maxStep - the speed at the rim
+ * @returns pixels to scroll this frame; negative is up
+ */
+export function autoscrollStep(
+  pointerY: number,
+  top: number,
+  bottom: number,
+  zone: number = AUTOSCROLL_ZONE_PX,
+  maxStep: number = AUTOSCROLL_MAX_STEP_PX
+): number {
+  const height = bottom - top;
+  // A container with no height has no inside, so no position within it can be
+  // near an edge. Returning 0 rather than dividing by it.
+  if (height <= 0 || zone <= 0 || maxStep <= 0) return 0;
+
+  const band = Math.min(zone, height / 2);
+
+  const intoTop = top + band - pointerY;
+  if (intoTop > 0) return -ramp(intoTop, band, maxStep);
+
+  const intoBottom = pointerY - (bottom - band);
+  if (intoBottom > 0) return ramp(intoBottom, band, maxStep);
+
+  return 0;
+}
+
+/**
+ * The speed at a given depth into a band: linear, and never past `maxStep`.
+ *
+ * Linear rather than eased, because the author is aiming rather than watching an
+ * animation — a curve that accelerates makes the same hand movement mean
+ * different things at different depths, which is the opposite of controllable.
+ */
+function ramp(depth: number, band: number, maxStep: number): number {
+  return Math.min(depth / band, 1) * maxStep;
+}

--- a/packages/builder/src/canvas-drag.tsx
+++ b/packages/builder/src/canvas-drag.tsx
@@ -46,6 +46,7 @@ import { findNode } from "@nextlyhq/blocks-engine";
 import { NODE_ID_ATTRIBUTE } from "@nextlyhq/blocks-react";
 import * as React from "react";
 
+import { autoscrollStep } from "./autoscroll";
 import { nodeIdFromEvent } from "./canvas";
 import {
   collectRegions,
@@ -58,7 +59,12 @@ import {
 } from "./drop-targets";
 import type { EditorState } from "./editor-state";
 import type { Point, Rect } from "./geometry";
-import { canvasContentPoint, canvasContentRect } from "./geometry-dom";
+import {
+  canvasContentPoint,
+  canvasContentRect,
+  containerEdges,
+  scrollableAncestor,
+} from "./geometry-dom";
 import type { SlotSource } from "./inserter";
 import { lockBlockingMove } from "./locking";
 import {
@@ -140,6 +146,26 @@ interface Gesture {
   switchState: TargetSwitchState;
   /** Targets by id, so the committed id resolves back to something drawable. */
   targets: Map<string, DropTarget>;
+  /**
+   * The canvas root, kept so a frame with no pointer event still has it.
+   *
+   * Autoscroll runs between moves — a pointer resting in the edge band produces
+   * no events at all — so the element cannot come from `event.currentTarget`
+   * the way every other read here does.
+   */
+  readonly root: HTMLElement;
+  /**
+   * The element that actually scrolls, or `null` when nothing does.
+   *
+   * Resolved once at drag start rather than per frame: it is a walk up the tree
+   * reading computed styles, and the answer cannot change mid-gesture.
+   */
+  readonly scroller: HTMLElement | null;
+  /** The last pointer position, in CLIENT coordinates. */
+  clientX: number;
+  clientY: number;
+  /** The scheduled frame, or `null` when no loop is running. */
+  frame: number | null;
 }
 
 /**
@@ -200,6 +226,13 @@ export function useCanvasDrag({
   latest.current = { editor, slots, nesting };
 
   const reset = React.useCallback(() => {
+    // Cancelling here rather than in each ending: `reset` is what pointer-up,
+    // Escape and unmount all funnel through, so a frame cannot outlive the
+    // gesture it scrolls for by any route.
+    const running = gesture.current?.frame;
+    if (running !== null && running !== undefined) {
+      cancelAnimationFrame(running);
+    }
     gesture.current = null;
     setState({ draggingId: null, target: null, refusal: null });
   }, []);
@@ -240,52 +273,28 @@ export function useCanvasDrag({
         active: false,
         switchState: NO_TARGET,
         targets: new Map(),
+        root,
+        scroller: scrollableAncestor(root),
+        clientX: event.clientX,
+        clientY: event.clientY,
+        frame: null,
       };
       // NOT captured here. See the activation branch in `onPointerMove`.
     },
     []
   );
 
-  const onPointerMove = React.useCallback(
-    (event: React.PointerEvent<HTMLElement>) => {
-      const drag = gesture.current;
-      if (drag === null) return;
-
-      const root = event.currentTarget;
-      const pointer = canvasContentPoint(event.clientX, event.clientY, root);
-
-      if (!drag.active) {
-        const travelled = Math.hypot(
-          pointer.x - drag.origin.x,
-          pointer.y - drag.origin.y
-        );
-        if (travelled < activationPx) return;
-        drag.active = true;
-        /*
-         * Capture the pointer HERE rather than on the press, so that a press
-         * which stays a click never captures at all.
-         *
-         * Capture retargets every later pointer event to the capturing element,
-         * and the browser derives a `click`'s target from where the press and
-         * the release landed — so capturing on `pointerdown` makes every click
-         * on the canvas report the CANVAS ROOT as its target. The canvas
-         * resolves a click by walking up from the target to the nearest block,
-         * finds none above the root, and reads that as "the author clicked the
-         * background": selecting a block by clicking it cleared the selection
-         * instead.
-         *
-         * A drag needs capture because it may leave the canvas and must keep
-         * receiving moves. A click does not, and until the pointer has travelled
-         * far enough there is no way to tell which one this is — so the capture
-         * waits for the answer.
-         */
-        event.currentTarget.setPointerCapture(event.pointerId);
-        // Selecting on activation rather than on press: a press that turns out
-        // to be a click is handled by the canvas's own click handler, and
-        // selecting here as well would run the same decision twice.
-        latest.current.editor.select(drag.nodeId);
-      }
-
+  /**
+   * Re-aim the drag at a content point, and draw the result.
+   *
+   * Shared by the pointer handler and the autoscroll frame because they ask the
+   * same question at different moments: a move changes where the pointer is, and
+   * a scroll changes what is under it. Computing the answer twice is how the
+   * indicator and the committed target come apart — the frame would draw one
+   * thing and the release would apply another.
+   */
+  const aim = React.useCallback(
+    (drag: Gesture, pointer: Point) => {
       const resolution = resolveDrop(
         {
           blockName: drag.blockName,
@@ -336,7 +345,102 @@ export function useCanvasDrag({
         refusal: resolution.kind === "refused" ? resolution.refusal : null,
       });
     },
-    [activationPx, switchPx]
+    [switchPx]
+  );
+
+  /**
+   * Scroll the canvas while the pointer rests near an edge, and keep aiming.
+   *
+   * A drag can only drop where it can point, so without this a block cannot be
+   * moved anywhere outside the visible band of a long page — the position it
+   * would land at never comes on screen.
+   *
+   * **Re-aiming is not optional.** The pointer may not move at all while this
+   * runs, and the rects were measured once at drag start in CONTENT coordinates,
+   * which scrolling deliberately does not invalidate. What changes is which of
+   * them the pointer is over, so a frame that scrolled without re-aiming would
+   * slide the page beneath a frozen indicator.
+   *
+   * The loop runs for as long as the drag does rather than starting and stopping
+   * with the band, because a pointer held still inside it produces no events to
+   * restart on.
+   */
+  const pump = React.useCallback(() => {
+    const drag = gesture.current;
+    if (drag === null || !drag.active) return;
+
+    const scroller = drag.scroller;
+    if (scroller === null) return;
+
+    // The SCROLLER's edges, not the canvas root's. The root grows to its
+    // content, so once a page is long enough to need scrolling its bottom edge
+    // is somewhere below the window and a band measured against it never
+    // contains the pointer — the case autoscroll exists for is exactly the case
+    // that would stop working.
+    const edges = containerEdges(scroller);
+    const step = autoscrollStep(drag.clientY, edges.top, edges.bottom);
+    if (step !== 0) {
+      const before = scroller.scrollTop;
+      scroller.scrollTop = before + step;
+      // Only when the scroll actually moved. At either end of the content the
+      // assignment is clamped to what it already was, and re-aiming then costs
+      // a full resolve per frame to arrive at the answer already on screen.
+      if (scroller.scrollTop !== before) {
+        aim(drag, canvasContentPoint(drag.clientX, drag.clientY, drag.root));
+      }
+    }
+    drag.frame = requestAnimationFrame(pump);
+  }, [aim]);
+
+  const onPointerMove = React.useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      const drag = gesture.current;
+      if (drag === null) return;
+
+      const root = event.currentTarget;
+      const pointer = canvasContentPoint(event.clientX, event.clientY, root);
+      // Recorded for the frame loop, which runs between moves and has no event
+      // of its own to read a position from.
+      drag.clientX = event.clientX;
+      drag.clientY = event.clientY;
+
+      if (!drag.active) {
+        const travelled = Math.hypot(
+          pointer.x - drag.origin.x,
+          pointer.y - drag.origin.y
+        );
+        if (travelled < activationPx) return;
+        drag.active = true;
+        /*
+         * Capture the pointer HERE rather than on the press, so that a press
+         * which stays a click never captures at all.
+         *
+         * Capture retargets every later pointer event to the capturing element,
+         * and the browser derives a `click`'s target from where the press and
+         * the release landed — so capturing on `pointerdown` makes every click
+         * on the canvas report the CANVAS ROOT as its target. The canvas
+         * resolves a click by walking up from the target to the nearest block,
+         * finds none above the root, and reads that as "the author clicked the
+         * background": selecting a block by clicking it cleared the selection
+         * instead.
+         *
+         * A drag needs capture because it may leave the canvas and must keep
+         * receiving moves. A click does not, and until the pointer has travelled
+         * far enough there is no way to tell which one this is — so the capture
+         * waits for the answer.
+         */
+        event.currentTarget.setPointerCapture(event.pointerId);
+        // Started once, at activation. A press that stays a click never scrolls.
+        drag.frame = requestAnimationFrame(pump);
+        // Selecting on activation rather than on press: a press that turns out
+        // to be a click is handled by the canvas's own click handler, and
+        // selecting here as well would run the same decision twice.
+        latest.current.editor.select(drag.nodeId);
+      }
+
+      aim(drag, pointer);
+    },
+    [activationPx, aim, pump]
   );
 
   const onPointerUp = React.useCallback(

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -91,3 +91,54 @@ export function canvasContentPoint(
     y: clientY - rootBox.y + root.scrollTop,
   };
 }
+
+/**
+ * The nearest ancestor that actually scrolls, or `null` when nothing does.
+ *
+ * The canvas root is NOT it. That element carries the drag handlers and sizes
+ * itself to its content — `overflow: visible` — so assigning `scrollTop` on it
+ * is silently ignored, and an autoscroll written against it does nothing on a
+ * page long enough to need one. The scrolling is done by an ancestor the shell
+ * owns, which is where the visible window's edges live too.
+ *
+ * Matched on the COMPUTED overflow rather than on whether the element currently
+ * overflows. A container is the scroller because of how it is styled, not
+ * because of how much happens to be in it right now — testing the current
+ * amount would answer "no" for an empty canvas and change its mind once a block
+ * was added, which is a different element for the same drag.
+ *
+ * Starts at the root's parent: the root is excluded by definition, since it is
+ * the thing being scrolled WITHIN.
+ */
+export function scrollableAncestor(root: HTMLElement): HTMLElement | null {
+  let element = root.parentElement;
+  while (element !== null) {
+    const overflowY = getComputedStyle(element).overflowY;
+    if (overflowY === "auto" || overflowY === "scroll") return element;
+    element = element.parentElement;
+  }
+  return null;
+}
+
+/**
+ * The container's top and bottom edges, in CLIENT coordinates.
+ *
+ * Client rather than content, because the only caller compares them against a
+ * pointer's client position to decide whether it is resting near an edge. That
+ * question is about where the container sits on SCREEN, and converting either
+ * side into content space would answer a different one — a container scrolled
+ * halfway down its content has the same edges on screen as one scrolled to the
+ * top.
+ *
+ * Here rather than at the caller because this module is the one place allowed to
+ * read layout from the DOM, and a guard enforces it. The rule is worth the
+ * indirection: every reflow-forcing read being in one file is what makes the
+ * cost of one findable.
+ */
+export function containerEdges(root: HTMLElement): {
+  top: number;
+  bottom: number;
+} {
+  const box = root.getBoundingClientRect();
+  return { top: box.top, bottom: box.bottom };
+}


### PR DESCRIPTION
On a page taller than the window, a block could not be dragged anywhere outside
the visible band — not slowly, not awkwardly, **not at all**, because the
position it would land at never came on screen. B-8 in Plan 04.

## The speed curve is the design

**Proportional, not constant.** A fixed speed forces a choice between one too
slow to cross a long page and one that overshoots a target near the edge.
Ramping from nothing at the band's inner boundary to full speed at the rim gives
both — the author controls the rate by how far in they push, so a long haul and a
one-line nudge are the same gesture at different depths.

Linear rather than eased, because the author is aiming rather than watching an
animation: a curve that accelerates makes the same hand movement mean different
things at different depths.

**Past the edge behaves like the edge.** A drag captures the pointer, so it
reports positions from outside the container. Letting those scale would make the
speed depend on how far outside the window a hand happens to be.

**A short container cannot scroll both ways at once.** Where the two bands would
overlap, the effective band shrinks to half the height, so the midpoint stays
still. Without that the same pointer sits in both bands and whichever is tested
first wins.

## Two things the browser caught that tests could not

**The canvas root does not scroll.** The drag handlers sit on `.nx-canvas`, which
is `overflow: visible` and sizes itself to its content — assigning `scrollTop`
there is silently ignored. The scrolling is done by an ancestor the shell owns.
The first wiring scrolled the wrong element and every unit test still passed,
because the curve was never the thing that was wrong.

That also decides where the EDGES come from: the root grows to its content, so
once a page is long enough to need scrolling its bottom edge is below the window,
and a band measured against it would never contain the pointer — the case
autoscroll exists for is exactly the case that would stop working.

**The DOM read belongs in `geometry-dom.ts`.** `geometry-ownership.test.ts`
failed the first attempt for reading `getBoundingClientRect` in `canvas-drag`.
The guard was right; `containerEdges` and `scrollableAncestor` now live in the
one module allowed to read layout.

## Verification

**Unit: 11 new cases** over the curve — the still middle, both directions, the
inner boundary, the ramp increasing with depth, full speed at the rim, the clamp
past it, symmetry, the short-container band, and the degenerate inputs.
`packages/builder` goes 803 → 814.

**Browser**, on a 90-block page (2,160px of content in a 620px window), one
gesture per page load:

| pointer held at | scrolled in 500ms |
|---|---|
| middle of the canvas | **0** |
| 48px from the edge | **279px** |
| at the rim | **1519px** (reaches the end of the content) |

### A false finding I chased, recorded because it nearly cost a wrong fix

An earlier sweep reported the band behaving as a **cliff** — zero at every depth
except the last few pixels. It was a MEASUREMENT artifact: that sweep ran nine
drags back to back in one page, and the later gestures never registered, so the
zeros were "no drag" rather than "no scroll".

I found it by instrumenting the running code rather than reasoning further — a
temporary probe in the frame loop reported `clientY: 620, step: 4.5` at the depth
that had measured zero, exactly what the pure function predicts. The probe was
removed, the restore verified byte-identical, and the pushed tree swept for it
with a positive control on the sweep.

The re-measurement with one gesture per page load is the table above. Nothing was
changed in response to the false finding.