### PR TITLE
fix(nextly): let a core table gain an indexed column on an upgrade

### DIFF
--- a/.changeset/degraded-push-index-before-column.md
+++ b/.changeset/degraded-push-index-before-column.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Let a core table gain an indexed column when upgrading an existing database.
+
+The additive-tables-only recovery pass is diffed from an empty snapshot, so it
+emits every index in the desired schema while never emitting the column
+additions those indexes depend on. Creating an index over a column the live
+table has not gained yet failed, and because that is not an idempotency error
+it stopped the reconcile before the pass that adds the column could run.

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/fresh-push.index-over-added-column.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/fresh-push.index-over-added-column.integration.test.ts
@@ -1,0 +1,129 @@
+/**
+ * A core table that gains an INDEXED column reaches an existing database.
+ *
+ * The degraded pass is diffed from an EMPTY snapshot, which is what lets it
+ * create a missing table without altering an existing one. That snapshot also
+ * carries every index, so the pass emits `CREATE INDEX` for indexes over
+ * columns the live table does not have yet — while never emitting the
+ * `ALTER TABLE ADD COLUMN` that would create them, by design.
+ *
+ * Those index statements fail with "no such column". That is not an
+ * idempotency error, so before this was handled it escaped, the first pass
+ * threw, and the SECOND pass — the one that adds the column and then indexes
+ * it — never ran. The net effect was that no core table could gain an indexed
+ * column on any dialect that degrades.
+ *
+ * The old shape here is synthetic rather than historical: the mechanism is
+ * "an index in the desired schema names a column the live table lacks", and
+ * dropping any indexed column from a live table reproduces it. `version_no` is
+ * used because it is nullable on every dialect, so the second pass can add it
+ * without a default and the test observes the pipeline rather than a
+ * NOT NULL rebuild.
+ */
+import { existsSync, mkdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import Database from "better-sqlite3";
+import { drizzle as drizzleSqlite } from "drizzle-orm/better-sqlite3";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { getDialectTablesForPush } from "../../../../database/index";
+import { freshPushSchema } from "../fresh-push";
+
+const TEST_DIR = join(
+  tmpdir(),
+  `nextly-fresh-push-indexed-column-${process.pid}-${Date.now()}`
+);
+const TEST_DB_PATH = join(TEST_DIR, "legacy.db");
+
+/** `nextly_versions` without `version_no`, which two of its indexes name. */
+const LEGACY_VERSIONS = `
+  CREATE TABLE "nextly_versions" (
+    "id" TEXT PRIMARY KEY NOT NULL,
+    "scope_kind" TEXT NOT NULL,
+    "scope_slug" TEXT NOT NULL,
+    "entry_id" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "is_autosave" INTEGER NOT NULL DEFAULT 0,
+    "snapshot" TEXT NOT NULL,
+    "label" TEXT,
+    "locale" TEXT,
+    "source_version_no" INTEGER,
+    "created_by" TEXT,
+    "created_at" INTEGER NOT NULL,
+    "updated_at" INTEGER NOT NULL,
+    "revision" INTEGER NOT NULL DEFAULT 0
+  )`;
+
+/** The orphan that makes the resolver degrade; without it this path is not taken. */
+const CONTENT_TABLE = `
+  CREATE TABLE "dc_articles" (
+    "id" TEXT PRIMARY KEY,
+    "title" TEXT
+  )`;
+
+describe("fresh-push: a core table gains an indexed column", () => {
+  let sqlite: Database.Database;
+
+  beforeAll(() => {
+    if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true });
+    sqlite = new Database(TEST_DB_PATH);
+    sqlite.exec(LEGACY_VERSIONS);
+    sqlite.exec(CONTENT_TABLE);
+    sqlite
+      .prepare(
+        `INSERT INTO nextly_versions
+           (id, scope_kind, scope_slug, entry_id, status, is_autosave,
+            snapshot, created_at, updated_at)
+         VALUES ('v-1', 'collection', 'posts', 'e-1', 'draft', 0, '{}', 1000, 1000)`
+      )
+      .run();
+  });
+
+  afterAll(() => {
+    try {
+      sqlite?.close();
+    } catch {
+      // ignore teardown errors
+    }
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  const columnNames = (): string[] =>
+    (
+      sqlite.prepare(`PRAGMA table_info("nextly_versions")`).all() as Array<{
+        name: string;
+      }>
+    ).map(c => c.name);
+
+  const indexNames = (): string[] =>
+    (
+      sqlite
+        .prepare(`SELECT name FROM sqlite_master WHERE type = 'index'`)
+        .all() as Array<{ name: string }>
+    ).map(r => r.name);
+
+  it("adds the column and its index instead of throwing", async () => {
+    // The premise: the column really is missing and the orphan really is there.
+    expect(columnNames()).not.toContain("version_no");
+    expect(
+      sqlite
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type='table' AND name='dc_articles'`
+        )
+        .all()
+    ).toHaveLength(1);
+
+    const db = drizzleSqlite({ client: sqlite });
+    await freshPushSchema("sqlite", db, getDialectTablesForPush("sqlite"));
+
+    expect(columnNames()).toContain("version_no");
+    expect(indexNames()).toContain("nextly_versions_seq_uidx");
+    // The existing row survives: a reconcile that reached the new shape by
+    // recreating the table would have thrown the content away.
+    expect(
+      sqlite.prepare(`SELECT id FROM nextly_versions WHERE id = 'v-1'`).all()
+    ).toHaveLength(1);
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/is-missing-column-error.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/is-missing-column-error.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isIdempotencyError,
+  isMissingColumnError,
+} from "../sql-statement-utils";
+
+describe("isMissingColumnError", () => {
+  it("recognises the message each dialect uses", () => {
+    expect(isMissingColumnError(new Error("no such column: draft_key"))).toBe(
+      true
+    );
+    expect(
+      isMissingColumnError(
+        new Error("Key column 'draft_key' doesn't exist in table")
+      )
+    ).toBe(true);
+    expect(
+      isMissingColumnError(new Error('column "draft_key" does not exist'))
+    ).toBe(true);
+  });
+
+  it("reads the cause, which is where the driver error lands", () => {
+    const wrapped = new Error("Failed query: CREATE UNIQUE INDEX ...", {
+      cause: new Error("no such column: draft_key"),
+    });
+    expect(isMissingColumnError(wrapped)).toBe(true);
+  });
+
+  it("does not fire on an unrelated failure", () => {
+    // The whole value of this predicate is that it stays narrow: an index that
+    // fails for any other reason must still stop the reconcile.
+    expect(isMissingColumnError(new Error("disk I/O error"))).toBe(false);
+    expect(
+      isMissingColumnError(new Error("UNIQUE constraint failed: t.c"))
+    ).toBe(false);
+    expect(isMissingColumnError(new Error("syntax error near INDEX"))).toBe(
+      false
+    );
+  });
+
+  it("is a different question from idempotency", () => {
+    // Idempotency means the work is already done; this means its precondition
+    // is not done yet. Conflating them would let a genuinely absent column pass
+    // as an already-applied change.
+    const missing = new Error("no such column: draft_key");
+    expect(isIdempotencyError(missing)).toBe(false);
+
+    const existing = new Error("index already exists");
+    expect(isMissingColumnError(existing)).toBe(false);
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/fresh-push.ts
+++ b/packages/nextly/src/domains/schema/pipeline/fresh-push.ts
@@ -50,7 +50,11 @@ import {
   filterUnsafeStatements,
   findUnexpectedDestructiveStatements,
 } from "./filter-unsafe-statements";
-import { isIdempotencyError, splitStatements } from "./sql-statement-utils";
+import {
+  isIdempotencyError,
+  isMissingColumnError,
+  splitStatements,
+} from "./sql-statement-utils";
 
 // Re-exported so existing importers (v1-golden suite) keep working; the
 // implementation lives in sql-statement-utils.ts.
@@ -179,7 +183,13 @@ async function applyPushResult(
     );
   }
 
-  const executed = await executeStatements(dialect, db, runnable);
+  // A degraded pass cannot add a column, so an index over one it lacks is a
+  // casualty of the baseline rather than a fault; the pass that follows builds
+  // both in order.
+  const degraded = result.hints.some(h =>
+    h.hint.startsWith(DEGRADED_PASS_HINT)
+  );
+  const executed = await executeStatements(dialect, db, runnable, degraded);
 
   return { hints, statementsExecuted: executed };
 }
@@ -298,6 +308,28 @@ async function withResolverCrashFallback(
   }
 }
 
+/**
+ * Whether a failed statement is an index the additive baseline could not build
+ * yet.
+ *
+ * The baseline is diffed from an EMPTY snapshot, so it carries every index in
+ * the desired schema while emitting no `ALTER TABLE ADD COLUMN` at all. An
+ * index naming a column the live table has not gained yet therefore fails on a
+ * precondition the same pass is incapable of satisfying. Skipping it is safe
+ * only because a degraded pass is always followed by another, and that one adds
+ * the column and then indexes it.
+ *
+ * Narrow on purpose: only CREATE INDEX, only a missing-column error, and only
+ * when the caller says the pass degraded. A failure to create an index for any
+ * other reason still stops the reconcile.
+ */
+function isIndexAwaitingItsColumn(statement: string, err: unknown): boolean {
+  return (
+    /^\s*CREATE\s+(UNIQUE\s+)?INDEX/i.test(statement) &&
+    isMissingColumnError(err)
+  );
+}
+
 // Executes statements per dialect, swallowing idempotency errors
 // ("already exists" / duplicate column) so re-runs over an existing
 // schema reconcile instead of failing. v1 wraps driver errors in
@@ -306,7 +338,8 @@ async function withResolverCrashFallback(
 async function executeStatements(
   dialect: FreshPushDialect,
   db: unknown,
-  statements: string[]
+  statements: string[],
+  degraded: boolean
 ): Promise<string[]> {
   if (statements.length === 0) return [];
   const { sql: sqlTag } = await import("drizzle-orm");
@@ -350,6 +383,7 @@ async function executeStatements(
           executed.push(stmt);
         } catch (err) {
           if (isIdempotencyError(err)) continue;
+          if (degraded && isIndexAwaitingItsColumn(stmt, err)) continue;
           throw err;
         }
       }
@@ -378,6 +412,7 @@ async function executeStatements(
       executed.push(stmt);
     } catch (err) {
       if (isIdempotencyError(err)) continue;
+      if (degraded && isIndexAwaitingItsColumn(stmt, err)) continue;
       throw err;
     }
   }

--- a/packages/nextly/src/domains/schema/pipeline/sql-statement-utils.ts
+++ b/packages/nextly/src/domains/schema/pipeline/sql-statement-utils.ts
@@ -58,6 +58,31 @@ export function splitStatements(sqlStatements: string[]): string[] {
  * exist", which on PostgreSQL is also what a statement referencing a genuinely
  * missing table reports — swallowing that would hide a real broken reconcile.
  */
+/**
+ * Whether an execution error says a statement named a column the table lacks.
+ *
+ * Distinct from {@link isIdempotencyError}: that one recognises work already
+ * done, this one recognises work whose PRECONDITION has not been done yet. The
+ * only caller that may act on it is the additive-tables-only baseline, where an
+ * index over a not-yet-added column is an expected casualty of diffing from an
+ * empty snapshot and the following pass creates both in order.
+ */
+export function isMissingColumnError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  const causeMsg =
+    err instanceof Error && err.cause instanceof Error ? err.cause.message : "";
+  return [msg, causeMsg].some(m =>
+    [
+      // SQLite
+      /no such column/i,
+      // MySQL (ER_KEY_COLUMN_DOES_NOT_EXIST)
+      /key column .* doesn't exist in table/i,
+      // PostgreSQL
+      /column .* does not exist/i,
+    ].some(p => p.test(m))
+  );
+}
+
 export function isIdempotencyError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
   const causeMsg =

--- a/packages/nextly/src/domains/schema/pipeline/sql-statement-utils.ts
+++ b/packages/nextly/src/domains/schema/pipeline/sql-statement-utils.ts
@@ -35,6 +35,20 @@ export function splitStatements(sqlStatements: string[]): string[] {
 }
 
 /**
+ * Test an error's own message AND its cause's against a set of wordings.
+ *
+ * drizzle-kit v1 wraps driver errors in a DrizzleQueryError carrying the
+ * original on `.cause`, so the dialect's actual wording is one level down and
+ * reading only the top message misses every one of them.
+ */
+function errorSays(err: unknown, patterns: RegExp[]): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  const causeMsg =
+    err instanceof Error && err.cause instanceof Error ? err.cause.message : "";
+  return [msg, causeMsg].some(m => patterns.some(p => p.test(m)));
+}
+
+/**
  * True when an error is a re-run-over-existing-schema artifact that an
  * idempotent reconcile should tolerate. The match is anchored to the
  * documented DDL wordings ONLY — "already exists" (all dialects), SQLite's
@@ -58,6 +72,15 @@ export function splitStatements(sqlStatements: string[]): string[] {
  * exist", which on PostgreSQL is also what a statement referencing a genuinely
  * missing table reports — swallowing that would hide a real broken reconcile.
  */
+export function isIdempotencyError(err: unknown): boolean {
+  return errorSays(err, [
+    /already exists/i,
+    /duplicate column name/i,
+    /duplicate key name/i,
+    /check that column\/key exists/i,
+  ]);
+}
+
 /**
  * Whether an execution error says a statement named a column the table lacks.
  *
@@ -65,34 +88,21 @@ export function splitStatements(sqlStatements: string[]): string[] {
  * done, this one recognises work whose PRECONDITION has not been done yet. The
  * only caller that may act on it is the additive-tables-only baseline, where an
  * index over a not-yet-added column is an expected casualty of diffing from an
- * empty snapshot and the following pass creates both in order.
+ * empty snapshot, and the pass that follows creates the column and the index in
+ * order.
+ *
+ * PostgreSQL's wording is matched as `column ... does not exist` rather than a
+ * bare "does not exist", for the same reason error 1091 is matched in full
+ * above: a bare match would also catch a statement naming a genuinely missing
+ * TABLE, and treating that as tolerable would hide a broken reconcile.
  */
 export function isMissingColumnError(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err);
-  const causeMsg =
-    err instanceof Error && err.cause instanceof Error ? err.cause.message : "";
-  return [msg, causeMsg].some(m =>
-    [
-      // SQLite
-      /no such column/i,
-      // MySQL (ER_KEY_COLUMN_DOES_NOT_EXIST)
-      /key column .* doesn't exist in table/i,
-      // PostgreSQL
-      /column .* does not exist/i,
-    ].some(p => p.test(m))
-  );
-}
-
-export function isIdempotencyError(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err);
-  const causeMsg =
-    err instanceof Error && err.cause instanceof Error ? err.cause.message : "";
-  return [msg, causeMsg].some(m =>
-    [
-      /already exists/i,
-      /duplicate column name/i,
-      /duplicate key name/i,
-      /check that column\/key exists/i,
-    ].some(p => p.test(m))
-  );
+  return errorSays(err, [
+    // SQLite
+    /no such column/i,
+    // MySQL (ER_KEY_COLUMN_DOES_NOT_EXIST)
+    /key column .* doesn't exist in table/i,
+    // PostgreSQL
+    /column .* does not exist/i,
+  ]);
 }


### PR DESCRIPTION
## What this fixes

A core table could not gain an **indexed** column on an existing SQLite or MySQL database. The upgrade threw:

```
Failed query: CREATE UNIQUE INDEX `..._uidx` ON `nextly_versions` (`version_no`)
Caused by: SqliteError: no such column: version_no
```

## Why

When a live database holds ordinary content tables, drizzle-kit's rename resolver crashes and the reconcile recovers with a baseline diffed from an **empty snapshot**. That baseline is additive-tables-only by design — it never emits `ALTER TABLE ADD COLUMN`, which `fresh-push.ts` documents at the `withResolverCrashFallback` comment. The second pass is what emits the alterations.

But the empty-snapshot baseline also carries **every index in the desired schema**, including indexes over columns the live table has not gained yet. Those statements fail with `no such column`, which is not an idempotency error, so the first pass threw and **the second pass never ran**.

So the two-pass fix handles a new column, but not a new column with an index on it.

## The change

`executeStatements` now skips a failing statement when **all three** hold:

1. the pass degraded (the caller passes this explicitly, read from the pass's own hint),
2. the statement is a `CREATE INDEX` / `CREATE UNIQUE INDEX`, and
3. the error says a named column does not exist.

Anything else still stops the reconcile. This is deliberately narrower than the existing idempotency tolerance: that one recognises work already done, this one recognises work whose precondition is not done yet, and only in the one pass that is incapable of satisfying it.

`isMissingColumnError` matches PostgreSQL's wording as `column ... does not exist` rather than a bare "does not exist", for the same reason error 1091 is matched in full above it — a bare match would also catch a statement naming a genuinely missing TABLE.

The message/cause reader both predicates need is now one function, since drizzle-kit v1 puts the dialect's real wording on `.cause`.

## Verification

- **New integration test builds a pre-change database and upgrades it**: `nextly_versions` without `version_no` (a column two of its indexes name), plus an orphan `dc_articles` so the resolver actually degrades — without the orphan this path is never taken. It asserts the column lands, the index lands, and the pre-existing row survives. It **fails on `main`** with `no such column: version_no`.
- The old shape is synthetic rather than historical, and says so: the mechanism is "an index names a column the live table lacks", and `version_no` is used because it is nullable on every dialect, so the test observes the pipeline rather than a NOT NULL rebuild.
- **Unit tests pin the predicate's narrowness**: it reads the cause, it does not fire on a unique-constraint failure, a disk error or a syntax error, and it is explicitly not the same question as idempotency.
- Schema suites green on all three dialects: 28 files / 102 tests.
- 6 failures in field-column mapping are **pre-existing** — confirmed by restoring both changed files to `main`'s content in place and re-running, not by assuming.
- fallow: `pass`, 0 introduced across all four categories.

## Note

This blocks a follow-up branch that adds an indexed column to `nextly_versions`, which is how it was found. It is not specific to that work: it blocks any indexed column on any core table.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema updates for databases with legacy or incomplete table structures.
  * Fresh schema pushes now recover from missing-column errors while preserving existing data.
  * Indexes skipped during an initial recovery pass are retried automatically.
  * Added support for recognizing missing-column errors across SQLite, MySQL, and PostgreSQL.
* **Tests**
  * Added coverage for degraded schema pushes, error handling, and database compatibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->