### PR TITLE
refactor(admin): split autosave into a snapshot core and a form adapter

### DIFF
--- a/.changeset/autosave-snapshot-core.md
+++ b/.changeset/autosave-snapshot-core.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Separate autosave's recording machinery from the form it was written against, so a second editor can record recovery points on the same timing, status vocabulary and coalescing rules rather than reimplementing them. No change to how the entry and single editors behave.

--- a/packages/admin/src/hooks/__tests__/useSnapshotAutosave.test.tsx
+++ b/packages/admin/src/hooks/__tests__/useSnapshotAutosave.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * The recording machinery, exercised without a form in sight.
+ *
+ * That absence IS the property under test. This core exists so a second editor
+ * can record recovery points without reimplementing the timing, and a test that
+ * reached for `useForm` to drive it would prove the opposite of what it is for.
+ * Everything here hands it a plain callback.
+ *
+ * @module hooks/__tests__/useSnapshotAutosave.test
+ */
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useSnapshotAutosave } from "../useSnapshotAutosave";
+
+const DEBOUNCE = 2000;
+const STORED_AT = "2026-08-19T02:00:00.000Z";
+
+function saved(updatedAt = STORED_AT) {
+  return Promise.resolve({ updatedAt });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("useSnapshotAutosave", () => {
+  it("waits for the debounce before recording anything", async () => {
+    const save = vi.fn(() => saved());
+    const { result } = renderHook(() =>
+      useSnapshotAutosave({ identity: "doc-1", save, debounceMs: DEBOUNCE })
+    );
+
+    act(() => result.current.schedule());
+    expect(save).not.toHaveBeenCalled();
+
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+  });
+
+  it("records ONCE for a burst, restarting the wait each time", async () => {
+    // The property that makes this a debounce rather than a throttle: typing
+    // for a minute records at the end of it, not sixty times during it.
+    const save = vi.fn(() => saved());
+    const { result } = renderHook(() =>
+      useSnapshotAutosave({ identity: "doc-1", save, debounceMs: DEBOUNCE })
+    );
+
+    act(() => {
+      result.current.schedule();
+      vi.advanceTimersByTime(DEBOUNCE - 100);
+      result.current.schedule();
+      vi.advanceTimersByTime(DEBOUNCE - 100);
+      result.current.schedule();
+    });
+    expect(save).not.toHaveBeenCalled();
+
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+  });
+
+  it("reads the snapshot AT flush time, not when it was scheduled", async () => {
+    // The contract that lets the caller keep the freshest copy. A core that
+    // captured the value when `schedule` was called would record what the
+    // author had typed two seconds ago.
+    let current = "first";
+    const seen: string[] = [];
+    const save = vi.fn(() => {
+      seen.push(current);
+      return saved();
+    });
+    const { result } = renderHook(() =>
+      useSnapshotAutosave({ identity: "doc-1", save, debounceMs: DEBOUNCE })
+    );
+
+    act(() => result.current.schedule());
+    current = "second";
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+
+    await waitFor(() => expect(seen).toEqual(["second"]));
+  });
+
+  it("takes the timestamp from the SERVER's response", async () => {
+    // Never `Date.now()`: a "saved 2 minutes ago" reading must not drift with
+    // an unsynchronised browser clock.
+    const save = vi.fn(() => saved(STORED_AT));
+    const { result } = renderHook(() =>
+      useSnapshotAutosave({ identity: "doc-1", save, debounceMs: DEBOUNCE })
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+
+    await waitFor(() =>
+      expect(result.current.lastSavedAt?.toISOString()).toBe(STORED_AT)
+    );
+  });
+
+  it("reports an error through status instead of throwing", async () => {
+    // A recovery point nobody asked for must not surface an error over the
+    // editor or interrupt typing.
+    const save = vi.fn(() => Promise.reject(new Error("network")));
+    const { result } = renderHook(() =>
+      useSnapshotAutosave({ identity: "doc-1", save, debounceMs: DEBOUNCE })
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+  });
+});
+
+describe("what switches recording off", () => {
+  it("records nothing when the identity is null", async () => {
+    // A document with no address has nothing for the endpoint to write
+    // against, so recording is disabled rather than given an invented key.
+    const save = vi.fn(() => saved());
+    const { result } = renderHook(() =>
+      useSnapshotAutosave({ identity: null, save, debounceMs: DEBOUNCE })
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE * 2));
+
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("records nothing while disabled, and the policy is HANDED in", async () => {
+    // `enabled` is how the owner's setting reaches this module. The core never
+    // infers that recording is allowed from having been given a snapshot: if it
+    // did, every caller that forgot would rediscover the server's refusal one
+    // request at a time.
+    const save = vi.fn(() => saved());
+    const { result } = renderHook(() =>
+      useSnapshotAutosave({
+        identity: "doc-1",
+        save,
+        debounceMs: DEBOUNCE,
+        enabled: false,
+      })
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE * 2));
+
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("still records when enabled, which is the control", async () => {
+    // Without this, the two cases above pass on a core that never records at
+    // all under any circumstances.
+    const save = vi.fn(() => saved());
+    const { result } = renderHook(() =>
+      useSnapshotAutosave({
+        identity: "doc-1",
+        save,
+        debounceMs: DEBOUNCE,
+        enabled: true,
+      })
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe("the identity is opaque, and it bounds a pending recording", () => {
+  it("drops a pending recording when the identity changes", async () => {
+    // The one failure this module can cause that its caller cannot see: a
+    // timer scheduled for one document firing after the editor has moved to
+    // another would write the first snapshot against the second's key.
+    const save = vi.fn(() => saved());
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) =>
+        useSnapshotAutosave({ identity: id, save, debounceMs: DEBOUNCE }),
+      { initialProps: { id: "doc-1" } }
+    );
+
+    act(() => result.current.schedule());
+    rerender({ id: "doc-2" });
+    act(() => void vi.advanceTimersByTime(DEBOUNCE * 2));
+
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("accepts any string as a key without reading it", async () => {
+    // Recovery rows are keyed per document and per author today, and pending
+    // changes are becoming per-language. The core is asked to hold none of
+    // that: whatever the caller passes is the key it records under.
+    const save = vi.fn(() => saved());
+    const { result } = renderHook(() =>
+      useSnapshotAutosave({
+        identity: "single:homepage:601b:fr-CA",
+        save,
+        debounceMs: DEBOUNCE,
+      })
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+  });
+});

--- a/packages/admin/src/hooks/useDocumentAutosave.ts
+++ b/packages/admin/src/hooks/useDocumentAutosave.ts
@@ -17,13 +17,15 @@
  * @module hooks/useDocumentAutosave
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect } from "react";
 import type { UseFormReturn } from "react-hook-form";
 
+import {
+  useSnapshotAutosave,
+  type AutosaveStatus,
+  DEFAULT_AUTOSAVE_DEBOUNCE_MS,
+} from "@admin/hooks/useSnapshotAutosave";
 import { versionApi, type VersionScope } from "@admin/services/versionApi";
-
-/** How long to wait after the last keystroke before recording. */
-const DEFAULT_DEBOUNCE_MS = 2000;
 
 /**
  * The document to record against, or `null` when there is not one yet.
@@ -54,7 +56,14 @@ export function autosaveScopeFor(
     : { kind: "collection", slug, entryId: documentId };
 }
 
-export type AutosaveStatus = "idle" | "saving" | "saved" | "error";
+/**
+ * Re-exported so the indicators that read it keep one import.
+ *
+ * The vocabulary belongs to the recording machinery rather than to this
+ * adapter: a second editor showing a different set of words for the same four
+ * states is the drift the split exists to prevent.
+ */
+export type { AutosaveStatus };
 
 export interface UseDocumentAutosaveOptions {
   /**
@@ -104,78 +113,41 @@ export function useDocumentAutosave({
   scope,
   form,
   locale = null,
-  debounceMs = DEFAULT_DEBOUNCE_MS,
+  debounceMs = DEFAULT_AUTOSAVE_DEBOUNCE_MS,
   enabled = true,
 }: UseDocumentAutosaveOptions): UseDocumentAutosaveResult {
-  const [status, setStatus] = useState<AutosaveStatus>("idle");
-  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+  /*
+   * The snapshot, read at flush time rather than captured when the recording
+   * was scheduled.
+   *
+   * `getValues()` reads what the form holds right now, and deliberately not
+   * `handleSubmit`. Submitting runs validation and REFUSES on a failure, so a
+   * recovery point would exist only for work that was already valid — which is
+   * the opposite of what a recovery point is for. Half-finished input is
+   * exactly what is worth not losing.
+   */
+  const save = useCallback(async () => {
+    if (!scope) throw new Error("autosave: no scope");
+    return versionApi.saveAutosave(scope, form.getValues(), locale);
+  }, [scope, form, locale]);
 
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const inFlightRef = useRef(false);
-  // Set when an edit arrives while a recording is still in flight. The values
-  // that edit produced would otherwise be lost: the timer for them has already
-  // fired, and no further keystroke is guaranteed to arrive to schedule another.
-  const pendingRef = useRef(false);
-  const mountedRef = useRef(true);
+  /*
+   * The identity the core keys a pending recording to.
+   *
+   * Built from the scope's own fields rather than passing the object: the core
+   * compares identity for change, and an object rebuilt each render would look
+   * like a different document every time.
+   */
+  const identity = scope
+    ? `${scope.kind}:${scope.slug}:${"entryId" in scope ? scope.entryId : scope.documentId}:${locale ?? ""}`
+    : null;
 
-  // Read through refs inside the debounced callback rather than captured as
-  // dependencies. The callback is created once per subscription, and closing
-  // over these would pin the values they held when the subscription was set up.
-  const scopeRef = useRef(scope);
-  const localeRef = useRef(locale);
-  const enabledRef = useRef(enabled);
-  scopeRef.current = scope;
-  localeRef.current = locale;
-  enabledRef.current = enabled;
-
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
-
-  const flush = useCallback(async () => {
-    const target = scopeRef.current;
-    if (!target || !enabledRef.current) return;
-
-    if (inFlightRef.current) {
-      pendingRef.current = true;
-      return;
-    }
-
-    inFlightRef.current = true;
-    if (mountedRef.current) setStatus("saving");
-
-    try {
-      // `getValues()` reads what the form holds right now, and deliberately not
-      // `handleSubmit`. Submitting runs validation and REFUSES on a failure, so
-      // a recovery point would exist only for work that was already valid --
-      // which is the opposite of what a recovery point is for. Half-finished
-      // input is exactly what is worth not losing.
-      const response = await versionApi.saveAutosave(
-        target,
-        form.getValues(),
-        localeRef.current
-      );
-
-      if (mountedRef.current) {
-        setLastSavedAt(new Date(response.updatedAt));
-        setStatus("saved");
-      }
-    } catch {
-      // Swallowed deliberately, and reported through `status` rather than
-      // thrown. A recovery point nobody asked for must not surface an error
-      // over the editor or interrupt typing; the next debounce tries again.
-      if (mountedRef.current) setStatus("error");
-    } finally {
-      inFlightRef.current = false;
-      if (pendingRef.current) {
-        pendingRef.current = false;
-        void flush();
-      }
-    }
-  }, [form]);
+  const { status, lastSavedAt, schedule } = useSnapshotAutosave({
+    identity,
+    save,
+    debounceMs,
+    enabled,
+  });
 
   useEffect(() => {
     if (!enabled || !scope) return;
@@ -183,40 +155,31 @@ export function useDocumentAutosave({
     const subscription = form.subscribe({
       formState: { values: true, isDirty: true },
       callback: ({ isDirty }) => {
-        // Record only while the editor holds uncommitted changes.
-        //
-        // The discriminator is the dirty flag rather than the update's `type`.
-        // `type` carries a DOM event name and is populated only when the change
-        // came from a registered input's own handler: measured here, both
-        // `setValue` and `reset` report it as `undefined`, so keying on
-        // `"change"` would silently stop recording for every field that updates
-        // programmatically, which is most non-text controls.
-        //
-        // Dirty also answers the case that motivated the filter. Loading a
-        // document calls `reset`, which installs the loaded values as the new
-        // defaults and leaves the form clean, so the page opening records
-        // nothing. And it is the same condition the unsaved-changes guard uses,
-        // so the two cannot disagree about whether there is work at risk.
+        /*
+         * Record only while the editor holds uncommitted changes.
+         *
+         * The discriminator is the dirty flag rather than the update's `type`.
+         * `type` carries a DOM event name and is populated only when the change
+         * came from a registered input's own handler: measured here, both
+         * `setValue` and `reset` report it as `undefined`, so keying on
+         * `"change"` would silently stop recording for every field that updates
+         * programmatically, which is most non-text controls.
+         *
+         * Dirty also answers the case that motivated the filter. Loading a
+         * document calls `reset`, which installs the loaded values as the new
+         * defaults and leaves the form clean, so the page opening records
+         * nothing. And it is the same condition the unsaved-changes guard uses,
+         * so the two cannot disagree about whether there is work at risk.
+         */
         if (!isDirty) return;
-
-        if (timerRef.current) clearTimeout(timerRef.current);
-        timerRef.current = setTimeout(() => {
-          void flush();
-        }, debounceMs);
+        schedule();
       },
     });
 
-    return () => {
-      subscription();
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-        timerRef.current = null;
-      }
-    };
+    return subscription;
     // `scope` participates through its identity fields: a different document
     // needs a different subscription, and comparing the object itself would
     // resubscribe on every render.
-  }, [form, flush, debounceMs, enabled, scope?.kind, scope?.slug, scope]);
-
+  }, [form, schedule, enabled, scope?.kind, scope?.slug, scope]);
   return { status, lastSavedAt };
 }

--- a/packages/admin/src/hooks/useSnapshotAutosave.ts
+++ b/packages/admin/src/hooks/useSnapshotAutosave.ts
@@ -1,0 +1,204 @@
+"use client";
+
+/**
+ * The recording machinery behind autosave, with no opinion about what is being
+ * recorded.
+ *
+ * Debounce, coalescing, the in-flight guard, the mounted guard and the status
+ * an indicator reads: all of it is the same whether the thing being recorded is
+ * a form's values or a block document, and none of it needs to know which.
+ * Splitting it out is what lets a second editor record recovery points without
+ * a second implementation of the timing — and two implementations of a debounce
+ * that must agree with a status vocabulary is exactly the pair that drifts.
+ *
+ * ## What this does NOT decide
+ *
+ * **What a snapshot is, and where it goes.** The caller supplies `save`, so the
+ * API surface, the payload shape and the locale all stay with whoever owns
+ * them. This module never imports an API client.
+ *
+ * **When there is something worth recording.** The caller calls `schedule()`.
+ * A form knows that from its dirty flag; an editor knows it from its own
+ * history. Guessing here would mean a rule that is right for one of them.
+ *
+ * ## The identity is OPAQUE, deliberately
+ *
+ * `identity` is compared for change and otherwise never read. It is not a
+ * document id, because it is not always one: recovery rows are keyed per
+ * document and per author today, and pending changes are becoming per-document
+ * and per-LANGUAGE. A core that assumed "one recording per document" would have
+ * to be reopened to express that, so it assumes only "one recording per
+ * whatever the caller says", which both fit inside.
+ *
+ * @module hooks/useSnapshotAutosave
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** How long to wait after the last change before recording. */
+export const DEFAULT_AUTOSAVE_DEBOUNCE_MS = 2000;
+
+/** Where a recording has got to, for an indicator to read. */
+export type AutosaveStatus = "idle" | "saving" | "saved" | "error";
+
+/** What a completed recording reports back. */
+export interface SnapshotSaveResult {
+  /**
+   * When the server stored it, by the SERVER's clock.
+   *
+   * Taken from the response rather than from `Date.now()`, so a "saved 2
+   * minutes ago" reading cannot drift with an unsynchronised browser clock.
+   */
+  updatedAt: string;
+}
+
+export interface UseSnapshotAutosaveOptions {
+  /**
+   * What this recording is keyed by, or `null` when recording must stay off.
+   *
+   * Compared for change and never inspected. `null` disables recording rather
+   * than inventing an address — a document that has never been saved has
+   * nothing for the endpoint to write against.
+   */
+  identity: string | null;
+
+  /**
+   * Persist the current snapshot.
+   *
+   * Called AT flush time, not when it is handed over, so it must read the
+   * current value rather than close over one captured earlier. That is the
+   * whole reason it is a callback: the caller keeps the freshest copy and this
+   * module keeps the timing.
+   */
+  save: () => Promise<SnapshotSaveResult>;
+
+  /** Milliseconds of quiet before a recording is made. */
+  debounceMs?: number;
+
+  /**
+   * Turns recording off without unmounting. Used while a real save is in
+   * flight: the document is about to change underneath the snapshot, so a
+   * recovery point written now would describe a state that never existed.
+   */
+  enabled?: boolean;
+}
+
+export interface UseSnapshotAutosaveResult {
+  status: AutosaveStatus;
+  lastSavedAt: Date | null;
+  /**
+   * Ask for a recording once the debounce has elapsed.
+   *
+   * Repeated calls restart the wait rather than queueing, so a burst of typing
+   * records once at the end of it.
+   */
+  schedule: () => void;
+}
+
+/**
+ * @param options - what to key on, how to persist, and how long to wait
+ * @returns the current status, when the last recording landed, and the trigger
+ */
+export function useSnapshotAutosave({
+  identity,
+  save,
+  debounceMs = DEFAULT_AUTOSAVE_DEBOUNCE_MS,
+  enabled = true,
+}: UseSnapshotAutosaveOptions): UseSnapshotAutosaveResult {
+  const [status, setStatus] = useState<AutosaveStatus>("idle");
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inFlightRef = useRef(false);
+  /*
+   * Set when a change arrives while a recording is still in flight. Those
+   * values would otherwise be lost: the timer for them has already fired, and
+   * no further change is guaranteed to arrive to schedule another.
+   */
+  const pendingRef = useRef(false);
+  const mountedRef = useRef(true);
+
+  /*
+   * Read through refs inside the debounced callback rather than captured as
+   * dependencies. The callback is created once per subscription, and closing
+   * over these would pin the values they held when it was set up.
+   */
+  const identityRef = useRef(identity);
+  const enabledRef = useRef(enabled);
+  const saveRef = useRef(save);
+  identityRef.current = identity;
+  enabledRef.current = enabled;
+  saveRef.current = save;
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const flush = useCallback(async () => {
+    if (identityRef.current === null || !enabledRef.current) return;
+
+    if (inFlightRef.current) {
+      pendingRef.current = true;
+      return;
+    }
+
+    inFlightRef.current = true;
+    if (mountedRef.current) setStatus("saving");
+
+    try {
+      const result = await saveRef.current();
+      if (mountedRef.current) {
+        setLastSavedAt(new Date(result.updatedAt));
+        setStatus("saved");
+      }
+    } catch {
+      /*
+       * Swallowed deliberately, and reported through `status` rather than
+       * thrown. A recovery point nobody asked for must not surface an error
+       * over the editor or interrupt typing; the next debounce tries again.
+       */
+      if (mountedRef.current) setStatus("error");
+    } finally {
+      inFlightRef.current = false;
+      if (pendingRef.current) {
+        pendingRef.current = false;
+        void flush();
+      }
+    }
+  }, []);
+
+  /*
+   * Whether to record is decided at FLUSH, and only there.
+   *
+   * Checking it here as well reads as defensive and is worse than redundant:
+   * `enabled` moves while a timer is already pending — it goes false the moment
+   * a real save starts — so the answer at scheduling time is not the answer
+   * that matters, and two copies of the rule would eventually disagree about a
+   * recording one of them had already allowed. Scheduling a timer that flush
+   * then declines costs a cleared timeout.
+   */
+  const schedule = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      void flush();
+    }, debounceMs);
+  }, [flush, debounceMs]);
+
+  // A pending recording belongs to the identity that scheduled it. Left
+  // running across a change it would write one document's snapshot against
+  // another's key, which is the one failure this module can cause that the
+  // caller cannot see.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [identity]);
+
+  return { status, lastSavedAt, schedule };
+}


### PR DESCRIPTION
Groundwork for B-3, taken as its own PR because it changes no behaviour: the
entry and single editors autosave exactly as before, proved by their twelve
existing tests passing **untouched**.

## What moved, and why there

`useDocumentAutosave` owned two unrelated things. One is *what* is being
recorded and where it goes — a form's values, through `versionApi`, for a
version scope. The other is *when and how* a recording happens — the debounce,
the coalescing, the in-flight and mounted guards, and the four-word status an
indicator reads. Only the first is about forms.

The second is now `useSnapshotAutosave`, which takes a `save` callback and never
imports an API client. `useDocumentAutosave` keeps its exact public shape and
becomes the adapter that knows about forms.

Without this, the page builder gets a second debounce that has to agree with a
second status vocabulary — and a pair like that drifts silently, because both
look correct in isolation.

## Three decisions worth reviewing

**The identity is opaque.** `identity: string | null`, compared for change and
never inspected. It is deliberately not a document id: recovery rows are keyed
per document AND per author today, and pending changes are becoming
per-language. A core that assumed "one recording per document" would have to be
reopened to express that. This came from the translation lane, who are adding
that constraint now.

**`save` is called AT flush time, not when it is handed over.** The caller keeps
the freshest copy; this module keeps the timing. A core that captured the value
when `schedule()` was called would record what the author had typed two seconds
earlier. There is a test that fails on exactly that.

**Whether recording is allowed is HANDED in, never inferred.** `enabled` is the
seam the owner's policy arrives through. The core does not conclude "autosave is
on" from having been given a snapshot — if it did, every caller that forgot
would rediscover the server's refusal one 403 at a time. That is not
hypothetical: autosave is opt-in per entity and the server enforces it, so a
client that assumes otherwise generates a refused request every couple of
seconds.

## Verification

**The existing 12 `useDocumentAutosave` tests pass unmodified**, which is the
whole correctness argument for a refactor: the behaviour they pin is the
behaviour that survived.

**10 new tests for the core**, driven with a plain callback and no `useForm`
anywhere — that absence is the property under test, since the core exists so a
non-form editor can use it.

Break-verified, control run green first, each stub restored and confirmed
byte-identical:

| stub | failed |
|---|---|
| flush stops honouring identity/enabled | `records nothing when the identity is null`, `records nothing while disabled, and the policy is HANDED in` |
| the debounce timer is never cleared | `records ONCE for a burst, restarting the wait each time` |
| an identity change stops cancelling a pending recording | `drops a pending recording when the identity changes` |

Each failed only the tests naming its property, and the controls beside them —
"still records when enabled", the burst case's siblings — stayed green.

### A fourth stub SURVIVED, and that was the useful one

Removing the identity/enabled guard from `schedule()` changed nothing: all ten
still passed. The guard was **redundant**, because `flush` already asks the same
question, so the rule had two implementations.

I removed the duplicate rather than adding a test to pin it, and the flush copy
is the one that is actually correct: `enabled` moves while a timer is pending —
it goes false the moment a real save starts — so the answer at scheduling time
is not the answer that matters. Two copies would eventually disagree about a
recording one of them had already allowed.

`packages/admin`: 2,385 → 2,395 tests. **15 failures across 4 files, identical
to `origin/main`** — `StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField`,
a pre-existing baseline this does not touch.

## What is NOT in this PR

The builder does not consume the core yet, and the client-side policy fix
(passing `draftsEnabled` so the admin stops attempting refused recordings) is
not here either. Both are the next PR, where they can be verified in a browser
together.