### PR TITLE
test(admin): pin what an identity change does to a pending recording

### DIFF
--- a/packages/admin/src/hooks/__tests__/useSnapshotAutosave.test.tsx
+++ b/packages/admin/src/hooks/__tests__/useSnapshotAutosave.test.tsx
@@ -174,9 +174,21 @@ describe("what switches recording off", () => {
 
 describe("the identity is opaque, and it bounds a pending recording", () => {
   it("drops a pending recording when the identity changes", async () => {
-    // The one failure this module can cause that its caller cannot see: a
-    // timer scheduled for one document firing after the editor has moved to
-    // another would write the first snapshot against the second's key.
+    /*
+     * The one failure this module can cause that its caller cannot see: a
+     * timer scheduled for one document firing after the editor has moved to
+     * another would write the first snapshot against the second's key.
+     *
+     * DROPPED rather than flushed first, and the difference is reachable as
+     * soon as an identity carries a language: switch from Spanish to French
+     * mid-debounce and the two answers diverge. Flushing on the way out looks
+     * kinder — it would record the Spanish work rather than discard it — but
+     * `save` reads the snapshot AT flush time, so by then the editor is
+     * already showing French, and the "kind" version writes French content
+     * into the Spanish row. Losing an unwritten recovery point is recoverable:
+     * the document itself is untouched and the next edit schedules again.
+     * Mislabelling one is not, because nothing downstream can tell.
+     */
     const save = vi.fn(() => saved());
     const { result, rerender } = renderHook(
       ({ id }: { id: string }) =>
@@ -189,6 +201,28 @@ describe("the identity is opaque, and it bounds a pending recording", () => {
     act(() => void vi.advanceTimersByTime(DEBOUNCE * 2));
 
     expect(save).not.toHaveBeenCalled();
+  });
+
+  it("still records under the NEW identity afterwards, which is the control", async () => {
+    // Without this, the case above passes on a hook whose cleanup left it dead:
+    // "nothing was recorded" is satisfied perfectly by never recording again.
+    const save = vi.fn(() => saved());
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) =>
+        useSnapshotAutosave({ identity: id, save, debounceMs: DEBOUNCE }),
+      { initialProps: { id: "doc-1" } }
+    );
+
+    act(() => result.current.schedule());
+    rerender({ id: "doc-2" });
+    act(() => void vi.advanceTimersByTime(DEBOUNCE * 2));
+    expect(save).not.toHaveBeenCalled();
+
+    // A fresh edit under the new identity records normally.
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
   });
 
   it("accepts any string as a key without reading it", async () => {


### PR DESCRIPTION
Follows #1057, which merged while this was being written. Tests only, no
changeset.

## The gap

#1057 covered what happens to a pending recording when the identity changes —
it is dropped — with a case asserting that nothing was written.

**That assertion is satisfied just as well by a hook that never records
again.** "Nothing was recorded" cannot tell a working cancellation from a
permanently dead timer, so the case passed on both.

Measured rather than argued: with `schedule()` stubbed to arm no timer at all —
a hook that can never record under any circumstances — **8 of 11 cases fail and
3 pass.** The three survivors are exactly the assertions phrased as absence:

- `records nothing when the identity is null`
- `records nothing while disabled, and the policy is HANDED in`
- `drops a pending recording when the identity changes`

The first two already had a control beside them (`still records when enabled`).
The third did not. It does now: after the identity changes and the pending
recording is dropped, a fresh `schedule()` records under the NEW identity. That
case is among the 8 that fail on the dead hook, so it carries signal the
original could not.

## The question it answers, written down

The translation lane asked what a pending timer does when the identity changes,
because per-language identities make it reachable in ordinary use: an author
edits Spanish, a debounce is armed, they click into French before it fires.

The answer is **dropped, not flushed**, and the reasoning is now in the test
rather than only in my head:

Flushing on the way out looks kinder — it would record the Spanish work instead
of discarding it. But `save` reads the snapshot AT flush time, which is the
contract that lets the caller keep the freshest copy. By the time that flush
ran the editor would already be showing French, so the "kind" version writes
French content into the Spanish row.

Losing an unwritten recovery point is recoverable: the document itself is
untouched and the next edit schedules again. **Mislabelling one is not, because
nothing downstream can tell.** That asymmetry is why the drop is the right
default, and it is what the comment now says.

## Note on how this arrived separately

This was written as a follow-up commit on #1057's branch. Checking that PR's
state before committing showed it had already merged, so the commit went to a
branch whose pull request was closed. It was cherry-picked onto current `main`
here instead.

Worth recording because the check is cheap and the failure is not: a commit
pushed to a merged branch is stranded silently, and this repository has lost
work that way before.