### PR TITLE
fix(nextly): hold a document to one pending change per language

### DIFF
--- a/.changeset/working-draft-uniqueness.md
+++ b/.changeset/working-draft-uniqueness.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Hold a document to one pending change per language in the database.
+
+A working draft is the only row class the version table's sequence index cannot
+constrain: it carries no version number, and SQL treats NULL as distinct from
+NULL. A dedicated key column, set only on that row class, lets one ordinary
+unique index enforce the rule on every dialect, so two writers can no longer
+each store a pending change for the same document and language.

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -206,6 +206,7 @@ export function generateSqliteCoreTableStatements(): string[] {
       "label" TEXT,
       "locale" TEXT,
       "source_version_no" INTEGER,
+      "draft_key" TEXT,
       "created_by" TEXT,
       "created_at" INTEGER NOT NULL,
       "updated_at" INTEGER NOT NULL,
@@ -213,6 +214,12 @@ export function generateSqliteCoreTableStatements(): string[] {
     )`,
     `CREATE UNIQUE INDEX IF NOT EXISTS "nextly_versions_seq_uidx"
       ON "nextly_versions" ("scope_kind", "scope_slug", "entry_id", "version_no")`,
+    // Its own statement, guarded with IF NOT EXISTS, so re-running this
+    // bootstrap restores the index if it is ever missing. The CREATE TABLE
+    // above cannot do the same for the column: SQLite skips that statement
+    // wholesale once the table exists.
+    `CREATE UNIQUE INDEX IF NOT EXISTS "nextly_versions_working_draft_uidx"
+      ON "nextly_versions" ("draft_key")`,
     `CREATE INDEX IF NOT EXISTS "nextly_versions_doc_recent_idx"
       ON "nextly_versions" ("scope_kind", "scope_slug", "entry_id", "created_at")`,
     // No REFERENCES to "email_providers": that table is not bootstrapped here,

--- a/packages/nextly/src/domains/versions/__tests__/working-draft-key.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/working-draft-key.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import type { VersionRef } from "../versions-repository";
+import { workingDraftKey } from "../working-draft-key";
+
+const ref = (slug: string, entryId: string): VersionRef => ({
+  scopeKind: "collection",
+  scopeSlug: slug,
+  entryId,
+});
+
+describe("workingDraftKey", () => {
+  it("is a fixed-width lowercase hex digest", () => {
+    expect(workingDraftKey(ref("posts", "e1"), "en")).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is stable for the same inputs", () => {
+    expect(workingDraftKey(ref("posts", "e1"), "en")).toBe(
+      workingDraftKey(ref("posts", "e1"), "en")
+    );
+  });
+
+  it("separates one language from another", () => {
+    expect(workingDraftKey(ref("posts", "e1"), "en")).not.toBe(
+      workingDraftKey(ref("posts", "e1"), "es")
+    );
+  });
+
+  it("separates an unlocalized document from a localized one", () => {
+    expect(workingDraftKey(ref("posts", "e1"), null)).not.toBe(
+      workingDraftKey(ref("posts", "e1"), "en")
+    );
+  });
+
+  it("cannot be forged by moving the delimiter into a segment", () => {
+    // Without per-segment encoding, ("posts:a", "e1") and ("posts", "a:e1")
+    // would join to the same string and collapse two documents into one key.
+    expect(workingDraftKey(ref("posts:a", "e1"), null)).not.toBe(
+      workingDraftKey(ref("posts", "a:e1"), null)
+    );
+  });
+
+  it("separates scope kinds", () => {
+    const asSingle: VersionRef = {
+      scopeKind: "single",
+      scopeSlug: "posts",
+      entryId: "e1",
+    };
+    expect(workingDraftKey(asSingle, null)).not.toBe(
+      workingDraftKey(ref("posts", "e1"), null)
+    );
+  });
+});

--- a/packages/nextly/src/domains/versions/__tests__/working-draft-key.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/working-draft-key.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 
+import { nextlyVersionsMysql } from "../../../schemas/versions/mysql";
+import { nextlyVersionsPg } from "../../../schemas/versions/postgres";
+import { nextlyVersionsSqlite } from "../../../schemas/versions/sqlite";
 import type { VersionRef } from "../versions-repository";
 import { workingDraftKey } from "../working-draft-key";
 
@@ -49,5 +52,22 @@ describe("workingDraftKey", () => {
     expect(workingDraftKey(asSingle, null)).not.toBe(
       workingDraftKey(ref("posts", "e1"), null)
     );
+  });
+});
+
+describe("draft_key column", () => {
+  // Declared on every dialect, or the constraint holds on some databases and
+  // not others, which is worse than not holding at all: the same code would be
+  // correct in development and lossy in production.
+  it("is declared on all three dialects", () => {
+    expect(nextlyVersionsPg.draftKey.name).toBe("draft_key");
+    expect(nextlyVersionsMysql.draftKey.name).toBe("draft_key");
+    expect(nextlyVersionsSqlite.draftKey.name).toBe("draft_key");
+  });
+
+  it("is nullable on all three dialects", () => {
+    expect(nextlyVersionsPg.draftKey.notNull).toBe(false);
+    expect(nextlyVersionsMysql.draftKey.notNull).toBe(false);
+    expect(nextlyVersionsSqlite.draftKey.notNull).toBe(false);
   });
 });

--- a/packages/nextly/src/domains/versions/__tests__/working-draft-uniqueness.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/working-draft-uniqueness.integration.test.ts
@@ -20,13 +20,21 @@ import {
 } from "../../../plugins/test-nextly";
 import { VersionsRepository, type VersionRef } from "../versions-repository";
 
-const describeIfPg = process.env.TEST_POSTGRES_URL ? describe : describe.skip;
+// Both server dialects, because the constraint is expressed once in the shared
+// Drizzle schema but each dialect creates it its own way, and MySQL in
+// particular has an index key length limit a wider key would have hit. SQLite is
+// absent deliberately: it serializes its writers, so it cannot express two
+// transactions reading before either writes.
+const DIALECTS = [
+  { name: "postgresql" as const, url: process.env.TEST_POSTGRES_URL },
+  { name: "mysql" as const, url: process.env.TEST_MYSQL_URL },
+].filter(d => Boolean(d.url));
 
-describeIfPg("working-draft uniqueness (integration)", () => {
+describe.each(DIALECTS)("working-draft uniqueness on $name", ({ name }) => {
   let handle: TestNextly;
 
   beforeAll(async () => {
-    handle = await createTestNextly({ dialect: "postgresql" });
+    handle = await createTestNextly({ dialect: name });
   });
 
   afterAll(async () => {
@@ -152,5 +160,25 @@ describeIfPg("working-draft uniqueness (integration)", () => {
       { where: { and: [{ column: "entryId", op: "=", value: ref.entryId }] } }
     );
     expect(rows).toHaveLength(4);
+  });
+});
+
+// SQLite cannot express the concurrent case, but the constraint still has to
+// EXIST there: the schema declares it once for all three dialects, and a
+// dialect that quietly failed to create it would enforce nothing while every
+// other signal looked identical.
+describe("working-draft uniqueness on sqlite", () => {
+  it("creates the unique index", async () => {
+    const handle = await createTestNextly();
+    try {
+      const rows = await handle.adapter.executeQuery(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'nextly_versions_working_draft_uidx'"
+      );
+      expect(JSON.stringify(rows)).toContain(
+        "nextly_versions_working_draft_uidx"
+      );
+    } finally {
+      await handle.destroy();
+    }
   });
 });

--- a/packages/nextly/src/domains/versions/__tests__/working-draft-uniqueness.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/working-draft-uniqueness.integration.test.ts
@@ -1,0 +1,156 @@
+/**
+ * A document has at most one working draft per locale, and the database is what
+ * makes that true. The repository reads before it writes, but nothing holds a
+ * lock across that read: the only locking read in the enclosing write flow sits
+ * inside the status-transition guard, which returns immediately when the write
+ * names no status, and a working-draft save always names none. So two writers
+ * can both observe no draft and both insert, and only a constraint can refuse
+ * the second.
+ *
+ * These run against a real PostgreSQL because a second connection is the whole
+ * point; SQLite serializes its writers and cannot express the case.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { isDatabaseError } from "@nextlyhq/adapter-drizzle/types";
+
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { VersionsRepository, type VersionRef } from "../versions-repository";
+
+const describeIfPg = process.env.TEST_POSTGRES_URL ? describe : describe.skip;
+
+describeIfPg("working-draft uniqueness (integration)", () => {
+  let handle: TestNextly;
+
+  beforeAll(async () => {
+    handle = await createTestNextly({ dialect: "postgresql" });
+  });
+
+  afterAll(async () => {
+    await handle.destroy();
+  });
+
+  const workingDraftRows = (entryId: string) =>
+    handle.adapter.select<{ id: string; snapshot: unknown; draftKey: string }>(
+      "nextly_versions",
+      {
+        where: {
+          and: [
+            { column: "entryId", op: "=", value: entryId },
+            { column: "isAutosave", op: "=", value: false },
+            { column: "versionNo", op: "IS NULL" },
+          ],
+        },
+      }
+    );
+
+  it("keeps exactly one working draft when two transactions interleave", async () => {
+    const ref: VersionRef = {
+      scopeKind: "collection",
+      scopeSlug: "wduniq",
+      entryId: "e-wduniq-1",
+    };
+
+    // The interleaving is forced rather than raced. Each transaction reads
+    // before either writes, which is exactly what the production path permits:
+    // the working-draft save runs inside a transaction and takes no lock on the
+    // document, so neither writer can see the other's uncommitted row. Racing
+    // two calls and hoping they overlap proves nothing when they happen not to.
+    let readA = (): void => {};
+    let readB = (): void => {};
+    const hasReadA = new Promise<void>(resolve => (readA = resolve));
+    const hasReadB = new Promise<void>(resolve => (readB = resolve));
+
+    // Two transactions on the booted adapter's pool, which is what two HTTP
+    // requests are: each checks out its own connection, so neither sees the
+    // other's uncommitted row.
+    const write = async (
+      title: string,
+      announce: () => void,
+      waitForOther: Promise<void>
+    ): Promise<void> => {
+      await handle.adapter.transaction(async tx => {
+        // Open the transaction and take its snapshot before anyone writes.
+        await tx.select("nextly_versions", {
+          where: { and: [{ column: "entryId", op: "=", value: ref.entryId }] },
+          limit: 1,
+        });
+        announce();
+        await waitForOther;
+        await new VersionsRepository(tx).upsertWorkingDraft({
+          ref,
+          locale: null,
+          snapshot: { title },
+          createdBy: title,
+        });
+      });
+    };
+
+    const outcomes = await Promise.allSettled([
+      write("from A", readA, hasReadB),
+      write("from B", readB, hasReadA),
+    ]);
+
+    // One writer commits and the other is refused. Which one loses depends on
+    // who reaches the insert second and is not worth pinning; what matters is
+    // that the loser is TOLD, rather than both landing and a later read picking
+    // between them arbitrarily.
+    const rejected = outcomes.filter(o => o.status === "rejected");
+    expect(outcomes.filter(o => o.status === "fulfilled")).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    const reason = (rejected[0] as PromiseRejectedResult).reason;
+    expect(isDatabaseError(reason) && reason.kind === "unique_violation").toBe(
+      true
+    );
+
+    expect(await workingDraftRows(ref.entryId)).toHaveLength(1);
+  });
+
+  it("does not constrain durable or autosave rows", async () => {
+    const ref: VersionRef = {
+      scopeKind: "collection",
+      scopeSlug: "wduniq",
+      entryId: "e-wduniq-3",
+    };
+    const repo = new VersionsRepository(handle.adapter);
+    // Two durable rows and two authors' autosave rows for one document all
+    // carry a NULL draft_key, so the unique index must ignore them entirely.
+    await repo.insertVersion({
+      ref,
+      versionNo: 1,
+      status: "published",
+      isAutosave: false,
+      snapshot: { v: 1 },
+      createdBy: "u1",
+    });
+    await repo.insertVersion({
+      ref,
+      versionNo: 2,
+      status: "published",
+      isAutosave: false,
+      snapshot: { v: 2 },
+      createdBy: "u1",
+    });
+    await repo.upsertAutosave({
+      ref,
+      status: "draft",
+      snapshot: { v: 3 },
+      createdBy: "u1",
+    });
+    await repo.upsertAutosave({
+      ref,
+      status: "draft",
+      snapshot: { v: 4 },
+      createdBy: "u2",
+    });
+
+    const rows = await handle.adapter.select<{ id: string }>(
+      "nextly_versions",
+      { where: { and: [{ column: "entryId", op: "=", value: ref.entryId }] } }
+    );
+    expect(rows).toHaveLength(4);
+  });
+});

--- a/packages/nextly/src/domains/versions/__tests__/working-draft-upgrade.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/working-draft-upgrade.integration.test.ts
@@ -1,0 +1,152 @@
+/**
+ * An existing database gains the working-draft constraint, and the constraint
+ * actually refuses a duplicate once it is there.
+ *
+ * A freshly created database gets the column and the index straight from the
+ * schema, so a test built on one would pass while proving nothing about the
+ * case that matters. This builds the PRE-CHANGE shape by hand — a historical
+ * artifact, deliberately not derived from today's definition — alongside an
+ * ordinary content table, because an orphan `dc_*` table is what makes
+ * drizzle-kit's resolver degrade to a CREATE-only pass that can add a table but
+ * never alter one. Without the orphan this would exercise the easy path.
+ *
+ * The final assertion is a WRITE. Introspection can report a column and an
+ * index while the constraint enforces nothing, and only a refused insert
+ * separates those.
+ */
+import { existsSync, mkdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import Database from "better-sqlite3";
+import { drizzle as drizzleSqlite } from "drizzle-orm/better-sqlite3";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { getDialectTablesForPush } from "../../../database/index";
+import { freshPushSchema } from "../../schema/pipeline/fresh-push";
+import { workingDraftKey } from "../working-draft-key";
+
+const TEST_DIR = join(
+  tmpdir(),
+  `nextly-working-draft-upgrade-${process.pid}-${Date.now()}`
+);
+const TEST_DB_PATH = join(TEST_DIR, "legacy.db");
+
+/** `nextly_versions` as it stood before the working-draft constraint. */
+const LEGACY_VERSIONS = `
+  CREATE TABLE "nextly_versions" (
+    "id" TEXT PRIMARY KEY NOT NULL,
+    "scope_kind" TEXT NOT NULL,
+    "scope_slug" TEXT NOT NULL,
+    "entry_id" TEXT NOT NULL,
+    "version_no" INTEGER,
+    "status" TEXT NOT NULL,
+    "is_autosave" INTEGER NOT NULL DEFAULT 0,
+    "snapshot" TEXT NOT NULL,
+    "label" TEXT,
+    "locale" TEXT,
+    "source_version_no" INTEGER,
+    "created_by" TEXT,
+    "created_at" INTEGER NOT NULL,
+    "updated_at" INTEGER NOT NULL,
+    "revision" INTEGER NOT NULL DEFAULT 0
+  )`;
+
+/** The orphan: ordinary user content, absent from the core-only push. */
+const CONTENT_TABLE = `
+  CREATE TABLE "dc_articles" (
+    "id" TEXT PRIMARY KEY,
+    "title" TEXT
+  )`;
+
+interface ColumnInfo {
+  name: string;
+}
+
+describe("working-draft constraint on a pre-change database", () => {
+  let sqlite: Database.Database;
+
+  beforeAll(() => {
+    if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true });
+    sqlite = new Database(TEST_DB_PATH);
+    sqlite.exec(LEGACY_VERSIONS);
+    sqlite.exec(CONTENT_TABLE);
+    // A working draft already stored under the old shape, so the upgrade is
+    // proven to run against real data rather than an empty table.
+    sqlite
+      .prepare(
+        `INSERT INTO nextly_versions
+           (id, scope_kind, scope_slug, entry_id, version_no, status,
+            is_autosave, snapshot, locale, created_at, updated_at)
+         VALUES (?, ?, ?, ?, NULL, 'draft', 0, ?, NULL, 1000, 1000)`
+      )
+      .run("v-1", "collection", "posts", "e-1", '{"title":"before"}');
+  });
+
+  afterAll(() => {
+    try {
+      sqlite?.close();
+    } catch {
+      // ignore teardown errors
+    }
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  const indexNames = (): string[] =>
+    (
+      sqlite
+        .prepare(`SELECT name FROM sqlite_master WHERE type = 'index'`)
+        .all() as Array<{ name: string }>
+    ).map(r => r.name);
+
+  const columnNames = (): string[] =>
+    (
+      sqlite
+        .prepare(`PRAGMA table_info("nextly_versions")`)
+        .all() as ColumnInfo[]
+    ).map(c => c.name);
+
+  it("adds the column and the index, and the index then refuses a duplicate", async () => {
+    // The premise: the old shape really is in place, and there really is an
+    // orphan for the resolver to trip over.
+    expect(columnNames()).not.toContain("draft_key");
+    expect(indexNames()).not.toContain("nextly_versions_working_draft_uidx");
+    expect(
+      sqlite
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type='table' AND name='dc_articles'`
+        )
+        .all()
+    ).toHaveLength(1);
+
+    const db = drizzleSqlite({ client: sqlite });
+    await freshPushSchema("sqlite", db, getDialectTablesForPush("sqlite"));
+
+    expect(columnNames()).toContain("draft_key");
+    expect(indexNames()).toContain("nextly_versions_working_draft_uidx");
+
+    // The row that was there before the upgrade is still there.
+    expect(
+      sqlite.prepare(`SELECT id FROM nextly_versions WHERE id = 'v-1'`).all()
+    ).toHaveLength(1);
+
+    // And the constraint does its job: two working drafts for one document and
+    // locale cannot both exist.
+    const key = workingDraftKey(
+      { scopeKind: "collection", scopeSlug: "posts", entryId: "e-2" },
+      null
+    );
+    const insertDraft = (id: string): void => {
+      sqlite
+        .prepare(
+          `INSERT INTO nextly_versions
+             (id, scope_kind, scope_slug, entry_id, version_no, status,
+              is_autosave, snapshot, locale, draft_key, created_at, updated_at)
+           VALUES (?, 'collection', 'posts', 'e-2', NULL, 'draft', 0, ?, NULL, ?, 1000, 1000)`
+        )
+        .run(id, '{"title":"x"}', key);
+    };
+    insertDraft("v-2");
+    expect(() => insertDraft("v-3")).toThrow(/UNIQUE constraint failed/);
+  });
+});

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -24,6 +24,7 @@ import type {
   VersionsWhereCondition,
 } from "./db-api";
 import type { PrunableVersion } from "./retention";
+import { workingDraftKey } from "./working-draft-key";
 
 const TABLE = "nextly_versions";
 
@@ -282,31 +283,39 @@ export class VersionsRepository {
       );
       return;
     }
-    await this.db.insert(
-      TABLE,
-      {
-        id: crypto.randomUUID(),
-        scopeKind: input.ref.scopeKind,
-        scopeSlug: input.ref.scopeSlug,
-        entryId: input.ref.entryId,
-        // A working draft is neither a durable history version (no sequence
-        // number) nor an autosave row; it is the sidecar draft head.
-        versionNo: null,
-        status: "draft",
-        isAutosave: false,
-        // Pre-stringified for the same cross-dialect reason as insertVersion:
-        // the transaction insert path binds this value straight into the driver
-        // query with no column-type awareness.
-        snapshot: serializedSnapshot,
-        label: null,
-        locale: input.locale ?? null,
-        sourceVersionNo: null,
-        createdBy: input.createdBy ?? null,
-        createdAt: now,
-        updatedAt: now,
-      },
-      { returning: [] }
-    );
+    const row = {
+      id: crypto.randomUUID(),
+      scopeKind: input.ref.scopeKind,
+      scopeSlug: input.ref.scopeSlug,
+      entryId: input.ref.entryId,
+      // A working draft is neither a durable history version (no sequence
+      // number) nor an autosave row; it is the sidecar draft head.
+      versionNo: null,
+      status: "draft",
+      isAutosave: false,
+      // Pre-stringified for the same cross-dialect reason as insertVersion:
+      // the transaction insert path binds this value straight into the driver
+      // query with no column-type awareness.
+      snapshot: serializedSnapshot,
+      label: null,
+      locale: input.locale ?? null,
+      // Carried only by this row class, and unique across it, so the database
+      // holds the one-per-document-per-locale rule the read above cannot.
+      draftKey: workingDraftKey(input.ref, input.locale ?? null),
+      sourceVersionNo: null,
+      createdBy: input.createdBy ?? null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    // A concurrent writer that committed its own draft between the read above
+    // and this insert makes the unique index refuse this row. That refusal is
+    // the point: without it both rows land and a later read, which takes the
+    // first of an unordered match, picks between them arbitrarily. The
+    // violation is left to travel — the write path above this owns turning it
+    // into an answer the caller can act on, and a repository has no way to know
+    // whether it is inside a caller's transaction, where PostgreSQL has already
+    // marked everything after the error unusable.
+    await this.db.insert(TABLE, row, { returning: [] });
   }
 
   /** Fetch the working draft (snapshot included) for a document in one locale. */

--- a/packages/nextly/src/domains/versions/working-draft-key.ts
+++ b/packages/nextly/src/domains/versions/working-draft-key.ts
@@ -1,0 +1,42 @@
+/**
+ * The value stored in `nextly_versions.draft_key`.
+ *
+ * A working draft is the one row class the table's sequence index cannot
+ * constrain: it carries no `version_no`, and SQL treats NULL as distinct from
+ * NULL, so a unique index over `(scope_kind, scope_slug, entry_id, version_no)`
+ * lets any number of them coexist. This column carries a value ONLY on a
+ * working draft, so a plain unique index over it alone constrains that class
+ * and leaves durable and autosave rows untouched — the same NULL tolerance
+ * `nextly_versions_seq_uidx` already relies on.
+ *
+ * A digest rather than the readable composite: the four inputs are bounded, but
+ * percent-encoding can triple a segment and MySQL's index key limit is 3072
+ * bytes, which utf8mb4 spends at 768 characters. Capping the length would let a
+ * truncation merge two documents into one key, which is precisely the failure
+ * the constraint exists to prevent. The row keeps all four source columns, so
+ * the value can always be recomputed.
+ *
+ * Segments are percent-encoded before joining so a delimiter occurring inside a
+ * slug or an id cannot forge a collision.
+ *
+ * @module domains/versions/working-draft-key
+ */
+import { createHash } from "node:crypto";
+
+import type { VersionRef } from "./versions-repository";
+
+/**
+ * The uniqueness key for the working draft of one document in one language.
+ *
+ * `null` locale is the unlocalized document, and encodes to the empty segment —
+ * unambiguous because encoding leaves every configured locale non-empty.
+ */
+export function workingDraftKey(
+  ref: VersionRef,
+  locale: string | null
+): string {
+  const joined = [ref.scopeKind, ref.scopeSlug, ref.entryId, locale ?? ""]
+    .map(encodeURIComponent)
+    .join(":");
+  return createHash("sha256").update(joined, "utf8").digest("hex");
+}

--- a/packages/nextly/src/schemas/versions/mysql.ts
+++ b/packages/nextly/src/schemas/versions/mysql.ts
@@ -43,6 +43,16 @@ export const nextlyVersionsMysql = mysqlTable(
     label: text("label"),
     locale: varchar("locale", { length: 32 }),
     sourceVersionNo: int("source_version_no"),
+    // Set ONLY on a working draft, to the digest of the four values that
+    // identify it (see workingDraftKey). NULL on durable and autosave rows, so
+    // the unique index below constrains working drafts alone: all three
+    // dialects allow unlimited NULLs in a unique index. The sequence index
+    // cannot do this job — a working draft carries no version_no, and NULL is
+    // distinct from NULL, so any number of them satisfy it.
+    // 64 = the fixed width of the sha256 hex digest workingDraftKey produces.
+    // A fixed width keeps this well inside InnoDB's 3072-byte index key limit,
+    // which a variable readable composite would not be.
+    draftKey: varchar("draft_key", { length: 64 }),
 
     // 191 to match users.id (varchar(191)); created_by holds a user id, which
     // is wider than the 36-char UUID used for this table's own id.
@@ -71,6 +81,8 @@ export const nextlyVersionsMysql = mysqlTable(
       table.entryId,
       table.versionNo
     ),
+    // One working draft per document per locale.
+    uniqueIndex("nextly_versions_working_draft_uidx").on(table.draftKey),
     index("nextly_versions_doc_recent_idx").on(
       table.scopeKind,
       table.scopeSlug,

--- a/packages/nextly/src/schemas/versions/postgres.ts
+++ b/packages/nextly/src/schemas/versions/postgres.ts
@@ -49,6 +49,13 @@ export const nextlyVersionsPg = pgTable(
     locale: text("locale"),
     // Restore lineage: the version_no a restore-forward copied from.
     sourceVersionNo: integer("source_version_no"),
+    // Set ONLY on a working draft, to the digest of the four values that
+    // identify it (see workingDraftKey). NULL on durable and autosave rows, so
+    // the unique index below constrains working drafts alone: all three
+    // dialects allow unlimited NULLs in a unique index. The sequence index
+    // cannot do this job — a working draft carries no version_no, and NULL is
+    // distinct from NULL, so any number of them satisfy it.
+    draftKey: text("draft_key"),
 
     createdBy: text("created_by"),
     createdAt: timestamp("created_at", { withTimezone: true })
@@ -81,6 +88,8 @@ export const nextlyVersionsPg = pgTable(
     uniqueIndex("nextly_versions_autosave_uidx")
       .on(table.scopeKind, table.scopeSlug, table.entryId, table.createdBy)
       .where(sql`${table.isAutosave} = true`),
+    // One working draft per document per locale.
+    uniqueIndex("nextly_versions_working_draft_uidx").on(table.draftKey),
     // The only hot read: this document, newest first.
     index("nextly_versions_doc_recent_idx").on(
       table.scopeKind,

--- a/packages/nextly/src/schemas/versions/sqlite.ts
+++ b/packages/nextly/src/schemas/versions/sqlite.ts
@@ -46,6 +46,13 @@ export const nextlyVersionsSqlite = sqliteTable(
     label: text("label"),
     locale: text("locale"),
     sourceVersionNo: integer("source_version_no"),
+    // Set ONLY on a working draft, to the digest of the four values that
+    // identify it (see workingDraftKey). NULL on durable and autosave rows, so
+    // the unique index below constrains working drafts alone: all three
+    // dialects allow unlimited NULLs in a unique index. The sequence index
+    // cannot do this job — a working draft carries no version_no, and NULL is
+    // distinct from NULL, so any number of them satisfy it.
+    draftKey: text("draft_key"),
 
     createdBy: text("created_by"),
     createdAt: integer("created_at", { mode: "timestamp" })
@@ -72,6 +79,8 @@ export const nextlyVersionsSqlite = sqliteTable(
       table.entryId,
       table.versionNo
     ),
+    // One working draft per document per locale.
+    uniqueIndex("nextly_versions_working_draft_uidx").on(table.draftKey),
     index("nextly_versions_doc_recent_idx").on(
       table.scopeKind,
       table.scopeSlug,


### PR DESCRIPTION
First of six PRs making pending changes work everywhere. Design: `2026-08-19-pending-changes-everywhere-design.md` (§3 PR1).

## The defect

`versions-repository.ts` stated, in its own comment, that a database constraint kept a document to one working draft per locale:

> "this shape is unambiguous and matches the partial unique index that keeps it to one per document per locale"

**That index did not exist on any dialect.** The table has two unique indexes and neither constrains a working draft:

- the sequence index only covers rows with a version number, and a working draft deliberately has none — and `NULL` never collides with `NULL`, so it constrains nothing here;
- the autosave index only covers autosave rows, and is declared on Postgres alone.

Writing a working draft is therefore *read, then insert*, and the transaction takes **no lock on the document**: the only locking read in that flow lives inside the status-transition guard, which returns immediately when a write names no status — and a working-draft save always names none.

**Reproduced before fixing**, with two transactions each reading before either writes:

```
expected [ { …(16) }, { …(16) } ] to have a length of 1 but got 2
```

Two working drafts for one document. `findWorkingDraft` then reads with `limit: 1` and no ordering, so which editor's work survives is whatever the database returns first, and promote or discard removes both.

## The fix

A `draft_key` column, set **only** on a working draft to a digest of the four values identifying it, and `NULL` on every other row. One ordinary `UNIQUE` index on that column then constrains working drafts alone, because all three dialects permit unlimited `NULL`s in a unique index.

**This is the pattern the table already uses.** `nextly_versions_seq_uidx` is a full unique index relying on exactly the same NULL tolerance, with the same index name across dialects — see its comment in `schemas/versions/mysql.ts`. This applies it to the second row class.

**Why a digest rather than a readable composite.** The four inputs are bounded at 32 + 255 + 36 + 32 characters, but percent-encoding can triple a segment and InnoDB's index key limit is 3072 bytes — 768 characters in utf8mb4. A readable key would need a length cap, and a cap that truncates merges two documents into one key, which is the exact failure the constraint exists to prevent. A fixed 64-character digest has no length to run out of, and the row keeps all four source columns so the value stays recomputable.

**A collision is left to travel rather than mapped here.** I first mapped it to a conflict error inside the repository and measured that this does not work: `PostgresAdapter.transaction` runs `classifyError` over anything thrown inside a transaction, so the domain error is converted back to a `DatabaseError`. Turning a collision into an answer the caller can act on belongs above the transaction, which is PR2's write path. Retrying in place was also rejected: PostgreSQL marks a transaction aborted after any statement error, so the follow-up write would fail there while succeeding on MySQL and SQLite, and one behaviour that differs by dialect is worse than one refused everywhere.

## Verification

- **The constraint refuses a duplicate through the production write path on Postgres AND MySQL** — two transactions, each reading before either writes, forced with a barrier rather than raced. The interleaving is deterministic; hoping two calls overlap proves nothing on the runs where they do not.
- **Durable and autosave rows are unconstrained** — four rows for one document, all carrying `NULL`, coexist.
- **SQLite asserts the index exists**, since it serializes writers and cannot express the concurrent case. That assertion was negative-controlled: pointed at a non-existent index name it fails, so it can distinguish.
- **An existing database gains both the column and the index**, proven by building the pre-change shape by hand alongside an orphan content table, upgrading it, and then writing: the pre-existing row survives and a duplicate is refused. A fresh-database test would have passed while proving nothing.
- Versions integration: 13 files / 63 tests green across all three dialects. Typecheck (both configs) and lint clean.

## Two things worth knowing

**This PR found the defect that became #1056.** Adding an indexed column to a core table broke the upgrade of every existing SQLite and MySQL database, because the degraded reconcile pass emits every index but never the column additions. That is fixed and merged; this branch is rebased on it, and the upgrade test above is what fails without it.

**fallow reports `warn`, one introduced duplication, deliberately not "fixed".** It is the parallel index block in `schemas/versions/mysql.ts` and `sqlite.ts` — pre-existing structural parallelism that adding one more index tipped over the threshold. I tried reducing it by trimming the shared comments and **measured the result: duplication went from 1 to 2**, because making the two files more alike is the opposite of the fix. The dialect-typed builders admit no clean extraction without casts, which the repo forbids. Restored the informative comments and left the warn.
