### PR TITLE
feat(admin): tell a field which document it is inside

### DIFF
--- a/.changeset/document-identity-for-fields.md
+++ b/.changeset/document-identity-for-fields.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Let a contributed field know which document it is being edited inside. `useDocumentIdentity()` reports the collection entry or Single around a field, and the Single editor now supplies that context where only the entry editor did before — so a plugin field can address the document it belongs to instead of only the value it was bound to.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -542,6 +542,7 @@ export function EntryForm({
   if (embedded) {
     return (
       <EntryFormContextProvider
+        kind="collection"
         entryId={entry?.id}
         collectionSlug={collection.name}
         isCreateMode={mode === "create"}

--- a/packages/admin/src/components/features/entries/EntryForm/EntryFormContext.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryFormContext.tsx
@@ -34,6 +34,38 @@ export interface EntryFormContextValue {
    * Whether the form is in create mode (vs edit mode).
    */
   isCreateMode: boolean;
+
+  /**
+   * Which family of document this form edits.
+   *
+   * Defaults to `"collection"`, so every existing provider keeps its meaning
+   * without naming it. A Single is not a collection entry — it has exactly one
+   * document, addressed by its own slug — and a consumer that guessed from the
+   * presence of an id would be wrong for a Single that has not been
+   * materialised yet.
+   */
+  kind: "collection" | "single";
+}
+
+/**
+ * Which document a field is being rendered inside.
+ *
+ * The plugin-facing shape, and deliberately NOT a versions scope. A field that
+ * wants to talk to any document API needs to know which document it is in;
+ * versions is one consumer of that and should not get to define the vocabulary
+ * for the rest. Mapping this to whatever a particular API wants is that API's
+ * job.
+ *
+ * `documentId` is absent while a collection entry is being created, because
+ * there is no document yet. A caller that must address one checks for it rather
+ * than inventing a placeholder.
+ */
+export interface DocumentIdentity {
+  kind: "collection" | "single";
+  /** The collection name, or the Single's slug. */
+  slug: string;
+  /** The saved document's id, absent until it has been created once. */
+  documentId?: string;
 }
 
 export interface EntryFormContextProviderProps {
@@ -51,6 +83,9 @@ export interface EntryFormContextProviderProps {
    * Whether the form is in create mode.
    */
   isCreateMode?: boolean;
+
+  /** Which family of document this form edits. Defaults to `"collection"`. */
+  kind?: "collection" | "single";
 
   /**
    * Child components.
@@ -89,6 +124,7 @@ export function EntryFormContextProvider({
   entryId,
   collectionSlug,
   isCreateMode = false,
+  kind = "collection",
   children,
 }: EntryFormContextProviderProps) {
   const value = useMemo(
@@ -96,8 +132,9 @@ export function EntryFormContextProvider({
       entryId,
       collectionSlug,
       isCreateMode,
+      kind,
     }),
-    [entryId, collectionSlug, isCreateMode]
+    [entryId, collectionSlug, isCreateMode, kind]
   );
 
   return (
@@ -172,4 +209,31 @@ export function useEntryFormContext(): EntryFormContextValue {
  */
 export function useOptionalEntryFormContext(): EntryFormContextValue | null {
   return useContext(EntryFormContext);
+}
+
+/**
+ * Which document the surrounding form is editing, or `null` outside one.
+ *
+ * Returns `null` rather than throwing, unlike {@link useEntryFormContext}. A
+ * field component is rendered by the entry editor, by the Single editor, and by
+ * previews and pickers that have no document at all — so "there is no document
+ * here" is an ordinary answer a caller has to handle, not a programming error.
+ * Throwing would make every such caller wrap this in a try/catch, and the ones
+ * that forgot would break the surface they were embedded in.
+ *
+ * @example
+ * ```tsx
+ * const document = useDocumentIdentity();
+ * // Recording anything against a document needs one that exists.
+ * const canRecord = document?.documentId !== undefined;
+ * ```
+ */
+export function useDocumentIdentity(): DocumentIdentity | null {
+  const context = useContext(EntryFormContext);
+  if (!context) return null;
+  return {
+    kind: context.kind,
+    slug: context.collectionSlug,
+    documentId: context.entryId,
+  };
 }

--- a/packages/admin/src/components/features/entries/EntryForm/EntryFormContext.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryFormContext.tsx
@@ -59,6 +59,25 @@ export interface EntryFormContextValue {
  * `documentId` is absent while a collection entry is being created, because
  * there is no document yet. A caller that must address one checks for it rather
  * than inventing a placeholder.
+ *
+ * ## Language is deliberately NOT here
+ *
+ * A document's identity is the same whichever language you are reading it in:
+ * `posts/abc123` in Spanish and in French is one document. Folding the active
+ * locale in would make this answer CHANGE as an author switches language, which
+ * is wrong for every consumer that only wanted to know which document it is —
+ * a related query, a link, a permission check — and convenient for the one that
+ * did want the locale.
+ *
+ * So a surface needing the active language gets its own reader beside this one
+ * rather than a widened `DocumentIdentity`. The admin already resolves it
+ * internally (`useEntryLocaleContext`, `useEditorLocale`); none of that is
+ * exported to plugins yet, and it becomes necessary when anything
+ * plugin-contributed stores something per-language.
+ *
+ * The same reasoning keeps versions out: what a recording is KEYED by —
+ * per author today, per document and locale later — is the versions layer's
+ * decision, made by mapping this identity onto its own scope.
  */
 export interface DocumentIdentity {
   kind: "collection" | "single";

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/useDocumentIdentity.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/useDocumentIdentity.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Which document a field is rendered inside.
+ *
+ * A field component receives a name and a control and nothing that says what it
+ * is editing, so anything addressing the document itself had to be given this
+ * ambiently. These cases pin the three answers a caller has to handle: a
+ * collection entry, a Single, and no document at all.
+ *
+ * @module components/features/entries/EntryForm/__tests__/useDocumentIdentity.test
+ */
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+
+import {
+  EntryFormContextProvider,
+  useDocumentIdentity,
+} from "../EntryFormContext";
+
+function inProvider(props: {
+  kind?: "collection" | "single";
+  collectionSlug: string;
+  entryId?: string;
+}) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <EntryFormContextProvider {...props}>{children}</EntryFormContextProvider>
+    );
+  };
+}
+
+describe("useDocumentIdentity", () => {
+  it("answers null outside any form, rather than throwing", () => {
+    // Field components also render in previews and pickers, which have no
+    // document. Throwing would make every caller wrap this, and the ones that
+    // forgot would break the surface they were embedded in.
+    const { result } = renderHook(() => useDocumentIdentity());
+
+    expect(result.current).toBeNull();
+  });
+
+  it("names a collection entry", () => {
+    const { result } = renderHook(() => useDocumentIdentity(), {
+      wrapper: inProvider({ collectionSlug: "posts", entryId: "e1" }),
+    });
+
+    expect(result.current).toEqual({
+      kind: "collection",
+      slug: "posts",
+      documentId: "e1",
+    });
+  });
+
+  it("names a Single, which the entry shape cannot express", () => {
+    // THE case this was extended for. A Single has one document addressed by
+    // its own slug, and a consumer guessing from the presence of an id would
+    // read it as a collection entry.
+    const { result } = renderHook(() => useDocumentIdentity(), {
+      wrapper: inProvider({
+        kind: "single",
+        collectionSlug: "homepage",
+        entryId: "601b",
+      }),
+    });
+
+    expect(result.current?.kind).toBe("single");
+    expect(result.current?.slug).toBe("homepage");
+  });
+
+  it("reports no documentId while an entry is being created", () => {
+    // There is no document yet, so anything addressing one must not be given a
+    // placeholder to address.
+    const { result } = renderHook(() => useDocumentIdentity(), {
+      wrapper: inProvider({ collectionSlug: "posts" }),
+    });
+
+    expect(result.current?.documentId).toBeUndefined();
+    // The control: the identity itself still exists, so a caller can tell
+    // "inside a form, not yet saved" from "no form at all". Collapsing those
+    // would make a create form look like a preview.
+    expect(result.current?.slug).toBe("posts");
+  });
+
+  it("defaults to a collection, so existing providers keep their meaning", () => {
+    const { result } = renderHook(() => useDocumentIdentity(), {
+      wrapper: inProvider({ collectionSlug: "posts", entryId: "e1" }),
+    });
+
+    expect(result.current?.kind).toBe("collection");
+  });
+});

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -31,6 +31,7 @@ import { z } from "zod";
 import { singleSourceFetcher } from "@admin/components/features/entries/entry-locale-source";
 import { AutosaveRecoveryBanner } from "@admin/components/features/entries/EntryForm/AutosaveRecoveryBanner";
 import { EntryFormContent } from "@admin/components/features/entries/EntryForm/EntryFormContent";
+import { EntryFormContextProvider } from "@admin/components/features/entries/EntryForm/EntryFormContext";
 import { EntryFormProvider } from "@admin/components/features/entries/EntryForm/EntryFormProvider";
 import { EntryFormSidebar } from "@admin/components/features/entries/EntryForm/EntryFormSidebar";
 import { EntryFormToolbarSlots } from "@admin/components/features/entries/EntryForm/EntryFormToolbarSlots";
@@ -524,159 +525,175 @@ export function SingleForm({
     // A single is only ever edited standalone, so unlike the entry editor there
     // is no embedded case to exclude.
     <UnsavedChangesGuard isDirty={isDirty} disabled={isSubmitting}>
-      <EntryLocaleProvider value={localeCtx}>
-        {/* Renders its child alone when there is no source — see the module. */}
-        <TranslationPanes
-          source={translationMode.source}
-          onExit={translationMode.onExit}
-          control={form.control}
-        >
-          <div className={cn("space-y-0", className)}>
-            <EntryFormProvider form={form} onSubmit={handleSubmit}>
-              <FormErrorSummary
-                errors={errors}
-                submitCount={submitCount}
-                className="mx-6 mt-3"
-              />
+      {/*
+        Which document the fields are inside. The entry editor has always
+        supplied this and the Single editor did not, so a field rendered here
+        could not tell what it was editing — which is fine for an input bound to
+        a name, and not fine for one that has to address the document itself.
 
-              <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-m-8">
-                {/* Main column */}
-                <div className="flex-1 min-w-0 flex flex-col">
-                  {/* Why: same fix as EntryForm — the parent flex's @4xl/content:-m-8
+        `isCreateMode` is false by construction: a Single is materialised before
+        its form renders, so there is no create mode to be in.
+      */}
+      <EntryFormContextProvider
+        kind="single"
+        collectionSlug={schema.slug}
+        entryId={document.id}
+        isCreateMode={false}
+      >
+        <EntryLocaleProvider value={localeCtx}>
+          {/* Renders its child alone when there is no source — see the module. */}
+          <TranslationPanes
+            source={translationMode.source}
+            onExit={translationMode.onExit}
+            control={form.control}
+          >
+            <div className={cn("space-y-0", className)}>
+              <EntryFormProvider form={form} onSubmit={handleSubmit}>
+                <FormErrorSummary
+                  errors={errors}
+                  submitCount={submitCount}
+                  className="mx-6 mt-3"
+                />
+
+                <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-m-8">
+                  {/* Main column */}
+                  <div className="flex-1 min-w-0 flex flex-col">
+                    {/* Why: same fix as EntryForm — the parent flex's @4xl/content:-m-8
                 already cancels PageContainer's px-8, so wrapping the header / meta
                 strip in another -mx-8 was double-negative and pushed them
                 past the page edges. */}
-                  <EntrySystemHeader
-                    autosaveEnabled={autosaveScope !== null}
-                    autosaveStatus={autosave.status}
-                    autosaveLastSavedAt={autosave.lastSavedAt}
-                    mode="edit"
-                    titleField={titleField}
-                    historyFields={schema.fields}
-                    historyEnabled={historyEnabledFrom(schema)}
-                    hasStatus={hasStatus}
-                    isSubmitting={isSubmitting}
-                    isDirty={isDirty}
-                    entry={entryLike}
-                    collectionSlug={schema.slug}
-                    /* i18n: forward the active locale + switch handler so a localized single shows
+                    <EntrySystemHeader
+                      autosaveEnabled={autosaveScope !== null}
+                      autosaveStatus={autosave.status}
+                      autosaveLastSavedAt={autosave.lastSavedAt}
+                      mode="edit"
+                      titleField={titleField}
+                      historyFields={schema.fields}
+                      historyEnabled={historyEnabledFrom(schema)}
+                      hasStatus={hasStatus}
+                      isSubmitting={isSubmitting}
+                      isDirty={isDirty}
+                      entry={entryLike}
+                      collectionSlug={schema.slug}
+                      /* i18n: forward the active locale + switch handler so a localized single shows
                    the primary header language switcher (the sidebar pills are unavailable when
                    the rail is collapsed or on narrow layouts). The switcher self-hides when the
                    single isn't localized / localization isn't configured. */
-                    locale={locale}
-                    onLocaleChange={onLocaleChange}
-                    localized={schema.localized === true}
-                    toolbarSlot={
-                      <EntryFormToolbarSlots
-                        context="single"
-                        controllerField={controllerNames[0]}
-                      />
-                    }
-                    onSaveDraft={() => {
-                      void handleSubmit(undefined, "save-draft");
-                    }}
-                    onPublish={() => {
-                      void handleSubmit(undefined, "publish");
-                    }}
-                    onSaveChanges={() => {
-                      void handleSubmit(undefined, "save-changes");
-                    }}
-                    onUnpublish={() => {
-                      void handleSubmit(undefined, "unpublish");
-                    }}
-                    onCancel={handleCancel}
-                    onViewApi={onViewApi}
-                    /* Why: Singles share the Show JSON dialog with collections,
+                      locale={locale}
+                      onLocaleChange={onLocaleChange}
+                      localized={schema.localized === true}
+                      toolbarSlot={
+                        <EntryFormToolbarSlots
+                          context="single"
+                          controllerField={controllerNames[0]}
+                        />
+                      }
+                      onSaveDraft={() => {
+                        void handleSubmit(undefined, "save-draft");
+                      }}
+                      onPublish={() => {
+                        void handleSubmit(undefined, "publish");
+                      }}
+                      onSaveChanges={() => {
+                        void handleSubmit(undefined, "save-changes");
+                      }}
+                      onUnpublish={() => {
+                        void handleSubmit(undefined, "unpublish");
+                      }}
+                      onCancel={handleCancel}
+                      onViewApi={onViewApi}
+                      /* Why: Singles share the Show JSON dialog with collections,
                  but at the /api/singles/{slug} URL pattern. Passing
                  `scope="single"` routes the dialog through singleApi
                  instead of entryApi. */
-                    scope="single"
-                    lockIdentity
-                    isRailCollapsed={railCollapsed}
-                    onToggleRail={toggleRail}
-                  />
-                  <EntryMetaStrip
-                    slugField={slugField}
-                    hasStatus={hasStatus}
-                    status={documentStatus}
-                    isRailCollapsed={railCollapsed}
-                    lockSlug
-                  />
+                      scope="single"
+                      lockIdentity
+                      isRailCollapsed={railCollapsed}
+                      onToggleRail={toggleRail}
+                    />
+                    <EntryMetaStrip
+                      slugField={slugField}
+                      hasStatus={hasStatus}
+                      status={documentStatus}
+                      isRailCollapsed={railCollapsed}
+                      lockSlug
+                    />
 
-                  {/* Inside the main column, below the header, matching the entry
+                    {/* Inside the main column, below the header, matching the entry
                   editor. Placed above the flex row it sat UNDER the sticky
                   header, which intercepted pointer events: the offer was
                   visible and its buttons were not clickable. */}
-                  {recovery.offer ? (
-                    <AutosaveRecoveryBanner
-                      savedAt={recovery.offer.savedAt}
-                      onRestore={restoreRecovery}
-                      onDismiss={recovery.dismiss}
-                      className="mx-6 mt-3"
-                    />
-                  ) : null}
+                    {recovery.offer ? (
+                      <AutosaveRecoveryBanner
+                        savedAt={recovery.offer.savedAt}
+                        onRestore={restoreRecovery}
+                        onDismiss={recovery.dismiss}
+                        className="mx-6 mt-3"
+                      />
+                    ) : null}
 
-                  {/* The language panel, inline. The rail that otherwise carries it
+                    {/* The language panel, inline. The rail that otherwise carries it
                   is `hidden @4xl/content:flex`, so this is the exact
                   complement: shown only where the rail is not, and rendered
                   unconditionally once the author collapses the rail. Without
                   it a single loses its language workflow entirely at narrow
                   widths, which is the failure this panel exists to remove. */}
-                  {localizationEnabled && (
-                    <div
-                      className={cn(
-                        "px-6 pt-4",
-                        !railCollapsed && "@4xl/content:hidden"
-                      )}
-                    >
-                      <LanguagePanel
-                        {...(singleTranslations === undefined
-                          ? {}
-                          : { translations: singleTranslations })}
-                        {...(locale === undefined
-                          ? {}
-                          : { activeLocale: locale })}
-                        {...(onLocaleChange === undefined
-                          ? {}
-                          : { onSelect: onLocaleChange })}
-                        hasStatus={hasStatus}
-                      />
-                    </div>
-                  )}
+                    {localizationEnabled && (
+                      <div
+                        className={cn(
+                          "px-6 pt-4",
+                          !railCollapsed && "@4xl/content:hidden"
+                        )}
+                      >
+                        <LanguagePanel
+                          {...(singleTranslations === undefined
+                            ? {}
+                            : { translations: singleTranslations })}
+                          {...(locale === undefined
+                            ? {}
+                            : { activeLocale: locale })}
+                          {...(onLocaleChange === undefined
+                            ? {}
+                            : { onSelect: onLocaleChange })}
+                          hasStatus={hasStatus}
+                        />
+                      </div>
+                    )}
 
-                  {mainFields.length > 0 && (
-                    <div className="@4xl/content:p-8 pt-6">
-                      <EntryFormContent
-                        fields={mainFields}
-                        disabled={isSubmitting}
-                        withCard
-                      />
+                    {mainFields.length > 0 && (
+                      <div className="@4xl/content:p-8 pt-6">
+                        <EntryFormContent
+                          fields={mainFields}
+                          disabled={isSubmitting}
+                          withCard
+                        />
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Rail (collapsible). Same shape and width as collections. */}
+                  {!railCollapsed && (
+                    <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
+                      <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
+                        <EntryFormSidebar
+                          mode="edit"
+                          entry={entryLike}
+                          hasStatus={hasStatus}
+                          isDirty={isDirty}
+                          {...(locale === undefined ? {} : { locale })}
+                          {...(onLocaleChange === undefined
+                            ? {}
+                            : { onLocaleChange })}
+                        />
+                      </div>
                     </div>
                   )}
                 </div>
-
-                {/* Rail (collapsible). Same shape and width as collections. */}
-                {!railCollapsed && (
-                  <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
-                    <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
-                      <EntryFormSidebar
-                        mode="edit"
-                        entry={entryLike}
-                        hasStatus={hasStatus}
-                        isDirty={isDirty}
-                        {...(locale === undefined ? {} : { locale })}
-                        {...(onLocaleChange === undefined
-                          ? {}
-                          : { onLocaleChange })}
-                      />
-                    </div>
-                  </div>
-                )}
-              </div>
-            </EntryFormProvider>
-          </div>
-        </TranslationPanes>
-      </EntryLocaleProvider>
+              </EntryFormProvider>
+            </div>
+          </TranslationPanes>
+        </EntryLocaleProvider>
+      </EntryFormContextProvider>
     </UnsavedChangesGuard>
   );
 }

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -80,6 +80,17 @@ export { useRecentActivity } from "./hooks/queries/useRecentActivity";
 export { useDebouncedValue } from "./hooks/useDebouncedValue";
 // Permission gating (D36) — client-side UX checks for admin + plugin UI.
 export { useCan } from "./hooks/useCan";
+/**
+ * Which document a field is rendered inside.
+ *
+ * Exported for the plugin surface: a contributed field that has to address the
+ * document — to record against it, to query it, to link to it — cannot derive
+ * that from the props a field receives, which name a value and nothing else.
+ */
+export {
+  useDocumentIdentity,
+  type DocumentIdentity,
+} from "./components/features/entries/EntryForm/EntryFormContext";
 export { Can } from "./components/guards/Can";
 export type { CanProps } from "./components/guards/Can";
 export { useRowSelection } from "./hooks/useRowSelection";

--- a/packages/plugin-sdk/src/admin.ts
+++ b/packages/plugin-sdk/src/admin.ts
@@ -13,6 +13,18 @@ export {
   registerComponents,
   registerKnownPlugin,
 } from "@nextlyhq/admin";
+
+/**
+ * Which document the surrounding form is editing, or `null` outside one
+ * (@experimental).
+ *
+ * A field component receives a name and a control and nothing that says which
+ * document it is inside, so anything addressing the document itself — a
+ * recovery point, a related query, a link — had no way to ask. `null` is an
+ * ordinary answer rather than an error: field components also render in
+ * previews and pickers, which have no document.
+ */
+export { useDocumentIdentity, type DocumentIdentity } from "@nextlyhq/admin";
 export type { ComponentPath } from "@nextlyhq/admin";
 
 /**


### PR DESCRIPTION
Groundwork for B-3's second half. A field component receives a `name` and a
`control` and **nothing that says which document it is editing** — so anything
addressing the document itself has no way to ask.

The page builder needs that to record a recovery point, but the gap is not
specific to it: any contributed field wanting to query the document, link to it,
or record against it has the same problem.

## What was actually missing

The entry editor has carried this context since it was written, and its docblock
says it exists "to provide entry-level information like entryId and
collectionSlug to deeply nested field components".

**The Single editor never supplied it.** So the answer existed for one of the
two surfaces a field renders in, and a field could not tell whether it was
getting `null` because there was no document or because nobody had said.

## Three decisions

**Identity, not a versions scope.** The exported shape is
`{ kind, slug, documentId? }`, not `VersionScope`. Versions is one consumer of
"which document is this" and should not define the vocabulary for the rest — a
field wanting to run a related query needs the same fact and nothing to do with
history. Mapping identity onto a particular API's shape is that API's job. There
is a negative control on this in the verification below.

**`kind` is explicit, not inferred.** A Single has exactly one document
addressed by its own slug; a consumer guessing from the presence of an id reads
it as a collection entry. It defaults to `"collection"`, so every existing
provider keeps its meaning, and both editors now name it rather than leaning on
the default.

**`null` outside a form, rather than throwing.** Field components also render in
previews and pickers, which have no document. Throwing would make every caller
wrap this, and the ones that forgot would break the surface they were embedded
in. `null` is an ordinary answer a caller handles.

## Verification

**5 tests**, covering the three answers a caller must handle — a collection
entry, a Single, and no document — plus a create-mode entry, where the identity
exists but `documentId` does not. That last one carries its own control: the
slug is still asserted, so "inside a form, not yet saved" cannot collapse into
"no form at all".

Break-verified, control run green first, restores confirmed byte-identical:

| stub | failed |
|---|---|
| `kind` not threaded through the provider | `names a Single, which the entry shape cannot express` |
| the hook throws outside a provider | `answers null outside any form, rather than throwing` |

Each failed only the test naming its property.

**A negative control on the plugin surface**: `VersionScope` must not appear in
`plugin-sdk/src/admin.ts`, and does not. That is the check that the abstraction
actually holds rather than being described as holding.

`packages/admin`: 2,401 tests, **15 failing across 4 files — identical to
`origin/main`**, a pre-existing baseline this does not touch.

**The 128 deleted lines in `SingleForm.tsx` are re-indentation**, from wrapping
its tree in the new provider. Verified rather than asserted: every removed line
reappears among the additions, and the count of removed content absent from the
additions is **0**.

## What is NOT verified here

**That `SingleForm` supplies this to a real field is verified by types and by
the provider being in the render tree, not by observation.** The next PR — the
page builder consuming it to record checkpoints — is where that becomes
observable in a browser, and I would rather say so than let a green unit suite
imply more than it covers.