### PR TITLE
fix(nextly): hold a status-less edit on every collection write path

### DIFF
--- a/.changeset/draft-split-every-write-path.md
+++ b/.changeset/draft-split-every-write-path.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Hold a status-less edit on every collection write path.
+
+Editing a published document on a drafts-enabled collection stores the change
+and leaves the live row alone. That was true only of the interactive path: the
+same edit made through the transaction API or a bulk update went straight to
+the live row, so it reached the public site without anyone publishing it.

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-split-write-paths.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-split-write-paths.integration.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The draft/published split holds on EVERY collection write path.
+ *
+ * A status-less update to a published, drafts-enabled document must store the
+ * pending edit and leave the live row alone. That was true only of the pooled
+ * `updateEntry` path: the eligibility predicate had one call site, so the
+ * transaction-owning surface the Direct API and plugins use, and the batch
+ * surface underneath bulk updates, wrote straight to the live row.
+ *
+ * Each case asserts BOTH halves, in the same test. "The live row is unchanged"
+ * is satisfied just as well by a write that stored nothing at all, so the
+ * pending change has to be shown to exist beside it — otherwise a system that
+ * silently dropped the edit would pass.
+ *
+ * `updateEntry` is included as the control. It passes before the fix and after
+ * it, which is what separates "the test works" from "the surface works".
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../../plugins/test-nextly";
+import type { CollectionEntryService } from "../../../../services/collections/collection-entry-service";
+import type { CollectionsHandler } from "../../../../services/collections-handler";
+
+let handle: TestNextly | undefined;
+
+afterEach(async () => {
+  await handle?.destroy();
+  handle = undefined;
+});
+
+const COLLECTION = "wpposts";
+const TABLE = "dc_wpposts";
+
+async function boot(): Promise<CollectionEntryService> {
+  handle = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: COLLECTION,
+        status: true,
+        versions: { drafts: true },
+        fields: [text({ name: "title" }), text({ name: "body" })],
+      }),
+    ],
+  });
+  return (
+    handle.getService("collectionsHandler") as CollectionsHandler
+  ).getEntryService() as CollectionEntryService;
+}
+
+/** A published document to edit. */
+async function publish(entries: CollectionEntryService): Promise<string> {
+  const created = await entries.createEntry(
+    { collectionName: COLLECTION, overrideAccess: true },
+    { title: "live title", body: "live body", status: "published" }
+  );
+  return (created.data as { id: string }).id;
+}
+
+async function liveRow(id: string): Promise<{ title: string; body: string }> {
+  const rows = await handle!.adapter.select<{ title: string; body: string }>(
+    TABLE,
+    { where: { and: [{ column: "id", op: "=", value: id }] }, limit: 1 }
+  );
+  return rows[0];
+}
+
+/** The pending change for a document, if the split stored one. */
+async function workingDrafts(id: string): Promise<{ snapshot: unknown }[]> {
+  return handle!.adapter.select<{ snapshot: unknown }>("nextly_versions", {
+    where: {
+      and: [
+        { column: "entryId", op: "=", value: id },
+        { column: "isAutosave", op: "=", value: false },
+        { column: "versionNo", op: "IS NULL" },
+        { column: "status", op: "=", value: "draft" },
+      ],
+    },
+  });
+}
+
+describe("draft/published split on every write path (integration)", () => {
+  it("holds the edit on updateEntry (the control)", async () => {
+    const entries = await boot();
+    const id = await publish(entries);
+
+    await entries.updateEntry(
+      { collectionName: COLLECTION, entryId: id, overrideAccess: true },
+      { body: "edited body" }
+    );
+
+    expect(await workingDrafts(id)).toHaveLength(1);
+    expect((await liveRow(id)).body).toBe("live body");
+  });
+
+  it("holds the edit on updateEntryInTransaction", async () => {
+    const entries = await boot();
+    const id = await publish(entries);
+
+    await handle!.adapter.transaction(tx =>
+      entries.updateEntryInTransaction(
+        tx as never,
+        { collectionName: COLLECTION, entryId: id, overrideAccess: true },
+        { body: "edited body" }
+      )
+    );
+
+    expect(await workingDrafts(id)).toHaveLength(1);
+    expect((await liveRow(id)).body).toBe("live body");
+  });
+
+  it("holds the edit on a bulk update", async () => {
+    const entries = await boot();
+    const first = await publish(entries);
+    const second = await publish(entries);
+
+    // More than one entry, so the batch shape is real rather than a batch of one.
+    await entries.updateEntries({ collectionName: COLLECTION }, [
+      { id: first, data: { body: "edited body" } },
+      { id: second, data: { body: "edited body" } },
+    ]);
+
+    for (const id of [first, second]) {
+      expect(await workingDrafts(id)).toHaveLength(1);
+      expect((await liveRow(id)).body).toBe("live body");
+    }
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4425,6 +4425,51 @@ export class CollectionMutationService extends BaseService {
   }
 
   /**
+   * Whether this write should hold its edit as a working draft, and the
+   * component schemas the decision needed.
+   *
+   * One implementation of the question for every write path. Asked separately
+   * in each of them, the three answers could drift, and a surface that answered
+   * "no" where the others answered "yes" would publish an edit nobody published
+   * — which is the shape of the defect this exists to prevent.
+   */
+  private async resolveWorkingDraftHold(args: {
+    collection: unknown;
+    fields: FieldDefinition[];
+    /** The status this write names, if any. */
+    namedStatus: unknown;
+    /** The committed status of the row being written. */
+    liveStatus: unknown;
+  }): Promise<{ hold: boolean; componentSchemas: ComponentSchemas | null }> {
+    const collectionHasStatus =
+      (args.collection as { status?: boolean }).status === true;
+    const versionsConfig = (args.collection as Record<string, unknown>)
+      .versions as ResolvedVersionsConfig | null | undefined;
+    const documentLocalized =
+      (args.collection as { localized?: boolean }).localized === true;
+    // Resolved only once the cheap disqualifiers pass, so a collection the
+    // split can never take never pays for a registry read.
+    const componentSchemas =
+      collectionHasStatus &&
+      versionsConfig?.drafts?.enabled === true &&
+      !documentLocalized &&
+      !hasPasswordField(args.fields)
+        ? await resolveComponentSchemas(args.fields as unknown as FieldConfig[])
+        : null;
+    const hold =
+      isDraftSplitEligible({
+        collectionHasStatus,
+        draftsVersioningEnabled: versionsConfig?.drafts?.enabled === true,
+        documentLocalized,
+        fields: args.fields as unknown as FieldConfig[],
+        componentSchemas,
+      }) &&
+      args.namedStatus === undefined &&
+      args.liveStatus === "published";
+    return { hold, componentSchemas };
+  }
+
+  /**
    * The document a working draft should now hold, after this save.
    *
    * Accumulates onto the draft already stored rather than re-deriving from the
@@ -8021,16 +8066,38 @@ export class CollectionMutationService extends BaseService {
         });
       }
 
-      const [updated] = await tx.update<unknown>(
-        tableName,
-        {
-          ...stripImmutableSystemFields(finalData, "collection"),
-          updatedAt: nowForTxUpdate,
-          ...(txUpdateStamp ? { first_published_at: txUpdateStamp } : {}),
-        },
-        this.whereEq("id", params.entryId),
-        { returning: "*" }
-      );
+      // The same eligibility question the pooled path asks, through the same
+      // predicate: a status-less update to a published document on a
+      // drafts-enabled collection holds the edit instead of writing the live
+      // row. Asked here because this surface reaches the row write without
+      // passing through that path, which is why an update through the
+      // transaction API published an edit its author had not published.
+      const {
+        hold: txStoreAsWorkingDraft,
+        componentSchemas: txSplitComponentSchemas,
+      } = await this.resolveWorkingDraftHold({
+        collection,
+        fields,
+        namedStatus: finalData.status,
+        liveStatus: existingEntry.status,
+      });
+
+      // Skip the live-row UPDATE for a held edit; the pending change is stored
+      // below instead. `updated` still carries a row so everything after this
+      // reports the document as it stands — which, for a held edit, is the
+      // published content the public still sees.
+      const [updated] = txStoreAsWorkingDraft
+        ? [existingEntry]
+        : await tx.update<unknown>(
+            tableName,
+            {
+              ...stripImmutableSystemFields(finalData, "collection"),
+              updatedAt: nowForTxUpdate,
+              ...(txUpdateStamp ? { first_published_at: txUpdateStamp } : {}),
+            },
+            this.whereEq("id", params.entryId),
+            { returning: "*" }
+          );
 
       if (!updated) {
         return {
@@ -8089,23 +8156,64 @@ export class CollectionMutationService extends BaseService {
       // after the delete+insert below would report the new ids as the old ones.
       // The pre-update parent row plus its current (pre-rewrite) component and
       // m2m relations, read on `tx`.
-      const { document: previousDocument } = await this.readTxDocumentParts(
-        tx,
-        {
+      const { documentParts: previousParts, document: previousDocument } =
+        await this.readTxDocumentParts(tx, {
           collectionName: params.collectionName,
           tableName,
           entryId: params.entryId,
           parentRow: this.readShapeEventDocument(existingEntry, fields),
           fields,
           manyToManyFields,
-          needsRelations: previousNeedsRelations,
-        }
-      );
+          // A held edit needs the live relations whether or not anything is
+          // being recorded: they are the base the pending change accumulates
+          // onto, and without them the draft would drop every component and
+          // relationship the author had not touched in this save.
+          needsRelations: previousNeedsRelations || txStoreAsWorkingDraft,
+        });
+
+      // Store the pending edit rather than the live row, through the same
+      // method the pooled path uses so the two cannot answer differently.
+      let txWorkingDraftDocument: Record<string, unknown> | undefined;
+      if (txStoreAsWorkingDraft) {
+        ({ workingDraftDocument: txWorkingDraftDocument } =
+          await this.storeWorkingDraftInTx(tx, {
+            collection,
+            collectionHasStatus:
+              (collection as { status?: boolean }).status === true,
+            // This surface writes no component subtrees of its own, so the
+            // draft's components come from the live read alone.
+            componentFieldData: {},
+            fields,
+            manyToManyData,
+            params: {
+              collectionName: params.collectionName,
+              entryId: params.entryId,
+              user: params.user,
+            },
+            parentRow: this.readShapeEventDocument(
+              {
+                ...existingEntry,
+                ...stripImmutableSystemFields(finalData, "collection"),
+              },
+              fields
+            ),
+            snapshotComponents: previousParts.components,
+            snapshotM2M: previousParts.manyToMany,
+            splitComponentSchemas: txSplitComponentSchemas,
+            updatePayload: finalData,
+          }));
+      }
 
       // Handle many-to-many relationships on the caller's transaction so the
-      // junction writes commit atomically with the update.
+      // junction writes commit atomically with the update. Skipped for a held
+      // edit: the junction rows ARE live content, so rewriting them would put
+      // the pending relationship change on the public site while the rest of
+      // the edit waits.
       for (const field of manyToManyFields) {
-        if (manyToManyData[field.name] !== undefined) {
+        if (
+          !txStoreAsWorkingDraft &&
+          manyToManyData[field.name] !== undefined
+        ) {
           await this.relationshipService.deleteManyToManyRelations(
             params.collectionName,
             params.entryId,
@@ -8149,15 +8257,19 @@ export class CollectionMutationService extends BaseService {
           manyToManyFields,
           needsRelations,
         });
-      await this.captureTxVersion(tx, {
-        collectionName: params.collectionName,
-        entryId: params.entryId,
-        contentStatus: (updated as { status?: unknown }).status,
-        createdBy: params.user?.id ?? null,
-        versionsConfig,
-        documentParts: updatedParts,
-        fields,
-      });
+      // A held edit records no durable version: nothing was published, and a
+      // version here would enter the history as though it had been.
+      if (!txStoreAsWorkingDraft) {
+        await this.captureTxVersion(tx, {
+          collectionName: params.collectionName,
+          entryId: params.entryId,
+          contentStatus: (updated as { status?: unknown }).status,
+          createdBy: params.user?.id ?? null,
+          versionsConfig,
+          documentParts: updatedParts,
+          fields,
+        });
+      }
       const eventFields = await this.webhookFieldTreeIfRecording(
         params.collectionName,
         fields,
@@ -8254,7 +8366,10 @@ export class CollectionMutationService extends BaseService {
         success: true,
         statusCode: 200,
         message: "Entry updated successfully",
-        data: updated,
+        // A held edit answers with the pending document, not the live row. The
+        // caller asked for its own change back; returning the published content
+        // it did not write reads as the write having been ignored.
+        data: txWorkingDraftDocument ?? updated,
         eventRecorded,
         revalidationIntent,
       };
@@ -9605,16 +9720,35 @@ export class CollectionMutationService extends BaseService {
         });
       }
 
-      const [updated] = await tx.update<unknown>(
-        tableName,
-        {
-          ...stripImmutableSystemFields(finalData, "collection"),
-          updatedAt: nowForBulkUpdate,
-          ...(bulkUpdateStamp ? { first_published_at: bulkUpdateStamp } : {}),
-        },
-        this.whereEq("id", entryId),
-        { returning: "*" }
-      );
+      // The same eligibility question the other two paths ask, through the same
+      // predicate. Without it a bulk update publishes every held edit in the
+      // batch, which is the widest form of the defect: one call, many documents.
+      const {
+        hold: bulkStoreAsWorkingDraft,
+        componentSchemas: bulkSplitComponentSchemas,
+      } = await this.resolveWorkingDraftHold({
+        collection,
+        fields,
+        namedStatus: finalData.status,
+        liveStatus: existingEntry.status,
+      });
+
+      // Skip the live-row UPDATE for a held edit; the pending change is stored
+      // below instead.
+      const [updated] = bulkStoreAsWorkingDraft
+        ? [existingEntry]
+        : await tx.update<unknown>(
+            tableName,
+            {
+              ...stripImmutableSystemFields(finalData, "collection"),
+              updatedAt: nowForBulkUpdate,
+              ...(bulkUpdateStamp
+                ? { first_published_at: bulkUpdateStamp }
+                : {}),
+            },
+            this.whereEq("id", entryId),
+            { returning: "*" }
+          );
 
       if (!updated) {
         return {
@@ -9672,24 +9806,59 @@ export class CollectionMutationService extends BaseService {
       // so a relationship-only update still lists the changed field: reading m2m
       // after the delete+insert below would report the new ids as the old ones.
       // The pre-update parent row plus its current (pre-rewrite) relations on `tx`.
-      const { document: previousDocument } = await this.readTxDocumentParts(
-        tx,
-        {
+      const { documentParts: previousParts, document: previousDocument } =
+        await this.readTxDocumentParts(tx, {
           collectionName: params.collectionName,
           tableName,
           entryId,
           parentRow: this.readShapeEventDocument(existingEntry, fields),
           fields,
           manyToManyFields,
-          needsRelations: previousNeedsRelations,
-        }
-      );
+          // A held edit needs the live relations regardless of what is being
+          // recorded: they are the base the pending change accumulates onto.
+          needsRelations: previousNeedsRelations || bulkStoreAsWorkingDraft,
+        });
+
+      // Store the pending edit rather than the live row, through the same
+      // method the other two paths use.
+      let bulkWorkingDraftDocument: Record<string, unknown> | undefined;
+      if (bulkStoreAsWorkingDraft) {
+        ({ workingDraftDocument: bulkWorkingDraftDocument } =
+          await this.storeWorkingDraftInTx(tx, {
+            collection,
+            collectionHasStatus:
+              (collection as { status?: boolean }).status === true,
+            componentFieldData: {},
+            fields,
+            manyToManyData,
+            params: {
+              collectionName: params.collectionName,
+              entryId,
+              user: params.user,
+            },
+            parentRow: this.readShapeEventDocument(
+              {
+                ...existingEntry,
+                ...stripImmutableSystemFields(finalData, "collection"),
+              },
+              fields
+            ),
+            snapshotComponents: previousParts.components,
+            snapshotM2M: previousParts.manyToMany,
+            splitComponentSchemas: bulkSplitComponentSchemas,
+            updatePayload: finalData,
+          }));
+      }
 
       // Handle many-to-many relationships on the caller's transaction so the
       // junction writes commit atomically with the update.
       const txExecutor = tx.getDrizzle<RelationshipDbExecutor>();
       for (const field of manyToManyFields) {
-        if (manyToManyData[field.name] !== undefined) {
+        // Skipped for a held edit: junction rows are live content.
+        if (
+          !bulkStoreAsWorkingDraft &&
+          manyToManyData[field.name] !== undefined
+        ) {
           // Delete existing relations
           await this.relationshipService.deleteManyToManyRelations(
             params.collectionName,
@@ -9734,15 +9903,18 @@ export class CollectionMutationService extends BaseService {
           manyToManyFields,
           needsRelations,
         });
-      await this.captureTxVersion(tx, {
-        collectionName: params.collectionName,
-        entryId,
-        contentStatus: (updated as { status?: unknown }).status,
-        createdBy: params.user?.id ?? null,
-        versionsConfig,
-        documentParts: updatedParts,
-        fields,
-      });
+      // A held edit records no durable version: nothing was published.
+      if (!bulkStoreAsWorkingDraft) {
+        await this.captureTxVersion(tx, {
+          collectionName: params.collectionName,
+          entryId,
+          contentStatus: (updated as { status?: unknown }).status,
+          createdBy: params.user?.id ?? null,
+          versionsConfig,
+          documentParts: updatedParts,
+          fields,
+        });
+      }
       const eventFields = await this.webhookFieldTreeIfRecording(
         params.collectionName,
         fields,
@@ -9847,7 +10019,8 @@ export class CollectionMutationService extends BaseService {
         success: true,
         statusCode: 200,
         message: "Entry updated successfully",
-        data: updated,
+        // A held edit answers with the pending document, not the live row.
+        data: bulkWorkingDraftDocument ?? updated,
         eventRecorded,
         revalidationIntent,
       };


### PR DESCRIPTION
PR 2b of six. Design: `2026-08-19-pending-changes-everywhere-design.md` §3 PR2. Follows #1061, which extracted the write this calls.

**This PR changes behaviour**, deliberately: a status-less update to a published, drafts-enabled document through the transaction API or a bulk update now HOLDS the edit instead of publishing it.

## The defect, observed

`isDraftSplitEligible` had one call site. `updateEntryInTransaction` (the Direct API's transaction surface, used by importers and plugins) and `updateSingleEntryInTransaction` (underneath bulk updates) had none, so both wrote the live row unconditionally.

The new suite covers all three paths. `updateEntry` is included as the **control** — it passed before this change and after it, which is what separates "the test works" from "the surface works". The other two failed:

```
expected [] to have a length of 1          ← no pending change was stored
expected 'edited body' to be 'live body'   ← and the edit went to the live row
```

I measured the second one deliberately, by flipping the assertion order, because the first assertion fires first and would otherwise have left the actual harm unobserved. On a published page this means an edit reached the public site with nobody having published it.

**Every case asserts both halves in the same test.** "The live row is unchanged" is satisfied just as well by a write that stored nothing at all, so each case also asserts the pending change exists. The bulk case updates two entries rather than one, so the batch shape is real.

## The change

Both in-transaction paths now ask the same question through the same predicate and, when the answer is yes:

- skip the live-row `UPDATE`;
- skip the many-to-many junction rewrite — junction rows **are** live content, so rewriting them would put the pending relationship change on the public site while the rest of the edit waits;
- skip the durable version capture — nothing was published, and a version would enter the history as though it had been;
- call the same `storeWorkingDraftInTx` the interactive path uses;
- answer with the pending document rather than the live row, because a caller that asked for its own change back and received the published content it did not write would read that as the write having been ignored.

**Eligibility is one implementation**, `resolveWorkingDraftHold`. Asked separately in three places the answers could drift, and a surface answering "no" where the others answer "yes" publishes an edit nobody published — the defect in a new form.

**The relations read is forced for a held edit.** It is normally skipped when nothing will consume it, but the live relations are the base a pending change accumulates onto; without them the draft would silently drop every component and relationship the author had not touched in that save.

## Verification

- New suite: 3 cases green on **Postgres, MySQL and SQLite**.
- Collections + versions integration: **49 files / 395 passed**, 2+10 skipped. Baseline was 35 files / 331 for collections alone; the delta is exactly this PR's new file plus the versions suites.
- Webhooks + versions (the suites that exercise these write paths directly): 35 files / 275 passed, unchanged.
- Typecheck clean on both configs; lint clean.

## fallow: `warn`, 3 introduced duplications, reported not fixed

All three are pre-existing structure that a one-line guard tipped over the threshold:

| clone | what it is | my contribution |
|---|---|---|
| 47 lines | the `versionsConfig` / `needsRelations` / `readTxDocumentParts` preamble, identical in both in-transaction methods before this PR | added `\|\| storeAsWorkingDraft` to one line |
| 21 lines | the m2m rewrite loop, identical in the interactive and transaction paths before this PR | added `!storeAsWorkingDraft &&` to the condition |
| 20 lines | the `captureTxVersion` call, identical in both in-transaction methods before this PR | wrapped it in an `if` |

The real duplication is that `updateEntryInTransaction` and `updateSingleEntryInTransaction` share a long preamble, which predates this work. Extracting it is a genuine improvement and a separate refactor of code this PR does not otherwise touch, so folding it in here would make a behaviour change unreviewable. Worth its own PR.
