### PR TITLE
feat(plugin-page-builder): record recovery points from the block editor

### DIFF
--- a/.changeset/builder-recovery-checkpoints.md
+++ b/.changeset/builder-recovery-checkpoints.md
@@ -1,0 +1,36 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Work laid out in the page builder now survives a lost tab. While the block
+editor is open its live document is recorded as a recovery point on the same
+debounce the entry and Single editors already use, and reopening the document
+offers it back behind the existing restore prompt.
+
+Autosave also stops re-asking once the server has declined it. An entity whose
+owner has not enabled recovery points previously collected a rejected request
+every couple of seconds for as long as an editor stayed open.

--- a/apps/playground/src/singles/homepage.ts
+++ b/apps/playground/src/singles/homepage.ts
@@ -15,6 +15,10 @@ import { defineSingle, text } from "nextly/config";
 export const Homepage = defineSingle({
   slug: "homepage",
   label: { singular: "Homepage" },
+  // Recovery points are opt-in per entity and the server enforces it, so
+  // without this every autosave against this single is correctly refused —
+  // which is what exercises the page builder's own recording here.
+  versions: { drafts: true },
   fields: [
     text({ name: "title" }),
     blocks({ name: "layout", label: "Layout", blocks: { allow: ["core/*"] } }),

--- a/packages/admin/src/hooks/__tests__/useDocumentCheckpoint.test.tsx
+++ b/packages/admin/src/hooks/__tests__/useDocumentCheckpoint.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * The plugin-facing way for a field to record a recovery point.
+ *
+ * Driven through the REAL providers a field is rendered inside, because the
+ * whole point of this hook is that a caller passes neither a document nor a
+ * language: it reads both from where it is mounted, and a stubbed context would
+ * be a second implementation of the resolution being tested.
+ */
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { saveSpy } = vi.hoisted(() => ({ saveSpy: vi.fn() }));
+
+vi.mock("@admin/services/versionApi", () => ({
+  versionApi: { saveAutosave: saveSpy },
+}));
+
+import { EntryFormContextProvider } from "@admin/components/features/entries/EntryForm/EntryFormContext";
+import { EntryLocaleProvider } from "@admin/components/features/entries/EntryLocaleContext";
+
+import { useDocumentCheckpoint } from "../useDocumentCheckpoint";
+
+const DEBOUNCE = 2000;
+
+/** A field rendered inside a document, with an optional active language. */
+function inDocument(
+  options: {
+    kind?: "collection" | "single";
+    slug?: string;
+    /** `null` means the document has never been saved, so there is no id. */
+    documentId?: string | null;
+    locale?: string;
+  } = {}
+) {
+  const {
+    kind = "collection",
+    slug = "posts",
+    documentId = "e1",
+    locale,
+  } = options;
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <EntryFormContextProvider
+        kind={kind}
+        collectionSlug={slug}
+        entryId={documentId ?? undefined}
+        isCreateMode={false}
+      >
+        <EntryLocaleProvider
+          value={{
+            locale,
+            rtl: false,
+            collectionLocalized: locale !== undefined,
+            isNonDefaultLocale: false,
+          }}
+        >
+          {children}
+        </EntryLocaleProvider>
+      </EntryFormContextProvider>
+    );
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  saveSpy.mockResolvedValue({
+    updatedAt: "2026-08-19T09:00:00.000Z",
+    locale: null,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useDocumentCheckpoint", () => {
+  it("records against the document it is rendered inside", async () => {
+    // The caller names no document. Reading it from the surrounding form is
+    // what lets a plugin field record at all: the props a field receives name a
+    // value and nothing that addresses the document holding it.
+    const { result } = renderHook(
+      () =>
+        useDocumentCheckpoint({
+          snapshot: { title: "Hi" },
+          debounceMs: DEBOUNCE,
+        }),
+      { wrapper: inDocument() }
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+
+    await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1));
+    expect(saveSpy).toHaveBeenCalledWith(
+      { kind: "collection", slug: "posts", entryId: "e1" },
+      { title: "Hi" },
+      null
+    );
+  });
+
+  it("addresses a Single by its slug rather than as an entry", async () => {
+    // A Single has one document addressed by its own slug, and sending it as a
+    // collection entry would write against a document that does not exist.
+    const { result } = renderHook(
+      () =>
+        useDocumentCheckpoint({
+          snapshot: { headline: "x" },
+          debounceMs: DEBOUNCE,
+        }),
+      {
+        wrapper: inDocument({
+          kind: "single",
+          slug: "homepage",
+          documentId: "s1",
+        }),
+      }
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+
+    await waitFor(() =>
+      expect(saveSpy).toHaveBeenCalledWith(
+        { kind: "single", slug: "homepage", documentId: "s1" },
+        { headline: "x" },
+        null
+      )
+    );
+  });
+
+  it("carries the ACTIVE content language", async () => {
+    // The row is one per document per author, so a recording made under the
+    // wrong language overwrites the one the form's own recording wrote.
+    const { result } = renderHook(
+      () =>
+        useDocumentCheckpoint({
+          snapshot: { title: "Bonjour" },
+          debounceMs: DEBOUNCE,
+        }),
+      { wrapper: inDocument({ locale: "fr-CA" }) }
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+
+    await waitFor(() =>
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        "fr-CA"
+      )
+    );
+  });
+
+  it("sends the snapshot as it stands AT FLUSH, not when it was scheduled", async () => {
+    // The surface goes on editing during the debounce. Capturing the value at
+    // scheduling time would record what the author had two seconds ago.
+    const { result, rerender } = renderHook(
+      ({ snapshot }: { snapshot: Record<string, unknown> }) =>
+        useDocumentCheckpoint({ snapshot, debounceMs: DEBOUNCE }),
+      { wrapper: inDocument(), initialProps: { snapshot: { title: "first" } } }
+    );
+
+    act(() => result.current.schedule());
+    rerender({ snapshot: { title: "second" } });
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+
+    await waitFor(() =>
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        { title: "second" },
+        null
+      )
+    );
+  });
+});
+
+describe("what switches recording off", () => {
+  it("records nothing outside a document", async () => {
+    // A field component also renders in previews and pickers, which have no
+    // document. Doing nothing is the ordinary answer there, not an error.
+    const { result } = renderHook(() =>
+      useDocumentCheckpoint({ snapshot: { title: "Hi" }, debounceMs: DEBOUNCE })
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE * 2));
+
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  it("records nothing while the document has never been saved", async () => {
+    // A collection entry has no id until it has been created once, and the
+    // endpoint addresses a document that exists.
+    const { result } = renderHook(
+      () =>
+        useDocumentCheckpoint({
+          snapshot: { title: "Hi" },
+          debounceMs: DEBOUNCE,
+        }),
+      { wrapper: inDocument({ documentId: null }) }
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE * 2));
+
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  it("records nothing while disabled", async () => {
+    const { result } = renderHook(
+      () =>
+        useDocumentCheckpoint({
+          snapshot: { title: "Hi" },
+          enabled: false,
+          debounceMs: DEBOUNCE,
+        }),
+      { wrapper: inDocument() }
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE * 2));
+
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  it("still records when enabled and addressable, which is the control", async () => {
+    // Without this, the three cases above pass on a hook that never records at
+    // all under any circumstances.
+    const { result } = renderHook(
+      () =>
+        useDocumentCheckpoint({
+          snapshot: { title: "Hi" },
+          enabled: true,
+          debounceMs: DEBOUNCE,
+        }),
+      { wrapper: inDocument() }
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+
+    await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1));
+  });
+});

--- a/packages/admin/src/hooks/__tests__/useSnapshotAutosave.test.tsx
+++ b/packages/admin/src/hooks/__tests__/useSnapshotAutosave.test.tsx
@@ -244,3 +244,150 @@ describe("the identity is opaque, and it bounds a pending recording", () => {
     await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
   });
 });
+
+describe("a refusal is not asked again", () => {
+  /** The shape `parseApiError` gives every non-2xx response. */
+  function refused(status: number) {
+    const error = new Error("nope") as Error & { status: number };
+    error.status = status;
+    return error;
+  }
+
+  it("stops asking after the server refuses", async () => {
+    // Recording is opt-in per entity and enforced on the server, so an entity
+    // whose owner has not enabled it answers identically every time. Without
+    // this the editor collects one rejected request every debounce for as long
+    // as it stays open.
+    const save = vi.fn(() => Promise.reject(refused(403)));
+    const { result } = renderHook(() =>
+      useSnapshotAutosave({ identity: "doc-1", save, debounceMs: DEBOUNCE })
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE * 3));
+
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps trying after a failure that is not an answer, which is the control", async () => {
+    // Without this, the case above passes on a core that stops recording after
+    // ANY rejection — which would silently give up on a document because one
+    // request timed out.
+    const save = vi.fn(() => Promise.reject(new Error("network")));
+    const { result } = renderHook(() =>
+      useSnapshotAutosave({ identity: "doc-1", save, debounceMs: DEBOUNCE })
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(2));
+  });
+
+  it("treats a server fault as retryable, not as a refusal", async () => {
+    // 5xx is not an answer about this request; asking again can produce a
+    // different one. Only the 4xx class is a settled no.
+    const save = vi.fn(() => Promise.reject(refused(500)));
+    const { result } = renderHook(() =>
+      useSnapshotAutosave({ identity: "doc-1", save, debounceMs: DEBOUNCE })
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(2));
+  });
+
+  it("keeps trying after a 401, which the session refresh may yet fix", async () => {
+    // The admin refreshes an expired token and retries underneath this module,
+    // so a 401 reaching here means the REFRESH failed — for a reason that may
+    // not last. Latching would stop recording for the rest of a session whose
+    // credentials were never actually rejected.
+    const save = vi.fn(() => Promise.reject(refused(401)));
+    const { result } = renderHook(() =>
+      useSnapshotAutosave({ identity: "doc-1", save, debounceMs: DEBOUNCE })
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(2));
+  });
+
+  it("keeps trying after a rate limit, which is a later-not-never", async () => {
+    const save = vi.fn(() => Promise.reject(refused(429)));
+    const { result } = renderHook(() =>
+      useSnapshotAutosave({ identity: "doc-1", save, debounceMs: DEBOUNCE })
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(2));
+  });
+
+  it("shows a refusal as idle rather than as an error", async () => {
+    // An entity whose owner never turned recording on has not failed at
+    // anything, and an indicator stuck on "Couldn't save" would report a
+    // policy as a fault over an editor whose work is not at risk that way.
+    const save = vi.fn(() => Promise.reject(refused(403)));
+    const { result } = renderHook(() =>
+      useSnapshotAutosave({ identity: "doc-1", save, debounceMs: DEBOUNCE })
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("asks again under a new identity", async () => {
+    // The refusal belonged to that document. Another document is another
+    // entity with its own setting and its own access, so inheriting the answer
+    // would disable recording on a document nobody has refused.
+    const save = vi.fn(() => Promise.reject(refused(403)));
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) =>
+        useSnapshotAutosave({ identity: id, save, debounceMs: DEBOUNCE }),
+      { initialProps: { id: "doc-1" } }
+    );
+
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+
+    // The latch is ON first. Without asserting that here, this case passes on a
+    // core that never latches at all: "it asked again" is satisfied perfectly
+    // by never having stopped.
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+    expect(save).toHaveBeenCalledTimes(1);
+
+    rerender({ id: "doc-2" });
+    act(() => result.current.schedule());
+    act(() => void vi.advanceTimersByTime(DEBOUNCE));
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(2));
+  });
+});

--- a/packages/admin/src/hooks/useDocumentCheckpoint.ts
+++ b/packages/admin/src/hooks/useDocumentCheckpoint.ts
@@ -1,0 +1,148 @@
+"use client";
+
+/**
+ * Record a recovery point for the document the caller is rendered inside.
+ *
+ * The plugin-facing way in to the same machinery the entry and Single editors
+ * use. A contributed field that holds its own editing state — a block canvas, a
+ * diagram, a spreadsheet — has work at risk that the form cannot see, because
+ * that state is not in the form until the surface commits it. This hook lets
+ * such a surface put its live state where a crash cannot take it, without
+ * knowing the versions API, the debounce, or which document it is in.
+ *
+ * ## Why the caller supplies the WHOLE snapshot
+ *
+ * A recovery point is one rolling row per document per author, and restoring it
+ * replaces the form's values wholesale. A surface that recorded only its own
+ * field would therefore write a snapshot whose restore blanks every other field
+ * in the document. So the snapshot passed here is the complete document as the
+ * caller believes it stands: its own live value merged over everything else the
+ * form holds.
+ *
+ * Doing the merge in the caller rather than here is also what keeps this hook
+ * free of a form library. The admin's fields receive a `react-hook-form`
+ * control, but this surface is exported to plugins, and pinning a form
+ * library's types into that contract would make every future field component
+ * depend on the one the admin happens to use today.
+ *
+ * ## Why `schedule` is called by the caller
+ *
+ * Only the surface knows when its state has actually changed in a way worth
+ * keeping — an editor with its own undo stack has a different answer than a
+ * form's dirty flag. Recording on every render would write the document opening
+ * as a recovery point, which then offers the author their own unmodified
+ * document back as "unsaved changes".
+ *
+ * @module hooks/useDocumentCheckpoint
+ */
+
+import { useCallback, useMemo, useRef } from "react";
+
+import { useDocumentIdentity } from "@admin/components/features/entries/EntryForm/EntryFormContext";
+import { useEntryLocale } from "@admin/components/features/entries/EntryLocaleContext";
+import { autosaveScopeFor } from "@admin/hooks/useDocumentAutosave";
+import {
+  useSnapshotAutosave,
+  type AutosaveStatus,
+  DEFAULT_AUTOSAVE_DEBOUNCE_MS,
+} from "@admin/hooks/useSnapshotAutosave";
+import { versionApi } from "@admin/services/versionApi";
+
+export interface UseDocumentCheckpointOptions {
+  /**
+   * The whole document as the caller believes it stands, read at flush time.
+   *
+   * Held in a ref and read when a recording is actually made, so the value that
+   * reaches the server is the current one rather than whatever was passed when
+   * the debounce started.
+   */
+  snapshot: Record<string, unknown>;
+
+  /**
+   * Turns recording off without unmounting.
+   *
+   * Not a substitute for the owner's setting, which is enforced on the server
+   * and never inferred here. Use it for a moment when recording is wrong even
+   * though it is allowed — while a real save is in flight, for instance, when
+   * the document is about to change underneath the snapshot.
+   */
+  enabled?: boolean;
+
+  /** Milliseconds of quiet before a recording is made. */
+  debounceMs?: number;
+}
+
+export interface UseDocumentCheckpointResult {
+  status: AutosaveStatus;
+  /** When the server stored the last recording, by the SERVER's clock. */
+  lastSavedAt: Date | null;
+  /**
+   * Ask for a recording once the debounce has elapsed.
+   *
+   * Safe to call from a surface that has no document to record against: with
+   * nothing addressable, this does nothing rather than failing, so a caller
+   * rendered in a preview or a picker needs no special case.
+   */
+  schedule: () => void;
+}
+
+export type { AutosaveStatus };
+
+/**
+ * @param options - the snapshot to record, and whether to record at all
+ * @returns the recording status, when the last one landed, and the trigger
+ */
+export function useDocumentCheckpoint({
+  snapshot,
+  enabled = true,
+  debounceMs = DEFAULT_AUTOSAVE_DEBOUNCE_MS,
+}: UseDocumentCheckpointOptions): UseDocumentCheckpointResult {
+  const identity = useDocumentIdentity();
+  // The active content language, read here rather than asked of the caller: a
+  // plugin field has no way to know it, and a recording made under the wrong
+  // language would overwrite the row the form's own recording writes.
+  const { locale } = useEntryLocale();
+
+  /*
+   * Memoised on the identity's own fields rather than on the identity object,
+   * which `useDocumentIdentity` rebuilds each render. Without this the scope is
+   * a new object every time, and everything keyed on it — the callback below,
+   * and the subscription the recording machinery makes — is rebuilt with it.
+   */
+  const kind = identity?.kind ?? null;
+  const slug = identity?.slug ?? null;
+  const documentId = identity?.documentId;
+  const scope = useMemo(
+    () =>
+      kind === null || slug === null
+        ? null
+        : autosaveScopeFor(kind, slug, documentId),
+    [kind, slug, documentId]
+  );
+
+  const snapshotRef = useRef(snapshot);
+  snapshotRef.current = snapshot;
+
+  const save = useCallback(async () => {
+    if (!scope) throw new Error("checkpoint: no document to record against");
+    return versionApi.saveAutosave(scope, snapshotRef.current, locale ?? null);
+  }, [scope, locale]);
+
+  /*
+   * Keyed the same way the form's own recording is, so the two describe the
+   * same document to the machinery that bounds a pending write. They write the
+   * same row, and a pending recording that outlived a switch to another
+   * document — or another language — would store this document's content under
+   * that one's key.
+   */
+  const recordingKey = scope
+    ? `${scope.kind}:${scope.slug}:${"entryId" in scope ? scope.entryId : scope.documentId}:${locale ?? ""}`
+    : null;
+
+  return useSnapshotAutosave({
+    identity: recordingKey,
+    save,
+    debounceMs,
+    enabled,
+  });
+}

--- a/packages/admin/src/hooks/useSnapshotAutosave.ts
+++ b/packages/admin/src/hooks/useSnapshotAutosave.ts
@@ -4,9 +4,10 @@
  * The recording machinery behind autosave, with no opinion about what is being
  * recorded.
  *
- * Debounce, coalescing, the in-flight guard, the mounted guard and the status
- * an indicator reads: all of it is the same whether the thing being recorded is
- * a form's values or a block document, and none of it needs to know which.
+ * Debounce, coalescing, the in-flight guard, the mounted guard, the latch that
+ * stops asking once the server has refused, and the status an indicator reads:
+ * all of it is the same whether the thing being recorded is a form's values or
+ * a block document, and none of it needs to know which.
  * Splitting it out is what lets a second editor record recovery points without
  * a second implementation of the timing — and two implementations of a debounce
  * that must agree with a status vocabulary is exactly the pair that drifts.
@@ -35,6 +36,49 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
+/**
+ * A refusal the server will give again, told apart from a failure that may not.
+ *
+ * Recording is opt-in per entity and enforced on the server, so an entity whose
+ * owner has not enabled it answers every request the same way. Asking again on
+ * the next debounce produces one rejected request every couple of seconds for
+ * as long as the editor is open, which is the shape this predicate exists to
+ * stop — and the same is true of a caller who simply may not write this
+ * document.
+ *
+ * Keyed on the status rather than on a reason string. The reason the server
+ * logs (`autosave-not-enabled`) stays in its log context and never reaches the
+ * client, and a client that pattern-matched a message would be reading prose
+ * that is free to change.
+ *
+ * The 4xx class carries the distinction that matters — a 4xx is an answer about
+ * this request, while a 5xx or a dropped connection is not an answer at all —
+ * minus the four statuses that HTTP defines as answers which can change on
+ * their own. Those are not exceptions to the rule; they are the part of the
+ * class that fails the test the rule is made of.
+ */
+const RETRYABLE_CLIENT_STATUSES = new Set([
+  /*
+   * The admin refreshes an expired access token and retries underneath this
+   * module, so a 401 usually never surfaces at all. It surfaces when the
+   * REFRESH itself fails for a non-auth reason — a 5xx, a dropped connection —
+   * and the original 401 propagates. Latching there would stop recording for
+   * the rest of a session whose credentials were never actually rejected.
+   */
+  401,
+  // A timeout, an early send and a rate limit are all "not now" rather than
+  // "no", and the next debounce is exactly the later moment they ask for.
+  408, 425, 429,
+]);
+
+function isRefusal(error: unknown): boolean {
+  const status = (error as { status?: unknown } | null)?.status;
+  if (typeof status !== "number") return false;
+  return (
+    status >= 400 && status < 500 && !RETRYABLE_CLIENT_STATUSES.has(status)
+  );
+}
+
 /** How long to wait after the last change before recording. */
 export const DEFAULT_AUTOSAVE_DEBOUNCE_MS = 2000;
 
@@ -50,6 +94,42 @@ export interface SnapshotSaveResult {
    * minutes ago" reading cannot drift with an unsynchronised browser clock.
    */
   updatedAt: string;
+}
+
+/**
+ * Whether a recording must NOT be made.
+ *
+ * One question with one implementation, asked at flush and only there. Checking
+ * any of these at scheduling time as well reads as defensive and is worse than
+ * redundant: `enabled` moves while a timer is already pending — it goes false
+ * the moment a real save starts — so the answer then is not the answer that
+ * matters, and two copies of the rule would eventually disagree about a
+ * recording one of them had already allowed.
+ */
+function recordingBlocked(state: {
+  identity: string | null;
+  enabled: boolean;
+  refused: boolean;
+}): boolean {
+  return state.identity === null || !state.enabled || state.refused;
+}
+
+/**
+ * What a failed attempt means: whether the server has settled the question, and
+ * what an indicator should show for it.
+ *
+ * A refusal shows as `idle` rather than `error`, because an entity whose owner
+ * never turned recording on has not failed at anything. An indicator stuck on
+ * "Couldn't save" would report a policy as a fault, over an editor whose work
+ * is not at risk in the way that reads.
+ */
+function outcomeOfFailure(error: unknown): {
+  refused: boolean;
+  status: AutosaveStatus;
+} {
+  return isRefusal(error)
+    ? { refused: true, status: "idle" }
+    : { refused: false, status: "error" };
 }
 
 export interface UseSnapshotAutosaveOptions {
@@ -117,6 +197,13 @@ export function useSnapshotAutosave({
    */
   const pendingRef = useRef(false);
   const mountedRef = useRef(true);
+  /*
+   * Set once the server has refused, and cleared only by a change of identity.
+   * A ref rather than state because nothing renders differently for it: the
+   * status it leaves behind is `idle`, which is what an editor with no
+   * recording available should show.
+   */
+  const refusedRef = useRef(false);
 
   /*
    * Read through refs inside the debounced callback rather than captured as
@@ -138,7 +225,14 @@ export function useSnapshotAutosave({
   }, []);
 
   const flush = useCallback(async () => {
-    if (identityRef.current === null || !enabledRef.current) return;
+    if (
+      recordingBlocked({
+        identity: identityRef.current,
+        enabled: enabledRef.current,
+        refused: refusedRef.current,
+      })
+    )
+      return;
 
     if (inFlightRef.current) {
       pendingRef.current = true;
@@ -154,13 +248,21 @@ export function useSnapshotAutosave({
         setLastSavedAt(new Date(result.updatedAt));
         setStatus("saved");
       }
-    } catch {
+    } catch (error) {
       /*
        * Swallowed deliberately, and reported through `status` rather than
        * thrown. A recovery point nobody asked for must not surface an error
-       * over the editor or interrupt typing; the next debounce tries again.
+       * over the editor or interrupt typing; the next debounce tries again —
+       * unless the server refused, and then there is nothing to try again.
+       *
+       * A refusal shows as `idle` rather than `error`, because an entity whose
+       * owner never turned recording on has not failed at anything. An
+       * indicator stuck on "Couldn't save" would report a policy as a fault,
+       * over an editor whose work is not at risk in the way that reads.
        */
-      if (mountedRef.current) setStatus("error");
+      const outcome = outcomeOfFailure(error);
+      refusedRef.current = outcome.refused;
+      if (mountedRef.current) setStatus(outcome.status);
     } finally {
       inFlightRef.current = false;
       if (pendingRef.current) {
@@ -192,6 +294,10 @@ export function useSnapshotAutosave({
   // another's key, which is the one failure this module can cause that the
   // caller cannot see.
   useEffect(() => {
+    // A refusal belongs to the document it was given for. Another document is
+    // another entity with its own setting and its own access, so the answer is
+    // asked again rather than inherited.
+    refusedRef.current = false;
     return () => {
       if (timerRef.current) {
         clearTimeout(timerRef.current);

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -91,6 +91,19 @@ export {
   useDocumentIdentity,
   type DocumentIdentity,
 } from "./components/features/entries/EntryForm/EntryFormContext";
+/**
+ * Put a contributed surface's live state somewhere a crash cannot take it.
+ *
+ * Exported for the plugin surface alongside the identity above: a field holding
+ * its own editing state has work at risk that the form cannot see, because that
+ * state does not reach the form until the surface commits it.
+ */
+export {
+  useDocumentCheckpoint,
+  type UseDocumentCheckpointOptions,
+  type UseDocumentCheckpointResult,
+  type AutosaveStatus,
+} from "./hooks/useDocumentCheckpoint";
 export { Can } from "./components/guards/Can";
 export type { CanProps } from "./components/guards/Can";
 export { useRowSelection } from "./hooks/useRowSelection";

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -55,10 +55,14 @@ import {
   useCanvasDrag,
   useEditorState,
 } from "@nextlyhq/builder/shell";
-import { useSuppressAdminChrome } from "@nextlyhq/plugin-sdk/admin";
-import { useCallback, useMemo, useState } from "react";
+import {
+  useDocumentCheckpoint,
+  useSuppressAdminChrome,
+} from "@nextlyhq/plugin-sdk/admin";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   useController,
+  useWatch,
   type Control,
   type FieldValues,
   type Path,
@@ -68,6 +72,7 @@ import { emptyBlockDocument } from "../fields/blocks-document";
 import { siteSheet } from "../site-style";
 
 import { BlocksSummary } from "./BlocksSummary";
+import { withValueAtPath } from "./snapshot-merge";
 
 export interface BlocksFieldProps<
   TFieldValues extends FieldValues = FieldValues,
@@ -211,6 +216,10 @@ export function BlocksField<TFieldValues extends FieldValues = FieldValues>({
       initialValue={field.value}
       onCommit={field.onChange}
       onClose={() => setOpen(false)}
+      // Named and controlled so the editor can record its live document as
+      // part of the whole document's recovery point — see `useCheckpoints`.
+      name={name}
+      control={control}
     />
   ) : (
     <div className="flex flex-col gap-3">
@@ -239,6 +248,54 @@ export function BlocksField<TFieldValues extends FieldValues = FieldValues>({
 }
 
 /**
+ * Record the LIVE document as this author's recovery point while the editor is
+ * open.
+ *
+ * The form cannot do this for itself. Its own recording writes the values it
+ * holds, and this field's value is deliberately not among them until the editor
+ * exits — so an author who spends twenty minutes laying out a page and then
+ * loses the tab has, from the form's point of view, changed nothing at all. The
+ * recording is what closes that gap; the commit-on-exit rule above is what
+ * makes it necessary, and neither is a workaround for the other.
+ *
+ * Recorded as the WHOLE document rather than as this field alone, because
+ * restoring a recovery point replaces the form's values wholesale: a snapshot
+ * carrying only the layout would restore cleanly and blank the title beside it.
+ *
+ * The very document the editor opened with is deliberately not recorded. It is
+ * what the server already holds, and storing it would offer the author their
+ * own unmodified page back as "unsaved changes from a moment ago".
+ */
+function useCheckpoints<TFieldValues extends FieldValues>({
+  name,
+  control,
+  document,
+}: {
+  name: Path<TFieldValues>;
+  control: Control<TFieldValues>;
+  document: BlockDocument;
+}): void {
+  const values = useWatch({ control });
+  const snapshot = useMemo(
+    () => withValueAtPath(values as Record<string, unknown>, name, document),
+    [values, name, document]
+  );
+
+  const { schedule } = useDocumentCheckpoint({ snapshot });
+
+  /*
+   * A new document object is what an edit produces — the editor's state is
+   * replaced rather than mutated — so reference inequality is the signal, and
+   * a render caused by anything else asks for nothing.
+   */
+  const openedWith = useRef(document);
+  useEffect(() => {
+    if (document === openedWith.current) return;
+    schedule();
+  }, [document, schedule]);
+}
+
+/**
  * The editor itself, mounted only while open.
  *
  * Separate component so the hooks below — editor state, and the chrome request
@@ -246,14 +303,18 @@ export function BlocksField<TFieldValues extends FieldValues = FieldValues>({
  * ask the admin to hide its navigation for every entry form holding a blocks
  * field, open or not.
  */
-function BlocksEditor({
+function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   initialValue,
   onCommit,
   onClose,
+  name,
+  control,
 }: {
   initialValue: unknown;
   onCommit: (value: BlockDocument) => void;
   onClose: () => void;
+  name: Path<TFieldValues>;
+  control: Control<TFieldValues>;
 }) {
   // Before anything reads the registry. Inside the component that mounts the
   // editor rather than at module scope: this file is imported by the field
@@ -279,6 +340,8 @@ function BlocksEditor({
   const slots = useMemo(registrySlotSource, []);
   const nesting = useMemo(registryNestingSource, []);
   const drag = useCanvasDrag({ editor, slots, nesting });
+
+  useCheckpoints({ name, control, document: editor.document });
 
   /*
    * Writing back on the way out rather than on every keystroke.

--- a/packages/plugin-page-builder/src/admin/snapshot-merge.test.ts
+++ b/packages/plugin-page-builder/src/admin/snapshot-merge.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The merge that turns one field's live value into a whole-document snapshot.
+ *
+ * Worth pinning apart from the editor because getting it wrong is silent: a
+ * snapshot with the value under the wrong key restores successfully and simply
+ * does not contain the author's work.
+ */
+import { describe, expect, it } from "vitest";
+
+import { withValueAtPath } from "./snapshot-merge";
+
+const DOC = { nodes: [] };
+
+describe("withValueAtPath", () => {
+  it("replaces a top-level field and keeps the siblings", () => {
+    // The siblings matter: restoring a recovery point replaces the form's
+    // values wholesale, so a snapshot missing them blanks the document.
+    const result = withValueAtPath(
+      { title: "Home", layout: null },
+      "layout",
+      DOC
+    );
+
+    expect(result).toEqual({ title: "Home", layout: DOC });
+  });
+
+  it("writes a dotted path INTO the object it names, not as a literal key", () => {
+    // The failure this exists to prevent: `{ "hero.layout": doc }` restores
+    // cleanly, leaves the real field untouched, and loses the work.
+    const result = withValueAtPath(
+      { hero: { heading: "Hi", layout: null } },
+      "hero.layout",
+      DOC
+    );
+
+    expect(result).toEqual({ hero: { heading: "Hi", layout: DOC } });
+    expect(Object.keys(result)).not.toContain("hero.layout");
+  });
+
+  it("writes through an array index", () => {
+    const result = withValueAtPath(
+      { sections: [{ layout: null }, { layout: "keep" }] },
+      "sections.1.layout",
+      DOC
+    );
+
+    expect(result).toEqual({
+      sections: [{ layout: null }, { layout: DOC }],
+    });
+  });
+
+  it("does not mutate the values it was given", () => {
+    // The form owns those objects and is still rendering from them.
+    const values = { hero: { layout: null } };
+    withValueAtPath(values, "hero.layout", DOC);
+
+    expect(values).toEqual({ hero: { layout: null } });
+  });
+
+  it("creates containers a path runs through that do not exist yet", () => {
+    // A field can be edited before anything has written its parent, and
+    // refusing here would drop the recording for exactly that field.
+    const result = withValueAtPath({}, "hero.layout", DOC);
+
+    expect(result).toEqual({ hero: { layout: DOC } });
+  });
+
+  it("makes an ARRAY when the next segment is an index", () => {
+    // An object with a "0" key serialises differently and restores as an
+    // object, so the container's kind is decided by the segment that follows.
+    const result = withValueAtPath({}, "sections.0.layout", DOC);
+
+    expect(Array.isArray((result as { sections: unknown }).sections)).toBe(
+      true
+    );
+    expect(result).toEqual({ sections: [{ layout: DOC }] });
+  });
+});

--- a/packages/plugin-page-builder/src/admin/snapshot-merge.ts
+++ b/packages/plugin-page-builder/src/admin/snapshot-merge.ts
@@ -1,0 +1,93 @@
+/**
+ * Place one field's value into a copy of the document that holds it.
+ *
+ * A recovery point is the WHOLE document as the editor believes it stands, so a
+ * surface recording its own live state has to merge that state over everything
+ * else the form is holding. A field's path is not always a top-level key —
+ * inside a group, a component or a repeatable it arrives dotted
+ * (`hero.layout`, `sections.2.layout`) — and writing that string as a literal
+ * key would store a snapshot whose restore leaves the real field untouched and
+ * adds a stray one nobody reads.
+ *
+ * Copies only the containers along the path. Everything else is shared with the
+ * original, which is what a snapshot wants: it is serialised immediately and
+ * never mutated.
+ *
+ * @module @nextlyhq/plugin-page-builder/admin/snapshot-merge
+ */
+
+/** A path segment that addresses a position in an array rather than a key. */
+function isIndex(segment: string): boolean {
+  return /^\d+$/.test(segment);
+}
+
+/**
+ * A container to write the next segment into.
+ *
+ * Reuses what is already there when it is the right shape, and otherwise makes
+ * a fresh one — a path can legitimately run through a value the form has not
+ * created yet, and refusing there would drop the recording for a field the
+ * author is actively editing.
+ */
+function containerFor(
+  current: unknown,
+  nextSegment: string
+): unknown[] | Record<string, unknown> {
+  if (isIndex(nextSegment)) {
+    return Array.isArray(current) ? [...current] : [];
+  }
+  return typeof current === "object" &&
+    current !== null &&
+    !Array.isArray(current)
+    ? { ...(current as Record<string, unknown>) }
+    : {};
+}
+
+/**
+ * @param values - the form's current values
+ * @param path - the field's RHF path, dotted for anything nested
+ * @param value - what to place there
+ * @returns a copy of `values` with `path` set to `value`
+ */
+export function withValueAtPath(
+  values: Record<string, unknown>,
+  path: string,
+  value: unknown
+): Record<string, unknown> {
+  const segments = path.split(".").filter(segment => segment.length > 0);
+  if (segments.length === 0) return { ...values };
+
+  const root = { ...values };
+  let cursor: unknown[] | Record<string, unknown> = root;
+
+  /** Read one segment from whichever container kind the cursor is on. */
+  function read(
+    container: unknown[] | Record<string, unknown>,
+    segment: string
+  ) {
+    return Array.isArray(container)
+      ? container[Number(segment)]
+      : container[segment];
+  }
+
+  /** Write one segment, likewise. */
+  function write(
+    container: unknown[] | Record<string, unknown>,
+    segment: string,
+    next: unknown
+  ) {
+    if (Array.isArray(container)) container[Number(segment)] = next;
+    else container[segment] = next;
+  }
+
+  for (let i = 0; i < segments.length - 1; i += 1) {
+    const segment = segments[i];
+    const child = containerFor(read(cursor, segment), segments[i + 1]);
+    write(cursor, segment, child);
+    cursor = child;
+  }
+
+  write(cursor, segments[segments.length - 1], value);
+
+  return root;
+}

--- a/packages/plugin-sdk/src/admin.ts
+++ b/packages/plugin-sdk/src/admin.ts
@@ -28,6 +28,27 @@ export { useDocumentIdentity, type DocumentIdentity } from "@nextlyhq/admin";
 export type { ComponentPath } from "@nextlyhq/admin";
 
 /**
+ * Record a recovery point for the surrounding document (@experimental).
+ *
+ * For a contributed field that holds its own editing state — a canvas, a
+ * diagram, an editor with its own history — whose work the form cannot see
+ * until the surface commits it. The caller passes the WHOLE document as it
+ * believes it stands (its own live value merged over the form's other values),
+ * because restoring a recovery point replaces the form's values wholesale, and
+ * calls `schedule()` when its state has changed in a way worth keeping.
+ *
+ * Whether recording is permitted at all is the entity owner's setting and is
+ * enforced on the server; a refusal is not retried, and nothing here needs to
+ * ask.
+ */
+export {
+  useDocumentCheckpoint,
+  type UseDocumentCheckpointOptions,
+  type UseDocumentCheckpointResult,
+  type AutosaveStatus,
+} from "@nextlyhq/admin";
+
+/**
  * Token-driven layout primitives (@experimental). Compose plugin admin UI from
  * these so it inherits the admin's design system with no plugin build step:
  * `Card` (+ its parts) for surfaces, `Stack`/`Grid` for layout, `Stat` for


### PR DESCRIPTION
## What this fixes

The page builder commits its document to the form **on exit**, deliberately: committing on every change would mark the entry dirty for an edit the author then undoes, and would make the form's undo and the editor's undo two answers to one question.

The cost of that decision was invisible until now. While the editor is open the form's own autosave records a `layout` the author has not seen since they opened it, so a lost tab took the entire layout session with it. There was nothing wrong with the recording — the work simply was not in the place being recorded.

## What changed

**The editor records its live document.** `BlocksField` now asks the surrounding form which document it is inside, merges its live block document over the form's other values, and records that through the same debounce the entry and Single editors use. Reopening the document offers it back through the restore prompt that already exists — no second recovery surface, and no second recovery row to disagree with the first.

**The whole document is recorded, not just the field.** Restoring a recovery point replaces the form's values wholesale, so a snapshot carrying only the layout would restore cleanly and blank the title beside it.

**`useDocumentCheckpoint` is the plugin-facing way in**, exported through `@nextlyhq/plugin-sdk/admin`. It takes a snapshot and a trigger and nothing else: the document, the active language, the API and the timing are all resolved inside the admin. Deliberately no form-library types in that signature — the admin's fields happen to use react-hook-form, and pinning it into a plugin contract would outlive the choice.

**Autosave stops asking once the server has answered.** Recording is opt-in per entity and enforced server-side, so an entity whose owner has not enabled it previously collected a rejected request every couple of seconds for as long as any editor stayed open. The four statuses HTTP defines as answers that can change on their own (401, 408, 425, 429) keep retrying; the rest of the 4xx class does not.

## A wrong turn worth recording

The obvious gate was `enabled: draftsEnabled`, which the schema already sends to the client. **It is the wrong flag, in both directions.**

`draftsEnabled` is draft/published *split eligibility* — `isDraftSplitEligible` requires `status: true`, no localization, and no reachable password field. Autosave is gated on `versions.drafts.autosave.enabled`, which shares none of those conditions.

- `site-settings` in the playground is `versions: { drafts: true }` **and** `localized: true`. Autosave works there; `draftsEnabled` is `false`. Gating on it would delete working recovery points for exactly the documents most worth recovering.
- `versions: { drafts: { autosave: false } }` leaves `draftsEnabled` true, so the rejected requests would have continued anyway.
- The singles schema read does not send `draftsEnabled` at all, so every Single would have had recording switched off.

Reading the server's own answer avoids duplicating a policy across four schema-read paths, and cannot drift from it.

## Verified in a browser

On `/admin/singles/homepage` at 1600×1000, after asserting the auth control (`h1` reads "Welcome, Dev"):

- opening the editor records **nothing** — with the editor's presence asserted first, since "no request" is satisfied perfectly by an editor that never opened;
- inserting a block issues one `PUT .../singles/homepage/versions/autosave` → **200**, body carrying `slug`, `title` and the live `layout`;
- reloading offers *"You have unsaved changes from moments ago. Restore"*;
- restoring and reopening the editor shows the inserted block back on the canvas.

The browser run also produced the 401 finding above: the admin's refresh interceptor retries underneath this module, and the first PUT was observed as a 401 followed by a 200 from one `save` call. A refresh that fails for a non-auth reason propagates the original 401, which the first version of the latch would have treated as final.

`apps/playground/src/singles/homepage.ts` gains `versions: { drafts: true }` because without it the endpoint correctly refuses and there is nothing to exercise.

## Tests

`packages/admin` measured against its standing baseline of 15 failures in 4 files (`StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField`): **15 failed, 2401 passed** — the same 15, plus 15 new tests. `plugin-page-builder` 71 → 77.

Every new test was stub-verified, and one round found a hole rather than a bug: stubbing the trigger left "asks again under a new identity" passing on a core that never latched at all, because "it asked again" is satisfied by never having stopped. It now asserts the latch is on first.

## Not verified by tests

The wiring inside `BlocksField` — that `useWatch` supplies the sibling values, and that the document the editor opened with is not recorded — has no unit coverage: this package runs in a node environment with no DOM harness, and adding one for a single hook is its own decision. Both properties were verified in the browser, above. The merge itself (`withValueAtPath`) and the recording core are unit-tested.
