### PR TITLE
test(plugin-sdk): record the document hooks in the surface snapshot

### DIFF
--- a/packages/plugin-sdk/src/__snapshots__/plugin-surface.test.ts.snap
+++ b/packages/plugin-sdk/src/__snapshots__/plugin-surface.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`plugin-sdk public export surface > \`./admin\` surface is unchanged 1`] = `
 [
   "AdminChromeLayer (type)",
+  "AutosaveStatus (type)",
   "BulkAction (type)",
   "Card (value)",
   "CardAction (value)",
@@ -32,6 +33,7 @@ exports[`plugin-sdk public export surface > \`./admin\` surface is unchanged 1`]
   "DataTableTarget (type)",
   "DataTableView (value)",
   "DataTableViewProps (type)",
+  "DocumentIdentity (type)",
   "FieldDefaultOption (type)",
   "FieldDefaultValueInput (value)",
   "FieldDefaultValueInputProps (type)",
@@ -56,6 +58,8 @@ exports[`plugin-sdk public export surface > \`./admin\` surface is unchanged 1`]
   "StackProps (type)",
   "Stat (value)",
   "StatProps (type)",
+  "UseDocumentCheckpointOptions (type)",
+  "UseDocumentCheckpointResult (type)",
   "ValidationNumberField (value)",
   "ValidationNumberFieldProps (type)",
   "operatorTakesValue (value)",
@@ -68,6 +72,8 @@ exports[`plugin-sdk public export surface > \`./admin\` surface is unchanged 1`]
   "registerKnownPlugin (value)",
   "registerRowAction (value)",
   "transformColumns (value)",
+  "useDocumentCheckpoint (value)",
+  "useDocumentIdentity (value)",
   "usePluginClientConfig (value)",
   "usePluginFieldTypeEntries (value)",
   "useSuppressAdminChrome (value)",


### PR DESCRIPTION
## main is red, and this is the fix

`@nextlyhq/plugin-sdk#test` is failing on `main`. `plugin-surface.test.ts` snapshots the public export surface of each `plugin-sdk` entry point, and `./admin` gained six exports without it being regenerated.

**This is mine, and it is older than it looks.** Two of the six — `useDocumentIdentity` and `DocumentIdentity` — landed in #1060, so the check has been failing since that merge, not since #1063. #1063 added four more to an already-red check. I did not notice either time because I ran the suites of the packages whose *behaviour* I changed and not the suite of `plugin-sdk`, whose `admin.ts` I had edited in both PRs.

The simple rule I should have followed: **run the tests of every package you edited a file in**, not of every package you thought you were working on.

## What changed

Six additions to the snapshot, nothing removed:

- `useDocumentIdentity`, `DocumentIdentity` (#1060)
- `useDocumentCheckpoint`, `UseDocumentCheckpointOptions`, `UseDocumentCheckpointResult`, `AutosaveStatus` (#1063)

Every one is an intended widening of the plugin API, already argued in its own PR. **That the delta is additions-only is the check worth making here** — a removal in this diff would mean an accidental surface regression riding along with a snapshot refresh, which is exactly what regenerating a snapshot can hide.

## The guard is still live

Regenerating a snapshot can quietly disable the thing it guards, so I confirmed it still fires: adding a throwaway export to `admin.ts` fails the test naming it, and removing it passes. The restore was verified by `diff` and by a search for the marker.

`plugin-sdk`: 16 passed.

No changeset — this changes a test fixture and nothing a user installs.
