### PR TITLE
feat(nextly): key a working draft by the locale it belongs to

### DIFF
--- a/.changeset/working-draft-locale-key.md
+++ b/.changeset/working-draft-locale-key.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Key a pending change by the language it belongs to, and clean it up correctly.
+
+Deleting a document now removes its pending changes in every language rather
+than only the unlocalized one, which would otherwise leave rows behind pointing
+at a document that no longer exists. A write that cannot name the language it is
+for no longer stores a pending change under the wrong key, where nothing would
+find it again.

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -116,6 +116,7 @@ import {
 } from "../../i18n/runtime/companion-readiness";
 import { assembleDocument } from "../../versions/assemble-document";
 import { captureInTx } from "../../versions/capture-in-tx";
+import { resolveDraftHold } from "../../versions/draft-hold";
 import { isDraftSplitEligible } from "../../versions/draft-split-eligibility";
 import {
   buildRestorePayload,
@@ -133,6 +134,7 @@ import {
 import { VersionCaptureService } from "../../versions/version-capture-service";
 import { withVersionConflictRetry } from "../../versions/version-conflict";
 import { VersionsRepository } from "../../versions/versions-repository";
+import { workingDraftLocale } from "../../versions/working-draft-locale";
 import { expandComponentFields } from "../../webhooks/expand-component-fields";
 import { projectFields } from "../../webhooks/project-fields";
 import {
@@ -361,6 +363,14 @@ interface WorkingDraftWriteContext {
   collection: unknown;
   collectionHasStatus: boolean;
   componentFieldData: Record<string, unknown>;
+  /**
+   * The locale this document's working draft is keyed under, from
+   * `workingDraftLocale`. `null` is the unlocalized slot, not "unknown": the
+   * store, the read overlay, the promote and the discard must all derive it the
+   * same way, because a draft written under one key and looked for under
+   * another is never found again and the edit disappears without an error.
+   */
+  draftLocale: string | null;
   fields: FieldDefinition[];
   manyToManyData: Record<string, string[]>;
   params: { collectionName: string; entryId: string; user?: UserContext };
@@ -1494,6 +1504,13 @@ export class CollectionMutationService extends BaseService {
   async discardWorkingDraft(params: {
     collectionName: string;
     entryId: string;
+    /**
+     * Which language's pending change to discard. Discarding is one language's
+     * concern: a document can hold a pending change in several at once, and
+     * removing them all would throw away work in languages the author never
+     * opened. Ignored for an unlocalized document, which has one.
+     */
+    locale?: string | null;
   }): Promise<void> {
     const collection = await this.collectionService.getCollection(
       params.collectionName
@@ -1509,7 +1526,11 @@ export class CollectionMutationService extends BaseService {
           scopeSlug: params.collectionName,
           entryId: params.entryId,
         },
-        null
+        workingDraftLocale({
+          documentLocalized:
+            (collection as { localized?: boolean }).localized === true,
+          requestLocale: params.locale ?? null,
+        })
       );
     });
   }
@@ -4440,7 +4461,17 @@ export class CollectionMutationService extends BaseService {
     namedStatus: unknown;
     /** The committed status of the row being written. */
     liveStatus: unknown;
-  }): Promise<{ hold: boolean; componentSchemas: ComponentSchemas | null }> {
+    /**
+     * The locale this write is for. Omitted by a surface that has no locale
+     * concept, which is what makes such a surface decline to hold a localized
+     * document's edit rather than key it under the wrong slot.
+     */
+    requestLocale?: string | null;
+  }): Promise<{
+    hold: boolean;
+    componentSchemas: ComponentSchemas | null;
+    draftLocale: string | null;
+  }> {
     const collectionHasStatus =
       (args.collection as { status?: boolean }).status === true;
     const versionsConfig = (args.collection as Record<string, unknown>)
@@ -4456,17 +4487,17 @@ export class CollectionMutationService extends BaseService {
       !hasPasswordField(args.fields)
         ? await resolveComponentSchemas(args.fields as unknown as FieldConfig[])
         : null;
-    const hold =
-      isDraftSplitEligible({
-        collectionHasStatus,
-        draftsVersioningEnabled: versionsConfig?.drafts?.enabled === true,
-        documentLocalized,
-        fields: args.fields as unknown as FieldConfig[],
-        componentSchemas,
-      }) &&
-      args.namedStatus === undefined &&
-      args.liveStatus === "published";
-    return { hold, componentSchemas };
+    const { hold, draftLocale } = resolveDraftHold({
+      collectionHasStatus,
+      draftsVersioningEnabled: versionsConfig?.drafts?.enabled === true,
+      documentLocalized,
+      fields: args.fields as unknown as FieldConfig[],
+      componentSchemas,
+      namedStatus: args.namedStatus,
+      liveStatus: args.liveStatus,
+      requestLocale: args.requestLocale,
+    });
+    return { hold, componentSchemas, draftLocale };
   }
 
   /**
@@ -4578,6 +4609,7 @@ export class CollectionMutationService extends BaseService {
     const {
       collection,
       collectionHasStatus,
+      draftLocale,
       fields,
       params,
       splitComponentSchemas,
@@ -4590,7 +4622,10 @@ export class CollectionMutationService extends BaseService {
       scopeSlug: params.collectionName,
       entryId: params.entryId,
     };
-    const existingDraft = await draftRepo.findWorkingDraft(draftRef, null);
+    const existingDraft = await draftRepo.findWorkingDraft(
+      draftRef,
+      draftLocale
+    );
     // The fields this save actually touched, at the assembled read
     // shape. `patchedDocument` overlaid the current patch onto the live
     // relations and REPLACED a single component whole, so a partial
@@ -4637,7 +4672,7 @@ export class CollectionMutationService extends BaseService {
       // request locale would orphan it when a later read or publish
       // arrives under a different locale in a localization-configured
       // app. The read overlay and promote use the same null key.
-      locale: null,
+      locale: draftLocale,
       snapshot: draftDocument,
       createdBy: params.user?.id ?? null,
     });
@@ -5160,6 +5195,14 @@ export class CollectionMutationService extends BaseService {
       // design and is handled separately.
       const documentLocalized =
         (collection as { localized?: boolean }).localized === true;
+      // The one key this document's working draft is stored, read, promoted and
+      // discarded under, in this method. Derived once: the store and the read
+      // disagreeing is a silent loss, because a draft written under one key is
+      // simply never found under another and no error is raised anywhere.
+      const draftLocaleKey = workingDraftLocale({
+        documentLocalized,
+        requestLocale: params.locale ?? null,
+      });
       // The component schemas reachable from this collection, resolved once off
       // the transaction (registry reads on the pooled connection, the same reason
       // as `webhookFields` below) and reused by the promote path. Skipped when a
@@ -5262,7 +5305,7 @@ export class CollectionMutationService extends BaseService {
             scopeSlug: params.collectionName,
             entryId: params.entryId,
           },
-          null
+          draftLocaleKey
         );
         if (advisoryDraft) {
           const { payload: draftInput } = buildRestorePayload(
@@ -5562,8 +5605,20 @@ export class CollectionMutationService extends BaseService {
             : (((preUpdateRow as { status?: unknown } | undefined)?.status as
                 | string
                 | undefined) ?? null);
-          storeAsWorkingDraft =
-            splitEnabled && namesNoStatus && draftLiveStatus === "published";
+          // The one hold rule, shared with the transaction and batch surfaces.
+          // Eligibility is passed in rather than recomputed: it was resolved
+          // off the transaction because it reads the component registry, and
+          // the promote path below needs it too.
+          storeAsWorkingDraft = resolveDraftHold({
+            collectionHasStatus,
+            draftsVersioningEnabled: versionsConfig?.drafts?.enabled === true,
+            documentLocalized,
+            fields: fields as unknown as FieldConfig[],
+            componentSchemas: splitComponentSchemas,
+            namedStatus: namesNoStatus ? undefined : transitionNextStatus,
+            liveStatus: draftLiveStatus,
+            requestLocale: params.locale ?? null,
+          }).hold;
 
           // TOCTOU-safe authorization: classify the transition against the
           // status just read UNDER THE ROW LOCK (`preUpdateRow` /
@@ -5656,7 +5711,7 @@ export class CollectionMutationService extends BaseService {
                 scopeSlug: params.collectionName,
                 entryId: params.entryId,
               },
-              null
+              draftLocaleKey
             );
             if (workingDraft) {
               // Promoting a working draft publishes (or unpublishes) its pending
@@ -6148,6 +6203,12 @@ export class CollectionMutationService extends BaseService {
                   collection,
                   collectionHasStatus,
                   componentFieldData,
+                  // The locale this write is for: the companion row's write
+                  // locale when the patch touched localized columns, and the
+                  // request's otherwise. Derived through the same function the
+                  // read overlay and the promote use, so all three look under
+                  // one key.
+                  draftLocale: draftLocaleKey,
                   fields,
                   manyToManyData,
                   params,
@@ -6176,7 +6237,7 @@ export class CollectionMutationService extends BaseService {
                     entryId: params.entryId,
                   },
                   // Same unlocalized key the fetch and store use.
-                  null
+                  draftLocaleKey
                 );
               }
 
@@ -6197,7 +6258,7 @@ export class CollectionMutationService extends BaseService {
                     scopeSlug: params.collectionName,
                     entryId: params.entryId,
                   },
-                  null
+                  draftLocaleKey
                 );
               }
 
@@ -6222,7 +6283,7 @@ export class CollectionMutationService extends BaseService {
                     scopeSlug: params.collectionName,
                     entryId: params.entryId,
                   },
-                  null
+                  draftLocaleKey
                 );
               }
 
@@ -8072,6 +8133,7 @@ export class CollectionMutationService extends BaseService {
       const {
         hold: txStoreAsWorkingDraft,
         componentSchemas: txSplitComponentSchemas,
+        draftLocale: txDraftLocale,
       } = await this.resolveWorkingDraftHold({
         collection,
         fields,
@@ -8180,6 +8242,7 @@ export class CollectionMutationService extends BaseService {
             // This surface writes no component subtrees of its own, so the
             // draft's components come from the live read alone.
             componentFieldData: {},
+            draftLocale: txDraftLocale,
             fields,
             manyToManyData,
             params: {
@@ -9720,6 +9783,7 @@ export class CollectionMutationService extends BaseService {
       const {
         hold: bulkStoreAsWorkingDraft,
         componentSchemas: bulkSplitComponentSchemas,
+        draftLocale: bulkDraftLocale,
       } = await this.resolveWorkingDraftHold({
         collection,
         fields,
@@ -9823,6 +9887,7 @@ export class CollectionMutationService extends BaseService {
             collectionHasStatus:
               (collection as { status?: boolean }).status === true,
             componentFieldData: {},
+            draftLocale: bulkDraftLocale,
             fields,
             manyToManyData,
             params: {

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -6972,18 +6972,15 @@ export class CollectionMutationService extends BaseService {
         if (deletedCount === 0) return;
         deletedRow = true;
 
-        // Remove any pending working-draft sidecar for the deleted entry in the
+        // Remove EVERY locale's pending working-draft sidecar for the deleted
         // same transaction: it is keyed by entry id and excluded from history and
         // retention queries, so after the row it belongs to is gone it would
         // otherwise linger unreachable in nextly_versions. A no-op when none.
-        await new VersionsRepository(tx).deleteWorkingDraft(
-          {
-            scopeKind: "collection",
-            scopeSlug: params.collectionName,
-            entryId: params.entryId,
-          },
-          null
-        );
+        await new VersionsRepository(tx).deleteAllWorkingDrafts({
+          scopeKind: "collection",
+          scopeSlug: params.collectionName,
+          entryId: params.entryId,
+        });
 
         // Recovery points go with it, every author's. They are excluded from
         // history, from version reads and from retention pruning, so nothing
@@ -8600,17 +8597,14 @@ export class CollectionMutationService extends BaseService {
       }
       deleteNeedsRollback = true;
 
-      // Remove any pending working-draft sidecar for the deleted entry in the
+      // Remove EVERY locale's pending working-draft sidecar for the deleted
       // same transaction, so it does not linger unreachable in nextly_versions
       // after its row is gone. A no-op when none exists.
-      await new VersionsRepository(tx).deleteWorkingDraft(
-        {
-          scopeKind: "collection",
-          scopeSlug: params.collectionName,
-          entryId: params.entryId,
-        },
-        null
-      );
+      await new VersionsRepository(tx).deleteAllWorkingDrafts({
+        scopeKind: "collection",
+        scopeSlug: params.collectionName,
+        entryId: params.entryId,
+      });
 
       // Recovery points go with it; see the single-delete path.
       await new VersionsRepository(tx).deleteAutosaves({
@@ -10299,17 +10293,14 @@ export class CollectionMutationService extends BaseService {
       }
       deleteNeedsRollback = true;
 
-      // Remove any pending working-draft sidecar for the deleted entry in the
+      // Remove EVERY locale's pending working-draft sidecar for the deleted
       // same transaction, so a batch delete does not leave it unreachable in
       // nextly_versions after its row is gone. A no-op when none exists.
-      await new VersionsRepository(tx).deleteWorkingDraft(
-        {
-          scopeKind: "collection",
-          scopeSlug: params.collectionName,
-          entryId,
-        },
-        null
-      );
+      await new VersionsRepository(tx).deleteAllWorkingDrafts({
+        scopeKind: "collection",
+        scopeSlug: params.collectionName,
+        entryId,
+      });
 
       // Recovery points go with it; see the single-delete path.
       await new VersionsRepository(tx).deleteAutosaves({

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -113,6 +113,7 @@ import {
 import { resolveComponentSchemas } from "../../versions/restore-version";
 import { rehydrateSnapshotDates } from "../../versions/tag-component-types";
 import { VersionsRepository } from "../../versions/versions-repository";
+import { workingDraftLocale } from "../../versions/working-draft-locale";
 
 import type { CollectionAccessService } from "./collection-access-service";
 import type { CollectionHookService } from "./collection-hook-service";
@@ -2697,10 +2698,16 @@ export class CollectionQueryService extends BaseService {
             scopeSlug: params.collectionName,
             entryId,
           },
-          // Non-localized split: the draft is keyed under the unlocalized
-          // `locale IS NULL` slot, matching the store and promote, so it is
-          // found regardless of the request locale.
-          null
+          // The same key the store, the promote and the discard derive, from
+          // the same function: an unlocalized document under the `locale IS
+          // NULL` slot, a localized one under the language being read. A read
+          // that looked elsewhere would report no pending change and serve the
+          // published content as though the author had never saved.
+          workingDraftLocale({
+            documentLocalized:
+              (collection as { localized?: boolean }).localized === true,
+            requestLocale: params.locale ?? null,
+          })
         );
         // Mirror the write gate's eligibility check before overlaying: a
         // component that turned localized or unresolvable after this draft was

--- a/packages/nextly/src/domains/versions/__tests__/draft-hold.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/draft-hold.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { text } from "../../../config";
+import { resolveDraftHold, type DraftHoldInput } from "../draft-hold";
+
+/** An eligible, published, unlocalized document with a status-less write. */
+const base = (): DraftHoldInput => ({
+  collectionHasStatus: true,
+  draftsVersioningEnabled: true,
+  documentLocalized: false,
+  fields: [text({ name: "title" })] as never,
+  componentSchemas: null,
+  namedStatus: undefined,
+  liveStatus: "published",
+});
+
+describe("resolveDraftHold", () => {
+  it("holds a status-less edit to a published document", () => {
+    expect(resolveDraftHold(base())).toEqual({ hold: true, draftLocale: null });
+  });
+
+  it("does not hold a write that names a status", () => {
+    // Naming a status IS the publish/unpublish intent; holding it would mean
+    // the author asked to publish and nothing went live.
+    expect(resolveDraftHold({ ...base(), namedStatus: "published" }).hold).toBe(
+      false
+    );
+  });
+
+  it("does not hold an edit to a document that is not published", () => {
+    // Nothing is live to protect, so the edit belongs on the row.
+    expect(resolveDraftHold({ ...base(), liveStatus: "draft" }).hold).toBe(
+      false
+    );
+  });
+
+  it("does not hold when the collection has no lifecycle or no drafts", () => {
+    expect(
+      resolveDraftHold({ ...base(), collectionHasStatus: false }).hold
+    ).toBe(false);
+    expect(
+      resolveDraftHold({ ...base(), draftsVersioningEnabled: false }).hold
+    ).toBe(false);
+  });
+
+  it("derives the language key for a localized edit, and defers to eligibility", () => {
+    // The key is derived whether or not the write is held: the two are separate
+    // questions. A localized document is currently excluded from the split by
+    // `isDraftSplitEligible`, so the answer today is a key with no hold.
+    expect(
+      resolveDraftHold({
+        ...base(),
+        documentLocalized: true,
+        requestLocale: "es",
+      })
+    ).toEqual({ hold: false, draftLocale: "es" });
+  });
+
+  it("refuses to hold a localized edit whose locale it cannot name", () => {
+    // The case that matters: a surface with no locale concept must NOT store
+    // the draft under the unlocalized slot. Nothing would read it there, and
+    // the author would be told the save succeeded.
+    const decision = resolveDraftHold({
+      ...base(),
+      documentLocalized: true,
+    });
+    expect(decision).toEqual({ hold: false, draftLocale: null });
+  });
+
+  it("ignores a locale on an unlocalized document", () => {
+    // A localization-configured app can send a locale to a collection that is
+    // not localized; keying by it would strand the draft.
+    expect(resolveDraftHold({ ...base(), requestLocale: "es" })).toEqual({
+      hold: true,
+      draftLocale: null,
+    });
+  });
+});

--- a/packages/nextly/src/domains/versions/__tests__/working-draft-locale.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/working-draft-locale.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { workingDraftLocale } from "../working-draft-locale";
+
+describe("workingDraftLocale", () => {
+  it("is null for an unlocalized document, whatever locale was requested", () => {
+    // The key has to be stable across requests: a later read or publish
+    // arriving under a different locale must find the same draft.
+    expect(
+      workingDraftLocale({ documentLocalized: false, requestLocale: "es" })
+    ).toBeNull();
+    expect(workingDraftLocale({ documentLocalized: false })).toBeNull();
+  });
+
+  it("is the requested locale for a localized document", () => {
+    expect(
+      workingDraftLocale({ documentLocalized: true, requestLocale: "es" })
+    ).toBe("es");
+  });
+
+  it("falls back to the default locale when none was requested", () => {
+    expect(
+      workingDraftLocale({ documentLocalized: true, defaultLocale: "en" })
+    ).toBe("en");
+  });
+
+  it("prefers the requested locale over the default", () => {
+    expect(
+      workingDraftLocale({
+        documentLocalized: true,
+        requestLocale: "fr",
+        defaultLocale: "en",
+      })
+    ).toBe("fr");
+  });
+
+  it("is null for a localized document with no locale resolvable", () => {
+    // Rather than inventing one: a draft stored under a guessed locale is
+    // stranded, because no later read would look under that key.
+    expect(workingDraftLocale({ documentLocalized: true })).toBeNull();
+  });
+});

--- a/packages/nextly/src/domains/versions/__tests__/working-draft-orphans.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/working-draft-orphans.integration.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Deleting a document removes EVERY language's pending change.
+ *
+ * Discarding a pending change and deleting the document it belongs to are two
+ * different questions. Discard is one language's; delete is all of them. A
+ * delete that removed only the unlocalized row would leave every other
+ * language's draft behind, pointing at a row that no longer exists — invisible,
+ * because nothing reads a draft for a document that is gone, right up until a
+ * new document reuses the id or a retention sweep trips over it.
+ *
+ * The drafts are stored straight through the repository, which has always been
+ * per-locale; only its callers were not. That is what lets this prove the
+ * delete side before the write side is threaded through.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionEntryService } from "../../../services/collections/collection-entry-service";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+import { VersionsRepository, type VersionRef } from "../versions-repository";
+
+let handle: TestNextly | undefined;
+
+afterEach(async () => {
+  await handle?.destroy();
+  handle = undefined;
+});
+
+const COLLECTION = "orphanposts";
+
+async function boot(): Promise<CollectionEntryService> {
+  handle = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: COLLECTION,
+        status: true,
+        versions: { drafts: true },
+        fields: [text({ name: "title" })],
+      }),
+    ],
+  });
+  return (
+    handle.getService("collectionsHandler") as CollectionsHandler
+  ).getEntryService() as CollectionEntryService;
+}
+
+async function draftRowCount(entryId: string): Promise<number> {
+  const rows = await handle!.adapter.select<{ id: string }>("nextly_versions", {
+    where: {
+      and: [
+        { column: "entryId", op: "=", value: entryId },
+        { column: "isAutosave", op: "=", value: false },
+        { column: "versionNo", op: "IS NULL" },
+        { column: "status", op: "=", value: "draft" },
+      ],
+    },
+  });
+  return rows.length;
+}
+
+/** Two pending changes for one document, in two different languages. */
+async function seedTwoLanguages(entryId: string): Promise<void> {
+  const repo = new VersionsRepository(handle!.adapter);
+  const ref: VersionRef = {
+    scopeKind: "collection",
+    scopeSlug: COLLECTION,
+    entryId,
+  };
+  await repo.upsertWorkingDraft({
+    ref,
+    locale: "en",
+    snapshot: { title: "pending en" },
+    createdBy: "u1",
+  });
+  await repo.upsertWorkingDraft({
+    ref,
+    locale: "es",
+    snapshot: { title: "pending es" },
+    createdBy: "u1",
+  });
+  // The fixture has to have worked, or "nothing was left behind" is trivially
+  // true and this suite proves nothing.
+  expect(await draftRowCount(entryId)).toBe(2);
+}
+
+describe("deleting a document removes every language's pending change", () => {
+  it("through deleteEntry", async () => {
+    const entries = await boot();
+    const created = await entries.createEntry(
+      { collectionName: COLLECTION, overrideAccess: true },
+      { title: "live", status: "published" }
+    );
+    const id = (created.data as { id: string }).id;
+    await seedTwoLanguages(id);
+
+    await entries.deleteEntry({
+      collectionName: COLLECTION,
+      entryId: id,
+      overrideAccess: true,
+    });
+
+    expect(await draftRowCount(id)).toBe(0);
+  });
+
+  it("through deleteEntryInTransaction", async () => {
+    const entries = await boot();
+    const created = await entries.createEntry(
+      { collectionName: COLLECTION, overrideAccess: true },
+      { title: "live", status: "published" }
+    );
+    const id = (created.data as { id: string }).id;
+    await seedTwoLanguages(id);
+
+    await handle!.adapter.transaction(tx =>
+      entries.deleteEntryInTransaction(tx as never, {
+        collectionName: COLLECTION,
+        entryId: id,
+      })
+    );
+
+    expect(await draftRowCount(id)).toBe(0);
+  });
+});

--- a/packages/nextly/src/domains/versions/draft-hold.ts
+++ b/packages/nextly/src/domains/versions/draft-hold.ts
@@ -1,0 +1,65 @@
+/**
+ * Whether one write holds its edit as a working draft, and under which key.
+ *
+ * Pure and exported so the rule can be tested directly. It composes the two
+ * questions that were already separate — is this document eligible for the
+ * split, and which locale keys its draft — into the single answer every write
+ * path needs, so no caller can arrive at "hold" without also arriving at a key.
+ *
+ * Holding without a key is the failure this shape makes unrepresentable. A
+ * draft written under a slot no later read looks in is lost in the worst
+ * possible way: the author is told the save succeeded.
+ *
+ * @module domains/versions/draft-hold
+ */
+
+import type { FieldConfig } from "../../collections/fields/types";
+
+import { isDraftSplitEligible } from "./draft-split-eligibility";
+import type { ComponentSchemas } from "./restore-snapshot";
+import { workingDraftLocale } from "./working-draft-locale";
+
+export interface DraftHoldInput {
+  collectionHasStatus: boolean;
+  draftsVersioningEnabled: boolean;
+  documentLocalized: boolean;
+  fields: FieldConfig[];
+  componentSchemas: ComponentSchemas | null;
+  /** The status this write names, if any. A write that names one is not held. */
+  namedStatus: unknown;
+  /** The committed status of the row being written. */
+  liveStatus: unknown;
+  /**
+   * The locale this write is for. A surface with no locale concept passes
+   * nothing, which is what makes it decline a localized document rather than
+   * key one under the wrong slot.
+   */
+  requestLocale?: string | null;
+}
+
+export interface DraftHoldDecision {
+  hold: boolean;
+  draftLocale: string | null;
+}
+
+/** Decide whether this write holds its edit, and under which locale key. */
+export function resolveDraftHold(input: DraftHoldInput): DraftHoldDecision {
+  const draftLocale = workingDraftLocale({
+    documentLocalized: input.documentLocalized,
+    requestLocale: input.requestLocale,
+  });
+  const eligible = isDraftSplitEligible({
+    collectionHasStatus: input.collectionHasStatus,
+    draftsVersioningEnabled: input.draftsVersioningEnabled,
+    documentLocalized: input.documentLocalized,
+    fields: input.fields,
+    componentSchemas: input.componentSchemas,
+  });
+  const hold =
+    eligible &&
+    input.namedStatus === undefined &&
+    input.liveStatus === "published" &&
+    // A localized document whose locale this write cannot name is not held.
+    !(input.documentLocalized && draftLocale === null);
+  return { hold, draftLocale };
+}

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -331,6 +331,27 @@ export class VersionsRepository {
   }
 
   /**
+   * Delete EVERY working draft this document has, in every locale, returning
+   * the number of rows removed. Called when the document itself goes away.
+   *
+   * Separate from {@link deleteWorkingDraft} because they answer different
+   * questions, and reaching for the wrong one is harmful in both directions:
+   * removing one locale's draft on a document delete strands the rest, pointing
+   * at a row that no longer exists, while removing all of them on a discard
+   * throws away pending work in languages the author never touched.
+   */
+  async deleteAllWorkingDrafts(ref: VersionRef): Promise<number> {
+    return this.db.delete(TABLE, {
+      and: [
+        ...this.docWhere(ref),
+        { column: "isAutosave", op: "=", value: false },
+        { column: "versionNo", op: "IS NULL" },
+        { column: "status", op: "=", value: "draft" },
+      ],
+    });
+  }
+
+  /**
    * Delete the working draft for a document in one locale, returning the number
    * of rows removed. Called when the draft is promoted (published) or discarded.
    */

--- a/packages/nextly/src/domains/versions/working-draft-locale.ts
+++ b/packages/nextly/src/domains/versions/working-draft-locale.ts
@@ -1,0 +1,43 @@
+/**
+ * Which locale keys a document's working draft.
+ *
+ * One function owns this because the store, the read overlay, the promote and
+ * the discard all have to agree. Asked separately at each of them the answers
+ * could drift, and the failure is silent: a draft written under one key and
+ * looked for under another is simply never found again, so the author's pending
+ * edit disappears with no error anywhere. That is the same failure mode the
+ * eligibility question had before it was given one implementation.
+ *
+ * An unlocalized document keys under `null` regardless of the locale on the
+ * request. A localization-configured app can send a locale on a write to a
+ * collection that is not localized, and keying by it would strand the draft the
+ * moment a later read arrived under a different one.
+ *
+ * @module domains/versions/working-draft-locale
+ */
+
+/** What the caller knows about the document and the request. */
+export interface WorkingDraftLocaleInput {
+  /** `collection.localized === true`. */
+  documentLocalized: boolean;
+  /** The locale this request resolved to, if any. */
+  requestLocale?: string | null;
+  /** The app's default locale, used when the request named none. */
+  defaultLocale?: string | null;
+}
+
+/**
+ * The locale to key this document's working draft under, or `null` for the
+ * unlocalized slot.
+ *
+ * Returns `null` for a localized document whose locale cannot be resolved.
+ * Inventing one would store the draft under a key nothing later reads, which
+ * loses the edit as surely as not storing it — and does so while reporting
+ * success.
+ */
+export function workingDraftLocale(
+  input: WorkingDraftLocaleInput
+): string | null {
+  if (!input.documentLocalized) return null;
+  return input.requestLocale ?? input.defaultLocale ?? null;
+}


### PR DESCRIPTION
PR 3a of six. Design: `2026-08-19-pending-changes-everywhere-design.md` §3 PR3. Plan: `2026-08-19-plan-pr3-per-language-pending-changes.md`.

**Behaviour-neutral.** Localized collections remain excluded from the split, so every locale resolution here returns exactly the `null` that was passed before. 3b removes the exclusion; this makes doing so safe.

## Why this is separate

The substrate has always been per-language — `nextly_versions.locale` stores one locale per snapshot, companion rows carry per-locale `_status`, and #1059 constrains a document to one working draft **per locale**. What was missing is that **twelve call sites passed `null`**, and they were two different questions:

- **nine are "this locale's draft"** — store, read overlay, promote read, promote delete, discard;
- **three are "all of this document's drafts"** — `deleteEntry`, `deleteEntryInTransaction`, `deleteSingleEntryInTransaction`.

Threading a locale through all twelve alike would have introduced a defect. That is what this PR gets right before 3b makes it reachable.

## The orphan defect, proven before fixing

Two pending changes for one document in two languages, then delete the document:

```
expected 2 to be +0
```

Both survived. With per-locale keys, `deleteWorkingDraft(ref, null)` removes only the unlocalized row and leaves every other language's draft behind, pointing at a row that no longer exists — invisible, because nothing reads a draft for a document that is gone.

`deleteAllWorkingDrafts` now exists beside `deleteWorkingDraft`, and their docblocks say why both do: reaching for the wrong one either strands rows or destroys another language's work.

The fixture asserts it created two rows before deleting. Without that, "nothing was left behind" is trivially true against a repository that stored nothing.

## One rule, one key

`resolveDraftHold` is a pure function next to `isDraftSplitEligible` and `workingDraftLocale`. It answers **both** questions at once — should this write hold its edit, and under which key — so no caller can arrive at "hold" without also arriving at a key.

That shape exists because of a measurement. `updateEntryInTransaction` and `updateSingleEntryInTransaction` contain **zero** references to a locale, across ~700 lines each: those surfaces have no locale concept at all. So a localized document reached through them cannot be keyed, and the rule now declines to hold it rather than writing it to the unlocalized slot. **Storing it there would report success and lose the edit at the next read** — worse than writing the live row, because the author is told it was saved.

Within `updateEntry` the key is derived **once**, into `draftLocaleKey`, and used by all five of its sites. The store and the read disagreeing is a silent loss with no error anywhere, so one derivation is the only safe arrangement.

## Verification

- **Identical, not merely green:** draft-published-split + draft-split-write-paths = **51 tests**, exactly the 48 + 3 baseline, on Postgres, MySQL and SQLite.
- Collections + versions integration: **50 files / 397 passed** = the 49/395 baseline plus this PR's orphan suite.
- `versions` unit suites: 27 files / 370 tests, including 7 new for `resolveDraftHold` and 5 for `workingDraftLocale`.
- Typecheck clean on both configs; lint clean.

## fallow

Complexity: **0 introduced.** The first draft put the hold rule in a private service method where CRAP hit 37.1 — cognitive was 4, so the number was really about unit-test coverage of a method no unit test could reach. The fix was to make it a pure exported function with real tests, not to carve it up to suit the metric.

Duplication: **1 introduced**, the two document-delete blocks, which are pre-existing parallel code that rewriting both to `deleteAllWorkingDrafts` made more alike. Same category as the dialect-schema parallelism on #1059, where trimming to reduce it measured *worse*.

## Research behind 3b

Payload shipped per-locale status in **v3.72.0 (January 2026) as experimental/beta**, needing a migration that converts `_status` from a string to a locale object, with reported bugs including publishing one locale publishing all of them. Payload's v4 discussion (#15125) is **open, not shipped**, and states the problem is largely unresolved: each locale is still one document, and its versions are one document too.

Nextly's substrate does not have that problem. One snapshot row per locale, per-locale `_status`, and a per-(document, locale) constraint. 3b turns on what is already shaped correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Working drafts now support consistent locale-specific handling across create, update, bulk, and discard operations.
  * Localized drafts use the requested locale, with fallback to the default locale when needed.
  * Deleting an entry now removes its pending drafts across all locales.

* **Bug Fixes**
  * Prevented orphaned localized drafts and incorrect draft retrieval.
  * Improved draft holding for published localized and unlocalized entries.

* **Tests**
  * Added coverage for locale resolution, draft holding, and cleanup across deletion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->