### PR TITLE
feat(nextly): hold pending changes per language

### DIFF
--- a/.changeset/pending-changes-per-language.md
+++ b/.changeset/pending-changes-per-language.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Hold pending changes per language on a translated document.
+
+Editing a published translation now holds the change for that language and
+leaves the other translations alone, and publishing a language publishes that
+language's pending change. Previously a multilingual collection had no pending
+changes at all: every edit to a published translation went straight to the live
+site.

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -1867,7 +1867,7 @@ describe("draft/published split — schema and component eligibility (integratio
     ],
   });
 
-  it("keeps a status-less edit live (no draft) when the collection embeds a localized component", async () => {
+  it("holds a status-less edit when the collection embeds a localized component", async () => {
     const entries = await bootFile(withHero(true));
     const ctx = { collectionName: COLLECTION, overrideAccess: true };
 
@@ -1875,8 +1875,10 @@ describe("draft/published split — schema and component eligibility (integratio
     const [row] = await handle!.adapter.select<LiveRow>(TABLE);
     const id = row.id;
 
-    // A localized component makes the collection ineligible for the split, so a
-    // status-less edit writes the live row directly rather than storing a draft.
+    // A localized component is representable in a draft snapshot, which holds
+    // exactly one locale's values and is keyed by that locale. What is still
+    // refused is an UNRESOLVED component, whose subtree would be dropped on
+    // promote without anyone noticing.
     const res = await entries.updateEntry(
       { ...ctx, entryId: id },
       { title: "edited" }
@@ -1884,8 +1886,8 @@ describe("draft/published split — schema and component eligibility (integratio
     expect(res.success).toBe(true);
 
     const [live] = await handle!.adapter.select<LiveRow>(TABLE);
-    expect(live.title).toBe("edited");
-    expect(await workingDraftCount(id)).toBe(0);
+    expect(live.title).toBe("live");
+    expect(await workingDraftCount(id)).toBe(1);
   });
 
   it("prunes fields the current schema no longer declares from a draft read", async () => {
@@ -2253,7 +2255,10 @@ describe("draft/published split — schema draftsEnabled flag (integration)", ()
     ).toBe(false);
   });
 
-  it("is false for a localized collection", async () => {
+  it("is true for a localized collection", async () => {
+    // The editor is told drafts are on for a translated document, because they
+    // are: a pending change is held per language, keyed by the language it
+    // belongs to.
     expect(
       await draftsEnabledFor(
         defineCollection({
@@ -2264,7 +2269,7 @@ describe("draft/published split — schema draftsEnabled flag (integration)", ()
           fields: [text({ name: "title" })],
         })
       )
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("is false for a collection with a reachable password field", async () => {

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-split-per-language.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-split-per-language.integration.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Pending changes work per language.
+ *
+ * A localized document is a set of variants with their own lifecycle state, not
+ * one document with one state. Editing the Spanish translation of a published
+ * page holds the Spanish edit and leaves English alone; publishing Spanish
+ * publishes Spanish. Until this worked, "Nextly has drafts" was a claim that
+ * failed on the first multilingual site, because the split refused any
+ * localized collection outright.
+ *
+ * Every "unaffected" assertion is paired with a positive one in the same case.
+ * "English is untouched" is satisfied just as well by a system that stores no
+ * pending change at all, so each case also proves the Spanish one exists.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../../plugins/test-nextly";
+import type { CollectionEntryService } from "../../../../services/collections/collection-entry-service";
+import type { CollectionsHandler } from "../../../../services/collections-handler";
+
+let handle: TestNextly | undefined;
+
+afterEach(async () => {
+  await handle?.destroy();
+  handle = undefined;
+});
+
+const COLLECTION = "langposts";
+
+async function boot(): Promise<CollectionEntryService> {
+  handle = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: COLLECTION,
+        localized: true,
+        status: true,
+        versions: { drafts: true },
+        fields: [text({ name: "title" }), text({ name: "body" })],
+      }),
+    ],
+    localization: { locales: ["en", "es"], defaultLocale: "en" },
+  });
+  return (
+    handle.getService("collectionsHandler") as CollectionsHandler
+  ).getEntryService() as CollectionEntryService;
+}
+
+/** A document published in both languages. */
+async function publishBoth(entries: CollectionEntryService): Promise<string> {
+  const created = await entries.createEntry(
+    { collectionName: COLLECTION, overrideAccess: true, locale: "en" },
+    { title: "en title", body: "en body", status: "published" }
+  );
+  const id = (created.data as { id: string }).id;
+  await entries.updateEntry(
+    {
+      collectionName: COLLECTION,
+      entryId: id,
+      overrideAccess: true,
+      locale: "es",
+    },
+    { title: "es title", body: "es body", status: "published" }
+  );
+  return id;
+}
+
+/** Pending changes for a document, by the language they are keyed under. */
+async function pendingLocales(entryId: string): Promise<string[]> {
+  const rows = await handle!.adapter.select<{ locale: string | null }>(
+    "nextly_versions",
+    {
+      where: {
+        and: [
+          { column: "entryId", op: "=", value: entryId },
+          { column: "isAutosave", op: "=", value: false },
+          { column: "versionNo", op: "IS NULL" },
+          { column: "status", op: "=", value: "draft" },
+        ],
+      },
+    }
+  );
+  return rows.map(r => r.locale ?? "(none)").sort();
+}
+
+async function readBody(
+  entries: CollectionEntryService,
+  id: string,
+  locale: string
+): Promise<unknown> {
+  const res = await entries.getEntry({
+    collectionName: COLLECTION,
+    entryId: id,
+    overrideAccess: true,
+    locale,
+  });
+  return (res.data as { body?: unknown } | null)?.body;
+}
+
+describe("pending changes per language (integration)", () => {
+  it("holds a Spanish edit under Spanish and leaves English alone", async () => {
+    const entries = await boot();
+    const id = await publishBoth(entries);
+
+    await entries.updateEntry(
+      {
+        collectionName: COLLECTION,
+        entryId: id,
+        overrideAccess: true,
+        locale: "es",
+      },
+      { body: "es edited" }
+    );
+
+    // The positive half: the pending change exists, keyed under Spanish.
+    expect(await pendingLocales(id)).toEqual(["es"]);
+    // The negative half, which alone would prove nothing.
+    expect(await readBody(entries, id, "en")).toBe("en body");
+  });
+
+  it("keeps two languages' pending changes apart", async () => {
+    const entries = await boot();
+    const id = await publishBoth(entries);
+
+    await entries.updateEntry(
+      {
+        collectionName: COLLECTION,
+        entryId: id,
+        overrideAccess: true,
+        locale: "es",
+      },
+      { body: "es edited" }
+    );
+    await entries.updateEntry(
+      {
+        collectionName: COLLECTION,
+        entryId: id,
+        overrideAccess: true,
+        locale: "en",
+      },
+      { body: "en edited" }
+    );
+
+    expect(await pendingLocales(id)).toEqual(["en", "es"]);
+    // Neither live translation moved.
+    expect(await readBody(entries, id, "es")).toBe("es body");
+    expect(await readBody(entries, id, "en")).toBe("en body");
+  });
+
+  it("publishes the language being published, and only that one", async () => {
+    const entries = await boot();
+    const id = await publishBoth(entries);
+
+    await entries.updateEntry(
+      {
+        collectionName: COLLECTION,
+        entryId: id,
+        overrideAccess: true,
+        locale: "es",
+      },
+      { body: "es edited" }
+    );
+    await entries.updateEntry(
+      {
+        collectionName: COLLECTION,
+        entryId: id,
+        overrideAccess: true,
+        locale: "en",
+      },
+      { body: "en edited" }
+    );
+
+    const published = await entries.updateEntry(
+      {
+        collectionName: COLLECTION,
+        entryId: id,
+        overrideAccess: true,
+        locale: "es",
+      },
+      { status: "published" }
+    );
+    // Assert the operation SUCCEEDED before asserting its effects: a soft
+    // failure would otherwise read as "the promote did nothing".
+    expect({
+      success: published.success,
+      message: published.message,
+    }).toEqual({ success: true, message: expect.any(String) });
+
+    // Spanish went live and its pending change is gone; English is still
+    // pending and its live content is unchanged.
+    expect(await readBody(entries, id, "es")).toBe("es edited");
+    expect(await pendingLocales(id)).toEqual(["en"]);
+    expect(await readBody(entries, id, "en")).toBe("en body");
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1023,7 +1023,14 @@ export class CollectionMutationService extends BaseService {
     collectionName: string,
     entryData: Record<string, unknown>,
     locale: string | undefined,
-    isCreate: boolean
+    isCreate: boolean,
+    /**
+     * Transaction-bound executor, when this runs inside a caller's transaction.
+     * The companion metadata read would otherwise check out a second pooled
+     * connection the open transaction is holding, which stalls against a small
+     * pool.
+     */
+    executor?: unknown
   ): Promise<{
     companionTableName: string;
     writeLocale: string;
@@ -1039,8 +1046,10 @@ export class CollectionMutationService extends BaseService {
     hasStatus: boolean;
   } | null> {
     if (!this.localization) return null;
-    const companion =
-      await this.fileManager.loadCompanionSchema(collectionName);
+    const companion = await this.fileManager.loadCompanionSchema(
+      collectionName,
+      executor
+    );
     if (!companion) return null;
 
     // Route to the companion ONLY when it physically exists (the migration has run). Before
@@ -4483,7 +4492,6 @@ export class CollectionMutationService extends BaseService {
     const componentSchemas =
       collectionHasStatus &&
       versionsConfig?.drafts?.enabled === true &&
-      !documentLocalized &&
       !hasPasswordField(args.fields)
         ? await resolveComponentSchemas(args.fields as unknown as FieldConfig[])
         : null;
@@ -5079,7 +5087,7 @@ export class CollectionMutationService extends BaseService {
       // body — see the create path.
       const intendedStatus = finalData.status;
 
-      const localizedUpdate = await this.splitLocalizedWriteData(
+      let localizedUpdate = await this.splitLocalizedWriteData(
         params.collectionName,
         finalData,
         params.locale,
@@ -5097,7 +5105,7 @@ export class CollectionMutationService extends BaseService {
       // companion `_status` the split produced (a string only when one was
       // provided), otherwise the main-row status.
       const transitionNextStatus = isNonDefaultLocaleStatusWrite
-        ? localizedUpdate.companionData._status
+        ? localizedUpdate?.companionData._status
         : intendedStatus;
       // Resolve the one publish permission this write could require — keyed on
       // the status it will persist — BEFORE the transaction opens, so the RBAC
@@ -5213,7 +5221,6 @@ export class CollectionMutationService extends BaseService {
       const splitComponentSchemas =
         collectionHasStatus &&
         versionsConfig?.drafts?.enabled === true &&
-        !documentLocalized &&
         !hasPasswordField(fields)
           ? await resolveComponentSchemas(fields as unknown as FieldConfig[])
           : null;
@@ -5228,7 +5235,6 @@ export class CollectionMutationService extends BaseService {
       const splitEnabled = isDraftSplitEligible({
         collectionHasStatus,
         draftsVersioningEnabled: versionsConfig?.drafts?.enabled === true,
-        documentLocalized,
         fields: fields as unknown as FieldConfig[],
         componentSchemas: splitComponentSchemas,
       });
@@ -5277,9 +5283,11 @@ export class CollectionMutationService extends BaseService {
             hasTitle:
               !isPluginForRestore || fields.some(f => f.name === "title"),
             componentSchemas: splitComponentSchemas ?? undefined,
-            // The split is non-localized-only, so the document holds no per-locale
-            // values and the snapshot's locale is the resolved request locale.
-            documentLocalized: false,
+            documentLocalized,
+            // A working draft always knows which language it holds: it is keyed
+            // by that language, and a write that cannot name one does not store
+            // a draft at all. So the snapshot's locale is never the unknown one
+            // here, and its translatable values need not be held back.
             localeUnknown: false,
           }
         : null;
@@ -5795,6 +5803,27 @@ export class CollectionMutationService extends BaseService {
               finalData = mergedPromoteData;
               componentFieldData = draftParts.componentFieldData;
               manyToManyData = draftParts.manyToManyData;
+              // Rebuild the companion payload from the promoted document, and
+              // do it BEFORE the main-row payload is taken: the split moves a
+              // localized field out of the document and into the companion, so
+              // taking the main payload first would carry translated values to
+              // the main table, which has no column for them.
+              //
+              // It was originally split from the CALLER's patch before this
+              // transaction, and a publish carries no content of its own — so
+              // without this the draft's translated values never reach the
+              // language's row at all and the translation publishes unchanged.
+              //
+              // Bound to this transaction's executor: the companion metadata
+              // read would otherwise take a second pooled connection that this
+              // open transaction is holding.
+              localizedUpdate = await this.splitLocalizedWriteData(
+                params.collectionName,
+                finalData,
+                draftLocaleKey ?? params.locale,
+                false,
+                tx.getDrizzle()
+              );
               updatePayload = {
                 ...stripImmutableSystemFields(finalData, "collection"),
                 updatedAt: updatePayload.updatedAt,
@@ -6425,7 +6454,7 @@ export class CollectionMutationService extends BaseService {
                 localizedStatusRecorded = await this.recordStatusEvents(tx, {
                   collection: params.collectionName,
                   id: params.entryId,
-                  locale: localizedUpdate.writeLocale,
+                  locale: localizedUpdate?.writeLocale,
                   from: localizedPreviousStatus,
                   to: companionNext,
                   isCreate: false,

--- a/packages/nextly/src/domains/versions/__tests__/draft-hold.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/draft-hold.test.ts
@@ -43,17 +43,14 @@ describe("resolveDraftHold", () => {
     ).toBe(false);
   });
 
-  it("derives the language key for a localized edit, and defers to eligibility", () => {
-    // The key is derived whether or not the write is held: the two are separate
-    // questions. A localized document is currently excluded from the split by
-    // `isDraftSplitEligible`, so the answer today is a key with no hold.
+  it("holds a localized edit under the language being written", () => {
     expect(
       resolveDraftHold({
         ...base(),
         documentLocalized: true,
         requestLocale: "es",
       })
-    ).toEqual({ hold: false, draftLocale: "es" });
+    ).toEqual({ hold: true, draftLocale: "es" });
   });
 
   it("refuses to hold a localized edit whose locale it cannot name", () => {

--- a/packages/nextly/src/domains/versions/__tests__/draft-split-eligibility.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/draft-split-eligibility.test.ts
@@ -42,7 +42,6 @@ const components = (
 const base: DraftSplitEligibilityInput = {
   collectionHasStatus: true,
   draftsVersioningEnabled: true,
-  documentLocalized: false,
   fields: textFields,
   componentSchemas: new Map(),
 };
@@ -64,10 +63,13 @@ describe("isDraftSplitEligible", () => {
     ).toBe(false);
   });
 
-  it("is off for a localized document", () => {
-    expect(isDraftSplitEligible({ ...base, documentLocalized: true })).toBe(
-      false
-    );
+  it("does not ask whether the document is localized", () => {
+    // A localized document is eligible: a snapshot holds exactly one locale's
+    // values, and the draft is keyed by that locale. Which locale, and whether
+    // the writing surface can name one at all, is decided by `resolveDraftHold`
+    // — keeping the two apart is what stops an edit being held under a key
+    // nothing reads.
+    expect(isDraftSplitEligible(base)).toBe(true);
   });
 
   it("is off for a top-level (or grouped) password field", () => {
@@ -85,13 +87,16 @@ describe("isDraftSplitEligible", () => {
     ).toBe(false);
   });
 
-  it("is off for a localized component", () => {
+  it("stays eligible with a localized component", () => {
+    // Representable, for the same reason the document itself is: a snapshot
+    // holds one locale's values and the draft is keyed by that locale. An
+    // UNRESOLVED component is still refused, below.
     expect(
       isDraftSplitEligible({
         ...base,
         componentSchemas: components({ localized: true }),
       })
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("is off for an unresolved component", () => {

--- a/packages/nextly/src/domains/versions/__tests__/schema-drafts-enabled.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/schema-drafts-enabled.test.ts
@@ -65,15 +65,17 @@ describe("schemaDraftsEnabled", () => {
     ).resolves.toBe(true);
   });
 
-  it("is false for a localized component without failing", async () => {
+  it("is true for a localized component", async () => {
     getComponentBySlugSpy.mockResolvedValue({
       fields: [{ name: "heading", type: "text" }],
       localized: true,
     });
 
+    // A localized component is representable: a snapshot holds one locale's
+    // values and the draft is keyed by that locale.
     await expect(
       schemaDraftsEnabled(draftsCollection(componentFields))
-    ).resolves.toBe(false);
+    ).resolves.toBe(true);
   });
 
   it("never touches the registry when the collection has no components", async () => {

--- a/packages/nextly/src/domains/versions/draft-hold.ts
+++ b/packages/nextly/src/domains/versions/draft-hold.ts
@@ -51,7 +51,6 @@ export function resolveDraftHold(input: DraftHoldInput): DraftHoldDecision {
   const eligible = isDraftSplitEligible({
     collectionHasStatus: input.collectionHasStatus,
     draftsVersioningEnabled: input.draftsVersioningEnabled,
-    documentLocalized: input.documentLocalized,
     fields: input.fields,
     componentSchemas: input.componentSchemas,
   });

--- a/packages/nextly/src/domains/versions/draft-split-eligibility.ts
+++ b/packages/nextly/src/domains/versions/draft-split-eligibility.ts
@@ -32,8 +32,6 @@ export interface DraftSplitEligibilityInput {
   collectionHasStatus: boolean;
   /** `collection.versions?.drafts?.enabled === true`. */
   draftsVersioningEnabled: boolean;
-  /** `collection.localized === true` — the split is off for localized documents. */
-  documentLocalized: boolean;
   /** The collection's top-level fields, for the reachable-password check. */
   fields: FieldConfig[];
   /**
@@ -53,11 +51,7 @@ export interface DraftSplitEligibilityInput {
 export function isDraftSplitEligible(
   input: DraftSplitEligibilityInput
 ): boolean {
-  if (
-    !input.collectionHasStatus ||
-    !input.draftsVersioningEnabled ||
-    input.documentLocalized
-  ) {
+  if (!input.collectionHasStatus || !input.draftsVersioningEnabled) {
     return false;
   }
   // A reachable password field disqualifies the whole collection: the snapshot
@@ -70,10 +64,11 @@ export function isDraftSplitEligible(
   const schemas = input.componentSchemas
     ? [...input.componentSchemas.values()]
     : [];
-  // A localized or unresolved component cannot be represented faithfully in a
-  // draft snapshot; a component holding a password is disqualified for the same
-  // reason as a top-level one.
-  if (schemas.some(schema => schema.localized || !schema.resolved)) {
+  // An unresolved component cannot be represented faithfully in a draft
+  // snapshot: its subtree would be dropped on promote, silently. A LOCALIZED
+  // component is representable, because a snapshot holds exactly one locale's
+  // values and the draft is keyed by that locale.
+  if (schemas.some(schema => !schema.resolved)) {
     return false;
   }
   if (schemas.some(schema => hasPasswordField(schema.fields))) {
@@ -107,18 +102,18 @@ export async function schemaDraftsEnabled(
 ): Promise<boolean> {
   const collectionHasStatus = collection.status === true;
   const draftsVersioningEnabled = collection.versions?.drafts?.enabled === true;
-  const documentLocalized = collection.localized === true;
+  // Resolved for a localized collection too: a localized component is
+  // representable now, but an UNRESOLVED one still is not, and skipping the
+  // registry read here would let it through unchecked.
   const componentSchemas =
     collectionHasStatus &&
     draftsVersioningEnabled &&
-    !documentLocalized &&
     !hasPasswordField(collection.fields)
       ? await resolveComponentSchemas(collection.fields)
       : null;
   return isDraftSplitEligible({
     collectionHasStatus,
     draftsVersioningEnabled,
-    documentLocalized,
     fields: collection.fields,
     componentSchemas,
   });


### PR DESCRIPTION
PR 3b of six, and the one the program exists for. Design: `2026-08-19-pending-changes-everywhere-design.md` §3 PR3. Follows #1065.

**Behaviour change:** on a localized collection, a status-less update to a published translation now HOLDS the edit instead of publishing it.

## What was false before this

"Nextly has drafts" failed on the first multilingual site. `isDraftSplitEligible` refused any localized collection outright, so editing a published translation wrote the live row — the change was on the public site immediately, with no way to hold it. Three cases, all failing before:

```
expected [] to deeply equal [ 'es' ]
expected [] to deeply equal [ 'en', 'es' ]
expected [] to deeply equal [ 'en' ]
```

No pending change stored at all, in any language.

## What it does now

- a Spanish edit is held under Spanish, and English's live content is untouched;
- two languages hold pending changes independently;
- publishing Spanish publishes Spanish, consumes only its pending change, and leaves English pending with its live content unchanged.

The exclusion is gone from `isDraftSplitEligible`, and with it the **localized-component** exclusion: a localized component is representable exactly because a snapshot holds one locale's values and the draft is keyed by that locale. **An unresolved component is still refused** — its subtree would be dropped on promote without anyone noticing. The password exclusion also stands; both are PR6's subject.

## The defect this uncovered, which is the substance of the PR

Turning eligibility on was not enough — publishing a translation produced:

```
no such column: title
```

`localizedUpdate` is split from the **caller's** patch before the transaction opens. A publish carries no content of its own, so when the promote folds the accumulated draft into `finalData`, the draft's translated values had nowhere to go: they were aimed at the main row, which has no column for them. The companion payload is now rebuilt from the promoted document.

Two details that had to be right, and were not obvious:

1. **Order.** `splitLocalizedWriteData` *mutates* its input, moving localized fields out of the document and into the companion payload. Rebuilding after taking the main-row payload leaves the translated values on the main row — the error above. The split must run first.
2. **Connection.** That rebuild reads companion metadata, which is a database read. Inside a caller's transaction it would check out a second pooled connection the transaction is holding, and stall against a small pool. `loadCompanionSchema` already accepts an executor for exactly this reason; `splitLocalizedWriteData` now threads one through.

Also corrected: `promoteRestoreCtx` hard-coded `documentLocalized: false` under a comment asserting "the split is non-localized-only". Inert while `localeUnknown` is false, but a lie that would mislead the next reader. It now carries the real value, and says why a working draft's locale is never the unknown one: it is keyed by that locale, and a write that cannot name one stores no draft.

## Two tests changed deliberately, not to match new output

Both encoded the exclusion this PR removes, and the regression run found them:

- `is false for a localized collection` → **is true**. The editor is told drafts are on for a translated document because they are.
- `keeps a status-less edit live (no draft) when the collection embeds a localized component` → **holds the edit**, asserting a draft now exists and the live row is unchanged.

The unit suites for `isDraftSplitEligible`, `schemaDraftsEnabled` and `resolveDraftHold` were flipped for the same reason. The `resolveDraftHold` case is the one I wrote in #1065 predicting this exact flip, and its diff is the flip.

## Verification

- New per-language suite: 3 cases green on **Postgres, MySQL and SQLite**.
- Collections + versions integration: **51 files / 400 passed**, 2+10 skipped.
- `versions` unit: 27 files / 370 tests.
- **The 11 unit failures in `collection-mutation` / `collection-access` / `collection-hooks` are pre-existing** — confirmed by reverting all three changed source files to `main`'s content in place and re-running: the identical 11 fail. Not assumed from a baseline note.
- Typecheck clean on both configs; lint clean; fallow `pass`, 0 introduced across all four categories.

## Competitive note

Payload shipped per-locale status in **v3.72.0 (January 2026) as experimental/beta**, requiring a migration converting `_status` from a string to a locale object, with reported bugs including publishing one locale publishing all. Its v4 discussion (#15125) is **open, not shipped**, and states the problem is largely unresolved because each locale's versions are still one document. Nextly stores one snapshot row per locale with per-locale `_status` and a per-(document, locale) constraint, which is why this is a behaviour flip rather than a migration.
