### PR TITLE
feat(builder): type a block's text in place on the canvas

### DIFF
--- a/.changeset/inline-prop-marking.md
+++ b/.changeset/inline-prop-marking.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Blocks can now say which of their values an editor may let an author type
+directly on the canvas, and which element holds each one. `core/heading`,
+`core/text` and `core/quote` declare theirs.
+
+Nothing changes on a published page: the marking is emitted only when a
+renderer is asked for editor addresses, so published markup is unchanged.

--- a/packages/blocks-engine/src/block.ts
+++ b/packages/blocks-engine/src/block.ts
@@ -23,6 +23,21 @@ import type { MigrationMap } from "./migration";
  */
 export interface PropSchema {
   type: string;
+  /**
+   * Whether an editor may let an author type this value directly on the canvas.
+   *
+   * Opt-in per prop, and it is a claim about the PROP rather than about the
+   * block: a quote's quoted text is edited in place, while the URL it cites is
+   * not, and no block-level flag can say that. Named after the same opt-in in
+   * Puck, whose `contentEditable` is likewise declared per field.
+   *
+   * Declaring it is half of the contract. The other half is the block marking
+   * WHICH element carries the value, through `markProp` in
+   * {@link BlockRenderArgs} — a prop declared inline whose element is never
+   * marked simply is not editable in place, which is the safe direction: the
+   * inspector still edits it.
+   */
+  inline?: boolean;
   [option: string]: unknown;
 }
 
@@ -112,6 +127,31 @@ export interface BlockRenderArgs<P, C = unknown> {
    * render a single element and never wrap it, so styles target that element.
    */
   className: string;
+  /**
+   * Marks the element that carries a named prop's value, for an editor.
+   *
+   * Spread onto the element the value is rendered into:
+   * `<p {...markProp?.("text")}>`. Absent outside an editor, and a renderer
+   * that supplies it returns nothing for a prop the block never declared
+   * `inline` — so a published page carries none of this and a block written
+   * against an older renderer keeps working.
+   *
+   * ## Why the BLOCK says where its text is
+   *
+   * Nothing else can. A quote renders three separate text props into three
+   * different nested elements, and the structure it chooses depends on which
+   * of them are empty; a heading renders its text inside an anchor when it has
+   * a link and directly otherwise. An editor inferring the element from the
+   * rendered DOM would be guessing, and guessing WRONG puts an author's typing
+   * into a different prop than the one they aimed at.
+   *
+   * The alternative the field is deliberately avoiding is a second render path
+   * for editing — the shape Gutenberg takes, where a block writes `edit` and
+   * `save` separately and the two must agree. One renderer draws both the
+   * canvas and the published page here, and that property is worth more than
+   * the convenience of an editor-only component.
+   */
+  markProp?: (name: string) => Record<string, string>;
   /**
    * Render one of this block's slots, optionally under a different context.
    *

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -115,6 +115,36 @@ function isAllowedAttribute(name: string): boolean {
 /** The attribute an editor addresses a node by. Named, so one string decides it. */
 export const NODE_ID_ATTRIBUTE = "data-nx-node";
 
+/**
+ * The attribute naming which prop an element renders, for an editor.
+ *
+ * Written only when the editor asked for node addresses, so a published page
+ * carries none of it — the same condition {@link NODE_ID_ATTRIBUTE} rides on,
+ * because the two answer one question together: an editor needs to know which
+ * node it is looking at AND which of that node's values an element holds, and
+ * either alone addresses nothing.
+ */
+export const PROP_ATTRIBUTE = "data-nx-prop";
+
+/**
+ * Builds the `markProp` a block spreads onto the element carrying a value.
+ *
+ * Returns nothing at all outside an editor, and nothing for a prop the block
+ * has not declared `inline` — so the declaration and the marking have to agree
+ * before an editor sees anything, and a block that marks an element it never
+ * declared gets silence rather than an editable region nobody intended.
+ */
+function propMarker(
+  definition: { props?: Record<string, { inline?: boolean } | undefined> },
+  enabled: boolean
+): ((name: string) => Record<string, string>) | undefined {
+  if (!enabled) return undefined;
+  return (name: string): Record<string, string> => {
+    if (definition.props?.[name]?.inline !== true) return {};
+    return { [PROP_ATTRIBUTE]: name };
+  };
+}
+
 function withNodeAttributes(
   output: ReactNode,
   node: BlockNode,
@@ -529,6 +559,8 @@ export function BlockBoundary({
     declaresNothing = false;
   }
 
+  const marker = propMarker(definition, nodeAttribute === true);
+
   let output: unknown;
   try {
     output = definition.render({
@@ -536,6 +568,10 @@ export function BlockBoundary({
       node,
       className,
       ctx: context,
+      // Undefined rather than a no-op function when this is not an editor
+      // render, so `markProp?.("text")` spreads nothing and a published page
+      // is byte-identical to one rendered before this existed.
+      ...(marker === undefined ? {} : { markProp: marker }),
       // The renderer's, not the context's. A block may replace the context its
       // slot children see; it can neither drop nor forge this.
       ...(hostPolicy === undefined ? {} : { hostPolicy }),

--- a/packages/blocks-react/src/blocks/heading.tsx
+++ b/packages/blocks-react/src/blocks/heading.tsx
@@ -39,10 +39,16 @@ export interface HeadingProps {
 export function renderHeading({
   props,
   className,
+  markProp,
 }: BlockRenderArgs<HeadingProps>): ReactElement {
   const level = oneOf(props.level, HEADING_LEVELS, "h2");
   const label = text(props.text);
   const href = url(props.href);
+
+  // The text moves between two elements, which is why the block marks it rather
+  // than an editor inferring it: linked, the words live inside the anchor;
+  // unlinked, they are the heading's own child.
+  const mark = markProp?.("text") ?? {};
 
   // The anchor goes INSIDE the heading. Wrapping the heading in a link instead
   // would put a block-level element in a phrasing context and, more usefully,
@@ -57,12 +63,13 @@ export function renderHeading({
           ...(relFor(props.target, props.rel) === undefined
             ? {}
             : { rel: relFor(props.target, props.rel) }),
+          ...mark,
         },
         label
       )
     : label;
 
-  return createElement(level, { className }, content);
+  return createElement(level, { className, ...(href ? {} : mark) }, content);
 }
 
 // Defined against the ENGINE's `defineBlock`, not the plugin SDK's: the engine
@@ -83,7 +90,7 @@ export const heading = defineBlock<HeadingProps, PageContext>({
     keywords: ["title", "headline", "h1", "h2"],
   },
   props: {
-    text: { type: "text" },
+    text: { type: "text", inline: true },
     level: { type: "select", options: [...HEADING_LEVELS] },
     href: { type: "url" },
     target: { type: "select", options: ["_self", "_blank"] },

--- a/packages/blocks-react/src/blocks/paragraph.tsx
+++ b/packages/blocks-react/src/blocks/paragraph.tsx
@@ -25,8 +25,13 @@ export interface ParagraphProps {
 export function renderParagraph({
   props,
   className,
+  markProp,
 }: BlockRenderArgs<ParagraphProps>): ReactElement {
-  return <p className={className}>{text(props.text)}</p>;
+  return (
+    <p className={className} {...markProp?.("text")}>
+      {text(props.text)}
+    </p>
+  );
 }
 
 // Defined against the ENGINE's `defineBlock`, not the plugin SDK's: the engine
@@ -46,7 +51,7 @@ export const paragraph = defineBlock<ParagraphProps, PageContext>({
     category: CONTENT,
     keywords: ["paragraph", "copy", "body", "prose"],
   },
-  props: { text: { type: "textarea" } },
+  props: { text: { type: "textarea", inline: true } },
   defaultProps: { text: "" },
   // The opening prose is what a search result should quote. Offered whole and
   // untruncated: how long a description may be is the metadata layer's rule,

--- a/packages/blocks-react/src/blocks/quote.tsx
+++ b/packages/blocks-react/src/blocks/quote.tsx
@@ -33,15 +33,26 @@ export interface QuoteProps {
 export function renderQuote({
   props,
   className,
+  markProp,
 }: BlockRenderArgs<QuoteProps>): ReactElement {
   const quoted = text(props.text);
   const attribution = text(props.attribution);
   const source = text(props.source);
   const citeUrl = url(props.citeUrl);
 
+  /*
+   * Only the two values that already have an element of their own are marked.
+   * `attribution` is a bare text node inside the figcaption, and an attribute
+   * needs an element — wrapping it in a span to gain one would change the
+   * published markup for the editor's convenience, which is the wrong trade.
+   * It stays editable in the inspector, which is the safe direction.
+   */
+  const markText = markProp?.("text");
+  const markSource = markProp?.("source");
+
   const blockquote = (
     <blockquote {...(citeUrl === undefined ? {} : { cite: citeUrl })}>
-      <p>{quoted}</p>
+      <p {...markText}>{quoted}</p>
     </blockquote>
   );
 
@@ -52,7 +63,7 @@ export function renderQuote({
         className={className}
         {...(citeUrl === undefined ? {} : { cite: citeUrl })}
       >
-        <p>{quoted}</p>
+        <p {...markText}>{quoted}</p>
       </blockquote>
     );
   }
@@ -63,7 +74,7 @@ export function renderQuote({
       <figcaption>
         {attribution}
         {attribution !== "" && source !== "" ? ", " : null}
-        {source === "" ? null : <cite>{source}</cite>}
+        {source === "" ? null : <cite {...markSource}>{source}</cite>}
       </figcaption>
     </figure>
   );
@@ -87,9 +98,9 @@ export const quote = defineBlock<QuoteProps, PageContext>({
     keywords: ["blockquote", "pull quote", "citation"],
   },
   props: {
-    text: { type: "textarea" },
+    text: { type: "textarea", inline: true },
     attribution: { type: "text" },
-    source: { type: "text" },
+    source: { type: "text", inline: true },
     citeUrl: { type: "url" },
   },
   defaultProps: { text: "" },

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -213,6 +213,7 @@ describe("the root entry", () => {
       "BlockList",
       "BlockPlaceholder",
       "NODE_ID_ATTRIBUTE",
+      "PROP_ATTRIBUTE",
       "PageRenderer",
       "createBlockResolver",
       "createStandaloneContext",

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -59,7 +59,7 @@ export { BlockBoundary, BlockList } from "./block-boundary";
 // `NODE_ID_ATTRIBUTE` is published deliberately: an editor hit-testing on the
 // attribute must not hard-code its spelling, or the renderer and the editor hold
 // two copies of one string and the editor breaks silently when it moves.
-export { NODE_ID_ATTRIBUTE } from "./block-boundary";
+export { NODE_ID_ATTRIBUTE, PROP_ATTRIBUTE } from "./block-boundary";
 export type { BlockBoundaryProps, BlockListProps } from "./block-boundary";
 
 export { BlockPlaceholder } from "./placeholder";

--- a/packages/blocks-react/src/inline-props.test.tsx
+++ b/packages/blocks-react/src/inline-props.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * The contract that makes inline editing possible: a block says which of its
+ * values a canvas may let an author type into, and which element holds it.
+ *
+ * Both halves are asserted together, because either alone is inert and the
+ * failure is silent. A prop declared `inline` whose element is never marked
+ * gives an editor nothing to attach to; an element marked for a prop that was
+ * never declared gives an editor a region the block never offered.
+ *
+ * @module inline-props.test
+ */
+import { renderToReadableStream } from "react-dom/server";
+import type { ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+
+import { coreBlocks } from "./blocks";
+import { PROP_ATTRIBUTE } from "./block-boundary";
+import { PageRenderer } from "./page-renderer";
+import { createBlockResolver } from "./resolver";
+
+import type {
+  AnyBlockDefinition,
+  BlockDocument,
+} from "@nextlyhq/blocks-engine";
+
+async function renderToHtml(element: ReactElement): Promise<string> {
+  const stream = await renderToReadableStream(element, {
+    onError(error) {
+      throw error;
+    },
+  });
+  await stream.allReady;
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let html = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    html += decoder.decode(value, { stream: true });
+  }
+  return html + decoder.decode();
+}
+
+function documentOf(
+  type: string,
+  props: Record<string, unknown>
+): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [{ id: "n1", type, version: 1, props }],
+  } as unknown as BlockDocument;
+}
+
+/** Render as an editor does, or as a published page does. */
+function html(document: BlockDocument, forEditor: boolean): Promise<string> {
+  return renderToHtml(
+    <PageRenderer
+      document={document}
+      blocks={createBlockResolver(coreBlocks as AnyBlockDefinition[])}
+      {...(forEditor ? { nodeAttribute: true } : {})}
+    />
+  );
+}
+
+describe("a block marks the element carrying an inline prop", () => {
+  it("marks the heading's own element when it has no link", async () => {
+    const markup = await html(
+      documentOf("core/heading", { text: "Hello" }),
+      true
+    );
+
+    expect(markup).toContain(`${PROP_ATTRIBUTE}="text"`);
+    // On the heading itself, which is where the words are.
+    expect(markup).toMatch(new RegExp(`<h2[^>]*${PROP_ATTRIBUTE}="text"`));
+  });
+
+  it("marks the ANCHOR instead once the heading is linked", async () => {
+    // The property no editor could infer: the same prop renders into a
+    // different element depending on another prop's value.
+    const markup = await html(
+      documentOf("core/heading", {
+        text: "Hello",
+        href: "https://example.com",
+      }),
+      true
+    );
+
+    expect(markup).toMatch(new RegExp(`<a[^>]*${PROP_ATTRIBUTE}="text"`));
+    expect(markup).not.toMatch(new RegExp(`<h2[^>]*${PROP_ATTRIBUTE}="text"`));
+  });
+
+  it("marks the text block's paragraph", async () => {
+    const markup = await html(documentOf("core/text", { text: "Words" }), true);
+
+    expect(markup).toMatch(new RegExp(`<p[^>]*${PROP_ATTRIBUTE}="text"`));
+  });
+
+  it("marks a quote's two element-bearing values, and not the third", async () => {
+    // `attribution` is a bare text node with no element to carry an attribute,
+    // so it is deliberately not offered for inline editing.
+    const markup = await html(
+      documentOf("core/quote", {
+        text: "Quoted",
+        attribution: "Someone",
+        source: "A Book",
+      }),
+      true
+    );
+
+    expect(markup).toMatch(new RegExp(`<p[^>]*${PROP_ATTRIBUTE}="text"`));
+    expect(markup).toMatch(new RegExp(`<cite[^>]*${PROP_ATTRIBUTE}="source"`));
+    expect(markup).not.toContain(`${PROP_ATTRIBUTE}="attribution"`);
+  });
+});
+
+describe("a published page carries none of it", () => {
+  it.each([
+    ["core/heading", { text: "Hello" }],
+    ["core/heading", { text: "Hello", href: "https://example.com" }],
+    ["core/text", { text: "Words" }],
+    ["core/quote", { text: "Quoted", attribution: "A", source: "B" }],
+  ] as const)(
+    "%s renders without the marker outside an editor",
+    async (type, props) => {
+      const markup = await html(documentOf(type, props), false);
+
+      expect(markup).not.toContain(PROP_ATTRIBUTE);
+      // The control: this render produced the block at all, so the absence above
+      // is about the marker rather than about an empty page.
+      expect(markup.length).toBeGreaterThan(10);
+      expect(markup).toContain(String(props.text));
+    }
+  );
+});
+
+describe("the declaration and the marking must agree", () => {
+  it("marks nothing for a prop the block never declared inline", async () => {
+    // `rel` is a real heading prop with a schema and no `inline`, so a block
+    // marking it would still get silence — the renderer, not the block, is
+    // what decides an element is offered.
+    const markup = await html(
+      documentOf("core/heading", { text: "Hello", rel: "nofollow" }),
+      true
+    );
+
+    expect(markup).not.toContain(`${PROP_ATTRIBUTE}="rel"`);
+    // Control: the marker mechanism ran on this render.
+    expect(markup).toContain(`${PROP_ATTRIBUTE}="text"`);
+  });
+
+  it("every prop declared inline is marked somewhere by its block", async () => {
+    // The half that rots. A prop can gain `inline: true` in a schema while
+    // nobody touches the render, and the result is a promise the canvas cannot
+    // keep — invisible until an author double-clicks and nothing happens.
+    const declared = coreBlocks.flatMap(block =>
+      Object.entries(block.props ?? {})
+        .filter(
+          ([, schema]) => (schema as { inline?: boolean })?.inline === true
+        )
+        .map(([name]) => [block.name, name] as const)
+    );
+
+    // The population, before the verdict: an empty list would satisfy every
+    // assertion below by having nothing to contradict.
+    expect(declared.length).toBeGreaterThan(0);
+
+    for (const [blockName, propName] of declared) {
+      const definition = coreBlocks.find(block => block.name === blockName);
+      const example = definition?.example?.props ?? {};
+      const markup = await html(
+        documentOf(blockName, { ...example, [propName]: "Sample text" }),
+        true
+      );
+      expect(
+        markup,
+        `${blockName} declares "${propName}" inline but never marks an element for it`
+      ).toContain(`${PROP_ATTRIBUTE}="${propName}"`);
+    }
+  });
+});

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -175,6 +175,16 @@ export interface CanvasProps {
    */
   dragHandlers?: CanvasDragHandlers;
   /**
+   * Raised when a double-click lands on the page.
+   *
+   * Separate from `onSelect` because the two gestures mean different things and
+   * one handler deciding between them by counting clicks would be a second
+   * place the distinction lives. A double-click that hits no editable value
+   * does nothing, which the handler decides — the canvas does not know what is
+   * editable.
+   */
+  onDoubleClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
+  /**
    * Editor chrome drawn ABOVE the page — the drop indicator today.
    *
    * Inside the root rather than beside it, because the overlay is positioned in
@@ -202,6 +212,7 @@ export function Canvas({
   render,
   className,
   dragHandlers,
+  onDoubleClick,
   overlay,
 }: CanvasProps) {
   const root = useRef<HTMLDivElement | null>(null);
@@ -296,6 +307,12 @@ export function Canvas({
       // right up until someone writes a selector against the wrong one.
       data-nx-selected-id={selectedId ?? undefined}
       onClick={handleClick}
+      // Chrome is excluded for the same reason it is on click: a double-click
+      // on a control drawn over the page is not a double-click on the page.
+      onDoubleClick={event => {
+        if (isChrome(event.target)) return;
+        onDoubleClick?.(event);
+      }}
       // Spread rather than merged with a handler of this component's own: the
       // canvas has no pointer behaviour of its own apart from the drag, so
       // there is nothing to combine, and merging would create a second place

--- a/packages/builder/src/inline-text.test.ts
+++ b/packages/builder/src/inline-text.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Which values a canvas may let an author type into, and what a finished edit
+ * writes.
+ *
+ * Driven through the real registry, because "the block declares it" is the
+ * whole rule — a stub restating which props are inline would be the second
+ * answer this module exists to avoid.
+ *
+ * @module inline-text.test
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  clearBlocks,
+  registerBlocks,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+
+import { inlineTarget, inlineTargets, inlineTextOp } from "./inline-text";
+
+const base = {
+  version: 1,
+  description: "A block.",
+  example: { props: {} },
+  render: () => null,
+};
+
+afterEach(clearBlocks);
+
+function documentOf(nodes: BlockNode[]): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+}
+
+/** A block declaring one inline value, one multiline one, and two that are not. */
+function withQuote(
+  props: Record<string, unknown> = {},
+  node: Partial<BlockNode> = {}
+) {
+  registerBlocks(
+    [
+      {
+        ...base,
+        name: "acme/quote",
+        props: {
+          text: { type: "textarea", inline: true },
+          source: { type: "text", inline: true },
+          attribution: { type: "text" },
+          citeUrl: { type: "url" },
+        },
+      },
+    ] as never,
+    { source: "inline-text-test" }
+  );
+  return documentOf([
+    { id: "a", type: "acme/quote", version: 1, props, ...node } as BlockNode,
+  ]);
+}
+
+describe("inlineTargets", () => {
+  it("offers only the values the block declared inline", () => {
+    // `attribution` and `citeUrl` are real props with schemas and no `inline`,
+    // so a canvas must not offer them: nothing marked their element, and an
+    // author double-clicking one would find text that never becomes editable.
+    const targets = inlineTargets(withQuote({ text: "Hi" }), "a");
+
+    expect(targets.map(t => t.prop)).toEqual(["text", "source"]);
+  });
+
+  it("reads whether a value may hold line breaks from its schema", () => {
+    // What decides where Enter goes. Kept as a derivation rather than a list of
+    // prop names here, so a block changing a field from one type to the other
+    // changes this with it.
+    const targets = inlineTargets(withQuote(), "a");
+
+    expect(targets.find(t => t.prop === "text")?.multiline).toBe(true);
+    expect(targets.find(t => t.prop === "source")?.multiline).toBe(false);
+  });
+
+  it("carries the stored value, and reads a non-string as empty", () => {
+    // A stored document holds whatever a migration or an import left there.
+    // Putting `[object Object]` into an editable element would let an author
+    // "keep" a value they never typed.
+    const targets = inlineTargets(
+      withQuote({ text: { nope: 1 }, source: "S" }),
+      "a"
+    );
+
+    expect(targets.find(t => t.prop === "text")?.value).toBe("");
+    expect(targets.find(t => t.prop === "source")?.value).toBe("S");
+  });
+
+  it("offers nothing for a LOCKED block", () => {
+    // A lock has to be honoured at every entry point or it is honoured at none,
+    // which is the state where an author believes a block is protected.
+    const locked = inlineTargets(
+      withQuote({ text: "Hi" }, { locked: true }),
+      "a"
+    );
+
+    expect(locked).toEqual([]);
+  });
+
+  it("still offers them when the block is not locked, which is the control", () => {
+    // Without this, the case above passes on a module that offers nothing under
+    // any circumstances.
+    expect(
+      inlineTargets(withQuote({ text: "Hi" }), "a").length
+    ).toBeGreaterThan(0);
+  });
+
+  it("offers nothing for a node whose type is not registered", () => {
+    const document = documentOf([
+      { id: "a", type: "acme/absent", version: 1, props: {} } as BlockNode,
+    ]);
+
+    expect(inlineTargets(document, "a")).toEqual([]);
+  });
+
+  it("offers nothing for a node that is not there", () => {
+    expect(inlineTargets(withQuote(), "missing")).toEqual([]);
+  });
+});
+
+describe("inlineTarget", () => {
+  it("answers for one named value", () => {
+    expect(inlineTarget(withQuote({ source: "S" }), "a", "source")?.value).toBe(
+      "S"
+    );
+  });
+
+  it("refuses a prop the block did not declare inline", () => {
+    expect(inlineTarget(withQuote(), "a", "attribution")).toBeNull();
+  });
+});
+
+describe("inlineTextOp", () => {
+  it("writes the new text as one update", () => {
+    const document = withQuote({ text: "before", source: "S" });
+
+    const op = inlineTextOp(document, "a", "text", "after");
+
+    expect(op).toEqual({
+      kind: "update",
+      id: "a",
+      // The whole props record, because that is what a patch replaces — the
+      // sibling value has to survive the edit.
+      patch: { props: { text: "after", source: "S" } },
+    });
+  });
+
+  it("writes NOTHING when the text did not change", () => {
+    // An author who enters an edit and leaves without typing has made no edit.
+    // Recording one would put an entry on the undo stack that appears to do
+    // nothing, which reads as the history being broken.
+    const document = withQuote({ text: "same" });
+
+    expect(inlineTextOp(document, "a", "text", "same")).toBeNull();
+  });
+
+  it("writes an op when the text DID change, which is the control", () => {
+    const document = withQuote({ text: "same" });
+
+    expect(inlineTextOp(document, "a", "text", "different")).not.toBeNull();
+  });
+
+  it("writes nothing when the block was locked while the edit was open", () => {
+    // The document is read as it stands NOW, not as it stood when the caret
+    // went in — a block can be locked from the layers panel mid-edit.
+    const document = withQuote({ text: "before" }, { locked: true });
+
+    expect(inlineTextOp(document, "a", "text", "after")).toBeNull();
+  });
+
+  it("writes nothing when the node was deleted while the edit was open", () => {
+    expect(
+      inlineTextOp(withQuote({ text: "x" }), "gone", "text", "after")
+    ).toBeNull();
+  });
+
+  it("stores an emptied value rather than removing the prop", () => {
+    // An empty string is a value an author chose. Unsetting the prop would fall
+    // back to the block's default, which is how clearing a heading puts the
+    // placeholder text back and reads as the edit being rejected.
+    const document = withQuote({ text: "something" });
+
+    expect(inlineTextOp(document, "a", "text", "")).toEqual({
+      kind: "update",
+      id: "a",
+      patch: { props: { text: "" } },
+    });
+  });
+});

--- a/packages/builder/src/inline-text.ts
+++ b/packages/builder/src/inline-text.ts
@@ -1,0 +1,157 @@
+/**
+ * Which of a block's values an author may type directly on the canvas, and the
+ * op a finished edit produces.
+ *
+ * Pure, like every rule in this package, and for the same reason: whether a
+ * value is editable in place, and whether a finished edit changed anything, are
+ * derivations — and a component test in jsdom cannot separate a correct answer
+ * from a plausible wrong one, because both render a caret.
+ *
+ * **The block decides, not this module.** A prop is offered here only when its
+ * schema declares `inline`, which is the same declaration the renderer reads
+ * when it marks the element holding the value. Two lists would be two answers
+ * to one question, and the failure is quiet: an editor that offers a value the
+ * canvas never marked leaves an author double-clicking text that never becomes
+ * editable.
+ *
+ * @module inline-text
+ */
+
+import {
+  findNode,
+  getBlock,
+  type BlockDocument,
+  type BlockNode,
+  type PropSchema,
+} from "@nextlyhq/blocks-engine";
+
+import { propPatch } from "./inspector";
+import { isLocked } from "./locking";
+import type { BuilderOp } from "./ops";
+
+/** One value a canvas may let an author type into. */
+export interface InlineTextTarget {
+  readonly nodeId: string;
+  readonly prop: string;
+  /**
+   * Whether the value may hold line breaks, which is what decides where Enter
+   * goes: into the text for a paragraph, and out of the edit for a heading.
+   *
+   * Read from the schema's own `type` rather than from a list of prop names
+   * kept here, so a block that changes a field from one to the other changes
+   * this with it.
+   */
+  readonly multiline: boolean;
+  /** The value as the document holds it, normalised to a string. */
+  readonly value: string;
+}
+
+/**
+ * A stored value as text.
+ *
+ * Anything that is not a string reads as empty rather than as `"undefined"` or
+ * `"[object Object]"`. A stored document holds whatever a migration, an import
+ * or a hand-edited row left there, and putting one of those spellings into an
+ * editable element would let an author "keep" a value they never typed.
+ */
+function asText(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/** Whether a schema opted this value into editing on the canvas. */
+function declaresInline(schema: PropSchema | undefined): boolean {
+  return schema?.inline === true;
+}
+
+function targetFor(
+  node: BlockNode,
+  prop: string,
+  schema: PropSchema | undefined
+): InlineTextTarget {
+  return {
+    nodeId: node.id,
+    prop,
+    multiline: schema?.type === "textarea",
+    value: asText((node.props as Record<string, unknown> | undefined)?.[prop]),
+  };
+}
+
+/**
+ * Every value on this node that may be typed on the canvas, in the order the
+ * block declared them.
+ *
+ * Empty for a LOCKED block, and for a node whose type is not registered. A lock
+ * is what an author set to stop the block changing, and inline editing is a
+ * change — the lock has to be honoured at every entry point or it is honoured
+ * at none, which is the state where an author believes a block is protected.
+ *
+ * @param document - the document being edited
+ * @param nodeId - the node to ask about
+ * @returns the editable values, empty when there are none
+ */
+export function inlineTargets(
+  document: BlockDocument,
+  nodeId: string
+): readonly InlineTextTarget[] {
+  const node = findNode(document.nodes, nodeId);
+  if (node === undefined || isLocked(node)) return [];
+  const definition = getBlock(node.type);
+  if (definition === undefined) return [];
+  const props = definition.props ?? {};
+  return Object.keys(props)
+    .filter(name => declaresInline(props[name]))
+    .map(name => targetFor(node, name, props[name]));
+}
+
+/**
+ * One named value, or `null` when it is not editable on the canvas.
+ *
+ * Derived from {@link inlineTargets} rather than repeating its rules, so a
+ * block that is locked, unregistered or has not declared the prop answers the
+ * same way to both.
+ *
+ * @param document - the document being edited
+ * @param nodeId - the node to ask about
+ * @param prop - the value's name
+ * @returns the target, or `null`
+ */
+export function inlineTarget(
+  document: BlockDocument,
+  nodeId: string,
+  prop: string
+): InlineTextTarget | null {
+  return inlineTargets(document, nodeId).find(t => t.prop === prop) ?? null;
+}
+
+/**
+ * The op a finished edit produces, or `null` when there is nothing to write.
+ *
+ * `null` for an unchanged value, deliberately: an author who enters an edit and
+ * leaves without typing has made no edit, and recording one would put an entry
+ * on the undo stack that appears to do nothing — which reads as the history
+ * being broken rather than as an empty change.
+ *
+ * `null` also when the value stopped being editable while the edit was open. A
+ * node can be deleted or locked from the layers panel, from a keyboard action,
+ * or by another surface entirely, and writing the text back then would either
+ * address a node that is gone or defeat a lock that was applied after the
+ * caret went in.
+ *
+ * @param document - the document as it stands NOW, not when the edit began
+ * @param nodeId - the node being edited
+ * @param prop - the value being edited
+ * @param next - the text the author left behind
+ * @returns one op, or `null`
+ */
+export function inlineTextOp(
+  document: BlockDocument,
+  nodeId: string,
+  prop: string,
+  next: string
+): BuilderOp | null {
+  const target = inlineTarget(document, nodeId, prop);
+  if (target === null || target.value === next) return null;
+  const node = findNode(document.nodes, nodeId);
+  if (node === undefined) return null;
+  return { kind: "update", id: nodeId, patch: propPatch(node, prop, next) };
+}

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -200,6 +200,19 @@ export interface BlockKeyboardActionsOptions {
    * than unmounting the canvas, so the selection survives whatever is over it.
    */
   enabled?: boolean;
+  /**
+   * Begin typing the selected block's text in place, reporting whether it
+   * could be.
+   *
+   * The keyboard route to the gesture a double-click performs. A pointer-only
+   * way into editing would leave the text of every block unreachable without a
+   * mouse, which is the plainest kind of WCAG 2.1.1 failure — and it is a real
+   * one here, because the canvas is where the text is.
+   *
+   * Optional: a host that has not wired inline editing registers no binding at
+   * all, rather than one that presses and does nothing.
+   */
+  onEditText?: (nodeId: string) => boolean;
 }
 
 /** What the hook hands back: the region's text, and the verbs behind the keys. */
@@ -227,6 +240,7 @@ export interface BlockKeyboardActionsResult {
 export function useBlockKeyboardActions({
   editor,
   enabled = true,
+  onEditText,
 }: BlockKeyboardActionsOptions): BlockKeyboardActionsResult {
   // The message a live region reads out. Held as state rather than written to
   // the DOM directly so React owns the node — a region mutated behind React's
@@ -527,7 +541,39 @@ export function useBlockKeyboardActions({
     [announce, deleteSelected, duplicateSelected]
   );
 
-  useShortcuts([...bindings, ...editing], {
+  /*
+   * Enter opens the selected block's text for typing, which is the keyboard
+   * route to what a double-click does on the canvas.
+   *
+   * Registered only when a host supplied the verb: a binding that presses and
+   * does nothing is worse than no binding, because it teaches an author the key
+   * is broken rather than absent.
+   *
+   * `whenTyping: false` is what stops it firing again once the caret is in.
+   * The shortcut manager counts a `contentEditable` element as a typing target,
+   * so an author pressing Enter inside a paragraph gets a line break from the
+   * element rather than a second attempt to begin an edit that is already open.
+   */
+  const inlineEditing = React.useMemo(
+    () =>
+      onEditText === undefined
+        ? []
+        : [
+            {
+              keys: "Enter",
+              description: "Edit the selected block's text",
+              when: () => latest.current.selectedId !== null,
+              whenTyping: false,
+              run: () => {
+                const id = latest.current.selectedId;
+                if (id !== null) onEditText(id);
+              },
+            },
+          ],
+    [onEditText]
+  );
+
+  useShortcuts([...bindings, ...editing, ...inlineEditing], {
     name: "builder-block-actions",
     enabled,
   });
@@ -611,6 +657,7 @@ export function useBlockKeyboardActions({
 export function BlockKeyboardActions({
   editor,
   enabled,
+  onEditText,
   children,
 }: BlockKeyboardActionsOptions & {
   readonly children?: React.ReactNode;
@@ -618,6 +665,7 @@ export function BlockKeyboardActions({
   const { announcement, actions } = useBlockKeyboardActions({
     editor,
     enabled,
+    ...(onEditText === undefined ? {} : { onEditText }),
   });
 
   // `polite`, not `assertive`: a move is the author's own action and its result

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -156,6 +156,16 @@ export type { EditorState, UseEditorStateArgs } from "./editor-state";
  * caller can reach them without loading React.
  */
 export { DropIndicator, useCanvasDrag } from "./canvas-drag";
+/**
+ * Typing a block's text in place on the canvas.
+ *
+ * The hook owns the caret and the handover; the rules about WHAT may be edited
+ * are `inline-text`'s, and a block declares its own through its prop schemas.
+ */
+export { useInlineText, EDITING_ATTRIBUTE } from "./use-inline-text";
+export type { InlineTextEditing, UseInlineTextResult } from "./use-inline-text";
+export { inlineTargets, inlineTarget, inlineTextOp } from "./inline-text";
+export type { InlineTextTarget } from "./inline-text";
 export type {
   CanvasDrag,
   CanvasDragHandlers,

--- a/packages/builder/src/use-inline-text.test.ts
+++ b/packages/builder/src/use-inline-text.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+/**
+ * Finding the element that carries a value.
+ *
+ * The part of inline editing that varies per block, and the part a hook's
+ * result cannot show: a wrong answer here is an edit that quietly never begins,
+ * which reads to an author as a key that does nothing.
+ *
+ * @module use-inline-text.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { editableElement } from "./use-inline-text";
+
+/** Build a rendered fragment the way the renderer marks one. */
+function render(html: string): HTMLElement {
+  const root = document.createElement("div");
+  root.innerHTML = html;
+  return root;
+}
+
+describe("editableElement", () => {
+  it("finds a marker on the node's OWN root element", () => {
+    // An unlinked heading is exactly this: one `<h2>` carrying both attributes.
+    // A descendant-only search misses it, and the failure is silent.
+    const root = render(`<h2 data-nx-node="a" data-nx-prop="text">Hello</h2>`);
+
+    const found = editableElement(root, { nodeId: "a", prop: "text" });
+
+    expect(found?.tagName).toBe("H2");
+  });
+
+  it("finds a marker on a DESCENDANT of the node", () => {
+    // A linked heading puts the words inside the anchor, and a quote puts them
+    // inside a paragraph nested in a figure.
+    const root = render(
+      `<h2 data-nx-node="a"><a href="/x" data-nx-prop="text">Hello</a></h2>`
+    );
+
+    const found = editableElement(root, { nodeId: "a", prop: "text" });
+
+    expect(found?.tagName).toBe("A");
+  });
+
+  it("finds the named value among several on one node", () => {
+    const root = render(
+      `<figure data-nx-node="a">
+         <blockquote><p data-nx-prop="text">Quoted</p></blockquote>
+         <figcaption><cite data-nx-prop="source">A Book</cite></figcaption>
+       </figure>`
+    );
+
+    expect(
+      editableElement(root, { nodeId: "a", prop: "source" })?.tagName
+    ).toBe("CITE");
+    expect(editableElement(root, { nodeId: "a", prop: "text" })?.tagName).toBe(
+      "P"
+    );
+  });
+
+  it("does not reach into ANOTHER node's marked element", () => {
+    // Nodes nest, so a container's search would otherwise find its child's
+    // text and put the caret in a block the author did not select.
+    const root = render(
+      `<section data-nx-node="outer">
+         <h2 data-nx-node="inner" data-nx-prop="text">Child</h2>
+       </section>`
+    );
+
+    expect(editableElement(root, { nodeId: "outer", prop: "text" })).toBeNull();
+    // The control: the same tree does answer for the node that owns the value.
+    expect(
+      editableElement(root, { nodeId: "inner", prop: "text" })?.textContent
+    ).toBe("Child");
+  });
+
+  it("answers null for a value nothing marked", () => {
+    const root = render(`<h2 data-nx-node="a" data-nx-prop="text">Hi</h2>`);
+
+    expect(editableElement(root, { nodeId: "a", prop: "source" })).toBeNull();
+  });
+
+  it("answers null for a node that is not rendered", () => {
+    const root = render(`<h2 data-nx-node="a" data-nx-prop="text">Hi</h2>`);
+
+    expect(editableElement(root, { nodeId: "b", prop: "text" })).toBeNull();
+  });
+
+  it("treats a node id as data rather than as a selector", () => {
+    // Ids reach this from stored documents. Interpolated into a selector, a
+    // character CSS treats specially either throws or matches something else —
+    // so an id full of them still resolves to its own element, and only to it.
+    const odd = 'a"],[data-nx-node="b';
+    const root = render(
+      `<h2 data-nx-node='${odd}' data-nx-prop="text">Odd</h2>
+       <h2 data-nx-node="b" data-nx-prop="text">Other</h2>`
+    );
+
+    expect(
+      editableElement(root, { nodeId: odd, prop: "text" })?.textContent
+    ).toBe("Odd");
+    expect(
+      editableElement(root, { nodeId: "b", prop: "text" })?.textContent
+    ).toBe("Other");
+  });
+});

--- a/packages/builder/src/use-inline-text.ts
+++ b/packages/builder/src/use-inline-text.ts
@@ -1,0 +1,316 @@
+"use client";
+
+/**
+ * Typing a block's text directly on the canvas.
+ *
+ * The DOM half of {@link module:inline-text}, which decides WHAT may be edited;
+ * this decides how. The split is the same one the rest of this package makes,
+ * and here it earns its keep twice over: the rules are asserted without a
+ * browser, and the parts that genuinely need one are small enough to read.
+ *
+ * ## The element is left UNCONTROLLED while the caret is in it
+ *
+ * No op is dispatched per keystroke. React renders the canvas from the
+ * document, so an edit that wrote through on every character would re-render
+ * the element the author is typing into and move the caret out from under
+ * them — the standard failure of `contentEditable` inside a framework that
+ * owns the DOM. Every editor that does this well hands the element over for
+ * the duration: Gutenberg, Lexical and Puck all do.
+ *
+ * So the document is untouched until the edit finishes, and finishing writes
+ * ONE op. That also gives the behaviour an author expects from undo: a
+ * sentence typed and then undone comes back as a sentence, not as forty
+ * characters.
+ *
+ * The visible cost is that the inspector shows the value the document holds
+ * rather than the letters being typed, until the edit is committed. That is
+ * the same rule the blocks field itself follows when it commits its document
+ * on exit, and one editor with two answers about when a change counts is
+ * worse than a panel that updates a moment later.
+ *
+ * ## `plaintext-only`, with a fallback that still cannot store markup
+ *
+ * The values here are plain text, and `contenteditable="plaintext-only"` is
+ * what stops a paste bringing markup, a bold shortcut inserting a `<b>`, and
+ * Enter inserting a `<div>`. Where a browser does not support it the attribute
+ * falls back to ordinary editing, so the commit reads `textContent` — which is
+ * text whatever the element ended up containing.
+ *
+ * @module use-inline-text
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { EditorState } from "./editor-state";
+import { inlineTarget, inlineTargets, inlineTextOp } from "./inline-text";
+
+/** The attribute naming the element an author is currently typing into. */
+export const EDITING_ATTRIBUTE = "data-nx-editing";
+
+/** Which value is being edited. */
+export interface InlineTextEditing {
+  readonly nodeId: string;
+  readonly prop: string;
+}
+
+export interface UseInlineTextResult {
+  /** The value being edited, or `null` when none is. */
+  editing: InlineTextEditing | null;
+  /**
+   * Start editing a value, reporting whether it could be.
+   *
+   * `prop` defaults to the block's FIRST declared inline value, which is what
+   * a keyboard caller wants: it has a selected block and no element.
+   */
+  begin: (nodeId: string, prop?: string) => boolean;
+  /** Finish, writing whatever the author left behind. */
+  commit: () => void;
+  /** Finish, discarding it. */
+  cancel: () => void;
+  /**
+   * Enter an edit from a double-click on the canvas.
+   *
+   * Handed to `Canvas` rather than attached here, because the canvas owns its
+   * own root and a second listener on the same tree would be a second place
+   * the gesture is decided.
+   */
+  onDoubleClick: (event: { target: EventTarget | null }) => void;
+}
+
+/**
+ * The element the author is typing into, found from what they double-clicked.
+ *
+ * Walks UP from the event target rather than reading it: a click lands on
+ * whatever leaf is under the pointer, and the element carrying the mark may be
+ * an ancestor of it.
+ */
+function editableFrom(target: EventTarget | null): {
+  element: HTMLElement;
+  prop: string;
+  nodeId: string;
+} | null {
+  if (!(target instanceof Element)) return null;
+  const element = target.closest<HTMLElement>("[data-nx-prop]");
+  if (element === null) return null;
+  const prop = element.getAttribute("data-nx-prop");
+  const owner = element.closest("[data-nx-node]");
+  const nodeId = owner?.getAttribute("data-nx-node") ?? null;
+  if (prop === null || nodeId === null) return null;
+  return { element, prop, nodeId };
+}
+
+/**
+ * The element carrying a value, found from the rendered tree rather than from a
+ * click.
+ *
+ * For a keyboard caller, which has a selected node and no element. The node id
+ * is compared in JavaScript rather than interpolated into the selector: it
+ * reaches this from stored data, and putting it in a selector makes any
+ * character CSS treats specially either throw or match something else. The prop
+ * name is a key from the block's own schema and is escaped rather than
+ * compared, because it addresses an element that may have no other handle.
+ *
+ * Exported for its own test. Which element holds a value is the part of this
+ * module that varies per block, and it is not observable from the hook's
+ * result — a wrong answer here shows up as an edit that quietly never starts.
+ */
+export function editableElement(
+  root: ParentNode,
+  editing: InlineTextEditing
+): HTMLElement | null {
+  const owners = root.querySelectorAll<HTMLElement>("[data-nx-node]");
+  let found: HTMLElement | null = null;
+  // `forEach` rather than `for…of`: a `NodeList` is only iterable under a lib
+  // that declares its iterator, and this package compiles without one.
+  owners.forEach(owner => {
+    if (found !== null) return;
+    if (owner.getAttribute("data-nx-node") !== editing.nodeId) return;
+    // The owner ITSELF first. A block whose text is its own root element — an
+    // unlinked heading is exactly this, carrying both attributes on one `<h2>`
+    // — is missed entirely by a descendant search, and the failure is silent:
+    // the edit never begins and the key reads as broken.
+    if (owner.getAttribute("data-nx-prop") === editing.prop) {
+      found = owner;
+      return;
+    }
+    owner.querySelectorAll<HTMLElement>("[data-nx-prop]").forEach(candidate => {
+      if (found !== null) return;
+      if (candidate.getAttribute("data-nx-prop") !== editing.prop) return;
+      // Not a value belonging to a block nested inside this one. Blocks nest,
+      // so without this a container answers with its child's text and the
+      // caret lands in a block the author did not select.
+      if (candidate.closest("[data-nx-node]") !== owner) return;
+      found = candidate;
+    });
+  });
+  return found;
+}
+
+/** Put the caret across the whole value, so typing replaces it. */
+function selectAll(element: HTMLElement): void {
+  const selection = element.ownerDocument.defaultView?.getSelection();
+  if (!selection) return;
+  const range = element.ownerDocument.createRange();
+  range.selectNodeContents(element);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+/**
+ * @param editor - the editor state whose document is being edited
+ * @returns the current edit, the ways in and out, and the canvas handler
+ */
+export function useInlineText(editor: EditorState): UseInlineTextResult {
+  const [editing, setEditing] = useState<InlineTextEditing | null>(null);
+  /** The element handed over for the duration, so the exit can find it again. */
+  const elementRef = useRef<HTMLElement | null>(null);
+
+  /*
+   * Read through refs inside the listeners below rather than captured as
+   * dependencies. The listeners are attached once per edit, and closing over
+   * these would pin the document they saw when the caret went in — so a commit
+   * would be decided against a document that may have changed underneath.
+   */
+  const editorRef = useRef(editor);
+  editorRef.current = editor;
+  const editingRef = useRef(editing);
+  editingRef.current = editing;
+
+  /** Take the element back, whatever else happens. */
+  const release = useCallback(() => {
+    const element = elementRef.current;
+    elementRef.current = null;
+    setEditing(null);
+    if (element === null) return;
+    element.removeAttribute("contenteditable");
+    element.removeAttribute(EDITING_ATTRIBUTE);
+    return element;
+  }, []);
+
+  const commit = useCallback(() => {
+    const element = elementRef.current;
+    const current = editingRef.current;
+    // `textContent` rather than `innerText` or `innerHTML`: the first is what
+    // the value IS regardless of what the element ended up containing, and the
+    // last would store markup this value cannot hold.
+    const next = element?.textContent ?? null;
+    release();
+    if (current === null || next === null) return;
+    const op = inlineTextOp(
+      editorRef.current.document,
+      current.nodeId,
+      current.prop,
+      next
+    );
+    // `null` for an unchanged value and for one that stopped being editable
+    // while the caret was in it — see `inlineTextOp`.
+    if (op !== null) editorRef.current.apply(op);
+  }, [release]);
+
+  const cancel = useCallback(() => {
+    const element = elementRef.current;
+    const current = editingRef.current;
+    // Put back what the document holds before letting go. Without it the
+    // abandoned text stays on screen until something else re-renders the
+    // canvas, and the author sees an edit they explicitly discarded.
+    if (element !== null && current !== null) {
+      const target = inlineTarget(
+        editorRef.current.document,
+        current.nodeId,
+        current.prop
+      );
+      if (target !== null) element.textContent = target.value;
+    }
+    release();
+  }, [release]);
+
+  const begin = useCallback((nodeId: string, prop?: string) => {
+    const targets = inlineTargets(editorRef.current.document, nodeId);
+    const target =
+      prop === undefined ? targets[0] : targets.find(t => t.prop === prop);
+    if (target === undefined) return false;
+    setEditing({ nodeId: target.nodeId, prop: target.prop });
+    return true;
+  }, []);
+
+  const onDoubleClick = useCallback(
+    (event: { target: EventTarget | null }) => {
+      const found = editableFrom(event.target);
+      if (found === null) return;
+      if (begin(found.nodeId, found.prop)) elementRef.current = found.element;
+    },
+    [begin]
+  );
+
+  /*
+   * Hand the element over, and take it back on the way out.
+   *
+   * In an effect rather than in `begin` so the handover happens after React has
+   * finished rendering: setting `contentEditable` and focusing mid-render
+   * fights whatever the renderer is about to commit.
+   */
+  useEffect(() => {
+    if (editing === null) return;
+    const element =
+      elementRef.current ??
+      (globalThis.document === undefined
+        ? null
+        : editableElement(globalThis.document, editing));
+    if (element === null) {
+      // Nothing on screen carries this value. The node may have been removed
+      // between the request and this effect; dropping the edit is the honest
+      // answer, and leaving `editing` set would show a caret nobody can see.
+      setEditing(null);
+      return;
+    }
+    elementRef.current = element;
+
+    element.setAttribute("contenteditable", "plaintext-only");
+    element.setAttribute(EDITING_ATTRIBUTE, editing.prop);
+    element.focus();
+    selectAll(element);
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        cancel();
+        return;
+      }
+      if (event.key !== "Enter") return;
+      const target = inlineTarget(
+        editorRef.current.document,
+        editing.nodeId,
+        editing.prop
+      );
+      // Enter belongs to the VALUE: a line break in a paragraph, and the way
+      // out of a heading. The schema says which, so a block changing a field
+      // from one type to the other changes this with it.
+      if (target?.multiline === true) return;
+      event.preventDefault();
+      commit();
+    };
+    /*
+     * Stopped at the element rather than by teaching the canvas about editing.
+     * Selection and dragging both listen on the canvas root, so a press inside
+     * the text would start a drag instead of placing the caret — and the rule
+     * belongs to the element that is currently something else.
+     */
+    const swallow = (event: Event) => event.stopPropagation();
+
+    element.addEventListener("keydown", onKeyDown);
+    element.addEventListener("blur", commit);
+    element.addEventListener("pointerdown", swallow);
+    element.addEventListener("click", swallow);
+    element.addEventListener("dblclick", swallow);
+    return () => {
+      element.removeEventListener("keydown", onKeyDown);
+      element.removeEventListener("blur", commit);
+      element.removeEventListener("pointerdown", swallow);
+      element.removeEventListener("click", swallow);
+      element.removeEventListener("dblclick", swallow);
+    };
+  }, [editing, cancel, commit]);
+
+  return { editing, begin, commit, cancel, onDoubleClick };
+}

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -54,6 +54,7 @@ import {
   SelectionBreadcrumb,
   useCanvasDrag,
   useEditorState,
+  useInlineText,
 } from "@nextlyhq/builder/shell";
 import {
   useDocumentCheckpoint,
@@ -341,6 +342,12 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   const nesting = useMemo(registryNestingSource, []);
   const drag = useCanvasDrag({ editor, slots, nesting });
 
+  /*
+   * Typing a block's text on the canvas. The hook owns the caret; which values
+   * may be typed into is the block's own declaration, read by the builder.
+   */
+  const inline = useInlineText(editor);
+
   useCheckpoints({ name, control, document: editor.document });
 
   /*
@@ -413,7 +420,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
           It draws the live region and publishes the structural verbs to what it
           wraps, which is how the toolbar presses exactly what the keys press.
         */}
-        <BlockKeyboardActions editor={editor}>
+        <BlockKeyboardActions editor={editor} onEditText={inline.begin}>
           {/*
             Inside the verbs provider, which is what lets the palette run
             exactly what the keystrokes and the toolbar run.
@@ -432,6 +439,10 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             selectedIds={editor.selection.ids}
             onSelect={editor.select}
             dragHandlers={drag.handlers}
+            // The pointer route into typing a block's text. Its keyboard
+            // counterpart is the Enter binding above, registered in the same
+            // place so a surface cannot gain one without the other.
+            onDoubleClick={inline.onDoubleClick}
             // Both pieces of chrome go through the canvas rather than beside it,
             // because both are positioned in the canvas's own content
             // coordinates and the canvas root is what establishes them.


### PR DESCRIPTION
Closes B-18. Double-click a heading, a paragraph or a quote on the canvas and type; **Enter** does the same for the selected block from the keyboard. Escape discards. Leaving the value writes **one op**, so a typed sentence takes one undo to remove rather than one per character.

## The question that decided the design

An editor cannot infer which element holds which value, and the two blocks that prove it are already in the library:

- **`core/quote`** renders three text values into three different nested elements, and *changes that structure* depending on which of them are empty.
- **`core/heading`** puts its words inside an anchor when it has a link and directly inside itself when it does not.

Guessing lands an author's typing in a different value than the one they aimed at. So the block says: a prop schema declares `inline`, and the block spreads `markProp("text")` onto the element it renders that value into. The renderer emits the marker **only in editor mode and only for a prop that declared itself**, so both halves must agree before anything is offered, and an unmarked prop simply is not editable in place — the inspector still edits it.

**Published markup is unchanged**, asserted directly rather than assumed.

## What was considered and rejected

**Gutenberg's shape** — a block writes `edit` and `save` separately. That is a second render path for the same content, and `canvas.tsx` names one renderer for both the canvas and the published page as the property worth protecting. Its `RichText` still needs an `identifier` naming the attribute, so even there the binding is explicit; the duplication buys nothing this design needs.

**Puck's shape** — opt-in per field, which is the right granularity and is what `inline` copies. Its *mechanism* does not port: Puck swaps the field's type to a ReactNode and hands the component an editable element, but Nextly's block props are data that `seo()`, serialisation and normalisation also read. `renderHeading` runs `props.text` through `text()` before rendering it, so an injected element would be destroyed on the way through.

**Inferring from the DOM** — works for an unlinked heading and a paragraph, and silently does not for a linked heading, a quote's source, or anything else. An author cannot predict which blocks respond to a double-click, and the ones that don't look broken.

## Why the element is left uncontrolled while the caret is in it

No op is dispatched per keystroke. React renders the canvas from the document, so writing through on every character would re-render the element being typed into and move the caret out from under the author. Every editor that does this well hands the element over for the duration.

The visible cost: the inspector shows the value the document holds until the edit is committed, so it is a moment behind. That is the same rule `BlocksField` already follows when it commits its document on exit, and one editor with two answers about when a change counts is worse than a panel that catches up.

Where **Enter** goes is read from the value's own schema — a line break in a `textarea` value, the way out of a `text` one — so a block changing a field from one type to the other changes this with it.

## Accessibility

**WCAG 2.1.1**: the pointer gesture and its keyboard equivalent are registered in the same place, so a surface cannot gain one without the other. `whenTyping: false` is what stops Enter firing again once the caret is in — the shortcut manager counts a `contentEditable` element as a typing target.

Escape is stopped at the element, so cancelling an edit does **not** also fall through to the canvas's Escape layer and deselect the block. Verified.

`contenteditable="plaintext-only"` is what stops a paste bringing markup. Where a browser lacks it the attribute degrades to ordinary editing, and the commit reads `textContent` — which is text whatever the element ended up containing.

## Verified in a browser

At 1600×1000 on the homepage single, after asserting the auth control:

| gesture | result |
|---|---|
| double-click a heading | `contenteditable="plaintext-only"`, focused, whole value selected |
| type | replaces the selection |
| Enter (`text` value) | commits; **no element left contentEditable** |
| one undo | reverts the whole typed sentence, not one character |
| Enter on a selected block | opens its `<h2>` for editing — the keyboard route |
| Escape after typing | original restored, block stays selected |
| Enter (`textarea` value) | inserts a real newline and does **not** commit |
| click away | commits on blur, newline preserved |

## A defect the browser caught and the tests could not

The first version of the keyboard route looked for the marked element among a node's **descendants**. An unlinked heading carries `data-nx-node` and `data-nx-prop` on the *same* `<h2>`, so the search found nothing and the edit silently never began — while the double-click route, which reads the element from the event target, worked perfectly. `editableElement` is now exported and tested against both shapes, plus the nested case where a container must not answer with its child's text.

Its first implementation also used `CSS.escape`, which **is not defined in jsdom**. Every name is now compared in JavaScript rather than interpolated into a selector, which is what the codebase already does for node ids and removes the dependency entirely.

## Tests

`builder` 814 → 836, `blocks-react` 634 → 635, `blocks-engine` 1267, `plugin-page-builder` 71, `plugin-sdk` 16. All gates green; Fallow passes with nothing introduced.

Every rule is stub-verified. Two stubs partition the marking suite with no survivors — breaking the marker fails the 6 marking tests, ignoring the editor gate fails the 4 published-page tests — and the pure rules each fail exactly the tests that name them.
