### PR TITLE
feat(builder): show a getting-started checklist in the editor

### DIFF
--- a/.changeset/builder-onboarding-checklist.md
+++ b/.changeset/builder-onboarding-checklist.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The page builder now shows a getting-started card: add a block, write
+something, add a second one. Every step is read from the page itself rather
+than tracked, so it describes what is there rather than what someone once did.
+
+Dismissible, and a site can turn it off entirely with
+`pageBuilder({ checklist: false })`.

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -27,6 +27,7 @@ import * as React from "react";
 import { devWarnOnce } from "./dev-warn";
 import {
   DEFAULT_PREFERENCES,
+  browserStore,
   fitsFullShell,
   LEFT_PANELS,
   MIN_CANVAS_WIDTH,
@@ -118,6 +119,15 @@ export interface BuilderShellProps {
   /** The ancestor breadcrumb, along the bottom bar. */
   breadcrumb?: React.ReactNode;
   /**
+   * A card floated over the canvas — the getting-started checklist today.
+   *
+   * Positioned by the shell rather than passed through `Canvas.overlay`,
+   * because that overlay lives in the canvas's own content coordinates and
+   * would scroll away with the page. This one belongs to the editor's chrome
+   * and stays where it is put.
+   */
+  checklist?: React.ReactNode;
+  /**
    * Leaving the editor. Explicit and LABELLED, never an unmarked X: the author
    * is one click from losing a canvas full of work, and an ambiguous glyph is
    * how that happens.
@@ -155,21 +165,7 @@ export interface BuilderShellProps {
   className?: string;
 }
 
-/** A store that forgets, for a server render or a host that supplies its own. */
-const NO_STORAGE: PreferenceStore = {
-  read: () => null,
-  write: () => undefined,
-};
-
 const STORAGE_KEY = "nextly.builder.shell";
-
-function browserStore(): PreferenceStore {
-  if (typeof window === "undefined") return NO_STORAGE;
-  return {
-    read: () => window.localStorage.getItem(STORAGE_KEY),
-    write: value => window.localStorage.setItem(STORAGE_KEY, value),
-  };
-}
 
 /**
  * Whether the shell's own CONTAINER can carry the full layout, as it changes.
@@ -649,6 +645,7 @@ function ShellRegions({
   inspector,
   topBar,
   breadcrumb,
+  checklist,
   onExit,
   preferences,
   update,
@@ -904,16 +901,26 @@ function ShellRegions({
              * cycling focuses this node, and dropping either would lose the canvas as
              * a cycle target — which reads as a focus bug rather than a markup change.
              */}
-            <section
-              ref={element => {
-                regionRefs.current.canvas = element;
-              }}
-              tabIndex={-1}
-              aria-label="Canvas"
-              className="h-full overflow-auto"
-            >
-              {children}
-            </section>
+            <div className="relative h-full">
+              <section
+                ref={element => {
+                  regionRefs.current.canvas = element;
+                }}
+                tabIndex={-1}
+                aria-label="Canvas"
+                className="h-full overflow-auto"
+              >
+                {children}
+              </section>
+              {checklist === undefined ? null : (
+                // The positioner takes no pointer events, so it cannot swallow
+                // a click aimed at the page underneath it; the card itself
+                // takes them back.
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-end p-4">
+                  <div className="pointer-events-auto">{checklist}</div>
+                </div>
+              )}
+            </div>
           </ResizablePanel>
 
           <ResizableHandle withGrip />
@@ -966,7 +973,7 @@ export function BuilderShell({ store, ...props }: BuilderShellProps) {
   // swaps stores — signing into a second workspace, promoting a memory store to
   // a persisted one — went on reading and writing the store it had replaced.
   const fallbackStore = React.useRef<PreferenceStore | null>(null);
-  fallbackStore.current ??= browserStore();
+  fallbackStore.current ??= browserStore(STORAGE_KEY);
   const resolvedStore = store ?? fallbackStore.current;
   const [preferences, update, loadCount] = usePreferences(resolvedStore);
   const [measureShell, shellFits] = useFitsFullShell();

--- a/packages/builder/src/onboarding-checklist.test.tsx
+++ b/packages/builder/src/onboarding-checklist.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+/**
+ * Whether the card is on screen, and what stops it being.
+ *
+ * The steps themselves are `onboarding.test`; this is only the visibility rule
+ * and the dismissal, which are the parts a host can get wrong.
+ *
+ * @module onboarding-checklist.test
+ */
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearBlocks,
+  hasBlock,
+  registerBlocks,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+
+import { useBuilderChecklist } from "./onboarding-checklist";
+import type { PreferenceStore } from "./shell-state";
+
+afterEach(clearBlocks);
+
+function register() {
+  if (hasBlock("acme/heading")) return;
+  registerBlocks(
+    [
+      {
+        version: 1,
+        description: "A block.",
+        example: { props: {} },
+        render: () => null,
+        name: "acme/heading",
+        props: { text: { type: "text", inline: true } },
+      },
+    ] as never,
+    { source: "checklist-test" }
+  );
+}
+
+function documentOf(nodes: BlockNode[] = []): BlockDocument {
+  register();
+  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+}
+
+/** A store that remembers, so a dismissal can be observed rather than inferred. */
+function fakeStore(initial: string | null = null): PreferenceStore & {
+  written: string[];
+} {
+  let value = initial;
+  const written: string[] = [];
+  return {
+    written,
+    read: () => value,
+    write: next => {
+      written.push(next);
+      value = next;
+    },
+  };
+}
+
+describe("useBuilderChecklist", () => {
+  it("is visible on a page nobody has dismissed it for", () => {
+    const { result } = renderHook(() =>
+      useBuilderChecklist({ document: documentOf(), store: fakeStore() })
+    );
+
+    expect(result.current.visible).toBe(true);
+    expect(result.current.steps.length).toBeGreaterThan(0);
+  });
+
+  it("stays hidden once it has been dismissed before", () => {
+    const { result } = renderHook(() =>
+      useBuilderChecklist({ document: documentOf(), store: fakeStore("true") })
+    );
+
+    expect(result.current.visible).toBe(false);
+  });
+
+  it("hides on dismiss AND records it, so it stays hidden next time", () => {
+    // Both halves. Hiding without recording gives an author a card that comes
+    // back on every reload; recording without hiding does nothing they asked
+    // for.
+    const store = fakeStore();
+    const { result } = renderHook(() =>
+      useBuilderChecklist({ document: documentOf(), store })
+    );
+
+    act(() => result.current.dismiss());
+
+    expect(result.current.visible).toBe(false);
+    expect(store.written).toEqual(["true"]);
+  });
+
+  it("still hides when storage REFUSES the write", () => {
+    // Private browsing throws on write. An author who cannot persist the
+    // dismissal should still get the card off their screen for this session.
+    const refusing: PreferenceStore = {
+      read: () => null,
+      write: () => {
+        throw new Error("storage disabled");
+      },
+    };
+    const { result } = renderHook(() =>
+      useBuilderChecklist({ document: documentOf(), store: refusing })
+    );
+
+    act(() => result.current.dismiss());
+
+    expect(result.current.visible).toBe(false);
+  });
+
+  it("is hidden by the host's switch without anyone dismissing it", () => {
+    const store = fakeStore();
+    const { result } = renderHook(() =>
+      useBuilderChecklist({ document: documentOf(), enabled: false, store })
+    );
+
+    expect(result.current.visible).toBe(false);
+    // The switch is not a dismissal: turning it back on must show the card
+    // again rather than find it already dismissed for everyone.
+    expect(store.written).toEqual([]);
+  });
+
+  it("is visible when the switch is on, which is the control", () => {
+    // Without this, the two cases above pass on a hook that never shows the
+    // card under any circumstances.
+    const { result } = renderHook(() =>
+      useBuilderChecklist({
+        document: documentOf(),
+        enabled: true,
+        store: fakeStore(),
+      })
+    );
+
+    expect(result.current.visible).toBe(true);
+  });
+
+  it("reports the steps for the page it was given", () => {
+    const withBlock = documentOf([
+      {
+        id: "a",
+        type: "acme/heading",
+        version: 1,
+        props: { text: "Hi" },
+      } as BlockNode,
+    ]);
+    const { result } = renderHook(() =>
+      useBuilderChecklist({ document: withBlock, store: fakeStore() })
+    );
+
+    expect(result.current.steps.find(s => s.id === "add-block")?.done).toBe(
+      true
+    );
+    expect(result.current.steps.find(s => s.id === "write-text")?.done).toBe(
+      true
+    );
+    expect(result.current.steps.find(s => s.id === "build-page")?.done).toBe(
+      false
+    );
+  });
+});

--- a/packages/builder/src/onboarding-checklist.tsx
+++ b/packages/builder/src/onboarding-checklist.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+/**
+ * The first-run card: what an author has not done on this page yet.
+ *
+ * Presentational. What the steps ARE and whether each is done is
+ * {@link module:onboarding}'s derivation from the document; whether the card
+ * should be on screen at all is {@link useBuilderChecklist}'s. Splitting the
+ * three keeps the part with a rule in it testable without a DOM, which is the
+ * same split the rest of this package makes.
+ *
+ * ## It stays after the last box is ticked
+ *
+ * Vanishing at the moment of completion takes away the only confirmation the
+ * author gets, and reads as the card having crashed rather than as work being
+ * finished. It stays, saying so, until it is dismissed — one click, on a card
+ * that is plainly done.
+ *
+ * @module onboarding-checklist
+ */
+
+import type { BlockDocument } from "@nextlyhq/blocks-engine";
+import { cn } from "@nextlyhq/ui/utils";
+import { Check, X } from "lucide-react";
+import { useCallback, useState } from "react";
+
+import {
+  builderChecklist,
+  checklistComplete,
+  checklistDoneCount,
+  type ChecklistStep,
+} from "./onboarding";
+import { browserStore, type PreferenceStore } from "./shell-state";
+
+/** Where the dismissal is remembered. */
+export const CHECKLIST_STORAGE_KEY = "nextly.builder.checklist.dismissed";
+
+export interface UseBuilderChecklistOptions {
+  /** The page being edited. Every step is derived from it. */
+  document: BlockDocument;
+  /**
+   * Whether the checklist may be shown at all. Defaults to true.
+   *
+   * The host's kill switch. A site that has taught its authors the editor
+   * another way turns it off rather than asking every one of them to dismiss
+   * it.
+   */
+  enabled?: boolean;
+  /**
+   * Where the dismissal is remembered. Defaults to `localStorage`.
+   *
+   * A port rather than a direct call, so a test can drive it and a server
+   * render can have one that remembers nothing. Note what this is NOT: storage
+   * is per BROWSER, so two people sharing a profile share the dismissal. Per
+   * user in the sense that matters — nobody dismisses it for anyone else's
+   * machine — and not a claim about accounts.
+   */
+  store?: PreferenceStore;
+}
+
+export interface UseBuilderChecklistResult {
+  readonly steps: readonly ChecklistStep[];
+  readonly visible: boolean;
+  readonly dismiss: () => void;
+}
+
+/**
+ * Whether to show the card, and what it should say.
+ *
+ * @param options - the document, the kill switch, and where dismissal lives
+ * @returns the steps, whether to render, and the way to stop
+ */
+export function useBuilderChecklist({
+  document,
+  enabled = true,
+  store,
+}: UseBuilderChecklistOptions): UseBuilderChecklistResult {
+  // Read once on mount rather than on every render: the value only changes
+  // through `dismiss`, and reading storage during render makes the first
+  // client render disagree with the server's.
+  const [dismissed, setDismissed] = useState(() => {
+    const source = store ?? browserStore(CHECKLIST_STORAGE_KEY);
+    return source.read() === "true";
+  });
+
+  const dismiss = useCallback(() => {
+    const source = store ?? browserStore(CHECKLIST_STORAGE_KEY);
+    // Written before the state changes, and a failure is swallowed: private
+    // browsing refuses storage, and an author who cannot persist the dismissal
+    // should still get the card off their screen for this session.
+    try {
+      source.write("true");
+    } catch {
+      // Storage refused. The in-memory dismissal below still stands.
+    }
+    setDismissed(true);
+  }, [store]);
+
+  const steps = builderChecklist(document);
+  return { steps, visible: enabled && !dismissed, dismiss };
+}
+
+export interface OnboardingChecklistProps {
+  steps: readonly ChecklistStep[];
+  /** Stop showing it. */
+  onDismiss: () => void;
+  className?: string;
+}
+
+/**
+ * @param props - the steps and the way to dismiss them
+ * @returns the card, or nothing when there are no steps to show
+ */
+export function OnboardingChecklist({
+  steps,
+  onDismiss,
+  className,
+}: OnboardingChecklistProps) {
+  if (steps.length === 0) return null;
+  const done = checklistDoneCount(steps);
+  const complete = checklistComplete(steps);
+
+  return (
+    // `complementary` with a name: the card is beside the editor's work rather
+    // than part of it, and an unnamed region is announced as "region".
+    <aside
+      aria-label="Getting started"
+      className={cn(
+        "border-[color:var(--nx-builder-border)] bg-[color:var(--nx-builder-surface-raised)] text-[color:var(--nx-builder-text)] w-72 rounded-lg border p-4 shadow-lg",
+        className
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p className="text-sm font-semibold">
+            {complete ? "You're all set" : "Getting started"}
+          </p>
+          {/* The count is text rather than only a bar, so it is readable
+              without colour and announced without a label of its own. */}
+          <p className="text-[color:var(--nx-builder-text-muted)] text-xs">
+            {done} of {steps.length} done
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss getting started"
+          className="focus-visible:ring-ring text-[color:var(--nx-builder-text-muted)] -m-1 rounded p-1 focus-visible:ring-2 focus-visible:outline-none"
+        >
+          <X className="size-4" />
+        </button>
+      </div>
+
+      <ul className="mt-3 flex flex-col gap-3">
+        {steps.map(step => (
+          <li key={step.id} className="flex gap-2">
+            {/* Weight and a mark carry the state, not colour alone: a done
+                step reads as done in monochrome and to anyone who cannot
+                separate the two hues. */}
+            <span
+              aria-hidden
+              className="border-[color:var(--nx-builder-border)] mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border"
+            >
+              {step.done ? <Check className="size-3" /> : null}
+            </span>
+            <span className="min-w-0">
+              <span
+                className={cn(
+                  "block text-sm",
+                  step.done
+                    ? "text-[color:var(--nx-builder-text-muted)] font-normal line-through"
+                    : "font-medium"
+                )}
+              >
+                {step.label}
+              </span>
+              {/* The hint stays on a done step rather than disappearing: the
+                  card is also how an author looks the gesture up again. */}
+              <span className="text-[color:var(--nx-builder-text-muted)] block text-xs">
+                {step.hint}
+              </span>
+            </span>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/packages/builder/src/onboarding.test.ts
+++ b/packages/builder/src/onboarding.test.ts
@@ -1,0 +1,179 @@
+/**
+ * The checklist, derived from the page rather than tracked as the author works.
+ *
+ * Driven through the real registry: whether a value counts as text an author
+ * could have written is the block's own declaration, and a stub restating it
+ * would agree today and drift afterwards.
+ *
+ * @module onboarding.test
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  clearBlocks,
+  hasBlock,
+  registerBlocks,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+
+import {
+  builderChecklist,
+  checklistComplete,
+  checklistDoneCount,
+} from "./onboarding";
+
+const base = {
+  version: 1,
+  description: "A block.",
+  example: { props: {} },
+  render: () => null,
+};
+
+afterEach(clearBlocks);
+
+/**
+ * Registered once per test, not once per call.
+ *
+ * `registerBlocks` refuses a redefinition, and several cases below build two
+ * documents to compare — so a helper that registered unconditionally would
+ * throw in exactly the tests that assert a step changing.
+ */
+function register() {
+  if (hasBlock("acme/heading")) return;
+  registerBlocks(
+    [
+      {
+        ...base,
+        name: "acme/heading",
+        props: {
+          text: { type: "text", inline: true },
+          level: { type: "text" },
+        },
+      },
+      // A block with NOTHING an author can type into, so "write something"
+      // cannot be satisfied by adding one.
+      { ...base, name: "acme/divider", props: {} },
+    ] as never,
+    { source: "onboarding-test" }
+  );
+}
+
+function documentOf(nodes: BlockNode[]): BlockDocument {
+  register();
+  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+}
+
+function heading(id: string, text?: string): BlockNode {
+  return {
+    id,
+    type: "acme/heading",
+    version: 1,
+    props: text === undefined ? {} : { text },
+  } as BlockNode;
+}
+
+function step(document: BlockDocument, id: string) {
+  return builderChecklist(document).find(s => s.id === id);
+}
+
+describe("builderChecklist", () => {
+  it("asks for a first block on an empty page", () => {
+    const empty = documentOf([]);
+
+    expect(step(empty, "add-block")?.done).toBe(false);
+    expect(step(empty, "write-text")?.done).toBe(false);
+    expect(step(empty, "build-page")?.done).toBe(false);
+  });
+
+  it("counts the first block as done once one is there", () => {
+    expect(step(documentOf([heading("a")]), "add-block")?.done).toBe(true);
+  });
+
+  it("does NOT count writing as done for a block with empty text", () => {
+    // The step an inserted-but-untouched block would otherwise complete for
+    // free, telling an author they had learned a gesture they never used.
+    expect(step(documentOf([heading("a", "")]), "write-text")?.done).toBe(
+      false
+    );
+  });
+
+  it("does not count whitespace as writing", () => {
+    expect(step(documentOf([heading("a", "   ")]), "write-text")?.done).toBe(
+      false
+    );
+  });
+
+  it("counts writing as done once a block carries text", () => {
+    expect(step(documentOf([heading("a", "Hello")]), "write-text")?.done).toBe(
+      true
+    );
+  });
+
+  it("finds text on a NESTED block", () => {
+    // The page is a tree. A walk that read only the top level would ask an
+    // author to write something they had already written inside a container.
+    const nested = documentOf([
+      {
+        id: "outer",
+        type: "acme/divider",
+        version: 1,
+        props: {},
+        slots: { content: [heading("inner", "Nested words")] },
+      } as BlockNode,
+    ]);
+
+    expect(step(nested, "write-text")?.done).toBe(true);
+  });
+
+  it("cannot be satisfied by a block with nothing to type into", () => {
+    const dividers = documentOf([
+      { id: "a", type: "acme/divider", version: 1, props: {} } as BlockNode,
+    ]);
+
+    expect(step(dividers, "add-block")?.done).toBe(true);
+    expect(step(dividers, "write-text")?.done).toBe(false);
+  });
+
+  it("asks for a second block until there are two", () => {
+    expect(step(documentOf([heading("a", "Hi")]), "build-page")?.done).toBe(
+      false
+    );
+    expect(
+      step(documentOf([heading("a", "Hi"), heading("b")]), "build-page")?.done
+    ).toBe(true);
+  });
+
+  it("goes BACK to incomplete when the work is undone", () => {
+    // Derivation's honest cost, asserted rather than left to be discovered.
+    // The checklist describes the page, not a person's history with it.
+    expect(step(documentOf([heading("a", "Hi")]), "write-text")?.done).toBe(
+      true
+    );
+    expect(step(documentOf([heading("a", "")]), "write-text")?.done).toBe(
+      false
+    );
+  });
+});
+
+describe("checklistComplete", () => {
+  it("is true only when every step is done", () => {
+    const full = documentOf([heading("a", "Hi"), heading("b")]);
+
+    expect(checklistComplete(builderChecklist(full))).toBe(true);
+    expect(checklistDoneCount(builderChecklist(full))).toBe(3);
+  });
+
+  it("is false while any step is outstanding", () => {
+    const partial = documentOf([heading("a", "Hi")]);
+
+    expect(checklistComplete(builderChecklist(partial))).toBe(false);
+    expect(checklistDoneCount(builderChecklist(partial))).toBe(2);
+  });
+
+  it("is false for an empty list rather than vacuously true", () => {
+    // `every` on nothing is true, which would report a checklist that failed to
+    // build as finished — and the card would never appear.
+    expect(checklistComplete([])).toBe(false);
+  });
+});

--- a/packages/builder/src/onboarding.ts
+++ b/packages/builder/src/onboarding.ts
@@ -1,0 +1,108 @@
+/**
+ * What a first-time author has not done yet, derived from the page itself.
+ *
+ * Every step is DERIVED from the document rather than tracked as the author
+ * works. Tracking would need a second store of "has this person inserted a
+ * block", which drifts from the page the moment anything else changes it —
+ * an import, a duplicate of an existing page, a colleague's edit — and then
+ * congratulates someone for work they did not do, or asks them to do what is
+ * already there.
+ *
+ * Derivation has one honest cost: a step completed and then undone goes back to
+ * incomplete. That is the right reading. The checklist describes the PAGE, not
+ * a person's history with it, and a page with no blocks is a page whose author
+ * still needs to add one.
+ *
+ * ## Why these three
+ *
+ * They are the gestures nothing else in the editor teaches, in the order an
+ * author meets them, and each is separately observable in the document. A step
+ * that completed as a side effect of another would tell an author they had
+ * learned something they never did.
+ *
+ * @module onboarding
+ */
+
+import { walkNodes, type BlockDocument } from "@nextlyhq/blocks-engine";
+
+import { inlineTargets } from "./inline-text";
+
+/** One thing to do, and whether the page shows it has been done. */
+export interface ChecklistStep {
+  readonly id: string;
+  /** What to do, in the imperative. */
+  readonly label: string;
+  /** How to do it, naming the gesture. */
+  readonly hint: string;
+  readonly done: boolean;
+}
+
+/** Whether any block on the page carries text an author typed. */
+function hasAuthoredText(document: BlockDocument): boolean {
+  let found = false;
+  walkNodes(document.nodes, node => {
+    if (found) return;
+    // Asked of the same rule the canvas uses to decide what may be typed into,
+    // so "text an author could have written here" means one thing in both
+    // places. A block with no inline values cannot satisfy this step, which is
+    // correct: there was nothing to type.
+    found = inlineTargets(document, node.id).some(
+      target => target.value.trim() !== ""
+    );
+  });
+  return found;
+}
+
+/** How many top-level blocks the page holds. */
+function topLevelCount(document: BlockDocument): number {
+  return document.nodes.length;
+}
+
+/**
+ * The checklist for this page.
+ *
+ * @param document - the page being edited
+ * @returns the steps, in the order an author meets them
+ */
+export function builderChecklist(
+  document: BlockDocument
+): readonly ChecklistStep[] {
+  const blocks = topLevelCount(document);
+  return [
+    {
+      id: "add-block",
+      label: "Add your first block",
+      // The one gesture nothing else on screen suggests: an empty canvas looks
+      // like a page with nothing wrong with it.
+      hint: "Open Insert in the left rail and choose one.",
+      done: blocks > 0,
+    },
+    {
+      id: "write-text",
+      label: "Write something",
+      hint: "Double-click text on the canvas, or select a block and press Enter.",
+      done: hasAuthoredText(document),
+    },
+    {
+      id: "build-page",
+      label: "Add a second block",
+      hint: "A page is a stack of blocks. Drag one above another to reorder.",
+      done: blocks > 1,
+    },
+  ];
+}
+
+/**
+ * Whether every step is done.
+ *
+ * Derived here rather than counted by each caller, so the card and anything
+ * that decides whether to render it cannot disagree about what finished means.
+ */
+export function checklistComplete(steps: readonly ChecklistStep[]): boolean {
+  return steps.length > 0 && steps.every(step => step.done);
+}
+
+/** How many are done, for a progress reading. */
+export function checklistDoneCount(steps: readonly ChecklistStep[]): number {
+  return steps.filter(step => step.done).length;
+}

--- a/packages/builder/src/shell-state.ts
+++ b/packages/builder/src/shell-state.ts
@@ -179,6 +179,32 @@ export interface PreferenceStore {
   write: (value: string) => void;
 }
 
+/** A store that remembers nothing, for a server render and for a browser that refuses storage. */
+export const NO_STORAGE: PreferenceStore = {
+  read: () => null,
+  write: () => undefined,
+};
+
+/**
+ * A `localStorage`-backed store under one key.
+ *
+ * Takes the key rather than owning one, so the shell's chrome preferences and
+ * anything else the editor remembers share this port instead of each writing
+ * their own `typeof window` check and their own swallow. Outside a browser it
+ * degrades to {@link NO_STORAGE} rather than throwing, which is the whole
+ * reason the port exists.
+ *
+ * @param key - where to store the value
+ * @returns a store, or one that remembers nothing outside a browser
+ */
+export function browserStore(key: string): PreferenceStore {
+  if (typeof window === "undefined") return NO_STORAGE;
+  return {
+    read: () => window.localStorage.getItem(key),
+    write: value => window.localStorage.setItem(key, value),
+  };
+}
+
 /**
  * A stored layout, accepted only if every entry is a usable percentage.
  *

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -165,6 +165,28 @@ export { DropIndicator, useCanvasDrag } from "./canvas-drag";
 export { useInlineText, EDITING_ATTRIBUTE } from "./use-inline-text";
 export type { InlineTextEditing, UseInlineTextResult } from "./use-inline-text";
 export { inlineTargets, inlineTarget, inlineTextOp } from "./inline-text";
+/**
+ * The first-run checklist: what an author has not done on this page yet.
+ *
+ * Every step is DERIVED from the document rather than tracked, so it describes
+ * the page rather than a person's history with it.
+ */
+export {
+  OnboardingChecklist,
+  useBuilderChecklist,
+  CHECKLIST_STORAGE_KEY,
+} from "./onboarding-checklist";
+export type {
+  OnboardingChecklistProps,
+  UseBuilderChecklistOptions,
+  UseBuilderChecklistResult,
+} from "./onboarding-checklist";
+export {
+  builderChecklist,
+  checklistComplete,
+  checklistDoneCount,
+} from "./onboarding";
+export type { ChecklistStep } from "./onboarding";
 export type { InlineTextTarget } from "./inline-text";
 export type {
   CanvasDrag,

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -51,13 +51,16 @@ import {
   InsertPanel,
   InspectorPanel,
   LayersPanel,
+  OnboardingChecklist,
   SelectionBreadcrumb,
+  useBuilderChecklist,
   useCanvasDrag,
   useEditorState,
   useInlineText,
 } from "@nextlyhq/builder/shell";
 import {
   useDocumentCheckpoint,
+  usePluginClientConfig,
   useSuppressAdminChrome,
 } from "@nextlyhq/plugin-sdk/admin";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -348,6 +351,19 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    */
   const inline = useInlineText(editor);
 
+  /*
+   * The getting-started card, and the host's switch for it.
+   *
+   * `checklist === false` is the only value that turns it off: an absent
+   * config and a malformed one both leave it on, because the default is the
+   * behaviour a site that configured nothing asked for.
+   */
+  const clientConfig = usePluginClientConfig(PLUGIN_SOURCE);
+  const checklist = useBuilderChecklist({
+    document: editor.document,
+    enabled: clientConfig?.checklist !== false,
+  });
+
   useCheckpoints({ name, control, document: editor.document });
 
   /*
@@ -404,6 +420,17 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
         // slot rather than rendered beside the canvas so it cannot overlap the
         // page an author is editing.
         breadcrumb={<SelectionBreadcrumb editor={editor} />}
+        // Rendered only while it has somewhere to go: passing an element the
+        // shell would position and then hide leaves an empty positioner over
+        // the canvas.
+        checklist={
+          checklist.visible ? (
+            <OnboardingChecklist
+              steps={checklist.steps}
+              onDismiss={checklist.dismiss}
+            />
+          ) : undefined
+        }
         renderPanel={panel => {
           if (panel === "insert") {
             return (

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -23,6 +23,15 @@ export interface PageBuilderOptions {
   /** Disable behavior while still applying schema. Default true. */
   enabled?: boolean;
   /**
+   * Whether the editor shows its getting-started checklist. Default true.
+   *
+   * A site that teaches its authors the editor some other way turns it off
+   * here rather than asking every one of them to dismiss it. Travels to the
+   * browser through `clientConfig` for the same reason `remotePatterns` does:
+   * the canvas runs there, where a server-side option cannot reach it.
+   */
+  checklist?: boolean;
+  /**
    * Remote hosts a page may load images, video and embeds from, in the same
    * shape `next/image` uses.
    *
@@ -191,9 +200,20 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) =>
         // travels with the rest of the admin metadata. `remotePatterns` is
         // plain data and survives the trip; the serializer rejects it if a
         // future addition here does not.
-        ...(opts.remotePatterns !== undefined
+        // Sent only when the host said something. An always-present
+        // `clientConfig` would make every future reader distinguish "the host
+        // set this" from "the default is showing", which is what the absent
+        // key already says.
+        ...(opts.remotePatterns !== undefined || opts.checklist !== undefined
           ? {
-              clientConfig: { remotePatterns: opts.remotePatterns },
+              clientConfig: {
+                ...(opts.remotePatterns === undefined
+                  ? {}
+                  : { remotePatterns: opts.remotePatterns }),
+                ...(opts.checklist === undefined
+                  ? {}
+                  : { checklist: opts.checklist }),
+              },
             }
           : {}),
         menu: [


### PR DESCRIPTION
Closes B-22. An empty canvas looks like a page with nothing wrong with it, and nothing on screen says where blocks come from. The card names the three gestures nothing else teaches: **add a block, write in it, add a second one.**

## The one decision worth arguing about

**Every step is derived from the page, not tracked as the author works.**

Tracking needs a second store of what someone has done, and it drifts from the page the moment anything else changes it — an import, a duplicated page, a colleague's edit. Then it congratulates an author for work they did not do, or asks for what is already in front of them.

Derivation costs exactly one thing, and it is asserted rather than left to be discovered: **a step whose work is undone goes back to incomplete.** That is the right reading. The card describes the *page*, not a person's history with it, and a page with no blocks is a page whose author still needs to add one.

## What "writing" means is asked, not restated

The second step is done when a block carries text an author could have typed. That is `inlineTargets` — the same rule the canvas uses to decide what may be typed into, from the inline-editing work in #1067. Asking it rather than re-deriving it means the two cannot come to disagree, and a block with nothing typeable (a divider) can never satisfy the step, which is correct: there was nothing to write.

## It stays after the last box is ticked

Vanishing at the moment of completion takes away the only confirmation the author gets and reads as the card having crashed rather than as work being finished. It stays, saying "You're all set", until dismissed — one click, on a card that is plainly done.

## Reuse rather than a second implementation

`BuilderShell` already had a `localStorage` port with a `typeof window` guard and a swallow, private to that file and hardcoded to one key. Rather than writing a second one, it moves to `shell-state` and takes the key. Chrome preferences and this dismissal now share one implementation of "storage may refuse, and a server render has none."

Worth noting for review: **the admin already has an onboarding checklist** on the dashboard (`useOnboardingProgress` + `OnboardingChecklist`), deriving steps from dashboard stats. This is not that one and does not replace it — different surface, different steps, and `packages/builder` cannot import the admin's. The pattern is deliberately the same so the two read alike.

## Honest about what "per-user dismiss" means

The plan row says per-user. Storage is per **browser**, so two people sharing a profile share the dismissal. Per-user in the sense that matters — nobody dismisses it for anyone else's machine — and not a claim about accounts. The docblock says so rather than letting the plan's wording imply more.

## Verified in a browser

At 1600×1000, after asserting the auth control: the card renders bottom-right of the canvas region reading **"You're all set — 3 of 3 done"** on the fully-built homepage, with all three steps struck through and ticked. Dismissing it removes it and writes `nextly.builder.checklist.dismissed`; reopening the editor after a full reload leaves it gone, with the editor's presence asserted first so "no card" could not be satisfied by an editor that failed to open.

Screenshot reviewed rather than only queried — the card sits inside the canvas column and does not overlap the inspector.

## Accessibility and theming

`role="complementary"` with an accessible name, a labelled dismiss control, and focus-visible rings. Progress is **text** ("3 of 3 done") rather than only a bar, so it survives without colour. Done steps are marked by a tick and a weight change rather than by hue alone. Every colour is a `--nx-builder-*` token, so both modes follow the editor.

## Tests

`builder` 836 → 855. `plugin-page-builder` 71, `blocks-engine` 1267, `blocks-react` 635. All gates green; Fallow passes with nothing introduced.

Six stubs, each failing exactly the test that names its rule and nothing else: whitespace counting as writing, walking only the top level, an empty list reading as vacuously complete, the kill switch being ignored, a dismissal that is never recorded, and a refused write that also stops the hide.
