### PR TITLE
feat(nextly): hold a status-less edit on a published single

### DIFF
--- a/.changeset/singles-pending-changes.md
+++ b/.changeset/singles-pending-changes.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Hold a status-less edit on a published Single.
+
+Editing a published Single now holds the change instead of putting it on the
+live site, per language, the way a collection entry does. Publishing applies the
+pending change; publishing every language applies each of them. A Single's
+schema response also reports whether pending changes are on, so its editor can
+offer the matching actions.

--- a/packages/nextly/src/api/singles-schema-detail.ts
+++ b/packages/nextly/src/api/singles-schema-detail.ts
@@ -28,6 +28,7 @@ import {
   coerceBuilderMaxPerDoc,
   resolveBuilderVersions,
 } from "../domains/versions/builder-versions";
+import { schemaDraftsEnabled } from "../domains/versions/draft-split-eligibility";
 import { resolveBuilderWebhooks } from "../domains/webhooks/builder-webhooks";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
@@ -97,9 +98,25 @@ export const GET = withErrorHandler(
       });
     }
 
+    // Whether a status-less save on this Single holds the edit rather than
+    // writing the live row. Derived from the SAME predicate the write gates on,
+    // so the editor's affordance can never disagree with what a save does — an
+    // editor told drafts are off sends an explicit published save, which
+    // overwrites the live document.
+    //
+    // A resolution failure propagates rather than defaulting to false: for a
+    // drafts-configured Single, false is the destructive answer.
+    const draftsEnabled = await schemaDraftsEnabled({
+      status: (single as { status?: boolean }).status,
+      versions: single.versions,
+      localized: (single as { localized?: boolean }).localized,
+      fields: single.fields,
+    });
+
     return respondDoc({
       ...single,
       fields: enrichedFields,
+      draftsEnabled,
     } as unknown as typeof single);
   }
 );

--- a/packages/nextly/src/domains/singles/__tests__/draft-split-singles.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/draft-split-singles.integration.test.ts
@@ -1,0 +1,227 @@
+/**
+ * A published Single holds a status-less edit instead of publishing it.
+ *
+ * Singles had no pending-changes code at all: every edit to a published
+ * Homepage or Site Settings went straight to the live site. The engine pieces
+ * are shared with collections — the same hold rule, the same locale key, the
+ * same write — so this proves the wiring rather than re-proving the mechanism.
+ *
+ * Each "unaffected" assertion is paired with a positive one in the same case:
+ * "the stored document is unchanged" is satisfied just as well by a write that
+ * stored nothing at all. And each case asserts the operation SUCCEEDED before
+ * asserting its effects, because a soft failure otherwise reads as "the write
+ * did nothing".
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineSingle, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { SingleEntryService } from "../services/single-entry-service";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const SLUG = "preferences";
+
+async function bootPlain(): Promise<TestNextly> {
+  current = await createTestNextly({
+    singles: [
+      defineSingle({
+        slug: SLUG,
+        status: true,
+        versions: { drafts: true },
+        fields: [text({ name: "siteName" }), text({ name: "tagline" })],
+      }),
+    ],
+  });
+  return current;
+}
+
+async function bootLocalized(): Promise<TestNextly> {
+  current = await createTestNextly({
+    singles: [
+      defineSingle({
+        slug: SLUG,
+        localized: true,
+        status: true,
+        versions: { drafts: true },
+        fields: [text({ name: "siteName", localized: true })],
+      }),
+    ],
+    localization: { locales: ["en", "de"], defaultLocale: "en" },
+  });
+  return current;
+}
+
+function singlesOf(t: TestNextly): SingleEntryService {
+  return t.getService("singleEntryService");
+}
+
+/** Pending changes for this Single, by the language they are keyed under. */
+async function pendingLocales(t: TestNextly): Promise<string[]> {
+  const rows = await t.adapter.select<{ locale: string | null }>(
+    "nextly_versions",
+    {
+      where: {
+        and: [
+          { column: "scopeKind", op: "=", value: "single" },
+          { column: "scopeSlug", op: "=", value: SLUG },
+          { column: "isAutosave", op: "=", value: false },
+          { column: "versionNo", op: "IS NULL" },
+          { column: "status", op: "=", value: "draft" },
+        ],
+      },
+    }
+  );
+  return rows.map(r => r.locale ?? "(none)").sort();
+}
+
+async function storedName(t: TestNextly, locale?: string): Promise<unknown> {
+  const res = await singlesOf(t).get(SLUG, { locale, overrideAccess: true });
+  return (res.data as { siteName?: unknown } | null)?.siteName;
+}
+
+describe("pending changes for Singles (integration)", () => {
+  it("writes the live row when the Single is not published (control)", async () => {
+    const t = await bootPlain();
+    const singles = singlesOf(t);
+    const created = await singles.update(
+      SLUG,
+      { siteName: "first", status: "draft" },
+      { overrideAccess: true }
+    );
+    expect(created.success).toBe(true);
+
+    const res = await singles.update(
+      SLUG,
+      { siteName: "edited" },
+      { overrideAccess: true }
+    );
+    expect(res.success).toBe(true);
+
+    // Nothing is live to protect, so the edit belongs on the row.
+    expect(await storedName(t)).toBe("edited");
+    expect(await pendingLocales(t)).toEqual([]);
+  });
+
+  it("holds a status-less edit to a published Single", async () => {
+    const t = await bootPlain();
+    const singles = singlesOf(t);
+    expect(
+      (
+        await singles.update(
+          SLUG,
+          { siteName: "live", status: "published" },
+          { overrideAccess: true }
+        )
+      ).success
+    ).toBe(true);
+
+    const res = await singles.update(
+      SLUG,
+      { siteName: "edited" },
+      { overrideAccess: true }
+    );
+    expect(res.success).toBe(true);
+
+    expect(await pendingLocales(t)).toEqual(["(none)"]);
+    expect(await storedName(t)).toBe("live");
+  });
+
+  it("promotes the pending change when the Single is published", async () => {
+    const t = await bootPlain();
+    const singles = singlesOf(t);
+    await singles.update(
+      SLUG,
+      { siteName: "live", status: "published" },
+      { overrideAccess: true }
+    );
+    await singles.update(
+      SLUG,
+      { siteName: "edited" },
+      { overrideAccess: true }
+    );
+
+    const published = await singles.update(
+      SLUG,
+      { status: "published" },
+      { overrideAccess: true }
+    );
+    expect({ success: published.success }).toEqual({ success: true });
+
+    expect(await storedName(t)).toBe("edited");
+    expect(await pendingLocales(t)).toEqual([]);
+  });
+
+  it("holds a German edit under German and leaves English alone", async () => {
+    const t = await bootLocalized();
+    const singles = singlesOf(t);
+    await singles.update(
+      SLUG,
+      { siteName: "EN live", status: "published" },
+      { locale: "en", overrideAccess: true }
+    );
+    await singles.update(
+      SLUG,
+      { siteName: "DE live", status: "published" },
+      { locale: "de", overrideAccess: true }
+    );
+
+    const res = await singles.update(
+      SLUG,
+      { siteName: "DE edited" },
+      { locale: "de", overrideAccess: true }
+    );
+    expect(res.success).toBe(true);
+
+    // The positive half, without which the negative half proves nothing.
+    expect(await pendingLocales(t)).toEqual(["de"]);
+    expect(await storedName(t, "en")).toBe("EN live");
+    expect(await storedName(t, "de")).toBe("DE live");
+  });
+
+  it("publishAllLocales applies every language's pending change", async () => {
+    const t = await bootLocalized();
+    const singles = singlesOf(t);
+    await singles.update(
+      SLUG,
+      { siteName: "EN live", status: "published" },
+      { locale: "en", overrideAccess: true }
+    );
+    await singles.update(
+      SLUG,
+      { siteName: "DE live", status: "published" },
+      { locale: "de", overrideAccess: true }
+    );
+    await singles.update(
+      SLUG,
+      { siteName: "EN edited" },
+      { locale: "en", overrideAccess: true }
+    );
+    await singles.update(
+      SLUG,
+      { siteName: "DE edited" },
+      { locale: "de", overrideAccess: true }
+    );
+    // The fixture has to have held both, or the assertions below are trivially
+    // satisfied by a system that stored nothing.
+    expect(await pendingLocales(t)).toEqual(["de", "en"]);
+
+    const res = await singles.publishAllLocales(SLUG, {
+      overrideAccess: true,
+    });
+    expect({ success: res.success }).toEqual({ success: true });
+
+    // Both go live together, and neither pending change is left behind to be
+    // re-applied by a later publish.
+    expect(await storedName(t, "en")).toBe("EN edited");
+    expect(await storedName(t, "de")).toBe("DE edited");
+    expect(await pendingLocales(t)).toEqual([]);
+  });
+});

--- a/packages/nextly/src/domains/singles/services/apply-pending-change.ts
+++ b/packages/nextly/src/domains/singles/services/apply-pending-change.ts
@@ -1,0 +1,100 @@
+/**
+ * Turning a Single's pending change into the values a write persists.
+ *
+ * Two callers need this and must not answer differently: publishing one
+ * language folds its pending change into that write, and publishing every
+ * language applies each of them. A second copy of the mapping is how the two
+ * would drift, and the drift would be quiet — a translated value routed to the
+ * main table fails loudly with `no such column`, but one routed to the wrong
+ * locale's companion row simply publishes the wrong translation.
+ *
+ * @module domains/singles/services/apply-pending-change
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import { keysToSnakeCase } from "../../../lib/case-conversion";
+import { stripImmutableSystemFields } from "../../../lib/immutable-system-fields";
+import type { CompanionSchema } from "../../i18n/runtime/companion-io";
+import {
+  splitLocalizedWrite,
+  upsertCompanionRow,
+} from "../../i18n/runtime/companion-io";
+
+/** The column-shaped halves a pending change persists to. */
+export interface PendingChangeParts {
+  /** Values belonging on the Single's own row. */
+  main: Record<string, unknown>;
+  /** Values belonging on the write locale's companion row. */
+  companion: Record<string, unknown>;
+}
+
+/**
+ * Split a stored pending change into main-row and companion-row values.
+ *
+ * The snapshot is in read shape (field names, camelCased timestamps), so it is
+ * mapped to columns before the split — and the split runs LAST, because it is
+ * what moves translated values out of the document. Anything merged in
+ * afterwards would land on the main row, which has no column for it.
+ *
+ * `overrides` are the caller's own values, applied on top: a publish that also
+ * sets a field is saying something about that field now, and outranks what the
+ * pending change said earlier.
+ */
+export function splitPendingChange(
+  snapshot: unknown,
+  companion: CompanionSchema | null,
+  overrides?: Record<string, unknown>
+): PendingChangeParts {
+  const payload = stripImmutableSystemFields(
+    {
+      ...(keysToSnakeCase(snapshot) as Record<string, unknown>),
+      ...(overrides ?? {}),
+    },
+    "single"
+  );
+  if (!companion) return { main: payload, companion: {} };
+  const { main, companion: companionValues } = splitLocalizedWrite(
+    payload,
+    companion.localizedFields
+  );
+  return { main, companion: companionValues };
+}
+
+/** The transaction surface a companion write needs. */
+export interface CompanionWriteTx {
+  execute<T = unknown>(sql: string, params?: unknown[]): Promise<T[]>;
+}
+
+/**
+ * Write one language's values to its companion row, on the caller's
+ * transaction.
+ *
+ * The adapter shim is built here rather than at each call site: it binds the
+ * write to the transaction's own connection, and a site that forgot it would
+ * take a second pooled connection the transaction is holding and stall.
+ */
+export async function writeCompanionValues(args: {
+  tx: CompanionWriteTx;
+  dialect: SupportedDialect;
+  companionTableName: string;
+  entryId: string;
+  locale: string;
+  values: Record<string, unknown>;
+  /** The per-locale lifecycle to stamp, when this write sets one. */
+  status?: string;
+}): Promise<void> {
+  const txWriteAdapter = {
+    dialect: args.dialect,
+    executeQuery: <T = unknown>(sql: string, params?: unknown[]) =>
+      args.tx.execute<T>(sql, params),
+  };
+  await upsertCompanionRow(
+    txWriteAdapter,
+    args.companionTableName,
+    args.entryId,
+    args.locale,
+    args.values,
+    args.status
+  );
+}

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -83,7 +83,6 @@ import {
 import {
   buildCompanionSchema,
   splitLocalizedWrite,
-  upsertCompanionRow,
 } from "../../i18n/runtime/companion-io";
 import {
   cachedCompanionReadiness,
@@ -91,6 +90,8 @@ import {
   resolveCompanionReadiness,
 } from "../../i18n/runtime/companion-readiness";
 import { captureInTx } from "../../versions/capture-in-tx";
+import { resolveDraftHold } from "../../versions/draft-hold";
+import { resolveComponentSchemas } from "../../versions/restore-version";
 import {
   resolveComponentFieldMap,
   tagComponentTypes,
@@ -109,6 +110,10 @@ import type {
   UpdateSingleOptions,
 } from "../types";
 
+import {
+  splitPendingChange,
+  writeCompanionValues,
+} from "./apply-pending-change";
 import { resolveSingleForRequest } from "./ensure-runtime-table";
 import {
   SingleQueryService,
@@ -405,6 +410,16 @@ export class SingleMutationService extends BaseService {
       }
 
       const fieldConfigs = singleMeta.fields;
+
+      // The component schemas the hold decision needs, resolved OFF the
+      // transaction: this reads the component registry, and a registry read
+      // inside the transaction would take a second pooled connection that the
+      // open transaction is holding.
+      const singleComponentSchemas =
+        (singleMeta as { status?: boolean }).status === true &&
+        singleMeta.versions?.drafts?.enabled === true
+          ? await resolveComponentSchemas(fieldConfigs)
+          : null;
 
       // 6.1. Field-level access + beforeValidate hooks (functions resolved
       // via the field-level registry; serialized field defs drop them).
@@ -962,7 +977,7 @@ export class SingleMutationService extends BaseService {
             // drop the translatable values on the floor. While the table is absent
             // they stay on the main table — the pre-companion fallback — which the
             // pre-transaction guard above has already proven is actually possible.
-            const { main: mainPayload, companion: companionData } =
+            let { main: mainPayload, companion: companionData } =
               companion && companionPhysicallyExists
                 ? splitLocalizedWrite(updatePayload, companion.localizedFields)
                 : {
@@ -1047,12 +1062,101 @@ export class SingleMutationService extends BaseService {
                 new Date();
             }
 
-            const rows = await tx.update<SingleDocument>(
-              singleMeta.tableName,
-              mainPayload,
-              this.whereEq("id", existingDoc.id),
-              { returning: "*" }
-            );
+            // Whether this write holds its edit instead of publishing it.
+            // The same rule the collection write paths use, so a Single and an
+            // entry can never answer differently about the same question.
+            //
+            // The live status is the one belonging to the language being
+            // written: a non-default language's lifecycle lives on its
+            // companion `_status`, not on the main row, so reading the main row
+            // would judge a translation by another language's state.
+            const singleLiveStatus =
+              companion &&
+              writeLocale !== undefined &&
+              this.localization &&
+              writeLocale !== this.localization.defaultLocale
+                ? await this.readCompanionStatusInTx(
+                    tx,
+                    companion,
+                    existingDoc.id,
+                    writeLocale
+                  )
+                : preRowMainStatus;
+            const { hold: holdEdit, draftLocale: singleDraftLocale } =
+              resolveDraftHold({
+                collectionHasStatus:
+                  (singleMeta as { status?: boolean }).status === true,
+                draftsVersioningEnabled:
+                  singleMeta.versions?.drafts?.enabled === true,
+                documentLocalized: singleMeta.localized === true,
+                fields: fieldConfigs,
+                componentSchemas: singleComponentSchemas,
+                namedStatus: (updatePayload as Record<string, unknown>).status,
+                liveStatus: singleLiveStatus,
+                requestLocale: writeLocale ?? null,
+              });
+
+            // Publishing folds this language's pending change into the write.
+            // Merged BEFORE the payload is re-split: the split moves translated
+            // values out of the document and into the companion payload, so
+            // merging afterwards would carry them to the main table, which has
+            // no column for them.
+            //
+            // The caller's own payload wins over the draft: a publish that also
+            // sets a field is saying something about that field now.
+            let promotedDraft = false;
+            if (
+              !holdEdit &&
+              (singleMeta as { status?: boolean }).status === true &&
+              singleMeta.versions?.drafts?.enabled === true &&
+              (updatePayload as Record<string, unknown>).status === "published"
+            ) {
+              const pendingDraft = await new VersionsRepository(
+                tx
+              ).findWorkingDraft(
+                {
+                  scopeKind: "single",
+                  scopeSlug: slug,
+                  entryId: existingDoc.id,
+                },
+                singleDraftLocale
+              );
+              if (pendingDraft) {
+                // The caller's own payload wins over the pending change: a
+                // publish that also sets a field is saying something about that
+                // field now.
+                ({ main: mainPayload, companion: companionData } =
+                  splitPendingChange(
+                    pendingDraft.snapshot,
+                    companion && companionPhysicallyExists ? companion : null,
+                    updatePayload
+                  ));
+                // A non-default language's lifecycle lives on its companion
+                // `_status`; the main row must not be clobbered by it.
+                if (
+                  writeLocale !== undefined &&
+                  this.localization &&
+                  writeLocale !== this.localization.defaultLocale &&
+                  Object.prototype.hasOwnProperty.call(mainPayload, "status")
+                ) {
+                  delete mainPayload.status;
+                }
+                promotedDraft = true;
+              }
+            }
+
+            // Skip the live-row UPDATE for a held edit; the pending change is
+            // stored below instead. The stored row still travels onward so
+            // everything after this reports the document as it stands, which
+            // for a held edit is the published content the public still sees.
+            const rows = holdEdit
+              ? [existingDoc]
+              : await tx.update<SingleDocument>(
+                  singleMeta.tableName,
+                  mainPayload,
+                  this.whereEq("id", existingDoc.id),
+                  { returning: "*" }
+                );
 
             // Nothing updated: return the empty result; the 500 is surfaced after
             // the (empty) transaction, and the component write is skipped.
@@ -1445,6 +1549,7 @@ export class SingleMutationService extends BaseService {
             // write locale is threaded so an embedded localized component stores
             // its translatable fields to the companion for this language.
             if (
+              !holdEdit &&
               this.fieldGroupDataService &&
               Object.keys(attemptComponentData).length > 0
             ) {
@@ -1477,25 +1582,25 @@ export class SingleMutationService extends BaseService {
             // fails inside the transaction and rolls back the very write the fallback exists to
             // let through.
             if (
+              // A held edit writes no companion row: the translation stored
+              // there IS live content, so writing it would publish the
+              // translated half of a change whose rest is still pending.
+              !holdEdit &&
               companion &&
               companionPhysicallyExists &&
               writeLocale !== undefined &&
               (Object.keys(companionData).length > 0 ||
                 companionStatus !== undefined)
             ) {
-              const txWriteAdapter = {
+              await writeCompanionValues({
+                tx,
                 dialect: this.adapter.dialect,
-                executeQuery: <T = unknown>(sql: string, params?: unknown[]) =>
-                  tx.execute<T>(sql, params as never),
-              };
-              await upsertCompanionRow(
-                txWriteAdapter,
-                companion.companionTableName,
-                existingDoc.id,
-                writeLocale,
-                companionData,
-                companionStatus
-              );
+                companionTableName: companion.companionTableName,
+                entryId: existingDoc.id,
+                locale: writeLocale,
+                values: companionData,
+                status: companionStatus,
+              });
               const row = rows[0] as Record<string, unknown>;
               for (const f of companion.localizedFields) {
                 if (
@@ -1509,9 +1614,73 @@ export class SingleMutationService extends BaseService {
             // Capture a version snapshot atomically with the write when the single
             // opts into versioning. Singles have no many-to-many fields; the
             // updated parent row (top-level keys camelCased to the read shape) plus
+            // A promoted pending change is consumed: its content is now live,
+            // and leaving the row would re-apply it on the next publish.
+            if (promotedDraft) {
+              await new VersionsRepository(tx).deleteWorkingDraft(
+                {
+                  scopeKind: "single",
+                  scopeSlug: slug,
+                  entryId: existingDoc.id,
+                },
+                singleDraftLocale
+              );
+            }
+
+            // Store the pending edit as this Single's working draft for the
+            // language being written. Accumulated onto the draft already there
+            // rather than re-derived from the stored document: a second
+            // status-less save of different fields would otherwise rebuild from
+            // live content and silently revert the first pending edit.
+            if (holdEdit) {
+              const draftRepo = new VersionsRepository(tx);
+              const draftRef = {
+                scopeKind: "single" as const,
+                scopeSlug: slug,
+                entryId: existingDoc.id,
+              };
+              const existingDraft = await draftRepo.findWorkingDraft(
+                draftRef,
+                singleDraftLocale
+              );
+              const base = existingDraft
+                ? (existingDraft.snapshot as Record<string, unknown>)
+                : convertTimestampsToCamelCase({
+                    ...(existingDoc as Record<string, unknown>),
+                  });
+              const pending: Record<string, unknown> = {
+                ...base,
+                ...convertTimestampsToCamelCase({ ...mainPayload }),
+              };
+              // A localized Single keeps its translatable values on the
+              // companion row, so this write's translated values reach the
+              // snapshot only by being overlaid here — keyed by field name to
+              // match the read shape, as the version capture does.
+              if (companion) {
+                for (const f of companion.localizedFields) {
+                  if (
+                    Object.prototype.hasOwnProperty.call(
+                      companionData,
+                      f.column
+                    )
+                  ) {
+                    pending[f.name] = companionData[f.column];
+                  }
+                }
+              }
+              await draftRepo.upsertWorkingDraft({
+                ref: draftRef,
+                locale: singleDraftLocale,
+                snapshot: pending,
+                createdBy: options.user?.id ?? null,
+              });
+            }
+
             // component subtrees form the snapshot.
             const versionsConfig = singleMeta.versions;
-            if (versionsConfig?.enabled) {
+            // A held edit records no durable version: nothing was published, and
+            // a version here would enter the history as though it had been.
+            if (!holdEdit && versionsConfig?.enabled) {
               // Match the read shape: keep user field keys (field.name, which
               // may contain underscores like `site_title`) exactly, converting
               // only the timestamp columns — camel-casing every key would rewrite

--- a/packages/nextly/src/domains/singles/services/single-publish-all.ts
+++ b/packages/nextly/src/domains/singles/services/single-publish-all.ts
@@ -56,6 +56,7 @@ import {
 } from "../../versions/tag-component-types";
 import { VersionCaptureService } from "../../versions/version-capture-service";
 import { withVersionConflictRetry } from "../../versions/version-conflict";
+import { VersionsRepository } from "../../versions/versions-repository";
 import { expandComponentFields } from "../../webhooks/expand-component-fields";
 import { recordMutationEvent } from "../../webhooks/record-mutation-event";
 import { isOutboxRecordingActive } from "../../webhooks/recording-activation";
@@ -67,6 +68,10 @@ import type {
   UserContext,
 } from "../types";
 
+import {
+  splitPendingChange,
+  writeCompanionValues,
+} from "./apply-pending-change";
 import { resolveSingleForRequest } from "./ensure-runtime-table";
 import { checkSingleAccess } from "./single-query-service";
 import type { SingleRegistryService } from "./single-registry-service";
@@ -623,6 +628,12 @@ export class SinglePublishAllService extends BaseService {
       );
     }
 
+    // Every language's pending change goes live with its status. Without this
+    // the statuses would all say published while the content each author was
+    // holding stayed unapplied — the document would report itself fully
+    // published and show none of the work being published.
+    await this.promotePendingChanges(tx, plan, publishNow);
+
     if (companion && plan.companionPublishable) {
       // Every stored translation moves in ONE statement, through the adapter's
       // typed update rather than an interpolated string, so the dialect quoting
@@ -644,6 +655,65 @@ export class SinglePublishAllService extends BaseService {
       },
       mainRowTransitioned,
     };
+  }
+
+  /**
+   * Apply every language's pending change, then consume it.
+   *
+   * Split per language the same way an ordinary write is: a translated value
+   * belongs on that language's companion row, and folding it into the main row
+   * would write it to a table with no column for it.
+   */
+  private async promotePendingChanges(
+    tx: TransactionContext,
+    plan: PublishPlan,
+    publishNow: Date
+  ): Promise<void> {
+    const { slug, singleMeta, existingDoc, companion } = plan;
+    if (singleMeta.versions?.drafts?.enabled !== true) return;
+
+    const repo = new VersionsRepository(tx);
+    const ref = {
+      scopeKind: "single" as const,
+      scopeSlug: slug,
+      entryId: existingDoc.id,
+    };
+    const pending = await repo.findAllWorkingDrafts(ref);
+    if (pending.length === 0) return;
+
+    for (const draft of pending) {
+      // The pending change carries no lifecycle of its own; the statuses this
+      // publish writes are the ones that count.
+      const { main, companion: companionValues } = splitPendingChange(
+        draft.snapshot,
+        companion
+      );
+      delete main.status;
+
+      if (Object.keys(main).length > 0) {
+        await tx.update(
+          singleMeta.tableName,
+          { ...main, updated_at: publishNow },
+          this.whereEq("id", existingDoc.id)
+        );
+      }
+      if (
+        companion &&
+        draft.locale &&
+        Object.keys(companionValues).length > 0
+      ) {
+        await writeCompanionValues({
+          tx,
+          dialect: this.adapter.dialect,
+          companionTableName: companion.companionTableName,
+          entryId: existingDoc.id,
+          locale: draft.locale,
+          values: companionValues,
+        });
+      }
+    }
+
+    await repo.deleteAllWorkingDrafts(ref);
   }
 
   /**

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -331,6 +331,25 @@ export class VersionsRepository {
   }
 
   /**
+   * Every working draft this document holds, one per locale.
+   *
+   * For the operations that act on the whole document at once — publishing all
+   * of its languages — rather than on the language in front of the author.
+   */
+  async findAllWorkingDrafts(ref: VersionRef): Promise<VersionRow[]> {
+    return this.db.select<VersionRow>(TABLE, {
+      where: {
+        and: [
+          ...this.docWhere(ref),
+          { column: "isAutosave", op: "=", value: false },
+          { column: "versionNo", op: "IS NULL" },
+          { column: "status", op: "=", value: "draft" },
+        ],
+      },
+    });
+  }
+
+  /**
    * Delete EVERY working draft this document has, in every locale, returning
    * the number of rows removed. Called when the document itself goes away.
    *


### PR DESCRIPTION
PR4 of the program. Plan: `2026-08-19-plan-pr4-singles-pending-changes.md`.

**Sequencing changed on evidence.** The spec put the admin before Singles; this swaps them. `LanguagePanel` is rendered by BOTH `EntryForm` and `SingleForm` and both consume `useEntryLocaleContext`, so one admin pass covers both editors only if both engines support the feature — and `api/singles-schema-detail.ts` sent no `draftsEnabled` at all, so the Singles editor could not even ask. The admin pass becomes PR5 and covers both at once.

## What was false before this

`src/domains/singles/**` contained **zero** references to a working draft. Every edit to a published Homepage or Site Settings went straight to the live site, with no way to hold it.

## What it does now

- a status-less edit to a published Single is held; the stored document is unchanged;
- publishing applies the pending change and consumes it;
- per language: a German edit is held under German and English is untouched;
- `publishAllLocales` applies **every** language's pending change in the transaction that flips the statuses;
- the Singles schema response carries `draftsEnabled`, derived from the same predicate the write gates on, so the editor's affordance can never disagree with what a save does.

## Reuse, not reimplementation

`resolveDraftHold`, `workingDraftLocale`, `VersionsRepository` and `schemaDraftsEnabled` are all used as-is. A second reading of the hold rule for Singles is exactly how the collection surfaces drifted, and it is what `resolveDraftHold` exists to prevent.

The live status passed to it is the one belonging to the language being written — a non-default language's lifecycle lives on its companion `_status`, so reading the main row would judge a translation by another language's state.

## The correctness gap this closed on the way

`writePublishedStatuses` flipped every status without applying any pending content. Publishing all languages would have reported the document fully published while every author's held edit stayed unapplied — a Single claiming to be published and showing none of the work. `publishAllLocales` now promotes each language's pending change in the same transaction.

That case **passed on its first run**, which proves nothing, so I broke the promotion deliberately and confirmed the test names the property and fails: `expected 'EN live' to be 'EN edited'`. Restored from a `cp` backup and re-verified.

## Two extractions, both prompted by fallow and both real

fallow first reported one complexity finding and one duplication. The duplication was genuine and mine: the promote mapping existed in both the per-language write and publish-all. `apply-pending-change.ts` now owns it —

- `splitPendingChange` maps a read-shaped snapshot to columns and splits it, **with the split last**, because the split is what moves translated values out of the document and anything merged afterwards lands on the main table, which has no column for it. That failure mode cost a wrong diagnosis in #1066 and is now impossible to reintroduce at one of two sites.
- `writeCompanionValues` owns the transaction-bound adapter shim, so no call site can forget it and take a second pooled connection the transaction is holding.

**fallow now: `pass`, 0 introduced across all four categories.** The complexity number was coverage-driven (cognitive 10, well under threshold), and the honest fix was the extraction, not carving a method to suit a metric.

Also removed on the way: three `as never` casts I had reached for, replaced with the real types (`SupportedDialect`, the companion write surface). Two more turned out to be unnecessary assertions the linter removed.

## Verification

- New Singles suite: 5 cases green on **Postgres, MySQL and SQLite**.
- Singles integration: 12 files / 99 tests.
- Singles + versions + collections + api: **64 files / 503 passed**, 2+10 skipped.
- Typecheck clean on both configs; lint clean; fallow `pass`.

## Known and deliberate

Discard for Singles is **not** in this PR. It is a route plus a dispatcher method mirroring the collections one, it has no consumer until the admin pass, and folding it in would widen a behaviour PR with an unexercised endpoint. It lands with PR5, where the button that calls it does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added draft support for Singles, allowing edits to published content to remain pending until publication.
  * Added locale-specific pending changes for localized Singles.
  * Publishing a Single now promotes pending changes, including all localized drafts.
  * Single responses now indicate whether drafts are enabled.

* **Bug Fixes**
  * Ensured draft behavior is consistent across editing, saving, and publishing workflows.

* **Tests**
  * Added integration coverage for pending edits, localization, promotion, and publishing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->