### PR TITLE
feat(nextly): report which languages hold unpublished changes

### DIFF
--- a/.changeset/translation-overview-pending.md
+++ b/.changeset/translation-overview-pending.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Report which languages hold unpublished changes.
+
+The translation overview said whether each language was translated and whether
+it was live, but not whether someone had saved work in it that was never
+published. An editor could only find that out by opening each language in turn,
+so on a document with several it went unnoticed.

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -348,9 +348,21 @@ export class CollectionQueryService extends BaseService {
     const companion =
       preloaded ?? (await this.fileManager.loadCompanionSchema(collectionName));
     if (!companion) return;
+    // Which languages hold a pending change, for this whole page in one query.
+    // Read here rather than inside the join because the versions repository
+    // takes the adapter this service already has, and because a per-row lookup
+    // would turn a list render into one round trip per document.
+    const pendingChangeLocales = await new VersionsRepository(
+      this.adapter
+    ).findPendingChangeLocales(
+      "collection",
+      collectionName,
+      rows.map(r => r.id).filter((id): id is string => typeof id === "string")
+    );
     await populateTranslationStatus({
       db: this.db as never,
       companionTable: companion.table,
+      pendingChangeLocales,
       readiness: await resolveCompanionSchemaReadiness(this.adapter, companion),
       localizedFields: companion.localizedFields,
       rows,

--- a/packages/nextly/src/domains/i18n/companion-join.ts
+++ b/packages/nextly/src/domains/i18n/companion-join.ts
@@ -529,6 +529,19 @@ export interface LocaleTranslationMeta {
    * collection has per-locale status (i18n M6) and a companion row exists for the locale.
    */
   status?: string;
+  /**
+   * Whether this language holds a saved change that has not been published.
+   *
+   * Separate from `status` deliberately: `status` says what the language is,
+   * this says whether something is waiting. An overview that reported only the
+   * status would show a document as fully published while an author's held work
+   * sat inside it, visible only by opening that language — which with several
+   * languages means it is not seen at all.
+   *
+   * Absent rather than `false` when there is nothing pending, matching how the
+   * rest of this map omits what does not apply.
+   */
+  pendingChange?: boolean;
 }
 
 export interface TranslationStatusArgs {
@@ -548,11 +561,47 @@ export interface TranslationStatusArgs {
   /** Row key to write the per-locale map under (default `_translations`). */
   outKey?: string;
   /**
+   * Which languages hold a pending change, keyed by document id.
+   *
+   * Supplied by the caller rather than read here: this module owns the
+   * companion join and holds no versions handle, and the lookup is one batched
+   * query the caller already has an adapter for. Absent means report none,
+   * which is the right answer for a collection with no draft lifecycle.
+   */
+  pendingChangeLocales?: Map<string, Set<string | null>>;
+  /**
    * Per-locale status filter (i18n M6). When set (e.g. `"published"`), a companion row whose
    * `_status` differs is treated as absent, so a published read's overview never reports a
    * draft-only translation as present. Undefined = report every row (admin / no per-locale status).
    */
   statusValue?: string;
+}
+
+/**
+ * Mark the languages of one document that hold a saved, unpublished change.
+ *
+ * Carried separately from `status` on purpose: `status` answers what a language
+ * IS, this answers whether something is waiting. Keeping them apart means a new
+ * lifecycle state later does not have to be crossed with "has pending work".
+ *
+ * A pending change stored under no locale belongs to the default language: that
+ * is the language a document is edited in when localization is configured but
+ * the document itself is not localized.
+ */
+function markPendingChanges(
+  meta: Record<string, LocaleTranslationMeta>,
+  locales: string[],
+  defaultLocale: string,
+  pending: Set<string | null> | undefined
+): void {
+  if (!pending) return;
+  for (const code of locales) {
+    const entry = meta[code];
+    if (!entry) continue;
+    if (pending.has(code) || (code === defaultLocale && pending.has(null))) {
+      entry.pendingChange = true;
+    }
+  }
 }
 
 /**
@@ -631,6 +680,12 @@ export async function populateTranslationStatus(
       }
       meta[code] = entry;
     }
+    markPendingChanges(
+      meta,
+      locales,
+      defaultLocale,
+      args.pendingChangeLocales?.get(String(row[idKey]))
+    );
     row[outKey] = meta;
   }
 }

--- a/packages/nextly/src/domains/i18n/translation-status-pending.integration.test.ts
+++ b/packages/nextly/src/domains/i18n/translation-status-pending.integration.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The translation overview reports which languages have unpublished changes.
+ *
+ * An author looking at a document sees a list of its languages. The failure
+ * this exists to prevent is the one every CMS runs into: the document looks
+ * finished while pending work sits inside it, visible only if you open the
+ * language it is in. With several languages there is no reason to open any of
+ * them, so the fact has to travel with the overview.
+ *
+ * Both halves are asserted in the same case. "German reports nothing pending"
+ * is satisfied just as well by a builder that reports nothing for any language,
+ * so the language that DOES have a pending change is asserted beside it.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../config";
+import { createTestNextly, type TestNextly } from "../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../services/collections-handler";
+import type { CollectionEntryService } from "../../services/collections/collection-entry-service";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const SLUG = "pendingpages";
+
+async function boot(): Promise<TestNextly> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: SLUG,
+        localized: true,
+        status: true,
+        versions: { drafts: true },
+        fields: [text({ name: "title" }), text({ name: "body" })],
+      }),
+    ],
+    localization: { locales: ["en", "de"], defaultLocale: "en" },
+  });
+  return current;
+}
+
+function handlerOf(t: TestNextly): CollectionsHandler {
+  return t.getService("collectionsHandler");
+}
+
+function entriesOf(t: TestNextly): CollectionEntryService {
+  return handlerOf(t).getEntryService() as CollectionEntryService;
+}
+
+interface TranslationMeta {
+  translated?: boolean;
+  status?: string;
+  pendingChange?: boolean;
+}
+
+describe("translation overview reports pending changes (integration)", () => {
+  it("names the language holding unpublished changes, and only that one", async () => {
+    const t = await boot();
+    const entries = entriesOf(t);
+
+    const created = await entries.createEntry(
+      { collectionName: SLUG, overrideAccess: true, locale: "en" },
+      { title: "EN", body: "EN body", status: "published" }
+    );
+    const id = (created.data as { id: string }).id;
+    await entries.updateEntry(
+      { collectionName: SLUG, entryId: id, overrideAccess: true, locale: "de" },
+      { title: "DE", body: "DE body", status: "published" }
+    );
+
+    // Hold an edit in German only.
+    const held = await entries.updateEntry(
+      { collectionName: SLUG, entryId: id, overrideAccess: true, locale: "de" },
+      { body: "DE edited" }
+    );
+    expect(held.success).toBe(true);
+
+    const res = await handlerOf(t).getEntry({
+      collectionName: SLUG,
+      entryId: id,
+      translationStatus: true,
+      overrideAccess: true,
+    });
+    const translations = (
+      res.data as { _translations?: Record<string, TranslationMeta> }
+    )?._translations;
+
+    expect(translations?.de?.pendingChange).toBe(true);
+    // The other language, in the same read: without this the assertion above
+    // would pass against a builder that marks everything pending.
+    expect(translations?.en?.pendingChange ?? false).toBe(false);
+  });
+});

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -101,6 +101,7 @@ import {
 import { captureInTx } from "../../versions/capture-in-tx";
 import { VersionCaptureService } from "../../versions/version-capture-service";
 import { withVersionConflictRetry } from "../../versions/version-conflict";
+import { VersionsRepository } from "../../versions/versions-repository";
 import type {
   GetSingleOptions,
   SingleDocument,
@@ -1885,9 +1886,22 @@ export class SingleQueryService extends BaseService {
       status: (singleMeta as { status?: boolean }).status === true,
     });
     if (!companion) return;
+    // Which languages hold a pending change. One document here, but the same
+    // batched lookup the collection read uses, so both overviews answer the
+    // question the same way.
+    const docId = (doc as { id?: unknown }).id;
+    const pendingChangeLocales =
+      typeof docId === "string"
+        ? await new VersionsRepository(this.adapter).findPendingChangeLocales(
+            "single",
+            slug,
+            [docId]
+          )
+        : undefined;
     await populateTranslationStatus({
       db: this.adapter.getDrizzle(),
       companionTable: companion.table,
+      pendingChangeLocales,
       localizedFields: companion.localizedFields,
       rows: [doc],
       locales: this.localization.locales.map(l => l.code),

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -331,6 +331,48 @@ export class VersionsRepository {
   }
 
   /**
+   * Which languages hold a pending change, for many documents at once.
+   *
+   * One query for a whole page of documents rather than one per document: the
+   * overview that consumes this is built for a list, and a per-row query there
+   * turns a page render into N round trips.
+   *
+   * Returns only the (document, locale) pairs that HAVE one, so a caller reads
+   * absence as absence rather than having to distinguish it from a document it
+   * never asked about.
+   */
+  async findPendingChangeLocales(
+    scopeKind: VersionScopeKind,
+    scopeSlug: string,
+    entryIds: string[]
+  ): Promise<Map<string, Set<string | null>>> {
+    const byEntry = new Map<string, Set<string | null>>();
+    if (entryIds.length === 0) return byEntry;
+    const rows = await this.db.select<{
+      entryId: string;
+      locale: string | null;
+    }>(TABLE, {
+      columns: ["entryId", "locale"],
+      where: {
+        and: [
+          { column: "scopeKind", op: "=", value: scopeKind },
+          { column: "scopeSlug", op: "=", value: scopeSlug },
+          { column: "entryId", op: "IN", value: entryIds },
+          { column: "isAutosave", op: "=", value: false },
+          { column: "versionNo", op: "IS NULL" },
+          { column: "status", op: "=", value: "draft" },
+        ],
+      },
+    });
+    for (const row of rows) {
+      const set = byEntry.get(row.entryId) ?? new Set<string | null>();
+      set.add(row.locale ?? null);
+      byEntry.set(row.entryId, set);
+    }
+    return byEntry;
+  }
+
+  /**
    * Every working draft this document holds, one per locale.
    *
    * For the operations that act on the whole document at once — publishing all


### PR DESCRIPTION
PR 5a. Plan: `2026-08-19-plan-pr5-per-language-pending-admin.md`. The read half of the admin work; 5b renders it.

## The gap

`_translations` reports `{ translated, status }` per language and says nothing about pending changes. So an author looking at a document's languages cannot tell which ones hold work they saved and never published — they would have to open each language in turn to find out.

```
expected undefined to be true
```

## Why this is the failure worth designing against

It is the one every CMS runs into. Optimizely's editors can only see a block's draft by previewing that block, so a page "looks finished" with hidden drafts inside it. Netlify CMS reports Published while changes are unpersisted. Payload's own v4 discussion asks for clearer per-version state.

For a multilingual document it is worse: there are N places to look and no reason to look in any of them. So the fact has to travel with the overview rather than waiting to be found.

## The design decision

`pendingChange` is carried **orthogonally to `status`**, not as a fifth state value.

`status` answers what a language IS. `pendingChange` answers whether something is waiting. Today a pending change implies published — the split only holds edits to published documents — so a fifth enum value would be accurate, and would also be a trap: scheduled publishing and review stages each add lifecycle values, and each would then have to be crossed with "has pending work". Keeping them separate matches how the engine models it (status on the row, pending change in `nextly_versions`), so neither has to be rewritten when the other grows.

It is absent rather than `false` when nothing is pending, matching how the rest of the map omits what does not apply.

## Shape

One batched query per page, not one per row — the overview exists for lists, and a per-row lookup turns a page render into N round trips. `findPendingChangeLocales` returns only the pairs that HAVE a pending change, so callers read absence as absence.

The lookup lives with the callers rather than inside the companion join: that module owns the companion join and holds no versions handle, while both query services already have the adapter. Both readers — collections and Singles — use the same method, so the two overviews cannot answer differently.

A pending change stored under no locale is reported against the default language, which is the language a document is edited in when localization is configured but the document itself is not.

## Verification

- The new case asserts **both halves in one read**: the language with a pending change reports it, and the language without one does not. Without the second assertion the first would pass against a builder that marks everything pending.
- i18n integration: 25 files / 135 tests, green on **Postgres, MySQL and SQLite**.
- i18n + singles + collections + versions: 88 files / 634 passed.
- Typecheck clean, lint clean, fallow `pass` with 0 introduced.

## One note on a false alarm

`plugin-sdk`'s typecheck failed against `useDocumentStatus` / `pillStateFromForm` / `PILL_LABEL`, which looked like a broken `main`. It was a stale local `dist`: `plugin-sdk` resolves `@nextlyhq/admin` through its build output, and `main` exports all three. Rebuilding admin cleared it. Recording it because the failure reads exactly like someone else's breakage and is not.
