### PR TITLE
fix(admin): do not record a past version as unsaved work

### DIFF
--- a/.changeset/no-autosave-while-reading-history.md
+++ b/.changeset/no-autosave-while-reading-history.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Reading a past version no longer records it as the author's unsaved work.
+Choosing a version replaces the form's values, which looked like typing, so the
+old version was stored as a recovery point and offered back on the next visit
+as "unsaved changes".

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -505,10 +505,20 @@ export function EntryForm({
     scope: autosaveScope,
     form,
     locale: locale ?? null,
-    // Held off while a real save is in flight. The document is about to change
-    // underneath the snapshot, so a recovery point written now would describe a
-    // state that never existed.
-    enabled: !isSubmitting,
+    /*
+     * Held off while a real save is in flight: the document is about to change
+     * underneath the snapshot, so a recovery point written now would describe a
+     * state that never existed.
+     *
+     * And held off while a PAST VERSION is on screen, which is the sharper
+     * case. Choosing a version replaces the form's values, so the form goes
+     * dirty exactly as it would for typing — and recording that stores an old
+     * version as this author's unsaved work. The offer on the next visit then
+     * reads "you have unsaved changes", and accepting it silently reverts the
+     * document to whatever the reader happened to be looking at. Reading is not
+     * editing, and the write is the only part of that which is recoverable.
+     */
+    enabled: !isSubmitting && viewingVersion === null,
   });
   const linkLocale = previewLinkLocale({
     localized: collection.localized === true,


### PR DESCRIPTION
**`main` is red on `Browser tests`, and has been since #1058 — which is mine.** This is the fix.

## What is broken

`version-history-isolation.spec.ts` → *"issues no autosave while a past version is on screen"* fails. Choosing a version replaces the form's values, so the form goes dirty exactly as it would for typing, and autosave records it.

The consequence is worse than a failing test. The old version becomes this author's recovery point, so the next visit offers **"you have unsaved changes"** — and accepting reverts the document to whatever the reader happened to be *looking at*. Reading is not editing, and the write is the only part of that which is not recoverable.

## Attribution, measured rather than assumed

Walking `Browser tests` back over main's history:

| commit | result |
|---|---|
| `2827ea246` (#1056) | **last green** |
| `37cb775ee` (#1058, mine) | **first failure** |
| #1060 – #1063 | `skipped` — the dependent-job cascade |
| #1064 onward | failure, every merge |

So it broke at #1058 and then went **invisible for four merges**, because `Lint / Typecheck / Test / Build` was red (the plugin-surface snapshot, also mine) and `Browser tests` `needs:` it. #1064 fixed the snapshot, `Browser tests` ran again, and it has been red ever since.

I flagged that cascade at the time — *"their first real run will be after #1064 lands"* — and then did not go back and check. Worse, **I reported `5bf740d57` as "fully green" when `Browser tests` had failed on it.** That claim was wrong and this PR is where I correct it.

## The fix

`enabled: !isSubmitting && viewingVersion === null`.

Placed beside the existing in-flight-save guard rather than in a second place: both are moments when the form's values do not describe work the author is doing.

## What is verified, and what is not

**Verified locally:** the failure reproduces on current `main` with the exact assertion CI reports. `admin` typecheck and lint clean; Fallow passes; the admin suite is **15 failed / 2406 passed**, matching its standing baseline of 15 in 4 files.

**NOT verified locally:** that this fix makes the spec pass. After the change, every local run of that spec times out in `global-setup.ts:44` waiting for `locator('main')` — before the spec is reached at all. Four dev servers are running on this machine and the setup does not get a response in 60s. I freed my own and it did not help.

So the honest position is: **the failure is reproduced and understood, the fix is reasoned and typechecks, and this PR's own `Browser tests` job is the verification.** I would rather say that than let a green-looking summary imply I watched it pass. Please do not merge on the strength of the reasoning alone — merge on the strength of that job.

## Not in this PR

The `mod+s` shortcut, which is what I set out to look at. It shares a root cause worth recording: `useEntryFormShortcuts` guards on `when: () => isDirty && !isSubmitting`, and **the form's dirty flag is false through an entire page-builder session** because `BlocksField` commits on exit. So the save shortcut is not inert — it is correctly declining, on a flag that cannot be true there. Fixing it means letting a field report that it holds unsaved work, which is a narrower grant than letting a field save, and it belongs in its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented historical document versions from being incorrectly saved as recoverable unsaved work.
  * Autosave recovery remains disabled while a save is in progress or when viewing a past version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->