### PR TITLE
fix(admin): let a field tell the form it holds unsaved work

### DIFF
--- a/.changeset/field-reports-unsaved-work.md
+++ b/.changeset/field-reports-unsaved-work.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The save shortcut works inside the page builder, and leaving with unsaved
+block edits now warns.
+
+A field that keeps its own editing state can tell the form so with
+`useReportUnsavedWork`. It reports one boolean about itself; it cannot save or
+publish.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -75,6 +75,7 @@ import { EntrySystemHeader } from "./EntrySystemHeader";
 import { FormErrorSummary } from "./FormErrorSummary";
 import { PublicUrlChangeNotice } from "./PublicUrlChangeNotice";
 import { UnsavedChangesGuard } from "./UnsavedChangesGuard";
+import { UnsavedWorkProvider, useFormUnsavedWork } from "./UnsavedWorkContext";
 import {
   useEntryForm,
   getCollectionFields,
@@ -501,6 +502,15 @@ export function EntryForm({
     recovery.dismiss();
   }, [recovery, form]);
 
+  /*
+   * Work a FIELD holds that the form's values do not contain. The page builder
+   * keeps its document in its own store and commits on exit, so without this
+   * the form is not dirty through an entire editing session — and the guard,
+   * the save shortcut and the header are all wrong together.
+   */
+  const unsavedWork = useFormUnsavedWork(isDirty);
+  const hasUnsavedWork = unsavedWork.hasUnsavedWork;
+
   const autosave = useDocumentAutosave({
     scope: autosaveScope,
     form,
@@ -545,7 +555,10 @@ export function EntryForm({
       void handleSubmit(undefined, keyboardSaveIntent);
     },
     onCancel: handleCancel,
-    isDirty,
+    // Includes work a field holds. Without it the save shortcut DECLINES inside
+    // the page builder — correctly, on a flag that cannot be true there — which
+    // reads to an author as the shortcut being broken.
+    isDirty: hasUnsavedWork,
     isSubmitting,
     enabled: !embedded,
   });
@@ -620,32 +633,33 @@ export function EntryForm({
     // closing the dialog rather than a history move — and a modal opened FROM
     // this editor would mount a second interceptor over this one, so two
     // dialogs would answer one navigation.
-    <UnsavedChangesGuard isDirty={isDirty} disabled={isSubmitting}>
-      <EntryLocaleProvider value={localeCtx}>
-        <DocumentHistoryContext.Provider value={documentHistory}>
-          {/* Renders its child alone when there is no source — see the module. */}
-          <TranslationPanes
-            source={translationMode.source}
-            onExit={translationMode.onExit}
-            control={form.control}
-          >
-            <EntryFormContextProvider
-              entryId={entry?.id}
-              collectionSlug={collection.name}
-              isCreateMode={mode === "create"}
+    <UnsavedChangesGuard isDirty={hasUnsavedWork} disabled={isSubmitting}>
+      <UnsavedWorkProvider report={unsavedWork.report}>
+        <EntryLocaleProvider value={localeCtx}>
+          <DocumentHistoryContext.Provider value={documentHistory}>
+            {/* Renders its child alone when there is no source — see the module. */}
+            <TranslationPanes
+              source={translationMode.source}
+              onExit={translationMode.onExit}
+              control={form.control}
             >
-              <div className={cn("space-y-0", className)}>
-                <EntryFormProvider form={form} onSubmit={handleSubmit}>
-                  <FormErrorSummary
-                    errors={errors}
-                    submitCount={submitCount}
-                    className="mx-6 mt-3"
-                  />
+              <EntryFormContextProvider
+                entryId={entry?.id}
+                collectionSlug={collection.name}
+                isCreateMode={mode === "create"}
+              >
+                <div className={cn("space-y-0", className)}>
+                  <EntryFormProvider form={form} onSubmit={handleSubmit}>
+                    <FormErrorSummary
+                      errors={errors}
+                      submitCount={submitCount}
+                      className="mx-6 mt-3"
+                    />
 
-                  <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-m-8">
-                    {/* Main column */}
-                    <div className="flex-1 min-w-0 flex flex-col">
-                      {/* Why: the parent flex's @4xl/content:-m-8 already cancels
+                    <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-m-8">
+                      {/* Main column */}
+                      <div className="flex-1 min-w-0 flex flex-col">
+                        {/* Why: the parent flex's @4xl/content:-m-8 already cancels
                   PageContainer's px-8 padding so the form runs edge-to-edge
                   once the panel is wide enough. Wrapping the system
                   header / meta strip in another -mx-8 doubled the negative
@@ -653,207 +667,212 @@ export function EntryForm({
                   each side — clipping the title's first character on the
                   left and the rail toggle / right-edge buttons on the right.
                   Letting them fill the Main column naturally fixes that. */}
-                      <EntrySystemHeader
-                        mode={mode}
-                        titleField={titleField}
-                        hasStatus={hasStatus}
-                        draftsEnabled={collection.draftsEnabled === true}
-                        isSubmitting={isSubmitting}
-                        isDirty={isDirty}
-                        autosaveEnabled={autosaveScope !== null}
-                        autosaveStatus={autosave.status}
-                        autosaveLastSavedAt={autosave.lastSavedAt}
-                        entry={entry}
-                        collectionSlug={collection.name}
-                        historyFields={getCollectionFields(collection)}
-                        historyEnabled={historyEnabledFrom(collection)}
-                        locale={locale}
-                        onLocaleChange={onLocaleChange}
-                        localized={collection.localized === true}
-                        // Withheld while the language is unknown as well as while
-                        // the entry is unsaved: a link minted without a resolvable
-                        // locale is either refused by the mint route or, if the claim
-                        // were dropped to avoid that, a grant over every translation.
-                        isLinkAvailable={
-                          savedEntryId !== "" &&
-                          linkLocale.kind !== "unresolved"
-                        }
-                        {...(savedEntryId === ""
-                          ? {}
-                          : {
-                              onCopyLink: () => {
-                                previewLink.mutate();
-                              },
-                            })}
-                        isCopyingLink={previewLink.isPending}
-                        toolbarSlot={
-                          <EntryFormToolbarSlots
-                            context="collection"
-                            controllerField={controllerNames[0]}
-                          />
-                        }
-                        onSaveDraft={() => {
-                          void handleSubmit(undefined, "save-draft");
-                        }}
-                        onPublish={() => {
-                          void handleSubmit(undefined, "publish");
-                        }}
-                        onSaveChanges={() => {
-                          void handleSubmit(undefined, "save-changes");
-                        }}
-                        onSaveWorkingDraft={() => {
-                          void handleSubmit(undefined, "save-working-draft");
-                        }}
-                        onUnpublish={() => {
-                          void handleSubmit(undefined, "unpublish");
-                        }}
-                        onCancel={handleCancel}
-                        onDelete={handleDelete}
-                        onDiscardWorkingDraft={handleDiscardWorkingDraft}
-                        isRailCollapsed={railCollapsed}
-                        onToggleRail={mode === "edit" ? toggleRail : undefined}
-                      />
-                      {/* Above the fields and below the header: the reader sees
+                        <EntrySystemHeader
+                          mode={mode}
+                          titleField={titleField}
+                          hasStatus={hasStatus}
+                          draftsEnabled={collection.draftsEnabled === true}
+                          isSubmitting={isSubmitting}
+                          isDirty={isDirty}
+                          autosaveEnabled={autosaveScope !== null}
+                          autosaveStatus={autosave.status}
+                          autosaveLastSavedAt={autosave.lastSavedAt}
+                          entry={entry}
+                          collectionSlug={collection.name}
+                          historyFields={getCollectionFields(collection)}
+                          historyEnabled={historyEnabledFrom(collection)}
+                          locale={locale}
+                          onLocaleChange={onLocaleChange}
+                          localized={collection.localized === true}
+                          // Withheld while the language is unknown as well as while
+                          // the entry is unsaved: a link minted without a resolvable
+                          // locale is either refused by the mint route or, if the claim
+                          // were dropped to avoid that, a grant over every translation.
+                          isLinkAvailable={
+                            savedEntryId !== "" &&
+                            linkLocale.kind !== "unresolved"
+                          }
+                          {...(savedEntryId === ""
+                            ? {}
+                            : {
+                                onCopyLink: () => {
+                                  previewLink.mutate();
+                                },
+                              })}
+                          isCopyingLink={previewLink.isPending}
+                          toolbarSlot={
+                            <EntryFormToolbarSlots
+                              context="collection"
+                              controllerField={controllerNames[0]}
+                            />
+                          }
+                          onSaveDraft={() => {
+                            void handleSubmit(undefined, "save-draft");
+                          }}
+                          onPublish={() => {
+                            void handleSubmit(undefined, "publish");
+                          }}
+                          onSaveChanges={() => {
+                            void handleSubmit(undefined, "save-changes");
+                          }}
+                          onSaveWorkingDraft={() => {
+                            void handleSubmit(undefined, "save-working-draft");
+                          }}
+                          onUnpublish={() => {
+                            void handleSubmit(undefined, "unpublish");
+                          }}
+                          onCancel={handleCancel}
+                          onDelete={handleDelete}
+                          onDiscardWorkingDraft={handleDiscardWorkingDraft}
+                          isRailCollapsed={railCollapsed}
+                          onToggleRail={
+                            mode === "edit" ? toggleRail : undefined
+                          }
+                        />
+                        {/* Above the fields and below the header: the reader sees
                     the document it refers to without the offer covering it. */}
-                      {recovery.offer ? (
-                        <AutosaveRecoveryBanner
-                          savedAt={recovery.offer.savedAt}
-                          onRestore={restoreRecovery}
-                          onDismiss={recovery.dismiss}
-                        />
-                      ) : null}
-                      {viewingVersion ? (
-                        <HistoricalDocumentBanner
-                          versionNo={viewingVersion.versionNo}
-                          locale={viewingVersion.locale}
-                          // Routed through the panel when one is mounted, so its
-                          // selection clears with the shared state. The direct
-                          // fallback keeps the banner working without a panel.
-                          onReturnToCurrent={
-                            restoreAffordance?.returnToCurrent ??
-                            (() => setViewingVersion(null))
+                        {recovery.offer ? (
+                          <AutosaveRecoveryBanner
+                            savedAt={recovery.offer.savedAt}
+                            onRestore={restoreRecovery}
+                            onDismiss={recovery.dismiss}
+                          />
+                        ) : null}
+                        {viewingVersion ? (
+                          <HistoricalDocumentBanner
+                            versionNo={viewingVersion.versionNo}
+                            locale={viewingVersion.locale}
+                            // Routed through the panel when one is mounted, so its
+                            // selection clears with the shared state. The direct
+                            // fallback keeps the banner working without a panel.
+                            onReturnToCurrent={
+                              restoreAffordance?.returnToCurrent ??
+                              (() => setViewingVersion(null))
+                            }
+                            // Offered only when the panel says this caller may write.
+                            onRestore={
+                              restoreAffordance?.canRestore
+                                ? restoreAffordance.request
+                                : undefined
+                            }
+                            // And only once the version is actually on screen:
+                            // restoring from a skeleton, or from a failed read, is a
+                            // decision made without having seen what is being chosen.
+                            restoreDisabled={!versionOnScreen}
+                          />
+                        ) : null}
+                        <EntryMetaStrip
+                          slugField={slugField}
+                          hasStatus={hasStatus}
+                          // The pill reports the language being edited, matching the header's submit
+                          // affordances. Reading the main row instead would show "Published" beside a
+                          // Publish button whenever a translation lags its default language.
+                          status={
+                            effectiveEntryStatus(
+                              entry,
+                              locale,
+                              defaultLocale
+                            ) ?? "draft"
                           }
-                          // Offered only when the panel says this caller may write.
-                          onRestore={
-                            restoreAffordance?.canRestore
-                              ? restoreAffordance.request
-                              : undefined
-                          }
-                          // And only once the version is actually on screen:
-                          // restoring from a skeleton, or from a failed read, is a
-                          // decision made without having seen what is being chosen.
-                          restoreDisabled={!versionOnScreen}
+                          hasWorkingDraft={hasPendingWorkingDraft(entry)}
+                          isRailCollapsed={railCollapsed}
+                          hasPublicAddress={hasPublicAddress}
                         />
-                      ) : null}
-                      <EntryMetaStrip
-                        slugField={slugField}
-                        hasStatus={hasStatus}
-                        // The pill reports the language being edited, matching the header's submit
-                        // affordances. Reading the main row instead would show "Published" beside a
-                        // Publish button whenever a translation lags its default language.
-                        status={
-                          effectiveEntryStatus(entry, locale, defaultLocale) ??
-                          "draft"
-                        }
-                        hasWorkingDraft={hasPendingWorkingDraft(entry)}
-                        isRailCollapsed={railCollapsed}
-                        hasPublicAddress={hasPublicAddress}
-                      />
 
-                      {/* The language panel, inline. Its rail mount is
+                        {/* The language panel, inline. Its rail mount is
                       `hidden @4xl/content:flex`, so this is the exact
                       complement: shown only where the rail is not. When the
                       rail cannot carry it at all — create mode, or the author
                       collapsed it — the panel renders unconditionally instead,
                       because "the actions live in the rail" is precisely the
                       failure this stage removes. */}
-                      {localizationEnabled && (
-                        <div
-                          className={cn(
-                            "px-6 pt-4",
-                            mode === "edit" &&
-                              !railCollapsed &&
-                              "@4xl/content:hidden"
-                          )}
-                        >
-                          <LanguagePanel
-                            {...(entry?._translations === undefined
-                              ? {}
-                              : {
-                                  translations: entry._translations as Record<
-                                    string,
-                                    { translated: boolean; status?: string }
-                                  >,
-                                })}
-                            {...(locale === undefined
-                              ? {}
-                              : { activeLocale: locale })}
-                            {...(onLocaleChange === undefined
-                              ? {}
-                              : { onSelect: onLocaleChange })}
-                            hasStatus={hasStatus}
-                            actionsDisabled={viewingVersion !== null}
-                          />
-                        </div>
-                      )}
+                        {localizationEnabled && (
+                          <div
+                            className={cn(
+                              "px-6 pt-4",
+                              mode === "edit" &&
+                                !railCollapsed &&
+                                "@4xl/content:hidden"
+                            )}
+                          >
+                            <LanguagePanel
+                              {...(entry?._translations === undefined
+                                ? {}
+                                : {
+                                    translations: entry._translations as Record<
+                                      string,
+                                      { translated: boolean; status?: string }
+                                    >,
+                                  })}
+                              {...(locale === undefined
+                                ? {}
+                                : { activeLocale: locale })}
+                              {...(onLocaleChange === undefined
+                                ? {}
+                                : { onSelect: onLocaleChange })}
+                              hasStatus={hasStatus}
+                              actionsDisabled={viewingVersion !== null}
+                            />
+                          </div>
+                        )}
 
-                      {/* Reading a past version replaces the document rather than
+                        {/* Reading a past version replaces the document rather than
                     opening beside it: the question an editor is asking is how
                     this page read then, and that is answered by the page. The
                     live form stays mounted underneath — the historical values
                     are rendered against a form of their own, so nothing typed
                     here is disturbed and nothing historical can reach a save. */}
-                      {viewingVersion ? (
-                        <div className="@4xl/content:p-8 pt-6">
-                          {viewingVersion.error ? (
-                            // A failed read must not render as an empty document:
-                            // that is a different and wrong claim about the version.
-                            <Alert variant="destructive">
-                              <AlertDescription>
-                                This version could not be loaded.
-                              </AlertDescription>
-                            </Alert>
-                          ) : !versionOnScreen ? (
-                            <div
-                              className="flex flex-col gap-4"
-                              aria-busy="true"
-                            >
-                              <span className="sr-only" role="status">
-                                Loading version {viewingVersion.versionNo}
-                              </span>
-                              {[0, 1, 2, 3].map(i => (
-                                <div key={i} className="flex flex-col gap-1">
-                                  <Skeleton className="h-3 w-24" />
-                                  <Skeleton className="h-9 w-full" />
-                                </div>
-                              ))}
-                            </div>
-                          ) : (
-                            <VersionSnapshotForm
-                              fields={historicalFields ?? mainFields}
-                              snapshot={viewingVersion.snapshot}
-                            />
-                          )}
-                        </div>
-                      ) : (
-                        mainFields.length > 0 && (
+                        {viewingVersion ? (
                           <div className="@4xl/content:p-8 pt-6">
-                            {/* Forward the form mode: in edit mode a blank password
+                            {viewingVersion.error ? (
+                              // A failed read must not render as an empty document:
+                              // that is a different and wrong claim about the version.
+                              <Alert variant="destructive">
+                                <AlertDescription>
+                                  This version could not be loaded.
+                                </AlertDescription>
+                              </Alert>
+                            ) : !versionOnScreen ? (
+                              <div
+                                className="flex flex-col gap-4"
+                                aria-busy="true"
+                              >
+                                <span className="sr-only" role="status">
+                                  Loading version {viewingVersion.versionNo}
+                                </span>
+                                {[0, 1, 2, 3].map(i => (
+                                  <div key={i} className="flex flex-col gap-1">
+                                    <Skeleton className="h-3 w-24" />
+                                    <Skeleton className="h-9 w-full" />
+                                  </div>
+                                ))}
+                              </div>
+                            ) : (
+                              <VersionSnapshotForm
+                                fields={historicalFields ?? mainFields}
+                                snapshot={viewingVersion.snapshot}
+                              />
+                            )}
+                          </div>
+                        ) : (
+                          mainFields.length > 0 && (
+                            <div className="@4xl/content:p-8 pt-6">
+                              {/* Forward the form mode: in edit mode a blank password
                       field means "keep the current password" rather than a
                       required-field violation (see note on the layout form
                       above). */}
-                            <EntryFormContent
-                              fields={mainFields}
-                              disabled={isSubmitting}
-                              withCard
-                              mode={mode}
-                            />
-                          </div>
-                        )
-                      )}
-                    </div>
+                              <EntryFormContent
+                                fields={mainFields}
+                                disabled={isSubmitting}
+                                withCard
+                                mode={mode}
+                              />
+                            </div>
+                          )
+                        )}
+                      </div>
 
-                    {/* Rail (collapsible). Width 320px. Hidden until the content panel
+                      {/* Rail (collapsible). Width 320px. Hidden until the content panel
                 is wide enough (@4xl) to fit it beside the main column, until a
                 future mobile sheet ships.
 
@@ -862,30 +881,31 @@ export function EntryForm({
                 nothing to show. Rendering it anyway left an empty 320px
                 strip down the right side of the page, which reads as a
                 failed load rather than as an absence. */}
-                    {mode === "edit" && !railCollapsed && (
-                      <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
-                        <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
-                          <EntryFormSidebar
-                            mode={mode}
-                            entry={entry}
-                            hasStatus={hasStatus}
-                            {...(locale === undefined ? {} : { locale })}
-                            {...(onLocaleChange === undefined
-                              ? {}
-                              : { onLocaleChange })}
-                            actionsDisabled={viewingVersion !== null}
-                            isDirty={isDirty}
-                          />
+                      {mode === "edit" && !railCollapsed && (
+                        <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
+                          <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
+                            <EntryFormSidebar
+                              mode={mode}
+                              entry={entry}
+                              hasStatus={hasStatus}
+                              {...(locale === undefined ? {} : { locale })}
+                              {...(onLocaleChange === undefined
+                                ? {}
+                                : { onLocaleChange })}
+                              actionsDisabled={viewingVersion !== null}
+                              isDirty={isDirty}
+                            />
+                          </div>
                         </div>
-                      </div>
-                    )}
-                  </div>
-                </EntryFormProvider>
-              </div>
-            </EntryFormContextProvider>
-          </TranslationPanes>
-        </DocumentHistoryContext.Provider>
-      </EntryLocaleProvider>
+                      )}
+                    </div>
+                  </EntryFormProvider>
+                </div>
+              </EntryFormContextProvider>
+            </TranslationPanes>
+          </DocumentHistoryContext.Provider>
+        </EntryLocaleProvider>
+      </UnsavedWorkProvider>
     </UnsavedChangesGuard>
   );
 }

--- a/packages/admin/src/components/features/entries/EntryForm/UnsavedWorkContext.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/UnsavedWorkContext.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+/**
+ * A field saying it holds work the form's values do not contain.
+ *
+ * The form decides what "unsaved" means for everything it can see, and that is
+ * nearly always enough: a field writes through `react-hook-form`, so the dirty
+ * flag moves and the guard, the save shortcut and the header all follow.
+ *
+ * It is not enough for a field that holds its own editing state. The page
+ * builder is the case in hand: it opens over the form, keeps the block document
+ * in its own store, and commits on EXIT — deliberately, so the form's undo and
+ * the editor's undo are not two answers to one question. The cost is that
+ * through an entire editing session the form is not dirty, and everything
+ * derived from that flag is wrong in the same direction at once:
+ *
+ * - the unsaved-changes guard does not warn on navigation, on back, or on
+ *   closing the tab;
+ * - the save shortcut declines, because its `when` reads the same flag;
+ * - the header shows no pending work.
+ *
+ * ## What this is NOT
+ *
+ * A way for a field to save, publish, or write to the form. It reports one
+ * boolean about itself. The form still decides what to do about it, which is
+ * the difference between telling someone the kettle is boiling and being
+ * allowed to pour.
+ *
+ * @module components/features/entries/EntryForm/UnsavedWorkContext
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+/** How a surface reports itself. `null` outside a form, where nobody is asking. */
+type Report = ((key: string, unsaved: boolean) => void) | null;
+
+const UnsavedWorkContext = createContext<Report>(null);
+
+export interface UnsavedWork {
+  /** Whether any surface inside the form says it holds unsaved work. */
+  anyUnsaved: boolean;
+  /** Passed to {@link UnsavedWorkProvider}. */
+  report: (key: string, unsaved: boolean) => void;
+}
+
+/**
+ * Held by the FORM, above the guard that reads it.
+ *
+ * A set rather than a boolean because a document may hold more than one such
+ * surface — two blocks fields on one page is an ordinary schema — and a single
+ * flag would let the second to report `false` clear the first one's work.
+ *
+ * @returns whether anything is unsaved, and the reporter to provide
+ */
+export function useUnsavedWork(): UnsavedWork {
+  const [keys, setKeys] = useState<ReadonlySet<string>>(() => new Set());
+
+  const report = useCallback((key: string, unsaved: boolean) => {
+    setKeys(current => {
+      // The SAME set back when nothing changed. Returning a new one would
+      // re-render the whole form on every report, and a surface that reports on
+      // each edit would re-render it on every keystroke.
+      if (current.has(key) === unsaved) return current;
+      const next = new Set(current);
+      if (unsaved) next.add(key);
+      else next.delete(key);
+      return next;
+    });
+  }, []);
+
+  return { anyUnsaved: keys.size > 0, report };
+}
+
+/**
+ * The whole question a form asks: is there unsaved work anywhere in me?
+ *
+ * Combines the form's own dirty flag with what its fields report, so the rule
+ * is stated once rather than in each editor. Two copies of `isDirty || …` would
+ * agree today and drift the first time one of them gained a third source.
+ *
+ * @param formIsDirty - the form library's own answer about its values
+ * @returns the combined answer, and the reporter to provide to fields
+ */
+export function useFormUnsavedWork(formIsDirty: boolean): {
+  hasUnsavedWork: boolean;
+  report: (key: string, unsaved: boolean) => void;
+} {
+  const { anyUnsaved, report } = useUnsavedWork();
+  return { hasUnsavedWork: formIsDirty || anyUnsaved, report };
+}
+
+export function UnsavedWorkProvider({
+  report,
+  children,
+}: {
+  report: (key: string, unsaved: boolean) => void;
+  children: ReactNode;
+}) {
+  return (
+    <UnsavedWorkContext.Provider value={report}>
+      {children}
+    </UnsavedWorkContext.Provider>
+  );
+}
+
+/**
+ * Report that this surface holds work the form cannot see.
+ *
+ * Retracted when the surface unmounts, which is the handoff that makes this
+ * safe: the page builder commits its document on the way out, so the form goes
+ * dirty in the same moment this stops claiming anything. Without the retraction
+ * a closed editor would leave the form permanently "unsaved".
+ *
+ * Silently does nothing outside a form. A field also renders in previews and
+ * pickers, where there is nobody to tell.
+ *
+ * @param key - identifies this surface among any others reporting
+ * @param unsaved - whether it currently holds unsaved work
+ */
+export function useReportUnsavedWork(key: string, unsaved: boolean): void {
+  const report = useContext(UnsavedWorkContext);
+
+  useEffect(() => {
+    report?.(key, unsaved);
+  }, [report, key, unsaved]);
+
+  /*
+   * The retraction reads the key from a ref rather than closing over it, so a
+   * surface whose key changed retracts the key it actually reported. Closing
+   * over `key` would need it in the dependency list, which would run the
+   * cleanup on every key change and turn this into the per-change retraction
+   * the effect above already handles.
+   */
+  const keyRef = useRef(key);
+  keyRef.current = key;
+  useEffect(() => {
+    return () => {
+      report?.(keyRef.current, false);
+    };
+  }, [report]);
+}

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/useUnsavedWork.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/useUnsavedWork.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * A field reporting that it holds work the form cannot see.
+ *
+ * The page builder keeps its document outside the form and commits on exit, so
+ * through an entire editing session the form is not dirty — and the guard, the
+ * save shortcut and the header are all wrong in the same direction. These cases
+ * pin the reporting, and in particular the retraction, which is what stops a
+ * closed editor leaving a form permanently unsaved.
+ *
+ * @module components/features/entries/EntryForm/__tests__/useUnsavedWork.test
+ */
+import { act, render, renderHook, screen } from "@testing-library/react";
+import { useState, type ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+
+import {
+  UnsavedWorkProvider,
+  useFormUnsavedWork,
+  useReportUnsavedWork,
+  useUnsavedWork,
+} from "../UnsavedWorkContext";
+
+describe("useUnsavedWork", () => {
+  it("is quiet until something reports", () => {
+    const { result } = renderHook(useUnsavedWork);
+
+    expect(result.current.anyUnsaved).toBe(false);
+  });
+
+  it("says so once a surface reports", () => {
+    const { result } = renderHook(useUnsavedWork);
+
+    act(() => result.current.report("blocks:layout", true));
+
+    expect(result.current.anyUnsaved).toBe(true);
+  });
+
+  it("goes quiet again when it retracts", () => {
+    const { result } = renderHook(useUnsavedWork);
+
+    act(() => result.current.report("blocks:layout", true));
+    act(() => result.current.report("blocks:layout", false));
+
+    expect(result.current.anyUnsaved).toBe(false);
+  });
+
+  it("keeps one surface's work when ANOTHER retracts", () => {
+    // Two blocks fields on one page is an ordinary schema. A single boolean
+    // would let the second to finish clear the first one's work.
+    const { result } = renderHook(useUnsavedWork);
+
+    act(() => result.current.report("blocks:hero", true));
+    act(() => result.current.report("blocks:body", true));
+    act(() => result.current.report("blocks:body", false));
+
+    expect(result.current.anyUnsaved).toBe(true);
+  });
+
+  it("does not re-render ONCE PER report that changes nothing", () => {
+    /*
+     * A surface reporting on every edit would otherwise re-render the whole
+     * form on every keystroke.
+     *
+     * "At most one more" rather than "no more", because React documents that a
+     * `setState` returning the identical value may still render that component
+     * once before bailing out. What must not happen is a render PER report,
+     * which is what the count below separates: five identical reports move the
+     * count by at most one.
+     */
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders += 1;
+      return useUnsavedWork();
+    });
+
+    act(() => result.current.report("blocks:layout", true));
+    const afterFirst = renders;
+    for (let i = 0; i < 5; i += 1) {
+      act(() => result.current.report("blocks:layout", true));
+    }
+
+    expect(renders).toBeLessThanOrEqual(afterFirst + 1);
+  });
+});
+
+/** A surface that reports while mounted, so the retraction can be observed. */
+function Surface({ unsaved }: { unsaved: boolean }) {
+  useReportUnsavedWork("blocks:layout", unsaved);
+  return <span>surface</span>;
+}
+
+function Harness({ children }: { children: (state: boolean) => ReactNode }) {
+  const work = useUnsavedWork();
+  return (
+    <UnsavedWorkProvider report={work.report}>
+      <output>{work.anyUnsaved ? "unsaved" : "clean"}</output>
+      {children(work.anyUnsaved)}
+    </UnsavedWorkProvider>
+  );
+}
+
+describe("useReportUnsavedWork", () => {
+  it("reports through the provider", () => {
+    render(<Harness>{() => <Surface unsaved />}</Harness>);
+
+    expect(screen.getByRole("status").textContent).toBe("unsaved");
+  });
+
+  it("RETRACTS when the surface unmounts", () => {
+    /*
+     * The handoff that makes this safe. The page builder commits its document
+     * on the way out, so the form goes dirty in the same moment this stops
+     * claiming anything — and without the retraction a closed editor would
+     * leave the form permanently unsaved, warning on every navigation forever.
+     */
+    function Host() {
+      const [open, setOpen] = useState(true);
+      return (
+        <Harness>
+          {() => (
+            <>
+              {open ? <Surface unsaved /> : null}
+              <button type="button" onClick={() => setOpen(false)}>
+                close
+              </button>
+            </>
+          )}
+        </Harness>
+      );
+    }
+    render(<Host />);
+    expect(screen.getByRole("status").textContent).toBe("unsaved");
+
+    act(() => screen.getByRole("button", { name: "close" }).click());
+
+    expect(screen.getByRole("status").textContent).toBe("clean");
+  });
+
+  it("says nothing when the surface has no unsaved work", () => {
+    render(<Harness>{() => <Surface unsaved={false} />}</Harness>);
+
+    expect(screen.getByRole("status").textContent).toBe("clean");
+  });
+
+  it("renders outside a form without complaining", () => {
+    // A field also renders in previews and pickers, where nobody is asking.
+    expect(() => render(<Surface unsaved />)).not.toThrow();
+  });
+});
+
+describe("useFormUnsavedWork", () => {
+  it("is unsaved when the FORM is dirty and nothing reported", () => {
+    const { result } = renderHook(() => useFormUnsavedWork(true));
+
+    expect(result.current.hasUnsavedWork).toBe(true);
+  });
+
+  it("is unsaved when a FIELD reported and the form is clean", () => {
+    // The case the whole seam exists for: the page builder holds its document
+    // outside the form, so the form is clean while real work is outstanding.
+    const { result } = renderHook(() => useFormUnsavedWork(false));
+
+    act(() => result.current.report("blocks:layout", true));
+
+    expect(result.current.hasUnsavedWork).toBe(true);
+  });
+
+  it("is clean only when NEITHER says otherwise", () => {
+    const { result } = renderHook(() => useFormUnsavedWork(false));
+
+    expect(result.current.hasUnsavedWork).toBe(false);
+
+    // And a field retracting does not clear a dirty form, which is the other
+    // direction: the two sources are combined, not swapped.
+    act(() => result.current.report("blocks:layout", true));
+    act(() => result.current.report("blocks:layout", false));
+    expect(result.current.hasUnsavedWork).toBe(false);
+  });
+
+  it("keeps saying unsaved while the form is dirty, whatever a field retracts", () => {
+    const { result } = renderHook(() => useFormUnsavedWork(true));
+
+    act(() => result.current.report("blocks:layout", true));
+    act(() => result.current.report("blocks:layout", false));
+
+    expect(result.current.hasUnsavedWork).toBe(true);
+  });
+});

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -43,6 +43,10 @@ import { EntrySystemHeader } from "@admin/components/features/entries/EntryForm/
 import { FormErrorSummary } from "@admin/components/features/entries/EntryForm/FormErrorSummary";
 import { UnsavedChangesGuard } from "@admin/components/features/entries/EntryForm/UnsavedChangesGuard";
 import {
+  UnsavedWorkProvider,
+  useFormUnsavedWork,
+} from "@admin/components/features/entries/EntryForm/UnsavedWorkContext";
+import {
   mapIntentToPayload,
   passwordFieldNames,
   type EntryFormIntent,
@@ -353,12 +357,23 @@ export function SingleForm({
   // Keyboard Shortcuts
   // ---------------------------------------------------------------------------
 
+  /*
+   * Work a FIELD holds that the form's values do not contain — the page builder
+   * commits its document on exit, so the form is not dirty while it is open.
+   *
+   * Declared HERE rather than beside the autosave below, because the shortcut
+   * registration that reads it comes first: a save shortcut guarded on the
+   * form's own flag declines for the whole time the editor is open.
+   */
+  const unsavedWork = useFormUnsavedWork(isDirty);
+  const hasUnsavedWork = unsavedWork.hasUnsavedWork;
+
   useEntryFormShortcuts({
     onSave: () => {
       void handleSubmit();
     },
     onCancel: handleCancel,
-    isDirty,
+    isDirty: hasUnsavedWork,
     isSubmitting,
     enabled: true,
   });
@@ -527,8 +542,9 @@ export function SingleForm({
   return (
     // A single is only ever edited standalone, so unlike the entry editor there
     // is no embedded case to exclude.
-    <UnsavedChangesGuard isDirty={isDirty} disabled={isSubmitting}>
-      {/*
+    <UnsavedChangesGuard isDirty={hasUnsavedWork} disabled={isSubmitting}>
+      <UnsavedWorkProvider report={unsavedWork.report}>
+        {/*
         Which document the fields are inside. The entry editor has always
         supplied this and the Single editor did not, so a field rendered here
         could not tell what it was editing — which is fine for an input bound to
@@ -537,175 +553,176 @@ export function SingleForm({
         `isCreateMode` is false by construction: a Single is materialised before
         its form renders, so there is no create mode to be in.
       */}
-      <EntryFormContextProvider
-        kind="single"
-        collectionSlug={schema.slug}
-        entryId={document.id}
-        isCreateMode={false}
-        // The same status the meta strip below shows, plus the pending-draft
-        // fact the strip does not yet surface for a Single. Carrying the richer
-        // answer rather than the strip's: "changed" means published with a
-        // pending change, so a field reading it says MORE than the strip rather
-        // than something different.
-        documentStatus={{
-          status: documentStatus,
-          hasWorkingDraft: hasPendingWorkingDraft(document),
-        }}
-      >
-        <EntryLocaleProvider value={localeCtx}>
-          {/* Renders its child alone when there is no source — see the module. */}
-          <TranslationPanes
-            source={translationMode.source}
-            onExit={translationMode.onExit}
-            control={form.control}
-          >
-            <div className={cn("space-y-0", className)}>
-              <EntryFormProvider form={form} onSubmit={handleSubmit}>
-                <FormErrorSummary
-                  errors={errors}
-                  submitCount={submitCount}
-                  className="mx-6 mt-3"
-                />
+        <EntryFormContextProvider
+          kind="single"
+          collectionSlug={schema.slug}
+          entryId={document.id}
+          isCreateMode={false}
+          // The same status the meta strip below shows, plus the pending-draft
+          // fact the strip does not yet surface for a Single. Carrying the richer
+          // answer rather than the strip's: "changed" means published with a
+          // pending change, so a field reading it says MORE than the strip rather
+          // than something different.
+          documentStatus={{
+            status: documentStatus,
+            hasWorkingDraft: hasPendingWorkingDraft(document),
+          }}
+        >
+          <EntryLocaleProvider value={localeCtx}>
+            {/* Renders its child alone when there is no source — see the module. */}
+            <TranslationPanes
+              source={translationMode.source}
+              onExit={translationMode.onExit}
+              control={form.control}
+            >
+              <div className={cn("space-y-0", className)}>
+                <EntryFormProvider form={form} onSubmit={handleSubmit}>
+                  <FormErrorSummary
+                    errors={errors}
+                    submitCount={submitCount}
+                    className="mx-6 mt-3"
+                  />
 
-                <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-m-8">
-                  {/* Main column */}
-                  <div className="flex-1 min-w-0 flex flex-col">
-                    {/* Why: same fix as EntryForm — the parent flex's @4xl/content:-m-8
+                  <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-m-8">
+                    {/* Main column */}
+                    <div className="flex-1 min-w-0 flex flex-col">
+                      {/* Why: same fix as EntryForm — the parent flex's @4xl/content:-m-8
                 already cancels PageContainer's px-8, so wrapping the header / meta
                 strip in another -mx-8 was double-negative and pushed them
                 past the page edges. */}
-                    <EntrySystemHeader
-                      autosaveEnabled={autosaveScope !== null}
-                      autosaveStatus={autosave.status}
-                      autosaveLastSavedAt={autosave.lastSavedAt}
-                      mode="edit"
-                      titleField={titleField}
-                      historyFields={schema.fields}
-                      historyEnabled={historyEnabledFrom(schema)}
-                      hasStatus={hasStatus}
-                      isSubmitting={isSubmitting}
-                      isDirty={isDirty}
-                      entry={entryLike}
-                      collectionSlug={schema.slug}
-                      /* i18n: forward the active locale + switch handler so a localized single shows
+                      <EntrySystemHeader
+                        autosaveEnabled={autosaveScope !== null}
+                        autosaveStatus={autosave.status}
+                        autosaveLastSavedAt={autosave.lastSavedAt}
+                        mode="edit"
+                        titleField={titleField}
+                        historyFields={schema.fields}
+                        historyEnabled={historyEnabledFrom(schema)}
+                        hasStatus={hasStatus}
+                        isSubmitting={isSubmitting}
+                        isDirty={isDirty}
+                        entry={entryLike}
+                        collectionSlug={schema.slug}
+                        /* i18n: forward the active locale + switch handler so a localized single shows
                    the primary header language switcher (the sidebar pills are unavailable when
                    the rail is collapsed or on narrow layouts). The switcher self-hides when the
                    single isn't localized / localization isn't configured. */
-                      locale={locale}
-                      onLocaleChange={onLocaleChange}
-                      localized={schema.localized === true}
-                      toolbarSlot={
-                        <EntryFormToolbarSlots
-                          context="single"
-                          controllerField={controllerNames[0]}
-                        />
-                      }
-                      onSaveDraft={() => {
-                        void handleSubmit(undefined, "save-draft");
-                      }}
-                      onPublish={() => {
-                        void handleSubmit(undefined, "publish");
-                      }}
-                      onSaveChanges={() => {
-                        void handleSubmit(undefined, "save-changes");
-                      }}
-                      onUnpublish={() => {
-                        void handleSubmit(undefined, "unpublish");
-                      }}
-                      onCancel={handleCancel}
-                      onViewApi={onViewApi}
-                      /* Why: Singles share the Show JSON dialog with collections,
+                        locale={locale}
+                        onLocaleChange={onLocaleChange}
+                        localized={schema.localized === true}
+                        toolbarSlot={
+                          <EntryFormToolbarSlots
+                            context="single"
+                            controllerField={controllerNames[0]}
+                          />
+                        }
+                        onSaveDraft={() => {
+                          void handleSubmit(undefined, "save-draft");
+                        }}
+                        onPublish={() => {
+                          void handleSubmit(undefined, "publish");
+                        }}
+                        onSaveChanges={() => {
+                          void handleSubmit(undefined, "save-changes");
+                        }}
+                        onUnpublish={() => {
+                          void handleSubmit(undefined, "unpublish");
+                        }}
+                        onCancel={handleCancel}
+                        onViewApi={onViewApi}
+                        /* Why: Singles share the Show JSON dialog with collections,
                  but at the /api/singles/{slug} URL pattern. Passing
                  `scope="single"` routes the dialog through singleApi
                  instead of entryApi. */
-                      scope="single"
-                      lockIdentity
-                      isRailCollapsed={railCollapsed}
-                      onToggleRail={toggleRail}
-                    />
-                    <EntryMetaStrip
-                      slugField={slugField}
-                      hasStatus={hasStatus}
-                      status={documentStatus}
-                      isRailCollapsed={railCollapsed}
-                      lockSlug
-                    />
+                        scope="single"
+                        lockIdentity
+                        isRailCollapsed={railCollapsed}
+                        onToggleRail={toggleRail}
+                      />
+                      <EntryMetaStrip
+                        slugField={slugField}
+                        hasStatus={hasStatus}
+                        status={documentStatus}
+                        isRailCollapsed={railCollapsed}
+                        lockSlug
+                      />
 
-                    {/* Inside the main column, below the header, matching the entry
+                      {/* Inside the main column, below the header, matching the entry
                   editor. Placed above the flex row it sat UNDER the sticky
                   header, which intercepted pointer events: the offer was
                   visible and its buttons were not clickable. */}
-                    {recovery.offer ? (
-                      <AutosaveRecoveryBanner
-                        savedAt={recovery.offer.savedAt}
-                        onRestore={restoreRecovery}
-                        onDismiss={recovery.dismiss}
-                        className="mx-6 mt-3"
-                      />
-                    ) : null}
+                      {recovery.offer ? (
+                        <AutosaveRecoveryBanner
+                          savedAt={recovery.offer.savedAt}
+                          onRestore={restoreRecovery}
+                          onDismiss={recovery.dismiss}
+                          className="mx-6 mt-3"
+                        />
+                      ) : null}
 
-                    {/* The language panel, inline. The rail that otherwise carries it
+                      {/* The language panel, inline. The rail that otherwise carries it
                   is `hidden @4xl/content:flex`, so this is the exact
                   complement: shown only where the rail is not, and rendered
                   unconditionally once the author collapses the rail. Without
                   it a single loses its language workflow entirely at narrow
                   widths, which is the failure this panel exists to remove. */}
-                    {localizationEnabled && (
-                      <div
-                        className={cn(
-                          "px-6 pt-4",
-                          !railCollapsed && "@4xl/content:hidden"
-                        )}
-                      >
-                        <LanguagePanel
-                          {...(singleTranslations === undefined
-                            ? {}
-                            : { translations: singleTranslations })}
-                          {...(locale === undefined
-                            ? {}
-                            : { activeLocale: locale })}
-                          {...(onLocaleChange === undefined
-                            ? {}
-                            : { onSelect: onLocaleChange })}
-                          hasStatus={hasStatus}
-                        />
-                      </div>
-                    )}
+                      {localizationEnabled && (
+                        <div
+                          className={cn(
+                            "px-6 pt-4",
+                            !railCollapsed && "@4xl/content:hidden"
+                          )}
+                        >
+                          <LanguagePanel
+                            {...(singleTranslations === undefined
+                              ? {}
+                              : { translations: singleTranslations })}
+                            {...(locale === undefined
+                              ? {}
+                              : { activeLocale: locale })}
+                            {...(onLocaleChange === undefined
+                              ? {}
+                              : { onSelect: onLocaleChange })}
+                            hasStatus={hasStatus}
+                          />
+                        </div>
+                      )}
 
-                    {mainFields.length > 0 && (
-                      <div className="@4xl/content:p-8 pt-6">
-                        <EntryFormContent
-                          fields={mainFields}
-                          disabled={isSubmitting}
-                          withCard
-                        />
+                      {mainFields.length > 0 && (
+                        <div className="@4xl/content:p-8 pt-6">
+                          <EntryFormContent
+                            fields={mainFields}
+                            disabled={isSubmitting}
+                            withCard
+                          />
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Rail (collapsible). Same shape and width as collections. */}
+                    {!railCollapsed && (
+                      <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
+                        <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
+                          <EntryFormSidebar
+                            mode="edit"
+                            entry={entryLike}
+                            hasStatus={hasStatus}
+                            isDirty={isDirty}
+                            {...(locale === undefined ? {} : { locale })}
+                            {...(onLocaleChange === undefined
+                              ? {}
+                              : { onLocaleChange })}
+                          />
+                        </div>
                       </div>
                     )}
                   </div>
-
-                  {/* Rail (collapsible). Same shape and width as collections. */}
-                  {!railCollapsed && (
-                    <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
-                      <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
-                        <EntryFormSidebar
-                          mode="edit"
-                          entry={entryLike}
-                          hasStatus={hasStatus}
-                          isDirty={isDirty}
-                          {...(locale === undefined ? {} : { locale })}
-                          {...(onLocaleChange === undefined
-                            ? {}
-                            : { onLocaleChange })}
-                        />
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </EntryFormProvider>
-            </div>
-          </TranslationPanes>
-        </EntryLocaleProvider>
-      </EntryFormContextProvider>
+                </EntryFormProvider>
+              </div>
+            </TranslationPanes>
+          </EntryLocaleProvider>
+        </EntryFormContextProvider>
+      </UnsavedWorkProvider>
     </UnsavedChangesGuard>
   );
 }

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -101,6 +101,13 @@ export {
   hasPendingWorkingDraft,
   type DocumentStatus,
 } from "./components/features/entries/EntryForm/EntryFormContext";
+/**
+ * A field telling the form it holds work the form's values do not contain.
+ *
+ * Exported for the plugin surface: a contributed field with its own editing
+ * state is invisible to the dirty flag everything else is derived from.
+ */
+export { useReportUnsavedWork } from "./components/features/entries/EntryForm/UnsavedWorkContext";
 export {
   pillStateFromForm,
   PILL_LABEL,

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -61,6 +61,7 @@ import {
 import {
   useDocumentCheckpoint,
   usePluginClientConfig,
+  useReportUnsavedWork,
   useSuppressAdminChrome,
 } from "@nextlyhq/plugin-sdk/admin";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -366,6 +367,18 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   });
 
   useCheckpoints({ name, control, document: editor.document });
+
+  /*
+   * Tell the form this editor holds work its values do not contain, so the
+   * navigation guard warns and the save shortcut works while the canvas is
+   * open. `undoDepth` rather than comparing documents: an edit and its undo
+   * leave a document equal to the original but not identical to it, so a
+   * reference comparison would report work that was taken back.
+   *
+   * Retracted when this component unmounts, which is the same moment `done`
+   * commits the document and makes the form dirty for real.
+   */
+  useReportUnsavedWork(`blocks:${name}`, editor.undoDepth > 0);
 
   /*
    * Writing back on the way out rather than on every keystroke.

--- a/packages/plugin-sdk/src/__snapshots__/plugin-surface.test.ts.snap
+++ b/packages/plugin-sdk/src/__snapshots__/plugin-surface.test.ts.snap
@@ -81,6 +81,7 @@ exports[`plugin-sdk public export surface > \`./admin\` surface is unchanged 1`]
   "useDocumentStatus (value)",
   "usePluginClientConfig (value)",
   "usePluginFieldTypeEntries (value)",
+  "useReportUnsavedWork (value)",
   "useSuppressAdminChrome (value)",
   "withOptionIds (value)",
 ]

--- a/packages/plugin-sdk/src/admin.ts
+++ b/packages/plugin-sdk/src/admin.ts
@@ -51,6 +51,21 @@ export {
 } from "@nextlyhq/admin";
 
 /**
+ * Tell the surrounding form this surface holds unsaved work (@experimental).
+ *
+ * For a field that keeps its own editing state rather than writing through the
+ * form — the page builder holds its block document and commits on exit — so the
+ * form's dirty flag stays false while real work is outstanding, and everything
+ * derived from it is wrong together: the navigation guard does not warn, the
+ * save shortcut declines, and the header shows nothing pending.
+ *
+ * It reports ONE BOOLEAN about itself. It cannot save, publish, or write to the
+ * form; the form still decides what to do about it. Retracted automatically
+ * when the surface unmounts.
+ */
+export { useReportUnsavedWork } from "@nextlyhq/admin";
+
+/**
  * Record a recovery point for the surrounding document (@experimental).
  *
  * For a contributed field that holds its own editing state — a canvas, a


### PR DESCRIPTION
## Read this before the diff

`EntryForm.tsx` shows ~480 changed lines and `SingleForm.tsx` ~317. **`git diff -w` collapses both to 44 insertions and 7 deletions.** Everything else is re-indentation from one new wrapper element. The real change in each file is: one hook call, one derived boolean, two props rewired, one provider added.

## The defect

The page builder keeps its block document in its own store and commits on **exit** — deliberately, so the form's undo and the editor's undo are not two answers to one question. The cost was never priced: through an entire editing session **the form is not dirty**, and everything derived from that flag was wrong at once.

- the unsaved-changes guard did not warn — on in-app navigation, on back/forward, or on closing the tab;
- the save shortcut declined;
- the header showed nothing pending.

**The save shortcut was never inert.** `useEntryFormShortcuts` guards on `when: () => isDirty && !isSubmitting`, and it was correctly refusing on a flag that cannot be true there. I had this recorded as "unexplained" for two sessions; it was one line away the whole time.

## The narrowest fix that works

`useReportUnsavedWork(key, unsaved)`. A surface reports **one boolean about itself**, retracted when it unmounts. It cannot save, publish, or write to the form — the form still decides what to do about it. That distinction matters: it is the read-only half of the grant we deferred, and it does not pre-empt that decision.

**The retraction is the handoff.** The editor commits its document on the way out, so the form goes dirty in the same moment the report stops. Without it, a closed editor would leave the form permanently "unsaved", warning on every navigation forever — which is why it has its own test.

**A set, not a flag.** Two blocks fields on one page is an ordinary schema, and a single boolean would let the second to finish clear the first one's work.

**The same set is returned when nothing changed**, so a surface reporting on every edit does not re-render the form on every keystroke.

**`useFormUnsavedWork` combines it with the form's own flag in one place**, so the two editors cannot come to disagree about what unsaved means. It also exists because `EntryForm` is already CRITICAL on complexity and the gate correctly attributed my two extra lines to it — the extraction fixed both problems.

## Verified in a browser, with the precondition asserted

Node count **90 → 91** first, so the editor was provably dirty before anything was concluded. Then `mod+s` issued **`PATCH /admin/api/singles/homepage`**. Before this change the same gesture issued nothing.

That control earned its place immediately: an earlier run showed no request and no autosave checkpoint, and I nearly recorded it as "the fix does not work". The insert had silently missed — the fixture never reached the mechanism.

## NOT verified in a browser

**The navigation-guard warning.** I attempted it twice and the insert missed both times, so the dialog assertion would have been made against an editor that was never dirty. The guard path is covered by unit tests — the report arrives, the combination is right, the retraction fires on unmount — but nobody has watched the dialog appear. Please treat that half as unit-tested rather than demonstrated.

## Tests

`admin` against its standing baseline of 15 failures in 4 files: **15 failed, 2419 passed** — the same 15, plus 13 new. All gates green; Fallow passes with nothing introduced.

Two stubs, each failing exactly its own case: collapsing the set to a single flag fails the two-surface case, and dropping the unmount retraction fails the handoff case.

One test was repaired rather than kept: "does not re-render for a report that changes nothing" asserted an exact render count and failed at 3 vs 2, because React documents that a `setState` returning the identical value may still render once before bailing out. It now asserts what actually matters — five identical reports move the count by **at most one**, not once per report.
