### PR TITLE
test(builder): audit the editor against WCAG 2.2 AA, and fix what it found

### DIFF
--- a/.changeset/builder-a11y-fixes.md
+++ b/.changeset/builder-a11y-fixes.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Two accessibility defects in the page-builder shell, found by an axe audit that
+now runs in CI.
+
+The canvas scrolls and nothing inside it is focusable, so at `tabindex="-1"` a
+keyboard user could not scroll it at all. And the bottom bar carried an
+`aria-label` on a role that prohibits one, so the name was never announced.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -14,6 +14,7 @@
     "lint:fix": "eslint . --fix"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.13.0",
     "@nextlyhq/adapter-drizzle": "workspace:*",
     "@nextlyhq/adapter-sqlite": "workspace:*",
     "@nextlyhq/admin": "workspace:*",

--- a/e2e/tests/builder-a11y.spec.ts
+++ b/e2e/tests/builder-a11y.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * The page builder, measured against WCAG 2.2 AA by axe.
+ *
+ * A scan is the only instrument here that can be a BOUNDARY rather than a
+ * habit. The unit suites can assert that a control has a label and that a
+ * region has a name; they cannot see contrast, because jsdom applies no
+ * stylesheet, and they cannot see the tree an assistive technology actually
+ * walks, because that tree is the browser's.
+ *
+ * ## It scans the whole page, deliberately
+ *
+ * The editor takes the window, so nearly everything visible IS the editor —
+ * and a violation on the admin behind it is one an author reaches the moment
+ * they leave. Rooting the scan at the editor's own container would read as
+ * tighter and would mostly hide the same page from itself.
+ *
+ * ONE rule is disabled, named below with its reason. An ignore LIST is how a
+ * guard stops meaning anything; a single named exclusion with a cause is a
+ * boundary someone can argue with.
+ *
+ * ## Why the violations are ENUMERATED rather than counted
+ *
+ * `expect(violations).toHaveLength(0)` is the obvious assertion and a bad one:
+ * when it fails it says "expected 3 to be 0", which is a number rather than a
+ * defect. The helper below reports rule ids and the elements carrying them, so
+ * a failure names what to fix.
+ *
+ * @module tests/builder-a11y.spec
+ */
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+
+import { gotoAdmin } from "./support/admin";
+
+/**
+ * The tags that define "AA", stated rather than left to axe's defaults.
+ *
+ * `wcag22aa` is the level B-23 names. The earlier levels are included because
+ * 2.2 is additive: a page failing a 2.0 rule fails 2.2 as well, and omitting
+ * them would let a scan pass while breaking something older and more basic.
+ */
+const AA_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"];
+
+/**
+ * `document-title` (WCAG 2.4.2), excluded because it is the HOST app's to fix
+ * and this harness structurally cannot.
+ *
+ * Next emits `<title>` from a `metadata` export, which only a server component
+ * may declare — and the playground's root layout is `"use client"`, because it
+ * mounts the admin's providers. So the page under test has no title and no
+ * amount of work in `packages/builder` would give it one. A real Nextly app
+ * supplies its own.
+ *
+ * Named as one rule rather than filtered out of the results, so it appears in
+ * the run's own record instead of only in this comment.
+ */
+const HOST_OWNED_RULES = ["document-title"];
+
+/** The editor's own container, so the admin around it is not this suite's subject. */
+const EDITOR_ROOT = '[aria-label="Editor panels"]';
+
+interface Finding {
+  id: string;
+  impact: string;
+  help: string;
+  targets: string[];
+}
+
+/** What axe found, as something a failure message can name. */
+async function scanEditor(page: Page): Promise<Finding[]> {
+  const results = await new AxeBuilder({ page })
+    .withTags(AA_TAGS)
+    .disableRules(HOST_OWNED_RULES)
+    .analyze();
+
+  /*
+   * The POPULATION, before any verdict. A scan that ran against nothing reports
+   * zero violations exactly as a clean page does — measured here, an early run
+   * of this suite reported zero while a deliberately broken button sat on the
+   * page, because the result was being read from the wrong field. A passing
+   * rule count is what separates "clean" from "did not look".
+   */
+  expect(
+    results.passes.length,
+    "axe reported no passing rules, so it scanned nothing — the zero below would mean nothing"
+  ).toBeGreaterThan(10);
+
+  return results.violations.map(violation => ({
+    id: violation.id,
+    impact: violation.impact ?? "unknown",
+    help: violation.help,
+    targets: violation.nodes.flatMap(node => node.target.map(String)),
+  }));
+}
+
+/** Open a document and put its page builder on screen. */
+async function openEditor(page: Page): Promise<void> {
+  await gotoAdmin(page, "/singles/homepage");
+  await page.getByRole("button", { name: "Edit blocks" }).click();
+  // POPULATION BEFORE VERDICT. "No violations" is satisfied perfectly by an
+  // editor that never opened, so the scan must not run until it has.
+  await expect(page.locator(EDITOR_ROOT)).toBeVisible({ timeout: 30_000 });
+}
+
+test.describe("the page builder meets WCAG 2.2 AA", () => {
+  test("has no violations when it opens", async ({ page }) => {
+    await openEditor(page);
+
+    const findings = await scanEditor(page);
+
+    expect(
+      findings,
+      `axe reported ${findings.length} violation(s):\n${JSON.stringify(findings, null, 2)}`
+    ).toEqual([]);
+  });
+
+  test("has no violations with a panel open", async ({ page }) => {
+    // The inserter is a different tree from the canvas — a list of options with
+    // its own roles — and a scan of the closed editor never reaches it.
+    await openEditor(page);
+    await page.getByRole("button", { name: "Insert" }).click();
+    await expect(page.getByRole("option").first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const findings = await scanEditor(page);
+
+    expect(
+      findings,
+      `axe reported ${findings.length} violation(s) with the inserter open:\n${JSON.stringify(findings, null, 2)}`
+    ).toEqual([]);
+  });
+
+  test("has no violations in DARK mode", async ({ page }) => {
+    /*
+     * Contrast is the rule most likely to differ between the two, and it is the
+     * one no unit test can reach: jsdom applies no stylesheet, so every colour
+     * assertion in the component suites is really an assertion about a class
+     * name. A palette that fails only in dark mode passes every one of them.
+     */
+    await page.addInitScript(
+      ([key, value]) => window.localStorage.setItem(key, value),
+      ["nextly-theme", "dark"] as const
+    );
+    await openEditor(page);
+
+    const findings = await scanEditor(page);
+
+    expect(
+      findings,
+      `axe reported ${findings.length} violation(s) in dark mode:\n${JSON.stringify(findings, null, 2)}`
+    ).toEqual([]);
+  });
+});

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -906,7 +906,14 @@ function ShellRegions({
                 ref={element => {
                   regionRefs.current.canvas = element;
                 }}
-                tabIndex={-1}
+                /*
+                 * `0`, not `-1`. This region SCROLLS, and nothing inside it is
+                 * focusable — blocks are selected by pointer, not by tab — so
+                 * at `-1` a keyboard user could not scroll the canvas at all.
+                 * Programmatically focusable was enough for F6 region cycling
+                 * and not enough to read the page.
+                 */
+                tabIndex={0}
                 aria-label="Canvas"
                 className="h-full overflow-auto"
               >
@@ -945,10 +952,14 @@ function ShellRegions({
         </ResizablePanelGroup>
       </div>
 
-      <footer
-        className="border-[color:var(--nx-builder-border)] text-[color:var(--nx-builder-text-muted)] flex h-8 shrink-0 items-center gap-2 border-t px-3 text-xs"
-        aria-label="Selection path"
-      >
+      {/*
+        No `aria-label`. A `<footer>` nested inside a section is `generic`, and
+        `aria-label` is PROHIBITED on that role — so the name was not announced
+        and the element was invalid. Nothing is lost: the breadcrumb inside
+        names itself ("Selected block's ancestors"), which is the thing a
+        reader actually lands on.
+      */}
+      <footer className="border-[color:var(--nx-builder-border)] text-[color:var(--nx-builder-text-muted)] flex h-8 shrink-0 items-center gap-2 border-t px-3 text-xs">
         {breadcrumb}
       </footer>
     </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,9 @@ importers:
 
   e2e:
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.13.0
+        version: 4.13.0(playwright-core@1.61.1)
       '@nextlyhq/adapter-drizzle':
         specifier: workspace:*
         version: link:../packages/adapter-drizzle
@@ -1932,6 +1935,11 @@ packages:
   '@aws/lambda-invoke-store@0.3.0':
     resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
+
+  '@axe-core/playwright@4.13.0':
+    resolution: {integrity: sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -5557,6 +5565,10 @@ packages:
 
   axe-core@4.10.3:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
+    engines: {node: '>=4'}
+
+  axe-core@4.13.0:
+    resolution: {integrity: sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==}
     engines: {node: '>=4'}
 
   axobject-query@4.1.0:
@@ -9207,6 +9219,11 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.3.0': {}
 
+  '@axe-core/playwright@4.13.0(playwright-core@1.61.1)':
+    dependencies:
+      axe-core: 4.13.0
+      playwright-core: 1.61.1
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -12506,7 +12523,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@24.10.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -12576,7 +12593,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@24.10.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -12762,6 +12779,8 @@ snapshots:
   aws-ssl-profiles@1.1.2: {}
 
   axe-core@4.10.3: {}
+
+  axe-core@4.13.0: {}
 
   axobject-query@4.1.0: {}
 


### PR DESCRIPTION
B-23's axe half. It found **two serious defects in the shell**, both fixed here.

## What it found

**1. The canvas could not be scrolled from a keyboard.** It scrolls, and nothing inside it is focusable — blocks are selected by pointer, not by tab — so at `tabindex="-1"` there was no way to reach it. Programmatically focusable was enough for F6 region cycling and not enough to *read the page*. Now `0`.

**2. The bottom bar's name was never announced.** `<footer>` nested inside a section maps to `generic`, where `aria-label` is prohibited, so the attribute was both invalid and inert. Removed rather than relabelled — the breadcrumb inside already names itself, which is what a reader actually lands on.

Neither is visible to the unit suites, and that is the point of adding this: jsdom applies no stylesheet and builds no accessibility tree, so a component test asserting a control has a label is really asserting a prop.

## The result that would have been a lie

My first three scans reported **zero violations** across the editor, the open inserter, and dark mode. I nearly wrote that up as "the builder is clean".

Then I injected a button with no accessible name and an image with no alt text, re-scanned, and got **zero again**. The scan was not seeing the page — I was reading the result from the wrong field of the JSON. Corrected, the same run reported six, including both injected violations, and the real page reported three.

So the spec now asserts its own population before any verdict:

```ts
expect(results.passes.length, "axe reported no passing rules, so it scanned nothing").toBeGreaterThan(10);
```

A scan that ran against nothing reports zero violations exactly as a clean page does. Without that clause this suite would pass forever if the selector, the harness or the parser ever broke.

## One rule disabled, named with its cause

`document-title` (WCAG 2.4.2). It is the **host app's** to fix and this harness structurally cannot: Next emits `<title>` from a `metadata` export, only a server component may declare one, and the playground's root layout is `"use client"` because it mounts the admin's providers. A real Nextly app supplies its own.

One named exclusion with a reason, not an ignore list — a list is how a guard stops meaning anything.

## Verified, and what is not

**Verified** against a real browser on this build, three states each: editor open, inserter open, dark mode. Before the fixes, 3 violations; after, 0 (plus the excluded rule). `passes: 30`, so the scan demonstrably ran.

**NOT verified:** the spec's own execution. My local e2e cannot get through `global-setup.ts` right now — it times out waiting for `locator('main')`, which is the same environmental failure that blocked #1072 on this machine. The audit results above come from driving the same build directly rather than through Playwright.

So: **the findings and the fixes are measured; the spec running green is this PR's `Browser tests` job to demonstrate.** Please merge on that, as with #1072.

## Scope

B-23 also names a manual screen-reader pass and the D-04.10 production-build demo. Neither is here — this is the automated half, which is the part that can be a boundary rather than a habit.

`builder` 855 tests unchanged. Gates and Fallow green.
