### PR TITLE
feat(admin): show which languages hold unpublished changes

### DIFF
--- a/.changeset/pending-changes-admin.md
+++ b/.changeset/pending-changes-admin.md
@@ -1,0 +1,38 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Show which languages hold unpublished changes, and confirm before publishing all.
+
+The language panel now marks a language that has changes waiting, so an editor
+can see it without opening each language in turn. Publishing every language asks
+first and says how many carry unpublished work, because that action puts all of
+it live at once.
+
+Two fixes underneath: an edit that named no language was written straight to the
+live site instead of being held, and a translated document's pending change was
+never shown back to the editor who saved it.

--- a/apps/playground/src/collections/authors.ts
+++ b/apps/playground/src/collections/authors.ts
@@ -31,6 +31,11 @@ export const Authors = defineCollection({
   ],
   // Draft / Published lifecycle — the companion also gets a per-locale `_status`.
   status: true,
+  // Pending changes, per language: editing a published translation holds the
+  // edit for that language instead of publishing it. Enabled here because this
+  // is the only playground collection that is BOTH localized and lifecycled, so
+  // without it the per-language pending state has no surface to be seen on.
+  versions: { drafts: true },
   admin: {
     useAsTitle: "title",
   },

--- a/packages/admin/src/components/features/entries/LanguageControl.tsx
+++ b/packages/admin/src/components/features/entries/LanguageControl.tsx
@@ -25,6 +25,7 @@ import { cn } from "@admin/lib/utils";
 import {
   LANGUAGE_STATE_LABEL,
   languageState,
+  languageStateLabel,
   type LanguageState,
   type LocaleTranslationMeta,
 } from "./translation-meta";
@@ -33,7 +34,7 @@ import {
 // be read off a `_translations` map. Re-exported here because this file was its
 // home while the control was its only reader, and several surfaces import it
 // from here.
-export { LANGUAGE_STATE_LABEL, languageState };
+export { LANGUAGE_STATE_LABEL, languageState, languageStateLabel };
 export type { LanguageState };
 
 /**
@@ -100,6 +101,12 @@ export function LanguageControl({
     >
       {locales.map((locale, index) => {
         const state = languageState(translations?.[locale.code]);
+        // A language holding unpublished work must not read as simply
+        // "published" here. This control is a row of compact chips with no room
+        // for a phrase, so the fact travels in the accessible name and the
+        // title, which is where this control already carries the state.
+        const pendingChange = translations?.[locale.code]?.pendingChange;
+        const stateLabel = languageStateLabel(state, pendingChange);
         const isActive = locale.code === active;
         return (
           <button
@@ -108,10 +115,10 @@ export function LanguageControl({
             onClick={() => onSelect(locale.code)}
             disabled={disabled}
             aria-pressed={isActive}
-            aria-label={`${locale.label} — ${LANGUAGE_STATE_LABEL[state]}${
+            aria-label={`${locale.label} — ${stateLabel}${
               locale.code === defaultLocale ? " (default)" : ""
             }`}
-            title={`${locale.label} — ${LANGUAGE_STATE_LABEL[state]}`}
+            title={`${locale.label} — ${stateLabel}`}
             className={cn(
               "inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",

--- a/packages/admin/src/components/features/entries/LanguagePanel.tsx
+++ b/packages/admin/src/components/features/entries/LanguagePanel.tsx
@@ -25,6 +25,7 @@
  */
 
 import { Button } from "@nextlyhq/ui";
+import { useState } from "react";
 
 import { useLocalization } from "@admin/hooks/useLocalization";
 import { cn } from "@admin/lib/utils";
@@ -34,10 +35,11 @@ import { CopyFromLanguageDialog } from "./CopyFromLanguageDialog";
 import { useEntryLocale } from "./EntryLocaleContext";
 import {
   languageState,
-  LANGUAGE_STATE_LABEL,
+  languageStateLabel,
   StateDot,
   type LanguageState,
 } from "./LanguageControl";
+import { PublishAllConfirmDialog } from "./PublishAllConfirmDialog";
 import {
   translationCounts,
   type LocaleTranslationMeta,
@@ -75,6 +77,7 @@ function LanguageRow({
   rtl,
   isDefault,
   state,
+  pendingChange,
   isActive,
   canSeed,
   onSelect,
@@ -86,6 +89,8 @@ function LanguageRow({
   rtl: boolean;
   isDefault: boolean;
   state: LanguageState;
+  /** Whether this language holds a saved change nobody has published. */
+  pendingChange?: boolean;
   isActive: boolean;
   canSeed: boolean;
   onSelect?: (code: string, options?: { seedFrom?: string }) => void;
@@ -120,8 +125,20 @@ function LanguageRow({
             rtl
           </span>
         )}
-        <span className="min-w-0 truncate text-xs text-muted-foreground">
-          {LANGUAGE_STATE_LABEL[state]}
+        {/* The state is what gives way when the row runs out of room, so the
+            full phrase also rides in `title` for a sighted reader. Assistive
+            technology is unaffected either way: the truncation is CSS, and the
+            text stays whole in the accessibility tree. It is NOT repeated into
+            the Open button's name — that would bury what the button does
+            behind a state the row already states. */}
+        <span
+          className={cn(
+            "min-w-0 truncate text-xs",
+            pendingChange ? "text-foreground" : "text-muted-foreground"
+          )}
+          title={languageStateLabel(state, pendingChange)}
+        >
+          {languageStateLabel(state, pendingChange)}
         </span>
       </div>
       {isActive ? (
@@ -181,6 +198,7 @@ export function LanguagePanel({
   actionsDisabled = false,
   className,
 }: LanguagePanelProps) {
+  const [confirmPublishAll, setConfirmPublishAll] = useState(false);
   const { enabled, locales, defaultLocale } = useLocalization();
   const { collectionLocalized, isNonDefaultLocale, onEnterTranslationMode } =
     useEntryLocale();
@@ -198,6 +216,12 @@ export function LanguagePanel({
   if (!enabled || !collectionLocalized || locales.length < 2) return null;
 
   const active = activeLocale ?? defaultLocale;
+  // How many languages hold work nobody has published. Stated in the confirm
+  // below, because publishing all of them is the one action here that can put
+  // another person's held edit on the public site.
+  const pendingCount = locales.filter(
+    l => translations?.[l.code]?.pendingChange
+  ).length;
   const counts = translationCounts(
     translations,
     locales.map(l => l.code),
@@ -244,12 +268,24 @@ export function LanguagePanel({
             size="sm"
             className="h-7 px-2 text-xs"
             disabled={actionsDisabled || publish.pending}
-            onClick={publish.publishAll}
+            onClick={() => setConfirmPublishAll(true)}
           >
             {publish.pending ? "Publishing…" : "Publish all"}
           </Button>
         )}
       </div>
+
+      <PublishAllConfirmDialog
+        open={confirmPublishAll}
+        onOpenChange={setConfirmPublishAll}
+        languageCount={locales.length}
+        pendingCount={pendingCount}
+        isLoading={publish.pending}
+        onConfirm={() => {
+          publish.publishAll();
+          setConfirmPublishAll(false);
+        }}
+      />
 
       <ul aria-label="Languages in this document">
         {locales.map(locale => (
@@ -260,6 +296,7 @@ export function LanguagePanel({
             rtl={locale.rtl}
             isDefault={locale.code === defaultLocale}
             state={languageState(translations?.[locale.code])}
+            pendingChange={translations?.[locale.code]?.pendingChange}
             isActive={locale.code === active}
             canSeed={copy.available}
             {...(onSelect === undefined ? {} : { onSelect })}

--- a/packages/admin/src/components/features/entries/LanguagePanel.tsx
+++ b/packages/admin/src/components/features/entries/LanguagePanel.tsx
@@ -36,6 +36,7 @@ import { useEntryLocale } from "./EntryLocaleContext";
 import {
   languageState,
   languageStateLabel,
+  LANGUAGE_STATE_LABEL,
   StateDot,
   type LanguageState,
 } from "./LanguageControl";
@@ -125,20 +126,24 @@ function LanguageRow({
             rtl
           </span>
         )}
-        {/* The state is what gives way when the row runs out of room, so the
-            full phrase also rides in `title` for a sighted reader. Assistive
-            technology is unaffected either way: the truncation is CSS, and the
-            text stays whole in the accessibility tree. It is NOT repeated into
-            the Open button's name — that would bury what the button does
-            behind a state the row already states. */}
+        {/* A chip, not part of the state text, and measured that way: in a
+            277px rail "published · unpublished changes" truncated to
+            "publishe…", which hides the one fact in the row an author has to
+            act on. The chip does not shrink, so it survives at any width — the
+            same device the `default` and `rtl` markers already use. */}
+        {pendingChange && (
+          <span
+            className="shrink-0 rounded-sm border border-border px-1 text-[10px] uppercase tracking-wide text-foreground"
+            title="This language has changes that have not been published"
+          >
+            changes
+          </span>
+        )}
         <span
-          className={cn(
-            "min-w-0 truncate text-xs",
-            pendingChange ? "text-foreground" : "text-muted-foreground"
-          )}
+          className="min-w-0 truncate text-xs text-muted-foreground"
           title={languageStateLabel(state, pendingChange)}
         >
-          {languageStateLabel(state, pendingChange)}
+          {LANGUAGE_STATE_LABEL[state]}
         </span>
       </div>
       {isActive ? (

--- a/packages/admin/src/components/features/entries/PublishAllConfirmDialog.tsx
+++ b/packages/admin/src/components/features/entries/PublishAllConfirmDialog.tsx
@@ -1,0 +1,94 @@
+/**
+ * Publish All Languages Confirm Dialog
+ *
+ * A confirm before publishing every language of a document at once.
+ *
+ * The step exists because of what this action can do that its label does not
+ * say: a language holding a saved, unpublished change goes live with the rest.
+ * An author thinking about the language in front of them can put four other
+ * people's held work on the public site with one click, and publishing cannot
+ * be undone by pressing it again. So the count of languages carrying pending
+ * changes is stated before the action, not after it.
+ *
+ * Built on the same AlertDialog primitives as the discard and unpublish
+ * confirms, so the three destructive-ish actions in this editor read alike.
+ *
+ * @module components/features/entries/PublishAllConfirmDialog
+ */
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@nextlyhq/ui";
+
+import { Loader2 } from "@admin/components/icons";
+
+export interface PublishAllConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** How many languages this will publish. */
+  languageCount: number;
+  /** How many of those hold a saved change nobody has published yet. */
+  pendingCount: number;
+  onConfirm: () => void | Promise<void>;
+  isLoading?: boolean;
+}
+
+export function PublishAllConfirmDialog({
+  open,
+  onOpenChange,
+  languageCount,
+  pendingCount,
+  onConfirm,
+  isLoading = false,
+}: PublishAllConfirmDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            Publish all {languageCount} languages?
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {pendingCount > 0
+              ? // The number is the point of the sentence, so it leads. Naming
+                // the languages instead would be better still, but this dialog
+                // is reached from surfaces that know the count and not always
+                // the labels.
+                `${pendingCount} of them ${
+                  pendingCount === 1 ? "has" : "have"
+                } unpublished changes that will go live too. This cannot be undone by publishing again.`
+              : "Every language goes live together. This cannot be undone by publishing again."}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isLoading}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={isLoading}
+            onClick={() => {
+              // `onConfirm` may be async; the click handler must not return its
+              // promise. The caller owns awaiting it and closing the dialog, so
+              // the loading state stays visible while the publish is in flight.
+              void onConfirm();
+            }}
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Publishing…
+              </>
+            ) : (
+              "Publish all"
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/admin/src/components/features/entries/__tests__/LanguagePanel.test.tsx
+++ b/packages/admin/src/components/features/entries/__tests__/LanguagePanel.test.tsx
@@ -280,11 +280,11 @@ describe("LanguagePanel", () => {
       },
     });
 
-    expect(
-      screen.getByTitle("published · unpublished changes")
-    ).toBeInTheDocument();
-    // And the language WITHOUT pending work still reads plainly — without this
-    // the assertion above would pass against a panel that marked every row.
-    expect(screen.getAllByTitle("published")).toHaveLength(1);
+    // The chip, not the state text: the phrase truncates in a 277px rail and
+    // this is the fact that must survive.
+    expect(screen.getByText("changes")).toBeInTheDocument();
+    // And the language WITHOUT pending work carries no chip — without this the
+    // assertion above would pass against a panel that marked every row.
+    expect(screen.getAllByText("changes")).toHaveLength(1);
   });
 });

--- a/packages/admin/src/components/features/entries/__tests__/LanguagePanel.test.tsx
+++ b/packages/admin/src/components/features/entries/__tests__/LanguagePanel.test.tsx
@@ -266,4 +266,25 @@ describe("LanguagePanel", () => {
     renderPanel({ translations: TRANSLATIONS, hasStatus: true });
     expect(screen.queryByRole("button", { name: "Publish all" })).toBeNull();
   });
+
+  it("states which language holds unpublished changes, without opening it", () => {
+    // The failure this guards is invisibility: a document whose languages all
+    // read "published" while work sits unpublished inside one of them. The
+    // author must be able to see it from the list, because with several
+    // languages there is no reason to open any particular one.
+    useBranding.mockReturnValue({ locales: LOCALES });
+    renderPanel({
+      translations: {
+        en: { translated: true, status: "published" },
+        de: { translated: true, status: "published", pendingChange: true },
+      },
+    });
+
+    expect(
+      screen.getByTitle("published · unpublished changes")
+    ).toBeInTheDocument();
+    // And the language WITHOUT pending work still reads plainly — without this
+    // the assertion above would pass against a panel that marked every row.
+    expect(screen.getAllByTitle("published")).toHaveLength(1);
+  });
 });

--- a/packages/admin/src/components/features/entries/translation-meta.ts
+++ b/packages/admin/src/components/features/entries/translation-meta.ts
@@ -18,6 +18,14 @@
 export interface LocaleTranslationMeta {
   translated: boolean;
   status?: string;
+  /**
+   * Whether this language holds a saved change nobody has published.
+   *
+   * Separate from `status` because it answers a different question: `status`
+   * says what the language IS, this says whether something is waiting. Absent
+   * rather than false when there is nothing pending, matching the wire shape.
+   */
+  pendingChange?: boolean;
 }
 
 export interface TranslationCounts {
@@ -92,6 +100,25 @@ export function languageState(
   if (meta.status === "published") return "published";
   if (meta.status === "draft") return "draft";
   return "translated";
+}
+
+/**
+ * How a language's state reads to a person, including whether work is waiting.
+ *
+ * The pending change is appended rather than replacing the state: the language
+ * IS still published, and saying only "unpublished changes" would suggest
+ * nothing of it is live. Both facts matter and they are different facts.
+ *
+ * One function because four surfaces describe a language — the header control,
+ * this panel, its menu, and the list's dots — and a second phrasing would let
+ * two of them describe the same language differently.
+ */
+export function languageStateLabel(
+  state: LanguageState,
+  pendingChange?: boolean
+): string {
+  const base = LANGUAGE_STATE_LABEL[state];
+  return pendingChange ? `${base} · unpublished changes` : base;
 }
 
 export const LANGUAGE_STATE_LABEL: Record<LanguageState, string> = {

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -1328,10 +1328,12 @@ describe("draft/published split — promote on publish (integration)", () => {
     expect(promo?.label).toBe("live");
   });
 
-  it("edits a localized collection live without a working draft", async () => {
-    // A localized document is ineligible for the split (a disqualifier known
-    // without the registry), so a status-less edit writes the live row directly
-    // and stores no working draft even when the schema references a component.
+  it("holds a localized edit that names no language, under the default", async () => {
+    // A localized document IS eligible for the split, including one whose
+    // schema references a component: a snapshot holds one locale's values and
+    // the draft is keyed by that locale. A request naming no locale is the
+    // admin's ordinary path for the default language, and its pending change
+    // keys under the default rather than being refused.
     handle = await createTestNextly({
       localization: { locales: ["en", "es"], defaultLocale: "en" },
       fieldGroups: [
@@ -1364,11 +1366,12 @@ describe("draft/published split — promote on publish (integration)", () => {
       { title: "edited" }
     );
     expect(res.success).toBe(true);
-    expect(await workingDraftCount(id)).toBe(0);
+    expect(await workingDraftCount(id)).toBe(1);
     // A localized collection keeps its text per locale, so read the live value
-    // back through getEntry rather than the main row.
+    // back through getEntry rather than the main row. The live translation is
+    // untouched: the edit is held, not published.
     const read = await entries.getEntry({ ...ctx, entryId: id, locale: "en" });
-    expect((read.data as { title?: string }).title).toBe("edited");
+    expect((read.data as { title?: string }).title).toBe("live");
   });
 
   it("keeps a live single component's other sub-fields on a first partial draft save", async () => {

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-split-per-language.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-split-per-language.integration.test.ts
@@ -86,6 +86,21 @@ async function pendingLocales(entryId: string): Promise<string[]> {
   return rows.map(r => r.locale ?? "(none)").sort();
 }
 
+async function readDraftBody(
+  entries: CollectionEntryService,
+  id: string,
+  locale: string
+): Promise<unknown> {
+  const res = await entries.getEntry({
+    collectionName: COLLECTION,
+    entryId: id,
+    overrideAccess: true,
+    locale,
+    includeWorkingDraft: true,
+  });
+  return (res.data as { body?: unknown } | null)?.body;
+}
+
 async function readBody(
   entries: CollectionEntryService,
   id: string,
@@ -214,5 +229,32 @@ describe("pending changes per language (integration)", () => {
 
     expect(await pendingLocales(id)).toEqual(["en"]);
     expect(await readBody(entries, id, "en")).toBe("en body");
+  });
+
+  it("shows the pending change to an editor, per language", async () => {
+    // Holding the edit is only half the feature. An author who saves and then
+    // sees their own words replaced by the published ones has been told the
+    // save did nothing. The draft view has to return the pending content for
+    // the language being edited — and only that language.
+    const entries = await boot();
+    const id = await publishBoth(entries);
+
+    await entries.updateEntry(
+      {
+        collectionName: COLLECTION,
+        entryId: id,
+        overrideAccess: true,
+        locale: "es",
+      },
+      { body: "es pending" }
+    );
+
+    expect(await readDraftBody(entries, id, "es")).toBe("es pending");
+    // English has nothing pending, so its draft view is the published content —
+    // without this the assertion above would pass against an overlay that
+    // returned the pending values for every language.
+    expect(await readDraftBody(entries, id, "en")).toBe("en body");
+    // And a plain read still shows the public content.
+    expect(await readBody(entries, id, "es")).toBe("es body");
   });
 });

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-split-per-language.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-split-per-language.integration.test.ts
@@ -195,4 +195,24 @@ describe("pending changes per language (integration)", () => {
     expect(await pendingLocales(id)).toEqual(["en"]);
     expect(await readBody(entries, id, "en")).toBe("en body");
   });
+
+  it("holds an edit that names no language, under the default", async () => {
+    // The admin omits `?locale=` when editing the default language, so this is
+    // the ordinary path rather than an edge case. A localized document whose
+    // request names no locale still lands somewhere — the default language —
+    // and its pending change has to key there too. Treating "unnamed" as
+    // "unknown" refuses the hold and puts the edit straight on the live site,
+    // which is the opposite of what the author asked for.
+    const entries = await boot();
+    const id = await publishBoth(entries);
+
+    const res = await entries.updateEntry(
+      { collectionName: COLLECTION, entryId: id, overrideAccess: true },
+      { body: "edited with no locale named" }
+    );
+    expect(res.success).toBe(true);
+
+    expect(await pendingLocales(id)).toEqual(["en"]);
+    expect(await readBody(entries, id, "en")).toBe("en body");
+  });
 });

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1539,6 +1539,7 @@ export class CollectionMutationService extends BaseService {
           documentLocalized:
             (collection as { localized?: boolean }).localized === true,
           requestLocale: params.locale ?? null,
+          defaultLocale: this.localization?.defaultLocale ?? null,
         })
       );
     });
@@ -4504,6 +4505,7 @@ export class CollectionMutationService extends BaseService {
       namedStatus: args.namedStatus,
       liveStatus: args.liveStatus,
       requestLocale: args.requestLocale,
+      defaultLocale: this.localization?.defaultLocale ?? null,
     });
     return { hold, componentSchemas, draftLocale };
   }
@@ -5210,6 +5212,7 @@ export class CollectionMutationService extends BaseService {
       const draftLocaleKey = workingDraftLocale({
         documentLocalized,
         requestLocale: params.locale ?? null,
+        defaultLocale: this.localization?.defaultLocale ?? null,
       });
       // The component schemas reachable from this collection, resolved once off
       // the transaction (registry reads on the pooled connection, the same reason
@@ -5626,6 +5629,7 @@ export class CollectionMutationService extends BaseService {
             namedStatus: namesNoStatus ? undefined : transitionNextStatus,
             liveStatus: draftLiveStatus,
             requestLocale: params.locale ?? null,
+            defaultLocale: this.localization?.defaultLocale ?? null,
           }).hold;
 
           // TOCTOU-safe authorization: classify the transition against the

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -2719,6 +2719,7 @@ export class CollectionQueryService extends BaseService {
             documentLocalized:
               (collection as { localized?: boolean }).localized === true,
             requestLocale: params.locale ?? null,
+            defaultLocale: this.localization?.defaultLocale ?? null,
           })
         );
         // Mirror the write gate's eligibility check before overlaying: a

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -2647,10 +2647,6 @@ export class CollectionQueryService extends BaseService {
       // routeAuthorized` excludes an anonymous caller passing `?status=all`.
       const draftEligible =
         (collectionForStatus as { status?: boolean }).status === true &&
-        // The working-draft split is non-localized-only (the write path stores
-        // no draft for a localized collection), so skip the lookup there rather
-        // than issue a read that can only miss.
-        (collectionForStatus as { localized?: boolean }).localized !== true &&
         // Only when drafts are still enabled. If the collection turned drafts
         // off after a working draft was written, the write path no longer
         // promotes or deletes it, so surfacing it here would shadow the live

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -1094,6 +1094,7 @@ export class SingleMutationService extends BaseService {
                 namedStatus: (updatePayload as Record<string, unknown>).status,
                 liveStatus: singleLiveStatus,
                 requestLocale: writeLocale ?? null,
+                defaultLocale: this.localization?.defaultLocale ?? null,
               });
 
             // Publishing folds this language's pending change into the write.

--- a/packages/nextly/src/domains/versions/draft-hold.ts
+++ b/packages/nextly/src/domains/versions/draft-hold.ts
@@ -35,6 +35,15 @@ export interface DraftHoldInput {
    * key one under the wrong slot.
    */
   requestLocale?: string | null;
+  /**
+   * The app's default locale, for a request that named none.
+   *
+   * A write that names no locale still lands somewhere — the default language —
+   * so its pending change has to key there too. Without this, a localized
+   * document edited without an explicit locale is refused a hold and its edit
+   * goes live, which is the opposite of what the caller asked for.
+   */
+  defaultLocale?: string | null;
 }
 
 export interface DraftHoldDecision {
@@ -47,6 +56,7 @@ export function resolveDraftHold(input: DraftHoldInput): DraftHoldDecision {
   const draftLocale = workingDraftLocale({
     documentLocalized: input.documentLocalized,
     requestLocale: input.requestLocale,
+    defaultLocale: input.defaultLocale,
   });
   const eligible = isDraftSplitEligible({
     collectionHasStatus: input.collectionHasStatus,


### PR DESCRIPTION
PR 5b. Plan: `2026-08-19-plan-pr5-per-language-pending-admin.md`. The surface half; #1071 was the read.

**Browser verification found two engine defects that every test suite had passed over.** Both are fixed here, with tests that fail without the fix.

## What an author sees now

The language panel marks a language holding unpublished work, so it is visible from the list of languages without opening any of them. Publishing every language asks first and says how many carry pending changes.

## Defect 1 — an edit that named no language went straight to the live site

The admin omits `?locale=` when editing the default language. That is the ordinary path, not an edge case. `workingDraftLocale` returned `null` for a localized document with no locale named, and `resolveDraftHold` then refused to hold — by my own rule, added in #1065, that a write which cannot name its locale must not key a draft under the wrong slot.

The rule is right; the inputs were wrong. A write that names no locale still lands somewhere — the default language — so its pending change keys there too. Every call site now passes the app's default locale.

**Observed in the browser before it was understood:** a status-less PATCH with a body carrying no `status` at all, and the live row updated anyway.

## Defect 2 — a translated document's pending change was invisible to its own editor

The read overlay still carried the exclusion that #1066 removed from the write:

```
// The working-draft split is non-localized-only (the write path stores
// no draft for a localized collection), so skip the lookup there
(collectionForStatus as { localized?: boolean }).localized !== true &&
```

So the write held the edit and the editor could never see it. An author saves, their words are replaced by the published ones, and nothing says why.

**Why my own tests missed it:** #1066's per-language tests assert the LIVE value is untouched — that was their point. None of them asserted that a draft view returns the pending content. The new test does, per language, with the other language as the control.

## The UI decision, made by measuring rather than reasoning

I first appended the state to the row's text: `published · unpublished changes`. In the real 277px rail it rendered as **`publishe…`** — the phrase truncates before reaching the words that matter, so a sighted author saw nothing at all. The assumption that truncation was acceptable here was wrong, because this is the one fact in the row an author has to act on.

It is now a non-shrinking `CHANGES` chip, the same device the row already uses for `DEFAULT` and `RTL`, placed before the text that gives way. Measured after the change: every control sits inside the row (`overflowRight ≤ 0`), so nothing was pushed off — the failure this row has a documented history of.

The full phrase stays in `title` and in the header control's accessible name, where there is no width constraint.

**Not repeated into the Open button's accessible name.** I tried that and an existing test caught it: the state text is CSS-truncated but whole in the accessibility tree, so a screen reader already reads it from the row. Appending it to the button buried what the button does behind a state already stated.

## Verification

- Walked in the running product: published document, status-less edit, confirmed the draft row is stored under `en` with the edited value while the live companion row keeps the published one, and the panel shows `CHANGES` on that language and nothing on the others.
- `packages/nextly` integration: 88 files / 636 passed, 2+14 skipped, all three dialects for the draft suites.
- `packages/admin`: **15 failing across 4 files — exactly the pre-existing baseline** (`StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField`).
- Typecheck and lint clean; fallow `pass`, 0 introduced in all four categories.

## Also in here

`authors` in the playground gains `versions: { drafts: true }`. It is the only playground collection that is both localized and lifecycled, so without it this feature had no dev surface at all — which is why nobody had seen either defect.

## Deliberately NOT in here

**The Singles discard endpoint.** I started it and stopped: `discardWorkingDraft` calls `collectionsHandler.getEntry`, so it is collections-only, and a Singles discard needs a real implementation rather than a route alias. Adding a route pointing at a method that does not exist would have been worse than leaving it out. It needs its own PR alongside the Singles Discard button.
