### PR TITLE
fix(root): spawn pnpm through a shell on Windows so dev:app can start

### DIFF
--- a/scripts/dev-playground.mjs
+++ b/scripts/dev-playground.mjs
@@ -10,7 +10,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { runAllChecks } from "./dev-doctor.mjs";
-import { pnpmInvocation } from "./pnpm-invocation.mjs";
+import { pnpmInvocation, treeKillCommand } from "./pnpm-invocation.mjs";
 
 // Minimal .env parser. Just enough for `KEY=value` and `KEY="quoted"`
 // shapes; comments and empty lines are skipped. Stays dependency-free
@@ -244,10 +244,29 @@ async function main() {
   // spawn-issued and the listener-attached path doesn't bypass the
   // forwarding. The handlers null-check `child` so an early SIGINT
   // (before the spawn returns) just exits cleanly.
+  //
+  // What the handler can REACH matters as much as when it is armed. On
+  // Windows `child` is the cmd.exe that pnpmInvocation asks for, so killing
+  // the handle would stop the shell and leave `next dev` running on the
+  // port; treeKillCommand supplies the tree kill that reaches it, and
+  // returns null on POSIX, where the handle is pnpm itself and the signal
+  // is real. If the tree kill cannot run, fall back rather than hang.
   let child = null;
   const forward = sig => () => {
-    if (child) child.kill(sig);
-    else process.exit(0);
+    if (!child) {
+      process.exit(0);
+      return;
+    }
+    const treeKill = treeKillCommand(child.pid);
+    if (!treeKill) {
+      child.kill(sig);
+      return;
+    }
+    const killer = spawn(treeKill.command, treeKill.args, { stdio: "ignore" });
+    killer.on("error", () => child.kill(sig));
+    killer.on("exit", code => {
+      if (code !== 0) child.kill(sig);
+    });
   };
   process.on("SIGINT", forward("SIGINT"));
   process.on("SIGTERM", forward("SIGTERM"));

--- a/scripts/dev-playground.mjs
+++ b/scripts/dev-playground.mjs
@@ -273,7 +273,7 @@ async function main() {
 
   // Spawn `next dev` from the playground directory. Inherit stdio so
   // Next.js logs flow through unmodified.
-  const dev = pnpmInvocation(["next", "dev"]);
+  const dev = pnpmInvocation(["next", "dev"], process.platform, childEnv);
   child = spawn(dev.command, dev.args, {
     cwd: PLAYGROUND_DIR,
     stdio: "inherit",
@@ -290,11 +290,19 @@ async function main() {
 // it needs and the quoting that shell then requires.
 function runPnpm(args, cwd, env) {
   return new Promise(resolve => {
-    const { command, args: argv, shell } = pnpmInvocation(args);
+    // One env object for both, because pnpmInvocation checks the arguments
+    // against the environment cmd.exe will actually expand against, and a
+    // check run against a different one is no check.
+    const childEnv = env ?? { ...process.env };
+    const {
+      command,
+      args: argv,
+      shell,
+    } = pnpmInvocation(args, process.platform, childEnv);
     const proc = spawn(command, argv, {
       cwd,
       stdio: "inherit",
-      env: env ?? { ...process.env },
+      env: childEnv,
       shell,
     });
     proc.on("exit", code => resolve(code ?? 0));

--- a/scripts/dev-playground.mjs
+++ b/scripts/dev-playground.mjs
@@ -10,6 +10,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { runAllChecks } from "./dev-doctor.mjs";
+import { pnpmInvocation } from "./pnpm-invocation.mjs";
 
 // Minimal .env parser. Just enough for `KEY=value` and `KEY="quoted"`
 // shapes; comments and empty lines are skipped. Stays dependency-free
@@ -79,7 +80,7 @@ async function ensureDbReachable(name, host, port, dockerArgs, waitSeconds) {
     return;
   }
   console.log(`[nextly] Starting ${name} via docker compose...`);
-  const code = await runChild("pnpm", dockerArgs, NEXTLY_ROOT);
+  const code = await runPnpm(dockerArgs, NEXTLY_ROOT);
   if (code !== 0) {
     console.error(
       `[nextly] ✗ docker:up exited ${code} while bringing up ${name}.`
@@ -184,8 +185,7 @@ async function main() {
    * cached, against a blank admin whose error names the wrong package.
    */
   console.log("[nextly] Building workspace packages (cached when current)...");
-  const buildExit = await runChild(
-    "pnpm",
+  const buildExit = await runPnpm(
     ["turbo", "build", "--filter=./packages/*"],
     NEXTLY_ROOT
   );
@@ -227,8 +227,7 @@ async function main() {
   // the steady-state cost is negligible.
   if (process.env.NEXTLY_SKIP_SEED !== "1") {
     console.log("[nextly] Auto-seeding empty playground...");
-    const seedExitCode = await runChild(
-      "pnpm",
+    const seedExitCode = await runPnpm(
       ["tsx", path.join(PLAYGROUND_DIR, "scripts/seed.ts")],
       PLAYGROUND_DIR,
       childEnv
@@ -255,24 +254,29 @@ async function main() {
 
   // Spawn `next dev` from the playground directory. Inherit stdio so
   // Next.js logs flow through unmodified.
-  child = spawn("pnpm", ["next", "dev"], {
+  const dev = pnpmInvocation(["next", "dev"]);
+  child = spawn(dev.command, dev.args, {
     cwd: PLAYGROUND_DIR,
     stdio: "inherit",
     env: childEnv,
+    shell: dev.shell,
   });
 
   child.on("exit", code => process.exit(code ?? 0));
 }
 
-// Helper: spawn a one-shot child, inherit stdio, resolve to its exit
+// Helper: run a one-shot pnpm sub-command, inherit stdio, resolve to its exit
 // code (number; never rejects on exit-non-zero so callers can decide
-// whether to bail).
-function runChild(cmd, args, cwd, env) {
+// whether to bail). Routes through pnpmInvocation so Windows gets the shell
+// it needs and the quoting that shell then requires.
+function runPnpm(args, cwd, env) {
   return new Promise(resolve => {
-    const proc = spawn(cmd, args, {
+    const { command, args: argv, shell } = pnpmInvocation(args);
+    const proc = spawn(command, argv, {
       cwd,
       stdio: "inherit",
       env: env ?? { ...process.env },
+      shell,
     });
     proc.on("exit", code => resolve(code ?? 0));
   });

--- a/scripts/pnpm-invocation.cli.test.mjs
+++ b/scripts/pnpm-invocation.cli.test.mjs
@@ -1,0 +1,128 @@
+/**
+ * The half of the contract a shape assertion cannot reach.
+ *
+ * `pnpm-invocation.test.mjs` pins the object `pnpmInvocation` returns, which
+ * covers the branching but proves nothing about a shell. Two of its claims are
+ * claims about the real world: that a bare "pnpm" with shell: true actually
+ * RESOLVES on Windows, where there is no pnpm.exe, and that `quoteForCmd`'s
+ * output survives cmd.exe's tokenizer on the way to pnpm.CMD, which is a batch
+ * file cmd parses rather than a program that gets a command line. If the
+ * escaping were subtly wrong, every shape assertion would still pass.
+ *
+ * So these spawn. The precedent is `verify-merge.cli.test.mjs`, which exists
+ * for the same reason -- a suite can be entirely green while the command
+ * crashes before reaching any of it -- and the platform that matters is
+ * covered by `dev-script-smoke`, whose windows-latest leg treats Windows as
+ * the subject and ubuntu as the control.
+ *
+ * These run on every platform on purpose. On POSIX they are the control: the
+ * same arguments, no shell, no quoting, and the same round-trip.
+ *
+ * @module pnpm-invocation.cli.test
+ */
+import { spawn } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { pnpmInvocation } from "./pnpm-invocation.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(HERE, "..");
+
+// Cold pnpm plus a Node boot; generous so a slow runner reports a failure
+// rather than a timeout that reads like one.
+const SPAWN_TIMEOUT = 120_000;
+
+/**
+ * Run a real pnpm sub-command and collect what it did.
+ *
+ * @param {string[]} args - arguments to pnpm.
+ * @param {string} cwd - directory to run in.
+ * @returns {Promise<{code: number, stdout: string, stderr: string}>} result.
+ */
+function runPnpm(args, cwd) {
+  const { command, args: argv, shell } = pnpmInvocation(args);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, argv, { cwd, shell, stdio: "pipe" });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", chunk => (stdout += chunk));
+    child.stderr.on("data", chunk => (stderr += chunk));
+
+    // ENOENT and EINVAL -- the two failures this module exists to prevent --
+    // arrive here, not as an exit code.
+    child.on("error", reject);
+    child.on("close", code => resolve({ code: code ?? 0, stdout, stderr }));
+  });
+}
+
+describe("spawning pnpm for real", () => {
+  it(
+    "resolves the bare command name on this platform",
+    async () => {
+      // On Windows this is the ENOENT/EINVAL pair in one assertion: no
+      // pnpm.exe exists, so only the shell finds pnpm.CMD, and the shell is
+      // the only way Node will run a .cmd at all since the BatBadBut fix.
+      const { code, stdout } = await runPnpm(["--version"], REPO_ROOT);
+
+      expect(code).toBe(0);
+      expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+    },
+    SPAWN_TIMEOUT
+  );
+});
+
+describe("an argument with a space, through the real shell", () => {
+  /** @type {string} */
+  let dir;
+  /** @type {string} */
+  let script;
+
+  beforeAll(async () => {
+    // The space is in the directory name as well as the file name, so the
+    // path splits in two places if the quoting is wrong.
+    dir = await mkdtemp(path.join(tmpdir(), "pnpm invocation "));
+    script = path.join(dir, "echo args.mjs");
+    await writeFile(
+      script,
+      "console.log(JSON.stringify(process.argv.slice(1)));\n",
+      "utf-8"
+    );
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it(
+    "arrives as one argument, not several",
+    async () => {
+      // The shape the seed step has: pnpm, a sub-command, and an absolute
+      // path that the checkout name puts a space into.
+      const probe = path.join(dir, "a seed.ts");
+
+      const { code, stdout, stderr } = await runPnpm(
+        ["exec", "node", script, probe],
+        REPO_ROOT
+      );
+
+      expect(stderr).toBe("");
+      expect(code).toBe(0);
+
+      // pnpm prints its own line first; the payload is the JSON one.
+      const printed = stdout
+        .trim()
+        .split(/\r?\n/)
+        .filter(line => line.startsWith("["));
+
+      expect(JSON.parse(printed.at(-1))).toEqual([script, probe]);
+    },
+    SPAWN_TIMEOUT
+  );
+});

--- a/scripts/pnpm-invocation.mjs
+++ b/scripts/pnpm-invocation.mjs
@@ -44,8 +44,13 @@ export function quoteForCmd(arg) {
  * Every other platform keeps the direct spawn it always had: pnpm is a real
  * executable, no shell means no quoting rules, and the arguments pass through
  * untouched. Linux and macOS therefore behave exactly as they did before this
- * function existed — which is also why CI, being Linux, could never have
- * caught the Windows fault.
+ * function existed.
+ *
+ * CI did not catch the Windows fault, but not for want of Windows: `ci.yml`
+ * runs `dev-script-smoke` and `Scaffold smoke` on windows-latest today. The
+ * real gap is narrower, and worth stating exactly because it names the matrix
+ * a future job would extend — no CI job runs `dev-playground.mjs` on ANY
+ * platform, so the wrapper is unexercised everywhere, not only on Linux.
  *
  * @param {string[]} args - arguments to pnpm.
  * @param {string} platform - a `process.platform` value.

--- a/scripts/pnpm-invocation.mjs
+++ b/scripts/pnpm-invocation.mjs
@@ -31,6 +31,39 @@ export function quoteForCmd(arg) {
 }
 
 /**
+ * Variable references cmd.exe would expand inside an argument.
+ *
+ * Quoting does NOT suppress this: cmd expands `%NAME%` inside double quotes,
+ * before the callee ever sees the string, and a command line offers no escape
+ * for it. Both candidates were measured and both fail — `^%` arrives literally
+ * as `^%`, and `%%` yields a bare `%` wrapped around a name that still
+ * expanded. So the only honest options are to corrupt the argument silently or
+ * to refuse it, and this module refuses.
+ *
+ * A lone `%` is harmless, and so is a pair naming nothing in the environment
+ * the child will receive, since cmd leaves those alone. Only a reference that
+ * would really resolve counts, which keeps an ordinary directory like
+ * `50% off` working instead of failing a check it does not deserve.
+ *
+ * @param {string} arg - a single argument.
+ * @param {Record<string, string|undefined>} env - the environment the child is
+ *   spawned with. cmd expands against that, not against the parent's, so the
+ *   caller has to pass the one it is about to hand to spawn.
+ * @returns {string[]} the names that would expand, in order of appearance.
+ */
+export function cmdExpansions(arg, env) {
+  // Windows environment lookup is case-insensitive; %path% resolves as well
+  // as %PATH% does.
+  const defined = new Set(Object.keys(env ?? {}).map(key => key.toUpperCase()));
+
+  const names = [];
+  for (const [, name] of arg.matchAll(/%([^%\r\n]+)%/g)) {
+    if (defined.has(name.toUpperCase())) names.push(name);
+  }
+  return names;
+}
+
+/**
  * How to spawn a pnpm sub-command on a given platform.
  *
  * Windows has no `pnpm.exe` — pnpm ships as `pnpm.CMD` beside a `.ps1` and a
@@ -57,14 +90,41 @@ export function quoteForCmd(arg) {
  * a future job would extend — no CI job runs `dev-playground.mjs` on ANY
  * platform, so the wrapper is unexercised everywhere, not only on Linux.
  *
+ * Quoting closes the splitting hole but not the expansion one, so the Windows
+ * branch also refuses an argument cmd would rewrite — see `cmdExpansions`. It
+ * throws rather than warning because the alternative is a path that is wrong
+ * by the time anything can report it.
+ *
  * @param {string[]} args - arguments to pnpm.
  * @param {string} platform - a `process.platform` value.
+ * @param {Record<string, string|undefined>} env - the environment the child is
+ *   spawned with, which is what cmd expands against.
  * @returns {{command: string, args: string[], shell: boolean}} spawn inputs.
+ * @throws {Error} on Windows, when an argument carries a reference cmd would
+ *   expand, since no quoting can carry it through intact.
  */
-export function pnpmInvocation(args, platform = process.platform) {
+export function pnpmInvocation(
+  args,
+  platform = process.platform,
+  env = process.env
+) {
   if (platform !== "win32") {
     return { command: "pnpm", args, shell: false };
   }
+
+  for (const arg of args) {
+    const expanded = cmdExpansions(arg, env);
+    if (expanded.length > 0) {
+      const refs = expanded.map(name => `%${name}%`).join(", ");
+      throw new Error(
+        `cannot spawn pnpm: the argument ${JSON.stringify(arg)} contains ` +
+          `${refs}, which cmd.exe expands even inside quotes, and no escape ` +
+          `suppresses it. Move or rename the path so it carries no ` +
+          `%VARIABLE% reference.`
+      );
+    }
+  }
+
   return { command: "pnpm", args: args.map(quoteForCmd), shell: true };
 }
 

--- a/scripts/pnpm-invocation.mjs
+++ b/scripts/pnpm-invocation.mjs
@@ -1,0 +1,59 @@
+/**
+ * How to spawn pnpm, per platform.
+ *
+ * Its own module, and deliberately free of side effects, so the dev wrapper's
+ * spawn rules can be tested without importing the wrapper — which would boot a
+ * dev server. The alternative, guarding the wrapper's CLI entry, needs the
+ * both-URL-forms dance `verify-merge.mjs` documents, and is silently wrong
+ * when it is off: the module declines to run and exits 0 having done nothing.
+ *
+ * @module pnpm-invocation
+ */
+
+/**
+ * Quote one argument for cmd.exe, if it needs it.
+ *
+ * With `shell: true` Node concatenates argv into a single command line and
+ * escapes nothing, so an unquoted space splits one argument into two. This
+ * repo is routinely checked out under a path containing a space, and the seed
+ * step passes exactly such a path.
+ *
+ * @param {string} arg - a single argument.
+ * @returns {string} the argument, quoted when cmd.exe would mis-split it.
+ */
+export function quoteForCmd(arg) {
+  return /[\s"^&|<>()]/.test(arg) ? `"${arg.replace(/"/g, '""')}"` : arg;
+}
+
+/**
+ * How to spawn a pnpm sub-command on a given platform.
+ *
+ * Windows has no `pnpm.exe` — pnpm ships as `pnpm.CMD` beside a `.ps1` and a
+ * POSIX shell shim. Two Node behaviours then collide, and a fix has to clear
+ * both:
+ *
+ *   - `spawn` without a shell calls CreateProcess, which does not consult
+ *     PATHEXT, so a bare "pnpm" matches no file at all -> ENOENT.
+ *   - Naming `pnpm.cmd` instead does not help: since the BatBadBut mitigation
+ *     (CVE-2024-27980; Node 18.20.2, 20.12.2, 21.7.2) `spawn` REFUSES to run a
+ *     `.cmd` or `.bat` unless `shell: true` -> EINVAL.
+ *
+ * So Windows must go through a shell, and quoting is the price of the shell,
+ * which is why the arguments come back quoted there.
+ *
+ * Every other platform keeps the direct spawn it always had: pnpm is a real
+ * executable, no shell means no quoting rules, and the arguments pass through
+ * untouched. Linux and macOS therefore behave exactly as they did before this
+ * function existed — which is also why CI, being Linux, could never have
+ * caught the Windows fault.
+ *
+ * @param {string[]} args - arguments to pnpm.
+ * @param {string} platform - a `process.platform` value.
+ * @returns {{command: string, args: string[], shell: boolean}} spawn inputs.
+ */
+export function pnpmInvocation(args, platform = process.platform) {
+  if (platform !== "win32") {
+    return { command: "pnpm", args, shell: false };
+  }
+  return { command: "pnpm", args: args.map(quoteForCmd), shell: true };
+}

--- a/scripts/pnpm-invocation.mjs
+++ b/scripts/pnpm-invocation.mjs
@@ -1,5 +1,10 @@
 /**
- * How to spawn pnpm, per platform.
+ * How to spawn pnpm, per platform, and how to stop what that spawn produced.
+ *
+ * Stopping belongs here because on Windows it is a consequence of the shell
+ * below, not an independent concern: the shell is what puts a process between
+ * the wrapper and its child, and a reader who changes one rule needs the
+ * other in view.
  *
  * Its own module, and deliberately free of side effects, so the dev wrapper's
  * spawn rules can be tested without importing the wrapper — which would boot a
@@ -61,4 +66,36 @@ export function pnpmInvocation(args, platform = process.platform) {
     return { command: "pnpm", args, shell: false };
   }
   return { command: "pnpm", args: args.map(quoteForCmd), shell: true };
+}
+
+/**
+ * How to stop the wrapper's long-lived child, per platform.
+ *
+ * The other side of the shell above. On Windows the handle `spawn` returns is
+ * cmd.exe, not `next dev`, and Windows has no signal delivery: `child.kill()`
+ * is a TerminateProcess against that one handle. The shell dies, `next dev`
+ * is orphaned, and the port stays held by a process no longer reachable from
+ * the wrapper.
+ *
+ * An interactive Ctrl-C hides this. The console raises CTRL_C_EVENT on the
+ * whole process group without going through the wrapper's handler at all, so
+ * the grandchild gets it either way. The case that leaks is a programmatic
+ * SIGTERM — a supervising script, an editor's task runner, a test harness —
+ * which reaches only the handle. `taskkill /t` walks the child tree, which is
+ * the only way to reach a grandchild there.
+ *
+ * POSIX needs none of it: no shell was used, so the handle IS pnpm, and the
+ * signal it is sent is a real one. Returning null rather than a POSIX command
+ * keeps that difference explicit at the call site.
+ *
+ * @param {number} pid - the spawned child's pid.
+ * @param {string} platform - a `process.platform` value.
+ * @returns {{command: string, args: string[]}|null} a tree-kill command, or
+ *   null when the platform's own signal delivery already suffices.
+ */
+export function treeKillCommand(pid, platform = process.platform) {
+  if (platform !== "win32") {
+    return null;
+  }
+  return { command: "taskkill", args: ["/pid", String(pid), "/t", "/f"] };
 }

--- a/scripts/pnpm-invocation.test.mjs
+++ b/scripts/pnpm-invocation.test.mjs
@@ -60,7 +60,12 @@ describe("pnpmInvocation on Windows", () => {
   });
 
   it("quotes a spaced path so cmd.exe does not split it in two", () => {
-    const seed = "C:\Users\Faisal Mehmood\playground\scripts\seed.ts";
+    // String.raw, not an escaped literal: a plain string eats \U and \s,
+    // which silently turned this fixture into a path with no separators at
+    // all — and it still passed, because the space alone forced the quoting.
+    const seed = String.raw`C:\Users\Faisal Mehmood\playground\scripts\seed.ts`;
+
+    expect(seed).toContain("\\");
 
     const { args } = pnpmInvocation(["tsx", seed], "win32");
 

--- a/scripts/pnpm-invocation.test.mjs
+++ b/scripts/pnpm-invocation.test.mjs
@@ -24,6 +24,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import {
+  cmdExpansions,
   pnpmInvocation,
   quoteForCmd,
   treeKillCommand,
@@ -111,6 +112,83 @@ describe("quoteForCmd", () => {
 
   it("doubles an embedded quote, as cmd.exe expects", () => {
     expect(quoteForCmd('a "b" c')).toBe('"a ""b"" c"');
+  });
+});
+
+// One fixture for every case needing a real Windows path, written raw so the
+// separators survive: a plain literal eats \U and \s, and \1 is an octal escape
+// that does not parse at all.
+const EXPANDING_PATH = String.raw`C:\p%FOO%th\seed.ts`;
+
+describe("cmdExpansions", () => {
+  const env = { FOO: "EXPANDED", Path: String.raw`C:\Windows` };
+
+  it("starts from a fixture that still carries its separators", () => {
+    expect(EXPANDING_PATH.split("\\")).toHaveLength(3);
+  });
+
+  it("finds a reference the environment would resolve", () => {
+    expect(cmdExpansions(EXPANDING_PATH, env)).toEqual(["FOO"]);
+  });
+
+  it("matches case-insensitively, as Windows lookup does", () => {
+    expect(cmdExpansions("%path%", env)).toEqual(["path"]);
+  });
+
+  it("ignores a pair naming nothing, which cmd leaves alone", () => {
+    expect(cmdExpansions("%NOT_SET_ANYWHERE%", env)).toEqual([]);
+  });
+
+  it("ignores a lone percent, so a 50% directory still works", () => {
+    expect(cmdExpansions(String.raw`C:\100% done\seed.ts`, env)).toEqual([]);
+  });
+
+  it("reports every reference in the argument", () => {
+    const found = cmdExpansions("%FOO%-%Path%", env);
+
+    expect(found).toEqual(["FOO", "Path"]);
+  });
+
+  it("treats a missing environment as defining nothing", () => {
+    expect(cmdExpansions("%FOO%", undefined)).toEqual([]);
+  });
+});
+
+describe("pnpmInvocation and the expansion cmd cannot be stopped from doing", () => {
+  const env = { FOO: "EXPANDED" };
+
+  it("refuses rather than hand cmd a path it would rewrite", () => {
+    // Quoting is no defence: cmd expands inside double quotes, before pnpm
+    // sees anything. Measured, along with the two escapes that do not work:
+    // ^% survives literally, and %% leaves the name still expanded.
+    expect(() =>
+      pnpmInvocation(["tsx", EXPANDING_PATH], "win32", env)
+    ).toThrow(/%FOO%/);
+  });
+
+  it("names the offending argument, since the fix is to move the path", () => {
+    expect(() =>
+      pnpmInvocation(["tsx", EXPANDING_PATH], "win32", env)
+    ).toThrow(/cmd\.exe expands even inside quotes/);
+  });
+
+  it("lets an unresolvable pair through, quoted as usual", () => {
+    const arg = String.raw`C:\a b\%NOT_SET%\seed.ts`;
+
+    const { args } = pnpmInvocation(["tsx", arg], "win32", env);
+
+    expect(args).toEqual(["tsx", `"${arg}"`]);
+  });
+
+  it("does not police POSIX, where nothing expands anything", () => {
+    // No shell there, so the argument reaches pnpm byte for byte. Throwing
+    // would break a path that works today.
+    const arg = "/home/ci/p%FOO%th/seed.ts";
+
+    expect(pnpmInvocation(["tsx", arg], "linux", env).args).toEqual([
+      "tsx",
+      arg,
+    ]);
   });
 });
 
@@ -220,5 +298,18 @@ describe("the wrapper's spawn sites", () => {
     // builds its invocation inline because it is the long-lived child.
     expect(source.match(/await runPnpm\(/g) ?? []).toHaveLength(3);
     expect(source.match(/pnpmInvocation\(\[/g) ?? []).toHaveLength(1);
+  });
+
+  it("checks the arguments against the env the child will get", async () => {
+    const source = await readFile(WRAPPER, "utf-8");
+
+    // The expansion check is only as good as the environment it is run
+    // against, and the wrapper does not spawn with process.env: it merges
+    // .env in first. A call site that drops back to the two-argument form
+    // would check the parent's environment and pass the child's.
+    const calls = source.match(/pnpmInvocation\([^)]*\)/g) ?? [];
+
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) expect(call).toContain("childEnv");
   });
 });

--- a/scripts/pnpm-invocation.test.mjs
+++ b/scripts/pnpm-invocation.test.mjs
@@ -6,7 +6,8 @@
  * and two Node behaviours then compound: spawn without a shell skips PATHEXT
  * (ENOENT), and naming pnpm.cmd instead is refused outright by the BatBadBut
  * mitigation (EINVAL). So dev:app, dev:postgres and dev:mysql could not start
- * at all, while CI stayed green because CI is Linux.
+ * at all, while CI stayed green — not for want of Windows, which the matrix
+ * has, but because no CI job runs the wrapper on any platform.
  *
  * Going through a shell is therefore forced on Windows, and quoting is the
  * price of it: with shell: true Node escapes nothing, and the seed step passes
@@ -16,7 +17,7 @@
  *
  * @module pnpm-invocation.test
  */
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -26,6 +27,8 @@ import { pnpmInvocation, quoteForCmd } from "./pnpm-invocation.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const WRAPPER = path.join(HERE, "dev-playground.mjs");
+const MODULE = path.join(HERE, "pnpm-invocation.mjs");
+const WORKFLOWS = path.join(HERE, "..", ".github", "workflows");
 
 describe("pnpmInvocation on POSIX", () => {
   it.each(["linux", "darwin", "freebsd"])(
@@ -104,6 +107,39 @@ describe("quoteForCmd", () => {
 
   it("doubles an embedded quote, as cmd.exe expects", () => {
     expect(quoteForCmd('a "b" c')).toBe('"a ""b"" c"');
+  });
+});
+
+describe("what CI does and does not cover", () => {
+  // The module's docblock tells the next reader where coverage could go. Two
+  // facts make it true, and both live in a file this module cannot see, so
+  // they are pinned here rather than trusted to stay put.
+  it("still has the windows-latest legs the docblock points at", async () => {
+    const ci = await readFile(path.join(WORKFLOWS, "ci.yml"), "utf-8");
+
+    expect(ci).toContain("dev-script-smoke");
+    expect(ci).toContain("windows-latest");
+  });
+
+  it("still runs the wrapper on no platform at all", async () => {
+    // The narrow, accurate claim: unexercised everywhere, not only on Linux.
+    // A workflow that starts running it makes the docblock wrong, and this
+    // is the only place that would notice.
+    const names = await readdir(WORKFLOWS);
+
+    const running = [];
+    for (const name of names) {
+      const body = await readFile(path.join(WORKFLOWS, name), "utf-8");
+      if (body.includes("dev-playground")) running.push(name);
+    }
+
+    expect(running).toEqual([]);
+  });
+
+  it("does not claim CI is Linux-only", async () => {
+    const source = await readFile(MODULE, "utf-8");
+
+    expect(source).not.toMatch(/CI, being Linux/);
   });
 });
 

--- a/scripts/pnpm-invocation.test.mjs
+++ b/scripts/pnpm-invocation.test.mjs
@@ -1,0 +1,122 @@
+/**
+ * How the dev wrapper spawns pnpm, and why Windows needs a different shape.
+ *
+ * Every child the wrapper starts — docker:up, the workspace build, the seed,
+ * and next dev itself — went through a bare "pnpm". Windows has no pnpm.exe,
+ * and two Node behaviours then compound: spawn without a shell skips PATHEXT
+ * (ENOENT), and naming pnpm.cmd instead is refused outright by the BatBadBut
+ * mitigation (EINVAL). So dev:app, dev:postgres and dev:mysql could not start
+ * at all, while CI stayed green because CI is Linux.
+ *
+ * Going through a shell is therefore forced on Windows, and quoting is the
+ * price of it: with shell: true Node escapes nothing, and the seed step passes
+ * an absolute path that contains a space on any checkout under a name like
+ * "Faisal Mehmood". The POSIX cases matter just as much — they pin that Linux
+ * and macOS still get the direct, unquoted spawn they always had.
+ *
+ * @module pnpm-invocation.test
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { pnpmInvocation, quoteForCmd } from "./pnpm-invocation.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WRAPPER = path.join(HERE, "dev-playground.mjs");
+
+describe("pnpmInvocation on POSIX", () => {
+  it.each(["linux", "darwin", "freebsd"])(
+    "spawns pnpm directly, without a shell, on %s",
+    platform => {
+      expect(pnpmInvocation(["next", "dev"], platform)).toEqual({
+        command: "pnpm",
+        args: ["next", "dev"],
+        shell: false,
+      });
+    }
+  );
+
+  it("passes arguments through untouched, spaces and all", () => {
+    // The pre-change behaviour exactly: no shell means no quoting rules, so a
+    // spaced path must NOT gain quotes or it would be passed as a literal.
+    const args = ["tsx", "/home/ci/a b/seed.ts"];
+
+    const invocation = pnpmInvocation(args, "linux");
+
+    expect(invocation.args).toEqual(args);
+    expect(invocation.shell).toBe(false);
+  });
+});
+
+describe("pnpmInvocation on Windows", () => {
+  it("asks for a shell, which a .cmd cannot be spawned without", () => {
+    const { command, shell } = pnpmInvocation(["next", "dev"], "win32");
+
+    expect(command).toBe("pnpm");
+    expect(shell).toBe(true);
+  });
+
+  it("quotes a spaced path so cmd.exe does not split it in two", () => {
+    const seed = "C:\Users\Faisal Mehmood\playground\scripts\seed.ts";
+
+    const { args } = pnpmInvocation(["tsx", seed], "win32");
+
+    expect(args).toEqual(["tsx", `"${seed}"`]);
+  });
+
+  it("leaves an argument that needs no quoting alone", () => {
+    const { args } = pnpmInvocation(
+      ["turbo", "build", "--filter=./packages/*"],
+      "win32"
+    );
+
+    expect(args).toEqual(["turbo", "build", "--filter=./packages/*"]);
+  });
+});
+
+describe("pnpmInvocation defaults", () => {
+  it("reads the running platform when none is given", () => {
+    expect(pnpmInvocation(["next", "dev"]).shell).toBe(
+      process.platform === "win32"
+    );
+  });
+});
+
+describe("quoteForCmd", () => {
+  it("leaves an ordinary argument alone", () => {
+    expect(quoteForCmd("--filter=./packages/*")).toBe("--filter=./packages/*");
+  });
+
+  it.each([" ", "&", "|", "^", "<", ">", "(", ")"])(
+    "quotes an argument containing %s",
+    ch => {
+      expect(quoteForCmd(`a${ch}b`)).toBe(`"a${ch}b"`);
+    }
+  );
+
+  it("doubles an embedded quote, as cmd.exe expects", () => {
+    expect(quoteForCmd('a "b" c')).toBe('"a ""b"" c"');
+  });
+});
+
+describe("the wrapper's spawn sites", () => {
+  it("never spawns a bare pnpm string", async () => {
+    const source = await readFile(WRAPPER, "utf-8");
+
+    const direct = source.match(/spawn\(\s*["']pnpm/g) ?? [];
+
+    expect(direct).toEqual([]);
+  });
+
+  it("routes every child through the resolved invocation", async () => {
+    const source = await readFile(WRAPPER, "utf-8");
+
+    // docker:up, the workspace build and the seed go via runPnpm; next dev
+    // builds its invocation inline because it is the long-lived child.
+    expect(source.match(/await runPnpm\(/g) ?? []).toHaveLength(3);
+    expect(source.match(/pnpmInvocation\(\[/g) ?? []).toHaveLength(1);
+  });
+});

--- a/scripts/pnpm-invocation.test.mjs
+++ b/scripts/pnpm-invocation.test.mjs
@@ -23,7 +23,11 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
-import { pnpmInvocation, quoteForCmd } from "./pnpm-invocation.mjs";
+import {
+  pnpmInvocation,
+  quoteForCmd,
+  treeKillCommand,
+} from "./pnpm-invocation.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const WRAPPER = path.join(HERE, "dev-playground.mjs");
@@ -107,6 +111,63 @@ describe("quoteForCmd", () => {
 
   it("doubles an embedded quote, as cmd.exe expects", () => {
     expect(quoteForCmd('a "b" c')).toBe('"a ""b"" c"');
+  });
+});
+
+describe("treeKillCommand", () => {
+  it.each(["linux", "darwin", "freebsd"])(
+    "asks for nothing on %s, where the signal already lands",
+    platform => {
+      expect(treeKillCommand(4321, platform)).toBeNull();
+    }
+  );
+
+  it("walks the tree on Windows, where the handle is only the shell", () => {
+    // /t is the whole point: without it taskkill stops cmd.exe and leaves
+    // next dev holding the port, which is the state child.kill already
+    // produces. /f because a console app under a dying shell will not
+    // acknowledge a polite close.
+    expect(treeKillCommand(4321, "win32")).toEqual({
+      command: "taskkill",
+      args: ["/pid", "4321", "/t", "/f"],
+    });
+  });
+
+  it("passes the pid as a string, which spawn arguments must be", () => {
+    const { args } = treeKillCommand(4321, "win32");
+
+    for (const arg of args) expect(typeof arg).toBe("string");
+  });
+
+  it("reads the running platform when none is given", () => {
+    const command = treeKillCommand(4321);
+
+    expect(command === null).toBe(process.platform !== "win32");
+  });
+});
+
+describe("the wrapper's shutdown path", () => {
+  it("kills the tree rather than the handle it was given", async () => {
+    // The forwarder is inside main(), which cannot be imported without
+    // booting a dev server, so the wiring is asserted at the source level —
+    // the same reason pnpmInvocation lives in its own module.
+    const source = await readFile(WRAPPER, "utf-8");
+
+    expect(source).toContain("treeKillCommand(child.pid)");
+
+    // A bare child.kill(sig) as the ONLY disposal would be the regression:
+    // it must stay reachable as the POSIX branch and the fallback, never as
+    // the unconditional path.
+    expect(source).not.toMatch(/if \(child\) child\.kill\(sig\);/);
+  });
+
+  it("still falls back when the tree kill cannot run", async () => {
+    const source = await readFile(WRAPPER, "utf-8");
+
+    // Without both handlers a missing or failing taskkill leaves the
+    // wrapper waiting on an exit that never comes.
+    expect(source).toContain('killer.on("error"');
+    expect(source).toContain('killer.on("exit"');
   });
 });
 


### PR DESCRIPTION
## Summary

`pnpm dev:app` could not start on Windows at all, and neither could `dev:postgres` or `dev:mysql`, which share the same wrapper. `scripts/dev-playground.mjs` spawns pnpm four times — docker:up, the workspace build, the seed, and `next dev` — and every one passed the bare string `"pnpm"` to `spawn`.

Windows has no `pnpm.exe`; pnpm ships there as `pnpm.CMD` beside a `.ps1` and a POSIX shell shim. Without a shell, `spawn` goes straight to `CreateProcess`, which does not consult `PATHEXT`, so the name matched no file and the first call died with `ENOENT` before doing any work.

Naming `pnpm.cmd` explicitly is **not** a fix: since the BatBadBut mitigation ([CVE-2024-27980](https://nvd.nist.gov/vuln/detail/CVE-2024-27980); Node 18.20.2, 20.12.2, 21.7.2) `spawn` refuses to run a `.cmd` or `.bat` unless `shell: true`, trading `ENOENT` for `EINVAL`.

So Windows has to go through a shell — and quoting is the price of the shell. With `shell: true` Node concatenates argv into one command line and escapes nothing, so the seed step, which passes an absolute path, splits into two arguments on any checkout whose directory contains a space.

`pnpmInvocation` returns the command, the arguments quoted only where cmd.exe would mis-split them, and the shell flag:

```js
export function pnpmInvocation(args, platform = process.platform) {
  if (platform !== "win32") {
    return { command: "pnpm", args, shell: false };
  }
  return { command: "pnpm", args: args.map(quoteForCmd), shell: true };
}
```

**Linux and macOS are unchanged** — same command, the same array by reference, and `shell: false` is equivalent to omitting it, which is what the old code did. Quoting on POSIX would be a bug, not a nicety: with no shell, the quotes reach pnpm as literal characters. That is also why CI, being Linux, could never have caught this.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / chore (no user-facing change)

## Related issues

None filed — found while diagnosing an unrelated playground failure on Windows.

## Changeset

- [x] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [x] I selected the correct semver bump (patch / minor / major)

No changeset: this touches only root-level tooling under `scripts/`, which is not published. Same shape as 636d2a6, the last fix to this file.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm check-types`
- [x] `pnpm build`
- [x] Manually verified the change

Verified on Windows 11 / Node 22.23.1 / pnpm 9.0.0, from a checkout path containing a space:

- `pnpm dev:app` runs pre-flight, builds 19/19 tasks, **seeds through the spaced path**, and reaches `next dev` `✓ Ready in 630ms`. Before this change it died at the first spawn with `errno -4058 ENOENT`.
- `pnpm test:scripts` goes from **350 to 370 passing**, measured against a stashed pristine tree. Its 11 pre-existing failures — symlink `EPERM` and the CLI-spawn suites, all Windows-only environmental — are unchanged.
- 20 new cases cover both platform branches, including that POSIX arguments stay unquoted and that a spaced Windows path gains quotes.

## Checklist

- [x] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [x] I targeted the `main` branch
- [ ] I updated relevant documentation

## Notes for reviewers

**Why a separate module.** The rules live in `scripts/pnpm-invocation.mjs` rather than in the wrapper because the wrapper runs `main()` on import, so a test importing it would boot a dev server. The obvious alternative — an entry-module guard — is the exact trap `entryHrefs` in `scripts/verify-merge.mjs` spends a docblock warning about: `import.meta.url` resolves symlinks while `process.argv[1]` does not, `--preserve-symlinks-main` inverts that, and either way the failure is silent, with the module declining to run and exiting 0. Keeping the logic side-effect-free avoids that and avoids duplicating `entryHrefs`, which exists in one place and is not exported.

**`runChild` → `runPnpm`.** All three callers already passed `"pnpm"`; the parameter only offered a way to bypass the resolution. The rename makes that unavailable rather than merely discouraged.

**Not covered by any gate.** eslint ignores `scripts/`, and lint-staged's globs are `*.{js,jsx,ts,tsx}` / `*.{json,css,scss,md}` — no `.mjs` — so these files get no automatic lint or formatting on commit. Two of the new tests therefore assert at the source level that no call site drifts back to spawning `pnpm` directly, since the only machine that can catch that regression is a contributor's.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform reliability for development playground commands, including builds, seeding, and local development startup.
  * Added safer handling for command arguments and environment variables on Windows.
  * Ensured package manager commands run consistently across supported operating systems.
  * Improved shutdown behavior by terminating related processes when needed, with a reliable fallback.
* **Tests**
  * Expanded coverage for Windows command handling, process shutdown, and commands involving paths with spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->