### PR TITLE
refactor(admin): draw the signed-out screens with two shared cards

### DIFF
--- a/.changeset/auth-screens-share-their-cards.md
+++ b/.changeset/auth-screens-share-their-cards.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The signed-out screens are drawn by two shared cards instead of fifteen
+hand-written copies. Sign in, sign up, first-run setup, forgot password, reset
+password, accept invite and verify email looked alike by repetition, so the
+logo, the mount fade and the branded product name could drift apart on any one
+of them. Nothing changes on screen.

--- a/packages/admin/src/components/features/auth-accept-invite/index.tsx
+++ b/packages/admin/src/components/features/auth-accept-invite/index.tsx
@@ -102,15 +102,13 @@ export function AcceptInvite({ searchParams }: AcceptInviteProps) {
         title="Invalid Link"
         description="This invite link is missing its token. Ask whoever invited you to send the link again."
       >
-        <div className="mt-2 text-left">
-          <Link
-            href={ROUTES.LOGIN}
-            className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
-          >
-            Go to Sign In
-            <ArrowRight className="h-4 w-4 ml-2" />
-          </Link>
-        </div>
+        <Link
+          href={ROUTES.LOGIN}
+          className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
+        >
+          Go to Sign In
+          <ArrowRight className="h-4 w-4 ml-2" />
+        </Link>
       </AuthStatusCard>
     );
   }
@@ -122,15 +120,13 @@ export function AcceptInvite({ searchParams }: AcceptInviteProps) {
         title="Account Ready"
         description="Your password is set and your account is active. You can now sign in."
       >
-        <div className="mt-2 text-left">
-          <Link
-            href={ROUTES.LOGIN}
-            className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
-          >
-            Go to Sign In
-            <ArrowRight className="h-4 w-4 ml-2" />
-          </Link>
-        </div>
+        <Link
+          href={ROUTES.LOGIN}
+          className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
+        >
+          Go to Sign In
+          <ArrowRight className="h-4 w-4 ml-2" />
+        </Link>
       </AuthStatusCard>
     );
   }

--- a/packages/admin/src/components/features/auth-accept-invite/index.tsx
+++ b/packages/admin/src/components/features/auth-accept-invite/index.tsx
@@ -1,22 +1,15 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  Button,
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-  Input,
-} from "@nextlyhq/ui";
-import { useState, useEffect } from "react";
+import { Button, Input } from "@nextlyhq/ui";
+import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { ArrowRight, Eye, EyeOff, Loader2 } from "@admin/components/icons";
 import { PasswordStrengthIndicator } from "@admin/components/shared";
-import { ThemeAwareLogo } from "@admin/components/shared/ThemeAwareLogo";
+import { AuthFormCard } from "@admin/components/shared/auth/AuthFormCard";
+import { AuthStatusCard } from "@admin/components/shared/auth/AuthStatusCard";
 import { toast } from "@admin/components/ui";
 import {
   FormControl,
@@ -27,9 +20,7 @@ import {
 } from "@admin/components/ui/form";
 import { Link } from "@admin/components/ui/link";
 import { ROUTES } from "@admin/constants/routes";
-import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { getCsrfToken } from "@admin/lib/api/csrf";
-import { cn } from "@admin/lib/utils";
 import { passwordSchema } from "@admin/lib/validation";
 import { acceptInvite } from "@admin/services/authApi";
 
@@ -48,14 +39,11 @@ interface AcceptInviteProps {
 }
 
 export function AcceptInvite({ searchParams }: AcceptInviteProps) {
-  const branding = useBranding();
-  const appName = branding.logoText ?? "Nextly";
   const token =
     typeof searchParams?.token === "string" ? searchParams.token : null;
 
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const [isVisible, setIsVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
 
@@ -69,10 +57,6 @@ export function AcceptInvite({ searchParams }: AcceptInviteProps) {
   });
 
   const newPasswordValue = form.watch("newPassword");
-
-  useEffect(() => {
-    setIsVisible(true);
-  }, []);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     if (!token) return;
@@ -114,217 +98,166 @@ export function AcceptInvite({ searchParams }: AcceptInviteProps) {
   // No token in URL — the link is incomplete.
   if (!token) {
     return (
-      <div className="w-full max-w-[480px] mx-auto">
-        <Card className="transition-all duration-300 ease-in-out border-border-strong shadow-none p-10 opacity-100">
-          <CardHeader className="space-y-1 p-0 mb-8" noBorder>
-            <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
-              Invalid Link
-            </CardTitle>
-            <CardDescription className="text-base text-muted-foreground">
-              This invite link is missing its token. Ask whoever invited you to
-              send the link again.
-            </CardDescription>
-          </CardHeader>
-
-          <CardContent className="p-0">
-            <div className="mt-2 text-left">
-              <Link
-                href={ROUTES.LOGIN}
-                className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
-              >
-                Go to Sign In
-                <ArrowRight className="h-4 w-4 ml-2" />
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <AuthStatusCard
+        title="Invalid Link"
+        description="This invite link is missing its token. Ask whoever invited you to send the link again."
+      >
+        <div className="mt-2 text-left">
+          <Link
+            href={ROUTES.LOGIN}
+            className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
+          >
+            Go to Sign In
+            <ArrowRight className="h-4 w-4 ml-2" />
+          </Link>
+        </div>
+      </AuthStatusCard>
     );
   }
 
   // Success state
   if (isSuccess) {
     return (
-      <div className="w-full max-w-[480px] mx-auto">
-        <Card className="transition-all duration-300 ease-in-out border-border-strong shadow-none p-10 opacity-100">
-          <CardHeader className="space-y-1 p-0 mb-8" noBorder>
-            <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
-              Account Ready
-            </CardTitle>
-            <CardDescription className="text-base text-muted-foreground">
-              Your password is set and your account is active. You can now sign
-              in.
-            </CardDescription>
-          </CardHeader>
-
-          <CardContent className="p-0">
-            <div className="mt-2 text-left">
-              <Link
-                href={ROUTES.LOGIN}
-                className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
-              >
-                Go to Sign In
-                <ArrowRight className="h-4 w-4 ml-2" />
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <AuthStatusCard
+        title="Account Ready"
+        description="Your password is set and your account is active. You can now sign in."
+      >
+        <div className="mt-2 text-left">
+          <Link
+            href={ROUTES.LOGIN}
+            className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
+          >
+            Go to Sign In
+            <ArrowRight className="h-4 w-4 ml-2" />
+          </Link>
+        </div>
+      </AuthStatusCard>
     );
   }
 
   // Form state
   return (
-    <div className="w-full max-w-[480px] mx-auto">
-      <Card
-        className={cn(
-          "transition-all duration-300 ease-in-out border-border-strong shadow-none p-2 sm:p-4 md:p-6",
-          isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
-        )}
-      >
-        <CardHeader className="space-y-1 pb-10 pt-8" noBorder>
-          <div className="flex items-center justify-start mb-10 transition-opacity duration-300">
-            <div className="inline-flex items-center justify-center w-12 h-12 overflow-hidden">
-              <ThemeAwareLogo
-                alt={appName}
-                className="w-full h-full object-contain"
-              />
-            </div>
-          </div>
-          <div>
-            <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
-              Set Your Password
-            </CardTitle>
-            <CardDescription className="text-base text-muted-foreground">
-              Choose a password to finish setting up your account
-            </CardDescription>
-          </div>
-        </CardHeader>
+    <AuthFormCard
+      title="Set Your Password"
+      description="Choose a password to finish setting up your account"
+    >
+      <FormProvider {...form}>
+        <form
+          onSubmit={e => {
+            void form.handleSubmit(onSubmit)(e);
+          }}
+          className="space-y-6"
+        >
+          <FormField
+            control={form.control}
+            name="newPassword"
+            render={({ field }) => (
+              <FormItem className="space-y-1">
+                <FormLabel className="text-sm font-medium text-foreground">
+                  Password
+                </FormLabel>
+                <div className="relative">
+                  <FormControl>
+                    <Input
+                      required
+                      type={showPassword ? "text" : "password"}
+                      autoComplete="new-password"
+                      placeholder="Create a strong password…"
+                      {...field}
+                      className="pr-10 h-11 rounded-md border-input"
+                    />
+                  </FormControl>
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    aria-label={
+                      showPassword ? "Hide password" : "Show password"
+                    }
+                    className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    {showPassword ? (
+                      <EyeOff className="h-5 w-5" />
+                    ) : (
+                      <Eye className="h-5 w-5" />
+                    )}
+                  </button>
+                </div>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-        <CardContent className="pb-10">
-          <FormProvider {...form}>
-            <form
-              onSubmit={e => {
-                void form.handleSubmit(onSubmit)(e);
-              }}
-              className="space-y-6"
-            >
-              <FormField
-                control={form.control}
-                name="newPassword"
-                render={({ field }) => (
-                  <FormItem className="space-y-1">
-                    <FormLabel className="text-sm font-medium text-foreground">
-                      Password
-                    </FormLabel>
-                    <div className="relative">
-                      <FormControl>
-                        <Input
-                          required
-                          type={showPassword ? "text" : "password"}
-                          autoComplete="new-password"
-                          placeholder="Create a strong password…"
-                          {...field}
-                          className="pr-10 h-11 rounded-md border-input"
-                        />
-                      </FormControl>
-                      <button
-                        type="button"
-                        onClick={() => setShowPassword(!showPassword)}
-                        aria-label={
-                          showPassword ? "Hide password" : "Show password"
-                        }
-                        className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        {showPassword ? (
-                          <EyeOff className="h-5 w-5" />
-                        ) : (
-                          <Eye className="h-5 w-5" />
-                        )}
-                      </button>
-                    </div>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+          <FormField
+            control={form.control}
+            name="confirmPassword"
+            render={({ field }) => (
+              <FormItem className="space-y-1">
+                <FormLabel className="text-sm font-medium text-foreground">
+                  Confirm Password
+                </FormLabel>
+                <div className="relative">
+                  <FormControl>
+                    <Input
+                      required
+                      type={showConfirmPassword ? "text" : "password"}
+                      autoComplete="new-password"
+                      placeholder="Confirm your password…"
+                      {...field}
+                      className="pr-10 h-11 rounded-md border-input"
+                    />
+                  </FormControl>
+                  <button
+                    type="button"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    aria-label={
+                      showConfirmPassword ? "Hide password" : "Show password"
+                    }
+                    className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    {showConfirmPassword ? (
+                      <EyeOff className="h-5 w-5" />
+                    ) : (
+                      <Eye className="h-5 w-5" />
+                    )}
+                  </button>
+                </div>
 
-              <FormField
-                control={form.control}
-                name="confirmPassword"
-                render={({ field }) => (
-                  <FormItem className="space-y-1">
-                    <FormLabel className="text-sm font-medium text-foreground">
-                      Confirm Password
-                    </FormLabel>
-                    <div className="relative">
-                      <FormControl>
-                        <Input
-                          required
-                          type={showConfirmPassword ? "text" : "password"}
-                          autoComplete="new-password"
-                          placeholder="Confirm your password…"
-                          {...field}
-                          className="pr-10 h-11 rounded-md border-input"
-                        />
-                      </FormControl>
-                      <button
-                        type="button"
-                        onClick={() =>
-                          setShowConfirmPassword(!showConfirmPassword)
-                        }
-                        aria-label={
-                          showConfirmPassword
-                            ? "Hide password"
-                            : "Show password"
-                        }
-                        className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        {showConfirmPassword ? (
-                          <EyeOff className="h-5 w-5" />
-                        ) : (
-                          <Eye className="h-5 w-5" />
-                        )}
-                      </button>
-                    </div>
+                <PasswordStrengthIndicator password={newPasswordValue} />
 
-                    <PasswordStrengthIndicator password={newPasswordValue} />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+          <Button
+            size="md"
+            type="submit"
+            disabled={isLoading}
+            className="w-full h-11 rounded-md shadow-none bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] transition-all duration-100 mt-2"
+          >
+            {isLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin ml-2" />
+            ) : (
+              <>
+                Set Password &amp; Continue
+                <ArrowRight className="h-4 w-4 ml-2" />
+              </>
+            )}
+          </Button>
+        </form>
+      </FormProvider>
 
-              <Button
-                size="md"
-                type="submit"
-                disabled={isLoading}
-                className="w-full h-11 rounded-md shadow-none bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] transition-all duration-100 mt-2"
-              >
-                {isLoading ? (
-                  <Loader2 className="h-4 w-4 animate-spin ml-2" />
-                ) : (
-                  <>
-                    Set Password &amp; Continue
-                    <ArrowRight className="h-4 w-4 ml-2" />
-                  </>
-                )}
-              </Button>
-            </form>
-          </FormProvider>
-
-          <div className="mt-8 text-left">
-            <p className="text-muted-foreground">
-              Already have access?{" "}
-              <Link
-                href={ROUTES.LOGIN}
-                className="text-primary cursor-pointer font-medium transition-colors"
-              >
-                Sign in
-              </Link>
-            </p>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+      <div className="mt-8 text-left">
+        <p className="text-muted-foreground">
+          Already have access?{" "}
+          <Link
+            href={ROUTES.LOGIN}
+            className="text-primary cursor-pointer font-medium transition-colors"
+          >
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </AuthFormCard>
   );
 }

--- a/packages/admin/src/components/features/auth-accept-invite/index.tsx
+++ b/packages/admin/src/components/features/auth-accept-invite/index.tsx
@@ -6,10 +6,11 @@ import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
-import { ArrowRight, Eye, EyeOff, Loader2 } from "@admin/components/icons";
+import { ArrowRight, Loader2 } from "@admin/components/icons";
 import { PasswordStrengthIndicator } from "@admin/components/shared";
 import { AuthFormCard } from "@admin/components/shared/auth/AuthFormCard";
 import { AuthStatusCard } from "@admin/components/shared/auth/AuthStatusCard";
+import { PasswordVisibilityToggle } from "@admin/components/shared/auth/PasswordVisibilityToggle";
 import { toast } from "@admin/components/ui";
 import {
   FormControl,
@@ -163,20 +164,10 @@ export function AcceptInvite({ searchParams }: AcceptInviteProps) {
                       className="pr-10 h-11 rounded-md border-input"
                     />
                   </FormControl>
-                  <button
-                    type="button"
-                    onClick={() => setShowPassword(!showPassword)}
-                    aria-label={
-                      showPassword ? "Hide password" : "Show password"
-                    }
-                    className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    {showPassword ? (
-                      <EyeOff className="h-5 w-5" />
-                    ) : (
-                      <Eye className="h-5 w-5" />
-                    )}
-                  </button>
+                  <PasswordVisibilityToggle
+                    visible={showPassword}
+                    onToggle={() => setShowPassword(!showPassword)}
+                  />
                 </div>
                 <FormMessage />
               </FormItem>
@@ -202,20 +193,12 @@ export function AcceptInvite({ searchParams }: AcceptInviteProps) {
                       className="pr-10 h-11 rounded-md border-input"
                     />
                   </FormControl>
-                  <button
-                    type="button"
-                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                    aria-label={
-                      showConfirmPassword ? "Hide password" : "Show password"
+                  <PasswordVisibilityToggle
+                    visible={showConfirmPassword}
+                    onToggle={() =>
+                      setShowConfirmPassword(!showConfirmPassword)
                     }
-                    className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    {showConfirmPassword ? (
-                      <EyeOff className="h-5 w-5" />
-                    ) : (
-                      <Eye className="h-5 w-5" />
-                    )}
-                  </button>
+                  />
                 </div>
 
                 <PasswordStrengthIndicator password={newPasswordValue} />

--- a/packages/admin/src/components/features/auth-forgot-password/index.tsx
+++ b/packages/admin/src/components/features/auth-forgot-password/index.tsx
@@ -64,15 +64,13 @@ export function ForgotPassword() {
         title="Check Your Email"
         description="If an account with that email exists, we've sent a password reset link. Please check your inbox and spam folder."
       >
-        <div className="mt-2 text-left">
-          <Link
-            href={ROUTES.LOGIN}
-            className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            Back to Sign In
-          </Link>
-        </div>
+        <Link
+          href={ROUTES.LOGIN}
+          className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Sign In
+        </Link>
       </AuthStatusCard>
     );
   }

--- a/packages/admin/src/components/features/auth-forgot-password/index.tsx
+++ b/packages/admin/src/components/features/auth-forgot-password/index.tsx
@@ -1,21 +1,14 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  Button,
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-  Input,
-} from "@nextlyhq/ui";
-import { useState, useEffect } from "react";
+import { Button, Input } from "@nextlyhq/ui";
+import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { ArrowLeft, ArrowRight, Loader2 } from "@admin/components/icons";
-import { ThemeAwareLogo } from "@admin/components/shared/ThemeAwareLogo";
+import { AuthFormCard } from "@admin/components/shared/auth/AuthFormCard";
+import { AuthStatusCard } from "@admin/components/shared/auth/AuthStatusCard";
 import { toast } from "@admin/components/ui";
 import {
   FormControl,
@@ -26,9 +19,7 @@ import {
 } from "@admin/components/ui/form";
 import { Link } from "@admin/components/ui/link";
 import { ROUTES } from "@admin/constants/routes";
-import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { getCsrfToken } from "@admin/lib/api/csrf";
-import { cn } from "@admin/lib/utils";
 import { requestPasswordReset } from "@admin/services/authApi";
 
 const formSchema = z.object({
@@ -40,10 +31,6 @@ const formSchema = z.object({
 });
 
 export function ForgotPassword() {
-  const branding = useBranding();
-  const appName = branding.logoText ?? "Nextly";
-
-  const [isVisible, setIsVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
 
@@ -54,10 +41,6 @@ export function ForgotPassword() {
       email: "",
     },
   });
-
-  useEffect(() => {
-    setIsVisible(true);
-  }, []);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setIsLoading(true);
@@ -77,124 +60,88 @@ export function ForgotPassword() {
 
   if (isSubmitted) {
     return (
-      <div className="w-full max-w-[480px] mx-auto">
-        <Card className="transition-all duration-300 ease-in-out border-border-strong shadow-none p-10 opacity-100">
-          <CardHeader className="space-y-1 p-0 mb-8" noBorder>
-            <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
-              Check Your Email
-            </CardTitle>
-            <CardDescription className="text-base text-muted-foreground">
-              If an account with that email exists, we&apos;ve sent a password
-              reset link. Please check your inbox and spam folder.
-            </CardDescription>
-          </CardHeader>
-
-          <CardContent className="p-0">
-            <div className="mt-2 text-left">
-              <Link
-                href={ROUTES.LOGIN}
-                className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
-              >
-                <ArrowLeft className="h-4 w-4" />
-                Back to Sign In
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <AuthStatusCard
+        title="Check Your Email"
+        description="If an account with that email exists, we've sent a password reset link. Please check your inbox and spam folder."
+      >
+        <div className="mt-2 text-left">
+          <Link
+            href={ROUTES.LOGIN}
+            className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to Sign In
+          </Link>
+        </div>
+      </AuthStatusCard>
     );
   }
 
   return (
-    <div className="w-full max-w-[480px] mx-auto">
-      <Card
-        className={cn(
-          "transition-all duration-300 ease-in-out border-border-strong shadow-none p-2 sm:p-4 md:p-6",
-          isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
-        )}
-      >
-        <CardHeader className="space-y-1 pb-10 pt-8" noBorder>
-          <div className="flex items-center justify-start mb-10 transition-opacity duration-300">
-            <div className="inline-flex items-center justify-center w-12 h-12 overflow-hidden">
-              <ThemeAwareLogo
-                alt={appName}
-                className="w-full h-full object-contain"
-              />
-            </div>
-          </div>
-          <div>
-            <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
-              Forgot Password
-            </CardTitle>
-            <CardDescription className="text-base text-muted-foreground">
-              Enter your email and we&apos;ll send you a reset link
-            </CardDescription>
-          </div>
-        </CardHeader>
+    <AuthFormCard
+      title="Forgot Password"
+      description="Enter your email and we'll send you a reset link"
+    >
+      <FormProvider {...form}>
+        <form
+          onSubmit={e => {
+            void form.handleSubmit(onSubmit)(e);
+          }}
+          className="space-y-6"
+        >
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-sm font-medium text-foreground">
+                  Email Address
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    required
+                    type="email"
+                    autoComplete="email"
+                    spellCheck={false}
+                    placeholder="Enter your email address…"
+                    {...field}
+                    className="h-11 rounded-md border-input"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-        <CardContent className="pb-10">
-          <FormProvider {...form}>
-            <form
-              onSubmit={e => {
-                void form.handleSubmit(onSubmit)(e);
-              }}
-              className="space-y-6"
-            >
-              <FormField
-                control={form.control}
-                name="email"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-sm font-medium text-foreground">
-                      Email Address
-                    </FormLabel>
-                    <FormControl>
-                      <Input
-                        required
-                        type="email"
-                        autoComplete="email"
-                        spellCheck={false}
-                        placeholder="Enter your email address…"
-                        {...field}
-                        className="h-11 rounded-md border-input"
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+          <Button
+            size="md"
+            type="submit"
+            disabled={isLoading}
+            className="w-full h-11 rounded-md shadow-none bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] transition-all duration-100 mt-2"
+          >
+            {isLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <>
+                Send Reset Link
+                <ArrowRight className="h-4 w-4 ml-2" />
+              </>
+            )}
+          </Button>
+        </form>
+      </FormProvider>
 
-              <Button
-                size="md"
-                type="submit"
-                disabled={isLoading}
-                className="w-full h-11 rounded-md shadow-none bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] transition-all duration-100 mt-2"
-              >
-                {isLoading ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <>
-                    Send Reset Link
-                    <ArrowRight className="h-4 w-4 ml-2" />
-                  </>
-                )}
-              </Button>
-            </form>
-          </FormProvider>
-
-          <div className="mt-8 text-left">
-            <p className="text-muted-foreground">
-              Remember your password?{" "}
-              <Link
-                href={ROUTES.LOGIN}
-                className="text-primary cursor-pointer font-medium transition-colors"
-              >
-                Sign in
-              </Link>
-            </p>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+      <div className="mt-8 text-left">
+        <p className="text-muted-foreground">
+          Remember your password?{" "}
+          <Link
+            href={ROUTES.LOGIN}
+            className="text-primary cursor-pointer font-medium transition-colors"
+          >
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </AuthFormCard>
   );
 }

--- a/packages/admin/src/components/features/auth-login/index.tsx
+++ b/packages/admin/src/components/features/auth-login/index.tsx
@@ -24,7 +24,7 @@ import {
 } from "@admin/components/ui/form";
 import { Link } from "@admin/components/ui/link";
 import { ROUTES } from "@admin/constants/routes";
-import { useBranding } from "@admin/context/providers/BrandingProvider";
+import { useAppName } from "@admin/context/providers/BrandingProvider";
 import { useApi } from "@admin/hooks/useApi";
 import { getCsrfToken } from "@admin/lib/api/csrf";
 import type { ActionResponse } from "@admin/lib/api/response-types";
@@ -46,8 +46,7 @@ const formSchema = z.object({
 
 export function Login() {
   const { api } = useApi();
-  const branding = useBranding();
-  const appName = branding.logoText ?? "Nextly";
+  const appName = useAppName();
 
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);

--- a/packages/admin/src/components/features/auth-login/index.tsx
+++ b/packages/admin/src/components/features/auth-login/index.tsx
@@ -1,16 +1,8 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  Button,
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-  Input,
-} from "@nextlyhq/ui";
-import { useState, useEffect } from "react";
+import { Button, Input } from "@nextlyhq/ui";
+import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -21,7 +13,7 @@ import {
   Loader2,
   Mail,
 } from "@admin/components/icons";
-import { ThemeAwareLogo } from "@admin/components/shared/ThemeAwareLogo";
+import { AuthFormCard } from "@admin/components/shared/auth/AuthFormCard";
 import { toast } from "@admin/components/ui";
 import {
   FormControl,
@@ -36,7 +28,6 @@ import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { useApi } from "@admin/hooks/useApi";
 import { getCsrfToken } from "@admin/lib/api/csrf";
 import type { ActionResponse } from "@admin/lib/api/response-types";
-import { cn } from "@admin/lib/utils";
 
 import { AuthUiExtras, AuthChallenge, useAuthUi } from "./auth-ui-extras";
 import { SetInitialPassword } from "./set-initial-password";
@@ -59,7 +50,6 @@ export function Login() {
   const appName = branding.logoText ?? "Nextly";
 
   const [showPassword, setShowPassword] = useState(false);
-  const [isVisible, setIsVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [emailNotVerified, setEmailNotVerified] = useState(false);
   const [resendingVerification, setResendingVerification] = useState(false);
@@ -84,10 +74,6 @@ export function Login() {
       password: "",
     },
   });
-
-  useEffect(() => {
-    setIsVisible(true);
-  }, []);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setIsLoading(true);
@@ -213,193 +199,167 @@ export function Login() {
   }
 
   return (
-    <div className="w-full max-w-[480px] mx-auto">
-      <Card
-        className={cn(
-          "transition-all duration-300 ease-in-out border-border-strong shadow-none p-2 sm:p-4 md:p-6",
-          isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
-        )}
-      >
-        <CardHeader className="space-y-1 pb-10 pt-8" noBorder>
-          {/* Logo */}
-          <div className="flex items-center justify-start mb-10 transition-opacity duration-300">
-            <div className="inline-flex items-center justify-center w-12 h-12 overflow-hidden">
-              <ThemeAwareLogo
-                alt={appName}
-                className="w-full h-full object-contain"
-              />
-            </div>
-          </div>
-          <div>
-            <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
-              Welcome Back
-            </CardTitle>
-            <CardDescription className="text-base text-muted-foreground">
-              Sign in to your {appName} account
-            </CardDescription>
-          </div>
-        </CardHeader>
-
-        <CardContent className="pb-10">
-          {mustChangePassword ? (
-            <SetInitialPassword
-              pendingToken={mustChangePassword.pendingToken}
-              onDone={() => {
-                window.location.href = ROUTES.DASHBOARD;
+    <AuthFormCard
+      title="Welcome Back"
+      description={`Sign in to your ${appName} account`}
+    >
+      {mustChangePassword ? (
+        <SetInitialPassword
+          pendingToken={mustChangePassword.pendingToken}
+          onDone={() => {
+            window.location.href = ROUTES.DASHBOARD;
+          }}
+        />
+      ) : challenge ? (
+        <AuthChallenge
+          authUi={authUi}
+          challengeType={challenge.challengeType}
+          pendingToken={challenge.pendingToken}
+          onResolved={() => {
+            window.location.href = ROUTES.DASHBOARD;
+          }}
+        />
+      ) : (
+        <>
+          <FormProvider {...form}>
+            <form
+              onSubmit={e => {
+                void form.handleSubmit(onSubmit)(e);
               }}
-            />
-          ) : challenge ? (
-            <AuthChallenge
-              authUi={authUi}
-              challengeType={challenge.challengeType}
-              pendingToken={challenge.pendingToken}
-              onResolved={() => {
-                window.location.href = ROUTES.DASHBOARD;
-              }}
-            />
-          ) : (
-            <>
-              <FormProvider {...form}>
-                <form
-                  onSubmit={e => {
-                    void form.handleSubmit(onSubmit)(e);
-                  }}
-                  className="space-y-6"
-                >
-                  {emailNotVerified && (
-                    <div className="flex items-start gap-3 rounded-lg border border-warning bg-warning/10 p-4 mb-6">
-                      <Mail className="h-5 w-5 text-warning mt-0.5 shrink-0" />
-                      <div className="flex-1 text-sm">
-                        <p className="font-medium text-foreground">
-                          Email not verified
-                        </p>
-                        <p className="text-muted-foreground mt-1">
-                          Please check your inbox and click the verification
-                          link before signing in.
-                        </p>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            void handleResendVerification();
-                          }}
-                          disabled={resendingVerification}
-                          className="mt-2 text-sm font-medium text-foreground underline underline-offset-2 hover:text-foreground/80 disabled:opacity-50"
-                        >
-                          {resendingVerification
-                            ? "Sending..."
-                            : "Resend verification email"}
-                        </button>
-                      </div>
-                    </div>
-                  )}
-
-                  <FormField
-                    control={form.control}
-                    name="email"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel className="text-sm font-medium text-foreground">
-                          Email Address
-                        </FormLabel>
-                        <FormControl>
-                          <Input
-                            required
-                            type="email"
-                            autoComplete="email"
-                            spellCheck={false}
-                            placeholder="Enter your email address…"
-                            {...field}
-                            className="h-11 rounded-md border-input"
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  <FormField
-                    control={form.control}
-                    name="password"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Password</FormLabel>
-                        <div className="relative">
-                          <FormControl>
-                            <Input
-                              required
-                              type={showPassword ? "text" : "password"}
-                              autoComplete="current-password"
-                              placeholder="Enter your password…"
-                              {...field}
-                              className="pr-10 h-11 rounded-md border-input"
-                            />
-                          </FormControl>
-                          <button
-                            type="button"
-                            onClick={() => setShowPassword(!showPassword)}
-                            tabIndex={-1}
-                            className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                          >
-                            {showPassword ? (
-                              <EyeOff className="h-5 w-5" />
-                            ) : (
-                              <Eye className="h-5 w-5" />
-                            )}
-                          </button>
-                        </div>
-                        <div className="flex justify-end">
-                          <Link
-                            href={ROUTES.FORGOT_PASSWORD}
-                            className="text-sm text-primary cursor-pointer transition-colors font-medium mt-1"
-                          >
-                            Forgot password?
-                          </Link>
-                        </div>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  <Button
-                    size="md"
-                    type="submit"
-                    disabled={isLoading}
-                    className="w-full h-11 rounded-md shadow-none bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] transition-all duration-100 mt-2"
-                  >
-                    {isLoading ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <>
-                        Sign In
-                        <ArrowRight className="h-4 w-4 ml-2" />
-                      </>
-                    )}
-                  </Button>
-                </form>
-              </FormProvider>
-              {(authUi.providers.length > 0 ||
-                authUi.slots.beforeForm.length > 0 ||
-                authUi.slots.afterForm.length > 0 ||
-                authUi.slots.branding.length > 0) && (
-                <div className="mt-6">
-                  <AuthUiExtras authUi={authUi} />
+              className="space-y-6"
+            >
+              {emailNotVerified && (
+                <div className="flex items-start gap-3 rounded-lg border border-warning bg-warning/10 p-4 mb-6">
+                  <Mail className="h-5 w-5 text-warning mt-0.5 shrink-0" />
+                  <div className="flex-1 text-sm">
+                    <p className="font-medium text-foreground">
+                      Email not verified
+                    </p>
+                    <p className="text-muted-foreground mt-1">
+                      Please check your inbox and click the verification link
+                      before signing in.
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void handleResendVerification();
+                      }}
+                      disabled={resendingVerification}
+                      className="mt-2 text-sm font-medium text-foreground underline underline-offset-2 hover:text-foreground/80 disabled:opacity-50"
+                    >
+                      {resendingVerification
+                        ? "Sending..."
+                        : "Resend verification email"}
+                    </button>
+                  </div>
                 </div>
               )}
-              <div className="mt-8 text-left">
-                <p className="text-muted-foreground">
-                  Don&apos;t have an account?{" "}
-                  <Link
-                    href={ROUTES.REGISTER}
-                    className="text-primary cursor-pointer font-medium transition-colors"
-                  >
-                    Sign up
-                  </Link>
-                </p>
-              </div>
-            </>
+
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="text-sm font-medium text-foreground">
+                      Email Address
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        required
+                        type="email"
+                        autoComplete="email"
+                        spellCheck={false}
+                        placeholder="Enter your email address…"
+                        {...field}
+                        className="h-11 rounded-md border-input"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Password</FormLabel>
+                    <div className="relative">
+                      <FormControl>
+                        <Input
+                          required
+                          type={showPassword ? "text" : "password"}
+                          autoComplete="current-password"
+                          placeholder="Enter your password…"
+                          {...field}
+                          className="pr-10 h-11 rounded-md border-input"
+                        />
+                      </FormControl>
+                      <button
+                        type="button"
+                        onClick={() => setShowPassword(!showPassword)}
+                        tabIndex={-1}
+                        className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      >
+                        {showPassword ? (
+                          <EyeOff className="h-5 w-5" />
+                        ) : (
+                          <Eye className="h-5 w-5" />
+                        )}
+                      </button>
+                    </div>
+                    <div className="flex justify-end">
+                      <Link
+                        href={ROUTES.FORGOT_PASSWORD}
+                        className="text-sm text-primary cursor-pointer transition-colors font-medium mt-1"
+                      >
+                        Forgot password?
+                      </Link>
+                    </div>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <Button
+                size="md"
+                type="submit"
+                disabled={isLoading}
+                className="w-full h-11 rounded-md shadow-none bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] transition-all duration-100 mt-2"
+              >
+                {isLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <>
+                    Sign In
+                    <ArrowRight className="h-4 w-4 ml-2" />
+                  </>
+                )}
+              </Button>
+            </form>
+          </FormProvider>
+          {(authUi.providers.length > 0 ||
+            authUi.slots.beforeForm.length > 0 ||
+            authUi.slots.afterForm.length > 0 ||
+            authUi.slots.branding.length > 0) && (
+            <div className="mt-6">
+              <AuthUiExtras authUi={authUi} />
+            </div>
           )}
-        </CardContent>
-      </Card>
-    </div>
+          <div className="mt-8 text-left">
+            <p className="text-muted-foreground">
+              Don&apos;t have an account?{" "}
+              <Link
+                href={ROUTES.REGISTER}
+                className="text-primary cursor-pointer font-medium transition-colors"
+              >
+                Sign up
+              </Link>
+            </p>
+          </div>
+        </>
+      )}
+    </AuthFormCard>
   );
 }

--- a/packages/admin/src/components/features/auth-login/index.tsx
+++ b/packages/admin/src/components/features/auth-login/index.tsx
@@ -6,14 +6,9 @@ import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
-import {
-  Eye,
-  EyeOff,
-  ArrowRight,
-  Loader2,
-  Mail,
-} from "@admin/components/icons";
+import { ArrowRight, Loader2, Mail } from "@admin/components/icons";
 import { AuthFormCard } from "@admin/components/shared/auth/AuthFormCard";
+import { PasswordVisibilityToggle } from "@admin/components/shared/auth/PasswordVisibilityToggle";
 import { toast } from "@admin/components/ui";
 import {
   FormControl,
@@ -295,18 +290,10 @@ export function Login() {
                           className="pr-10 h-11 rounded-md border-input"
                         />
                       </FormControl>
-                      <button
-                        type="button"
-                        onClick={() => setShowPassword(!showPassword)}
-                        tabIndex={-1}
-                        className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        {showPassword ? (
-                          <EyeOff className="h-5 w-5" />
-                        ) : (
-                          <Eye className="h-5 w-5" />
-                        )}
-                      </button>
+                      <PasswordVisibilityToggle
+                        visible={showPassword}
+                        onToggle={() => setShowPassword(!showPassword)}
+                      />
                     </div>
                     <div className="flex justify-end">
                       <Link

--- a/packages/admin/src/components/features/auth-login/set-initial-password.tsx
+++ b/packages/admin/src/components/features/auth-login/set-initial-password.tsx
@@ -6,8 +6,9 @@ import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
-import { ArrowRight, Eye, EyeOff, Loader2 } from "@admin/components/icons";
+import { ArrowRight, Loader2 } from "@admin/components/icons";
 import { PasswordStrengthIndicator } from "@admin/components/shared";
+import { PasswordVisibilityToggle } from "@admin/components/shared/auth/PasswordVisibilityToggle";
 import { toast } from "@admin/components/ui";
 import {
   FormControl,
@@ -129,20 +130,10 @@ export function SetInitialPassword({
                       className="pr-10 h-11 rounded-md border-input"
                     />
                   </FormControl>
-                  <button
-                    type="button"
-                    onClick={() => setShowPassword(!showPassword)}
-                    aria-label={
-                      showPassword ? "Hide password" : "Show password"
-                    }
-                    className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    {showPassword ? (
-                      <EyeOff className="h-5 w-5" />
-                    ) : (
-                      <Eye className="h-5 w-5" />
-                    )}
-                  </button>
+                  <PasswordVisibilityToggle
+                    visible={showPassword}
+                    onToggle={() => setShowPassword(!showPassword)}
+                  />
                 </div>
                 <FormMessage />
               </FormItem>
@@ -168,20 +159,12 @@ export function SetInitialPassword({
                       className="pr-10 h-11 rounded-md border-input"
                     />
                   </FormControl>
-                  <button
-                    type="button"
-                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                    aria-label={
-                      showConfirmPassword ? "Hide password" : "Show password"
+                  <PasswordVisibilityToggle
+                    visible={showConfirmPassword}
+                    onToggle={() =>
+                      setShowConfirmPassword(!showConfirmPassword)
                     }
-                    className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    {showConfirmPassword ? (
-                      <EyeOff className="h-5 w-5" />
-                    ) : (
-                      <Eye className="h-5 w-5" />
-                    )}
-                  </button>
+                  />
                 </div>
 
                 <PasswordStrengthIndicator password={newPasswordValue} />

--- a/packages/admin/src/components/features/auth-reset-password/index.tsx
+++ b/packages/admin/src/components/features/auth-reset-password/index.tsx
@@ -1,16 +1,8 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  Button,
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-  Input,
-} from "@nextlyhq/ui";
-import { useState, useEffect } from "react";
+import { Button, Input } from "@nextlyhq/ui";
+import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -22,7 +14,8 @@ import {
   Loader2,
 } from "@admin/components/icons";
 import { PasswordStrengthIndicator } from "@admin/components/shared";
-import { ThemeAwareLogo } from "@admin/components/shared/ThemeAwareLogo";
+import { AuthFormCard } from "@admin/components/shared/auth/AuthFormCard";
+import { AuthStatusCard } from "@admin/components/shared/auth/AuthStatusCard";
 import { toast } from "@admin/components/ui";
 import {
   FormControl,
@@ -33,9 +26,7 @@ import {
 } from "@admin/components/ui/form";
 import { Link } from "@admin/components/ui/link";
 import { ROUTES } from "@admin/constants/routes";
-import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { getCsrfToken } from "@admin/lib/api/csrf";
-import { cn } from "@admin/lib/utils";
 import { passwordSchema } from "@admin/lib/validation";
 import { resetPassword } from "@admin/services/authApi";
 
@@ -54,14 +45,11 @@ interface ResetPasswordProps {
 }
 
 export function ResetPassword({ searchParams }: ResetPasswordProps) {
-  const branding = useBranding();
-  const appName = branding.logoText ?? "Nextly";
   const token =
     typeof searchParams?.token === "string" ? searchParams.token : null;
 
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const [isVisible, setIsVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
 
@@ -75,10 +63,6 @@ export function ResetPassword({ searchParams }: ResetPasswordProps) {
   });
 
   const newPasswordValue = form.watch("newPassword");
-
-  useEffect(() => {
-    setIsVisible(true);
-  }, []);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     if (!token) return;
@@ -109,211 +93,162 @@ export function ResetPassword({ searchParams }: ResetPasswordProps) {
   // No token in URL show error state
   if (!token) {
     return (
-      <div className="w-full max-w-[480px] mx-auto">
-        <Card className="transition-all duration-300 ease-in-out border-border-strong shadow-none p-10 opacity-100">
-          <CardHeader className="space-y-1 p-0 mb-8" noBorder>
-            <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
-              Invalid Link
-            </CardTitle>
-            <CardDescription className="text-base text-muted-foreground">
-              This password reset link is missing a token. Please request a new
-              password reset link.
-            </CardDescription>
-          </CardHeader>
-
-          <CardContent className="p-0">
-            <div className="mt-2 text-left">
-              <Link
-                href={ROUTES.FORGOT_PASSWORD}
-                className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
-              >
-                <ArrowLeft className="h-4 w-4" />
-                Request New Link
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <AuthStatusCard
+        title="Invalid Link"
+        description="This password reset link is missing a token. Please request a new password reset link."
+      >
+        <div className="mt-2 text-left">
+          <Link
+            href={ROUTES.FORGOT_PASSWORD}
+            className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Request New Link
+          </Link>
+        </div>
+      </AuthStatusCard>
     );
   }
 
   // Success state
   if (isSuccess) {
     return (
-      <div className="w-full max-w-[480px] mx-auto">
-        <Card className="transition-all duration-300 ease-in-out border-border-strong shadow-none p-10 opacity-100">
-          <CardHeader className="space-y-1 p-0 mb-8" noBorder>
-            <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
-              Password Reset
-            </CardTitle>
-            <CardDescription className="text-base text-muted-foreground">
-              Your password has been reset successfully. You can now sign in
-              with your new password.
-            </CardDescription>
-          </CardHeader>
-
-          <CardContent className="p-0">
-            <div className="mt-2 text-left">
-              <Link
-                href={ROUTES.LOGIN}
-                className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
-              >
-                Go to Sign In
-                <ArrowRight className="h-4 w-4 ml-2" />
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <AuthStatusCard
+        title="Password Reset"
+        description="Your password has been reset successfully. You can now sign in with your new password."
+      >
+        <div className="mt-2 text-left">
+          <Link
+            href={ROUTES.LOGIN}
+            className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
+          >
+            Go to Sign In
+            <ArrowRight className="h-4 w-4 ml-2" />
+          </Link>
+        </div>
+      </AuthStatusCard>
     );
   }
 
   // Form state
   return (
-    <div className="w-full max-w-[480px] mx-auto">
-      <Card
-        className={cn(
-          "transition-all duration-300 ease-in-out border-border-strong shadow-none p-2 sm:p-4 md:p-6",
-          isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
-        )}
-      >
-        <CardHeader className="space-y-1 pb-10 pt-8" noBorder>
-          <div className="flex items-center justify-start mb-10 transition-opacity duration-300">
-            <div className="inline-flex items-center justify-center w-12 h-12 overflow-hidden">
-              <ThemeAwareLogo
-                alt={appName}
-                className="w-full h-full object-contain"
-              />
-            </div>
-          </div>
-          <div>
-            <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
-              Reset Password
-            </CardTitle>
-            <CardDescription className="text-base text-muted-foreground">
-              Enter your new password below
-            </CardDescription>
-          </div>
-        </CardHeader>
+    <AuthFormCard
+      title="Reset Password"
+      description="Enter your new password below"
+    >
+      <FormProvider {...form}>
+        <form
+          onSubmit={e => {
+            void form.handleSubmit(onSubmit)(e);
+          }}
+          className="space-y-6"
+        >
+          <FormField
+            control={form.control}
+            name="newPassword"
+            render={({ field }) => (
+              <FormItem className="space-y-1">
+                <FormLabel className="text-sm font-medium text-foreground">
+                  New Password
+                </FormLabel>
+                <div className="relative">
+                  <FormControl>
+                    <Input
+                      required
+                      type={showPassword ? "text" : "password"}
+                      autoComplete="new-password"
+                      placeholder="Create a strong password…"
+                      {...field}
+                      className="pr-10 h-11 rounded-md border-input"
+                    />
+                  </FormControl>
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    tabIndex={-1}
+                    className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    {showPassword ? (
+                      <EyeOff className="h-5 w-5" />
+                    ) : (
+                      <Eye className="h-5 w-5" />
+                    )}
+                  </button>
+                </div>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-        <CardContent className="pb-10">
-          <FormProvider {...form}>
-            <form
-              onSubmit={e => {
-                void form.handleSubmit(onSubmit)(e);
-              }}
-              className="space-y-6"
-            >
-              <FormField
-                control={form.control}
-                name="newPassword"
-                render={({ field }) => (
-                  <FormItem className="space-y-1">
-                    <FormLabel className="text-sm font-medium text-foreground">
-                      New Password
-                    </FormLabel>
-                    <div className="relative">
-                      <FormControl>
-                        <Input
-                          required
-                          type={showPassword ? "text" : "password"}
-                          autoComplete="new-password"
-                          placeholder="Create a strong password…"
-                          {...field}
-                          className="pr-10 h-11 rounded-md border-input"
-                        />
-                      </FormControl>
-                      <button
-                        type="button"
-                        onClick={() => setShowPassword(!showPassword)}
-                        tabIndex={-1}
-                        className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        {showPassword ? (
-                          <EyeOff className="h-5 w-5" />
-                        ) : (
-                          <Eye className="h-5 w-5" />
-                        )}
-                      </button>
-                    </div>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+          <FormField
+            control={form.control}
+            name="confirmPassword"
+            render={({ field }) => (
+              <FormItem className="space-y-1">
+                <FormLabel className="text-sm font-medium text-foreground">
+                  Confirm Password
+                </FormLabel>
+                <div className="relative">
+                  <FormControl>
+                    <Input
+                      required
+                      type={showConfirmPassword ? "text" : "password"}
+                      autoComplete="new-password"
+                      placeholder="Confirm your password…"
+                      {...field}
+                      className="pr-10 h-11 rounded-md border-input"
+                    />
+                  </FormControl>
+                  <button
+                    type="button"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    tabIndex={-1}
+                    className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    {showConfirmPassword ? (
+                      <EyeOff className="h-5 w-5" />
+                    ) : (
+                      <Eye className="h-5 w-5" />
+                    )}
+                  </button>
+                </div>
 
-              <FormField
-                control={form.control}
-                name="confirmPassword"
-                render={({ field }) => (
-                  <FormItem className="space-y-1">
-                    <FormLabel className="text-sm font-medium text-foreground">
-                      Confirm Password
-                    </FormLabel>
-                    <div className="relative">
-                      <FormControl>
-                        <Input
-                          required
-                          type={showConfirmPassword ? "text" : "password"}
-                          autoComplete="new-password"
-                          placeholder="Confirm your password…"
-                          {...field}
-                          className="pr-10 h-11 rounded-md border-input"
-                        />
-                      </FormControl>
-                      <button
-                        type="button"
-                        onClick={() =>
-                          setShowConfirmPassword(!showConfirmPassword)
-                        }
-                        tabIndex={-1}
-                        className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        {showConfirmPassword ? (
-                          <EyeOff className="h-5 w-5" />
-                        ) : (
-                          <Eye className="h-5 w-5" />
-                        )}
-                      </button>
-                    </div>
+                <PasswordStrengthIndicator password={newPasswordValue} />
 
-                    <PasswordStrengthIndicator password={newPasswordValue} />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+          <Button
+            size="md"
+            type="submit"
+            disabled={isLoading}
+            className="w-full h-11 rounded-md shadow-none bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] transition-all duration-100 mt-2"
+          >
+            {isLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin ml-2" />
+            ) : (
+              <>
+                Reset Password
+                <ArrowRight className="h-4 w-4 ml-2" />
+              </>
+            )}
+          </Button>
+        </form>
+      </FormProvider>
 
-              <Button
-                size="md"
-                type="submit"
-                disabled={isLoading}
-                className="w-full h-11 rounded-md shadow-none bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] transition-all duration-100 mt-2"
-              >
-                {isLoading ? (
-                  <Loader2 className="h-4 w-4 animate-spin ml-2" />
-                ) : (
-                  <>
-                    Reset Password
-                    <ArrowRight className="h-4 w-4 ml-2" />
-                  </>
-                )}
-              </Button>
-            </form>
-          </FormProvider>
-
-          <div className="mt-8 text-left">
-            <p className="text-muted-foreground">
-              Remember your password?{" "}
-              <Link
-                href={ROUTES.LOGIN}
-                className="text-primary cursor-pointer font-medium transition-colors"
-              >
-                Sign in
-              </Link>
-            </p>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+      <div className="mt-8 text-left">
+        <p className="text-muted-foreground">
+          Remember your password?{" "}
+          <Link
+            href={ROUTES.LOGIN}
+            className="text-primary cursor-pointer font-medium transition-colors"
+          >
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </AuthFormCard>
   );
 }

--- a/packages/admin/src/components/features/auth-reset-password/index.tsx
+++ b/packages/admin/src/components/features/auth-reset-password/index.tsx
@@ -6,16 +6,11 @@ import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
-import {
-  ArrowLeft,
-  ArrowRight,
-  Eye,
-  EyeOff,
-  Loader2,
-} from "@admin/components/icons";
+import { ArrowLeft, ArrowRight, Loader2 } from "@admin/components/icons";
 import { PasswordStrengthIndicator } from "@admin/components/shared";
 import { AuthFormCard } from "@admin/components/shared/auth/AuthFormCard";
 import { AuthStatusCard } from "@admin/components/shared/auth/AuthStatusCard";
+import { PasswordVisibilityToggle } from "@admin/components/shared/auth/PasswordVisibilityToggle";
 import { toast } from "@admin/components/ui";
 import {
   FormControl,
@@ -158,18 +153,10 @@ export function ResetPassword({ searchParams }: ResetPasswordProps) {
                       className="pr-10 h-11 rounded-md border-input"
                     />
                   </FormControl>
-                  <button
-                    type="button"
-                    onClick={() => setShowPassword(!showPassword)}
-                    tabIndex={-1}
-                    className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    {showPassword ? (
-                      <EyeOff className="h-5 w-5" />
-                    ) : (
-                      <Eye className="h-5 w-5" />
-                    )}
-                  </button>
+                  <PasswordVisibilityToggle
+                    visible={showPassword}
+                    onToggle={() => setShowPassword(!showPassword)}
+                  />
                 </div>
                 <FormMessage />
               </FormItem>
@@ -195,18 +182,12 @@ export function ResetPassword({ searchParams }: ResetPasswordProps) {
                       className="pr-10 h-11 rounded-md border-input"
                     />
                   </FormControl>
-                  <button
-                    type="button"
-                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                    tabIndex={-1}
-                    className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    {showConfirmPassword ? (
-                      <EyeOff className="h-5 w-5" />
-                    ) : (
-                      <Eye className="h-5 w-5" />
-                    )}
-                  </button>
+                  <PasswordVisibilityToggle
+                    visible={showConfirmPassword}
+                    onToggle={() =>
+                      setShowConfirmPassword(!showConfirmPassword)
+                    }
+                  />
                 </div>
 
                 <PasswordStrengthIndicator password={newPasswordValue} />

--- a/packages/admin/src/components/features/auth-reset-password/index.tsx
+++ b/packages/admin/src/components/features/auth-reset-password/index.tsx
@@ -97,15 +97,13 @@ export function ResetPassword({ searchParams }: ResetPasswordProps) {
         title="Invalid Link"
         description="This password reset link is missing a token. Please request a new password reset link."
       >
-        <div className="mt-2 text-left">
-          <Link
-            href={ROUTES.FORGOT_PASSWORD}
-            className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            Request New Link
-          </Link>
-        </div>
+        <Link
+          href={ROUTES.FORGOT_PASSWORD}
+          className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Request New Link
+        </Link>
       </AuthStatusCard>
     );
   }
@@ -117,15 +115,13 @@ export function ResetPassword({ searchParams }: ResetPasswordProps) {
         title="Password Reset"
         description="Your password has been reset successfully. You can now sign in with your new password."
       >
-        <div className="mt-2 text-left">
-          <Link
-            href={ROUTES.LOGIN}
-            className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
-          >
-            Go to Sign In
-            <ArrowRight className="h-4 w-4 ml-2" />
-          </Link>
-        </div>
+        <Link
+          href={ROUTES.LOGIN}
+          className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
+        >
+          Go to Sign In
+          <ArrowRight className="h-4 w-4 ml-2" />
+        </Link>
       </AuthStatusCard>
     );
   }

--- a/packages/admin/src/components/features/auth-setup/index.tsx
+++ b/packages/admin/src/components/features/auth-setup/index.tsx
@@ -6,9 +6,10 @@ import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
-import { ArrowRight, Eye, EyeOff, Loader2 } from "@admin/components/icons";
+import { ArrowRight, Loader2 } from "@admin/components/icons";
 import { PasswordStrengthIndicator } from "@admin/components/shared";
 import { AuthFormCard } from "@admin/components/shared/auth/AuthFormCard";
+import { PasswordVisibilityToggle } from "@admin/components/shared/auth/PasswordVisibilityToggle";
 import { toast } from "@admin/components/ui";
 import {
   FormControl,
@@ -191,18 +192,10 @@ export function Setup() {
                         className="pr-10 h-11 rounded-md border-input"
                       />
                     </FormControl>
-                    <button
-                      type="button"
-                      onClick={() => setShowPassword(!showPassword)}
-                      tabIndex={-1}
-                      className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                      {showPassword ? (
-                        <EyeOff className="h-5 w-5" />
-                      ) : (
-                        <Eye className="h-5 w-5" />
-                      )}
-                    </button>
+                    <PasswordVisibilityToggle
+                      visible={showPassword}
+                      onToggle={() => setShowPassword(!showPassword)}
+                    />
                   </div>
                   <FormMessage />
                 </FormItem>
@@ -228,20 +221,12 @@ export function Setup() {
                         className="pr-10 h-11 rounded-md border-input"
                       />
                     </FormControl>
-                    <button
-                      type="button"
-                      onClick={() =>
+                    <PasswordVisibilityToggle
+                      visible={showConfirmPassword}
+                      onToggle={() =>
                         setShowConfirmPassword(!showConfirmPassword)
                       }
-                      tabIndex={-1}
-                      className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                      {showConfirmPassword ? (
-                        <EyeOff className="h-5 w-5" />
-                      ) : (
-                        <Eye className="h-5 w-5" />
-                      )}
-                    </button>
+                    />
                   </div>
                   <FormMessage />
                 </FormItem>

--- a/packages/admin/src/components/features/auth-setup/index.tsx
+++ b/packages/admin/src/components/features/auth-setup/index.tsx
@@ -18,7 +18,7 @@ import {
   FormMessage,
 } from "@admin/components/ui/form";
 import { ROUTES } from "@admin/constants/routes";
-import { useBranding } from "@admin/context/providers/BrandingProvider";
+import { useAppName } from "@admin/context/providers/BrandingProvider";
 import { useApi } from "@admin/hooks/useApi";
 import { getCsrfToken } from "@admin/lib/api/csrf";
 import type { ActionResponse } from "@admin/lib/api/response-types";
@@ -46,8 +46,7 @@ const formSchema = z
 
 export function Setup() {
   const { api } = useApi();
-  const branding = useBranding();
-  const appName = branding.logoText ?? "Nextly";
+  const appName = useAppName();
 
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);

--- a/packages/admin/src/components/features/auth-setup/index.tsx
+++ b/packages/admin/src/components/features/auth-setup/index.tsx
@@ -1,22 +1,14 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  Button,
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-  Input,
-} from "@nextlyhq/ui";
-import { useState, useEffect } from "react";
+import { Button, Input } from "@nextlyhq/ui";
+import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { ArrowRight, Eye, EyeOff, Loader2 } from "@admin/components/icons";
 import { PasswordStrengthIndicator } from "@admin/components/shared";
-import { ThemeAwareLogo } from "@admin/components/shared/ThemeAwareLogo";
+import { AuthFormCard } from "@admin/components/shared/auth/AuthFormCard";
 import { toast } from "@admin/components/ui";
 import {
   FormControl,
@@ -30,7 +22,6 @@ import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { useApi } from "@admin/hooks/useApi";
 import { getCsrfToken } from "@admin/lib/api/csrf";
 import type { ActionResponse } from "@admin/lib/api/response-types";
-import { cn } from "@admin/lib/utils";
 import { passwordSchema } from "@admin/lib/validation";
 
 const formSchema = z
@@ -60,7 +51,6 @@ export function Setup() {
 
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const [isVisible, setIsVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
   const form = useForm<z.infer<typeof formSchema>>({
@@ -75,10 +65,6 @@ export function Setup() {
   });
 
   const password = form.watch("password");
-
-  useEffect(() => {
-    setIsVisible(true);
-  }, []);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setIsLoading(true);
@@ -126,188 +112,163 @@ export function Setup() {
   }
 
   return (
-    <div className="w-full max-w-[480px] mx-auto">
-      <Card
-        className={cn(
-          "transition-all duration-300 ease-in-out border-border-strong shadow-none p-2 sm:p-4 md:p-6",
-          isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
-        )}
-      >
-        <CardHeader className="space-y-1 pb-10 pt-8" noBorder>
-          <div className="flex items-center justify-start mb-10 transition-opacity duration-300">
-            <div className="inline-flex items-center justify-center w-12 h-12 overflow-hidden">
-              <ThemeAwareLogo
-                alt={appName}
-                className="w-full h-full object-contain"
-              />
-            </div>
+    <AuthFormCard
+      title={`Welcome to ${appName}`}
+      description="Create your first admin account to get started"
+    >
+      <FormProvider {...form}>
+        <form
+          onSubmit={e => {
+            void form.handleSubmit(onSubmit)(e);
+          }}
+          className="space-y-6"
+        >
+          <div className="grid grid-cols-1 gap-6">
+            <FormField
+              control={form.control}
+              name="fullName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-sm font-medium text-foreground">
+                    Full Name
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      required
+                      type="text"
+                      autoComplete="name"
+                      placeholder="Enter your full name…"
+                      {...field}
+                      className="h-11 rounded-md border-input"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-sm font-medium text-foreground">
+                    Email Address
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      required
+                      type="email"
+                      autoComplete="email"
+                      spellCheck={false}
+                      placeholder="Enter your email address…"
+                      {...field}
+                      className="h-11 rounded-md border-input"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
           </div>
-          <div>
-            <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
-              Welcome to {appName}
-            </CardTitle>
-            <CardDescription className="text-base text-muted-foreground">
-              Create your first admin account to get started
-            </CardDescription>
+
+          <div className="grid grid-cols-1 gap-6">
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-sm font-medium text-foreground">
+                    Password
+                  </FormLabel>
+                  <div className="relative">
+                    <FormControl>
+                      <Input
+                        required
+                        type={showPassword ? "text" : "password"}
+                        autoComplete="new-password"
+                        placeholder="Create a strong password…"
+                        {...field}
+                        className="pr-10 h-11 rounded-md border-input"
+                      />
+                    </FormControl>
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword(!showPassword)}
+                      tabIndex={-1}
+                      className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      {showPassword ? (
+                        <EyeOff className="h-5 w-5" />
+                      ) : (
+                        <Eye className="h-5 w-5" />
+                      )}
+                    </button>
+                  </div>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="confirmPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-sm font-medium text-foreground">
+                    Confirm Password
+                  </FormLabel>
+                  <div className="relative">
+                    <FormControl>
+                      <Input
+                        required
+                        type={showConfirmPassword ? "text" : "password"}
+                        autoComplete="new-password"
+                        placeholder="Confirm your password…"
+                        {...field}
+                        className="pr-10 h-11 rounded-md border-input"
+                      />
+                    </FormControl>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setShowConfirmPassword(!showConfirmPassword)
+                      }
+                      tabIndex={-1}
+                      className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      {showConfirmPassword ? (
+                        <EyeOff className="h-5 w-5" />
+                      ) : (
+                        <Eye className="h-5 w-5" />
+                      )}
+                    </button>
+                  </div>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
           </div>
-        </CardHeader>
 
-        <CardContent className="pb-10">
-          <FormProvider {...form}>
-            <form
-              onSubmit={e => {
-                void form.handleSubmit(onSubmit)(e);
-              }}
-              className="space-y-6"
-            >
-              <div className="grid grid-cols-1 gap-6">
-                <FormField
-                  control={form.control}
-                  name="fullName"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-sm font-medium text-foreground">
-                        Full Name
-                      </FormLabel>
-                      <FormControl>
-                        <Input
-                          required
-                          type="text"
-                          autoComplete="name"
-                          placeholder="Enter your full name…"
-                          {...field}
-                          className="h-11 rounded-md border-input"
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
+          <PasswordStrengthIndicator password={password} />
 
-                <FormField
-                  control={form.control}
-                  name="email"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-sm font-medium text-foreground">
-                        Email Address
-                      </FormLabel>
-                      <FormControl>
-                        <Input
-                          required
-                          type="email"
-                          autoComplete="email"
-                          spellCheck={false}
-                          placeholder="Enter your email address…"
-                          {...field}
-                          className="h-11 rounded-md border-input"
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-
-              <div className="grid grid-cols-1 gap-6">
-                <FormField
-                  control={form.control}
-                  name="password"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-sm font-medium text-foreground">
-                        Password
-                      </FormLabel>
-                      <div className="relative">
-                        <FormControl>
-                          <Input
-                            required
-                            type={showPassword ? "text" : "password"}
-                            autoComplete="new-password"
-                            placeholder="Create a strong password…"
-                            {...field}
-                            className="pr-10 h-11 rounded-md border-input"
-                          />
-                        </FormControl>
-                        <button
-                          type="button"
-                          onClick={() => setShowPassword(!showPassword)}
-                          tabIndex={-1}
-                          className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                        >
-                          {showPassword ? (
-                            <EyeOff className="h-5 w-5" />
-                          ) : (
-                            <Eye className="h-5 w-5" />
-                          )}
-                        </button>
-                      </div>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="confirmPassword"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-sm font-medium text-foreground">
-                        Confirm Password
-                      </FormLabel>
-                      <div className="relative">
-                        <FormControl>
-                          <Input
-                            required
-                            type={showConfirmPassword ? "text" : "password"}
-                            autoComplete="new-password"
-                            placeholder="Confirm your password…"
-                            {...field}
-                            className="pr-10 h-11 rounded-md border-input"
-                          />
-                        </FormControl>
-                        <button
-                          type="button"
-                          onClick={() =>
-                            setShowConfirmPassword(!showConfirmPassword)
-                          }
-                          tabIndex={-1}
-                          className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                        >
-                          {showConfirmPassword ? (
-                            <EyeOff className="h-5 w-5" />
-                          ) : (
-                            <Eye className="h-5 w-5" />
-                          )}
-                        </button>
-                      </div>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-
-              <PasswordStrengthIndicator password={password} />
-
-              <Button
-                size="md"
-                type="submit"
-                disabled={isLoading}
-                className="w-full h-11 rounded-md shadow-none bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] transition-all duration-100 mt-2"
-              >
-                {isLoading ? (
-                  <Loader2 className="h-4 w-4 animate-spin ml-2" />
-                ) : (
-                  <>
-                    Create Admin Account
-                    <ArrowRight className="h-4 w-4 ml-2" />
-                  </>
-                )}
-              </Button>
-            </form>
-          </FormProvider>
-        </CardContent>
-      </Card>
-    </div>
+          <Button
+            size="md"
+            type="submit"
+            disabled={isLoading}
+            className="w-full h-11 rounded-md shadow-none bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] transition-all duration-100 mt-2"
+          >
+            {isLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin ml-2" />
+            ) : (
+              <>
+                Create Admin Account
+                <ArrowRight className="h-4 w-4 ml-2" />
+              </>
+            )}
+          </Button>
+        </form>
+      </FormProvider>
+    </AuthFormCard>
   );
 }

--- a/packages/admin/src/components/features/auth-signup/index.tsx
+++ b/packages/admin/src/components/features/auth-signup/index.tsx
@@ -6,9 +6,10 @@ import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
-import { ArrowRight, Eye, EyeOff, Loader2 } from "@admin/components/icons";
+import { ArrowRight, Loader2 } from "@admin/components/icons";
 import { PasswordStrengthIndicator } from "@admin/components/shared";
 import { AuthFormCard } from "@admin/components/shared/auth/AuthFormCard";
+import { PasswordVisibilityToggle } from "@admin/components/shared/auth/PasswordVisibilityToggle";
 import { toast } from "@admin/components/ui";
 import {
   FormControl,
@@ -188,18 +189,10 @@ export function Signup() {
                         className="pr-10 h-11 rounded-md border-input"
                       />
                     </FormControl>
-                    <button
-                      type="button"
-                      onClick={() => setShowPassword(!showPassword)}
-                      tabIndex={-1}
-                      className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                      {showPassword ? (
-                        <EyeOff className="h-5 w-5" />
-                      ) : (
-                        <Eye className="h-5 w-5" />
-                      )}
-                    </button>
+                    <PasswordVisibilityToggle
+                      visible={showPassword}
+                      onToggle={() => setShowPassword(!showPassword)}
+                    />
                   </div>
                   <FormMessage />
                 </FormItem>
@@ -225,20 +218,12 @@ export function Signup() {
                         className="pr-10 h-11 rounded-md border-input"
                       />
                     </FormControl>
-                    <button
-                      type="button"
-                      onClick={() =>
+                    <PasswordVisibilityToggle
+                      visible={showConfirmPassword}
+                      onToggle={() =>
                         setShowConfirmPassword(!showConfirmPassword)
                       }
-                      tabIndex={-1}
-                      className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                      {showConfirmPassword ? (
-                        <EyeOff className="h-5 w-5" />
-                      ) : (
-                        <Eye className="h-5 w-5" />
-                      )}
-                    </button>
+                    />
                   </div>
                   <FormMessage />
                 </FormItem>

--- a/packages/admin/src/components/features/auth-signup/index.tsx
+++ b/packages/admin/src/components/features/auth-signup/index.tsx
@@ -1,22 +1,14 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  Button,
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-  Input,
-} from "@nextlyhq/ui";
-import { useState, useEffect } from "react";
+import { Button, Input } from "@nextlyhq/ui";
+import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { ArrowRight, Eye, EyeOff, Loader2 } from "@admin/components/icons";
 import { PasswordStrengthIndicator } from "@admin/components/shared";
-import { ThemeAwareLogo } from "@admin/components/shared/ThemeAwareLogo";
+import { AuthFormCard } from "@admin/components/shared/auth/AuthFormCard";
 import { toast } from "@admin/components/ui";
 import {
   FormControl,
@@ -32,7 +24,6 @@ import { useApi } from "@admin/hooks/useApi";
 import { getCsrfToken } from "@admin/lib/api/csrf";
 import type { ActionResponse } from "@admin/lib/api/response-types";
 import { navigateTo } from "@admin/lib/navigation";
-import { cn } from "@admin/lib/utils";
 import { passwordSchema } from "@admin/lib/validation";
 
 const formSchema = z
@@ -62,7 +53,6 @@ export function Signup() {
 
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const [isVisible, setIsVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
   const form = useForm<z.infer<typeof formSchema>>({
@@ -77,10 +67,6 @@ export function Signup() {
   });
 
   const password = form.watch("password");
-
-  useEffect(() => {
-    setIsVisible(true);
-  }, []);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setIsLoading(true);
@@ -123,200 +109,175 @@ export function Signup() {
   }
 
   return (
-    <div className="w-full max-w-[480px] mx-auto">
-      <Card
-        className={cn(
-          "transition-all duration-300 ease-in-out border-border-strong shadow-none p-2 sm:p-4 md:p-6",
-          isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
-        )}
-      >
-        <CardHeader className="space-y-1 pb-10 pt-8" noBorder>
-          <div className="flex items-center justify-start mb-10 transition-opacity duration-300">
-            <div className="inline-flex items-center justify-center w-12 h-12 overflow-hidden">
-              <ThemeAwareLogo
-                alt={appName}
-                className="w-full h-full object-contain"
-              />
-            </div>
+    <AuthFormCard
+      title="Create Account"
+      description={`Join ${appName} and start managing your content`}
+    >
+      <FormProvider {...form}>
+        <form
+          onSubmit={e => {
+            void form.handleSubmit(onSubmit)(e);
+          }}
+          className="space-y-6"
+        >
+          <div className="grid grid-cols-1 gap-6">
+            <FormField
+              control={form.control}
+              name="fullName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-sm font-medium text-foreground">
+                    Full Name
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      required
+                      type="text"
+                      autoComplete="name"
+                      placeholder="Enter your full name…"
+                      {...field}
+                      className="h-11 rounded-md border-input"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-sm font-medium text-foreground">
+                    Email Address
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      required
+                      type="email"
+                      autoComplete="email"
+                      spellCheck={false}
+                      placeholder="Enter your email address…"
+                      {...field}
+                      className="h-11 rounded-md border-input"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
           </div>
-          <div>
-            <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
-              Create Account
-            </CardTitle>
-            <CardDescription className="text-base text-muted-foreground">
-              Join {appName} and start managing your content
-            </CardDescription>
+
+          <div className="grid grid-cols-1 gap-6">
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-sm font-medium text-foreground">
+                    Password
+                  </FormLabel>
+                  <div className="relative">
+                    <FormControl>
+                      <Input
+                        required
+                        type={showPassword ? "text" : "password"}
+                        autoComplete="new-password"
+                        placeholder="Create a strong password…"
+                        {...field}
+                        className="pr-10 h-11 rounded-md border-input"
+                      />
+                    </FormControl>
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword(!showPassword)}
+                      tabIndex={-1}
+                      className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      {showPassword ? (
+                        <EyeOff className="h-5 w-5" />
+                      ) : (
+                        <Eye className="h-5 w-5" />
+                      )}
+                    </button>
+                  </div>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="confirmPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-sm font-medium text-foreground">
+                    Confirm Password
+                  </FormLabel>
+                  <div className="relative">
+                    <FormControl>
+                      <Input
+                        required
+                        type={showConfirmPassword ? "text" : "password"}
+                        autoComplete="new-password"
+                        placeholder="Confirm your password…"
+                        {...field}
+                        className="pr-10 h-11 rounded-md border-input"
+                      />
+                    </FormControl>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setShowConfirmPassword(!showConfirmPassword)
+                      }
+                      tabIndex={-1}
+                      className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      {showConfirmPassword ? (
+                        <EyeOff className="h-5 w-5" />
+                      ) : (
+                        <Eye className="h-5 w-5" />
+                      )}
+                    </button>
+                  </div>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
           </div>
-        </CardHeader>
 
-        <CardContent className="pb-10">
-          <FormProvider {...form}>
-            <form
-              onSubmit={e => {
-                void form.handleSubmit(onSubmit)(e);
-              }}
-              className="space-y-6"
-            >
-              <div className="grid grid-cols-1 gap-6">
-                <FormField
-                  control={form.control}
-                  name="fullName"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-sm font-medium text-foreground">
-                        Full Name
-                      </FormLabel>
-                      <FormControl>
-                        <Input
-                          required
-                          type="text"
-                          autoComplete="name"
-                          placeholder="Enter your full name…"
-                          {...field}
-                          className="h-11 rounded-md border-input"
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
+          <PasswordStrengthIndicator password={password} />
 
-                <FormField
-                  control={form.control}
-                  name="email"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-sm font-medium text-foreground">
-                        Email Address
-                      </FormLabel>
-                      <FormControl>
-                        <Input
-                          required
-                          type="email"
-                          autoComplete="email"
-                          spellCheck={false}
-                          placeholder="Enter your email address…"
-                          {...field}
-                          className="h-11 rounded-md border-input"
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
+          <Button
+            size="md"
+            type="submit"
+            disabled={isLoading}
+            className="w-full h-11 rounded-md shadow-none bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] transition-all duration-100"
+          >
+            {isLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin mr-2" />
+            ) : (
+              <>
+                Create Account
+                <ArrowRight className="h-4 w-4 ml-2" />
+              </>
+            )}
+          </Button>
+        </form>
+      </FormProvider>
 
-              <div className="grid grid-cols-1 gap-6">
-                <FormField
-                  control={form.control}
-                  name="password"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-sm font-medium text-foreground">
-                        Password
-                      </FormLabel>
-                      <div className="relative">
-                        <FormControl>
-                          <Input
-                            required
-                            type={showPassword ? "text" : "password"}
-                            autoComplete="new-password"
-                            placeholder="Create a strong password…"
-                            {...field}
-                            className="pr-10 h-11 rounded-md border-input"
-                          />
-                        </FormControl>
-                        <button
-                          type="button"
-                          onClick={() => setShowPassword(!showPassword)}
-                          tabIndex={-1}
-                          className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                        >
-                          {showPassword ? (
-                            <EyeOff className="h-5 w-5" />
-                          ) : (
-                            <Eye className="h-5 w-5" />
-                          )}
-                        </button>
-                      </div>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="confirmPassword"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-sm font-medium text-foreground">
-                        Confirm Password
-                      </FormLabel>
-                      <div className="relative">
-                        <FormControl>
-                          <Input
-                            required
-                            type={showConfirmPassword ? "text" : "password"}
-                            autoComplete="new-password"
-                            placeholder="Confirm your password…"
-                            {...field}
-                            className="pr-10 h-11 rounded-md border-input"
-                          />
-                        </FormControl>
-                        <button
-                          type="button"
-                          onClick={() =>
-                            setShowConfirmPassword(!showConfirmPassword)
-                          }
-                          tabIndex={-1}
-                          className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                        >
-                          {showConfirmPassword ? (
-                            <EyeOff className="h-5 w-5" />
-                          ) : (
-                            <Eye className="h-5 w-5" />
-                          )}
-                        </button>
-                      </div>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-
-              <PasswordStrengthIndicator password={password} />
-
-              <Button
-                size="md"
-                type="submit"
-                disabled={isLoading}
-                className="w-full h-11 rounded-md shadow-none bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] transition-all duration-100"
-              >
-                {isLoading ? (
-                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
-                ) : (
-                  <>
-                    Create Account
-                    <ArrowRight className="h-4 w-4 ml-2" />
-                  </>
-                )}
-              </Button>
-            </form>
-          </FormProvider>
-
-          <div className="mt-8 text-left">
-            <p className="text-muted-foreground">
-              Already have an account?{" "}
-              <Link
-                href={ROUTES.LOGIN}
-                className="text-primary cursor-pointer font-medium transition-colors"
-              >
-                Sign in
-              </Link>
-            </p>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+      <div className="mt-8 text-left">
+        <p className="text-muted-foreground">
+          Already have an account?{" "}
+          <Link
+            href={ROUTES.LOGIN}
+            className="text-primary cursor-pointer font-medium transition-colors"
+          >
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </AuthFormCard>
   );
 }

--- a/packages/admin/src/components/features/auth-signup/index.tsx
+++ b/packages/admin/src/components/features/auth-signup/index.tsx
@@ -19,7 +19,7 @@ import {
 } from "@admin/components/ui/form";
 import { Link } from "@admin/components/ui/link";
 import { ROUTES } from "@admin/constants/routes";
-import { useBranding } from "@admin/context/providers/BrandingProvider";
+import { useAppName } from "@admin/context/providers/BrandingProvider";
 import { useApi } from "@admin/hooks/useApi";
 import { getCsrfToken } from "@admin/lib/api/csrf";
 import type { ActionResponse } from "@admin/lib/api/response-types";
@@ -48,8 +48,7 @@ const formSchema = z
 
 export function Signup() {
   const { api } = useApi();
-  const branding = useBranding();
-  const appName = branding.logoText ?? "Nextly";
+  const appName = useAppName();
 
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);

--- a/packages/admin/src/components/features/auth-verify-email/index.tsx
+++ b/packages/admin/src/components/features/auth-verify-email/index.tsx
@@ -1,15 +1,9 @@
 "use client";
 
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@nextlyhq/ui";
 import { useEffect, useRef, useState } from "react";
 
 import { ArrowLeft, ArrowRight, Loader2 } from "@admin/components/icons";
+import { AuthStatusCard } from "@admin/components/shared/auth/AuthStatusCard";
 import { Link } from "@admin/components/ui/link";
 import { ROUTES } from "@admin/constants/routes";
 import { verifyEmail } from "@admin/services/authApi";
@@ -58,114 +52,74 @@ export function VerifyEmail({ searchParams }: VerifyEmailProps) {
   // No token in URL
   if (state === "no-token") {
     return (
-      <div className="w-full max-w-[480px] mx-auto">
-        <Card className="transition-all duration-300 ease-in-out border-border-strong shadow-none p-10 opacity-100">
-          <CardHeader className="space-y-1 p-0 mb-8" noBorder>
-            <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
-              Invalid Link
-            </CardTitle>
-            <CardDescription className="text-base text-muted-foreground">
-              This verification link is missing a token. If you need to verify
-              your email, please check your inbox for the original verification
-              email.
-            </CardDescription>
-          </CardHeader>
-
-          <CardContent className="p-0">
-            <div className="mt-2 text-left">
-              <Link
-                href={ROUTES.LOGIN}
-                className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
-              >
-                <ArrowLeft className="h-4 w-4" />
-                Back to Sign In
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <AuthStatusCard
+        title="Invalid Link"
+        description="This verification link is missing a token. If you need to verify your email, please check your inbox for the original verification email."
+      >
+        <div className="mt-2 text-left">
+          <Link
+            href={ROUTES.LOGIN}
+            className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to Sign In
+          </Link>
+        </div>
+      </AuthStatusCard>
     );
   }
 
   // Loading state
   if (state === "loading") {
     return (
-      <div className="w-full max-w-[480px] mx-auto">
-        <Card className="transition-all duration-300 ease-in-out border-border-strong shadow-none p-10 opacity-100">
-          <CardHeader className="space-y-1 p-0 mb-8" noBorder>
-            <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
-              Verifying Your Email
-            </CardTitle>
-            <CardDescription className="text-base text-muted-foreground">
-              Please wait while we verify your email address...
-            </CardDescription>
-          </CardHeader>
-
-          <CardContent className="p-0 flex justify-start">
-            <Loader2 className="h-6 w-6 animate-spin text-primary" />
-          </CardContent>
-        </Card>
-      </div>
+      <AuthStatusCard
+        title="Verifying Your Email"
+        description="Please wait while we verify your email address..."
+      >
+        <div className="flex justify-start">
+          <Loader2 className="h-6 w-6 animate-spin text-primary" />
+        </div>
+      </AuthStatusCard>
     );
   }
 
   // Success state
   if (state === "success") {
     return (
-      <div className="w-full max-w-[480px] mx-auto">
-        <Card className="transition-all duration-300 ease-in-out border-border-strong shadow-none p-10 opacity-100">
-          <CardHeader className="space-y-1 p-0 mb-8" noBorder>
-            <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
-              Email Verified
-            </CardTitle>
-            <CardDescription className="text-base text-muted-foreground">
-              Your email has been verified successfully. You can now sign in to
-              your account.
-            </CardDescription>
-          </CardHeader>
-
-          <CardContent className="p-0">
-            <div className="mt-2 text-left">
-              <Link
-                href={ROUTES.LOGIN}
-                className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
-              >
-                Go to Sign In
-                <ArrowRight className="h-4 w-4 ml-2" />
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <AuthStatusCard
+        title="Email Verified"
+        description="Your email has been verified successfully. You can now sign in to your account."
+      >
+        <div className="mt-2 text-left">
+          <Link
+            href={ROUTES.LOGIN}
+            className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
+          >
+            Go to Sign In
+            <ArrowRight className="h-4 w-4 ml-2" />
+          </Link>
+        </div>
+      </AuthStatusCard>
     );
   }
 
   // Error state
   return (
-    <div className="w-full max-w-[480px] mx-auto">
-      <Card className="transition-all duration-300 ease-in-out border-border-strong shadow-none p-10 opacity-100">
-        <CardHeader className="space-y-1 p-0 mb-8" noBorder>
-          <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
-            Verification Failed
-          </CardTitle>
-          <CardDescription className="text-base text-muted-foreground">
-            {errorMessage ||
-              "This verification link is invalid or has expired."}
-          </CardDescription>
-        </CardHeader>
-
-        <CardContent className="p-0">
-          <div className="mt-2 text-left">
-            <Link
-              href={ROUTES.LOGIN}
-              className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              Back to Sign In
-            </Link>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+    <AuthStatusCard
+      title="Verification Failed"
+      description={
+        errorMessage || "This verification link is invalid or has expired."
+      }
+    >
+      <div className="mt-2 text-left">
+        <Link
+          href={ROUTES.LOGIN}
+          className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Sign In
+        </Link>
+      </div>
+    </AuthStatusCard>
   );
 }

--- a/packages/admin/src/components/features/auth-verify-email/index.tsx
+++ b/packages/admin/src/components/features/auth-verify-email/index.tsx
@@ -56,15 +56,13 @@ export function VerifyEmail({ searchParams }: VerifyEmailProps) {
         title="Invalid Link"
         description="This verification link is missing a token. If you need to verify your email, please check your inbox for the original verification email."
       >
-        <div className="mt-2 text-left">
-          <Link
-            href={ROUTES.LOGIN}
-            className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            Back to Sign In
-          </Link>
-        </div>
+        <Link
+          href={ROUTES.LOGIN}
+          className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Sign In
+        </Link>
       </AuthStatusCard>
     );
   }
@@ -90,15 +88,13 @@ export function VerifyEmail({ searchParams }: VerifyEmailProps) {
         title="Email Verified"
         description="Your email has been verified successfully. You can now sign in to your account."
       >
-        <div className="mt-2 text-left">
-          <Link
-            href={ROUTES.LOGIN}
-            className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
-          >
-            Go to Sign In
-            <ArrowRight className="h-4 w-4 ml-2" />
-          </Link>
-        </div>
+        <Link
+          href={ROUTES.LOGIN}
+          className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
+        >
+          Go to Sign In
+          <ArrowRight className="h-4 w-4 ml-2" />
+        </Link>
       </AuthStatusCard>
     );
   }
@@ -111,15 +107,13 @@ export function VerifyEmail({ searchParams }: VerifyEmailProps) {
         errorMessage || "This verification link is invalid or has expired."
       }
     >
-      <div className="mt-2 text-left">
-        <Link
-          href={ROUTES.LOGIN}
-          className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Back to Sign In
-        </Link>
-      </div>
+      <Link
+        href={ROUTES.LOGIN}
+        className="inline-flex items-center text-primary cursor-pointer font-medium transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to Sign In
+      </Link>
     </AuthStatusCard>
   );
 }

--- a/packages/admin/src/components/shared/auth/AuthFormCard.tsx
+++ b/packages/admin/src/components/shared/auth/AuthFormCard.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@nextlyhq/ui";
+import { useEffect, useState, type ReactNode } from "react";
+
+import { ThemeAwareLogo } from "@admin/components/shared/ThemeAwareLogo";
+import { useBranding } from "@admin/context/providers/BrandingProvider";
+import { cn } from "@admin/lib/utils";
+
+export interface AuthFormCardProps {
+  /** The heading, rendered as the card's title. */
+  title: ReactNode;
+  /** One line under the heading saying what this screen is for. */
+  description: ReactNode;
+  /** The form. */
+  children: ReactNode;
+}
+
+/**
+ * The card every signed-out screen with a form is drawn in: sign in, sign up,
+ * first-run setup, forgot password, reset password, accept invite.
+ *
+ * The mount fade lives here rather than in each screen because it is the CARD
+ * appearing — six copies of the same `isVisible` state could only drift, and a
+ * screen that forgot the effect would render at `opacity-0` forever.
+ *
+ * The logo reads the branding itself for the same reason: every caller passed
+ * the same `branding.logoText ?? "Nextly"`, so the fallback was written six
+ * times and could disagree six ways.
+ */
+export function AuthFormCard({
+  title,
+  description,
+  children,
+}: AuthFormCardProps) {
+  const branding = useBranding();
+  const appName = branding.logoText ?? "Nextly";
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    setIsVisible(true);
+  }, []);
+
+  return (
+    <div className="w-full max-w-[480px] mx-auto">
+      <Card
+        className={cn(
+          "transition-all duration-300 ease-in-out border-border-strong shadow-none p-2 sm:p-4 md:p-6",
+          isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
+        )}
+      >
+        <CardHeader className="space-y-1 pb-10 pt-8" noBorder>
+          <div className="flex items-center justify-start mb-10 transition-opacity duration-300">
+            <div className="inline-flex items-center justify-center w-12 h-12 overflow-hidden">
+              <ThemeAwareLogo
+                alt={appName}
+                className="w-full h-full object-contain"
+              />
+            </div>
+          </div>
+          <div>
+            <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
+              {title}
+            </CardTitle>
+            <CardDescription className="text-base text-muted-foreground">
+              {description}
+            </CardDescription>
+          </div>
+        </CardHeader>
+
+        <CardContent className="pb-10">{children}</CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/admin/src/components/shared/auth/AuthFormCard.tsx
+++ b/packages/admin/src/components/shared/auth/AuthFormCard.tsx
@@ -10,7 +10,7 @@ import {
 import { useEffect, useState, type ReactNode } from "react";
 
 import { ThemeAwareLogo } from "@admin/components/shared/ThemeAwareLogo";
-import { useBranding } from "@admin/context/providers/BrandingProvider";
+import { useAppName } from "@admin/context/providers/BrandingProvider";
 import { cn } from "@admin/lib/utils";
 
 export interface AuthFormCardProps {
@@ -30,17 +30,17 @@ export interface AuthFormCardProps {
  * appearing — six copies of the same `isVisible` state could only drift, and a
  * screen that forgot the effect would render at `opacity-0` forever.
  *
- * The logo reads the branding itself for the same reason: every caller passed
- * the same `branding.logoText ?? "Nextly"`, so the fallback was written six
- * times and could disagree six ways.
+ * The logo asks `useAppName` what the product is called rather than spelling
+ * the fallback here. Three of these screens interpolate the same name into
+ * their own title or description, so a fallback written in this file would sit
+ * one line above a different answer written in theirs.
  */
 export function AuthFormCard({
   title,
   description,
   children,
 }: AuthFormCardProps) {
-  const branding = useBranding();
-  const appName = branding.logoText ?? "Nextly";
+  const appName = useAppName();
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {

--- a/packages/admin/src/components/shared/auth/AuthStatusCard.tsx
+++ b/packages/admin/src/components/shared/auth/AuthStatusCard.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@nextlyhq/ui";
+import { type ReactNode } from "react";
+
+export interface AuthStatusCardProps {
+  /** What happened, as a heading: "Email Verified", "Invalid Link". */
+  title: ReactNode;
+  /** The explanation under it. */
+  description: ReactNode;
+  /** Where the reader goes next — usually one link, sometimes a spinner. */
+  children?: ReactNode;
+}
+
+/**
+ * The card a signed-out screen shows when there is no form to fill in: a link
+ * that was invalid or expired, a verification in progress, a password that was
+ * reset, an invite already accepted.
+ *
+ * Deliberately NOT a variant of `AuthFormCard`. It carries no logo, no mount
+ * fade and different padding, and the two are told apart by what they are for
+ * rather than by a flag — nine call sites would otherwise share a boolean whose
+ * true and false branches have nothing in common.
+ */
+export function AuthStatusCard({
+  title,
+  description,
+  children,
+}: AuthStatusCardProps) {
+  return (
+    <div className="w-full max-w-[480px] mx-auto">
+      <Card className="transition-all duration-300 ease-in-out border-border-strong shadow-none p-10 opacity-100">
+        <CardHeader className="space-y-1 p-0 mb-8" noBorder>
+          <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
+            {title}
+          </CardTitle>
+          <CardDescription className="text-base text-muted-foreground">
+            {description}
+          </CardDescription>
+        </CardHeader>
+
+        {children ? (
+          <CardContent className="p-0">{children}</CardContent>
+        ) : null}
+      </Card>
+    </div>
+  );
+}

--- a/packages/admin/src/components/shared/auth/AuthStatusCard.tsx
+++ b/packages/admin/src/components/shared/auth/AuthStatusCard.tsx
@@ -14,7 +14,12 @@ export interface AuthStatusCardProps {
   title: ReactNode;
   /** The explanation under it. */
   description: ReactNode;
-  /** Where the reader goes next — usually one link, sometimes a spinner. */
+  /**
+   * Where the reader goes next — usually one link, sometimes a spinner.
+   *
+   * Rendered in the card's own action area, so a caller passes the link itself
+   * rather than a wrapper around it.
+   */
   children?: ReactNode;
 }
 
@@ -27,6 +32,11 @@ export interface AuthStatusCardProps {
  * fade and different padding, and the two are told apart by what they are for
  * rather than by a flag — nine call sites would otherwise share a boolean whose
  * true and false branches have nothing in common.
+ *
+ * The `transition-all` is not decoration: the border and background are theme
+ * tokens, so it animates them when the theme changes. There is no `opacity-100`
+ * beside it, because nothing here ever changes opacity — unlike `AuthFormCard`,
+ * which fades in on mount and needs the pair.
  */
 export function AuthStatusCard({
   title,
@@ -35,7 +45,7 @@ export function AuthStatusCard({
 }: AuthStatusCardProps) {
   return (
     <div className="w-full max-w-[480px] mx-auto">
-      <Card className="transition-all duration-300 ease-in-out border-border-strong shadow-none p-10 opacity-100">
+      <Card className="transition-all duration-300 ease-in-out border-border-strong shadow-none p-10">
         <CardHeader className="space-y-1 p-0 mb-8" noBorder>
           <CardTitle className="text-xl font-bold tracking-tight text-foreground mb-3 text-wrap-balance">
             {title}
@@ -46,7 +56,9 @@ export function AuthStatusCard({
         </CardHeader>
 
         {children ? (
-          <CardContent className="p-0">{children}</CardContent>
+          <CardContent className="p-0">
+            <div className="mt-2 text-left">{children}</div>
+          </CardContent>
         ) : null}
       </Card>
     </div>

--- a/packages/admin/src/components/shared/auth/PasswordVisibilityToggle.tsx
+++ b/packages/admin/src/components/shared/auth/PasswordVisibilityToggle.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Eye, EyeOff } from "@admin/components/icons";
+
+export interface PasswordVisibilityToggleProps {
+  /** Whether the field beside it is currently showing the password. */
+  visible: boolean;
+  /** Flip it. */
+  onToggle: () => void;
+}
+
+/**
+ * The eye button that reveals a password, for the field it sits inside.
+ *
+ * It exists because the same button was written eleven times and the copies
+ * had stopped agreeing: four carried an `aria-label` and seven carried
+ * `tabIndex={-1}` instead. On those seven a screen reader announced an unnamed
+ * button and a keyboard user could not reach it at all — the control that
+ * exists to help someone check what they typed was the one control they could
+ * not operate.
+ *
+ * One implementation cannot drift that way, which is why this is a component
+ * rather than seven repaired copies.
+ *
+ * Positioned by the field that renders it: the field owns the `relative` box
+ * and leaves room with `pr-10`.
+ */
+export function PasswordVisibilityToggle({
+  visible,
+  onToggle,
+}: PasswordVisibilityToggleProps) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-label={visible ? "Hide password" : "Show password"}
+      className="absolute cursor-pointer right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+    >
+      {visible ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+    </button>
+  );
+}

--- a/packages/admin/src/components/shared/auth/__tests__/auth-cards.test.tsx
+++ b/packages/admin/src/components/shared/auth/__tests__/auth-cards.test.tsx
@@ -11,9 +11,16 @@ import { AuthStatusCard } from "../AuthStatusCard";
  * area at all.
  */
 
-const { useBranding } = vi.hoisted(() => ({ useBranding: vi.fn() }));
+const { useBranding, useAppName } = vi.hoisted(() => ({
+  useBranding: vi.fn(),
+  useAppName: vi.fn(),
+}));
+// `useAppName` is mocked separately from `useBranding` on purpose: the card
+// ASKS for the product name rather than deriving it, and the fallback it would
+// otherwise re-derive is covered where it lives, in BrandingProvider.test.tsx.
 vi.mock("@admin/context/providers/BrandingProvider", () => ({
   useBranding: () => useBranding(),
+  useAppName: () => useAppName(),
 }));
 
 beforeEach(() => {
@@ -25,6 +32,7 @@ beforeEach(() => {
     logoText: "Acme Docs",
     logoUrl: "https://cdn.example/logo.svg",
   });
+  useAppName.mockReturnValue("Acme Docs");
 });
 
 describe("AuthFormCard", () => {
@@ -55,7 +63,12 @@ describe("AuthFormCard", () => {
     expect(container.querySelector(".opacity-0")).toBeNull();
   });
 
-  it("labels the logo with the configured product name", () => {
+  // The card must ASK for the name rather than reading branding itself: three
+  // screens interpolate the same name into their own copy, and a second
+  // derivation here could disagree with the sentence directly beneath it.
+  it("labels the logo with the name the app is called", () => {
+    useAppName.mockReturnValue("Acme Docs");
+
     render(
       <AuthFormCard title="t" description="d">
         <span />
@@ -65,8 +78,8 @@ describe("AuthFormCard", () => {
     expect(screen.getByAltText("Acme Docs")).toBeInTheDocument();
   });
 
-  it("falls back to Nextly when branding names nothing", () => {
-    useBranding.mockReturnValue({ logoUrl: "https://cdn.example/logo.svg" });
+  it("follows that name when it changes, rather than re-deriving one", () => {
+    useAppName.mockReturnValue("Other Product");
 
     render(
       <AuthFormCard title="t" description="d">
@@ -74,7 +87,8 @@ describe("AuthFormCard", () => {
       </AuthFormCard>
     );
 
-    expect(screen.getByAltText("Nextly")).toBeInTheDocument();
+    expect(screen.getByAltText("Other Product")).toBeInTheDocument();
+    expect(screen.queryByAltText("Acme Docs")).toBeNull();
   });
 });
 
@@ -91,6 +105,27 @@ describe("AuthStatusCard", () => {
     expect(
       screen.getByRole("link", { name: "Go to Sign In" })
     ).toBeInTheDocument();
+  });
+
+  // Eight of the nine call sites used to pass this wrapper themselves. The card
+  // owns it now, so a caller passes the link and nothing around it.
+  it("puts what comes next in its own action area", () => {
+    render(
+      <AuthStatusCard title="t" description="d">
+        <a href="/login">Back to Sign In</a>
+      </AuthStatusCard>
+    );
+
+    const link = screen.getByRole("link", { name: "Back to Sign In" });
+    expect(link.parentElement).toHaveClass("mt-2", "text-left");
+  });
+
+  it("renders no action area when there is nothing to do next", () => {
+    const { container } = render(
+      <AuthStatusCard title="Invalid Link" description="No token." />
+    );
+
+    expect(container.querySelector(".mt-2")).toBeNull();
   });
 
   it("carries no logo — it is not the form card wearing a flag", () => {

--- a/packages/admin/src/components/shared/auth/__tests__/auth-cards.test.tsx
+++ b/packages/admin/src/components/shared/auth/__tests__/auth-cards.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AuthFormCard } from "../AuthFormCard";
+import { AuthStatusCard } from "../AuthStatusCard";
+
+/**
+ * The two cards every signed-out screen is drawn in. What is held here is what
+ * the seven screens stopped saying for themselves: the branded logo, the mount
+ * fade, and the fact that a status card with nothing to do renders no action
+ * area at all.
+ */
+
+const { useBranding } = vi.hoisted(() => ({ useBranding: vi.fn() }));
+vi.mock("@admin/context/providers/BrandingProvider", () => ({
+  useBranding: () => useBranding(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // A configured `logoUrl` is what makes the logo an <img> carrying the alt
+  // text; with none, ThemeAwareLogo draws the built-in inline mark instead and
+  // there is no alt to assert on.
+  useBranding.mockReturnValue({
+    logoText: "Acme Docs",
+    logoUrl: "https://cdn.example/logo.svg",
+  });
+});
+
+describe("AuthFormCard", () => {
+  it("renders its heading, its explanation and the form", () => {
+    render(
+      <AuthFormCard title="Welcome Back" description="Sign in to continue">
+        <button type="submit">Sign in</button>
+      </AuthFormCard>
+    );
+
+    expect(screen.getByText("Welcome Back")).toBeInTheDocument();
+    expect(screen.getByText("Sign in to continue")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign in" })).toBeInTheDocument();
+  });
+
+  // Each screen used to own this state, so one that forgot the effect would
+  // have rendered at opacity-0 forever.
+  it("fades in once mounted", async () => {
+    const { container } = render(
+      <AuthFormCard title="t" description="d">
+        <span />
+      </AuthFormCard>
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector(".opacity-100")).not.toBeNull();
+    });
+    expect(container.querySelector(".opacity-0")).toBeNull();
+  });
+
+  it("labels the logo with the configured product name", () => {
+    render(
+      <AuthFormCard title="t" description="d">
+        <span />
+      </AuthFormCard>
+    );
+
+    expect(screen.getByAltText("Acme Docs")).toBeInTheDocument();
+  });
+
+  it("falls back to Nextly when branding names nothing", () => {
+    useBranding.mockReturnValue({ logoUrl: "https://cdn.example/logo.svg" });
+
+    render(
+      <AuthFormCard title="t" description="d">
+        <span />
+      </AuthFormCard>
+    );
+
+    expect(screen.getByAltText("Nextly")).toBeInTheDocument();
+  });
+});
+
+describe("AuthStatusCard", () => {
+  it("renders its heading, its explanation and what comes next", () => {
+    render(
+      <AuthStatusCard title="Email Verified" description="You can sign in now.">
+        <a href="/login">Go to Sign In</a>
+      </AuthStatusCard>
+    );
+
+    expect(screen.getByText("Email Verified")).toBeInTheDocument();
+    expect(screen.getByText("You can sign in now.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Go to Sign In" })
+    ).toBeInTheDocument();
+  });
+
+  it("carries no logo — it is not the form card wearing a flag", () => {
+    render(<AuthStatusCard title="Invalid Link" description="No token." />);
+
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+});

--- a/packages/admin/src/components/shared/auth/__tests__/password-visibility-toggle.test.tsx
+++ b/packages/admin/src/components/shared/auth/__tests__/password-visibility-toggle.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { PasswordVisibilityToggle } from "../PasswordVisibilityToggle";
+
+/**
+ * The eleven copies of this button had drifted into two behaviours: four
+ * carried an accessible name, seven carried `tabIndex={-1}` and none. These
+ * hold the properties that made the seven unusable — a name, and a place in
+ * the tab order — so one implementation cannot quietly lose them again.
+ */
+describe("PasswordVisibilityToggle", () => {
+  it("names itself for the state it will move to", async () => {
+    const { rerender } = render(
+      <PasswordVisibilityToggle visible={false} onToggle={vi.fn()} />
+    );
+
+    expect(screen.getByRole("button", { name: "Show password" })).toBeVisible();
+
+    rerender(<PasswordVisibilityToggle visible onToggle={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Hide password" })).toBeVisible();
+  });
+
+  // The defect that motivated this component: `tabIndex={-1}` took the control
+  // out of the tab order, so a keyboard user could not reach the one control
+  // that exists to check what they typed.
+  it("is reachable by keyboard", async () => {
+    const user = userEvent.setup();
+    render(<PasswordVisibilityToggle visible={false} onToggle={vi.fn()} />);
+
+    const toggle = screen.getByRole("button", { name: "Show password" });
+    expect(toggle).not.toHaveAttribute("tabindex", "-1");
+
+    await user.tab();
+    expect(toggle).toHaveFocus();
+  });
+
+  it("reports the toggle rather than deciding the state itself", async () => {
+    const onToggle = vi.fn();
+    const user = userEvent.setup();
+    render(<PasswordVisibilityToggle visible={false} onToggle={onToggle} />);
+
+    await user.click(screen.getByRole("button", { name: "Show password" }));
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  // A submit button inside a form would submit it; this one must not.
+  it("does not submit the form it sits in", () => {
+    render(<PasswordVisibilityToggle visible={false} onToggle={vi.fn()} />);
+
+    expect(
+      screen.getByRole("button", { name: "Show password" })
+    ).toHaveAttribute("type", "button");
+  });
+});

--- a/packages/admin/src/context/providers/BrandingProvider.test.tsx
+++ b/packages/admin/src/context/providers/BrandingProvider.test.tsx
@@ -134,8 +134,23 @@ describe("useBrandingStatus", () => {
  * while the screen supplies the sentence under it.
  */
 describe("useAppName", () => {
+  /**
+   * Reports the arrival of the response beside the name it produced.
+   *
+   * Waiting on the NAME alone cannot test a fallback: "Nextly" is also what
+   * renders before the request answers, so `waitFor` succeeds on the very
+   * first check and the assertion never sees the response at all. Measured —
+   * both fallback cases below passed with the guard removed until this probe
+   * made arrival observable.
+   */
   function NameProbe() {
-    return <span data-testid="name">{useAppName()}</span>;
+    const { isPending } = useBrandingStatus();
+    return (
+      <>
+        <span data-testid="name">{useAppName()}</span>
+        <span data-testid="arrived">{isPending ? "no" : "yes"}</span>
+      </>
+    );
   }
 
   function renderName(client: QueryClient) {
@@ -148,6 +163,13 @@ describe("useAppName", () => {
     );
   }
 
+  /** The response has landed, so what the name reads is about the response. */
+  async function arrived() {
+    await waitFor(() =>
+      expect(screen.getByTestId("arrived").textContent).toBe("yes")
+    );
+  }
+
   it("uses the configured name", async () => {
     get.mockResolvedValue({ logoText: "Acme Docs" } as AdminBranding);
     protectedGet.mockResolvedValue({ plugins: [] } as AdminBranding);
@@ -156,9 +178,23 @@ describe("useAppName", () => {
       new QueryClient({ defaultOptions: { queries: { retry: false } } })
     );
 
-    await waitFor(() =>
-      expect(screen.getByTestId("name").textContent).toBe("Acme Docs")
+    await arrived();
+    expect(screen.getByTestId("name").textContent).toBe("Acme Docs");
+  });
+
+  // A project that clears the field in Settings sends "", which `??` would let
+  // through — leaving the sign-in line reading "Sign in to your  account" and
+  // the logo with an empty accessible name.
+  it("treats a blank configured name as unset", async () => {
+    get.mockResolvedValue({ logoText: "   " } as AdminBranding);
+    protectedGet.mockResolvedValue({ plugins: [] } as AdminBranding);
+
+    renderName(
+      new QueryClient({ defaultOptions: { queries: { retry: false } } })
     );
+
+    await arrived();
+    expect(screen.getByTestId("name").textContent).toBe("Nextly");
   });
 
   it("falls back to Nextly when branding names nothing", async () => {
@@ -169,9 +205,8 @@ describe("useAppName", () => {
       new QueryClient({ defaultOptions: { queries: { retry: false } } })
     );
 
-    await waitFor(() =>
-      expect(screen.getByTestId("name").textContent).toBe("Nextly")
-    );
+    await arrived();
+    expect(screen.getByTestId("name").textContent).toBe("Nextly");
   });
 });
 

--- a/packages/admin/src/context/providers/BrandingProvider.test.tsx
+++ b/packages/admin/src/context/providers/BrandingProvider.test.tsx
@@ -23,6 +23,7 @@ vi.mock("@admin/lib/api/protectedApi", () => ({
 
 import {
   BrandingProvider,
+  useAppName,
   useBrandingStatus,
 } from "@admin/context/providers/BrandingProvider";
 
@@ -123,6 +124,54 @@ describe("useBrandingStatus", () => {
     );
 
     await waitFor(() => expect(status()).toBe("unavailable"));
+  });
+});
+
+/**
+ * The product's name is one decision, so it has one implementation. A screen
+ * that spelled `branding.logoText ?? "Nextly"` for itself could disagree with
+ * the component beside it — the signed-out card supplies the logo's label
+ * while the screen supplies the sentence under it.
+ */
+describe("useAppName", () => {
+  function NameProbe() {
+    return <span data-testid="name">{useAppName()}</span>;
+  }
+
+  function renderName(client: QueryClient) {
+    return render(
+      <QueryClientProvider client={client}>
+        <BrandingProvider>
+          <NameProbe />
+        </BrandingProvider>
+      </QueryClientProvider>
+    );
+  }
+
+  it("uses the configured name", async () => {
+    get.mockResolvedValue({ logoText: "Acme Docs" } as AdminBranding);
+    protectedGet.mockResolvedValue({ plugins: [] } as AdminBranding);
+
+    renderName(
+      new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("name").textContent).toBe("Acme Docs")
+    );
+  });
+
+  it("falls back to Nextly when branding names nothing", async () => {
+    get.mockResolvedValue({} as AdminBranding);
+    protectedGet.mockResolvedValue({ plugins: [] } as AdminBranding);
+
+    renderName(
+      new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("name").textContent).toBe("Nextly")
+    );
   });
 });
 

--- a/packages/admin/src/context/providers/BrandingProvider.tsx
+++ b/packages/admin/src/context/providers/BrandingProvider.tsx
@@ -65,6 +65,19 @@ export function useBranding(): AdminBranding {
 }
 
 /**
+ * What to call this product on screen.
+ *
+ * One implementation, because the answer is one decision: a screen that spells
+ * `branding.logoText ?? "Nextly"` for itself can disagree with the component
+ * beside it. The signed-out screens had that shape — the card supplied the
+ * logo's label while the screen supplied the sentence under it, so a change to
+ * either fallback made the two contradict each other on one page.
+ */
+export function useAppName(): string {
+  return useBranding().logoText ?? "Nextly";
+}
+
+/**
  * The admin-meta request's state, for readers that draw a conclusion from
  * something being MISSING from branding.
  *

--- a/packages/admin/src/context/providers/BrandingProvider.tsx
+++ b/packages/admin/src/context/providers/BrandingProvider.tsx
@@ -74,7 +74,11 @@ export function useBranding(): AdminBranding {
  * either fallback made the two contradict each other on one page.
  */
 export function useAppName(): string {
-  return useBranding().logoText ?? "Nextly";
+  // `??` alone would let a configured-but-empty `logoText` through, and an
+  // empty name is worse than a default one: the sign-in line reads "Sign in to
+  // your  account" and the card passes `alt=""`, which strips the logo's
+  // accessible name rather than just looking odd.
+  return useBranding().logoText?.trim() || "Nextly";
 }
 
 /**


### PR DESCRIPTION
## Summary

The seven signed-out screens each carried their own copy of the card markup: the same `Card`/`CardHeader`/`CardTitle` nesting, the same mount fade driven by a local `isVisible` state, and the same product name spelled `branding.logoText ?? "Nextly"`. Fifteen hand-written copies of two layouts, so the logo, the fade and the fallback name could drift apart on any one screen without anything failing loudly.

Two components now own those layouts:

- **`AuthFormCard`** — the screens that carry a form (sign in, sign up, first-run setup, forgot password, reset password, accept invite). It holds the mount fade itself, because it is the card that appears: six copies of that effect could only drift, and a screen that forgot the effect would render at `opacity-0` forever. It reads branding directly for the same reason, so the fallback name is written once rather than six times.
- **`AuthStatusCard`** — the screens with nothing to fill in (invalid link, verifying, verified, password reset, invite already accepted). Deliberately **not** a variant of the first: no logo, no fade, different padding. Nine call sites would otherwise share a boolean whose two branches have nothing in common.

Net **−348 lines** of product code across the three extractions.

**Review rounds changed the behaviour claim, so it is stated plainly rather than left standing.** The card extraction is behaviour-preserving and the pixel comparison below evidences it. Two later commits are not, both deliberately:

- **Blank product name** (5b6060e7d). `??` let a configured-but-empty `logoText` through, so a project that cleared the field in Settings saw "Sign in to your  account" and a logo with `alt=""`, which strips its accessible name. `useAppName` now treats blank as unset.
- **Reveal-password button** (6e060774d). The same button was written **eleven** times; four carried an `aria-label` and seven carried `tabIndex={-1}` and no accessible name, so on those seven a screen reader announced an unnamed button and a keyboard user could not reach it at all. `PasswordVisibilityToggle` is that button once. **Those seven buttons now take focus in tab order** — that is the change, and it is the point.

The pixel comparison below was taken before those two commits.

Measured with fallow, scoped to `@nextlyhq/admin`, against this branch's base:

| | before | after |
| --- | --- | --- |
| clone groups | 207 | **199** |
| duplicated lines | 11,506 (2.2%) | **10,998 (2.1%)** |
| files carrying duplication | 167 | **166** |

**8 clone groups and 508 duplicated lines resolved.** All of it duplication — no dead-code, dependency or cycle findings change here (1 unused export, 18 unused dependencies, 24 cycles before and after). Reproduce with `pnpm exec fallow dupes -w '@nextlyhq/admin'`.

Note that the audit gate reports `duplication_introduced` above zero for this change, and that is attribution rather than new duplication: rewriting a file re-attributes its surviving clone groups from inherited to introduced. The absolute count above is the honest measure.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [x] Refactor / chore (no user-facing change)

## Related issues

None.

## Changeset

- [x] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [x] I selected the correct semver bump (patch / minor / major)

`.changeset/auth-screens-share-their-cards.md`, patch across the lockstep group.

## Test plan

- [x] `pnpm lint` — 22/22 packages
- [x] `pnpm check-types` — clean
- [x] `pnpm build` — 19/19 packages
- [x] Manually verified the change

New suite `packages/admin/src/components/shared/auth/__tests__/auth-cards.test.tsx` (6 tests) covers both cards: what they render, that the form card fades in once mounted, that the logo carries the configured product name and falls back to `Nextly`, and that the status card carries no logo. Together with the existing `auth-ui-extras` suite that is 12 passing tests over the touched area.

The fade test was break-verified: removing the mount effect fails it, restoring it passes.

Whole admin suite before and after this change: the same 7 files and the same 19 tests fail, none of them in `auth-*` or `shared/auth`. That failing set is pre-existing and untouched here.

**Verified in the browser** on the playground, all seven screens in light and dark. Every screen returns 200 and renders exactly one card, with no page errors.

## Screenshots / recordings

Before/after of all seven screens in both themes, captured on the same server, database and browser — only the seven `auth-*` directories differed between the two runs. Left is `main`, right is this branch.

**Sign in — light.** The one screen with a measurable difference, explained below.

![sign in, light](https://raw.githubusercontent.com/nextlyhq/nextly/pr-1077-screenshots/.github/pr-assets/1077/side-by-side/light-01-login.png)

**Sign in — dark.**

![sign in, dark](https://raw.githubusercontent.com/nextlyhq/nextly/pr-1077-screenshots/.github/pr-assets/1077/side-by-side/dark-01-login.png)

**Verify email, invalid link — dark.** An `AuthStatusCard`: no logo, tighter padding. Pixel-identical.

![verify email invalid, dark](https://raw.githubusercontent.com/nextlyhq/nextly/pr-1077-screenshots/.github/pr-assets/1077/side-by-side/dark-06-verify-email-invalid.png)

<details>
<summary>The other eleven pairs</summary>

![sign up, light](https://raw.githubusercontent.com/nextlyhq/nextly/pr-1077-screenshots/.github/pr-assets/1077/side-by-side/light-02-register.png)
![sign up, dark](https://raw.githubusercontent.com/nextlyhq/nextly/pr-1077-screenshots/.github/pr-assets/1077/side-by-side/dark-02-register.png)
![forgot password, light](https://raw.githubusercontent.com/nextlyhq/nextly/pr-1077-screenshots/.github/pr-assets/1077/side-by-side/light-03-forgot-password.png)
![forgot password, dark](https://raw.githubusercontent.com/nextlyhq/nextly/pr-1077-screenshots/.github/pr-assets/1077/side-by-side/dark-03-forgot-password.png)
![reset password invalid, light](https://raw.githubusercontent.com/nextlyhq/nextly/pr-1077-screenshots/.github/pr-assets/1077/side-by-side/light-04-reset-password-invalid.png)
![reset password invalid, dark](https://raw.githubusercontent.com/nextlyhq/nextly/pr-1077-screenshots/.github/pr-assets/1077/side-by-side/dark-04-reset-password-invalid.png)
![accept invite invalid, light](https://raw.githubusercontent.com/nextlyhq/nextly/pr-1077-screenshots/.github/pr-assets/1077/side-by-side/light-05-accept-invite-invalid.png)
![accept invite invalid, dark](https://raw.githubusercontent.com/nextlyhq/nextly/pr-1077-screenshots/.github/pr-assets/1077/side-by-side/dark-05-accept-invite-invalid.png)
![verify email invalid, light](https://raw.githubusercontent.com/nextlyhq/nextly/pr-1077-screenshots/.github/pr-assets/1077/side-by-side/light-06-verify-email-invalid.png)
![verify email failed, light](https://raw.githubusercontent.com/nextlyhq/nextly/pr-1077-screenshots/.github/pr-assets/1077/side-by-side/light-07-verify-email-failed.png)
![verify email failed, dark](https://raw.githubusercontent.com/nextlyhq/nextly/pr-1077-screenshots/.github/pr-assets/1077/side-by-side/dark-07-verify-email-failed.png)

</details>

Per-pixel comparison of the fourteen pairs:

| screen | light | dark |
| --- | --- | --- |
| sign in | 68 px (0.0083%) | 70 px (0.0085%) |
| sign up | 124 px (0.0133%) | 126 px (0.0135%) |
| forgot password | **0** | **0** |
| reset password, invalid link | **0** | **0** |
| accept invite, invalid link | **0** | **0** |
| verify email, invalid link | **0** | **0** |
| verify email, failed | **0** | **0** |

Ten of fourteen are pixel-identical. The rest differ inside a 10x10 box on sign in and an 18x10 box on sign up — every differing pixel sits on the letter **"a"** of "account", immediately after the product name:

![differing pixels on sign in](https://raw.githubusercontent.com/nextlyhq/nextly/pr-1077-screenshots/.github/pr-assets/1077/diff/light-01-login.png)

That is the seam where the interpolation used to be. The description was JSX with three children (`Sign in to your {appName} account`), so the browser laid out three text nodes; it is now a single interpolated string passed as a prop. Same characters, same layout, same line breaks — only the subpixel antialiasing at the former node boundary differs. The corroboration: **only the two screens whose description interpolates the product name moved at all.** Forgot password's description is a plain literal and is pixel-identical, as are all five status screens.

<sub>Images live on the throwaway `pr-1077-screenshots` branch so they stay out of this review diff. Delete that branch once this lands.</sub>

## Checklist

- [x] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [x] I targeted the `main` branch
- [ ] I updated relevant documentation

## Notes for reviewers

**Three controls, one disease.** The card shells were hand-written 15 times, the status card action wrapper 8 times, and the reveal-password button 11 times — and each had already drifted: the shells in their fallback name, the wrapper not at all yet, the button into two different accessibility behaviours. Review rounds found the second and third; the first is what the PR opened with.



**Read the diff with `git diff --ignore-all-space`.** The children moved out one nesting level, so prettier reindented whole bodies; `auth-verify-email` is 24/−70 that way against 152 raw. The reindentation is most of the line count.

**`/admin/setup` is the one call site not photographed.** It renders the login screen once an admin account exists, so it cannot be reached on a seeded playground without emptying the database. It uses the same `AuthFormCard` as the other five form screens and is covered by the same tests.

**What is deliberately still duplicated.** The password fields and the sign-up/setup form body remain clone groups (145 / 111 / 69 lines). They are the obvious next extraction and are left out here to keep this diff to one idea.

**Two behaviours moved into `AuthFormCard` rather than being deleted**: the mount fade and the `branding.logoText ?? "Nextly"` fallback. Every screen that previously showed the branded name still shows it, read from branding rather than hard-coded — visible as "Nextly Playground" in the screenshots.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent shared layouts for sign-in, sign-up, password recovery, invitation, setup, reset, and email verification screens.
  * Added reusable status cards for success, error, and informational authentication states.
  * Authentication branding now consistently displays the configured application name, with a default fallback.

* **UI Improvements**
  * Standardized authentication card styling, logos, spacing, and responsive presentation.
  * Preserved existing form controls, validation, loading states, and navigation flows.

* **Tests**
  * Added coverage for shared authentication cards and application-name behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
