### PR TITLE
fix(nextly): discard the language's pending change, not the default's

### DIFF
--- a/.changeset/per-language-discard.md
+++ b/.changeset/per-language-discard.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Discarding a pending change now removes the language it was asked for. On a
+localized collection the discard named no language, so it resolved to the
+default: the editor's Discard threw away the default language's pending
+change while leaving the one on screen, and reset the form to the default
+language's live values.

--- a/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
@@ -478,6 +478,10 @@ export function useEntryForm({
   const discardMutation = useDiscardWorkingDraft({
     collectionSlug: collection.name,
     entryId: entry?.id ?? "",
+    // The editor discards the language it is showing. Without this a localized
+    // document's discard falls to the default language, throwing away a pending
+    // change the author is not looking at and leaving the one they are.
+    locale,
   });
 
   // Singular label for UI

--- a/packages/admin/src/hooks/queries/__tests__/useDiscardWorkingDraft.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useDiscardWorkingDraft.test.tsx
@@ -103,6 +103,60 @@ describe("useDiscardWorkingDraft", () => {
     );
   });
 
+  it("seeds only the discarded language's cache, leaving another language's alone", async () => {
+    // The response is ONE language's live document, and the detail key is a
+    // prefix of every scoped variant. Seeding it across all of them would write
+    // Spanish values into the English cache entry, which the editor then shows
+    // as English content on the next language switch.
+    const client = makeClient();
+    const enKey = entryKeys.detailScoped("posts", "e1", {
+      locale: null,
+      draft: true,
+    });
+    const esKey = entryKeys.detailScoped("posts", "e1", {
+      locale: "es",
+      draft: true,
+    });
+    client.setQueryData(enKey, {
+      id: "e1",
+      title: "English live",
+      _isWorkingDraft: true,
+    });
+    client.setQueryData(esKey, {
+      id: "e1",
+      title: "Spanish draft",
+      _isWorkingDraft: true,
+    });
+
+    discardSpy.mockResolvedValue({
+      message: "Working draft discarded.",
+      item: { id: "e1", title: "Spanish live", status: "published" },
+    });
+
+    const { result } = renderHook(
+      () =>
+        useDiscardWorkingDraft({
+          collectionSlug: "posts",
+          entryId: "e1",
+          locale: "es",
+        }),
+      { wrapper: makeWrapper(client) }
+    );
+
+    await result.current.mutateAsync();
+
+    // Spanish takes the response...
+    expect(client.getQueryData(esKey)).toMatchObject({
+      title: "Spanish live",
+      _isWorkingDraft: false,
+    });
+    // ...and English is untouched, still holding its own pending change.
+    expect(client.getQueryData(enKey)).toMatchObject({
+      title: "English live",
+      _isWorkingDraft: true,
+    });
+  });
+
   it("toasts the error and does not invalidate on failure", async () => {
     const client = makeClient();
     const invalidateSpy = vi.spyOn(client, "invalidateQueries");

--- a/packages/admin/src/hooks/queries/__tests__/useDiscardWorkingDraft.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useDiscardWorkingDraft.test.tsx
@@ -59,15 +59,48 @@ describe("useDiscardWorkingDraft", () => {
 
     await result.current.mutateAsync();
 
-    expect(discardSpy).toHaveBeenCalledWith({
-      kind: "collection",
-      slug: "posts",
-      entryId: "e1",
-    });
+    // No locale named: the caller is an unlocalized collection, or the default
+    // language, which the editor addresses without naming it.
+    expect(discardSpy).toHaveBeenCalledWith(
+      {
+        kind: "collection",
+        slug: "posts",
+        entryId: "e1",
+      },
+      undefined
+    );
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: entryKeys.detail("posts", "e1"),
     });
     expect(toastSuccessSpy).toHaveBeenCalledWith("Working draft discarded");
+  });
+
+  it("names the language whose pending change is being discarded", async () => {
+    // A localized document holds one pending change per language. Dropping the
+    // locale here would discard the default language's, which is neither the
+    // one the author is looking at nor one they asked about.
+    const client = makeClient();
+    discardSpy.mockResolvedValue({
+      message: "Working draft discarded.",
+      item: { id: "e1", status: "published" },
+    });
+
+    const { result } = renderHook(
+      () =>
+        useDiscardWorkingDraft({
+          collectionSlug: "posts",
+          entryId: "e1",
+          locale: "es",
+        }),
+      { wrapper: makeWrapper(client) }
+    );
+
+    await result.current.mutateAsync();
+
+    expect(discardSpy).toHaveBeenCalledWith(
+      { kind: "collection", slug: "posts", entryId: "e1" },
+      "es"
+    );
   });
 
   it("toasts the error and does not invalidate on failure", async () => {

--- a/packages/admin/src/hooks/queries/useDiscardWorkingDraft.ts
+++ b/packages/admin/src/hooks/queries/useDiscardWorkingDraft.ts
@@ -72,8 +72,26 @@ export function useDiscardWorkingDraft({
       // showing Changed, and a remount could briefly restore the discarded
       // values. `_isWorkingDraft` is cleared explicitly — the live item omits it,
       // so a plain spread would let the stale `true` survive.
+      // Only the variants reading the SAME language. The response is one
+      // language's live document, and the detail key is a prefix of every scoped
+      // variant, so seeding it across all of them writes this language's values
+      // into another language's cache entry — which the editor would then show
+      // on switching, as that language's content.
       queryClient.setQueriesData<Record<string, unknown>>(
-        { queryKey: entryKeys.detail(collectionSlug, entryId) },
+        {
+          queryKey: entryKeys.detail(collectionSlug, entryId),
+          predicate: query => {
+            const scope = query.queryKey[query.queryKey.length - 1];
+            // An entry cached under the bare detail key carries no read
+            // dimensions to disagree with, so it is still seeded.
+            if (typeof scope !== "object" || scope === null) return true;
+            // `detailScoped` normalises an absent locale to null, and so does
+            // this hook, so the default language compares equal on both sides.
+            return (
+              (scope as { locale?: string | null }).locale === (locale ?? null)
+            );
+          },
+        },
         old => (old ? { ...old, ...data.item, _isWorkingDraft: false } : old)
       );
 

--- a/packages/admin/src/hooks/queries/useDiscardWorkingDraft.ts
+++ b/packages/admin/src/hooks/queries/useDiscardWorkingDraft.ts
@@ -28,6 +28,13 @@ export interface UseDiscardWorkingDraftOptions {
   collectionSlug: string;
   /** The entry whose working draft is being discarded. */
   entryId: string;
+  /**
+   * Which language's pending change to discard. A localized document holds one
+   * per language, so discarding without naming one would throw away a language
+   * the author never opened. Absent for an unlocalized collection, and for the
+   * default language, which the editor addresses without naming it.
+   */
+  locale?: string | null;
   /** Callback fired on a successful discard, with the live published document. */
   onSuccess?: (data: DiscardWorkingDraftResponse) => void;
   /** Callback fired on error. */
@@ -39,6 +46,7 @@ export interface UseDiscardWorkingDraftOptions {
 export function useDiscardWorkingDraft({
   collectionSlug,
   entryId,
+  locale,
   onSuccess,
   onError,
   showToast = true,
@@ -47,11 +55,14 @@ export function useDiscardWorkingDraft({
 
   return useMutation<DiscardWorkingDraftResponse, Error, void>({
     mutationFn: () =>
-      versionApi.discardWorkingDraft({
-        kind: "collection",
-        slug: collectionSlug,
-        entryId,
-      }),
+      versionApi.discardWorkingDraft(
+        {
+          kind: "collection",
+          slug: collectionSlug,
+          entryId,
+        },
+        locale
+      ),
 
     onSuccess: data => {
       // Seed the authoritative live row the discard returned into every scoped

--- a/packages/admin/src/services/__tests__/versionApi.test.ts
+++ b/packages/admin/src/services/__tests__/versionApi.test.ts
@@ -104,6 +104,27 @@ describe("versionApi.discardWorkingDraft", () => {
       "/collections/posts/entries/e1/versions/working-draft"
     );
   });
+
+  it("names the language in the query string when one is given", async () => {
+    // A localized document holds one pending change per language, so the
+    // request has to say which one it is throwing away.
+    await versionApi.discardWorkingDraft(collection, "es");
+
+    expect(delSpy).toHaveBeenCalledWith(
+      "/collections/posts/entries/e1/versions/working-draft?locale=es"
+    );
+  });
+
+  it("omits the query string when no language is named", async () => {
+    // An unlocalized collection, and the default language the editor addresses
+    // without naming it, both reach the server with no locale — which it
+    // resolves to the default rather than refusing.
+    await versionApi.discardWorkingDraft(collection, null);
+
+    expect(delSpy).toHaveBeenCalledWith(
+      "/collections/posts/entries/e1/versions/working-draft"
+    );
+  });
 });
 
 /**

--- a/packages/admin/src/services/versionApi.ts
+++ b/packages/admin/src/services/versionApi.ts
@@ -206,15 +206,23 @@ export const versionApi = {
    * reverting the editor to the live published row. A DELETE on the sidecar
    * sub-resource; the response carries the live published document.
    *
-   * Collection-only: the split gives a published document a separate draft head,
-   * which a Single — one row, no published/draft pair — never has.
+   * A localized document holds one pending change per language, so the locale
+   * names which one is being thrown away and which language's live values come
+   * back. Omitting it means the request names no language, which the server
+   * resolves to the default — the ordinary path when editing that language.
    */
   discardWorkingDraft: (
-    scope: Extract<VersionScope, { kind: "collection" }>
-  ): Promise<DiscardWorkingDraftResponse> =>
-    protectedApi.delete<DiscardWorkingDraftResponse>(
-      `${basePath(scope)}/working-draft`
-    ),
+    scope: Extract<VersionScope, { kind: "collection" }>,
+    locale?: string | null
+  ): Promise<DiscardWorkingDraftResponse> => {
+    const search = new URLSearchParams();
+    if (locale) search.set("locale", locale);
+    const query = search.toString();
+
+    return protectedApi.delete<DiscardWorkingDraftResponse>(
+      `${basePath(scope)}/working-draft${query ? `?${query}` : ""}`
+    );
+  },
 
   /**
    * Record the editor's current values as this author's recovery point.

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -232,6 +232,10 @@ export const COLLECTION_VERSION_METHODS: Record<
         entryId: String(p.entryId ?? ""),
         user: userFromParams(p),
         params: p,
+        // `?locale=` names the language whose pending change is being thrown
+        // away. An empty value is the same as none: the request named no
+        // language, which a localized document resolves to its default.
+        locale: typeof p.locale === "string" && p.locale ? p.locale : null,
       });
       return respondMutation("Working draft discarded.", item);
     },

--- a/packages/nextly/src/dispatcher/handlers/versions-methods.ts
+++ b/packages/nextly/src/dispatcher/handlers/versions-methods.ts
@@ -609,9 +609,20 @@ export async function restoreVersionForDocument(
  * Returns the published document as a plain read would, so the editor can reset
  * to the live values without a second request. A no-op that still returns the
  * live row when no working draft exists.
+ *
+ * A localized document holds one pending change per language, so the request
+ * names the language it discards; the others are left alone.
  */
 export async function discardWorkingDraftForDocument(
-  args: VersionMethodArgs & { params: Params }
+  args: Omit<VersionMethodArgs, "locale"> & {
+    params: Params;
+    /**
+     * Which language's pending change to discard. Absent (or null) means the
+     * request named none, which a localized document resolves to its default
+     * language — the admin omits `?locale=` when editing that one.
+     */
+    locale?: string | null;
+  }
 ): Promise<unknown> {
   const caller = readAccessCallerFromParams(args.params, args.user);
 
@@ -655,6 +666,7 @@ export async function discardWorkingDraftForDocument(
     slug: args.slug,
     entryId: args.entryId,
     user: args.user,
+    locale: args.locale ?? null,
     authenticatedScope,
   });
 }

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -60,6 +60,22 @@ type VersionRow = {
   versionNo: number | null;
 };
 
+async function workingDraftLocales(id: string): Promise<string[]> {
+  const rows = await handle!.adapter.select<
+    VersionRow & { locale: string | null }
+  >("nextly_versions", {
+    where: {
+      and: [
+        { column: "entryId", op: "=", value: id },
+        { column: "isAutosave", op: "=", value: false },
+        { column: "versionNo", op: "IS NULL" },
+        { column: "status", op: "=", value: "draft" },
+      ],
+    },
+  });
+  return rows.map(r => r.locale ?? "").sort();
+}
+
 async function workingDraftCount(id: string): Promise<number> {
   return (
     await handle!.adapter.select<VersionRow>("nextly_versions", {
@@ -554,6 +570,67 @@ describe("draft/published split — discard working draft (integration)", () => 
     const [liveAfter] = await handle.adapter.select<LiveRow>(TABLE);
     expect(liveAfter.title).toBe("live");
     expect(liveAfter.status).toBe("published");
+  });
+
+  it("discards only the language it was asked for, leaving other languages' pending changes", async () => {
+    // A localized document holds one pending change per language, so a discard
+    // is one language's concern. Throwing away a language the author never
+    // opened destroys work nobody asked to lose, and leaving the language they
+    // DID ask about means the editor still shows the edit it just reported
+    // discarding.
+    handle = await createTestNextly({
+      localization: { locales: ["en", "es"], defaultLocale: "en" },
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          localized: true,
+          versions: { drafts: true },
+          access: { read: () => true, update: () => true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const trusted = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(trusted, {
+      title: "live-en",
+      status: "published",
+    });
+    const [row] = await handle.adapter.select<{ id: string }>(TABLE);
+    const id = row.id;
+
+    // A pending change in each language. The English save names no locale,
+    // which is the admin's ordinary path for the default language.
+    await entries.updateEntry(
+      { ...trusted, entryId: id },
+      { title: "edited-en" }
+    );
+    await entries.updateEntry(
+      { ...trusted, entryId: id, locale: "es" },
+      { title: "edited-es" }
+    );
+    expect(await workingDraftLocales(id)).toEqual(["en", "es"]);
+
+    // The editor is on Spanish and discards. The request names that language.
+    await discardWorkingDraftForDocument({
+      scopeKind: "collection",
+      slug: COLLECTION,
+      entryId: id,
+      user: { id: "editor-1" },
+      locale: "es",
+      params: {
+        collectionName: COLLECTION,
+        entryId: id,
+        _authenticatedUserId: "editor-1",
+      },
+    });
+
+    // Spanish is gone and English survives untouched.
+    expect(await workingDraftLocales(id)).toEqual(["en"]);
   });
 });
 

--- a/packages/nextly/src/domains/versions/__tests__/discard-working-draft.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/discard-working-draft.test.ts
@@ -72,15 +72,40 @@ describe("discardWorkingDraft", () => {
       title: "live",
       status: "published",
     });
+    // A request naming no language reaches the handler as an explicit null, so
+    // the one rule that resolves a language decides what that means rather than
+    // the delete falling to whichever key happens to be absent.
     expect(discardSpy).toHaveBeenCalledWith({
       collectionName: "posts",
       entryId: "e1",
+      locale: null,
     });
     expect(unlockedDeleteSpy).not.toHaveBeenCalled();
     // The live read precedes the deletion, so a read failure can leave the draft
     // intact (pinned by the next case).
     expect(getEntrySpy.mock.invocationCallOrder[0]).toBeLessThan(
       discardSpy.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("forwards the language being discarded to the read and the delete", async () => {
+    // A localized document holds one pending change per language. Both halves
+    // need the language: the delete to remove the right one, and the read so the
+    // values handed back are the ones the editor resets to.
+    getEntrySpy.mockResolvedValue({
+      success: true,
+      data: { id: "e1", title: "vive", status: "published" },
+    });
+
+    await discardWorkingDraft({ ...args, locale: "es" });
+
+    expect(discardSpy).toHaveBeenCalledWith({
+      collectionName: "posts",
+      entryId: "e1",
+      locale: "es",
+    });
+    expect(getEntrySpy).toHaveBeenCalledWith(
+      expect.objectContaining({ locale: "es" })
     );
   });
 

--- a/packages/nextly/src/domains/versions/discard-working-draft.ts
+++ b/packages/nextly/src/domains/versions/discard-working-draft.ts
@@ -7,6 +7,10 @@
  * is public. Durable history is never touched — this reverts unpublished edits,
  * it does not rewrite a version.
  *
+ * A localized document holds one pending change per language, so discarding is
+ * one language's concern: the request names the language it is discarding, and
+ * the other languages' pending changes are left alone.
+ *
  * Authorization is the caller's concern: the dispatcher handler establishes
  * read and update on the document before calling in here, so this module only
  * performs the removal and the re-read.
@@ -20,11 +24,18 @@ import { errorFromServiceEnvelope } from "../../errors/from-service-envelope";
 import type { UserContext } from "../singles/types";
 
 export interface DiscardWorkingDraftArgs {
-  /** Collection slug. The split is a collection feature, so there is no Single
-   *  variant: a Single has a single row, not a published/draft pair. */
+  /** Collection slug. */
   slug: string;
   entryId: string;
   user: UserContext;
+  /**
+   * Which language's pending change to discard, and which language's live
+   * values to hand back. Absent means the request named none, which for a
+   * localized document is the default language — the admin omits `?locale=`
+   * when editing it. Ignored for an unlocalized document, which has one
+   * pending change rather than one per language.
+   */
+  locale?: string | null;
   /**
    * The caller's authenticated scope, forwarded to the re-read so a scoped API
    * key is judged on its OWN read grant rather than the key owner's roles.
@@ -58,6 +69,10 @@ export async function discardWorkingDraft(
     routeAuthorized: true,
     authenticatedScope: args.authenticatedScope,
     status: "all",
+    // Read the language being discarded, so the values handed back are the ones
+    // the editor resets to. Reading another language's would reset the form to
+    // text that belongs to a language the author is not looking at.
+    ...(args.locale ? { locale: args.locale } : {}),
   });
 
   // A failed read (a concurrent delete, or an after-read hook or database error)
@@ -75,13 +90,12 @@ export async function discardWorkingDraft(
   // Now remove the sidecar through the collections handler, which deletes it
   // under the same parent-row lock a draft save takes: a save committing between
   // this request's authorization checks and the delete would otherwise have its
-  // brand-new draft removed with both requests reporting success. The split
-  // stores the working draft under the null locale key (it applies only to
-  // non-localized collections). Deleting when none exists is a no-op, not an
-  // error.
+  // brand-new draft removed with both requests reporting success. Deleting when
+  // none exists is a no-op, not an error.
   await getService("collectionsHandler").discardWorkingDraft({
     collectionName: args.slug,
     entryId: args.entryId,
+    locale: args.locale ?? null,
   });
 
   return result.data;

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -742,10 +742,9 @@ export class CollectionsHandler {
    * keeps it from deleting a draft another editor committed after this request's
    * authorization checks. The discard handler authorizes read and update first.
    */
-  async discardWorkingDraft(params: {
-    collectionName: string;
-    entryId: string;
-  }): Promise<void> {
+  async discardWorkingDraft(
+    params: Parameters<CollectionEntryService["discardWorkingDraft"]>[0]
+  ): Promise<void> {
     return this.entryService.discardWorkingDraft(params);
   }
 

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -624,10 +624,13 @@ export class CollectionEntryService extends BaseService {
    * concurrent save committed after the discard's checks. The discard handler
    * has already authorized read and update on the document.
    */
-  async discardWorkingDraft(params: {
-    collectionName: string;
-    entryId: string;
-  }): Promise<void> {
+  // Params are taken from the method being delegated to rather than restated,
+  // for the reason the note below records: a restated list forwards the whole
+  // object at runtime while the type denies the fields it omits, so a caller
+  // naming the language of the pending change it is discarding could not say so.
+  async discardWorkingDraft(
+    params: Parameters<CollectionMutationService["discardWorkingDraft"]>[0]
+  ): Promise<void> {
     return this.mutationService.discardWorkingDraft(params);
   }
 


### PR DESCRIPTION
## The defect

A localized document holds one pending change **per language**. The discard chain carried no language at all — the admin request, the dispatcher entry, the domain function and both handler facades each dropped it — so the delete fell through to `workingDraftLocale`'s default resolution and removed the **default language's** pending change.

Editing a translation and pressing Discard therefore:

1. destroyed the default language's unpublished work, which the author never opened, and
2. left the pending change they actually asked to discard, so the editor still showed it, and
3. reset the form to the default language's live values.

The mutation service has accepted a `locale` since the per-language work landed; nothing above it ever passed one.

## Reproduced first, on the real path

An integration test drives `discardWorkingDraftForDocument` on a localized, drafts-enabled collection holding a pending change in `en` and `es`, discards `es`, and asserts `en` survives. Before the fix:

```
AssertionError: expected [ 'es' ] to deeply equal [ 'en' ]
```

The exact inverse: English deleted, Spanish left standing.

Break-verified with four checks — control green, both locales asserted present before the discard, the test that names the property failing when the locale is dropped at the handler call (same `['es']` vs `['en']` signature), and green again after restoring from a backup.

## Verified in the running product

Not only in tests, since this is a wiring defect and a green suite would not have caught the admin half. On the playground's `authors` collection (localized + drafts), with a pending change in both languages:

- the request from the Spanish editor carries `?locale=es` (captured off the real click, not asserted in a mock)
- the Spanish row is removed and **the English row survives**
- the Spanish editor resets to its live published value rather than the discarded edit, and the panel drops its `CHANGES` chip while English keeps its own

## What changed

The language travels the whole chain: `?locale=` → dispatcher → `discardWorkingDraftForDocument` → `discardWorkingDraft` → the handler. It reaches the **pre-read** too, so the values handed back belong to the language being discarded rather than to the default.

Both facade signatures now derive their parameters from the method they delegate to (`Parameters<...>[0]`) instead of restating them. `collection-entry-service.ts` already carries a note recording that a restated list there had previously dropped `overrideAccess`, `routeAuthorized` and `transitionAuth`; this was the same drop a third time, so the fix removes the restatement rather than adding one more field to it.

## Tests

- 1 new integration case (the reproduction above)
- 1 new domain unit case — the language reaches both the read and the delete
- 3 new admin cases — the locale rides the query string, is omitted when absent, and is forwarded by the hook
- 2 existing cases updated deliberately, both asserting the old call shape (`{collectionName, entryId}` with no locale; `discardWorkingDraft(scope)` with no second argument). Each now asserts the new shape, including that a request naming no language reaches the handler as an explicit `null` so one rule decides what that means.

## Gates

- Integration, all three dialects: Postgres **637 passed / 88 files**, MySQL **617**, SQLite **579**. No failures.
- `packages/admin`: 15 failures across `StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField` — identical file set to the recorded baseline, all pre-existing.
- `packages/nextly` unit: **44 failures across 4 files on this branch and 44 across the same 4 files on `origin/main`**, measured in a throwaway worktree at `591f92b96` rather than assumed. Nothing introduced.
- fallow: `pass`, all four `*_introduced` counters at 0.

## Note for reviewers

`useDiscardWorkingDraft` treats an absent locale as "the request names no language", which the server resolves to the default. That is deliberate and load-bearing: the admin omits `?locale=` when editing the default language, so refusing to hold in that case is what published edits silently once before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Discarding a working draft in a localized document now removes the draft for the language currently displayed.
  * Drafts in other languages remain unchanged when one localized draft is discarded.
  * Unlocalized and default-language entries continue to discard drafts as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->