### PR TITLE
feat(playground): serve page-builder pages at their own urls

### DIFF
--- a/apps/playground/src/app/(frontend)/[...slug]/page.tsx
+++ b/apps/playground/src/app/(frontend)/[...slug]/page.tsx
@@ -1,0 +1,99 @@
+/**
+ * The public page-builder route: every page an author builds, served at its own
+ * URL.
+ *
+ * This is the pages-collection model. One route file resolves ANY path against
+ * the `pages` collection the page builder contributes, so an author who creates
+ * a page with the slug `about` and publishes it has `/about` live immediately.
+ * Adding a page needs no developer, no route file and no deploy, which is the
+ * whole reason a page builder exists.
+ *
+ * ## Why a REQUIRED catch-all, not an optional one
+ *
+ * `[...slug]` matches `/about` and `/pricing/enterprise` but never `/`, whereas
+ * `[[...slug]]` would also match the root. This app already serves `/` from
+ * `app/page.tsx`, which redirects contributors to the admin, and two routes
+ * resolving the same path is a build error rather than a precedence question. A
+ * real site with a public home page uses the optional form and drops that
+ * redirect.
+ *
+ * ## Why it sits inside `(frontend)`
+ *
+ * A route group is parentheses on disk and nothing in the URL. It keeps public
+ * pages separate from `/admin` in the tree, and it keeps this catch-all out of
+ * the app root, where an optional catch-all conflicts with sibling routes. The
+ * name matches `templates/blog`, so both surfaces group public pages the same
+ * way.
+ *
+ * ## Why this does not swallow `/blocks` or `/admin`
+ *
+ * Two independent reasons, and both matter. Next resolves static segments
+ * before dynamic ones, so `/blocks/x` reaches the route that declares that
+ * segment. Independently, the helper refuses a reserved path outright, so a
+ * page stored with the slug `admin` 404s here instead of shadowing the panel —
+ * the routing table is not the only thing standing between an author and the
+ * admin URL.
+ *
+ * @module app/(frontend)/[...slug]
+ */
+import { createBlockResolver } from "@nextlyhq/blocks-react";
+import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
+import { createBlocksPage } from "@nextlyhq/blocks-react/next";
+
+import { siteReader, SITE_STYLE_CONTEXT } from "../../../lib/site-content";
+
+/**
+ * Access-enforced and per-request, which is the secure default.
+ *
+ * `createBlocksPage` reads as the visitor would, so the answer depends on who
+ * is asking and no path can be pre-rendered. It returns no
+ * `generateStaticParams`, Next classifies the route dynamic because nothing
+ * claims otherwise, and the build reads no database — which is what lets this
+ * app build on a machine that has none.
+ *
+ * A site whose pages are wholly public calls `createPublicBlocksPage` instead
+ * and exports the `generateStaticParams` it returns, pairing it with `tags` so
+ * publishing busts the cached page rather than waiting for a rebuild. That is
+ * the right posture for a marketing site and the wrong one here: it needs a
+ * database during `next build`. The posture is the factory you call, not an
+ * option you pass.
+ */
+const { ContentPage, generateMetadata } = createBlocksPage({
+  // The collection the page builder plugin contributes. It already carries
+  // `title`, a unique `slug` and a Draft/Published lifecycle, so an unpublished
+  // page 404s here rather than rendering.
+  collections: ["pages"],
+  // Named rather than defaulted: guessing a field renders a blank page instead
+  // of an error, which is the least debuggable outcome available.
+  field: "content",
+  nextly: siteReader,
+  // Stated even though it is this site's default language. An omitted locale
+  // still serves the right page, but it is also what a `draft` decision would
+  // compare a preview token against, and a token always names a resolved locale
+  // rather than a blank one. Omitting it leaves the next change that adds a
+  // preview gate refusing every default-language preview, behind a published
+  // page that looks entirely correct.
+  locale: "en",
+  // An explicit set, not the process registry. `registeredBlocks()` reads the
+  // engine's global registry, which is populated by whatever booted the editor
+  // — so a public route depending on it renders the unknown-block placeholder
+  // whenever this request arrived before the admin did.
+  blocks: createBlockResolver(coreBlocks),
+  styleContext: SITE_STYLE_CONTEXT,
+  metadata: (entry, context, derived) => ({
+    title: derived.title ?? (entry.title as string | undefined),
+    description: derived.description,
+    // `derived.canonical` is the entry's path within its collection, already
+    // rooted. This route is mounted at the site root, so it needs no prefix —
+    // unlike `/blocks`, which prepends its own mount.
+    ...(derived.canonical
+      ? { alternates: { canonical: derived.canonical } }
+      : {}),
+    ...(derived.image
+      ? { openGraph: { images: [{ url: derived.image }] } }
+      : {}),
+  }),
+});
+
+export { generateMetadata };
+export default ContentPage;

--- a/apps/playground/src/app/blocks/[[...slug]]/page.tsx
+++ b/apps/playground/src/app/blocks/[[...slug]]/page.tsx
@@ -1,98 +1,31 @@
 /**
- * Public route for the code-first blocks renderer.
+ * Public route for the CODE-FIRST blocks renderer.
  *
  * The whole route is `createBlocksPage` plus the re-exports Next wants — there
  * is no per-request wiring here, which is the point of the helper.
  *
- * The document this renders is a `@nextlyhq/blocks-engine` `BlockDocument`, NOT
- * the page builder's `BlockNode`. They are different shapes (`styles` and a
- * `visibility` that may carry conditions, against `style`/`styleHover` and a
- * per-breakpoint boolean map), so this route and the page builder's
- * `(site)/[...slug]` route are not interchangeable and neither can read the
- * other's rows. That is why this reads its own collection.
+ * ## What makes this different from the page-builder route
+ *
+ * Not the document. Both store the engine's `BlockDocument`: `blocks()` declares
+ * `storage: "json"` exactly as `json()` does, and there is one `BlockDocument`
+ * in the repo. A document authored here renders there and vice versa.
+ *
+ * The difference is who WRITES it. `block-pages` holds its document in a plain
+ * `json` field, so it is authored in code or by an API client and has no editor
+ * attached — which is the path a developer takes who wants blocks without the
+ * page builder installed. `(frontend)/[...slug]` reads the plugin's `pages`
+ * collection, whose `blocks()` field mounts the visual editor.
+ *
+ * Keeping both is deliberate: converting this collection's field would leave
+ * nothing covering the code-authored path.
+ *
+ * @module app/blocks/[[...slug]]
  */
 import { createBlockResolver } from "@nextlyhq/blocks-react";
 import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
 import { createBlocksPage } from "@nextlyhq/blocks-react/next";
-import { getNextly } from "nextly";
-import type { NextlyContentReader } from "nextly/runtime";
 
-import nextlyConfig from "../../../../nextly.config";
-
-type NextlyInstance = Awaited<ReturnType<typeof getNextly>>;
-
-/**
- * The site's breakpoints, and the reason this route compiles its own sheet.
- *
- * `PageRenderer` emits class NAMES unconditionally and CSS only when it is
- * given either a stored `styles` artifact or a `styleContext` to compile from.
- * This collection stores the document alone — there is no write path here
- * producing a compiled sheet — so without a context every authored node style
- * and every `visibility.devices` rule would resolve to a class that no rule
- * ever defines, and the page would render structurally correct and visually
- * bare.
- *
- * Declared by the host because breakpoints are a site decision: the engine
- * never reads storage and ships no default set. Ids must be unique across both
- * axes, and the base breakpoint carries no `maxWidth` — it is the fallback the
- * others narrow.
- *
- * Left unannotated deliberately. `StyleCompileContext` is what
- * `createBlocksPage` accepts, and `@nextlyhq/blocks-react` does not re-export
- * it — naming the type here would mean taking a direct dependency on
- * `@nextlyhq/blocks-engine` purely to label a config object. The shape is still
- * fully checked where it is passed, so nothing is lost but the label.
- */
-const STYLE_CONTEXT = {
-  breakpoints: {
-    viewport: [
-      { id: "base", label: "Base" },
-      { id: "tablet", label: "Tablet", maxWidth: 1024 },
-      { id: "mobile", label: "Mobile", maxWidth: 640 },
-    ],
-    container: [],
-  },
-};
-
-/**
- * The route's reader, resolved per call.
- *
- * `createBlocksPage` otherwise falls back to the synchronous `getNextly()` from
- * `nextly/runtime`, which returns the already-registered singleton and throws
- * when nothing has registered it. A public page can be the FIRST request a cold
- * server handles, so relying on that means the route works only once something
- * else has booted the CMS — in this app, a visit to `/admin`.
- *
- * Async boot cannot happen where the config is captured (module scope), so the
- * indirection is per call rather than a value. `getNextly` caches its instance,
- * so every call after the first is a lookup.
- */
-const instance = () => getNextly({ config: nextlyConfig });
-
-/**
- * Just the media lookup `createBlocksPage` probes for.
- *
- * Narrower than the instance's whole `media` namespace on purpose: this reader
- * exists to be READ from, and forwarding `upload`/`update`/`delete` would offer
- * a public page route a write surface it has no reason to hold.
- */
-type MediaLookup = Pick<NextlyInstance["media"], "findByID">;
-
-const reader: NextlyContentReader & { media: MediaLookup } = {
-  find: async args => (await instance()).find(args),
-  findByID: async args => (await instance()).findByID(args),
-  // The media namespace, forwarded rather than dropped.
-  //
-  // Ordinary Nextly media lives in a SYSTEM table with its own namespace, and
-  // `createBlocksPage` resolves an image's `mediaId` through `reader.media
-  // .findByID`. A wrapper exposing only `find` and `findByID` satisfies
-  // `NextlyContentReader` and silently loses that lookup, so every `core/image`
-  // storing a media id — rather than a literal `src` — resolves to null and
-  // draws nothing.
-  media: {
-    findByID: async args => (await instance()).media.findByID(args),
-  },
-};
+import { siteReader, SITE_STYLE_CONTEXT } from "../../../lib/site-content";
 
 /**
  * Where this route is mounted, for canonical URLs.
@@ -135,7 +68,7 @@ function canonicalFor(path: string): string {
 const { ContentPage, generateMetadata } = createBlocksPage({
   collections: ["block-pages"],
   field: "content",
-  nextly: reader,
+  nextly: siteReader,
   // Stated even though it is this site's default language, because the read is
   // not the only thing it feeds. An omitted locale still serves the right page
   // — the read defaults it internally — but it is also what a `draft` decision
@@ -149,7 +82,7 @@ const { ContentPage, generateMetadata } = createBlocksPage({
   // editor — so a public route depending on it renders the unknown-block
   // placeholder whenever this request arrived before the admin did.
   blocks: createBlockResolver(coreBlocks),
-  styleContext: STYLE_CONTEXT,
+  styleContext: SITE_STYLE_CONTEXT,
   metadata: (entry, context, derived) => ({
     title: derived.title ?? (entry.title as string | undefined),
     description: derived.description,

--- a/apps/playground/src/lib/site-content.ts
+++ b/apps/playground/src/lib/site-content.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared wiring for the playground's public block routes.
+ *
+ * Two routes draw block documents — the code-first `/blocks` collection and the
+ * page builder's `pages` — and both need the same two things: a reader that can
+ * resolve entries and media, and the set of breakpoints this site styles
+ * against.
+ *
+ * They live here rather than in each route because a second answer to "what are
+ * this site's breakpoints" is how a page's own sheet and the shared site sheet
+ * come to emit the same tier under different at-rules. Each sheet stays
+ * internally consistent, so the disagreement never surfaces as an error — only
+ * as a layout that is wrong at one width.
+ *
+ * @module lib/site-content
+ */
+import { getNextly } from "nextly";
+import type { NextlyContentReader } from "nextly/runtime";
+
+import nextlyConfig from "../../nextly.config";
+
+type NextlyInstance = Awaited<ReturnType<typeof getNextly>>;
+
+/**
+ * The instance, resolved per call.
+ *
+ * A route helper otherwise falls back to the synchronous `getNextly()` from
+ * `nextly/runtime`, which returns the already-registered singleton and throws
+ * when nothing has registered it. A public page can be the FIRST request a cold
+ * server handles, so relying on that means the route works only once something
+ * else has booted the CMS — in this app, a visit to `/admin`.
+ *
+ * Async boot cannot happen where the config is captured (module scope), so this
+ * is a function rather than a value. `getNextly` caches, so every call after the
+ * first is a lookup.
+ */
+const instance = () => getNextly({ config: nextlyConfig });
+
+/**
+ * Just the media lookup the route helpers probe for.
+ *
+ * Narrower than the instance's whole `media` namespace on purpose: this reader
+ * exists to be READ from, and forwarding `upload`/`update`/`delete` would offer
+ * a public page route a write surface it has no reason to hold.
+ */
+type MediaLookup = Pick<NextlyInstance["media"], "findByID">;
+
+/**
+ * The reader every public content route on this site resolves through.
+ *
+ * The media namespace is forwarded rather than dropped. Ordinary Nextly media
+ * lives in a SYSTEM table with its own namespace, and the block route resolves
+ * an image's `mediaId` through `reader.media.findByID`. A wrapper exposing only
+ * `find` and `findByID` satisfies `NextlyContentReader` and silently loses that
+ * lookup, so every `core/image` storing a media id — rather than a literal
+ * `src` — resolves to null and draws nothing.
+ */
+export const siteReader: NextlyContentReader & { media: MediaLookup } = {
+  find: async args => (await instance()).find(args),
+  findByID: async args => (await instance()).findByID(args),
+  media: {
+    findByID: async args => (await instance()).media.findByID(args),
+  },
+};
+
+/**
+ * The site's breakpoints, and the reason a route compiles its own sheet.
+ *
+ * `PageRenderer` emits class NAMES unconditionally and CSS only when it is given
+ * either a stored `styles` artifact or a `styleContext` to compile from. Neither
+ * of this app's block routes stores a compiled sheet, so without a context every
+ * authored node style and every `visibility.devices` rule would resolve to a
+ * class that no rule ever defines, and the page would render structurally
+ * correct and visually bare.
+ *
+ * Declared by the host because breakpoints are a site decision: the engine never
+ * reads storage and ships no default set. Ids must be unique across both axes,
+ * and the base breakpoint carries no `maxWidth` — it is the fallback the others
+ * narrow.
+ *
+ * Left unannotated deliberately. `StyleCompileContext` is what the route helpers
+ * accept, and `@nextlyhq/blocks-react` does not re-export it — naming the type
+ * here would mean taking a direct dependency on `@nextlyhq/blocks-engine` purely
+ * to label a config object. The shape is still fully checked where it is passed.
+ */
+export const SITE_STYLE_CONTEXT = {
+  breakpoints: {
+    viewport: [
+      { id: "base", label: "Base" },
+      { id: "tablet", label: "Tablet", maxWidth: 1024 },
+      { id: "mobile", label: "Mobile", maxWidth: 640 },
+    ],
+    container: [],
+  },
+};

--- a/packages/plugin-page-builder/GUIDE.md
+++ b/packages/plugin-page-builder/GUIDE.md
@@ -194,26 +194,27 @@ After logging in you'll land on the dashboard. In the left sidebar (or on the
 dashboard cards) you'll see a **Pages** collection — that's the one the plugin
 added. Click it, then click **New Page** (or **Create Page**).
 
-### 6.3 Switch between Normal and Page Builder
+### 6.3 The builder opens automatically
 
-At the top-right of the page editor there's a small toggle with two options:
+There is no editor switch. Whether a page is edited visually is decided by the
+FIELD on the collection rather than per entry: the plugin's `pages` collection
+declares a blocks field named `content`, so opening a page shows the builder
+canvas.
 
-- **Normal** — a plain form (simple fields).
-- **Page Builder** — the full visual editor.
-
-Click **Page Builder**. The form is replaced by the builder canvas (this is the
-"takeover" view). You can switch back to **Normal** at any time; your choice is
-saved per page.
+An earlier release stored that choice per page in an `editorMode` column. It is
+gone. A UI preference stored as content travelled in API responses and exports and
+could be set by any writer, and both editors' content persisted at once with only
+one of them ever shown.
 
 ### 6.4 Build the page
 
 The builder has three areas:
 
-| Area                 | What it's for                                                                                                                                            |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Left — Blocks**    | The building blocks: Paragraph, Heading, Button, Container, Grid, Image, Video, Query Loop. Click **Insert** (or drag) to add one to the canvas.         |
-| **Middle — Canvas**  | A live preview of your page. Click any block to select it. Use the **Desktop / Tablet / Mobile** buttons on top to preview different screen sizes.       |
-| **Right — Settings** | When a block is selected, its options appear here (e.g. a Heading's text and level H1–H6), organized into **Content**, **Style**, and **Advanced** tabs. |
+| Area                 | What it's for                                                                                                                                                                                                                                            |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Left — Blocks**    | The nineteen building blocks: Heading, Text, Button, Section, Box, Columns, Column, Card, Image, Gallery, Embed, List, Quote, Accordion, Accordion item, Divider, Spacer, Form and Collection loop. Click **Insert** (or drag) to add one to the canvas. |
+| **Middle — Canvas**  | A live preview of your page. Click any block to select it. Use the **Desktop / Tablet / Mobile** buttons on top to preview different screen sizes.                                                                                                       |
+| **Right — Settings** | When a block is selected, its options appear here (e.g. a Heading's text and level H1–H6), organized into **Content**, **Style**, and **Advanced** tabs.                                                                                                 |
 
 Try it: insert a **Heading**, then edit its text and level in the Settings panel on
 the right. You'll see the canvas update immediately.
@@ -229,130 +230,163 @@ publishing.
 ## Step 7 — Show your pages on the public website (frontend)
 
 Everything so far happens inside the admin. The builder **saves each page into your
-database** — but it does not automatically create the public web page. You add one
-small route to your app that reads a page from the database (by its slug) and hands
-it to the plugin's renderer. Do this once and **every** page your team builds is
-served automatically.
+database**, but it does not create the public web page. You add **one** small route
+to your app, and from then on every page your team publishes is served
+automatically, with no further code and no deploy.
 
-### 7.1 Create the route file
+This is the "pages collection" model: the page's **slug** is its URL. An author
+creates a page, types `about`, publishes, and `/about` is live.
+
+### 7.1 Install the renderer
+
+The route draws block documents, which is `@nextlyhq/blocks-react`'s job. Add it to
+your app's own dependencies rather than relying on it being installed underneath
+the plugin — package managers do not guarantee that a dependency of a dependency is
+importable from your code.
+
+```bash
+npm install @nextlyhq/blocks-react
+```
+
+### 7.2 Create the route file
 
 Create this file in your app:
 
 ```text
-src/app/(site)/[...slug]/page.tsx
+src/app/(frontend)/[...slug]/page.tsx
 ```
 
-- `(site)` is a route group — it just keeps your public pages separate from
-  `/admin`. The parentheses mean it does **not** show up in the URL.
+- `(frontend)` is a **route group**. The parentheses mean it does not appear in the
+  URL; it only keeps your public pages separate from `/admin` in the file tree.
 - `[...slug]` is a **catch-all**: it matches any path (`/about`, `/pricing`,
-  `/blog/hello`, …) and passes it to your code as the page's slug.
+  `/pricing/enterprise`, …) and hands it to your code.
 
-### 7.2 Paste this code
+Use `[...slug]` with single brackets when your app already has its own `/` page,
+which most do. The optional form `[[...slug]]` matches the site root as well, and
+two routes claiming `/` is a build error rather than a question of precedence.
+
+### 7.3 Paste this code
 
 ```tsx
-import {
-  PageRenderer,
-  type DataProvider,
-} from "@nextlyhq/plugin-page-builder/render";
-import { notFound } from "next/navigation";
+import { createBlockResolver } from "@nextlyhq/blocks-react";
+import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
+import { createBlocksPage } from "@nextlyhq/blocks-react/next";
 import { getNextly } from "nextly";
+import type { NextlyContentReader } from "nextly/runtime";
 
 // Adjust the number of "../" so this points at your project's nextly.config file.
-import nextlyConfig from "../../../../nextly.config";
-
-// Pages live in the database, so render them fresh on each request instead of
-// trying to pre-build them (the build machine has no database).
-export const dynamic = "force-dynamic";
+import nextlyConfig from "../../../nextly.config";
 
 type NextlyInstance = Awaited<ReturnType<typeof getNextly>>;
 
-// The renderer doesn't talk to your database directly — you give it this small
-// adapter so it can fetch related content (e.g. a Query Loop block listing posts)
-// and resolve media. This is the same for every project; copy it as-is.
-function makeDataProvider(nx: NextlyInstance): DataProvider {
-  return {
-    find: async args => {
-      const result = await nx.find(args as never);
-      return { items: (result.items ?? []) as Record<string, unknown>[] };
+// Resolved per call, not once. A public page can be the very first request a cold
+// server handles, so a value captured at module scope would work only after
+// something else had booted the CMS. `getNextly` caches, so later calls are a
+// lookup.
+const instance = () => getNextly({ config: nextlyConfig });
+
+const reader: NextlyContentReader & {
+  media: Pick<NextlyInstance["media"], "findByID">;
+} = {
+  find: async args => (await instance()).find(args),
+  findByID: async args => (await instance()).findByID(args),
+  // Images that store a media id resolve through this. Leave it out and every
+  // such image renders nothing, while images with a literal URL still work —
+  // which makes it look like a content problem rather than a wiring one.
+  media: {
+    findByID: async args => (await instance()).media.findByID(args),
+  },
+};
+
+const { ContentPage, generateMetadata } = createBlocksPage({
+  // The collection the plugin contributes. It already has a unique `slug` and a
+  // Draft/Published lifecycle, so an unpublished page 404s rather than rendering.
+  collections: ["pages"],
+  // The blocks field on that collection. Named rather than guessed: a wrong guess
+  // renders a blank page instead of raising an error.
+  field: "content",
+  nextly: reader,
+  // An explicit set rather than the global registry, which is populated by
+  // whatever booted the editor — so a public route that relies on it renders
+  // placeholders whenever a visitor arrives before an admin does.
+  blocks: createBlockResolver(coreBlocks),
+  // Your site's breakpoints. The renderer always emits class NAMES and emits CSS
+  // only when it has something to compile from, so without this the page comes
+  // out structurally correct and visually bare. The base tier carries no
+  // `maxWidth`: it is the fallback the others narrow.
+  styleContext: {
+    breakpoints: {
+      viewport: [
+        { id: "base", label: "Base" },
+        { id: "tablet", label: "Tablet", maxWidth: 1024 },
+        { id: "mobile", label: "Mobile", maxWidth: 640 },
+      ],
+      container: [],
     },
-    findOne: async ({ collection, id }) => {
-      const doc = await nx.findByID({ collection, id } as never);
-      return (doc ?? null) as Record<string, unknown> | null;
-    },
-    resolveMedia: async () => null,
-  };
-}
+  },
+});
 
-interface PageData {
-  content?: unknown;
-  customCss?: string;
-  editorMode?: string;
-  body?: string;
-}
-
-export default async function SitePage({
-  params,
-}: {
-  params: Promise<{ slug: string[] }>;
-}) {
-  const { slug } = await params;
-  const nx = await getNextly({ config: nextlyConfig });
-
-  // Look up the published page whose slug matches the URL.
-  const { items } = await nx.find({
-    collection: "pages",
-    where: {
-      slug: { equals: slug.join("/") },
-      status: { equals: "published" },
-    },
-    limit: 1,
-    richTextFormat: "html", // so "Normal" pages come back as ready-to-show HTML
-  } as never);
-
-  const page = items[0] as PageData | undefined;
-  if (!page) notFound(); // no matching page -> 404
-
-  // A page saved in "Normal" mode is plain rich text — just render its HTML.
-  if (page.editorMode === "normal") {
-    return <article dangerouslySetInnerHTML={{ __html: page.body ?? "" }} />;
-  }
-
-  // A page built with the visual builder -> hand its block tree to the renderer.
-  if (!page.content) notFound();
-  return (
-    <PageRenderer
-      document={page.content as never}
-      customCss={page.customCss}
-      dataProvider={makeDataProvider(nx)}
-    />
-  );
-}
+export { generateMetadata };
+export default ContentPage;
 ```
 
-### 7.3 What this code does, in plain terms
+### 7.4 What this does, in plain terms
 
-1. It reads the URL (e.g. `/about` → slug `"about"`).
+1. It reads the URL (`/about` → slug `"about"`).
 2. It asks Nextly for the **published** page with that slug.
-3. If there isn't one, it shows a **404**.
-4. If the page was made in **Normal** mode, it renders that page's rich-text HTML.
-5. If the page was made in the **Page Builder**, it passes the saved blocks to
-   `<PageRenderer>`, which turns them back into a real web page. Any custom CSS you
-   set on the page is applied automatically.
+3. If there is not one, it shows a **404**.
+4. If there is, it hands the saved blocks to the renderer, which turns them back
+   into a real web page — and returns the page's SEO metadata to Next as well.
 
-You do **not** need extra `next.config` changes for this — the plugin is already in
-`transpilePackages` from Step 2, and that covers the renderer too.
+You do **not** need extra `next.config` changes for this: the plugin is already in
+`transpilePackages` from Step 2.
 
-### 7.4 See it live
+Two things the helper does that are easy to miss. It refuses **reserved paths**, so
+a page saved with the slug `admin` or `api` 404s here instead of shadowing your
+admin panel. And it reads content **as the visitor would**, enforcing your access
+rules on every request, which is why it needs no database at build time.
 
-1. In the admin, open a page, give it a slug (e.g. `about`), and click **Publish**.
-2. Visit it in the browser: `http://localhost:3000/about`.
+### 7.5 See it live
 
-Your built page is now served to the public. 🎉
+1. In the admin, open a page, give it a slug (for example `about`), and click
+   **Publish**.
+2. Visit `http://localhost:3000/about`.
 
-> **Tip — a fixed landing page.** The catch-all above handles every slug. If you
-> also want a specific route (say your homepage at `/`), create
-> `src/app/(site)/page.tsx` with the same code but look up a fixed slug (e.g.
-> `where: { slug: { equals: "home" } }`) instead of reading it from the URL.
+Your built page is now served to the public.
+
+### 7.6 Structured content needs its own route
+
+The catch-all above is for **free-form pages** — the ones an author invents without
+asking a developer. Content with a predictable URL shape, such as blog posts under
+`/blog/...`, is better served by its own route file (`src/app/(frontend)/blog/[slug]/page.tsx`)
+that renders the fields you designed for it. Next.js matches more specific routes
+first, so the two live side by side with nothing to configure.
+
+### 7.7 Going faster: pre-built pages
+
+`createBlocksPage` renders on each request. For a public marketing site, swap it
+for `createPublicBlocksPage`, which pre-renders pages at build time and returns a
+`generateStaticParams` for you to export alongside the other two:
+
+```tsx
+const { ContentPage, generateMetadata, generateStaticParams } =
+  createPublicBlocksPage({
+    /* the same options, plus: */
+    // A write to the collection busts these, so publishing updates the live page
+    // immediately instead of waiting for the next deploy.
+    tags: ["pages"],
+  });
+
+export { generateMetadata, generateStaticParams };
+export default ContentPage;
+```
+
+Two things change with it, and both are deliberate. It reads content **without**
+enforcing access rules, on the assumption that everything in the collection is
+public — so do not point it at a collection that is not. And it reads your database
+during `next build`, which means your build environment needs one.
+
+The posture is the factory you call. There is no option to flip.
 
 ---
 
@@ -377,16 +411,13 @@ If it still misbehaves, delete the `.next` folder and restart.
 Make sure you completed Step 3 (registered `pageBuilder()` in `nextly.config.ts`)
 and Step 4 (`npx nextly db:sync`), then restart the dev server.
 
-**You see two "editor" controls (a toggle at the top _and_ an "Editor" dropdown in
-the form)**
-This is a known cosmetic duplication in the current release; the dropdown will be
-hidden in an upcoming version. Use the top toggle — both do the same thing.
-
 **Visiting your page URL shows a 404 (Step 7)**
-Three things to check: (1) the page is **Published**, not just saved as a draft;
+Four things to check: (1) the page is **Published**, not just saved as a draft;
 (2) the page's **slug** matches the URL you're visiting; (3) the `import
 nextlyConfig from "../../.../nextly.config"` line has the right number of `../` to
-reach your project's `nextly.config` file.
+reach your project's `nextly.config` file; (4) the slug is not a **reserved path** —
+anything under `admin`, `api`, `_next` or `static`, and well-known files such as
+`sitemap.xml`, are refused so content cannot shadow your admin panel.
 
 **Visiting your page URL shows a blank page**
 The page probably has no blocks yet, or was saved empty. Open it in the builder,
@@ -410,9 +441,10 @@ npx nextly db:sync
 # 5. Run
 npm run dev
 
-# 6. Open http://localhost:3000/admin  ->  Pages  ->  New Page  ->  "Page Builder"
+# 6. Open http://localhost:3000/admin  ->  Pages  ->  New Page
 
-# 7. Frontend: add src/app/(site)/[...slug]/page.tsx (see Step 7) to serve pages,
+# 7. Frontend: npm install @nextlyhq/blocks-react, then add
+#    src/app/(frontend)/[...slug]/page.tsx (see Step 7) to serve every page,
 #    then visit http://localhost:3000/<your-page-slug>
 ```
 

--- a/packages/plugin-page-builder/README.md
+++ b/packages/plugin-page-builder/README.md
@@ -37,64 +37,79 @@ draft/publish status) whose Edit view is the page builder.
 
 ### 2. Add the public render route
 
-A plugin can't inject Next.js routes, so the consuming app declares **one** catch-all
-route and hands the stored block tree to `PageRenderer`. The renderer never imports the
-CMS runtime — you inject a small `dataProvider` backed by `getNextly()`:
+A plugin cannot inject Next.js routes, so the consuming app declares **one** catch-all
+route. `createBlocksPage` fills its body: it resolves the path against your collections,
+404s on a miss or a reserved path, and renders the stored document.
+
+Install the renderer in your own app rather than relying on it being present underneath
+this plugin:
+
+```bash
+npm install @nextlyhq/blocks-react
+```
 
 ```tsx
-// app/(site)/[...slug]/page.tsx
-import {
-  PageRenderer,
-  type DataProvider,
-} from "@nextlyhq/plugin-page-builder/render";
-import { notFound } from "next/navigation";
+// app/(frontend)/[...slug]/page.tsx
+import { createBlockResolver } from "@nextlyhq/blocks-react";
+import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
+import { createBlocksPage } from "@nextlyhq/blocks-react/next";
 import { getNextly } from "nextly";
-import nextlyConfig from "../../../../nextly.config";
+import type { NextlyContentReader } from "nextly/runtime";
 
-function dataProvider(nx: Awaited<ReturnType<typeof getNextly>>): DataProvider {
-  return {
-    find: async args => ({ items: (await nx.find(args as never)).items ?? [] }),
-    findOne: async ({ collection, id }) =>
-      (await nx.findByID({ collection, id })) ?? null,
-    resolveMedia: async () => null,
-  };
-}
+import nextlyConfig from "../../../nextly.config";
 
-export default async function SitePage({
-  params,
-}: {
-  params: Promise<{ slug: string[] }>;
-}) {
-  const { slug } = await params;
-  const nx = await getNextly({ config: nextlyConfig });
-  const { items } = await nx.find({
-    collection: "pages",
-    where: {
-      slug: { equals: slug.join("/") },
-      status: { equals: "published" },
+type NextlyInstance = Awaited<ReturnType<typeof getNextly>>;
+
+// Per call rather than once: a public page can be the first request a cold server
+// handles. `getNextly` caches, so later calls are a lookup.
+const instance = () => getNextly({ config: nextlyConfig });
+
+const reader: NextlyContentReader & {
+  media: Pick<NextlyInstance["media"], "findByID">;
+} = {
+  find: async args => (await instance()).find(args),
+  findByID: async args => (await instance()).findByID(args),
+  // Images storing a media id resolve through this; omit it and they draw nothing
+  // while images with a literal URL keep working.
+  media: {
+    findByID: async args => (await instance()).media.findByID(args),
+  },
+};
+
+const { ContentPage, generateMetadata } = createBlocksPage({
+  collections: ["pages"],
+  field: "content",
+  nextly: reader,
+  blocks: createBlockResolver(coreBlocks),
+  // Without a breakpoint set the renderer emits class names with no CSS behind
+  // them, and the page comes out structurally correct and visually bare.
+  styleContext: {
+    breakpoints: {
+      viewport: [
+        { id: "base", label: "Base" },
+        { id: "tablet", label: "Tablet", maxWidth: 1024 },
+        { id: "mobile", label: "Mobile", maxWidth: 640 },
+      ],
+      container: [],
     },
-    limit: 1,
-  });
-  const page = items[0] as
-    | { content?: unknown; customCss?: string }
-    | undefined;
-  if (!page?.content) notFound();
-  return (
-    <PageRenderer
-      document={page.content as never}
-      customCss={page.customCss}
-      dataProvider={dataProvider(nx)}
-    />
-  );
-}
+  },
+});
+
+export { generateMetadata };
+export default ContentPage;
 ```
+
+`createBlocksPage` reads **access-enforced** content, so it needs no database during
+`next build`. A wholly public site calls `createPublicBlocksPage` instead, which reads
+trusted, pre-renders, and returns a `generateStaticParams` to export beside the other two.
+The posture is the factory you call; there is no option for it.
 
 ## Field mount (collections **and** singles)
 
-Use the builder as a **field** alongside other fields — in any collection or single:
+Use the builder as a **field** alongside other fields, in any collection or single:
 
 ```ts
-import { pageBuilderField } from "@nextlyhq/plugin-page-builder";
+import { blocks } from "@nextlyhq/plugin-page-builder";
 import { defineSingle, text } from "nextly/config";
 
 export const Homepage = defineSingle({
@@ -102,80 +117,43 @@ export const Homepage = defineSingle({
   label: { singular: "Homepage" },
   fields: [
     text({ name: "title" }),
-    pageBuilderField("layout", { label: "Layout" }),
+    blocks({ name: "layout", label: "Layout", blocks: { allow: ["core/*"] } }),
   ],
 });
 ```
 
-`pageBuilderField` stores the block tree as JSON and mounts the editor via the field's
-`admin.component`. The **host form** persists it (no separate save button). Render it the
-same way — hand the field's value to `PageRenderer` (for a single, fetch via
-`nx.findSingle({ slug })`).
+`blocks()` stores a `BlockDocument` as JSON and mounts the editor through the field's
+admin component. The **host form** persists it; there is no separate save button.
 
-## Per-entry editor choice (Default vs Page Builder)
+The field decides how an entry is edited, and nothing decides it per entry. An earlier
+release shipped a stored `editorMode` select that let each entry choose between the normal
+form and the builder. It is gone: a UI preference stored as content travelled in API
+responses and exports, both editors' columns stayed live with only one of them rendered,
+and it applied only to collections declared in code.
 
-Let **each entry** of a collection or single choose between the normal Nextly fields and the
-visual Page Builder canvas — Elementor/WordPress-style.
-
-**Code-first:** wrap the config with `withPageBuilder()`. It adds an `editorMode` select + the
-reserved `content` page-builder field, and sets `admin.pageBuilder.enabled`:
-
-```ts
-import { withPageBuilder } from "@nextlyhq/plugin-page-builder";
-import { defineCollection, text, textarea } from "nextly/config";
-
-export const Articles = defineCollection(
-  withPageBuilder({
-    slug: "articles",
-    labels: { singular: "Article", plural: "Articles" },
-    status: true,
-    fields: [
-      text({ name: "title", required: true }),
-      text({ name: "slug", required: true, unique: true }),
-      textarea({ name: "excerpt" }),
-    ],
-  })
-);
-```
-
-**UI-created collections/singles:** open the schema builder → toggle **"Use Page Builder"**
-(shown only when this plugin is installed). It adds/removes the same two fields.
-
-When an entry picks **Page Builder**, the edit screen shows the canvas plus the essentials
-(title, slug, status); the other fields are hidden. Picking **Default** shows the normal form.
-
-**Front-end** — render whichever the entry chose:
-
-```tsx
-import { PageRenderer } from "@nextlyhq/plugin-page-builder/render";
-
-const article = await nx.findOne({ collection: "articles", where: { slug } });
-export default function Article() {
-  return article.editormode === "builder" ? (
-    <PageRenderer
-      document={article.content}
-      registry={registry}
-      dataProvider={dp}
-    />
-  ) : (
-    <NormalArticle entry={article} />
-  ); // your normal-fields template
-}
-```
+Render a single the same way you render a collection, reading it with
+`nextly.findSingle({ slug })` and handing the field's value to the renderer.
 
 ## Built-in blocks
 
-`core/heading`, `core/paragraph`, `core/image`, `core/button`, `core/video`,
-`core/container`, `core/grid`, and the dynamic `core/query-loop`. Each declares content
-fields (Content tab) and style controls (Style/Responsive tabs) that drive the inspector.
+Nineteen, from `@nextlyhq/blocks-react/blocks`:
 
-## Query Loop
+`core/accordion`, `core/accordion-item`, `core/box`, `core/button`,
+`core/collection-loop`, `core/card`, `core/column`, `core/columns`, `core/divider`,
+`core/embed`, `core/form`, `core/gallery`, `core/heading`, `core/image`, `core/list`,
+`core/quote`, `core/section`, `core/spacer`, `core/text`.
 
-Drop a **Query Loop**, set its collection/sort/limit, and place a template inside it. At
-render the loop fetches entries through your `dataProvider` and renders the template once
-per item. Bind any content field on a nested block to an item field (Content tab → **Bind**
-→ path, e.g. `title` or `author.name`) — bindings resolve at any depth. Empty / error /
-config states are first-class, and a per-page query budget bounds nested loops.
+Each declares its props (Content tab) and which style groups it supports, and those drive
+the inspector.
+
+## Collection Loop
+
+Drop a **`core/collection-loop`**, set its collection, sort and limit, and place a template
+inside it. At render the loop fetches entries through the route's data access and renders
+the template once per item. Bind any prop on a nested block to an item field (Content tab →
+**Bind** → path, for example `title` or `author.name`); bindings resolve at any depth.
+Empty, error and unconfigured states are first-class, and a per-page query budget bounds
+nested loops — depth in a document becomes multiplication in reads.
 
 ## Styling, tokens & responsive
 
@@ -190,43 +168,50 @@ Page-level **custom CSS** is parsed, allow-listed, and scoped under the page roo
 
 ## Extending — add your own block
 
-The block registry is the single extensibility seam. One `defineBlock` call wires the
-validator, renderer, and inspector — no core edit:
+The block registry is the extensibility seam. One `defineBlock` call describes the
+props, the editor metadata and the renderer:
 
 ```tsx
-import { defineBlock } from "@nextlyhq/plugin-page-builder";
+import { defineBlock } from "@nextlyhq/plugin-sdk/blocks";
 
-defineBlock({
-  type: "acme/pricing-table", // must be namespaced
+export const pricingTable = defineBlock({
+  name: "acme/pricing-table", // must be namespaced
   version: 1,
-  label: "Pricing Table",
-  icon: "Table",
-  category: "basic",
+  description: "A plan comparison table.",
+  editor: {
+    label: "Pricing Table",
+    category: "content",
+    keywords: ["plan", "pricing"],
+  },
+  props: {
+    plan: { type: "text" },
+  },
   defaultProps: { plan: "Pro" },
-  contentFields: [{ name: "plan", type: "text", label: "Plan" }],
-  styleControls: [
-    { control: "color", styleKey: "backgroundColor", label: "Background" },
-  ],
+  supports: { typography: true, color: true, spacing: true },
   render: ({ props, className }) => (
     <div className={className}>{String(props.plan)}</div>
   ),
 });
 ```
 
-Blocks can bump `version` and ship a pure `migrate(old, fromVersion)`, and unknown blocks are
-preserved (never dropped).
+Hand it to the route beside the core set so the public page can draw it:
 
-Migration runs when the **editor** loads a document, so the inspector reads props through controls
-that describe them. Where it PERSISTS depends on the mount:
+```ts
+blocks: createBlockResolver([...coreBlocks, pricingTable]);
+```
 
-- the **edit view** saves what the editor holds, so an opened-and-saved page is upgraded;
-- a **field mount** (`PageBuilderField`) does not. The host form keeps the value it was given, and
-  the upgrade reaches storage with the author's first real edit rather than on open;
-- the **published page** does not migrate at all: `PageRenderer` draws the stored document as it is.
+Pass an explicit set rather than relying on the process-wide registry: that registry is
+populated by whatever booted the editor, so a public route depending on it renders the
+unknown-block placeholder whenever a visitor arrives before an admin does.
 
-So blocks have to read their props defensively whatever version wrote them — which they must do
-anyway for a hand-edited or plugin-authored document. Migration only ever moves a document
-FORWARD: a node written by a newer definition than this build registers is left exactly as found.
+Blocks may bump `version` and ship a pure `migrate(old, fromVersion)`, and unknown blocks
+are preserved rather than dropped. Migration runs when the **editor** loads a document, so
+where it PERSISTS depends on the mount: a field mount keeps the value the host form was
+given, and the upgrade reaches storage with the author's first real edit. The published
+page does not migrate at all — it draws the stored document as it is. So a block reads its
+props defensively whatever version wrote them, which it must do anyway for a hand-edited or
+API-authored document. Migration only ever moves a document FORWARD: a node written by a
+newer definition than this build registers is left exactly as found.
 
 ## Security
 
@@ -235,14 +220,19 @@ FORWARD: a node written by a newer definition than this build registers is left 
 - Custom CSS is parser-validated, scoped, and allow-listed.
 - Structural limits: max depth, max node count, unique ids, no move-into-descendant,
   namespaced types, slot allow-lists.
-- The `./render` entry imports no CMS runtime and no admin code (enforced by a test).
+- The renderer's root entry imports no CMS runtime, no admin code and no `next/*`
+  (enforced by a layering test), so it is usable standalone.
 
 ## Package entries
 
-- `.` — isomorphic core (registries, tree/validate/migrate, `pageBuilder`, `pageBuilderField`).
-- `./render` — server-first `PageRenderer` (+ `DataProvider`).
+- `.` — isomorphic, React-free registration surface (`pageBuilder`, `blocks`,
+  `pagesCollection`, the document types).
+- `./blocks` — the blocks this plugin contributes.
 - `./admin` — the React editor (registers its components on import).
 - `./styles/editor.css` — editor styles.
+
+Rendering lives in `@nextlyhq/blocks-react`, and the document model in
+`@nextlyhq/blocks-engine`. This package registers them rather than reimplementing them.
 
 ## Environment note
 


### PR DESCRIPTION
## What this closes

Nothing rendered the page builder's output publicly, so the phase's exit criterion — publish a page to a real URL and load it in a production build — could not be demonstrated at all.

Measured before building:

- `/blocks/[[...slug]]` reads `block-pages`, whose document is authored in code (`json` field, no editor attached).
- The `blocks()` field otherwise sat on the `homepage` and `landing-page` **singles**, and singles have no public route.
- The blocks route's own docblock named the builder's route as `(site)/[...slug]`, which does not exist — it was removed in `8364d8b3e`.

So a page built in the editor could be published and then reached by nothing.

## The route

One file over the `pages` collection `pageBuilder()` already contributes (`plugin.ts:164`) — it already has `title`, a unique `slug`, a Draft/Published lifecycle, and `content` as a `blocks()` field. This is the pages-collection model: the slug **is** the URL, so an author publishes `about` and `/about` is live with no developer and no deploy.

A **required** catch-all (`[...slug]`), not the optional form. The app already serves `/` from `app/page.tsx`, and two routes claiming one path is a build error rather than a question of precedence.

`createBlocksPage` rather than `createPublicBlocksPage`: it reads access-enforced content and returns no `generateStaticParams`, so Next classifies the route dynamic and **the build reads no database** — which is what lets this app build on a box that has none. The production route table prints it as dynamic.

## A stale claim this PR disproves

The blocks route's docblock asserted the two renderers store different, non-interchangeable documents. They do not:

- `blocksField.ts:49` declares `storage: "json"`, exactly as `json()` does.
- There is exactly **one** `BlockDocument` in the repo, `blocks-engine/src/document.ts:74`, whose own docblock reads *"The stored value of a `blocks` field and the body of every builder document."*

That comment described the world before `8364d8b3e` removed the plugin's parallel implementation. Leaving it in the same commit that renders builder output through the same helper would be worse than either state alone, so it now records the real difference: not the document, but who **writes** it.

## Shared wiring

The reader and the site's breakpoints move to `src/lib/site-content.ts`. Both public routes need both, and two answers to "what are this site's breakpoints" is how a page's own sheet and the shared site sheet come to emit the same tier under different at-rules — each internally consistent, the disagreement invisible until a layout is wrong at one width.

## Docs

The plugin's published README and its GUIDE were describing a package that no longer exists:

- Both told users to `import { PageRenderer } from "@nextlyhq/plugin-page-builder/render"`. **That subpath is not in the export map** — the package exports `.`, `./blocks`, `./admin` and a stylesheet. Anyone following the README got a module-not-found on their first attempt.
- Both documented `pageBuilderField` and `withPageBuilder`. Both return **0 hits** in `src`.
- **Five of the eight** block names the README listed do not exist: `core/paragraph`, `core/video`, `core/container`, `core/grid`, `core/query-loop` are really `core/text`, `core/embed`, `core/box`/`core/section`, `core/columns`, `core/collection-loop`. The real list is 19, read from the built artifact rather than from source (a source grep found only 13, because several blocks name themselves through a constant).
- The `defineBlock` example used the removed `type`/`label`/`contentFields`/`styleControls` shape.
- The GUIDE's "switch between Normal and Page Builder" section describes an `editorMode` column that was deliberately removed.

All corrected against the code, and the route example is now the same one this PR ships, so the docs and a working file agree.

## Verification

**In a production build**, which is the point of the exercise:

- `next build` → route table lists `/[...slug]` as dynamic; the build read no database.
- `next start`, then `/about` → **200**, carrying the authored heading, with `<title>` derived from it by the heading block's `seo` hook.
- Published HTML: `data-nx-prop` **0**, `data-nx-node` **0**, `contenteditable` **0** — with the `h2` and the scoped style class as positive controls that the page rendered real content rather than nothing.
- Negative controls: a nonexistent slug **404s**; `/admin` still resolves to the admin.

**The full author loop in the browser** (dev): created a page, inserted a Heading (node count asserted to move 0 → 1), edited its text inline, exited the editor, saved, and the public page served the new text.

**Gates:** playground typecheck and lint clean — and eslint's own JSON output was read to confirm both new files were actually among the 38 it linted, rather than trusting a green exit. `plugin-page-builder` 71/71 (matching baseline), playground 19/19. Fallow audit: no issues in 5 changed files.

## Process note against myself

My first pass showed the **old** heading text on the public page and I nearly filed "inline editing does not persist" as a defect. It was my error: I had pressed `Escape`, which correctly **cancels** an inline edit. Committing by blur works, and the second pass proves it. Escape-cancels is right behaviour.

## Not in this PR

- **Page-level custom CSS never reaches the published page.** `customCss` appears in 39 files across `packages` and **zero** in `blocks-react/src` (positive control: `PageRenderer` resolves there). Real gap, its own task.
- **There is no route helper for singles.** `createContentRoute` takes `collections` only, and the routing directory has zero references to singles. The hand-wired path works (`findSingle` + `nextlySingleTags` + `cachedFind`) but skips the reserved-path guard, preview scoping and metadata derivation, and reads through the trusted Direct API rather than as a visitor. Worth a `createSinglePage`, and it needs a decision on enforced vs trusted first.
- `block-pages.ts` carries a weaker version of the same stale comment; left alone to keep this diff focused.

## No changeset

No published code changed. The diff is the playground app (not published) plus two documentation files.
