### PR TITLE
fix(nextly): register code-defined access for a config with no collections

### DIFF
--- a/.changeset/register-code-defined-access.md
+++ b/.changeset/register-code-defined-access.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Code-defined `access` blocks are registered for every config, not only one that
+declares code-first collections. The registration ran inside the collection
+sync, which returns early when there are none, so an app defining only Singles
+never registered their rules — and an unregistered rule does not fail closed,
+it stops applying, falling through to the caller's stored permissions.

--- a/packages/nextly/src/di/__tests__/code-defined-access-registration.integration.test.ts
+++ b/packages/nextly/src/di/__tests__/code-defined-access-registration.integration.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Code-defined `access` blocks reach the RBAC registry whatever else the config
+ * contains.
+ *
+ * `checkAccess` resolves them from an in-memory registry, and a slug missing
+ * from it falls through to the caller's stored permissions. That is the
+ * dangerous direction: an unregistered rule does not fail closed, it stops
+ * applying — so a `read: () => false` written to restrict a Single silently
+ * stops restricting.
+ *
+ * The case that matters is a config with NO code-first collections, because the
+ * collection sync returns early for it.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, defineSingle, text } from "../../config";
+import { createTestNextly, type TestNextly } from "../../plugins/test-nextly";
+import type { RBACAccessControlService } from "../../domains/auth/services/rbac-access-control-service";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+function registeredAccess(t: TestNextly, slug: string): unknown {
+  const rbac = t.getService(
+    "rbacAccessControlService"
+  ) as RBACAccessControlService;
+  return rbac.getRegisteredAccess(slug);
+}
+
+describe("code-defined access registration (integration)", () => {
+  it("registers a Single's access when the config has no collections", async () => {
+    // The regression: this registration used to live inside the code-first
+    // COLLECTION sync, which returns early when there are none — so a
+    // Singles-only app never registered any of its rules.
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          access: { read: () => true, update: () => false },
+          fields: [text({ name: "siteName" })],
+        }),
+      ],
+    });
+
+    const access = registeredAccess(current, "preferences") as
+      | { read?: unknown; update?: unknown }
+      | undefined;
+    expect(access).toBeDefined();
+    expect(typeof access?.read).toBe("function");
+    expect(typeof access?.update).toBe("function");
+  });
+
+  it("applies that Single's rule rather than falling through to stored permissions", async () => {
+    // Registration is the mechanism; this is the consequence, and it is the half
+    // worth pinning. A user with no stored grants is REFUSED by the rule, and a
+    // rule that never registered would let `hasPermission` answer instead.
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          access: { read: () => false },
+          fields: [text({ name: "siteName" })],
+        }),
+        defineSingle({
+          slug: "public-notes",
+          access: { read: () => true },
+          fields: [text({ name: "body" })],
+        }),
+      ],
+    });
+    const rbac = current.getService(
+      "rbacAccessControlService"
+    ) as RBACAccessControlService;
+
+    // The positive control: the permissive rule is reached and answers true for
+    // the same user, so a blanket denial cannot explain the refusal below.
+    await expect(
+      rbac.checkAccess({
+        userId: "user-1",
+        operation: "read",
+        resource: "public-notes",
+      })
+    ).resolves.toBe(true);
+
+    await expect(
+      rbac.checkAccess({
+        userId: "user-1",
+        operation: "read",
+        resource: "preferences",
+      })
+    ).resolves.toBe(false);
+  });
+
+  it("still registers collection access when collections are present", async () => {
+    // The path that always worked, kept so the extraction cannot quietly drop it.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          access: { read: () => true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          access: { read: () => true },
+          fields: [text({ name: "siteName" })],
+        }),
+      ],
+    });
+
+    expect(registeredAccess(current, "posts")).toBeDefined();
+    expect(registeredAccess(current, "preferences")).toBeDefined();
+  });
+});

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -1013,6 +1013,12 @@ export async function registerServices(
   // ----------------------------------------
   await syncCodeFirstCollections(adapter, resolvedLogger, transformedConfig);
 
+  // Independent of that sync, and deliberately not inside it: an app with no
+  // code-first collections still has Singles whose access functions decide what
+  // its callers may do. Registration only writes to an in-memory map, so it owes
+  // nothing to the table sync above.
+  registerCodeDefinedAccess(transformedConfig);
+
   // ----------------------------------------
   // Layer 5: Sync Code-First Components
   // ----------------------------------------
@@ -1758,6 +1764,36 @@ function logStorageConfiguration(
  * auto-creates their tables so plugin-provided collections work without
  * a separate CLI run.
  */
+/**
+ * Publish every code-defined `access` block to the RBAC service.
+ *
+ * `checkAccess` resolves these from an in-memory registry, and a slug missing
+ * from it falls through to the caller's stored permissions — so a rule that is
+ * never registered does not fail closed, it stops applying. A restrictive
+ * `access.read` silently stops restricting.
+ *
+ * Registration therefore runs for its own reasons rather than as a step of the
+ * collection sync: a config with no code-first collections still has Singles
+ * whose rules have to apply, and the sync returns early for exactly that config.
+ */
+function registerCodeDefinedAccess(
+  transformedConfig: NextlyServiceConfig
+): void {
+  const rbacService = container.get<RBACAccessControlService>(
+    "rbacAccessControlService"
+  );
+  for (const collection of transformedConfig.collections ?? []) {
+    if (collection.access) {
+      rbacService.registerCollectionAccess(collection.slug, collection.access);
+    }
+  }
+  for (const single of transformedConfig.singles ?? []) {
+    if (single.access) {
+      rbacService.registerSingleAccess(single.slug, single.access);
+    }
+  }
+}
+
 async function syncCodeFirstCollections(
   adapter: DrizzleAdapter,
   logger: Logger,
@@ -1865,25 +1901,6 @@ async function syncCodeFirstCollections(
         .map(e => `  - ${e.slug}: ${e.error}`)
         .join("\n");
       throw new Error(`Failed to register collections:\n${errorDetails}`);
-    }
-  }
-
-  // Register code-defined access control configs with RBAC service.
-  // Access functions are stored in-memory (not DB) and auto-resolved
-  // during checkAccess().
-  const rbacService = container.get<RBACAccessControlService>(
-    "rbacAccessControlService"
-  );
-  for (const collection of transformedConfig.collections) {
-    if (collection.access) {
-      rbacService.registerCollectionAccess(collection.slug, collection.access);
-    }
-  }
-  if (transformedConfig.singles) {
-    for (const single of transformedConfig.singles) {
-      if (single.access) {
-        rbacService.registerSingleAccess(single.slug, single.access);
-      }
     }
   }
 


### PR DESCRIPTION
## The defect

Publishing code-defined `access` blocks to the RBAC registry ran **inside** `syncCodeFirstCollections`, which returns early when a config declares no code-first collections:

```ts
if (!transformedConfig.collections || transformedConfig.collections.length === 0) {
  return;   // ← and the Singles access registration sat below this
}
```

So an app defining only Singles — or one whose collections come from the Builder rather than code — registered **no access rules at all**.

## Why this is worse than it sounds

An unregistered rule does not fail closed. `checkAccess` resolves code access from the in-memory registry and, finding nothing for the slug, falls through to `hasPermission`:

```ts
const codeAccess = params.codeAccess ?? this.getRegisteredAccess(resource);
const operationAccess = codeAccess?.[operation];
if (operationAccess !== undefined) { /* the rule decides */ }
return hasPermission(userId, operation, resource, executor);   // ← otherwise
```

So it fails in both directions, and one of them is a security hole:

- a restrictive `access: { read: () => false }` **silently stops restricting** — the Single becomes readable by anyone holding the stored `read-{slug}` permission, which is the rule's whole purpose defeated;
- a permissive `access: { read: () => true }` stops granting.

Nothing about the boot logs, the config, or the admin surfaces says the rule is inert.

## How it was found

Not by reading — by a fixture. Writing the Singles discard endpoint, a `defineSingle` with `access: { read: () => true, update: () => true }` was refused by the read gate. Probing the registry directly returned nothing for that slug, which is what pointed at the early return rather than at the gate.

## The fix

Registration is now its own function, called from the same point in boot but unconditionally. It only writes to an in-memory map, so it owed the table sync nothing to begin with — being a step of that sync is what coupled it to a condition that has nothing to do with access.

## Tests

Three cases in `di/__tests__/code-defined-access-registration.integration.test.ts`:

1. a Singles-only config registers its Single's access;
2. **the rule actually applies** rather than falling through to stored permissions;
3. a config that does declare collections still registers both, so the extraction cannot quietly drop the path that always worked.

Break-verified: re-gating registration on `collections.length > 0` fails (1) with `expected undefined to be defined` and (2) with `expected false to be true`, while (3) still passes — the regression is correctly scoped to the no-collections case. Restored, green again.

**Note on case (2), because it is the one that could have been unsound.** Its headline assertion is that a `read: () => false` Single refuses — but that assertion passes on the broken code too, since `hasPermission` also returns false for a user with no grants. Absence would have satisfied it. What makes it evidence is the positive control beside it: a second Single with `read: () => true` must return **true** for the same user, which only happens if the registry was actually consulted. That control is the assertion that fails when the fix is removed.

## Gates

- `packages/nextly` integration (`di`, `domains/singles`, `domains/collections`), SQLite: **421 passed / 51 files**, no failures.
- `packages/nextly` unit over `src/di src/domains/auth`: **262 failed / 682 passed on this branch and 262 / 682 on `origin/main`**, with the failing FILE SETS diffed and byte-identical (12 files both sides), measured in a throwaway worktree at `19746bf07`. Nothing introduced.
- fallow: `pass`, all four `*_introduced` counters at 0.

## Sequencing

This lands before the Singles discard endpoint, whose tests need a Singles-only fixture whose access rules apply.
