### PR TITLE
feat(nextly): discard a Single's pending change for one language

### DIFF
--- a/.changeset/singles-discard-working-draft.md
+++ b/.changeset/singles-discard-working-draft.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A Single's pending change can now be discarded. `DELETE /singles/{slug}/versions/working-draft`
+removes one language's held edit under the same row lock a draft save takes, and returns
+the live published document. Discarding was collections-only, so a Single could hold a
+pending change with no way to throw one away.

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-dispatch.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-dispatch.test.ts
@@ -59,6 +59,8 @@ describe("version methods are registered", () => {
   it("exposes every single version method", () => {
     expect(Object.keys(SINGLE_VERSION_METHODS).sort()).toEqual([
       "autosaveSingle",
+      // The Single equivalent of the entry list's `discardWorkingDraft`.
+      "discardSingleWorkingDraft",
       "getSingleAutosave",
       "getSingleVersion",
       "getSingleVersionDiff",

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -112,6 +112,7 @@ import { assertSchemaVersionMatch } from "./schema-version-guard";
 import {
   assertLabelRequestValid,
   autosaveForDocument,
+  discardWorkingDraftForDocument,
   getAutosaveForDocument,
   requireSnapshotBody,
   getVersionDiffForDocument,
@@ -372,6 +373,28 @@ export const SINGLE_VERSION_METHODS: Record<
           headers: { [SKIP_TIMEZONE_FORMAT_HEADER]: "1" },
         })
       );
+    },
+  },
+  discardSingleWorkingDraft: {
+    execute: async (_svc, p) => {
+      const slug = String(p.slug ?? "");
+      // The document id comes from the live row rather than the URL, as
+      // everywhere in this handler: it is what the authorization checks are
+      // made against, and a client-supplied one would let a caller aim them at
+      // a document other than the one being written.
+      const entryId = await requireLiveSingleId(slug);
+      const item = await discardWorkingDraftForDocument({
+        scopeKind: "single",
+        slug,
+        entryId,
+        user: userFromParams(p),
+        params: p,
+        // `?locale=` names the language whose pending change is being thrown
+        // away. An empty value is the same as none: the request named no
+        // language, which a localized Single resolves to its default.
+        locale: typeof p.locale === "string" && p.locale ? p.locale : null,
+      });
+      return respondMutation("Working draft discarded.", item);
     },
   },
 };

--- a/packages/nextly/src/dispatcher/handlers/versions-methods.ts
+++ b/packages/nextly/src/dispatcher/handlers/versions-methods.ts
@@ -663,6 +663,7 @@ export async function discardWorkingDraftForDocument(
   );
 
   return discardWorkingDraft({
+    scopeKind: args.scopeKind,
     slug: args.slug,
     entryId: args.entryId,
     user: args.user,

--- a/packages/nextly/src/dispatcher/handlers/versions-methods.ts
+++ b/packages/nextly/src/dispatcher/handlers/versions-methods.ts
@@ -36,7 +36,10 @@ import {
   type VersionMetaWithAuthor,
 } from "../../domains/versions/author-hydration";
 import type { VersionDiff } from "../../domains/versions/diff";
-import { discardWorkingDraft } from "../../domains/versions/discard-working-draft";
+import {
+  discardWorkingDraft,
+  type DiscardScopeKind,
+} from "../../domains/versions/discard-working-draft";
 import { restoreVersion } from "../../domains/versions/restore-version";
 import {
   resolveComponentFieldMap,
@@ -614,7 +617,12 @@ export async function restoreVersionForDocument(
  * names the language it discards; the others are left alone.
  */
 export async function discardWorkingDraftForDocument(
-  args: Omit<VersionMethodArgs, "locale"> & {
+  args: Omit<VersionMethodArgs, "locale" | "scopeKind"> & {
+    /**
+     * Narrower than the shared `VersionMethodArgs` scope, because a discard is
+     * implemented for these two kinds only — see `DiscardScopeKind`.
+     */
+    scopeKind: DiscardScopeKind;
     params: Params;
     /**
      * Which language's pending change to discard. Absent (or null) means the

--- a/packages/nextly/src/domains/singles/__tests__/draft-split-singles.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/draft-split-singles.integration.test.ts
@@ -19,6 +19,7 @@ import {
   createTestNextly,
   type TestNextly,
 } from "../../../plugins/test-nextly";
+import { discardWorkingDraftForDocument } from "../../../dispatcher/handlers/versions-methods";
 import type { SingleEntryService } from "../services/single-entry-service";
 
 let current: TestNextly | undefined;
@@ -36,6 +37,10 @@ async function bootPlain(): Promise<TestNextly> {
         slug: SLUG,
         status: true,
         versions: { drafts: true },
+        // The discard cases below drive the DISPATCHER, which authorizes read
+        // and update on the document. The service-level cases pass
+        // `overrideAccess`, so these rules do not change what they exercise.
+        access: { read: () => true, update: () => true },
         fields: [text({ name: "siteName" }), text({ name: "tagline" })],
       }),
     ],
@@ -51,6 +56,7 @@ async function bootLocalized(): Promise<TestNextly> {
         localized: true,
         status: true,
         versions: { drafts: true },
+        access: { read: () => true, update: () => true },
         fields: [text({ name: "siteName", localized: true })],
       }),
     ],
@@ -222,6 +228,117 @@ describe("pending changes for Singles (integration)", () => {
     // re-applied by a later publish.
     expect(await storedName(t, "en")).toBe("EN edited");
     expect(await storedName(t, "de")).toBe("DE edited");
+    expect(await pendingLocales(t)).toEqual([]);
+  });
+});
+
+/**
+ * Throwing a Single's pending change away.
+ *
+ * Driven through the dispatcher method rather than the service, because the
+ * gap this closes was never in the delete: a Single had no discard PATH at all,
+ * so a service-level test would pass over exactly the wiring that was missing.
+ */
+describe("discarding a Single's pending change (integration)", () => {
+  /** The live document id, which a Single's caller resolves rather than names. */
+  async function liveId(t: TestNextly): Promise<string> {
+    const res = await singlesOf(t).get(SLUG, { overrideAccess: true });
+    return (res.data as { id: string }).id;
+  }
+
+  it("removes the sidecar and returns the live row, leaving the document untouched", async () => {
+    const t = await bootPlain();
+    const singles = singlesOf(t);
+    await singles.update(
+      SLUG,
+      { siteName: "live", status: "published" },
+      { overrideAccess: true }
+    );
+    const res = await singles.update(
+      SLUG,
+      { siteName: "edited" },
+      { overrideAccess: true }
+    );
+    expect(res.success).toBe(true);
+    // The fixture must actually hold a pending change, or the assertions below
+    // are satisfied by a Single that never stored one.
+    expect(await pendingLocales(t)).toEqual(["(none)"]);
+
+    const discarded = await discardWorkingDraftForDocument({
+      scopeKind: "single",
+      slug: SLUG,
+      entryId: await liveId(t),
+      user: { id: "editor-1" },
+      params: { slug: SLUG, _authenticatedUserId: "editor-1" },
+    });
+
+    expect(await pendingLocales(t)).toEqual([]);
+    // The response is the LIVE document, not the edit just thrown away.
+    expect((discarded as { siteName?: string }).siteName).toBe("live");
+    // And the live row itself never moved.
+    expect(await storedName(t)).toBe("live");
+  });
+
+  it("discards only the language it was asked for", async () => {
+    const t = await bootLocalized();
+    const singles = singlesOf(t);
+    await singles.update(
+      SLUG,
+      { siteName: "EN live", status: "published" },
+      { locale: "en", overrideAccess: true }
+    );
+    await singles.update(
+      SLUG,
+      { siteName: "DE live", status: "published" },
+      { locale: "de", overrideAccess: true }
+    );
+    await singles.update(
+      SLUG,
+      { siteName: "EN edited" },
+      { locale: "en", overrideAccess: true }
+    );
+    await singles.update(
+      SLUG,
+      { siteName: "DE edited" },
+      { locale: "de", overrideAccess: true }
+    );
+    expect(await pendingLocales(t)).toEqual(["de", "en"]);
+
+    const discarded = await discardWorkingDraftForDocument({
+      scopeKind: "single",
+      slug: SLUG,
+      entryId: await liveId(t),
+      user: { id: "editor-1" },
+      locale: "de",
+      params: { slug: SLUG, _authenticatedUserId: "editor-1" },
+    });
+
+    // German goes; English survives, because it is work the author never opened.
+    expect(await pendingLocales(t)).toEqual(["en"]);
+    // The values handed back are GERMAN's live ones, not the default language's.
+    expect((discarded as { siteName?: string }).siteName).toBe("DE live");
+    expect(await storedName(t, "de")).toBe("DE live");
+  });
+
+  it("is a no-op that still returns the live row when nothing is pending", async () => {
+    const t = await bootPlain();
+    const singles = singlesOf(t);
+    await singles.update(
+      SLUG,
+      { siteName: "live", status: "published" },
+      { overrideAccess: true }
+    );
+    expect(await pendingLocales(t)).toEqual([]);
+
+    const discarded = await discardWorkingDraftForDocument({
+      scopeKind: "single",
+      slug: SLUG,
+      entryId: await liveId(t),
+      user: { id: "editor-1" },
+      params: { slug: SLUG, _authenticatedUserId: "editor-1" },
+    });
+
+    expect((discarded as { siteName?: string }).siteName).toBe("live");
     expect(await pendingLocales(t)).toEqual([]);
   });
 });

--- a/packages/nextly/src/domains/singles/services/single-entry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-entry-service.ts
@@ -175,6 +175,21 @@ export class SingleEntryService extends BaseService {
   }
 
   /**
+   * Remove a Single's pending working-draft sidecar for one language.
+   *
+   * Deliberately without the post-write plumbing `update` and
+   * `publishAllLocales` carry. Those flush cache tags and offer a retention pass
+   * because they changed the LIVE document; a discard removes an unpublished
+   * sidecar and leaves the live row byte-identical, so there is nothing for a
+   * reader's cache to be stale about and no new version to prune.
+   */
+  async discardWorkingDraft(
+    params: Parameters<SingleMutationService["discardWorkingDraft"]>[0]
+  ): Promise<void> {
+    return this.mutationService.discardWorkingDraft(params);
+  }
+
+  /**
    * Publish every language of a Single at once.
    *
    * The main row's status and every companion `_status` move in one

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -100,6 +100,7 @@ import {
 import { VersionCaptureService } from "../../versions/version-capture-service";
 import { withVersionConflictRetry } from "../../versions/version-conflict";
 import { VersionsRepository } from "../../versions/versions-repository";
+import { workingDraftLocale } from "../../versions/working-draft-locale";
 import { expandComponentFields } from "../../webhooks/expand-component-fields";
 import { recordMutationEvent } from "../../webhooks/record-mutation-event";
 import { isOutboxRecordingActive } from "../../webhooks/recording-activation";
@@ -246,6 +247,75 @@ export class SingleMutationService extends BaseService {
    * Auto-creates the document if it doesn't exist, then applies the
    * provided partial data.
    */
+  /**
+   * Remove a Single's pending working-draft sidecar for one language, under the
+   * same row lock a draft save takes.
+   *
+   * A status-less save to a published Single stores its edit as a working draft
+   * rather than overwriting the live row. Discarding removes that sidecar so the
+   * editor resets to what is public; the live row and the durable history are
+   * both untouched.
+   *
+   * The lock is what makes it safe to interleave with saves: a save committing
+   * between this request's authorization checks and the delete would otherwise
+   * have its brand-new draft removed with both requests reporting success. It is
+   * a no-op where row locking is unavailable (SQLite, which already serializes
+   * writers).
+   *
+   * Authorization is the caller's concern: the discard handler establishes read
+   * and update on the document first. Deleting when no working draft exists is a
+   * no-op, not an error.
+   */
+  async discardWorkingDraft(params: {
+    slug: string;
+    /**
+     * Which language's pending change to discard. A localized Single holds one
+     * per language, and removing them all would throw away work in languages the
+     * author never opened. Ignored for an unlocalized Single, which has one.
+     */
+    locale?: string | null;
+  }): Promise<void> {
+    const singleMeta = await resolveSingleForRequest(
+      this.adapter,
+      this.singleRegistryService,
+      params.slug,
+      this.logger
+    );
+    if (!singleMeta) {
+      throw NextlyError.notFound({
+        logContext: {
+          reason: "discard-working-draft-single-not-found",
+          scopeSlug: params.slug,
+        },
+      });
+    }
+
+    await this.adapter.transaction(async tx => {
+      // A Single is one row, so its identity comes from reading that row rather
+      // than from the request. No row means the document has never been written,
+      // which cannot have a pending change against it.
+      const row = await tx.selectOne<{ id?: string }>(singleMeta.tableName, {});
+      const entryId = row?.id;
+      if (entryId === undefined) return;
+
+      // Serialize with concurrent draft-save upserts, which lock this same row
+      // before writing the sidecar.
+      await tx.lockRow(singleMeta.tableName, entryId);
+      await new VersionsRepository(tx).deleteWorkingDraft(
+        {
+          scopeKind: "single",
+          scopeSlug: params.slug,
+          entryId,
+        },
+        workingDraftLocale({
+          documentLocalized: singleMeta.localized === true,
+          requestLocale: params.locale ?? null,
+          defaultLocale: this.localization?.defaultLocale ?? null,
+        })
+      );
+    });
+  }
+
   async update(
     slug: string,
     data: Record<string, unknown>,

--- a/packages/nextly/src/domains/versions/__tests__/discard-working-draft.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/discard-working-draft.test.ts
@@ -51,6 +51,9 @@ function buildEntryErrorEnvelope(error: Error) {
 const user = { id: "u1", roles: ["editor"] } as unknown as UserContext;
 
 const args = {
+  // The kind is explicit now that one function serves both: a discard for a
+  // Single reads and deletes through different services.
+  scopeKind: "collection" as const,
   slug: "posts",
   entryId: "e1",
   user,

--- a/packages/nextly/src/domains/versions/discard-working-draft.ts
+++ b/packages/nextly/src/domains/versions/discard-working-draft.ts
@@ -30,9 +30,24 @@ import { errorFromServiceEnvelope } from "../../errors/from-service-envelope";
 import type { VersionScopeKind } from "../../schemas/versions/types";
 import type { UserContext } from "../singles/types";
 
+/**
+ * The document kinds a discard is implemented for.
+ *
+ * Narrower than `VersionScopeKind`, which also admits `"page"`. The branch below
+ * routes anything that is not a Single to the collection services, so accepting
+ * the wider type would let a page request read and delete a COLLECTION's working
+ * draft whenever the slug and id happened to match. Naming the two supported
+ * kinds makes that unrepresentable, and makes a future page discard declare
+ * itself rather than inherit collection behaviour by falling through.
+ */
+export type DiscardScopeKind = Extract<
+  VersionScopeKind,
+  "collection" | "single"
+>;
+
 export interface DiscardWorkingDraftArgs {
   /** Which kind of document owns the pending change. */
-  scopeKind: VersionScopeKind;
+  scopeKind: DiscardScopeKind;
   /** Collection or Single slug. */
   slug: string;
   /**
@@ -80,11 +95,17 @@ export async function discardWorkingDraft(
   // language being discarded is named, so the values handed back are the ones the
   // editor resets to: reading another language's would reset the form to text
   // belonging to a language the author is not looking at.
+  //
+  // `overrideAccess: false` is stated rather than left off. Omitting it enforces
+  // access here too, but only because undefined is falsy — so the call site reads
+  // as though it might be trusted, and this is the document a caller receives.
+  // The live-document read gate beside this one states it for the same reason.
   const locale = args.locale ? { locale: args.locale } : {};
   const result =
     args.scopeKind === "single"
       ? await getService("singleEntryService").get(args.slug, {
           user: args.user,
+          overrideAccess: false,
           routeAuthorized: true,
           authenticatedScope: args.authenticatedScope,
           status: "all",
@@ -94,6 +115,7 @@ export async function discardWorkingDraft(
           collectionName: args.slug,
           entryId: args.entryId,
           user: args.user,
+          overrideAccess: false,
           routeAuthorized: true,
           authenticatedScope: args.authenticatedScope,
           status: "all",

--- a/packages/nextly/src/domains/versions/discard-working-draft.ts
+++ b/packages/nextly/src/domains/versions/discard-working-draft.ts
@@ -11,6 +11,12 @@
  * one language's concern: the request names the language it is discarding, and
  * the other languages' pending changes are left alone.
  *
+ * Collections and Singles share this one implementation. Only the services
+ * differ — which one reads the live document and which one owns the delete. The
+ * ordering below is the part worth having once: reading before deleting is what
+ * makes the discard effectively atomic, and a second copy of it would be a
+ * second place for that to be got wrong.
+ *
  * Authorization is the caller's concern: the dispatcher handler establishes
  * read and update on the document before calling in here, so this module only
  * performs the removal and the re-read.
@@ -21,11 +27,19 @@
 import type { AuthenticatedScope } from "../../auth/authenticated-scope";
 import { getService } from "../../di";
 import { errorFromServiceEnvelope } from "../../errors/from-service-envelope";
+import type { VersionScopeKind } from "../../schemas/versions/types";
 import type { UserContext } from "../singles/types";
 
 export interface DiscardWorkingDraftArgs {
-  /** Collection slug. */
+  /** Which kind of document owns the pending change. */
+  scopeKind: VersionScopeKind;
+  /** Collection or Single slug. */
   slug: string;
+  /**
+   * The live document's id. A Single's URL carries none — there is only ever one
+   * document — so its caller resolves the id from the live row rather than
+   * letting a client name it.
+   */
   entryId: string;
   user: UserContext;
   /**
@@ -44,9 +58,9 @@ export interface DiscardWorkingDraftArgs {
 }
 
 /**
- * Remove the working-draft sidecar for a published collection entry and return
- * the live published document as a plain read would shape it. A no-op that
- * still returns the live row when no working draft exists.
+ * Remove the working-draft sidecar for a published document and return the live
+ * published document as a plain read would shape it. A no-op that still returns
+ * the live row when no working draft exists.
  */
 export async function discardWorkingDraft(
   args: DiscardWorkingDraftArgs
@@ -60,20 +74,31 @@ export async function discardWorkingDraft(
   // removed, leaving the pending draft intact rather than deleting it and then
   // reporting a failure the admin treats as a no-op (which would keep the stale
   // draft on screen and let a later Publish push its values straight to live).
-  const result = await getService("collectionsHandler").getEntry({
-    collectionName: args.slug,
-    entryId: args.entryId,
-    user: args.user,
-    // Read and update were established by the caller; skip only the redundant
-    // coarse RBAC re-check while the document's own rules still run in getEntry.
-    routeAuthorized: true,
-    authenticatedScope: args.authenticatedScope,
-    status: "all",
-    // Read the language being discarded, so the values handed back are the ones
-    // the editor resets to. Reading another language's would reset the form to
-    // text that belongs to a language the author is not looking at.
-    ...(args.locale ? { locale: args.locale } : {}),
-  });
+  //
+  // Read and update were established by the caller, so both reads skip only the
+  // redundant coarse RBAC re-check while the document's own rules still run. The
+  // language being discarded is named, so the values handed back are the ones the
+  // editor resets to: reading another language's would reset the form to text
+  // belonging to a language the author is not looking at.
+  const locale = args.locale ? { locale: args.locale } : {};
+  const result =
+    args.scopeKind === "single"
+      ? await getService("singleEntryService").get(args.slug, {
+          user: args.user,
+          routeAuthorized: true,
+          authenticatedScope: args.authenticatedScope,
+          status: "all",
+          ...locale,
+        })
+      : await getService("collectionsHandler").getEntry({
+          collectionName: args.slug,
+          entryId: args.entryId,
+          user: args.user,
+          routeAuthorized: true,
+          authenticatedScope: args.authenticatedScope,
+          status: "all",
+          ...locale,
+        });
 
   // A failed read (a concurrent delete, or an after-read hook or database error)
   // is propagated as the error it carries rather than returned as a successful
@@ -92,11 +117,18 @@ export async function discardWorkingDraft(
   // this request's authorization checks and the delete would otherwise have its
   // brand-new draft removed with both requests reporting success. Deleting when
   // none exists is a no-op, not an error.
-  await getService("collectionsHandler").discardWorkingDraft({
-    collectionName: args.slug,
-    entryId: args.entryId,
-    locale: args.locale ?? null,
-  });
+  if (args.scopeKind === "single") {
+    await getService("singleEntryService").discardWorkingDraft({
+      slug: args.slug,
+      locale: args.locale ?? null,
+    });
+  } else {
+    await getService("collectionsHandler").discardWorkingDraft({
+      collectionName: args.slug,
+      entryId: args.entryId,
+      locale: args.locale ?? null,
+    });
+  }
 
   return result.data;
 }

--- a/packages/nextly/src/route-handler/__tests__/route-parser.versions.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.versions.test.ts
@@ -206,6 +206,60 @@ describe("version routes", () => {
     expect(parsed.routeParams?.versionNo).toBeUndefined();
   });
 
+  it("parses a Single's working-draft discard as a write, with no entry id", () => {
+    const parsed = parseRestRoute(
+      ["singles", "settings", "versions", "working-draft"],
+      "DELETE"
+    );
+
+    expect(parsed).toMatchObject({
+      service: "singles",
+      // An update of the document: it changes what the editor sees, not history.
+      operation: "update",
+      method: "discardSingleWorkingDraft",
+    });
+    expect(parsed.routeParams?.slug).toBe("settings");
+    // A Single's URL names no document; the server resolves it from the live row.
+    expect(parsed.routeParams?.entryId).toBeUndefined();
+    // `working-draft` is a named sub-resource, never read as a version number.
+    expect(parsed.routeParams?.versionNo).toBeUndefined();
+  });
+
+  it("routes only DELETE on the working-draft path, and nothing deeper", () => {
+    const path = ["singles", "settings", "versions", "working-draft"];
+
+    expect(parseRestRoute(path, "DELETE").method).toBe(
+      "discardSingleWorkingDraft"
+    );
+    // Asserted per verb rather than "not the discard method": the weaker form
+    // passes when a verb falls through to some other wrong route.
+    expect(parseRestRoute(path, "PUT").method).toBeUndefined();
+    expect(parseRestRoute(path, "POST").method).toBeUndefined();
+    // GET falls through to the ordinary version read with `working-draft` in the
+    // version-NUMBER position, which is what ANY non-numeric segment does here.
+    // Recorded rather than asserted as undefined because that is the existing
+    // shape of this path: the handler coerces the segment with `Number(...)`, so
+    // the read fails to find a version rather than reaching anything else.
+    expect(parseRestRoute(path, "GET").method).toBe("getSingleVersion");
+    // PATCH on this path is a version LABEL write, which coerces the segment to
+    // a number and so rejects `working-draft` rather than treating it as one.
+    expect(parseRestRoute(path, "PATCH").method).toBe("setSingleVersionLabel");
+
+    // A deeper path is not this route's.
+    expect(parseRestRoute([...path, "extra"], "DELETE").method).toBeUndefined();
+  });
+
+  it("does not resolve an inherited object member as a named sub-resource", () => {
+    // The sub-resource lookup is keyed by a URL segment. On an object literal a
+    // key like `constructor` or `toString` resolves through the prototype, so
+    // the request would match a route that was never declared.
+    for (const forged of ["constructor", "toString", "__proto__", "valueOf"]) {
+      const path = ["singles", "settings", "versions", forged];
+      expect(parseRestRoute(path, "DELETE").method).toBeUndefined();
+      expect(parseRestRoute(path, "PUT").method).toBeUndefined();
+    }
+  });
+
   it("resolves each verb on the autosave path to its own route", () => {
     // Asserted as an exact method per verb rather than "not the write method".
     // The weaker form passes when a verb resolves to something else wrong, and

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -1010,6 +1010,24 @@ function parseSingleVersionRoutes(
     };
   }
 
+  // `versions/working-draft` DELETE throws away this Single's pending change for
+  // one language. A named sub-resource like `autosave` above, so it cannot
+  // collide with the numeric version paths. Authorized as an update: it changes
+  // what the editor sees, not the document's history.
+  if (
+    subId === "working-draft" &&
+    additionalParams.length === 0 &&
+    httpMethod === "DELETE"
+  ) {
+    routeParams.slug = id;
+    return {
+      service: "singles",
+      operation: "update",
+      method: "discardSingleWorkingDraft",
+      routeParams,
+    };
+  }
+
   // See the collection parser: naming a version is an idempotent write on
   // history, authorized as an update.
   if (subId && additionalParams.length === 0 && httpMethod === "PATCH") {

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -941,6 +941,34 @@ function parseCollectionEntryVersionRoutes(
  * `/singles/{slug}/versions[/{versionNo}]` — the Single equivalent, nesting
  * under the document for the same reason.
  */
+/**
+ * Named sub-resources under a Single's `versions`, keyed by `"{name} {METHOD}"`.
+ *
+ * A table rather than a branch each: every one of these tests the same three
+ * things and returns a fixed descriptor, so a branch per entry is decision
+ * points spent restating a shape.
+ *
+ * A `Map` rather than an object literal because the key is built from a URL
+ * segment: a lookup on an object would reach inherited members, so a request for
+ * `versions/constructor` would find one.
+ *
+ * `autosave` is PUT because the row is rolling — one per document and author,
+ * rewritten in place — so repeating the request leaves one recovery point.
+ * `working-draft` is DELETE of the pending change, authorized as an update
+ * because it changes what the editor sees rather than the document's history.
+ */
+const SINGLE_VERSION_SUBRESOURCES = new Map<
+  string,
+  { operation: OperationType; method: string }
+>([
+  ["autosave PUT", { operation: "update", method: "autosaveSingle" }],
+  ["autosave GET", { operation: "single", method: "getSingleAutosave" }],
+  [
+    "working-draft DELETE",
+    { operation: "update", method: "discardSingleWorkingDraft" },
+  ],
+]);
+
 function parseSingleVersionRoutes(
   id: string | undefined,
   subresource: string | undefined,
@@ -972,60 +1000,19 @@ function parseSingleVersionRoutes(
     };
   }
 
-  // `versions/autosave` PUT records the author's rolling recovery point, the
-  // Single equivalent of the collection route above and PUT for the same reason:
-  // one row per document and author, rewritten in place, so repeating the
-  // request leaves the same single row.
-  //
-  // A Single's history nests directly under the document, so `autosave` arrives
-  // as `subId` where the collection parser sees it in `additionalParams`. It is
-  // a named sub-resource and a version number is always numeric, so the two
-  // cannot collide here either.
-  if (
-    subId === "autosave" &&
-    additionalParams.length === 0 &&
-    httpMethod === "PUT"
-  ) {
-    routeParams.slug = id;
-    return {
-      service: "singles",
-      operation: "update",
-      method: "autosaveSingle",
-      routeParams,
-    };
-  }
-
-  // The matching read, claimed here for the same reason as the collection one.
-  if (
-    subId === "autosave" &&
-    additionalParams.length === 0 &&
-    httpMethod === "GET"
-  ) {
-    routeParams.slug = id;
-    return {
-      service: "singles",
-      operation: "single",
-      method: "getSingleAutosave",
-      routeParams,
-    };
-  }
-
-  // `versions/working-draft` DELETE throws away this Single's pending change for
-  // one language. A named sub-resource like `autosave` above, so it cannot
-  // collide with the numeric version paths. Authorized as an update: it changes
-  // what the editor sees, not the document's history.
-  if (
-    subId === "working-draft" &&
-    additionalParams.length === 0 &&
-    httpMethod === "DELETE"
-  ) {
-    routeParams.slug = id;
-    return {
-      service: "singles",
-      operation: "update",
-      method: "discardSingleWorkingDraft",
-      routeParams,
-    };
+  // The named sub-resources of a Single's history, matched from the table above
+  // rather than as one `if` each. A Single's history nests directly under the
+  // document, so these arrive as `subId` where the collection parser sees them
+  // in `additionalParams`; a version number is always numeric, so a name can
+  // never collide with one.
+  if (subId !== undefined && additionalParams.length === 0) {
+    const named = SINGLE_VERSION_SUBRESOURCES.get(
+      `${subId} ${httpMethod.toUpperCase()}`
+    );
+    if (named) {
+      routeParams.slug = id;
+      return { service: "singles", ...named, routeParams };
+    }
   }
 
   // See the collection parser: naming a version is an idempotent write on

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -614,6 +614,10 @@ export const SINGLE_DOCUMENT_METHODS = new Set([
   // definition mutation's manage-settings. The service checks `publish-{slug}`
   // on top, which no route-level gate can express.
   "publishAllSingleLocales",
+  // Discarding the working draft reverts the document to its live row. Left out
+  // of the read branch below so it resolves to `update-{slug}`: a caller who may
+  // not update the document may not throw away its pending edits either.
+  "discardSingleWorkingDraft",
 ]);
 
 /**


### PR DESCRIPTION
## What this adds

`DELETE /singles/{slug}/versions/working-draft` — throw away a Single's pending change for one language and get the live published document back.

A Single could **hold** a pending change since #1069 but had no way to discard one: `discardWorkingDraft` reached the collections handler and was collections-only. I started this route during #1075 and reverted it rather than ship a route pointing at a method that does not exist.

## Design

**One implementation of the ordering rule, not two.** `discardWorkingDraft` now takes a `scopeKind` and serves both kinds. Only the services differ — which one reads the live document, which one owns the delete. The read-before-delete ordering is the part worth having once: reading first is what makes the discard effectively atomic, so a read failure surfaces before anything is removed and leaves the pending draft intact for a retry.

**The delete takes the same row lock a draft save takes.** Without it, a save committing between this request's authorization checks and the delete has its brand-new draft removed with both requests reporting success. No-op on SQLite, which already serializes writers.

**The document id comes from the live row, never the URL** — as everywhere else in the Single version handlers. A Single has one document and the client must not name which; a client-supplied id would aim the authorization checks at a different document than the one being written.

**Per language**, for the reason #1079 established: discarding all of them throws away work in languages the author never opened.

## The route parser became a table, and that was not cosmetic

Adding one more branch pushed `parseSingleVersionRoutes` past **both** complexity thresholds — cyclomatic 23 (limit 20), cognitive 16 (limit 15), which failed the fallow gate.

The fix is a genuine reduction rather than a suppression. Three branches (`autosave` PUT, `autosave` GET, `working-draft` DELETE) tested the same three things and returned a fixed descriptor, so a branch each spent decision points restating one shape. They are now one lookup, and the gate passes with `complexity_introduced: 0`.

**A `Map`, not an object literal**, because the key is built from a URL segment: an object lookup reaches inherited members, so `versions/constructor` would resolve to a route nobody declared. There is a test for exactly that (`constructor`, `toString`, `__proto__`, `valueOf`).

## Tests

- **3 integration cases** (`draft-split-singles.integration.test.ts`), driven through the **dispatcher** rather than the service — the gap this closes was never in the delete, it was that no discard PATH existed, so a service-level test would pass straight over the missing wiring.
- **3 route-parser cases** — the route parses, only DELETE owns it, and the prototype-key hazard above.
- **1 existing registration guard updated** deliberately: `versions-dispatch.test.ts` enumerates the registered Single version methods and correctly failed when I added one.

Break-verified: stubbing the delete so it never runs fails exactly the two cases that name the property (`expected [ '(none)' ] to deeply equal []` and `expected [ 'de', 'en' ] to deeply equal [ 'en' ]`), while the third — the no-op case — correctly still passes, since "nothing pending stays nothing pending" is true either way. Restored from a backup, green again.

**One test assertion corrected during review of my own work.** I first asserted `GET` on the working-draft path resolves to nothing. It does not — it falls through to the ordinary version read with `working-draft` in the version-NUMBER position, which is what *any* non-numeric segment does there and is unchanged by this PR. The test now records that behaviour rather than asserting a tidier one that was false.

## Gates

- Integration, three dialects: Postgres **1235 passed / 182 files**, MySQL **1177 passed**, SQLite **108 passed** over `domains/singles` + `di`. No failures.
- `packages/nextly` unit over `route-handler` + `dispatcher`: **2 failures on this branch and the same 2, by name, on `origin/main` (`d560eabc0`)** — `redacts the snapshot before returning it` and `gates on the live document before reading history` — measured in a throwaway worktree. 401 passed here against 398 on main, which is exactly the 3 route tests added.
- fallow: `pass`, all four `*_introduced` counters at 0.

## Scope: why there is no Discard button in this PR

Deliberately engine-only, because the button cannot work yet and I would rather not ship a dark affordance.

**A Single's pending change is currently write-only.** The engine holds a status-less edit, publish promotes it, publish-all applies it — but **there is no working-draft read overlay for Singles at all**. `GetSingleOptions` has no `includeWorkingDraft`, and nothing sets `_isWorkingDraft` outside the collection services (positive control: both writes of that flag in the tree are in `collection-mutation-service.ts` and `collection-query-service.ts`).

So an author saves an edit to a published Single, the read hands the live values straight back, and the edit is invisible until they publish it. `EntrySystemHeader` gates the Discard item on `hasWorkingDraft && !!onDiscardWorkingDraft`, and the first half can never be true for a Single today.

That read overlay is the next PR; the admin wiring follows it. The hook and the widened fetcher for that wiring are written and held back rather than merged unused.

This is the same shape as the defect browser testing caught during the pending-changes program: the per-language tests asserted the live value was *unaffected*, and none asserted that a draft view returns the pending content — because for Singles that view does not exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for discarding pending changes on Single documents.
  - Supports localized and non-localized content while preserving live data.
  - Added routing and access handling for Single-document working-draft deletion.
  - Extended working-draft discard support across Single and Collection documents.

- **Bug Fixes**
  - Ensured discarding a draft is safely handled when no pending change exists.
  - Improved route validation to reject invalid or forged sub-resource paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->