### PR TITLE
fix(admin): re-request session-gated admin metadata after sign-in

### DIFF
--- a/.changeset/session-gated-admin-meta-retries.md
+++ b/.changeset/session-gated-admin-meta-retries.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Plugin-contributed fields and the language switcher no longer disappear after
+moving around the admin. The request that lists installed plugins and configured
+locales is session-gated and does not retry, so one made before sign-in failed
+permanently and nothing re-ran it — leaving an author told to reload the page
+before they could edit the field. Signing in now issues a fresh request, and the
+request is not made at all until the session is known.

--- a/packages/admin/src/components/guards/PrivateRoute.tsx
+++ b/packages/admin/src/components/guards/PrivateRoute.tsx
@@ -1,86 +1,68 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
 import type React from "react";
 import { useEffect } from "react";
 
 import { ROUTES } from "@admin/constants/routes";
-import { isAuthenticated as checkIsAuthenticated } from "@admin/lib/auth/session";
-import { checkSetupStatus } from "@admin/lib/auth/setup-status";
+import { useAuthSession } from "@admin/hooks/queries/useAuthSession";
 import { navigateTo } from "@admin/lib/navigation";
-
-async function verifyAuth(): Promise<{
-  isSetup: boolean;
-  isAuthenticated: boolean;
-}> {
-  const isSetup = await checkSetupStatus();
-  if (!isSetup) {
-    return { isSetup: false, isAuthenticated: false };
-  }
-  const authenticated = await checkIsAuthenticated();
-  return { isSetup: true, isAuthenticated: authenticated };
-}
 
 interface PrivateRouteProps {
   children: React.ReactNode;
 }
 
+/**
+ * Where an unusable session has to send the visitor, or `null` when it is
+ * usable.
+ *
+ * One answer, read by both the effect that navigates and the placeholder that
+ * says where it is going. They used to decide separately from the same fields,
+ * which is two implementations of one question: a change to either could send
+ * someone to setup while telling them they were going to login.
+ */
+function redirectFor(session: {
+  isSetup: boolean;
+  isAuthenticated: boolean;
+}): { path: string; destination: string } | null {
+  if (!session.isSetup) return { path: ROUTES.SETUP, destination: "setup" };
+  if (!session.isAuthenticated)
+    return { path: ROUTES.LOGIN, destination: "login" };
+  return null;
+}
+
+/** The themed placeholder shown for the moment before the browser moves. */
+function RedirectNotice({ destination }: { destination: string }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <p className="text-muted-foreground dark:text-muted-foreground">
+        Redirecting to {destination}...
+      </p>
+    </div>
+  );
+}
+
 export function PrivateRoute({ children }: PrivateRouteProps) {
-  const { data, status } = useQuery({
-    queryKey: ["auth", "session"],
-    queryFn: verifyAuth,
-    staleTime: 5 * 60 * 1000, // 5 min — don't re-verify on every navigation
-    gcTime: 10 * 60 * 1000,
-    retry: false,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false, // Trust the cache within staleTime
-  });
+  // The shared session query, not a second verification of the same fact. The
+  // data providers read this same key, so a session is fetched once and every
+  // reader of it agrees.
+  const { data, status } = useAuthSession();
 
-  // Only redirect when the query has DEFINITIVELY resolved with data.
-  // In React Query v5, `isLoading` (isPending && isFetching) can be false
-  // while data is still undefined (e.g. error state, or transient states
-  // during route transitions). Using `status === 'success'` ensures we
-  // only act on confirmed auth results — never during pending, error,
-  // or any intermediate state that could trigger a premature redirect
-  // to LOGIN and cause an infinite loop with PublicRoute.
+  // Only acted on once the query has DEFINITIVELY resolved with data. In React
+  // Query v5 `isLoading` can be false while data is still undefined — an error
+  // state, or a transient one during a route transition — and redirecting from
+  // there sends the visitor to LOGIN on a result that never arrived, which
+  // loops against PublicRoute.
+  const settled = status === "success" && data !== undefined;
+  const redirect = settled ? redirectFor(data) : null;
+
   useEffect(() => {
-    if (status !== "success") return;
+    if (redirect) navigateTo(redirect.path);
+  }, [redirect]);
 
-    if (!data.isSetup) {
-      navigateTo(ROUTES.SETUP);
-      return;
-    }
-
-    if (!data.isAuthenticated) {
-      navigateTo(ROUTES.LOGIN);
-    }
-  }, [data, status]);
-
-  // While auth verification is pending, render an empty themed container so
-  // the layout doesn't flash a mismatched background.
-  if (status !== "success" || !data) {
-    return <div className="min-h-screen bg-background" />;
-  }
-
-  if (!data.isSetup) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-background">
-        <p className="text-muted-foreground dark:text-muted-foreground">
-          Redirecting to setup...
-        </p>
-      </div>
-    );
-  }
-
-  if (!data.isAuthenticated) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-background">
-        <p className="text-muted-foreground dark:text-muted-foreground">
-          Redirecting to login...
-        </p>
-      </div>
-    );
-  }
+  // Nothing decided yet: an empty themed container, so the layout does not
+  // flash a mismatched background.
+  if (!settled) return <div className="min-h-screen bg-background" />;
+  if (redirect) return <RedirectNotice destination={redirect.destination} />;
 
   return <>{children}</>;
 }

--- a/packages/admin/src/components/guards/__tests__/PrivateRoute.test.tsx
+++ b/packages/admin/src/components/guards/__tests__/PrivateRoute.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * The guard's subtlety is that "not authenticated" and "no answer yet" both
+ * read as falsy, and acting on the second is what sends someone to LOGIN on a
+ * result that never arrived — which then loops against PublicRoute. So the
+ * unsettled cases are asserted as explicitly as the decided ones.
+ *
+ * The destination and the message it shows come from ONE derivation, so a test
+ * that pins the message is also pinning where the browser is being sent.
+ */
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ROUTES } from "@admin/constants/routes";
+
+const mockUseAuthSession = vi.fn();
+vi.mock("@admin/hooks/queries/useAuthSession", () => ({
+  useAuthSession: () => mockUseAuthSession(),
+  authSessionKey: ["auth", "session"],
+}));
+
+const mockNavigateTo = vi.fn();
+vi.mock("@admin/lib/navigation", () => ({
+  navigateTo: (path: string) => mockNavigateTo(path),
+}));
+
+import { PrivateRoute } from "../PrivateRoute";
+
+function renderGuard() {
+  return render(
+    <PrivateRoute>
+      <span>protected</span>
+    </PrivateRoute>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PrivateRoute", () => {
+  it("renders the protected content for a valid session", () => {
+    mockUseAuthSession.mockReturnValue({
+      status: "success",
+      data: { isSetup: true, isAuthenticated: true },
+    });
+
+    renderGuard();
+
+    expect(screen.getByText("protected")).toBeInTheDocument();
+    expect(mockNavigateTo).not.toHaveBeenCalled();
+  });
+
+  it("sends an unauthenticated visitor to login", () => {
+    mockUseAuthSession.mockReturnValue({
+      status: "success",
+      data: { isSetup: true, isAuthenticated: false },
+    });
+
+    renderGuard();
+
+    expect(mockNavigateTo).toHaveBeenCalledWith(ROUTES.LOGIN);
+    expect(screen.getByText(/Redirecting to login/)).toBeInTheDocument();
+    expect(screen.queryByText("protected")).not.toBeInTheDocument();
+  });
+
+  it("sends an unconfigured installation to setup, not to login", () => {
+    // Setup is checked FIRST: an installation with no admin account yet has no
+    // session either, so deciding on authentication would send the very first
+    // visitor to a login screen no one can pass.
+    mockUseAuthSession.mockReturnValue({
+      status: "success",
+      data: { isSetup: false, isAuthenticated: false },
+    });
+
+    renderGuard();
+
+    expect(mockNavigateTo).toHaveBeenCalledWith(ROUTES.SETUP);
+    expect(screen.getByText(/Redirecting to setup/)).toBeInTheDocument();
+  });
+
+  it("waits while the session is still pending, and navigates nowhere", () => {
+    mockUseAuthSession.mockReturnValue({ status: "pending", data: undefined });
+
+    renderGuard();
+
+    expect(mockNavigateTo).not.toHaveBeenCalled();
+    expect(screen.queryByText("protected")).not.toBeInTheDocument();
+  });
+
+  it("navigates nowhere when the session query ERRORED", () => {
+    // The case that loops: an error leaves `data` undefined, and treating that
+    // as "not authenticated" redirects to LOGIN, whose own guard sends the
+    // visitor back here.
+    mockUseAuthSession.mockReturnValue({ status: "error", data: undefined });
+
+    renderGuard();
+
+    expect(mockNavigateTo).not.toHaveBeenCalled();
+    expect(screen.queryByText("protected")).not.toBeInTheDocument();
+  });
+
+  it("does not render children on a success whose data has not arrived", () => {
+    // React Query can report success with data still undefined during a
+    // transition; rendering the protected tree there shows it to nobody in
+    // particular.
+    mockUseAuthSession.mockReturnValue({ status: "success", data: undefined });
+
+    renderGuard();
+
+    expect(screen.queryByText("protected")).not.toBeInTheDocument();
+    expect(mockNavigateTo).not.toHaveBeenCalled();
+  });
+});

--- a/packages/admin/src/context/providers/BrandingProvider.session.test.tsx
+++ b/packages/admin/src/context/providers/BrandingProvider.session.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * The workspace half of admin-meta is session-gated and does not retry, so a
+ * request made before a session existed answers 401 and stays failed. Signing in
+ * has to produce a NEW request; nothing revives the dead one.
+ *
+ * These cover that transition, because every consumer that reads the plugin list
+ * or the locale list reads it through this provider — and the failure they saw
+ * was not an error but a plausible-looking "nothing is installed".
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AdminBranding } from "@admin/types/branding";
+
+const get = vi.fn();
+const protectedGet = vi.fn();
+const session = vi.fn();
+
+vi.mock("@admin/lib/api/publicApi", () => ({
+  publicApi: { get: (...args: unknown[]) => get(...args) },
+}));
+
+vi.mock("@admin/lib/api/protectedApi", () => ({
+  protectedApi: { get: (...args: unknown[]) => protectedGet(...args) },
+}));
+
+vi.mock("@admin/hooks/queries/useAuthSession", () => ({
+  useAuthSession: () => session(),
+  authSessionKey: ["auth", "session"],
+}));
+
+import {
+  BrandingProvider,
+  useBrandingStatus,
+} from "@admin/context/providers/BrandingProvider";
+
+function Probe() {
+  const { isPending, isUnavailable } = useBrandingStatus();
+  return (
+    <span data-testid="status">
+      {isPending ? "pending" : isUnavailable ? "unavailable" : "answered"}
+    </span>
+  );
+}
+
+function renderProbe() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const utils = render(
+    <QueryClientProvider client={client}>
+      <BrandingProvider>
+        <Probe />
+      </BrandingProvider>
+    </QueryClientProvider>
+  );
+  return {
+    ...utils,
+    rerender: () =>
+      utils.rerender(
+        <QueryClientProvider client={client}>
+          <BrandingProvider>
+            <Probe />
+          </BrandingProvider>
+        </QueryClientProvider>
+      ),
+  };
+}
+
+const WORKSPACE = { plugins: [] } as unknown as AdminBranding;
+
+/** The session as this provider reads it. */
+function signedOut() {
+  return { data: { isSetup: true, isAuthenticated: false }, isPending: false };
+}
+function signedIn() {
+  return { data: { isSetup: true, isAuthenticated: true }, isPending: false };
+}
+function resolving() {
+  return { data: undefined, isPending: true };
+}
+
+afterEach(() => {
+  get.mockReset();
+  protectedGet.mockReset();
+  session.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("the session-gated half of admin-meta", () => {
+  it("does not ask while the session is still resolving", async () => {
+    session.mockReturnValue(resolving());
+    get.mockResolvedValue({} as AdminBranding);
+
+    renderProbe();
+
+    // Asserted after a settle, so this is "never asked" rather than "not asked
+    // yet on the first paint" — the two look identical at render time.
+    await waitFor(() => expect(get).toHaveBeenCalled());
+    expect(protectedGet).not.toHaveBeenCalled();
+    expect(screen.getByTestId("status").textContent).toBe("pending");
+  });
+
+  it("asks again after sign-in, rather than reusing the failed anonymous answer", async () => {
+    get.mockResolvedValue({} as AdminBranding);
+    protectedGet.mockRejectedValueOnce(new Error("401"));
+    session.mockReturnValue(signedOut());
+
+    const { rerender } = renderProbe();
+
+    // The anonymous attempt fails and, with no retry, is final for that key.
+    await waitFor(() =>
+      expect(screen.getByTestId("status").textContent).toBe("unavailable")
+    );
+    expect(protectedGet).toHaveBeenCalledTimes(1);
+
+    // Signing in must produce a fresh request. Before this fix the failed query
+    // was simply read again and every consumer stayed degraded until a reload.
+    protectedGet.mockResolvedValueOnce(WORKSPACE);
+    session.mockReturnValue(signedIn());
+    rerender();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("status").textContent).toBe("answered")
+    );
+    expect(protectedGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports unavailable when the session itself could not be established", async () => {
+    // A session query that failed still releases this one: the answer is that
+    // the list is unavailable, which is true, rather than a skeleton forever.
+    get.mockResolvedValue({} as AdminBranding);
+    protectedGet.mockRejectedValue(new Error("401"));
+    session.mockReturnValue({ data: undefined, isPending: false });
+
+    renderProbe();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("status").textContent).toBe("unavailable")
+    );
+  });
+});

--- a/packages/admin/src/context/providers/BrandingProvider.tsx
+++ b/packages/admin/src/context/providers/BrandingProvider.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import type React from "react";
 import { createContext, useContext, useEffect, useMemo } from "react";
 
+import { useAuthSession } from "../../hooks/queries/useAuthSession";
 import { protectedApi } from "../../lib/api/protectedApi";
 import { publicApi } from "../../lib/api/publicApi";
 import {
@@ -212,19 +213,40 @@ export function BrandingProvider({ children }: BrandingProviderProps) {
     retry: false,
   });
 
-  // The half that describes the installation rather than its appearance. It
-  // comes from a session-gated route, so before sign-in this query fails and
-  // contributes nothing — which is correct, since no pre-session surface reads
-  // these fields.
+  /*
+   * The half that describes the installation rather than its appearance, from a
+   * SESSION-GATED route.
+   *
+   * Both the session state and the settled-ness of the session query are load
+   * bearing, and for different reasons.
+   *
+   * `signedIn` is in the KEY, not in a refetch effect. A request made before a
+   * session existed answers 401, and this query does not retry — so signing in
+   * has to produce a DIFFERENT cache entry rather than revive a dead one.
+   * Expressing that as an invalidation instead leaves a window: the 401 can land
+   * after the sign-in effect has already run, and the query then stays failed
+   * with nothing left to trigger it. A key cannot lose that race, because the
+   * new key has no result yet whenever it appears.
+   *
+   * `enabled` waits for the session query to SETTLE rather than to succeed. It
+   * stops the anonymous 401 being fired speculatively on every load, and a
+   * session query that itself failed still releases this one — reporting
+   * unavailable, which is true, instead of holding every reader on a skeleton
+   * for a fact that will never arrive.
+   */
+  const { data: session, isPending: sessionPending } = useAuthSession();
+  const signedIn = session?.isAuthenticated === true;
+
   const {
     data: workspaceData,
     isPending: workspacePending,
     isLoadingError: workspaceUnavailable,
   } = useQuery<AdminBranding>({
-    queryKey: ["admin-meta", "workspace"],
+    queryKey: ["admin-meta", "workspace", signedIn],
     queryFn: () => protectedApi.get<AdminBranding>("/admin-meta/workspace"),
     staleTime: 5 * 60 * 1000,
     retry: false,
+    enabled: !sessionPending,
   });
 
   useColorInjection(brandingData?.colors);
@@ -250,7 +272,10 @@ export function BrandingProvider({ children }: BrandingProviderProps) {
       // reports "still loading" while the only relevant query has settled, so
       // a stalled public request would hold the reader on a loading state
       // indefinitely and hide a definitive workspace error behind it.
-      isPending: workspacePending,
+      // True while the session is still resolving as well. Until it settles this
+      // query has not been allowed to run, and reporting anything else would
+      // let a reader conclude something from a list that was never requested.
+      isPending: sessionPending || workspacePending,
       // Reported from the WORKSPACE query. The reader this exists for treats a
       // plugin's absence from the list as a fact about the project, and the
       // plugin list lives in that half — so branding having arrived says
@@ -261,6 +286,7 @@ export function BrandingProvider({ children }: BrandingProviderProps) {
   }, [
     brandingData,
     workspaceData,
+    sessionPending,
     workspacePending,
     workspaceUnavailable,
     brandingUnavailable,

--- a/packages/admin/src/hooks/queries/useAuthSession.ts
+++ b/packages/admin/src/hooks/queries/useAuthSession.ts
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * The admin's one answer to "is there a session, and is the installation set
+ * up yet".
+ *
+ * Extracted so the route guard and the data providers ask the SAME query rather
+ * than each verifying separately. Two verifications of one fact drift — and
+ * here they would drift silently, because both would be right about the server
+ * and wrong about each other, leaving a provider acting on a session the guard
+ * had already replaced.
+ *
+ * Sharing the key is what makes it one request: a second caller mounting with
+ * this key reads the same cache entry instead of issuing another `/auth/session`.
+ *
+ * @module hooks/queries/useAuthSession
+ */
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { isAuthenticated as checkIsAuthenticated } from "@admin/lib/auth/session";
+import { checkSetupStatus } from "@admin/lib/auth/setup-status";
+
+/** The cache key every reader of the session shares. */
+export const authSessionKey = ["auth", "session"] as const;
+
+export interface AuthSession {
+  /** Whether the installation has completed first-run setup. */
+  isSetup: boolean;
+  /** Whether this browser currently holds a valid session. */
+  isAuthenticated: boolean;
+}
+
+async function verifyAuth(): Promise<AuthSession> {
+  const isSetup = await checkSetupStatus();
+  // An installation with no setup has no session to check, and asking anyway
+  // would report "not authenticated" for a reason that is not about the caller.
+  if (!isSetup) return { isSetup: false, isAuthenticated: false };
+  return { isSetup: true, isAuthenticated: await checkIsAuthenticated() };
+}
+
+/**
+ * The session, as one shared query.
+ *
+ * `retry: false` because an unauthenticated answer is an ANSWER rather than a
+ * failure, and retrying it would delay every anonymous surface behind a result
+ * that is already known.
+ */
+export function useAuthSession(): UseQueryResult<AuthSession> {
+  return useQuery({
+    queryKey: authSessionKey,
+    queryFn: verifyAuth,
+    staleTime: 5 * 60 * 1000, // don't re-verify on every navigation
+    gcTime: 10 * 60 * 1000,
+    retry: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false, // trust the cache within staleTime
+  });
+}


### PR DESCRIPTION
## The symptom

Load `/admin`, then **click** from the dashboard into a page. The page-builder field refuses to render:

> This field could not be loaded because the list of installed plugins is unavailable. Reload the page to try again.

The language switcher disappears at the same time. Reload the same URL and both come back. Clicking is the normal way people move around the admin, so this is the common path.

Two sessions hit this independently. One saw the language half and could not reproduce it; this reproduces on demand.

## The cause

`/admin-meta` is two queries in `BrandingProvider`. The public half is fine. The other is **session-gated** and carries **both** `plugins` (what the field renderer needs) and `locales` (what the language row needs) — which is why one bug had two faces.

That query had `retry: false` and **no gate on authentication**, so it fired at app mount before a session existed, took a 401, and stayed failed for the life of the query client. Nothing re-ran it on sign-in. A full reload builds a new query client, which is the entire difference between "reload works" and "clicking does not".

The provider's own comment said failing before sign-in "is correct, since no pre-session surface reads these fields". That is right about **rendering** and wrong about **recovery**, and the gap between those two readings is the defect.

**The measurement that identifies it**, because a 401 in a network log alone does not distinguish "auth is broken" from "the query gave up" — and those have opposite fixes. From inside the very page rendering the failure, with the same credentials:

```js
await fetch('/admin/api/admin-meta/workspace', { credentials: 'same-origin' })
// 200, full payload, locales included
```

The session was valid the whole time. The query had simply stopped asking.

**This failure was seen before and worked around rather than fixed.** `pages/dashboard/plugins/components/InstalledPluginsUnavailable.tsx` contains a manual retry button that invalidates exactly this key — a recovery affordance built for this exact failure, on one page, while the source went unfixed. It is the only `invalidateQueries` for that key in the admin.

## The fix

**Auth state goes in the query KEY, not into a refetch.** Signing in produces a different cache entry, so there is no dead result to revive. An invalidation would have to land *after* the 401 — and the 401 can arrive later, leaving the query failed with nothing left to trigger it. A key cannot lose that race, because a new key has no result whenever it appears.

**The request waits for the session query to SETTLE, not to succeed.** That stops an anonymous 401 being fired speculatively on every load, and a session query that itself failed still releases this one, reporting the list as unavailable — which is true — rather than holding readers on a skeleton forever.

**`isPending` now covers the pre-settle window.** A reader concluding anything there would be concluding from a list that was never requested. This narrows a state that previously conflated "we asked and the answer is no" with "we have not asked yet"; that conflation is what let the field renderer tell an author to reload instead of saying something was wrong.

**One session query, shared.** The route guard and the providers each verified separately. Two verifications of one fact drift, and here they would drift silently: both right about the server, wrong about each other.

**`PrivateRoute` derives its redirect once.** The effect that navigates and the placeholder that names the destination decided independently from the same fields, so a change to either could send someone to setup while telling them they were going to login.

## On sign-out and user switching

Raised in review before it was written, and worth recording since a key encoding identity is where this gets easy to get wrong. Two independent reasons it is safe:

- `useLogout.ts` calls `queryClient.clear()`, so no workspace data survives a sign-out into another user's session.
- The payload is not user-varying. The handler documents it as *"gated on a SESSION rather than on a permission… every signed-in role needs its sidebar and its plugin routes to render"*, so every signed-in role receives the same response.

## Verification

**Stub-verified, both restores confirmed by `diff`:**

| stub | result |
|---|---|
| auth state removed from the query key | **only** "asks again after sign-in" failed |
| the settle gate removed | **only** "does not ask while the session is still resolving" failed |

**In the browser**, on the exact path that failed, against a rebuilt admin:

```
before: buttons = ["Toggle mobile menu","9+","D","Save"]
after:  buttons = [... ,"Save","English","Spanish","Arabic","Languages","Edit blocks"]
failureMessagePresent: false   editBlocksPresent: true   languagesPresent: true
```

The two positive controls matter: without them "the error is gone" is also satisfied by a page that rendered nothing.

Admin suite: **15 failures in the same 4 files as the existing baseline** (`StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField`), no new ones; passing count rises with the 9 tests added here.

## Why `PrivateRoute` gained tests

The hygiene gate flagged it, and its own recommended action was the right one: the score was high because an auth guard had **zero coverage**, not because the function was tangled. Suppressing would have left that true. The new tests pin the loop this component exists to prevent — a pending session, an errored one, and a success whose data has not arrived all navigate nowhere.
