### PR TITLE
fix(admin): give a code field a label that lands

### DIFF
--- a/.changeset/code-field-label-lands.md
+++ b/.changeset/code-field-label-lands.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A code field is now announced by its label. It renders an editor built from
+several elements with no single control to attach the label to, so the label
+resolved to nothing and a screen reader reached an unnamed region. It is exposed
+as a named group instead, matching how rich text, relationship and upload fields
+are already handled.

--- a/packages/admin/src/components/features/entries/fields/FieldWrapper.labelling.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldWrapper.labelling.test.tsx
@@ -93,6 +93,9 @@ describe("FieldWrapper labelling — composite fields are named groups", () => {
     ["richText", "content", "Content"],
     ["relationship", "categories", "Categories"],
     ["upload", "featuredImage", "Featured Image"],
+    // Measured on the page-builder `pages` collection: the code editor builds
+    // its focusable surface at runtime, so the label had nothing to land on.
+    ["code", "customCss", "Custom Css"],
   ])("names a %s field through role=group", (type, name, label) => {
     const { container } = renderWith({ name, type, label });
     const el = wrapper(container);

--- a/packages/admin/src/components/features/entries/fields/FieldWrapper.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldWrapper.tsx
@@ -116,7 +116,11 @@ const WIDTH_STYLES: Record<string, string> = {
  *
  * Measured dangling on `/admin/collections/posts/create` in both themes before
  * this list existed: `richText:content`, `relationship:categories`,
- * `relationship:tags`, `upload:featuredImage`.
+ * `relationship:tags`, `upload:featuredImage`. `code:customCss` was measured
+ * the same way on the page-builder `pages` collection, and belongs here for the
+ * same reason rich text does: the editor is a scrolling surface built from
+ * several elements, and the one that takes focus is created by the editor at
+ * runtime rather than being the element an id could be placed on.
  *
  * The list covers the types this codebase has evidence for. It is deliberately
  * NOT a guess at the rest: `useFieldLabelLandingCheck` below fires in
@@ -128,6 +132,7 @@ const GROUP_FIELD_TYPES: ReadonlySet<string> = new Set([
   "richText",
   "relationship",
   "upload",
+  "code",
 ]);
 
 /**


### PR DESCRIPTION
## What

A `code` field's label named nothing, so a screen reader reached an unnamed region.

Found by the admin's **own** development-time check, which fired the first time the field was opened during browser testing:

> The label "Custom Css" points at `#customCss`, but no element carries that id, so the label names nothing. Field type "code" renders no single control the id can attach to. Add "code" to `GROUP_FIELD_TYPES` in `FieldWrapper.tsx` so the field is exposed as a group instead.

That check exists precisely so a missing entry "announces itself the first time the field is opened instead of failing silently". It did. This adds the entry it asked for.

## Why a group rather than an id

`FieldWrapper` renders `{children}` without cloning, so `<label for>` only resolves when the input independently sets a matching `id`. A code editor cannot: it is a scrolling surface assembled from several elements, and the one that takes focus is created by the editor at runtime.

Pointing the label at the wrapping element would resolve the reference while naming something that cannot be focused — worse than leaving it dangling, because it looks fixed. Rich text, relationship and upload already take the group treatment for the same reason; `code` is the fourth instance of one shape, not a new case.

## Verification

**Stub-verified**: removing `"code"` from the set failed **only** `names a code field through role=group`; restore confirmed by `diff`, 11/11 after.

**In the browser**, against a rebuilt admin, on the page that produced the warning:

```
before: [warning] The label "Custom Css" points at #customCss ... names nothing
after:  0 occurrences

role="group"  aria-labelledby="customCss-group-label"  →  resolves to "Custom Css"
```

The positive control matters: the same check confirms the field actually rendered (`customCssLabel: true`, `editBlocks: true`), so the warning is absent because the problem is fixed rather than because nothing was on screen to check.

## Note

This field's stored value never reaches a published page — nothing renders `customCss`, and there is no sanitiser for it. That is a separate finding, not addressed here; this change is only about the field being announced correctly in the editor.
