### PR TITLE
fix(nextly): pick a branded foreground that meets WCAG AA

### DIFF
--- a/.changeset/branded-foreground-meets-aa.md
+++ b/.changeset/branded-foreground-meets-aa.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Branded admin surfaces now pick a foreground that meets WCAG AA. The picker
+compared its dark candidate using the contrast ratio for pure black while
+returning slate-900, so a mid-tone brand colour could be given a foreground it
+had never measured: `#6366f1` shipped 4.00:1 against a 4.5 threshold, making
+primary buttons fail contrast for every user of that colour.

--- a/e2e/tests/builder-a11y.spec.ts
+++ b/e2e/tests/builder-a11y.spec.ts
@@ -56,8 +56,21 @@ const AA_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"];
  */
 const HOST_OWNED_RULES = ["document-title"];
 
-/** The editor's own container, so the admin around it is not this suite's subject. */
-const EDITOR_ROOT = '[aria-label="Editor panels"]';
+/**
+ * The readiness anchor — NOT a scan root.
+ *
+ * `scanEditor` deliberately does not `.include()` this: the scan is whole-page,
+ * for the reason the module docblock gives. This constant only answers "has the
+ * editor finished opening", so the scan never runs against a page that has not
+ * arrived.
+ *
+ * Stated because the name invites the opposite reading, and acting on that
+ * reading would be a regression rather than a tightening: the one violation
+ * this suite has caught so far was admin chrome painted with a branded token —
+ * a real defect reachable from the builder, which a scan rooted here would not
+ * have seen.
+ */
+const EDITOR_READY_ANCHOR = '[aria-label="Editor panels"]';
 
 interface Finding {
   id: string;
@@ -99,7 +112,9 @@ async function openEditor(page: Page): Promise<void> {
   await page.getByRole("button", { name: "Edit blocks" }).click();
   // POPULATION BEFORE VERDICT. "No violations" is satisfied perfectly by an
   // editor that never opened, so the scan must not run until it has.
-  await expect(page.locator(EDITOR_ROOT)).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator(EDITOR_READY_ANCHOR)).toBeVisible({
+    timeout: 30_000,
+  });
 }
 
 test.describe("the page builder meets WCAG 2.2 AA", () => {

--- a/packages/admin/src/context/providers/BrandingProvider.tsx
+++ b/packages/admin/src/context/providers/BrandingProvider.tsx
@@ -113,9 +113,15 @@ function useColorInjection(colors: ResolvedBrandingColors | undefined) {
 
     if (primaryHsl) {
       rules.push(`--nx-primary: ${primaryHsl};`);
-      rules.push(
-        `--nx-primary-foreground: ${colors.primaryForeground ?? "0 0% 100%"};`
-      );
+      // Only when the API resolved one. The fallback was the bare triplet
+      // "0 0% 100%", which lands in `color: var(--nx-primary-foreground)` as an
+      // invalid value: the declaration is dropped and the text inherits the
+      // ambient foreground, which on a branded surface is the page's dark text.
+      // Emitting nothing instead leaves the theme's own token in force, which is
+      // a real colour chosen for the mode rather than one invented here.
+      if (colors.primaryForeground) {
+        rules.push(`--nx-primary-foreground: ${colors.primaryForeground};`);
+      }
       // Derived tokens that reference --nx-primary HSL triplet
       rules.push(`--nx-ring: ${primaryHsl};`);
       rules.push(`--nx-focus-ring: ${primaryHsl};`);
@@ -125,9 +131,10 @@ function useColorInjection(colors: ResolvedBrandingColors | undefined) {
 
     if (accentHsl) {
       rules.push(`--nx-accent: ${accentHsl};`);
-      rules.push(
-        `--nx-accent-foreground: ${colors.accentForeground ?? "0 0% 100%"};`
-      );
+      // Conditional for the same reason as the primary foreground above.
+      if (colors.accentForeground) {
+        rules.push(`--nx-accent-foreground: ${colors.accentForeground};`);
+      }
       rules.push(`--nx-chart-2: ${accentHsl};`);
     }
 

--- a/packages/nextly/src/utils/__tests__/color-utils.test.ts
+++ b/packages/nextly/src/utils/__tests__/color-utils.test.ts
@@ -47,6 +47,73 @@ describe("getForegroundForBackground", () => {
     expect(fg).toBe("hsl(222.2 47.4% 11.2%)");
     expect(fg).toMatch(COMPLETE_CSS_COLOR);
   });
+
+  /**
+   * The two cases above are the achromatic EXTREMES, where every candidate
+   * ordering agrees and a broken comparison still lands on the right answer.
+   * They passed against an implementation that compared the dark option using
+   * the ratio for pure black while returning slate-900. A mid-tone brand is the
+   * separating case, so it is the one asserted by measured ratio below.
+   */
+  const luminance = (hex: string): number => {
+    const clean = hex.replace("#", "");
+    const channel = (offset: number) => {
+      const c = parseInt(clean.slice(offset, offset + 2), 16) / 255;
+      return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+    };
+    return 0.2126 * channel(0) + 0.7152 * channel(2) + 0.0722 * channel(4);
+  };
+  const ratio = (a: string, b: string): number => {
+    const la = luminance(a);
+    const lb = luminance(b);
+    return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+  };
+  /** The hex each emitted CSS color stands for, so a ratio can be computed. */
+  const HEX_FOR_CSS: Record<string, string> = {
+    "hsl(0 0% 100%)": "#ffffff",
+    "hsl(222.2 47.4% 11.2%)": "#0f172a",
+    "hsl(0 0% 0%)": "#000000",
+  };
+
+  it.each([
+    // A mid-tone indigo: white 4.47 and slate-900 4.00 both miss AA, black
+    // reaches 4.70. The shipped picker chose slate-900 here and produced 4.00.
+    "#6366f1",
+    // A mid-tone green and a mid-tone red, so the case is not one lucky colour.
+    "#2e8b57",
+    "#c2410c",
+  ])("picks a foreground that MEETS AA on %s", background => {
+    const fg = getForegroundForBackground(background);
+    const hex = HEX_FOR_CSS[fg];
+    // The emitted value must be one this test can measure, or the assertion
+    // below would silently pass on an unrecognised colour.
+    expect(hex, `unmeasurable foreground ${fg}`).toBeDefined();
+    expect(
+      ratio(background, hex as string),
+      `${fg} on ${background} is below AA for normal text`
+    ).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("prefers the designed dark tone over pure black when it already passes", () => {
+    // The escalation must not fire where the designed pair works: a very light
+    // background clears AA with slate-900, so black would be a needless change
+    // of the product's look.
+    expect(getForegroundForBackground("#f8fafc")).toBe(
+      "hsl(222.2 47.4% 11.2%)"
+    );
+  });
+
+  it("returns the best available foreground when nothing can reach AA", () => {
+    // A mid-grey has no accessible foreground at all: white and black both land
+    // near 3.9. The picker still returns the higher of the two rather than
+    // inventing a colour, and the shortfall is a fact about the brand.
+    const fg = getForegroundForBackground("#808080");
+    const hex = HEX_FOR_CSS[fg];
+    expect(hex).toBeDefined();
+    expect(ratio("#808080", hex as string)).toBeGreaterThanOrEqual(
+      ratio("#808080", "#ffffff")
+    );
+  });
 });
 
 describe("isValidHex", () => {

--- a/packages/nextly/src/utils/color-utils.ts
+++ b/packages/nextly/src/utils/color-utils.ts
@@ -1,3 +1,5 @@
+import { checkContrast } from "@nextlyhq/blocks-engine";
+
 /**
  * Color utility functions for admin branding.
  *
@@ -49,32 +51,61 @@ export function hexToCssColor(hex: string): string {
   return `hsl(${hDeg} ${sPct}% ${lPct}%)`;
 }
 
-/**
- * Determine the best foreground color (white or dark) for readable text on
- * the given background hex color, using WCAG relative luminance.
+/** Foreground candidates: the hex the ratio is measured from, and the CSS emitted.
  *
- * Returns a CSS color:
- * - "hsl(0 0% 100%)"          → white (used on dark/saturated backgrounds)
- * - "hsl(222.2 47.4% 11.2%)"  → slate-900 (used on light backgrounds)
+ * Two spellings because they answer different questions. `checkContrast` parses
+ * hex and `rgb()` and NOT `hsl()`, so the measurement takes the hex; the tokens
+ * hold complete CSS colors, so the emitted value stays the `hsl()` form the
+ * theme and the existing branding contract already use.
+ */
+const WHITE = { hex: "#ffffff", css: "hsl(0 0% 100%)" };
+/** slate-900 — the designed dark tone, softer than black and preferred when it passes. */
+const SLATE_900 = { hex: "#0f172a", css: "hsl(222.2 47.4% 11.2%)" };
+/** Pure black, the maximum-contrast dark. Only reached when the designed pair fails. */
+const BLACK = { hex: "#000000", css: "hsl(0 0% 0%)" };
+
+/**
+ * The measured ratio between a candidate and the background, or 0 when either
+ * colour cannot be read.
+ *
+ * Zero rather than a thrown error or a default verdict: an unreadable input
+ * must not be able to WIN a comparison, and every caller here validates the
+ * background with `isValidHex` first, so this is a floor rather than a path.
+ */
+function ratioAgainst(background: string, candidateHex: string): number {
+  return checkContrast(candidateHex, background)?.ratio ?? 0;
+}
+
+/** WCAG 2.2 AA for normal-size text. Buttons and labels are normal text. */
+const AA_NORMAL_TEXT = 4.5;
+
+/**
+ * The most readable foreground for text on the given background.
+ *
+ * Prefers the designed pair — white or slate-900 — and takes whichever has the
+ * higher measured contrast. When NEITHER reaches AA it escalates to the
+ * higher-contrast extreme, because if neither extreme clears the threshold then
+ * no foreground can and the brand colour itself is what cannot carry text.
+ *
+ * The escalation fires only where the designed pair would otherwise ship a
+ * failing pair, so a brand whose palette already works is unaffected. A mid-tone
+ * brand is where it matters: `#6366f1` gives white 4.47 and slate-900 4.00, both
+ * under 4.5, while black reaches 4.70.
+ *
+ * The previous implementation compared white against `1.05 / (L + 0.05)` and the
+ * dark tone against `(L + 0.05) / 0.05` — the second being the ratio against
+ * pure BLACK while the value returned was slate-900. It chose by a number the
+ * result never had, so `#6366f1` was given slate-900 believing 4.70 and shipping
+ * 4.00.
  */
 export function getForegroundForBackground(hex: string): string {
-  const clean = hex.replace("#", "");
-  const r = parseInt(clean.slice(0, 2), 16) / 255;
-  const g = parseInt(clean.slice(2, 4), 16) / 255;
-  const b = parseInt(clean.slice(4, 6), 16) / 255;
+  const white = ratioAgainst(hex, WHITE.hex);
+  const preferred =
+    white >= ratioAgainst(hex, SLATE_900.hex) ? WHITE : SLATE_900;
 
-  const toLinear = (c: number) =>
-    c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  if (ratioAgainst(hex, preferred.hex) >= AA_NORMAL_TEXT) return preferred.css;
 
-  const L = 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
-
-  // Compare contrast ratios against pure white (L=1) and slate-900 (L≈0.017)
-  const whiteContrast = 1.05 / (L + 0.05);
-  const darkContrast = (L + 0.05) / 0.05;
-
-  return whiteContrast >= darkContrast
-    ? "hsl(0 0% 100%)"
-    : "hsl(222.2 47.4% 11.2%)";
+  return white >= ratioAgainst(hex, BLACK.hex) ? WHITE.css : BLACK.css;
 }
 
 /**


### PR DESCRIPTION
Fixes the `Browser tests` failure that has made `main` red since **#1074** — twenty-odd merges, always the same three tests, always `3 failed / 117 passed`.

**The three failures were one defect, and the defect is in the product, not the test.**

## What axe was actually reporting

All three tests failed on a single finding:

```
id: "color-contrast"   impact: "serious"   targets: [".bg-primary"]
```

Pulled from a local run with the full node detail, the element and its measured colours:

```
<button data-slot="button.default" type="submit" form="entry-form">
foreground #0f172a · background #6366f1 · ratio 3.99 · needs 4.5:1
```

That is the Save button on a branded admin, with **near-black text on indigo**. Not white text 0.03 short — dark text, a long way short.

## Why

`getForegroundForBackground` picks white or slate-900 by contrast. It computed the two candidates like this:

```ts
const whiteContrast = 1.05 / (L + 0.05);
const darkContrast  = (L + 0.05) / 0.05;   // ← the ratio against pure BLACK
return whiteContrast >= darkContrast ? white : "hsl(222.2 47.4% 11.2%)";  // ← returns slate-900
```

`(L + 0.05) / 0.05` is the ratio against a luminance of **0**, i.e. pure black. The value returned is **slate-900**, whose luminance is 0.0088. The function chose by a number its own result never had. Its comment even said "slate-900 (L≈0.017)" while the formula used 0 — the two had disagreed since it was written.

For `#6366f1` (L = 0.1851):

| candidate | what the code believed | actual |
|---|---|---|
| white | 4.467 | 4.467 |
| slate-900 | **4.701** | **3.997** |
| black | — | 4.701 |

It picked slate-900 on a belief of 4.70 and shipped 3.997. axe measured 3.99.

**This affects every install with a mid-tone brand colour**, not just the e2e suite. The e2e branding flag is only what made it visible.

## The fix

Measurement now comes from `checkContrast` in `@nextlyhq/blocks-engine` — which already existed, is already tested, handles alpha compositing, and which `packages/nextly` already depends on. My first version added a fourth copy of the WCAG formula; fallow caught it as introduced duplication against the two that already existed in `blocks-engine` and `packages/ui`, so the copy is gone.

The picker still prefers the designed pair (white / slate-900) and escalates to the higher-contrast extreme **only when neither reaches AA**. A brand whose palette already works is unchanged — `#f8fafc` still gets slate-900, and there is a test pinning that.

Also fixed, the same failure by another route: the client injector emitted a bare `"0 0% 100%"` triplet when no foreground was resolved. The tokens hold complete colours, so that lands in `color:` as invalid, the declaration is dropped, and the text inherits the ambient dark. It now emits nothing in that case and leaves the theme's own token in force — which is a real colour chosen per mode rather than one invented at the call site.

## Tests

The existing suite covered only `#000000` and `#ffffff` — the achromatic extremes, where every candidate ordering agrees and a broken comparison still lands on the right answer. That is why this survived: the tests asserted a property both a correct and a broken implementation satisfy.

Added mid-tone cases asserted **by measured ratio** rather than by expected constant, plus the two boundary behaviours:

- `#6366f1`, `#2e8b57`, `#c2410c` must each receive a foreground reaching 4.5:1
- a very light background still gets slate-900, so the escalation cannot fire where the designed pair works
- a mid-grey, where nothing can reach AA, still returns the best available rather than inventing one

Break-verified: restoring the original formula fails exactly the mid-tone cases, reporting **3.9966** for `#6366f1` — the same number axe measured in the browser. The extreme-value tests keep passing under the break, which is the point about why they never caught it.

## What is NOT changed, deliberately

**The scan is still whole-page.** `builder-a11y.spec.ts` scans the entire admin by design, and its docblock argues for it. Narrowing it to the editor subtree would have made these three tests green while hiding a real, user-facing branding defect — the scan working as intended is what surfaced this. I renamed the misleading `EDITOR_ROOT` constant to `EDITOR_READY_ANCHOR` and documented that it is a readiness anchor rather than a scan root, because the name invited exactly that narrowing.

**The e2e brand colour is unchanged.** Making the suite pass by choosing a friendlier colour would have left every real user of `#6366f1` with the failing pair.

## Verification

- `builder-a11y.spec.ts`: **3 passed**, was 3 failed
- Full e2e suite: **120 passed**, was 117 passed / 3 failed
- `packages/nextly` `src/utils`: 50 passed
- `packages/admin` `src/context`: 14 passed
- fallow: `pass`, all four `*_introduced` counters at 0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved text color selection for branded backgrounds using WCAG contrast checks.
  - Provides more readable foreground colors across mid-tone and difficult background colors.
  - Uses a reliable fallback when the preferred color does not meet accessibility standards.

- **Bug Fixes**
  - Prevented invalid or misleading foreground color styles from being applied when suitable values are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->