### PR TITLE
feat: show and discard a Single's pending change

### DIFF
--- a/.changeset/singles-pending-change-visible.md
+++ b/.changeset/singles-pending-change-visible.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A Single's pending change is now visible and discardable in its own editor. The
+engine has held status-less edits to a published Single since the split shipped,
+but no read returned them and the editor never asked: its Save named the status,
+and a write that names one is never held. So the feature was dark for every
+Single, and an author's held edit was invisible to them.

--- a/apps/playground/src/singles/announcement.ts
+++ b/apps/playground/src/singles/announcement.ts
@@ -24,6 +24,13 @@ export const Announcement = defineSingle({
   // what "publish every language" exists to move at once.
   status: true,
   localized: true,
+  // Drafts versioning, which is what turns a status-less save on a PUBLISHED
+  // language into a held pending change rather than a live write. With the
+  // lifecycle alone the split never applies, so this is the only Single that
+  // exercises the combination — status + drafts + localized — that the
+  // per-language pending-change surfaces are about. Without it the feature has
+  // no dev surface and nobody sees it work, which is how it stayed dark.
+  versions: { drafts: true },
   fields: [
     // Shared across languages — the campaign is one thing whatever it is called.
     text({ name: "campaign", label: "Campaign", localized: false }),

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -59,6 +59,7 @@ import { useTranslationSource } from "@admin/components/features/entries/Transla
 import { useEntryLocaleContext } from "@admin/components/features/entries/useEntryLocaleContext";
 import { historyEnabledFrom } from "@admin/components/features/versions/history-enabled";
 import { useBranding } from "@admin/context/providers/BrandingProvider";
+import { useDiscardSingleWorkingDraft } from "@admin/hooks/queries/useDiscardSingleWorkingDraft";
 import { usePublishAllSingleLocales } from "@admin/hooks/queries/usePublishAllSingleLocales";
 import { useAutosaveRecovery } from "@admin/hooks/useAutosaveRecovery";
 import { useAutoSlug } from "@admin/hooks/useAutoSlug";
@@ -110,6 +111,13 @@ export interface SingleSchema {
    * `dynamic_singles.localized`.
    */
   localized?: boolean;
+  /**
+   * Whether a status-less save to this published Single is HELD as a pending
+   * change rather than written live (the draft/published split). Derived
+   * server-side from the same eligibility rule the write uses, so the editor
+   * cannot offer an affordance the engine will not honour.
+   */
+  draftsEnabled?: boolean;
 }
 
 /**
@@ -447,6 +455,15 @@ export function SingleForm({
     }
   )._translations;
 
+  // Throwing away this language's pending change. Scoped to the active locale:
+  // a localized Single holds one per language, so discarding without naming one
+  // would remove work in a language the author never opened.
+  const discardMutation = useDiscardSingleWorkingDraft({
+    slug: schema.slug,
+    documentId: document.id,
+    locale,
+  });
+
   // Adapt the SingleDocumentData shape into what EntrySystemHeader and the
   // rail panels expect (entry.id / entry.status / entry.created_at /
   // entry.updated_at). The structural alignment is straightforward — singles
@@ -455,6 +472,11 @@ export function SingleForm({
   const entryLike = {
     id: document.id,
     status: documentStatus,
+    // The flag the header reads to show Changed and offer Discard. Forwarded
+    // rather than recomputed: the server sets it only when a pending change was
+    // actually overlaid, which is what makes it per-language.
+    _isWorkingDraft:
+      (document as { _isWorkingDraft?: boolean })._isWorkingDraft === true,
     createdAt: (document as { createdAt?: string }).createdAt,
     updatedAt: document.updatedAt,
     title: (document as { title?: string }).title,
@@ -625,8 +647,21 @@ export function SingleForm({
                         onSaveChanges={() => {
                           void handleSubmit(undefined, "save-changes");
                         }}
+                        /* The draft/published split. Without this the header
+                   takes its `draftsEnabled: false` branch, whose Save names the
+                   status — and a write that names one is never held, so the
+                   engine's pending-change support stayed dark for every Single.
+                   The label is the visible tell: "Save changes" rather than
+                   "Save". */
+                        draftsEnabled={schema.draftsEnabled === true}
+                        onSaveWorkingDraft={() => {
+                          void handleSubmit(undefined, "save-working-draft");
+                        }}
                         onUnpublish={() => {
                           void handleSubmit(undefined, "unpublish");
+                        }}
+                        onDiscardWorkingDraft={async () => {
+                          await discardMutation.mutateAsync();
                         }}
                         onCancel={handleCancel}
                         onViewApi={onViewApi}

--- a/packages/admin/src/hooks/queries/__tests__/useDiscardSingleWorkingDraft.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useDiscardSingleWorkingDraft.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Discarding a Single's pending change.
+ *
+ * The cache consequence is the one worth pinning: the response is ONE language's
+ * live document, and the Single's detail key is a prefix of every locale-keyed
+ * variant — so seeding it through the unscoped key would write this language's
+ * values into another language's cache entry.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { discardSpy, toastSuccessSpy, toastErrorSpy } = vi.hoisted(() => ({
+  discardSpy: vi.fn(),
+  toastSuccessSpy: vi.fn(),
+  toastErrorSpy: vi.fn(),
+}));
+
+vi.mock("@admin/services/versionApi", () => ({
+  versionApi: { discardWorkingDraft: discardSpy },
+}));
+
+vi.mock("@admin/components/ui", () => ({
+  toast: { success: toastSuccessSpy, error: toastErrorSpy },
+}));
+
+import { singleDocumentKeys } from "../useSingles";
+
+import { useDiscardSingleWorkingDraft } from "../useDiscardSingleWorkingDraft";
+
+function makeWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+const makeClient = () =>
+  new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+
+describe("useDiscardSingleWorkingDraft", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("addresses the Single by slug, with no document id in the request", async () => {
+    // A Single's URL carries no entry id — the server resolves it from the live
+    // row rather than trusting the client — so the id rides in the scope for
+    // cache identity only.
+    const client = makeClient();
+    discardSpy.mockResolvedValue({
+      message: "Working draft discarded.",
+      item: { id: "s1", status: "published" },
+    });
+
+    const { result } = renderHook(
+      () =>
+        useDiscardSingleWorkingDraft({ slug: "homepage", documentId: "s1" }),
+      { wrapper: makeWrapper(client) }
+    );
+    await result.current.mutateAsync();
+
+    expect(discardSpy).toHaveBeenCalledWith(
+      { kind: "single", slug: "homepage", documentId: "s1" },
+      undefined
+    );
+    expect(toastSuccessSpy).toHaveBeenCalledWith("Working draft discarded");
+  });
+
+  it("names the language whose pending change is being discarded", async () => {
+    const client = makeClient();
+    discardSpy.mockResolvedValue({
+      message: "Working draft discarded.",
+      item: { id: "s1" },
+    });
+
+    const { result } = renderHook(
+      () =>
+        useDiscardSingleWorkingDraft({
+          slug: "homepage",
+          documentId: "s1",
+          locale: "es",
+        }),
+      { wrapper: makeWrapper(client) }
+    );
+    await result.current.mutateAsync();
+
+    expect(discardSpy).toHaveBeenCalledWith(
+      { kind: "single", slug: "homepage", documentId: "s1" },
+      "es"
+    );
+  });
+
+  it("seeds only the discarded language's cache, leaving another language's alone", async () => {
+    const client = makeClient();
+    const enKey = [
+      ...singleDocumentKeys.detail("homepage"),
+      { locale: null, fallbackLocale: null, translationStatus: false },
+    ];
+    const esKey = [
+      ...singleDocumentKeys.detail("homepage"),
+      { locale: "es", fallbackLocale: null, translationStatus: false },
+    ];
+    client.setQueryData(enKey, {
+      id: "s1",
+      title: "English live",
+      _isWorkingDraft: true,
+    });
+    client.setQueryData(esKey, {
+      id: "s1",
+      title: "Spanish draft",
+      _isWorkingDraft: true,
+    });
+
+    discardSpy.mockResolvedValue({
+      message: "Working draft discarded.",
+      item: { id: "s1", title: "Spanish live", status: "published" },
+    });
+
+    const { result } = renderHook(
+      () =>
+        useDiscardSingleWorkingDraft({
+          slug: "homepage",
+          documentId: "s1",
+          locale: "es",
+        }),
+      { wrapper: makeWrapper(client) }
+    );
+    await result.current.mutateAsync();
+
+    expect(client.getQueryData(esKey)).toMatchObject({
+      title: "Spanish live",
+      _isWorkingDraft: false,
+    });
+    // English keeps its own pending change. Without the predicate this entry
+    // would be overwritten with the Spanish response and shown as English.
+    expect(client.getQueryData(enKey)).toMatchObject({
+      title: "English live",
+      _isWorkingDraft: true,
+    });
+  });
+
+  it("toasts the error and leaves the cache alone on failure", async () => {
+    const client = makeClient();
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+    discardSpy.mockRejectedValue(new Error("nope"));
+
+    const { result } = renderHook(
+      () =>
+        useDiscardSingleWorkingDraft({ slug: "homepage", documentId: "s1" }),
+      { wrapper: makeWrapper(client) }
+    );
+
+    await expect(result.current.mutateAsync()).rejects.toThrow("nope");
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    expect(toastErrorSpy).toHaveBeenCalledWith(
+      "Failed to discard working draft: nope"
+    );
+  });
+});

--- a/packages/admin/src/hooks/queries/__tests__/useSingleEditorDocument.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useSingleEditorDocument.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * What the Single editor asks for when it reads.
+ *
+ * The options are the whole point of this hook: each one is a rule whose
+ * failure mode is showing an author another language's text as their own, or
+ * hiding a pending change they just saved. Asserted on the OPTIONS rather than
+ * on rendered output, because that is where the rules live.
+ */
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { docSpy } = vi.hoisted(() => ({ docSpy: vi.fn() }));
+
+vi.mock("../useSingles", () => ({
+  useSingleDocument: (...args: unknown[]) => {
+    docSpy(...args);
+    return { data: undefined, isLoading: false, error: null };
+  },
+}));
+
+import { useSingleEditorDocument } from "../useSingleEditorDocument";
+
+/** The options the EDIT read was issued with (the first call). */
+const editRead = () => docSpy.mock.calls[0]?.[1] as Record<string, unknown>;
+/** The options the SOURCE read was issued with (the second call). */
+const sourceRead = () => docSpy.mock.calls[1]?.[1] as Record<string, unknown>;
+
+describe("useSingleEditorDocument", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("asks for the pending change when the split applies", () => {
+    renderHook(() =>
+      useSingleEditorDocument({
+        slug: "homepage",
+        localizationEnabled: false,
+        draftsEnabled: true,
+      })
+    );
+
+    expect(editRead().draft).toBe(true);
+  });
+
+  it("does not ask for it when the split does not apply", () => {
+    // An ordinary Single's read stays exactly as it was.
+    renderHook(() =>
+      useSingleEditorDocument({
+        slug: "homepage",
+        localizationEnabled: false,
+        draftsEnabled: false,
+      })
+    );
+
+    expect(editRead().draft).toBe(false);
+  });
+
+  it("disables fallback on a localized app so an untranslated field reads empty", () => {
+    // With fallback on, the default language's text appears IN the field and a
+    // save would store it as this language's translation.
+    renderHook(() =>
+      useSingleEditorDocument({
+        slug: "homepage",
+        locale: "es",
+        defaultLocale: "en",
+        localizationEnabled: true,
+        draftsEnabled: false,
+      })
+    );
+
+    expect({
+      fallbackLocale: editRead().fallbackLocale,
+      translationStatus: editRead().translationStatus,
+    }).toEqual({ fallbackLocale: "none", translationStatus: true });
+  });
+
+  it("leaves fallback alone when the app is not localized", () => {
+    renderHook(() =>
+      useSingleEditorDocument({
+        slug: "homepage",
+        localizationEnabled: false,
+        draftsEnabled: false,
+      })
+    );
+
+    expect(editRead().fallbackLocale).toBeUndefined();
+  });
+
+  it("reads the source at the app default, and only off the default language", () => {
+    const { result } = renderHook(() =>
+      useSingleEditorDocument({
+        slug: "homepage",
+        locale: "es",
+        defaultLocale: "en",
+        localizationEnabled: true,
+        draftsEnabled: false,
+      })
+    );
+
+    expect(result.current.isNonDefaultLocale).toBe(true);
+    expect(sourceRead().locale).toBe("en");
+    expect((sourceRead().queryOptions as { enabled?: boolean }).enabled).toBe(
+      true
+    );
+  });
+
+  it("does not issue a source read while editing the default language", () => {
+    const { result } = renderHook(() =>
+      useSingleEditorDocument({
+        slug: "homepage",
+        locale: "en",
+        defaultLocale: "en",
+        localizationEnabled: true,
+        draftsEnabled: false,
+      })
+    );
+
+    expect(result.current.isNonDefaultLocale).toBe(false);
+    expect((sourceRead().queryOptions as { enabled?: boolean }).enabled).toBe(
+      false
+    );
+  });
+
+  it("reads the source at the language translation mode named", () => {
+    renderHook(() =>
+      useSingleEditorDocument({
+        slug: "homepage",
+        locale: "ar",
+        defaultLocale: "en",
+        localizationEnabled: true,
+        draftsEnabled: false,
+        translateFrom: "es",
+      })
+    );
+
+    // Not the app default: translation mode names the source explicitly, and
+    // reading the default instead would present the wrong language as source.
+    expect(sourceRead().locale).toBe("es");
+    // The source read never falls back, or an untranslated source field
+    // resolves to yet another language and is copied in as a translation.
+    expect(sourceRead().fallbackLocale).toBe("none");
+  });
+});

--- a/packages/admin/src/hooks/queries/useDiscardSingleWorkingDraft.ts
+++ b/packages/admin/src/hooks/queries/useDiscardSingleWorkingDraft.ts
@@ -1,0 +1,114 @@
+"use client";
+
+/**
+ * useDiscardSingleWorkingDraft — throw away a Single's pending change for one
+ * language and reset the editor to the live published document.
+ *
+ * The collection equivalent is `useDiscardWorkingDraft`. They stay separate for
+ * the reason `usePublishAllSingleLocales` records: the two are addressed
+ * differently — an entry by collection slug and id, a Single by its slug alone —
+ * and each owns its own query keys. What they share is the server behaviour,
+ * which lives in one place already.
+ *
+ * @see services/versionApi.ts - discardWorkingDraft fetcher
+ * @see hooks/queries/useDiscardWorkingDraft.ts - the collection equivalent
+ */
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { toast } from "@admin/components/ui";
+import {
+  versionApi,
+  type DiscardWorkingDraftResponse,
+} from "@admin/services/versionApi";
+
+import { singleDocumentKeys } from "./useSingles";
+
+export interface UseDiscardSingleWorkingDraftOptions {
+  /** The Single's slug. */
+  slug: string;
+  /**
+   * The live document's id. Not sent — the server resolves it from the live row
+   * rather than trusting the client — but required by the scope so a cache can
+   * tell one incarnation of a Single from a recreated one.
+   */
+  documentId: string;
+  /**
+   * Which language's pending change to discard. A localized Single holds one per
+   * language, so discarding without naming one would throw away a language the
+   * author never opened. Absent for an unlocalized Single, and for the default
+   * language, which the editor addresses without naming it.
+   */
+  locale?: string | null;
+  /** Fired on success with the live published document. */
+  onSuccess?: (data: DiscardWorkingDraftResponse) => void;
+  onError?: (error: Error) => void;
+  /** Whether to show toast notifications (default: true). */
+  showToast?: boolean;
+}
+
+export function useDiscardSingleWorkingDraft({
+  slug,
+  documentId,
+  locale,
+  onSuccess,
+  onError,
+  showToast = true,
+}: UseDiscardSingleWorkingDraftOptions) {
+  const queryClient = useQueryClient();
+
+  return useMutation<DiscardWorkingDraftResponse, Error, void>({
+    mutationFn: () =>
+      versionApi.discardWorkingDraft(
+        { kind: "single", slug, documentId },
+        locale
+      ),
+
+    onSuccess: data => {
+      // Seed the live document the discard returned before invalidating, so a
+      // slow or failed refetch cannot leave the editor showing Changed against
+      // values that no longer exist.
+      //
+      // Only the variants reading the SAME language. The response is one
+      // language's document and `detail(slug)` is a prefix of every locale-keyed
+      // variant, so seeding across all of them would write this language's
+      // values into another language's cache entry.
+      queryClient.setQueriesData<Record<string, unknown>>(
+        {
+          queryKey: singleDocumentKeys.detail(slug),
+          predicate: query => {
+            const scope = query.queryKey[query.queryKey.length - 1];
+            // An entry cached under the bare detail key carries no read
+            // dimensions to disagree with, so it is still seeded.
+            if (typeof scope !== "object" || scope === null) return true;
+            // The read key normalises an absent locale to null, and so does this
+            // hook, so the default language compares equal on both sides.
+            return (
+              (scope as { locale?: string | null }).locale === (locale ?? null)
+            );
+          },
+        },
+        old => (old ? { ...old, ...data.item, _isWorkingDraft: false } : old)
+      );
+
+      // The editor reads with the draft overlay; with the sidecar gone the
+      // server has no draft to apply, so a refetch reconciles with the live row.
+      void queryClient.invalidateQueries({
+        queryKey: singleDocumentKeys.detail(slug),
+      });
+
+      if (showToast) {
+        toast.success("Working draft discarded");
+      }
+
+      onSuccess?.(data);
+    },
+
+    onError: (error: Error) => {
+      if (showToast) {
+        toast.error(`Failed to discard working draft: ${error.message}`);
+      }
+      onError?.(error);
+    },
+  });
+}

--- a/packages/admin/src/hooks/queries/useSingleEditorDocument.ts
+++ b/packages/admin/src/hooks/queries/useSingleEditorDocument.ts
@@ -1,0 +1,89 @@
+"use client";
+
+/**
+ * What the Single editor reads: the document it edits, and the source document
+ * it shows while translating.
+ *
+ * Extracted from the page because the two reads are one concern with several
+ * interlocking rules — which language, whether to fall back, whether to ask for
+ * the pending change — and each rule is a place where getting it wrong shows the
+ * author another language's text as their own.
+ *
+ * @module hooks/queries/useSingleEditorDocument
+ */
+
+import type { SingleDocument } from "@admin/services/singleApi";
+
+import { useSingleDocument } from "./useSingles";
+
+export interface UseSingleEditorDocumentArgs {
+  slug?: string;
+  /** The active content language. `undefined` = the app default. */
+  locale?: string;
+  /** The app's default locale, for deciding whether a source read is needed. */
+  defaultLocale?: string;
+  /** Whether content localization is configured at all. */
+  localizationEnabled: boolean;
+  /**
+   * Whether a status-less save on this Single is HELD as a pending change.
+   * When it is, the editor asks to see that pending change rather than the
+   * published document — otherwise an author's own held edit is invisible to
+   * them, and the save that stored it reported success.
+   */
+  draftsEnabled: boolean;
+  /** The language translation mode is translating FROM, if it named one. */
+  translateFrom?: string;
+}
+
+export interface UseSingleEditorDocumentResult {
+  document: SingleDocument | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  /** The source-language document, while translating. */
+  sourceDoc: SingleDocument | undefined;
+  /** Whether the active language differs from the app default. */
+  isNonDefaultLocale: boolean;
+}
+
+export function useSingleEditorDocument({
+  slug,
+  locale,
+  defaultLocale,
+  localizationEnabled,
+  draftsEnabled,
+  translateFrom,
+}: UseSingleEditorDocumentArgs): UseSingleEditorDocumentResult {
+  const {
+    data: document,
+    isLoading,
+    error,
+  } = useSingleDocument(slug, {
+    locale,
+    // Edit the ACTUAL per-locale values — no fallback, so an untranslated field
+    // shows empty rather than the default language's text, which would bleed the
+    // source into the field and risk saving it as this language's translation.
+    fallbackLocale: localizationEnabled ? "none" : undefined,
+    translationStatus: localizationEnabled,
+    draft: draftsEnabled,
+  });
+
+  const isNonDefaultLocale =
+    !!locale && !!defaultLocale && locale !== defaultLocale;
+
+  // The language the source is read AT. Translation mode names it explicitly;
+  // otherwise the inline hint's source has always been the app default.
+  const sourceLocale = translateFrom ?? defaultLocale;
+  const { data: sourceDoc } = useSingleDocument(slug, {
+    locale: sourceLocale,
+    // No fallback, matching `entry-locale-source.ts`'s SOURCE_READ. With
+    // fallback on, an untranslated SOURCE field resolves to yet another
+    // language's text — presented as this language's source and copied into the
+    // target as if it were a translation.
+    fallbackLocale: "none",
+    queryOptions: {
+      enabled: (isNonDefaultLocale || !!translateFrom) && !!slug,
+    },
+  });
+
+  return { document, isLoading, error, sourceDoc, isNonDefaultLocale };
+}

--- a/packages/admin/src/hooks/queries/useSingles.ts
+++ b/packages/admin/src/hooks/queries/useSingles.ts
@@ -456,6 +456,14 @@ export function useSingleDocument(
     locale?: string;
     fallbackLocale?: string;
     translationStatus?: boolean;
+    /**
+     * Opt into the working-draft overlay. Part of the cache identity below for
+     * the same reason `locale` is: the editor learns `draftsEnabled` only after
+     * the schema loads, flipping this false -> true on a cold load, and without
+     * it in the key the stale-time would keep serving the published document and
+     * hide an existing pending change (and the Changed / Discard affordances).
+     */
+    draft?: boolean;
     queryOptions?: Omit<
       UseQueryOptions<SingleDocument, Error>,
       "queryKey" | "queryFn"
@@ -472,6 +480,7 @@ export function useSingleDocument(
             locale: options?.locale ?? null,
             fallbackLocale: options?.fallbackLocale ?? null,
             translationStatus: options?.translationStatus ?? false,
+            draft: options?.draft ?? false,
           },
         ]
       : singleDocumentKeys.details(),
@@ -482,6 +491,7 @@ export function useSingleDocument(
       return await singleApi.getDocument(slug, {
         depth: options?.depth,
         locale: options?.locale,
+        draft: options?.draft,
         fallbackLocale: options?.fallbackLocale,
         translationStatus: options?.translationStatus,
       });

--- a/packages/admin/src/pages/dashboard/singles/[slug]/index.tsx
+++ b/packages/admin/src/pages/dashboard/singles/[slug]/index.tsx
@@ -29,6 +29,7 @@ import { QueryErrorBoundary } from "@admin/components/shared/query-error-boundar
 import { toast } from "@admin/components/ui";
 import { Link } from "@admin/components/ui/link";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
+import { useSingleEditorDocument } from "@admin/hooks/queries/useSingleEditorDocument";
 import {
   useSingleSchema,
   useUpdateSingleDocument,

--- a/packages/admin/src/pages/dashboard/singles/[slug]/index.tsx
+++ b/packages/admin/src/pages/dashboard/singles/[slug]/index.tsx
@@ -30,7 +30,6 @@ import { toast } from "@admin/components/ui";
 import { Link } from "@admin/components/ui/link";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import {
-  useSingleDocument,
   useSingleSchema,
   useUpdateSingleDocument,
 } from "@admin/hooks/queries/useSingles";
@@ -172,43 +171,29 @@ export default function SingleEditPage({
     error: schemaError,
   } = useSingleSchema(slug);
 
-  // Fetch Single document data
-  const {
-    data: document,
-    isLoading: isLoadingDocument,
-    error: documentError,
-  } = useSingleDocument(slug, {
-    locale,
-    // i18n: edit the ACTUAL per-locale values — disable fallback so an untranslated field shows
-    // empty (not the default-language value, which would bleed the source text into the field and
-    // risk saving it into the target locale). The inline source hint is shown from `sourceDoc`.
-    fallbackLocale: localizationEnabled ? "none" : undefined,
-    translationStatus: localizationEnabled,
-  });
-
-  // i18n: while translating another language, also load the SOURCE document so
-  // the editor can show its text — inline on each translatable field, and in
-  // translation mode's source pane.
-  const isNonDefaultLocale =
-    !!locale && !!defaultLocale && locale !== defaultLocale;
   const { translateFrom, enterTranslationMode, exitTranslationMode } =
     useTranslationMode({
       activeLocale: locale,
       defaultLocale,
     });
-  // The language the source is read AT. Translation mode names it explicitly;
-  // otherwise the inline hint's source has always been the app default.
-  const sourceLocale = translateFrom ?? defaultLocale;
-  const { data: sourceDoc } = useSingleDocument(slug, {
-    locale: sourceLocale,
-    // No fallback, matching `entry-locale-source.ts`'s SOURCE_READ. With
-    // fallback on, an untranslated SOURCE field resolves to yet another
-    // language's text — which would be presented as this language's source and
-    // copied into the target as if it were a translation.
-    fallbackLocale: "none",
-    queryOptions: {
-      enabled: (isNonDefaultLocale || !!translateFrom) && !!slug,
-    },
+
+  // What this editor reads: the document it edits, and — while translating — the
+  // source-language document shown alongside it.
+  const {
+    document,
+    isLoading: isLoadingDocument,
+    error: documentError,
+    sourceDoc,
+    isNonDefaultLocale,
+  } = useSingleEditorDocument({
+    slug,
+    locale,
+    defaultLocale,
+    localizationEnabled,
+    // Ask for the pending change only where the split applies. The server gates
+    // it on an actual update-capability probe regardless.
+    draftsEnabled: schema?.draftsEnabled === true,
+    translateFrom,
   });
 
   // Update mutation — routes the save to the active language's companion row.

--- a/packages/admin/src/services/singleApi.ts
+++ b/packages/admin/src/services/singleApi.ts
@@ -228,6 +228,13 @@ export const singleApi = {
       locale?: string;
       fallbackLocale?: string;
       translationStatus?: boolean;
+      /**
+       * Opt into the working-draft overlay, so an editor sees this Single's
+       * pending change rather than the published document. Gated server-side on
+       * an update-capability probe, so passing it never widens what a
+       * read-only caller can see.
+       */
+      draft?: boolean;
     }
   ): Promise<SingleDocument> => {
     const params = new URLSearchParams();
@@ -240,6 +247,7 @@ export const singleApi = {
       params.set("fallback-locale", options.fallbackLocale);
     }
     if (options?.translationStatus) params.set("translation-status", "1");
+    if (options?.draft) params.set("draft", "1");
     // context is trusted; pass status=all so a freshly-created Single
     // (auto-created with status='draft') is reachable. Without this
     // the user sees "Failed to load Single: Not found." on the page

--- a/packages/admin/src/services/versionApi.ts
+++ b/packages/admin/src/services/versionApi.ts
@@ -210,9 +210,12 @@ export const versionApi = {
    * names which one is being thrown away and which language's live values come
    * back. Omitting it means the request names no language, which the server
    * resolves to the default — the ordinary path when editing that language.
+   *
+   * Both scopes, sharing `basePath`. A Single's URL carries no document id: the
+   * server resolves it from the live row rather than trusting the client.
    */
   discardWorkingDraft: (
-    scope: Extract<VersionScope, { kind: "collection" }>,
+    scope: VersionScope,
     locale?: string | null
   ): Promise<DiscardWorkingDraftResponse> => {
     const search = new URLSearchParams();

--- a/packages/admin/src/types/entities.ts
+++ b/packages/admin/src/types/entities.ts
@@ -299,6 +299,18 @@ export interface ApiSingle {
   localized?: boolean;
 
   /**
+   * Whether a status-less save on this Single is HELD as a pending change
+   * rather than written to the live document (the draft/published split).
+   *
+   * Server-DERIVED from the same predicate the write gates on, never stored:
+   * the split also depends on the fields (a reachable password field, an
+   * unresolvable component), so a flag persisted beside `status` would drift
+   * from what a save actually does. An editor told drafts are off sends an
+   * explicit published save, which overwrites the live document.
+   */
+  draftsEnabled?: boolean;
+
+  /**
    * Resolved version-history config, or null/absent when the Single is
    * unversioned. The server normalizes the Schema Builder's on/off into this
    * shape, so reads carry the object while writes send a boolean — see

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -65,6 +65,7 @@ import type { SingleEntryService } from "../../domains/singles/services/single-e
 import type { SingleMetadataService } from "../../domains/singles/services/single-metadata-service";
 import type { SingleRegistryService } from "../../domains/singles/services/single-registry-service";
 import { resolveBuilderVersions } from "../../domains/versions/builder-versions";
+import { schemaDraftsEnabled } from "../../domains/versions/draft-split-eligibility";
 import { resolveBuilderWebhooks } from "../../domains/webhooks/builder-webhooks";
 import { NextlyError } from "../../errors";
 import { transformRichTextFields } from "../../lib/field-transform";
@@ -102,6 +103,7 @@ import {
 } from "../helpers/service-envelope";
 import {
   parseRichTextFormat,
+  isTruthyParam,
   parseStatusParam,
   requireParam,
   toNumber,
@@ -725,6 +727,10 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         locale: p.locale,
         fallbackLocale: p["fallback-locale"],
         translationStatus: p["translation-status"] === "1",
+        // `?draft=1` opts into the working-draft overlay, matching the entry
+        // read. Gated server-side on an actual update-capability probe, so a
+        // read-only caller passing it still sees the published document.
+        includeWorkingDraft: isTruthyParam(p.draft),
         status,
       });
 
@@ -893,12 +899,30 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         }
       }
 
+      // Whether a status-less save on this Single holds the edit rather than
+      // writing the live row. Derived from the SAME predicate the write gates
+      // on, which its own module requires of every call site: an editor told
+      // drafts are off sends an explicit published save, and a write that names
+      // a status is never held — so the pending-change support stays dark and
+      // the live document is overwritten. Derived from the ORIGINAL fields, not
+      // the enriched ones, because enrichment drops the markers component
+      // eligibility reads.
+      const draftsEnabled = await schemaDraftsEnabled({
+        status: (single as { status?: boolean }).status,
+        versions: single.versions,
+        localized: (single as { localized?: boolean }).localized,
+        fields: single.fields,
+      });
+
       // The schema record IS the doc here, so the admin Schema Builder
       // reads slug/fields/admin off the response body directly without
       // an envelope wrapper.
-      return respondDoc(
-        injectSingleDefaultFields(enrichedData as unknown as SingleWithFields)
-      );
+      return respondDoc({
+        ...injectSingleDefaultFields(
+          enrichedData as unknown as SingleWithFields
+        ),
+        draftsEnabled,
+      });
     },
   },
 

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -1968,6 +1968,22 @@ describe("draft/published split — schema and component eligibility (integratio
     const [live] = await handle!.adapter.select<LiveRow>(TABLE);
     expect(live.title).toBe("live");
     expect(await workingDraftCount(id)).toBe(1);
+
+    // The half the assertions above cannot reach: a held edit the author can
+    // never see is lost in the worst way, because the save reported success.
+    // "The live row is untouched" is satisfied just as well by a system that
+    // stored nothing, so the draft VIEW has to be asserted too.
+    const draftRead = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      includeWorkingDraft: true,
+      status: "all",
+    });
+    expect(draftRead.success).toBe(true);
+    expect((draftRead.data as { title?: string }).title).toBe("edited");
+    expect(
+      (draftRead.data as { _isWorkingDraft?: boolean })._isWorkingDraft
+    ).toBe(true);
   });
 
   it("prunes fields the current schema no longer declares from a draft read", async () => {
@@ -2158,7 +2174,7 @@ describe("draft/published split — schema and component eligibility (integratio
     expect(await workingDraftCount(id)).toBe(0);
   });
 
-  it("stops overlaying the draft when an embedded component becomes localized after the draft was written", async () => {
+  it("shows the draft a publish would ship when an embedded component turns localized", async () => {
     const entries = await bootFile(withHero(false));
     const ctx = { collectionName: COLLECTION, overrideAccess: true };
 
@@ -2176,9 +2192,13 @@ describe("draft/published split — schema and component eligibility (integratio
     await handle!.destroy();
     handle = undefined;
 
-    // Re-open with the component now localized: no write can consume the sidecar
-    // (the mutation path stopped promoting and deleting it), so the read overlay
-    // must fall back to the live row rather than shadow it with a stale draft.
+    // Re-open with the component now localized. This case previously asserted
+    // that the read FELL BACK to the live row, on the premise that no write
+    // could consume the sidecar any more. That premise stopped being true when a
+    // localized component became representable in a draft snapshot: measured
+    // here, the publish below succeeds, promotes the draft's content and clears
+    // the sidecar. So the old behaviour meant an author was shown "live",
+    // pressed Publish, and shipped content they had never seen.
     const reopened = await bootFile(withHero(true));
 
     const draftRead = await reopened.getEntry({
@@ -2187,7 +2207,22 @@ describe("draft/published split — schema and component eligibility (integratio
       overrideAccess: true,
       includeWorkingDraft: true,
     });
-    expect((draftRead.data as { title?: string }).title).toBe("live");
+    expect((draftRead.data as { title?: string }).title).toBe("draft-title");
+
+    // The invariant, asserted as the pair rather than as two separate facts:
+    // what the editor is shown and what a publish would ship must be the same
+    // document. Either alone can be right while the two disagree.
+    const published = await reopened.updateEntry(
+      { ...ctx, entryId: id },
+      { status: "published" }
+    );
+    expect(published.success).toBe(true);
+    const [afterPublish] = await handle!.adapter.select<LiveRow>(TABLE);
+    expect({
+      shown: (draftRead.data as { title?: string }).title,
+      shipped: afterPublish?.title,
+    }).toEqual({ shown: "draft-title", shipped: "draft-title" });
+    expect(await workingDraftCount(id)).toBe(0);
   });
 
   it("rejects a publish when the pending draft violates a tightened schema rule", async () => {

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -1405,6 +1405,49 @@ describe("draft/published split — promote on publish (integration)", () => {
     expect(promo?.label).toBe("live");
   });
 
+  it("returns the pending change to an explicit draft view of a LOCALIZED document", async () => {
+    // The draft-status read and the overlay must agree about what is eligible.
+    // A second, hand-rolled copy of the predicate decided whether to suppress
+    // the draft-only filter on the live row, and it still excluded a localized
+    // document — so the query filtered a PUBLISHED main row to `status = draft`,
+    // matched nothing, and answered 404 before the overlay could run. The write
+    // had held the edit; the read said the document did not exist.
+    handle = await createTestNextly({
+      localization: { locales: ["en", "es"], defaultLocale: "en" },
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          localized: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, { title: "live", status: "published" });
+    const [row] = await handle.adapter.select<{ id: string }>(TABLE);
+    const id = row.id;
+
+    await entries.updateEntry({ ...ctx, entryId: id }, { title: "edited" });
+    expect(await workingDraftCount(id)).toBe(1);
+
+    const draftView = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      includeWorkingDraft: true,
+      status: "draft",
+      locale: "en",
+    });
+
+    expect(draftView.success).toBe(true);
+    expect((draftView.data as { title?: string }).title).toBe("edited");
+  });
+
   it("holds a localized edit that names no language, under the default", async () => {
     // A localized document IS eligible for the split, including one whose
     // schema references a component: a snapshot holds one locale's values and

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -215,6 +215,23 @@ function buildComponentValueCondition(
   return valueCondition;
 }
 
+/**
+ * A collection's declared top-level fields.
+ *
+ * The stored record carries them under `schemaDefinition.fields` for a
+ * Builder collection and `fields` for a code-first one. Read through one
+ * function because the draft-overlay decision and the read assembly both need
+ * them, and a second copy of this fallback would be a second place for the two
+ * to disagree about what the collection declares.
+ */
+function collectionFieldsFor(collection: unknown): FieldDefinition[] {
+  const record = collection as Record<string, unknown>;
+  const schemaDefinition = record.schemaDefinition as
+    | Record<string, unknown>
+    | undefined;
+  return (schemaDefinition?.fields || record.fields || []) as FieldDefinition[];
+}
+
 export class CollectionQueryService extends BaseService {
   constructor(
     adapter: DrizzleAdapter,
@@ -1404,13 +1421,7 @@ export class CollectionQueryService extends BaseService {
       const collection = await this.collectionService.getCollection(
         params.collectionName
       );
-      const fields = ((
-        (collection as Record<string, unknown>).schemaDefinition as
-          | Record<string, unknown>
-          | undefined
-      )?.fields ||
-        (collection as Record<string, unknown>).fields ||
-        []) as FieldDefinition[];
+      const fields = collectionFieldsFor(collection);
       const storedHooks = this.hookService.getStoredHooks(
         collection as Record<string, unknown>
       );
@@ -2461,20 +2472,38 @@ export class CollectionQueryService extends BaseService {
       // surface the pending draft. Drop it for a drafts-enabled collection when
       // `includeWorkingDraft` is set; the overlay returns the draft (or the live
       // row when none exists). Every other status filter is applied as usual.
+      // Whether this read could surface a working draft at all, from the same
+      // rule the overlay below uses. Computed ONCE and consulted twice: this
+      // predicate and the overlay must agree about what is eligible, and a
+      // second hand-rolled copy here is exactly how they came apart — it still
+      // excluded a localized document, so a draft-status read filtered a
+      // PUBLISHED main row to `status = draft`, matched nothing, and answered
+      // 404 before the overlay could run. The write had held the edit; the read
+      // said the document did not exist.
+      //
+      // Component schemas are left unresolved to keep the registry reads off the
+      // common path; the confirming check against resolved schemas runs before
+      // any draft is exposed.
+      const draftOverlayPossible = resolveDraftOverlay({
+        ...draftDocumentFacts(collectionForStatus as DraftDocumentConfig),
+        fields: collectionFieldsFor(collectionForStatus) as FieldConfig[],
+        componentSchemas: null,
+        includeWorkingDraft: params.includeWorkingDraft === true,
+        requestedStatus: params.status,
+        // The capability is probed against the loaded row further down; this
+        // asks only whether the document and the request allow an overlay.
+        callerMayEdit: true,
+        requestLocale: params.locale ?? null,
+        defaultLocale: this.localization?.defaultLocale ?? null,
+      }).overlay;
+
+      // An explicit `status: "draft"` view that opts into the working draft must
+      // not filter the live row to draft-only: the split keeps the main row
+      // published, so that predicate would 404 before the overlay can surface
+      // the pending draft. When nothing is overlaid after all, the 404 below
+      // still refuses to return the published row to a draft-only view.
       const suppressDraftStatusFilter =
-        params.includeWorkingDraft === true &&
-        statusFilter?.value === "draft" &&
-        // Only in the split's own domain: a non-localized status collection with
-        // drafts on. Outside it (a localized collection, or one with no status
-        // column) the normal draft predicate must stand, so a draft-status read
-        // still filters correctly and the no-draft 404 below does not apply.
-        (collectionForStatus as { status?: boolean }).status === true &&
-        (collectionForStatus as { localized?: boolean }).localized !== true &&
-        (
-          collectionForStatus as {
-            versions?: { drafts?: { enabled?: boolean } };
-          }
-        ).versions?.drafts?.enabled === true;
+        draftOverlayPossible && statusFilter?.value === "draft";
       const statusCondition =
         statusFilter && schema.status && !suppressDraftStatusFilter
           ? eq(schema.status, statusFilter.value)

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -106,6 +106,7 @@ import {
 } from "../../i18n/resolve-locale";
 import { resolveCompanionSchemaReadiness } from "../../i18n/runtime/companion-readiness";
 import { resolveComponentTableName } from "../../schema/utils/resolve-table-name";
+import { resolveDraftOverlay } from "../../versions/draft-overlay";
 import {
   buildRestorePayload,
   type ComponentSchemas,
@@ -2645,25 +2646,32 @@ export class CollectionQueryService extends BaseService {
       // a published-only or untrusted read: `statusFilter === null` excludes the
       // published default and `?status=published`, and `overrideAccess ||
       // routeAuthorized` excludes an anonymous caller passing `?status=all`.
-      const draftEligible =
-        (collectionForStatus as { status?: boolean }).status === true &&
-        // Only when drafts are still enabled. If the collection turned drafts
-        // off after a working draft was written, the write path no longer
-        // promotes or deletes it, so surfacing it here would shadow the live
-        // document with a sidecar nothing can ever consume.
-        (
-          collectionForStatus as {
-            versions?: { drafts?: { enabled?: boolean } };
-          }
-        ).versions?.drafts?.enabled === true &&
-        // The caller explicitly asked to see the working draft (an editor
-        // opening the document to edit). This is opt-in on purpose: many
-        // internal callers issue a status-less read (duplicate, reference
-        // labels) and must keep seeing the published row, so draft visibility
-        // follows an explicit editor intent, not every status-less read.
-        params.includeWorkingDraft === true &&
-        // An explicit published view still suppresses the draft.
-        params.status !== "published";
+      // The CHEAP half of the shared rule, with component schemas unresolved so
+      // the registry reads stay off the common read path. With no schemas the
+      // eligibility test can only be MORE permissive, so a `false` here is final
+      // while a `true` is provisional — confirmed below against resolved schemas
+      // before any draft is exposed.
+      const draftEligible = resolveDraftOverlay({
+        collectionHasStatus:
+          (collectionForStatus as { status?: boolean }).status === true,
+        draftsVersioningEnabled:
+          (
+            collectionForStatus as {
+              versions?: { drafts?: { enabled?: boolean } };
+            }
+          ).versions?.drafts?.enabled === true,
+        documentLocalized:
+          (collection as { localized?: boolean }).localized === true,
+        fields: fields as FieldConfig[],
+        componentSchemas: null,
+        includeWorkingDraft: params.includeWorkingDraft === true,
+        requestedStatus: params.status,
+        // The capability is probed below against the loaded row; this half asks
+        // only whether the document and the request allow an overlay at all.
+        callerMayEdit: true,
+        requestLocale: params.locale ?? null,
+        defaultLocale: this.localization?.defaultLocale ?? null,
+      }).overlay;
       // Even with the opt-in, a pending draft is surfaced only to a caller
       // trusted to EDIT the document. `overrideAccess` attests that directly.
       // `routeAuthorized` is NOT trusted: on this read path the REST dispatcher
@@ -2728,16 +2736,28 @@ export class CollectionQueryService extends BaseService {
         const draftComponentSchemas = workingDraft
           ? await resolveComponentSchemas(fields as FieldConfig[])
           : null;
-        const draftIneligible = draftComponentSchemas
-          ? hasPasswordField(fields) ||
-            [...draftComponentSchemas.values()].some(
-              schema =>
-                schema.localized ||
-                !schema.resolved ||
-                hasPasswordField(schema.fields)
-            )
-          : false;
-        if (workingDraft && !draftIneligible) {
+        // The CONFIRMING half, against resolved schemas and through the same
+        // rule the write uses. It replaced an inline copy that additionally
+        // refused `schema.localized` — a clause the write dropped when a
+        // localized component became representable in a snapshot. The write held
+        // those edits and this read declined to show them, so the author saw
+        // their own save reported as successful and the old content returned.
+        const draftShowable =
+          draftComponentSchemas === null ||
+          resolveDraftOverlay({
+            collectionHasStatus: true,
+            draftsVersioningEnabled: true,
+            documentLocalized:
+              (collection as { localized?: boolean }).localized === true,
+            fields: fields as FieldConfig[],
+            componentSchemas: draftComponentSchemas,
+            includeWorkingDraft: true,
+            requestedStatus: params.status,
+            callerMayEdit: true,
+            requestLocale: params.locale ?? null,
+            defaultLocale: this.localization?.defaultLocale ?? null,
+          }).overlay;
+        if (workingDraft && draftShowable) {
           const rawSnapshot = workingDraft.snapshot as Record<string, unknown>;
           // Shape the snapshot to the current schema before exposing it. A field
           // removed or renamed while the draft was pending leaves a key the

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -106,7 +106,11 @@ import {
 } from "../../i18n/resolve-locale";
 import { resolveCompanionSchemaReadiness } from "../../i18n/runtime/companion-readiness";
 import { resolveComponentTableName } from "../../schema/utils/resolve-table-name";
-import { resolveDraftOverlay } from "../../versions/draft-overlay";
+import {
+  draftDocumentFacts,
+  resolveDraftOverlay,
+  type DraftDocumentConfig,
+} from "../../versions/draft-overlay";
 import {
   buildRestorePayload,
   type ComponentSchemas,
@@ -2652,16 +2656,12 @@ export class CollectionQueryService extends BaseService {
       // while a `true` is provisional — confirmed below against resolved schemas
       // before any draft is exposed.
       const draftEligible = resolveDraftOverlay({
-        collectionHasStatus:
-          (collectionForStatus as { status?: boolean }).status === true,
-        draftsVersioningEnabled:
-          (
-            collectionForStatus as {
-              versions?: { drafts?: { enabled?: boolean } };
-            }
-          ).versions?.drafts?.enabled === true,
-        documentLocalized:
-          (collection as { localized?: boolean }).localized === true,
+        ...draftDocumentFacts({
+          ...(collectionForStatus as DraftDocumentConfig),
+          // Localization is read off the collection record, which is where the
+          // read path already carries it.
+          localized: (collection as { localized?: boolean }).localized,
+        }),
         fields: fields as FieldConfig[],
         componentSchemas: null,
         includeWorkingDraft: params.includeWorkingDraft === true,

--- a/packages/nextly/src/domains/singles/__tests__/draft-split-singles.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/draft-split-singles.integration.test.ts
@@ -239,6 +239,152 @@ describe("pending changes for Singles (integration)", () => {
  * gap this closes was never in the delete: a Single had no discard PATH at all,
  * so a service-level test would pass over exactly the wiring that was missing.
  */
+/**
+ * Seeing a Single's pending change.
+ *
+ * Until this existed the hold was WRITE-ONLY: the engine stored the edit, the
+ * publish promoted it, and no read ever returned it — so an author saved, got
+ * the live values back, and could not tell their work had been kept.
+ */
+describe("reading a Single's pending change (integration)", () => {
+  it("returns the pending change to an editor who asks for it", async () => {
+    const t = await bootPlain();
+    const singles = singlesOf(t);
+    await singles.update(
+      SLUG,
+      { siteName: "live", status: "published" },
+      { overrideAccess: true }
+    );
+    const held = await singles.update(
+      SLUG,
+      { siteName: "edited" },
+      { overrideAccess: true }
+    );
+    expect(held.success).toBe(true);
+    expect(await pendingLocales(t)).toEqual(["(none)"]);
+
+    const draft = await singles.get(SLUG, {
+      overrideAccess: true,
+      includeWorkingDraft: true,
+      status: "all",
+    });
+
+    expect((draft.data as { siteName?: string }).siteName).toBe("edited");
+    expect((draft.data as { _isWorkingDraft?: boolean })._isWorkingDraft).toBe(
+      true
+    );
+    // The live document is still the published one: the overlay is a view, not
+    // a write. Paired with the assertion above, because "live is untouched" is
+    // satisfied just as well by a system that stored nothing.
+    expect(await storedName(t)).toBe("live");
+  });
+
+  it("does not surface the draft to a read that did not ask", async () => {
+    // The public route and every internal read issue status-less reads and must
+    // keep seeing the published document.
+    const t = await bootPlain();
+    const singles = singlesOf(t);
+    await singles.update(
+      SLUG,
+      { siteName: "live", status: "published" },
+      { overrideAccess: true }
+    );
+    await singles.update(
+      SLUG,
+      { siteName: "edited" },
+      { overrideAccess: true }
+    );
+    expect(await pendingLocales(t)).toEqual(["(none)"]);
+
+    const plain = await singles.get(SLUG, { overrideAccess: true });
+    expect((plain.data as { siteName?: string }).siteName).toBe("live");
+    expect(
+      (plain.data as { _isWorkingDraft?: boolean })._isWorkingDraft
+    ).toBeUndefined();
+  });
+
+  it("shows each language its OWN pending change, and no other's", async () => {
+    const t = await bootLocalized();
+    const singles = singlesOf(t);
+    await singles.update(
+      SLUG,
+      { siteName: "EN live", status: "published" },
+      { locale: "en", overrideAccess: true }
+    );
+    await singles.update(
+      SLUG,
+      { siteName: "DE live", status: "published" },
+      { locale: "de", overrideAccess: true }
+    );
+    await singles.update(
+      SLUG,
+      { siteName: "DE edited" },
+      { locale: "de", overrideAccess: true }
+    );
+    expect(await pendingLocales(t)).toEqual(["de"]);
+
+    const de = await singles.get(SLUG, {
+      locale: "de",
+      overrideAccess: true,
+      includeWorkingDraft: true,
+      status: "all",
+    });
+    expect((de.data as { siteName?: string }).siteName).toBe("DE edited");
+    expect((de.data as { _isWorkingDraft?: boolean })._isWorkingDraft).toBe(
+      true
+    );
+
+    // English holds no pending change, so the same opt-in read returns its live
+    // values and reports no draft. This is what makes the flag per-language
+    // rather than per-document.
+    const en = await singles.get(SLUG, {
+      locale: "en",
+      overrideAccess: true,
+      includeWorkingDraft: true,
+      status: "all",
+    });
+    expect((en.data as { siteName?: string }).siteName).toBe("EN live");
+    expect(
+      (en.data as { _isWorkingDraft?: boolean })._isWorkingDraft
+    ).toBeUndefined();
+  });
+
+  it("shows what a publish would ship", async () => {
+    // The invariant that makes the overlay worth having, asserted as a PAIR:
+    // either half can be right on its own while the two disagree, and a reader
+    // shown one document who ships another is the failure this prevents.
+    const t = await bootPlain();
+    const singles = singlesOf(t);
+    await singles.update(
+      SLUG,
+      { siteName: "live", status: "published" },
+      { overrideAccess: true }
+    );
+    await singles.update(
+      SLUG,
+      { siteName: "edited" },
+      { overrideAccess: true }
+    );
+
+    const shown = await singles.get(SLUG, {
+      overrideAccess: true,
+      includeWorkingDraft: true,
+      status: "all",
+    });
+    const publish = await singles.update(
+      SLUG,
+      { status: "published" },
+      { overrideAccess: true }
+    );
+    expect(publish.success).toBe(true);
+
+    expect({
+      shown: (shown.data as { siteName?: string }).siteName,
+      shipped: await storedName(t),
+    }).toEqual({ shown: "edited", shipped: "edited" });
+  });
+});
+
 describe("discarding a Single's pending change (integration)", () => {
   /** The live document id, which a Single's caller resolves rather than names. */
   async function liveId(t: TestNextly): Promise<string> {

--- a/packages/nextly/src/domains/singles/__tests__/draft-split-singles.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/draft-split-singles.integration.test.ts
@@ -14,7 +14,7 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
-import { defineSingle, text } from "../../../config";
+import { defineSingle, group, text } from "../../../config";
 import {
   createTestNextly,
   type TestNextly,
@@ -42,6 +42,27 @@ async function bootPlain(): Promise<TestNextly> {
         // `overrideAccess`, so these rules do not change what they exercise.
         access: { read: () => true, update: () => true },
         fields: [text({ name: "siteName" }), text({ name: "tagline" })],
+      }),
+    ],
+  });
+  return current;
+}
+
+async function bootWithGroup(): Promise<TestNextly> {
+  current = await createTestNextly({
+    singles: [
+      defineSingle({
+        slug: SLUG,
+        status: true,
+        versions: { drafts: true },
+        access: { read: () => true, update: () => true },
+        fields: [
+          text({ name: "siteName" }),
+          group({
+            name: "seo",
+            fields: [text({ name: "metaTitle" })],
+          }),
+        ],
       }),
     ],
   });
@@ -347,6 +368,46 @@ describe("reading a Single's pending change (integration)", () => {
     expect(
       (en.data as { _isWorkingDraft?: boolean })._isWorkingDraft
     ).toBeUndefined();
+  });
+
+  it("returns a JSON-backed field in the same shape a live read does", async () => {
+    // The overlay replaces the assembled document, so every stage the live read
+    // applied has to be applied to the snapshot too. A group is stored
+    // serialized: handing the stored string back gives the editor — and any
+    // afterRead hook — a string where a live read gives an object.
+    const t = await bootWithGroup();
+    const singles = singlesOf(t);
+    await singles.update(
+      SLUG,
+      {
+        siteName: "live",
+        seo: { metaTitle: "live title" },
+        status: "published",
+      },
+      { overrideAccess: true }
+    );
+    const held = await singles.update(
+      SLUG,
+      { seo: { metaTitle: "pending title" } },
+      { overrideAccess: true }
+    );
+    expect(held.success).toBe(true);
+
+    const live = await singles.get(SLUG, { overrideAccess: true });
+    const draft = await singles.get(SLUG, {
+      overrideAccess: true,
+      includeWorkingDraft: true,
+      status: "all",
+    });
+
+    // Asserted against the LIVE read's shape rather than against a literal, so
+    // the two cannot drift apart whatever that shape becomes.
+    expect(typeof (draft.data as { seo?: unknown }).seo).toBe(
+      typeof (live.data as { seo?: unknown }).seo
+    );
+    expect(
+      (draft.data as { seo?: { metaTitle?: string } }).seo?.metaTitle
+    ).toBe("pending title");
   });
 
   it("shows what a publish would ship", async () => {

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -28,7 +28,7 @@ import { isFieldGroupField } from "../../../collections/fields/guards";
 import type { RBACAccessControlService } from "../../../domains/auth/services/rbac-access-control-service";
 import { NextlyError } from "../../../errors/nextly-error";
 import type { HookRegistry } from "../../../hooks/hook-registry";
-import { keysToSnakeCase } from "../../../lib/case-conversion";
+import { keysToSnakeCase, toSnakeCase } from "../../../lib/case-conversion";
 import { stripImmutableSystemFields } from "../../../lib/immutable-system-fields";
 import {
   resolvePublishTransition,
@@ -47,7 +47,10 @@ import {
 import { expansionAccess } from "../../../services/collections/trust-bound";
 import type { FieldGroupDataService } from "../../../services/field-groups/field-group-data-service";
 import { BaseService } from "../../../shared/base-service";
-import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
+import {
+  SYSTEM_TIMESTAMP_KEYS,
+  convertTimestampsToCamelCase,
+} from "../../../shared/lib/case-conversion";
 import { validateEntryData } from "../../../shared/lib/entry-validation";
 import {
   applyFieldReadAccess,
@@ -1719,10 +1722,37 @@ export class SingleMutationService extends BaseService {
                 : convertTimestampsToCamelCase({
                     ...(existingDoc as Record<string, unknown>),
                   });
-              const pending: Record<string, unknown> = {
-                ...base,
-                ...convertTimestampsToCamelCase({ ...mainPayload }),
-              };
+              // The base is the READ shape (field names); `mainPayload` is the
+              // WRITE shape (columns). Spreading one onto the other put both
+              // spellings of every edited field in the snapshot — the live value
+              // under `siteName` and the pending one under `site_name` — so which
+              // value a consumer saw depended on which spelling it asked for.
+              // The promote read the column and shipped the edit; anything
+              // reading by field name got the stale live value.
+              //
+              // Mapped through the declared fields rather than camel-cased
+              // wholesale, for the reason the version capture below gives: a
+              // field genuinely named `site_title` must keep its own spelling.
+              const pending: Record<string, unknown> = { ...base };
+              for (const field of singleMeta.fields) {
+                if (field.name === undefined) continue;
+                const column = toSnakeCase(field.name);
+                if (Object.prototype.hasOwnProperty.call(mainPayload, column)) {
+                  pending[field.name] = (
+                    mainPayload as Record<string, unknown>
+                  )[column];
+                }
+              }
+              // The system columns the loop above does not declare — status and
+              // the timestamps — still ride along at the read shape.
+              const systemPatch = convertTimestampsToCamelCase({
+                ...(mainPayload as Record<string, unknown>),
+              });
+              for (const key of ["status", ...SYSTEM_TIMESTAMP_KEYS]) {
+                if (Object.prototype.hasOwnProperty.call(systemPatch, key)) {
+                  pending[key] = systemPatch[key];
+                }
+              }
               // A localized Single keeps its translatable values on the
               // companion row, so this write's translated values reach the
               // snapshot only by being overlaid here — keyed by field name to

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -99,6 +99,13 @@ import {
   isTextStorageKind,
 } from "../../schema/services/field-column-descriptor";
 import { captureInTx } from "../../versions/capture-in-tx";
+import {
+  draftDocumentFacts,
+  resolveDraftOverlay,
+} from "../../versions/draft-overlay";
+import type { ComponentSchemas } from "../../versions/restore-snapshot";
+import { resolveComponentSchemas } from "../../versions/restore-version";
+import { shapeDraftSnapshot } from "../../versions/shape-draft-snapshot";
 import { VersionCaptureService } from "../../versions/version-capture-service";
 import { withVersionConflictRetry } from "../../versions/version-conflict";
 import { VersionsRepository } from "../../versions/versions-repository";
@@ -724,6 +731,147 @@ export class SingleQueryService extends BaseService {
    * runs and nothing is written, so this is safe to perform for a caller who may
    * still be refused.
    */
+  /**
+   * Replace the assembled live document with this Single's pending change, when
+   * the caller asked for it and may edit the document.
+   *
+   * Returns the document unchanged whenever no overlay applies, so the caller
+   * reads as one statement rather than a branch.
+   */
+  /**
+   * Whether this read shows the Single's pending change, and what it needs to
+   * fetch it — or `null` when it does not.
+   *
+   * Separated from the application below because they answer different
+   * questions and fail for different reasons: this one is entirely about
+   * eligibility and trust, and returns nothing the caller has to interpret.
+   */
+  private async resolveWorkingDraftView(params: {
+    slug: string;
+    singleMeta: DynamicSingleRecord;
+    options: GetSingleOptions;
+  }): Promise<{
+    draftLocale: string | null;
+    componentSchemas: ComponentSchemas;
+  } | null> {
+    const { slug, singleMeta, options } = params;
+
+    const overlayInput = {
+      ...draftDocumentFacts(singleMeta),
+      fields: singleMeta.fields,
+      includeWorkingDraft: options.includeWorkingDraft === true,
+      requestedStatus: options.status,
+      requestLocale: options.locale ?? null,
+      defaultLocale: this.localization?.defaultLocale ?? null,
+    };
+
+    // The CHEAP half: component schemas unresolved, so the registry reads stay
+    // off the common read path. With no schemas the eligibility test can only be
+    // more permissive, so a `false` here is final.
+    if (
+      !resolveDraftOverlay({
+        ...overlayInput,
+        componentSchemas: null,
+        callerMayEdit: true,
+      }).overlay
+    ) {
+      return null;
+    }
+
+    if (!(await this.callerMayEditSingle(slug, singleMeta, options))) {
+      return null;
+    }
+
+    const componentSchemas = await resolveComponentSchemas(singleMeta.fields);
+    const decision = resolveDraftOverlay({
+      ...overlayInput,
+      componentSchemas,
+      callerMayEdit: true,
+    });
+    return decision.overlay
+      ? { draftLocale: decision.draftLocale, componentSchemas }
+      : null;
+  }
+
+  /**
+   * Whether this caller may EDIT the Single, which is what a pending change is
+   * shown to.
+   *
+   * `routeAuthorized` is deliberately not consulted: on the read path it attests
+   * that a READ was authorized, so trusting it would hand one author's
+   * unpublished work to any authenticated reader.
+   */
+  private async callerMayEditSingle(
+    slug: string,
+    singleMeta: DynamicSingleRecord,
+    options: GetSingleOptions
+  ): Promise<boolean> {
+    if (options.overrideAccess === true) return true;
+    if (options.user === undefined) return false;
+
+    const updateDenied = await checkSingleAccess({
+      slug,
+      operation: "update",
+      accessRules: singleMeta.accessRules,
+      user: options.user,
+      overrideAccess: false,
+      routeAuthorized: false,
+      rbacAccessControlService: this.rbacAccessControlService,
+      accessControlService: this.accessControlService,
+      authenticatedScope: options.authenticatedScope,
+      logger: this.logger,
+    });
+    return !updateDenied;
+  }
+
+  /**
+   * Replace the assembled live document with this Single's pending change, when
+   * one applies.
+   *
+   * Returns the document unchanged whenever no overlay applies, so the caller
+   * reads as one statement rather than a branch.
+   */
+  private async overlayWorkingDraft(params: {
+    slug: string;
+    singleMeta: DynamicSingleRecord;
+    doc: SingleDocument;
+    options: GetSingleOptions;
+  }): Promise<SingleDocument> {
+    const { slug, singleMeta, doc, options } = params;
+
+    const entryId = (doc as { id?: string }).id;
+    if (entryId === undefined) return doc;
+
+    const view = await this.resolveWorkingDraftView({
+      slug,
+      singleMeta,
+      options,
+    });
+    if (view === null) return doc;
+
+    const workingDraft = await new VersionsRepository(
+      this.adapter
+    ).findWorkingDraft(
+      { scopeKind: "single", scopeSlug: slug, entryId },
+      view.draftLocale
+    );
+    if (!workingDraft) return doc;
+
+    const overlaid = shapeDraftSnapshot({
+      snapshot: workingDraft.snapshot as Record<string, unknown>,
+      fields: singleMeta.fields,
+      componentSchemas: view.componentSchemas,
+      hasSlug: singleMeta.fields.some(f => f.name === "slug"),
+      hasTitle: singleMeta.fields.some(f => f.name === "title"),
+    }) as unknown as SingleDocument;
+
+    // The flag the editor reads to show "Changed" and offer Discard. Set only
+    // when a draft was actually overlaid, so a read of a language with no
+    // pending change reports nothing — which is what makes it per-language.
+    (overlaid as Record<string, unknown>)._isWorkingDraft = true;
+    return overlaid;
+  }
+
   private async assembleStoredDocument(params: {
     slug: string;
     singleMeta: DynamicSingleRecord;
@@ -1679,6 +1827,23 @@ export class SingleQueryService extends BaseService {
           responseWithheld
         );
       }
+
+      // On a trusted draft-view read, surface this Single's pending change in
+      // place of the live document. Placed AFTER the live assembly, so
+      // re-reading live companion values by the same id cannot clobber the
+      // draft's, and BEFORE the password strip, the afterRead hooks and the
+      // field-level read access below, so a snapshot is redacted and judged
+      // exactly like any other read.
+      //
+      // The decision comes from the same rule the WRITE uses. A read that
+      // decided this for itself is how a held edit becomes invisible: the write
+      // reports success and the read returns the old content.
+      doc = await this.overlayWorkingDraft({
+        slug,
+        singleMeta,
+        doc,
+        options,
+      });
 
       // attach the per-locale `_translations` overview for the admin's language pills
       // (opt-in via `?translation-status=1`). No-op for non-localized singles / public reads.

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -857,13 +857,36 @@ export class SingleQueryService extends BaseService {
     );
     if (!workingDraft) return doc;
 
-    const overlaid = shapeDraftSnapshot({
+    const shaped = shapeDraftSnapshot({
       snapshot: workingDraft.snapshot as Record<string, unknown>,
       fields: singleMeta.fields,
       componentSchemas: view.componentSchemas,
       hasSlug: singleMeta.fields.some(f => f.name === "slug"),
       hasTitle: singleMeta.fields.some(f => f.name === "title"),
     }) as unknown as SingleDocument;
+
+    // The snapshot REPLACES the assembled document, so every response-shaping
+    // stage the live read applied has to be applied to it too — otherwise a
+    // drafted Single comes back in a different shape from a published one, and
+    // an afterRead hook receives a serialized string where it expects an object.
+    // The snapshot stores JSON-backed fields serialized and relations as ids,
+    // exactly as the live row does, so the same stages restore both.
+    let overlaid = this.deserializeJsonFields(shaped, singleMeta.fields);
+    overlaid = await this.expandUploadFields(
+      overlaid,
+      singleMeta.fields,
+      expansionAccess(options)
+    );
+    overlaid = await this.expandRelationshipFields(
+      overlaid,
+      singleMeta.fields,
+      options.depth,
+      expansionAccess(options)
+    );
+    // Component POPULATION is deliberately NOT re-run, mirroring the collection
+    // overlay. The snapshot already carries the draft's own component values;
+    // re-reading them from their tables would replace the pending edits with
+    // live content, which is the one thing an overlay must not do.
 
     // The flag the editor reads to show "Changed" and offer Discard. Set only
     // when a draft was actually overlaid, so a read of a language with no

--- a/packages/nextly/src/domains/singles/types.ts
+++ b/packages/nextly/src/domains/singles/types.ts
@@ -113,6 +113,18 @@ export interface GetSingleOptions {
    */
   status?: StatusOption;
 
+  /**
+   * Opt in to the working-draft overlay: a trusted editor read returns this
+   * Single's pending change in place of the live document.
+   *
+   * Opt-in on purpose, matching the collection read. Internal reads (the public
+   * route, reference labels, expansion) issue status-less reads and must keep
+   * seeing the published document, so draft visibility follows an editor's
+   * intent rather than the absence of a status filter. Gated on an actual
+   * update-capability probe, so a read-only caller passing it still sees live.
+   */
+  includeWorkingDraft?: boolean;
+
   /** Arbitrary data passed to hooks via context. */
   context?: Record<string, unknown>;
 }

--- a/packages/nextly/src/domains/versions/__tests__/draft-overlay.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/draft-overlay.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The read-side overlay rule.
+ *
+ * The cases that matter most are the ones where this rule and the WRITE rule
+ * must agree, because a disagreement is invisible from either side: the write
+ * reports success and the read shows the old content.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { FieldConfig } from "../../../collections/fields/types";
+import { text } from "../../../config";
+import { resolveDraftHold } from "../draft-hold";
+import { resolveDraftOverlay } from "../draft-overlay";
+import type { ComponentSchemas } from "../restore-snapshot";
+
+const FIELDS = [text({ name: "title" })] as unknown as FieldConfig[];
+
+/** A resolved, LOCALIZED component — representable in a snapshot since #1066. */
+const LOCALIZED_COMPONENT = new Map([
+  ["hero", { resolved: true, localized: true, fields: [] }],
+]) as unknown as ComponentSchemas;
+
+/** A component that could not be resolved — never representable. */
+const UNRESOLVED_COMPONENT = new Map([
+  ["hero", { resolved: false, localized: false, fields: [] }],
+]) as unknown as ComponentSchemas;
+
+const base = {
+  collectionHasStatus: true,
+  draftsVersioningEnabled: true,
+  documentLocalized: false,
+  fields: FIELDS,
+  componentSchemas: null as ComponentSchemas | null,
+  includeWorkingDraft: true,
+  callerMayEdit: true,
+};
+
+describe("resolveDraftOverlay", () => {
+  it("overlays an eligible document for an editor who asked", () => {
+    expect(resolveDraftOverlay(base)).toEqual({
+      overlay: true,
+      draftLocale: null,
+    });
+  });
+
+  it.each([
+    ["the caller did not ask", { includeWorkingDraft: false }],
+    ["the caller may not edit", { callerMayEdit: false }],
+    ["an explicit published view", { requestedStatus: "published" }],
+    ["the lifecycle is off", { collectionHasStatus: false }],
+    ["drafts versioning is off", { draftsVersioningEnabled: false }],
+    [
+      "a component cannot be resolved",
+      { componentSchemas: UNRESOLVED_COMPONENT },
+    ],
+  ])("declines when %s", (_why, patch) => {
+    expect(resolveDraftOverlay({ ...base, ...patch }).overlay).toBe(false);
+  });
+
+  it("keys a localized document under the language being read", () => {
+    expect(
+      resolveDraftOverlay({
+        ...base,
+        documentLocalized: true,
+        requestLocale: "es",
+        defaultLocale: "en",
+      })
+    ).toEqual({ overlay: true, draftLocale: "es" });
+  });
+
+  it("keys a localized document under the default when the read names none", () => {
+    // The admin omits `?locale=` for the default language, so this is the
+    // ordinary path rather than an edge case.
+    expect(
+      resolveDraftOverlay({
+        ...base,
+        documentLocalized: true,
+        defaultLocale: "en",
+      })
+    ).toEqual({ overlay: true, draftLocale: "en" });
+  });
+
+  it("declines a localized document whose language it cannot name", () => {
+    // No request locale and no default: there is no slot to look in, and
+    // reading the unlocalized one would report no pending change for a document
+    // that has one.
+    expect(
+      resolveDraftOverlay({ ...base, documentLocalized: true }).overlay
+    ).toBe(false);
+  });
+
+  /**
+   * The regression this rule exists for. A LOCALIZED component is representable
+   * in a snapshot — the write has held such edits since #1066 — while the read
+   * overlay still tested `schema.localized` and refused them. The author's edit
+   * was stored and then shown as the old content.
+   */
+  it("agrees with the WRITE rule about a localized component", () => {
+    const shared = {
+      collectionHasStatus: true,
+      draftsVersioningEnabled: true,
+      documentLocalized: false,
+      fields: FIELDS,
+      componentSchemas: LOCALIZED_COMPONENT,
+    };
+
+    const held = resolveDraftHold({
+      ...shared,
+      namedStatus: undefined,
+      liveStatus: "published",
+    });
+    const shown = resolveDraftOverlay({
+      ...shared,
+      includeWorkingDraft: true,
+      callerMayEdit: true,
+    });
+
+    // Asserted as the PAIR, not as two independent truths: what matters is that
+    // they cannot differ, and a test asserting only `shown.overlay === true`
+    // would still pass if the write later stopped holding.
+    expect({ held: held.hold, shown: shown.overlay }).toEqual({
+      held: true,
+      shown: true,
+    });
+    expect(shown.draftLocale).toBe(held.draftLocale);
+  });
+
+  it("agrees with the WRITE rule about an unresolved component", () => {
+    const shared = {
+      collectionHasStatus: true,
+      draftsVersioningEnabled: true,
+      documentLocalized: false,
+      fields: FIELDS,
+      componentSchemas: UNRESOLVED_COMPONENT,
+    };
+
+    const held = resolveDraftHold({
+      ...shared,
+      namedStatus: undefined,
+      liveStatus: "published",
+    });
+    const shown = resolveDraftOverlay({
+      ...shared,
+      includeWorkingDraft: true,
+      callerMayEdit: true,
+    });
+
+    // Neither side may act, and the point is that they match — an overlay with
+    // no write behind it shadows the live document with a sidecar nothing can
+    // ever promote.
+    expect({ held: held.hold, shown: shown.overlay }).toEqual({
+      held: false,
+      shown: false,
+    });
+  });
+});

--- a/packages/nextly/src/domains/versions/__tests__/shape-draft-snapshot.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/shape-draft-snapshot.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Shaping a stored snapshot for a draft read.
+ *
+ * The half of an overlay with no database in it, so it is asserted directly
+ * rather than through a service that would need one.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { FieldConfig } from "../../../collections/fields/types";
+import { text } from "../../../config";
+import { shapeDraftSnapshot } from "../shape-draft-snapshot";
+
+const FIELDS = [
+  text({ name: "title" }),
+  text({ name: "body" }),
+] as unknown as FieldConfig[];
+
+const base = {
+  fields: FIELDS,
+  componentSchemas: undefined,
+  hasSlug: true,
+  hasTitle: true,
+};
+
+describe("shapeDraftSnapshot", () => {
+  it("keeps the values the schema still declares", () => {
+    const shaped = shapeDraftSnapshot({
+      ...base,
+      snapshot: { title: "pending", body: "also pending", status: "draft" },
+    });
+
+    expect(shaped.title).toBe("pending");
+    expect(shaped.body).toBe("also pending");
+  });
+
+  it("prunes a key the schema no longer declares", () => {
+    // A field dropped while the draft was pending leaves a key the snapshot
+    // still carries. A live read of the same document would not return it, and
+    // the redaction and hooks downstream only inspect declared fields — so an
+    // obsolete value would reach the response unexamined.
+    const shaped = shapeDraftSnapshot({
+      ...base,
+      snapshot: { title: "pending", subtitle: "removed from the schema" },
+    });
+
+    expect(shaped.title).toBe("pending");
+    expect("subtitle" in shaped).toBe(false);
+  });
+
+  it("carries the identity and timestamp columns the prune holds back", () => {
+    // The prune withholds these because a RESTORE must not resubmit them. A
+    // read carries them, so they are copied back — and taken from the shared
+    // list, which is why the first-publication marker survives.
+    const shaped = shapeDraftSnapshot({
+      ...base,
+      snapshot: {
+        id: "doc-1",
+        title: "pending",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-02-02T00:00:00.000Z",
+        firstPublishedAt: "2026-01-15T00:00:00.000Z",
+      },
+    });
+
+    expect({
+      id: shaped.id,
+      createdAt: shaped.createdAt,
+      updatedAt: shaped.updatedAt,
+      firstPublishedAt: shaped.firstPublishedAt,
+    }).toEqual({
+      id: "doc-1",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-02-02T00:00:00.000Z",
+      firstPublishedAt: "2026-01-15T00:00:00.000Z",
+    });
+  });
+
+  it("does not invent a system column the snapshot never held", () => {
+    // Absence is copied as absence: a snapshot written before the document was
+    // first published carries no marker, and reporting one would date a
+    // publication that never happened.
+    const shaped = shapeDraftSnapshot({
+      ...base,
+      snapshot: { title: "pending" },
+    });
+
+    expect("firstPublishedAt" in shaped).toBe(false);
+    expect("id" in shaped).toBe(false);
+  });
+
+  it("keeps a synthesized column out when the document has none", () => {
+    // A plugin-contributed collection gets no synthesized slug/title pair, so
+    // claiming they exist would keep an obsolete key the schema never declared.
+    const shaped = shapeDraftSnapshot({
+      ...base,
+      hasSlug: false,
+      hasTitle: false,
+      fields: [text({ name: "body" })] as unknown as FieldConfig[],
+      snapshot: { body: "pending", slug: "stale", title: "stale" },
+    });
+
+    expect(shaped.body).toBe("pending");
+    expect({ slug: "slug" in shaped, title: "title" in shaped }).toEqual({
+      slug: false,
+      title: false,
+    });
+  });
+});

--- a/packages/nextly/src/domains/versions/draft-overlay.ts
+++ b/packages/nextly/src/domains/versions/draft-overlay.ts
@@ -1,0 +1,121 @@
+/**
+ * Whether one read surfaces a document's working draft, and which language's.
+ *
+ * The read-side mirror of {@link resolveDraftHold}, and deliberately the same
+ * shape: one call answering both "overlay?" and "under which key?", so no caller
+ * can arrive at "overlay" without also arriving at the key it must look under.
+ *
+ * ## Why this is shared rather than written per domain
+ *
+ * The write decides whether an edit is HELD; the read decides whether a held
+ * edit is SHOWN. When those two disagree the author is told the save succeeded
+ * and then shown the old content, which is the worst available outcome — worse
+ * than writing live, because nothing tells them their work is elsewhere.
+ *
+ * That has now happened twice from the same cause: a read carrying an exclusion
+ * the write had dropped. Once at the document level (a localized document held
+ * an edit no read would surface) and once at the component level (a collection
+ * embedding a LOCALIZED component held an edit the read refused to overlay,
+ * because the read still tested `schema.localized` after the write stopped).
+ * Both were invisible because each side looked correct on its own.
+ *
+ * Deriving both answers from {@link isDraftSplitEligible} and
+ * {@link workingDraftLocale} makes that class of divergence unrepresentable:
+ * there is one statement of what is eligible and one of where its draft lives.
+ *
+ * ## What stays with the caller
+ *
+ * The capability question — may this caller EDIT this document — is resolved by
+ * the domain and passed in, because collections and Singles ask it of different
+ * services against different rows. So is the assembly that follows an overlay:
+ * relation expansion and component population differ per domain, and are not a
+ * rule.
+ *
+ * @module domains/versions/draft-overlay
+ */
+
+import type { FieldConfig } from "../../collections/fields/types";
+
+import { isDraftSplitEligible } from "./draft-split-eligibility";
+import type { ComponentSchemas } from "./restore-snapshot";
+import { workingDraftLocale } from "./working-draft-locale";
+
+export interface DraftOverlayInput {
+  /** `status === true` — the document has the Draft/Published lifecycle. */
+  collectionHasStatus: boolean;
+  /** `versions?.drafts?.enabled === true`. */
+  draftsVersioningEnabled: boolean;
+  /** Whether the document itself is localized. */
+  documentLocalized: boolean;
+  /** Top-level fields, for the reachable-password check. */
+  fields: FieldConfig[];
+  /**
+   * Reachable component schemas. `null` is permitted for a CHEAP pre-check that
+   * skips resolution: with no schemas the eligibility test can only be more
+   * permissive, so a `false` answer is final while a `true` one is provisional
+   * and must be confirmed with resolved schemas before a draft is exposed.
+   */
+  componentSchemas: ComponentSchemas | null;
+  /**
+   * Whether the caller explicitly asked for the draft view.
+   *
+   * Opt-in on purpose: internal reads (duplicate, reference labels, expansion)
+   * issue status-less reads and must keep seeing the published row, so draft
+   * visibility follows an editor's intent rather than the absence of a filter.
+   */
+  includeWorkingDraft: boolean;
+  /** The status the request named. An explicit published view suppresses the draft. */
+  requestedStatus?: string | undefined;
+  /**
+   * Whether this caller may UPDATE this document.
+   *
+   * Resolved by the domain against the LOADED row, never inferred from a route
+   * having authorized a READ: an owner-only update rule passes the coarse check
+   * pending a row-level predicate, so treating a reader as an editor would leak
+   * one author's pending edits to another.
+   */
+  callerMayEdit: boolean;
+  /** The language being read, if the request named one. */
+  requestLocale?: string | null;
+  /** The app's default locale, for a request that named none. */
+  defaultLocale?: string | null;
+}
+
+export interface DraftOverlayDecision {
+  /** Whether to look for a working draft and overlay it on the live document. */
+  overlay: boolean;
+  /** The language whose draft to look for. `null` for an unlocalized document. */
+  draftLocale: string | null;
+}
+
+/**
+ * Resolve whether this read surfaces a working draft, and which language's.
+ */
+export function resolveDraftOverlay(
+  input: DraftOverlayInput
+): DraftOverlayDecision {
+  const draftLocale = workingDraftLocale({
+    documentLocalized: input.documentLocalized,
+    requestLocale: input.requestLocale ?? null,
+    defaultLocale: input.defaultLocale ?? null,
+  });
+
+  const eligible = isDraftSplitEligible({
+    collectionHasStatus: input.collectionHasStatus,
+    draftsVersioningEnabled: input.draftsVersioningEnabled,
+    fields: input.fields,
+    componentSchemas: input.componentSchemas,
+  });
+
+  const overlay =
+    eligible &&
+    input.includeWorkingDraft &&
+    input.callerMayEdit &&
+    input.requestedStatus !== "published" &&
+    // A localized document whose language this read cannot name has no slot to
+    // look in. Reading the unlocalized slot would report "no pending change" for
+    // a document that has one, which reads as the author's edit having vanished.
+    !(input.documentLocalized && draftLocale === null);
+
+  return { overlay, draftLocale };
+}

--- a/packages/nextly/src/domains/versions/draft-overlay.ts
+++ b/packages/nextly/src/domains/versions/draft-overlay.ts
@@ -40,6 +40,37 @@ import { isDraftSplitEligible } from "./draft-split-eligibility";
 import type { ComponentSchemas } from "./restore-snapshot";
 import { workingDraftLocale } from "./working-draft-locale";
 
+/**
+ * The three facts about a document that decide whether the split applies to it.
+ *
+ * Read through one function rather than cast at each call site: collections and
+ * Singles hold the same three properties in the same shape, and each reading
+ * them for itself is how the two ended up disagreeing about eligibility in the
+ * first place.
+ */
+export interface DraftDocumentConfig {
+  status?: boolean;
+  localized?: boolean;
+  versions?: { drafts?: { enabled?: boolean } } | null;
+}
+
+export interface DraftDocumentFacts {
+  collectionHasStatus: boolean;
+  draftsVersioningEnabled: boolean;
+  documentLocalized: boolean;
+}
+
+/** The split-relevant facts a document's config carries. */
+export function draftDocumentFacts(
+  config: DraftDocumentConfig
+): DraftDocumentFacts {
+  return {
+    collectionHasStatus: config.status === true,
+    draftsVersioningEnabled: config.versions?.drafts?.enabled === true,
+    documentLocalized: config.localized === true,
+  };
+}
+
 export interface DraftOverlayInput {
   /** `status === true` — the document has the Draft/Published lifecycle. */
   collectionHasStatus: boolean;

--- a/packages/nextly/src/domains/versions/shape-draft-snapshot.ts
+++ b/packages/nextly/src/domains/versions/shape-draft-snapshot.ts
@@ -1,0 +1,75 @@
+/**
+ * Shaping a stored working-draft snapshot into the document a read returns.
+ *
+ * A snapshot is written under one schema and read under whatever the schema is
+ * now. Between those two moments a field can be dropped or renamed, leaving a
+ * key the snapshot still carries that a live read of the same document no longer
+ * returns — so exposing the raw snapshot would show content the collection no
+ * longer declares, and hand it to hooks and field-level access that only inspect
+ * declared fields.
+ *
+ * The prune is the one the PROMOTE path applies, so what an editor is shown and
+ * what a publish would ship are shaped identically. The identity and timestamp
+ * columns it deliberately holds back — a restore must not resubmit them, a read
+ * carries them — are copied back afterwards.
+ *
+ * Pure and DI-free so the shaping can be tested directly, which is the half of
+ * an overlay that has no database in it.
+ *
+ * @module domains/versions/shape-draft-snapshot
+ */
+
+import type { FieldConfig } from "../../collections/fields/types";
+import { SYSTEM_TIMESTAMP_KEYS } from "../../shared/lib/case-conversion";
+
+import { buildRestorePayload } from "./restore-snapshot";
+import type { ComponentSchemas } from "./restore-snapshot";
+
+export interface ShapeDraftSnapshotInput {
+  /** The snapshot as stored. */
+  snapshot: Record<string, unknown>;
+  /** The document's fields, as currently declared. */
+  fields: FieldConfig[];
+  /** Reachable component schemas, for pruning inside component subtrees. */
+  componentSchemas: ComponentSchemas | undefined;
+  /**
+   * Whether the document synthesizes `slug` and `title` columns.
+   *
+   * A plugin-contributed collection gets no synthesized pair, so claiming they
+   * exist would keep an obsolete snapshot key the current schema never declared.
+   */
+  hasSlug: boolean;
+  hasTitle: boolean;
+}
+
+/**
+ * The document a draft read returns, pruned to the current schema.
+ */
+export function shapeDraftSnapshot(
+  input: ShapeDraftSnapshotInput
+): Record<string, unknown> {
+  const { payload } = buildRestorePayload(input.snapshot, input.fields, {
+    // Reaching this function at all means the draft/published split applied,
+    // which requires the lifecycle column.
+    hasStatus: true,
+    hasSlug: input.hasSlug,
+    hasTitle: input.hasTitle,
+    componentSchemas: input.componentSchemas,
+    // The snapshot holds exactly one language's values already, so it is shaped
+    // as an unlocalized document; which language it belongs to is the sidecar's
+    // key, not something the payload re-derives.
+    documentLocalized: false,
+    localeUnknown: false,
+  });
+
+  // Taken from the shared list rather than named here. Naming them is why the
+  // first-publication marker was once pruned from this view while an ordinary
+  // read of the same document returned it.
+  for (const key of ["id", ...SYSTEM_TIMESTAMP_KEYS]) {
+    if (key in input.snapshot) {
+      payload[key] = input.snapshot[key];
+    }
+  }
+
+  return payload;
+}


### PR DESCRIPTION
A Single's pending change is now **visible and discardable in its own editor**. It was write-only: the engine held the edit, publish promoted it, and nothing ever showed it — so an author saved, got the live values back, and had no way to tell their work had been kept.

Three commits, each with its own story.

## 1. One rule for holding and showing — and a live divergence it fixed

The **write** decided whether an edit is HELD through one shared rule. The **read** decided whether a held edit is SHOWN through an inline copy, and the copy still refused a **localized component** after the write stopped refusing it.

Reproduced before touching anything, by adding the draft-READ assertion to a test that had only asserted the write held:

```
AssertionError: expected 'live' to be 'edited'
```

An existing test asserted the read should fall back to live here, on the premise that *"no write can consume the sidecar"*. I measured that rather than trusting it:

```
publishSucceeded: true · liveTitle: "draft-title" · draftsLeft: 0
```

The premise was false. So the old behaviour meant an author was shown `live`, pressed Publish, and **shipped content they had never seen**. Rewritten to assert the invariant — what the editor is shown and what a publish would ship are the same document, asserted as a pair so neither half can drift alone.

Both halves of the read now derive from `resolveDraftOverlay`, the read-side mirror of `resolveDraftHold`.

## 2. The Singles read overlay — and a snapshot storing both spellings

Wiring the overlay returned `live` instead of `edited`. Probing the stored row directly:

```json
{"siteName": "live", "site_name": "edited"}
```

The draft accumulation spread a **column-keyed** payload onto a **field-keyed** base, so every edited field sat in the snapshot twice. Promote read the column and shipped correctly, which is exactly why no test caught it — the existing ones asserted the live row was untouched, that a draft row existed, and that publish promoted *something*. None asserted what the snapshot **contained**.

Fixed by mapping through the declared fields, which is what the localized branch three lines below already did. A blanket camel-case would be wrong: a field genuinely named `site_title` must keep its spelling.

The overlay's capability check is an actual UPDATE probe against the loaded row. `routeAuthorized` attests a READ on this path, so trusting it would hand one author's unpublished work to any authenticated reader.

## 3. The editor — and why the feature was dark

Two wiring gaps, each invisible to every test:

- **`SingleForm` never passed `draftsEnabled` to `EntrySystemHeader`**, so the header took its false branch, whose Save sends `status: "published"` — and a write that names a status is never held. The visible tell was the button label: **"Save changes"** rather than **"Save"**. Captured off the real request: `{…,"status":"published"}`.
- **`getSingleSchema`, the route the admin actually calls, never returned `draftsEnabled`.** A different file computed it for a surface the admin does not use. It is now derived there from `schemaDraftsEnabled` — the shared predicate whose own module says every call site must derive it.

**The playground had no Single with both the lifecycle and drafts versioning**, so the combination these surfaces are about was never exercised in development. That is the same gap that kept the collections feature dark until #1075. `announcement` now has both.

## Verified in the running product

Not only in tests, because both gaps above are invisible to a green suite:

- a status-less save stores `single|announcement|en|draft`
- the status pill reads **CHANGED**
- the language rail shows **`English | DEFAULT | CHANGES | published`** while Spanish stays clean — the flag is per-language because the overlay only sets it when a draft was actually applied
- **Discard draft** appears, removes that row, and resets the editor to PUBLISHED

## What fallow forced, and it was right each time

Three CRAP failures, none resolved by gaming a number:

- `shapeDraftSnapshot` — pure, 5 unit tests, replacing what would have been a second copy of the promote path's prune
- `draftDocumentFacts` — the three config properties collections and Singles each cast for themselves, now read through one function by both
- `useSingleEditorDocument` — the editor's read rules extracted from a page that my one added line had pushed past every threshold, with 7 tests pinning the rules whose failure mode is showing an author another language's text as their own

My first version of the shared contrast helper in an earlier PR added a fourth copy of a formula; the same discipline applies here. Nothing was suppressed.

## Gates

- Integration, three dialects: Postgres **1214 passed / 175 files**, MySQL **1156**, SQLite **472** over the touched domains. No failures.
- `packages/nextly` versions unit: **388 passed**.
- `packages/admin`: **15 failures across `StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField`** — identical file set to the recorded baseline, all pre-existing.
- `check-types` clean on both configs; fallow `pass`, all four `*_introduced` at 0.

Break-verified throughout: restoring the column-shaped spread fails exactly the two tests that name it (`{shown:'live', shipped:'edited'}`); removing the locale predicate from the discard hook fails the cache-isolation case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added working-draft support for localized Singles.
  * Editors can save, view, and discard Single drafts by locale.
  * Draft-enabled Single configurations now expose draft status in the admin interface.
  * Draft reads are available when explicitly requested and authorized.
* **Bug Fixes**
  * Improved localized draft isolation and translation source handling.
  * Preserved draft content consistently through publishing and schema changes.
  * Prevented obsolete fields and duplicate field names from appearing in drafts.
* **Tests**
  * Added coverage for draft editing, localization, publishing, discarding, and schema updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->