### PR TITLE
test(playground): a harness route that mounts the real canvas

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -65,6 +65,16 @@
   //     bin shim and one page-builder spec. Present after `pnpm build` and
   //     absent on a clean checkout, so gating on them would make the verdict
   //     depend on build order.
+  //   @nextlyhq/ui/styles.css and @nextlyhq/builder/styles.css = declared
+  //     exports subpaths that resolve to build output — ./dist/styles.css and
+  //     ./dist/builder-chrome.css — and `dist` is gitignored. Same build-order
+  //     dependence as the two above, and measured as exactly that: a local
+  //     audit after `pnpm build` resolves both and reports no issue, while CI
+  //     audits after install and before build and reports both unresolved. The
+  //     harness routes that import them cannot drop the imports: the editor's
+  //     sheet ships neither the `--nx-*` tokens nor the base reset, because the
+  //     host owns both, so without them the shell renders with its colours
+  //     resolving to nothing — which is a bug the shell suite has a test for.
   //
   // Every entry is an exact specifier rather than a prefix. These match the
   // raw import string, so `../dist/**` would also swallow a typo like
@@ -75,6 +85,8 @@
     "nextly/field-catalog",
     "../dist/cli.mjs",
     "../dist/render/index.js",
+    "@nextlyhq/ui/styles.css",
+    "@nextlyhq/builder/styles.css",
   ],
 
   // Three pnpm `overrides` entries pin a version of a package nothing here

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -26,6 +26,7 @@
     "@nextlyhq/adapter-postgres": "workspace:^",
     "@nextlyhq/adapter-sqlite": "workspace:^",
     "@nextlyhq/admin": "workspace:^",
+    "@nextlyhq/blocks-engine": "workspace:^",
     "@nextlyhq/blocks-react": "workspace:^",
     "@nextlyhq/builder": "workspace:*",
     "@nextlyhq/plugin-form-builder": "workspace:^",

--- a/apps/playground/src/app/builder-canvas/harness.tsx
+++ b/apps/playground/src/app/builder-canvas/harness.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import {
+  hasBlock,
+  registerBlocks,
+  registryNestingSource,
+} from "@nextlyhq/blocks-engine";
+import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
+import { registrySlotSource } from "@nextlyhq/builder";
+import {
+  Canvas,
+  DropIndicator,
+  useCanvasDrag,
+  useEditorState,
+} from "@nextlyhq/builder/shell";
+import { useMemo } from "react";
+
+// The design system's sheet FIRST, then the editor's, which supplements it —
+// the same order and the same reason as the shell harness: the editor's sheet
+// ships neither the `--nx-*` tokens nor the base reset, because the host owns
+// both and a second copy would make the result depend on which one won.
+import "@nextlyhq/ui/styles.css";
+import "@nextlyhq/builder/styles.css";
+
+import { canvasHarnessDocument } from "./seed";
+
+const HARNESS_SOURCE = "e2e-canvas-harness";
+
+/**
+ * The canvas, mounted for real, so a browser can drive it.
+ *
+ * SEPARATE from the shell harness on purpose. That route's slots are inert by
+ * decision — its own docblock says "anything interactive here would be testing
+ * the harness rather than the shell" — and its twenty-seven passing tests
+ * measure the shell's geometry against markers. Mounting a live canvas into it
+ * would put a moving, scrolling, drag-handling surface inside the box those
+ * tests measure, so the two harnesses would share a failure mode with nothing
+ * naming which one broke.
+ *
+ * So the shell keeps its markers and this route mounts the real thing: `Canvas`
+ * with `useCanvasDrag`, over a document with the neighbours the drop rules
+ * actually turn on. No shell chrome at all — the rail, panels and top bar are
+ * the shell's subject, not the canvas's, and a canvas that fills the viewport
+ * is the one a pointer test can reach every edge of.
+ *
+ * What this harness must NOT do is compute anything the canvas computes. It
+ * seeds a document and renders the editor's own components; every threshold,
+ * every drop decision and every indicator position comes from the engine under
+ * test. A harness that positioned its own indicator would certify itself.
+ */
+export function BuilderCanvasHarness() {
+  /*
+   * Register the core blocks before anything reads the registry.
+   *
+   * Only the ones missing, and through the same guarded call the production
+   * host uses: the registry is process-wide, so a second unconditional
+   * registration throws on a dev-server hot reload where the module is
+   * re-evaluated but the registry survives.
+   */
+  useMemo(() => {
+    const missing = coreBlocks.filter(block => !hasBlock(block.name));
+    if (missing.length > 0) registerBlocks(missing, { source: HARNESS_SOURCE });
+  }, []);
+
+  const initialDocument = useMemo(() => canvasHarnessDocument(), []);
+  const editor = useEditorState({ initialDocument });
+
+  /*
+   * Both drop questions answered by the SAME registry the inserter reads, which
+   * is the production wiring rather than a harness shortcut. Given separate
+   * sources, a container the palette would insert into and a container a drag
+   * may aim at could disagree — and a suite built on the disagreement would
+   * certify the wrong rule.
+   */
+  const slots = useMemo(() => registrySlotSource(), []);
+  const nesting = useMemo(() => registryNestingSource(), []);
+  const drag = useCanvasDrag({ editor, slots, nesting });
+
+  /*
+   * The site sheet the published route passes. Empty breakpoint sets: this
+   * fixture asserts nothing responsive, and a breakpoint here would make the
+   * canvas's own width one more thing a drop coordinate depends on.
+   */
+  const siteStyles = useMemo(
+    () => ({ breakpoints: { viewport: [], container: [] } }),
+    []
+  );
+
+  return (
+    <div
+      data-testid="canvas-harness"
+      /*
+       * A fixed, non-viewport height with its own scroll, because autoscroll is
+       * one of the properties under test and it engages on the canvas's
+       * scrollable box. A canvas sized to the window would make the test depend
+       * on the browser's own scrolling instead.
+       */
+      style={{ height: "100vh", overflow: "auto" }}
+      /*
+       * Reported rather than asserted here: the drag's live state, so a test can
+       * read what the ENGINE decided instead of inferring it from pixels. A
+       * property about which target is active is otherwise only observable
+       * through the indicator's position, which is a second derivation of the
+       * same fact and fails for a different reason than the rule it stands in
+       * for.
+       */
+      data-nx-dragging={drag.draggingId ?? ""}
+      data-nx-drop-target={drag.target ? JSON.stringify(drag.target) : ""}
+    >
+      <Canvas
+        document={editor.document}
+        siteStyles={siteStyles}
+        selectedId={editor.selectedId}
+        selectedIds={editor.selection.ids}
+        onSelect={editor.select}
+        dragHandlers={drag.handlers}
+        overlay={<DropIndicator target={drag.target} />}
+      />
+    </div>
+  );
+}

--- a/apps/playground/src/app/builder-canvas/page.tsx
+++ b/apps/playground/src/app/builder-canvas/page.tsx
@@ -1,0 +1,33 @@
+import { notFound } from "next/navigation";
+
+import { BuilderCanvasHarness } from "./harness";
+
+/**
+ * A harness route for the canvas itself.
+ *
+ * The canvas's guarantees are about POINTER MOTION — a press that travels far
+ * enough becomes a drag, a target that stops switching under jitter, an
+ * indicator that leads the pointer into a gap — and none of them is checkable
+ * from a unit test. `useCanvasDrag` reads live `clientX`/`clientY` off real
+ * `pointermove` events and keys both its activation and its switch hysteresis on
+ * ACCUMULATED TRAVEL, so a test that sets a position rather than moving through
+ * one exercises none of the machinery and passes against a canvas that is broken
+ * for a real user. jsdom cannot help either: it reports every element as
+ * zero-sized, and every drop decision here is a statement about rectangles.
+ *
+ * Separate from `/builder-shell`, which stays inert. That route's slots are
+ * markers by decision — its docblock says anything interactive there would test
+ * the harness rather than the shell — and its suite measures the shell's
+ * geometry against those markers. A live canvas inside that box would be a
+ * moving, scrolling surface in the middle of what those tests measure.
+ *
+ * Same env gate as the shell harness and the style fixture, for the same reason
+ * those have one: a dev-only route under `src/app/` is otherwise reachable in
+ * `pnpm dev:app` and indistinguishable from product. That exact shape once put a
+ * test-double plugin into a contributor's real plugins list.
+ */
+export default async function BuilderCanvasHarnessRoute() {
+  if (process.env.NEXTLY_E2E_CANVAS_HARNESS !== "1") notFound();
+
+  return <BuilderCanvasHarness />;
+}

--- a/apps/playground/src/app/builder-canvas/seed.ts
+++ b/apps/playground/src/app/builder-canvas/seed.ts
@@ -1,0 +1,73 @@
+import type { BlockDocument } from "@nextlyhq/blocks-engine";
+
+/**
+ * The document the canvas harness opens with.
+ *
+ * Hand-authored rather than generated, because every property the acceptance
+ * suite checks is a statement about SPECIFIC neighbours: which region owns a
+ * point, where a switch boundary falls between two blocks, whether an indicator
+ * leads the pointer into the gap between them. A generated tree makes those
+ * assertions depend on the generator, and a change to it would move the
+ * boundaries the tests pin without any test naming the change.
+ *
+ * Ids are literal and stable for the same reason. The suite addresses nodes by
+ * id, so a fresh uuid per render would make every selector a guess.
+ *
+ * The MIX of heights is the point of the fixture, not decoration. `core/divider`
+ * renders a hairline and `core/spacer` takes its height from the style system
+ * with no lower bound — the two shapes that refuted every size-based drop rule
+ * this engine was built to replace, in the author's own words: "any minimum size
+ * excludes some authored block and makes it impossible to drop beside." A
+ * fixture of uniformly-sized text blocks would let a height-thresholded
+ * implementation pass the suite it is supposed to fail.
+ *
+ * `version` is required on every node and is the block definition's schema
+ * version — 1 for every core block today. Forgiving rendering and the manifest
+ * version stamp both read it unconditionally.
+ */
+export function canvasHarnessDocument(): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      // `level` is a select over HEADING_LEVELS and its values are strings:
+      // `defaultProps` is `{ text: "", level: "h2" }`, not a number.
+      {
+        id: "hx-heading",
+        type: "core/heading",
+        version: 1,
+        props: { text: "Canvas harness", level: "h1" },
+      },
+      {
+        id: "hx-text-tall",
+        type: "core/text",
+        version: 1,
+        props: {
+          text: "A deliberately tall block, so the blocks above and below it differ in height. Ranking a drop by distance to a zone's MIDDLE puts the switch boundary at each child's centre whatever the children's sizes are, which is exactly what goes wrong once adjacent blocks differ — so the fixture has to contain that difference or the rule under test is never exercised.",
+        },
+      },
+      // A hairline. Any rule that reads a block's height as a threshold makes
+      // this one impossible to drop beside.
+      { id: "hx-divider", type: "core/divider", version: 1, props: {} },
+      {
+        id: "hx-text-short",
+        type: "core/text",
+        version: 1,
+        props: { text: "Short." },
+      },
+      // No props at all by declaration: the spacer's height comes from the
+      // style system (`supports.dimensions`), which is the other end of the
+      // same problem as the divider — a block whose size is authored, with no
+      // floor a drop rule could rely on.
+      { id: "hx-spacer", type: "core/spacer", version: 1, props: {} },
+      {
+        id: "hx-text-last",
+        type: "core/text",
+        version: 1,
+        props: {
+          text: "The last sibling at the root, so a drop AFTER the final child is reachable and distinguishable from a drop into nothing.",
+        },
+      },
+    ],
+  };
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -125,6 +125,10 @@ export default defineConfig({
       // reason: a dev-only route under `src/app/` is otherwise reachable in
       // `pnpm dev:app` and indistinguishable from product.
       NEXTLY_E2E_SHELL_HARNESS: "1",
+      // The canvas harness route. Separate from the shell's because the two
+      // harnesses are deliberately different: the shell's slots are inert
+      // markers, and this one mounts the real canvas so a pointer can drive it.
+      NEXTLY_E2E_CANVAS_HARNESS: "1",
     },
   },
 

--- a/e2e/tests/canvas/harness-route.spec.ts
+++ b/e2e/tests/canvas/harness-route.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * The canvas harness route is real, and the canvas on it is live.
+ *
+ * NOT the twelve-point acceptance suite — that is its own task and its own
+ * file. This spec certifies the thing that suite will stand on: that a browser
+ * can reach a mounted `Canvas` driven by `useCanvasDrag`, over a document whose
+ * blocks are actually there. Until this passes, every canvas property is
+ * untestable in a browser for want of a route rather than for want of a test.
+ *
+ * It asserts its POPULATION before it asserts anything else. A drag test
+ * against an empty canvas reports the same green as a drag test against a
+ * working one, and this programme has already paid for that twice — a fixture
+ * whose block insert silently missed, twice read as "no save and no warning".
+ */
+
+const ROUTE = "/builder-canvas";
+
+/** The renderer's own attribute. NOT `data-nx-id`, which nothing emits. */
+const NODE = "[data-nx-node]";
+
+/** The seeded ids, in document order. */
+const SEEDED = [
+  "hx-heading",
+  "hx-text-tall",
+  "hx-divider",
+  "hx-text-short",
+  "hx-spacer",
+  "hx-text-last",
+];
+
+test.describe("the canvas harness route", () => {
+  test("renders every seeded block, addressable by id", async ({ page }) => {
+    await page.goto(ROUTE);
+
+    // The population, before any claim about behaviour.
+    await expect(page.locator(NODE)).toHaveCount(SEEDED.length);
+
+    const ids = await page
+      .locator(NODE)
+      .evaluateAll(nodes =>
+        nodes.map(node => node.getAttribute("data-nx-node"))
+      );
+    expect(ids).toEqual(SEEDED);
+  });
+
+  test("the canvas is live: a click selects the block under the pointer", async ({
+    page,
+  }) => {
+    await page.goto(ROUTE);
+    await expect(page.locator(NODE)).toHaveCount(SEEDED.length);
+
+    const heading = page.locator('[data-nx-node="hx-heading"]');
+    // Nothing is selected before the click — the positive control for the
+    // assertion below, which would otherwise pass against a canvas that marks
+    // everything selected.
+    await expect(page.locator("[data-nx-selected]")).toHaveCount(0);
+
+    await heading.click();
+
+    await expect(heading).toHaveAttribute("data-nx-selected", "primary");
+  });
+
+  test("a press that does not travel is a click, not a drag", async ({
+    page,
+  }) => {
+    await page.goto(ROUTE);
+    const harness = page.locator('[data-testid="canvas-harness"]');
+    await expect(page.locator(NODE)).toHaveCount(SEEDED.length);
+
+    const box = await page
+      .locator('[data-nx-node="hx-text-short"]')
+      .boundingBox();
+    if (box === null) throw new Error("the seeded block has no box to press");
+
+    // Two pixels: inside the 4px activation threshold the engine keys on
+    // accumulated travel. A drag must NOT start.
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width / 2 + 2, box.y + box.height / 2, {
+      steps: 4,
+    });
+
+    await expect(harness).toHaveAttribute("data-nx-dragging", "");
+
+    await page.mouse.up();
+
+    // The document did not reorder.
+    const ids = await page
+      .locator(NODE)
+      .evaluateAll(nodes =>
+        nodes.map(node => node.getAttribute("data-nx-node"))
+      );
+    expect(ids).toEqual(SEEDED);
+  });
+
+  test("a press that travels far enough DOES start a drag", async ({
+    page,
+  }) => {
+    await page.goto(ROUTE);
+    const harness = page.locator('[data-testid="canvas-harness"]');
+    await expect(page.locator(NODE)).toHaveCount(SEEDED.length);
+
+    const box = await page
+      .locator('[data-nx-node="hx-text-short"]')
+      .boundingBox();
+    if (box === null) throw new Error("the seeded block has no box to press");
+
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    // Well past the 4px activation threshold, moved through intermediate
+    // points rather than jumped: the engine accumulates travel from real
+    // `pointermove` events, so a single hop exercises none of it.
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 - 60, {
+      steps: 12,
+    });
+
+    // The engine's own report, not an inference from pixels.
+    await expect(harness).toHaveAttribute("data-nx-dragging", "hx-text-short");
+
+    await page.mouse.up();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       '@nextlyhq/admin':
         specifier: workspace:^
         version: link:../../packages/admin
+      '@nextlyhq/blocks-engine':
+        specifier: workspace:^
+        version: link:../../packages/blocks-engine
       '@nextlyhq/blocks-react':
         specifier: workspace:^
         version: link:../../packages/blocks-react
@@ -12523,7 +12526,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.10.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -12593,7 +12596,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.10.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.10':
     dependencies:


### PR DESCRIPTION
The canvas had nowhere a browser could drive it, so every property of the drag engine was untestable in a browser for want of a **route** rather than for want of a test. This adds one, plus the spec that proves it is live.

## Why a second route

`/builder-shell` fills its canvas slot with an inert marker **by decision** — its own docblock says anything interactive there would test the harness rather than the shell — and its 27 passing tests measure the shell's geometry against those markers. A live, scrolling, drag-handling canvas inside the box they measure would give the two harnesses one failure mode with nothing naming which one broke. So the shell keeps its markers and `/builder-canvas` mounts the real `Canvas` with `useCanvasDrag`.

Gated by `NEXTLY_E2E_CANVAS_HARNESS`, the same convention and the same reason as `NEXTLY_E2E_SHELL_HARNESS` and `NEXTLY_E2E_STYLE_FIXTURE`: a dev-only route under `src/app/` is otherwise reachable in `pnpm dev:app` and indistinguishable from product.

## The fixture's heights are the point

`core/divider` renders a hairline and `core/spacer` takes its height from the style system with no lower bound — the two shapes that refuted every size-based drop rule this engine replaced (`fd5355c06`: "any minimum size excludes some authored block and makes it impossible to drop beside"). A fixture of uniform text blocks would let a height-thresholded implementation pass the suite that exists to fail it.

## Evidence

- `playwright test canvas/harness-route` → **4 passed**, re-run after the final lint fix rather than carried forward.
- `playground` lint, `tsc --noEmit`, and `vitest run` (**19 passed**) all clean; `e2e` lint and `check-types` clean.
- The spec asserts its **population** first — six seeded nodes, in order — because a drag test against an empty canvas reports the same green as one against a working canvas.
- The activation pair is self-controlling: 2px of travel must stay a click, 60px must become a drag. Neither can pass against an inert canvas.

## The two `ignoreUnresolvedImports` entries

`@nextlyhq/ui/styles.css` and `@nextlyhq/builder/styles.css` are declared exports subpaths resolving to build output (`./dist/styles.css`, `./dist/builder-chrome.css`) under a gitignored `dist`, so a clean checkout cannot resolve them — the same build-order dependence the entries above them document.

Verified rather than assumed, with the cache off and the built CSS absent: **without** the entries the audit reports exactly the two unresolved imports CI reported, **with** them the changed files are clean. (A first attempt with the cache on failed to reproduce and would have shipped an unverified fix.)

The imports cannot simply be dropped — the editor's sheet ships neither the `--nx-*` tokens nor the base reset, because the host owns both, so without them the shell renders with its colours resolving to nothing, which the shell suite has a test for.

## Two things worth a reviewer's eye

- **`data-nx-node`, not `data-nx-id`.** That is the attribute `block-boundary.tsx` actually emits. A surviving comment in `e2e/tests/canvas/driver.ts` still names `data-nx-id`, and the twelve-point suite built on that name would match nothing.
- **`@nextlyhq/blocks-engine` becomes a playground dependency**, because `registerBlocks` / `hasBlock` / `registryNestingSource` live only there; `blocks-react` re-exports the document type but not the registry.

No changeset: test infrastructure, and the playground is private.

Follow-up (not in this PR): rebuild the twelve-point acceptance suite on this route. The original was retired in `c12e43472` along with the PoC canvas it drove.