### PR TITLE
fix(plugin-page-builder): render the author's node styles in the editor canvas

### DIFF
--- a/.changeset/editor-canvas-renders-node-styles.md
+++ b/.changeset/editor-canvas-renders-node-styles.md
@@ -1,0 +1,45 @@
+---
+
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+
+The editor canvas drew every block flush and unstyled while the published page drew the author's
+real spacing. An author setting a margin, a height or any other per-node style saw nothing change
+until they published.
+
+Node styles are a SEPARATE tier from the site sheet, and `PageRenderer` compiles them only when it
+is handed a style context. The public routes pass one; the editor never did. The failure is silent
+by construction rather than loud: `resolvePageStyles` withholds the sheet and keeps the class names,
+so every block carried its `nx-pb-<hash>` class and nothing defined it — the markup looked correct
+and the page looked unstyled.
+
+Measured both ways on one document, with the style context the only variable: without it, zero
+scoped rules, zero gaps between siblings and a spacer collapsed to zero pixels; with it, six rules,
+24px gaps and the spacer at its authored 48px. That collapse is also why dragging felt broken —
+the 2px drop indicator had no gap to draw into and landed on top of flush text.
+
+The breakpoints come from `siteBreakpoints()` rather than a set spelled at the call site, because
+`site-style.ts` exists so the field validator and the canvas cannot disagree about what this site's
+breakpoints are. The canvas is now its third consumer.

--- a/apps/playground/src/app/builder-canvas/harness.tsx
+++ b/apps/playground/src/app/builder-canvas/harness.tsx
@@ -110,6 +110,14 @@ export function BuilderCanvasHarness() {
       <Canvas
         document={editor.document}
         siteStyles={siteStyles}
+        // Mirrors what `BlocksField` passes. The per-node style tier compiles
+        // only when the renderer is given a style context, and without it the
+        // canvas draws every block flush and unstyled while the published page
+        // draws the author's real spacing — so a harness omitting it would
+        // certify a canvas nobody ships.
+        render={{
+          styleContext: { breakpoints: { viewport: [], container: [] } },
+        }}
         selectedId={editor.selectedId}
         selectedIds={editor.selection.ids}
         onSelect={editor.select}

--- a/apps/playground/src/app/builder-canvas/seed.ts
+++ b/apps/playground/src/app/builder-canvas/seed.ts
@@ -25,6 +25,27 @@ import type { BlockDocument } from "@nextlyhq/blocks-engine";
  * version — 1 for every core block today. Forgiving rendering and the manifest
  * version stamp both read it unconditionally.
  */
+/**
+ * The gap between siblings, in CSS pixels.
+ *
+ * Real gaps are not decoration. Acceptance property 6 is "the indicator leads
+ * the pointer into a 6px gap" and property 4 is "zero layout shift when drop
+ * zones appear" — neither is expressible on a document whose blocks are flush,
+ * and an unstyled document is exactly that: every block's top equals the
+ * previous block's bottom, to the pixel.
+ */
+const GAP_PX = "24px";
+
+/**
+ * Applied to every sibling.
+ *
+ * `margin: { blockEnd }`, not `marginBottom`. The catalog is LOGICAL and
+ * structured (`catalog.ts:282-285`, `logicalSides`); a physical `marginBottom`
+ * is rejected outright as `unknown-style-property`. Measured by compiling this
+ * document rather than guessed.
+ */
+const GAP = { base: { base: { margin: { blockEnd: GAP_PX } } } } as const;
+
 export function canvasHarnessDocument(): BlockDocument {
   return {
     formatVersion: 1,
@@ -37,6 +58,7 @@ export function canvasHarnessDocument(): BlockDocument {
         type: "core/heading",
         version: 1,
         props: { text: "Canvas harness", level: "h1" },
+        styles: GAP,
       },
       {
         id: "hx-text-tall",
@@ -45,21 +67,41 @@ export function canvasHarnessDocument(): BlockDocument {
         props: {
           text: "A deliberately tall block, so the blocks above and below it differ in height. Ranking a drop by distance to a zone's MIDDLE puts the switch boundary at each child's centre whatever the children's sizes are, which is exactly what goes wrong once adjacent blocks differ — so the fixture has to contain that difference or the rule under test is never exercised.",
         },
+        styles: GAP,
       },
       // A hairline. Any rule that reads a block's height as a threshold makes
       // this one impossible to drop beside.
-      { id: "hx-divider", type: "core/divider", version: 1, props: {} },
+      {
+        id: "hx-divider",
+        type: "core/divider",
+        version: 1,
+        props: {},
+        styles: GAP,
+      },
       {
         id: "hx-text-short",
         type: "core/text",
         version: 1,
         props: { text: "Short." },
+        styles: GAP,
       },
       // No props at all by declaration: the spacer's height comes from the
       // style system (`supports.dimensions`), which is the other end of the
       // same problem as the divider — a block whose size is authored, with no
       // floor a drop rule could rely on.
-      { id: "hx-spacer", type: "core/spacer", version: 1, props: {} },
+      {
+        id: "hx-spacer",
+        type: "core/spacer",
+        version: 1,
+        props: {},
+        // Its height is AUTHORED, with no floor a drop rule could lean on.
+        // Unstyled it renders zero pixels tall and shares a `top` with the
+        // block after it, which makes it unhittable and silently deletes the
+        // case this fixture exists to cover.
+        styles: {
+          base: { base: { height: "48px", margin: { blockEnd: GAP_PX } } },
+        },
+      },
       {
         id: "hx-text-last",
         type: "core/text",
@@ -67,6 +109,7 @@ export function canvasHarnessDocument(): BlockDocument {
         props: {
           text: "The last sibling at the root, so a drop AFTER the final child is reachable and distinguishable from a drop into nothing.",
         },
+        styles: GAP,
       },
     ],
   };

--- a/e2e/tests/canvas/harness-route.spec.ts
+++ b/e2e/tests/canvas/harness-route.spec.ts
@@ -121,4 +121,69 @@ test.describe("the canvas harness route", () => {
 
     await page.mouse.up();
   });
+
+  test("renders the author's own node styles, not just their class names", async ({
+    page,
+  }) => {
+    await page.goto(ROUTE);
+    await expect(page.locator(NODE)).toHaveCount(SEEDED.length);
+
+    // The POSITIVE CONTROL for everything below: the fixture has to carry
+    // styles at all. A seed that lost them would make every assertion here
+    // pass against a canvas that renders nothing — which is exactly how this
+    // regression was introduced and then re-discovered.
+    const authored = await page.locator(NODE).evaluateAll(nodes =>
+      nodes.map(node => {
+        const cls = [...node.classList].find(c => c.startsWith("nx-pb-"));
+        return cls ?? null;
+      })
+    );
+    expect(authored.every(c => c !== null)).toBe(true);
+
+    // The class alone proves nothing: `resolvePageStyles` keeps class names
+    // even when it withholds the sheet, so a canvas given no style context
+    // emits every class and defines none of them. Assert the RULES exist.
+    const scopedRules = await page.evaluate(() => {
+      let count = 0;
+      for (const sheet of Array.from(document.styleSheets)) {
+        let rules: CSSRuleList;
+        try {
+          rules = sheet.cssRules;
+        } catch {
+          continue;
+        }
+        for (const rule of Array.from(rules)) {
+          if (rule.cssText.includes("nx-pb-") && rule.cssText.includes("{")) {
+            count += 1;
+          }
+        }
+      }
+      return count;
+    });
+    expect(scopedRules).toBeGreaterThan(0);
+
+    // And that they took effect. Geometry rather than computed style, because
+    // a rule can exist and lose the cascade: the authored 24px gaps are what
+    // the drop indicator needs somewhere to draw, and the spacer's authored
+    // height is what makes it hittable at all.
+    const { gaps, spacerHeight } = await page.evaluate(() => {
+      const nodes = Array.from(document.querySelectorAll("[data-nx-node]"));
+      const boxes = nodes.map(node => {
+        const rect = node.getBoundingClientRect();
+        return {
+          id: node.getAttribute("data-nx-node"),
+          top: Math.round(rect.top),
+          height: Math.round(rect.height),
+        };
+      });
+      return {
+        gaps: boxes
+          .slice(1)
+          .map((box, i) => box.top - (boxes[i].top + boxes[i].height)),
+        spacerHeight: boxes.find(box => box.id === "hx-spacer")?.height ?? null,
+      };
+    });
+    expect(gaps.every(gap => gap > 0)).toBe(true);
+    expect(spacerHeight).toBeGreaterThan(0);
+  });
 });

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -74,7 +74,7 @@ import {
 } from "react-hook-form";
 
 import { emptyBlockDocument } from "../fields/blocks-document";
-import { siteSheet } from "../site-style";
+import { siteBreakpoints, siteSheet } from "../site-style";
 
 import { BlocksSummary } from "./BlocksSummary";
 import { DocumentStatusPill } from "./DocumentStatusPill";
@@ -484,6 +484,27 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             selectedId={editor.selectedId}
             selectedIds={editor.selection.ids}
             onSelect={editor.select}
+            // The per-node style tier, which is a SEPARATE input from
+            // `siteStyles` and was reaching only the published page.
+            //
+            // `PageRenderer` compiles a document's own node styles only when it
+            // is given a style context; without one `resolvePageStyles`
+            // withholds the sheet and — in its own words — "Classes are kept
+            // either way, so blocks still carry the names the rest of the
+            // system expects". The symptom is therefore silent and specific:
+            // every block carries its `nx-pb-<hash>` class and nothing defines
+            // it, so an author's margins, spacing and dimensions render on the
+            // published page and vanish in the editor. Measured before this
+            // line existed: the same document rendered zero scoped rules and
+            // flush blocks here, six rules and 24px gaps through the public
+            // route.
+            //
+            // The breakpoints come from `siteBreakpoints()` rather than a set
+            // spelled here, because `site-style.ts` exists precisely so the
+            // field validator and the canvas cannot disagree about what this
+            // site's breakpoints are — and this is now the third consumer of
+            // that one answer.
+            render={{ styleContext: { breakpoints: siteBreakpoints() } }}
             dragHandlers={drag.handlers}
             // The pointer route into typing a block's text. Its keyboard
             // counterpart is the Enter binding above, registered in the same


### PR DESCRIPTION
## The bug

The editor canvas drew every block **flush and unstyled** while the published page drew the author's real spacing. Set a margin or a height on a block and nothing changed until you published it.

## Why it was silent

Node styles are a **separate tier** from the site sheet. `PageRenderer` compiles them only when handed a `styleContext`. The public routes pass one (`blocks-react/src/next.ts:352,380,967,1013`); `BlocksField` never did.

`resolvePageStyles` then withholds the sheet **and keeps the class names** — in its own words, *"Classes are kept either way, so blocks still carry the names the rest of the system expects."* So every block carried its `nx-pb-<hash>` class with nothing defining it. The markup looked right, the page looked unstyled, and nothing raised.

## Evidence

One document, style context as the only variable:

| | scoped CSS rules | gaps between siblings | spacer height |
|---|---|---|---|
| before | **0** | 0, 0, 0, 0, 0 | **0px** |
| after | **6** | 24, 24, 24, 24, 24 | **48px** (its authored value) |

## This also explains "drag and drop is broken"

It isn't. A full drag reorders the document correctly and the indicator resolves a valid target — verified in a browser. But with every block flush, the 2px drop indicator had **no gap to draw into** and landed on top of text, so the gesture looked like it did nothing. The styling collapse was the visible symptom.

## Where the breakpoints come from

`siteBreakpoints()`, not a set spelled at the call site. `site-style.ts` exists precisely so the field validator and the canvas cannot disagree about this site's breakpoints; the canvas is now its third consumer.

## The fixture

The harness seed regains what makes it a fixture: an authored spacer height and gaps for an indicator to land in. Note its seed uses `margin: { blockEnd }` — the style catalog is **logical and structured** (`catalog.ts:282-285`), and a physical `marginBottom` is rejected as `unknown-style-property`.

## Verification

- New spec `renders the author's own node styles, not just their class names` — **fails without this change** (verified by removing the context, watching it go red, then restoring)
- `playwright test canvas/harness-route` → **5 passed**
- `plugin-page-builder` → **69 tests passed**, typecheck and lint clean
- `playground` and `e2e` lint + typecheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled node-specific responsive styles in the page builder canvas using site breakpoints.
  * Added visible spacing between canvas blocks and ensured spacer elements occupy their configured height.

* **Bug Fixes**
  * Improved canvas rendering so authored styles are applied correctly, beyond generating style class names.

* **Tests**
  * Added end-to-end coverage verifying responsive styles, block spacing, and spacer dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->