### PR TITLE
fix(ci): the browser job never used its own Playwright cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,8 +601,41 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
-      - name: Install Chromium
+      # `--with-deps` shells out to apt on EVERY run, and apt fetches ~21MB of
+      # CJK and legacy font packages that `ubuntu-latest` does not ship. Twice on
+      # 2026-08-19 the public mirror served those at a few hundred kB/minute and
+      # the job burned its whole 20-minute budget inside this step without
+      # reaching a single test. Retries and a per-request timeout turn a slow
+      # mirror into a retried request rather than a stalled job.
+      - name: Harden apt before the Chromium dependency install
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-ci-retries >/dev/null <<'APT'
+          Acquire::Retries "5";
+          Acquire::http::Timeout "15";
+          Acquire::https::Timeout "15";
+          APT
+
+      # The cache above declared an `id` and NOTHING read it, so the browser
+      # download ran unconditionally — the comment above it says a download is
+      # most of this job's runtime, which was the intent this restores.
+      #
+      # Two branches rather than one, because a cache hit still needs the SYSTEM
+      # libraries: they live in /usr, `ubuntu-latest` is a fresh VM per job, and
+      # no browser cache carries them. Skipping them on a hit produces
+      # "Host system is missing dependencies" instead of a fast job.
+      #
+      # `timeout-minutes` on both, deliberately shorter than the job's 20: a
+      # stuck mirror should fail HERE, named and in five minutes, rather than
+      # consume the whole budget and report an ambiguous cancellation.
+      - name: Install Chromium and its system dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 5
         run: pnpm --filter @nextlyhq/e2e exec playwright install --with-deps chromium
+
+      - name: Install Chromium's system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 5
+        run: pnpm --filter @nextlyhq/e2e exec playwright install-deps chromium
 
       # The playground loads the admin and the plugins from their built output,
       # not their source, so a stale dist is a stale test.


### PR DESCRIPTION
## What was wrong

The `Browser tests` job cached Playwright browsers under `id: playwright-cache` — and **nothing ever read `cache-hit`**. So the install ran unconditionally every time, while the comment directly above the cache step says *"a download is most of this job's runtime"*. This restores the intent that comment describes.

## The measured failure

`--with-deps` shells out to `apt`, which fetches ~21MB of CJK and legacy font packages `ubuntu-latest` does not ship. On 2026-08-19 the public mirror served them at a few hundred kB/minute — **twice**:

```
16:11:37  Get:2 fonts-ipafont-gothic  3.5MB
16:16:25  Get:3 fonts-freefont-ttf    5.6MB   ← ~5 min for one package
16:26:55  Get:4 fonts-tlwg-loma-otf   107kB   ← ~10 min
16:29:59  ##[error]The operation was canceled  ← 20-min job budget gone
```

Both runs died in that step. Neither reached a single test.

## What this changes

| | |
|---|---|
| **Cache guard** | The install is skipped when the browser cache hits — the intent that was written and never wired |
| **Two branches** | A cache hit still installs *system deps*. They live in `/usr`, the runner is a fresh VM per job, and no browser cache carries them; skipping them yields `Host system is missing dependencies` |
| **apt retries + timeouts** | A slow mirror becomes a retried request rather than a stalled job |
| **`timeout-minutes: 5`** | Shorter than the job's 20, so a stuck mirror fails *here*, named, in five minutes instead of as an ambiguous cancellation |

## Honest limits

- **The guard alone would not have prevented either failure.** Both branches still call apt; that is why the retry/timeout hardening is the substantive half.
- **A mirror that is down, not slow, still fails.** The official Playwright container image removes apt from this path entirely and is the escalation if this proves insufficient. Not taken now: its tag cannot be read from `pnpm-lock.yaml` and would silently drift from `@playwright/test`, and [microsoft/playwright#34619](https://github.com/microsoft/playwright/issues/34619) is an open corepack/pnpm bug in that image family — trading this flake for another of the same shape.
- Playwright's own docs [discourage caching browsers](https://playwright.dev/docs/ci) on the grounds that restore time ≈ download time. That guidance covers `~/.cache/ms-playwright` only and says nothing about apt-installed system libraries, which is where this job actually burned its budget. Whether to drop the cache entirely is a separate, measurable question this repo has not tested; I left it alone rather than guess.

## Verification

- YAML parses; the four steps carry the intended `if`, `timeout-minutes` and `id` (checked structurally, not by eye).
- The apt heredoc survives YAML block-scalar indentation — terminator lands at column 0 — and the exact parsed script was **executed locally**, exit 0, producing the intended three-line config.

No changeset: CI-only.