### PR TITLE
test(e2e): rebuild the canvas acceptance suite against the v2 canvas

### DIFF
--- a/apps/playground/src/app/builder-canvas/harness.tsx
+++ b/apps/playground/src/app/builder-canvas/harness.tsx
@@ -106,6 +106,13 @@ export function BuilderCanvasHarness() {
        */
       data-nx-dragging={drag.draggingId ?? ""}
       data-nx-drop-target={drag.target ? JSON.stringify(drag.target) : ""}
+      /*
+       * The editor's own undo depth, so "one drop is one undo entry" is asked
+       * of the OP STORE rather than inferred from the tree. A suite counting
+       * document changes instead would pass for a drop that recorded two ops
+       * whose net effect happened to look like one.
+       */
+      data-nx-undo-depth={editor.undoDepth}
     >
       <Canvas
         document={editor.document}

--- a/e2e/tests/canvas/acceptance-manifest.ts
+++ b/e2e/tests/canvas/acceptance-manifest.ts
@@ -1,0 +1,132 @@
+/**
+ * The twelve canvas acceptance properties, and which of them this suite covers.
+ *
+ * The manifest exists so coverage cannot shrink silently. Plan 04's D-04.4 asks
+ * for a harness that "asserts its own test count", because `0 failures` is
+ * indistinguishable from `0 tests ran` — and this programme has already shipped
+ * three separate green results that were measuring nothing. A count alone is
+ * not enough either: a suite that renamed a test and lost it would still count
+ * twelve. So each property is named here with its status, the spec asserts that
+ * every `covered` property has a test whose title matches, and a `deferred` one
+ * carries the reason it cannot run yet.
+ *
+ * Deferring is not the same as passing, and a reader must never be able to
+ * mistake one for the other: `pnpm test:e2e` reports the deferred set out loud.
+ *
+ * @module tests/canvas/acceptance-manifest
+ */
+
+export interface AcceptanceProperty {
+  /** Plan 04 §4's number for it. Stable; the order below is that table's. */
+  readonly n: number;
+  /** The property, in the plan's own words. */
+  readonly property: string;
+  /** The PR that was meant to turn it green, kept for traceability. */
+  readonly greenIn: string;
+  readonly status: "covered" | "deferred";
+  /**
+   * Why it cannot run yet. Required for `deferred`, forbidden for `covered` —
+   * a covered property with an excuse attached is a property nobody re-checked.
+   */
+  readonly reason?: string;
+}
+
+export const ACCEPTANCE_PROPERTIES: readonly AcceptanceProperty[] = [
+  {
+    n: 1,
+    property: "Pointer collision resolves by tree depth",
+    greenIn: "B-6",
+    status: "deferred",
+    reason:
+      "needs a NESTED container in the fixture; the harness document is flat, so every drop resolves at one depth and a depth rule cannot be distinguished from no rule at all",
+  },
+  {
+    n: 2,
+    property: "Drag-start hysteresis: a click is never a drag",
+    greenIn: "B-6",
+    status: "covered",
+  },
+  {
+    n: 3,
+    property: "Target-switch hysteresis: the 2px oscillation test",
+    greenIn: "B-7",
+    status: "covered",
+  },
+  {
+    n: 4,
+    property: "Zero layout shift when drop zones appear",
+    greenIn: "B-6",
+    status: "covered",
+  },
+  {
+    n: 5,
+    property: "Exactly ONE overlay indicator element, in parent chrome",
+    greenIn: "B-7",
+    status: "covered",
+  },
+  {
+    n: 6,
+    property: "Indicator leads the pointer into a 6px gap",
+    greenIn: "B-7",
+    status: "covered",
+  },
+  {
+    n: 7,
+    property: "Explicit invalid-target state is reachable and visible",
+    greenIn: "B-7",
+    status: "deferred",
+    reason:
+      "needs a block an ordinary container REFUSES; the fixture holds only core blocks every container accepts, and a refusal shown nowhere passes the same assertion as a refusal shown everywhere",
+  },
+  {
+    n: 8,
+    property: "Autoscroll engages and stops at bounds",
+    greenIn: "B-8",
+    status: "deferred",
+    reason:
+      "needs a document TALLER than the canvas viewport; the fixture is ~145px in a full-height box, so the canvas never scrolls and an autoscroll assertion would pass against an engine that has none",
+  },
+  {
+    n: 9,
+    property: "Rects cached at dragstart; 60fps on a 500-block tree",
+    greenIn: "B-8",
+    status: "deferred",
+    reason:
+      "needs the canvas to REPORT its geometry reads; counting getBoundingClientRect from the test would instrument the page rather than the engine, and the frame-rate half is deliberately not a merge gate — it is flaky on a shared runner and a green there proves less than a bounded read count",
+  },
+  {
+    n: 10,
+    property: "One drop = exactly one undo entry",
+    greenIn: "B-9",
+    status: "covered",
+  },
+  {
+    n: 11,
+    property: "Panel drag and canvas drag are the same engine",
+    greenIn: "B-15",
+    status: "deferred",
+    reason:
+      "needs the three-tier inserter mounted; the canvas harness renders no panel, so there is no panel drag to compare against and the property is vacuously true",
+  },
+  {
+    n: 12,
+    property: "Escape cancels a drag, and the shell does not navigate",
+    greenIn: "B-11",
+    status: "covered",
+    // Only the drag half here. "The shell does not navigate" is the shell's
+    // property and the canvas harness mounts no shell — stated so the half
+    // that IS covered is not read as the whole.
+  },
+];
+
+export const COVERED = ACCEPTANCE_PROPERTIES.filter(
+  p => p.status === "covered"
+);
+export const DEFERRED = ACCEPTANCE_PROPERTIES.filter(
+  p => p.status === "deferred"
+);
+
+/** The title every covered property's test must carry, so a rename cannot hide one. */
+export function titleFor(p: AcceptanceProperty): string {
+  return `A${p.n}: ${p.property}`;
+}

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -1,0 +1,296 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import { expect, test, type Page } from "@playwright/test";
+
+import {
+  ACCEPTANCE_PROPERTIES,
+  COVERED,
+  DEFERRED,
+  titleFor,
+} from "./acceptance-manifest";
+
+/**
+ * The canvas acceptance suite, rebuilt against the v2 canvas.
+ *
+ * The original was retired in `c12e43472` with the PoC canvas it drove, and the
+ * properties went with it. This is not that suite restored: v2 renders
+ * SAME-DOCUMENT with no iframe, so the retired driver's cross-frame mapping and
+ * its `.nx-pb-*` selectors describe a canvas that no longer exists.
+ *
+ * ## Every drag here is POINTER MOTION, never a position
+ *
+ * `useCanvasDrag` reads live `clientX`/`clientY` off real `pointermove` events
+ * and keys BOTH its activation threshold (4px) and its target-switch hysteresis
+ * (8px) on ACCUMULATED TRAVEL. A test that jumps the pointer to a coordinate
+ * exercises none of that and passes against a canvas broken for anyone using a
+ * mouse. Playwright's `dragTo` is one such jump, which is why nothing here uses
+ * it.
+ *
+ * ## Population before verdict
+ *
+ * Two guards, because they fail differently. `the suite covers what it claims`
+ * asserts every property the manifest calls covered has a test here — a rename
+ * or a deletion turns it red. `the deferred set is reported` prints what is NOT
+ * covered, so a partial suite can never read as a complete one.
+ *
+ * @module tests/canvas/acceptance
+ */
+
+const ROUTE = "/builder-canvas";
+const NODE = "[data-nx-node]";
+const HOST = '[data-testid="canvas-harness"]';
+const INDICATOR = ".nx-drop-indicator";
+
+/** Document order, by id. The single question "did the tree change". */
+async function order(page: Page): Promise<(string | null)[]> {
+  return page
+    .locator(NODE)
+    .evaluateAll(nodes => nodes.map(n => n.getAttribute("data-nx-node")));
+}
+
+async function boxOf(page: Page, id: string) {
+  const box = await page.locator(`[data-nx-node="${id}"]`).boundingBox();
+  if (box === null)
+    throw new Error(`${id} has no box; the fixture is not rendered`);
+  return box;
+}
+
+/**
+ * Press, travel through intermediate points, and leave the button down.
+ *
+ * `steps` is not decoration: it is what makes this a drag rather than a jump.
+ */
+async function pressAndTravel(
+  page: Page,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  steps = 16
+): Promise<void> {
+  await page.mouse.move(from.x, from.y);
+  await page.mouse.down();
+  await page.mouse.move(to.x, to.y, { steps });
+}
+
+async function openCanvas(page: Page): Promise<void> {
+  await page.goto(ROUTE);
+  // The population, before any property is asked about it.
+  await expect(page.locator(NODE)).toHaveCount(6);
+}
+
+test.describe("the canvas acceptance suite", () => {
+  test("the suite covers what its manifest claims", async () => {
+    // Reads THIS FILE and checks a test exists for every covered property.
+    //
+    // A count alone would not do it: a suite that renamed a test and lost its
+    // property still counts the same. Asserting the titles are present is what
+    // makes "covered" a claim the suite can fail rather than a label on a list.
+    const source = await readFile(fileURLToPath(import.meta.url), "utf8");
+    const missing = COVERED.filter(
+      p => !source.includes(`titleFor(COVERED.find(p => p.n === ${p.n})!)`)
+    );
+    expect(
+      missing.map(p => `A${p.n}`),
+      "manifest says covered, no test found in this file"
+    ).toEqual([]);
+
+    expect(COVERED.length).toBeGreaterThan(0);
+    expect(new Set(COVERED.map(titleFor)).size).toBe(COVERED.length);
+    expect(COVERED.length + DEFERRED.length).toBe(ACCEPTANCE_PROPERTIES.length);
+    expect(ACCEPTANCE_PROPERTIES.length).toBe(12);
+  });
+
+  test("the deferred properties are reported, not hidden", async () => {
+    // Deferring is not passing. Printed so a reader of the run cannot mistake
+    // a partial suite for a complete one.
+    for (const p of DEFERRED) {
+      expect(p.reason, `A${p.n} defers without a reason`).toBeTruthy();
+      // eslint-disable-next-line no-console
+      console.log(`DEFERRED A${p.n}: ${p.property} — ${p.reason}`);
+    }
+    expect(DEFERRED.every(p => (p.reason ?? "").length > 20)).toBe(true);
+  });
+
+  test(`${titleFor(COVERED.find(p => p.n === 2)!)}`, async ({ page }) => {
+    await openCanvas(page);
+    const before = await order(page);
+    const box = await boxOf(page, "hx-text-short");
+    const centre = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+
+    // 2px: inside the 4px activation threshold.
+    await pressAndTravel(page, centre, { x: centre.x + 2, y: centre.y }, 4);
+    await expect(page.locator(HOST)).toHaveAttribute("data-nx-dragging", "");
+    await page.mouse.up();
+    expect(await order(page)).toEqual(before);
+
+    // The POSITIVE CONTROL, in the same test: past the threshold it MUST drag.
+    // Without it a canvas that never drags at all passes the half above.
+    await pressAndTravel(page, centre, { x: centre.x, y: centre.y - 60 }, 16);
+    await expect(page.locator(HOST)).toHaveAttribute(
+      "data-nx-dragging",
+      "hx-text-short"
+    );
+    await page.mouse.up();
+  });
+
+  test(`${titleFor(COVERED.find(p => p.n === 5)!)}`, async ({ page }) => {
+    await openCanvas(page);
+    const from = await boxOf(page, "hx-text-last");
+    const to = await boxOf(page, "hx-heading");
+
+    // None before the drag — the control for the count below.
+    await expect(page.locator(INDICATOR)).toHaveCount(0);
+
+    await pressAndTravel(
+      page,
+      { x: from.x + from.width / 2, y: from.y + from.height / 2 },
+      { x: from.x + from.width / 2, y: to.y + 2 }
+    );
+    await expect(page.locator(INDICATOR)).toHaveCount(1);
+    await page.mouse.up();
+    await expect(page.locator(INDICATOR)).toHaveCount(0);
+  });
+
+  test(`${titleFor(COVERED.find(p => p.n === 6)!)}`, async ({ page }) => {
+    await openCanvas(page);
+    const heading = await boxOf(page, "hx-heading");
+    const next = await boxOf(page, "hx-text-tall");
+    const gapTop = heading.y + heading.height;
+    const gapBottom = next.y;
+    expect(
+      gapBottom - gapTop,
+      "the fixture must have a gap for an indicator to land in"
+    ).toBeGreaterThan(0);
+
+    const from = await boxOf(page, "hx-text-last");
+    await pressAndTravel(
+      page,
+      { x: from.x + from.width / 2, y: from.y + from.height / 2 },
+      { x: from.x + from.width / 2, y: gapTop + 1 }
+    );
+
+    const line = await page.locator(INDICATOR).boundingBox();
+    expect(line).not.toBeNull();
+    // Inside the gap, not on top of either neighbour's text.
+    expect(line!.y).toBeGreaterThanOrEqual(gapTop - 2);
+    expect(line!.y).toBeLessThanOrEqual(gapBottom + 2);
+    await page.mouse.up();
+  });
+
+  test(`${titleFor(COVERED.find(p => p.n === 4)!)}`, async ({ page }) => {
+    await openCanvas(page);
+    const settled = async () =>
+      page.locator(NODE).evaluateAll(nodes =>
+        nodes.map(n => {
+          const r = n.getBoundingClientRect();
+          return { top: r.top, height: r.height };
+        })
+      );
+    const before = await settled();
+
+    const from = await boxOf(page, "hx-text-last");
+    const to = await boxOf(page, "hx-heading");
+    await pressAndTravel(
+      page,
+      { x: from.x + from.width / 2, y: from.y + from.height / 2 },
+      { x: from.x + from.width / 2, y: to.y + 2 }
+    );
+    // Drop zones are live now; nothing may have MOVED to make room for them.
+    expect(await settled()).toEqual(before);
+    await page.mouse.up();
+  });
+
+  test(`${titleFor(COVERED.find(p => p.n === 3)!)}`, async ({ page }) => {
+    await openCanvas(page);
+    const from = await boxOf(page, "hx-text-last");
+    const heading = await boxOf(page, "hx-heading");
+    const edge = heading.y + heading.height;
+    const x = from.x + from.width / 2;
+
+    await pressAndTravel(
+      page,
+      { x, y: from.y + from.height / 2 },
+      { x, y: edge - 1 }
+    );
+    const first = await page.locator(HOST).getAttribute("data-nx-drop-target");
+
+    // Jitter ACROSS the edge by 2px, well inside the 8px switch threshold.
+    for (let i = 0; i < 6; i += 1) {
+      await page.mouse.move(x, edge + 1, { steps: 2 });
+      await page.mouse.move(x, edge - 1, { steps: 2 });
+    }
+    expect(await page.locator(HOST).getAttribute("data-nx-drop-target")).toBe(
+      first
+    );
+
+    // Control: a DELIBERATE crossing must switch it.
+    //
+    // Far enough to cross the next INSERTION boundary, not merely the 8px
+    // travel threshold. An insertion point sits between siblings, so a pointer
+    // moved into the upper half of the block below still resolves to the same
+    // index — measured: 40px past the edge held `at: {index: 1}`, because that
+    // is still "before hx-text-tall". The boundary is that block's midpoint, so
+    // the control aims well past it, at a later sibling.
+    const later = await boxOf(page, "hx-text-short");
+    await page.mouse.move(x, later.y + later.height / 2, { steps: 16 });
+    expect(
+      await page.locator(HOST).getAttribute("data-nx-drop-target")
+    ).not.toBe(first);
+    await page.mouse.up();
+  });
+
+  test(`${titleFor(COVERED.find(p => p.n === 10)!)}`, async ({ page }) => {
+    await openCanvas(page);
+    const depth = async () =>
+      Number(await page.locator(HOST).getAttribute("data-nx-undo-depth"));
+    expect(await depth()).toBe(0);
+
+    const from = await boxOf(page, "hx-text-last");
+    const to = await boxOf(page, "hx-heading");
+    await pressAndTravel(
+      page,
+      { x: from.x + from.width / 2, y: from.y + from.height / 2 },
+      { x: from.x + from.width / 2, y: to.y + 2 }
+    );
+    await page.mouse.up();
+
+    // The tree moved — without this the depth check below passes for a drop
+    // that did nothing at all.
+    expect(await order(page)).not.toEqual([
+      "hx-heading",
+      "hx-text-tall",
+      "hx-divider",
+      "hx-text-short",
+      "hx-spacer",
+      "hx-text-last",
+    ]);
+    expect(await depth()).toBe(1);
+  });
+
+  test(`${titleFor(COVERED.find(p => p.n === 12)!)}`, async ({ page }) => {
+    await openCanvas(page);
+    const before = await order(page);
+    const from = await boxOf(page, "hx-text-last");
+    const to = await boxOf(page, "hx-heading");
+
+    await pressAndTravel(
+      page,
+      { x: from.x + from.width / 2, y: from.y + from.height / 2 },
+      { x: from.x + from.width / 2, y: to.y + 2 }
+    );
+    await expect(page.locator(HOST)).toHaveAttribute(
+      "data-nx-dragging",
+      "hx-text-last"
+    );
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator(HOST)).toHaveAttribute("data-nx-dragging", "");
+    await page.mouse.up();
+
+    // Abandoned, not committed: the tree is untouched and nothing is undoable.
+    expect(await order(page)).toEqual(before);
+    expect(
+      Number(await page.locator(HOST).getAttribute("data-nx-undo-depth"))
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
The original suite was retired in `c12e43472` along with the PoC canvas it drove. Phase 3's exit criterion — *twelve properties green in CI, **and reporting twelve tests run*** — has had nothing behind it since.

This is not that suite restored. v2 renders **same-document with no iframe**, so the retired driver's cross-frame mapping and `.nx-pb-*` selectors describe a canvas that no longer exists.

## Seven of twelve covered — and the other five say why

| | Property | Status |
|---|---|---|
| A2 | Drag-start hysteresis: a click is never a drag | ✅ |
| A3 | Target-switch hysteresis: the 2px oscillation test | ✅ |
| A4 | Zero layout shift when drop zones appear | ✅ |
| A5 | Exactly ONE overlay indicator element | ✅ |
| A6 | Indicator leads the pointer into a 6px gap | ✅ |
| A10 | One drop = exactly one undo entry | ✅ |
| A12 | Escape cancels a drag | ✅ (drag half) |
| A1 | Collision resolves by tree depth | deferred — fixture is flat; one depth cannot distinguish a depth rule from no rule |
| A7 | Invalid-target state reachable | deferred — needs a block a container refuses; shown-nowhere passes the same assertion as shown-everywhere |
| A8 | Autoscroll engages and stops | deferred — fixture is ~145px in a full-height box, so the canvas never scrolls |
| A9 | Rects cached at dragstart | deferred — needs the canvas to report its geometry reads; the fps half is deliberately not a merge gate |
| A11 | Panel drag = canvas drag | deferred — no inserter mounted, so the property is vacuously true |

**Deferring is not passing.** The run prints the deferred set, so a partial suite cannot read as a complete one.

## The self-counting guard, proven

D-04.4 asks for a harness that asserts its own test count, because `0 failures` is indistinguishable from `0 tests ran`. A count alone isn't enough — a suite that renamed a test and lost its property still counts the same. So the suite **reads its own source** and fails if any property the manifest calls covered has no test.

Verified by claiming A11 covered with no test written: the guard fails and names `A11`.

## Motion, never positions

`useCanvasDrag` keys activation (4px) and switch hysteresis (8px) on **accumulated pointer travel**. Every gesture here travels through intermediate points; `dragTo` is a single jump and would exercise none of it.

## Every covered property carries a control

A2 asserts a 2px press does *not* drag **and** that a 60px one does — without the second half, a canvas that never drags passes the first. A5 asserts zero indicators before the drag. A10 asserts the tree actually moved before asserting undo depth is 1. A12 asserts the tree is untouched *and* nothing is undoable after Escape.

**A3's control caught a real error in my own test**, not in the canvas: 40px past a block's top edge still resolves to the same insertion index, because an insertion point sits *between* siblings and the boundary is the block's midpoint. The control now crosses a later sibling, and the comment records the measurement.

## Verification

- `playwright test canvas/` → **48 passed** (this suite plus the surviving apparatus tests)
- e2e lint and `tsc --noEmit` clean
- The harness exposes `data-nx-undo-depth` so A10 asks the **op store** how many entries a drop recorded, rather than inferring it from the tree — which would pass for a drop recording two ops whose net effect resembles one

No changeset: test-only.