### PR TITLE
fix(root): measure-facts final seams — honest header, pre-mangle guard, fixture tests

### DIFF
--- a/scripts/measure-facts-guards.test.mjs
+++ b/scripts/measure-facts-guards.test.mjs
@@ -1,0 +1,72 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The pr-scopes row and the carry-forward are the two measure-facts
+ * mechanisms whose failure is silent: a scopes extraction that degrades
+ * records a wrong list at exit 0, and a carried heavy row that loses its
+ * stamp publishes an old number as a fresh one. Both are exercised here
+ * against fixtures, reading the live command out of the script rather than
+ * retyping it, so the test cannot drift from the implementation.
+ */
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** The pr-scopes command exactly as the generator will run it. */
+function scopesCmd() {
+  const src = readFileSync(resolve(repoRoot, "scripts/measure-facts.mjs"), "utf8");
+  const m = src.match(/id: "pr-scopes"[\s\S]*?cmd: "((?:[^"\\]|\\.)*)"/);
+  expect(m, "pr-scopes cmd not found in measure-facts.mjs").toBeTruthy();
+  return JSON.parse(`"${m[1]}"`);
+}
+
+function runInFixture(scopesLines) {
+  const dir = mkdtempSync(join(tmpdir(), "scopes-fixture-"));
+  mkdirSync(join(dir, ".github/workflows"), { recursive: true });
+  writeFileSync(
+    join(dir, ".github/workflows/pr-title.yml"),
+    `          scopes: |\n${scopesLines.map(l => `            ${l}`).join("\n")}\n          requireScope: false\n`,
+  );
+  return spawnSync("bash", ["-o", "pipefail", "-c", scopesCmd()], { cwd: dir, encoding: "utf8" });
+}
+
+describe("the pr-scopes extraction fails closed", () => {
+  it("reads a healthy block", () => {
+    const r = runInFixture(["nextly", "admin", "eslint-plugin"]);
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("nextly admin eslint-plugin");
+  });
+
+  it("refuses a token that is not scope-shaped", () => {
+    const r = runInFixture(["nextly", "{{ broken }}", "admin"]);
+    expect(r.status).not.toBe(0);
+  });
+
+  it("refuses a token with an internal space rather than concatenating it", () => {
+    const r = runInFixture(["nextly", "plugin sdk", "admin"]);
+    expect(r.status).not.toBe(0);
+  });
+});
+
+describe("carried heavy rows keep their original stamp", () => {
+  it("a cheap run re-emits the committed command line verbatim", () => {
+    const committed = readFileSync(resolve(repoRoot, "AGENTS.measured.md"), "utf8");
+    const row = committed.match(/## check-types-cold\n[\s\S]*?\n```\n(\$[^\n]*)\n/);
+    expect(row, "committed check-types-cold row not found").toBeTruthy();
+    const fresh = spawnSync(
+      "node",
+      ["scripts/measure-facts.mjs", "--only=check-types-cold", "--stdout"],
+      { cwd: repoRoot, encoding: "utf8" },
+    );
+    expect(fresh.status, fresh.stderr).toBe(0);
+    // The carried row's command line — its original revision stamp included —
+    // must survive the cheap run byte for byte; a fresh stamp here is the
+    // falsified-provenance defect this guards against.
+    expect(fresh.stdout).toContain(row[1]);
+  });
+});

--- a/scripts/measure-facts-guards.test.mjs
+++ b/scripts/measure-facts-guards.test.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 /**
- * The pr-scopes row and the carry-forward are the two measure-facts
+ * The `pr-scopes` row and the carry-forward are the two measure-facts
  * mechanisms whose failure is silent: a scopes extraction that degrades
  * records a wrong list at exit 0, and a carried heavy row that loses its
  * stamp publishes an old number as a fresh one. Both are exercised here
@@ -17,7 +17,7 @@ import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
-/** The pr-scopes command exactly as the generator will run it. */
+/** The `pr-scopes` command exactly as the generator will run it. */
 function scopesCmd() {
   const src = readFileSync(resolve(repoRoot, "scripts/measure-facts.mjs"), "utf8");
   const m = src.match(/id: "pr-scopes"[\s\S]*?cmd: "((?:[^"\\]|\\.)*)"/);

--- a/scripts/measure-facts.mjs
+++ b/scripts/measure-facts.mjs
@@ -5,9 +5,11 @@
 // re-run rather than trust.
 //
 // Cheap facts run on every invocation. Facts needing a forced turbo run are
-// heavy (minutes of CPU) and run only with --full; without it they are listed
-// as not measured in this run, never seeded from memory — an unmeasured row
-// must not look like a measured one.
+// heavy (minutes of CPU) and run only with --full. A cheap run CARRIES the
+// previous file's heavy rows forward verbatim — original command line and
+// revision stamp included — so an old number always names the tree it was
+// read from; a heavy row with no prior measurement is listed as unmeasured
+// rather than invented.
 //
 // Two properties this file holds deliberately:
 // - the command shown in each row is the command that RAN — one
@@ -80,7 +82,7 @@ const facts = [
   {
     id: "pr-scopes",
     what: "PR scopes accepted by the title check (the enforced list; commitlint checks format only, not scope membership)",
-    cmd: "sed -n '/scopes: |/,/requireScope/p' .github/workflows/pr-title.yml | sed '1d;$d' | tr -d ' ' | grep . | awk '/^[a-z0-9-]+$/{print;next}{exit 1}' | tr '\\n' ' '",
+    cmd: "sed -n '/scopes: |/,/requireScope/p' .github/workflows/pr-title.yml | sed '1d;$d' | grep -vE '^ *$' | awk '/^ *[a-z0-9-]+ *$/{gsub(/ +/,\"\");print;next}{exit 1}' | tr '\\n' ' '",
   },
   {
     id: "engines",


### PR DESCRIPTION
## Summary

Closes the four findings from the review round on #1094 (which merged mid-round; these land its corrections):

- The module header claimed heavy rows are "never seeded from memory" two PRs after carriedForward began doing exactly that. It now describes the carry-forward: original command line and revision stamp travel with the number.
- The token-shape guard on the pr-scopes extraction now validates the RAW line before spaces are stripped: `plugin sdk` previously became `pluginsdk` — a different, valid-looking token — before the guard could see it. The one malformed class that produced a silently wrong list now refuses.
- Both previously-untested mechanisms gain fixture tests (scripts/measure-facts-guards.test.mjs) that read the live command out of the script rather than retyping it, so the guard and its test cannot drift apart.

## Test plan
- New suite proven by break-and-restore: healthy fixture passes; garbage token and internal-space token both refuse; reinstating the old narrowing pipeline fails exactly the two refusal tests; restore greens all 4.
- Full scripts suite + comment convention + fallow gate + build all green (exit codes read unpiped).

Changeset skipped: repo tooling and docs only.