### PR TITLE
ci(root): accept admin-css and module-specifiers as PR scopes

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -37,6 +37,7 @@ jobs:
           scopes: |
             nextly
             admin
+            admin-css
             client
             ui
             adapter-postgres
@@ -56,6 +57,7 @@ jobs:
             create-nextly-app
             eslint-config
             eslint-plugin
+            module-specifiers
             prettier-config
             tsconfig
             telemetry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,17 +251,16 @@ Before editing a package, read its README.md and check for a nested AGENTS.md.
 - Conventional Commits: commitlint (husky) checks the FORMAT; the PR-title
   check is what enforces the scope LIST below (commitlint extends
   config-conventional only, so it accepts any scope).
-  Allowed PR scopes are package-based (`nextly`, `admin`, `ui`,
+  Allowed PR scopes are package-based (`nextly`, `admin`, `admin-css`, `ui`,
   `adapter-postgres`, `adapter-mysql`, `adapter-sqlite`, `adapter-drizzle`,
   `storage-s3`, `storage-vercel-blob`, `storage-uploadthing`,
   `plugin-form-builder`, `plugin-page-builder`, `plugin-seo`, `plugin-sdk`,
   `blocks-engine`, `blocks-react`, `builder`,
-  `create-nextly-app`, `eslint-config`, `eslint-plugin`, `prettier-config`, `tsconfig`,
+  `create-nextly-app`, `eslint-config`, `eslint-plugin`, `module-specifiers`,
+  `prettier-config`, `tsconfig`,
   `telemetry`, `client`) plus `playground`, `root`, `ci`, `docs`, `deps`,
   `release`. Scope is optional; the subject must not start with an uppercase
-  letter. Subsystem names are not valid scopes. Packages currently without an
-  accepted scope (`admin-css`, `module-specifiers`) get scoped to the nearest
-  listed package until that gap is closed.
+  letter. Subsystem names are not valid scopes.
 - Errors thrown inside `packages/nextly/**` PRODUCT CODE use `NextlyError`
   (static factories: `notFound`, `forbidden`, `validation`, `conflict`,
   `duplicate`, `authRequired`, `invalidCredentials`, `rateLimited`,

--- a/scripts/agents-md-scopes-agree.test.mjs
+++ b/scripts/agents-md-scopes-agree.test.mjs
@@ -37,11 +37,11 @@ function documentedScopes() {
   return names.map(n => n.replace(/`/g, "")).sort();
 }
 
-/** The packages AGENTS.md names as having no accepted scope. */
+/** The packages AGENTS.md names as having no accepted scope, empty when the document names none. */
 function documentedUnscoped() {
   const doc = read("AGENTS.md");
   const sentence = doc.match(/Packages currently without an\n\s+accepted scope \(([^)]*)\)/);
-  expect(sentence, "unscoped-packages sentence not found in AGENTS.md — the anchor moved").toBeTruthy();
+  if (!sentence) return [];
   return (sentence[1].match(/`([^`]+)`/g) || []).map(n => n.replace(/`/g, "")).sort();
 }
 


### PR DESCRIPTION
## Summary

Executes the ruled decision `adr:unscoped-packages`: both packages exist and receive real commits, but the title check never listed them, so their commits borrowed a neighbour's scope. Adding them rejects nothing that passes today.

The scope-agreement test forces AGENTS.md to update in the same change (it did), and the gap sentence is removed with the gap — the test's second assertion now proves the workspace has NO unscoped package, rather than anchoring on prose describing one.

## Test plan
- `agents-md-scopes-agree`: 2 tests green with the change; removing `module-specifiers` from the doc list fails the test naming exactly that scope (break-and-restore run).
- Comment-convention exit 1 is PRE-EXISTING on main (`e2e/tests/canvas/acceptance-manifest.ts`, arrived via #1097, filed as `finding:e2e-manifest-comment-convention` for the pb lane) — no new offences from this change.

Changeset skipped: CI configuration and repo docs only.