### PR TITLE
feat(plugin-page-builder): the entry's other fields, inside the builder

### DIFF
--- a/.changeset/entry-fields-panel-in-takeover-surfaces.md
+++ b/.changeset/entry-fields-panel-in-takeover-surfaces.md
@@ -1,0 +1,39 @@
+---
+
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+
+A field that covers the whole entry form left its author unable to reach the rest of the entry.
+The page builder opens full-screen over the form, so setting an SEO description or a publish date
+meant closing the editor — and closing it discards its undo history.
+
+The builder's left rail now offers a Settings panel holding the entry's other fields, rendered by
+the form's own renderer through `useEntryFieldsPanel`. What the panel draws and what the form
+submits are one thing; a second form instance would fork the state and lose whichever copy did not
+save.
+
+The asking field is excluded, and so is the field its `admin.condition` depends on: offering a page
+builder inside its own settings panel would nest an editor in its own chrome, and offering the
+control that un-renders it would be an unlabelled second exit.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -42,6 +42,7 @@ import { usePreviewLink } from "@admin/hooks/usePreviewLink";
 import {
   computeMainFields,
   takeoverControllerNames,
+  computeFieldsBeside,
   takeoverTypesFromBranding,
 } from "@admin/lib/builder/takeoverLayout";
 import { cn } from "@admin/lib/utils";
@@ -358,6 +359,36 @@ export function EntryForm({
   );
   const mainFields = computeMainFields(allFields, { takeoverTypes, values });
 
+  /*
+   * A renderer for the entry's OTHER fields, handed to whatever surface takes
+   * the body over.
+   *
+   * A full-screen field — the page builder is the one that ships — covers the
+   * form completely, so its author cannot reach the SEO fields, the relations
+   * or anything else this collection declares without closing the editor and
+   * losing its undo history. This is what lets that surface offer them back.
+   *
+   * Takes the asking field's path, so the surface is never offered ITSELF:
+   * rendering the page builder inside the page builder's own settings panel
+   * would nest an editor in its own chrome. Keyed on the path rather than on
+   * `layout: "takeover"` because no shipped plugin declares that flag, so a
+   * rule conditioned on it would never fire.
+   *
+   * Built from THIS form's `control`, so what the surface draws and what the
+   * form submits are one thing. A second `EntryForm` would fork the state and
+   * lose the edit made in whichever copy did not save.
+   */
+  const renderEntryFields = useCallback(
+    (excludePath: string) => (
+      <EntryFormContent
+        fields={computeFieldsBeside(allFields, excludePath)}
+        disabled={isSubmitting}
+        mode={mode}
+      />
+    ),
+    [allFields, isSubmitting, mode]
+  );
+
   // Get form errors and submit attempt count. submitCount gates the
   // top-level "Please fix the following errors" toast in FormErrorSummary
   // so it only appears after the user actually clicks Save / Publish, not
@@ -647,6 +678,10 @@ export function EntryForm({
                 entryId={entry?.id}
                 collectionSlug={collection.name}
                 isCreateMode={mode === "create"}
+                // Only where a takeover can happen. The embedded branch renders
+                // the whole body in a modal and hides nothing, so a panel there
+                // would offer a second copy of fields already on screen.
+                renderEntryFields={renderEntryFields}
               >
                 <div className={cn("space-y-0", className)}>
                   <EntryFormProvider form={form} onSubmit={handleSubmit}>

--- a/packages/admin/src/components/features/entries/EntryForm/EntryFormContext.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryFormContext.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  EntryFormContextProvider,
+  useEntryFieldsPanel,
+} from "./EntryFormContext";
+
+/**
+ * The seam a takeover surface reaches the rest of the entry through.
+ *
+ * A field that covers the whole form — the page builder is the one that ships —
+ * leaves its author unable to reach the entry's other fields without closing the
+ * editor and losing its undo history. `useEntryFieldsPanel` is how that surface
+ * offers them back, so the two states it can return are the contract: a renderer,
+ * or null.
+ */
+function Consumer({ exclude }: { exclude: string }) {
+  const render = useEntryFieldsPanel();
+  if (render === null) return <p>no panel</p>;
+  return <div data-testid="panel">{render(exclude)}</div>;
+}
+
+describe("useEntryFieldsPanel", () => {
+  it("returns null outside an entry form, so a surface offers no panel", () => {
+    // Not a thrown error: a field rendered in a preview or a standalone harness
+    // is a legitimate arrangement, and the caller needs an answer it can branch
+    // on rather than an exception it must catch.
+    render(<Consumer exclude="content" />);
+    expect(screen.getByText("no panel")).toBeInTheDocument();
+  });
+
+  it("returns null when the form supplies no renderer", () => {
+    // The provider is present but this form hides nothing, which must be
+    // distinguishable from "there is a renderer that happens to draw nothing" —
+    // the first means withhold the panel, the second means show an empty one.
+    render(
+      <EntryFormContextProvider collectionSlug="posts">
+        <Consumer exclude="content" />
+      </EntryFormContextProvider>
+    );
+    expect(screen.getByText("no panel")).toBeInTheDocument();
+  });
+
+  it("hands back the form's own renderer, and passes the excluded path to it", () => {
+    // The path travels to the renderer rather than being resolved here: which
+    // field is asking is the CALLER's fact, and a context that guessed it would
+    // be wrong for the second takeover surface a collection ever declares.
+    render(
+      <EntryFormContextProvider
+        collectionSlug="posts"
+        renderEntryFields={excludePath => (
+          <span>fields beside {excludePath}</span>
+        )}
+      >
+        <Consumer exclude="sections" />
+      </EntryFormContextProvider>
+    );
+    expect(screen.getByTestId("panel")).toBeInTheDocument();
+    expect(screen.getByText("fields beside sections")).toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryForm/EntryFormContext.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryFormContext.tsx
@@ -75,6 +75,28 @@ export interface EntryFormContextValue {
    * a published page was unpublished.
    */
   documentStatus?: DocumentStatus;
+
+  /**
+   * Renders the fields an active TAKEOVER field removed from the form body.
+   *
+   * Absent when nothing takes the body over, which is the honest answer rather
+   * than an empty renderer: with no takeover nothing is hidden, and a surface
+   * offering a panel for it would reserve space to display nothing.
+   *
+   * A closure rather than a field list, because the caller must not have to
+   * know how this admin renders a field — that is `EntryFormContent`'s
+   * contract, and a plugin reconstructing it would be a second renderer that
+   * drifts. It is built from the form's OWN `control`, so what a takeover
+   * surface draws and what the form submits are one thing; constructing a
+   * second `EntryForm` would fork the form state and lose an edit made in
+   * whichever copy did not save.
+   *
+   * Read through {@link useEntryFieldsPanel}. Handed down as context rather
+   * than as a prop because a takeover field is rendered by the generic field
+   * renderer, which passes four shared props to all fifteen input types and is
+   * deliberately not where per-plugin wiring goes.
+   */
+  renderEntryFields?: (excludePath: string) => ReactNode;
 }
 
 /**
@@ -185,6 +207,12 @@ export interface EntryFormContextProviderProps {
   documentStatus?: DocumentStatus;
 
   /**
+   * Renders the entry's other fields for a surface that covers the form,
+   * excluding the field at the path it is given.
+   */
+  renderEntryFields?: (excludePath: string) => ReactNode;
+
+  /**
    * Child components.
    */
   children: ReactNode;
@@ -223,6 +251,7 @@ export function EntryFormContextProvider({
   isCreateMode = false,
   kind = "collection",
   documentStatus,
+  renderEntryFields,
   children,
 }: EntryFormContextProviderProps) {
   /*
@@ -246,8 +275,22 @@ export function EntryFormContextProvider({
               hasWorkingDraft: hasWorkingDraft === true,
             },
           }),
+      /*
+       * Spread rather than always present, matching `documentStatus` above:
+       * absent means nothing takes the body over, and a consumer must be able
+       * to tell that from a renderer that draws nothing.
+       */
+      ...(renderEntryFields === undefined ? {} : { renderEntryFields }),
     }),
-    [entryId, collectionSlug, isCreateMode, kind, status, hasWorkingDraft]
+    [
+      entryId,
+      collectionSlug,
+      isCreateMode,
+      kind,
+      status,
+      hasWorkingDraft,
+      renderEntryFields,
+    ]
   );
 
   return (
@@ -370,6 +413,25 @@ export function useDocumentIdentity(): DocumentIdentity | null {
  *   : null;
  * ```
  */
+/**
+ * A renderer for the entry's other fields, or null outside an entry form.
+ *
+ * Pass the asking field's path; it is excluded from what comes back. Null means
+ * there is no surrounding form to draw from — a preview or a standalone
+ * harness — and a caller should offer no panel at all rather than an empty one,
+ * because reserving width to show nothing reads as a broken control.
+ *
+ * Optional-context by construction, like {@link useDocumentIdentity}: a field
+ * rendered outside an entry form is a legitimate arrangement (a preview, a
+ * standalone harness) and gets null rather than a thrown error.
+ */
+export function useEntryFieldsPanel():
+  | ((excludePath: string) => ReactNode)
+  | null {
+  const context = useOptionalEntryFormContext();
+  return context?.renderEntryFields ?? null;
+}
+
 export function useDocumentStatus(): DocumentStatus | null {
   return useContext(EntryFormContext)?.documentStatus ?? null;
 }

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -112,6 +112,14 @@ export {
   type DocumentStatus,
 } from "./components/features/entries/EntryForm/EntryFormContext";
 /**
+ * The fields an active takeover hid, for the surface that took the body over.
+ *
+ * A takeover collapses the form body to the takeover field alone, so the rest
+ * of the entry is removed from the page rather than merely covered. Whatever
+ * took the body over is the only surface left that can still show them.
+ */
+export { useEntryFieldsPanel } from "./components/features/entries/EntryForm/EntryFormContext";
+/**
  * A field telling the form it holds work the form's values do not contain.
  *
  * Exported for the plugin surface: a contributed field with its own editing

--- a/packages/admin/src/lib/builder/takeoverLayout.test.ts
+++ b/packages/admin/src/lib/builder/takeoverLayout.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   computeMainFields,
+  computeFieldsBeside,
   takeoverControllerNames,
   takeoverTypesFromBranding,
 } from "./takeoverLayout";
@@ -140,5 +141,51 @@ describe("takeoverControllerNames", () => {
 
   it("returns empty when no takeover field is present", () => {
     expect(takeoverControllerNames(fields, [])).toEqual([]);
+  });
+});
+
+describe("computeFieldsBeside", () => {
+  it("offers every body field except the one asking and its controller", () => {
+    const out = computeFieldsBeside(fields, "content");
+    expect(out.map(f => f.name)).toEqual(["summary"]);
+  });
+
+  it("withholds the field that decides whether the asking field is visible", () => {
+    // `content` renders only while `editormode` equals "builder". Offering
+    // `editormode` inside `content`'s own panel would let an author un-render
+    // the surface they are standing in, from a control that does not say so.
+    expect(
+      computeFieldsBeside(fields, "content").map(f => f.name)
+    ).not.toContain("editormode");
+  });
+
+  it("never offers the asking field back to itself", () => {
+    // Rendering `content` inside `content`'s own panel would nest an editor in
+    // its own settings.
+    expect(
+      computeFieldsBeside(fields, "content").map(f => f.name)
+    ).not.toContain("content");
+  });
+
+  it("omits system fields, which the system header already draws", () => {
+    // A second editor for the title would be a second answer to one value.
+    const names = computeFieldsBeside(fields, "content").map(f => f.name);
+    expect(names).not.toContain("title");
+    expect(names).not.toContain("slug");
+  });
+
+  it("does not depend on a takeover being active", () => {
+    // `layout: "takeover"` is declared in the branding type and no shipped
+    // plugin sets it, so a rule conditioned on an ACTIVE takeover would be
+    // permanently inert. The same fields are offered either way.
+    const asIfActive = computeFieldsBeside(fields, "content");
+    const asIfNot = computeFieldsBeside(fields, "content");
+    expect(asIfActive.map(f => f.name)).toEqual(asIfNot.map(f => f.name));
+    expect(asIfActive.length).toBeGreaterThan(0);
+  });
+
+  it("works for the code-first shape, which is addressed by the same name", () => {
+    const out = computeFieldsBeside(codeFirstFields, "content");
+    expect(out.map(f => f.name)).toEqual(["summary"]);
   });
 });

--- a/packages/admin/src/lib/builder/takeoverLayout.ts
+++ b/packages/admin/src/lib/builder/takeoverLayout.ts
@@ -150,6 +150,50 @@ export function computeMainFields<T extends LayoutField>(
   );
 }
 
+/**
+ * The body fields a surface may offer BESIDE the one it was opened for.
+ *
+ * Everything the form body would show, minus the field at `excludePath` — the
+ * field whose own surface is asking. A page builder rendering this inside its
+ * own panel must not be offered itself, which would nest an editor in its own
+ * settings.
+ *
+ * Deliberately NOT keyed on whether a takeover is active. `layout: "takeover"`
+ * is declared in the branding type and no shipped plugin sets it, so a rule
+ * conditioned on it would be inert: the body never collapses, and a panel
+ * derived from "what the takeover hid" would be permanently empty. Excluding
+ * one path by name works whether or not the body also shows these fields —
+ * and while a full-screen surface covers the body, showing them is the only
+ * way an author reaches them without leaving it.
+ *
+ * System fields are already stripped, so the title and slug drawn by the system
+ * header are not offered a second, competing editor here.
+ */
+export function computeFieldsBeside<T extends LayoutField>(
+  fields: T[],
+  excludePath: string
+): T[] {
+  /*
+   * The field whose value decides whether the asking field is visible at all is
+   * withheld too.
+   *
+   * A page builder shown only when `editorMode === "page-builder"` would
+   * otherwise offer `editorMode` inside its own panel, where changing it
+   * un-renders the surface the author is standing in. Leaving the editor is
+   * what the exit control is for; a settings panel should not be a second,
+   * unlabelled way to do it.
+   */
+  const asking = fields.find(f => (f.name ?? "") === excludePath);
+  const controller = asking === undefined ? undefined : controllerName(asking);
+  return fields.filter(
+    f =>
+      !SYSTEM_FIELDS.has(f.name ?? "") &&
+      !isHidden(f) &&
+      (f.name ?? "") !== excludePath &&
+      (f.name ?? "") !== controller
+  );
+}
+
 /** Resolve the value a field's condition source currently holds. */
 function valueFor(f: LayoutField, values: Record<string, unknown>): unknown {
   const field = controllerName(f);

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -61,6 +61,7 @@ import {
 import {
   useDocumentCheckpoint,
   usePluginClientConfig,
+  useEntryFieldsPanel,
   useReportUnsavedWork,
   useSuppressAdminChrome,
 } from "@nextlyhq/plugin-sdk/admin";
@@ -119,6 +120,20 @@ export interface BlocksFieldProps<
  * declared ahead of the panels.
  */
 const AVAILABLE_PANELS = ["insert", "layers"] as const;
+
+/**
+ * With an entry-fields panel to fill, `settings` joins them.
+ *
+ * Derived rather than declared twice: the shell draws a panel outside
+ * `availablePanels` as disabled and "coming soon", and warns against OPENING
+ * one nothing renders into — reserving width to display nothing reads as a
+ * broken control rather than an absent feature. So the list and the renderer
+ * move together by construction, and the rail cannot disagree with the body.
+ */
+const AVAILABLE_PANELS_WITH_SETTINGS = [
+  ...AVAILABLE_PANELS,
+  "settings",
+] as const;
 
 /** Names the registry attributes these blocks to, for diagnostics. */
 const PLUGIN_SOURCE = "@nextlyhq/plugin-page-builder";
@@ -354,6 +369,12 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   const inline = useInlineText(editor);
 
   /*
+   * The entry's other fields, or null when there is no surrounding form. Null
+   * is what withholds the panel rather than opening an empty one.
+   */
+  const renderEntryFields = useEntryFieldsPanel();
+
+  /*
    * The getting-started card, and the host's switch for it.
    *
    * `checklist === false` is the only value that turns it off: an absent
@@ -420,7 +441,11 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
     <div className="fixed inset-0 z-50 bg-background">
       <BuilderShell
         onExit={done}
-        availablePanels={AVAILABLE_PANELS}
+        availablePanels={
+          renderEntryFields === null
+            ? AVAILABLE_PANELS
+            : AVAILABLE_PANELS_WITH_SETTINGS
+        }
         // Whether the page is live, which the admin's own chrome would have
         // shown had this editor not asked for it to be hidden. `undoDepth` is
         // the editor's OWN dirty signal: the form's is false for as long as the
@@ -457,6 +482,14 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             );
           }
           if (panel === "layers") return <LayersPanel editor={editor} />;
+          /*
+           * The entry's own fields — SEO, relations, whatever this collection
+           * declares — which the takeover removed from the page behind this
+           * editor. Rendered by the ADMIN's closure, not reconstructed here: how
+           * a field is drawn is the entry form's contract, and a second
+           * renderer would drift from it.
+           */
+          if (panel === "settings") return renderEntryFields?.(name) ?? null;
           return null;
         }}
       >

--- a/packages/plugin-sdk/src/__snapshots__/plugin-surface.test.ts.snap
+++ b/packages/plugin-sdk/src/__snapshots__/plugin-surface.test.ts.snap
@@ -81,6 +81,7 @@ exports[`plugin-sdk public export surface > \`./admin\` surface is unchanged 1`]
   "useDocumentIdentity (value)",
   "useDocumentLocale (value)",
   "useDocumentStatus (value)",
+  "useEntryFieldsPanel (value)",
   "usePluginClientConfig (value)",
   "usePluginFieldTypeEntries (value)",
   "useReportUnsavedWork (value)",

--- a/packages/plugin-sdk/src/admin.ts
+++ b/packages/plugin-sdk/src/admin.ts
@@ -84,6 +84,26 @@ export {
 export { useReportUnsavedWork } from "@nextlyhq/admin";
 
 /**
+ * Render the entry's remaining fields inside a takeover surface (@experimental).
+ *
+ * A field whose type is registered as a TAKEOVER collapses the form body to
+ * itself, so an entry edited through one has its SEO, its relations and its
+ * custom fields removed from the page — not merely covered. This returns a
+ * renderer for exactly those, so the surface that took the body over can offer
+ * them back without the author leaving it.
+ *
+ * Null when nothing is hidden, which is a different answer from a renderer that
+ * draws nothing: the first means offer no panel, the second means offer an
+ * empty one. A shell that reserves width to display nothing reads as a broken
+ * control rather than an absent feature.
+ *
+ * The renderer is built from the FORM'S OWN control, so what the surface draws
+ * and what the form submits are one thing. Constructing a second form would
+ * fork the state and lose the edit made in whichever copy did not save.
+ */
+export { useEntryFieldsPanel } from "@nextlyhq/admin";
+
+/**
  * Record a recovery point for the surrounding document (@experimental).
  *
  * For a contributed field that holds its own editing state — a canvas, a


### PR DESCRIPTION
Implements the shape you ruled on in `decision:pb-d8-entry-panel-vs-modal` — option (c), settings **off the canvas** but reachable without leaving the editor.

## The problem

The page builder opens full-screen over the entry form. Setting an SEO description, a publish date or any other field meant **closing the editor** — and closing it discards the editor's undo history.

The shell's left rail already declared a `settings` panel. It was empty. Now it holds the entry's other fields.

## The correction that shaped this

The obvious source was `layout: "takeover"` — the flag marking a field whose body collapses to itself. **Measured: no shipped plugin declares it.** `BLOCKS_FIELD_TYPE` doesn't set it, so `takeoverTypesFromBranding` returns an empty set, the body never collapses, and a panel derived from "what the takeover hid" would be **permanently empty**.

Confirmed two independent ways: the flag appears in no plugin, and the running admin shows Excerpt / Meta Title / Meta Description sitting beside the page-builder field right now.

So `computeFieldsBeside` excludes **one path**, supplied by the caller. That holds whether or not a takeover is ever active.

It also withholds the field the asking field's `admin.condition` reads. A builder shown only when `editorMode === "page-builder"` must not offer `editorMode` inside its own panel, where changing it un-renders the surface the author is standing in — an unlabelled second exit.

## Why a hook and not a prop

`FieldRenderer`'s `commonProps` is four keys shared by all fifteen input types; even `mode` is deliberately kept out of it. The precedent for "an opaque plugin field asks the surrounding form for something" is a context hook — `BlocksField` already consumes three (`useDocumentCheckpoint`, `useReportUnsavedWork`, `useSuppressAdminChrome`). This is the fourth.

The renderer is built from the form's **own** `control`, so what the panel draws and what the form submits are one thing. A second `EntryForm` would fork the state and lose the edit made in whichever copy did not save.

## The rail cannot disagree with the panel

`availablePanels` gains `settings` only when a renderer exists — the shell draws an unavailable panel as "coming soon" and warns against opening one nothing renders into, because reserving width to display nothing reads as a broken control rather than an absent feature.

## Verification

| | |
|---|---|
| `computeFieldsBeside` | 6 tests — what is offered, what is withheld, both field shapes |
| `useEntryFieldsPanel` | 3 tests — the three states a consumer meets: outside a form, inside one supplying nothing, inside one that does |
| admin | 2475 passed; the 15 failures are the documented standing baseline in `StatsCard` / `BasicsTab` / `SlugInput` / `DefaultValueField`, unchanged by this PR |
| plugin-sdk | 16 passed — surface snapshot updated deliberately, exactly one line: `useEntryFieldsPanel (value)` |
| plugin-page-builder | 69 passed |
| lint + typecheck | clean on all three packages |

**In the running admin**, with a page-builder field active: the rail's **Settings entry is enabled** while Components, Tokens, Fonts and Pages remain disabled — so the availability wiring is doing what it claims.

## What I did NOT verify

I could not get a clean browser reading of the **panel's rendered contents** — my first attempt read labels from the form body still mounted behind the modal, which cannot distinguish panel from body, and later attempts hit a tab reset. The rail-availability check above is real; the panel-contents claim rests on the unit tests, not on a screenshot. Worth a reviewer opening it once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a settings panel to the page builder for editing related entry fields.
  * Entry fields hidden by the builder can now be rendered and edited within the builder interface.
  * Exposed a new admin hook for integrations that need access to these fields.

* **Bug Fixes**
  * Improved field selection so hidden, system, title, slug, and controlling fields remain excluded appropriately.

* **Tests**
  * Added coverage for entry-field rendering and takeover field selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->