### PR TITLE
fix(nextly): a float rename on PostgreSQL keeps its column

### DIFF
--- a/.changeset/float-rename-keeps-its-column.md
+++ b/.changeset/float-rename-keeps-its-column.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Renaming a decimal or float field on PostgreSQL now keeps the column's contents. Such a column is reported by introspection as `float8`, a spelling the rename detector did not recognise, so it judged the column incompatible with itself and offered only to drop it and recreate it empty.

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/rename-detector-type-families.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/rename-detector-type-families.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { CANONICAL_TYPE_TOKENS } from "../diff/normalize-type";
 import {
   isTypesCompatible,
   typeFamilyOf,
@@ -134,5 +135,41 @@ describe("isTypesCompatible - symmetry", () => {
     expect(isTypesCompatible("text", "integer", "postgresql")).toBe(
       isTypesCompatible("integer", "text", "postgresql")
     );
+  });
+});
+
+// Two implementations answer "which spellings mean one type", and only one is consulted when a
+// rename decides whether to move the data.
+//
+//   normalizeType   collapses aliases to a canonical token — the string PostgreSQL introspection
+//                   actually reports, because `udt_name` names the underlying type
+//   PG_FAMILIES     is keyed by SPELLING, so it recognises only what it happens to list
+//
+// A spelling the family table lists but introspection never returns is dead weight; a canonical
+// token it omits is worse — that column is incompatible with ITSELF, because `typeFamilyOf` answers
+// null for both sides of the pair and the detector falls to drop_and_add. It recreates the column
+// empty for a change the diff says is not a change.
+//
+// Asserted over the alias TARGETS rather than a hand-written list of types, so it is complete over
+// the set where the two implementations can disagree at all: a non-aliased token passes through
+// `normalizeType` unchanged and so already matches whatever the table lists. Adding an alias now
+// forces a family decision here rather than failing silently on a live database.
+describe("every canonical type token PostgreSQL introspection can report has a family", () => {
+  it("leaves no canonical token without one", () => {
+    // 🔴 The population is asserted by MEMBERSHIP, not by size. The assertion below passes on an
+    // empty filter result, which a float-less token set satisfies perfectly — so a later edit to
+    // `TYPE_ALIASES` dropping the float entries would leave this green while removing the very pair
+    // it exists to watch. Naming them is what makes that edit fail here.
+    expect(
+      CANONICAL_TYPE_TOKENS,
+      "the floating-point canonical tokens this check exists to cover"
+    ).toEqual(expect.arrayContaining(["float8", "float4"]));
+
+    expect(
+      CANONICAL_TYPE_TOKENS.filter(
+        token => typeFamilyOf(token, "postgresql") === null
+      ),
+      "introspection reports these spellings and the rename detector does not recognise them — a rename between two columns of such a type drops the data"
+    ).toEqual([]);
   });
 });

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/rename-type-agreement.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/rename-type-agreement.test.ts
@@ -209,17 +209,16 @@ function asIntrospected(declared: string, dialect: SupportedDialect): string {
  * spellings recreates the column empty, for a change the diff itself says is not a change.
  */
 const ACCEPTED: Record<string, string> = {
-  // One entry, and it is worth saying why there is not a second. The family table also splits
-  // MySQL's `boolean` from `tinyint`, which looks like the same class of bug. That spelling never
-  // reaches the detector: a column declared `boolean` is reported by MySQL as `tinyint(1)`, so a
-  // checkbox rename compares `tinyint(1)` with itself and is already compatible.
+  // Empty, and it is worth saying why rather than leaving the next reader to wonder whether the
+  // list was ever populated. It held one entry: `float8` was absent from the PostgreSQL family
+  // table, so a float column was incompatible with ITSELF and every rename of one fell to
+  // drop_and_add. Adding `float8` and `float4` to that table resolved it, and the assertion below
+  // is what forced this entry out with them.
   //
-  // 🔴 `float8` is absent from the PostgreSQL family table entirely, so it is incompatible with
-  // ITSELF: `typeFamilyOf` answers null and every pair involving it falls to drop_and_add. `real`
-  // (float4) and `numeric` are both present, which is why this went unnoticed. Consequence:
-  // renaming a float number field on PostgreSQL drops the column.
-  "postgresql:float8->float8":
-    "float8 missing from the PostgreSQL family table",
+  // The family table also splits MySQL's `boolean` from `tinyint`, which looks like the same class
+  // of bug and must not be added here. That spelling never reaches the detector: a column declared
+  // `boolean` is reported by MySQL as `tinyint(1)`, so a checkbox rename compares `tinyint(1)` with
+  // itself and is already compatible.
 };
 
 const keyFor = (dialect: string, from: string, to: string): string =>

--- a/packages/nextly/src/domains/schema/pipeline/diff/normalize-type.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/normalize-type.ts
@@ -77,6 +77,22 @@ const TYPE_ALIASES: Record<string, string> = {
 };
 
 /**
+ * Every canonical token an ALIASED spelling collapses to.
+ *
+ * Derived from `TYPE_ALIASES` rather than listed beside it, so a new alias cannot be added without
+ * its target appearing here.
+ *
+ * 🔴 This is the set on which two spellings of one type can disagree between implementations. A
+ * token that is not an alias target passes through `normalizeType` unchanged, so any table keyed by
+ * the spelling already matches it; an aliased one does not — the live side reports `float8` while a
+ * table listing `double precision` never sees that string. Consumers keyed by type spelling are
+ * therefore complete only if they cover these.
+ */
+export const CANONICAL_TYPE_TOKENS: readonly string[] = [
+  ...new Set(Object.values(TYPE_ALIASES)),
+];
+
+/**
  * Return the canonical form of a column-type string for diff comparison.
  * `undefined` is passed through unchanged. The diff still emits the original,
  * un-normalised type names in the op so downstream tooling sees what's stored.

--- a/packages/nextly/src/domains/schema/pipeline/rename-detector-type-families.ts
+++ b/packages/nextly/src/domains/schema/pipeline/rename-detector-type-families.ts
@@ -48,11 +48,22 @@ const PG_FAMILIES: Record<TypeFamily, readonly string[]> = {
     "bigserial",
     "smallserial",
   ],
+  // float8 and float4 are what PG's information_schema.columns.udt_name
+  // returns for `double precision` and `real`; the SQL-standard spellings
+  // beside them only ever reach this table from the DESIRED side. Without
+  // the internal names a float column is not merely unmatched against its
+  // SQL spelling — it is incompatible with ITSELF, because both sides of the
+  // pair introspect as `float8`, typeFamilyOf answers null for each, and the
+  // rename falls to drop_and_add. `numeric` and the integer family's int2 /
+  // int4 / int8 already carry both spellings, which is why this gap was
+  // confined to floats.
   decimal: [
     "decimal",
     "numeric",
     "real",
+    "float4",
     "double precision",
+    "float8",
     "double",
     "float",
   ],


### PR DESCRIPTION
Renaming a float or decimal number field on PostgreSQL dropped the column and recreated it empty.

## The defect

PostgreSQL introspection reads `information_schema.columns.udt_name`, which reports a `double precision` column as **`float8`** and a `real` column as **`float4`**. Neither spelling was in the rename detector's PostgreSQL `decimal` family — it listed only the SQL-standard names, which arrive from the *desired* side and never from the live one.

So `typeFamilyOf("float8", "postgresql")` answered `null`. In `rename-detector.ts:59` both sides of a float rename are `float8`, both resolve to `null`, `isTypesCompatible` returns false, and `defaultSuggestion` becomes `drop_and_add`. The column was incompatible with **itself**.

`numeric` and the integer family's `int2`/`int4`/`int8` already carried both spellings, which is why the gap was confined to floats.

## Evidence

Establishing that the accepted entry was load-bearing rather than decorative — removing it on **unfixed** code:

```
AssertionError: a rename between these spellings recreates the column empty,
for a change the diff says is not a change
+ "float8 -> float8: the diff reads one column (float8), the detector offers drop_and_add"
Tests  1 failed | 3 passed (4)
```

The new guard, run against the **unfixed** family table — it names the two missing tokens and nothing else:

```
AssertionError: introspection reports these spellings and the rename detector
does not recognise them — a rename between two columns of such a type drops the data
+ [ "float8", "float4" ]
Tests  1 failed | 22 passed (23)
```

After the fix, both suites: `Tests 27 passed (27)`, against a baseline of 26 — the delta is the new test, so the count went up rather than down.

## The guard

Rather than adding two more spellings to a hand-kept list, the check is derived from the canonicaliser that already owns this question. `normalizeType` collapses aliases to the token introspection actually returns, so its alias **targets** are exactly the set on which the two implementations can disagree — a non-aliased token passes through unchanged and so already matches whatever the family table lists. `CANONICAL_TYPE_TOKENS` is computed from `TYPE_ALIASES` rather than listed beside it.

The population is asserted by **membership**, not by size: the assertion's passing condition is an empty filter result, which a float-less token set would satisfy perfectly, so an edit to `TYPE_ALIASES` that dropped the float entries would otherwise leave the check green while removing the pair it exists to watch.

Adding a future alias now forces a family decision here instead of failing silently against a live database.

## Gates

| gate | result |
| --- | --- |
| `pnpm install` / `pnpm build` (fresh worktree) | exit 0 / exit 0 |
| `turbo check-types --filter=nextly --force` | exit 0, `7 successful`, `0 cached` |
| `turbo lint --filter=nextly --force` | exit 0, `1 successful`, `0 cached` |
| `vitest run src/domains/schema/pipeline` | 4 pre-existing failures, unchanged |
| `fallow audit --gate-marker agent` | `verdict: pass`, 5 changed files, 0 introduced |

Every exit status was read directly, never through a pipe.

## Pre-existing failures, confirmed not mine

The affected-domain run showed 9 failures across 5 files, two of which sit in this change's blast radius (`does NOT auto-rename manyToMany relations`, `maps number fields to float8`). I reverted the source changes and re-ran the same five files on a pristine tree: **the same 9 failures, by name**. They belong to the known stale-mock baseline (`task:test-baseline-repair`).

## Not verified

- **No PostgreSQL integration leg was run.** The evidence above is unit-level. The claim that `udt_name` reports `float8` rests on PostgreSQL's documentation and on this repository's own already-measured comments in `normalize-type.ts` and `build-from-fields.ts`, not on a live server I queried.
- **`float4` is not reachable from Nextly's own builders** — the descriptor emits `real` only on SQLite, so only `float8` is currently produced on PG. `float4` is included because introspection would report it for a `real` column in a user's pre-existing database, and Nextly runs against the user's own schema. That path is untested here.
- The two spellings are added to the same `decimal` family as `numeric`, matching the existing decision that already places `real` and `numeric` together. Whether floats deserve their own family is not revisited.

## Follow-up worth filing

The underlying shape is two implementations of "which spellings mean one type". Routing `typeFamilyOf` through `normalizeType` for PostgreSQL would make the divergence impossible by construction rather than detectable by test. I checked the mapping and it is behaviour-preserving on every spelling currently listed — but it changes a data-loss-critical path across three dialects and deserves its own review, so it is not in this PR.
