### PR TITLE
fix(release): close the frontmatter on two changesets that block every publish

### DIFF
--- a/.changeset/editor-canvas-renders-node-styles.md
+++ b/.changeset/editor-canvas-renders-node-styles.md
@@ -1,5 +1,4 @@
 ---
-
 "nextly": patch
 "create-nextly-app": patch
 "@nextlyhq/admin": patch
@@ -24,6 +23,7 @@
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/builder": patch
 "@nextlyhq/module-specifiers": patch
+---
 
 The editor canvas drew every block flush and unstyled while the published page drew the author's
 real spacing. An author setting a margin, a height or any other per-node style saw nothing change

--- a/.changeset/entry-fields-panel-in-takeover-surfaces.md
+++ b/.changeset/entry-fields-panel-in-takeover-surfaces.md
@@ -1,5 +1,4 @@
 ---
-
 "nextly": patch
 "create-nextly-app": patch
 "@nextlyhq/admin": patch
@@ -24,6 +23,7 @@
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/builder": patch
 "@nextlyhq/module-specifiers": patch
+---
 
 A field that covers the whole entry form left its author unable to reach the rest of the entry.
 The page builder opens full-screen over the form, so setting an SEO description or a publish date

--- a/scripts/changesets-parse.test.mjs
+++ b/scripts/changesets-parse.test.mjs
@@ -1,0 +1,79 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import parse from "@changesets/parse";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Every changeset must parse, because the release workflow reads them all at
+ * once and one malformed file fails the whole run.
+ *
+ * The failure is remote from its cause in both directions, which is what makes
+ * it worth a test rather than a convention. A changeset is added by one pull
+ * request and read by `Version & Publish` on a LATER push to `main`, so the run
+ * that goes red belongs to whoever merged next — and the changeset itself is
+ * never executed by the pull request that introduced it. Nothing in `lint`,
+ * `check-types` or any package's suite opens these files.
+ *
+ * 🔴 Uses the release tooling's OWN parser rather than a reader of the same
+ * question. The defect this was written for is a blank line between the opening
+ * `---` and the first package, which every Markdown tool and every human reader
+ * accepts, and which `@changesets/parse` rejects. A hand-rolled check would
+ * encode whichever spellings its author happened to think of and would answer
+ * differently from the tool that actually decides.
+ *
+ * Measured: two changesets on `main` carried that blank line and
+ * `Version & Publish` failed with "could not parse changeset - missing or
+ * invalid frontmatter", blocking the release train for every package.
+ */
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const changesetDir = resolve(repoRoot, ".changeset");
+
+/** `parse` is published CJS; the namespace import carries it on `default`. */
+const parseChangeset = parse.default ?? parse;
+
+/**
+ * The changeset files, which are every `.md` except the directory's own README.
+ *
+ * `config.json` and `pre.json` are not Markdown and are not candidates.
+ */
+const changesetFiles = readdirSync(changesetDir)
+  .filter(name => name.endsWith(".md") && name !== "README.md")
+  .sort();
+
+describe("every changeset", () => {
+  /**
+   * Asserted before the verdict, and by a floor rather than by nothing.
+   *
+   * The check below passes on an empty list of files exactly as it passes on a
+   * directory of valid ones — so a glob that stopped matching, or a directory
+   * that moved, would certify the release train while reading nothing at all.
+   */
+  it("is discovered at all", () => {
+    expect(
+      changesetFiles.length,
+      "changeset files found in .changeset"
+    ).toBeGreaterThan(0);
+  });
+
+  it("parses with the parser the release workflow uses", () => {
+    const unparseable = [];
+    for (const name of changesetFiles) {
+      try {
+        parseChangeset(readFileSync(join(changesetDir, name), "utf8"));
+      } catch (error) {
+        // The message is kept whole and the file named, because the release log
+        // truncates the offending content and the reader otherwise cannot tell
+        // WHICH of several hundred files failed.
+        unparseable.push(`${name}: ${error.message.split("\n")[0]}`);
+      }
+    }
+
+    expect(
+      unparseable,
+      "the release workflow reads every changeset in one pass, so one of these fails the whole publish"
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
`main` is red on `Version & Publish` and the release train is stopped for every package.

## What broke

`Version & Publish` reads every changeset in one pass, so a single unparseable file fails the whole run. Two changesets carried a blank line after the opening `---` **and no closing delimiter at all**, leaving the frontmatter unterminated and the package list part of the summary.

Measured on the merge commit for #1103 (`7f47d66b9`), job [96188382287](https://github.com/nextlyhq/nextly/actions/runs/32289953709/job/96188382287):

```
##[error]Error: could not parse changeset - missing or invalid frontmatter.
Changesets must start with frontmatter delimited by "---".
```

The two files:
- `.changeset/editor-canvas-renders-node-styles.md`
- `.changeset/entry-fields-panel-in-takeover-surfaces.md`

**Neither is mine, and neither PR that introduced them could have caught it.** A changeset is written by one change and read by `Version & Publish` on a *later* push to `main`, so the run that goes red belongs to whoever merged next. Nothing in `lint`, `check-types` or any package suite opens these files. I found it while verifying my own merge and checked whether it was my changeset first — it parses fine.

## The fix

One line per file: drop the stray blank line, close the frontmatter before the prose.

```diff
 ---
-
 "nextly": patch
 …
 "@nextlyhq/module-specifiers": patch
+---
 
 The editor canvas drew every block flush and unstyled…
```

Both now parse with the summary intact — 24 releases and 1271/819 summary characters respectively, so no prose was swallowed into the frontmatter.

## The guard, and a mistake worth recording

`scripts/changesets-parse.test.mjs` parses every changeset with **`@changesets/parse` itself** — the release tooling's own parser — rather than a reader of the same question. It runs in CI via `pnpm test:scripts` (`ci.yml:370`).

That choice was not stylistic. My first pass at this used a hand-written check, which reported *only* the blank line, `continue`d, and never reached the missing-delimiter case. I "fixed" both files on that diagnosis and they were **still broken** — the parser was what caught it. A check that encodes whichever spellings its author thought of is exactly the second-implementation defect `derived-checks.md` describes, and it produced a false clean within ten minutes of being written.

The population is asserted before the verdict: an empty list of changeset files would satisfy the parse assertion exactly as a directory of valid ones does, so the test first requires that any files were discovered.

## Evidence

Control — the guard against the **unfixed** files, naming both:

```
AssertionError: the release workflow reads every changeset in one pass,
so one of these fails the whole publish: expected [ …(2) ] to deeply equal []
+ "editor-canvas-renders-node-styles.md: could not parse changeset - missing or invalid frontmatter.",
+ "entry-fields-panel-in-takeover-surfaces.md: could not parse changeset - missing or invalid frontmatter.",
Tests  1 failed | 579 passed (580)
```

After the fix:

```
pnpm test:scripts   EXIT=0    Test Files 21 passed (21)   Tests 580 passed (580)
```

Re-verified **after** the commit, because lint-staged runs prettier over `*.md` and reformatting is the class of thing that caused this: 668 changesets scanned, 0 bad.

`fallow audit` — `verdict: pass`, 0 introduced findings.

No changeset in this PR: it changes release tooling and adds a test, and touches no product code.

## Note on territory

The two changesets belong to the page-builder lane's merged work. I edited only their frontmatter delimiters — no wording, no package list, no summary — because `main` is red and the fix is unambiguous. Flagging it explicitly so that lane knows their files were touched.

## Not verified

- I did not re-run `Version & Publish` — it triggers on push to `main`, so the real confirmation is the next push after this merges. The evidence here is that the exact parser the workflow uses now accepts all 668 files.
- I did not audit *why* the delimiters went missing. Both files show the same shape, which suggests a common tool or template rather than two independent slips, but I have not established that and the guard catches it either way.
