### PR TITLE
test(nextly): the family guard asserts which family, not merely that there is one

### DIFF
--- a/.changeset/float-rename-keeps-its-column.md
+++ b/.changeset/float-rename-keeps-its-column.md
@@ -26,4 +26,4 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-Renaming a decimal or float field on PostgreSQL now keeps the column's contents. Such a column is reported by introspection as `float8`, a spelling the rename detector did not recognise, so it judged the column incompatible with itself and offered only to drop it and recreate it empty.
+Renaming a float number field on PostgreSQL now keeps the column's contents. Such a column is reported by introspection as `float8`, a spelling the rename detector did not recognise, so it judged the column incompatible with itself and offered only to drop it and recreate it empty. Decimal fields were never affected: they introspect as `numeric`, which the detector already recognised.

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/rename-detector-type-families.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/rename-detector-type-families.test.ts
@@ -150,26 +150,42 @@ describe("isTypesCompatible - symmetry", () => {
 // null for both sides of the pair and the detector falls to drop_and_add. It recreates the column
 // empty for a change the diff says is not a change.
 //
-// Asserted over the alias TARGETS rather than a hand-written list of types, so it is complete over
-// the set where the two implementations can disagree at all: a non-aliased token passes through
-// `normalizeType` unchanged and so already matches whatever the table lists. Adding an alias now
-// forces a family decision here rather than failing silently on a live database.
+// Asserted over the alias TARGETS rather than a hand-written list of types. That covers the
+// SCALAR spellings, which is where the divergence this repairs lived, and it is narrower than the
+// set of strings the detector can receive — `normalizeType` also produces array tokens (`_int4`
+// and `integer[]` both canonicalise to `int4[]`), and `Object.values(TYPE_ALIASES)` contains none
+// of them. An array column is incompatible with itself here exactly as `float8` was; no field type
+// renders one today, because `hasMany` reaches `jsonb`, so the pair is unreachable from this
+// product rather than handled.
 describe("every canonical type token PostgreSQL introspection can report has a family", () => {
-  it("leaves no canonical token without one", () => {
-    // 🔴 The population is asserted by MEMBERSHIP, not by size. The assertion below passes on an
-    // empty filter result, which a float-less token set satisfies perfectly — so a later edit to
-    // `TYPE_ALIASES` dropping the float entries would leave this green while removing the very pair
-    // it exists to watch. Naming them is what makes that edit fail here.
+  it("puts each canonical token in the family that type belongs to", () => {
+    // 🔴 The population is asserted by MEMBERSHIP, not by size. The filter below passes on an empty
+    // result, which a float-less token set satisfies perfectly — so a later edit to `TYPE_ALIASES`
+    // dropping the float entries would leave this green while removing the very pair it exists to
+    // watch. Naming them is what makes that edit fail here.
     expect(
       CANONICAL_TYPE_TOKENS,
       "the floating-point canonical tokens this check exists to cover"
     ).toEqual(expect.arrayContaining(["float8", "float4"]));
 
+    // 🔴 Null-reachability — that `typeFamilyOf` can still answer null at all — is what stops the
+    // filter below being vacuous, and it is asserted by "returns null for unknown types" above
+    // rather than here. Declared rather than left to be inferred: a neighbouring control is a real
+    // control and a fragile one, and rewriting that test silently empties this one.
     expect(
       CANONICAL_TYPE_TOKENS.filter(
         token => typeFamilyOf(token, "postgresql") === null
       ),
       "introspection reports these spellings and the rename detector does not recognise them — a rename between two columns of such a type drops the data"
     ).toEqual([]);
+
+    // Non-null is the weaker property, and for the self-pair it is enough: one spelling cannot
+    // disagree with itself about which family it is in. It says nothing about whether the table is
+    // RIGHT, and the separating property is that spellings meaning one storage type share a family.
+    // Measured: moving `float8` into `binary` leaves every assertion above green while
+    // `numeric -> float8` — a number field whose format changes from decimal to float — silently
+    // becomes drop_and_add, which is the same data loss one type along.
+    expect(typeFamilyOf("float8", "postgresql")).toBe("decimal");
+    expect(typeFamilyOf("float4", "postgresql")).toBe("decimal");
   });
 });


### PR DESCRIPTION
Follow-up to #1103, from the local review fleet. #1103 merged before the reviewers reported, so these are post-merge repairs.

## The finding that mattered

My guard in #1103 asserted `typeFamilyOf(token, "postgresql") !== null` — that a canonical token has **a** family. The separating property for a family table is that spellings meaning one storage type share **the same** family, and non-null is strictly weaker.

Verified by mutation rather than by reading. Moving `float8` out of `decimal` and into `binary`:

```diff
-  decimal: [… "float4", "double precision", "float8", …],
+  decimal: [… "float4", "double precision", …],
-  binary: ["bytea"],
+  binary: ["bytea", "float8"],
```

**All 27 tests still passed, exit 0.** Under that table `numeric → float8` — a number field whose format changes from decimal to float — silently becomes `drop_and_add`, which is the same data loss #1103 fixed, one type along.

Non-null *is* sufficient for the self-pair #1103 actually repaired, because one spelling cannot disagree with itself about where it belongs. So the guard reached that mechanism; it just said nothing about whether the table is right.

Now asserted directly:

```ts
expect(typeFamilyOf("float8", "postgresql")).toBe("decimal");
expect(typeFamilyOf("float4", "postgresql")).toBe("decimal");
```

Control — the same mutation against the strengthened test:

```
AssertionError: expected 'binary' to be 'decimal'
Tests  1 failed | 22 passed (23)
```

## Two comment corrections

**The completeness claim was wider than the assertion.** #1103's header said the check was "complete over the set where the two implementations can disagree at all", justified by "a non-aliased token passes through `normalizeType` unchanged and so already matches whatever the table lists."

Both halves are wrong. `normalizeType` canonicalises through **two** mechanisms and `CANONICAL_TYPE_TOKENS` derives from one: array notation is applied *after* the alias lookup (`normalize-type.ts:121-134`), so no array token can appear in `Object.values(TYPE_ALIASES)`. And a non-aliased token the family table does not list is not "already matched" — it is `null` on both sides, the identical incompatible-with-itself shape.

Measured: `_text` and `text[]` both canonicalise to `text[]`, both give `family: null`, `compatible: false`. The comment now states the boundary instead of claiming there isn't one.

**The null-reachability control is now declared.** The filter assertion is satisfied by absence, so its meaning depends on `typeFamilyOf` still being *able* to return null. That control lives in the neighbouring `returns null for unknown types` test. `derived-checks.md` asks for such a dependency to be declared rather than inferred, since rewriting the neighbour silently empties this one.

## Changeset wording

`.changeset/float-rename-keeps-its-column.md` claimed "decimal or float". A decimal field introspects as `numeric`, which the family table already listed, so decimal renames were never broken — and the entry's own next sentence contradicted it by saying the column is reported as `float8`. #1103 removed exactly one accepted disagreement, `postgresql:float8->float8`. Corrected, since release notes reach users and this one told them their money columns were at risk.

## Evidence

| gate | result |
| --- | --- |
| `vitest` on both touched suites | `27 passed (27)`, exit 0 |
| mutation control (float8 → binary) | fails `expected 'binary' to be 'decimal'` |
| `@changesets/parse` over `.changeset` | 668 scanned, 0 bad — re-run **after** commit, since prettier rewrites `.md` |
| `fallow audit` | `verdict: pass`, 0 introduced |

Test count is unchanged at 27: this strengthens an existing assertion rather than adding a test, so nothing was dropped.

No changeset for the test change itself; the one edit here is to an existing unreleased changeset's wording.

## Deliberately not in this PR

The correctness review raised that widening `decimal` newly makes `numeric ↔ float8` a same-family pair, so `conversionForRename` emits `ALTER COLUMN … TYPE float8 USING …::float8` and the operator is told `(data preserved)` while exact decimal becomes binary float — and the reverse direction can raise `numeric field overflow` at `DEFAULT_DECIMAL_PRECISION = 10`.

I am not changing that here, for two reasons: it is pre-existing policy rather than a new class (MySQL's `double ↔ decimal(10,2)` were already one family, as were `text → varchar(N)`), and converting is still strictly better than the `drop_and_add` that preceded it, which destroyed the column outright. But the `(data preserved)` label overstates a lossy conversion, and that deserves its own decision. Filing it separately.

## Not verified

- Still no PostgreSQL integration leg — all evidence is unit-level.
- The array-token gap is stated, not closed. No field type renders an array column today (`hasMany` reaches `jsonb`), so there is no live data-loss path, but core schema does declare one — `packages/nextly/src/schemas/media/postgres.ts:82`, `tags: text("tags").array()` — and no user action produces a drop+add pair on it. Unreachable rather than handled.
