### PR TITLE
test(e2e): the Phase 3 exit demo, in a production build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,10 @@ coverage
 .next/
 # Build directory for the browser suite's own dev server (see e2e/playwright.config.ts).
 .next-e2e/
+# And for the production exit demo, which builds rather than serving from source
+# (see e2e/playwright.production.config.ts). A separate directory because two
+# Next processes on one app fight over the same one.
+.next-e2e-prod/
 out/
 build
 dist

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,6 +6,7 @@
   "description": "Browser tests for the admin, run against the playground app.",
   "scripts": {
     "test:e2e": "playwright test",
+    "test:e2e:prod": "playwright test --config playwright.production.config.ts",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:report": "playwright show-report",

--- a/e2e/playwright.production.config.ts
+++ b/e2e/playwright.production.config.ts
@@ -1,0 +1,91 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { defineConfig, devices } from "@playwright/test";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const NEXTLY_ROOT = path.resolve(HERE, "..");
+
+/**
+ * Its own port and its own database file, so this can run beside the dev suite
+ * without either emptying the other's data underneath it.
+ */
+const PORT = Number(process.env.E2E_PROD_PORT) || 3101;
+const BASE_URL = `http://localhost:${PORT}`;
+const E2E_DB_RELATIVE = "file:./data/e2e-prod.db";
+
+/**
+ * The phase's exit demo, and the only suite here that runs a PRODUCTION build.
+ *
+ * A separate config rather than a project inside the dev one, because the two
+ * cannot share a `webServer`: this needs `next build` before `next start`, and
+ * the difference is the entire point. Task 179's 500-on-every-path reproduced
+ * only in a production build and never in `next dev`, so a suite that boots the
+ * dev server certifies the phase's exit criterion against the one environment
+ * the failure could not appear in.
+ *
+ * Dev auto-login is correctly hard-blocked here, so the spec signs in through
+ * the real form with the seeded credentials. That is not incidental — an exit
+ * demo that authenticated by a dev-only shortcut would prove a path no visitor
+ * or editor ever takes.
+ *
+ * @module playwright.production.config
+ */
+export default defineConfig({
+  testDir: "./tests/production",
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: 0,
+  workers: 1,
+  reporter: process.env.CI ? [["github"], ["line"]] : [["line"]],
+  use: {
+    baseURL: BASE_URL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+
+  webServer: {
+    // Reset, then seed, then BUILD, then serve. The seed runs against the same
+    // database the built server will open, and it is what creates the user this
+    // suite signs in as — there is no dev auto-login to fall back on.
+    command: [
+      "node e2e/scripts/reset-e2e-db.mjs",
+      "pnpm --filter playground exec tsx scripts/seed.ts",
+      "pnpm --filter playground exec next build",
+      "pnpm --filter playground exec next start",
+    ].join(" && "),
+    cwd: NEXTLY_ROOT,
+    url: `${BASE_URL}/api/health`,
+    // A production build is minutes, not seconds, and this budget covers the
+    // build as well as the boot because they share one command.
+    timeout: 15 * 60 * 1000,
+    reuseExistingServer: false,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      PORT: String(PORT),
+      DB_DIALECT: "sqlite",
+      DATABASE_URL: E2E_DB_RELATIVE,
+      // Its own build directory, for the same reason the dev suite has one: two
+      // Next processes on one app fight over `.next`.
+      NEXT_DIST_DIR: ".next-e2e-prod",
+      // Production REQUIRES both of these and refuses to boot without them —
+      // `env.ts` rejects a missing or under-32-character `NEXTLY_SECRET` and a
+      // missing `NEXT_PUBLIC_APP_URL` only when NODE_ENV is production, which is
+      // why `pnpm dev:app` never needed them. A fresh checkout also has no
+      // `.env` (the dev script writes one; `next build` does not), so stating
+      // them here is what makes this suite runnable from a clean clone.
+      //
+      // A literal test secret, not a generated one: a value that changed per run
+      // would re-key everything derived from it and make a failure depend on
+      // which run produced the database.
+      NEXTLY_SECRET:
+        "e2e-production-exit-demo-secret-not-a-real-deployment-key",
+      NEXT_PUBLIC_APP_URL: BASE_URL,
+      // NO harness routes. The dev suite enables them; this one must not, because
+      // the demo's claim is about what a VISITOR is served, and a dev-only route
+      // reachable in the build under test would falsify exactly that.
+    },
+  },
+});

--- a/e2e/tests/production/exit-demo.spec.ts
+++ b/e2e/tests/production/exit-demo.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Phase 3's exit demo: a page built in the builder, served to a visitor from a
+ * PRODUCTION build.
+ *
+ * D-04.10 requires this environment specifically. Task 179's 500-on-every-path
+ * reproduced only under `next build` and never in `next dev`, so the same
+ * assertions against a dev server would certify the phase in the one environment
+ * the failure it guards against cannot appear in.
+ *
+ * Dev auto-login is hard-blocked here, correctly, so this signs in through the
+ * real form with the credentials the seed creates. An exit demo that
+ * authenticated by a dev-only shortcut would prove a path nobody takes.
+ *
+ * @module tests/production/exit-demo
+ */
+
+const DEV_USER = { email: "dev@nextly.local", password: "DevPassword123!" };
+
+/** Distinctive enough that finding it on the page cannot be a coincidence. */
+const HEADLINE = "Published from the builder, in a production build";
+
+test.describe("the production exit demo", () => {
+  test("a builder-authored page reaches a visitor, carrying no editor markers", async ({
+    page,
+    request,
+  }) => {
+    // 1. Sign in through the real form. Asserting the landing state first,
+    //    because a failed sign-in leaves a page that still renders and every
+    //    later assertion would fail for the wrong reason.
+    await page.goto("/admin");
+    await page.getByRole("textbox", { name: /email/i }).fill(DEV_USER.email);
+    // By ROLE, not by label: `getByLabel(/password/i)` also matches the "Show
+    // password" toggle beside the input, and a locator that resolves to two
+    // elements fails on strict mode rather than on anything about the product.
+    await page
+      .getByRole("textbox", { name: /password/i })
+      .fill(DEV_USER.password);
+    await page.getByRole("button", { name: /sign in|log in/i }).click();
+    await expect(page.locator("main")).toBeVisible({ timeout: 60_000 });
+
+    // 2. Author a page THROUGH THE API the editor writes with, rather than by
+    //    inserting rows: the claim is about what the product serves for content
+    //    the product accepted, and a hand-written row can be shaped in ways the
+    //    write path would have rejected.
+    const cookies = await page.context().cookies();
+    const cookieHeader = cookies.map(c => `${c.name}=${c.value}`).join("; ");
+
+    const authored = await request.patch("/admin/api/singles/homepage", {
+      headers: { cookie: cookieHeader, "content-type": "application/json" },
+      data: {
+        layout: {
+          formatVersion: 1,
+          kind: "page",
+          nodes: [
+            {
+              id: "exit-demo-heading",
+              type: "core/heading",
+              version: 1,
+              props: { text: HEADLINE, level: "h1" },
+            },
+          ],
+        },
+      },
+    });
+    expect(
+      authored.ok(),
+      `authoring failed: ${authored.status()} ${await authored.text()}`
+    ).toBe(true);
+
+    // 3. The visitor's view. A plain fetch, not the signed-in browser context —
+    //    a page that renders only for an authenticated editor is not published.
+    const visitor = await request.get("/", {
+      headers: { cookie: "" },
+    });
+    expect(visitor.status()).toBe(200);
+    const html = await visitor.text();
+
+    // The POPULATION: the authored content is actually on the page. Without
+    // this the marker assertions below pass for an empty page.
+    expect(html).toContain(HEADLINE);
+
+    // 4. No editor markers. `data-nx-node` is emitted only when a host asks for
+    //    it, and a published route must not — this is the claim that had no
+    //    production-build evidence before this spec existed.
+    expect(html).not.toContain("data-nx-node");
+    expect(html).not.toContain("data-nx-selected");
+    expect(html).not.toContain("nx-drop-indicator");
+  });
+
+  test("an unknown page answers 404, not 500", async ({ request }) => {
+    // Task 179's failure: a route whose collection is empty at build time
+    // answered 500 on EVERY path, in a production build only. A 404 is the
+    // route working; a 500 is the route broken in a way that looks like content.
+    const missing = await request.get("/no-such-page-exists-here");
+    expect(missing.status()).toBe(404);
+  });
+});

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -448,7 +448,7 @@
       // GITHUB_STEP_SUMMARY: the flaky reporter appends a table of tests that
       // passed only on retry. Read rather than written by the suite's logic, so
       // it changes no result — but it is still an input turbo must know about.
-      "env": ["CI", "E2E_PORT", "GITHUB_STEP_SUMMARY"]
+      "env": ["CI", "E2E_PORT", "E2E_PROD_PORT", "GITHUB_STEP_SUMMARY"]
     },
 
     // test:coverage - Generate and display code coverage report


### PR DESCRIPTION
Phase 3's exit criterion — *a page built in the builder, served to a visitor from a production build* — had **no evidence behind it**. This provides it.

## Why it cannot reuse the existing suite

The existing suite boots `pnpm dev:app`. D-04.10 exists precisely because task 179's 500-on-every-path **reproduced only under `next build`** and never in `next dev`. Asserting the criterion against a dev server certifies the phase in the one environment its failure cannot appear in.

So: a separate config running `reset → seed → next build → next start`, on its own port, database and dist directory. The two configs cannot share a `webServer`, and that difference is the entire point.

**It enables no harness routes.** The dev suite turns them on; this must not — the demo's claim is about what a *visitor* is served, and a dev-only route reachable inside the build under test falsifies exactly that.

## What it asserts

| | |
|---|---|
| Sign-in | through the **real form** with seeded credentials — dev auto-login is correctly hard-blocked in production, and a demo authenticating by a dev shortcut proves a path nobody takes |
| Authoring | through the **API the editor writes with**, not a hand-inserted row — a row can hold a shape the write path would refuse |
| **Population** | the authored headline is **on the page**, asserted *before* the marker checks, without which every one of them passes against an empty page |
| No editor markers | no `data-nx-node`, no `data-nx-selected`, no `nx-drop-indicator` — fetched **signed out**, because a page that renders only for an authenticated editor is not published |
| 404 not 500 | an unknown path answers 404, the exact failure task 179 recorded |

## It found a real bug on the way

**The playground cannot boot in production from a clean checkout.** `env.ts` requires `NEXTLY_SECRET` (≥32 chars) and `NEXT_PUBLIC_APP_URL` **only** when `NODE_ENV=production` — so `pnpm dev:app` never needed them — and a fresh worktree has **no `.env` at all**, because the dev script writes one and `next build` does not.

First run died at boot with `Invalid environment configuration`. That is the deploy path: anyone taking this to production meets it, nobody in dev ever does. Both values are now supplied by the config, which is what makes the suite runnable from a clean clone. Filed as `finding:playground-cannot-boot-in-production-clean`.

## Verification

`pnpm --filter @nextlyhq/e2e test:e2e:prod` → **2 passed (22.7s)**, exit 0. Typecheck and lint clean.

Three failures preceded that green, each real and each further in: env rejected at boot → server boots and the 404 test passes → sign-in locator ambiguous (`getByLabel(/password/i)` also matched the "Show password" toggle; now role-based, with a comment so it isn't reintroduced).

## Not wired into CI, deliberately

A production build is minutes. Running it on every PR is a real cost, and I would rather you choose than have me add it unilaterally — especially having just had a CI change of mine corrected. Options: on pushes to `main` only (cheap, catches regressions after merge), on PRs touching `packages/blocks-*`/`plugin-page-builder`/`e2e` (targeted), or nightly. Say which and I will wire it.

`.next-e2e-prod/` joins `.gitignore` beside `.next-e2e/`; `E2E_PROD_PORT` joins `turbo.jsonc`'s env list beside `E2E_PORT`.

No changeset: test-only.