### PR TITLE
docs(root): the changeset parse guard describes the code, not the change

### DIFF
--- a/scripts/changesets-parse.test.mjs
+++ b/scripts/changesets-parse.test.mjs
@@ -10,22 +10,20 @@ import { describe, expect, it } from "vitest";
  * once and one malformed file fails the whole run.
  *
  * The failure is remote from its cause in both directions, which is what makes
- * it worth a test rather than a convention. A changeset is added by one pull
- * request and read by `Version & Publish` on a LATER push to `main`, so the run
- * that goes red belongs to whoever merged next — and the changeset itself is
- * never executed by the pull request that introduced it. Nothing in `lint`,
- * `check-types` or any package's suite opens these files.
+ * it worth a test rather than a convention. A changeset is authored at one
+ * commit and read by `Version & Publish` on a LATER push to `main`, so the run
+ * that goes red need not be the one that introduced the file — and nothing in
+ * `lint`, `check-types` or any package's suite opens these files at all.
  *
  * 🔴 Uses the release tooling's OWN parser rather than a reader of the same
- * question. The defect this was written for is a blank line between the opening
- * `---` and the first package, which every Markdown tool and every human reader
- * accepts, and which `@changesets/parse` rejects. A hand-rolled check would
- * encode whichever spellings its author happened to think of and would answer
- * differently from the tool that actually decides.
+ * question. A blank line between the opening `---` and the first package, and a
+ * frontmatter block that never closes, are both accepted by every Markdown tool
+ * and by a human reader, and both are rejected by `@changesets/parse`. A
+ * hand-rolled reader encodes whichever spellings its author thought of and
+ * answers differently from the tool that actually decides.
  *
- * Measured: two changesets on `main` carried that blank line and
- * `Version & Publish` failed with "could not parse changeset - missing or
- * invalid frontmatter", blocking the release train for every package.
+ * Both spellings have reached `main` and stopped the release train for every
+ * package, with "could not parse changeset - missing or invalid frontmatter".
  */
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");


### PR DESCRIPTION
A comment I added in #1104 trips the comment-convention check. Fixing my own offence.

## What happened

`scripts/changesets-parse.test.mjs` said "never executed by **the pull request** that introduced it". `scripts/check-comment-convention.mjs:98` matches `/\b(this|the)\s+(PR|pull request)\b/i` and reads that as narration about a change rather than a description of behaviour — correctly, by the convention's own terms.

The mechanism the sentence was reaching for is real and worth keeping, so it is now stated as a property of *when the release workflow runs* rather than as a story about a change: a changeset is authored at one commit and read by `Version & Publish` on a later push to `main`, so the run that goes red need not be the one that introduced the file.

The rewrite also names the unterminated-frontmatter spelling beside the blank-line one, since both are forms `@changesets/parse` rejects and both have reached `main`.

## Evidence

Before, on `main` (`057a89ac5`) — two files disagree:

```
e2e/tests/canvas/acceptance-manifest.ts — 1 offence(s)
scripts/changesets-parse.test.mjs      — 1 offence(s)
```

After this change — mine is gone:

```
1 file(s) disagree with scripts/comment-convention-allowlist.json:
  e2e/tests/canvas/acceptance-manifest.ts — 1 offence(s), 0 allowed:
      refers to the change rather than the code — /** The PR that was meant to turn it green, kept for traceability. */
```

`pnpm test:scripts` — exit 0, `Test Files 21 passed (21)`, `Tests 580 passed (580)`.

No allowlist entry was added. The check's own instruction is explicit that the allowlist may only shrink and that a new comment must be rewritten rather than silenced, so the comment was rewritten.

## The check is still red on main, and that part is not mine

`e2e/tests/canvas/acceptance-manifest.ts` carries `/** The PR that was meant to turn it green, kept for traceability. */`. It predates #1104 — it was already the sole offence when the review fleet ran against #1103, before this test file existed. `Comment convention` therefore stays red on `main` after this merges.

I have deliberately not touched it. It reads as intentional traceability belonging to the page-builder acceptance work, and rewriting someone else's traceability note to clear a check is a decision for whoever owns that file, not a drive-by. Say the word and I will fix it in a follow-up.

## Not verified

I did not re-run the full CI matrix locally; the evidence here is the convention checker and the script suite, both read by exit status rather than through a pipe.

No changeset: this is a comment change to a test file and touches no product code.
