### PR TITLE
docs(root): greenIn's comment describes what the field holds

### DIFF
--- a/e2e/tests/canvas/acceptance-manifest.ts
+++ b/e2e/tests/canvas/acceptance-manifest.ts
@@ -21,7 +21,10 @@ export interface AcceptanceProperty {
   readonly n: number;
   /** The property, in the plan's own words. */
   readonly property: string;
-  /** The PR that was meant to turn it green, kept for traceability. */
+  /**
+   * Identifier of the work that was meant to turn it green, kept for
+   * traceability — a plan item such as `B-6`, not a revision or a branch.
+   */
   readonly greenIn: string;
   readonly status: "covered" | "deferred";
   /**


### PR DESCRIPTION
`Comment convention` has been red on `main` for some time on a single comment. This clears it, and fixes an inaccuracy while doing so.

## The comment was wrong about its own field

```ts
/** The PR that was meant to turn it green, kept for traceability. */
readonly greenIn: string;
```

`greenIn` does not hold a pull request. Every value in the table below it is a plan item — `"B-6"`, `"B-7"`. So the comment named the wrong kind of value for anyone reading the interface before reaching the data.

Saying what the string actually is also settles the check, which reads the pull-request vocabulary as narration about a change (`scripts/check-comment-convention.mjs:98`).

```ts
/**
 * Identifier of the work that was meant to turn it green, kept for
 * traceability — a plan item such as `B-6`, not a revision or a branch.
 */
```

This is a rewrite, not a suppression: no allowlist entry was added. The check's own output states the allowlist may only shrink and that a new comment must be rewritten rather than silenced.

## Evidence

Before, on `main`:

```
1 file(s) disagree with scripts/comment-convention-allowlist.json:
  e2e/tests/canvas/acceptance-manifest.ts — 1 offence(s), 0 allowed
EXIT=1
```

After:

```
EXIT=0
4062 of 4086 source files across ., packages, apps, e2e, templates, scripts:
no new comment names a review, tool or change; 24 read with the pull-request
vocabulary allowed; 402 pre-existing offence(s) still allowlisted.
```

The population is in the checker's own output — 4062 of 4086 files read, so this is a green from a run that looked at the repository rather than at nothing.

Re-run **after** committing, because lint-staged rewrites staged files with prettier and eslint: still `EXIT=0`.

`turbo run check-types lint --filter=@nextlyhq/e2e --force` — exit 0, `17 successful`, `0 cached`.

## One thing stays reported, and it is meant to

`.github/workflows/code-hygiene.yml` carries an offence the checker prints as **ADVISORY** and deliberately does not fail on, because that reader is a line scan rather than a parser and has reported against valid input. Untouched.

## Not verified

I did not run the Playwright suite — this changes a doc comment on an interface, and the type and lint gates above are what can see it. No changeset: no product code.
