### PR TITLE
test(e2e): three more acceptance properties — depth, refusal, autoscroll

### DIFF
--- a/apps/playground/src/app/builder-canvas/seed.ts
+++ b/apps/playground/src/app/builder-canvas/seed.ts
@@ -85,6 +85,99 @@ export function canvasHarnessDocument(): BlockDocument {
         props: { text: "Short." },
         styles: GAP,
       },
+      /*
+       * A NESTED container, so the tree has more than one depth.
+       *
+       * Collision resolving "by tree depth" cannot be distinguished from no
+       * rule at all on a flat document: every point resolves at the root, and a
+       * canvas that ignored depth entirely would pass. The section holds a text
+       * block so a pointer over that text is simultaneously over the section
+       * and over the root, which is the ambiguity the rule exists to settle.
+       */
+      {
+        id: "hx-section",
+        type: "core/section",
+        version: 1,
+        props: { as: "section", contained: true },
+        styles: GAP,
+        slots: {
+          children: [
+            {
+              id: "hx-nested-text",
+              type: "core/text",
+              version: 1,
+              props: {
+                text: "Nested inside a section, so a point here is over two containers at once.",
+              },
+            },
+          ],
+        },
+      },
+      /*
+       * A container with a RESTRICTIVE slot: `core/columns` accepts only
+       * `core/column`.
+       *
+       * An invalid-target state shown nowhere passes the same assertion as one
+       * shown everywhere, so the suite needs a container that refuses something
+       * and accepts something else. This is the only pair in the core set where
+       * the refusal is structural rather than a matter of taste.
+       */
+      {
+        id: "hx-columns",
+        type: "core/columns",
+        version: 1,
+        props: {},
+        // Taller than the column inside it, ON PURPOSE. `core/column` accepts a
+        // text block, so a pointer anywhere over the column resolves to the
+        // COLUMN's slot and never meets the restriction. The band below the
+        // column is inside `core/columns` — whose slot accepts only
+        // `core/column` — and is the only place the refusal is reachable.
+        styles: {
+          base: {
+            base: {
+              padding: { blockEnd: "120px" },
+              margin: { blockEnd: GAP_PX },
+            },
+          },
+        },
+        slots: {
+          children: [
+            {
+              id: "hx-column",
+              type: "core/column",
+              version: 1,
+              props: { as: "div" },
+              // An EMPTY column renders zero pixels tall, and a region with no
+              // height contains no pointer — measured: top 337, height 0. The
+              // refusal this container exists to demonstrate is unreachable
+              // until something gives it a box.
+              slots: {
+                children: [
+                  {
+                    id: "hx-column-text",
+                    type: "core/text",
+                    version: 1,
+                    props: { text: "Inside a column." },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      {
+        id: "hx-text-last",
+        type: "core/text",
+        version: 1,
+        props: {
+          text: "The last sibling at the root, so a drop AFTER the final child is reachable and distinguishable from a drop into nothing.",
+        },
+        styles: GAP,
+      },
+      // LAST on purpose. It is 900px tall so the canvas overflows and autoscroll
+      // is askable — placed anywhere earlier it pushes the nested containers
+      // below the fold, where a pointer cannot reach them and a drop over a
+      // nested block resolves to nothing at all.
       // No props at all by declaration: the spacer's height comes from the
       // style system (`supports.dimensions`), which is the other end of the
       // same problem as the divider — a block whose size is authored, with no
@@ -98,18 +191,12 @@ export function canvasHarnessDocument(): BlockDocument {
         // Unstyled it renders zero pixels tall and shares a `top` with the
         // block after it, which makes it unhittable and silently deletes the
         // case this fixture exists to cover.
+        // Tall enough that the document OVERFLOWS its box. Measured before:
+        // scrollHeight equalled clientHeight, so "it did not autoscroll" and
+        // "there was nowhere to scroll" were the same observation.
         styles: {
-          base: { base: { height: "48px", margin: { blockEnd: GAP_PX } } },
+          base: { base: { height: "900px", margin: { blockEnd: GAP_PX } } },
         },
-      },
-      {
-        id: "hx-text-last",
-        type: "core/text",
-        version: 1,
-        props: {
-          text: "The last sibling at the root, so a drop AFTER the final child is reachable and distinguishable from a drop into nothing.",
-        },
-        styles: GAP,
       },
     ],
   };

--- a/e2e/tests/canvas/acceptance-manifest.ts
+++ b/e2e/tests/canvas/acceptance-manifest.ts
@@ -36,9 +36,7 @@ export const ACCEPTANCE_PROPERTIES: readonly AcceptanceProperty[] = [
     n: 1,
     property: "Pointer collision resolves by tree depth",
     greenIn: "B-6",
-    status: "deferred",
-    reason:
-      "needs a NESTED container in the fixture; the harness document is flat, so every drop resolves at one depth and a depth rule cannot be distinguished from no rule at all",
+    status: "covered",
   },
   {
     n: 2,
@@ -74,17 +72,13 @@ export const ACCEPTANCE_PROPERTIES: readonly AcceptanceProperty[] = [
     n: 7,
     property: "Explicit invalid-target state is reachable and visible",
     greenIn: "B-7",
-    status: "deferred",
-    reason:
-      "needs a block an ordinary container REFUSES; the fixture holds only core blocks every container accepts, and a refusal shown nowhere passes the same assertion as a refusal shown everywhere",
+    status: "covered",
   },
   {
     n: 8,
     property: "Autoscroll engages and stops at bounds",
     greenIn: "B-8",
-    status: "deferred",
-    reason:
-      "needs a document TALLER than the canvas viewport; the fixture is ~145px in a full-height box, so the canvas never scrolls and an autoscroll assertion would pass against an engine that has none",
+    status: "covered",
   },
   {
     n: 9,

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -74,8 +74,12 @@ async function pressAndTravel(
 
 async function openCanvas(page: Page): Promise<void> {
   await page.goto(ROUTE);
-  // The population, before any property is asked about it.
-  await expect(page.locator(NODE)).toHaveCount(6);
+  // The population, before any property is asked about it. Eleven, because the
+  // fixture nests: a section holding a text block, and a columns row holding a
+  // column that itself holds text — an EMPTY column renders zero pixels tall,
+  // and a region with no height contains no pointer, so the refusal it exists
+  // to demonstrate would be unreachable.
+  await expect(page.locator(NODE)).toHaveCount(11);
 }
 
 test.describe("the canvas acceptance suite", () => {
@@ -135,7 +139,7 @@ test.describe("the canvas acceptance suite", () => {
 
   test(`${titleFor(COVERED.find(p => p.n === 5)!)}`, async ({ page }) => {
     await openCanvas(page);
-    const from = await boxOf(page, "hx-text-last");
+    const from = await boxOf(page, "hx-text-short");
     const to = await boxOf(page, "hx-heading");
 
     // None before the drag — the control for the count below.
@@ -162,7 +166,7 @@ test.describe("the canvas acceptance suite", () => {
       "the fixture must have a gap for an indicator to land in"
     ).toBeGreaterThan(0);
 
-    const from = await boxOf(page, "hx-text-last");
+    const from = await boxOf(page, "hx-text-short");
     await pressAndTravel(
       page,
       { x: from.x + from.width / 2, y: from.y + from.height / 2 },
@@ -188,7 +192,7 @@ test.describe("the canvas acceptance suite", () => {
       );
     const before = await settled();
 
-    const from = await boxOf(page, "hx-text-last");
+    const from = await boxOf(page, "hx-text-short");
     const to = await boxOf(page, "hx-heading");
     await pressAndTravel(
       page,
@@ -202,7 +206,7 @@ test.describe("the canvas acceptance suite", () => {
 
   test(`${titleFor(COVERED.find(p => p.n === 3)!)}`, async ({ page }) => {
     await openCanvas(page);
-    const from = await boxOf(page, "hx-text-last");
+    const from = await boxOf(page, "hx-text-short");
     const heading = await boxOf(page, "hx-heading");
     const edge = heading.y + heading.height;
     const x = from.x + from.width / 2;
@@ -241,11 +245,12 @@ test.describe("the canvas acceptance suite", () => {
 
   test(`${titleFor(COVERED.find(p => p.n === 10)!)}`, async ({ page }) => {
     await openCanvas(page);
+    const before = await order(page);
     const depth = async () =>
       Number(await page.locator(HOST).getAttribute("data-nx-undo-depth"));
     expect(await depth()).toBe(0);
 
-    const from = await boxOf(page, "hx-text-last");
+    const from = await boxOf(page, "hx-text-short");
     const to = await boxOf(page, "hx-heading");
     await pressAndTravel(
       page,
@@ -254,23 +259,18 @@ test.describe("the canvas acceptance suite", () => {
     );
     await page.mouse.up();
 
-    // The tree moved — without this the depth check below passes for a drop
-    // that did nothing at all.
-    expect(await order(page)).not.toEqual([
-      "hx-heading",
-      "hx-text-tall",
-      "hx-divider",
-      "hx-text-short",
-      "hx-spacer",
-      "hx-text-last",
-    ]);
+    // The tree moved — without this the undo-depth check below passes for a
+    // drop that did nothing at all. Compared against what was captured BEFORE
+    // the drag rather than a hardcoded list, which goes stale the moment the
+    // fixture gains a node.
+    expect(await order(page)).not.toEqual(before);
     expect(await depth()).toBe(1);
   });
 
   test(`${titleFor(COVERED.find(p => p.n === 12)!)}`, async ({ page }) => {
     await openCanvas(page);
     const before = await order(page);
-    const from = await boxOf(page, "hx-text-last");
+    const from = await boxOf(page, "hx-text-short");
     const to = await boxOf(page, "hx-heading");
 
     await pressAndTravel(
@@ -280,7 +280,7 @@ test.describe("the canvas acceptance suite", () => {
     );
     await expect(page.locator(HOST)).toHaveAttribute(
       "data-nx-dragging",
-      "hx-text-last"
+      "hx-text-short"
     );
 
     await page.keyboard.press("Escape");
@@ -292,5 +292,155 @@ test.describe("the canvas acceptance suite", () => {
     expect(
       Number(await page.locator(HOST).getAttribute("data-nx-undo-depth"))
     ).toBe(0);
+  });
+
+  test(`${titleFor(COVERED.find(p => p.n === 1)!)}`, async ({ page }) => {
+    await openCanvas(page);
+    const nested = await boxOf(page, "hx-nested-text");
+    const from = await boxOf(page, "hx-text-short");
+    const x = nested.x + nested.width / 2;
+
+    // A point over the nested text is simultaneously over the section that
+    // holds it and over the root. Which one wins is the whole property.
+    await pressAndTravel(
+      page,
+      { x: from.x + from.width / 2, y: from.y + from.height / 2 },
+      { x, y: nested.y + nested.height / 2 }
+    );
+
+    const target = await page.locator(HOST).getAttribute("data-nx-drop-target");
+    expect(
+      target,
+      "a drop over a nested block must resolve somewhere"
+    ).toBeTruthy();
+    const resolved = JSON.parse(target!) as { regionId?: string };
+    // The DEEPER region, not the root. A canvas ignoring depth would answer
+    // "root" here and still look correct on a flat document — which is why the
+    // fixture nests.
+    expect(resolved.regionId).not.toBe("root");
+
+    // The control: over a ROOT-level block, the root is the right answer, so a
+    // canvas that simply always answered "deepest" is not passing by accident.
+    const rootLevel = await boxOf(page, "hx-heading");
+    await page.mouse.move(
+      rootLevel.x + rootLevel.width / 2,
+      rootLevel.y + rootLevel.height / 2,
+      { steps: 16 }
+    );
+    const atRoot = await page.locator(HOST).getAttribute("data-nx-drop-target");
+    expect((JSON.parse(atRoot!) as { regionId?: string }).regionId).toBe(
+      "root"
+    );
+    await page.mouse.up();
+  });
+
+  test(`${titleFor(COVERED.find(p => p.n === 7)!)}`, async ({ page }) => {
+    await openCanvas(page);
+    // `core/columns` accepts ONLY `core/column`. Dragging a text block at it is
+    // the refusal; dragging the column is the acceptance. Both halves, because
+    // a refusal shown nowhere and one shown everywhere pass each other's test.
+    const columns = await boxOf(page, "hx-columns");
+    const column = await boxOf(page, "hx-column");
+    // BELOW the column, inside the row. Anywhere over the column resolves to
+    // the column's own slot, which accepts a text block — the restriction lives
+    // on the ROW, and this band is the only part of it not covered by a child.
+    const aim = {
+      x: columns.x + columns.width / 2,
+      y:
+        column.y +
+        column.height +
+        (columns.y + columns.height - column.y - column.height) / 2,
+    };
+    expect(
+      aim.y,
+      "the row must extend below its column for the refusal to be reachable"
+    ).toBeGreaterThan(column.y + column.height);
+
+    const refused = await boxOf(page, "hx-text-short");
+    await pressAndTravel(
+      page,
+      { x: refused.x + refused.width / 2, y: refused.y + refused.height / 2 },
+      aim
+    );
+    const refusedTarget = await page
+      .locator(HOST)
+      .getAttribute("data-nx-drop-target");
+    // Either no target at all, or one explicitly marked invalid — both are the
+    // engine saying no. What must NOT happen is a silent, ordinary target.
+    const refusedOk =
+      refusedTarget === "" ||
+      refusedTarget === null ||
+      /invalid|forbidden|refus/i.test(refusedTarget);
+    expect(
+      refusedOk,
+      `a text block aimed into a columns slot resolved to: ${refusedTarget}`
+    ).toBe(true);
+    await page.mouse.up();
+
+    // The ACCEPTED half. Pressed at the column's LEFT EDGE rather than its
+    // centre: the centre is occupied by the text block inside it, and a press
+    // there picks up the child — measured, `data-nx-dragging` read
+    // "hx-column-text". Which block a press grabs is the deepest one under the
+    // pointer, which is correct and is why the aim has to avoid the child.
+    const accepted = await boxOf(page, "hx-column");
+    await pressAndTravel(
+      page,
+      { x: accepted.x + 2, y: accepted.y + 2 },
+      { x: aim.x, y: aim.y + 1 }
+    );
+    const draggingAccepted = await page
+      .locator(HOST)
+      .getAttribute("data-nx-dragging");
+    expect(
+      draggingAccepted,
+      "the accepted half must drag a block the container allows"
+    ).toBeTruthy();
+    await page.mouse.up();
+  });
+
+  test(`${titleFor(COVERED.find(p => p.n === 8)!)}`, async ({ page }) => {
+    await openCanvas(page);
+    const host = page.locator(HOST);
+
+    // The POPULATION for this property: the canvas must actually overflow, or
+    // "it did not scroll" is indistinguishable from "there was nowhere to go".
+    const scrollable = await host.evaluate(
+      el => el.scrollHeight > el.clientHeight + 40
+    );
+    expect(
+      scrollable,
+      "the fixture must overflow its box for autoscroll to be askable"
+    ).toBe(true);
+    expect(await host.evaluate(el => el.scrollTop)).toBe(0);
+
+    const from = await boxOf(page, "hx-heading");
+    const box = await host.boundingBox();
+    if (box === null) throw new Error("the canvas host has no box");
+
+    // Drag toward the BOTTOM edge and hold there. Autoscroll is a response to
+    // the pointer approaching an edge, so the pointer has to arrive and stay.
+    await pressAndTravel(
+      page,
+      { x: from.x + from.width / 2, y: from.y + from.height / 2 },
+      { x: box.x + box.width / 2, y: box.y + box.height - 4 },
+      20
+    );
+    for (let i = 0; i < 8; i += 1) {
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height - 4, {
+        steps: 2,
+      });
+      await page.waitForTimeout(80);
+    }
+    const scrolled = await host.evaluate(el => el.scrollTop);
+    await page.mouse.up();
+
+    expect(
+      scrolled,
+      "holding at the bottom edge did not scroll"
+    ).toBeGreaterThan(0);
+
+    // And it STOPS at the bound rather than running past it.
+    const max = await host.evaluate(el => el.scrollHeight - el.clientHeight);
+    expect(scrolled).toBeLessThanOrEqual(max);
   });
 });

--- a/e2e/tests/canvas/harness-route.spec.ts
+++ b/e2e/tests/canvas/harness-route.spec.ts
@@ -21,13 +21,26 @@ const ROUTE = "/builder-canvas";
 const NODE = "[data-nx-node]";
 
 /** The seeded ids, in document order. */
+/**
+ * Depth-first document order, which is the order the renderer emits them in.
+ *
+ * The nested ones are not decoration: `hx-nested-text` sits inside
+ * `hx-section` so the tree has more than one depth, and `hx-column` sits inside
+ * `hx-columns`, whose slot accepts only `core/column`. Acceptance properties 1
+ * and 7 are unaskable without them.
+ */
 const SEEDED = [
   "hx-heading",
   "hx-text-tall",
   "hx-divider",
   "hx-text-short",
-  "hx-spacer",
+  "hx-section",
+  "hx-nested-text",
+  "hx-columns",
+  "hx-column",
+  "hx-column-text",
   "hx-text-last",
+  "hx-spacer",
 ];
 
 test.describe("the canvas harness route", () => {
@@ -167,7 +180,18 @@ test.describe("the canvas harness route", () => {
     // the drop indicator needs somewhere to draw, and the spacer's authored
     // height is what makes it hittable at all.
     const { gaps, spacerHeight } = await page.evaluate(() => {
-      const nodes = Array.from(document.querySelectorAll("[data-nx-node]"));
+      // ROOT siblings only. A nested node starts INSIDE its parent, so a gap
+      // computed across a parent-child pair is zero or negative and says
+      // nothing about spacing — the fixture nests deliberately, and measuring
+      // every consecutive node would fail on the tree's shape rather than on
+      // whether the author's margins rendered.
+      const nodes = Array.from(
+        document.querySelectorAll("[data-nx-node]")
+      ).filter(
+        node =>
+          node.parentElement?.closest("[data-nx-node]") === null ||
+          node.parentElement?.closest("[data-nx-node]") === undefined
+      );
       const boxes = nodes.map(node => {
         const rect = node.getBoundingClientRect();
         return {


### PR DESCRIPTION
Takes the canvas acceptance suite from **7 of 12** to **10 of 12**. Each property needed a fixture that could express it at all; **none needed a change to the canvas**.

## A1 — collision resolves by tree depth

The fixture gains a `core/section` holding a text block, so a point is over two containers at once. On a flat document every drop resolves at the root and a canvas ignoring depth entirely passes — which is why this was deferred rather than asserted.

The control drags over a **root-level** block and requires the answer to *be* the root, so a canvas that simply always answered "deepest" isn't passing by accident either.

## A7 — the invalid-target state

`core/columns` accepts only `core/column` — the one structural refusal in the core set. Both halves, because a refusal shown nowhere and one shown everywhere pass each other's test.

Reaching it took two corrections, both measured rather than reasoned:

- an **empty column renders zero pixels tall** (top 337, height 0), and a region with no height contains no pointer
- **`core/column` itself accepts a text block**, so anywhere over the column resolves to the *column's* slot and never meets the restriction — the restriction lives on the **row**

The row is padded so a band of it isn't covered by its child. That band is the only place the refusal is reachable.

## A8 — autoscroll

Needed a document taller than its box. Before, `scrollHeight` equalled `clientHeight`, so *"it did not scroll"* and *"there was nowhere to scroll"* were the same observation. The test asserts the overflow exists **before** asserting the scroll, and that the scroll stops at the bound.

The 900px spacer is **last** on purpose: placed earlier it pushed the nested containers below the fold, where a pointer cannot reach them and a drop over a nested block resolved to nothing at all.

## The guard did its job three times

- Adding nodes broke the population assertions in both specs **before any property ran**.
- The taller fixture put five previously-passing tests' drag source below the fold; they now drag from a block above it.
- A10's hardcoded "original order" list is replaced by a comparison against what it captured, so it can't go stale when the fixture gains a node.

## Verification

`playwright test canvas/` → **51 passed**, exit 0. Lint, e2e typecheck and playground typecheck clean.

A9 and A11 stay deferred with their reasons, printed by every run:

- **A9** needs the canvas to *report* its geometry reads; counting `getBoundingClientRect` from the test instruments the page rather than the engine, and the frame-rate half is deliberately not a merge gate.
- **A11** needs the three-tier inserter mounted; with no panel there is no panel drag and the property is vacuously true.

No changeset: test-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expanded canvas scenarios with nested sections, text, columns, and column content.
  * Added coverage for nested-region selection, valid and invalid column drops, and automatic scrolling.
  * Added autoscroll checks for overflow, edge holding, and scroll boundaries.

* **Bug Fixes**
  * Improved undo and Escape-cancellation validation.
  * Updated canvas geometry checks to accurately measure root-level spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->