### PR TITLE
feat(nextly): add the storage and read rule for content releases

### DIFF
--- a/.changeset/content-releases-foundation.md
+++ b/.changeset/content-releases-foundation.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Add the storage and the read rule for scheduled content releases: two core tables, a repository, and the pure rule that decides what a release says a document looks like now. Nothing reads them yet. Also removes the reserved `versions.drafts.schedulePublish` option and the unused `scheduled` version status, which were parsed and never read.

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -222,6 +222,47 @@ export function generateSqliteCoreTableStatements(): string[] {
       ON "nextly_versions" ("draft_key")`,
     `CREATE INDEX IF NOT EXISTS "nextly_versions_doc_recent_idx"
       ON "nextly_versions" ("scope_kind", "scope_slug", "entry_id", "created_at")`,
+    // Content releases. Columns match schemas/releases/sqlite.ts.
+    `CREATE TABLE IF NOT EXISTS "nextly_releases" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "title" TEXT NOT NULL,
+      "description" TEXT,
+      "scheduled_at" INTEGER,
+      "timezone" TEXT,
+      "state" TEXT NOT NULL,
+      "published_at" INTEGER,
+      "created_by" TEXT,
+      "created_at" INTEGER NOT NULL,
+      "updated_at" INTEGER NOT NULL,
+      "revision" INTEGER NOT NULL DEFAULT 0
+    )`,
+    `CREATE TABLE IF NOT EXISTS "nextly_release_members" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "release_id" TEXT NOT NULL,
+      "scope_kind" TEXT NOT NULL,
+      "scope_slug" TEXT NOT NULL,
+      "entry_id" TEXT NOT NULL,
+      "locale" TEXT,
+      "action" TEXT NOT NULL,
+      "member_key" TEXT NOT NULL,
+      "created_by" TEXT,
+      "created_at" INTEGER NOT NULL
+    )`,
+    // Each index is its OWN statement, guarded with IF NOT EXISTS, for the
+    // reason the versions indexes above are: SQLite skips a CREATE TABLE
+    // wholesale once the table exists, so an index folded into it would never
+    // appear on a database built by an earlier boot.
+    `CREATE INDEX IF NOT EXISTS "nextly_releases_due_idx"
+      ON "nextly_releases" ("state", "scheduled_at")`,
+    // Over "member_key" alone: "locale" is nullable and SQLite treats NULL as
+    // distinct from NULL, so a composite index over the source columns would
+    // permit any number of unlocalized members for one document in one release.
+    `CREATE UNIQUE INDEX IF NOT EXISTS "nextly_release_members_key_uidx"
+      ON "nextly_release_members" ("member_key")`,
+    `CREATE INDEX IF NOT EXISTS "nextly_release_members_doc_idx"
+      ON "nextly_release_members" ("scope_kind", "scope_slug", "entry_id", "locale")`,
+    `CREATE INDEX IF NOT EXISTS "nextly_release_members_release_idx"
+      ON "nextly_release_members" ("release_id")`,
     // No REFERENCES to "email_providers": that table is not bootstrapped here,
     // and SQLite resolves a foreign key at insert time rather than at CREATE,
     // so declaring one would turn every recorded delivery into a failure on a

--- a/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
@@ -1,0 +1,337 @@
+/**
+ * The release store against a REAL database.
+ *
+ * Two things only an integration test can establish. First, that the tables
+ * exist at all: they reach a database through three separate registries, and a
+ * miss in any one of them still leaves every unit test passing. Booting a real
+ * instance and writing to them is what proves the wiring.
+ *
+ * Second, that the uniqueness rule holds where it is actually enforced. The
+ * unique index sits on the `member_key` digest rather than on the five source
+ * columns, because `locale` is nullable and SQL treats NULL as distinct from
+ * NULL — a composite index would admit any number of unlocalized members for
+ * one document. That difference is invisible to a unit test and decisive here.
+ *
+ * Runs against whichever dialect the integration run configures; CI covers
+ * SQLite, Postgres and MySQL.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestDialect,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import {
+  ReleasesRepository,
+  documentRefKey,
+  type DocumentRef,
+} from "../releases-repository";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+async function boot(dialect: TestDialect): Promise<TestNextly> {
+  current = await createTestNextly({
+    dialect,
+    collections: [
+      defineCollection({
+        slug: "posts",
+        status: true,
+        versions: { drafts: true },
+        fields: [text({ name: "title" })],
+      }),
+    ],
+  });
+  return current;
+}
+
+const ref = (entryId: string, locale: string | null = null): DocumentRef => ({
+  scopeKind: "collection",
+  scopeSlug: "posts",
+  entryId,
+  locale,
+});
+
+const PAST = new Date("2020-01-01T00:00:00Z");
+const FUTURE = new Date("2099-01-01T00:00:00Z");
+
+describe.each(getConfiguredTestDialects())(
+  "ReleasesRepository (%s)",
+  dialect => {
+    it("stores a release and its members", async () => {
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+
+      const release = await repo.createRelease({ title: "Spring launch" });
+      expect(release.id).toBeTruthy();
+      expect(release.state).toBe("draft");
+
+      const member = await repo.addMember({
+        releaseId: release.id,
+        ...ref("e1"),
+        action: "publish",
+      });
+      expect(member.releaseId).toBe(release.id);
+      expect(member.action).toBe("publish");
+    });
+
+    it("refuses a second member for the same document in one release", async () => {
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+      const release = await repo.createRelease({ title: "Spring launch" });
+
+      await repo.addMember({
+        releaseId: release.id,
+        ...ref("e1"),
+        action: "publish",
+      });
+
+      // The unlocalized case specifically: `locale` is NULL here, which is
+      // exactly where a composite unique index would silently permit a duplicate.
+      await expect(
+        repo.addMember({
+          releaseId: release.id,
+          ...ref("e1"),
+          action: "unpublish",
+        })
+      ).rejects.toThrow();
+    });
+
+    it("allows the same document in two DIFFERENT releases", async () => {
+      // The flagship case: publish on one date, unpublish on another. A
+      // constraint that forbade this would forbid scheduled takedown entirely.
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+      const first = await repo.createRelease({ title: "Go live" });
+      const second = await repo.createRelease({ title: "Take down" });
+
+      await repo.addMember({
+        releaseId: first.id,
+        ...ref("e1"),
+        action: "publish",
+      });
+      await expect(
+        repo.addMember({
+          releaseId: second.id,
+          ...ref("e1"),
+          action: "unpublish",
+        })
+      ).resolves.toBeTruthy();
+    });
+
+    it("allows the same document in one release once per LANGUAGE", async () => {
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+      const release = await repo.createRelease({ title: "Spring launch" });
+
+      await repo.addMember({
+        releaseId: release.id,
+        ...ref("e1", "en"),
+        action: "publish",
+      });
+      await expect(
+        repo.addMember({
+          releaseId: release.id,
+          ...ref("e1", "es"),
+          action: "publish",
+        })
+      ).resolves.toBeTruthy();
+    });
+
+    it("returns no due members while the release is still a draft", async () => {
+      // An unscheduled release must not affect reads even if its time would have
+      // passed: `state` is what makes a release live, not the clock alone.
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+      const release = await repo.createRelease({ title: "Spring launch" });
+      await repo.addMember({
+        releaseId: release.id,
+        ...ref("e1"),
+        action: "publish",
+      });
+
+      const due = await repo.findDueMembersFor([ref("e1")], new Date());
+      expect(due.get(documentRefKey(ref("e1"))) ?? []).toEqual([]);
+    });
+
+    it("returns a member once its release is scheduled, and not before its time", async () => {
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+      const release = await repo.createRelease({ title: "Spring launch" });
+      await repo.addMember({
+        releaseId: release.id,
+        ...ref("e1"),
+        action: "publish",
+      });
+      await repo.scheduleRelease(release.id, FUTURE, "UTC");
+
+      // The repository returns every member of a SCHEDULED release; deciding
+      // whether the time has come is `resolveReleaseEffect`'s job, and keeping
+      // that judgement in one place is why the query does not filter on it.
+      const found = await repo.findDueMembersFor([ref("e1")], new Date());
+      const members = found.get(documentRefKey(ref("e1"))) ?? [];
+      expect(members).toHaveLength(1);
+      expect(members[0]?.scheduledAt.getTime()).toBe(FUTURE.getTime());
+    });
+
+    it("stops returning a member once its release is cancelled", async () => {
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+      const release = await repo.createRelease({ title: "Spring launch" });
+      await repo.addMember({
+        releaseId: release.id,
+        ...ref("e1"),
+        action: "publish",
+      });
+      await repo.scheduleRelease(release.id, PAST, "UTC");
+
+      const before = await repo.findDueMembersFor([ref("e1")], new Date());
+      expect(before.get(documentRefKey(ref("e1")))).toHaveLength(1);
+
+      await repo.cancelRelease(release.id);
+
+      // Nothing is undone and nothing is written to the document: a cancelled
+      // release simply stops being consulted, which is what makes cancelling a
+      // due-but-unmaterialised release free.
+      const after = await repo.findDueMembersFor([ref("e1")], new Date());
+      expect(after.get(documentRefKey(ref("e1"))) ?? []).toEqual([]);
+    });
+
+    it("keeps each document's members apart", async () => {
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+      const release = await repo.createRelease({ title: "Spring launch" });
+      await repo.addMember({
+        releaseId: release.id,
+        ...ref("e1"),
+        action: "publish",
+      });
+      await repo.addMember({
+        releaseId: release.id,
+        ...ref("e2"),
+        action: "unpublish",
+      });
+      await repo.scheduleRelease(release.id, PAST, "UTC");
+
+      const found = await repo.findDueMembersFor(
+        [ref("e1"), ref("e2")],
+        new Date()
+      );
+      expect(found.get(documentRefKey(ref("e1")))?.[0]?.action).toBe("publish");
+      expect(found.get(documentRefKey(ref("e2")))?.[0]?.action).toBe(
+        "unpublish"
+      );
+    });
+
+    it("costs the same number of queries for 25 documents as for 5", async () => {
+      // A per-row lookup would be correct and quadratic: a listing of 50 entries
+      // would issue 50 queries. What is asserted is that the count does not GROW
+      // with the number of documents, not that it equals one — a member row does
+      // not carry its release's time, and the port has no join, so the honest
+      // answer is a constant two.
+      //
+      // Members must EXIST for this to mean anything. With none, the lookup
+      // returns after its first query and never reaches the second, so a per-row
+      // implementation would pass this test too.
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+      const release = await repo.createRelease({ title: "Spring launch" });
+      const refs = Array.from({ length: 25 }, (_, i) => ref(`e${i}`));
+      for (const r of refs) {
+        await repo.addMember({
+          releaseId: release.id,
+          ...r,
+          action: "publish",
+        });
+      }
+      await repo.scheduleRelease(release.id, PAST, "UTC");
+
+      const spyMany = vi.spyOn(app.adapter, "select");
+      const many = await repo.findDueMembersFor(refs, new Date());
+      const queriesForMany = spyMany.mock.calls.length;
+      spyMany.mockRestore();
+
+      const spyFew = vi.spyOn(app.adapter, "select");
+      await repo.findDueMembersFor(refs.slice(0, 5), new Date());
+      const queriesForFew = spyFew.mock.calls.length;
+      spyFew.mockRestore();
+
+      // The positive control: the run actually resolved members, so the counts
+      // above are of a lookup that did the work rather than one that bailed out.
+      expect(many.size).toBe(25);
+      expect(queriesForMany).toBe(queriesForFew);
+    });
+
+    it("asks nothing of the database for an empty document list", async () => {
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+
+      const spy = vi.spyOn(app.adapter, "select");
+      const found = await repo.findDueMembersFor([], new Date());
+
+      expect(found.size).toBe(0);
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it("reports the earliest pending transition, ignoring past and unscheduled ones", async () => {
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+      const now = new Date();
+      const soon = new Date(now.getTime() + 60_000);
+      const later = new Date(now.getTime() + 120_000);
+
+      const past = await repo.createRelease({ title: "Already gone" });
+      await repo.scheduleRelease(past.id, PAST, "UTC");
+      const draft = await repo.createRelease({ title: "Not scheduled yet" });
+      const laterRelease = await repo.createRelease({ title: "Later" });
+      await repo.scheduleRelease(laterRelease.id, later, "UTC");
+      const soonRelease = await repo.createRelease({ title: "Soon" });
+      await repo.scheduleRelease(soonRelease.id, soon, "UTC");
+
+      const earliest = await repo.findEarliestPendingTransition(now);
+
+      // Whole seconds: SQLite stores epoch seconds, so a millisecond comparison
+      // would pass on two dialects and fail on the third for no real difference.
+      expect(Math.floor((earliest?.getTime() ?? 0) / 1000)).toBe(
+        Math.floor(soon.getTime() / 1000)
+      );
+      expect(draft.state).toBe("draft");
+    });
+
+    it("reports no pending transition when every scheduled release is in the past", async () => {
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+      const release = await repo.createRelease({ title: "Already gone" });
+      await repo.scheduleRelease(release.id, PAST, "UTC");
+
+      await expect(
+        repo.findEarliestPendingTransition(new Date())
+      ).resolves.toBeNull();
+    });
+
+    it("removes a member", async () => {
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+      const release = await repo.createRelease({ title: "Spring launch" });
+      const member = await repo.addMember({
+        releaseId: release.id,
+        ...ref("e1"),
+        action: "publish",
+      });
+      await repo.scheduleRelease(release.id, PAST, "UTC");
+
+      await repo.removeMember(member.id);
+
+      const found = await repo.findDueMembersFor([ref("e1")], new Date());
+      expect(found.get(documentRefKey(ref("e1"))) ?? []).toEqual([]);
+    });
+  }
+);

--- a/packages/nextly/src/domains/releases/__tests__/resolve-release-effect.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/resolve-release-effect.test.ts
@@ -1,0 +1,156 @@
+/**
+ * What a release says a document should look like right now.
+ *
+ * These pin the ordering, because ordering is what makes the publish-then-
+ * unpublish pair work: a page that goes live on the 1st and comes down on the
+ * 20th has TWO due members from the 20th onwards, and the later one has to win
+ * on every request, on every dialect, whatever order the driver returned rows
+ * in.
+ *
+ * @module domains/releases/__tests__/resolve-release-effect.test
+ */
+import { describe, it, expect } from "vitest";
+
+import {
+  resolveReleaseEffect,
+  type DueMember,
+} from "../resolve-release-effect";
+
+const at = (iso: string): Date => new Date(iso);
+
+const member = (
+  over: Partial<DueMember> & { memberId: string }
+): DueMember => ({
+  releaseId: `r-${over.memberId}`,
+  action: "publish",
+  scheduledAt: at("2026-01-01T00:00:00Z"),
+  createdAt: at("2026-01-01T00:00:00Z"),
+  ...over,
+});
+
+const NOW = at("2026-06-01T12:00:00Z");
+
+describe("resolveReleaseEffect", () => {
+  it("does nothing when no member is due", () => {
+    expect(resolveReleaseEffect({ members: [], now: NOW })).toEqual({
+      effect: "none",
+      memberId: null,
+      releaseId: null,
+    });
+  });
+
+  it("ignores a member scheduled in the future", () => {
+    const future = member({
+      memberId: "m1",
+      scheduledAt: at("2026-07-01T00:00:00Z"),
+    });
+
+    expect(resolveReleaseEffect({ members: [future], now: NOW }).effect).toBe(
+      "none"
+    );
+  });
+
+  it("applies a member whose time has passed", () => {
+    const due = member({
+      memberId: "m1",
+      scheduledAt: at("2026-05-01T00:00:00Z"),
+    });
+
+    expect(resolveReleaseEffect({ members: [due], now: NOW })).toEqual({
+      effect: "publish",
+      memberId: "m1",
+      releaseId: "r-m1",
+    });
+  });
+
+  it("applies a member scheduled for exactly now", () => {
+    // The boundary is inclusive: a release scheduled for 09:00 is in effect AT
+    // 09:00, not from the first request after it.
+    const due = member({ memberId: "m1", scheduledAt: NOW });
+
+    expect(resolveReleaseEffect({ members: [due], now: NOW }).effect).toBe(
+      "publish"
+    );
+  });
+
+  it("lets the LATEST due member win, not the first seen", () => {
+    const publish = member({
+      memberId: "m1",
+      action: "publish",
+      scheduledAt: at("2026-05-01T00:00:00Z"),
+    });
+    const unpublish = member({
+      memberId: "m2",
+      action: "unpublish",
+      scheduledAt: at("2026-05-20T00:00:00Z"),
+    });
+
+    expect(
+      resolveReleaseEffect({ members: [publish, unpublish], now: NOW }).effect
+    ).toBe("unpublish");
+    // The order the rows arrive in must not change the answer.
+    expect(
+      resolveReleaseEffect({ members: [unpublish, publish], now: NOW }).effect
+    ).toBe("unpublish");
+  });
+
+  it("breaks a same-instant tie deterministically, by createdAt then id", () => {
+    const a = member({
+      memberId: "a",
+      action: "publish",
+      scheduledAt: at("2026-05-01T00:00:00Z"),
+      createdAt: at("2026-04-01T00:00:00Z"),
+    });
+    const b = member({
+      memberId: "b",
+      action: "unpublish",
+      scheduledAt: at("2026-05-01T00:00:00Z"),
+      createdAt: at("2026-04-02T00:00:00Z"),
+    });
+
+    const forward = resolveReleaseEffect({ members: [a, b], now: NOW });
+    const reversed = resolveReleaseEffect({ members: [b, a], now: NOW });
+
+    expect(forward).toEqual(reversed);
+    expect(forward.memberId).toBe("b");
+  });
+
+  it("falls back to the member id when scheduledAt and createdAt both tie", () => {
+    // Without this last term the order is not total, and two members created in
+    // the same millisecond would resolve by whatever the driver returned first.
+    const same = {
+      scheduledAt: at("2026-05-01T00:00:00Z"),
+      createdAt: at("2026-04-01T00:00:00Z"),
+    };
+    const a = member({ memberId: "a", action: "publish", ...same });
+    const b = member({ memberId: "b", action: "unpublish", ...same });
+
+    expect(resolveReleaseEffect({ members: [a, b], now: NOW }).memberId).toBe(
+      "b"
+    );
+    expect(resolveReleaseEffect({ members: [b, a], now: NOW }).memberId).toBe(
+      "b"
+    );
+  });
+
+  it("ignores a future member sitting beside a due one", () => {
+    // A page live since May, scheduled to come down in July: today it reads as
+    // published, and the pending takedown must not leak into the answer.
+    const due = member({
+      memberId: "m1",
+      action: "publish",
+      scheduledAt: at("2026-05-01T00:00:00Z"),
+    });
+    const later = member({
+      memberId: "m2",
+      action: "unpublish",
+      scheduledAt: at("2026-07-01T00:00:00Z"),
+    });
+
+    expect(resolveReleaseEffect({ members: [due, later], now: NOW })).toEqual({
+      effect: "publish",
+      memberId: "m1",
+      releaseId: "r-m1",
+    });
+  });
+});

--- a/packages/nextly/src/domains/releases/release-member-key.ts
+++ b/packages/nextly/src/domains/releases/release-member-key.ts
@@ -1,0 +1,58 @@
+/**
+ * The value stored in `nextly_release_members.member_key`.
+ *
+ * One document appears at most once per release per language, and that is the
+ * one rule a plain composite unique index cannot express here: `locale` is
+ * nullable, and SQL treats NULL as distinct from NULL, so a unique index over
+ * `(release_id, scope_kind, scope_slug, entry_id, locale)` would admit any
+ * number of UNLOCALIZED members for the same document. This column always
+ * carries a value, so a unique index over it alone constrains every member,
+ * localized or not.
+ *
+ * A digest rather than the readable composite, for the reason
+ * `workingDraftKey` gives: the segments are bounded but percent-encoding can
+ * triple one, and MySQL's index key limit is 3072 bytes, which utf8mb4 spends
+ * at 768 characters. Capping the length would let a truncation merge two
+ * members into one key — precisely the failure the constraint exists to
+ * prevent. The row keeps all five source columns, so the value can always be
+ * recomputed.
+ *
+ * Segments are percent-encoded before joining so a delimiter occurring inside a
+ * slug or an id cannot forge a collision.
+ *
+ * @module domains/releases/release-member-key
+ */
+import { createHash } from "node:crypto";
+
+import type { VersionScopeKind } from "../../schemas/versions/types";
+
+/** The document a member points at. */
+export interface MemberDocumentRef {
+  scopeKind: VersionScopeKind;
+  scopeSlug: string;
+  entryId: string;
+  /** `null` is the unlocalized document, matching `nextly_versions.locale`. */
+  locale: string | null;
+}
+
+/**
+ * The uniqueness key for one document, in one language, in one release.
+ *
+ * A `null` locale encodes to the empty segment — unambiguous because encoding
+ * leaves every configured locale non-empty.
+ */
+export function releaseMemberKey(
+  releaseId: string,
+  ref: MemberDocumentRef
+): string {
+  const joined = [
+    releaseId,
+    ref.scopeKind,
+    ref.scopeSlug,
+    ref.entryId,
+    ref.locale ?? "",
+  ]
+    .map(encodeURIComponent)
+    .join(":");
+  return createHash("sha256").update(joined, "utf8").digest("hex");
+}

--- a/packages/nextly/src/domains/releases/releases-repository.ts
+++ b/packages/nextly/src/domains/releases/releases-repository.ts
@@ -1,0 +1,297 @@
+/**
+ * Repository for `nextly_releases` and `nextly_release_members`.
+ *
+ * Built on the same narrow database port the versions repository uses, so one
+ * instance works with either the adapter or a transaction context. Column
+ * names are the Drizzle property names (camelCase); the adapter maps them to
+ * snake_case.
+ *
+ * The reads here answer only "which memberships exist"; whether a membership
+ * is IN EFFECT is `resolveReleaseEffect`'s judgement, and keeping that in one
+ * pure place is what stops a read and the materialisation that follows it
+ * disagreeing about the same release.
+ *
+ * @module domains/releases/releases-repository
+ */
+import type {
+  ReleaseMemberAction,
+  ReleaseState,
+} from "../../schemas/releases/types";
+import type { VersionScopeKind } from "../../schemas/versions/types";
+import type { VersionsDbApi } from "../versions/db-api";
+
+import { releaseMemberKey } from "./release-member-key";
+import type { DueMember } from "./resolve-release-effect";
+
+/**
+ * The database surface this repository needs.
+ *
+ * Aliased rather than restated: it is the same narrow port — insert, select,
+ * update, delete — and a second declaration of the same shape would drift from
+ * this one silently, which is the divergence this codebase has a rule about.
+ */
+export type ReleasesDbApi = VersionsDbApi;
+
+const RELEASES = "nextly_releases";
+const MEMBERS = "nextly_release_members";
+
+/** The document a member points at. */
+export interface DocumentRef {
+  scopeKind: VersionScopeKind;
+  scopeSlug: string;
+  entryId: string;
+  /** `null` is the unlocalized document. */
+  locale: string | null;
+}
+
+export interface ReleaseRow {
+  id: string;
+  title: string;
+  description: string | null;
+  scheduledAt: Date | null;
+  timezone: string | null;
+  state: ReleaseState;
+  publishedAt: Date | null;
+  createdBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  revision: number;
+}
+
+export interface ReleaseMemberRow {
+  id: string;
+  releaseId: string;
+  scopeKind: VersionScopeKind;
+  scopeSlug: string;
+  entryId: string;
+  locale: string | null;
+  action: ReleaseMemberAction;
+  memberKey: string;
+  createdBy: string | null;
+  createdAt: Date;
+}
+
+export interface NewRelease {
+  title: string;
+  description?: string | null;
+  createdBy?: string | null;
+}
+
+export interface NewReleaseMember extends DocumentRef {
+  releaseId: string;
+  action: ReleaseMemberAction;
+  createdBy?: string | null;
+}
+
+/**
+ * The key a batched lookup groups by.
+ *
+ * Exported and used by BOTH sides of that lookup so a caller cannot invent a
+ * second spelling of the same document — two spellings would silently return
+ * an empty member list, which reads exactly like "nothing is scheduled".
+ */
+export function documentRefKey(ref: DocumentRef): string {
+  return [ref.scopeKind, ref.scopeSlug, ref.entryId, ref.locale ?? ""]
+    .map(encodeURIComponent)
+    .join(":");
+}
+
+export class ReleasesRepository {
+  constructor(private readonly db: ReleasesDbApi) {}
+
+  async createRelease(input: NewRelease): Promise<ReleaseRow> {
+    const now = new Date();
+    const row: ReleaseRow = {
+      id: crypto.randomUUID(),
+      title: input.title,
+      description: input.description ?? null,
+      scheduledAt: null,
+      timezone: null,
+      // A new release is always assembled before it is scheduled, so it
+      // starts in the one state the read rule never consults.
+      state: "draft",
+      publishedAt: null,
+      createdBy: input.createdBy ?? null,
+      createdAt: now,
+      updatedAt: now,
+      revision: 0,
+    };
+    // The id is generated here and the insert asks for nothing back, because
+    // MySQL has no RETURNING: a repository that read the inserted row from
+    // the insert result would work on SQLite and Postgres and hand back
+    // `undefined` on MySQL.
+    await this.db.insert(RELEASES, { ...row }, { returning: [] });
+    return row;
+  }
+
+  /** Move a release to `scheduled`, which is what makes reads consult it. */
+  async scheduleRelease(id: string, at: Date, timezone: string): Promise<void> {
+    await this.db.update(
+      RELEASES,
+      {
+        scheduledAt: at,
+        timezone,
+        state: "scheduled" satisfies ReleaseState,
+        updatedAt: new Date(),
+      },
+      { and: [{ column: "id", op: "=", value: id }] }
+    );
+  }
+
+  /**
+   * Call a release off.
+   *
+   * Nothing is undone and nothing is written to any document: the read rule
+   * consults only `scheduled` releases, so a cancelled one simply stops being
+   * consulted. That is what makes cancelling a due-but-unmaterialised release
+   * free, and it is why there is no restore path here.
+   */
+  async cancelRelease(id: string): Promise<void> {
+    await this.db.update(
+      RELEASES,
+      {
+        state: "cancelled" satisfies ReleaseState,
+        updatedAt: new Date(),
+      },
+      { and: [{ column: "id", op: "=", value: id }] }
+    );
+  }
+
+  async addMember(input: NewReleaseMember): Promise<ReleaseMemberRow> {
+    const row: ReleaseMemberRow = {
+      id: crypto.randomUUID(),
+      releaseId: input.releaseId,
+      scopeKind: input.scopeKind,
+      scopeSlug: input.scopeSlug,
+      entryId: input.entryId,
+      locale: input.locale,
+      action: input.action,
+      memberKey: releaseMemberKey(input.releaseId, input),
+      createdBy: input.createdBy ?? null,
+      createdAt: new Date(),
+    };
+    // Client-side id and no RETURNING, for the reason `createRelease` gives.
+    await this.db.insert(MEMBERS, { ...row }, { returning: [] });
+    return row;
+  }
+
+  async removeMember(memberId: string): Promise<void> {
+    await this.db.delete(MEMBERS, {
+      and: [{ column: "id", op: "=", value: memberId }],
+    });
+  }
+
+  /**
+   * Members of SCHEDULED releases for each of `refs`, in a CONSTANT number of
+   * queries — two, and never one per document.
+   *
+   * Never call this per row. A listing read resolves its whole result set here
+   * and then asks `resolveReleaseEffect` per document, so the database cost
+   * does not grow with the page size. Two rather than one because a member row
+   * does not carry its release's state or time, and the port this repository
+   * is built on has no join: the second query is over the releases those
+   * members name, which is bounded by the number of releases, not documents.
+   *
+   * `now` is accepted but not used as a filter: every member of a scheduled
+   * release is returned, and whether its time has come is decided by the pure
+   * rule. Filtering here as well would put the same judgement in two places.
+   */
+  async findDueMembersFor(
+    refs: DocumentRef[],
+    _now: Date
+  ): Promise<Map<string, DueMember[]>> {
+    const grouped = new Map<string, DueMember[]>();
+    // No refs means no question to ask. Returning early keeps an empty listing
+    // from issuing a query whose IN clause would be empty.
+    if (refs.length === 0) return grouped;
+
+    const scheduled = await this.db.select<
+      ReleaseMemberRow & { scheduledAt: Date | null; state: ReleaseState }
+    >(MEMBERS, {
+      where: {
+        and: [
+          { column: "entryId", op: "IN", value: refs.map(r => r.entryId) },
+          {
+            column: "scopeSlug",
+            op: "IN",
+            value: [...new Set(refs.map(r => r.scopeSlug))],
+          },
+        ],
+      },
+    });
+
+    // The release each member belongs to decides whether it counts, and the
+    // member row does not carry that. Resolved from a second lookup only
+    // when there are members at all, so the common case — nothing scheduled
+    // anywhere — still costs the single query above.
+    if (scheduled.length === 0) return grouped;
+    const releases = await this.loadScheduledReleases(
+      scheduled.map(m => m.releaseId)
+    );
+
+    const wanted = new Set(refs.map(documentRefKey));
+    for (const member of scheduled) {
+      const release = releases.get(member.releaseId);
+      if (release === undefined || release.scheduledAt === null) continue;
+      const key = documentRefKey(member);
+      if (!wanted.has(key)) continue;
+      const list = grouped.get(key) ?? [];
+      list.push({
+        memberId: member.id,
+        releaseId: member.releaseId,
+        action: member.action,
+        scheduledAt: release.scheduledAt,
+        createdAt: member.createdAt,
+      });
+      grouped.set(key, list);
+    }
+    return grouped;
+  }
+
+  /**
+   * The nearest scheduled instant still in the future, or `null`.
+   *
+   * Drives the cheap check that keeps the release lookup off the common read
+   * path: while `now` is before this, no document can be affected by anything.
+   */
+  async findEarliestPendingTransition(now: Date): Promise<Date | null> {
+    const rows = await this.db.select<{ scheduledAt: Date | null }>(RELEASES, {
+      columns: ["scheduledAt"],
+      where: {
+        and: [
+          { column: "state", op: "=", value: "scheduled" },
+          { column: "scheduledAt", op: "IS NOT NULL" },
+        ],
+      },
+      orderBy: [{ column: "scheduledAt", direction: "asc" }],
+    });
+    for (const row of rows) {
+      if (
+        row.scheduledAt !== null &&
+        row.scheduledAt.getTime() > now.getTime()
+      ) {
+        return row.scheduledAt;
+      }
+    }
+    return null;
+  }
+
+  private async loadScheduledReleases(
+    ids: string[]
+  ): Promise<Map<string, { scheduledAt: Date | null }>> {
+    const rows = await this.db.select<{
+      id: string;
+      state: ReleaseState;
+      scheduledAt: Date | null;
+    }>(RELEASES, {
+      columns: ["id", "state", "scheduledAt"],
+      where: {
+        and: [
+          { column: "id", op: "IN", value: [...new Set(ids)] },
+          { column: "state", op: "=", value: "scheduled" },
+        ],
+      },
+    });
+    return new Map(rows.map(row => [row.id, { scheduledAt: row.scheduledAt }]));
+  }
+}

--- a/packages/nextly/src/domains/releases/resolve-release-effect.ts
+++ b/packages/nextly/src/domains/releases/resolve-release-effect.ts
@@ -1,0 +1,103 @@
+/**
+ * What a release says a document should look like right now.
+ *
+ * The read-side source of truth for scheduled content. Materialisation applies
+ * the SAME function to the same members, so a scheduled change cannot mean one
+ * thing to a read and another to the write that later persists it — the class
+ * of divergence that produced two defects in the pending-changes work, each
+ * time because a read carried an exclusion the write had dropped.
+ *
+ * ## Why this is NOT the working-draft overlay
+ *
+ * `resolveDraftOverlay` gates on whether the caller may EDIT the document: a
+ * working draft is one author's unpublished work and is shown only to someone
+ * entitled to see it. A release whose time has passed is PUBLISHED, and must be
+ * shown to everyone — an anonymous visitor included.
+ *
+ * So the two rules answer different questions and only look alike. Widening the
+ * draft overlay to serve both would leak unpublished work to the public; that
+ * is why this is a sibling with its own predicate rather than a parameter on
+ * the existing one.
+ *
+ * ## Why the ordering is total
+ *
+ * A document may belong to several releases — "publish on the 1st" and
+ * "unpublish on the 20th" is the ordinary case, not an edge one — so from the
+ * 20th onwards two members are due at once and the later must win. Ordering on
+ * the scheduled instant alone is not enough: two releases can name the same
+ * instant, and then the answer would depend on the order the driver returned
+ * rows in, which differs by dialect and by query plan. Falling through to the
+ * creation time and finally to the id makes the order total, so every request
+ * on every dialect resolves the same way.
+ *
+ * @module domains/releases/resolve-release-effect
+ */
+import type { ReleaseMemberAction } from "../../schemas/releases/types";
+
+/** One release membership that could affect a document, as stored. */
+export interface DueMember {
+  memberId: string;
+  releaseId: string;
+  action: ReleaseMemberAction;
+  /** When the owning release takes effect. */
+  scheduledAt: Date;
+  /** When the member was added, the first tie-break. */
+  createdAt: Date;
+}
+
+/** `none` leaves the document exactly as the ordinary read would return it. */
+export type ReleaseEffect = "none" | "publish" | "unpublish";
+
+export interface ReleaseEffectDecision {
+  effect: ReleaseEffect;
+  /** The member that decided it, for reporting and for materialisation. */
+  memberId: string | null;
+  releaseId: string | null;
+}
+
+const NO_EFFECT: ReleaseEffectDecision = {
+  effect: "none",
+  memberId: null,
+  releaseId: null,
+};
+
+/**
+ * The winning member for one document, or no effect.
+ *
+ * `members` are the memberships for a SINGLE document; the caller batches the
+ * lookup across a result set and calls this once per document.
+ */
+export function resolveReleaseEffect(input: {
+  members: DueMember[];
+  now: Date;
+}): ReleaseEffectDecision {
+  const nowMs = input.now.getTime();
+  let winner: DueMember | null = null;
+
+  for (const candidate of input.members) {
+    // Inclusive: a release scheduled for 09:00 is in effect AT 09:00, not from
+    // the first request after it.
+    if (candidate.scheduledAt.getTime() > nowMs) continue;
+    if (winner === null || isLater(candidate, winner)) winner = candidate;
+  }
+
+  if (winner === null) return NO_EFFECT;
+  return {
+    effect: winner.action,
+    memberId: winner.memberId,
+    releaseId: winner.releaseId,
+  };
+}
+
+/**
+ * A total order over due members: scheduled instant, then creation time, then
+ * id. Every term is needed — see the module note on why the instant alone
+ * leaves the answer up to the driver.
+ */
+function isLater(a: DueMember, b: DueMember): boolean {
+  const byScheduled = a.scheduledAt.getTime() - b.scheduledAt.getTime();
+  if (byScheduled !== 0) return byScheduled > 0;
+  const byCreated = a.createdAt.getTime() - b.createdAt.getTime();
+  if (byCreated !== 0) return byCreated > 0;
+  return a.memberId > b.memberId;
+}

--- a/packages/nextly/src/domains/versions/__tests__/resolve-config.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/resolve-config.test.ts
@@ -19,7 +19,6 @@ describe("resolveVersionsConfig", () => {
       drafts: {
         enabled: true,
         autosave: { enabled: true, intervalMs: DEFAULT_AUTOSAVE_INTERVAL_MS },
-        schedulePublish: false,
       },
       maxPerDoc: DEFAULT_MAX_PER_DOC,
     });
@@ -42,15 +41,14 @@ describe("resolveVersionsConfig", () => {
     expect(resolved?.drafts.autosave.enabled).toBe(false);
   });
 
-  it("honors a custom autosave interval and schedulePublish", () => {
+  it("honors a custom autosave interval", () => {
     const resolved = resolveVersionsConfig({
-      drafts: { autosave: { intervalMs: 3000 }, schedulePublish: true },
+      drafts: { autosave: { intervalMs: 3000 } },
     });
     expect(resolved?.drafts.autosave).toEqual({
       enabled: true,
       intervalMs: 3000,
     });
-    expect(resolved?.drafts.schedulePublish).toBe(true);
   });
 
   it("honors maxPerDoc (number and unlimited)", () => {

--- a/packages/nextly/src/domains/versions/resolve-config.ts
+++ b/packages/nextly/src/domains/versions/resolve-config.ts
@@ -66,7 +66,6 @@ export function resolveVersionsConfig(
   // an object that explicitly disables it.
   let autosaveEnabled = draftsEnabled;
   let autosaveIntervalMs = DEFAULT_AUTOSAVE_INTERVAL_MS;
-  let schedulePublish = false;
 
   // `typeof null === "object"`, so guard against null before dereferencing:
   // options may arrive from untyped JS config or a Schema-Builder payload where
@@ -82,7 +81,6 @@ export function resolveVersionsConfig(
         autosaveIntervalMs = autosaveRaw.intervalMs;
       }
     }
-    schedulePublish = draftsRaw.schedulePublish === true;
   }
 
   // `maxPerDoc: false` means unlimited; otherwise a positive number, defaulting
@@ -102,7 +100,6 @@ export function resolveVersionsConfig(
         enabled: draftsEnabled && autosaveEnabled,
         intervalMs: autosaveIntervalMs,
       },
-      schedulePublish,
     },
     maxPerDoc,
   };

--- a/packages/nextly/src/schemas/_dialect-bundles/mysql.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/mysql.ts
@@ -69,3 +69,12 @@ export {
   nextlyWebhooks,
   nextlyWebhookDeliveries,
 } from "../webhooks/mysql";
+
+// Content releases; in the bundle so freshPushSchema creates them on a fresh
+// database. Being in getCoreSchema alone only makes a table diffable — the
+// apply pushes THIS map, so one missing here is proposed on every reconcile
+// and created by none.
+export {
+  nextlyReleasesMysql as nextlyReleases,
+  nextlyReleaseMembersMysql as nextlyReleaseMembers,
+} from "../releases/mysql";

--- a/packages/nextly/src/schemas/_dialect-bundles/postgres.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/postgres.ts
@@ -94,3 +94,12 @@ export {
   nextlyWebhooks,
   nextlyWebhookDeliveries,
 } from "../webhooks/postgres";
+
+// Content releases; in the bundle so freshPushSchema creates them on a fresh
+// database. Being in getCoreSchema alone only makes a table diffable — the
+// apply pushes THIS map, so one missing here is proposed on every reconcile
+// and created by none.
+export {
+  nextlyReleasesPg as nextlyReleases,
+  nextlyReleaseMembersPg as nextlyReleaseMembers,
+} from "../releases/postgres";

--- a/packages/nextly/src/schemas/_dialect-bundles/sqlite.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/sqlite.ts
@@ -69,3 +69,12 @@ export {
   nextlyWebhooks,
   nextlyWebhookDeliveries,
 } from "../webhooks/sqlite";
+
+// Content releases; in the bundle so freshPushSchema creates them on a fresh
+// database. Being in getCoreSchema alone only makes a table diffable — the
+// apply pushes THIS map, so one missing here is proposed on every reconcile
+// and created by none.
+export {
+  nextlyReleasesSqlite as nextlyReleases,
+  nextlyReleaseMembersSqlite as nextlyReleaseMembers,
+} from "../releases/sqlite";

--- a/packages/nextly/src/schemas/index.ts
+++ b/packages/nextly/src/schemas/index.ts
@@ -54,6 +54,7 @@ import { mediaTables } from "./media";
 import { nextlyI18nArchiveTables } from "./nextly-i18n-archive";
 import { nextlyMetaTables } from "./nextly-meta";
 import { rbacTables } from "./rbac";
+import { releasesTables } from "./releases";
 import { schemaEventsTables } from "./schema-events";
 import { siteSettingsMysql } from "./site-settings/mysql";
 import { siteSettingsPg } from "./site-settings/postgres";
@@ -183,6 +184,13 @@ export function getCoreSchema(
     // unlike the migration ledger), so declaring it here is sufficient:
     // core-reconcile creates it on fresh and existing databases.
     ...Object.values(versionsTables(dialect)),
+    // The release tables are first-class managed system tables, declared here
+    // for the same reason `nextly_versions` is: nothing records into them
+    // before they exist, so core-reconcile creating them on fresh and existing
+    // databases is sufficient. Declaring the Drizzle tables alone would not be
+    // — a table absent from this snapshot is never created by db:sync, and the
+    // SQLite bootstrap fallback would hide that on one dialect only.
+    ...Object.values(releasesTables(dialect)),
     ...Object.values(webhookTables(dialect)),
   ];
 
@@ -278,6 +286,8 @@ export const CORE_TABLE_NAMES: readonly string[] = [
   "nextly_schema_events",
   "nextly_i18n_archive",
   "nextly_versions",
+  "nextly_releases",
+  "nextly_release_members",
   "nextly_events",
   "nextly_webhooks",
   "nextly_webhook_deliveries",

--- a/packages/nextly/src/schemas/releases/__tests__/parity.test.ts
+++ b/packages/nextly/src/schemas/releases/__tests__/parity.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The three dialect tables are hand-mirrored from `./postgres.ts`, so a column
+ * added to one and forgotten in another is the failure to catch. Comparing
+ * NAME SETS rather than counts means a rename plus an addition cannot cancel
+ * out and read as agreement.
+ *
+ * @module schemas/releases/__tests__/parity.test
+ */
+import { getTableColumns } from "drizzle-orm";
+import { describe, it, expect } from "vitest";
+
+import { CORE_TABLE_NAMES, getCoreSchema } from "../../index";
+import { my, pg, sl } from "../index";
+import { RELEASE_MEMBER_ACTIONS, RELEASE_STATES } from "../types";
+
+/**
+ * Read the columns through Drizzle rather than `Object.keys`.
+ *
+ * A table object also carries dialect-specific METHODS as own enumerable
+ * properties — `enableRLS` exists on the pg builder and on neither of the
+ * others — so enumerating the object reports a difference that is not a column
+ * and never could be. `getTableColumns` returns exactly the columns.
+ *
+ * Both the property name and the database column name are compared: a mirror
+ * that keeps the property and mistypes the snake_case name would otherwise
+ * pass while producing a table the others cannot be read alongside.
+ */
+const columnNames = (table: Parameters<typeof getTableColumns>[0]): string[] =>
+  Object.entries(getTableColumns(table))
+    .map(([property, column]) => `${property}:${column.name}`)
+    .sort();
+
+describe("release tables are identical across dialects", () => {
+  it("nextly_releases has the same columns everywhere", () => {
+    const canonical = columnNames(pg.nextlyReleasesPg);
+    // The control: if this ever reads as empty, the comparisons below are
+    // satisfied by absence and prove nothing about either dialect.
+    expect(canonical.length).toBeGreaterThan(0);
+    expect(columnNames(my.nextlyReleasesMysql)).toEqual(canonical);
+    expect(columnNames(sl.nextlyReleasesSqlite)).toEqual(canonical);
+  });
+
+  it("nextly_release_members has the same columns everywhere", () => {
+    const canonical = columnNames(pg.nextlyReleaseMembersPg);
+    expect(canonical.length).toBeGreaterThan(0);
+    expect(columnNames(my.nextlyReleaseMembersMysql)).toEqual(canonical);
+    expect(columnNames(sl.nextlyReleaseMembersSqlite)).toEqual(canonical);
+  });
+
+  it("carries the member_key digest column, which the uniqueness rule needs", () => {
+    // Named rather than left to the set comparison: `locale` is nullable and
+    // SQL treats NULL as distinct from NULL, so without this column a unique
+    // index cannot stop two unlocalized members for one document in one
+    // release. Losing it would keep every dialect in agreement and silently
+    // remove the constraint.
+    for (const table of [
+      pg.nextlyReleaseMembersPg,
+      my.nextlyReleaseMembersMysql,
+      sl.nextlyReleaseMembersSqlite,
+    ]) {
+      expect(columnNames(table)).toContain("memberKey:member_key");
+    }
+  });
+});
+
+describe("release enums", () => {
+  it("lists every state and action exactly once", () => {
+    expect([...RELEASE_STATES]).toEqual([
+      "draft",
+      "scheduled",
+      "published",
+      "cancelled",
+    ]);
+    expect([...RELEASE_MEMBER_ACTIONS]).toEqual(["publish", "unpublish"]);
+  });
+});
+
+/**
+ * Declaring the Drizzle tables does not create them. A core table reaches a
+ * real database only if it is ALSO in the core schema snapshot and in
+ * `CORE_TABLE_NAMES`, which is what db:sync and boot-apply read. Missing that
+ * step fails in the least visible way available: the SQLite bootstrap DDL
+ * still creates the tables, so the feature works on one dialect and is absent
+ * on the other two.
+ */
+describe("the release tables are registered as core tables", () => {
+  it("is named in CORE_TABLE_NAMES", () => {
+    expect(CORE_TABLE_NAMES).toContain("nextly_releases");
+    expect(CORE_TABLE_NAMES).toContain("nextly_release_members");
+  });
+
+  it.each(["postgresql", "mysql", "sqlite"] as const)(
+    "appears in the %s core schema snapshot",
+    dialect => {
+      const names = getCoreSchema(dialect).tables.map(t => t.name);
+      // The control: an empty snapshot would satisfy neither assertion below
+      // for the right reason, so assert it read something first.
+      expect(names.length).toBeGreaterThan(0);
+      expect(names).toContain("nextly_releases");
+      expect(names).toContain("nextly_release_members");
+    }
+  );
+});

--- a/packages/nextly/src/schemas/releases/index.ts
+++ b/packages/nextly/src/schemas/releases/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Release tables - dialect-aware barrel.
+ *
+ * Re-exports the per-dialect release tables under canonical names; the runtime
+ * dialect selects which tables a caller sees.
+ *
+ * @module schemas/releases
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import { NextlyError } from "../../errors";
+
+import * as my from "./mysql";
+import * as pg from "./postgres";
+import * as sl from "./sqlite";
+
+export { pg, my, sl };
+
+/** Returns the Drizzle table objects for the releases feature group. */
+export function releasesTables(dialect: SupportedDialect) {
+  switch (dialect) {
+    case "postgresql":
+      return {
+        nextlyReleases: pg.nextlyReleasesPg,
+        nextlyReleaseMembers: pg.nextlyReleaseMembersPg,
+      };
+    case "mysql":
+      return {
+        nextlyReleases: my.nextlyReleasesMysql,
+        nextlyReleaseMembers: my.nextlyReleaseMembersMysql,
+      };
+    case "sqlite":
+      return {
+        nextlyReleases: sl.nextlyReleasesSqlite,
+        nextlyReleaseMembers: sl.nextlyReleaseMembersSqlite,
+      };
+    default: {
+      const _exhaustive: never = dialect;
+      // NextlyError (not bare Error) per the packages/nextly convention. This
+      // branch is unreachable given the SupportedDialect union; the `never`
+      // assignment is the compile-time exhaustiveness guard.
+      throw NextlyError.internal({
+        logContext: { dialect: String(_exhaustive) },
+      });
+    }
+  }
+}

--- a/packages/nextly/src/schemas/releases/mysql.ts
+++ b/packages/nextly/src/schemas/releases/mysql.ts
@@ -1,0 +1,102 @@
+/**
+ * `nextly_releases` and `nextly_release_members` - MySQL.
+ *
+ * See ./postgres.ts for the canonical column list (mirrored with MySQL types)
+ * and for why each index exists. Every index here is a plain one, so MySQL's
+ * lack of partial indexes costs nothing: the uniqueness rule is expressed over
+ * the `member_key` digest, which is never NULL.
+ *
+ * @module schemas/releases/mysql
+ */
+
+import {
+  mysqlTable,
+  varchar,
+  int,
+  datetime,
+  text,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/mysql-core";
+
+import type { VersionScopeKind } from "../versions/types";
+
+import type { ReleaseMemberAction, ReleaseState } from "./types";
+
+export const nextlyReleasesMysql = mysqlTable(
+  "nextly_releases",
+  {
+    id: varchar("id", { length: 36 })
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+
+    title: varchar("title", { length: 255 }).notNull(),
+    description: text("description"),
+
+    scheduledAt: datetime("scheduled_at", { fsp: 3 }),
+    timezone: varchar("timezone", { length: 64 }),
+
+    state: varchar("state", { length: 32 }).$type<ReleaseState>().notNull(),
+    publishedAt: datetime("published_at", { fsp: 3 }),
+
+    createdBy: varchar("created_by", { length: 36 }),
+    createdAt: datetime("created_at", { fsp: 3 })
+      .$defaultFn(() => new Date())
+      .notNull(),
+    updatedAt: datetime("updated_at", { fsp: 3 })
+      .$defaultFn(() => new Date())
+      .notNull(),
+
+    revision: int("revision").default(0).notNull(),
+  },
+  table => [index("nextly_releases_due_idx").on(table.state, table.scheduledAt)]
+);
+
+export const nextlyReleaseMembersMysql = mysqlTable(
+  "nextly_release_members",
+  {
+    id: varchar("id", { length: 36 })
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+
+    releaseId: varchar("release_id", { length: 36 }).notNull(),
+
+    scopeKind: varchar("scope_kind", { length: 32 })
+      .$type<VersionScopeKind>()
+      .notNull(),
+    scopeSlug: varchar("scope_slug", { length: 255 }).notNull(),
+    entryId: varchar("entry_id", { length: 36 }).notNull(),
+    locale: varchar("locale", { length: 32 }),
+
+    action: varchar("action", { length: 32 })
+      .$type<ReleaseMemberAction>()
+      .notNull(),
+
+    // A sha256 hex digest: 64 characters, well inside MySQL's 3072-byte index
+    // key limit. A readable composite of the same five values would not be —
+    // which is the second reason this column exists.
+    memberKey: varchar("member_key", { length: 64 }).notNull(),
+
+    createdBy: varchar("created_by", { length: 36 }),
+    createdAt: datetime("created_at", { fsp: 3 })
+      .$defaultFn(() => new Date())
+      .notNull(),
+  },
+  table => [
+    uniqueIndex("nextly_release_members_key_uidx").on(table.memberKey),
+    index("nextly_release_members_doc_idx").on(
+      table.scopeKind,
+      table.scopeSlug,
+      table.entryId,
+      table.locale
+    ),
+    index("nextly_release_members_release_idx").on(table.releaseId),
+  ]
+);
+
+export type NextlyReleaseMysql = typeof nextlyReleasesMysql.$inferSelect;
+export type NextlyReleaseInsertMysql = typeof nextlyReleasesMysql.$inferInsert;
+export type NextlyReleaseMemberMysql =
+  typeof nextlyReleaseMembersMysql.$inferSelect;
+export type NextlyReleaseMemberInsertMysql =
+  typeof nextlyReleaseMembersMysql.$inferInsert;

--- a/packages/nextly/src/schemas/releases/postgres.ts
+++ b/packages/nextly/src/schemas/releases/postgres.ts
@@ -1,0 +1,126 @@
+/**
+ * `nextly_releases` and `nextly_release_members` - PostgreSQL.
+ *
+ * The canonical column list; `./mysql.ts` and `./sqlite.ts` mirror it with
+ * their own types. `id` uses the client-side UUID pattern (text +
+ * `$defaultFn`) for cross-dialect parity with the other system tables.
+ *
+ * No partial indexes here, unlike `nextly_versions`: every index below is a
+ * plain one, so MySQL and SQLite express the same constraints directly instead
+ * of falling back to repository enforcement.
+ *
+ * @module schemas/releases/postgres
+ */
+
+import {
+  pgTable,
+  text,
+  integer,
+  timestamp,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+
+import type { VersionScopeKind } from "../versions/types";
+
+import type { ReleaseMemberAction, ReleaseState } from "./types";
+
+export const nextlyReleasesPg = pgTable(
+  "nextly_releases",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+
+    title: text("title").notNull(),
+    description: text("description"),
+
+    // NULL while the release is still being assembled: a `draft` release has
+    // no time yet, and storing a placeholder would make it indistinguishable
+    // from one deliberately scheduled for the epoch.
+    scheduledAt: timestamp("scheduled_at", { withTimezone: true }),
+    // The IANA zone the author chose the time in, kept for DISPLAY only.
+    // `scheduled_at` is the instant and is already absolute; this records that
+    // "09:00" meant 09:00 somewhere, which a bare UTC stamp loses.
+    timezone: text("timezone"),
+
+    state: text("state").$type<ReleaseState>().notNull(),
+    // When materialisation completed, not when it was due. The two differ
+    // whenever the reconciler ran late, and only the read rule cares about due.
+    publishedAt: timestamp("published_at", { withTimezone: true }),
+
+    createdBy: text("created_by"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .$defaultFn(() => new Date())
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .$defaultFn(() => new Date())
+      .notNull(),
+
+    // The compare-and-set token materialisation claims a release with, so two
+    // concurrent reconcilers cannot both apply it. A counter rather than
+    // `updated_at` for the reason `nextly_versions.revision` gives: stored
+    // timestamp resolution varies by dialect, so two writes close together can
+    // serialize to the same value and become indistinguishable.
+    revision: integer("revision").default(0).notNull(),
+  },
+  table => [
+    // The due-release query reads exactly these two columns together.
+    index("nextly_releases_due_idx").on(table.state, table.scheduledAt),
+  ]
+);
+
+export const nextlyReleaseMembersPg = pgTable(
+  "nextly_release_members",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+
+    releaseId: text("release_id").notNull(),
+
+    scopeKind: text("scope_kind").$type<VersionScopeKind>().notNull(),
+    scopeSlug: text("scope_slug").notNull(),
+    entryId: text("entry_id").notNull(),
+    // NULL is the unlocalized document, matching `nextly_versions.locale`.
+    locale: text("locale"),
+
+    action: text("action").$type<ReleaseMemberAction>().notNull(),
+
+    // The digest of (release, document, locale) — see `releaseMemberKey`.
+    //
+    // A plain unique index over the five source columns CANNOT enforce this
+    // rule: `locale` is nullable and SQL treats NULL as distinct from NULL, so
+    // any number of unlocalized members for one document would satisfy it.
+    // `nextly_versions.draft_key` exists for the same reason and is built the
+    // same way.
+    memberKey: text("member_key").notNull(),
+
+    // Materialisation acts AS this user, so the transition is subject to their
+    // permissions and the audit trail names the person who scheduled it rather
+    // than a system principal.
+    createdBy: text("created_by"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .$defaultFn(() => new Date())
+      .notNull(),
+  },
+  table => [
+    // One member per document per locale per release.
+    uniqueIndex("nextly_release_members_key_uidx").on(table.memberKey),
+    // The read-side lookup: given documents, which members mention them.
+    index("nextly_release_members_doc_idx").on(
+      table.scopeKind,
+      table.scopeSlug,
+      table.entryId,
+      table.locale
+    ),
+    // Listing a release's contents, and cascading a delete.
+    index("nextly_release_members_release_idx").on(table.releaseId),
+  ]
+);
+
+export type NextlyReleasePg = typeof nextlyReleasesPg.$inferSelect;
+export type NextlyReleaseInsertPg = typeof nextlyReleasesPg.$inferInsert;
+export type NextlyReleaseMemberPg = typeof nextlyReleaseMembersPg.$inferSelect;
+export type NextlyReleaseMemberInsertPg =
+  typeof nextlyReleaseMembersPg.$inferInsert;

--- a/packages/nextly/src/schemas/releases/sqlite.ts
+++ b/packages/nextly/src/schemas/releases/sqlite.ts
@@ -1,0 +1,103 @@
+/**
+ * `nextly_releases` and `nextly_release_members` - SQLite.
+ *
+ * See ./postgres.ts for the canonical column list (mirrored with SQLite types)
+ * and for why each index exists. Timestamps are integer epoch values
+ * (timestamp mode), matching the dynamic tables and the transaction-path Date
+ * encoding.
+ *
+ * Every index here is a plain one, so the drizzle-kit limitation that stops
+ * SQLite carrying a partial index (drizzle-team/drizzle-orm#4688) does not
+ * apply: the uniqueness rule is expressed over the `member_key` digest, which
+ * is never NULL.
+ *
+ * @module schemas/releases/sqlite
+ */
+
+import {
+  sqliteTable,
+  text,
+  integer,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+import type { VersionScopeKind } from "../versions/types";
+
+import type { ReleaseMemberAction, ReleaseState } from "./types";
+
+export const nextlyReleasesSqlite = sqliteTable(
+  "nextly_releases",
+  {
+    // NOT NULL PK: SQLite treats a bare TEXT PRIMARY KEY as nullable, which
+    // churns a drizzle-kit rebuild on every push otherwise.
+    id: text("id")
+      .primaryKey()
+      .notNull()
+      .$defaultFn(() => crypto.randomUUID()),
+
+    title: text("title").notNull(),
+    description: text("description"),
+
+    scheduledAt: integer("scheduled_at", { mode: "timestamp" }),
+    timezone: text("timezone"),
+
+    state: text("state").$type<ReleaseState>().notNull(),
+    publishedAt: integer("published_at", { mode: "timestamp" }),
+
+    createdBy: text("created_by"),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .$defaultFn(() => new Date())
+      .notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .$defaultFn(() => new Date())
+      .notNull(),
+
+    revision: integer("revision").default(0).notNull(),
+  },
+  table => [index("nextly_releases_due_idx").on(table.state, table.scheduledAt)]
+);
+
+export const nextlyReleaseMembersSqlite = sqliteTable(
+  "nextly_release_members",
+  {
+    id: text("id")
+      .primaryKey()
+      .notNull()
+      .$defaultFn(() => crypto.randomUUID()),
+
+    releaseId: text("release_id").notNull(),
+
+    scopeKind: text("scope_kind").$type<VersionScopeKind>().notNull(),
+    scopeSlug: text("scope_slug").notNull(),
+    entryId: text("entry_id").notNull(),
+    locale: text("locale"),
+
+    action: text("action").$type<ReleaseMemberAction>().notNull(),
+
+    memberKey: text("member_key").notNull(),
+
+    createdBy: text("created_by"),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .$defaultFn(() => new Date())
+      .notNull(),
+  },
+  table => [
+    uniqueIndex("nextly_release_members_key_uidx").on(table.memberKey),
+    index("nextly_release_members_doc_idx").on(
+      table.scopeKind,
+      table.scopeSlug,
+      table.entryId,
+      table.locale
+    ),
+    index("nextly_release_members_release_idx").on(table.releaseId),
+  ]
+);
+
+export type NextlyReleaseSqlite = typeof nextlyReleasesSqlite.$inferSelect;
+export type NextlyReleaseInsertSqlite =
+  typeof nextlyReleasesSqlite.$inferInsert;
+export type NextlyReleaseMemberSqlite =
+  typeof nextlyReleaseMembersSqlite.$inferSelect;
+export type NextlyReleaseMemberInsertSqlite =
+  typeof nextlyReleaseMembersSqlite.$inferInsert;

--- a/packages/nextly/src/schemas/releases/types.ts
+++ b/packages/nextly/src/schemas/releases/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Dialect-agnostic types for the content-release tables.
+ *
+ * A release is a set of content changes that take effect together at one
+ * instant. Its members POINT AT documents rather than carrying copies of them:
+ * the pending edit already lives in `nextly_versions` as a working draft, and a
+ * second copy would be a second thing to keep in step.
+ *
+ * @module schemas/releases/types
+ */
+
+/**
+ * Lifecycle of a release.
+ *
+ * Only `scheduled` affects reads. `draft` is still being assembled, `published`
+ * has already been materialised into the live rows, and `cancelled` was called
+ * off — so a read consults exactly one state and the other three cost nothing.
+ */
+export type ReleaseState = "draft" | "scheduled" | "published" | "cancelled";
+
+/** What a member does to its document when the release takes effect. */
+export type ReleaseMemberAction = "publish" | "unpublish";
+
+/** The release states, in lifecycle order. */
+export const RELEASE_STATES: readonly ReleaseState[] = [
+  "draft",
+  "scheduled",
+  "published",
+  "cancelled",
+];
+
+/** The member actions, in the order the admin offers them. */
+export const RELEASE_MEMBER_ACTIONS: readonly ReleaseMemberAction[] = [
+  "publish",
+  "unpublish",
+];
+
+/** Runtime guard: true iff `v` is one of the release states. */
+export function isReleaseState(v: unknown): v is ReleaseState {
+  return (
+    typeof v === "string" && (RELEASE_STATES as readonly string[]).includes(v)
+  );
+}
+
+/** Runtime guard: true iff `v` is one of the member actions. */
+export function isReleaseMemberAction(v: unknown): v is ReleaseMemberAction {
+  return (
+    typeof v === "string" &&
+    (RELEASE_MEMBER_ACTIONS as readonly string[]).includes(v)
+  );
+}

--- a/packages/nextly/src/schemas/versions/__tests__/types.test.ts
+++ b/packages/nextly/src/schemas/versions/__tests__/types.test.ts
@@ -8,7 +8,6 @@ describe("versions types", () => {
       "draft",
       "published",
       "unpublished",
-      "scheduled",
     ]);
   });
 

--- a/packages/nextly/src/schemas/versions/types.ts
+++ b/packages/nextly/src/schemas/versions/types.ts
@@ -11,9 +11,14 @@
 /**
  * Lifecycle state stamped on a version row. A restore is identified by a
  * non-null `sourceVersionNo`, not a distinct status, so the active set stays
- * small; `scheduled` is reserved for the future timed-publish executor.
+ * small.
+ *
+ * Scheduling is NOT one of these. A scheduled change is a pending edit plus a
+ * release membership, and stamping the version row as well would give two
+ * places an opinion on whether something is scheduled — with nothing keeping
+ * them in step.
  */
-export type VersionStatus = "draft" | "published" | "unpublished" | "scheduled";
+export type VersionStatus = "draft" | "published" | "unpublished";
 
 /** The kind of document a version belongs to (Nextly's `{ kind, slug }` scope). */
 export type VersionScopeKind = "collection" | "single" | "page";
@@ -23,7 +28,6 @@ export const VERSION_STATUSES: readonly VersionStatus[] = [
   "draft",
   "published",
   "unpublished",
-  "scheduled",
 ];
 
 /** Runtime guard: true iff `v` is one of the active version statuses. */
@@ -58,8 +62,6 @@ export interface VersionsConfig {
     | {
         /** Coalesced autosave of the in-progress draft. Default 1000ms when on. */
         autosave?: boolean | { intervalMs?: number };
-        /** Reserve the `scheduled` status for future timed publish. */
-        schedulePublish?: boolean;
       };
   /** Durable (non-autosave) versions kept per document. `false` = unlimited. Default 50. */
   maxPerDoc?: number | false;
@@ -80,7 +82,6 @@ export interface ResolvedVersionsConfig {
       enabled: boolean;
       intervalMs: number;
     };
-    schedulePublish: boolean;
   };
   /** Durable versions retained per document; `false` = unlimited. */
   maxPerDoc: number | false;


### PR DESCRIPTION
The storage and the read rule for scheduled content releases. **Nothing reads them yet** — this lands dark so it can go in without changing a single existing behaviour.

Design: `tasks/2026-08-19-content-releases-design.md`. Plan: `tasks/2026-08-20-plan-content-releases-engine.md`. This is PR 1 of 2 in the engine plan; the admin surfaces are a separate plan.

## What is here

- **Two core tables** on all three dialects, plus the SQLite bootstrap DDL.
- **`resolveReleaseEffect`** — the pure rule deciding what a release says a document looks like now.
- **`ReleasesRepository`** — create, schedule, cancel, add/remove member, and the batched lookup reads will use.
- **Removal** of `versions.drafts.schedulePublish` and the unused `"scheduled"` version status.

## Four things worth a reviewer's attention

**1. The release overlay is NOT the working-draft overlay.** `resolveDraftOverlay` gates on whether the caller may EDIT the document, because a working draft is one author's unpublished work. A release whose time has passed is *published* and must be visible to an anonymous visitor. These are different questions that only look alike — widening the existing rule to serve both would leak unpublished work to the public. That is why this is a sibling with its own predicate, and it is the single thing not to "tidy" later.

**2. The unique index is on a digest, not the five source columns.** `locale` is nullable and SQL treats NULL as distinct from NULL, so a composite unique index would admit **any number** of unlocalized members for one document in one release — exactly the case the constraint exists to stop. `nextly_versions.draft_key` solves the same problem the same way, and the digest also keeps the key inside MySQL's 3072-byte index limit. The integration test covers the unlocalized case specifically.

**3. A core table needs THREE registries, not one.** The schema snapshot, `CORE_TABLE_NAMES`, and the dialect bundle handed to drizzle-kit. I had wired the first two; the repo's own `core-tables-reach-the-push-bundle` guard caught the third and named both missing tables. Its comment says why that matters: miss it and "its DDL renders, a fixture creates it, and every unit test passes — against a table no real installation has."

**4. `schedulePublish` was dead public config.** Declared, parsed into `ResolvedVersionsConfig`, read by nothing — a user could set it and get silence. The removal step began by *proving* it was unread, with an explicit stop condition if anything consumed it. Nothing in docs, templates, apps or e2e referenced it.

## Verification

**Cross-dialect, and the first attempt was wrong.** `createTestNextly` defaults to SQLite regardless of `DB_DIALECT`, so my first "13 passed on Postgres / 13 passed on MySQL" runs were three SQLite runs with identical counts. A probe that *asserted* the dialect exposed it. Once the suite genuinely ran per dialect via `getConfiguredTestDialects()`, **MySQL failed 11 of 13**: it has no `RETURNING`, so reading the inserted row back gave `undefined`. Fixed by the house pattern — client-side id, `{ returning: [] }`. Now 39 pass = 13 × 3 dialects.

**Break-verified, four checks each:**
- parity test — remove a MySQL column, it names `description:description`
- core-table registration — remove it, all three dialect tests fail
- total ordering — `isLater → return true`, exactly the three ordering tests fail and the other five stay green

**The batching test originally could not exhibit its defect** — with no members the lookup returns after its first query and never reaches the second, so a per-row implementation would have passed. It now creates 25 members and asserts the query count does not *grow* between 25 documents and 5, with `many.size === 25` as the control that the run did the work.

**fallow:** `verdict: warn`, `dead_code_introduced: 0`, `complexity_introduced: 0`, `duplication_introduced: 7` — all seven are the dialect mirrors, which fallow itself classifies as *mirrored directories* (`schemas/releases/ ~ schemas/versions/`). Nothing suppressed.

## Not in this PR

Read-path wiring, materialisation, cache, and permissions are PR 2. The admin surfaces follow in their own plan.
