### PR TITLE
test(root): assert the canvas measures geometry once per drag

### DIFF
--- a/e2e/tests/canvas/acceptance-manifest.ts
+++ b/e2e/tests/canvas/acceptance-manifest.ts
@@ -87,9 +87,12 @@ export const ACCEPTANCE_PROPERTIES: readonly AcceptanceProperty[] = [
     n: 9,
     property: "Rects cached at dragstart; 60fps on a 500-block tree",
     greenIn: "B-8",
-    status: "deferred",
-    reason:
-      "needs the canvas to REPORT its geometry reads; counting getBoundingClientRect from the test would instrument the page rather than the engine, and the frame-rate half is deliberately not a merge gate — it is flaky on a shared runner and a green there proves less than a bounded read count",
+    status: "covered",
+    // The MECHANISM half only. Rect caching is observable by spying on
+    // `getBoundingClientRect` from the test, which watches the engine without
+    // altering it. The FRAME-RATE half stays out of the gate deliberately: it is
+    // flaky on a shared runner, and a green there proves less than a bounded
+    // read count does.
   },
   {
     n: 10,
@@ -103,7 +106,7 @@ export const ACCEPTANCE_PROPERTIES: readonly AcceptanceProperty[] = [
     greenIn: "B-15",
     status: "deferred",
     reason:
-      "needs the three-tier inserter mounted; the canvas harness renders no panel, so there is no panel drag to compare against and the property is vacuously true",
+      "the panel CANNOT be dragged from: insert-panel.tsx has no drag code at all and inserts by click (line 162). B-15's drag half was never built, so this is blocked on a feature rather than on scaffolding — mounting the panel would not help. See task:pb-inserter-drag",
   },
   {
     n: 12,

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -443,4 +443,69 @@ test.describe("the canvas acceptance suite", () => {
     const max = await host.evaluate(el => el.scrollHeight - el.clientHeight);
     expect(scrolled).toBeLessThanOrEqual(max);
   });
+
+  test(`${titleFor(COVERED.find(p => p.n === 9)!)}`, async ({ page }) => {
+    await openCanvas(page);
+
+    // Spy on the DOM API from the test rather than instrumenting the engine.
+    // This watches what the canvas does without changing it, which is the only
+    // honest way to assert "measured once" — an engine that reported its own
+    // read count could report anything.
+    await page.evaluate(() => {
+      const w = window as unknown as { __rectReads: number };
+      w.__rectReads = 0;
+      const original = Element.prototype.getBoundingClientRect;
+      Element.prototype.getBoundingClientRect = function patched(
+        this: Element
+      ): DOMRect {
+        w.__rectReads += 1;
+        return original.call(this);
+      };
+    });
+    const reads = async () =>
+      page.evaluate(
+        () => (window as unknown as { __rectReads: number }).__rectReads
+      );
+
+    const from = await boxOf(page, "hx-text-short");
+    const centre = { x: from.x + from.width / 2, y: from.y + from.height / 2 };
+    const before = await reads();
+
+    await page.mouse.move(centre.x, centre.y);
+    await page.mouse.down();
+    await page.mouse.move(centre.x, centre.y - 40, { steps: 8 });
+    const afterStart = await reads();
+
+    // The POPULATION: a snapshot actually happened. Without this, "no reads
+    // during moves" is satisfied by an engine that never measured anything —
+    // which is indistinguishable from one that measured once, on this metric.
+    expect(
+      afterStart - before,
+      "the drag must snapshot the tree's geometry when it starts"
+    ).toBeGreaterThanOrEqual(11);
+
+    // Now move a lot. If rects were re-read per move, this scales with the
+    // number of blocks times the number of moves.
+    for (let i = 0; i < 20; i += 1) {
+      await page.mouse.move(centre.x, centre.y - 40 - i, { steps: 2 });
+    }
+    const afterMoves = await reads();
+    await page.mouse.up();
+
+    const perMove = (afterMoves - afterStart) / 20;
+    // The property is that reads do NOT SCALE WITH THE TREE — a read per block
+    // per move is the reflow-per-frame the snapshot exists to avoid. A small
+    // constant is legitimate: the indicator has to be placed somewhere.
+    //
+    // Bounded at six rather than at the block count. Measured here: FOUR per
+    // move against eleven blocks. A bound of "fewer than the blocks" would
+    // express the property but loosen every time the fixture grows, and would
+    // still pass if the engine quietly went from four to ten. Six holds the
+    // measured behaviour with a little room, and a change past it is a real
+    // change somebody should look at rather than a threshold nobody noticed.
+    expect(
+      perMove,
+      `geometry reads per pointer move: ${perMove} (11 blocks in the fixture)`
+    ).toBeLessThanOrEqual(6);
+  });
 });


### PR DESCRIPTION
Takes the acceptance suite to **11 of 12**. **No canvas change** — the property was already true and simply unasserted.

`snapshotRects()` measures every node at drag start, and `canvas-drag.tsx`'s own docblock states why: re-reading `getBoundingClientRect` on each pointer move *"would force a reflow per frame to learn nothing."* This asserts it.

## Spying, not instrumenting

The test patches `Element.prototype.getBoundingClientRect` and counts. That watches the engine **without altering it** — the only honest way to assert "measured once", since an engine reporting its own read count could report anything.

**My earlier deferral reason was wrong.** I wrote that counting from the test "would instrument the page rather than the engine". Patching a DOM API from the test is *observation*, not instrumentation, and it's exactly what makes this askable.

## The bound, and why it's six

**Measured: 4 reads per pointer move against 11 blocks.** A small constant is legitimate — the indicator has to be placed somewhere. What must not happen is a read *per block per move*, which is the reflow-per-frame the snapshot exists to avoid.

Bounded at six rather than at the block count. "Fewer than the blocks" expresses the property but **loosens every time the fixture grows**, and would still pass if the engine went quietly from four to ten. Six holds the measured behaviour with a little room, so a change past it is something a human looks at.

The population is asserted first — the drag must snapshot **at least 11 rects** on start. Without that, "no reads during moves" is equally satisfied by an engine that never measured anything at all.

I verified the assertion can fail by tightening it to zero and watching it report the real number.

The **frame-rate half stays out of the gate** deliberately: flaky on a shared runner, and a green there proves less than a bounded read count does.

## A11's deferral reason was wrong, and is corrected here

It said the harness renders no panel. **Mounting one would not have helped** — `insert-panel.tsx` has *no drag code at all* and inserts by click (line 162). B-15's drag half was never built, so A11 is blocked on a **feature**, not scaffolding. Filed as `task:pb-inserter-drag`.

Worth noting which half shipped: click-to-insert is the WCAG 2.2 §2.5.7 single-pointer alternative that every drag gesture needs anyway. The accessible half exists; the convenience half doesn't.

## Verification

`playwright test canvas/` → **52 passed**, exit 0. e2e lint and typecheck clean.

No changeset: test-only.