### PR TITLE
refactor(nextly): one definition of the clock a lease is judged against

### DIFF
--- a/.changeset/one-lease-clock.md
+++ b/.changeset/one-lease-clock.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The field-group migration lock now reads its clock and derives its timings from one shared module, so a second lock cannot disagree with it about what time it is. No behaviour change: the same expressions and the same 120s/15s/90s values, reached by one definition instead of a private copy.

--- a/packages/nextly/src/database/__tests__/lease-clock.test.ts
+++ b/packages/nextly/src/database/__tests__/lease-clock.test.ts
@@ -1,0 +1,109 @@
+import { PgDialect } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveLeaseTimings,
+  futureExpression,
+  nowExpression,
+} from "../lease-clock";
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+/**
+ * Two lock mechanisms read this module, and each of the spellings below was a defect once.
+ *
+ * The expressions are compiled to text rather than compared as objects, because what reaches the
+ * database is the rendered SQL and an object comparison would pass on a `sql` template that
+ * interpolates something else entirely.
+ */
+const render = (dialect: SupportedDialect, seconds = 30) => ({
+  now: new PgDialect().sqlToQuery(nowExpression(dialect)).sql,
+  future: new PgDialect().sqlToQuery(futureExpression(dialect, seconds)).sql,
+});
+
+describe("the database clock a lease is judged against", () => {
+  it("reads PostgreSQL at STATEMENT time, never transaction time", () => {
+    const { now, future } = render("postgresql");
+    // `now()` is frozen for the whole transaction, so a statement that waited on a contended row
+    // reads the instant it began queueing. A claim judged live by that can already have expired.
+    expect(now).toContain("clock_timestamp()");
+    expect(now).not.toContain("now()");
+    // The pair must share one frame of reference, or the expiry written and the liveness test taken
+    // disagree about when the lease ends.
+    expect(future).toContain("clock_timestamp()");
+  });
+
+  it("reads MySQL on a zone-independent clock", () => {
+    const { now, future } = render("mysql");
+    // `expires_at` is a zone-less DATETIME. `NOW()` is SESSION-local, so a UTC holder writes an
+    // expiry a UTC+05 contender reads as hours past and takes a live claim, with nothing about the
+    // row looking wrong afterwards.
+    expect(now).toContain("UTC_TIMESTAMP()");
+    // Stripping the UTC form first is what stops this matching its own tail.
+    expect(now.replace(/UTC_TIMESTAMP\(\)/g, "")).not.toContain("NOW()");
+    expect(future.replace(/UTC_TIMESTAMP\(\)/g, "")).not.toContain("NOW()");
+  });
+
+  it("reads SQLite as integer seconds", () => {
+    const { now, future } = render("sqlite");
+    // The Drizzle column is `mode: "timestamp"`, i.e. unix seconds, so the arithmetic is integer
+    // rather than interval.
+    expect(now).toContain("unixepoch()");
+    expect(future).toContain("unixepoch()");
+  });
+
+  it("offsets on the same clock it reads, on every dialect", () => {
+    // A positive control on the loop below: an empty dialect list would satisfy every assertion in
+    // it while checking nothing.
+    const dialects: SupportedDialect[] = ["postgresql", "mysql", "sqlite"];
+    expect(dialects).toHaveLength(3);
+
+    for (const dialect of dialects) {
+      const { now, future } = render(dialect);
+      const clockFn = now.match(/[A-Za-z_]+\(\)/)?.[0];
+      expect(clockFn, `${dialect} names a clock function`).toBeDefined();
+      expect(future, `${dialect} offsets from its own clock`).toContain(
+        clockFn as string
+      );
+    }
+  });
+});
+
+describe("lease timings", () => {
+  it("derives every timing from the TTL", () => {
+    // The migration lock's shipped values, which this must reproduce exactly.
+    expect(deriveLeaseTimings(120, 8)).toEqual({
+      ttlSeconds: 120,
+      renewIntervalMs: 15_000,
+      lossAfterMs: 90_000,
+      renewMarginSeconds: 90,
+    });
+  });
+
+  it("leaves two renewal intervals of lease in hand at the loss deadline", () => {
+    // 🔴 The property, not the arithmetic. A holder must be told it is losing the claim while it is
+    // still protected; a deadline that landed ON expiry would tell it afterwards.
+    for (const [ttl, divisor] of [
+      [120, 8],
+      [150, 10],
+      [300, 30],
+    ] as const) {
+      const t = deriveLeaseTimings(ttl, divisor);
+      expect(
+        t.ttlSeconds * 1000 - t.lossAfterMs,
+        `ttl=${ttl} divisor=${divisor}`
+      ).toBe(2 * t.renewIntervalMs);
+      expect(
+        t.lossAfterMs,
+        `ttl=${ttl} is protected at its deadline`
+      ).toBeLessThan(t.ttlSeconds * 1000);
+    }
+  });
+
+  it("keeps the margin and the loss deadline in the same units", () => {
+    // These are read by different callers — one compares milliseconds, one writes a SQL interval in
+    // seconds — and a mismatch here is a lease that looks renewed and is not.
+    const t = deriveLeaseTimings(150, 10);
+    expect(t.renewMarginSeconds * 1000).toBe(t.lossAfterMs);
+  });
+});

--- a/packages/nextly/src/database/lease-clock.ts
+++ b/packages/nextly/src/database/lease-clock.ts
@@ -1,0 +1,110 @@
+/**
+ * The database's own clock, per dialect, and the timings a lease derives from it.
+ *
+ * Two mechanisms in this package hold a lease: the field-group migration lock, which refuses to
+ * steal a live claim because two concurrent migrations corrupt a schema, and the document soft
+ * lock, which permits a human to take one over. They disagree about acquisition on purpose. They
+ * cannot be allowed to disagree about WHAT TIME IT IS, which is what this module owns.
+ *
+ * 🔴 Never the application's clock. Contenders sit on different machines — and under serverless,
+ * on a different instance per request — whose clocks disagree. A claim written from one clock and
+ * judged against another is decided by that skew rather than by who holds the lock. Asking the
+ * database for both values puts every comparison in one frame of reference.
+ *
+ * @module database/lease-clock
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+import { sql, type SQL } from "drizzle-orm";
+
+/**
+ * The instant the database is at, as an expression it evaluates itself.
+ *
+ * SQLite stores these columns as unix SECONDS (the Drizzle declarations use `mode: "timestamp"`),
+ * so its expressions are integer arithmetic rather than interval arithmetic.
+ */
+export function nowExpression(dialect: SupportedDialect): SQL {
+  if (dialect === "sqlite") return sql`unixepoch()`;
+  // 🔴 PostgreSQL uses `clock_timestamp()`, NOT `now()`, and the difference decides correctness
+  // here rather than precision. `now()` is TRANSACTION start time and is frozen for the whole
+  // transaction, so a statement that waits on this row — which is exactly what contention means —
+  // reads the instant it began queueing rather than the instant it was admitted. A claim judged
+  // live by that stale reading can already have expired, and an expiry written from it can be in
+  // the past before the row is even updated.
+  //
+  // 🔴 MySQL uses `UTC_TIMESTAMP()`, NOT `NOW()`. `NOW()` returns the SESSION's local time, and
+  // `expires_at` is a `DATETIME`, which stores no zone — so a holder whose session is UTC writes an
+  // expiry a contender whose session is UTC+05 reads as five hours in the past, and takes a live
+  // claim instantly. Nothing about the row would look wrong afterwards: both runs believe they hold
+  // it. `UTC_TIMESTAMP()` is the same instant for every session whatever its `time_zone`.
+  //
+  // Both are statement-time rather than transaction-time, so neither needs Postgres's distinction.
+  return dialect === "mysql" ? sql`UTC_TIMESTAMP()` : sql`clock_timestamp()`;
+}
+
+/**
+ * `seconds` from now, on the same clock `nowExpression` reads.
+ *
+ * The pair has to share one frame of reference to mean anything: an expiry written from transaction
+ * time and a liveness test taken at statement time would disagree about when the lease ends.
+ */
+export function futureExpression(
+  dialect: SupportedDialect,
+  seconds: number
+): SQL {
+  if (dialect === "sqlite") return sql`unixepoch() + ${seconds}`;
+  if (dialect === "mysql") {
+    return sql`DATE_ADD(UTC_TIMESTAMP(), INTERVAL ${seconds} SECOND)`;
+  }
+  return sql`clock_timestamp() + make_interval(secs => ${seconds})`;
+}
+
+/** Every timing a lease needs, so a caller cannot hold two of them that disagree. */
+export interface LeaseTimings {
+  /** How long a confirmation grants. */
+  readonly ttlSeconds: number;
+  /** How often the holder confirms. */
+  readonly renewIntervalMs: number;
+  /**
+   * How long the holder may go without a CONFIRMED renewal before it must treat the claim as lost.
+   *
+   * 🔴 Deliberately not "how many renewals failed". A count is only a proxy for the question that
+   * decides safety — how much lease is left — and it goes wrong in both directions: retries can
+   * overlap, so a stale failure is counted against a lease a later success already extended; and
+   * the count reaches its limit at the moment the lease expires rather than before it, so the
+   * holder is told after it has stopped being protected rather than while it still is.
+   */
+  readonly lossAfterMs: number;
+  /**
+   * How much lease a confirmation must actually grant for the holder to rely on it.
+   *
+   * 🔴 "Not yet expired" is not the same as "safe to work on". A holder that accepts a renewal
+   * leaving almost nothing comes back to a claim that passes a liveness test with nothing left.
+   */
+  readonly renewMarginSeconds: number;
+}
+
+/**
+ * Derive every lease timing from the TTL, so no two of them can be chosen independently.
+ *
+ * 🔴 The derivation is the point. Two numbers picked side by side agree on the day they are written
+ * and drift afterwards, silently, because each looks reasonable alone — and the drift here is a
+ * holder that believes it is protected while a contender is already taking the row.
+ *
+ * `renewDivisor` is how many renewals fit in one TTL, and it is the only free parameter. The loss
+ * deadline then leaves TWO renewal intervals of lease still in hand, so a holder is told it is
+ * losing the claim while it is still protected rather than after.
+ */
+export function deriveLeaseTimings(
+  ttlSeconds: number,
+  renewDivisor: number
+): LeaseTimings {
+  const renewIntervalMs = (ttlSeconds / renewDivisor) * 1000;
+  const lossAfterMs = ttlSeconds * 1000 - 2 * renewIntervalMs;
+  return {
+    ttlSeconds,
+    renewIntervalMs,
+    lossAfterMs,
+    renewMarginSeconds: lossAfterMs / 1000,
+  };
+}

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -32,6 +32,11 @@ import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
 import { sql, type SQL } from "drizzle-orm";
 
 import { safeCode } from "../../../database/errors";
+import {
+  deriveLeaseTimings,
+  futureExpression,
+  nowExpression,
+} from "../../../database/lease-clock";
 import { NextlyError } from "../../../errors/nextly-error";
 import { fieldGroupLockColumnTypes } from "../../../schemas/field-group-lock";
 import type { Logger } from "../../../shared/types";
@@ -127,7 +132,16 @@ function toLockState(
  * update each and never pile up, because only one is ever in flight.
  */
 export const LOCK_TTL_SECONDS = 120;
-export const LOCK_RENEW_INTERVAL_MS = (LOCK_TTL_SECONDS / 8) * 1000;
+
+/**
+ * How many renewals fit in one TTL. The only number chosen here; every other timing below is
+ * derived from it, so no two of them can drift apart.
+ */
+const LOCK_RENEW_DIVISOR = 8;
+
+const LOCK_TIMINGS = deriveLeaseTimings(LOCK_TTL_SECONDS, LOCK_RENEW_DIVISOR);
+
+export const LOCK_RENEW_INTERVAL_MS = LOCK_TIMINGS.renewIntervalMs;
 
 /**
  * How long the session may go without CONFIRMING its lease before it declares the claim lost.
@@ -144,8 +158,7 @@ export const LOCK_RENEW_INTERVAL_MS = (LOCK_TTL_SECONDS / 8) * 1000;
  * threshold can sit wherever the margin needs to be. Here it leaves TWO renewal intervals of lease
  * still in hand, so the caller is told while it is still protected rather than after.
  */
-export const LOCK_LOSS_AFTER_MS =
-  LOCK_TTL_SECONDS * 1000 - 2 * LOCK_RENEW_INTERVAL_MS;
+export const LOCK_LOSS_AFTER_MS = LOCK_TIMINGS.lossAfterMs;
 
 /**
  * How long a shutdown waits for an in-flight legacy claim before giving up on releasing it.
@@ -176,50 +189,7 @@ export const LEGACY_SHUTDOWN_WAIT_MS = 5_000;
  * could be 16 seconds while the session went 90 without checking, leaving 74 seconds unprotected.
  * Tying the requirement to the window makes them agree by construction instead.
  */
-export const LOCK_RENEW_MARGIN_SECONDS = LOCK_LOSS_AFTER_MS / 1000;
-
-/**
- * The database's own clock, and an expiry computed from it, per dialect.
- *
- * 🔴 Never the application's clock. Two processes contending for this row can sit on machines whose
- * clocks disagree, and a claim written from one clock and judged against another is decided by that
- * skew rather than by who holds the lock. Asking the server for both values means every comparison
- * happens in one frame of reference.
- *
- * SQLite stores this column as unix SECONDS (the Drizzle declaration uses `mode: "timestamp"`), so
- * its expressions are integer arithmetic rather than interval arithmetic.
- */
-function nowExpression(dialect: MigrationDialect): SQL {
-  if (dialect === "sqlite") return sql`unixepoch()`;
-  // 🔴 PostgreSQL uses `clock_timestamp()`, NOT `now()`, and the difference decides correctness
-  // here rather than precision. `now()` is TRANSACTION start time and is frozen for the whole
-  // transaction, so a statement that waits on this row — which is exactly what contention means —
-  // reads the instant it began queueing rather than the instant it was admitted. A claim judged
-  // live by that stale reading can already have expired, and an expiry written from it can be in
-  // the past before the row is even updated.
-  //
-  // 🔴 MySQL uses `UTC_TIMESTAMP()`, NOT `NOW()`. `NOW()` returns the SESSION's local time, and
-  // `expires_at` is a `DATETIME`, which stores no zone — so a holder whose session is UTC writes an
-  // expiry a contender whose session is UTC+05 reads as five hours in the past, and takes a live
-  // claim instantly. Nothing about the row would look wrong afterwards: both runs believe they hold
-  // it. `UTC_TIMESTAMP()` is the same instant for every session whatever its `time_zone`.
-  //
-  // Both are statement-time rather than transaction-time, so neither needs Postgres's distinction.
-  return dialect === "mysql" ? sql`UTC_TIMESTAMP()` : sql`clock_timestamp()`;
-}
-
-function futureExpression(dialect: MigrationDialect, seconds: number): SQL {
-  if (dialect === "sqlite") {
-    return sql`unixepoch() + ${seconds}`;
-  }
-  if (dialect === "mysql") {
-    return sql`DATE_ADD(UTC_TIMESTAMP(), INTERVAL ${seconds} SECOND)`;
-  }
-  // The same clock as `nowExpression`, deliberately: an expiry written from transaction time and a
-  // liveness test taken at statement time would disagree about when the lease ends, and the pair
-  // has to share one frame of reference to mean anything.
-  return sql`clock_timestamp() + make_interval(secs => ${seconds})`;
-}
+export const LOCK_RENEW_MARGIN_SECONDS = LOCK_TIMINGS.renewMarginSeconds;
 
 function expiryExpression(dialect: MigrationDialect): SQL {
   return futureExpression(dialect, LOCK_TTL_SECONDS);


### PR DESCRIPTION
Foundation for `task:pb-softlock-server-lease` (Plan 04 B-21). No soft lock ships here — this is the shared floor it will stand on, separated so the refactor of safety-critical migration-lock code is reviewable on its own.

## Why

Two mechanisms in this package hold a lease, and they disagree about acquisition **on purpose**: the field-group migration lock refuses to steal a live claim, because two concurrent migrations corrupt a schema; the document soft lock permits a human to take one over. What they must never disagree about is *what time it is*.

The soft-lock task's body claimed a repo-wide search for lease machinery "returns only false positives." It returns 13 files, and `field-groups/migration/session.ts` is a complete lease implementation. Building a second one would have meant rediscovering four correctness-deciding facts, none of them obvious:

| dialect | required | why the obvious choice is wrong |
| --- | --- | --- |
| PostgreSQL | `clock_timestamp()` | `now()` is **transaction-start** time and frozen, so a statement waiting on a contended row — which is what contention *is* — reads the instant it began queueing. A claim judged live by that reading can already have expired. |
| MySQL | `UTC_TIMESTAMP()` | `NOW()` is **session-local** against a zone-less `DATETIME`, so a UTC holder writes an expiry a UTC+05 contender reads as five hours past, and takes a live claim. Nothing about the row looks wrong afterwards — both runs believe they hold it. |
| SQLite | `unixepoch()` | the column is `mode: "timestamp"`, i.e. unix seconds, so the arithmetic is integer rather than interval. |

AGENTS.md names this case exactly: *two functions that agree today drift, and the drift is silent because both look correct.*

## What changed

`packages/nextly/src/database/lease-clock.ts` — the dialect clock expressions, moved unchanged with their reasoning intact, plus `deriveLeaseTimings(ttlSeconds, renewDivisor)`.

The timings are **derived rather than restated**. `session.ts` already insisted on this in a comment — *"DERIVED from the loss deadline, not chosen alongside it… two independently chosen numbers [drift]"* — while computing them inline. Now the TTL and the renew divisor are the only chosen numbers; the loss deadline (leaving two renewal intervals still in hand) and the margin follow.

`session.ts` keeps its exported constant names and its values. **No behaviour change** — 120s/15s/90s, reached by one definition instead of a private copy.

## Evidence

The refactor is a **measurement, not an assertion**. A pure move that compiles proves nothing about whether the tests can see what moved, so I broke it:

```
clock_timestamp()  ->  now()      36 failed | 21 passed (57)
restored                          57 passed (57)
```

So the migration-lock suite genuinely exercises these expressions, and its green after the move is evidence about the SQL rather than about compilation.

New `lease-clock.test.ts`, 7 tests. Its derivation half is controlled too — changing the loss deadline from `2 *` to `1 *` fails 2 of 7. The dialect loop asserts its own population first, since an empty dialect list would satisfy every assertion inside it.

| gate | result |
| --- | --- |
| `turbo check-types lint --filter=nextly --force` | exit 0, `8 successful`, **`0 cached`** |
| `vitest src/database src/domains/field-groups` | `861 passed`, 1 pre-existing failure |
| `@changesets/parse` on the new changeset | `releases=25`, parses |
| `fallow audit` | `verdict: pass`, 0 introduced |

**The one failure is pre-existing**, not mine: `field-group-data-service > deleteComponentDataInTransaction > uses the transaction context instead of the adapter`. It is one of the nine I confirmed earlier today on a pristine tree, and it concerns delete/transaction plumbing, nothing to do with clocks.

## An aside worth recording

Building this PR's changeset, I seeded it with `head -26` from a neighbour and clipped the closing `---`. The guard added in #1104 caught it immediately — `could not parse changeset - missing or invalid frontmatter` — which is the same defect that stopped the release train this morning, caught this time before it could reach `main`.

## Not verified

- **No integration leg was run.** These expressions are asserted as rendered SQL text, not executed against live PostgreSQL, MySQL or SQLite. The existing `session.integration.test.ts` covers execution and is unchanged by this PR, but I did not run it.
- The soft lock itself is not here. Next: the lock table, the atomic claim via `ctx.lockRow` + conditional UPDATE + read-back, and `acquireLease`/`renewLease`/`releaseLease`.
