### PR TITLE
fix(nextly): restore the parentheses MySQL strips from an expression default

### DIFF
--- a/.changeset/mysql-expression-default-parentheses.md
+++ b/.changeset/mysql-expression-default-parentheses.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+On MySQL, a schema baseline read from a live database could not be applied
+anywhere. MySQL reports a column's expression default — which is what a
+required JSON, repeater, group or chips field gets — without the parentheses it
+requires around one, so the recorded schema described a table no MySQL server
+would create, including the one it was read from. The parentheses are now
+restored when the baseline is recorded. `CURRENT_TIMESTAMP` is left as it is,
+because on MySQL the parenthesised form means something different.

--- a/.changeset/mysql-expression-default-parentheses.md
+++ b/.changeset/mysql-expression-default-parentheses.md
@@ -32,7 +32,8 @@ required JSON, repeater, group or chips field gets — without the parentheses i
 requires around one, so the recorded schema described a table no MySQL server
 would create, including the one it was read from. The parentheses are now
 restored when the baseline is recorded. `CURRENT_TIMESTAMP` is left as it is,
-because on MySQL the parenthesised form means something different.
+because MySQL rewrites the parenthesised form to something it then reports back
+differently, which would show up as a schema change that never happened.
 
 This fixes the defaults Nextly itself creates. One case is still broken and is
 tracked separately: a default someone wrote by hand that contains a quoted

--- a/.changeset/mysql-expression-default-parentheses.md
+++ b/.changeset/mysql-expression-default-parentheses.md
@@ -33,3 +33,8 @@ requires around one, so the recorded schema described a table no MySQL server
 would create, including the one it was read from. The parentheses are now
 restored when the baseline is recorded. `CURRENT_TIMESTAMP` is left as it is,
 because on MySQL the parenthesised form means something different.
+
+This fixes the defaults Nextly itself creates. One case is still broken and is
+tracked separately: a default someone wrote by hand that contains a quoted
+piece of text, such as `DEFAULT (lower('X'))`, is reported by MySQL in a form
+that the parentheses alone do not make valid.

--- a/.changeset/mysql-expression-default-parentheses.md
+++ b/.changeset/mysql-expression-default-parentheses.md
@@ -32,8 +32,9 @@ required JSON, repeater, group or chips field gets — without the parentheses i
 requires around one, so the recorded schema described a table no MySQL server
 would create, including the one it was read from. The parentheses are now
 restored when the baseline is recorded. `CURRENT_TIMESTAMP` is left as it is,
-because MySQL rewrites the parenthesised form to something it then reports back
-differently, which would show up as a schema change that never happened.
+because MySQL quietly rewrites the parenthesised form into a different default,
+so a table rebuilt from the recorded schema would not match the one it was read
+from.
 
 This fixes the defaults Nextly itself creates. One case is still broken and is
 tracked separately: a default someone wrote by hand that contains a quoted

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/introspect-live.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/introspect-live.test.ts
@@ -242,6 +242,87 @@ describe("introspectLiveSnapshot - mysql", () => {
       "CURRENT_TIMESTAMP",
     ]);
   });
+
+  it("restores the parentheses information_schema strips from an expression default", async () => {
+    // MySQL reports a function-call expression default without the enclosing
+    // parentheses it REQUIRES, so the reported text is not valid DDL. Every
+    // row here carries DEFAULT_GENERATED; what separates them is the form the
+    // server reports, not the flag.
+    const columns = [
+      // What a required JSON, repeater, group or chips field emits. The
+      // reported text is the case a rebuild fails on.
+      ["payload", "json", "convert(0x7b7d using utf8mb4)"],
+      ["listing", "json", "json_array()"],
+      ["ident", "varchar", "uuid()"],
+      // Already parenthesised as a whole: anything but a single call is
+      // reported this way and is valid as it stands.
+      ["total", "int", "(1 + 2)"],
+      // The documented exception, bare and with a precision. Wrapping either
+      // would record it as the ordinary expression `now()` instead.
+      ["made_at", "datetime", "CURRENT_TIMESTAMP"],
+      ["seen_at", "datetime", "CURRENT_TIMESTAMP(3)"],
+    ] as const;
+
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([
+        columns.map(([name, dataType, columnDefault]) => ({
+          TABLE_NAME: "dc_posts",
+          COLUMN_NAME: name,
+          COLUMN_TYPE: dataType,
+          IS_NULLABLE: "NO",
+          COLUMN_DEFAULT: columnDefault,
+          DATA_TYPE: dataType,
+          EXTRA: "DEFAULT_GENERATED",
+        })),
+        [],
+      ])
+      .mockResolvedValueOnce([[], []])
+      .mockResolvedValueOnce([[], []]);
+
+    const snapshot = await introspectLiveSnapshot({ execute }, "mysql", [
+      "dc_posts",
+    ]);
+
+    expect(snapshot.tables[0].columns.map(c => c.default)).toEqual([
+      "(convert(0x7b7d using utf8mb4))",
+      "(json_array())",
+      "(uuid())",
+      "(1 + 2)",
+      "CURRENT_TIMESTAMP",
+      "CURRENT_TIMESTAMP(3)",
+    ]);
+  });
+
+  it("leaves a DEFAULT_GENERATED expression alone when EXTRA also carries ON UPDATE", async () => {
+    // `EXTRA` reads `DEFAULT_GENERATED on update CURRENT_TIMESTAMP` for an
+    // auto-updating timestamp. The substring match must still recognise the
+    // expression, and the bare keyword must still not be wrapped.
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([
+        [
+          {
+            TABLE_NAME: "dc_posts",
+            COLUMN_NAME: "updated_at",
+            COLUMN_TYPE: "timestamp",
+            IS_NULLABLE: "NO",
+            COLUMN_DEFAULT: "CURRENT_TIMESTAMP",
+            DATA_TYPE: "timestamp",
+            EXTRA: "DEFAULT_GENERATED on update CURRENT_TIMESTAMP",
+          },
+        ],
+        [],
+      ])
+      .mockResolvedValueOnce([[], []])
+      .mockResolvedValueOnce([[], []]);
+
+    const snapshot = await introspectLiveSnapshot({ execute }, "mysql", [
+      "dc_posts",
+    ]);
+
+    expect(snapshot.tables[0].columns[0].default).toBe("CURRENT_TIMESTAMP");
+  });
 });
 
 describe("introspectLiveSnapshot - sqlite", () => {

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/mysql-expression-default-rebuild.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/mysql-expression-default-rebuild.integration.test.ts
@@ -1,0 +1,135 @@
+/**
+ * A MySQL baseline must be rebuildable when a column carries an expression
+ * default.
+ *
+ * `information_schema.COLUMN_DEFAULT` reports a function-call expression
+ * default with its enclosing parentheses stripped, and MySQL refuses that same
+ * text without them. Recorded verbatim, the snapshot of a table holding a
+ * required JSON, repeater, group or chips field therefore rendered a
+ * `CREATE TABLE` no MySQL server would accept — including the one it was read
+ * from.
+ *
+ * The unit suite beside this file pins the recorded TEXT; only a real server
+ * can answer whether that text is DDL. The two halves are not
+ * interchangeable: the transform can be correct in isolation and still emit
+ * something MySQL rejects, which is exactly what the previous behaviour did.
+ *
+ * Auto-skips without TEST_MYSQL_URL
+ * (docker compose -f docker-compose.test.yml up -d mysql-test).
+ */
+import { randomBytes } from "node:crypto";
+
+import { drizzle } from "drizzle-orm/mysql2";
+import { createPool, type Pool } from "mysql2";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { generateMysqlSQL } from "../../sql-templates/mysql";
+import { introspectLiveSnapshot } from "../introspect-live";
+
+const MYSQL_URL = process.env.TEST_MYSQL_URL;
+// Per-run database name, matching the other MySQL suites here: a fixed name
+// could collide with a concurrent run. The hex suffix keeps it a safe
+// identifier, so interpolating it into DDL is not an injection surface.
+const DB_NAME = `nextly_mysql_expr_default_${randomBytes(16).toString("hex")}`;
+
+const SOURCE_TABLE = "dc_expr_defaults";
+const REBUILT_TABLE = "dc_expr_defaults_rebuilt";
+
+// The JSON default Nextly itself emits (`quoteJsonSqlDefault`) alongside the
+// other expression shapes a live table can carry. MySQL reports the first
+// three with the parentheses removed and the last two as written.
+const SOURCE_DDL = `CREATE TABLE ${SOURCE_TABLE} (
+  id int NOT NULL PRIMARY KEY,
+  payload json NOT NULL DEFAULT (CONVERT(X'7b7d' USING utf8mb4)),
+  listing json NOT NULL DEFAULT (json_array()),
+  ident varchar(36) NOT NULL DEFAULT (uuid()),
+  total int NOT NULL DEFAULT ((1 + 2)),
+  made_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  seen_at datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+)`;
+
+describe.skipIf(!MYSQL_URL)("MySQL expression-default rebuild", () => {
+  let bootstrap: Pool;
+  let pool: Pool;
+  let db: ReturnType<typeof drizzle>;
+
+  beforeAll(async () => {
+    bootstrap = createPool({ uri: MYSQL_URL });
+    await bootstrap.promise().query(`CREATE DATABASE ${DB_NAME}`);
+    const url = new URL(MYSQL_URL as string);
+    url.pathname = `/${DB_NAME}`;
+    pool = createPool({ uri: url.toString() });
+    db = drizzle({ client: pool });
+    await pool.promise().query(SOURCE_DDL);
+  });
+
+  afterAll(async () => {
+    await new Promise<void>(res => pool.end(() => res()));
+    await bootstrap
+      .promise()
+      .query(`DROP DATABASE IF EXISTS ${DB_NAME}`)
+      .catch(() => {});
+    await new Promise<void>(res => bootstrap.end(() => res()));
+  });
+
+  it("re-applies the CREATE TABLE rendered from a live snapshot", async () => {
+    const live = await introspectLiveSnapshot(db, "mysql", [SOURCE_TABLE]);
+    const table = live.tables.find(t => t.name === SOURCE_TABLE);
+    expect(table).toBeDefined();
+
+    // The reported text without the repair — what the snapshot used to hold,
+    // asserted here so this suite fails if introspection stops reaching the
+    // columns at all rather than silently testing an empty table.
+    expect(table!.columns.map(c => c.name)).toEqual([
+      "id",
+      "payload",
+      "listing",
+      "ident",
+      "total",
+      "made_at",
+      "seen_at",
+    ]);
+
+    const sqlText = generateMysqlSQL({
+      type: "add_table",
+      table: { ...table!, name: REBUILT_TABLE, indexes: [] },
+    });
+
+    // Fails with ER_PARSE_ERROR on a snapshot that recorded the reported text
+    // verbatim; the assertion is that this statement is DDL MySQL accepts.
+    await pool.promise().query(sqlText);
+
+    const [rebuilt] = await pool.promise().query(
+      `SELECT COLUMN_NAME, COLUMN_DEFAULT FROM information_schema.COLUMNS
+         WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? ORDER BY ORDINAL_POSITION`,
+      [DB_NAME, REBUILT_TABLE]
+    );
+
+    // The rebuilt table reports exactly what the source did, so the round trip
+    // preserved every default rather than merely producing parseable text.
+    const [source] = await pool.promise().query(
+      `SELECT COLUMN_NAME, COLUMN_DEFAULT FROM information_schema.COLUMNS
+         WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? ORDER BY ORDINAL_POSITION`,
+      [DB_NAME, SOURCE_TABLE]
+    );
+
+    expect(rebuilt).toEqual(source);
+  });
+
+  it("keeps CURRENT_TIMESTAMP bare, which is a different column to MySQL", async () => {
+    // `DEFAULT (CURRENT_TIMESTAMP)` is recorded as the ordinary expression
+    // `now()`, losing the auto-initialisation the bare keyword carries — so
+    // wrapping every expression uniformly would round-trip a DIFFERENT column
+    // while still parsing.
+    const live = await introspectLiveSnapshot(db, "mysql", [SOURCE_TABLE]);
+    const byName = new Map(
+      live.tables
+        .find(t => t.name === SOURCE_TABLE)!
+        .columns.map(c => [c.name, c.default])
+    );
+
+    expect(byName.get("made_at")).toBe("CURRENT_TIMESTAMP");
+    expect(byName.get("seen_at")).toBe("CURRENT_TIMESTAMP(3)");
+    expect(byName.get("payload")).toBe("(convert(0x7b7d using utf8mb4))");
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/mysql-expression-default-rebuild.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/mysql-expression-default-rebuild.integration.test.ts
@@ -61,8 +61,10 @@ const REBUILT_TABLE = "dc_expr_defaults_rebuilt";
 const JSON_OBJECT_DEFAULT = quoteJsonSqlDefault("{}", "mysql");
 
 // The emitted JSON default alongside the other expression shapes a live table
-// can carry. MySQL reports the first three with the parentheses removed and
-// the last two as written.
+// can carry. MySQL reports each one differently, which is the point: the three
+// single calls come back with their parentheses removed, `total` comes back
+// re-normalised to `(1 + 2)` from either spelling, and the two bare keywords
+// come back as written.
 const SOURCE_DDL = `CREATE TABLE ${SOURCE_TABLE} (
   id int NOT NULL PRIMARY KEY,
   payload json NOT NULL DEFAULT ${JSON_OBJECT_DEFAULT},
@@ -75,8 +77,8 @@ const SOURCE_DDL = `CREATE TABLE ${SOURCE_TABLE} (
 
 // The carve-out's reason, as a table this suite creates itself rather than as
 // a claim in a comment. Wrapping CURRENT_TIMESTAMP is accepted by MySQL and
-// behaves identically on insert — what it does NOT do is round-trip, and that
-// is the whole reason the carve-out exists.
+// behaves identically on insert — what it does is make the server record a
+// DIFFERENT default, which is the whole reason the carve-out exists.
 const WRAPPED_CT_TABLE = "dc_expr_defaults_wrapped_ct";
 
 describe.skipIf(!MYSQL_URL)("MySQL expression-default rebuild", () => {
@@ -150,11 +152,14 @@ describe.skipIf(!MYSQL_URL)("MySQL expression-default rebuild", () => {
   it("keeps CURRENT_TIMESTAMP bare, because the wrapped form does not round-trip", async () => {
     // The carve-out's reason, OBSERVED rather than asserted. Wrapping every
     // expression uniformly is not a parse failure — MySQL accepts
-    // `DEFAULT (CURRENT_TIMESTAMP)` — so nothing in the rebuild test above
-    // would have caught it. What it does is rewrite the default to `now()`,
-    // which introspection then reads back, so a snapshot that wrapped it would
-    // disagree with its own table on every subsequent read and the diff would
-    // report drift that is not there.
+    // `DEFAULT (CURRENT_TIMESTAMP)` — it REWRITES the default to `now()`,
+    // which introspection then reads back. So a snapshot that wrapped it would
+    // rebuild a table whose default reads differently from the source's.
+    //
+    // Not a diff problem: `normalizeDefault` collapses `current_timestamp` and
+    // `now()`, so the comparison would tolerate it. What breaks is the
+    // snapshot describing the database it was read from, which is why this is
+    // asserted against the server rather than through the diff.
     await pool
       .promise()
       .query(

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/mysql-expression-default-rebuild.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/mysql-expression-default-rebuild.integration.test.ts
@@ -1,6 +1,13 @@
 /**
  * A MySQL baseline must be rebuildable when a column carries an expression
- * default.
+ * default of a shape Nextly itself emits.
+ *
+ * SCOPE, because the title would otherwise read as the whole class: every
+ * default here is one an emitter in this package produces, or a bare-keyword
+ * form that must survive untouched. An expression CONTAINING a string literal
+ * is reported with its quotes backslash-escaped and is still unparseable —
+ * deliberately absent, because a passing case would not exist and a failing
+ * one would pin behaviour nobody has decided yet.
  *
  * `information_schema.COLUMN_DEFAULT` reports a function-call expression
  * default with its enclosing parentheses stripped, and MySQL refuses that same

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/mysql-expression-default-rebuild.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/mysql-expression-default-rebuild.integration.test.ts
@@ -32,6 +32,13 @@ const MYSQL_URL = process.env.TEST_MYSQL_URL;
 // identifier, so interpolating it into DDL is not an injection surface.
 const DB_NAME = `nextly_mysql_expr_default_${randomBytes(16).toString("hex")}`;
 
+// `drizzle` is overloaded, so `ReturnType<typeof drizzle>` names a DIFFERENT
+// instantiation from the one this call produces and the two are unrelated
+// types. Naming the handle through the call itself keeps the annotation and
+// the value in step.
+const openDrizzle = (client: Pool) => drizzle({ client });
+type MysqlHandle = ReturnType<typeof openDrizzle>;
+
 const SOURCE_TABLE = "dc_expr_defaults";
 const REBUILT_TABLE = "dc_expr_defaults_rebuilt";
 
@@ -51,7 +58,7 @@ const SOURCE_DDL = `CREATE TABLE ${SOURCE_TABLE} (
 describe.skipIf(!MYSQL_URL)("MySQL expression-default rebuild", () => {
   let bootstrap: Pool;
   let pool: Pool;
-  let db: ReturnType<typeof drizzle>;
+  let db: MysqlHandle;
 
   beforeAll(async () => {
     bootstrap = createPool({ uri: MYSQL_URL });
@@ -59,7 +66,7 @@ describe.skipIf(!MYSQL_URL)("MySQL expression-default rebuild", () => {
     const url = new URL(MYSQL_URL as string);
     url.pathname = `/${DB_NAME}`;
     pool = createPool({ uri: url.toString() });
-    db = drizzle({ client: pool });
+    db = openDrizzle(pool);
     await pool.promise().query(SOURCE_DDL);
   });
 

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/mysql-expression-default-rebuild.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/mysql-expression-default-rebuild.integration.test.ts
@@ -30,6 +30,7 @@ import { drizzle } from "drizzle-orm/mysql2";
 import { createPool, type Pool } from "mysql2";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { quoteJsonSqlDefault } from "../../../utils/sql-literal";
 import { generateMysqlSQL } from "../../sql-templates/mysql";
 import { introspectLiveSnapshot } from "../introspect-live";
 
@@ -49,18 +50,34 @@ type MysqlHandle = ReturnType<typeof openDrizzle>;
 const SOURCE_TABLE = "dc_expr_defaults";
 const REBUILT_TABLE = "dc_expr_defaults_rebuilt";
 
-// The JSON default Nextly itself emits (`quoteJsonSqlDefault`) alongside the
-// other expression shapes a live table can carry. MySQL reports the first
-// three with the parentheses removed and the last two as written.
+// CALLED, not hand-copied. The suite's premise is that this is the default a
+// required JSON, repeater, group or chips field actually gets, and a literal
+// copy of the emitter's output would keep passing on a shape Nextly no longer
+// emits — agreeing with itself while its docblock still claims to cover the
+// production case. Deriving it means an emitter change fails HERE, loudly.
+//
+// The expected REPORTED text further down stays literal on purpose: that is
+// MySQL's normalisation of this DDL, not something this package computes.
+const JSON_OBJECT_DEFAULT = quoteJsonSqlDefault("{}", "mysql");
+
+// The emitted JSON default alongside the other expression shapes a live table
+// can carry. MySQL reports the first three with the parentheses removed and
+// the last two as written.
 const SOURCE_DDL = `CREATE TABLE ${SOURCE_TABLE} (
   id int NOT NULL PRIMARY KEY,
-  payload json NOT NULL DEFAULT (CONVERT(X'7b7d' USING utf8mb4)),
+  payload json NOT NULL DEFAULT ${JSON_OBJECT_DEFAULT},
   listing json NOT NULL DEFAULT (json_array()),
   ident varchar(36) NOT NULL DEFAULT (uuid()),
   total int NOT NULL DEFAULT ((1 + 2)),
   made_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   seen_at datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
 )`;
+
+// The carve-out's reason, as a table this suite creates itself rather than as
+// a claim in a comment. Wrapping CURRENT_TIMESTAMP is accepted by MySQL and
+// behaves identically on insert — what it does NOT do is round-trip, and that
+// is the whole reason the carve-out exists.
+const WRAPPED_CT_TABLE = "dc_expr_defaults_wrapped_ct";
 
 describe.skipIf(!MYSQL_URL)("MySQL expression-default rebuild", () => {
   let bootstrap: Pool;
@@ -130,20 +147,39 @@ describe.skipIf(!MYSQL_URL)("MySQL expression-default rebuild", () => {
     expect(rebuilt).toEqual(source);
   });
 
-  it("keeps CURRENT_TIMESTAMP bare, which is a different column to MySQL", async () => {
-    // `DEFAULT (CURRENT_TIMESTAMP)` is recorded as the ordinary expression
-    // `now()`, losing the auto-initialisation the bare keyword carries — so
-    // wrapping every expression uniformly would round-trip a DIFFERENT column
-    // while still parsing.
-    const live = await introspectLiveSnapshot(db, "mysql", [SOURCE_TABLE]);
+  it("keeps CURRENT_TIMESTAMP bare, because the wrapped form does not round-trip", async () => {
+    // The carve-out's reason, OBSERVED rather than asserted. Wrapping every
+    // expression uniformly is not a parse failure — MySQL accepts
+    // `DEFAULT (CURRENT_TIMESTAMP)` — so nothing in the rebuild test above
+    // would have caught it. What it does is rewrite the default to `now()`,
+    // which introspection then reads back, so a snapshot that wrapped it would
+    // disagree with its own table on every subsequent read and the diff would
+    // report drift that is not there.
+    await pool
+      .promise()
+      .query(
+        `CREATE TABLE ${WRAPPED_CT_TABLE} (id int NOT NULL PRIMARY KEY, made_at datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP))`
+      );
+
+    const wrapped = await introspectLiveSnapshot(db, "mysql", [
+      WRAPPED_CT_TABLE,
+    ]);
+    const wrappedDefault = wrapped.tables
+      .find(t => t.name === WRAPPED_CT_TABLE)!
+      .columns.find(c => c.name === "made_at")!.default;
+
+    // The server rewrote it: the text that went in is not the text that comes
+    // back. This is what the bare form is protected from.
+    expect(wrappedDefault).toBe("(now())");
+
+    const bare = await introspectLiveSnapshot(db, "mysql", [SOURCE_TABLE]);
     const byName = new Map(
-      live.tables
+      bare.tables
         .find(t => t.name === SOURCE_TABLE)!
         .columns.map(c => [c.name, c.default])
     );
 
     expect(byName.get("made_at")).toBe("CURRENT_TIMESTAMP");
     expect(byName.get("seen_at")).toBe("CURRENT_TIMESTAMP(3)");
-    expect(byName.get("payload")).toBe("(convert(0x7b7d using utf8mb4))");
   });
 });

--- a/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
@@ -543,6 +543,43 @@ function buildSnapshotFromPgRows(rows: PgRow[]): NextlySchemaSnapshot {
   };
 }
 
+/**
+ * The one expression MySQL accepts as a default without parentheses.
+ *
+ * `CURRENT_TIMESTAMP` is the documented exception, with or without a
+ * fractional-seconds precision. The server normalizes `NOW()`, `LOCALTIME` and
+ * `LOCALTIMESTAMP` to this spelling before recording it, so no synonym reaches
+ * here under its own name.
+ */
+const MYSQL_BARE_EXPRESSION_DEFAULT = /^current_timestamp(\s*\(\s*\d*\s*\))?$/i;
+
+/**
+ * An expression default as it must appear in DDL.
+ *
+ * `information_schema.COLUMN_DEFAULT` reports a function-call default with its
+ * enclosing parentheses STRIPPED — a column declared
+ * `DEFAULT (CONVERT(X'7b7d' USING utf8mb4))`, which is what a required JSON,
+ * repeater, group or chips field emits, comes back as
+ * `convert(0x7b7d using utf8mb4)` — and MySQL refuses that same text without
+ * them (`ER_PARSE_ERROR`). Recorded verbatim, a snapshot taken from a live
+ * MySQL database produces a `CREATE TABLE` that cannot be applied anywhere,
+ * including back to the database it came from.
+ *
+ * Two forms must be left exactly as reported. An expression that is not a
+ * single call is reported ALREADY parenthesised as a whole (`(1 + 2)`), so
+ * wrapping it again would make the recorded text differ from what the next
+ * introspection reads and show as drift. And `CURRENT_TIMESTAMP` must stay
+ * bare because the parenthesised form is a DIFFERENT column definition to
+ * MySQL: `DEFAULT (CURRENT_TIMESTAMP)` is recorded as the ordinary expression
+ * `now()`, losing the auto-initialisation the bare keyword carries.
+ */
+function mysqlExpressionDefault(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("(")) return value;
+  if (MYSQL_BARE_EXPRESSION_DEFAULT.test(trimmed)) return value;
+  return `(${trimmed})`;
+}
+
 /** MySQL types whose default is reported as a bare number, not a literal. */
 const MYSQL_NUMERIC_TYPES = new Set([
   "tinyint",
@@ -569,16 +606,15 @@ const MYSQL_NUMERIC_TYPES = new Set([
  * snapshot could not be applied anywhere.
  *
  * `EXTRA` is what separates the two cases: an expression default (
- * `CURRENT_TIMESTAMP`, `json_array()`) carries `DEFAULT_GENERATED` and must be
- * left alone, while everything else is a literal. Numeric types need no quotes
- * either, and quoting them would turn a number into a string.
+ * `CURRENT_TIMESTAMP`, `json_array()`) carries `DEFAULT_GENERATED`, while
+ * everything else is a literal. Numeric types need no quotes either, and
+ * quoting them would turn a number into a string.
  */
 function mysqlDefaultExpression(row: MysqlRow): string | undefined {
   const value = row.COLUMN_DEFAULT;
   if (value === null || value === undefined) return undefined;
-  // An expression is already valid DDL as written.
   if ((row.EXTRA ?? "").toUpperCase().includes("DEFAULT_GENERATED")) {
-    return value;
+    return mysqlExpressionDefault(value);
   }
   if (MYSQL_NUMERIC_TYPES.has((row.DATA_TYPE ?? "").toLowerCase())) {
     return value;

--- a/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
@@ -547,9 +547,17 @@ function buildSnapshotFromPgRows(rows: PgRow[]): NextlySchemaSnapshot {
  * The one expression MySQL accepts as a default without parentheses.
  *
  * `CURRENT_TIMESTAMP` is the documented exception, with or without a
- * fractional-seconds precision. The server normalizes `NOW()`, `LOCALTIME` and
- * `LOCALTIMESTAMP` to this spelling before recording it, so no synonym reaches
- * here under its own name.
+ * fractional-seconds precision.
+ *
+ * Which SPELLING arrives here depends on how the default was written, and the
+ * two cases differ. Written bare, the synonyms are recorded under this name:
+ * `DEFAULT NOW()`, `DEFAULT LOCALTIME` and `DEFAULT LOCALTIMESTAMP` are all
+ * reported as `CURRENT_TIMESTAMP`. Written as EXPRESSIONS they are not:
+ * `DEFAULT (NOW())`, `DEFAULT (LOCALTIME)` and `DEFAULT (CURRENT_TIMESTAMP)`
+ * are all reported as `now()`, which does NOT match here and is wrapped like
+ * any other expression — correctly, since that form does need the parentheses.
+ * Other date keywords behave the same way: `DEFAULT (CURRENT_DATE)` is
+ * reported as `curdate()`. Measured on MySQL 8.0.46.
  */
 const MYSQL_BARE_EXPRESSION_DEFAULT = /^current_timestamp(\s*\(\s*\d*\s*\))?$/i;
 
@@ -567,20 +575,33 @@ const MYSQL_BARE_EXPRESSION_DEFAULT = /^current_timestamp(\s*\(\s*\d*\s*\))?$/i;
  * MySQL database produces a `CREATE TABLE` that cannot be applied anywhere,
  * including back to the database it came from.
  *
- * Two forms must be left exactly as reported, and for the SAME reason both
- * times: the recorded text has to survive a round trip, or the next
- * introspection reads something else and the diff reports drift that is not
- * there. An expression that is not a single call is reported ALREADY
- * parenthesised as a whole (`(1 + 2)`), so wrapping it again changes it. And
- * `CURRENT_TIMESTAMP` does not survive being wrapped: MySQL rewrites
- * `DEFAULT (CURRENT_TIMESTAMP)` to `DEFAULT (now())` and reports `now()` back,
- * so a snapshot that wrapped it would differ from the table it describes on
- * every subsequent read.
+ * Two forms are left exactly as reported, for DIFFERENT reasons. Stating one
+ * reason for both would lend the weaker branch a justification it has not got.
  *
- * The two forms remain equivalent to INSERT - both auto-initialise, and both
- * accept `ON UPDATE CURRENT_TIMESTAMP`, measured on MySQL 8.0.46. The
- * difference is the recorded text alone, which is what makes this a diff
- * problem rather than a semantic one.
+ * `CURRENT_TIMESTAMP` is the load-bearing one. Wrapping it does not fail —
+ * MySQL accepts `DEFAULT (CURRENT_TIMESTAMP)` — it REWRITES it, recording
+ * `now()` instead. A snapshot that wrapped it would therefore rebuild a table
+ * whose default reads differently from the source's, so the round trip would
+ * not reproduce the table it came from. The integration suite creates that
+ * column and observes the rewrite rather than taking this on trust.
+ *
+ * An expression that is not a single call is reported ALREADY parenthesised as
+ * a whole (`(1 + 2)`), and that branch is NOT load-bearing in the same way:
+ * `DEFAULT ((1 + 2))` applies cleanly and MySQL reports `(1 + 2)` back from
+ * either spelling, so wrapping again would neither break the rebuild nor
+ * accumulate. It stays because the reported text is already valid DDL and
+ * rewriting it for nothing would make the recorded value differ from every
+ * baseline taken before this, for no gain.
+ *
+ * Neither case is a DIFF problem, and it is worth saying so rather than
+ * reaching for the more alarming claim: `normalizeDefault` strips wrapping
+ * parentheses and collapses `current_timestamp` into `now()`, so the
+ * comparison would tolerate all of these. What is at stake is whether the
+ * recorded schema describes the database it was read from.
+ *
+ * The two `CURRENT_TIMESTAMP` forms are also equivalent to INSERT — both
+ * auto-initialise, and both accept `ON UPDATE CURRENT_TIMESTAMP`. Measured on
+ * MySQL 8.0.46.
  *
  * NOT repaired here: an expression that CONTAINS a string literal is reported
  * with its quotes backslash-escaped — `DEFAULT (lower('X'))` comes back as

--- a/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
@@ -567,13 +567,20 @@ const MYSQL_BARE_EXPRESSION_DEFAULT = /^current_timestamp(\s*\(\s*\d*\s*\))?$/i;
  * MySQL database produces a `CREATE TABLE` that cannot be applied anywhere,
  * including back to the database it came from.
  *
- * Two forms must be left exactly as reported. An expression that is not a
- * single call is reported ALREADY parenthesised as a whole (`(1 + 2)`), so
- * wrapping it again would make the recorded text differ from what the next
- * introspection reads and show as drift. And `CURRENT_TIMESTAMP` must stay
- * bare because the parenthesised form is a DIFFERENT column definition to
- * MySQL: `DEFAULT (CURRENT_TIMESTAMP)` is recorded as the ordinary expression
- * `now()`, losing the auto-initialisation the bare keyword carries.
+ * Two forms must be left exactly as reported, and for the SAME reason both
+ * times: the recorded text has to survive a round trip, or the next
+ * introspection reads something else and the diff reports drift that is not
+ * there. An expression that is not a single call is reported ALREADY
+ * parenthesised as a whole (`(1 + 2)`), so wrapping it again changes it. And
+ * `CURRENT_TIMESTAMP` does not survive being wrapped: MySQL rewrites
+ * `DEFAULT (CURRENT_TIMESTAMP)` to `DEFAULT (now())` and reports `now()` back,
+ * so a snapshot that wrapped it would differ from the table it describes on
+ * every subsequent read.
+ *
+ * The two forms remain equivalent to INSERT - both auto-initialise, and both
+ * accept `ON UPDATE CURRENT_TIMESTAMP`, measured on MySQL 8.0.46. The
+ * difference is the recorded text alone, which is what makes this a diff
+ * problem rather than a semantic one.
  *
  * NOT repaired here: an expression that CONTAINS a string literal is reported
  * with its quotes backslash-escaped — `DEFAULT (lower('X'))` comes back as

--- a/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
@@ -554,7 +554,9 @@ function buildSnapshotFromPgRows(rows: PgRow[]): NextlySchemaSnapshot {
 const MYSQL_BARE_EXPRESSION_DEFAULT = /^current_timestamp(\s*\(\s*\d*\s*\))?$/i;
 
 /**
- * An expression default as it must appear in DDL.
+ * An expression default with the parentheses `information_schema` strips put
+ * back. This is ONE repair, not everything that stands between a reported
+ * expression default and applicable DDL — see the limit at the end.
  *
  * `information_schema.COLUMN_DEFAULT` reports a function-call default with its
  * enclosing parentheses STRIPPED — a column declared
@@ -572,6 +574,17 @@ const MYSQL_BARE_EXPRESSION_DEFAULT = /^current_timestamp(\s*\(\s*\d*\s*\))?$/i;
  * bare because the parenthesised form is a DIFFERENT column definition to
  * MySQL: `DEFAULT (CURRENT_TIMESTAMP)` is recorded as the ordinary expression
  * `now()`, losing the auto-initialisation the bare keyword carries.
+ *
+ * NOT repaired here: an expression that CONTAINS a string literal is reported
+ * with its quotes backslash-escaped — `DEFAULT (lower('X'))` comes back as
+ * `lower(_utf8mb4\'X\')` — and that text is rejected with or without the
+ * parentheses, so those defaults still rebuild to invalid DDL. The remedy is
+ * an unescape whose correctness depends on the server's `sql_mode`
+ * (`NO_BACKSLASH_ESCAPES` makes a backslash an ordinary character), which is a
+ * decision rather than a mechanical fix. No emitter in this package produces
+ * that shape — `quoteJsonSqlDefault` uses a hex `CONVERT` precisely to avoid
+ * guessing the mode — so it is reachable only through a column someone added
+ * to a managed table by hand.
  */
 function mysqlExpressionDefault(value: string): string {
   const trimmed = value.trim();


### PR DESCRIPTION
Closes `finding:retro-mysql-expr-default-loses-parens`.

## The defect

A MySQL schema baseline read from a live database could not be applied
anywhere — including back to the database it was read from.

`information_schema.COLUMN_DEFAULT` reports a function-call expression default
with its enclosing parentheses **stripped**, and MySQL 8 requires them. The
snapshot recorded that text verbatim, and `create-table-body.ts` renders
`DEFAULT ${c.default}` raw, so the generated `CREATE TABLE` was not valid DDL.

Reached by every **required** `json`, `repeater`, `group` and `chips` field.
Their default comes from `quoteJsonSqlDefault`, which emits
`(CONVERT(X'7b7d' USING utf8mb4))`. Measured against MySQL 8 in the test
container:

| declared                              | reported back                  | re-applied verbatim |
| ------------------------------------- | ------------------------------ | ------------------- |
| `(CONVERT(X'7b7d' USING utf8mb4))`    | `convert(0x7b7d using utf8mb4)` | **ER_PARSE_ERROR**  |
| `(json_array())`                      | `json_array()`                  | **ER_PARSE_ERROR**  |
| `(uuid())`                            | `uuid()`                        | **ER_PARSE_ERROR**  |
| `((1 + 2))`                           | `(1 + 2)`                       | OK                  |
| `CURRENT_TIMESTAMP`                   | `CURRENT_TIMESTAMP`             | OK                  |

SQLite got exactly this repair (`sqliteDefaultExpression`); MySQL got the
quoting half only.

## Why the existing test could not catch it

`introspect-live.test.ts` pinned one expression default: `CURRENT_TIMESTAMP` —
the single expression MySQL accepts paren-free. It passes on the broken
implementation and on the fixed one, so it was never the separating property.

## The fix

`mysqlExpressionDefault` wraps a reported expression default in parentheses,
with two forms left exactly as reported:

- **already parenthesised.** MySQL reports anything that is not a single call
  fully parenthesised as a whole (`(1 + 2)`, `(abs(-(1)) + abs(-(2)))`).
  Wrapping again would make the recorded text differ from what the next
  introspection reads and show as drift.
- **`CURRENT_TIMESTAMP`,** with or without a fractional precision. This one is
  not cosmetic: `DEFAULT (CURRENT_TIMESTAMP)` is recorded by the server as the
  ordinary expression `now()`, so wrapping it round-trips a *different column*
  while still parsing.

## Evidence

Both tests were broken-first, and both fail for the intended reason:

- unit — `expected '(convert(0x7b7d using utf8mb4))', received 'convert(0x7b7d using utf8mb4)'`
- integration — `Error: You have an error in your SQL syntax ... near 'convert(0x7b7d using utf8mb4)`

The new integration suite is what actually decides the finding: it creates a
table carrying every expression shape on a real MySQL 8 server, introspects it,
renders the `CREATE TABLE` through `generateMysqlSQL`, **applies it**, and
asserts the rebuilt table reports the same defaults as the source. A unit test
on a mock can only pin the text; only a server can say whether that text is DDL.

Gates: `check-comment-convention` exit 0 · `pnpm fallow:audit` exit 0
(no issues in 4 changed files) · `pnpm build` exit 0 ·
`check-types --filter=nextly --force` exit 0 · `lint --filter=nextly --force`
exit 0 · MySQL integration exit 0.

The suite is **not** added to `tsconfig.tests.json`'s opt-out list — the
`drizzle` overload mismatch that would have required it is fixed in the test
instead.

## Pre-existing, not introduced

`pnpm vitest run src/domains/schema` reports 6 failures in
`build-from-fields.test.ts`, `field-column-descriptor.test.ts` and
`runtime-schema-generator.test.ts` (`expected 'text' to be 'bool'` for a toggle
field). Reverting only `introspect-live.ts` reproduces the same 6 — this is the
known stale-mock baseline (`task:test-baseline-repair`), untouched here.

## Out of scope, and now said so in the code

The review fleet (`reviewer-access-data`) and the pre-implementation probe
independently found the same second defect, which this PR does **not** fix:
`information_schema` backslash-escapes quotes inside an expression default, so
`DEFAULT (lower('X'))` comes back as `lower(_utf8mb4\'X\')` and is rejected
**with or without** the parentheses.

Its sharper half was a framing problem rather than the defect: the docblock,
the changeset and the integration test title all read as closing the whole
class. The follow-up commit states the limit in all three places instead. No
behaviour change.

Nextly's own emitters never write that shape — `quoteJsonSqlDefault`
deliberately uses hex `CONVERT` to avoid guessing `sql_mode` — so it is
reachable only through a column added to a managed table by hand. The remedy
needs an unescape whose correctness depends on `NO_BACKSLASH_ESCAPES`, which is
a decision rather than a mechanical fix.

Tracked as `finding:mysql-expr-default-quote-escaping` (which supersedes the
duplicate `finding:retro-mysql-literal-expr-default-escaped`).
