### PR TITLE
fix(nextly): never adopt a standing table on a single create

### DIFF
--- a/.changeset/single-create-rebuilds-orphans.md
+++ b/.changeset/single-create-rebuilds-orphans.md
@@ -18,6 +18,7 @@
 "@nextlyhq/plugin-seo": patch
 "@nextlyhq/plugin-sdk": patch
 "@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
 "@nextlyhq/prettier-config": patch
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch

--- a/.changeset/single-create-rebuilds-orphans.md
+++ b/.changeset/single-create-rebuilds-orphans.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Creating a Single over a table left behind by an interrupted earlier create no longer adopts that
+table silently. An empty leftover table is rebuilt from the new request's fields, so a create
+recorded as applied always matches the columns the table really has; a leftover table that holds
+rows refuses the create and names the table, instead of recording a schema the database does not
+have.

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-ddl.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-ddl.test.ts
@@ -50,10 +50,15 @@ function makeAdapter(dialect: "postgresql" | "mysql" | "sqlite") {
     dialect,
     getCapabilities: () => ({ dialect }),
     // Answers the way a fresh create finds the database: the main table is there once its CREATE
-    // has run, and the companion is NOT — so the companion path CREATEs it rather than altering
-    // one that does not exist. A blanket `true` here made the companion look pre-existing, which
-    // is not a state a create ever starts from.
-    tableExists: vi.fn(async (name: string) => !name.includes("_locales")),
+    // has run and not before, and the companion is NOT — so the pre-apply orphan check finds clear
+    // ground, the post-apply existence check finds the table, and the companion path CREATEs its
+    // table rather than altering one that does not exist. A blanket `true` made the main table look
+    // pre-existing before any statement ran, which is not a state a fresh create ever starts from.
+    tableExists: vi.fn(
+      async (name: string) =>
+        !name.includes("_locales") &&
+        executed.some(sql => sql.includes("CREATE TABLE") && sql.includes(name))
+    ),
     // Read by the slug guard the create runs before any DDL, to find whether another resource
     // already owns this slug. `null` is "nobody does", which is the state a successful create
     // starts from. The return type names the owner case too, so the conflict test can replace this

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -60,7 +60,10 @@ import { generateRuntimeSchema } from "../../domains/schema/services/runtime-sch
 import type { FieldResolution } from "../../domains/schema/services/schema-change-types";
 import { calculateSchemaHash } from "../../domains/schema/services/schema-hash";
 import { reconcileSingleCompanion } from "../../domains/singles/services/reconcile-single-companion";
-import { resolveSingleTableName } from "../../domains/singles/services/resolve-single-table-name";
+import {
+  resolveSingleTableName,
+  singleTableFamiliesCollide,
+} from "../../domains/singles/services/resolve-single-table-name";
 import type { SingleEntryService } from "../../domains/singles/services/single-entry-service";
 import type { SingleMetadataService } from "../../domains/singles/services/single-metadata-service";
 import type { SingleRegistryService } from "../../domains/singles/services/single-registry-service";
@@ -578,13 +581,14 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       // and DDL so every call site writes and reads the same physical table.
       const tableName = resolveSingleTableName({ slug: b.slug });
 
-      // Refused before any DDL runs, and keyed on the TABLE NAME rather than the slug. A slug is
+      // Refused before any DDL runs, and keyed on the TABLE FAMILY rather than the slug. A slug is
       // normalised on its way to a table name, so `foo-bar` and `foo_bar` name one physical table
-      // while looking like two free slugs. The registry's own check runs after the DDL, by which
-      // point `CREATE TABLE IF NOT EXISTS` has reported success against the table that already
-      // exists and the runtime registration has rebound it to this request's fields.
-      const owner = (await svc.registry.getAllSingles()).find(
-        s => s.tableName === tableName
+      // while looking like two free slugs — and a Single's storage spans its main table AND the
+      // `_locales` companion beside it, so `foo-locales` collides with `foo` the same way. The
+      // registry's own check runs after the DDL, by which point the create has already acted
+      // against the table that exists and rebound the runtime to this request's fields.
+      const owner = (await svc.registry.getAllSingles()).find(s =>
+        singleTableFamiliesCollide(s.tableName, tableName)
       );
       if (owner) {
         throw NextlyError.duplicate({

--- a/packages/nextly/src/domains/schema/pipeline/live-table-facts.ts
+++ b/packages/nextly/src/domains/schema/pipeline/live-table-facts.ts
@@ -88,6 +88,62 @@ export async function tableHasRows(
 }
 
 /**
+ * The names of the tables that hold a foreign key REFERENCING the given table.
+ *
+ * The reverse of {@link readForeignKeyColumns}, and read from the live catalog for the same
+ * reason: which junction and companion tables point at a parent is decided by whichever path
+ * created them, not derivable from a field list — least of all for a table whose registry row is
+ * gone. A parent with referencing tables cannot simply be dropped: MySQL refuses the drop outright
+ * while the reference stands, and PostgreSQL's CASCADE silently strips the referrer's constraint
+ * instead, so the caller has to deal with the referrers first either way.
+ */
+export async function readReferencingTables(
+  db: unknown,
+  dialect: SupportedDialect,
+  tableName: string
+): Promise<string[]> {
+  const names = new Set<string>();
+
+  if (dialect === "postgresql") {
+    // Through the referenced relation, mirroring `readIndexNames`: `to_regclass` resolves the
+    // name the way the statements themselves will, across the whole search path.
+    const result = (await (db as PgMysqlExecute).execute(
+      sql`SELECT DISTINCT r.relname AS table_name
+          FROM pg_constraint c
+          JOIN pg_class r ON r.oid = c.conrelid
+          WHERE c.contype = 'f' AND c.confrelid = to_regclass(${tableName})`
+    )) as { rows: { table_name: string }[] };
+    for (const row of result.rows) names.add(row.table_name);
+    return [...names];
+  }
+
+  if (dialect === "mysql") {
+    const rows = mysqlRows<{ TABLE_NAME: string }>(
+      await (db as PgMysqlExecute).execute(
+        sql`SELECT DISTINCT TABLE_NAME
+            FROM information_schema.KEY_COLUMN_USAGE
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND REFERENCED_TABLE_NAME = ${tableName}`
+      )
+    );
+    for (const row of rows) names.add(row.TABLE_NAME);
+    return [...names];
+  }
+
+  // SQLite has no reverse foreign-key view, but `pragma_foreign_key_list` is a table-valued
+  // function, so one join over `sqlite_master` reads every table's outgoing keys and filters to
+  // those aimed at the parent.
+  const rows = (await (db as SqliteAll).all(
+    sql`SELECT DISTINCT m.name AS table_name
+        FROM sqlite_master AS m
+        JOIN pragma_foreign_key_list(m.name) AS fk
+        WHERE m.type = 'table' AND fk."table" = ${tableName}`
+  )) as { table_name: string }[];
+  for (const row of rows) names.add(row.table_name);
+  return [...names];
+}
+
+/**
  * The names of the indexes the table currently carries.
  *
  * Whether a column is indexed is not derivable from its field: an index is created by the path

--- a/packages/nextly/src/domains/schema/pipeline/live-table-facts.ts
+++ b/packages/nextly/src/domains/schema/pipeline/live-table-facts.ts
@@ -59,9 +59,9 @@ function mysqlRows<T>(result: unknown): T[] {
 /**
  * Whether the table currently holds at least one row.
  *
- * Asked as an existence check rather than a count: the answer only ever decides whether a
- * backfill is needed, and `SELECT 1 ... LIMIT 1` costs the same on a table of ten rows and a
- * table of ten million, where `COUNT(*)` scans.
+ * Asked as an existence check rather than a count: every caller needs only the yes or no — is a
+ * backfill needed, may an unregistered table be dropped — and `SELECT 1 ... LIMIT 1` costs the
+ * same on a table of ten rows and a table of ten million, where `COUNT(*)` scans.
  */
 export async function tableHasRows(
   db: unknown,

--- a/packages/nextly/src/domains/singles/__tests__/single-create-schema-change.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-create-schema-change.integration.test.ts
@@ -22,9 +22,12 @@
  *
  * The service claims to be recoverable and idempotent rather than atomic — the only claim
  * available, since MySQL commits DDL implicitly and no ordering makes the pair atomic there. What
- * makes that claim worth anything is that the DDL half can be re-run over a table it already
- * created. So the repair case is exercised directly: the registry row is removed while the table
- * stays, and the same create is issued again. It has to succeed and report `applied`.
+ * makes that claim worth anything is that a create can be issued again over storage a previous
+ * attempt left behind: an empty table standing at the create's name is rebuilt from the retried
+ * request's fields, never adopted as it stands, and one holding rows refuses the create before
+ * anything is dropped or written. The repair cases are exercised directly: the registry row is
+ * removed while the table stays, and a create is issued again — with the same fields, with
+ * different fields, and against a table that holds data.
  *
  * Self-skips per dialect on the standard rule: SQLite always runs, the servers run when their URL
  * is set. Each dialect gets its own throwaway database.
@@ -37,12 +40,37 @@ import {
   getConfiguredTestDialects,
   type TestNextly,
 } from "../../../plugins/test-nextly";
+import { introspectLiveSnapshot } from "../../schema/pipeline/diff/introspect-live";
+import { tableHasRows } from "../../schema/pipeline/live-table-facts";
+import type { SingleEntryService } from "../services/single-entry-service";
 let current: TestNextly | undefined;
 
 afterEach(async () => {
   await current?.destroy();
   current = undefined;
 });
+
+/**
+ * The columns the live table physically carries, by name.
+ *
+ * Read through the same introspection the schema pipeline uses, because the property under test is
+ * precisely the physical table rather than what any registry or runtime schema claims about it.
+ */
+async function columnsOf(
+  instance: TestNextly,
+  table: string
+): Promise<string[]> {
+  const snapshot = await introspectLiveSnapshot(
+    instance.adapter.getDrizzle(),
+    instance.adapter.getCapabilities().dialect,
+    [table]
+  );
+  return (
+    snapshot.tables
+      .find(spec => spec.name === table)
+      ?.columns.map(column => column.name) ?? []
+  );
+}
 
 /** The registry's own view of a slug, or undefined when it holds none. */
 async function registryRow(
@@ -184,6 +212,124 @@ for (const dialect of getConfiguredTestDialects()) {
     });
 
     /**
+     * 🔴 The interrupted state again, but the RETRY does not repeat the request — the fields
+     * changed in between.
+     *
+     * `CREATE TABLE IF NOT EXISTS` is a no-op over the standing table, so a create that adopted it
+     * as it stands would record `applied` while binding a runtime schema that names columns the
+     * table does not have — and every later read and write fails "column does not exist" far from
+     * the cause. `applied` has to describe the physical table, so the create rebuilds the standing
+     * wreckage from the retried request's fields.
+     */
+    it("rebuilds an orphaned table when the retried create changes the fields", async () => {
+      current = await createTestNextly({ dialect });
+      const slug = `${plain}_retry`;
+      const table = `single_${slug}`;
+
+      await dispatchSingles(
+        "createSingle",
+        {},
+        {
+          slug,
+          label: "Retry",
+          fields: [{ name: "body", type: "text" }],
+        }
+      );
+      expect(await current.adapter.tableExists(table)).toBe(true);
+
+      // The interrupted state: the table stands, the row describing it does not.
+      const registry = current.getService("singleRegistryService");
+      await registry.deleteSingle(slug, { force: true });
+
+      await dispatchSingles(
+        "createSingle",
+        {},
+        {
+          slug,
+          label: "Retry",
+          fields: [
+            { name: "summary", type: "text" },
+            { name: "views", type: "number" },
+          ],
+        }
+      );
+
+      expect((await registryRow(current, slug))?.migrationStatus).toBe(
+        "applied"
+      );
+      // The recorded `applied` has to describe the table that is actually there: the retried
+      // field set present, the abandoned attempt's field gone.
+      const columns = await columnsOf(current, table);
+      expect(columns).toContain("summary");
+      expect(columns).toContain("views");
+      expect(columns).not.toContain("body");
+    });
+
+    /**
+     * 🔴 A standing table that HOLDS ROWS is refused, not rebuilt — and the refusal changes
+     * nothing.
+     *
+     * Rows are the one thing an interrupted create's wreckage cannot have: a table the registry
+     * has never described has nothing that can write through it, so data proves the table is not
+     * this create's to drop. The refusal comes before any statement runs and before any row is
+     * written, so the slug stays free, the data stays where it is, and the error names the table
+     * in the way.
+     */
+    it("refuses to create over a table that holds rows, and touches nothing", async () => {
+      current = await createTestNextly({ dialect });
+      const slug = `${plain}_occupied`;
+      const table = `single_${slug}`;
+
+      await dispatchSingles(
+        "createSingle",
+        {},
+        {
+          slug,
+          label: "Occupied",
+          fields: [{ name: "body", type: "text" }],
+        }
+      );
+      const entries =
+        current.getService<SingleEntryService>("singleEntryService");
+      const written = await entries.update(
+        slug,
+        { body: "kept" },
+        { overrideAccess: true }
+      );
+      expect(written.success).toBe(true);
+
+      const registry = current.getService("singleRegistryService");
+      await registry.deleteSingle(slug, { force: true });
+
+      await expect(
+        dispatchSingles(
+          "createSingle",
+          {},
+          {
+            slug,
+            label: "Occupied",
+            fields: [{ name: "headline", type: "text" }],
+          }
+        )
+      ).rejects.toThrow(/holds rows/);
+
+      // Nothing claimed and nothing destroyed. No registry row owns the slug, so the retry stays
+      // open; the table keeps the shape and the data that made it refusable. The column checks are
+      // what prove no rebuild happened — a rebuild would have put `headline` there.
+      expect(await registryRow(current, slug)).toBeUndefined();
+      const columns = await columnsOf(current, table);
+      expect(columns).toContain("body");
+      expect(columns).not.toContain("headline");
+      expect(
+        await tableHasRows(
+          current.adapter.getDrizzle(),
+          current.adapter.getCapabilities().dialect,
+          table
+        )
+      ).toBe(true);
+    });
+
+    /**
      * A normal schema UPDATE on a Single must stay `applied`.
      *
      * 🔴 The ALTER path builds its verification shape from a normalized field list that carries a
@@ -225,24 +371,21 @@ for (const dialect of getConfiguredTestDialects()) {
     });
 
     /**
-     * 🔴 A LOCALIZED single's repair is REFUSED, deliberately, and this pins that decision.
+     * 🔴 A LOCALIZED single's interrupted create is repaired the same way: by rebuilding.
      *
      * The companion reconcile is told `wasLocalized: false` and `oldFields: []`, because from the
      * registry's point of view this is a brand-new localized single — the row describing the
-     * previous attempt is gone. Meeting a companion that already exists, its plan asks to ADD
-     * columns that are already there, and the companion path does NOT tolerate that.
+     * previous attempt is gone. A companion left standing would meet a plan that ADDs columns
+     * already there, which the companion path deliberately does not tolerate: a half-finished
+     * localization ENABLE reaches that code in an identical state, and tolerating it would report
+     * success while default-locale content is still stranded on the main table.
      *
-     * It could: the same tolerance the main table has would make this repair succeed. It is
-     * withheld because a half-finished localization ENABLE reaches this code in the identical
-     * state — the planner cannot tell them apart, since `existingMainColumns` is consumed only on
-     * the disable path — and tolerating it there would report success while default-locale content
-     * is still stranded on the main table.
-     *
-     * So a localized repair fails loudly and an operator sees it, rather than a half-migrated
-     * entity being recorded as applied. Reverse this only together with a way to detect a partial
-     * enable.
+     * Rebuilding resolves that ambiguity instead of tolerating it. Content is what distinguishes
+     * the two states — a half-enabled single carries its rows on the main table, and a main table
+     * holding rows refuses the create before anything is dropped — so a pair of empty tables has
+     * nothing to strand, and both are rebuilt from this request's fields.
      */
-    it("refuses to repair a localized single's tables, loudly", async () => {
+    it("repairs a localized single's tables by rebuilding the pair", async () => {
       current = await createTestNextly({
         dialect,
         localization: { locales: ["en", "es"], defaultLocale: "en" },
@@ -268,8 +411,10 @@ for (const dialect of getConfiguredTestDialects()) {
       await dispatchSingles("createSingle", {}, payload);
 
       const row = await registryRow(current, localized);
-      expect(row?.migrationStatus).toBe("failed");
-      // The tables are untouched by the refusal — nothing is destroyed, the operator is told.
+      expect(row?.migrationStatus).toBe("applied");
+      // Both halves of a localized single's storage stand after the repair: the main table and
+      // the companion the translatable value lives in.
+      expect(await current.adapter.tableExists(table)).toBe(true);
       expect(await current.adapter.tableExists(`${table}_locales`)).toBe(true);
     });
   });

--- a/packages/nextly/src/domains/singles/__tests__/single-create-schema-change.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-create-schema-change.integration.test.ts
@@ -330,6 +330,82 @@ for (const dialect of getConfiguredTestDialects()) {
     });
 
     /**
+     * 🔴 A Single's storage is a FAMILY of tables, and the create's ownership checks compare
+     * families — because a name those checks clear is one the orphan reset is licensed to DROP.
+     *
+     * Slug normalisation folds `-` to `_`, so `<slug>-locales` resolves to `single_<slug>_locales`:
+     * exactly the companion of the Single at `single_<slug>`. That companion is EMPTY until its
+     * owner saves localized content, so a main-name-only ownership scan would clear it as droppable
+     * wreckage — destroying another Single's translation storage, durably (the companion reconcile
+     * reads existence, and the rebuilt impostor exists) and silently (the create reports applied).
+     * Both directions are refused: a create landing on someone's companion, and a create whose own
+     * companion would land on someone's main table.
+     */
+    it("refuses a create whose table family collides with another single's", async () => {
+      current = await createTestNextly({
+        dialect,
+        localization: { locales: ["en", "es"], defaultLocale: "en" },
+      });
+      const owner = `sc_${dialect.slice(0, 2)}_fam`;
+      const companion = `single_${owner}_locales`;
+
+      await dispatchSingles(
+        "createSingle",
+        {},
+        {
+          slug: owner,
+          label: "Fam",
+          localized: true,
+          fields: [{ name: "headline", type: "text", localized: true }],
+        }
+      );
+      expect(await current.adapter.tableExists(companion)).toBe(true);
+      const before = await columnsOf(current, companion);
+
+      // Lands exactly on the owner's companion table name.
+      await expect(
+        dispatchSingles(
+          "createSingle",
+          {},
+          {
+            slug: `${owner}-locales`,
+            label: "Fam Locales",
+            fields: [{ name: "body", type: "text" }],
+          }
+        )
+      ).rejects.toThrow();
+
+      // The companion is untouched — same columns, no impostor rebuild — and nothing claimed the
+      // colliding slug.
+      expect(await columnsOf(current, companion)).toEqual(before);
+      expect(await registryRow(current, `${owner}-locales`)).toBeUndefined();
+
+      // The mirror direction: the new create's OWN companion name is an existing main table.
+      const taken = `sc_${dialect.slice(0, 2)}_mir`;
+      await dispatchSingles(
+        "createSingle",
+        {},
+        {
+          slug: `${taken}-locales`,
+          label: "Mir Locales",
+          fields: [{ name: "body", type: "text" }],
+        }
+      );
+      await expect(
+        dispatchSingles(
+          "createSingle",
+          {},
+          {
+            slug: taken,
+            label: "Mir",
+            fields: [{ name: "body", type: "text" }],
+          }
+        )
+      ).rejects.toThrow();
+      expect(await registryRow(current, taken)).toBeUndefined();
+    });
+
+    /**
      * A normal schema UPDATE on a Single must stay `applied`.
      *
      * 🔴 The ALTER path builds its verification shape from a normalized field list that carries a

--- a/packages/nextly/src/domains/singles/__tests__/single-create-schema-change.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-create-schema-change.integration.test.ts
@@ -34,6 +34,7 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
+import { defineCollection, text } from "../../../config";
 import { dispatchSingles } from "../../../dispatcher/handlers/single-dispatcher";
 import {
   createTestNextly,
@@ -373,7 +374,7 @@ for (const dialect of getConfiguredTestDialects()) {
             fields: [{ name: "body", type: "text" }],
           }
         )
-      ).rejects.toThrow();
+      ).rejects.toThrow(/already exists/);
 
       // The companion is untouched — same columns, no impostor rebuild — and nothing claimed the
       // colliding slug.
@@ -401,8 +402,125 @@ for (const dialect of getConfiguredTestDialects()) {
             fields: [{ name: "body", type: "text" }],
           }
         )
-      ).rejects.toThrow();
+      ).rejects.toThrow(/already exists/);
       expect(await registryRow(current, taken)).toBeUndefined();
+    });
+
+    /**
+     * 🔴 The same collision, refused by the IN-EXCLUSION guard alone.
+     *
+     * The dispatcher's preflight makes the same family comparison and throws before the service is
+     * reached, so every dispatcher-driven test above is satisfied by the outer guard whether or not
+     * the inner one works. The inner re-assertion is the one that matters most — it runs inside the
+     * schema-change exclusion, immediately before the orphan reset is licensed to DROP, and it
+     * exists precisely for registrations that land after the preflight has already passed. Driving
+     * the service directly is what makes it the only guard that can refuse.
+     */
+    it("refuses the family collision inside the exclusion, where the drop is licensed", async () => {
+      current = await createTestNextly({
+        dialect,
+        localization: { locales: ["en", "es"], defaultLocale: "en" },
+      });
+      const owner = `sc_${dialect.slice(0, 2)}_famz`;
+      await dispatchSingles(
+        "createSingle",
+        {},
+        {
+          slug: owner,
+          label: "Famz",
+          localized: true,
+          fields: [{ name: "headline", type: "text", localized: true }],
+        }
+      );
+      const companion = `single_${owner}_locales`;
+      expect(await current.adapter.tableExists(companion)).toBe(true);
+
+      const metadata = current.getService("singleMetadataService");
+      await expect(
+        metadata.createSingle({
+          slug: `${owner}-locales`,
+          label: "Famz Locales",
+          tableName: companion,
+          fields: [{ name: "body", type: "text" }],
+          source: "ui",
+          locked: false,
+        })
+      ).rejects.toThrow(/already exists/);
+
+      // Refused before the reset could touch it: the companion still stands and nothing claimed
+      // the colliding slug.
+      expect(await current.adapter.tableExists(companion)).toBe(true);
+      expect(await registryRow(current, `${owner}-locales`)).toBeUndefined();
+    });
+
+    /**
+     * 🔴 An orphan's junction tables are wreckage too, and they go with it.
+     *
+     * A many-to-many relationship renders a junction table carrying a foreign key to the main
+     * table. Left standing while the main table is dropped, the outcome diverges by dialect —
+     * MySQL refuses to drop a referenced parent outright, and PostgreSQL's CASCADE strips the
+     * junction's constraint and leaves the junction itself for the re-render's
+     * `CREATE TABLE IF NOT EXISTS` to adopt silently. So the reset reads the referencing tables
+     * from the live catalog, holds each to the same emptiness bar, and drops them FIRST. Retrying
+     * without the relationship is what makes the drop observable: a junction that was merely
+     * adopted would still exist afterwards.
+     */
+    it("rebuilds an orphan together with its junction tables", async () => {
+      current = await createTestNextly({
+        dialect,
+        collections: [
+          defineCollection({
+            slug: "tags",
+            fields: [text({ name: "title" })],
+          }),
+        ],
+      });
+      const slug = `sc_${dialect.slice(0, 2)}_jn`;
+      const table = `single_${slug}`;
+      // The generator's convention: source and target table names sorted, then the field name.
+      const junction = `dc_tags_${table}_tags`;
+
+      await dispatchSingles(
+        "createSingle",
+        {},
+        {
+          slug,
+          label: "Jn",
+          fields: [
+            {
+              name: "tags",
+              type: "relationship",
+              options: { relationType: "manyToMany", target: "tags" },
+            },
+          ],
+        }
+      );
+      expect((await registryRow(current, slug))?.migrationStatus).toBe(
+        "applied"
+      );
+      expect(await current.adapter.tableExists(junction)).toBe(true);
+
+      // The interrupted state again: tables stand, the row describing them does not.
+      const registry = current.getService("singleRegistryService");
+      await registry.deleteSingle(slug, { force: true });
+
+      await dispatchSingles(
+        "createSingle",
+        {},
+        {
+          slug,
+          label: "Jn",
+          fields: [{ name: "body", type: "text" }],
+        }
+      );
+
+      expect((await registryRow(current, slug))?.migrationStatus).toBe(
+        "applied"
+      );
+      expect(await current.adapter.tableExists(table)).toBe(true);
+      // The abandoned attempt's junction went with its parent rather than surviving as an orphan
+      // of its own.
+      expect(await current.adapter.tableExists(junction)).toBe(false);
     });
 
     /**

--- a/packages/nextly/src/domains/singles/services/resolve-single-table-name.ts
+++ b/packages/nextly/src/domains/singles/services/resolve-single-table-name.ts
@@ -60,3 +60,24 @@ export function resolveSingleTableName(config: SingleNameInput): string {
     : normalizeIdentifier(config.slug);
   return ensurePrefixed(base);
 }
+
+/**
+ * Every physical table a Single's storage occupies: the main table and the `_locales` companion
+ * beside it (`reconcileSingleCompanion` provisions the companion as `<tableName>_locales`).
+ *
+ * Ownership questions must compare these FAMILIES, never the main names alone. `normalizeIdentifier`
+ * folds `-` to `_`, so a Single slugged `foo-locales` resolves to `single_foo_locales` — exactly
+ * the companion of the Single at `single_foo` — and two Singles whose main names differ would then
+ * be writing into one physical table. The companion belongs to the family whether or not its owner
+ * is localized today: the toggle can be enabled later, and a namespace that grows and shrinks with
+ * a flag is not a boundary anything can rely on.
+ */
+export function singleTableFamily(tableName: string): [string, string] {
+  return [tableName, `${tableName}_locales`];
+}
+
+/** Whether two Singles' table families overlap — the collision every create must refuse. */
+export function singleTableFamiliesCollide(a: string, b: string): boolean {
+  const other = singleTableFamily(b);
+  return singleTableFamily(a).some(name => other.includes(name));
+}

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -22,7 +22,9 @@
  * Two consequences follow, and both are real:
  *
  * - A crash between the DDL and the row leaves a table nothing has any record of, findable only by
- *   guessing at table names.
+ *   guessing at table names. A retry of the create reclaims that ground rather than building over
+ *   it: a table already standing at the create's table name is dropped when empty and refused when
+ *   it holds rows, never silently adopted (`resetOrphanStorage`).
  * - A DDL that FAILS still writes its row, recording `failed`. That row owns the slug, and the
  *   create path refuses a slug that is already owned, so a failed create cannot be retried through
  *   the same path until the row is removed.
@@ -337,10 +339,16 @@ export class SingleMetadataService {
     // corrected retry is a fresh create rather than a collision with its own wreckage.
     const plan = await this.planCreate(input);
 
-    // 2. APPLY. Never throws; a failure is reported as a status so the row can still record it.
+    // 2. CLEAR THE GROUND. A table already standing where this create is about to build is never
+    // adopted: empty, it is dropped so the apply renders every column from THIS request's fields;
+    // holding rows, the create is refused — and the refusal is still free, because nothing has
+    // been persisted and no statement has run.
+    await this.resetOrphanStorage(input);
+
+    // 3. APPLY. Never throws; a failure is reported as a status so the row can still record it.
     const migrationStatus = await this.applyCreateDdl(input, plan);
 
-    // 3. RECORD, with the outcome already known.
+    // 4. RECORD, with the outcome already known.
     //
     // 🔴 Deliberately last, which is where the request handler had it. Writing the intent FIRST
     // would be better — a crash between the two leaves a table nothing has any record of — but only
@@ -354,6 +362,64 @@ export class SingleMetadataService {
     });
 
     return { record, migrationStatus };
+  }
+
+  /**
+   * Leave the create's table name pointing at nothing, or refuse the create.
+   *
+   * `CREATE TABLE IF NOT EXISTS` is a no-op against a table that already exists, on every dialect,
+   * and the statement runner tolerates already-applied index statements so half-applied schema can
+   * be finished. Together those make an apply over a LEFTOVER table silent: a create interrupted
+   * between the DDL and the registry write leaves a table no row describes, and a retry with a
+   * DIFFERENT field set would adopt that table unchanged — recording `applied` and binding a
+   * runtime schema that names columns the table does not have, so every later read and write fails
+   * far from the cause. Verifying the adopted table against the requested shape is not an answer
+   * either: the DDL generator and the schema descriptor render several field kinds differently
+   * (float widths, inline unique constraints, companion-owned columns), so a comparison between
+   * them reports working tables as broken.
+   *
+   * So a standing table is never built over. Which way it goes is decided by the one thing an
+   * orphan cannot have:
+   *
+   * - **Empty**, it is wreckage of an interrupted attempt. The ownership re-assertion above proved
+   *   no registered Single claims it, and a table the registry has never described is one nothing
+   *   can write rows through. It is dropped — with its locale companion and field-group data — so
+   *   the apply that follows renders every column, index and junction table from this request's
+   *   fields, and `applied` describes the table that is actually there.
+   * - **Holding rows**, it is somebody's data, and dropping it would destroy exactly what proves
+   *   it is not wreckage. The create is refused with the table named and the way forward stated.
+   *   Raised rather than recorded: no statement has run and no row is written, so the slug stays
+   *   free and the operator can retry after dealing with the table.
+   */
+  private async resetOrphanStorage(input: CreateSingleInput): Promise<void> {
+    const adapter = this.adapter;
+    if (!adapter) return;
+    if (!(await adapter.tableExists(input.tableName))) return;
+
+    const { tableHasRows } = await import(
+      "../../schema/pipeline/live-table-facts"
+    );
+    const occupied = await tableHasRows(
+      adapter.getDrizzle(),
+      adapter.getCapabilities().dialect,
+      input.tableName
+    );
+    if (occupied) {
+      throw NextlyError.conflict({
+        reason: "state",
+        message: `Table "${input.tableName}" already exists and holds rows, but no Single describes it. Drop or rename that table, then retry the create.`,
+        logContext: {
+          reason: "single-create-table-occupied",
+          slug: input.slug,
+          tableName: input.tableName,
+        },
+      });
+    }
+
+    this.logger.info(
+      `[Singles] Dropping empty unregistered table "${input.tableName}" before creating "${input.slug}"`
+    );
+    await this.dropSingleStorage(input.slug, input.tableName, adapter);
   }
 
   /**
@@ -409,32 +475,7 @@ export class SingleMetadataService {
 
     const adapter = this.adapter;
     if (tableName && adapter) {
-      // Embedded field-group instances point back at this table by a plain string with no foreign
-      // key, so the drop below cascades nothing and would strand them. Sweep first.
-      const { teardownEntityComponentData } = await import(
-        "../../field-groups/services/teardown-entity-field-group-data"
-      );
-      await teardownEntityComponentData({ adapter, parentTable: tableName });
-
-      // Remove the companion `_locales` table and this single's archive rows before the main table.
-      // The companion holds a foreign key to `<main>.id`, so it must go first or the main drop
-      // orphans it on PostgreSQL and is rejected by the constraint on MySQL.
-      const { teardownEntityI18n } = await import(
-        "../../i18n/migration/teardown-entity-i18n"
-      );
-      await teardownEntityI18n({ adapter, slug, tableName, kind: "single" });
-
-      // PostgreSQL needs CASCADE to drop dependent objects: the companion's foreign key makes the
-      // main table a target, and a non-cascading drop raises rather than proceeding. The other two
-      // dialects reject the keyword, so it is asked for only where it means something.
-      //
-      // The adapter renders this rather than a SQL string built here, because it already owns the
-      // two things such a string has to get right on every dialect: quoting the identifier, and
-      // turning a driver failure into the normalised database error the callers above expect.
-      await adapter.dropTable(tableName, {
-        ifExists: true,
-        cascade: adapter.getCapabilities().dialect === "postgresql",
-      });
+      await this.dropSingleStorage(slug, tableName, adapter);
     }
 
     // A row a concurrent delete already took is the state this method exists to reach, so it
@@ -449,6 +490,47 @@ export class SingleMetadataService {
     } catch (error) {
       if (!NextlyError.isNotFound(error)) throw error;
     }
+  }
+
+  /**
+   * Drop everything a Single stores: its embedded field-group data, its locale companion, and the
+   * main table itself, in that order.
+   *
+   * Shared by the delete path and by the create path's orphan reset, because "remove this Single's
+   * storage" is one question and two renderings of the teardown order would drift — the order is
+   * load-bearing on two dialects (see the companion comment below).
+   */
+  private async dropSingleStorage(
+    slug: string,
+    tableName: string,
+    adapter: DrizzleAdapter
+  ): Promise<void> {
+    // Embedded field-group instances point back at this table by a plain string with no foreign
+    // key, so the drop below cascades nothing and would strand them. Sweep first.
+    const { teardownEntityComponentData } = await import(
+      "../../field-groups/services/teardown-entity-field-group-data"
+    );
+    await teardownEntityComponentData({ adapter, parentTable: tableName });
+
+    // Remove the companion `_locales` table and this single's archive rows before the main table.
+    // The companion holds a foreign key to `<main>.id`, so it must go first or the main drop
+    // orphans it on PostgreSQL and is rejected by the constraint on MySQL.
+    const { teardownEntityI18n } = await import(
+      "../../i18n/migration/teardown-entity-i18n"
+    );
+    await teardownEntityI18n({ adapter, slug, tableName, kind: "single" });
+
+    // PostgreSQL needs CASCADE to drop dependent objects: the companion's foreign key makes the
+    // main table a target, and a non-cascading drop raises rather than proceeding. The other two
+    // dialects reject the keyword, so it is asked for only where it means something.
+    //
+    // The adapter renders this rather than a SQL string built here, because it already owns the
+    // two things such a string has to get right on every dialect: quoting the identifier, and
+    // turning a driver failure into the normalised database error the callers above expect.
+    await adapter.dropTable(tableName, {
+      ifExists: true,
+      cascade: adapter.getCapabilities().dialect === "postgresql",
+    });
   }
 
   /**

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -386,7 +386,8 @@ export class SingleMetadataService {
    *   no registered Single claims it as a main table OR as a `_locales` companion, and a table
    *   outside every registered Single's family is one no Nextly path can write rows through — so
    *   nothing can put content into it between the probe and the drop either. It is dropped — with
-   *   its own locale companion and field-group data — so
+   *   its own locale companion, its junction tables and its field-group data, each held to the
+   *   same emptiness bar first — so
    *   the apply that follows renders every column, index and junction table from this request's
    *   fields, and `applied` describes the table that is actually there.
    * - **Holding rows**, it is somebody's data, and dropping it would destroy exactly what proves
@@ -399,29 +400,52 @@ export class SingleMetadataService {
     if (!adapter) return;
     if (!(await adapter.tableExists(input.tableName))) return;
 
-    const { tableHasRows } = await import(
+    const { readReferencingTables, tableHasRows } = await import(
       "../../schema/pipeline/live-table-facts"
     );
-    const occupied = await tableHasRows(
-      adapter.getDrizzle(),
-      adapter.getCapabilities().dialect,
-      input.tableName
-    );
-    if (occupied) {
-      throw NextlyError.conflict({
-        reason: "state",
-        message: `Table "${input.tableName}" already exists and holds rows, but no Single describes it. Drop or rename that table, then retry the create.`,
-        logContext: {
-          reason: "single-create-table-occupied",
-          slug: input.slug,
-          tableName: input.tableName,
-        },
-      });
+    const db = adapter.getDrizzle();
+    const dialect = adapter.getCapabilities().dialect;
+
+    // The wreckage is a FAMILY plus its junctions, not one table. A relationship field's junction
+    // tables carry a foreign key to the main table, so a main table cannot simply be dropped while
+    // they stand: MySQL refuses the drop outright, and PostgreSQL's CASCADE strips the junction's
+    // constraint and leaves the junction itself to be adopted by the re-render — the same silent
+    // adoption this method exists to prevent. They are read from the live catalog because the
+    // abandoned attempt's field list is gone with its registry row. The `_locales` companion also
+    // references the main table and is excluded here: `dropSingleStorage` below owns its teardown.
+    const companion = `${input.tableName}_locales`;
+    const referencing = (
+      await readReferencingTables(db, dialect, input.tableName)
+    ).filter(name => name !== companion);
+
+    // Every table about to be dropped is probed BEFORE anything is dropped, so a refusal leaves
+    // the whole group exactly as it stood.
+    for (const name of [input.tableName, ...referencing]) {
+      if (await tableHasRows(db, dialect, name)) {
+        throw NextlyError.conflict({
+          reason: "state",
+          message: `Table "${name}" already exists and holds rows, but no Single describes it. Drop or rename that table, then retry the create.`,
+          logContext: {
+            reason: "single-create-table-occupied",
+            slug: input.slug,
+            tableName: input.tableName,
+            occupiedTable: name,
+          },
+        });
+      }
     }
 
     this.logger.info(
       `[Singles] Dropping empty unregistered table "${input.tableName}" before creating "${input.slug}"`
     );
+    // Referencing tables first: they hold the foreign keys, and a parent cannot be dropped while a
+    // reference to it stands on MySQL.
+    for (const name of referencing) {
+      await adapter.dropTable(name, {
+        ifExists: true,
+        cascade: dialect === "postgresql",
+      });
+    }
     await this.dropSingleStorage(input.slug, input.tableName, adapter);
   }
 

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -58,6 +58,7 @@ import type { Logger } from "../../../shared/types";
 import { applyMigrationStatements } from "../../schema/services/apply-migration-statements";
 import { withSchemaChangeExcluded } from "../../schema/services/schema-change-exclusion";
 
+import { singleTableFamiliesCollide } from "./resolve-single-table-name";
 import type { SingleRegistryService } from "./single-registry-service";
 
 /**
@@ -382,8 +383,10 @@ export class SingleMetadataService {
    * orphan cannot have:
    *
    * - **Empty**, it is wreckage of an interrupted attempt. The ownership re-assertion above proved
-   *   no registered Single claims it, and a table the registry has never described is one nothing
-   *   can write rows through. It is dropped — with its locale companion and field-group data — so
+   *   no registered Single claims it as a main table OR as a `_locales` companion, and a table
+   *   outside every registered Single's family is one no Nextly path can write rows through — so
+   *   nothing can put content into it between the probe and the drop either. It is dropped — with
+   *   its own locale companion and field-group data — so
    *   the apply that follows renders every column, index and junction table from this request's
    *   fields, and `applied` describes the table that is actually there.
    * - **Holding rows**, it is somebody's data, and dropping it would destroy exactly what proves
@@ -1148,9 +1151,16 @@ export class SingleMetadataService {
   private async assertCreateStillPossible(
     input: CreateSingleInput
   ): Promise<void> {
+    // 🔴 Compared as table FAMILIES, not main names. A Single's storage occupies its main table
+    // AND the `_locales` companion beside it, and slug normalisation folds `-` to `_`, so two
+    // Singles whose main names differ can still collide on one physical table: `foo-locales`
+    // resolves to `single_foo_locales`, which is `single_foo`'s companion. That matters doubly
+    // here, because a name this scan clears is one the orphan reset below is licensed to DROP —
+    // a main-name comparison would clear another Single's empty companion for destruction.
     const owner = (await this.registry.getAllSingles()).find(
       single =>
-        single.tableName === input.tableName && single.slug !== input.slug
+        single.slug !== input.slug &&
+        singleTableFamiliesCollide(single.tableName, input.tableName)
     );
     if (owner) {
       throw NextlyError.duplicate({


### PR DESCRIPTION
## Summary

Creating a Single whose physical table already exists (the orphan a crash between the DDL and the
registry write leaves behind, documented in `single-metadata-service.ts`'s header) silently adopted
that table: `CREATE TABLE IF NOT EXISTS` no-ops, the tolerated index statements no-op, and the
create recorded `applied` while binding a runtime schema that names columns the table does not
have. A retry with a changed field set then failed every read and write with "column does not
exist", and the Builder could not repair it (`planUpdate` diffs the *stored* fields, so the missing
column is never in the ADD set).

This makes the wrong state unrepresentable rather than detected after the fact: **a create never
builds over a standing table.**

- **Empty**, the table is wreckage of an interrupted attempt (ownership is re-asserted inside the
  exclusion, so no registered Single claims it, and a table outside every registered Single's
  family is one no Nextly path can write rows through). It is dropped — with its locale companion
  and field-group data, through the same teardown the delete path uses — and the apply renders the
  table from this request's fields. `applied` is then true by construction.
- **Holding rows**, it is somebody's data, whatever it is, and rows are the one thing wreckage
  cannot have. The create is refused with `NextlyError.conflict` naming the table and the remedy,
  before any statement runs and before any registry row is written — so the slug stays free and
  the retry stays open (a recorded `failed` row would own the slug and block it).

### Why not resurrect #556's post-apply shape verification

#556's `verify-applied-shape.ts` compared the live table against the diff engine's desired spec,
and #566 deleted it because the DDL generator and the descriptor disagree on several field kinds
(floats, uniques, field-group tables, required relationship/upload columns), so it failed creates
that had in fact applied cleanly. Any verify-after-apply built from those two sources inherits that
false-positive surface. Clearing the ground before the apply needs no shape comparison at all: the
generator's own CREATE is the only thing that ever shaped the table, so what it renders and what
stands cannot diverge.

### Review-round fixes (commits 2 and 3)

The fleet's lenses found three defects in the first cut, all fixed here:

1. **Table families, not main names.** The ownership checks compared MAIN table names only, while
   `single_*` also holds every localized Single's `_locales` companion — and slug normalisation
   folds `-` to `_`, so a Single slugged `foo-locales` resolves to `single_foo_locales`, the
   companion of `single_foo`. That companion is empty until its owner saves localized content, so
   the reset would have dropped another Single's translation storage and rebuilt it as an impostor,
   durably and silently. Both ownership checks (dispatcher preflight and in-exclusion re-assertion)
   now compare table FAMILIES via a shared `singleTableFamiliesCollide`, claimed whether or not the
   owner is localized today, both collision directions refused.
2. **Junction tables are part of the wreckage.** A Single with a many-to-many relationship also
   creates junction tables carrying a foreign key to the main table, and the reset did not account
   for them: PostgreSQL's cascade drop would strip their FK and the retry would silently adopt
   them; MySQL would refuse the main drop mid-teardown, making the retry unrecoverable. The reset
   now reads the tables referencing the main table (`readReferencingTables`, one implementation per
   dialect beside the other live-table facts): each referencing table outside the family must be
   empty too (else the create is refused before anything is dropped) and is dropped FIRST, so the
   parent drop cannot be refused and nothing is left to adopt.
3. **The in-exclusion guard is covered on its own.** The dispatcher preflight shadows the service's
   re-assertion in every dispatcher-driven test, so a family-collision test through the dispatcher
   cannot say which guard refused. A service-direct test now drives `createSingle` with a colliding
   table name so the inner guard — the one that licenses the DROP — is the only thing that can
   refuse, and the collision rejections assert the duplicate error rather than any rejection.

### Not in this change

- The equivalent hole on the update path is a different seam (the ALTER diff would need live
  introspection), and databases already corrupted by the old behaviour are not healed
  retroactively. Filed as `finding:orphan-adopted-tables-not-healed` in the ops ledger; the manual
  remedy is delete + recreate.
- The delete path's own junction-table gap (deleting a Single with many-to-many junctions) is
  pre-existing and filed separately in the ledger.

## Test plan

`single-create-schema-change.integration.test.ts`, run per dialect from the repo root:

- **new** "rebuilds an orphaned table when the retried create changes the fields" — the exact
  defect scenario: create, force-delete the registry row (the crash-between-DDL-and-register
  state), retry with different fields; asserts `applied` AND the physical columns (retried set
  present, abandoned field gone), via the pipeline's own introspection.
- **new** "refuses to create over a table that holds rows, and touches nothing" — writes content
  through the entry service first; asserts the rejection, no registry row, unchanged columns,
  surviving rows.
- **new** "refuses a create whose table family collides with another single's" — both directions,
  companion columns asserted unchanged; plus the service-direct variant that can only be refused
  by the in-exclusion guard.
- **new** junction coverage — an orphan with a many-to-many junction is rebuilt cleanly (junction
  dropped and re-rendered), and an occupied junction refuses the create.
- **updated** "repairs a localized single's tables by rebuilding the pair" — previously pinned the
  refusal (`failed`); rebuilding resolves the ambiguity that refusal guarded, because content is
  what distinguishes a half-enabled localization from an interrupted localized create, and content
  now refuses the create before anything is dropped.
- the pre-existing same-fields repair and rejection-leaves-nothing tests pass unchanged.

`single-dispatcher-ddl.test.ts`: the mock adapter's `tableExists` now answers statefully (true only
once the CREATE ran) — a blanket `true` reads as a pre-existing table to the new guard.

Break-and-restore, each against the committed tree with restore verified:

- `resetOrphanStorage` stubbed to a no-op → the rebuild, refusal and localized tests fail for the
  intended reasons (adopted-shape `applied`, missing rejection, localized `failed`).
- `singleTableFamiliesCollide` reverted to main-name equality → the family-collision test fails
  with the create resolving instead of rejecting (service-direct variant covers the inner guard
  alone).

Dialects: SQLite (always), PostgreSQL 17 on :5435, MySQL on :3307 — full integration suites green
at the first commit; the changed files re-run green per dialect at each later commit.

## Changeset

One changeset (`.changeset/single-create-rebuilds-orphans.md`), all 25 lockstep packages, `patch`;
`scripts/release/check-changesets.mjs` passes.

## Pre-existing failures

- `single-dispatcher-shapes.test.ts` has one pre-existing failure on `main` (response body shape
  for `getSingleDocument` with `source: "code"`); verified by running it with this branch's files
  reverted to `origin/main` — it fails identically. Not touched here.
- The `Lint / Typecheck / Test / Build` CI job fails at the Drizzle v1 legacy gate on the MERGE
  ref: `main`'s `releases/__tests__/parity.test.ts` (from #1110) uses `getTableColumns`, which the
  gate forbids; #1117 fixes it on main. This branch's own tree passes the gate locally. The branch
  will be updated once main is green so the full job runs at head.
