### PR TITLE
feat(plugin-page-builder): persist site style in a plugin-owned single, layered over config defaults

### DIFF
--- a/.changeset/site-style-has-somewhere-to-live.md
+++ b/.changeset/site-style-has-somewhere-to-live.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A site's style inputs — design tokens with light/dark values, self-hosted fonts, named
+classes and breakpoints — now persist. The page builder registers a versioned Site Style
+single that stores admin edits, layered over optional code-stated defaults on
+`pageBuilder({ siteStyle })`; one merge resolves the two, writes are validated with the
+engine's own rules and refused on garbage, and a published route passes the merged result
+per request via `loadSiteStyle`, so a stored token or class reaches the served page's site
+sheet without a redeploy.

--- a/apps/playground/nextly.config.ts
+++ b/apps/playground/nextly.config.ts
@@ -33,6 +33,7 @@ import { Categories } from "./src/collections/categories";
 import { Posts } from "./src/collections/posts";
 import { Tags } from "./src/collections/tags";
 import { Seo } from "./src/field-groups/seo";
+import { SITE_STYLE_DEFAULTS } from "./src/lib/site-style-defaults";
 import { styleFixturePlugin } from "./src/plugins/style-fixture/plugin";
 import { Announcement } from "./src/singles/announcement";
 import { Homepage } from "./src/singles/homepage";
@@ -99,7 +100,10 @@ export default defineConfig({
   // is a test double listed among real plugins, and it injects a showcase
   // section into the Posts collection list, both of which read as product.
   plugins: [
-    pageBuilder(),
+    // The style defaults tier: the same object the public block routes hand to
+    // `loadSiteStyle`, so the validator, the canvas and the published page all
+    // read one statement of this site's breakpoints.
+    pageBuilder({ siteStyle: SITE_STYLE_DEFAULTS }),
     formBuilderPlugin,
     ...(process.env.NEXTLY_E2E_STYLE_FIXTURE === "1"
       ? [styleFixturePlugin]

--- a/apps/playground/src/app/(frontend)/[...slug]/page.tsx
+++ b/apps/playground/src/app/(frontend)/[...slug]/page.tsx
@@ -39,8 +39,10 @@
 import { createBlockResolver } from "@nextlyhq/blocks-react";
 import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
 import { createBlocksPage } from "@nextlyhq/blocks-react/next";
+import { loadSiteStyle } from "@nextlyhq/plugin-page-builder";
 
 import { siteReader, SITE_STYLE_CONTEXT } from "../../../lib/site-content";
+import { SITE_STYLE_DEFAULTS } from "../../../lib/site-style-defaults";
 
 /**
  * Access-enforced and per-request, which is the secure default.
@@ -80,6 +82,13 @@ const { ContentPage, generateMetadata } = createBlocksPage({
   // whenever this request arrived before the admin did.
   blocks: createBlockResolver(coreBlocks),
   styleContext: SITE_STYLE_CONTEXT,
+  // The site sheet's inputs, resolved PER REQUEST: the code-stated defaults
+  // with the stored Site Style document layered on top, so a token or class an
+  // admin saves reaches the next page view rather than the next deploy. The
+  // defaults are the same object `pageBuilder({ siteStyle })` was handed, so
+  // the canvas, the validator and this route agree by construction.
+  siteStyles: () =>
+    loadSiteStyle({ nextly: siteReader, defaults: SITE_STYLE_DEFAULTS }),
   metadata: (entry, context, derived) => ({
     title: derived.title ?? (entry.title as string | undefined),
     description: derived.description,

--- a/apps/playground/src/app/blocks/[[...slug]]/page.tsx
+++ b/apps/playground/src/app/blocks/[[...slug]]/page.tsx
@@ -24,8 +24,10 @@
 import { createBlockResolver } from "@nextlyhq/blocks-react";
 import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
 import { createBlocksPage } from "@nextlyhq/blocks-react/next";
+import { loadSiteStyle } from "@nextlyhq/plugin-page-builder";
 
 import { siteReader, SITE_STYLE_CONTEXT } from "../../../lib/site-content";
+import { SITE_STYLE_DEFAULTS } from "../../../lib/site-style-defaults";
 
 /**
  * Where this route is mounted, for canonical URLs.
@@ -83,6 +85,12 @@ const { ContentPage, generateMetadata } = createBlocksPage({
   // placeholder whenever this request arrived before the admin did.
   blocks: createBlockResolver(coreBlocks),
   styleContext: SITE_STYLE_CONTEXT,
+  // Resolved per request: defaults with the stored Site Style layered on top.
+  // The same statement the page-builder route makes, because both routes serve
+  // documents of one engine and a site sheet that differed between them would
+  // style one page two ways depending on its URL.
+  siteStyles: () =>
+    loadSiteStyle({ nextly: siteReader, defaults: SITE_STYLE_DEFAULTS }),
   metadata: (entry, context, derived) => ({
     title: derived.title ?? (entry.title as string | undefined),
     description: derived.description,

--- a/apps/playground/src/lib/site-content.ts
+++ b/apps/playground/src/lib/site-content.ts
@@ -19,6 +19,8 @@ import type { NextlyContentReader, NextlySingleReader } from "nextly/runtime";
 
 import nextlyConfig from "../../nextly.config";
 
+import { SITE_STYLE_DEFAULTS } from "./site-style-defaults";
+
 type NextlyInstance = Awaited<ReturnType<typeof getNextly>>;
 
 /**
@@ -79,10 +81,10 @@ export const siteReader: NextlyContentReader &
  * class that no rule ever defines, and the page would render structurally
  * correct and visually bare.
  *
- * Declared by the host because breakpoints are a site decision: the engine never
- * reads storage and ships no default set. Ids must be unique across both axes,
- * and the base breakpoint carries no `maxWidth` — it is the fallback the others
- * narrow.
+ * DERIVED from `SITE_STYLE_DEFAULTS` rather than declared beside it, because a
+ * second statement of the breakpoints is how the page sheet and the shared
+ * site sheet come to emit the same tier under different at-rules — each side
+ * internally consistent, so nothing errors.
  *
  * Left unannotated deliberately. `StyleCompileContext` is what the route helpers
  * accept, and `@nextlyhq/blocks-react` does not re-export it — naming the type
@@ -90,12 +92,5 @@ export const siteReader: NextlyContentReader &
  * to label a config object. The shape is still fully checked where it is passed.
  */
 export const SITE_STYLE_CONTEXT = {
-  breakpoints: {
-    viewport: [
-      { id: "base", label: "Base" },
-      { id: "tablet", label: "Tablet", maxWidth: 1024 },
-      { id: "mobile", label: "Mobile", maxWidth: 640 },
-    ],
-    container: [],
-  },
+  breakpoints: SITE_STYLE_DEFAULTS.breakpoints,
 };

--- a/apps/playground/src/lib/site-style-defaults.ts
+++ b/apps/playground/src/lib/site-style-defaults.ts
@@ -1,0 +1,42 @@
+/**
+ * This site's style defaults, stated once.
+ *
+ * The value feeds three surfaces, and defining it in its own module is what
+ * lets each of them import the same object instead of restating it:
+ *
+ * - `nextly.config.ts` hands it to `pageBuilder({ siteStyle })`, which wires
+ *   the blocks-field validator and the editor canvas.
+ * - The public block routes hand it to `loadSiteStyle({ defaults })`, which
+ *   layers the stored Site Style document over it per request.
+ * - `site-content.ts` derives the routes' `styleContext` breakpoints from it.
+ *
+ * Its own module rather than a `site-content.ts` export because the config
+ * needs it and `site-content.ts` imports the config — an import in the other
+ * direction would be a cycle.
+ *
+ * @module lib/site-style-defaults
+ */
+import type { SiteStyleData } from "@nextlyhq/plugin-page-builder";
+
+/**
+ * Breakpoints only. Tokens, fonts and classes are left to the engine's
+ * guaranteed defaults and to whatever the Site Style document stores — this
+ * app is a dev harness, and a hand-styled baseline here would make every
+ * canvas and page look "designed" in a way no fresh site would reproduce.
+ *
+ * Ids must be unique across both axes, and the base breakpoint carries no
+ * `maxWidth` — it is the fallback the others narrow.
+ */
+// `satisfies` rather than an annotation, so `.breakpoints` keeps its concrete
+// type: `SITE_STYLE_CONTEXT` reads it as a required `StyleCompileContext`
+// field, which an optional-typed property cannot satisfy.
+export const SITE_STYLE_DEFAULTS = {
+  breakpoints: {
+    viewport: [
+      { id: "base", label: "Base" },
+      { id: "tablet", label: "Tablet", maxWidth: 1024 },
+      { id: "mobile", label: "Mobile", maxWidth: 640 },
+    ],
+    container: [],
+  },
+} satisfies SiteStyleData;

--- a/e2e/tests/site-style.spec.ts
+++ b/e2e/tests/site-style.spec.ts
@@ -1,0 +1,234 @@
+/**
+ * Site style storage, proven on served pages rather than on internals.
+ *
+ * The Site Style single is the stored tier of the page builder's layered
+ * style model: config defaults under it, the engine's guaranteed tokens under
+ * both. Everything below writes through the ordinary single write path and
+ * then reads what a visitor's browser would receive, because the property
+ * under test is the whole road — stored JSON to compiled site sheet to
+ * response body — and any shorter assertion passes on a broken join.
+ *
+ * Three properties, in the order they can fail:
+ *
+ * 1. A stored token reaches a published page's site sheet, in BOTH modes.
+ *    The token's name exists nowhere else — not in the engine defaults, not
+ *    in this app's config — so its custom property appearing in the response
+ *    can only mean the stored document was read and layered in.
+ * 2. A stored named class reaches the same sheet as a `.nx-c-<slug>` rule,
+ *    and a node referencing it by ID actually renders with the class's
+ *    computed style — the served-output proof that the sheet is not merely
+ *    printed but applied.
+ * 3. Writes fail closed: a token value that would fetch is refused by the
+ *    single's validator, and the page keeps serving the last good value.
+ *
+ * Safe to write against: the suite owns its database and empties it before
+ * every run.
+ */
+import { expect, test, type APIResponse } from "@playwright/test";
+
+import { STORAGE_STATE } from "../global-setup";
+
+test.describe.configure({ mode: "serial" });
+
+const SITE_STYLE = "/admin/api/singles/site-style";
+const ENTRIES = "/admin/api/collections/block-pages/entries";
+
+const PAGE_SLUG = "site-style-dogfood";
+const PAGE_HEADING = "Styled by the site style single";
+
+/**
+ * A token name no other tier defines. `color.primary` would also prove the
+ * override wins, but a page would still render ITS property from the engine
+ * default and the assertion would have to parse which value won; a name only
+ * the stored document knows separates "storage reached the sheet" from
+ * everything else with a plain substring.
+ */
+const TOKEN_NAME = "color.e2e-accent";
+const TOKEN_PROPERTY = "--site-color-e2e-accent";
+const TOKEN_LIGHT = "#1b7f5c";
+const TOKEN_DARK = "#8fe3c0";
+
+/** The stored class, and the colour its rule applies. */
+const CLASS_ID = "e2e-accent-class";
+const CLASS_SLUG = "e2e-accent";
+const CLASS_COLOR = "#0f5132";
+const CLASS_COLOR_RGB = "rgb(15, 83, 50)";
+
+/** A node id, stable per fixture so a failure names the same node every run. */
+const id = (suffix: string) => `00000000-0000-4000-8000-0000000000${suffix}`;
+
+/**
+ * The page document: one heading carrying the stored class BY ID, which is
+ * how documents reference the class library. Its computed colour is what
+ * proves the served sheet was applied rather than merely emitted.
+ */
+const DOCUMENT = {
+  formatVersion: 1,
+  kind: "page",
+  nodes: [
+    {
+      id: id("01"),
+      type: "core/heading",
+      version: 1,
+      props: { text: PAGE_HEADING, level: "h1" },
+      classes: [CLASS_ID],
+    },
+  ],
+};
+
+/** The stored tier this suite writes: one token with both modes, one class. */
+const STORED_STYLE = {
+  tokens: {
+    tokens: [
+      {
+        name: TOKEN_NAME,
+        kind: "color",
+        values: { light: TOKEN_LIGHT, dark: TOKEN_DARK },
+      },
+    ],
+  },
+  classes: [
+    {
+      id: CLASS_ID,
+      slug: CLASS_SLUG,
+      orderIndex: 0,
+      styles: { base: { base: { color: CLASS_COLOR } } },
+    },
+  ],
+};
+
+/** Fail with the server's message rather than with a bare status code. */
+async function expectOk(response: APIResponse, what: string): Promise<void> {
+  if (!response.ok()) {
+    throw new Error(
+      `${what} failed: ${response.status()} ${await response.text()}`
+    );
+  }
+}
+
+/** The site sheet's CSS text, cut out of a served page's raw HTML. */
+function siteSheetOf(html: string): string {
+  // The renderer stamps the shared sheet with its content hash; matching the
+  // attribute rather than "a <style> element" keeps the assertion off the
+  // page's OWN sheet, which is a different artifact with different inputs.
+  const match = /<style data-nx-site-sheet="[^"]*">([\s\S]*?)<\/style>/.exec(
+    html
+  );
+  if (!match?.[1]) {
+    throw new Error("The response carries no site sheet <style> element.");
+  }
+  return match[1];
+}
+
+/**
+ * Seeds the stored style and the fixture page, in a hook rather than a test
+ * so no `--grep` can deselect it out from under the assertions.
+ */
+test.beforeAll(async ({ playwright }, testInfo) => {
+  const baseURL = testInfo.project.use.baseURL;
+  if (baseURL === undefined) throw new Error("[e2e] No baseURL configured.");
+
+  // Its own context: `request` is test-scoped and cannot be taken by a
+  // `beforeAll`. The signed-in state is the same one every test runs with.
+  const api = await playwright.request.newContext({
+    baseURL,
+    storageState: STORAGE_STATE,
+  });
+
+  try {
+    // PATCH is idempotent, so a retried run re-writes the same document and
+    // needs no duplicate handling.
+    await expectOk(
+      await api.patch(SITE_STYLE, { data: STORED_STYLE }),
+      "storing the site style"
+    );
+
+    const created = await api.post(ENTRIES, {
+      data: {
+        title: "Site style dogfood",
+        slug: PAGE_SLUG,
+        content: DOCUMENT,
+        status: "published",
+      },
+    });
+    // 409 IS the success case on a retry: the unique index on `slug` is what
+    // reports "this run already seeded me" — see blocks-page.spec.ts.
+    if (created.status() !== 409) {
+      await expectOk(created, `seeding ${PAGE_SLUG}`);
+    }
+  } finally {
+    await api.dispose();
+  }
+});
+
+test("a stored token reaches the published page's site sheet, both modes", async ({
+  request,
+}) => {
+  // Raw HTML rather than the DOM: the claim is about what the server SENDS.
+  const response = await request.get(`/blocks/${PAGE_SLUG}`);
+  await expectOk(response, "fetching the published page");
+  const sheet = siteSheetOf(await response.text());
+
+  // The light value on the root block, verbatim.
+  expect(sheet).toContain(`${TOKEN_PROPERTY}:${TOKEN_LIGHT}`);
+  // The dark value under the mode selector, which is what "modes are in the
+  // stored schema from day one" buys: nothing but the stored document could
+  // have put a dark block for this property into the sheet.
+  const darkIndex = sheet.indexOf(`${TOKEN_PROPERTY}:${TOKEN_DARK}`);
+  expect(darkIndex).toBeGreaterThan(-1);
+  expect(sheet.slice(0, darkIndex)).toContain('[data-nx-theme="dark"]');
+});
+
+test("a stored class is emitted as a rule and applied to a referencing node", async ({
+  page,
+  request,
+}) => {
+  // The rule text in the served sheet names the class by its CSS name...
+  const response = await request.get(`/blocks/${PAGE_SLUG}`);
+  await expectOk(response, "fetching the published page");
+  expect(siteSheetOf(await response.text())).toContain(
+    `.nx-c-${CLASS_SLUG}{color:${CLASS_COLOR}`
+  );
+
+  // ...and the COMPUTED colour proves the browser resolved a node's class
+  // reference through that rule — the difference between a sheet that was
+  // served and one that also governs the page.
+  await page.goto(`/blocks/${PAGE_SLUG}`);
+  await expect(page.getByRole("heading", { name: PAGE_HEADING })).toHaveCSS(
+    "color",
+    CLASS_COLOR_RGB
+  );
+});
+
+test("a token value that would fetch is refused, and the page keeps the last good style", async ({
+  request,
+}) => {
+  // `url(...)` in a token is the one thing the engine refuses as an ERROR:
+  // the eventual stylesheet contains only a var() substitution, so no origin
+  // policy downstream would ever see the URL. The write path must be where it
+  // stops.
+  const refused = await request.patch(SITE_STYLE, {
+    data: {
+      tokens: {
+        tokens: [
+          {
+            name: TOKEN_NAME,
+            kind: "color",
+            values: { light: "url(https://evil.example/pixel.png)" },
+          },
+        ],
+      },
+    },
+  });
+  expect(refused.ok()).toBe(false);
+
+  // Fail-closed means failed: the stored document is unchanged, so the page
+  // still serves the value the suite wrote first. Asserted rather than
+  // assumed, because a validator that reported an error AFTER persisting
+  // would pass the status check above and still poison every page.
+  const response = await request.get(`/blocks/${PAGE_SLUG}`);
+  await expectOk(response, "fetching the published page after the refusal");
+  expect(siteSheetOf(await response.text())).toContain(
+    `${TOKEN_PROPERTY}:${TOKEN_LIGHT}`
+  );
+});

--- a/e2e/tests/site-style.spec.ts
+++ b/e2e/tests/site-style.spec.ts
@@ -52,7 +52,7 @@ const TOKEN_DARK = "#8fe3c0";
 const CLASS_ID = "e2e-accent-class";
 const CLASS_SLUG = "e2e-accent";
 const CLASS_COLOR = "#0f5132";
-const CLASS_COLOR_RGB = "rgb(15, 83, 50)";
+const CLASS_COLOR_RGB = "rgb(15, 81, 50)";
 
 /** A node id, stable per fixture so a failure names the same node every run. */
 const id = (suffix: string) => `00000000-0000-4000-8000-0000000000${suffix}`;
@@ -183,11 +183,14 @@ test("a stored class is emitted as a rule and applied to a referencing node", as
   page,
   request,
 }) => {
-  // The rule text in the served sheet names the class by its CSS name...
+  // The rule text in the served sheet names the class by its CSS name. A
+  // regex rather than a substring, because the emitter scopes the selector
+  // under the page root and formats its declarations with spaces — the claim
+  // is "a rule for this class applies this colour", not a byte layout.
   const response = await request.get(`/blocks/${PAGE_SLUG}`);
   await expectOk(response, "fetching the published page");
-  expect(siteSheetOf(await response.text())).toContain(
-    `.nx-c-${CLASS_SLUG}{color:${CLASS_COLOR}`
+  expect(siteSheetOf(await response.text())).toMatch(
+    new RegExp(`\\.nx-c-${CLASS_SLUG}\\s*\\{\\s*color:\\s*${CLASS_COLOR}`)
   );
 
   // ...and the COMPUTED colour proves the browser resolved a node's class

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -17,6 +17,10 @@ export {
   COMPONENT_INSTANCE_TYPE,
   STYLE_STATES,
   MAX_BREAKPOINTS_PER_AXIS,
+  // Public alongside the per-axis cap: a store validating a class library on
+  // write must refuse what the compiler will not read, and a copy of this
+  // number in another package is a second statement that goes stale silently.
+  MAX_NAMED_CLASSES,
   isTokenRef,
   isBindingSource,
   isComponentInstance,

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -92,6 +92,13 @@ const WORKING_DRAFT_KEY = "_isWorkingDraft";
 const MEDIA_TAG_COLLECTION = "media";
 
 /**
+ * The site-wide style inputs a route accepts: a full `SiteSheetInput` less the
+ * breakpoint requirement, which may instead fall back to `styleContext`'s.
+ */
+export type SiteStylesInput = Omit<SiteSheetInput, "breakpoints"> &
+  Partial<Pick<SiteSheetInput, "breakpoints">>;
+
+/**
  * Config for {@link createBlocksPage}.
  *
  * Everything {@link ContentRouteConfig} accepts, minus `render` — supplying
@@ -147,9 +154,20 @@ export interface BlocksPageConfig
    * breakpoints once should not have to state them twice — and two answers to
    * "what are this site's breakpoints" is how the shared sheet and the page
    * sheet come to disagree about which at-rules a tier is emitted under.
+   *
+   * **A function is called per render**, exactly as `styles` is, for a site
+   * whose style inputs live in storage: a route module's config is captured
+   * once per server process, so a plain value here freezes an admin's saved
+   * tokens at whatever they were when the module loaded — the edit would reach
+   * the next deploy instead of the next page view. Returning `undefined`
+   * means what omitting the value means.
    */
-  siteStyles?: Omit<SiteSheetInput, "breakpoints"> &
-    Partial<Pick<SiteSheetInput, "breakpoints">>;
+  siteStyles?:
+    | SiteStylesInput
+    | (() =>
+        | SiteStylesInput
+        | undefined
+        | Promise<SiteStylesInput | undefined>);
   /**
    * A dynamic collection to resolve media ids against, for a site storing its
    * images in one of its own.
@@ -1061,13 +1079,20 @@ function blocksRouteConfig(
         resolveEntryPath,
       });
 
+      // Resolved per render when the config states a provider, so style
+      // inputs living in storage reach the next page view rather than the
+      // next deploy; a plain value passes through unchanged.
+      const configuredSiteStyles =
+        typeof config.siteStyles === "function"
+          ? await config.siteStyles()
+          : config.siteStyles;
       // Derived ONCE, from the breakpoints the site already stated. A second
       // answer to "what are this site's breakpoints" is how the shared sheet
       // and the page sheet come to disagree about which at-rules a tier is
       // emitted under — and the disagreement is invisible, because each sheet
       // is internally consistent.
       const siteBreakpoints =
-        config.siteStyles?.breakpoints ?? styleContext?.breakpoints;
+        configuredSiteStyles?.breakpoints ?? styleContext?.breakpoints;
       // A route emits the site sheet by DEFAULT: without it every `{ $token }`
       // resolves to nothing, which is the defect this closes. It needs a
       // breakpoint set to compile the block-default tier under, so a route that
@@ -1076,7 +1101,7 @@ function blocksRouteConfig(
       const siteStyles =
         siteBreakpoints === undefined
           ? undefined
-          : { ...config.siteStyles, breakpoints: siteBreakpoints };
+          : { ...configuredSiteStyles, breakpoints: siteBreakpoints };
 
       return createElement(PageRenderer, {
         document,

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -388,8 +388,24 @@ export function PageRenderer({
   // the scope lives on the artifact, the caps come from this prop, and a
   // caller's own fetch predicate needs an identity before a stored sheet can be
   // judged against it.
+  // The site's class library reaches the PAGE compile from the same value the
+  // shared sheet reads. The sheet writes the `.nx-c-<slug>` rule from
+  // `siteStyles.classes`, but a node's stored class IDS resolve to class NAMES
+  // during the page's own compile, from the context's `namedClasses` — two
+  // inputs that must be one list, or a stored class emits a rule no element
+  // ever carries and each half looks internally consistent. A context that
+  // states its own `namedClasses` outranks this, exactly as a context carrying
+  // its own `blockBases` does.
+  const pageStyleContext =
+    styleContext !== undefined &&
+    styleContext.namedClasses === undefined &&
+    siteStyles !== false &&
+    siteStyles?.classes !== undefined
+      ? { ...styleContext, namedClasses: siteStyles.classes }
+      : styleContext;
+
   const { context: compileContext, fetchPolicyId } = effectiveCompile({
-    styleContext,
+    styleContext: pageStyleContext,
     styles,
     limits,
     remotePatterns: hostPolicy?.remotePatterns,

--- a/packages/blocks-react/src/site-sheet.test.tsx
+++ b/packages/blocks-react/src/site-sheet.test.tsx
@@ -224,3 +224,66 @@ describe("the per-node DOM address", () => {
     expect(out).not.toContain(`${NODE_ID_ATTRIBUTE}="core/box"`);
   });
 });
+
+describe("a node's named-class references", () => {
+  const CLASSED: BlockDocument = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      {
+        id: "classed-node",
+        type: "core/box",
+        version: 1,
+        props: {},
+        classes: ["accent-id"],
+      },
+    ],
+  };
+
+  const ACCENT = {
+    id: "accent-id",
+    slug: "accent",
+    orderIndex: 0,
+    styles: { base: { base: { color: "#123123" } } },
+  };
+
+  it("resolve through the SAME class list the site sheet is compiled from", () => {
+    // The sheet writes the `.nx-c-<slug>` rule from `siteStyles.classes`; the
+    // node's stored ids resolve to names in the page compile, whose context
+    // said nothing about classes here. If the two read different lists, a
+    // stored class emits a rule no element carries — each half internally
+    // consistent — so the assertion is over both: the rule AND the name.
+    const out = renderToStaticMarkup(
+      <PageRenderer
+        document={CLASSED}
+        blocks={createBlockResolver([box])}
+        styleContext={{ breakpoints: BREAKPOINTS }}
+        siteStyles={{ breakpoints: BREAKPOINTS, classes: [ACCENT] }}
+      />
+    );
+
+    expect(out).toContain(".nx-c-accent");
+    // The name inside a class ATTRIBUTE, not merely anywhere in the markup —
+    // the sheet's own rule text also contains it.
+    expect(out).toMatch(/class="[^"]*\bnx-c-accent\b/);
+  });
+
+  it("defer to a compile context that states its OWN class list", () => {
+    // An explicit choice by the caller outranks what can be derived — the same
+    // rule the renderer applies to a context carrying its own blockBases. The
+    // context's empty list means "this site has no classes", so the node's
+    // reference resolves to nothing even though the sheet got a library.
+    const out = renderToStaticMarkup(
+      <PageRenderer
+        document={CLASSED}
+        blocks={createBlockResolver([box])}
+        styleContext={{ breakpoints: BREAKPOINTS, namedClasses: [] }}
+        siteStyles={{ breakpoints: BREAKPOINTS, classes: [ACCENT] }}
+      />
+    );
+
+    // The sheet still carries the library's rule; what the deferral changes
+    // is ATTRIBUTION, so the element must not carry the name.
+    expect(out).not.toMatch(/class="[^"]*\bnx-c-accent\b/);
+  });
+});

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -76,6 +76,7 @@ import {
 
 import { emptyBlockDocument } from "../fields/blocks-document";
 import { siteBreakpoints, siteSheet } from "../site-style";
+import { readSiteStyleRecord } from "../site-style-record";
 
 import { BlocksSummary } from "./BlocksSummary";
 import { DocumentStatusPill } from "./DocumentStatusPill";
@@ -387,6 +388,25 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
     enabled: clientConfig?.checklist !== false,
   });
 
+  /*
+   * The site style the canvas draws with: the host's config DEFAULTS, already
+   * resolved by the plugin factory and delivered as plain data. Narrowed with
+   * the same checks the server writes by, so a malformed value degrades to
+   * the empty style (block defaults and the engine's guaranteed tokens)
+   * rather than crashing the editor.
+   *
+   * Defaults only, deliberately. The STORED tier reaches the published page
+   * through `loadSiteStyle` on the route; wiring it into the canvas needs a
+   * fetch this surface does not have yet, and belongs to the style studios.
+   * Until then the canvas previews the code-stated design — closer to the
+   * published page than the empty sheet it drew before, and honestly short of
+   * it exactly where an admin has stored an override.
+   */
+  const canvasSiteStyle = useMemo(
+    () => readSiteStyleRecord(clientConfig?.siteStyle),
+    [clientConfig]
+  );
+
   useCheckpoints({ name, control, document: editor.document });
 
   /*
@@ -513,7 +533,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
           <EditorCommandPalette editor={editor} onExit={done} />
           <Canvas
             document={editor.document}
-            siteStyles={siteSheet()}
+            siteStyles={siteSheet(canvasSiteStyle)}
             selectedId={editor.selectedId}
             selectedIds={editor.selection.ids}
             onSelect={editor.select}
@@ -537,7 +557,9 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             // field validator and the canvas cannot disagree about what this
             // site's breakpoints are — and this is now the third consumer of
             // that one answer.
-            render={{ styleContext: { breakpoints: siteBreakpoints() } }}
+            render={{
+              styleContext: { breakpoints: siteBreakpoints(canvasSiteStyle) },
+            }}
             dragHandlers={drag.handlers}
             // The pointer route into typing a block's text. Its keyboard
             // counterpart is the Enter binding above, registered in the same

--- a/packages/plugin-page-builder/src/fields/blocks-validator.ts
+++ b/packages/plugin-page-builder/src/fields/blocks-validator.ts
@@ -53,17 +53,18 @@ export interface BlocksValidationOptions {
 /**
  * Breakpoints are site-level data owned by the page-builder plugin, and the
  * engine never reads storage, so core validates against whatever set it is
- * handed. A document referencing a breakpoint id therefore warns rather than
- * errors until the plugin supplies the real set — which is the arrangement that
- * keeps the engine storage-agnostic.
+ * handed. The plugin factory passes the config-supplied set in per call; a
+ * caller with no set falls back to `siteBreakpoints()` with nothing, which is
+ * the empty set — and against an empty set the engine treats a document's
+ * breakpoint reference as a warning rather than an error, so an unwired
+ * caller stays permissive rather than wrong.
  *
- * Read from `site-style` rather than declared here, because the editor canvas
- * compiles its stylesheet against the same set. Two declarations agree while
- * both are empty and diverge the day one gains a breakpoint, leaving the canvas
- * drawing a layout this validator rejects — each side internally consistent, so
- * neither looks wrong.
+ * Fallen back to through `site-style` rather than a set declared here,
+ * because the editor canvas compiles its stylesheet against the same one
+ * answer. Two declarations agree while both are empty and diverge the day one
+ * gains a breakpoint, leaving the canvas drawing a layout this validator
+ * rejects — each side internally consistent, so neither looks wrong.
  */
-const NO_BREAKPOINTS: BreakpointSet = siteBreakpoints();
 
 /** What a field accepts when it says nothing: its own entry's page content. */
 const DEFAULT_KINDS: readonly DocumentKind[] = ["page"];
@@ -84,7 +85,8 @@ export function validateBlocksValue(
   value: unknown,
   path: string,
   label: string,
-  options: BlocksValidationOptions
+  options: BlocksValidationOptions,
+  breakpoints: BreakpointSet = siteBreakpoints()
 ): Issue[] {
   // An absent document is an empty field. Required-ness is the shared rules'
   // to enforce, exactly as for every other type.
@@ -123,7 +125,7 @@ export function validateBlocksValue(
   // document JSON rewrites is fully measured and safe to walk, one holding an
   // accessor is neither, and both are errors.
   const { issues: allDocumentIssues, survey } = validateDocument(doc, {
-    breakpoints: NO_BREAKPOINTS,
+    breakpoints,
     mode: "forgiving",
     // Where a block declares the containers it may sit inside, this is the path
     // that has to enforce it: the editor refuses such a placement while

--- a/packages/plugin-page-builder/src/fields/blocksField.ts
+++ b/packages/plugin-page-builder/src/fields/blocksField.ts
@@ -17,11 +17,14 @@
 import {
   DOCUMENT_FORMAT_VERSION,
   DOCUMENT_KINDS,
+  type BreakpointSet,
 } from "@nextlyhq/blocks-engine";
 import type {
   PluginFieldInstance,
   PluginFieldType,
 } from "@nextlyhq/plugin-sdk";
+
+import { siteBreakpoints } from "../site-style";
 
 import { emptyBlockDocument } from "./blocks-document";
 import type { BlocksFieldOptions } from "./blocks-options";
@@ -44,144 +47,168 @@ function policyOf(field: PluginFieldInstance): BlocksFieldOptions {
   return declared;
 }
 
-export const BLOCKS_FIELD_TYPE: PluginFieldType = {
-  type: BLOCKS_TYPE,
-  storage: "json",
-  component: BLOCKS_FIELD_COMPONENT,
-  label: "Blocks",
-  description: "Page built from blocks",
-  category: "Structured",
-  icon: "LayoutGrid",
-
-  /**
-   * The document's own rules, run on every write.
-   *
-   * The engine owns every structural rule — ids, depth, node and byte caps,
-   * slot legality, the kind enum — so this adapts its result rather than
-   * restating any of it. Issues are addressed to the field, because the admin
-   * renders a blocks field as a single control and the position inside the
-   * document travels in the message.
-   */
-  validate: (value, args) => {
-    const issues = validateBlocksValue(
-      value,
-      args.path,
-      typeof args.field.label === "string" ? args.field.label : args.path,
-      policyOf(args.field)
-    );
-    return issues.length === 0 ? true : issues;
-  },
-
-  /**
-   * The declaration's own rules, run when a schema is registered.
-   *
-   * A policy that is the wrong shape, or one whose settings contradict each
-   * other, is a defect in the schema rather than in any value: reporting it
-   * per write would tell the writer, who cannot fix it, and would fail every
-   * write until whoever declared the field noticed.
-   */
-  validateOptions: field => {
-    const declared = (field as { blocks?: unknown }).blocks;
-    if (declared === undefined) return true;
-
-    if (
-      typeof declared !== "object" ||
-      declared === null ||
-      Array.isArray(declared)
-    ) {
-      return "blocks must be an object declaring allow and/or kinds.";
-    }
-
-    const { allow, kinds } = declared as { allow?: unknown; kinds?: unknown };
-
-    if (allow !== undefined) {
-      if (!Array.isArray(allow) || allow.some(e => typeof e !== "string")) {
-        return [
-          {
-            path: "blocks.allow",
-            message: "blocks.allow must be an array of block name strings.",
-          },
-        ];
-      }
-    }
-
-    if (kinds !== undefined) {
-      if (!Array.isArray(kinds)) {
-        return [
-          {
-            path: "blocks.kinds",
-            message: "blocks.kinds must be an array of document kinds.",
-          },
-        ];
-      }
-      // An empty list accepts no document at all, so nothing could ever be
-      // stored — including the empty document a required field is seeded with.
-      // The contradiction is in the declaration, not in any value.
-      if (kinds.length === 0) {
-        return [
-          {
-            path: "blocks.kinds",
-            message:
-              "blocks.kinds cannot be empty: the field would accept no document at all. Omit it to accept a page.",
-          },
-        ];
-      }
-
-      // The kind set is closed. A declaration is the only place an unknown one
-      // can be refused outright: the engine validates documents in forgiving
-      // mode, where an unrecognised kind is a warning, and the policy check
-      // then compares against the same bad value — so the field would accept
-      // documents nothing else in the system understands, and seed and generate
-      // for them too.
-      const unknown = kinds.filter(
-        kind => !(DOCUMENT_KINDS as readonly unknown[]).includes(kind)
-      );
-      if (unknown.length > 0) {
-        return [
-          {
-            path: "blocks.kinds",
-            message: `blocks.kinds contains unknown document kinds: ${unknown
-              .map(String)
-              .join(", ")}. Accepted: ${DOCUMENT_KINDS.join(", ")}.`,
-          },
-        ];
-      }
-    }
-
-    return true;
-  },
-
-  /**
-   * What the field holds before anything is written to it.
-   *
-   * The kind is read from the field's own policy: seeding a page into a field
-   * that only accepts templates would store a value the same field rejects.
-   */
-  emptyValue: field => emptyBlockDocument(policyOf(field).kinds),
-
-  codegen: {
-    // Imported from this package rather than the engine directly: an app
-    // depends on the plugin, and the engine is only a transitive dependency it
-    // has no guarantee of being able to resolve by name.
-    tsImports: [
-      { names: ["BlockDocument"], from: "@nextlyhq/plugin-page-builder" },
-    ],
-    tsType: () => "BlockDocument",
+/**
+ * Build the field type against the site's breakpoints.
+ *
+ * A factory rather than only a constant, because the breakpoint set is the
+ * host's configuration: the plugin factory knows it, and the validator has no
+ * other road to it — a field type's `validate` receives the value, the
+ * request and the field instance, none of which carry site configuration.
+ * Handing the set in here is what lets a write be judged against the same
+ * breakpoints the canvas draws with.
+ */
+export function blocksFieldType(breakpoints?: BreakpointSet): PluginFieldType {
+  return {
+    type: BLOCKS_TYPE,
+    storage: "json",
+    component: BLOCKS_FIELD_COMPONENT,
+    label: "Blocks",
+    description: "Page built from blocks",
+    category: "Structured",
+    icon: "LayoutGrid",
 
     /**
-     * The envelope, pinned to the format version the engine supports and to
-     * the kinds this field accepts, so a value the generated schema admits is
-     * one the server admits too. Accepting any numeric version would let an app
-     * validate a document the write path then rejects. The node tree is checked
-     * in depth by the engine on write rather than restated here.
+     * The document's own rules, run on every write.
+     *
+     * The engine owns every structural rule — ids, depth, node and byte caps,
+     * slot legality, the kind enum — so this adapts its result rather than
+     * restating any of it. Issues are addressed to the field, because the admin
+     * renders a blocks field as a single control and the position inside the
+     * document travels in the message.
      */
-    zodSchema: field => {
-      const kinds = policyOf(field).kinds;
-      const accepted = kinds ?? ["page"];
-      const kindSchema = `z.enum([${accepted
-        .map(kind => `"${String(kind).replace(/["\\]/g, "\\$&")}"`)
-        .join(", ")}])`;
-      return `z.object({ formatVersion: z.literal(${DOCUMENT_FORMAT_VERSION}), kind: ${kindSchema}, nodes: z.array(z.unknown()) }).passthrough()`;
+    validate: (value, args) => {
+      const issues = validateBlocksValue(
+        value,
+        args.path,
+        typeof args.field.label === "string" ? args.field.label : args.path,
+        policyOf(args.field),
+        // The set this factory was built with; the empty set otherwise, which
+        // the engine treats permissively (a breakpoint reference warns).
+        breakpoints ?? siteBreakpoints()
+      );
+      return issues.length === 0 ? true : issues;
     },
-  },
-};
+
+    /**
+     * The declaration's own rules, run when a schema is registered.
+     *
+     * A policy that is the wrong shape, or one whose settings contradict each
+     * other, is a defect in the schema rather than in any value: reporting it
+     * per write would tell the writer, who cannot fix it, and would fail every
+     * write until whoever declared the field noticed.
+     */
+    validateOptions: field => {
+      const declared = (field as { blocks?: unknown }).blocks;
+      if (declared === undefined) return true;
+
+      if (
+        typeof declared !== "object" ||
+        declared === null ||
+        Array.isArray(declared)
+      ) {
+        return "blocks must be an object declaring allow and/or kinds.";
+      }
+
+      const { allow, kinds } = declared as { allow?: unknown; kinds?: unknown };
+
+      if (allow !== undefined) {
+        if (!Array.isArray(allow) || allow.some(e => typeof e !== "string")) {
+          return [
+            {
+              path: "blocks.allow",
+              message: "blocks.allow must be an array of block name strings.",
+            },
+          ];
+        }
+      }
+
+      if (kinds !== undefined) {
+        if (!Array.isArray(kinds)) {
+          return [
+            {
+              path: "blocks.kinds",
+              message: "blocks.kinds must be an array of document kinds.",
+            },
+          ];
+        }
+        // An empty list accepts no document at all, so nothing could ever be
+        // stored — including the empty document a required field is seeded with.
+        // The contradiction is in the declaration, not in any value.
+        if (kinds.length === 0) {
+          return [
+            {
+              path: "blocks.kinds",
+              message:
+                "blocks.kinds cannot be empty: the field would accept no document at all. Omit it to accept a page.",
+            },
+          ];
+        }
+
+        // The kind set is closed. A declaration is the only place an unknown one
+        // can be refused outright: the engine validates documents in forgiving
+        // mode, where an unrecognised kind is a warning, and the policy check
+        // then compares against the same bad value — so the field would accept
+        // documents nothing else in the system understands, and seed and generate
+        // for them too.
+        const unknown = kinds.filter(
+          kind => !(DOCUMENT_KINDS as readonly unknown[]).includes(kind)
+        );
+        if (unknown.length > 0) {
+          return [
+            {
+              path: "blocks.kinds",
+              message: `blocks.kinds contains unknown document kinds: ${unknown
+                .map(String)
+                .join(", ")}. Accepted: ${DOCUMENT_KINDS.join(", ")}.`,
+            },
+          ];
+        }
+      }
+
+      return true;
+    },
+
+    /**
+     * What the field holds before anything is written to it.
+     *
+     * The kind is read from the field's own policy: seeding a page into a field
+     * that only accepts templates would store a value the same field rejects.
+     */
+    emptyValue: field => emptyBlockDocument(policyOf(field).kinds),
+
+    codegen: {
+      // Imported from this package rather than the engine directly: an app
+      // depends on the plugin, and the engine is only a transitive dependency it
+      // has no guarantee of being able to resolve by name.
+      tsImports: [
+        { names: ["BlockDocument"], from: "@nextlyhq/plugin-page-builder" },
+      ],
+      tsType: () => "BlockDocument",
+
+      /**
+       * The envelope, pinned to the format version the engine supports and to
+       * the kinds this field accepts, so a value the generated schema admits is
+       * one the server admits too. Accepting any numeric version would let an app
+       * validate a document the write path then rejects. The node tree is checked
+       * in depth by the engine on write rather than restated here.
+       */
+      zodSchema: field => {
+        const kinds = policyOf(field).kinds;
+        const accepted = kinds ?? ["page"];
+        const kindSchema = `z.enum([${accepted
+          .map(kind => `"${String(kind).replace(/["\\]/g, "\\$&")}"`)
+          .join(", ")}])`;
+        return `z.object({ formatVersion: z.literal(${DOCUMENT_FORMAT_VERSION}), kind: ${kindSchema}, nodes: z.array(z.unknown()) }).passthrough()`;
+      },
+    },
+  };
+}
+
+/**
+ * The field type with no site breakpoints attached.
+ *
+ * Kept as a constant because it is public API and because a registry needs a
+ * stable identity to compare against; the plugin factory registers the
+ * breakpoint-aware instance instead.
+ */
+export const BLOCKS_FIELD_TYPE: PluginFieldType = blocksFieldType();

--- a/packages/plugin-page-builder/src/index.ts
+++ b/packages/plugin-page-builder/src/index.ts
@@ -56,6 +56,20 @@ export type {
 } from "./fields/blocks-options";
 export { blocks, isBlocksField } from "./fields/blocksHelper";
 export { pagesCollection } from "./collections/pages";
+
+/**
+ * Site style: the layered answer to "what does this site define".
+ *
+ * `resolveSiteStyle` is the one merge of config defaults and stored edits;
+ * `siteBreakpoints`/`siteSheet` read the merged result; `loadSiteStyle` is
+ * what a published route calls per request to serve the stored tier, passing
+ * the result as the route helper's `siteStyles`. The stored tier lives in the
+ * plugin-owned `site-style` single, named by `SITE_STYLE_SLUG`.
+ */
+export { resolveSiteStyle, siteBreakpoints, siteSheet } from "./site-style";
+export type { SiteStyleData } from "./site-style";
+export { SITE_STYLE_SLUG, loadSiteStyle } from "./site-style-storage";
+export type { SiteStyleReader } from "./site-style-storage";
 /*
  * `editorChoiceFields` is gone, along with the per-entry editor switch.
  *

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -16,7 +16,10 @@ import {
 } from "./blocks/registration-service";
 import { pagesCollection } from "./collections/pages";
 import type { RemotePattern } from "./core/url-policy";
-import { BLOCKS_FIELD_TYPE } from "./fields/blocksField";
+import { blocksFieldType } from "./fields/blocksField";
+import { resolveSiteStyle, siteBreakpoints } from "./site-style";
+import type { SiteStyleData } from "./site-style";
+import { siteStyleSingle } from "./site-style-storage";
 
 export interface PageBuilderOptions {
   /** Disable behavior while still applying schema. Default true. */
@@ -95,14 +98,38 @@ export interface PageBuilderOptions {
    * input.
    */
   remotePatterns?: readonly RemotePattern[];
+  /**
+   * The site's style DEFAULTS: tokens, fonts, named classes and breakpoints
+   * stated in code. The stored Site Style document layers over these —
+   * `resolveSiteStyle` in `site-style` is the one merge — so a site whose
+   * design lives in the repository states it here, and an admin's saved edit
+   * overrides exactly what it names and nothing else.
+   *
+   * Feeds two surfaces from one statement: the blocks field's server-side
+   * validator judges documents against these breakpoints, and the editor
+   * canvas compiles its preview sheet from the whole set (it travels through
+   * `clientConfig`, so it must hold nothing secret — it is emitted into the
+   * CSS of every public page anyway).
+   *
+   * A published route states the same value once more, on `loadSiteStyle`'s
+   * `defaults`, for the same reason `remotePatterns` appears on more than one
+   * surface: the route helper runs where this option cannot reach it. Define
+   * the object once and hand it to both.
+   */
+  siteStyle?: SiteStyleData;
 }
 
 /**
  * The Page Builder plugin factory. Call it in a host app's
  * `defineConfig({ plugins: [pageBuilder()] })`.
  */
-export const pageBuilder = (opts: PageBuilderOptions = {}) =>
-  definePlugin({
+export const pageBuilder = (opts: PageBuilderOptions = {}) => {
+  // Resolved once, with no stored tier: at config time there is no database to
+  // read, so what the factory can wire into the validator and the canvas is
+  // the defaults tier. The stored tier reaches the published route through
+  // `loadSiteStyle`, which reads per request.
+  const configStyle = resolveSiteStyle(opts.siteStyle);
+  return definePlugin({
     name: "@nextlyhq/plugin-page-builder",
     version: PLUGIN_VERSION,
     // The floor states the version carrying the APIs this plugin needs, not the
@@ -161,13 +188,21 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) =>
         [BLOCK_SERVICE]: () => createBlockRegistrationService(),
       },
       collections: [pagesCollection()],
+      // The Site Style global: one versioned, access-controlled document the
+      // stored style tier lives in. Registered whether or not the host stated
+      // defaults, because the storage existing is what the style studios and
+      // the API write against.
+      singles: [siteStyleSingle()],
       // One field type, where there were two. The other named the previous
       // editor's document — a shape this package defined itself, stored under a
       // synthetic root, and validated with its own rules. A site that declared
       // it got a field the engine could not read and the current renderer could
       // not draw, so the two field types were not alternatives but rival
       // formats, and only this one is a format anything else understands.
-      fieldTypes: [BLOCKS_FIELD_TYPE],
+      // Built against the configured breakpoints, so a document write is
+      // validated against the same set the canvas draws with. With none
+      // configured this is the empty set, which the engine treats permissively.
+      fieldTypes: [blocksFieldType(siteBreakpoints(configStyle))],
       // No `publish` permission. One was declared here and nothing ever read
       // it: publishing a page is a status change on the entry, which
       // `update-pages` already covers, and no code path asked whether the user
@@ -186,7 +221,9 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) =>
         // `clientConfig` would make every future reader distinguish "the host
         // set this" from "the default is showing", which is what the absent
         // key already says.
-        ...(opts.remotePatterns !== undefined || opts.checklist !== undefined
+        ...(opts.remotePatterns !== undefined ||
+        opts.checklist !== undefined ||
+        opts.siteStyle !== undefined
           ? {
               clientConfig: {
                 ...(opts.remotePatterns === undefined
@@ -195,6 +232,13 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) =>
                 ...(opts.checklist === undefined
                   ? {}
                   : { checklist: opts.checklist }),
+                // The RESOLVED defaults tier rather than the raw option, so
+                // the canvas and the validator read one answer. Plain data:
+                // tokens, fonts, classes and breakpoints all serialize, and
+                // none of it is secret — a published page emits it as CSS.
+                ...(opts.siteStyle === undefined
+                  ? {}
+                  : { siteStyle: configStyle }),
               },
             }
           : {}),
@@ -218,3 +262,4 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) =>
       },
     },
   });
+};

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  checkStoredBreakpoints,
+  checkStoredClasses,
+  checkStoredFonts,
+  checkStoredTokens,
+  readSiteStyleRecord,
+} from "./site-style-record";
+
+/** One shape-valid stored token. */
+function token(name: string, light: string, dark?: string) {
+  return {
+    name,
+    kind: "color",
+    values: { light, ...(dark === undefined ? {} : { dark }) },
+  };
+}
+
+describe("checkStoredTokens", () => {
+  it("reports nothing for an absent section", () => {
+    expect(checkStoredTokens(undefined)).toEqual({ issues: [] });
+    expect(checkStoredTokens(null)).toEqual({ issues: [] });
+  });
+
+  it("refuses a section that is not a token set at all", () => {
+    const result = checkStoredTokens([token("color.primary", "#111111")]);
+    expect(result.value).toBeUndefined();
+    expect(result.issues).toHaveLength(1);
+  });
+
+  it("accepts a well-formed set, dark values included", () => {
+    const result = checkStoredTokens({
+      tokens: [token("color.primary", "#111111", "#eeeeee")],
+      darkMode: "media",
+    });
+    expect(result.issues).toEqual([]);
+    expect(result.value?.tokens[0]?.values.dark).toBe("#eeeeee");
+    expect(result.value?.darkMode).toBe("media");
+  });
+
+  it("reports a shape-broken entry AND excludes it from the narrowed value", () => {
+    const result = checkStoredTokens({
+      tokens: [token("color.primary", "#111111"), { name: "color.broken" }],
+    });
+    expect(result.issues).toHaveLength(1);
+    expect(result.value?.tokens.map(t => t.name)).toEqual(["color.primary"]);
+  });
+
+  it("reports what the engine's emitter refuses: a value that would fetch", () => {
+    const result = checkStoredTokens({
+      tokens: [token("color.primary", "url(https://evil.example/a.png)")],
+    });
+    // The message is the engine's own — the emitter is the validator.
+    expect(result.issues.join(" ")).toContain("would load a file");
+  });
+
+  it("reports a name that cannot become a custom property", () => {
+    const result = checkStoredTokens({
+      tokens: [token("color}body{", "#111111")],
+    });
+    expect(result.issues.join(" ")).toContain("is not a token name");
+  });
+});
+
+describe("checkStoredFonts", () => {
+  it("accepts a self-hosted face", () => {
+    const result = checkStoredFonts([
+      {
+        family: "Geist",
+        src: [{ url: "/fonts/geist.woff2", format: "woff2" }],
+      },
+    ]);
+    expect(result.issues).toEqual([]);
+    expect(result.value).toHaveLength(1);
+  });
+
+  it("carries the engine's refusal of a remote source to the writer", () => {
+    const result = checkStoredFonts([
+      { family: "Sneaky", src: [{ url: "https://cdn.example/f.woff2" }] },
+    ]);
+    expect(result.issues.join(" ")).toContain("another server");
+  });
+
+  it("refuses an entry that is not a face shape", () => {
+    const result = checkStoredFonts([{ family: "NoSrc" }]);
+    expect(result.issues).toHaveLength(1);
+    expect(result.value).toEqual([]);
+  });
+});
+
+describe("checkStoredClasses", () => {
+  const usable = {
+    id: "c1",
+    slug: "card",
+    orderIndex: 0,
+    styles: { base: { base: { color: "#111111" } } },
+  };
+
+  it("accepts a usable class", () => {
+    const result = checkStoredClasses([usable]);
+    expect(result.issues).toEqual([]);
+    expect(result.value).toEqual([usable]);
+  });
+
+  it("refuses a slug CSS cannot carry, with the engine's own predicate", () => {
+    const result = checkStoredClasses([{ ...usable, slug: "Card Title" }]);
+    expect(result.issues).toHaveLength(1);
+    expect(result.value).toEqual([]);
+  });
+
+  it("refuses a repeated slug: two rule sets on one selector", () => {
+    const result = checkStoredClasses([
+      usable,
+      { ...usable, id: "c2", orderIndex: 1 },
+    ]);
+    expect(result.issues.join(" ")).toContain('repeats the slug "card"');
+  });
+
+  it("refuses a repeated id: a node's reference would be ambiguous", () => {
+    const result = checkStoredClasses([
+      usable,
+      { ...usable, slug: "card-b", orderIndex: 1 },
+    ]);
+    expect(result.issues.join(" ")).toContain('repeats the id "c1"');
+  });
+
+  it("refuses a class with no numeric orderIndex", () => {
+    const result = checkStoredClasses([{ ...usable, orderIndex: "first" }]);
+    expect(result.issues).toHaveLength(1);
+  });
+});
+
+describe("checkStoredBreakpoints", () => {
+  it("accepts a set, reading an absent axis as empty", () => {
+    const result = checkStoredBreakpoints({
+      viewport: [
+        { id: "base", label: "Base" },
+        { id: "mobile", label: "Mobile", maxWidth: 640 },
+      ],
+    });
+    expect(result.issues).toEqual([]);
+    expect(result.value).toEqual({
+      viewport: [
+        { id: "base", label: "Base" },
+        { id: "mobile", label: "Mobile", maxWidth: 640 },
+      ],
+      container: [],
+    });
+  });
+
+  it("refuses an id repeated ACROSS axes: a style key carries no axis", () => {
+    const result = checkStoredBreakpoints({
+      viewport: [{ id: "base", label: "Base" }],
+      container: [{ id: "base", label: "Base" }],
+    });
+    expect(result.issues.join(" ")).toContain('repeats the id "base"');
+  });
+
+  it("refuses a non-positive maxWidth", () => {
+    const result = checkStoredBreakpoints({
+      viewport: [{ id: "mobile", label: "Mobile", maxWidth: 0 }],
+    });
+    expect(result.issues).toHaveLength(1);
+    expect(result.value?.viewport).toEqual([]);
+  });
+});
+
+describe("readSiteStyleRecord", () => {
+  it("reads the empty style from anything that is not a document", () => {
+    expect(readSiteStyleRecord(null)).toEqual({});
+    expect(readSiteStyleRecord("nonsense")).toEqual({});
+  });
+
+  it("keeps what it can type and drops what it cannot, silently", () => {
+    // The read posture: a legacy or hand-corrupted row must cost the broken
+    // entry, not every page on the site. The engine re-reports value-level
+    // problems at compile, so nothing is lost by not refusing here.
+    const style = readSiteStyleRecord({
+      tokens: {
+        tokens: [token("color.primary", "#123456"), { broken: true }],
+      },
+      classes: "not-an-array",
+      breakpoints: { viewport: [{ id: "base", label: "Base" }] },
+    });
+    expect(style.tokens?.tokens.map(t => t.name)).toEqual(["color.primary"]);
+    expect(style.classes).toBeUndefined();
+    expect(style.breakpoints?.viewport).toHaveLength(1);
+  });
+});

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -1,0 +1,354 @@
+/**
+ * Reading and checking a stored Site Style document, with the engine's rules.
+ *
+ * ## Two postures over ONE set of checks
+ *
+ * Each section (tokens, fonts, classes, breakpoints) has exactly one checker,
+ * and the write path and the read path differ only in what they do with its
+ * answer:
+ *
+ * - **Writes fail closed.** The Site Style single's field validators (in
+ *   `site-style-storage`) refuse the whole section on any issue, so garbage
+ *   never reaches storage quietly. The checks are the ENGINE's —
+ *   `emitTokenBlocks`, `validateFontFace`, `isUsableNamedClass` — because a
+ *   validator restated here would drift from the compiler it is guarding.
+ * - **Reads tolerate by narrowing.** Stored rows predate their validators, so
+ *   a read keeps what it can type and drops what it cannot, exactly as the
+ *   engine's own emitters drop what they cannot compile. A read that refused
+ *   would take down every page on the site over one legacy row.
+ *
+ * Isomorphic on purpose: only the engine is imported, so the editor canvas
+ * can narrow the serialized defaults it receives with the same checks the
+ * server writes by.
+ *
+ * @module @nextlyhq/plugin-page-builder/site-style-record
+ */
+import {
+  MAX_BREAKPOINTS_PER_AXIS,
+  MAX_NAMED_CLASSES,
+  TOKEN_KINDS,
+  emitTokenBlocks,
+  isPlainRecord,
+  isUsableNamedClass,
+  validateFontFace,
+  type BreakpointDef,
+  type BreakpointSet,
+  type FontFaceDef,
+  type NamedClass,
+  type SiteToken,
+  type SiteTokenSet,
+  type TokenKind,
+} from "@nextlyhq/blocks-engine";
+
+import { siteStyleOf, type SiteStyleData } from "./site-style";
+
+/**
+ * One section's verdict: the narrowed value a reader may use, and the issues
+ * a writer must not ignore.
+ *
+ * `value` is present whenever the section was SHAPE-readable — even when it
+ * carries value-level issues — because the engine already drops a bad token or
+ * face at compile time, per entry, and a read that pre-dropped whole sections
+ * would lose more than the compiler would. Entries the shape check itself
+ * cannot type are excluded from `value` AND reported, so a write refuses them
+ * and a read skips them, from the same finding.
+ */
+export interface SectionCheck<T> {
+  value?: T;
+  issues: string[];
+}
+
+/** An absent section: nothing stored, nothing wrong. */
+const EMPTY: SectionCheck<never> = { issues: [] };
+
+/** Shared shape guard: a string, when the slot allows one. */
+const optionalString = (value: unknown): value is string | undefined =>
+  value === undefined || typeof value === "string";
+
+/**
+ * The stored token set, checked with the engine's own rules.
+ *
+ * Shape first, because `emitTokenBlocks` walks entries it assumes are
+ * records — then the emitter itself, whose issues cover everything about
+ * VALUES: names that cannot become custom properties, missing light values,
+ * values CSS cannot hold, values that would fetch, colliding properties, and
+ * kind mismatches. Refusing on the emitter's whole report is deliberately
+ * stricter than the emitter (which writes a kind mismatch and warns): at
+ * write time the author is present to fix it, and accepting a value the
+ * browser will drop stores a defect for someone else to debug at render time.
+ */
+export function checkStoredTokens(raw: unknown): SectionCheck<SiteTokenSet> {
+  if (raw === undefined || raw === null) return EMPTY;
+  if (!isPlainRecord(raw) || !Array.isArray(raw.tokens)) {
+    return {
+      issues: ['Tokens must be an object with a "tokens" array.'],
+    };
+  }
+  const issues: string[] = [];
+  const tokens: SiteToken[] = [];
+  raw.tokens.forEach((entry: unknown, index) => {
+    if (
+      !isPlainRecord(entry) ||
+      typeof entry.name !== "string" ||
+      typeof entry.kind !== "string" ||
+      !(TOKEN_KINDS as readonly string[]).includes(entry.kind) ||
+      !isPlainRecord(entry.values) ||
+      typeof entry.values.light !== "string" ||
+      !optionalString(entry.values.dark) ||
+      !optionalString(entry.description)
+    ) {
+      issues.push(
+        `tokens[${index}] is not a token: it needs a string name, a kind (${TOKEN_KINDS.join(", ")}), and values with a light string (dark optional).`
+      );
+      return;
+    }
+    tokens.push({
+      name: entry.name,
+      kind: entry.kind as TokenKind,
+      values: {
+        light: entry.values.light,
+        ...(entry.values.dark === undefined ? {} : { dark: entry.values.dark }),
+      },
+      ...(entry.description === undefined
+        ? {}
+        : { description: entry.description }),
+      ...(isPlainRecord(entry.extensions)
+        ? { extensions: entry.extensions }
+        : {}),
+    });
+  });
+
+  if (!optionalString(raw.prefix)) {
+    issues.push("The token prefix must be a string when set.");
+  }
+  const darkMode = raw.darkMode;
+  if (
+    darkMode !== undefined &&
+    darkMode !== "attribute" &&
+    darkMode !== "media"
+  ) {
+    issues.push('darkMode must be "attribute" or "media" when set.');
+  }
+
+  const set: SiteTokenSet = {
+    tokens,
+    ...(typeof raw.prefix === "string" ? { prefix: raw.prefix } : {}),
+    ...(darkMode === "attribute" || darkMode === "media" ? { darkMode } : {}),
+  };
+  // The emitter is the validator: it is what will read this set on every
+  // page render, so its report is the one that counts. The selector is
+  // irrelevant to validation; the CSS is discarded.
+  for (const issue of emitTokenBlocks(set, ":root").issues) {
+    issues.push(issue.message);
+  }
+  return { value: set, issues };
+}
+
+/** The stored font faces, each checked by the engine's own face validator. */
+export function checkStoredFonts(
+  raw: unknown
+): SectionCheck<readonly FontFaceDef[]> {
+  if (raw === undefined || raw === null) return EMPTY;
+  if (!Array.isArray(raw)) {
+    return { issues: ["Fonts must be an array of font faces."] };
+  }
+  const issues: string[] = [];
+  const faces: FontFaceDef[] = [];
+  raw.forEach((entry: unknown, index) => {
+    const face = readFontFace(entry);
+    if (face === undefined) {
+      issues.push(
+        `fonts[${index}] is not a font face: it needs a string family and a src array of { url, format? } records.`
+      );
+      return;
+    }
+    faces.push(face);
+    // The engine decides what a servable face is — including the refusal of
+    // remote sources — so its messages travel to the writer verbatim.
+    for (const issue of validateFontFace(face, `fonts[${index}]`)) {
+      issues.push(issue.message);
+    }
+  });
+  return { value: faces, issues };
+}
+
+/** One face's shape, or nothing. Value rules stay `validateFontFace`'s. */
+function readFontFace(entry: unknown): FontFaceDef | undefined {
+  if (!isPlainRecord(entry)) return undefined;
+  if (typeof entry.family !== "string" || !Array.isArray(entry.src)) {
+    return undefined;
+  }
+  const src: FontFaceDef["src"][number][] = [];
+  for (const source of entry.src) {
+    const record: unknown = source;
+    if (
+      !isPlainRecord(record) ||
+      typeof record.url !== "string" ||
+      !optionalString(record.format)
+    ) {
+      return undefined;
+    }
+    src.push({
+      url: record.url,
+      ...(record.format === undefined ? {} : { format: record.format }),
+    });
+  }
+  if (
+    !optionalString(entry.weight) ||
+    !optionalString(entry.style) ||
+    !optionalString(entry.display) ||
+    !optionalString(entry.unicodeRange)
+  ) {
+    return undefined;
+  }
+  return {
+    family: entry.family,
+    src,
+    ...(entry.weight === undefined ? {} : { weight: entry.weight }),
+    ...(entry.style === undefined ? {} : { style: entry.style }),
+    ...(entry.display === undefined ? {} : { display: entry.display }),
+    ...(entry.unicodeRange === undefined
+      ? {}
+      : { unicodeRange: entry.unicodeRange }),
+  };
+}
+
+/**
+ * The stored class library.
+ *
+ * Usability per entry is the engine's `isUsableNamedClass` — the same
+ * predicate the compiler and the renderer consult, so a class stored here is
+ * a class they will read. `orderIndex` is checked on top because the
+ * predicate does not cover it, yet the type requires it and the library
+ * order is what precedence between classes MEANS.
+ *
+ * Duplicates are refused at write where the compiler would drop them at read:
+ * a duplicate slug puts two rule sets on one selector, and a duplicate id
+ * makes a node's reference ambiguous. Both are cheaper to reject while the
+ * writer is present than to explain after a page styles itself with the
+ * wrong preset.
+ */
+export function checkStoredClasses(
+  raw: unknown
+): SectionCheck<readonly NamedClass[]> {
+  if (raw === undefined || raw === null) return EMPTY;
+  if (!Array.isArray(raw)) {
+    return { issues: ["Classes must be an array of named classes."] };
+  }
+  const issues: string[] = [];
+  if (raw.length > MAX_NAMED_CLASSES) {
+    issues.push(
+      `The class library holds ${raw.length} entries; the compiler reads at most ${MAX_NAMED_CLASSES}.`
+    );
+  }
+  const classes: NamedClass[] = [];
+  const ids = new Set<string>();
+  const slugs = new Set<string>();
+  raw.forEach((entry: unknown, index) => {
+    if (!isUsableNamedClass(entry) || !Number.isFinite(entry.orderIndex)) {
+      issues.push(
+        `classes[${index}] is not a usable class: it needs a string id, a lowercase dash-separated slug, a numeric orderIndex and a styles record.`
+      );
+      return;
+    }
+    if (ids.has(entry.id)) {
+      issues.push(`classes[${index}] repeats the id "${entry.id}".`);
+      return;
+    }
+    if (slugs.has(entry.slug)) {
+      issues.push(`classes[${index}] repeats the slug "${entry.slug}".`);
+      return;
+    }
+    ids.add(entry.id);
+    slugs.add(entry.slug);
+    classes.push(entry);
+  });
+  return { value: classes, issues };
+}
+
+/**
+ * The stored breakpoint set.
+ *
+ * The rules are the ones the engine's validation states about the set it is
+ * handed: ids unique ACROSS both axes (a node's style key carries no axis, so
+ * a repeated id is ambiguous), at most `MAX_BREAKPOINTS_PER_AXIS` per axis,
+ * and a `maxWidth` that is a positive number when present. An absent axis
+ * reads as empty rather than refusing, so a document storing only viewport
+ * breakpoints — the common case — round-trips unchanged.
+ */
+export function checkStoredBreakpoints(
+  raw: unknown
+): SectionCheck<BreakpointSet> {
+  if (raw === undefined || raw === null) return EMPTY;
+  if (!isPlainRecord(raw)) {
+    return {
+      issues: ["Breakpoints must be an object with viewport/container arrays."],
+    };
+  }
+  const issues: string[] = [];
+  const seen = new Set<string>();
+  const readAxis = (axis: "viewport" | "container"): BreakpointDef[] => {
+    const rawAxis = raw[axis];
+    if (rawAxis === undefined) return [];
+    if (!Array.isArray(rawAxis)) {
+      issues.push(`breakpoints.${axis} must be an array.`);
+      return [];
+    }
+    if (rawAxis.length > MAX_BREAKPOINTS_PER_AXIS) {
+      issues.push(
+        `breakpoints.${axis} defines ${rawAxis.length} breakpoints; the maximum per axis is ${MAX_BREAKPOINTS_PER_AXIS}.`
+      );
+    }
+    const defs: BreakpointDef[] = [];
+    rawAxis.forEach((entry: unknown, index) => {
+      if (
+        !isPlainRecord(entry) ||
+        typeof entry.id !== "string" ||
+        entry.id === "" ||
+        typeof entry.label !== "string" ||
+        (entry.maxWidth !== undefined &&
+          (typeof entry.maxWidth !== "number" ||
+            !Number.isFinite(entry.maxWidth) ||
+            entry.maxWidth <= 0))
+      ) {
+        issues.push(
+          `breakpoints.${axis}[${index}] is not a breakpoint: it needs a string id, a label, and a positive maxWidth when one is set.`
+        );
+        return;
+      }
+      if (seen.has(entry.id)) {
+        issues.push(
+          `breakpoints.${axis}[${index}] repeats the id "${entry.id}"; ids must be unique across both axes.`
+        );
+        return;
+      }
+      seen.add(entry.id);
+      defs.push({
+        id: entry.id,
+        label: entry.label,
+        ...(entry.maxWidth === undefined ? {} : { maxWidth: entry.maxWidth }),
+      });
+    });
+    return defs;
+  };
+  const viewport = readAxis("viewport");
+  const container = readAxis("container");
+  return { value: { viewport, container }, issues };
+}
+
+/**
+ * The stored tier of the site style, read from a Site Style document.
+ *
+ * Reading posture: keep what the checkers could type, drop what they could
+ * not, and say nothing — the engine reports and skips value-level problems at
+ * compile, so re-reporting them per render would say the same thing twice.
+ */
+export function readSiteStyleRecord(doc: unknown): SiteStyleData {
+  if (!isPlainRecord(doc)) return {};
+  return siteStyleOf({
+    tokens: checkStoredTokens(doc.tokens).value,
+    fonts: checkStoredFonts(doc.fonts).value,
+    classes: checkStoredClasses(doc.classes).value,
+    breakpoints: checkStoredBreakpoints(doc.breakpoints).value,
+  });
+}

--- a/packages/plugin-page-builder/src/site-style-storage.ts
+++ b/packages/plugin-page-builder/src/site-style-storage.ts
@@ -1,0 +1,155 @@
+/**
+ * Where a site's style edits persist: the plugin-owned Site Style single.
+ *
+ * One global document — versioned, access-controlled, written through the
+ * ordinary single write path — holding the stored tier of the site style that
+ * `site-style.ts` layers over the config-supplied defaults. The arrangement is
+ * WordPress's theme.json + global-styles pairing: the code states a baseline,
+ * the stored document carries what admins changed, and one merge point
+ * resolves them.
+ *
+ * The section checkers live in `site-style-record`, which reads a stored
+ * document with the same rules these validators write by; this module is the
+ * server half — the single's schema, its fail-closed write validation, and
+ * the per-request loader a published route calls.
+ *
+ * Node-safe: no React, no admin imports. The single's validators run
+ * server-side on every write.
+ *
+ * @module @nextlyhq/plugin-page-builder/site-style-storage
+ */
+import { defineSingle, json } from "nextly/config";
+
+import { resolveSiteStyle, type SiteStyleData } from "./site-style";
+import {
+  checkStoredBreakpoints,
+  checkStoredClasses,
+  checkStoredFonts,
+  checkStoredTokens,
+  readSiteStyleRecord,
+  type SectionCheck,
+} from "./site-style-record";
+
+/** The single the stored tier lives in. One document per site, by design. */
+export const SITE_STYLE_SLUG = "site-style";
+
+/**
+ * A field `validate` that fails closed over one section checker.
+ *
+ * Any issue refuses the write — including the entries the shape check had to
+ * exclude, which each carry an issue of their own — so nothing that would be
+ * silently narrowed on read can be stored in the first place. An absent value
+ * is an empty section, exactly as for every other optional field.
+ */
+const refusing =
+  (check: (raw: unknown) => SectionCheck<unknown>) =>
+  (value: unknown): string | true => {
+    if (value === null || value === undefined) return true;
+    const { issues } = check(value);
+    return issues.length === 0 ? true : issues.join(" ");
+  };
+
+/**
+ * The Site Style single: the one global, versioned, access-controlled
+ * document a site's stored style edits live in.
+ *
+ * - `versions: true`, because a site's whole look changes in one write and a
+ *   restorable history is the difference between an experiment and an
+ *   accident.
+ * - Public read, because every anonymous page render is styled by this
+ *   document — its contents are emitted into the CSS of every public page,
+ *   so there is nothing to protect on the read side. Updates stay with the
+ *   role/permission checks every single falls back to.
+ * - Plain `json` fields rather than structured ones, because the shapes are
+ *   the ENGINE's contracts and the style studios that will edit them write
+ *   whole sections at a time; a field-per-property schema here would be a
+ *   third statement of shapes two packages already agree on.
+ */
+export function siteStyleSingle() {
+  return defineSingle({
+    slug: SITE_STYLE_SLUG,
+    label: { singular: "Site Style" },
+    versions: true,
+    // A function rather than a boolean: the single config validator accepts
+    // only functions for access rules. Public read is the intent — every
+    // anonymous page render is styled by this document, and its contents are
+    // emitted into the CSS of every public page, so there is nothing to
+    // protect on the read side. Updates stay with the role/permission checks
+    // every single falls back to.
+    access: { read: () => true },
+    admin: {
+      icon: "Palette",
+      description:
+        "Site-wide design tokens, fonts, classes and breakpoints for pages built from blocks.",
+    },
+    fields: [
+      json({
+        name: "tokens",
+        label: "Design tokens",
+        validate: refusing(checkStoredTokens),
+        admin: {
+          description:
+            'A token set: { tokens: [{ name, kind, values: { light, dark? } }], prefix?, darkMode? }. Values are per mode; "light" is what a reader with no mode set resolves.',
+        },
+      }),
+      json({
+        name: "fonts",
+        label: "Font faces",
+        validate: refusing(checkStoredFonts),
+        admin: {
+          description:
+            "Self-hosted @font-face definitions: [{ family, src: [{ url, format? }], weight?, style? }]. Files must live on this site.",
+        },
+      }),
+      json({
+        name: "classes",
+        label: "Named classes",
+        validate: refusing(checkStoredClasses),
+        admin: {
+          description:
+            "Reusable style presets: [{ id, slug, orderIndex, styles }]. Documents reference a class by id; a later orderIndex overrides an earlier one.",
+        },
+      }),
+      json({
+        name: "breakpoints",
+        label: "Breakpoints",
+        validate: refusing(checkStoredBreakpoints),
+        admin: {
+          description:
+            "The site's breakpoints: { viewport: [{ id, label, maxWidth? }], container: [...] }. Ids must be unique across both axes; the base breakpoint has no maxWidth.",
+        },
+      }),
+    ],
+  });
+}
+
+/**
+ * The one read a route needs: the stored single. Structural rather than the
+ * generated reader type, because the generated single-slug union is the HOST
+ * app's — it may not exist yet when this plugin is being wired, and this
+ * document's slug is the plugin's to know.
+ */
+export interface SiteStyleReader {
+  findSingle(args: { slug: string }): Promise<unknown>;
+}
+
+/**
+ * The site style a published route serves: config defaults with the stored
+ * document layered on top, ready to hand to a route helper's `siteStyles`.
+ *
+ * Called per request (route helpers accept it as an async provider), so an
+ * admin's saved edit reaches the next page view rather than the next deploy.
+ * A site that has never stored anything gets its defaults back: a single with
+ * no row reads as a default document whose sections are all absent.
+ *
+ * Errors propagate. A read that cannot reach the database will fail the page
+ * render anyway; catching here would serve an unstyled page that looks like a
+ * content decision instead of an outage.
+ */
+export async function loadSiteStyle(args: {
+  nextly: SiteStyleReader;
+  defaults?: SiteStyleData;
+}): Promise<SiteStyleData> {
+  const doc = await args.nextly.findSingle({ slug: SITE_STYLE_SLUG });
+  return resolveSiteStyle(args.defaults, readSiteStyleRecord(doc));
+}

--- a/packages/plugin-page-builder/src/site-style.test.ts
+++ b/packages/plugin-page-builder/src/site-style.test.ts
@@ -1,0 +1,177 @@
+import type {
+  BreakpointSet,
+  FontFaceDef,
+  NamedClass,
+  SiteTokenSet,
+} from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveSiteStyle,
+  siteBreakpoints,
+  siteSheet,
+  type SiteStyleData,
+} from "./site-style";
+
+/** A token set holding the given tokens and nothing site-wide. */
+function tokens(
+  entries: Array<{ name: string; light: string; dark?: string }>
+): SiteTokenSet {
+  return {
+    tokens: entries.map(entry => ({
+      name: entry.name,
+      kind: "color" as const,
+      values: {
+        light: entry.light,
+        ...(entry.dark === undefined ? {} : { dark: entry.dark }),
+      },
+    })),
+  };
+}
+
+/** A named class carrying just enough styles to be distinguishable. */
+function cls(id: string, slug: string, orderIndex: number): NamedClass {
+  return { id, slug, orderIndex, styles: { base: { base: { color: id } } } };
+}
+
+/** A face whose identity is its family/weight/style triple. */
+function face(family: string, weight?: string, style?: string): FontFaceDef {
+  return {
+    family,
+    src: [{ url: `/fonts/${family}.woff2`, format: "woff2" }],
+    ...(weight === undefined ? {} : { weight }),
+    ...(style === undefined ? {} : { style }),
+  };
+}
+
+const VIEWPORT_ONLY: BreakpointSet = {
+  viewport: [{ id: "base", label: "Base" }],
+  container: [],
+};
+
+describe("resolveSiteStyle", () => {
+  it("answers the empty style when nothing is stated on either tier", () => {
+    expect(resolveSiteStyle()).toEqual({});
+    expect(resolveSiteStyle({}, {})).toEqual({});
+  });
+
+  it("passes a lone tier through, whichever side states it", () => {
+    const style: SiteStyleData = {
+      tokens: tokens([{ name: "color.primary", light: "#111111" }]),
+    };
+    expect(resolveSiteStyle(style, undefined).tokens).toEqual(style.tokens);
+    expect(resolveSiteStyle(undefined, style).tokens).toEqual(style.tokens);
+  });
+
+  it("merges tokens by NAME, stored winning, defaults surviving", () => {
+    const merged = resolveSiteStyle(
+      {
+        tokens: tokens([
+          { name: "color.primary", light: "#111111" },
+          { name: "content.width", light: "60rem" },
+        ]),
+      },
+      { tokens: tokens([{ name: "color.primary", light: "#222222" }]) }
+    );
+    const byName = new Map(
+      (merged.tokens?.tokens ?? []).map(t => [t.name, t.values.light])
+    );
+    // The stored value took the name it stated; the default it did not name
+    // survived — losing it would silently invalidate every declaration that
+    // reads it, which is the failure per-name merging exists to prevent.
+    expect(byName.get("color.primary")).toBe("#222222");
+    expect(byName.get("content.width")).toBe("60rem");
+  });
+
+  it("takes prefix and darkMode from the stored tier when stated", () => {
+    const merged = resolveSiteStyle(
+      { tokens: { tokens: [], prefix: "--acme-", darkMode: "media" } },
+      { tokens: { tokens: [], prefix: "--brand-" } }
+    );
+    expect(merged.tokens?.prefix).toBe("--brand-");
+    // Unstated on the stored tier, so the default's site-wide choice holds.
+    expect(merged.tokens?.darkMode).toBe("media");
+  });
+
+  it("merges classes by ID, stored winning, defaults surviving", () => {
+    const merged = resolveSiteStyle(
+      { classes: [cls("a", "card", 0), cls("b", "hero", 1)] },
+      { classes: [cls("a", "card-tight", 5)] }
+    );
+    const byId = new Map((merged.classes ?? []).map(c => [c.id, c]));
+    expect(byId.get("a")?.slug).toBe("card-tight");
+    expect(byId.get("a")?.orderIndex).toBe(5);
+    expect(byId.get("b")?.slug).toBe("hero");
+  });
+
+  it("merges fonts by face identity: same family, different style, both kept", () => {
+    const merged = resolveSiteStyle(
+      { fonts: [face("Geist"), face("Geist", undefined, "italic")] },
+      { fonts: [face("Geist")] }
+    );
+    // The stored regular replaced the default regular; the italic — a
+    // different face of the same family — survived.
+    expect(merged.fonts).toHaveLength(2);
+    expect(merged.fonts?.[0]).toEqual(face("Geist"));
+    expect(merged.fonts?.[1]).toEqual(face("Geist", undefined, "italic"));
+  });
+
+  it("replaces breakpoints as a WHOLE set when the stored one defines any", () => {
+    const stored: BreakpointSet = {
+      viewport: [
+        { id: "base", label: "Base" },
+        { id: "narrow", label: "Narrow", maxWidth: 480 },
+      ],
+      container: [],
+    };
+    const merged = resolveSiteStyle(
+      { breakpoints: VIEWPORT_ONLY },
+      { breakpoints: stored }
+    );
+    // No splicing: the stored cascade wins outright.
+    expect(merged.breakpoints).toEqual(stored);
+  });
+
+  it("treats an EMPTY stored breakpoint set as not configured", () => {
+    const merged = resolveSiteStyle(
+      { breakpoints: VIEWPORT_ONLY },
+      { breakpoints: { viewport: [], container: [] } }
+    );
+    expect(merged.breakpoints).toEqual(VIEWPORT_ONLY);
+  });
+});
+
+describe("siteBreakpoints", () => {
+  it("answers the empty set with no style, so unwired callers stay permissive", () => {
+    expect(siteBreakpoints()).toEqual({ viewport: [], container: [] });
+  });
+
+  it("answers the merged style's set when one is defined", () => {
+    expect(siteBreakpoints({ breakpoints: VIEWPORT_ONLY })).toBe(VIEWPORT_ONLY);
+  });
+});
+
+describe("siteSheet", () => {
+  it("omits undefined sections rather than defaulting them", () => {
+    // An invented section would preview a design no published page has; the
+    // sheet compiler treats an absent key as "the site defines none".
+    expect(siteSheet()).toEqual({
+      breakpoints: { viewport: [], container: [] },
+    });
+  });
+
+  it("carries every defined section through to the sheet input", () => {
+    const style: SiteStyleData = {
+      tokens: tokens([{ name: "color.primary", light: "#123456" }]),
+      classes: [cls("a", "card", 0)],
+      fonts: [face("Geist")],
+      breakpoints: VIEWPORT_ONLY,
+    };
+    expect(siteSheet(style)).toEqual({
+      tokens: style.tokens,
+      classes: style.classes,
+      fonts: style.fonts,
+      breakpoints: VIEWPORT_ONLY,
+    });
+  });
+});

--- a/packages/plugin-page-builder/src/site-style.ts
+++ b/packages/plugin-page-builder/src/site-style.ts
@@ -1,51 +1,209 @@
 /**
  * The site's style inputs, in one place.
  *
- * Breakpoints are site-level data this plugin owns: the engine never reads
- * storage, so it validates against whatever set it is handed, and a document
- * naming a breakpoint id warns rather than errors until the real set arrives.
- * That arrangement is what keeps the engine storage-agnostic, and it puts the
- * answer here.
+ * Tokens, fonts, named classes and breakpoints are site-level data this plugin
+ * owns: the engine never reads storage, so it validates and compiles against
+ * whatever set it is handed, and the answer to "what does this site define"
+ * has to come from here.
  *
- * It lives in its own module because TWO surfaces need it and they must not
- * disagree. The field validator compiles a document against these breakpoints;
- * the editor canvas compiles the site sheet against them to draw the same
- * document. Two empty sets written separately look identical on the day they
- * are written, and the day one of them gains a real breakpoint is the day the
- * canvas draws a layout the validator does not accept — with each side
- * internally consistent, so nothing looks wrong.
+ * The inputs are LAYERED, and this module is the one merge point:
+ *
+ * 1. Config-supplied defaults — what the host's code states on the
+ *    `pageBuilder({ siteStyle })` factory. A site whose design lives in the
+ *    repository states it here and needs no database row.
+ * 2. The stored Site Style document — what admins write through the API or,
+ *    later, the style studios. Stored values override config defaults.
+ *
+ * `resolveSiteStyle` is the one implementation of that layering. The engine
+ * applies a third, lower tier on its own — `resolveSiteTokens` layers the
+ * merged token set over the engine's guaranteed defaults — so the full order
+ * on a published page is engine defaults, then config defaults, then stored
+ * edits: the theme.json arrangement of core, then the theme, then the user's
+ * saved styles.
+ *
+ * It lives in its own module because SEVERAL surfaces need it and they must
+ * not disagree. The field validator compiles a document against these
+ * breakpoints; the editor canvas compiles the site sheet against them to draw
+ * the same document; the published route compiles the sheet it serves. Two
+ * merges written separately look identical on the day they are written, and
+ * the day they diverge the canvas draws a layout the validator does not
+ * accept — with each side internally consistent, so nothing looks wrong.
  *
  * Node-safe: no React, no admin imports. The validator runs server-side.
  *
  * @module @nextlyhq/plugin-page-builder/site-style
  */
-import type { BreakpointSet, SiteSheetInput } from "@nextlyhq/blocks-engine";
+import type {
+  BreakpointSet,
+  FontFaceDef,
+  NamedClass,
+  SiteSheetInput,
+  SiteToken,
+  SiteTokenSet,
+} from "@nextlyhq/blocks-engine";
+
+/**
+ * One tier of site style: what a host's config states, or what the stored
+ * Site Style document holds. Every shape is the engine's own — a parallel
+ * declaration here would be a second statement of the same contract, free to
+ * drift from the one the compiler reads.
+ *
+ * `tokens` carries modes already: a `SiteToken`'s `values` holds `light`
+ * (required) and `dark` (optional), so a stored token set never needs a
+ * format migration when the mode UI arrives.
+ */
+export interface SiteStyleData {
+  /** Design tokens, with per-mode values. Emitted as custom properties. */
+  tokens?: SiteTokenSet;
+  /** Self-hosted font faces. Remote sources are refused by the engine. */
+  fonts?: readonly FontFaceDef[];
+  /** The named-class library, in the order classes override one another. */
+  classes?: readonly NamedClass[];
+  /** The site's breakpoints, on both axes. */
+  breakpoints?: BreakpointSet;
+}
+
+/**
+ * The merged site style: config defaults with stored edits layered on top.
+ *
+ * The granularity of "layered" differs by section, and each choice follows
+ * from what a partial override would mean there:
+ *
+ * - **Tokens merge by NAME.** A site storing one brand colour must not lose
+ *   the config's `content.width` — an unresolved custom property invalidates
+ *   the declaration silently, so replacement fails invisibly. Same reasoning,
+ *   same shape, as the engine's `resolveSiteTokens`, which this result is
+ *   later handed to for the engine-defaults tier. `prefix` and `darkMode` are
+ *   site-wide decisions, not per-token values, so the stored ones win when
+ *   stated.
+ * - **Classes merge by ID.** A document references a class by its id, so the
+ *   id is the unit of override: a stored class replaces the config class with
+ *   the same id and keeps every other one. Each entry keeps its own
+ *   `orderIndex`; precedence stays the engine's question.
+ * - **Fonts merge by face identity** — family, weight and style together,
+ *   because one family legitimately ships several faces and replacing by
+ *   family alone would drop the italics when someone re-uploads the regular.
+ * - **Breakpoints REPLACE as a whole set.** A breakpoint set is one designed
+ *   cascade; splicing half of one set into half of another produces at-rules
+ *   nobody chose. A stored set that defines any breakpoint wins outright; an
+ *   empty stored set means "not configured" and leaves the defaults standing.
+ */
+export function resolveSiteStyle(
+  defaults?: SiteStyleData,
+  stored?: SiteStyleData
+): SiteStyleData {
+  return siteStyleOf({
+    tokens: mergeTokens(defaults?.tokens, stored?.tokens),
+    fonts: mergeByKey(defaults?.fonts, stored?.fonts, faceIdentity),
+    classes: mergeByKey(defaults?.classes, stored?.classes, c => c.id),
+    breakpoints: hasBreakpoints(stored?.breakpoints)
+      ? stored?.breakpoints
+      : defaults?.breakpoints,
+  });
+}
+
+/**
+ * A style whose keys are only the DEFINED sections.
+ *
+ * An `undefined` property and an absent one mean the same thing to a reader,
+ * but not to everything downstream: `{ tokens: undefined }` overrides a
+ * spread's earlier value and survives `Object.keys`, so "absent means the
+ * site defines none" only holds if absence is real. One place builds the
+ * object so every producer of a `SiteStyleData` says absence the same way.
+ */
+export function siteStyleOf(sections: SiteStyleData): SiteStyleData {
+  return {
+    ...(sections.tokens === undefined ? {} : { tokens: sections.tokens }),
+    ...(sections.fonts === undefined ? {} : { fonts: sections.fonts }),
+    ...(sections.classes === undefined ? {} : { classes: sections.classes }),
+    ...(sections.breakpoints === undefined
+      ? {}
+      : { breakpoints: sections.breakpoints }),
+  };
+}
+
+/** Whether a set defines any breakpoint at all, on either axis. */
+function hasBreakpoints(set: BreakpointSet | undefined): boolean {
+  return (
+    set !== undefined && (set.viewport.length > 0 || set.container.length > 0)
+  );
+}
+
+/** What makes two font faces the same face: family, weight and style. */
+function faceIdentity(face: FontFaceDef): string {
+  // Weight and style default at emission (`normal` both), so an absent value
+  // and the default spelled out are the same face and must collide here.
+  return `${face.family} ${face.weight ?? "normal"} ${face.style ?? "normal"}`;
+}
+
+/**
+ * Defaults first, then overrides, each entry keyed by its identity — so an
+ * override with a known key replaces the default and a new key appends.
+ */
+function mergeByKey<T>(
+  defaults: readonly T[] | undefined,
+  overrides: readonly T[] | undefined,
+  keyOf: (entry: T) => string
+): readonly T[] | undefined {
+  if (defaults === undefined && overrides === undefined) return undefined;
+  const byKey = new Map<string, T>();
+  // Iterated rather than spread, so a later duplicate WITHIN one tier also
+  // wins — the same rule the engine applies to duplicate token names.
+  for (const entry of defaults ?? []) byKey.set(keyOf(entry), entry);
+  for (const entry of overrides ?? []) byKey.set(keyOf(entry), entry);
+  return [...byKey.values()];
+}
+
+/** Token sets merged by token name; `prefix`/`darkMode` from the override. */
+function mergeTokens(
+  defaults: SiteTokenSet | undefined,
+  stored: SiteTokenSet | undefined
+): SiteTokenSet | undefined {
+  if (defaults === undefined && stored === undefined) return undefined;
+  const tokens = mergeByKey<SiteToken>(
+    defaults?.tokens,
+    stored?.tokens,
+    token => token.name
+  );
+  const prefix = stored?.prefix ?? defaults?.prefix;
+  const darkMode = stored?.darkMode ?? defaults?.darkMode;
+  return {
+    tokens: tokens === undefined ? [] : [...tokens],
+    ...(prefix === undefined ? {} : { prefix }),
+    ...(darkMode === undefined ? {} : { darkMode }),
+  };
+}
 
 /**
  * The site's breakpoints.
  *
- * Empty because this plugin has nowhere to store them yet. Stated as a value
- * rather than left implicit so the storage, when it lands, has exactly one
- * function to replace — and both consumers move together by construction.
+ * Read from the merged style rather than declared here, so the storage has
+ * exactly one function every consumer goes through — and the validator, the
+ * canvas and the published route move together by construction. Called with
+ * nothing it answers the empty set, which is what a consumer with no access
+ * to the merged style validates against; the engine treats an unknown
+ * breakpoint id as a warning in forgiving mode, so that consumer stays
+ * permissive rather than wrong.
  */
-export function siteBreakpoints(): BreakpointSet {
-  return { viewport: [], container: [] };
+export function siteBreakpoints(style?: SiteStyleData): BreakpointSet {
+  return style?.breakpoints ?? { viewport: [], container: [] };
 }
 
 /**
- * What the editor canvas compiles its stylesheet from.
+ * What a canvas or a published route compiles its site stylesheet from.
  *
- * Only `breakpoints` is populated today. `tokens`, `fonts`, `classes` and
- * `blockBases` are a site's own design inputs, supplied by the host route's
- * config on a published page, and this plugin does not store them — so they are
- * OMITTED rather than defaulted. An invented token set would render a canvas
- * that looks finished and matches no published page, which is worse than one
- * that plainly shows block defaults: a wrong preview is trusted, an unstyled
- * one is questioned.
- *
- * The gap is real and worth naming: until a site's tokens reach the admin, the
- * canvas is a structural preview rather than a visual proof.
+ * Sections the merged style does not define are OMITTED rather than
+ * defaulted. An invented token set would render a canvas that looks finished
+ * and matches no published page, which is worse than one that plainly shows
+ * block defaults: a wrong preview is trusted, an unstyled one is questioned.
+ * `blockBases` is never part of site style — a block type's default look
+ * belongs to the block's definition, not to a site's stored edits.
  */
-export function siteSheet(): SiteSheetInput {
-  return { breakpoints: siteBreakpoints() };
+export function siteSheet(style?: SiteStyleData): SiteSheetInput {
+  return {
+    ...(style?.tokens === undefined ? {} : { tokens: style.tokens }),
+    ...(style?.fonts === undefined ? {} : { fonts: style.fonts }),
+    ...(style?.classes === undefined ? {} : { classes: style.classes }),
+    breakpoints: siteBreakpoints(style),
+  };
 }


### PR DESCRIPTION
## Summary

Site-level style inputs — design tokens (with light/dark values), self-hosted fonts, named classes and breakpoints — now have somewhere to live. `site-style.ts`'s "nowhere to store them yet" gap is closed with a **layered storage model**, mirroring WordPress's theme.json + global-styles pairing:

- **Stored tier** — a plugin-owned, versioned, access-controlled **Site Style single** (`site-style`), registered through `contributes.singles`. Written via the ordinary single write path (API/ops first; the style studios come later). Public read (its contents are emitted into the CSS of every public page); updates stay behind the usual role checks; `versions: true` records a restorable history.
- **Config tier** — a new `pageBuilder({ siteStyle })` option for code-stated defaults.
- **One merge point** — `resolveSiteStyle(defaults, stored)` in `site-style.ts`: tokens merge by NAME, classes by ID, fonts by face identity (family+weight+style), breakpoints replace as a whole set. The engine's `resolveSiteTokens` then layers the result over its guaranteed defaults, so a published page resolves engine → config → stored, the theme.json order.
- **Modes are in the stored schema from day one** — the stored token shape is the engine's `SiteToken`, whose `values` carry `light` (required) and `dark` (optional); the e2e proves a stored dark value round-trips into the served sheet's dark block. No format migration when the mode UI arrives.

### Feeding the consumers

- **Published route**: `loadSiteStyle({ nextly, defaults })` reads the stored single per request, merges, and is passed as the route helper's `siteStyles`. `BlocksPageConfig.siteStyles` now also accepts an async provider (same pattern as its `styles`), because a route module's config is captured once per process — a plain value would freeze an admin's saved tokens until the next deploy.
- **Field validator**: the `blocks` field type is now built by the plugin factory against the configured breakpoints (`blocksFieldType(breakpoints)`), so a document write is judged against the same set the canvas draws with. `validateBlocksValue` gained an optional `breakpoints` parameter; the zero-arg fallback is the empty set, which the engine treats permissively.
- **Editor canvas**: reads the resolved config defaults through `clientConfig` and compiles its preview sheet from them. Deliberately defaults-only for now: the stored tier reaching the canvas needs a fetch this surface doesn't have, and belongs to the style-studio wave — documented at the call site.

### Fail-closed writes, tolerant reads

One set of checkers (`site-style-record.ts`), two postures. The single's field validators refuse any section with issues — composed from the **engine's own rules** (`emitTokenBlocks`, `validateFontFace`, `isUsableNamedClass`, `MAX_BREAKPOINTS_PER_AXIS`, `MAX_NAMED_CLASSES` — the latter newly exported from the engine), never a parallel validator. Reads narrow: they keep what they can type and drop what they cannot, because a read that refused would take down every page over one legacy row.

### Playground

The playground states its breakpoints once (`site-style-defaults.ts`) and feeds all three surfaces from it; both public block routes call `loadSiteStyle` per request.

### A defect this surfaced, fixed here

`PageRenderer` compiled its shared sheet's `.nx-c-<slug>` rules from `siteStyles.classes`, but a node's stored class IDS resolve to class NAMES during the page's own compile — from the context's `namedClasses`, which no route supplied. A stored class therefore emitted a rule no element ever carried, each half internally consistent. The renderer now feeds its page compile from the same `siteStyles.classes` list the sheet reads (a context stating its own `namedClasses` still outranks it, matching the `blockBases` rule). Found by the e2e's computed-color assertion — the sheet-text assertion alone passed on the broken join.

## Test plan

- **e2e (`e2e/tests/site-style.spec.ts`)** — the acceptance, asserted on served output:
  - a stored token's custom property reaches a published page's site sheet verbatim, in BOTH modes (dark under the `[data-nx-theme="dark"]` selector);
  - a stored named class is emitted as a `.nx-c-<slug>` rule AND a node referencing it by id renders with the computed color;
  - a token value that would fetch (`url(...)`) is refused by the write path, and the page keeps serving the last good value.
- **Unit** — `site-style.test.ts` (merge precedence per section, empty-set breakpoint rule, sheet omission semantics), `site-style-record.test.ts` (fail-closed checks, engine-message forwarding, read narrowing), and two `site-sheet.test.tsx` cases for the renderer's class-list reconciliation (attribution through `siteStyles.classes`; a context's own `namedClasses` outranks). All new tests were broken-and-restored: precedence swap, emitter-issue drop, empty-set rule, duplicate-class detection, reconciliation removal, and a loader that ignores storage each failed exactly the intended test(s).
- Full `plugin-page-builder` (100), `blocks-react` (635) and `blocks-engine` (1267) unit suites pass; `check-types` passes for plugin-page-builder, blocks-react, blocks-engine and the playground; lint clean; comment-convention and fallow gates pass.

## Changeset

One patch changeset covering all published packages (lockstep): `.changeset/site-style-has-somewhere-to-live.md`.

## Notes for reviewers

- An observation, not changed here: `emitTokenBlocks`'s attribute-strategy dark block is emitted as `[data-nx-theme="dark"] :root{...}` in the site sheet (where the token selector is `:root`), a selector that cannot match if the attribute is set on `<html>` itself. Pre-existing engine behavior; this PR asserts emission, not application, of dark values.
- `BLOCKS_FIELD_TYPE` stays exported (public API); the factory registers a breakpoint-aware instance built by the new `blocksFieldType()`.
