### PR TITLE
fix(nextly): the single-create schema-change test compiles

### DIFF
--- a/packages/nextly/src/domains/singles/__tests__/single-create-schema-change.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-create-schema-change.integration.test.ts
@@ -43,7 +43,6 @@ import {
 } from "../../../plugins/test-nextly";
 import { introspectLiveSnapshot } from "../../schema/pipeline/diff/introspect-live";
 import { tableHasRows } from "../../schema/pipeline/live-table-facts";
-import type { SingleEntryService } from "../services/single-entry-service";
 let current: TestNextly | undefined;
 
 afterEach(async () => {
@@ -290,8 +289,7 @@ for (const dialect of getConfiguredTestDialects()) {
           fields: [{ name: "body", type: "text" }],
         }
       );
-      const entries =
-        current.getService<SingleEntryService>("singleEntryService");
+      const entries = current.getService("singleEntryService");
       const written = await entries.update(
         slug,
         { body: "kept" },
@@ -444,6 +442,9 @@ for (const dialect of getConfiguredTestDialects()) {
           fields: [{ name: "body", type: "text" }],
           source: "ui",
           locked: false,
+          // Required by the input type. Any value does: the create is rejected on the name
+          // collision below before the hash is ever read.
+          schemaHash: "hash-collision-probe",
         })
       ).rejects.toThrow(/already exists/);
 


### PR DESCRIPTION
`check-types` is red on `main`. Three errors, all in one file, all from `db03aac59 "fix(nextly): reset an orphan's junction tables and cover the in-exclusion guard"`.

## Why the gate caught it and review didn't

`tsconfig.json` excludes `**/*.test.ts`, so no test file is checked by the package's own config. `tsconfig.tests.json` exists to close that, and it checks every test file **except an opt-out list that is documented as one that shrinks**:

> The list is an opt-out that shrinks: deleting an entry and fixing that file is always an improvement, and adding one is a regression that should be argued for in review.

This file arrived not compiling and not on the list, so it failed the gate rather than being excused by it. That is the gate working exactly as designed.

## The three errors, which are two mistakes

**`getService` is generic over the service KEY, not the service type** (`di/register.ts:2843`):

```ts
export function getService<T extends keyof ServiceMap>(name: T): ServiceMap[T]
```

So `getService<SingleEntryService>("singleEntryService")` puts a class where `keyof ServiceMap` is required — `TS2344` — and the resulting `unknown` is what `TS18046` then reports on the next line. The key alone infers the right type, so the now-unused type import goes with it.

**`CreateSingleInput` requires `schemaHash`**, which the call omitted — `TS2345`. The value is arbitrary here because the call is asserted to be rejected on the name collision before the hash is ever read, and the comment says so rather than leaving a bare string looking meaningful.

## Evidence

```
before:  3 errors in single-create-schema-change.integration.test.ts
after:   turbo check-types lint --filter=nextly --force
         exit 0, 8 successful, 0 cached
```

**Verified by running it, not only by compiling it.** Adding a required field to a call changes what the call does, so a green typecheck is not sufficient evidence that the test still exercises what it claims:

```
TEST_POSTGRES_URL=... vitest run --config vitest.integration.config.ts \
  src/domains/singles/__tests__/single-create-schema-change.integration.test.ts
Test Files  1 passed (1)
Tests  22 passed (22)
```

against the real PostgreSQL 17 container.

## One thing I deliberately did not do

`src/domains/singles/__tests__/custom-read-constraint.integration.test.ts` makes the **identical** `getService` mistake and is invisible because it IS on the opt-out list. I left it alone: this change fixes the gate rather than starting a repo-wide cleanup, and the list is precisely the record of what remains. Shrinking it further is a good separate change.

## Not verified

I did not run the MySQL or SQLite legs of this file, only PostgreSQL. The change is dialect-independent — a generic parameter and a missing field — but I did not measure the other two.

No changeset: test-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test metadata to include the required schema identifier.
  * Simplified test setup by removing an unnecessary type reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->