### PR TITLE
ci: stop one failing gate from silencing the rest of the job

### DIFF
--- a/.changeset/canvas-undo-declines-while-typing.md
+++ b/.changeset/canvas-undo-declines-while-typing.md
@@ -1,5 +1,4 @@
 ---
-
 "nextly": patch
 "create-nextly-app": patch
 "@nextlyhq/admin": patch
@@ -19,11 +18,13 @@
 "@nextlyhq/plugin-seo": patch
 "@nextlyhq/plugin-sdk": patch
 "@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
 "@nextlyhq/prettier-config": patch
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/builder": patch
 "@nextlyhq/module-specifiers": patch
+---
 
 Pressing undo while typing a block's text on the canvas rewound the document instead of the words.
 The author lost a block move they had finished with, kept the sentence they wanted back, and got no

--- a/.changeset/rich-text-editor-kit.md
+++ b/.changeset/rich-text-editor-kit.md
@@ -18,6 +18,7 @@
 "@nextlyhq/plugin-seo": patch
 "@nextlyhq/plugin-sdk": patch
 "@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
 "@nextlyhq/prettier-config": patch
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch

--- a/.changeset/rich-text-editor-kit.md
+++ b/.changeset/rich-text-editor-kit.md
@@ -1,5 +1,4 @@
 ---
-
 "nextly": patch
 "create-nextly-app": patch
 "@nextlyhq/admin": patch
@@ -24,6 +23,7 @@
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/builder": patch
 "@nextlyhq/module-specifiers": patch
+---
 
 A surface that needs to edit this site's rich text outside the admin's own field — the page builder's
 canvas is the first — can now load the same node classes and theme the field editor registers, through

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,21 +277,47 @@ jobs:
           restore-keys: |
             turbo-v2-${{ runner.os }}-${{ github.job }}-
 
+      # Every verification step below carries
+      # `if: !cancelled() && steps.install.outcome == 'success'`, so ONE failing
+      # gate no longer cancels the rest of the job. The job still fails; what
+      # changes is how much it tells you.
+      #
+      # The default is to stop at the first failing step, and the cost of that
+      # is not theoretical. A grep gate two steps in went red, and the fifteen
+      # steps behind it - Script tests, Typecheck, Lint, Test, the changeset
+      # check, publint, attw - all reported `skipped`. The rollup showed one
+      # red job, which reads as one known problem, and seven pull requests were
+      # merged over it. Two of them carried defects those skipped steps existed
+      # to catch: a changeset whose frontmatter never closed (Script tests) and
+      # three type errors in a new test file (Typecheck). Neither was visible
+      # until the grep gate was repaired, days of merges later.
+      #
+      # So the ordering stays - cheap checks first is still right - but a cheap
+      # check may no longer decide whether the expensive ones are allowed to
+      # speak. `install` is the one exception, and it is identified here for
+      # that: without node_modules no step below can say anything, so its
+      # failure legitimately skips them all rather than producing fifteen
+      # identical module-resolution errors.
       - name: Install dependencies
+        id: install
         run: pnpm install --frozen-lockfile
 
       # F1 PR 5: enforce that drizzle-kit stays exact-pinned in
       # `packages/nextly/package.json` `dependencies` (no caret/tilde,
-      # not in peerDependencies). Cheap check, fails fast.
+      # not in peerDependencies). Cheap, and runs first because it is cheap -
+      # but it no longer STOPS the job, per the note above `install`.
       - name: Check drizzle-kit pin
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm check:drizzle-kit-pin
 
       # Drizzle v1 zero-legacy gate: no pre-v1 API, no removed kit symbols,
-      # no positional drizzle() constructors. Cheap check, fails fast.
+      # no positional drizzle() constructors.
       - name: Drizzle v1 legacy gate
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm check:drizzle-v1-legacy
 
       - name: Storage-spelling gate (field-group storage format)
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm check:storage-format-literals
 
       # `pnpm dev` refuses to start when the concurrency limit written into the
@@ -304,6 +330,7 @@ jobs:
       # twenty long-running watchers to observe a property that is decided
       # before any of them runs.
       - name: Dev concurrency gate (persistent task count)
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm check:dev-concurrency
 
       # Comments describe the code, never the process that produced it. A comment
@@ -319,6 +346,7 @@ jobs:
       # coverage, the #5782 cascade regression, RQB v2 conversions, and the
       # relations registry.
       - name: Drizzle v1 safety suites (unit)
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         # Build nextly's workspace dependencies first: this step runs a raw
         # vitest BEFORE the Build step below, so any package nextly imports
         # must already have a dist or vite fails to resolve its entry and the
@@ -358,6 +386,7 @@ jobs:
       #
       # Needs no build: the suite drives ESLint over this package's own source.
       - name: Bare-Error guard controls (unit)
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: |
           pnpm --filter nextly exec vitest run \
             src/errors/__tests__/bare-error-allowlist.test.ts
@@ -367,6 +396,7 @@ jobs:
       # the release-notes builder only surfaces during a real publish, after the
       # packages are already on npm. Needs no build, runs in milliseconds.
       - name: Script tests
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm test:scripts
 
       # The published packages version in lockstep, so a changeset that names
@@ -388,7 +418,7 @@ jobs:
       # changeset the branch picked up by merging `main` as one this branch
       # wrote, which is how a guard starts failing PRs over other people's files.
       - name: Changeset covers the lockstep group
-        if: github.event_name == 'pull_request'
+        if: ${{ !cancelled() && steps.install.outcome == 'success' && github.event_name == 'pull_request' }}
         run: |
           set -euo pipefail
           # `git diff` runs on its own line so a failure — an unavailable `HEAD^1`
@@ -419,6 +449,7 @@ jobs:
       # (no hsl(var(--x)) wrappers, no hardcoded colors, no stray !important).
       # See packages/ui/docs/plugin-ui-authoring.md. Cheap check, fails fast.
       - name: Design tokens lint
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm lint:design
 
       # Workspace manifest consistency across all 19 packages (sherif):
@@ -426,9 +457,11 @@ jobs:
       # drift, malformed manifests. All rules gate. Runs in milliseconds,
       # fails fast.
       - name: Workspace consistency
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm lint:workspace
 
       - name: Build
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm turbo build --filter='./packages/*' --filter='./apps/*'
         env:
           TURBO_CACHE_DIR: .turbo
@@ -436,11 +469,13 @@ jobs:
       # `./e2e` is named explicitly: it is a workspace member but sits under
       # neither glob, being neither something we publish nor something we run.
       - name: Lint
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm turbo lint --continue --filter='./packages/*' --filter='./apps/*' --filter='./e2e'
         env:
           TURBO_CACHE_DIR: .turbo
 
       - name: Typecheck
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm turbo check-types --continue
         env:
           TURBO_CACHE_DIR: .turbo
@@ -456,6 +491,7 @@ jobs:
       # ui / storage-s3 / storage-uploadthing have no test files yet; listed so
       # they gate automatically the moment they gain one.
       - name: Test
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: >-
           pnpm turbo test
           --filter=@nextlyhq/blocks-engine
@@ -482,6 +518,7 @@ jobs:
       # packages (nextly + create-nextly-app + 11 @nextlyhq/*). Failures here
       # block the release pipeline.
       - name: publint
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: >-
           pnpm -r
           --filter '@nextlyhq/*'
@@ -499,6 +536,7 @@ jobs:
       #                          dynamic import())
       # All other attw rules remain active and would catch real regressions.
       - name: arethetypeswrong
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: >-
           pnpm -r
           --filter '@nextlyhq/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,7 +460,22 @@ jobs:
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm lint:workspace
 
+      # Identified for the same reason `install` is, and the reason is in
+      # AGENTS.md rather than here: `turbo.jsonc` gives `lint` no dependency at
+      # all and `check-types` only `^check-types`, so neither rebuilds — they
+      # read whatever `dist` survived. On an unbuilt tree `check-types` fails
+      # workspace-wide on TS2307 through the siblings' export maps and `lint`
+      # fails on `import-x/no-unresolved`, and the dangerous half is that every
+      # TYPE-AWARE lint rule then reports on types the checker cannot see: the
+      # message names YOUR EXPRESSION and reads as a correctness defect whose
+      # obvious remedy is a real regression. `publint` and `arethetypeswrong`
+      # read `dist` directly and have nothing to say without one.
+      #
+      # So a failed Build legitimately skips those five, exactly as a failed
+      # install skips everything: reporting one defect five ways, four of them
+      # misleadingly, is the opposite of what this job was just changed to do.
       - name: Build
+        id: build
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm turbo build --filter='./packages/*' --filter='./apps/*'
         env:
@@ -469,13 +484,13 @@ jobs:
       # `./e2e` is named explicitly: it is a workspace member but sits under
       # neither glob, being neither something we publish nor something we run.
       - name: Lint
-        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.install.outcome == 'success' && steps.build.outcome == 'success' }}
         run: pnpm turbo lint --continue --filter='./packages/*' --filter='./apps/*' --filter='./e2e'
         env:
           TURBO_CACHE_DIR: .turbo
 
       - name: Typecheck
-        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.install.outcome == 'success' && steps.build.outcome == 'success' }}
         run: pnpm turbo check-types --continue
         env:
           TURBO_CACHE_DIR: .turbo
@@ -491,7 +506,7 @@ jobs:
       # ui / storage-s3 / storage-uploadthing have no test files yet; listed so
       # they gate automatically the moment they gain one.
       - name: Test
-        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.install.outcome == 'success' && steps.build.outcome == 'success' }}
         run: >-
           pnpm turbo test
           --filter=@nextlyhq/blocks-engine
@@ -518,7 +533,7 @@ jobs:
       # packages (nextly + create-nextly-app + 11 @nextlyhq/*). Failures here
       # block the release pipeline.
       - name: publint
-        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.install.outcome == 'success' && steps.build.outcome == 'success' }}
         run: >-
           pnpm -r
           --filter '@nextlyhq/*'
@@ -536,7 +551,7 @@ jobs:
       #                          dynamic import())
       # All other attw rules remain active and would catch real regressions.
       - name: arethetypeswrong
-        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.install.outcome == 'success' && steps.build.outcome == 'success' }}
         run: >-
           pnpm -r
           --filter '@nextlyhq/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,15 +447,16 @@ jobs:
 
       # Enforce the design-token theming contract in the admin + plugin packages
       # (no hsl(var(--x)) wrappers, no hardcoded colors, no stray !important).
-      # See packages/ui/docs/plugin-ui-authoring.md. Cheap check, fails fast.
+      # See packages/ui/docs/plugin-ui-authoring.md. Cheap, and no longer stops
+      # the job - see the note above `install`.
       - name: Design tokens lint
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm lint:design
 
       # Workspace manifest consistency across all 19 packages (sherif):
       # unordered keys, unsynced sibling versions, cross-package version
-      # drift, malformed manifests. All rules gate. Runs in milliseconds,
-      # fails fast.
+      # drift, malformed manifests. All rules gate. Runs in milliseconds, and
+      # no longer stops the job - see the note above `install`.
       - name: Workspace consistency
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm lint:workspace
@@ -471,9 +472,10 @@ jobs:
       # obvious remedy is a real regression. `publint` and `arethetypeswrong`
       # read `dist` directly and have nothing to say without one.
       #
-      # So a failed Build legitimately skips those five, exactly as a failed
-      # install skips everything: reporting one defect five ways, four of them
+      # So a failed Build legitimately skips those FOUR, exactly as a failed
+      # install skips everything: reporting one defect four ways, all of them
       # misleadingly, is the opposite of what this job was just changed to do.
+      # `Test` is deliberately not among them - see the note on that step.
       - name: Build
         id: build
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
@@ -505,8 +507,15 @@ jobs:
       #
       # ui / storage-s3 / storage-uploadthing have no test files yet; listed so
       # they gate automatically the moment they gain one.
+      # NOT gated on Build, unlike the four steps around it: turbo.jsonc gives
+      # `test` `dependsOn: ["^build"]`, so `turbo test` rebuilds the dependency
+      # subgraph of whatever it is filtered to. A Build failure in a package
+      # none of these seventeen depends on - an app, which is a leaf - would
+      # otherwise silence all seventeen suites for no reason, and a failure in
+      # one they DO depend on is reported as an attributed `#build` failure
+      # here rather than as the type-aware noise the others would produce.
       - name: Test
-        if: ${{ !cancelled() && steps.install.outcome == 'success' && steps.build.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: >-
           pnpm turbo test
           --filter=@nextlyhq/blocks-engine

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,7 +34,19 @@ jobs:
   integration:
     name: Integration (${{ matrix.dialect }})
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # 25 minutes until the suite outgrew it. The MySQL leg's last GREEN run
+    # finished in 24m52s — eight seconds inside the limit — and every run after
+    # that hit the ceiling. A timeout-minutes kill is reported as
+    # conclusion=cancelled rather than failure, so the leg stopped contributing
+    # a verdict while looking like somebody had cancelled the run: six
+    # consecutive PRs merged with MySQL coverage that never reported.
+    #
+    # `packages/nextly` runs its integration files sequentially on purpose
+    # (fileParallelism: false, single fork — the system-table suites share
+    # fixed table names), so this number only ever needs to grow. Raised with
+    # real headroom rather than to just past the last measurement, because a
+    # ceiling set at the current duration is a ceiling that fails on variance.
+    timeout-minutes: 45
 
     strategy:
       # One dialect failing must not cancel the others: seeing that a change
@@ -181,7 +193,9 @@ jobs:
   integration-sqlite:
     name: Integration (sqlite)
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Raised with the matrix legs above: this one passed at 22m18s, which is
+    # inside 25 but not by enough to leave alone while its siblings move.
+    timeout-minutes: 45
 
     steps:
       - name: Checkout

--- a/packages/ui/src/styles/__tests__/comments-describe-code.test.ts
+++ b/packages/ui/src/styles/__tests__/comments-describe-code.test.ts
@@ -532,6 +532,11 @@ describe("comments describe the code, not the process", () => {
     ).toEqual(["x.ts:2 a task number"]);
   });
 
+  // Timed out against vitest's 5s default on a loaded CI runner while taking
+  // ~200ms locally — a 25x margin, so the threshold was measuring the machine
+  // rather than the code. This walk reads every source file under three trees
+  // and grows with the repository, and there is nothing here whose SPEED is
+  // the property under test, so the budget is stated generously on purpose.
   it("has no comment pointing outside the codebase", () => {
     const violations = sources.flatMap(violationsIn);
 
@@ -542,5 +547,5 @@ describe("comments describe the code, not the process", () => {
         `the reason is genuinely a decision record, it belongs in a document, ` +
         `not in a reference the code cannot resolve.`
     ).toEqual([]);
-  });
+  }, 60_000);
 });

--- a/scripts/ci-steps-report-independently.test.mjs
+++ b/scripts/ci-steps-report-independently.test.mjs
@@ -173,16 +173,39 @@ function where(declared) {
 }
 
 /**
- * Every `steps.<id>.outcome` this condition names, sorted and de-duplicated.
+ * Every step this condition names, sorted and de-duplicated.
+ *
+ * Matches the reference rather than one SPELLING of it. `steps.<id>.outcome`
+ * is the form written here, but `steps.<id>.conclusion` chains a step just as
+ * effectively, and `steps['<id>']` is the same expression in bracket syntax —
+ * so reading only the first would let the identical silencing through under a
+ * different name.
  *
  * Sorted so the comparison is over a SET rather than over the order somebody
  * happened to write the conjuncts in.
  */
-function referencedOutcomeIds(condition) {
-  const ids = [...condition.matchAll(/steps\.([A-Za-z0-9_-]+)\.outcome/g)].map(
-    m => m[1]
-  );
+function referencedStepIds(condition) {
+  const dotted = [...condition.matchAll(/steps\.([A-Za-z0-9_-]+)\b/g)];
+  const bracketed = [...condition.matchAll(/steps\[\s*['"]([^'"]+)['"]\s*\]/g)];
+  const ids = [...dotted, ...bracketed].map(m => m[1]);
   return [...new Set(ids)].sort();
+}
+
+/**
+ * Every status function this condition calls, sorted and de-duplicated.
+ *
+ * `!cancelled()` is the only one a verification step may name. An EXPLICIT
+ * `success()` is the trap: it reproduces the implicit one GitHub applies when
+ * no status function is present, so a condition carrying both `!cancelled()`
+ * and `success()` keeps every required conjunct and is still skipped by any
+ * earlier failure — the behaviour this whole job was changed to stop, restored
+ * by an addition rather than a removal.
+ */
+function calledStatusFunctions(condition) {
+  const calls = [
+    ...condition.matchAll(/\b(success|always|cancelled|failure)\s*\(\s*\)/g),
+  ].map(m => m[1]);
+  return [...new Set(calls)].sort();
 }
 
 /** The first capture group, trimmed, or "" when the pattern does not match. */
@@ -222,13 +245,21 @@ describe("the ci job reports every gate, not only the first to fail", () => {
   it("requires !cancelled() on every verification step", async () => {
     const steps = ciJobSteps(await readFile(CI_WORKFLOW, "utf-8"));
 
-    const missing = verificationSteps(steps)
-      .filter(s => !s.ifCondition.includes(NOT_CANCELLED))
+    // An exact set, not a presence check. Missing `!cancelled()` restores the
+    // skipping by omission; ADDING `success()` beside it restores the same
+    // skipping while every required conjunct is still there, which no
+    // presence check can see and no reader spots by eye.
+    const wrong = verificationSteps(steps)
+      .filter(
+        s =>
+          !s.ifCondition.includes(NOT_CANCELLED) ||
+          calledStatusFunctions(s.ifCondition).join() !== "cancelled"
+      )
       .map(s => `${s.name || "(unnamed step)"}: ${s.ifCondition || "(no if:)"}`);
 
     expect(
-      missing,
-      "GitHub applies an implicit success() to an if: naming no status function, so a condition without !cancelled() is skipped after ANY earlier failure — the behaviour this job was changed to stop"
+      wrong,
+      "a verification step may call !cancelled() and no other status function: GitHub applies an implicit success() when none is named, and an explicit one reproduces it, so either way the step is skipped after ANY earlier failure"
     ).toEqual([]);
   });
 
@@ -246,7 +277,7 @@ describe("the ci job reports every gate, not only the first to fail", () => {
     const wrong = verificationSteps(steps)
       .map(s => ({
         step: s,
-        actual: referencedOutcomeIds(s.ifCondition),
+        actual: referencedStepIds(s.ifCondition),
         expected: BUILD_DEPENDENT.has(s.name)
           ? ["build", "install"]
           : ["install"],
@@ -281,7 +312,7 @@ describe("the ci job reports every gate, not only the first to fail", () => {
     );
 
     const tooEarly = steps.flatMap((s, index) =>
-      referencedOutcomeIds(s.ifCondition)
+      referencedStepIds(s.ifCondition)
         .filter(id => !resolvesBefore(declaredAt.get(id), index))
         .map(id => `${label(s, index)} references ${id}, declared at ${where(declaredAt.get(id))}`)
     );

--- a/scripts/ci-steps-report-independently.test.mjs
+++ b/scripts/ci-steps-report-independently.test.mjs
@@ -1,0 +1,111 @@
+/**
+ * One failing gate in `Lint / Typecheck / Test / Build` must not silence the
+ * rest of the job.
+ *
+ * The job runs twenty-odd verification steps in one sequence: cheap grep gates
+ * first, then Script tests, Build, Lint, Typecheck, Test, publint,
+ * arethetypeswrong. GitHub's default is to stop at the first failing step, so
+ * for as long as an early gate is red, every step behind it reports `skipped`
+ * and the rollup shows exactly one red job — indistinguishable from a job with
+ * one thing wrong.
+ *
+ * That is not hypothetical. A grep gate went red at step two; the fifteen steps
+ * behind it never ran; seven pull requests merged over the single red; and two
+ * of them carried defects the skipped steps existed to catch — a changeset
+ * whose frontmatter never closed (Script tests) and three type errors in a new
+ * test file (Typecheck). Neither surfaced until the grep gate was repaired,
+ * days of merges later.
+ *
+ * So every verification step carries
+ * `if: !cancelled() && steps.install.outcome == 'success'`. The job still
+ * fails; what changes is that it reports everything wrong rather than the
+ * first thing wrong.
+ *
+ * 🔴 The guard is what makes this true, and nothing else in the repository
+ * reads it. A step added later without the condition silently restores the old
+ * behaviour for every step behind it, and the only symptom is a rollup that
+ * looks the same as it does today. Hence a test rather than a comment.
+ *
+ * Parsed as TEXT rather than through a YAML library on purpose: `yaml` appears
+ * in this repository only as a pnpm override, so it is reachable here by
+ * hoisting rather than by declaration, and a resolution that depends on
+ * hoisting is not one to build a gate on.
+ *
+ * @module ci-steps-report-independently.test
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CI_WORKFLOW = path.join(HERE, "..", ".github", "workflows", "ci.yml");
+
+const GUARD = "steps.install.outcome == 'success'";
+
+/**
+ * The steps of the `ci` job, as `{ name, body }`.
+ *
+ * The job is found by its `name:` line and read to the next job at the same
+ * indentation, so a step belonging to `e2e` or `scaffold-smoke` cannot be
+ * mistaken for one of these.
+ */
+function ciJobSteps(source) {
+  const jobStart = source.indexOf("    name: Lint / Typecheck / Test / Build");
+  if (jobStart === -1) throw new Error("ci job not found by name");
+
+  // The next line at four-space indentation that starts a new job key.
+  const rest = source.slice(jobStart);
+  const nextJob = rest.slice(1).search(/\n {2}[a-z][a-z0-9-]*:\n/);
+  const jobBody = nextJob === -1 ? rest : rest.slice(0, nextJob + 1);
+
+  const chunks = jobBody.split(/\n(?=      - name: )/).slice(1);
+  return chunks.map(chunk => {
+    const name = /^ {6}- name: (.+)$/m.exec(chunk)?.[1] ?? "";
+    return { name: name.trim(), body: chunk };
+  });
+}
+
+describe("the ci job reports every gate, not only the first to fail", () => {
+  /**
+   * A floor before the verdict.
+   *
+   * Every assertion below is satisfied by an empty step list, so a parser that
+   * stopped matching would certify the workflow while reading nothing.
+   */
+  it("finds the job's steps at all", async () => {
+    const steps = ciJobSteps(await readFile(CI_WORKFLOW, "utf-8"));
+
+    expect(steps.length).toBeGreaterThan(10);
+    expect(steps.map(s => s.name)).toContain("Typecheck");
+  });
+
+  it("guards every step that runs a command", async () => {
+    const steps = ciJobSteps(await readFile(CI_WORKFLOW, "utf-8"));
+
+    // `install` is the deliberate exception: without node_modules no step
+    // below can say anything, so its failure legitimately skips them all.
+    // Steps that only set up the runner (checkout, node, cache) are not
+    // verification and are not required to carry the guard.
+    const unguarded = steps
+      .filter(s => /^\s+run:/m.test(s.body))
+      .filter(s => s.name !== "Install dependencies")
+      .filter(s => !s.body.includes(GUARD))
+      .map(s => s.name);
+
+    expect(
+      unguarded,
+      "a verification step without the install guard stops every step behind it, which is how a red job comes to mean 'one problem' when it means 'nothing after this ran'"
+    ).toEqual([]);
+  });
+
+  it("keeps install identified, because the guard names it", async () => {
+    const source = await readFile(CI_WORKFLOW, "utf-8");
+
+    // The guard reads `steps.install.outcome`; an unidentified step publishes
+    // no outcome, and GitHub evaluates the reference to empty rather than
+    // failing — so every guarded step would silently stop running.
+    expect(source).toMatch(/- name: Install dependencies\n\s+id: install\n/);
+  });
+});

--- a/scripts/ci-steps-report-independently.test.mjs
+++ b/scripts/ci-steps-report-independently.test.mjs
@@ -20,7 +20,8 @@
  * rather than inheriting "everything before me passed":
  *
  *   `!cancelled() && steps.install.outcome == 'success'`
- *   plus `&& steps.build.outcome == 'success'` for the five that read `dist`.
+ *   plus `&& steps.build.outcome == 'success'` for the four that read `dist`
+ *   without rebuilding it.
  *
  * Both conjuncts are load-bearing and they fail differently. Without
  * `!cancelled()` GitHub applies an implicit `success()` to any `if:` that names
@@ -93,23 +94,37 @@ const SETUP_STEPS = new Set([
   "Install dependencies",
 ]);
 
-/** The five steps that cannot say anything without `dist`. */
+/**
+ * The four steps that cannot say anything without `dist`.
+ *
+ * `Test` is NOT one of them, though it reads built output too: `turbo.jsonc`
+ * gives `test` `dependsOn: ["^build"]`, so it rebuilds the dependency subgraph
+ * of whatever it is filtered to. Gating it on Build would silence seventeen
+ * suites for a failure in a package none of them depends on.
+ */
 const BUILD_DEPENDENT = new Set([
   "Lint",
   "Typecheck",
-  "Test",
   "publint",
   "arethetypeswrong",
 ]);
 
 /**
- * The steps of the `ci` job as `{ name, ifCondition }`.
+ * The steps of the `ci` job as `{ name, ifCondition, id }`.
  *
- * `ifCondition` is read from the step's own `if:` key — the eight-space one
- * that belongs to this step — never by searching its text. A step chunk runs to
- * the next `- name:` and therefore CONTAINS the comment block introducing the
- * following step, and this file's comments quote the conditions verbatim, so
- * any substring search over a chunk answers about its neighbour.
+ * Split on the LIST-ITEM marker (`      - `), never on `- name:`. `name:` is
+ * optional in GitHub Actions and this repository already writes bare
+ * `- uses:` steps in four other workflows, and keying on the name defeats this
+ * file twice over: such a step is not in the population at all, AND its own
+ * eight-space `if:` falls inside the PRECEDING chunk, so an unguarded step is
+ * scored by its neighbour's condition. Both were break-verified against this
+ * job.
+ *
+ * A step's keys therefore sit either on the dash line itself or at eight
+ * spaces beneath it, and both positions are read. Nothing is matched by
+ * searching a chunk's free text: a chunk still runs to the next step and so
+ * contains the comment block introducing it, and this file's own comments
+ * quote the conditions verbatim.
  */
 function ciJobSteps(source) {
   const jobStart = source.indexOf("    name: Lint / Typecheck / Test / Build");
@@ -120,15 +135,26 @@ function ciJobSteps(source) {
   const jobBody = nextJob === -1 ? rest : rest.slice(0, nextJob + 1);
 
   return jobBody
-    .split(/\n(?=      - name: )/)
+    .split(/\n(?= {6}- \S)/)
     .slice(1)
     .map(chunk => ({
-      name: firstMatch(chunk, /^ {6}- name: (.+)$/m),
-      // Anchored to the step's OWN keys, at exactly eight spaces, so a later
-      // step's key inside the same chunk cannot be read instead.
-      ifCondition: firstMatch(chunk, /^ {8}if: (.+)$/m),
-      id: firstMatch(chunk, /^ {8}id: (.+)$/m),
+      name: stepKey(chunk, "name"),
+      ifCondition: stepKey(chunk, "if"),
+      id: stepKey(chunk, "id"),
     }));
+}
+
+/**
+ * One of a step's own keys, from the dash line or the eight-space block.
+ *
+ * Returns "" when the step does not declare it — which for `name` is a real
+ * answer rather than a parse failure, since an unnamed step is still a step
+ * and still has to carry a condition.
+ */
+function stepKey(chunk, key) {
+  const onDashLine = firstMatch(chunk, new RegExp(`^ {6}- ${key}: (.+)$`, "m"));
+  if (onDashLine !== "") return onDashLine;
+  return firstMatch(chunk, new RegExp(`^ {8}${key}: (.+)$`, "m"));
 }
 
 /** The first capture group, trimmed, or "" when the pattern does not match. */
@@ -137,9 +163,15 @@ function firstMatch(text, pattern) {
   return match === null ? "" : match[1].trim();
 }
 
-/** The steps that must carry a condition: everything that is not setup. */
-const verificationSteps = steps =>
-  steps.filter(s => !SETUP_STEPS.has(s.name) && s.name !== "");
+/**
+ * The steps that must carry a condition: everything that is not setup.
+ *
+ * An unnamed step stays IN, deliberately. It cannot appear in a name-keyed
+ * allowlist, so dropping it would exempt exactly the shape that is hardest to
+ * notice; keeping it means the population fails closed and such a step is
+ * reported by position.
+ */
+const verificationSteps = steps => steps.filter(s => !SETUP_STEPS.has(s.name));
 
 describe("the ci job reports every gate, not only the first to fail", () => {
   /**
@@ -164,7 +196,7 @@ describe("the ci job reports every gate, not only the first to fail", () => {
 
     const missing = verificationSteps(steps)
       .filter(s => !s.ifCondition.includes(NOT_CANCELLED))
-      .map(s => `${s.name}: ${s.ifCondition || "(no if:)"}`);
+      .map(s => `${s.name || "(unnamed step)"}: ${s.ifCondition || "(no if:)"}`);
 
     expect(
       missing,
@@ -177,7 +209,7 @@ describe("the ci job reports every gate, not only the first to fail", () => {
 
     const missing = verificationSteps(steps)
       .filter(s => !s.ifCondition.includes(INSTALL_OK))
-      .map(s => `${s.name}: ${s.ifCondition || "(no if:)"}`);
+      .map(s => `${s.name || "(unnamed step)"}: ${s.ifCondition || "(no if:)"}`);
 
     expect(
       missing,
@@ -191,7 +223,7 @@ describe("the ci job reports every gate, not only the first to fail", () => {
     const missing = verificationSteps(steps)
       .filter(s => BUILD_DEPENDENT.has(s.name))
       .filter(s => !s.ifCondition.includes(BUILD_OK))
-      .map(s => `${s.name}: ${s.ifCondition || "(no if:)"}`);
+      .map(s => `${s.name || "(unnamed step)"}: ${s.ifCondition || "(no if:)"}`);
 
     expect(
       missing,
@@ -201,6 +233,25 @@ describe("the ci job reports every gate, not only the first to fail", () => {
     // The population itself, so a rename cannot empty the check silently.
     const present = steps.map(s => s.name).filter(n => BUILD_DEPENDENT.has(n));
     expect(present.sort()).toEqual([...BUILD_DEPENDENT].sort());
+  });
+
+  it("does NOT gate Test on Build, which would silence seventeen suites", async () => {
+    const steps = ciJobSteps(await readFile(CI_WORKFLOW, "utf-8"));
+    const test = steps.find(s => s.name === "Test");
+
+    // Asserted as a negative because the mistake is an attractive one: the four
+    // steps around it carry the build conjunct, so adding it here reads as
+    // tidying up an inconsistency. It is not one — `turbo.jsonc` gives `test`
+    // `dependsOn: ["^build"]`, so it rebuilds what it needs, and gating it
+    // means a Build failure in a package none of the seventeen filters depends
+    // on contributes nothing instead of seventeen suites' worth of verdict.
+    expect(test).toBeDefined();
+    expect(test.ifCondition).toContain(NOT_CANCELLED);
+    expect(test.ifCondition).toContain(INSTALL_OK);
+    expect(
+      test.ifCondition,
+      "turbo rebuilds test's dependency subgraph, so gating it on Build only costs coverage"
+    ).not.toContain(BUILD_OK);
   });
 
   it("keeps install and build identified INSIDE this job", async () => {

--- a/scripts/ci-steps-report-independently.test.mjs
+++ b/scripts/ci-steps-report-independently.test.mjs
@@ -16,15 +16,45 @@
  * test file (Typecheck). Neither surfaced until the grep gate was repaired,
  * days of merges later.
  *
- * So every verification step carries
- * `if: !cancelled() && steps.install.outcome == 'success'`. The job still
- * fails; what changes is that it reports everything wrong rather than the
- * first thing wrong.
+ * So every verification step carries a condition naming its PREREQUISITES
+ * rather than inheriting "everything before me passed":
  *
- * 🔴 The guard is what makes this true, and nothing else in the repository
- * reads it. A step added later without the condition silently restores the old
- * behaviour for every step behind it, and the only symptom is a rollup that
- * looks the same as it does today. Hence a test rather than a comment.
+ *   `!cancelled() && steps.install.outcome == 'success'`
+ *   plus `&& steps.build.outcome == 'success'` for the five that read `dist`.
+ *
+ * Both conjuncts are load-bearing and they fail differently. Without
+ * `!cancelled()` GitHub applies an implicit `success()` to any `if:` that names
+ * no status function, so the step is skipped after ANY earlier failure — the
+ * exact behaviour being removed, restored by an expression that still mentions
+ * `steps.install`. Without the prerequisite the guard is too weak in the other
+ * direction: a step runs on a tree that cannot support it.
+ *
+ * 🔴 Nothing else in the repository reads these conditions. A step added later
+ * without one silently restores the old behaviour for every step behind it,
+ * and the only symptom is a rollup that looks exactly like today's.
+ *
+ * ## What this file learned about testing itself
+ *
+ * The first version asked four questions that were each satisfied by something
+ * other than the property, and all four were found by mutating the real
+ * workflow rather than by reading:
+ *
+ * - it matched `steps.install.outcome == 'success'` alone, so dropping
+ *   `!cancelled()` — the half that does the work — left it green;
+ * - it decided membership with a substring search over a chunk that runs to the
+ *   NEXT step, so a comment introducing step N+1 certified step N. This file's
+ *   own comments quote the condition verbatim, so that was live, not theoretical;
+ * - it asserted `id: install` over the WHOLE file, and four jobs have a step by
+ *   that name, so the ci job could lose its id while `e2e` supplied the match;
+ * - it required the guard only of steps spelling `run:`, exempting any gate
+ *   added as an action — and this repository already gates through
+ *   `fallow-rs/fallow` and `gitleaks` elsewhere.
+ *
+ * Hence: conditions are read from the step's OWN `if:` key, the population is
+ * an allowlist of setup steps rather than a filter on `run:`, and every
+ * assertion is scoped to the ci job. The break controls that matter are the
+ * subtle ones — weaken a condition, move the id to another job, add an
+ * action-shaped gate — not deleting an `if:` outright.
  *
  * Parsed as TEXT rather than through a YAML library on purpose: `yaml` appears
  * in this repository only as a pnpm override, so it is reachable here by
@@ -42,30 +72,74 @@ import { describe, expect, it } from "vitest";
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const CI_WORKFLOW = path.join(HERE, "..", ".github", "workflows", "ci.yml");
 
-const GUARD = "steps.install.outcome == 'success'";
+const NOT_CANCELLED = "!cancelled()";
+const INSTALL_OK = "steps.install.outcome == 'success'";
+const BUILD_OK = "steps.build.outcome == 'success'";
 
 /**
- * The steps of the `ci` job, as `{ name, body }`.
+ * Steps that prepare the runner rather than verify anything.
  *
- * The job is found by its `name:` line and read to the next job at the same
- * indentation, so a step belonging to `e2e` or `scaffold-smoke` cannot be
- * mistaken for one of these.
+ * An ALLOWLIST rather than a filter on `run:`, because the two fail in opposite
+ * directions: a name nobody added here is REQUIRED to carry a condition, so a
+ * gate arriving in any shape — `run:`, `uses:`, whatever comes next — is caught
+ * rather than waved through.
+ */
+const SETUP_STEPS = new Set([
+  "Checkout",
+  "Setup pnpm",
+  "Setup Node.js",
+  "Restore Turbo cache",
+  "Save Turbo cache",
+  "Install dependencies",
+]);
+
+/** The five steps that cannot say anything without `dist`. */
+const BUILD_DEPENDENT = new Set([
+  "Lint",
+  "Typecheck",
+  "Test",
+  "publint",
+  "arethetypeswrong",
+]);
+
+/**
+ * The steps of the `ci` job as `{ name, ifCondition }`.
+ *
+ * `ifCondition` is read from the step's own `if:` key — the eight-space one
+ * that belongs to this step — never by searching its text. A step chunk runs to
+ * the next `- name:` and therefore CONTAINS the comment block introducing the
+ * following step, and this file's comments quote the conditions verbatim, so
+ * any substring search over a chunk answers about its neighbour.
  */
 function ciJobSteps(source) {
   const jobStart = source.indexOf("    name: Lint / Typecheck / Test / Build");
   if (jobStart === -1) throw new Error("ci job not found by name");
 
-  // The next line at four-space indentation that starts a new job key.
   const rest = source.slice(jobStart);
   const nextJob = rest.slice(1).search(/\n {2}[a-z][a-z0-9-]*:\n/);
   const jobBody = nextJob === -1 ? rest : rest.slice(0, nextJob + 1);
 
-  const chunks = jobBody.split(/\n(?=      - name: )/).slice(1);
-  return chunks.map(chunk => {
-    const name = /^ {6}- name: (.+)$/m.exec(chunk)?.[1] ?? "";
-    return { name: name.trim(), body: chunk };
-  });
+  return jobBody
+    .split(/\n(?=      - name: )/)
+    .slice(1)
+    .map(chunk => ({
+      name: firstMatch(chunk, /^ {6}- name: (.+)$/m),
+      // Anchored to the step's OWN keys, at exactly eight spaces, so a later
+      // step's key inside the same chunk cannot be read instead.
+      ifCondition: firstMatch(chunk, /^ {8}if: (.+)$/m),
+      id: firstMatch(chunk, /^ {8}id: (.+)$/m),
+    }));
 }
+
+/** The first capture group, trimmed, or "" when the pattern does not match. */
+function firstMatch(text, pattern) {
+  const match = pattern.exec(text);
+  return match === null ? "" : match[1].trim();
+}
+
+/** The steps that must carry a condition: everything that is not setup. */
+const verificationSteps = steps =>
+  steps.filter(s => !SETUP_STEPS.has(s.name) && s.name !== "");
 
 describe("the ci job reports every gate, not only the first to fail", () => {
   /**
@@ -76,36 +150,69 @@ describe("the ci job reports every gate, not only the first to fail", () => {
    */
   it("finds the job's steps at all", async () => {
     const steps = ciJobSteps(await readFile(CI_WORKFLOW, "utf-8"));
+    const names = steps.map(s => s.name);
 
     expect(steps.length).toBeGreaterThan(10);
-    expect(steps.map(s => s.name)).toContain("Typecheck");
+    expect(names).toContain("Typecheck");
+    expect(names).toContain("Build");
+    // The allowlist is only meaningful if it actually matches something here.
+    expect(names).toContain("Install dependencies");
   });
 
-  it("guards every step that runs a command", async () => {
+  it("requires !cancelled() on every verification step", async () => {
     const steps = ciJobSteps(await readFile(CI_WORKFLOW, "utf-8"));
 
-    // `install` is the deliberate exception: without node_modules no step
-    // below can say anything, so its failure legitimately skips them all.
-    // Steps that only set up the runner (checkout, node, cache) are not
-    // verification and are not required to carry the guard.
-    const unguarded = steps
-      .filter(s => /^\s+run:/m.test(s.body))
-      .filter(s => s.name !== "Install dependencies")
-      .filter(s => !s.body.includes(GUARD))
-      .map(s => s.name);
+    const missing = verificationSteps(steps)
+      .filter(s => !s.ifCondition.includes(NOT_CANCELLED))
+      .map(s => `${s.name}: ${s.ifCondition || "(no if:)"}`);
 
     expect(
-      unguarded,
-      "a verification step without the install guard stops every step behind it, which is how a red job comes to mean 'one problem' when it means 'nothing after this ran'"
+      missing,
+      "GitHub applies an implicit success() to an if: naming no status function, so a condition without !cancelled() is skipped after ANY earlier failure — the behaviour this job was changed to stop"
     ).toEqual([]);
   });
 
-  it("keeps install identified, because the guard names it", async () => {
-    const source = await readFile(CI_WORKFLOW, "utf-8");
+  it("requires the install prerequisite on every verification step", async () => {
+    const steps = ciJobSteps(await readFile(CI_WORKFLOW, "utf-8"));
 
-    // The guard reads `steps.install.outcome`; an unidentified step publishes
-    // no outcome, and GitHub evaluates the reference to empty rather than
-    // failing — so every guarded step would silently stop running.
-    expect(source).toMatch(/- name: Install dependencies\n\s+id: install\n/);
+    const missing = verificationSteps(steps)
+      .filter(s => !s.ifCondition.includes(INSTALL_OK))
+      .map(s => `${s.name}: ${s.ifCondition || "(no if:)"}`);
+
+    expect(
+      missing,
+      "a verification step without the install prerequisite either stops every step behind it or runs without node_modules"
+    ).toEqual([]);
+  });
+
+  it("requires the build prerequisite on the steps that read dist", async () => {
+    const steps = ciJobSteps(await readFile(CI_WORKFLOW, "utf-8"));
+
+    const missing = verificationSteps(steps)
+      .filter(s => BUILD_DEPENDENT.has(s.name))
+      .filter(s => !s.ifCondition.includes(BUILD_OK))
+      .map(s => `${s.name}: ${s.ifCondition || "(no if:)"}`);
+
+    expect(
+      missing,
+      "turbo gives lint no dependency and check-types only ^check-types, so on a failed Build these read a stale dist — and a type-aware lint rule then names YOUR expression rather than the missing build"
+    ).toEqual([]);
+
+    // The population itself, so a rename cannot empty the check silently.
+    const present = steps.map(s => s.name).filter(n => BUILD_DEPENDENT.has(n));
+    expect(present.sort()).toEqual([...BUILD_DEPENDENT].sort());
+  });
+
+  it("keeps install and build identified INSIDE this job", async () => {
+    const steps = ciJobSteps(await readFile(CI_WORKFLOW, "utf-8"));
+
+    // Scoped to the ci job, because four jobs in this file have a step named
+    // "Install dependencies" — a whole-file search is discharged by any one of
+    // them. An unidentified step publishes no outcome, GitHub evaluates the
+    // reference to empty, and every guarded step silently stops running.
+    const ids = Object.fromEntries(steps.map(s => [s.name, s.id]));
+
+    expect(ids["Install dependencies"]).toBe("install");
+    expect(ids.Build).toBe("build");
   });
 });

--- a/scripts/ci-steps-report-independently.test.mjs
+++ b/scripts/ci-steps-report-independently.test.mjs
@@ -157,6 +157,34 @@ function stepKey(chunk, key) {
   return firstMatch(chunk, new RegExp(`^ {8}${key}: (.+)$`, "m"));
 }
 
+/** Whether a step declared at `declared` has already run by index `index`. */
+function resolvesBefore(declared, index) {
+  return declared !== undefined && declared < index;
+}
+
+/** A step's position, for a message that has to name one that has no name. */
+function label(step, index) {
+  return `${step.name || "(unnamed step)"} (#${index + 1})`;
+}
+
+/** Where an id was declared, or that it was not. */
+function where(declared) {
+  return declared === undefined ? "nowhere" : `#${declared + 1}`;
+}
+
+/**
+ * Every `steps.<id>.outcome` this condition names, sorted and de-duplicated.
+ *
+ * Sorted so the comparison is over a SET rather than over the order somebody
+ * happened to write the conjuncts in.
+ */
+function referencedOutcomeIds(condition) {
+  const ids = [...condition.matchAll(/steps\.([A-Za-z0-9_-]+)\.outcome/g)].map(
+    m => m[1]
+  );
+  return [...new Set(ids)].sort();
+}
+
 /** The first capture group, trimmed, or "" when the pattern does not match. */
 function firstMatch(text, pattern) {
   const match = pattern.exec(text);
@@ -204,35 +232,64 @@ describe("the ci job reports every gate, not only the first to fail", () => {
     ).toEqual([]);
   });
 
-  it("requires the install prerequisite on every verification step", async () => {
+  it("references EXACTLY the prerequisites each step is allowed", async () => {
     const steps = ciJobSteps(await readFile(CI_WORKFLOW, "utf-8"));
 
-    const missing = verificationSteps(steps)
-      .filter(s => !s.ifCondition.includes(INSTALL_OK))
-      .map(s => `${s.name || "(unnamed step)"}: ${s.ifCondition || "(no if:)"}`);
+    // An exact set rather than a presence check, because the two failures are
+    // opposite and both matter. A MISSING prerequisite lets a step run on a
+    // tree that cannot support it. An EXTRA one — a conjunct naming some other
+    // verification step — restores precisely the silencing this job was changed
+    // to stop: that peer failing skips this step, and the rollup goes back to
+    // one red with invisible skips beside it. The workflow itself establishes
+    // the idiom (four steps legitimately name `build`), so a chained condition
+    // is indistinguishable by eye from a blessed one.
+    const wrong = verificationSteps(steps)
+      .map(s => ({
+        step: s,
+        actual: referencedOutcomeIds(s.ifCondition),
+        expected: BUILD_DEPENDENT.has(s.name)
+          ? ["build", "install"]
+          : ["install"],
+      }))
+      .filter(r => r.actual.join() !== r.expected.join())
+      .map(
+        r =>
+          `${r.step.name || "(unnamed step)"}: references [${r.actual}], allowed [${r.expected}]`
+      );
 
     expect(
-      missing,
-      "a verification step without the install prerequisite either stops every step behind it or runs without node_modules"
-    ).toEqual([]);
-  });
-
-  it("requires the build prerequisite on the steps that read dist", async () => {
-    const steps = ciJobSteps(await readFile(CI_WORKFLOW, "utf-8"));
-
-    const missing = verificationSteps(steps)
-      .filter(s => BUILD_DEPENDENT.has(s.name))
-      .filter(s => !s.ifCondition.includes(BUILD_OK))
-      .map(s => `${s.name || "(unnamed step)"}: ${s.ifCondition || "(no if:)"}`);
-
-    expect(
-      missing,
-      "turbo gives lint no dependency and check-types only ^check-types, so on a failed Build these read a stale dist — and a type-aware lint rule then names YOUR expression rather than the missing build"
+      wrong,
+      "a verification step may name install (and build, if it reads dist without rebuilding it) and nothing else — any other outcome reference makes one gate's failure hide another's verdict"
     ).toEqual([]);
 
     // The population itself, so a rename cannot empty the check silently.
     const present = steps.map(s => s.name).filter(n => BUILD_DEPENDENT.has(n));
     expect(present.sort()).toEqual([...BUILD_DEPENDENT].sort());
+  });
+
+  it("declares install and build BEFORE the steps that reference them", async () => {
+    const steps = ciJobSteps(await readFile(CI_WORKFLOW, "utf-8"));
+
+    // The other half of "the reference must resolve". A missing id is one way
+    // `steps.<id>.outcome` evaluates to empty; referencing a step that has not
+    // RUN YET is the other, because the steps context only carries steps
+    // already executed. Both skip the step silently, and a skipped step does
+    // not fail the job — so the workflow would be GREEN with the gate never
+    // having run, which is the failure this file exists to prevent.
+    const declaredAt = new Map(
+      steps.map((s, index) => [s.id, index]).filter(([id]) => id !== "")
+    );
+
+    const tooEarly = steps.flatMap((s, index) =>
+      referencedOutcomeIds(s.ifCondition)
+        .filter(id => !resolvesBefore(declaredAt.get(id), index))
+        .map(id => `${label(s, index)} references ${id}, declared at ${where(declaredAt.get(id))}`)
+    );
+
+    expect(
+      tooEarly,
+      "a step referencing an id declared later reads empty and is skipped, and a skipped step does not fail the job"
+    ).toEqual([]);
   });
 
   it("does NOT gate Test on Build, which would silence seventeen suites", async () => {


### PR DESCRIPTION
Repairs `main` and fixes the mechanism that let it break quietly.

## Root cause

Every one of the last seven merged PRs merged with `Lint / Typecheck / Test / Build` at `completed/failure`. That is the finding, and the interesting part is not that they were merged red — it is what that red actually meant.

The job runs its verification steps in one sequence, cheap grep gates first, deliberately: *"Cheap check, fails fast."* GitHub stops at the first failing step. So when `Drizzle v1 legacy gate` — **step 2 of 22** — went red, the fifteen steps behind it reported `skipped`:

```
failure   Drizzle v1 legacy gate
skipped   Storage-spelling gate · Dev concurrency gate · Drizzle v1 safety suites
skipped   Bare-Error guard controls · Script tests · Changeset covers the lockstep group
skipped   Design tokens lint · Workspace consistency
skipped   Build · Lint · Typecheck · Test · publint · arethetypeswrong
```

One red job. **One red job reads as one known problem** — so the batch was merged over it. But it did not mean "one thing is broken"; it meant "nothing after step 2 was checked." Two defects walked straight through the gap:

| defect | the step that would have caught it | why it was invisible |
| --- | --- | --- |
| `rich-text-editor-kit.md` frontmatter never closed | `Script tests` | skipped |
| three type errors in `single-create-schema-change.integration.test.ts` | `Typecheck` | skipped |

The changeset one is the expensive one: `@changesets/parse` rejects the file, the release workflow reads every changeset **in one pass**, so that single file would have failed the publish for all 25 packages. `scripts/changesets-parse.test.mjs` exists precisely for this — its docblock records that both spellings have stopped the release train before. It caught this too. Nobody saw it, because it never ran.

The trigger was PR #1111, which merged at 20:25:40 — **12 minutes before its own gate reported** at 20:37:23.

## What this PR does

**1. Closes the changeset's frontmatter.** Opened `---`, blank line, package list, never closed.

**2. Types the singles integration test.** `getService` is generic over the service *key*, not the service type, so `getService<SingleEntryService>(…)` fails its `keyof ServiceMap` constraint and widens the result to `unknown`. The same spelling appears in three sibling suites and compiles in none of them — those files sit on `tsconfig.tests.json`'s opt-out list. `CreateSingleInput` requires `schemaHash`; it is now derived with `calculateSchemaHash` the way the dispatcher derives it, from a field list named once so the hash cannot describe fields the create did not carry.

**3. Fixes the mechanism.** Every verification step now carries `if: !cancelled() && steps.install.outcome == 'success'`. The job still fails — it now reports *everything* wrong instead of the first thing wrong. `install` is the deliberate exception and is given an `id` for it: without `node_modules` no later step can say anything, so its failure legitimately skips them all rather than producing fifteen identical module-resolution errors.

`scripts/ci-steps-report-independently.test.mjs` pins both halves, because a step added later without the guard silently restores the old behaviour and the only symptom is a rollup that looks unchanged. Proven by breaking each:

- guard removed from `Typecheck` → `expected [ 'Typecheck' ] to deeply equal []`
- `id: install` removed → the id assertion fails

That second one is not decoration: an unidentified step publishes no outcome, GitHub evaluates `steps.install.outcome` to empty, and **every guarded step silently stops running** — the same failure this PR exists to remove, wearing a different hat.

**4. Raises the integration timeout, 25 → 45.** The MySQL leg's last green run took **24m52s against a 25-minute limit — eight seconds of headroom** — and every run since has hit the ceiling, measured across six consecutive runs. A `timeout-minutes` kill reports as `conclusion=cancelled`, not `failure`, so the leg reads as a run somebody cancelled and **contributes no verdict at all**. Four PRs merged with MySQL coverage that never reported, including #1114, whose entire subject was MySQL DDL. Raised with real headroom rather than to just past the last measurement, since a ceiling at the current duration fails on variance. Sharding the suite is the better long-term answer and is a larger change than a stuck `main` deserves.

## Already fixed by others, verified not by me

Both `main` reds I filed earlier are resolved on current `main`: `check:drizzle-v1-legacy` passes (#1117), and the `nextly_releases` phantom diff passes (`51bab3947` added the tables to `POST_045_TABLES`). Confirmed by running both locally against `9c802403b` rather than assuming.

## Evidence

All read unpiped, `cmd > log 2>&1; echo "EXIT=$?"`, against `9c802403b`:

| gate | before | after |
| --- | --- | --- |
| `check:drizzle-kit-pin` · `check:drizzle-v1-legacy` · `check:storage-format-literals` · `check:dev-concurrency` | 0 | 0 |
| `test:scripts` | **1** | 0 |
| `lint:design` · `lint:workspace` | 0 | 0 |
| `turbo build` (packages + apps) | 0 | 0 |
| `turbo check-types --continue` | **2** | 0 |
| `turbo lint --continue` (packages + apps + e2e) | 0 | 0 |
| `turbo test` (CI's 17 filters) | 0 | 0 |
| `check-comment-convention` · `fallow:audit` | 0 | 0 (no issues in 5 changed files) |

Plus `single-create-schema-change.integration.test.ts` against real PostgreSQL 17: **22 passed**, and `upgrade-sim-045` **2 passed | 1 skipped**.

No changeset: CI-only and test-only throughout, per AGENTS.md. The changeset touched is *repaired*, not added — it makes an existing product change readable rather than describing a new one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved continuous integration reliability by allowing independent checks to report their results while preserving required prerequisites.
  - Increased integration-test time limits to reduce failures caused by longer-running database operations.

- **Tests**
  - Added automated validation to ensure CI verification steps retain the correct execution conditions.
  - Updated integration coverage for schema-change scenarios and companion-table collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->