### PR TITLE
fix(builder): undo must not rewind the document while the author types

### DIFF
--- a/.changeset/canvas-undo-declines-while-typing.md
+++ b/.changeset/canvas-undo-declines-while-typing.md
@@ -1,0 +1,34 @@
+---
+
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+
+Pressing undo while typing a block's text on the canvas rewound the document instead of the words.
+The author lost a block move they had finished with, kept the sentence they wanted back, and got no
+undo where they asked for one.
+
+`mod+z`, `mod+shift+z` and `mod+y` now decline while the caret is in text, leaving the keystroke to
+the element — which is what an uncontrolled `contentEditable` needs, since inline editing hands the
+DOM over precisely so the browser's own history serves the caret.

--- a/packages/builder/src/keyboard-actions.test.tsx
+++ b/packages/builder/src/keyboard-actions.test.tsx
@@ -1113,3 +1113,108 @@ describe("Escape belongs to the editor, not to the page behind it", () => {
     expect(hostCancel).toHaveBeenCalled();
   });
 });
+
+describe("the document's history while the author is typing", () => {
+  /**
+   * A block's text is edited in an uncontrolled `contentEditable`, and the
+   * shortcut manager reads "is the user typing" from the event's TARGET. So the
+   * keystroke has to be dispatched there — dispatching on the document exercises
+   * neither setting, which the `press` docblock above records as a mistake
+   * already made once here.
+   */
+  // `ctrlKey`, matching every other case in this file: `mod` resolves to ctrl
+  // in this environment, and a `metaKey` press matches NO binding here — so it
+  // asserts nothing while looking like it asserts everything. The controls
+  // below are what exposed that; the first version of these tests passed
+  // against both settings of `whenTyping` for exactly that reason.
+  function typingIn(): HTMLElement {
+    const el = window.document.createElement("div");
+    // jsdom implements NEITHER half of `contentEditable`: assigning the
+    // property sets no attribute, and `isContentEditable` reads `undefined`.
+    // Measured — a probe asserting both returned `{ attr: null, isCE: undefined }`.
+    // So the element has to be told what it is, or it is not a typing target
+    // and every assertion below passes against a canvas that never declines.
+    el.setAttribute("contenteditable", "true");
+    Object.defineProperty(el, "isContentEditable", {
+      value: true,
+      configurable: true,
+    });
+    window.document.body.appendChild(el);
+    return el;
+  }
+
+  /**
+   * The same rule, on an element jsdom DOES implement.
+   *
+   * A faked property proves the binding reads what it claims to; a real
+   * `<textarea>` proves the manager agrees about what typing is. Neither alone
+   * is convincing — the fake could be testing the fake.
+   */
+  function realTypingIn(): HTMLTextAreaElement {
+    const el = window.document.createElement("textarea");
+    window.document.body.appendChild(el);
+    return el;
+  }
+
+  it("leaves mod+z to the element the caret is in", () => {
+    const editor = editorSpy(pair(), "a");
+    editor.canUndo = true;
+    mount(editor);
+
+    const event = press("z", { ctrlKey: true }, typingIn());
+
+    // The DOCUMENT's history must not move: the author meant the words they
+    // just typed, and rewinding a block move they had finished with takes away
+    // something they were not asking about.
+    expect(editor.undo).not.toHaveBeenCalled();
+    // And the keystroke must reach the element, or the browser's own history
+    // cannot serve the caret either — leaving the author with no undo at all,
+    // which is worse than the wrong one.
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("leaves mod+z to a real textarea too", () => {
+    const editor = editorSpy(pair(), "a");
+    editor.canUndo = true;
+    mount(editor);
+
+    press("z", { ctrlKey: true }, realTypingIn());
+
+    expect(editor.undo).not.toHaveBeenCalled();
+  });
+
+  it("still owns mod+z when the caret is not in text", () => {
+    // The CONTROL. Without it, a canvas whose undo never fires at all passes
+    // the case above — and that is a different bug wearing the same green.
+    const editor = editorSpy(pair(), "a");
+    editor.canUndo = true;
+    mount(editor);
+
+    press("z", { ctrlKey: true });
+
+    expect(editor.undo).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves both redo spellings to the element too", () => {
+    const editor = editorSpy(pair(), "a");
+    editor.canRedo = true;
+    mount(editor);
+    const field = typingIn();
+
+    press("z", { ctrlKey: true, shiftKey: true }, field);
+    press("y", { ctrlKey: true }, field);
+
+    expect(editor.redo).not.toHaveBeenCalled();
+  });
+
+  it("still owns both redo spellings outside text", () => {
+    const editor = editorSpy(pair(), "a");
+    editor.canRedo = true;
+    mount(editor);
+
+    press("z", { ctrlKey: true, shiftKey: true });
+    press("y", { ctrlKey: true });
+
+    expect(editor.redo).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -506,6 +506,21 @@ export function useBlockKeyboardActions({
       {
         keys: "mod+z",
         description: "Undo the last change",
+        // Not while the caret is in a block's text.
+        //
+        // `whenTyping` defaults to TRUE for any binding opening on a modifier,
+        // and `preventDefault` to true with it — so without this the canvas
+        // SWALLOWS the author's undo mid-sentence and rewinds the DOCUMENT
+        // instead. They lose a block move they had finished with and keep the
+        // words they wanted back: both halves wrong at once.
+        //
+        // Declining leaves the keystroke to the element, which is what an
+        // uncontrolled `contentEditable` wants — inline editing hands the DOM
+        // over for the duration precisely so the browser's own history serves
+        // the caret. The document's history resumes owning `mod+z` the moment
+        // the edit commits, which is also when there is a document change worth
+        // undoing.
+        whenTyping: false,
         // No selection required: undo acts on the document's history, not on
         // whatever happens to be selected — and the commonest thing to undo is
         // a deletion, which leaves a different block selected than the one the
@@ -522,6 +537,10 @@ export function useBlockKeyboardActions({
         // arrive with whichever they learned.
         keys: "mod+shift+z",
         description: "Redo the last undone change",
+        // Same reason as `mod+z` above: a redo taken from the caret rewinds the
+        // wrong history. `mod+shift+z` opens on a modifier too, so it inherits
+        // the same firing default and needs the same refusal.
+        whenTyping: false,
         when: () => latest.current.canRedo,
         run: () => {
           latest.current.redo();
@@ -531,6 +550,7 @@ export function useBlockKeyboardActions({
       {
         keys: "mod+y",
         description: "Redo the last undone change",
+        whenTyping: false,
         when: () => latest.current.canRedo,
         run: () => {
           latest.current.redo();


### PR DESCRIPTION
A **shipped bug** in B-18's inline editing, found while scoping B-19.

## What an author experiences

They type a sentence into a block on the canvas, press undo expecting the last word back — and instead the canvas rewinds the **document**: a block move or insert from earlier disappears, while their typing stays. Two surprises at once, and no undo where they asked for one.

## Why

`whenTyping` **defaults to `true`** for any binding opening on a modifier (`shortcuts/manager.ts:371-383`), and `preventDefault` defaults to true with it — so the canvas's three history bindings *swallowed* the keystroke mid-sentence.

Their five siblings — delete, duplicate, the moves — all set `whenTyping: false` explicitly (lines 459, 478, 496, 503, 566). That's what makes the omission read as an oversight rather than a decision.

The sharpest evidence it was never intended: B-18's own docblock says the reason inline editing commits one op per edit is that *"a sentence typed and then undone comes back as a sentence."* This binding is precisely what prevented that.

Declining leaves the keystroke to the element — which is what an uncontrolled `contentEditable` needs, since inline editing hands the DOM over for the duration so the browser's history serves the caret. The document's history resumes owning undo the moment the edit commits, which is also when there's a document change worth undoing.

## Two false greens caught while writing the tests — both mine

**Wrong modifier.** My first version pressed `metaKey`; every other case in the file uses `ctrlKey`, because `mod` resolves to ctrl in this environment. The binding matched nothing, so all four assertions passed *while asserting nothing*. The **control** cases — requiring the canvas to still own undo outside text — are what exposed it.

**jsdom implements neither half of `contentEditable`.** Assigning the property sets no attribute and `isContentEditable` reads `undefined` — measured with a probe returning `{ attr: null, isCE: undefined }`. The test element was never a typing target. It's now told what it is, **and** a real `<textarea>` case sits beside it: a faked property can only prove the binding reads what it claims to; it takes an element jsdom actually implements to prove the manager agrees about what typing *is*.

## Verification

- Removing the fix turns all three typing cases red; restoring it turns them green
- **860 builder tests pass**; lint and typecheck clean

## Scope

Its own PR deliberately. This is B-18's regression, and folding it into B-19 would bury a shipped bug inside a feature. B-19 adds Lexical's own history to the same keystroke — and Lexical's undo handler doesn't `stopPropagation` — so it should inherit a sane baseline rather than arrive at three interacting undo stacks.

Note `main` is currently red on unrelated grounds (the releases/drizzle work), so this will need that repair before it can go green.