### PR TITLE
feat(blocks-react): render stored rich text in a block

### DIFF
--- a/.changeset/rich-text-in-blocks.md
+++ b/.changeset/rich-text-in-blocks.md
@@ -18,6 +18,7 @@
 "@nextlyhq/plugin-seo": patch
 "@nextlyhq/plugin-sdk": patch
 "@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
 "@nextlyhq/prettier-config": patch
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch
@@ -25,11 +26,29 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-Rich text can now live in a block and render on a published page. A block prop holds exactly what the
-rich-text field holds — Lexical's serialized tree — so an author's rich text is one kind of thing
-wherever they typed it.
+Rich text can now live in a block and render on a published page. A block prop
+holds exactly what the rich-text field holds — Lexical's serialized tree — so an
+author's rich text is one kind of thing wherever they typed it.
 
-The type and Lexical's format bits move into `blocks-engine`, which the CMS and the renderer both
-already depend on. They cannot share a reader: the renderer is forbidden from importing the CMS. They
-can share a definition, and now do — so the two can only ever disagree about output, never about what
-the data means.
+The type, the format bits and the "is this rich text" test move into
+`blocks-engine`, which the CMS and the renderer both already depend on, and the
+CMS now reads them from there instead of keeping its own. The two cannot share a
+READER: the renderer is forbidden from importing the CMS. They can share a
+DEFINITION, and now do, so the two can only disagree about output and never
+about what the data means. The copies this replaces had already drifted — the
+CMS's test accepted a root with no `children`, which its own serializer could
+only render as empty.
+
+A stored link URL is now sanitized before it reaches an `href`, through the same
+boundary every other stored URL in the renderer crosses; a destination that
+boundary refuses renders as the author's words rather than as a link. Links keep
+the `target` and `rel` the editor stored. Lexical's three case formats are
+recognised rather than dropped, and horizontal rules, tables, code blocks and
+collapsible sections render as themselves instead of as loose text.
+
+Two fixes to how stored text is read. A malformed node — a `null` where a node
+belongs — is skipped rather than throwing during the render of a published page.
+And plain-text extraction no longer inserts a space between every text leaf,
+which turned a part-bold `prefix` into `pre fix` for anything reading it for
+search or SEO; separators now fall at block boundaries, and the walk is
+iterative so a deeply nested value cannot exhaust the call stack.

--- a/.changeset/rich-text-in-blocks.md
+++ b/.changeset/rich-text-in-blocks.md
@@ -52,3 +52,11 @@ And plain-text extraction no longer inserts a space between every text leaf,
 which turned a part-bold `prefix` into `pre fix` for anything reading it for
 search or SEO; separators now fall at block boundaries, and the walk is
 iterative so a deeply nested value cannot exhaust the call stack.
+
+Dragging a block on the canvas no longer selects its text instead of moving it.
+Blocks are made of text, so a press that lands on a word and then moves is
+ambiguous, and the browser resolved it first: selection begins on the first
+move, while the drag engine waits for the pointer to travel far enough to mean
+a drag. Whether a given press hit a word depended on where the glyphs fell, so
+the same gesture worked or failed depending on the font. The canvas now treats a
+press as a grab, and text being edited opts back in to being selectable.

--- a/.changeset/rich-text-in-blocks.md
+++ b/.changeset/rich-text-in-blocks.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Rich text can now live in a block and render on a published page. A block prop holds exactly what the
+rich-text field holds — Lexical's serialized tree — so an author's rich text is one kind of thing
+wherever they typed it.
+
+The type and Lexical's format bits move into `blocks-engine`, which the CMS and the renderer both
+already depend on. They cannot share a reader: the renderer is forbidden from importing the CMS. They
+can share a definition, and now do — so the two can only ever disagree about output, never about what
+the data means.

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -34,6 +34,21 @@ const E2E_DB_RELATIVE = "file:./data/e2e.db";
 
 export default defineConfig({
   testDir: "./tests",
+  /*
+   * `tests/production` belongs to the OTHER config and must not run here.
+   *
+   * Those specs drive a production build: they sign in through the real form
+   * and assert what a visitor is served. This config runs `pnpm dev:app`, where
+   * `admin.devAutoLogin` puts the browser on the dashboard already signed in —
+   * so the sign-in form never renders and the spec fails waiting for an input
+   * that a production build would have shown it.
+   *
+   * The default `testDir` walks subdirectories, so a spec placed under `tests/`
+   * is picked up by this config whether or not it was written for it. Excluding
+   * by path is what keeps "which server does this suite need" a property of the
+   * directory rather than something each spec has to survive.
+   */
+  testIgnore: "**/production/**",
   outputDir: "./.playwright/results",
 
   // A failing assertion in a shared admin is usually a real failure, so the

--- a/e2e/tests/canvas/text-selection.spec.ts
+++ b/e2e/tests/canvas/text-selection.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * A press on a block is a grab, not a text selection.
+ *
+ * Blocks are made of text, so the two gestures start identically: pointer down
+ * on a word, then movement. The browser resolves that as a selection on the
+ * FIRST move, while `useCanvasDrag` does not call itself dragging until the
+ * pointer has travelled its activation distance — so without something saying
+ * otherwise, the browser's answer is the one that lands and the author gets
+ * highlighted words instead of a moved block.
+ *
+ * Whether a given press hits text at all depends on where the glyphs fall, so
+ * this reproduced on CI's font metrics while passing on the machine the canvas
+ * was written on. That is why the press here is aimed at a word deliberately
+ * rather than at a block's corner: the corner is only sometimes over text, and
+ * a test that is only sometimes over text only sometimes tests this.
+ *
+ * @module tests/canvas/text-selection
+ */
+
+const ROUTE = "/builder-canvas";
+const HOST = '[data-testid="canvas-harness"]';
+
+async function openCanvas(page: Page): Promise<void> {
+  await page.goto(ROUTE);
+  await page.locator(HOST).waitFor();
+}
+
+/** The middle of a rendered word, which is the ambiguous place to press. */
+async function wordPoint(
+  page: Page,
+  nodeId: string
+): Promise<{ x: number; y: number }> {
+  const point = await page
+    .locator(`[data-nx-node="${nodeId}"]`)
+    .evaluate(element => {
+      const text = element.ownerDocument.evaluate(
+        ".//text()[normalize-space()]",
+        element,
+        null,
+        9 /* FIRST_ORDERED_NODE_TYPE */,
+        null
+      ).singleNodeValue;
+      if (text === null) return null;
+      const range = element.ownerDocument.createRange();
+      range.selectNodeContents(text);
+      const rect = range.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return null;
+      return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+    });
+  if (point === null) throw new Error(`${nodeId} renders no measurable text`);
+  return point;
+}
+
+test.describe("pressing a block's text", () => {
+  test("drags the block instead of selecting the words", async ({ page }) => {
+    await openCanvas(page);
+
+    const from = await wordPoint(page, "hx-text-short");
+    await page.mouse.move(from.x, from.y);
+    await page.mouse.down();
+    // Stepped, because both the activation threshold and the browser's own
+    // selection respond to movement rather than to a final position.
+    await page.mouse.move(from.x, from.y + 120, { steps: 16 });
+
+    const dragging = await page.locator(HOST).getAttribute("data-nx-dragging");
+    const selected = await page.evaluate(() =>
+      (globalThis.getSelection()?.toString() ?? "").trim()
+    );
+
+    await page.mouse.up();
+
+    expect(
+      dragging,
+      "a press on a word then a drag must pick the block up"
+    ).toBeTruthy();
+    expect(
+      selected,
+      `the drag selected text instead of moving a block: ${JSON.stringify(selected)}`
+    ).toBe("");
+  });
+
+  test("still lets an editable block's own text be selected", async ({
+    page,
+  }) => {
+    // The canvas turns selection off; anything editable turns it back on. This
+    // is the half that keeps the rule from breaking inline editing, and it is
+    // asserted on a real element rather than by reading the stylesheet.
+    await openCanvas(page);
+    const editable = await page.evaluate(() => {
+      const canvas = document.querySelector(".nx-canvas");
+      if (canvas === null) return null;
+      const probe = document.createElement("p");
+      probe.setAttribute("contenteditable", "true");
+      probe.textContent = "editable text";
+      canvas.appendChild(probe);
+      const style = getComputedStyle(probe).userSelect;
+      probe.remove();
+      return style;
+    });
+    expect(editable).toBe("text");
+  });
+});

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -388,6 +388,7 @@ export {
  */
 export {
   hasFormat,
+  isRichTextNode,
   isRichTextValue,
   richTextToPlainText,
   TEXT_FORMAT,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -378,3 +378,19 @@ export {
   isReservedOperationName,
   type ReservedOperationName,
 } from "./operations";
+
+/**
+ * The stored shape of rich text.
+ *
+ * Shared here because the CMS and the renderer both read it and may not import
+ * each other — see the module for why a shared DEFINITION is the containable
+ * form of that, and two readers is not.
+ */
+export {
+  hasFormat,
+  isRichTextValue,
+  richTextToPlainText,
+  TEXT_FORMAT,
+  type RichTextNode,
+  type RichTextValue,
+} from "./rich-text";

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -387,6 +387,7 @@ export {
  * form of that, and two readers is not.
  */
 export {
+  codeTokenClass,
   hasFormat,
   isRichTextNode,
   isRichTextValue,

--- a/packages/blocks-engine/src/rich-text.test.ts
+++ b/packages/blocks-engine/src/rich-text.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isRichTextValue,
+  richTextToPlainText,
+  type RichTextValue,
+} from "./rich-text";
+
+const value = (children: RichTextValue["root"]["children"]): RichTextValue => ({
+  root: { type: "root", children },
+});
+
+describe("isRichTextValue", () => {
+  it("recognises a rooted value", () => {
+    expect(isRichTextValue(value([]))).toBe(true);
+  });
+
+  it("rejects the shapes a prop actually holds instead", () => {
+    // Every one of these is a real stored prop value elsewhere in the format,
+    // and a renderer choosing between "draw a tree" and "draw a string" has to
+    // tell them apart without guessing.
+    for (const other of ["", "text", 0, 42, null, undefined, [], {}]) {
+      expect(isRichTextValue(other), `${JSON.stringify(other)}`).toBe(false);
+    }
+  });
+
+  it("rejects a root that is not rooted", () => {
+    // The marker is the SHAPE, because the value arrives from storage as parsed
+    // JSON with no class to ask.
+    expect(isRichTextValue({ root: { type: "paragraph", children: [] } })).toBe(
+      false
+    );
+    expect(isRichTextValue({ root: { type: "root" } })).toBe(false);
+  });
+});
+
+describe("richTextToPlainText", () => {
+  it("reads text out of a nested tree", () => {
+    expect(
+      richTextToPlainText(
+        value([
+          {
+            type: "paragraph",
+            children: [
+              { type: "text", text: "Hello" },
+              { type: "link", children: [{ type: "text", text: "world" }] },
+            ],
+          },
+        ])
+      )
+    ).toBe("Hello world");
+  });
+
+  it("keeps two block-level nodes from becoming one word", () => {
+    // Concatenating would produce "firstsecond", which then indexes and reads
+    // as a word nobody wrote.
+    expect(
+      richTextToPlainText(
+        value([
+          { type: "paragraph", children: [{ type: "text", text: "first" }] },
+          { type: "paragraph", children: [{ type: "text", text: "second" }] },
+        ])
+      )
+    ).toBe("first second");
+  });
+
+  it("answers empty for an empty document rather than throwing", () => {
+    expect(richTextToPlainText(value([]))).toBe("");
+  });
+
+  it("ignores nodes carrying no text, without losing their children", () => {
+    expect(
+      richTextToPlainText(
+        value([
+          {
+            type: "list",
+            children: [
+              { type: "listitem", children: [{ type: "text", text: "one" }] },
+            ],
+          },
+        ])
+      )
+    ).toBe("one");
+  });
+});

--- a/packages/blocks-engine/src/rich-text.test.ts
+++ b/packages/blocks-engine/src/rich-text.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  isRichTextNode,
   isRichTextValue,
   richTextToPlainText,
+  TEXT_FORMAT,
+  type RichTextNode,
   type RichTextValue,
 } from "./rich-text";
 
@@ -36,13 +39,16 @@ describe("isRichTextValue", () => {
 
 describe("richTextToPlainText", () => {
   it("reads text out of a nested tree", () => {
+    // The space belongs to the text node, because that is where the author
+    // typed it — Lexical stores the separator between a word and a following
+    // link inside the preceding leaf, and nothing downstream adds one.
     expect(
       richTextToPlainText(
         value([
           {
             type: "paragraph",
             children: [
-              { type: "text", text: "Hello" },
+              { type: "text", text: "Hello " },
               { type: "link", children: [{ type: "text", text: "world" }] },
             ],
           },
@@ -81,5 +87,114 @@ describe("richTextToPlainText", () => {
         ])
       )
     ).toBe("one");
+  });
+});
+
+describe("isRichTextNode", () => {
+  it("accepts any node with a string type, including one nothing here knows", () => {
+    // Permissive about WHICH node, because a site registers its own and this
+    // package has no list of them.
+    expect(isRichTextNode({ type: "paragraph" })).toBe(true);
+    expect(isRichTextNode({ type: "some-plugin-node", payload: 1 })).toBe(true);
+  });
+
+  it("rejects the values a malformed `children` array actually holds", () => {
+    // Each of these survives JSON round-tripping into a children array, and
+    // every one of them throws when a walker reads `.text` off it.
+    for (const other of [null, undefined, "text", 0, true, [], { text: "x" }]) {
+      expect(isRichTextNode(other), `${JSON.stringify(other)}`).toBe(false);
+    }
+  });
+});
+
+describe("richTextToPlainText", () => {
+  it("does not insert a space where formatting split one word", () => {
+    // Lexical ends a text node at every format change, so a part-bold word
+    // arrives as two adjacent leaves. Joining leaves with a space would put a
+    // space inside the word and index `pre fix` for what the author typed as
+    // `prefix`.
+    expect(
+      richTextToPlainText(
+        value([
+          {
+            type: "paragraph",
+            children: [
+              { type: "text", text: "pre" },
+              { type: "text", text: "fix", format: TEXT_FORMAT.BOLD },
+            ],
+          },
+        ])
+      )
+    ).toBe("prefix");
+  });
+
+  it("does not push punctuation away from the word it follows", () => {
+    expect(
+      richTextToPlainText(
+        value([
+          {
+            type: "paragraph",
+            children: [
+              { type: "text", text: "Hello" },
+              { type: "text", text: ",", format: TEXT_FORMAT.BOLD },
+              { type: "text", text: " there" },
+            ],
+          },
+        ])
+      )
+    ).toBe("Hello, there");
+  });
+
+  it("keeps a link's text against the words around it", () => {
+    // A link is inline: it interrupts formatting, not the sentence.
+    expect(
+      richTextToPlainText(
+        value([
+          {
+            type: "paragraph",
+            children: [
+              { type: "text", text: "see " },
+              { type: "link", children: [{ type: "text", text: "docs" }] },
+              { type: "text", text: " now" },
+            ],
+          },
+        ])
+      )
+    ).toBe("see docs now");
+  });
+
+  it("separates at a line break", () => {
+    expect(
+      richTextToPlainText(
+        value([
+          {
+            type: "paragraph",
+            children: [
+              { type: "text", text: "one" },
+              { type: "linebreak" },
+              { type: "text", text: "two" },
+            ],
+          },
+        ])
+      )
+    ).toBe("one two");
+  });
+
+  it("survives a tree deep enough to overflow a recursive walk", () => {
+    // The document limits count block nodes, not the objects inside one prop,
+    // so nesting like this is reachable well under the size cap. A recursive
+    // implementation throws RangeError here and takes the request with it.
+    let node: RichTextNode = { type: "text", text: "bottom" };
+    for (let i = 0; i < 20_000; i++) {
+      node = { type: "paragraph", children: [node] };
+    }
+    expect(richTextToPlainText(value([node]))).toBe("bottom");
+  });
+
+  it("skips a malformed child instead of throwing", () => {
+    const malformed = {
+      root: { type: "root", children: [null, { type: "text", text: "kept" }] },
+    } as unknown as RichTextValue;
+    expect(richTextToPlainText(malformed)).toBe("kept");
   });
 });

--- a/packages/blocks-engine/src/rich-text.test.ts
+++ b/packages/blocks-engine/src/rich-text.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  codeTokenClass,
   isRichTextNode,
   isRichTextValue,
   richTextToPlainText,
@@ -196,5 +197,67 @@ describe("richTextToPlainText", () => {
       root: { type: "root", children: [null, { type: "text", text: "kept" }] },
     } as unknown as RichTextValue;
     expect(richTextToPlainText(malformed)).toBe("kept");
+  });
+});
+
+describe("richTextToPlainText malformed children", () => {
+  it("skips a string child instead of emitting it as text", () => {
+    // The walk marks block boundaries with a sentinel of its own. A string
+    // sentinel would be forgeable from storage: this `"injected"` would be read
+    // back as the marker and pushed into the output as if an author had typed
+    // it.
+    const malformed = {
+      root: {
+        type: "root",
+        children: [
+          {
+            type: "paragraph",
+            children: ["injected", { type: "text", text: "real" }],
+          },
+        ],
+      },
+    } as unknown as RichTextValue;
+    expect(richTextToPlainText(malformed)).toBe("real");
+  });
+
+  it("skips a node whose children are not an array", () => {
+    const malformed = {
+      root: {
+        type: "root",
+        children: [
+          { type: "paragraph", children: "oops" },
+          { type: "paragraph", children: [{ type: "text", text: "kept" }] },
+        ],
+      },
+    } as unknown as RichTextValue;
+    expect(richTextToPlainText(malformed)).toBe("kept");
+  });
+});
+
+describe("codeTokenClass", () => {
+  it("names the class a token type gets", () => {
+    expect(codeTokenClass("keyword")).toBe(
+      "nextly-code-token nextly-code-token--keyword"
+    );
+    expect(codeTokenClass("attr-name")).toBe(
+      "nextly-code-token nextly-code-token--attr-name"
+    );
+  });
+
+  it("refuses a type that could break out of a class attribute", () => {
+    // The CMS writes this into an HTML string by hand, so a type carrying a
+    // quote would close the attribute and inject markup.
+    for (const bad of [
+      '"><script>alert(1)</script>',
+      "Keyword",
+      "1keyword",
+      "key word",
+      "",
+      undefined,
+      null,
+      42,
+    ]) {
+      expect(codeTokenClass(bad), `${JSON.stringify(bad)}`).toBeUndefined();
+    }
   });
 });

--- a/packages/blocks-engine/src/rich-text.ts
+++ b/packages/blocks-engine/src/rich-text.ts
@@ -127,6 +127,17 @@ export function isRichTextValue(value: unknown): value is RichTextValue {
 const INLINE_CONTAINERS: ReadonlySet<string> = new Set(["link", "autolink"]);
 
 /**
+ * Marks where a block ended, while the walk is still in progress.
+ *
+ * A unique symbol rather than a string, because the stack also holds values
+ * that came out of storage. A string sentinel is forgeable: a `children` array
+ * holding `" "` — or any other string — would be read back as this marker and
+ * emitted as text, so malformed stored data could put words into the output
+ * instead of being skipped. Nothing in parsed JSON can equal a symbol.
+ */
+const BLOCK_BOUNDARY: unique symbol = Symbol("rich-text block boundary");
+
+/**
  * The plain text inside a rich-text value, for anything that needs words rather
  * than formatting.
  *
@@ -157,14 +168,14 @@ export function richTextToPlainText(value: RichTextValue): string {
   // A string on the stack is a separator to emit once the subtree that earned it
   // has been consumed; pushing it BEFORE that node's children is what places it
   // after them, since the stack pops in reverse.
-  const stack: (RichTextNode | string)[] = [];
+  const stack: (RichTextNode | typeof BLOCK_BOUNDARY)[] = [];
   pushChildren(stack, value.root.children);
 
   while (stack.length > 0) {
     const item = stack.pop();
     if (item === undefined) continue;
-    if (typeof item === "string") {
-      parts.push(item);
+    if (item === BLOCK_BOUNDARY) {
+      parts.push(" ");
       continue;
     }
     if (!isRichTextNode(item)) continue;
@@ -175,7 +186,7 @@ export function richTextToPlainText(value: RichTextValue): string {
       continue;
     }
 
-    if (!INLINE_CONTAINERS.has(item.type)) stack.push(" ");
+    if (!INLINE_CONTAINERS.has(item.type)) stack.push(BLOCK_BOUNDARY);
     if (Array.isArray(item.children)) pushChildren(stack, item.children);
   }
 
@@ -190,7 +201,7 @@ export function richTextToPlainText(value: RichTextValue): string {
  * value by hand can.
  */
 function pushChildren(
-  stack: (RichTextNode | string)[],
+  stack: (RichTextNode | typeof BLOCK_BOUNDARY)[],
   nodes: readonly RichTextNode[]
 ): void {
   for (let i = nodes.length - 1; i >= 0; i--) {
@@ -250,4 +261,29 @@ export function hasFormat(
   flag: (typeof TEXT_FORMAT)[keyof typeof TEXT_FORMAT]
 ): boolean {
   return ((format ?? 0) & flag) !== 0;
+}
+
+/**
+ * Token types the code tokenizer emits, as a class-name fragment.
+ *
+ * Checked rather than trusted: the value arrives from stored content and is
+ * written into a class attribute, where a crafted string could otherwise close
+ * the attribute and inject markup in a serializer that builds HTML by hand.
+ */
+const SAFE_HIGHLIGHT_TYPE = /^[a-z][a-z0-9-]*$/;
+
+/**
+ * The class a syntax-highlighted code token carries, or `undefined` for a token
+ * whose type is missing or unusable.
+ *
+ * Shared for the same reason the format bits are: the CMS builds an HTML string
+ * and the renderer builds a React element, but WHICH class a token gets is one
+ * question, and two answers to it means code highlighted on one surface and
+ * bare on the other with nothing raised on either. A token with no usable type
+ * is emitted unwrapped rather than given an element that would say nothing.
+ */
+export function codeTokenClass(highlightType: unknown): string | undefined {
+  if (typeof highlightType !== "string") return undefined;
+  if (!SAFE_HIGHLIGHT_TYPE.test(highlightType)) return undefined;
+  return `nextly-code-token nextly-code-token--${highlightType}`;
 }

--- a/packages/blocks-engine/src/rich-text.ts
+++ b/packages/blocks-engine/src/rich-text.ts
@@ -1,0 +1,148 @@
+/**
+ * The stored shape of rich text, shared by everything that reads it.
+ *
+ * Rich text is Lexical's own serialized editor state, and it is stored verbatim
+ * — the CMS's rich-text field has always done this, and a block's rich prop now
+ * holds the same thing (decision:inline-rich-text-shape, founder, 2026-08-20).
+ * An author's rich text is one kind of thing, so it has one stored shape
+ * wherever they typed it.
+ *
+ * ## Why the TYPE lives here and the renderers do not
+ *
+ * Two things must read this format and they may not import each other. The CMS
+ * derives HTML from it for API consumers; `blocks-react` draws it as a React
+ * tree, and its layering test forbids it from importing the CMS, the admin or
+ * the plugin SDK. So there is no package either of them could share a READER
+ * through.
+ *
+ * They can share a DEFINITION, though, and this package is the one place both
+ * already depend on — it is runtime-free by construction, which is what lets a
+ * renderer and a server both hold it. A React tree and an HTML string are
+ * genuinely different outputs, so two producers is not two implementations of
+ * one thing; what would be dangerous is two ideas of what a node IS, and that is
+ * the risk this module exists to remove.
+ *
+ * The risk is not imagined: two renderers in this programme once diverged on
+ * condition gating, in opposite directions, and nothing surfaced it until an
+ * audit went looking.
+ *
+ * ## Deliberately permissive
+ *
+ * Nodes carry an index signature and unknown types are not rejected. Lexical's
+ * node set is extensible and this package has no opinion about which nodes a
+ * site registered — an unknown node is a rendering question, answered by the
+ * renderer's placeholder, not a validation error that would refuse to store
+ * content an editor already accepted.
+ *
+ * @module rich-text
+ */
+
+/**
+ * One node of stored rich text.
+ *
+ * `type` is the only field every node has. `children`, `text` and `format` are
+ * the ones a reader can rely on when present, and everything else is whatever
+ * the node class serialized.
+ */
+export interface RichTextNode {
+  /** The node type, as its Lexical class serializes it — `paragraph`, `text`, `heading`. */
+  type: string;
+  /** Child nodes, for container types. */
+  children?: RichTextNode[];
+  /** The text itself, for text nodes. */
+  text?: string;
+  /** Lexical's format bitfield: bold, italic, underline and the rest. */
+  format?: number;
+  /** Whatever else the node serialized. */
+  [key: string]: unknown;
+}
+
+/** A whole rich-text value: Lexical's editor state, rooted. */
+export interface RichTextValue {
+  root: {
+    type: "root";
+    children: RichTextNode[];
+    [key: string]: unknown;
+  };
+}
+
+/**
+ * Whether a stored value is rich text.
+ *
+ * Structural, not nominal: it checks for the root a reader would walk, because
+ * the value arrives from storage as parsed JSON with no class to ask. A prop
+ * holding a string, a number or null is not rich text and this says so — which
+ * is what lets a renderer choose between drawing a tree and drawing a string
+ * without either guessing.
+ */
+export function isRichTextValue(value: unknown): value is RichTextValue {
+  if (typeof value !== "object" || value === null) return false;
+  const root = (value as { root?: unknown }).root;
+  if (typeof root !== "object" || root === null) return false;
+  const typed = root as { type?: unknown; children?: unknown };
+  return typed.type === "root" && Array.isArray(typed.children);
+}
+
+/**
+ * The plain text inside a rich-text value, for anything that needs words rather
+ * than formatting.
+ *
+ * SEO extraction and search indexing both want this, and both would otherwise
+ * write their own walk — which is the second-reader problem this module exists
+ * to avoid, in miniature.
+ *
+ * Block-level nodes are joined with a space rather than concatenated, so two
+ * paragraphs do not become one run-on word. Nothing is trimmed beyond that: a
+ * caller wanting a summary length has its own rule, and guessing here would give
+ * it a different answer than it asked for.
+ */
+export function richTextToPlainText(value: RichTextValue): string {
+  const parts: string[] = [];
+  const walk = (nodes: readonly RichTextNode[]): void => {
+    for (const node of nodes) {
+      if (typeof node.text === "string") parts.push(node.text);
+      if (Array.isArray(node.children)) walk(node.children);
+    }
+  };
+  walk(value.root.children);
+  return parts.join(" ").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Lexical's text-format bitfield.
+ *
+ * Here rather than in each reader because these numbers ARE what a node means.
+ * A renderer that re-declared them would agree on the day it was written and
+ * disagree the day Lexical adds a format — and the disagreement would show up
+ * as text rendering unstyled on one surface and styled on the other, with
+ * nothing raised on either.
+ *
+ * The values are Lexical's own and are part of the stored data: content saved
+ * today carries `format: 3` meaning bold-and-italic, so these cannot be
+ * renumbered without rewriting every document that used them.
+ *
+ * NOT YET THE ONLY COPY. `packages/nextly`'s HTML serializer still declares its
+ * own, identical set. Converging it is a separate change: that file carries
+ * pre-existing complexity findings which a five-line import would pull into
+ * whatever PR touched it, and an 88-line serializer deserves a refactor of its
+ * own rather than one taken in passing. Until then the drift risk is the one
+ * that already existed, and this is the copy new readers should use.
+ */
+export const TEXT_FORMAT = {
+  BOLD: 1,
+  ITALIC: 2,
+  STRIKETHROUGH: 4,
+  UNDERLINE: 8,
+  CODE: 16,
+  SUBSCRIPT: 32,
+  SUPERSCRIPT: 64,
+  HIGHLIGHT: 128,
+} as const;
+
+/** Whether a node's format bitfield carries one particular format. */
+export function hasFormat(
+  format: number | undefined,
+  flag: (typeof TEXT_FORMAT)[keyof typeof TEXT_FORMAT]
+): boolean {
+  return ((format ?? 0) & flag) !== 0;
+}

--- a/packages/blocks-engine/src/rich-text.ts
+++ b/packages/blocks-engine/src/rich-text.ts
@@ -1,11 +1,10 @@
 /**
  * The stored shape of rich text, shared by everything that reads it.
  *
- * Rich text is Lexical's own serialized editor state, and it is stored verbatim
- * — the CMS's rich-text field has always done this, and a block's rich prop now
- * holds the same thing (decision:inline-rich-text-shape, founder, 2026-08-20).
- * An author's rich text is one kind of thing, so it has one stored shape
- * wherever they typed it.
+ * Rich text is Lexical's own serialized editor state, and it is stored verbatim:
+ * the CMS's rich-text field holds it, and so does a block's rich prop. An
+ * author's rich text is one kind of thing, so it has one stored shape wherever
+ * they typed it.
  *
  * ## Why the TYPE lives here and the renderers do not
  *
@@ -26,13 +25,17 @@
  * condition gating, in opposite directions, and nothing surfaced it until an
  * audit went looking.
  *
- * ## Deliberately permissive
+ * ## Deliberately permissive about node TYPES, strict about node SHAPE
  *
- * Nodes carry an index signature and unknown types are not rejected. Lexical's
- * node set is extensible and this package has no opinion about which nodes a
- * site registered — an unknown node is a rendering question, answered by the
- * renderer's placeholder, not a validation error that would refuse to store
+ * Nodes carry an index signature and unknown `type` values are not rejected.
+ * Lexical's node set is extensible and this package has no opinion about which
+ * nodes a site registered — an unknown node is a rendering question, answered by
+ * the renderer's placeholder, not a validation error that would refuse to store
  * content an editor already accepted.
+ *
+ * That tolerance stops at shape. A value that is not an object, or whose `type`
+ * is not a string, is not a node any reader can walk, and treating it as one
+ * turns a malformed stored document into a crash on a published page.
  *
  * @module rich-text
  */
@@ -67,6 +70,30 @@ export interface RichTextValue {
 }
 
 /**
+ * Whether one value from a `children` array is a node a reader can walk.
+ *
+ * SHALLOW, and that is the design rather than an omission. The alternative is to
+ * validate the whole tree inside {@link isRichTextValue}, which walks every node
+ * of a document to answer a question about its root, and then the renderer walks
+ * it again to draw it. On a large document that is two full traversals where one
+ * would do, and the second one is spent on a value already known to be good.
+ *
+ * Checking each node as it is reached costs one comparison per node on a walk
+ * that was happening anyway, and it holds at every depth — including the nodes a
+ * deep validator would have to re-check after any caller built a tree by hand.
+ *
+ * `type` must be a string because it is what every reader switches on. Nothing
+ * else is required: a node's remaining fields belong to its own class, and a
+ * reader that wants one checks for it.
+ */
+export function isRichTextNode(value: unknown): value is RichTextNode {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  return typeof (value as { type?: unknown }).type === "string";
+}
+
+/**
  * Whether a stored value is rich text.
  *
  * Structural, not nominal: it checks for the root a reader would walk, because
@@ -74,6 +101,9 @@ export interface RichTextValue {
  * holding a string, a number or null is not rich text and this says so — which
  * is what lets a renderer choose between drawing a tree and drawing a string
  * without either guessing.
+ *
+ * `children` must be an array. A root without one is not walkable, and the
+ * readers of this format all reach for `root.children` immediately.
  */
 export function isRichTextValue(value: unknown): value is RichTextValue {
   if (typeof value !== "object" || value === null) return false;
@@ -84,6 +114,19 @@ export function isRichTextValue(value: unknown): value is RichTextValue {
 }
 
 /**
+ * Node types whose contents run INTO the surrounding text rather than standing
+ * apart from it.
+ *
+ * Everything else that has children is treated as block-level and gets a
+ * boundary after it. Listing the inline ones rather than the block ones is what
+ * makes this safe for a node type this package has never heard of: an unknown
+ * container is far more likely to be a block than an inline wrapper, and
+ * guessing block only ever inserts a space that was arguably wanted, where
+ * guessing inline runs two paragraphs together.
+ */
+const INLINE_CONTAINERS: ReadonlySet<string> = new Set(["link", "autolink"]);
+
+/**
  * The plain text inside a rich-text value, for anything that needs words rather
  * than formatting.
  *
@@ -91,21 +134,82 @@ export function isRichTextValue(value: unknown): value is RichTextValue {
  * write their own walk — which is the second-reader problem this module exists
  * to avoid, in miniature.
  *
- * Block-level nodes are joined with a space rather than concatenated, so two
- * paragraphs do not become one run-on word. Nothing is trimmed beyond that: a
- * caller wanting a summary length has its own rule, and guessing here would give
- * it a different answer than it asked for.
+ * ## Separators go at block boundaries, never between text leaves
+ *
+ * Lexical splits a run of text at every change of formatting, so the word
+ * `prefix` with only its second half bold is stored as two adjacent text nodes.
+ * Joining leaves with a space turns that into `pre fix`, and `Hello` followed by
+ * a bold comma into `Hello ,`. Adjacent leaves are therefore concatenated, and a
+ * space is introduced only when leaving a block-level container or crossing a
+ * line break — which is where the author put a boundary.
+ *
+ * ## Iterative
+ *
+ * The walk uses an explicit stack rather than recursion. Nesting depth here is
+ * bounded by what an editor produced, not by anything this package enforces:
+ * the document limits count block nodes, not the objects inside a prop, so a
+ * value well under the size cap can nest thousands of paragraphs deep. Recursion
+ * would exhaust the call stack on it, and this helper is exported to SEO and
+ * search paths where that would take down a request rather than a render.
  */
 export function richTextToPlainText(value: RichTextValue): string {
   const parts: string[] = [];
-  const walk = (nodes: readonly RichTextNode[]): void => {
-    for (const node of nodes) {
-      if (typeof node.text === "string") parts.push(node.text);
-      if (Array.isArray(node.children)) walk(node.children);
+  // A string on the stack is a separator to emit once the subtree that earned it
+  // has been consumed; pushing it BEFORE that node's children is what places it
+  // after them, since the stack pops in reverse.
+  const stack: (RichTextNode | string)[] = [];
+  pushChildren(stack, value.root.children);
+
+  while (stack.length > 0) {
+    const item = stack.pop();
+    if (item === undefined) continue;
+    if (typeof item === "string") {
+      parts.push(item);
+      continue;
     }
-  };
-  walk(value.root.children);
-  return parts.join(" ").replace(/\s+/g, " ").trim();
+    if (!isRichTextNode(item)) continue;
+
+    const leaf = leafText(item);
+    if (leaf !== null) {
+      parts.push(leaf);
+      continue;
+    }
+
+    if (!INLINE_CONTAINERS.has(item.type)) stack.push(" ");
+    if (Array.isArray(item.children)) pushChildren(stack, item.children);
+  }
+
+  return parts.join("").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Pushes children so the stack pops them in document order.
+ *
+ * Reversed, because a stack returns what went on last. The `undefined` skip is
+ * what a sparse array yields, which JSON cannot express but a caller building a
+ * value by hand can.
+ */
+function pushChildren(
+  stack: (RichTextNode | string)[],
+  nodes: readonly RichTextNode[]
+): void {
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    const child = nodes[i];
+    if (child !== undefined) stack.push(child);
+  }
+}
+
+/**
+ * The text this node contributes on its own, or `null` if it is a container to
+ * descend into.
+ *
+ * A line break contributes a space: it is where the author ended a line, and
+ * plain text has no other way to say so.
+ */
+function leafText(node: RichTextNode): string | null {
+  if (typeof node.text === "string") return node.text;
+  if (node.type === "linebreak") return " ";
+  return null;
 }
 
 /**
@@ -121,12 +225,10 @@ export function richTextToPlainText(value: RichTextValue): string {
  * today carries `format: 3` meaning bold-and-italic, so these cannot be
  * renumbered without rewriting every document that used them.
  *
- * NOT YET THE ONLY COPY. `packages/nextly`'s HTML serializer still declares its
- * own, identical set. Converging it is a separate change: that file carries
- * pre-existing complexity findings which a five-line import would pull into
- * whatever PR touched it, and an 88-line serializer deserves a refactor of its
- * own rather than one taken in passing. Until then the drift risk is the one
- * that already existed, and this is the copy new readers should use.
+ * The three case formats occupy bits 8 through 10, above a gap left by the
+ * inline formats. They are transforms of how existing text is drawn rather than
+ * elements wrapped around it, which is why a reader renders them as a style and
+ * not as a tag.
  */
 export const TEXT_FORMAT = {
   BOLD: 1,
@@ -137,6 +239,9 @@ export const TEXT_FORMAT = {
   SUBSCRIPT: 32,
   SUPERSCRIPT: 64,
   HIGHLIGHT: 128,
+  LOWERCASE: 256,
+  UPPERCASE: 512,
+  CAPITALIZE: 1024,
 } as const;
 
 /** Whether a node's format bitfield carries one particular format. */

--- a/packages/blocks-react/package.json
+++ b/packages/blocks-react/package.json
@@ -68,6 +68,7 @@
   "devDependencies": {
     "@nextlyhq/eslint-config": "workspace:*",
     "@nextlyhq/tsconfig": "workspace:*",
+    "@testing-library/react": "^16.3.0",
     "@types/node": "^20.19.17",
     "@types/react": "19.2.0",
     "@types/react-dom": "19.2.0",

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -24,6 +24,7 @@ import { describe, expect, it } from "vitest";
 import * as boundaryModule from "./block-boundary";
 import * as blocksEntry from "./blocks/index";
 import * as contextModule from "./context";
+import * as richTextModule from "./rich-text";
 import * as pageRendererModule from "./page-renderer";
 import * as placeholderModule from "./placeholder";
 import * as prepareModule from "./prepare-document";
@@ -83,6 +84,15 @@ const SOURCE_MODULES: ReadonlyArray<{
   internal: readonly string[];
 }> = [
   { name: "context", module: contextModule, internal: [] },
+  {
+    name: "rich-text",
+    module: richTextModule,
+    // Everything this module holds is public: the component and its props. The
+    // node-walking helpers are deliberately NOT exported — a caller wanting
+    // words out of rich text uses `richTextToPlainText` from the engine, which
+    // is the same walk the CMS uses, rather than a second one here.
+    internal: [],
+  },
   { name: "resolver", module: resolverModule, internal: [] },
   {
     name: "styles",
@@ -215,6 +225,7 @@ describe("the root entry", () => {
       "NODE_ID_ATTRIBUTE",
       "PROP_ATTRIBUTE",
       "PageRenderer",
+      "RichText",
       "createBlockResolver",
       "createStandaloneContext",
       "defineBlock",

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -62,6 +62,14 @@ export { BlockBoundary, BlockList } from "./block-boundary";
 export { NODE_ID_ATTRIBUTE, PROP_ATTRIBUTE } from "./block-boundary";
 export type { BlockBoundaryProps, BlockListProps } from "./block-boundary";
 
+/**
+ * Draw stored rich text as React.
+ *
+ * The CMS derives HTML from the same stored shape; this draws a React tree.
+ * Both read the type and format bits from `blocks-engine`, which is the only
+ * thing they can share — this package may not import the CMS.
+ */
+export { RichText, type RichTextProps } from "./rich-text";
 export { BlockPlaceholder } from "./placeholder";
 export type { BlockPlaceholderProps, PlaceholderReason } from "./placeholder";
 

--- a/packages/blocks-react/src/rich-text.test.tsx
+++ b/packages/blocks-react/src/rich-text.test.tsx
@@ -120,3 +120,242 @@ describe("RichText", () => {
     ).toBeTruthy();
   });
 });
+
+describe("RichText link destinations", () => {
+  // A stored URL reaching an `href` is the one place in this format where a
+  // value executes rather than merely displays, so each of these is a scheme
+  // that navigates to attacker-controlled code if it survives to the attribute.
+  const dangerous = [
+    "javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+    "blob:https://example.test/9f8c",
+    // Split by a tab so a naive scheme reader sees no scheme while a browser
+    // strips the tab and resolves one.
+    "java\tscript:alert(1)",
+    "  javascript:alert(1)",
+  ];
+
+  it.each(dangerous)("refuses %j and keeps the words", url => {
+    const { container } = render(
+      <RichText
+        value={doc([
+          {
+            type: "paragraph",
+            children: [
+              {
+                type: "link",
+                url,
+                children: [{ type: "text", text: "click" }],
+              },
+            ],
+          },
+        ])}
+      />
+    );
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).toBe("click");
+  });
+
+  it("keeps the destinations an author actually writes", () => {
+    for (const url of [
+      "https://example.test/a",
+      "http://example.test",
+      "mailto:a@example.test",
+      "tel:+15551234",
+      "/about",
+      "#section",
+    ]) {
+      const { container } = render(
+        <RichText
+          value={doc([
+            {
+              type: "paragraph",
+              children: [
+                { type: "link", url, children: [{ type: "text", text: "go" }] },
+              ],
+            },
+          ])}
+        />
+      );
+      expect(container.querySelector("a")?.getAttribute("href"), url).toBe(url);
+      cleanup();
+    }
+  });
+
+  it("carries the target the author chose, with the rel that makes it safe", () => {
+    // `_blank` hands the opened page a handle on this one unless `noopener`
+    // says otherwise, so the two travel together.
+    const { container } = render(
+      <RichText
+        value={doc([
+          {
+            type: "paragraph",
+            children: [
+              {
+                type: "link",
+                url: "https://example.test",
+                target: "_blank",
+                children: [{ type: "text", text: "go" }],
+              },
+            ],
+          },
+        ])}
+      />
+    );
+    const anchor = container.querySelector("a");
+    expect(anchor?.getAttribute("target")).toBe("_blank");
+    expect(anchor?.getAttribute("rel")).toContain("noopener");
+    expect(anchor?.getAttribute("rel")).toContain("noreferrer");
+  });
+
+  it("ignores a stored target that names a frame on this page", () => {
+    const { container } = render(
+      <RichText
+        value={doc([
+          {
+            type: "paragraph",
+            children: [
+              {
+                type: "link",
+                url: "https://example.test",
+                target: "some-frame",
+                children: [{ type: "text", text: "go" }],
+              },
+            ],
+          },
+        ])}
+      />
+    );
+    expect(container.querySelector("a")?.getAttribute("target")).toBeNull();
+  });
+});
+
+describe("RichText malformed storage", () => {
+  it("renders the surviving content when a child is not a node", () => {
+    // Storage holds parsed JSON, and JSON can put a null in an array the type
+    // says holds nodes. Reading `.text` off it throws during the render of a
+    // published page.
+    const value = {
+      root: {
+        type: "root",
+        children: [
+          null,
+          "not a node",
+          42,
+          { type: "paragraph", children: [{ type: "text", text: "kept" }] },
+        ],
+      },
+    } as unknown as RichTextValue;
+    const { container } = render(<RichText value={value} />);
+    expect(container.textContent).toBe("kept");
+  });
+
+  it("renders nothing for a root whose children are not an array", () => {
+    const value = { root: { type: "root" } } as unknown as RichTextValue;
+    const { container } = render(<RichText value={value} />);
+    expect(container.textContent).toBe("");
+  });
+});
+
+describe("RichText structural nodes", () => {
+  it("draws the case formats as a transform rather than a tag", () => {
+    for (const [flag, expected] of [
+      [TEXT_FORMAT.LOWERCASE, "lowercase"],
+      [TEXT_FORMAT.UPPERCASE, "uppercase"],
+      [TEXT_FORMAT.CAPITALIZE, "capitalize"],
+    ] as const) {
+      const { container } = render(<RichText value={para("word", flag)} />);
+      expect(
+        container.querySelector("span")?.style.textTransform,
+        expected
+      ).toBe(expected);
+      cleanup();
+    }
+  });
+
+  it("renders a horizontal rule, which has no children to fall back on", () => {
+    const { container } = render(
+      <RichText value={doc([{ type: "horizontalrule" }])} />
+    );
+    expect(container.querySelector("hr")).not.toBeNull();
+  });
+
+  it("renders a table with the tbody a browser would insert anyway", () => {
+    const { container } = render(
+      <RichText
+        value={doc([
+          {
+            type: "table",
+            children: [
+              {
+                type: "tablerow",
+                children: [
+                  {
+                    type: "tablecell",
+                    headerState: 1,
+                    children: [{ type: "text", text: "Head" }],
+                  },
+                  {
+                    type: "tablecell",
+                    headerState: 0,
+                    children: [{ type: "text", text: "Cell" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ])}
+      />
+    );
+    expect(container.querySelector("table > tbody > tr")).not.toBeNull();
+    expect(container.querySelector("th")?.textContent).toBe("Head");
+    expect(container.querySelector("td")?.textContent).toBe("Cell");
+  });
+
+  it("renders a collapsible as details and summary", () => {
+    const { container } = render(
+      <RichText
+        value={doc([
+          {
+            type: "collapsible-container",
+            children: [
+              {
+                type: "collapsible-title",
+                children: [{ type: "text", text: "More" }],
+              },
+              {
+                type: "collapsible-content",
+                children: [
+                  {
+                    type: "paragraph",
+                    children: [{ type: "text", text: "Body" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ])}
+      />
+    );
+    expect(container.querySelector("details > summary")?.textContent).toBe(
+      "More"
+    );
+    expect(container.querySelector("details > div p")?.textContent).toBe(
+      "Body"
+    );
+  });
+
+  it("renders a code block as pre and code", () => {
+    const { container } = render(
+      <RichText
+        value={doc([
+          { type: "code", children: [{ type: "text", text: "const a = 1;" }] },
+        ])}
+      />
+    );
+    expect(container.querySelector("pre > code")?.textContent).toBe(
+      "const a = 1;"
+    );
+  });
+});

--- a/packages/blocks-react/src/rich-text.test.tsx
+++ b/packages/blocks-react/src/rich-text.test.tsx
@@ -359,3 +359,167 @@ describe("RichText structural nodes", () => {
     );
   });
 });
+
+describe("RichText hostile stored node types", () => {
+  // `node.type` is a string from storage and the renderer's dispatch tables are
+  // object literals, so an inherited member is reachable by name unless the
+  // lookup asks for own keys only.
+  it.each([
+    "constructor",
+    "toString",
+    "valueOf",
+    "hasOwnProperty",
+    "__proto__",
+  ])("treats %j as an unknown node rather than an inherited member", type => {
+    const { container } = render(
+      <RichText
+        value={doc([{ type, children: [{ type: "text", text: "kept" }] }])}
+      />
+    );
+    expect(container.textContent).toBe("kept");
+  });
+});
+
+describe("RichText malformed nested children", () => {
+  it.each([
+    ["an object", {}],
+    ["a string", "oops"],
+    ["a number", 7],
+    ["null", null],
+  ])("renders nothing for children that are %s", (_label, badChildren) => {
+    const value = doc([
+      { type: "paragraph", children: badChildren },
+      { type: "paragraph", children: [{ type: "text", text: "kept" }] },
+    ] as unknown as RichTextValue["root"]["children"]);
+    const { container } = render(<RichText value={value} />);
+    expect(container.textContent).toBe("kept");
+  });
+});
+
+describe("RichText preserved node attributes", () => {
+  it("keeps a heading at the level the author chose", () => {
+    // Paired with the fallback case: without this, a HeadingView that ignored
+    // `tag` entirely and always returned h2 would still pass.
+    for (const tag of ["h1", "h3", "h6"]) {
+      const { container } = render(
+        <RichText
+          value={doc([
+            { type: "heading", tag, children: [{ type: "text", text: "T" }] },
+          ])}
+        />
+      );
+      expect(container.querySelector(tag), tag).not.toBeNull();
+      cleanup();
+    }
+  });
+
+  it("keeps an ordered list's starting number", () => {
+    const { container } = render(
+      <RichText
+        value={doc([
+          {
+            type: "list",
+            listType: "number",
+            start: 5,
+            children: [
+              { type: "listitem", children: [{ type: "text", text: "five" }] },
+            ],
+          },
+        ])}
+      />
+    );
+    expect(container.querySelector("ol")?.getAttribute("start")).toBe("5");
+  });
+
+  it("omits start for a value the attribute could not carry", () => {
+    for (const start of [0, -3, 1.5, "5", null]) {
+      const { container } = render(
+        <RichText
+          value={doc([
+            {
+              type: "list",
+              listType: "number",
+              start,
+              children: [
+                { type: "listitem", children: [{ type: "text", text: "x" }] },
+              ],
+            },
+          ] as unknown as RichTextValue["root"]["children"])}
+        />
+      );
+      expect(
+        container.querySelector("ol")?.getAttribute("start"),
+        `${JSON.stringify(start)}`
+      ).toBeNull();
+      cleanup();
+    }
+  });
+
+  it("keeps a collapsible open when the author left it open", () => {
+    const open = render(
+      <RichText
+        value={doc([
+          {
+            type: "collapsible-container",
+            open: true,
+            children: [
+              {
+                type: "collapsible-title",
+                children: [{ type: "text", text: "T" }],
+              },
+            ],
+          },
+        ])}
+      />
+    );
+    expect(open.container.querySelector("details")?.hasAttribute("open")).toBe(
+      true
+    );
+    cleanup();
+
+    const shut = render(
+      <RichText
+        value={doc([
+          {
+            type: "collapsible-container",
+            open: false,
+            children: [
+              {
+                type: "collapsible-title",
+                children: [{ type: "text", text: "T" }],
+              },
+            ],
+          },
+        ])}
+      />
+    );
+    expect(shut.container.querySelector("details")?.hasAttribute("open")).toBe(
+      false
+    );
+  });
+
+  it("gives a syntax token the class the CMS gives it", () => {
+    const { container } = render(
+      <RichText
+        value={doc([
+          {
+            type: "code",
+            children: [
+              {
+                type: "code-highlight",
+                text: "const",
+                highlightType: "keyword",
+              },
+              { type: "code-highlight", text: " x", highlightType: "!bad!" },
+            ],
+          },
+        ])}
+      />
+    );
+    const token = container.querySelector("span.nextly-code-token--keyword");
+    expect(token?.textContent).toBe("const");
+    // A type the engine refuses renders as text, not as an empty-class span.
+    expect(container.querySelectorAll("span").length).toBe(1);
+    expect(container.querySelector("pre > code")?.textContent).toBe("const x");
+  });
+});

--- a/packages/blocks-react/src/rich-text.test.tsx
+++ b/packages/blocks-react/src/rich-text.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { TEXT_FORMAT, type RichTextValue } from "@nextlyhq/blocks-engine";
+import { render, screen } from "@testing-library/react";
+import { cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { RichText } from "./rich-text";
+
+afterEach(cleanup);
+
+const doc = (children: RichTextValue["root"]["children"]): RichTextValue => ({
+  root: { type: "root", children },
+});
+
+const para = (text: string, format?: number) =>
+  doc([
+    {
+      type: "paragraph",
+      children: [
+        { type: "text", text, ...(format === undefined ? {} : { format }) },
+      ],
+    },
+  ]);
+
+describe("RichText", () => {
+  it("renders text inside its block element", () => {
+    const { container } = render(<RichText value={para("Hello")} />);
+    expect(container.querySelector("p")?.textContent).toBe("Hello");
+  });
+
+  it("applies the format bits the CMS serializer reads", () => {
+    // The SAME constants the HTML serializer uses, imported from the engine.
+    // If the two ever disagreed this is where it would show, which is the whole
+    // reason the bits are shared rather than re-declared.
+    const { container } = render(
+      <RichText value={para("loud", TEXT_FORMAT.BOLD | TEXT_FORMAT.ITALIC)} />
+    );
+    expect(container.querySelector("strong em")?.textContent).toBe("loud");
+  });
+
+  it("renders nothing for a value that is not rich text", () => {
+    // A prop's stored type is whatever was saved: a plain string from before a
+    // field became rich, a null, an empty object. None of those may throw on a
+    // live page.
+    for (const other of ["text", 0, null, undefined, {}, []]) {
+      const { container } = render(<RichText value={other} />);
+      expect(container.textContent, JSON.stringify(other)).toBe("");
+      cleanup();
+    }
+  });
+
+  it("keeps the words of a node type it does not know", () => {
+    // Dropping an unknown node deletes an author's content silently; refusing
+    // takes the page down for one unrecognised paragraph.
+    render(
+      <RichText
+        value={doc([
+          {
+            type: "some-future-node",
+            children: [{ type: "text", text: "still here" }],
+          },
+        ])}
+      />
+    );
+    expect(screen.getByText("still here")).toBeDefined();
+  });
+
+  it("renders a link, and renders one without a url as plain text", () => {
+    const { container } = render(
+      <RichText
+        value={doc([
+          { type: "link", url: "/x", children: [{ type: "text", text: "go" }] },
+          { type: "link", children: [{ type: "text", text: "nowhere" }] },
+        ])}
+      />
+    );
+    expect(container.querySelector('a[href="/x"]')?.textContent).toBe("go");
+    // An anchor with no destination is announced as a link by a screen reader
+    // and goes nowhere when followed.
+    expect(container.querySelectorAll("a")).toHaveLength(1);
+    expect(container.textContent).toContain("nowhere");
+  });
+
+  it("falls back to h2 for a heading whose tag is not one", () => {
+    const { container } = render(
+      <RichText
+        value={doc([
+          {
+            type: "heading",
+            tag: "h9",
+            children: [{ type: "text", text: "t" }],
+          },
+        ])}
+      />
+    );
+    expect(container.querySelector("h2")?.textContent).toBe("t");
+  });
+
+  it("renders ordered and unordered lists by listType", () => {
+    const list = (listType: string) =>
+      doc([
+        {
+          type: "list",
+          listType,
+          children: [
+            { type: "listitem", children: [{ type: "text", text: "i" }] },
+          ],
+        },
+      ]);
+    expect(
+      render(<RichText value={list("number")} />).container.querySelector(
+        "ol li"
+      )
+    ).toBeTruthy();
+    cleanup();
+    expect(
+      render(<RichText value={list("bullet")} />).container.querySelector(
+        "ul li"
+      )
+    ).toBeTruthy();
+  });
+});

--- a/packages/blocks-react/src/rich-text.tsx
+++ b/packages/blocks-react/src/rich-text.tsx
@@ -1,10 +1,13 @@
 import {
   hasFormat,
+  isRichTextNode,
   isRichTextValue,
   TEXT_FORMAT,
   type RichTextNode,
 } from "@nextlyhq/blocks-engine";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
+
+import { relFor, url } from "./blocks/props";
 
 /**
  * Drawing stored rich text as React.
@@ -27,6 +30,11 @@ import type { ReactNode } from "react";
  * make every stored document a place markup could execute from, which is a
  * surface this format does not otherwise have.
  *
+ * A stored URL is the one field where that is not enough. It reaches an `href`
+ * attribute, where a `javascript:` or `data:text/html` value executes without
+ * any markup being parsed at all, so it goes through the same `url()` boundary
+ * every other stored URL in this package crosses.
+ *
  * ## Unknown nodes render their children
  *
  * A site can register node types this renderer has never heard of. Dropping an
@@ -35,23 +43,68 @@ import type { ReactNode } from "react";
  * children keeps the words and loses only the wrapper, which is the forgiving
  * behaviour the format asks for everywhere else.
  *
+ * That fallback carries content only for nodes that HAVE children. The editor
+ * also registers leaf nodes that hold their content in their own fields —
+ * `image`, `video`, `gallery` and the button nodes — and those render as nothing
+ * here. Each needs a URL and host policy of the kind the media blocks already
+ * carry, so they are drawn by that work rather than guessed at here.
+ *
  * @module rich-text
  */
+
+/**
+ * The element each format bit wraps text in, outermost LAST.
+ *
+ * A table rather than a run of `if`s: every entry says the same thing, and the
+ * order is data — `code` sits at the end so it wraps the rest, matching how the
+ * CMS's serializer nests them. Read as a list, a reordering is visible; read as
+ * eight branches, it is not.
+ */
+const FORMAT_ELEMENTS: readonly {
+  flag: (typeof TEXT_FORMAT)[keyof typeof TEXT_FORMAT];
+  wrap: (inner: ReactNode) => ReactNode;
+}[] = [
+  { flag: TEXT_FORMAT.SUBSCRIPT, wrap: inner => <sub>{inner}</sub> },
+  { flag: TEXT_FORMAT.SUPERSCRIPT, wrap: inner => <sup>{inner}</sup> },
+  { flag: TEXT_FORMAT.STRIKETHROUGH, wrap: inner => <s>{inner}</s> },
+  { flag: TEXT_FORMAT.UNDERLINE, wrap: inner => <u>{inner}</u> },
+  { flag: TEXT_FORMAT.ITALIC, wrap: inner => <em>{inner}</em> },
+  { flag: TEXT_FORMAT.BOLD, wrap: inner => <strong>{inner}</strong> },
+  { flag: TEXT_FORMAT.HIGHLIGHT, wrap: inner => <mark>{inner}</mark> },
+  { flag: TEXT_FORMAT.CODE, wrap: inner => <code>{inner}</code> },
+];
+
+/**
+ * How the three case formats are drawn.
+ *
+ * A transform rather than an element, because that is what they are: the stored
+ * text is unchanged and only its presentation differs, so wrapping it in a tag
+ * would assert a meaning the author did not choose. The values are constants
+ * from this table and never stored text, so no author input reaches a style.
+ */
+const CASE_TRANSFORM: readonly {
+  flag: (typeof TEXT_FORMAT)[keyof typeof TEXT_FORMAT];
+  value: "lowercase" | "uppercase" | "capitalize";
+}[] = [
+  { flag: TEXT_FORMAT.LOWERCASE, value: "lowercase" },
+  { flag: TEXT_FORMAT.UPPERCASE, value: "uppercase" },
+  { flag: TEXT_FORMAT.CAPITALIZE, value: "capitalize" },
+];
 
 /** Wraps text in the elements its format bits ask for, innermost first. */
 function formatted(text: string, format: number | undefined): ReactNode {
   let out: ReactNode = text;
-  // Order matters only in that it decides nesting, not meaning. Code last so it
-  // wraps the rest, matching how the CMS's serializer reads.
-  if (hasFormat(format, TEXT_FORMAT.SUBSCRIPT)) out = <sub>{out}</sub>;
-  if (hasFormat(format, TEXT_FORMAT.SUPERSCRIPT)) out = <sup>{out}</sup>;
-  if (hasFormat(format, TEXT_FORMAT.STRIKETHROUGH)) out = <s>{out}</s>;
-  if (hasFormat(format, TEXT_FORMAT.UNDERLINE)) out = <u>{out}</u>;
-  if (hasFormat(format, TEXT_FORMAT.ITALIC)) out = <em>{out}</em>;
-  if (hasFormat(format, TEXT_FORMAT.BOLD)) out = <strong>{out}</strong>;
-  if (hasFormat(format, TEXT_FORMAT.HIGHLIGHT)) out = <mark>{out}</mark>;
-  if (hasFormat(format, TEXT_FORMAT.CODE)) out = <code>{out}</code>;
-  return out;
+  for (const { flag, wrap } of FORMAT_ELEMENTS) {
+    if (hasFormat(format, flag)) out = wrap(out);
+  }
+
+  // Outermost, and only one can apply: `text-transform` is a single CSS
+  // property, so a value carrying two case bits would otherwise render whichever
+  // wrapper happened to be inner. Taking the first keeps that deterministic.
+  const transform = CASE_TRANSFORM.find(entry => hasFormat(format, entry.flag));
+  if (transform === undefined) return out;
+  const style: CSSProperties = { textTransform: transform.value };
+  return <span style={style}>{out}</span>;
 }
 
 function children(nodes: readonly RichTextNode[] | undefined): ReactNode {
@@ -72,10 +125,19 @@ function children(nodes: readonly RichTextNode[] | undefined): ReactNode {
  * a switch makes ten identical branches look like ten decisions. What is left
  * in {@link RichTextNodeView} is only the nodes that genuinely differ.
  */
-const SIMPLE_ELEMENTS: Readonly<Record<string, "p" | "blockquote" | "li">> = {
+const SIMPLE_ELEMENTS: Readonly<
+  Record<
+    string,
+    "p" | "blockquote" | "li" | "details" | "summary" | "div" | "tbody" | "tr"
+  >
+> = {
   paragraph: "p",
   quote: "blockquote",
   listitem: "li",
+  "collapsible-container": "details",
+  "collapsible-title": "summary",
+  "collapsible-content": "div",
+  tablerow: "tr",
 };
 
 /** Heading levels Lexical serializes; anything else is a document from a version this does not know. */
@@ -94,14 +156,75 @@ function HeadingView({ node }: { node: RichTextNode }): ReactNode {
 }
 
 function LinkView({ node }: { node: RichTextNode }): ReactNode {
-  const url = typeof node.url === "string" ? node.url : null;
-  // A link with no destination renders as text. An anchor to nowhere is
-  // announced as a link by a screen reader and goes nowhere when followed.
-  if (url === null) return <>{children(node.children)}</>;
-  return <a href={url}>{children(node.children)}</a>;
+  // Sanitized, not merely read: the destination is stored text that lands in an
+  // `href`. `url()` is the same boundary the URL props cross, so a scheme
+  // refused in a button cannot be reached through a link beside it.
+  const href = url(node.url);
+  // A link with no usable destination renders as text. An anchor to nowhere is
+  // announced as a link by a screen reader and goes nowhere when followed, and
+  // that is also the right answer for a destination this refuses: the author's
+  // words survive, the navigation does not.
+  if (href === undefined) return <>{children(node.children)}</>;
+
+  // Only `_blank` is honoured. It is the one target the editor writes, and it
+  // is the one that needs the `rel` below; passing an arbitrary stored string
+  // through would let a document name a frame elsewhere on the page.
+  const target = node.target === "_blank" ? "_blank" : undefined;
+  return (
+    <a href={href} target={target} rel={relFor(target, node.rel)}>
+      {children(node.children)}
+    </a>
+  );
 }
 
+function TableCellView({ node }: { node: RichTextNode }): ReactNode {
+  // Lexical marks a header cell with `headerState`, a bitfield where any set bit
+  // means the cell heads its row or its column.
+  const header = typeof node.headerState === "number" && node.headerState !== 0;
+  const Cell = header ? "th" : "td";
+  return <Cell>{children(node.children)}</Cell>;
+}
+
+/**
+ * The nodes that are more than an element around their children.
+ *
+ * Keyed rather than branched for the same reason as {@link SIMPLE_ELEMENTS}: a
+ * lookup makes "which types does this renderer know" answerable by reading one
+ * list, where a chain of `if`s hides it in control flow.
+ */
+const NODE_VIEWS: Readonly<Record<string, (node: RichTextNode) => ReactNode>> =
+  {
+    heading: node => <HeadingView node={node} />,
+    link: node => <LinkView node={node} />,
+    autolink: node => <LinkView node={node} />,
+    list: node => {
+      const List = node.listType === "number" ? "ol" : "ul";
+      return <List>{children(node.children)}</List>;
+    },
+    linebreak: () => <br />,
+    horizontalrule: () => <hr />,
+    code: node => (
+      <pre>
+        <code>{children(node.children)}</code>
+      </pre>
+    ),
+    // `tbody` rather than bare rows: a browser inserts one anyway, and a React
+    // tree that omits it does not match the DOM that results.
+    table: node => (
+      <table>
+        <tbody>{children(node.children)}</tbody>
+      </table>
+    ),
+    tablecell: node => <TableCellView node={node} />,
+  };
+
 function RichTextNodeView({ node }: { node: RichTextNode }): ReactNode {
+  // A stored document can hold anything JSON can express, including a null in a
+  // `children` array. Reading `.text` off that throws, and it would throw during
+  // render of a published page. The type says this cannot happen; the storage
+  // does not.
+  if (!isRichTextNode(node)) return null;
+
   if (typeof node.text === "string") return formatted(node.text, node.format);
 
   const simple = SIMPLE_ELEMENTS[node.type];
@@ -110,15 +233,8 @@ function RichTextNodeView({ node }: { node: RichTextNode }): ReactNode {
     return <Element>{children(node.children)}</Element>;
   }
 
-  if (node.type === "heading") return <HeadingView node={node} />;
-  if (node.type === "link" || node.type === "autolink") {
-    return <LinkView node={node} />;
-  }
-  if (node.type === "list") {
-    const List = node.listType === "number" ? "ol" : "ul";
-    return <List>{children(node.children)}</List>;
-  }
-  if (node.type === "linebreak") return <br />;
+  const view = NODE_VIEWS[node.type];
+  if (view !== undefined) return view(node);
 
   // Unknown node: keep the words, lose the wrapper. See the module docblock.
   return <>{children(node.children)}</>;

--- a/packages/blocks-react/src/rich-text.tsx
+++ b/packages/blocks-react/src/rich-text.tsx
@@ -1,4 +1,5 @@
 import {
+  codeTokenClass,
   hasFormat,
   isRichTextNode,
   isRichTextValue,
@@ -108,7 +109,11 @@ function formatted(text: string, format: number | undefined): ReactNode {
 }
 
 function children(nodes: readonly RichTextNode[] | undefined): ReactNode {
-  if (nodes === undefined) return null;
+  // Array-checked, not undefined-checked. `children` is stored JSON like
+  // everything else here, so it can arrive as `{}` or `"oops"`, and calling
+  // `.map` on either throws while rendering a published page. The type cannot
+  // prevent it; only reading the value can.
+  if (!Array.isArray(nodes)) return null;
   return nodes.map((node, i) => (
     // Index keys, and the reason is that nothing better exists: a serialized
     // node carries no identity, and a rich-text tree is replaced wholesale on
@@ -134,7 +139,6 @@ const SIMPLE_ELEMENTS: Readonly<
   paragraph: "p",
   quote: "blockquote",
   listitem: "li",
-  "collapsible-container": "details",
   "collapsible-title": "summary",
   "collapsible-content": "div",
   tablerow: "tr",
@@ -195,11 +199,26 @@ function TableCellView({ node }: { node: RichTextNode }): ReactNode {
 const NODE_VIEWS: Readonly<Record<string, (node: RichTextNode) => ReactNode>> =
   {
     heading: node => <HeadingView node={node} />,
+    // `open` is serialized by the editor, default included, so a section the
+    // author left expanded publishes expanded.
+    "collapsible-container": node => (
+      <details open={node.open === true}>{children(node.children)}</details>
+    ),
     link: node => <LinkView node={node} />,
     autolink: node => <LinkView node={node} />,
     list: node => {
-      const List = node.listType === "number" ? "ol" : "ul";
-      return <List>{children(node.children)}</List>;
+      if (node.listType !== "number") return <ul>{children(node.children)}</ul>;
+      // A list imported from `<ol start="5">` keeps its first number. Dropped,
+      // the published list silently restarts at 1 and the prose around it —
+      // "step 5" — stops matching. Only a positive integer is forwarded;
+      // anything else is a value the attribute could not carry.
+      const start =
+        typeof node.start === "number" &&
+        Number.isInteger(node.start) &&
+        node.start > 0
+          ? node.start
+          : undefined;
+      return <ol start={start}>{children(node.children)}</ol>;
     },
     linebreak: () => <br />,
     horizontalrule: () => <hr />,
@@ -216,7 +235,22 @@ const NODE_VIEWS: Readonly<Record<string, (node: RichTextNode) => ReactNode>> =
       </table>
     ),
     tablecell: node => <TableCellView node={node} />,
+    "code-highlight": node => <CodeTokenView node={node} />,
   };
+
+/**
+ * One syntax-highlighted token inside a code block.
+ *
+ * The class comes from the engine so this and the CMS's HTML agree about which
+ * class a token type gets; a token whose type the engine rejects renders as
+ * bare text rather than in an element that would carry no styling anyway.
+ */
+function CodeTokenView({ node }: { node: RichTextNode }): ReactNode {
+  const text = typeof node.text === "string" ? node.text : "";
+  const className = codeTokenClass(node.highlightType);
+  if (className === undefined) return <>{text}</>;
+  return <span className={className}>{text}</span>;
+}
 
 function RichTextNodeView({ node }: { node: RichTextNode }): ReactNode {
   // A stored document can hold anything JSON can express, including a null in a
@@ -225,16 +259,26 @@ function RichTextNodeView({ node }: { node: RichTextNode }): ReactNode {
   // does not.
   if (!isRichTextNode(node)) return null;
 
+  // Before the generic text branch: a code token carries `text` too, and would
+  // otherwise return here having lost the type that decides its class.
+  if (node.type === "code-highlight") return <CodeTokenView node={node} />;
+
   if (typeof node.text === "string") return formatted(node.text, node.format);
 
-  const simple = SIMPLE_ELEMENTS[node.type];
-  if (simple !== undefined) {
-    const Element = simple;
+  // `Object.hasOwn` before either lookup, because `node.type` is a stored string
+  // and these tables inherit from `Object.prototype`. A node typed
+  // `"constructor"` or `"toString"` would otherwise resolve to an inherited
+  // function — used as a JSX element type, or called as a view — and throw,
+  // instead of taking the unknown-node fallback that exists for exactly this.
+  if (Object.hasOwn(SIMPLE_ELEMENTS, node.type)) {
+    const Element = SIMPLE_ELEMENTS[node.type] as "p";
     return <Element>{children(node.children)}</Element>;
   }
 
-  const view = NODE_VIEWS[node.type];
-  if (view !== undefined) return view(node);
+  if (Object.hasOwn(NODE_VIEWS, node.type)) {
+    const view = NODE_VIEWS[node.type];
+    if (view !== undefined) return view(node);
+  }
 
   // Unknown node: keep the words, lose the wrapper. See the module docblock.
   return <>{children(node.children)}</>;

--- a/packages/blocks-react/src/rich-text.tsx
+++ b/packages/blocks-react/src/rich-text.tsx
@@ -1,0 +1,144 @@
+import {
+  hasFormat,
+  isRichTextValue,
+  TEXT_FORMAT,
+  type RichTextNode,
+} from "@nextlyhq/blocks-engine";
+import type { ReactNode } from "react";
+
+/**
+ * Drawing stored rich text as React.
+ *
+ * The CMS derives HTML from the same stored shape for its API consumers; this
+ * draws a React tree for a page. Both read the type and the format bits from
+ * `blocks-engine`, which is the only thing they can share — this package's
+ * layering test forbids it from importing the CMS, the admin or the plugin SDK,
+ * so there is no module a common READER could live in.
+ *
+ * That is a real cost and it is worth naming: two producers must agree about
+ * what a node means. What contains it is that neither invents the meaning —
+ * `TEXT_FORMAT` and `RichTextNode` are imported, never re-declared, so the
+ * disagreement can only be about output and never about the data.
+ *
+ * ## No `dangerouslySetInnerHTML`
+ *
+ * Nodes become elements. Rich text arrives from storage, and storage holds
+ * whatever an editor once accepted — passing it through an HTML string would
+ * make every stored document a place markup could execute from, which is a
+ * surface this format does not otherwise have.
+ *
+ * ## Unknown nodes render their children
+ *
+ * A site can register node types this renderer has never heard of. Dropping an
+ * unknown node would silently delete an author's content; refusing to render
+ * would take the page down for one unrecognised paragraph. Descending into its
+ * children keeps the words and loses only the wrapper, which is the forgiving
+ * behaviour the format asks for everywhere else.
+ *
+ * @module rich-text
+ */
+
+/** Wraps text in the elements its format bits ask for, innermost first. */
+function formatted(text: string, format: number | undefined): ReactNode {
+  let out: ReactNode = text;
+  // Order matters only in that it decides nesting, not meaning. Code last so it
+  // wraps the rest, matching how the CMS's serializer reads.
+  if (hasFormat(format, TEXT_FORMAT.SUBSCRIPT)) out = <sub>{out}</sub>;
+  if (hasFormat(format, TEXT_FORMAT.SUPERSCRIPT)) out = <sup>{out}</sup>;
+  if (hasFormat(format, TEXT_FORMAT.STRIKETHROUGH)) out = <s>{out}</s>;
+  if (hasFormat(format, TEXT_FORMAT.UNDERLINE)) out = <u>{out}</u>;
+  if (hasFormat(format, TEXT_FORMAT.ITALIC)) out = <em>{out}</em>;
+  if (hasFormat(format, TEXT_FORMAT.BOLD)) out = <strong>{out}</strong>;
+  if (hasFormat(format, TEXT_FORMAT.HIGHLIGHT)) out = <mark>{out}</mark>;
+  if (hasFormat(format, TEXT_FORMAT.CODE)) out = <code>{out}</code>;
+  return out;
+}
+
+function children(nodes: readonly RichTextNode[] | undefined): ReactNode {
+  if (nodes === undefined) return null;
+  return nodes.map((node, i) => (
+    // Index keys, and the reason is that nothing better exists: a serialized
+    // node carries no identity, and a rich-text tree is replaced wholesale on
+    // every edit rather than reordered in place, so React never has to match a
+    // node across renders.
+    <RichTextNodeView key={i} node={node} />
+  ));
+}
+
+/**
+ * Node types that are just an element around their children.
+ *
+ * A table rather than cases, because every one of them says the same thing and
+ * a switch makes ten identical branches look like ten decisions. What is left
+ * in {@link RichTextNodeView} is only the nodes that genuinely differ.
+ */
+const SIMPLE_ELEMENTS: Readonly<Record<string, "p" | "blockquote" | "li">> = {
+  paragraph: "p",
+  quote: "blockquote",
+  listitem: "li",
+};
+
+/** Heading levels Lexical serializes; anything else is a document from a version this does not know. */
+const HEADING_TAGS = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
+
+function HeadingView({ node }: { node: RichTextNode }): ReactNode {
+  // `h2` rather than `h1` when the tag is unrecognised: guessing `h1` invents a
+  // second top-level heading and breaks the page outline, which is worse than
+  // rendering one level too deep.
+  const tag =
+    typeof node.tag === "string" && HEADING_TAGS.has(node.tag)
+      ? node.tag
+      : "h2";
+  const Heading = tag as "h1";
+  return <Heading>{children(node.children)}</Heading>;
+}
+
+function LinkView({ node }: { node: RichTextNode }): ReactNode {
+  const url = typeof node.url === "string" ? node.url : null;
+  // A link with no destination renders as text. An anchor to nowhere is
+  // announced as a link by a screen reader and goes nowhere when followed.
+  if (url === null) return <>{children(node.children)}</>;
+  return <a href={url}>{children(node.children)}</a>;
+}
+
+function RichTextNodeView({ node }: { node: RichTextNode }): ReactNode {
+  if (typeof node.text === "string") return formatted(node.text, node.format);
+
+  const simple = SIMPLE_ELEMENTS[node.type];
+  if (simple !== undefined) {
+    const Element = simple;
+    return <Element>{children(node.children)}</Element>;
+  }
+
+  if (node.type === "heading") return <HeadingView node={node} />;
+  if (node.type === "link" || node.type === "autolink") {
+    return <LinkView node={node} />;
+  }
+  if (node.type === "list") {
+    const List = node.listType === "number" ? "ol" : "ul";
+    return <List>{children(node.children)}</List>;
+  }
+  if (node.type === "linebreak") return <br />;
+
+  // Unknown node: keep the words, lose the wrapper. See the module docblock.
+  return <>{children(node.children)}</>;
+}
+
+export interface RichTextProps {
+  /** The stored value. Anything that is not rich text renders nothing. */
+  value: unknown;
+}
+
+/**
+ * Render a stored rich-text value.
+ *
+ * Takes `unknown` rather than `RichTextValue` because it is called with a block
+ * prop, and a prop's stored type is whatever was saved — a string from before a
+ * field became rich, a null, an empty object. Narrowing here means one check in
+ * one place instead of one at every call site, and it means a prop holding the
+ * wrong thing renders nothing rather than throwing on a live page.
+ */
+export function RichText({ value }: RichTextProps): ReactNode {
+  if (!isRichTextValue(value)) return null;
+  return <>{children(value.root.children)}</>;
+}

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -406,6 +406,39 @@
    * scrolls instead of being clipped to it.
    */
   min-height: 100%;
+
+  /*
+   * A press on a block is a grab, not a text selection.
+   *
+   * Blocks are made of text, so a press that lands on a word and then moves is
+   * ambiguous: the drag engine reads it as the start of a gesture while the
+   * browser reads it as the start of a selection. The browser wins, because
+   * selection begins on the first move and the engine does not call itself
+   * dragging until the pointer has travelled its activation distance — so the
+   * author gets highlighted words and a block that never moves. Whether it
+   * happens at all depends on where the text falls, which is why it reproduced
+   * on CI's font metrics and not on the author's.
+   *
+   * Declared here rather than as a `preventDefault` on the press, which would
+   * also suppress focus and the click that selects a block, and would have to
+   * decide what a press means before the travel that answers it.
+   */
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/*
+ * Text being EDITED is text again.
+ *
+ * The rule above is about pressing on a block to move it. Once a block's text
+ * is editable, selecting inside it is the whole point — a caret has to be
+ * placeable and a word has to be selectable — so the editable subtree opts back
+ * in rather than inheriting the canvas's answer.
+ */
+.nx-canvas [contenteditable="true"],
+.nx-canvas [contenteditable="true"] * {
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 /*

--- a/packages/nextly/src/collections/fields/types/rich-text.ts
+++ b/packages/nextly/src/collections/fields/types/rich-text.ts
@@ -9,6 +9,8 @@
  * @since 1.0.0
  */
 
+import type { RichTextNode, RichTextValue } from "@nextlyhq/blocks-engine";
+
 import type {
   BaseFieldConfig,
   FieldAdminOptions,
@@ -138,49 +140,16 @@ export type RichTextFeature =
  * }
  * ```
  */
-export interface RichTextValue {
-  /**
-   * The root node of the Lexical editor state.
-   */
-  root: {
-    type: "root";
-    children: RichTextNode[];
-    [key: string]: unknown;
-  };
-}
-
 /**
- * A node in the rich text structure.
+ * The stored shape of rich text, re-exported from the engine.
  *
- * Nodes can be paragraphs, headings, lists, text, or other
- * content types. Each node has a type and may have children.
+ * Declared in `@nextlyhq/blocks-engine` and named here so the CMS's field types
+ * read as one surface. It is the SAME type, not a matching one: rich text
+ * authored in a field and rich text held in a block prop are the same stored
+ * value, and two structurally identical declarations would let that stop being
+ * true one edit at a time, in silence, because both would still compile.
  */
-export interface RichTextNode {
-  /**
-   * The node type (e.g., 'paragraph', 'text', 'heading').
-   */
-  type: string;
-
-  /**
-   * Child nodes (for container nodes like paragraphs).
-   */
-  children?: RichTextNode[];
-
-  /**
-   * Text content (for text nodes).
-   */
-  text?: string;
-
-  /**
-   * Text formatting flags (bold, italic, etc.).
-   */
-  format?: number;
-
-  /**
-   * Additional node-specific properties.
-   */
-  [key: string]: unknown;
-}
+export type { RichTextNode, RichTextValue };
 
 /**
  * Possible value types for a rich text field.

--- a/packages/nextly/src/shared/lib/rich-text-html.ts
+++ b/packages/nextly/src/shared/lib/rich-text-html.ts
@@ -8,7 +8,11 @@
  * @since 1.0.0
  */
 
-import { isRichTextValue, TEXT_FORMAT } from "@nextlyhq/blocks-engine";
+import {
+  codeTokenClass,
+  isRichTextValue,
+  TEXT_FORMAT,
+} from "@nextlyhq/blocks-engine";
 
 import type { RichTextValue } from "../../collections/fields/types/rich-text";
 import {
@@ -26,15 +30,6 @@ export interface RichTextBothFormat {
   json: RichTextValue;
   html: string;
 }
-
-/**
- * Token types the tokenizer emits, as a class-name fragment.
- *
- * Checked rather than trusted: the value arrives from stored content and is
- * written into a class attribute, where a crafted string could otherwise
- * close the attribute and inject markup.
- */
-const SAFE_HIGHLIGHT_TYPE = /^[a-z][a-z0-9-]*$/;
 
 interface LexicalSerializedNode {
   type: string;
@@ -431,10 +426,13 @@ function serializeCodeNode(
  */
 function serializeCodeHighlightNode(node: LexicalSerializedNode): string {
   const text = escapeHtml(node.text || "");
-  const type = node.highlightType;
-  if (!type || !SAFE_HIGHLIGHT_TYPE.test(type)) return text;
+  // The class comes from the engine, so this and the React renderer cannot
+  // disagree about which class a token type gets — or about which types are
+  // safe to write into a class attribute at all.
+  const className = codeTokenClass(node.highlightType);
+  if (className === undefined) return text;
 
-  return `<span class="nextly-code-token nextly-code-token--${type}">${text}</span>`;
+  return `<span class="${className}">${text}</span>`;
 }
 
 function serializeHorizontalRuleNode(): string {

--- a/packages/nextly/src/shared/lib/rich-text-html.ts
+++ b/packages/nextly/src/shared/lib/rich-text-html.ts
@@ -8,6 +8,8 @@
  * @since 1.0.0
  */
 
+import { isRichTextValue, TEXT_FORMAT } from "@nextlyhq/blocks-engine";
+
 import type { RichTextValue } from "../../collections/fields/types/rich-text";
 import {
   sanitizeCssColor,
@@ -97,16 +99,11 @@ interface LexicalSerializedNode {
 // Text Format Flags (from Lexical)
 // ============================================================
 
-const TEXT_FORMAT = {
-  BOLD: 1,
-  ITALIC: 2,
-  STRIKETHROUGH: 4,
-  UNDERLINE: 8,
-  CODE: 16,
-  SUBSCRIPT: 32,
-  SUPERSCRIPT: 64,
-  HIGHLIGHT: 128,
-} as const;
+// Imported, never re-declared. These numbers are what a stored node MEANS, and
+// a second copy agrees on the day it is written and drifts the day Lexical adds
+// a format — silently, because both copies still compile and both still render
+// something. The engine's copy is the one both this serializer and the block
+// renderer read.
 
 // ============================================================
 // Element Format (Alignment) mapping
@@ -854,18 +851,9 @@ export function formatRichTextOutput(
   }
 }
 
-export function isRichTextValue(value: unknown): value is RichTextValue {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-
-  const obj = value as Record<string, unknown>;
-
-  return (
-    "root" in obj &&
-    typeof obj.root === "object" &&
-    obj.root !== null &&
-    "type" in (obj.root as Record<string, unknown>) &&
-    (obj.root as Record<string, unknown>).type === "root"
-  );
-}
+// Re-exported so this module's existing callers keep one import site, while the
+// answer itself comes from the engine. The local copy this replaces did not
+// require `root.children` to be an array, so it accepted a root this file's own
+// walker could only render as empty — the two disagreed about what rich text is,
+// which is the drift a shared definition exists to prevent.
+export { isRichTextValue };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -841,6 +841,9 @@ importers:
       '@nextlyhq/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/node':
         specifier: ^20.19.17
         version: 20.19.17


### PR DESCRIPTION
The first half of **B-19**. Rich text can now live in a block prop and render on a published page; editing it on the canvas follows separately.

Per `decision:inline-rich-text-shape` (yours, 2026-08-20), a block's rich text is stored in the **same shape the rich-text field uses** — Lexical's serialized tree. An author's rich text is one kind of thing, so it has one stored shape wherever they typed it.

## The type moves to where both readers can see it

Two things read this format and **they may not import each other**: the CMS derives HTML for API consumers, and `blocks-react` draws React for a page — its layering test forbids importing the CMS, the admin or the plugin SDK. There is no package a shared *reader* could live in.

`blocks-engine` is the one both already depend on, and it's runtime-free — which is exactly what lets a renderer and a server both hold it.

**The format bits matter most.** `TEXT_FORMAT` was a private const inside the CMS's serializer. A renderer that re-declared those numbers would agree today and diverge the day Lexical adds a format — text styled on one surface, plain on the other, nothing raised on either. The CMS now *imports* them rather than owning them.

This doesn't eliminate the two-reader risk and the module says so. A React tree and an HTML string are genuinely different outputs, so two producers isn't two implementations of one thing — but they must still agree about what a node *means*. Sharing the definition makes the disagreement impossible to be about the data. **Task 175 is why that's written down.**

## Rendering choices, each with a reason

- **No `dangerouslySetInnerHTML`.** Rich text comes from storage; routing it through an HTML string would make every stored document a place markup could execute from — a surface this format doesn't otherwise have.
- **An unknown node renders its children.** Dropping it deletes an author's content silently; refusing takes a page down for one unrecognised paragraph.
- **A link with no url renders as text** — an anchor to nowhere is announced as a link by a screen reader and goes nowhere when followed.
- **`RichText` takes `unknown`.** It's called with a block prop, whose stored type is whatever was saved: a string from before a field became rich, a null, an empty object. One narrowing in one place, and a wrong prop renders nothing rather than throwing on a live page.
- **`richTextToPlainText` ships beside the type**, so SEO and search don't each write their own walk — the second-reader problem again, in miniature.

## Verification

| | |
|---|---|
| blocks-engine | **1274 pass** |
| blocks-react | **644 pass** |
| CMS rich-text suite | **19 pass** — the serializer behaves identically reading the shared bits |
| lint + typecheck | clean on all three |

**Two surface guards fired and were satisfied deliberately:** the entry's exact export list, and the check that every re-exported module is registered for inspection. That second one is a good guard — a new module can't slip into the public surface unexamined.

The nextly suite's 360 failures are the documented stale-mock baseline (`task:test-baseline-repair`, ~361). **None is in a file this touches** — verified by listing the failing files, not by matching the count.

## Next

The editing half: one shared lazily-mounted Lexical instance via `loadRichTextEditorKit()` and `setRootElement()`, plus the floating toolbar. The undo hazard is already handled — #1120 made the canvas history bindings decline while the caret is in text.

Note `main` is red on unrelated grounds (releases/drizzle), so this needs that repair before it can go green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rich-text validation, format detection, plain-text conversion, and shared types.
  * Added a React rich-text renderer supporting formatted text, headings, links, lists, code, tables, collapsibles, and line breaks.
* **Bug Fixes**
  * Invalid content now renders safely without output.
  * Unsafe links are sanitized, while unknown nodes preserve their child content.
* **Tests**
  * Expanded coverage for validation, conversion, formatting, rendering, malformed content, and security scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->