### PR TITLE
fix(root): repair two changesets with unterminated frontmatter

### DIFF
--- a/.changeset/canvas-undo-declines-while-typing.md
+++ b/.changeset/canvas-undo-declines-while-typing.md
@@ -18,6 +18,7 @@
 "@nextlyhq/plugin-seo": patch
 "@nextlyhq/plugin-sdk": patch
 "@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
 "@nextlyhq/prettier-config": patch
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch

--- a/.changeset/canvas-undo-declines-while-typing.md
+++ b/.changeset/canvas-undo-declines-while-typing.md
@@ -1,5 +1,4 @@
 ---
-
 "nextly": patch
 "create-nextly-app": patch
 "@nextlyhq/admin": patch
@@ -24,6 +23,7 @@
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/builder": patch
 "@nextlyhq/module-specifiers": patch
+---
 
 Pressing undo while typing a block's text on the canvas rewound the document instead of the words.
 The author lost a block move they had finished with, kept the sentence they wanted back, and got no

--- a/.changeset/rich-text-editor-kit.md
+++ b/.changeset/rich-text-editor-kit.md
@@ -18,6 +18,7 @@
 "@nextlyhq/plugin-seo": patch
 "@nextlyhq/plugin-sdk": patch
 "@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
 "@nextlyhq/prettier-config": patch
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch

--- a/.changeset/rich-text-editor-kit.md
+++ b/.changeset/rich-text-editor-kit.md
@@ -1,5 +1,4 @@
 ---
-
 "nextly": patch
 "create-nextly-app": patch
 "@nextlyhq/admin": patch
@@ -24,6 +23,7 @@
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/builder": patch
 "@nextlyhq/module-specifiers": patch
+---
 
 A surface that needs to edit this site's rich text outside the admin's own field — the page builder's
 canvas is the first — can now load the same node classes and theme the field editor registers, through


### PR DESCRIPTION
**Both are mine, both are on `main`, and together they break the release workflow** — it reads every changeset in one pass, so one bad file stops the whole publish.

`canvas-undo-declines-while-typing.md` (#1120) and `rich-text-editor-kit.md` (#1111) open their frontmatter and never close it: the opening `---`, 24 of the 25 packages, then straight into prose.

## How they got that way

I wrote them by copying an existing changeset's **first 25 lines**. A valid file has its opening `---` on line 1 and its closing `---` on line **26** — so 25 lines is the delimiter plus 24 packages: one package short, and no close.

It reads as correct in a diff, which is why it survived review twice and why I didn't catch it locally: I ran each package's own tests, and this gate lives in the root `scripts/` suite that those don't cover.

## The repair

Frontmatter taken from a known-good file **up to its second delimiter** rather than by a line count — the same class of mistake can't recur — with each file's own body preserved unchanged.

## Verification

`scripts/changesets-parse.test.mjs` passes where it reported three unparseable files. That's the gate that caught this, run directly.

## The third one

`rich-text-in-blocks.md` has the same defect and is fixed in #1121, where it originates. This PR deliberately touches only the two already on `main`, so the fix for a red `main` isn't queued behind a feature review.

No changeset for this PR: it repairs changesets, and a third one written the same way would be the joke that writes itself.