### PR TITLE
feat(builder): derive style controls from the engine's catalog

### DIFF
--- a/.changeset/style-controls-derive-from-the-catalog.md
+++ b/.changeset/style-controls-derive-from-the-catalog.md
@@ -18,6 +18,7 @@
 "@nextlyhq/plugin-seo": patch
 "@nextlyhq/plugin-sdk": patch
 "@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
 "@nextlyhq/prettier-config": patch
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch

--- a/.changeset/style-controls-derive-from-the-catalog.md
+++ b/.changeset/style-controls-derive-from-the-catalog.md
@@ -1,0 +1,39 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The page builder gains the contract its style controls will be built on. Which controls a style
+property offers is now derived from the engine's own catalog rather than listed anywhere, so a
+property added to the catalog gains an editor with no control code written; a leaf kind the
+catalog grows that this build has no control for appears as a known gap instead of vanishing.
+Reading and writing a control's value goes through one address — state, breakpoint, property and
+the path inside it — so nothing spells that path a second time, and every value is checked by the
+catalog's own validator rather than by a control's idea of it. Dragging a value previews it by
+compiling the same declarations the published stylesheet carries, so a token still resolves to the
+custom property it resolves to on the page and a value the compiler would refuse never reaches the
+screen; releasing writes one operation, which is one step of undo. Whether a value was authored
+here, inherited from a class or never set is read from the record the compiler already writes, so
+a control cannot disagree with the page about where a value came from. No controls render yet.

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -395,6 +395,7 @@ export {
 export {
   readStyleValue,
   styleClearOp,
+  styleValueAtPath,
   styleWriteOp,
   type StyleAddress,
   type StylePolicy,
@@ -427,6 +428,7 @@ export {
 export {
   scrubCommitOp,
   scrubPreviewCss,
+  scrubStateFragments,
   type ScrubPreview,
   type ScrubTarget,
 } from "./style-scrub";

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -379,6 +379,7 @@ export {
   SUPPORTED_LEAF_KINDS,
   type StyleControl,
   type StyleControlKind,
+  type StyleControlOptions,
   type StyleControlSet,
   type StyleControlVariants,
 } from "./style-controls";

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -396,6 +396,7 @@ export {
   styleClearOp,
   styleWriteOp,
   type StyleAddress,
+  type StylePolicy,
   type StyleWrite,
 } from "./style-values";
 

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -360,3 +360,88 @@ export {
   type ToolbarPlacement,
   type ToolbarSize,
 } from "./toolbar-actions";
+
+/**
+ * @experimental The style controls SDK: what a property offers, and how a
+ * control reads, previews and writes it.
+ *
+ * From this entry because every piece is a plain function over a catalog entry
+ * or a style envelope. The controls a property offers are DERIVED from
+ * `catalog.ts` rather than listed, so a property added to the engine gains an
+ * editor with no code here — and an agent asked to "set the bottom margin"
+ * addresses the value through the same functions the panel does, rather than
+ * reaching into `node.styles` with its own idea of where a side lives.
+ *
+ * No control renders yet. This is the contract they will be built on.
+ */
+export {
+  styleControlsFor,
+  SUPPORTED_LEAF_KINDS,
+  type StyleControl,
+  type StyleControlKind,
+  type StyleControlSet,
+  type StyleControlVariants,
+} from "./style-controls";
+
+/**
+ * @experimental Addressing one control's value inside a node's style envelope.
+ *
+ * From this entry because the envelope is `state × breakpoint × property` and
+ * a caller that spelled that path itself would be a second answer to where a
+ * value lives. Validation is the catalog's, so a refused value comes back with
+ * the catalog's own reasons rather than a control's guess at them.
+ */
+export {
+  readStyleValue,
+  styleClearOp,
+  styleWriteOp,
+  type StyleAddress,
+  type StyleWrite,
+} from "./style-values";
+
+/**
+ * @experimental Whether a control's value was authored here, inherited, or
+ * never set.
+ *
+ * From this entry because it is a pure classification over the compiler's own
+ * provenance record. Anything showing where a value came from — a dot beside a
+ * control, an agent explaining why a page looks as it does — needs the answer
+ * the compiler already wrote, not a second walk of the cascade.
+ */
+export {
+  styleProvenance,
+  type StyleProvenance,
+  type StyleProvenanceQuery,
+} from "./style-provenance";
+
+/**
+ * @experimental Previewing a value mid-drag, and committing it once.
+ *
+ * From this entry because the preview is compiled through the same function
+ * that emits the published stylesheet, so what a drag shows is what a release
+ * would store. The rule sits at the compiler's own specificity and wins on
+ * document order, so the element carrying it belongs AFTER the compiled sheet.
+ */
+export {
+  scrubCommitOp,
+  scrubPreviewCss,
+  type ScrubPreview,
+  type ScrubTarget,
+} from "./style-scrub";
+
+/**
+ * @experimental Where a control's custom behaviour lives, referenced by name.
+ *
+ * From this entry because it is the seam a host configures. The catalog stays
+ * data — it is read by validation, the compiler, the inspector and the
+ * generated reference docs, and a function stored in it could not be
+ * serialized, reasoned about, or documented — so behaviour is registered under
+ * a key derived from the catalog's own identity instead. Ships empty.
+ */
+export {
+  NO_STYLE_CONTROL_BEHAVIOUR,
+  styleControlBehaviour,
+  styleControlBehaviourKey,
+  type StyleControlBehaviour,
+  type StyleControlBehaviours,
+} from "./style-control-behaviour";

--- a/packages/builder/src/ops.ts
+++ b/packages/builder/src/ops.ts
@@ -514,6 +514,26 @@ function equalWithin(a: unknown, b: unknown, budget: number): boolean {
 }
 
 /**
+ * Whether two stored values are the same one, by the comparison an `update` op
+ * uses to decide it changes nothing.
+ *
+ * Exported so a caller BUILDING an update can ask before `applyOp` answers by
+ * throwing. A surface that proposed an op which changes nothing would be
+ * advertising an operation that cannot be applied — and the natural cases are
+ * ordinary rather than exotic: resetting a control that was already unset, or
+ * retyping the value a node already holds.
+ *
+ * The same predicate rather than a second one, because the two would disagree
+ * about exactly the values that are hard — a token reference against an equal
+ * token reference, a composite whose keys were written in another order — and
+ * the disagreement surfaces as a thrown error from an op the caller was told
+ * was fine.
+ */
+export function sameStoredValue(a: unknown, b: unknown): boolean {
+  return equalWithin(a, b, COMPARISON_BUDGET);
+}
+
+/**
  * A detached copy of a value the caller still holds a reference to.
  *
  * An op is DATA describing an edit, and the document it produces has to be that

--- a/packages/builder/src/style-colour-boundary.test.ts
+++ b/packages/builder/src/style-colour-boundary.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -51,6 +51,57 @@ import { collectModules } from "./source-modules";
 const SRC_DIR = dirname(fileURLToPath(import.meta.url));
 const PACKAGE_ROOT = join(SRC_DIR, "..");
 const UI_MANIFEST = join(SRC_DIR, "..", "..", "ui", "package.json");
+
+/** The `ui` package's source root, whose barrel the editor is allowed to import. */
+const UI_SRC = join(SRC_DIR, "..", "..", "ui", "src");
+
+/**
+ * The file a relative specifier names, trying the extensions a bundler tries.
+ *
+ * Returns `undefined` for a specifier that resolves to nothing here, which is
+ * how a type-only or generated path drops out of the walk rather than failing
+ * it.
+ */
+function resolveModule(from: string, specifier: string): string | undefined {
+  const base = resolve(dirname(from), specifier);
+  const candidates = [
+    `${base}.ts`,
+    `${base}.tsx`,
+    join(base, "index.ts"),
+    join(base, "index.tsx"),
+    base,
+  ];
+  return candidates.find(path => /\.tsx?$/.test(path) && existsSync(path));
+}
+
+/**
+ * Every module reachable from an entry by following its relative specifiers.
+ *
+ * `importedSpecifiers` reports re-exports as well as imports — measured:
+ * `export * from`, `export {} from` and `export * as ns from` all come back —
+ * which is what makes this a reachability walk rather than an import scan.
+ */
+function reachableFrom(entry: string): Set<string> {
+  const seen = new Set<string>();
+  const pending = [entry];
+  while (pending.length > 0) {
+    const file = pending.pop();
+    if (file === undefined || seen.has(file)) continue;
+    seen.add(file);
+    const specifiers = importedSpecifiers(readFileSync(file, "utf8"), file);
+    for (const specifier of specifiers) {
+      if (!specifier.startsWith(".")) continue;
+      const next = resolveModule(file, specifier);
+      if (next !== undefined && !seen.has(next)) pending.push(next);
+    }
+  }
+  return seen;
+}
+
+/** Every module the `ui` root barrel can reach, re-exports included. */
+function reachableFromUiBarrel(): Set<string> {
+  return reachableFrom(join(UI_SRC, "index.ts"));
+}
 
 /** Every module specifier this package imports, with the file that imports it. */
 function everyImport(): { file: string; specifier: string }[] {
@@ -128,15 +179,32 @@ describe("the admin theme's contrast implementation is out of reach", () => {
     }
   });
 
-  it("is not re-exported from the root barrel the editor does import", () => {
+  it("is not reachable from the root barrel, however many re-exports deep", () => {
     // The route the export map leaves open: `@nextlyhq/ui` itself is allowed,
-    // so anything its root re-exports is reachable.
-    const barrel = readFileSync(
-      join(SRC_DIR, "..", "..", "ui", "src", "index.ts"),
-      "utf8"
+    // so anything its root re-exports is reachable — and a re-export chain is
+    // not one file. A literal search of `index.ts` stays green when the root
+    // does `export * from "./some-barrel"` and THAT barrel re-exports contrast,
+    // which is precisely the shape a boundary has to survive.
+    const reached = reachableFromUiBarrel();
+    // An absence search needs a positive control: the walk must demonstrably
+    // traverse the graph, or an empty result means only that it read nothing.
+    expect(reached.size).toBeGreaterThan(1);
+    const offenders = [...reached].filter(file =>
+      file.includes(join("styles", "contrast"))
     );
-    expect(barrel.length).toBeGreaterThan(0);
-    expect(barrel).not.toContain("styles/contrast");
+    expect(offenders).toEqual([]);
+  });
+
+  it("would SEE the contrast module if the barrel reached it", () => {
+    // The negative control for the walk itself: pointed at the module that DOES
+    // re-export contrast, it must find it. Without this, a walk that resolved
+    // nothing would satisfy the assertion above on any codebase.
+    const contrastIndex = join(UI_SRC, "styles", "contrast", "resolve.ts");
+    expect(existsSync(contrastIndex)).toBe(true);
+    const reached = reachableFrom(contrastIndex);
+    expect(
+      [...reached].some(file => file.includes(join("styles", "contrast")))
+    ).toBe(true);
   });
 
   it("is not reached by a relative path that climbs out of this package", () => {

--- a/packages/builder/src/style-colour-boundary.test.ts
+++ b/packages/builder/src/style-colour-boundary.test.ts
@@ -1,0 +1,133 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { importedSpecifiers } from "@nextlyhq/module-specifiers";
+import { describe, expect, it } from "vitest";
+
+import { collectModules } from "./source-modules";
+
+/**
+ * Which colour implementation the editor is allowed to reach.
+ *
+ * There are FOUR colour concerns in this repository and they are not
+ * interchangeable:
+ *
+ * - `checkColorValue` in `blocks-engine` — is this a valid CSS colour. The
+ *   canonical grammar check, reached through `validateStyleValues`.
+ * - `@nextlyhq/ui`'s `lib/color` — sRGB/HSV/OKLCH conversion for the picker
+ *   widget's own geometry. No accessibility maths at all.
+ * - `blocks-engine`'s `style/contrast.ts` — WCAG 2 contrast, dependency-free,
+ *   written for "tokens a person is choosing right now".
+ * - `@nextlyhq/ui`'s `styles/contrast` — WCAG 2 contrast for the ADMIN THEME,
+ *   built on `culori` and `postcss` and checked once in CI against a stylesheet.
+ *
+ * The last two compute the same two formulas and are deliberately unshared:
+ * importing ui's into the engine would end the engine's runtime-free guarantee,
+ * and importing the engine's into ui would point the design system at the page
+ * builder. They agree because both are anchored to the specification's own
+ * reference values, not because either defers to the other.
+ *
+ * **A control's contrast readout therefore calls the ENGINE's.** It is the one
+ * that answers while a picker is open, and it is the one the compiler already
+ * shares.
+ *
+ * ## What this file does NOT prove
+ *
+ * It proves what this package IMPORTS. It cannot prove that nothing here
+ * REIMPLEMENTS the maths: relative luminance is a dozen lines of arithmetic over
+ * numbers already in hand, so a fourth implementation written inside
+ * `packages/builder` would import nothing at all and every assertion below would
+ * pass. `layering.test.ts` records the same limit about rendering, for the same
+ * reason — an allowlist makes a shortcut inconvenient and cannot make it
+ * impossible.
+ *
+ * So this is not the control for "no third colour parser". That rule is a
+ * design constraint, enforced at review. What is enforced here is narrower and
+ * genuinely checkable: the admin theme's implementation is not reachable from
+ * the editor, by any route this package can take.
+ */
+
+const SRC_DIR = dirname(fileURLToPath(import.meta.url));
+const UI_MANIFEST = join(SRC_DIR, "..", "..", "ui", "package.json");
+
+/** Every module specifier this package imports, with the file that imports it. */
+function everyImport(): { file: string; specifier: string }[] {
+  const files = collectModules(
+    SRC_DIR,
+    at => readdirSync(at, { withFileTypes: true }),
+    join
+  );
+  return files.flatMap(file =>
+    importedSpecifiers(readFileSync(file, "utf8"), file).map(specifier => ({
+      file,
+      specifier,
+    }))
+  );
+}
+
+/** A specifier that climbs out of this package rather than staying inside it. */
+function escapesPackage(specifier: string): boolean {
+  return specifier.startsWith("../../");
+}
+
+describe("the admin theme's contrast implementation is out of reach", () => {
+  it("is not published as a subpath, so no import can resolve to it", () => {
+    // The strongest of the three checks, and the reason the others are cheap:
+    // a subpath absent from `exports` cannot be imported however it is spelled.
+    // Asserting it here means WIDENING that map becomes a deliberate act that
+    // fails a test in the package it would affect.
+    const manifest: unknown = JSON.parse(readFileSync(UI_MANIFEST, "utf8"));
+    expect(manifest).toHaveProperty("exports");
+    const exported = (manifest as { exports: Record<string, unknown> }).exports;
+    // The positive control: a manifest read from the wrong path, or one whose
+    // shape moved, would produce an empty object and every absence below would
+    // hold vacuously.
+    expect(Object.keys(exported).length).toBeGreaterThan(0);
+    expect(Object.keys(exported)).toContain(".");
+    for (const subpath of Object.keys(exported)) {
+      expect(subpath).not.toContain("contrast");
+    }
+  });
+
+  it("is not re-exported from the root barrel the editor does import", () => {
+    // The route the export map leaves open: `@nextlyhq/ui` itself is allowed,
+    // so anything its root re-exports is reachable.
+    const barrel = readFileSync(
+      join(SRC_DIR, "..", "..", "ui", "src", "index.ts"),
+      "utf8"
+    );
+    expect(barrel.length).toBeGreaterThan(0);
+    expect(barrel).not.toContain("styles/contrast");
+  });
+
+  it("is not reached by a relative path that climbs out of this package", () => {
+    // `layering.test.ts` filters to BARE specifiers, because a relative path is
+    // normally this package's own code. One that climbs past the package root
+    // is not, and it bypasses the export map entirely — so it is the one route
+    // an allowlist of package names cannot see.
+    const escaping = everyImport().filter(({ specifier }) =>
+      escapesPackage(specifier)
+    );
+    expect(escaping).toEqual([]);
+  });
+
+  it("finds the imports it is searching, so an empty result means something", () => {
+    // An absence search needs a positive control. This package demonstrably
+    // imports the engine; if the walk returned nothing, the assertion above
+    // would pass over code it never read.
+    const all = everyImport();
+    expect(all.length).toBeGreaterThan(0);
+    expect(
+      all.some(({ specifier }) => specifier === "@nextlyhq/blocks-engine")
+    ).toBe(true);
+  });
+
+  it("recognises a climbing specifier when it sees one", () => {
+    // The negative control for `escapesPackage`: a predicate that answered
+    // false for everything would make the sweep above pass on any codebase.
+    expect(escapesPackage("../../ui/src/styles/contrast/color")).toBe(true);
+    expect(escapesPackage("./style-controls")).toBe(false);
+    expect(escapesPackage("../source-modules")).toBe(false);
+  });
+});

--- a/packages/builder/src/style-colour-boundary.test.ts
+++ b/packages/builder/src/style-colour-boundary.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync, readdirSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { importedSpecifiers } from "@nextlyhq/module-specifiers";
@@ -49,6 +49,7 @@ import { collectModules } from "./source-modules";
  */
 
 const SRC_DIR = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = join(SRC_DIR, "..");
 const UI_MANIFEST = join(SRC_DIR, "..", "..", "ui", "package.json");
 
 /** Every module specifier this package imports, with the file that imports it. */
@@ -66,9 +67,35 @@ function everyImport(): { file: string; specifier: string }[] {
   );
 }
 
-/** A specifier that climbs out of this package rather than staying inside it. */
-function escapesPackage(specifier: string): boolean {
-  return specifier.startsWith("../../");
+/**
+ * A relative specifier that resolves OUTSIDE this package.
+ *
+ * Resolved rather than pattern-matched. Counting `../` segments answers a
+ * question about spelling, not about where the import lands: how many segments
+ * leave the package depends on how deep the importing file sits, so the same
+ * prefix escapes from `src/` and stays inside from `src/a/b/`. It also reports
+ * `../../builder/src/x` — which comes straight back in — as an escape, and
+ * misses a path whose `../` only appear after normalization.
+ */
+function escapesPackage(file: string, specifier: string): boolean {
+  if (!specifier.startsWith(".")) return false;
+  const target = resolve(dirname(file), specifier);
+  return relative(PACKAGE_ROOT, target).startsWith("..");
+}
+
+/**
+ * Every string an `exports` map can send an import to, however nested.
+ *
+ * The map's VALUES are what decide reachability; its keys are only what a
+ * caller types. A check reading keys alone passes a map whose key says nothing
+ * about contrast and whose target resolves straight into it.
+ */
+function exportTargets(node: unknown, found: string[] = []): string[] {
+  if (typeof node === "string") found.push(node);
+  else if (node !== null && typeof node === "object") {
+    for (const value of Object.values(node)) exportTargets(value, found);
+  }
+  return found;
 }
 
 describe("the admin theme's contrast implementation is out of reach", () => {
@@ -85,8 +112,19 @@ describe("the admin theme's contrast implementation is out of reach", () => {
     // hold vacuously.
     expect(Object.keys(exported).length).toBeGreaterThan(0);
     expect(Object.keys(exported)).toContain(".");
-    for (const subpath of Object.keys(exported)) {
-      expect(subpath).not.toContain("contrast");
+    const targets = exportTargets(exported);
+    // Targets as well as keys. A subpath named `./styles` pointing at the
+    // contrast build would pass a key-only check.
+    expect(targets.length).toBeGreaterThan(0);
+    for (const entry of [...Object.keys(exported), ...targets]) {
+      expect(entry).not.toContain("contrast");
+    }
+    // A WILDCARD would make the map unbounded and this check blind: `./x/*`
+    // admits every file under its target, and no string comparison here can
+    // enumerate them. Failing on one is the honest answer — it says the guard
+    // can no longer see what is reachable, rather than reporting clean.
+    for (const entry of [...Object.keys(exported), ...targets]) {
+      expect(entry).not.toContain("*");
     }
   });
 
@@ -106,8 +144,8 @@ describe("the admin theme's contrast implementation is out of reach", () => {
     // normally this package's own code. One that climbs past the package root
     // is not, and it bypasses the export map entirely — so it is the one route
     // an allowlist of package names cannot see.
-    const escaping = everyImport().filter(({ specifier }) =>
-      escapesPackage(specifier)
+    const escaping = everyImport().filter(({ file, specifier }) =>
+      escapesPackage(file, specifier)
     );
     expect(escaping).toEqual([]);
   });
@@ -123,11 +161,31 @@ describe("the admin theme's contrast implementation is out of reach", () => {
     ).toBe(true);
   });
 
-  it("recognises a climbing specifier when it sees one", () => {
-    // The negative control for `escapesPackage`: a predicate that answered
-    // false for everything would make the sweep above pass on any codebase.
-    expect(escapesPackage("../../ui/src/styles/contrast/color")).toBe(true);
-    expect(escapesPackage("./style-controls")).toBe(false);
-    expect(escapesPackage("../source-modules")).toBe(false);
+  it("recognises an escaping specifier from any depth, and only a real escape", () => {
+    // The controls for `escapesPackage`. A predicate answering false for
+    // everything would make the sweep above pass on any codebase; one answering
+    // by prefix would disagree with itself as files move between directories.
+    const shallow = join(SRC_DIR, "example.ts");
+    const deep = join(SRC_DIR, "nested", "deeper", "example.ts");
+
+    expect(escapesPackage(shallow, "../../ui/src/styles/contrast/color")).toBe(
+      true
+    );
+    // Same spelling, deeper file: it lands inside this package, so it is not an
+    // escape — which a prefix test cannot tell apart.
+    expect(escapesPackage(deep, "../../ui/src/styles/contrast/color")).toBe(
+      false
+    );
+    // A deeper file needs more segments to leave, and this one does.
+    expect(
+      escapesPackage(deep, "../../../../ui/src/styles/contrast/color")
+    ).toBe(true);
+    // Climbs out and comes straight back: not an escape, and a prefix test
+    // reports it as one.
+    expect(escapesPackage(shallow, "../../builder/src/style-controls")).toBe(
+      false
+    );
+    expect(escapesPackage(shallow, "./style-controls")).toBe(false);
+    expect(escapesPackage(shallow, "@nextlyhq/ui")).toBe(false);
   });
 });

--- a/packages/builder/src/style-colour-boundary.test.ts
+++ b/packages/builder/src/style-colour-boundary.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -74,10 +74,46 @@ function resolveModule(from: string, specifier: string): string | undefined {
   // reports the boundary intact for the route it could not follow, which is the
   // one failure this file exists to prevent.
   const candidates = [
+    // The specifier as written. A barrel using an explicit relative extension
+    // — `export * from "./barrel.js"` — is already a path, and appending to it
+    // only ever produces `barrel.js.ts`.
+    base,
+    // A `.js` specifier resolving to its TypeScript SOURCE, which is how ESM
+    // TypeScript is written: the emitted name is what the import says, and the
+    // file on disk is `.ts`. Same for the module-scoped spellings.
+    ...sourceForEmitted(base),
     ...MODULE_EXTENSIONS.map(ext => `${base}.${ext}`),
     ...MODULE_EXTENSIONS.map(ext => join(base, `index.${ext}`)),
   ];
-  return candidates.find(path => existsSync(path));
+  return candidates.find(path => existsSync(path) && !isDirectory(path));
+}
+
+/** Whether a path names a directory rather than a module. */
+function isDirectory(path: string): boolean {
+  return statSync(path).isDirectory();
+}
+
+/**
+ * The TypeScript sources an emitted-name specifier can resolve to.
+ *
+ * `./x.js` is how an ESM TypeScript import of `x.ts` is spelled, because the
+ * specifier names what will be emitted rather than what is on disk. A resolver
+ * that only appended extensions would never reach the source, so a re-export
+ * written that way would stop the walk — and a walk that stops reports the
+ * boundary intact for the route it could not follow.
+ */
+function sourceForEmitted(base: string): string[] {
+  const swaps: Readonly<Record<string, readonly string[]>> = {
+    ".js": ["ts", "tsx"],
+    ".mjs": ["mts"],
+    ".cjs": ["cts"],
+  };
+  for (const [emitted, sources] of Object.entries(swaps)) {
+    if (!base.endsWith(emitted)) continue;
+    const stem = base.slice(0, -emitted.length);
+    return sources.map(ext => `${stem}.${ext}`);
+  }
+  return [];
 }
 
 /**

--- a/packages/builder/src/style-colour-boundary.test.ts
+++ b/packages/builder/src/style-colour-boundary.test.ts
@@ -195,16 +195,19 @@ describe("the admin theme's contrast implementation is out of reach", () => {
     expect(offenders).toEqual([]);
   });
 
-  it("would SEE the contrast module if the barrel reached it", () => {
-    // The negative control for the walk itself: pointed at the module that DOES
-    // re-export contrast, it must find it. Without this, a walk that resolved
-    // nothing would satisfy the assertion above on any codebase.
-    const contrastIndex = join(UI_SRC, "styles", "contrast", "resolve.ts");
-    expect(existsSync(contrastIndex)).toBe(true);
-    const reached = reachableFrom(contrastIndex);
-    expect(
-      [...reached].some(file => file.includes(join("styles", "contrast")))
-    ).toBe(true);
+  it("follows a real edge, rather than reporting the entry it was handed", () => {
+    // The control for the walk itself, and it has to prove an EDGE. Starting at
+    // a file already under `styles/contrast` and then asserting something under
+    // `styles/contrast` was reached passes on the seed alone — traversal could
+    // return nothing and the assertion would still hold. So this requires a
+    // DISTINCT module: `resolve.ts` imports `./color`, and reaching that file
+    // is only possible by following the import.
+    const entry = join(UI_SRC, "styles", "contrast", "resolve.ts");
+    const neighbour = join(UI_SRC, "styles", "contrast", "color.ts");
+    expect(existsSync(entry)).toBe(true);
+    expect(existsSync(neighbour)).toBe(true);
+    const reached = reachableFrom(entry);
+    expect(reached.has(neighbour)).toBe(true);
   });
 
   it("is not reached by a relative path that climbs out of this package", () => {

--- a/packages/builder/src/style-colour-boundary.test.ts
+++ b/packages/builder/src/style-colour-boundary.test.ts
@@ -5,7 +5,11 @@ import { fileURLToPath } from "node:url";
 import { importedSpecifiers } from "@nextlyhq/module-specifiers";
 import { describe, expect, it } from "vitest";
 
-import { collectModules } from "./source-modules";
+import {
+  collectModules,
+  MODULE_EXTENSIONS,
+  TEST_GLOBS,
+} from "./source-modules";
 
 /**
  * Which colour implementation the editor is allowed to reach.
@@ -64,14 +68,16 @@ const UI_SRC = join(SRC_DIR, "..", "..", "ui", "src");
  */
 function resolveModule(from: string, specifier: string): string | undefined {
   const base = resolve(dirname(from), specifier);
+  // Every extension the bundler follows, from the package's OWN list rather
+  // than a shorter one written here. A resolver that tried only `.ts`/`.tsx`
+  // stops at a barrel written as `.mjs` or `.js` — and a walk that stops
+  // reports the boundary intact for the route it could not follow, which is the
+  // one failure this file exists to prevent.
   const candidates = [
-    `${base}.ts`,
-    `${base}.tsx`,
-    join(base, "index.ts"),
-    join(base, "index.tsx"),
-    base,
+    ...MODULE_EXTENSIONS.map(ext => `${base}.${ext}`),
+    ...MODULE_EXTENSIONS.map(ext => join(base, `index.${ext}`)),
   ];
-  return candidates.find(path => /\.tsx?$/.test(path) && existsSync(path));
+  return candidates.find(path => existsSync(path));
 }
 
 /**
@@ -258,5 +264,20 @@ describe("the admin theme's contrast implementation is out of reach", () => {
     );
     expect(escapesPackage(shallow, "./style-controls")).toBe(false);
     expect(escapesPackage(shallow, "@nextlyhq/ui")).toBe(false);
+  });
+});
+
+describe("the extensions the walk follows", () => {
+  it("tries every extension the bundler does, not just TypeScript's", () => {
+    // A barrel written as `.mjs` or `.js` is a module the bundler follows, and
+    // a resolver that skipped it would stop the walk there — reporting the
+    // boundary intact for the one route it could not see.
+    expect(MODULE_EXTENSIONS).toContain("mts");
+    expect(MODULE_EXTENSIONS).toContain("cjs");
+    expect(MODULE_EXTENSIONS).toContain("js");
+    // The resolver is built from that list, so growing it grows the walk.
+    for (const ext of MODULE_EXTENSIONS) {
+      expect(TEST_GLOBS.some(glob => glob.endsWith(`.${ext}`))).toBe(true);
+    }
   });
 });

--- a/packages/builder/src/style-control-behaviour.test.ts
+++ b/packages/builder/src/style-control-behaviour.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  NO_STYLE_CONTROL_BEHAVIOUR,
+  styleControlBehaviour,
+  styleControlBehaviourKey,
+  type StyleControlBehaviours,
+} from "./style-control-behaviour";
+
+describe("addressing behaviour by the catalog's own identity", () => {
+  it("keys a plain property by its catalog key", () => {
+    expect(styleControlBehaviourKey("opacity", [])).toBe("opacity");
+  });
+
+  it("keys a position inside a composite by property and path", () => {
+    expect(styleControlBehaviourKey("margin", ["blockEnd"])).toBe(
+      "margin.blockEnd"
+    );
+  });
+
+  it("keeps two sides of one property distinct", () => {
+    // The separating property against a key built from the property alone:
+    // registering a spoken form for the bottom margin must not also speak for
+    // the top one.
+    expect(styleControlBehaviourKey("margin", ["blockEnd"])).not.toBe(
+      styleControlBehaviourKey("margin", ["blockStart"])
+    );
+  });
+
+  it("needs nothing added to the catalog to address a control", () => {
+    // The whole point of the rule: the key is derived from what the catalog
+    // already says, so `catalog.ts` stays data and gains no field for this.
+    expect(
+      styleControlBehaviourKey("inventedByThisTest", ["deep", "path"])
+    ).toBe("inventedByThisTest.deep.path");
+  });
+});
+
+describe("looking behaviour up", () => {
+  it("ships with nothing registered", () => {
+    expect(NO_STYLE_CONTROL_BEHAVIOUR.size).toBe(0);
+    expect(
+      styleControlBehaviour(NO_STYLE_CONTROL_BEHAVIOUR, "opacity", [])
+    ).toBeUndefined();
+  });
+
+  it("returns what a host registered under the derived key", () => {
+    // The positive control for the absence above: a lookup that answered
+    // undefined unconditionally would satisfy that test forever.
+    const behaviours: StyleControlBehaviours = new Map([
+      [
+        "margin.blockEnd",
+        { ariaValueText: (value: unknown) => `${String(value)}, medium` },
+      ],
+    ]);
+    const found = styleControlBehaviour(behaviours, "margin", ["blockEnd"]);
+    expect(found?.ariaValueText?.("24px")).toBe("24px, medium");
+  });
+
+  it("does not answer for a control nothing was registered for", () => {
+    const behaviours: StyleControlBehaviours = new Map([
+      ["margin.blockEnd", {}],
+    ]);
+    expect(
+      styleControlBehaviour(behaviours, "margin", ["blockStart"])
+    ).toBeUndefined();
+  });
+});

--- a/packages/builder/src/style-control-behaviour.ts
+++ b/packages/builder/src/style-control-behaviour.ts
@@ -1,0 +1,85 @@
+/**
+ * Where a control's custom behaviour lives, when the generic mapping is not
+ * enough.
+ *
+ * Most controls need nothing here: a leaf's kind decides the control, and the
+ * leaf's own fields carry the units, bounds and keywords it draws with. A few
+ * will want something the catalog cannot express — a spoken value that reads
+ * "24 pixels, medium" rather than "24", a bespoke keyboard step.
+ *
+ * **That behaviour is referenced by NAME and never embedded in the catalog.**
+ * `catalog.ts` says of itself that it is data, not code, and four consumers
+ * depend on it: validation, the compiler, the inspector, and the generated
+ * reference documentation. A function stored in a catalog entry cannot be
+ * serialized for the first, cannot be reasoned about by the second, and cannot
+ * be documented at all by the fourth — so the catalog keeps its identity and
+ * this holds the behaviour under a key derived from it.
+ *
+ * The alternative was measured in the field rather than reasoned about: a
+ * visual builder that allows functions inside its input config has to stringify
+ * and re-evaluate them, and documents the consequence — such a function may not
+ * reference anything outside its own body, which typechecks and fails at
+ * runtime.
+ *
+ * **This registry is EMPTY, deliberately.** The shape is fixed so the contract
+ * is settled and a control needing behaviour has somewhere to put it; inventing
+ * entries before a control asks for one would be building against a guess.
+ *
+ * **A plain map rather than a mutable module global.** A registry a module
+ * mutates on import is one that differs between a test, a server render and a
+ * browser, and cannot be varied per editor instance. Passing the map keeps the
+ * lookup pure and makes "no behaviour registered" the default that needs no
+ * setup.
+ *
+ * @module style-control-behaviour
+ */
+
+import type { StyleValue } from "@nextlyhq/blocks-engine";
+
+/** Behaviour a control cannot derive from its leaf. */
+export interface StyleControlBehaviour {
+  /**
+   * What a screen reader announces in place of the raw value.
+   *
+   * A slider's thumb reports its number, and a number is the wrong unit of
+   * meaning for some properties. `aria-valuetext` is where a spoken form
+   * belongs, and it is read from the THUMB rather than inherited from anything.
+   */
+  readonly ariaValueText?: (value: StyleValue) => string;
+}
+
+/** Behaviour by key, as an editor is configured with it. */
+export type StyleControlBehaviours = ReadonlyMap<string, StyleControlBehaviour>;
+
+/**
+ * The default: nothing registered.
+ *
+ * Exported as a value so a caller has something to pass rather than reaching
+ * for `new Map()` and creating one per render.
+ */
+export const NO_STYLE_CONTROL_BEHAVIOUR: StyleControlBehaviours = new Map();
+
+/**
+ * The key a control's behaviour is registered under.
+ *
+ * Derived from the catalog's own identity — the property key and the path
+ * inside its value — so nothing has to be added to `catalog.ts` for a control
+ * to be addressable. A dot separates the segments because a catalog key is a
+ * JavaScript identifier and a path segment is a declared field name, so neither
+ * can contain one and the join is unambiguous.
+ */
+export function styleControlBehaviourKey(
+  property: string,
+  path: readonly string[]
+): string {
+  return [property, ...path].join(".");
+}
+
+/** The behaviour registered for a control, when there is one. */
+export function styleControlBehaviour(
+  behaviours: StyleControlBehaviours,
+  property: string,
+  path: readonly string[]
+): StyleControlBehaviour | undefined {
+  return behaviours.get(styleControlBehaviourKey(property, path));
+}

--- a/packages/builder/src/style-controls.test.ts
+++ b/packages/builder/src/style-controls.test.ts
@@ -1,5 +1,6 @@
 import {
   getStyleProperty,
+  shapeLeaves,
   STYLE_CATALOG,
   type StyleLeaf,
   type StyleProperty,
@@ -13,9 +14,18 @@ import {
   type StyleControlKind,
 } from "./style-controls";
 
-/** A leaf of one kind, with the fields every leaf carries. */
+/**
+ * A VALID leaf of one kind.
+ *
+ * Built per kind rather than by spreading one shape and casting, because the
+ * kinds do not carry the same fields: a keyword leaf without `values` is not a
+ * catalog entry the engine could ever produce, and a helper that emitted one
+ * would hand later tests a fixture that throws the moment anything reads it.
+ */
 function leaf(kind: StyleLeaf["kind"], cssProperty: string): StyleLeaf {
-  return { kind, cssProperty, tokenKinds: [] } as StyleLeaf;
+  const base = { cssProperty, tokenKinds: [] } as const;
+  if (kind === "keyword") return { ...base, kind, values: ["normal"] };
+  return { ...base, kind };
 }
 
 /** A catalog row, spelled the way `catalog.ts` spells one. */
@@ -336,5 +346,34 @@ describe("choosing between union arms that both accept tokens", () => {
       $token: "type.weight",
     });
     expect(set.controls[0].kind).toBe("number");
+  });
+});
+
+describe("the fixtures this file builds are ones the engine could produce", () => {
+  it("gives every synthetic leaf the fields its kind requires", () => {
+    // A fixture that is not a real catalog entry lets a test agree with a
+    // belief the engine does not share, which is how a broken comparison
+    // passes. `shapeLeaves` is the engine's own reader, so anything it can
+    // walk is a shape the engine accepts.
+    for (const kind of SUPPORTED_LEAF_KINDS) {
+      const built = leaf(kind, "p");
+      expect(shapeLeaves(built)).toEqual([built]);
+      if (built.kind === "keyword") {
+        expect(Array.isArray(built.values)).toBe(true);
+      }
+    }
+  });
+
+  it("resolves a keyword arm by its OWN values, which needs a real keyword leaf", () => {
+    // The case the old helper would have thrown on: a union whose keyword arm
+    // is consulted for a stored string.
+    const union = property("p", {
+      kind: "union",
+      of: [leaf("keyword", "p"), leaf("cssValue", "p")],
+    });
+    expect(styleControlsFor(union, "normal").controls[0].kind).toBe("select");
+    expect(styleControlsFor(union, "anything-else").controls[0].kind).toBe(
+      "css"
+    );
   });
 });

--- a/packages/builder/src/style-controls.test.ts
+++ b/packages/builder/src/style-controls.test.ts
@@ -178,7 +178,7 @@ describe("a union, which stores one value in more than one form", () => {
   });
 });
 
-describe("D-05.1 — the catalog drives the controls", () => {
+describe("the catalog drives the controls", () => {
   it("gives a property this module has never heard of a full set of controls", () => {
     // The point of the rule, stated as a test: a property invented here — no
     // entry in any list in `style-controls.ts`, no name it could match on —
@@ -404,5 +404,33 @@ describe("keywords as the engine compares them", () => {
     // keyword, or the select would be drawn for values it cannot represent.
     expect(fontStyleKind("oblique 40deg")).toBe("css");
     expect(fontStyleKind("italicish")).toBe("css");
+  });
+});
+
+describe("values that are legal wherever a value is", () => {
+  // `inherit`, `initial` and their siblings are accepted by every leaf, so the
+  // engine takes them through the EARLIEST arm — including a number arm that
+  // otherwise holds no strings at all.
+
+  function armKind(property: string, value: string) {
+    const entry = getStyleProperty(property);
+    return styleControlsFor(entry as StyleProperty, value).controls[0].kind;
+  }
+
+  it("takes a CSS-wide keyword through the first arm, not the free-form one", () => {
+    expect(armKind("fontStyle", "inherit")).toBe("select");
+    expect(armKind("fontStyle", "initial")).toBe("select");
+  });
+
+  it("takes one through a NUMBER arm, which holds no other string", () => {
+    expect(armKind("lineHeight", "inherit")).toBe("number");
+    expect(armKind("lineHeight", "unset")).toBe("number");
+  });
+
+  it("still sends an ordinary value to the arm that actually holds it", () => {
+    // The control: if every string were treated as universal, arm 0 would win
+    // always and the free-form and length arms would be unreachable.
+    expect(armKind("fontStyle", "oblique 40deg")).toBe("css");
+    expect(armKind("lineHeight", "1.5rem")).toBe("length");
   });
 });

--- a/packages/builder/src/style-controls.test.ts
+++ b/packages/builder/src/style-controls.test.ts
@@ -484,3 +484,58 @@ describe("whitespace CSS does not discard", () => {
     ).toBe("select");
   });
 });
+
+describe("a union with more than one composite arm", () => {
+  // No union the catalog ships has two composite arms, so nothing reaches this
+  // today — which is why a record-shaped test would be silent if one arrived.
+
+  const twoShapes = property("p", {
+    kind: "union",
+    of: [
+      { kind: "object", fields: { first: leaf("dimension", "a") } },
+      { kind: "object", fields: { second: leaf("color", "b") } },
+    ],
+  });
+
+  it("selects the arm whose fields the value actually names", () => {
+    const set = styleControlsFor(twoShapes, { second: "#fff" });
+    expect(paths(set.controls)).toEqual([["second"]]);
+    expect(set.variants[0].active).toBe(1);
+  });
+
+  it("still selects the first arm when the value names ITS fields", () => {
+    // The control: matching by fields must not simply invert the old answer.
+    const set = styleControlsFor(twoShapes, { first: "4px" });
+    expect(paths(set.controls)).toEqual([["first"]]);
+    expect(set.variants[0].active).toBe(0);
+  });
+
+  it("falls back to the first arm for a record naming neither", () => {
+    expect(styleControlsFor(twoShapes, { other: "x" }).variants[0].active).toBe(
+      0
+    );
+  });
+
+  it("keeps a partially-set composite on its own arm", () => {
+    // A stored value is sparse: a radius with only one corner is still the
+    // four-corner form, so any overlap counts rather than every field.
+    const radius = getStyleProperty("borderRadius");
+    const set = styleControlsFor(radius as StyleProperty, {
+      startStart: "4px",
+    });
+    expect(set.controls).toHaveLength(4);
+  });
+});
+
+describe("the universal-keyword cache", () => {
+  it("gives every spelling of one keyword the same answer", () => {
+    // Keyed by the canonical spelling, so case and ASCII-whitespace variants
+    // share an entry rather than each retaining one.
+    const entry = getStyleProperty("fontStyle");
+    for (const spelling of ["inherit", "INHERIT", " Inherit ", "InHeRiT"]) {
+      expect(
+        styleControlsFor(entry as StyleProperty, spelling).controls[0].kind
+      ).toBe("select");
+    }
+  });
+});

--- a/packages/builder/src/style-controls.test.ts
+++ b/packages/builder/src/style-controls.test.ts
@@ -575,3 +575,30 @@ describe("a union used as another union's arm", () => {
     expect(set.variants[0].active).toBe(0);
   });
 });
+
+describe("composite arms sharing a field name", () => {
+  // Field NAMES alone do not separate two composite arms that share one: both
+  // claim the value, and the controls returned would describe a form that
+  // cannot hold it.
+
+  const shared = property("p", {
+    kind: "union",
+    of: [
+      { kind: "object", fields: { value: leaf("keyword", "a") } },
+      { kind: "object", fields: { value: leaf("number", "b") } },
+    ],
+  });
+
+  it("selects the arm whose field SHAPE holds the value", () => {
+    expect(styleControlsFor(shared, { value: 2 }).controls[0].kind).toBe(
+      "number"
+    );
+  });
+
+  it("still selects the first arm when its shape holds the value", () => {
+    // The control: recursing must not simply prefer the later arm.
+    expect(styleControlsFor(shared, { value: "normal" }).controls[0].kind).toBe(
+      "select"
+    );
+  });
+});

--- a/packages/builder/src/style-controls.test.ts
+++ b/packages/builder/src/style-controls.test.ts
@@ -463,3 +463,24 @@ describe("a token whose kind no arm declares", () => {
     expect(set.controls[0].kind).toBe("length");
   });
 });
+
+describe("whitespace CSS does not discard", () => {
+  it("does not treat a non-breaking space as a separator", () => {
+    // The engine discards ASCII whitespace only — measured, a value carrying
+    // NBSP is refused where the same value with an ordinary space is accepted.
+    // `trim()` removes NBSP, which would match a closed keyword control to a
+    // value that control cannot represent.
+    const entry = getStyleProperty("fontStyle");
+    const nbsp = " italic ";
+    expect(
+      styleControlsFor(entry as StyleProperty, nbsp).controls[0].kind
+    ).toBe("css");
+  });
+
+  it("still discards the whitespace CSS does discard", () => {
+    const entry = getStyleProperty("fontStyle");
+    expect(
+      styleControlsFor(entry as StyleProperty, " italic\t").controls[0].kind
+    ).toBe("select");
+  });
+});

--- a/packages/builder/src/style-controls.test.ts
+++ b/packages/builder/src/style-controls.test.ts
@@ -377,3 +377,32 @@ describe("the fixtures this file builds are ones the engine could produce", () =
     );
   });
 });
+
+describe("keywords as the engine compares them", () => {
+  // CSS keywords are ASCII case-insensitive and parsing discards surrounding
+  // whitespace, so the validator accepts "Italic" and " italic " exactly as it
+  // accepts "italic". An exact match sends those to the free-form arm, which
+  // draws a text box where a select belongs.
+
+  function fontStyleKind(value: string) {
+    const entry = getStyleProperty("fontStyle");
+    return styleControlsFor(entry as StyleProperty, value).controls[0].kind;
+  }
+
+  it("matches a keyword whatever case it was stored in", () => {
+    expect(fontStyleKind("italic")).toBe("select");
+    expect(fontStyleKind("Italic")).toBe("select");
+    expect(fontStyleKind("ITALIC")).toBe("select");
+  });
+
+  it("matches a keyword carrying surrounding whitespace", () => {
+    expect(fontStyleKind(" italic ")).toBe("select");
+  });
+
+  it("still sends a value the vocabulary does not hold to the free-form arm", () => {
+    // The other half of the pair: normalizing must not make every string a
+    // keyword, or the select would be drawn for values it cannot represent.
+    expect(fontStyleKind("oblique 40deg")).toBe("css");
+    expect(fontStyleKind("italicish")).toBe("css");
+  });
+});

--- a/packages/builder/src/style-controls.test.ts
+++ b/packages/builder/src/style-controls.test.ts
@@ -10,6 +10,7 @@ import {
   styleControlsFor,
   SUPPORTED_LEAF_KINDS,
   type StyleControl,
+  type StyleControlKind,
 } from "./style-controls";
 
 /** A leaf of one kind, with the fields every leaf carries. */
@@ -28,15 +29,30 @@ function paths(controls: readonly StyleControl[]): string[][] {
 }
 
 describe("deriving controls from a leaf", () => {
-  it("maps every leaf kind the catalog can hold to a control", () => {
-    // The mapping is a mapped type, so an unmapped kind cannot compile. What
-    // this adds is that each kind resolves to a control at RUNTIME — a mapped
-    // type is satisfied by a key whose value is `undefined`.
+  it("maps every leaf kind to the control it is supposed to draw", () => {
+    // Stated here rather than read off the implementation, which is what gives
+    // the assertion content: deriving the expectation from the same mapping the
+    // code uses would agree with any mapping at all, including one that drew a
+    // dimension with the unitless number field.
+    const expected = {
+      keyword: "select",
+      dimension: "length",
+      number: "number",
+      color: "color",
+      cssValue: "css",
+      url: "url",
+    } satisfies Record<StyleLeaf["kind"], StyleControlKind>;
+
+    // The derived set must still cover every kind, or the sweep below runs on
+    // fewer kinds than the catalog can hold and passes by not looking.
+    expect([...SUPPORTED_LEAF_KINDS].sort()).toEqual(
+      Object.keys(expected).sort()
+    );
     for (const kind of SUPPORTED_LEAF_KINDS) {
       const { controls } = styleControlsFor(property("p", leaf(kind, "p")));
       expect(controls).toHaveLength(1);
       expect(controls[0].supported).toBe(true);
-      expect(controls[0].kind).toBeTypeOf("string");
+      expect(controls[0].kind).toBe(expected[kind]);
     }
   });
 
@@ -197,5 +213,60 @@ describe("D-05.1 — the catalog drives the controls", () => {
       }
     }
     expect(unsupported).toEqual([]);
+  });
+});
+
+describe("the unions the catalog actually ships", () => {
+  /** The control kinds a real catalog property resolves to for a stored value. */
+  function kindsFor(
+    name: string,
+    value: Parameters<typeof styleControlsFor>[1]
+  ) {
+    const entry = getStyleProperty(name);
+    expect(entry).toBeDefined();
+    return styleControlsFor(entry as StyleProperty, value).controls.map(
+      control => control.kind
+    );
+  }
+
+  // Three of the catalog's four unions have arms that are BOTH scalars, so a
+  // composite-versus-scalar test picks arm 0 for every value they can hold.
+  // These are the properties, and the values, that distinguish the arms.
+
+  it("draws a numeric fontWeight with the number control, not the keyword select", () => {
+    expect(kindsFor("fontWeight", 600)).toEqual(["number"]);
+  });
+
+  it("draws a keyword fontWeight with the select", () => {
+    expect(kindsFor("fontWeight", "bold")).toEqual(["select"]);
+  });
+
+  it("draws a unitless lineHeight with the number control", () => {
+    expect(kindsFor("lineHeight", 1.5)).toEqual(["number"]);
+  });
+
+  it("draws a measured lineHeight with the length control", () => {
+    expect(kindsFor("lineHeight", "1.5rem")).toEqual(["length"]);
+  });
+
+  it("draws a listed fontStyle with the select", () => {
+    expect(kindsFor("fontStyle", "italic")).toEqual(["select"]);
+  });
+
+  it("reaches fontStyle's free-form arm for a value the keywords do not list", () => {
+    expect(kindsFor("fontStyle", "oblique 40deg")).toEqual(["css"]);
+  });
+
+  it("sends a token to the arm that admits tokens", () => {
+    // `fontWeight`'s keyword arm declares no token kinds and its number arm
+    // declares two, so a token weight belongs to the number arm.
+    expect(kindsFor("fontWeight", { $token: "type.weight.bold" })).toEqual([
+      "number",
+    ]);
+  });
+
+  it("still separates borderRadius's scalar and composite arms", () => {
+    expect(kindsFor("borderRadius", "4px")).toEqual(["length"]);
+    expect(kindsFor("borderRadius", { startStart: "4px" })).toHaveLength(4);
   });
 });

--- a/packages/builder/src/style-controls.test.ts
+++ b/packages/builder/src/style-controls.test.ts
@@ -134,7 +134,7 @@ describe("a union, which stores one value in more than one form", () => {
   it("shows the FIRST variant when nothing is stored, which is the form the engine tries first", () => {
     const set = styleControlsFor(radius);
     expect(paths(set.controls)).toEqual([[]]);
-    expect(set.variants).toEqual({ active: 0, count: 2 });
+    expect(set.variants).toEqual([{ path: [], active: 0, count: 2 }]);
   });
 
   it("shows the composite variant when a record is stored", () => {
@@ -145,7 +145,7 @@ describe("a union, which stores one value in more than one form", () => {
       ["endStart"],
       ["endEnd"],
     ]);
-    expect(set.variants?.active).toBe(1);
+    expect(set.variants[0].active).toBe(1);
   });
 
   it("treats a token reference as a scalar, not as a composite", () => {
@@ -154,17 +154,17 @@ describe("a union, which stores one value in more than one form", () => {
     // token in none of them.
     const set = styleControlsFor(radius, { $token: "Radius.Card" });
     expect(paths(set.controls)).toEqual([[]]);
-    expect(set.variants?.active).toBe(0);
+    expect(set.variants[0].active).toBe(0);
   });
 
   it("records how many variants exist, so an editor can offer the other one", () => {
-    expect(styleControlsFor(radius).variants?.count).toBe(2);
+    expect(styleControlsFor(radius).variants[0].count).toBe(2);
   });
 
   it("reports no variants for a property that is not a union", () => {
     expect(
       styleControlsFor(property("p", leaf("color", "p"))).variants
-    ).toBeUndefined();
+    ).toEqual([]);
   });
 });
 
@@ -268,5 +268,73 @@ describe("the unions the catalog actually ships", () => {
   it("still separates borderRadius's scalar and composite arms", () => {
     expect(kindsFor("borderRadius", "4px")).toEqual(["length"]);
     expect(kindsFor("borderRadius", { startStart: "4px" })).toHaveLength(4);
+  });
+});
+
+describe("a union nested below the property root", () => {
+  // `position.zIndex` is a number OR the `auto` keyword. Reporting choices only
+  // at the root would leave a renderer no way to offer `auto`.
+
+  function positionSet(value?: Parameters<typeof styleControlsFor>[1]) {
+    const entry = getStyleProperty("position");
+    expect(entry).toBeDefined();
+    return styleControlsFor(entry as StyleProperty, value);
+  }
+
+  it("records the choice at the path it sits on", () => {
+    const set = positionSet();
+    const zIndex = set.variants.find(v => v.path.join(".") === "zIndex");
+    expect(zIndex).toBeDefined();
+    expect(zIndex?.count).toBe(2);
+  });
+
+  it("selects the arm the stored value is written in", () => {
+    const numeric = positionSet({ zIndex: 3 });
+    const keyword = positionSet({ zIndex: "auto" });
+    const kindAt = (set: ReturnType<typeof positionSet>) =>
+      set.controls.find(c => c.path.join(".") === "zIndex")?.kind;
+    expect(kindAt(numeric)).toBe("number");
+    expect(kindAt(keyword)).toBe("select");
+  });
+});
+
+describe("choosing between union arms that both accept tokens", () => {
+  // `lineHeight` takes a number token on one arm and a dimension token on the
+  // other, and a stored reference carries only its name.
+
+  function lineHeightKind(
+    token: string,
+    tokens?: { kindOf: (n: string) => never }
+  ) {
+    const entry = getStyleProperty("lineHeight");
+    return styleControlsFor(
+      entry as StyleProperty,
+      { $token: token },
+      tokens === undefined ? undefined : { tokens }
+    ).controls[0].kind;
+  }
+
+  it("uses the site's token table when it has one", () => {
+    const table = {
+      kindOf: (name: string) => (name === "space.gap" ? "dimension" : "number"),
+    } as never;
+    expect(lineHeightKind("space.gap", table)).toBe("length");
+    expect(lineHeightKind("type.ratio", table)).toBe("number");
+  });
+
+  it("falls back to the catalog's arm order without a table", () => {
+    // Stated rather than left implicit: the name alone cannot separate the arms,
+    // and arm order is the engine's own fallback for a name it cannot resolve.
+    expect(lineHeightKind("space.gap")).toBe("number");
+  });
+
+  it("skips an arm that accepts no tokens at all", () => {
+    // `fontWeight`'s keyword arm declares no token kinds, so a token belongs to
+    // the number arm whatever the table says.
+    const entry = getStyleProperty("fontWeight");
+    const set = styleControlsFor(entry as StyleProperty, {
+      $token: "type.weight",
+    });
+    expect(set.controls[0].kind).toBe("number");
   });
 });

--- a/packages/builder/src/style-controls.test.ts
+++ b/packages/builder/src/style-controls.test.ts
@@ -1,0 +1,201 @@
+import {
+  getStyleProperty,
+  STYLE_CATALOG,
+  type StyleLeaf,
+  type StyleProperty,
+} from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import {
+  styleControlsFor,
+  SUPPORTED_LEAF_KINDS,
+  type StyleControl,
+} from "./style-controls";
+
+/** A leaf of one kind, with the fields every leaf carries. */
+function leaf(kind: StyleLeaf["kind"], cssProperty: string): StyleLeaf {
+  return { kind, cssProperty, tokenKinds: [] } as StyleLeaf;
+}
+
+/** A catalog row, spelled the way `catalog.ts` spells one. */
+function property(name: string, shape: StyleProperty["shape"]): StyleProperty {
+  return { property: name, group: "spacing", shape, summary: name };
+}
+
+/** The paths a control set addresses, in order. */
+function paths(controls: readonly StyleControl[]): string[][] {
+  return controls.map(control => [...control.path]);
+}
+
+describe("deriving controls from a leaf", () => {
+  it("maps every leaf kind the catalog can hold to a control", () => {
+    // The mapping is a mapped type, so an unmapped kind cannot compile. What
+    // this adds is that each kind resolves to a control at RUNTIME — a mapped
+    // type is satisfied by a key whose value is `undefined`.
+    for (const kind of SUPPORTED_LEAF_KINDS) {
+      const { controls } = styleControlsFor(property("p", leaf(kind, "p")));
+      expect(controls).toHaveLength(1);
+      expect(controls[0].supported).toBe(true);
+      expect(controls[0].kind).toBeTypeOf("string");
+    }
+  });
+
+  it("carries the catalog's own leaf through, so a control reads units and bounds from it", () => {
+    const bounded: StyleLeaf = {
+      kind: "number",
+      cssProperty: "opacity",
+      tokenKinds: [],
+      min: 0,
+      max: 1,
+    };
+    const { controls } = styleControlsFor(property("opacity", bounded));
+    expect(controls[0].leaf).toBe(bounded);
+  });
+
+  it("reports a leaf kind this build has no control for as a KNOWN gap", () => {
+    // A document written by a newer engine can carry a kind absent from this
+    // build's mapping. The descriptor must still appear — omitting it presents
+    // an incomplete property as a complete one — and must say it is not
+    // editable here rather than reaching a renderer as `undefined`.
+    const future = { kind: "gradient", cssProperty: "x", tokenKinds: [] };
+    const { controls } = styleControlsFor(
+      property("x", future as unknown as StyleLeaf)
+    );
+    expect(controls).toHaveLength(1);
+    expect(controls[0].supported).toBe(false);
+    expect(controls[0].kind).toBeUndefined();
+  });
+});
+
+describe("deriving controls from a composite", () => {
+  it("gives a logical-sides property one control per side, addressed by name", () => {
+    const margin = getStyleProperty("margin");
+    expect(margin).toBeDefined();
+    const { controls } = styleControlsFor(margin as StyleProperty);
+    expect(paths(controls)).toEqual([
+      ["blockStart"],
+      ["blockEnd"],
+      ["inlineStart"],
+      ["inlineEnd"],
+    ]);
+  });
+
+  it("recurses through nested objects, carrying the full path", () => {
+    const nested = property("outline", {
+      kind: "object",
+      fields: {
+        width: leaf("dimension", "outline-width"),
+        inner: {
+          kind: "object",
+          fields: { color: leaf("color", "outline-color") },
+        },
+      },
+    });
+    expect(paths(styleControlsFor(nested).controls)).toEqual([
+      ["width"],
+      ["inner", "color"],
+    ]);
+  });
+});
+
+describe("a union, which stores one value in more than one form", () => {
+  const radius = property("radius", {
+    kind: "union",
+    of: [
+      leaf("dimension", "border-radius"),
+      {
+        kind: "logicalCorners",
+        corners: {
+          startStart: leaf("dimension", "border-start-start-radius"),
+          startEnd: leaf("dimension", "border-start-end-radius"),
+          endStart: leaf("dimension", "border-end-start-radius"),
+          endEnd: leaf("dimension", "border-end-end-radius"),
+        },
+      },
+    ],
+  });
+
+  it("shows the FIRST variant when nothing is stored, which is the form the engine tries first", () => {
+    const set = styleControlsFor(radius);
+    expect(paths(set.controls)).toEqual([[]]);
+    expect(set.variants).toEqual({ active: 0, count: 2 });
+  });
+
+  it("shows the composite variant when a record is stored", () => {
+    const set = styleControlsFor(radius, { startStart: "4px" });
+    expect(paths(set.controls)).toEqual([
+      ["startStart"],
+      ["startEnd"],
+      ["endStart"],
+      ["endEnd"],
+    ]);
+    expect(set.variants?.active).toBe(1);
+  });
+
+  it("treats a token reference as a scalar, not as a composite", () => {
+    // `{ $token }` is one value spelled as an object. Judging by `typeof` alone
+    // would show a token-valued radius in the four-corner control with the
+    // token in none of them.
+    const set = styleControlsFor(radius, { $token: "Radius.Card" });
+    expect(paths(set.controls)).toEqual([[]]);
+    expect(set.variants?.active).toBe(0);
+  });
+
+  it("records how many variants exist, so an editor can offer the other one", () => {
+    expect(styleControlsFor(radius).variants?.count).toBe(2);
+  });
+
+  it("reports no variants for a property that is not a union", () => {
+    expect(
+      styleControlsFor(property("p", leaf("color", "p"))).variants
+    ).toBeUndefined();
+  });
+});
+
+describe("D-05.1 — the catalog drives the controls", () => {
+  it("gives a property this module has never heard of a full set of controls", () => {
+    // The point of the rule, stated as a test: a property invented here — no
+    // entry in any list in `style-controls.ts`, no name it could match on —
+    // resolves to controls purely from its declared shape.
+    const invented = property("inventedByThisTest", {
+      kind: "logicalSides",
+      sides: {
+        blockStart: leaf("dimension", "invented-block-start"),
+        blockEnd: leaf("dimension", "invented-block-end"),
+        inlineStart: leaf("number", "invented-inline-start"),
+        inlineEnd: leaf("color", "invented-inline-end"),
+      },
+    });
+    const { controls } = styleControlsFor(invented);
+    expect(paths(controls)).toEqual([
+      ["blockStart"],
+      ["blockEnd"],
+      ["inlineStart"],
+      ["inlineEnd"],
+    ]);
+    // Each side resolves through its OWN leaf, so a shape mixing kinds is not
+    // collapsed onto whatever the first side happened to be.
+    expect(controls.map(c => c.kind)).toEqual([
+      "length",
+      "length",
+      "number",
+      "color",
+    ]);
+  });
+
+  it("draws a control for every property the real catalog ships", () => {
+    // An empty offender list is only evidence once the search is shown to
+    // work: this asserts the walk reaches the shipped catalog at all, so the
+    // sweep below cannot pass by finding nothing.
+    expect(STYLE_CATALOG.length).toBeGreaterThan(0);
+    const unsupported: string[] = [];
+    for (const entry of STYLE_CATALOG) {
+      const { controls } = styleControlsFor(entry);
+      expect(controls.length).toBeGreaterThan(0);
+      for (const control of controls) {
+        if (!control.supported) unsupported.push(`${entry.property}`);
+      }
+    }
+    expect(unsupported).toEqual([]);
+  });
+});

--- a/packages/builder/src/style-controls.test.ts
+++ b/packages/builder/src/style-controls.test.ts
@@ -527,15 +527,51 @@ describe("a union with more than one composite arm", () => {
   });
 });
 
-describe("the universal-keyword cache", () => {
-  it("gives every spelling of one keyword the same answer", () => {
-    // Keyed by the canonical spelling, so case and ASCII-whitespace variants
-    // share an entry rather than each retaining one.
+describe("spellings of one universal keyword", () => {
+  // NOT a test of the cache. Canonical keying and raw keying return the same
+  // ANSWER — only the number of retained entries differs — so this passes
+  // either way, and break-verifying it confirms that. What it does cover is
+  // the normalization: every spelling resolves to the same arm.
+  //
+  // The cache's BOUND has no test. It is a memory property with no observable
+  // output, and asserting it would mean exporting the cache for a test to
+  // read — surface added for a test rather than for a caller. Said here so the
+  // green beside it is not read as coverage it does not have.
+
+  it("resolves every spelling to the same arm", () => {
     const entry = getStyleProperty("fontStyle");
     for (const spelling of ["inherit", "INHERIT", " Inherit ", "InHeRiT"]) {
       expect(
         styleControlsFor(entry as StyleProperty, spelling).controls[0].kind
       ).toBe("select");
     }
+  });
+});
+
+describe("a union used as another union's arm", () => {
+  // A union arm is neither a leaf nor a record of named fields, and a union of
+  // scalars declares no fields at all — which the composite matcher reads as
+  // "any record fits". Nothing in the catalog nests a union inside a union
+  // today, so this case would be silent if one arrived.
+
+  const nested = property("p", {
+    kind: "union",
+    of: [
+      { kind: "union", of: [leaf("number", "a"), leaf("dimension", "b")] },
+      { kind: "object", fields: { side: leaf("dimension", "c") } },
+    ],
+  });
+
+  it("does not let a nested scalar union swallow a composite value", () => {
+    const set = styleControlsFor(nested, { side: "1px" });
+    expect(paths(set.controls)).toEqual([["side"]]);
+    expect(set.variants[0].active).toBe(1);
+  });
+
+  it("still takes a scalar through the nested union", () => {
+    // The control: recursing must not push every value to the object arm.
+    const set = styleControlsFor(nested, 3);
+    expect(paths(set.controls)).toEqual([[]]);
+    expect(set.variants[0].active).toBe(0);
   });
 });

--- a/packages/builder/src/style-controls.test.ts
+++ b/packages/builder/src/style-controls.test.ts
@@ -434,3 +434,32 @@ describe("values that are legal wherever a value is", () => {
     expect(armKind("lineHeight", "1.5rem")).toBe("length");
   });
 });
+
+describe("a token whose kind no arm declares", () => {
+  // `token-kind-mismatch` is a WARNING: the engine accepts the value and writes
+  // it through the arm that admits tokens at all. Rejecting every arm would
+  // fall through to arm 0 — a keyword select, for a stored token that control
+  // cannot represent.
+
+  it("shows the arm that takes tokens, not the first arm", () => {
+    const entry = getStyleProperty("fontWeight");
+    const set = styleControlsFor(
+      entry as StyleProperty,
+      { $token: "brand.blue" },
+      { tokens: { kindOf: () => "color" } }
+    );
+    expect(set.controls[0].kind).toBe("number");
+    expect(set.variants[0].active).toBe(1);
+  });
+
+  it("still prefers an arm that DOES declare the kind", () => {
+    // The control: falling back always would ignore a lookup that matched.
+    const entry = getStyleProperty("lineHeight");
+    const set = styleControlsFor(
+      entry as StyleProperty,
+      { $token: "space.gap" },
+      { tokens: { kindOf: () => "dimension" } }
+    );
+    expect(set.controls[0].kind).toBe("length");
+  });
+});

--- a/packages/builder/src/style-controls.ts
+++ b/packages/builder/src/style-controls.ts
@@ -228,7 +228,7 @@ function variantHolds(
     return variant.of.some(arm => variantHolds(arm, value, tokens));
   }
   if (!isStyleLeaf(variant)) {
-    return isCompositeValue(value) && addressesAnyField(variant, value);
+    return isCompositeValue(value) && fieldsHold(variant, value, tokens);
   }
   return !isCompositeValue(value) && leafHolds(variant, value, tokens);
 }
@@ -248,25 +248,55 @@ function fieldsOf(shape: StyleShape): readonly string[] {
   }
 }
 
+/** The shape a composite declares at one of its field names. */
+function shapeAt(variant: StyleShape, name: string): StyleShape | undefined {
+  if (isStyleLeaf(variant)) return undefined;
+  switch (variant.kind) {
+    case "logicalSides":
+      return Object.hasOwn(variant.sides, name)
+        ? variant.sides[name as keyof typeof variant.sides]
+        : undefined;
+    case "logicalCorners":
+      return Object.hasOwn(variant.corners, name)
+        ? variant.corners[name as keyof typeof variant.corners]
+        : undefined;
+    case "object":
+      return Object.hasOwn(variant.fields, name)
+        ? variant.fields[name]
+        : undefined;
+    case "union":
+      return undefined;
+  }
+}
+
 /**
- * Whether a stored record names anything this composite arm declares.
+ * Whether a composite arm holds the fields a stored record names.
  *
- * "Is it a record" is not enough to tell two composite arms apart: a union of
- * `{ first }` and `{ second }` would take every record through the first, and
- * the controls returned would address fields the value does not have. No union
- * the catalog ships has two composite arms today, so nothing reaches that
- * case — which is exactly why it would be silent if one arrived.
+ * Field NAMES alone do not tell two composite arms apart when they share one:
+ * `{ value: keyword }` beside `{ value: number }` both claim `{ value: 2 }`, and
+ * the controls returned would describe a form that cannot hold it. So each named
+ * field is checked against the shape this arm declares for it, recursively,
+ * which is the same walk the leaf matching already performs one level down.
  *
- * ANY overlap rather than all, because a stored value is sparse: a radius with
- * only its top-left corner set is still the four-corner form.
+ * Only the fields the value NAMES are checked, because a stored value is
+ * sparse: a radius with just its top-left corner set is still the four-corner
+ * form, and requiring every field would push it to the scalar arm.
  */
-function addressesAnyField(
+function fieldsHold(
   variant: StyleShape,
-  value: CompositeValue
+  value: CompositeValue,
+  tokens: TokenLookup | undefined
 ): boolean {
   const fields = fieldsOf(variant);
   if (fields.length === 0) return true;
-  return Object.keys(value).some(key => fields.includes(key));
+  const named = Object.keys(value).filter(key => fields.includes(key));
+  if (named.length === 0) return false;
+  return named.every(name => {
+    const shape = shapeAt(variant, name);
+    const held = value[name];
+    if (shape === undefined || held === undefined) return false;
+    return variantHolds(shape, held, tokens);
+  });
 }
 
 /**

--- a/packages/builder/src/style-controls.ts
+++ b/packages/builder/src/style-controls.ts
@@ -266,9 +266,20 @@ function numberLeafHolds(leaf: StyleLeaf, value: number): boolean {
  *
  * Normalized with the engine's OWN primitives rather than a lowercase-and-trim
  * written here, so the two cannot disagree about what an escape means.
+ *
+ * The whitespace stripped is ASCII only, which is what CSS discards.
+ * JavaScript's `trim()` also removes NBSP and the Unicode spaces, and the engine
+ * does NOT — measured, a value carrying NBSP is refused where the same value
+ * with an ordinary space is accepted. Trimming it here would match a closed
+ * keyword control to a value that control cannot represent.
+ */
+const CSS_TRIM = /^[ \t\n\f\r]+|[ \t\n\f\r]+$/g;
+
+/**
+ * A keyword in the spelling the engine compares keywords in.
  */
 function keywordKey(value: string): string {
-  return asciiLower(decodeIdentifier(value.trim()));
+  return asciiLower(decodeIdentifier(value.replace(CSS_TRIM, "")));
 }
 
 /**
@@ -281,8 +292,20 @@ function keywordKey(value: string): string {
  */
 const UNIVERSAL_PROBE_PROPERTY = "textAlign";
 
-/** Answers already derived, so a repeated value costs one lookup. */
+/**
+ * Answers already derived, so a repeated value costs one lookup.
+ *
+ * The values that ARE universal are a closed, tiny set, so caching those costs
+ * nothing. A NEGATIVE answer is any author-supplied string that reached a
+ * scalar union — free-form `fontStyle` input, half-typed values, rejected ones —
+ * so caching every one of those in a long-lived editor grows without bound, and
+ * each key can be as long as the style-value limit allows. Negatives are
+ * therefore capped: past the cap they are recomputed rather than retained.
+ */
 const UNIVERSALLY_ACCEPTED = new Map<string, boolean>();
+
+/** How many refusals to remember before recomputing them instead. */
+const NEGATIVE_CACHE_LIMIT = 64;
 
 /**
  * Whether every leaf accepts this string whatever its own vocabulary says.
@@ -313,7 +336,7 @@ function isUniversallyAccepted(value: string): boolean {
   // reason, and would report every such word as universal.
   const key = keywordKey(value);
   if (probe.shape.values.some(keyword => keywordKey(keyword) === key)) {
-    UNIVERSALLY_ACCEPTED.set(value, false);
+    remember(value, false);
     return false;
   }
   const compiled = compileStyleValues(
@@ -323,8 +346,14 @@ function isUniversallyAccepted(value: string): boolean {
   const accepted =
     compiled.declarations.length > 0 &&
     !compiled.warnings.some(issue => issue.severity === "error");
-  UNIVERSALLY_ACCEPTED.set(value, accepted);
+  remember(value, accepted);
   return accepted;
+}
+
+/** Keep an answer, bounding what the refusals can grow to. */
+function remember(value: string, accepted: boolean): void {
+  if (!accepted && UNIVERSALLY_ACCEPTED.size >= NEGATIVE_CACHE_LIMIT) return;
+  UNIVERSALLY_ACCEPTED.set(value, accepted);
 }
 
 /**

--- a/packages/builder/src/style-controls.ts
+++ b/packages/builder/src/style-controls.ts
@@ -25,6 +25,7 @@
 
 import {
   isStyleLeaf,
+  isTokenRef,
   type StyleLeaf,
   type StyleProperty,
   type StyleShape,
@@ -70,22 +71,24 @@ const CONTROL_KIND_BY_LEAF: {
 /**
  * The leaf kinds this build can draw.
  *
- * Named as a set rather than inferred from the mapping's keys, so the answer
- * survives a document written by a NEWER engine: a catalog carrying a leaf kind
- * this build has never heard of resolves to an unsupported descriptor rather
- * than to `undefined` flowing into a renderer. Same policy as `inspector.ts`'s
- * `SUPPORTED_PROP_TYPES`, and for the same reason — the author is told the
- * property exists and is not editable here, because omitting it entirely would
- * present an incomplete property as a complete one.
+ * DERIVED from the mapping rather than listed beside it. A second list agrees
+ * with the mapping on the day it is written: adding a leaf kind and its
+ * required map entry while forgetting the list still compiles, and
+ * `controlForLeaf` then reports a kind it can perfectly well draw as
+ * unsupported.
+ *
+ * Membership is still checked at runtime rather than trusted from the type,
+ * because a catalog written by a NEWER engine can carry a kind absent from
+ * both — and indexing a mapped type with it returns `undefined` while the type
+ * says otherwise. Such a kind resolves to an unsupported descriptor rather
+ * than to `undefined` flowing into a renderer, the same policy as
+ * `inspector.ts`'s `SUPPORTED_PROP_TYPES`: the author is told the property
+ * exists and is not editable here, because omitting it entirely would present
+ * an incomplete property as a complete one.
  */
-export const SUPPORTED_LEAF_KINDS: readonly StyleLeaf["kind"][] = [
-  "keyword",
-  "dimension",
-  "number",
-  "color",
-  "cssValue",
-  "url",
-];
+export const SUPPORTED_LEAF_KINDS = Object.keys(
+  CONTROL_KIND_BY_LEAF
+) as readonly StyleLeaf["kind"][];
 
 /**
  * One editable position inside a property's value, with everything a control
@@ -145,25 +148,65 @@ export interface StyleControlSet {
  *
  * A PRESENTATION choice and never a validity judgement: it decides which
  * control to draw, and `validateStyleValues` remains the only thing that
- * decides whether a value may be written. Drawing the wrong control is a
- * legibility bug that the next keystroke corrects; the write is gated
- * elsewhere either way, so this deliberately does not re-implement the
- * validator's arm-matching in order to agree with it.
+ * decides whether a value may be written.
  *
- * The test is structural and shallow because that is the distinction that
- * separates the variants in practice — a scalar is stored as a string, a number
- * or a token reference, and a composite is stored as a record. Absent a value,
- * the FIRST variant wins, which is the same order the engine tries them in and
- * therefore the canonical spelling of the property.
+ * Absent a value the FIRST variant wins, which is the order the engine tries
+ * them in and therefore the canonical spelling of the property. With a value,
+ * the arm that HOLDS it wins — see {@link variantHolds}, which reads the
+ * catalog's own declarations rather than restating any grammar.
  */
 function variantForValue(
   variants: readonly StyleShape[],
   value: StyleValue | undefined
 ): number {
   if (value === undefined) return 0;
-  const stored = isCompositeValue(value);
-  const found = variants.findIndex(variant => !isStyleLeaf(variant) === stored);
+  const found = variants.findIndex(variant => variantHolds(variant, value));
   return found === -1 ? 0 : found;
+}
+
+/**
+ * Whether a variant is the shape a stored value is written in.
+ *
+ * Composite against scalar is not enough on its own, and three of the four
+ * unions the catalog ships are the case it misses: `fontWeight` is a keyword OR
+ * a number, `lineHeight` a number OR a dimension, `fontStyle` a keyword OR a
+ * free-form value. Every arm of those is a leaf, so a composite test picks the
+ * first one every time — a numeric weight would draw the keyword select, and a
+ * `1.5rem` line height the unitless number field.
+ */
+function variantHolds(variant: StyleShape, value: StyleValue): boolean {
+  if (!isStyleLeaf(variant)) return isCompositeValue(value);
+  return !isCompositeValue(value) && leafHolds(variant, value);
+}
+
+/**
+ * Whether a leaf is the one a scalar is stored under.
+ *
+ * Reads the catalog's own declarations — a keyword leaf's `values`, a
+ * dimension's `allowNumber` — rather than restating any grammar. It stays a
+ * PRESENTATION choice: `validateStyleValues` remains the only thing deciding
+ * whether a value may be written, and it owes this no agreement. Drawing the
+ * wrong control is a legibility bug the next keystroke corrects; the write is
+ * gated either way.
+ */
+function leafHolds(leaf: StyleLeaf, value: StyleValue): boolean {
+  // A token is a scalar whichever arm holds it, so the arm admitting tokens at
+  // all is the one it belongs to.
+  if (isTokenRef(value)) return leaf.tokenKinds.length > 0;
+  if (typeof value === "number") {
+    if (leaf.kind === "number") return true;
+    // `0` is the one measurement that needs no unit, which is why a dimension
+    // accepts it without `allowNumber`.
+    return (
+      leaf.kind === "dimension" && (leaf.allowNumber === true || value === 0)
+    );
+  }
+  if (typeof value !== "string") return false;
+  // A keyword leaf claims a string only when the string is one of ITS keywords.
+  // Every other scalar leaf stores its value as a string, so the catalog's arm
+  // order decides between those exactly as the engine's own order does.
+  if (leaf.kind === "keyword") return leaf.values.includes(value);
+  return leaf.kind !== "number";
 }
 
 /** A stored value holding named sub-values, as a composite shape addresses. */
@@ -184,7 +227,9 @@ type CompositeValue = { readonly [key: string]: StyleValue };
  */
 function isCompositeValue(value: StyleValue): value is CompositeValue {
   if (typeof value !== "object" || value === null) return false;
-  return !("$token" in value);
+  // Asked of the engine rather than by looking for the marker key, so a change
+  // to what counts as a reference cannot leave this reading the old spelling.
+  return !isTokenRef(value);
 }
 
 /** One descriptor for a leaf, resolving the control it draws with. */

--- a/packages/builder/src/style-controls.ts
+++ b/packages/builder/src/style-controls.ts
@@ -9,9 +9,9 @@
  * **The catalog decides, and nothing here holds a second list.** A property's
  * `shape` names its value form; this walks that shape and answers with one
  * descriptor per editable leaf. Adding a property to `catalog.ts` gives it
- * controls with no edit here, which is the whole of D-05.1 — and the mapping
- * from leaf kind to control kind is a mapped type, so a leaf kind added to the
- * engine is a compile error in exactly one place rather than a silent
+ * controls with no edit here, which is the property worth protecting — and the
+ * mapping from leaf kind to control kind is a mapped type, so a leaf kind added
+ * to the engine is a compile error in exactly one place rather than a silent
  * fallthrough at runtime.
  *
  * **What this module does NOT do.** It does not decide which properties a block
@@ -25,7 +25,9 @@
 
 import {
   asciiLower,
+  compileStyleValues,
   decodeIdentifier,
+  getStyleProperty,
   isStyleLeaf,
   isTokenRef,
   type StyleLeaf,
@@ -258,6 +260,62 @@ function keywordKey(value: string): string {
 }
 
 /**
+ * A plain keyword property, used to ask the engine what any leaf would accept.
+ *
+ * `textAlign` is a single keyword leaf with a closed vocabulary. A value it
+ * accepts that is NOT in that vocabulary is accepted for a reason that has
+ * nothing to do with this property — it is legal wherever a value is — which is
+ * exactly the question below.
+ */
+const UNIVERSAL_PROBE_PROPERTY = "textAlign";
+
+/** Answers already derived, so a repeated value costs one lookup. */
+const UNIVERSALLY_ACCEPTED = new Map<string, boolean>();
+
+/**
+ * Whether every leaf accepts this string whatever its own vocabulary says.
+ *
+ * The CSS-wide keywords — `inherit`, `initial` and their siblings — are legal
+ * wherever a value is, so a keyword leaf accepts them alongside its own list and
+ * a number leaf accepts them despite taking numbers. Without this, a stored
+ * `fontStyle: "inherit"` misses the keyword arm and lands on the free-form one,
+ * and `lineHeight: "inherit"` misses the number arm — in both cases disagreeing
+ * with the arm the engine itself would accept the value through.
+ *
+ * ASKED of the engine rather than listed here. The engine holds that set and
+ * does not export it, so a copy would be a second statement of which keywords
+ * are universal, and the two would agree until either moved. Compiling one
+ * probe answers it, and a keyword this engine learns is picked up with no edit.
+ */
+function isUniversallyAccepted(value: string): boolean {
+  const cached = UNIVERSALLY_ACCEPTED.get(value);
+  if (cached !== undefined) return cached;
+  const probe = getStyleProperty(UNIVERSAL_PROBE_PROPERTY);
+  if (probe === undefined || probe.shape.kind !== "keyword") {
+    throw new Error(
+      `${UNIVERSAL_PROBE_PROPERTY} is no longer a plain keyword property, so ` +
+        `the engine cannot be asked which values are legal everywhere`
+    );
+  }
+  // A value inside the probe's OWN vocabulary would be accepted for the wrong
+  // reason, and would report every such word as universal.
+  const key = keywordKey(value);
+  if (probe.shape.values.some(keyword => keywordKey(keyword) === key)) {
+    UNIVERSALLY_ACCEPTED.set(value, false);
+    return false;
+  }
+  const compiled = compileStyleValues(
+    { [UNIVERSAL_PROBE_PROPERTY]: value },
+    ""
+  );
+  const accepted =
+    compiled.declarations.length > 0 &&
+    !compiled.warnings.some(issue => issue.severity === "error");
+  UNIVERSALLY_ACCEPTED.set(value, accepted);
+  return accepted;
+}
+
+/**
  * Whether a leaf stores this string.
  *
  * A keyword leaf claims one only when the string is one of ITS keywords. Every
@@ -271,6 +329,10 @@ function keywordKey(value: string): string {
  * engine's own fallback and not a wrong answer.
  */
 function stringLeafHolds(leaf: StyleLeaf, value: string): boolean {
+  // Checked FIRST and for every kind, because a value legal everywhere is one
+  // the engine accepts through the earliest arm — including a number arm that
+  // otherwise takes no strings at all.
+  if (isUniversallyAccepted(value)) return true;
   if (leaf.kind !== "keyword") return leaf.kind !== "number";
   const key = keywordKey(value);
   return leaf.values.some(keyword => keywordKey(keyword) === key);

--- a/packages/builder/src/style-controls.ts
+++ b/packages/builder/src/style-controls.ts
@@ -30,6 +30,7 @@ import {
   type StyleProperty,
   type StyleShape,
   type StyleValue,
+  type TokenLookup,
 } from "@nextlyhq/blocks-engine";
 
 /**
@@ -129,18 +130,38 @@ export interface StyleControl {
  * catalog's own list instead of re-deriving which forms exist.
  */
 export interface StyleControlVariants {
+  /**
+   * Where in the property's value the choice sits, empty at the root.
+   *
+   * Carried because a union is not only a top-level shape: `position.zIndex` is
+   * a number OR the `auto` keyword, nested a level down. Reporting choices only
+   * at the root would leave a renderer no way to offer `auto` at all.
+   */
+  readonly path: readonly string[];
   /** Which variant the returned controls describe, as an index into the union. */
   readonly active: number;
   /** How many variants the catalog declares at this position. */
   readonly count: number;
 }
 
-/** A property's controls, and the variant they describe when it is a union. */
+/** What a caller can tell the resolver about the site. */
+export interface StyleControlOptions {
+  /**
+   * The site's token table, for choosing between union arms that both accept
+   * tokens.
+   *
+   * Optional: without it the catalog's arm order decides, which is the engine's
+   * own fallback for a name it cannot resolve.
+   */
+  readonly tokens?: TokenLookup;
+}
+
+/** A property's controls, and every choice of form its shape offers. */
 export interface StyleControlSet {
   readonly property: string;
   readonly controls: readonly StyleControl[];
-  /** Absent when the property's shape is not a union. */
-  readonly variants?: StyleControlVariants;
+  /** Empty when the property's shape holds no union at any depth. */
+  readonly variants: readonly StyleControlVariants[];
 }
 
 /**
@@ -157,10 +178,13 @@ export interface StyleControlSet {
  */
 function variantForValue(
   variants: readonly StyleShape[],
-  value: StyleValue | undefined
+  value: StyleValue | undefined,
+  tokens: TokenLookup | undefined
 ): number {
   if (value === undefined) return 0;
-  const found = variants.findIndex(variant => variantHolds(variant, value));
+  const found = variants.findIndex(variant =>
+    variantHolds(variant, value, tokens)
+  );
   return found === -1 ? 0 : found;
 }
 
@@ -174,39 +198,77 @@ function variantForValue(
  * first one every time — a numeric weight would draw the keyword select, and a
  * `1.5rem` line height the unitless number field.
  */
-function variantHolds(variant: StyleShape, value: StyleValue): boolean {
+function variantHolds(
+  variant: StyleShape,
+  value: StyleValue,
+  tokens: TokenLookup | undefined
+): boolean {
   if (!isStyleLeaf(variant)) return isCompositeValue(value);
-  return !isCompositeValue(value) && leafHolds(variant, value);
+  return !isCompositeValue(value) && leafHolds(variant, value, tokens);
+}
+
+/**
+ * Whether a leaf admits this token reference.
+ *
+ * Which arm a token belongs to is a fact about the TOKEN, and the stored
+ * reference carries only its name. `lineHeight` accepts tokens on both its arms
+ * — numbers on one, dimensions on the other — so without the site's table the
+ * name alone cannot separate them, and the catalog's arm order decides exactly
+ * as the engine's own union check falls back to it.
+ */
+function tokenLeafHolds(
+  leaf: StyleLeaf,
+  name: string,
+  tokens: TokenLookup | undefined
+): boolean {
+  if (leaf.tokenKinds.length === 0) return false;
+  const kind = tokens?.kindOf(name);
+  return kind === undefined || leaf.tokenKinds.includes(kind);
+}
+
+/**
+ * Whether a leaf stores this number.
+ *
+ * `0` is the one measurement that needs no unit, which is why a dimension
+ * accepts it without `allowNumber`.
+ */
+function numberLeafHolds(leaf: StyleLeaf, value: number): boolean {
+  if (leaf.kind === "number") return true;
+  if (leaf.kind !== "dimension") return false;
+  return leaf.allowNumber === true || value === 0;
+}
+
+/**
+ * Whether a leaf stores this string.
+ *
+ * A keyword leaf claims one only when the string is one of ITS keywords. Every
+ * other scalar leaf stores its value as a string, so the catalog's arm order
+ * decides between those exactly as the engine's own order does.
+ */
+function stringLeafHolds(leaf: StyleLeaf, value: string): boolean {
+  if (leaf.kind === "keyword") return leaf.values.includes(value);
+  return leaf.kind !== "number";
 }
 
 /**
  * Whether a leaf is the one a scalar is stored under.
  *
  * Reads the catalog's own declarations — a keyword leaf's `values`, a
- * dimension's `allowNumber` — rather than restating any grammar. It stays a
- * PRESENTATION choice: `validateStyleValues` remains the only thing deciding
- * whether a value may be written, and it owes this no agreement. Drawing the
- * wrong control is a legibility bug the next keystroke corrects; the write is
- * gated either way.
+ * dimension's `allowNumber`, an arm's `tokenKinds` — rather than restating any
+ * grammar. It stays a PRESENTATION choice: `validateStyleValues` remains the
+ * only thing deciding whether a value may be written, and it owes this no
+ * agreement. Drawing the wrong control is a legibility bug the next keystroke
+ * corrects; the write is gated either way.
  */
-function leafHolds(leaf: StyleLeaf, value: StyleValue): boolean {
-  // A token is a scalar whichever arm holds it, so the arm admitting tokens at
-  // all is the one it belongs to.
-  if (isTokenRef(value)) return leaf.tokenKinds.length > 0;
-  if (typeof value === "number") {
-    if (leaf.kind === "number") return true;
-    // `0` is the one measurement that needs no unit, which is why a dimension
-    // accepts it without `allowNumber`.
-    return (
-      leaf.kind === "dimension" && (leaf.allowNumber === true || value === 0)
-    );
-  }
-  if (typeof value !== "string") return false;
-  // A keyword leaf claims a string only when the string is one of ITS keywords.
-  // Every other scalar leaf stores its value as a string, so the catalog's arm
-  // order decides between those exactly as the engine's own order does.
-  if (leaf.kind === "keyword") return leaf.values.includes(value);
-  return leaf.kind !== "number";
+function leafHolds(
+  leaf: StyleLeaf,
+  value: StyleValue,
+  tokens: TokenLookup | undefined
+): boolean {
+  if (isTokenRef(value)) return tokenLeafHolds(leaf, value.$token, tokens);
+  if (typeof value === "number") return numberLeafHolds(leaf, value);
+  if (typeof value === "string") return stringLeafHolds(leaf, value);
+  return false;
 }
 
 /** A stored value holding named sub-values, as a composite shape addresses. */
@@ -258,29 +320,38 @@ function walk(
   property: string,
   path: readonly string[],
   shape: StyleShape,
-  value: StyleValue | undefined
+  value: StyleValue | undefined,
+  tokens: TokenLookup | undefined,
+  // Collected as the walk descends rather than returned alongside, so a union
+  // at ANY depth is recorded by the same line that resolves it.
+  variants: StyleControlVariants[]
 ): StyleControl[] {
+  const down = (step: string, child: StyleShape): StyleControl[] =>
+    walk(
+      property,
+      [...path, step],
+      child,
+      childValue(value, step),
+      tokens,
+      variants
+    );
   if (isStyleLeaf(shape)) return [controlForLeaf(property, path, shape)];
   switch (shape.kind) {
     case "logicalSides":
-      return entriesOf(shape.sides).flatMap(([side, leaf]) =>
-        walk(property, [...path, side], leaf, childValue(value, side))
-      );
+      return entriesOf(shape.sides).flatMap(([side, leaf]) => down(side, leaf));
     case "logicalCorners":
       return entriesOf(shape.corners).flatMap(([corner, leaf]) =>
-        walk(property, [...path, corner], leaf, childValue(value, corner))
+        down(corner, leaf)
       );
     case "object":
       return entriesOf(shape.fields).flatMap(([field, child]) =>
-        walk(property, [...path, field], child, childValue(value, field))
+        down(field, child)
       );
-    case "union":
-      return walk(
-        property,
-        path,
-        shape.of[variantForValue(shape.of, value)],
-        value
-      );
+    case "union": {
+      const active = variantForValue(shape.of, value, tokens);
+      variants.push({ path, active, count: shape.of.length });
+      return walk(property, path, shape.of[active], value, tokens, variants);
+    }
   }
 }
 
@@ -313,19 +384,17 @@ function childValue(
  */
 export function styleControlsFor(
   property: StyleProperty,
-  value?: StyleValue
+  value?: StyleValue,
+  options?: StyleControlOptions
 ): StyleControlSet {
-  const { shape } = property;
-  const controls = walk(property.property, [], shape, value);
-  if (shape.kind !== "union") {
-    return { property: property.property, controls };
-  }
-  return {
-    property: property.property,
-    controls,
-    variants: {
-      active: variantForValue(shape.of, value),
-      count: shape.of.length,
-    },
-  };
+  const variants: StyleControlVariants[] = [];
+  const controls = walk(
+    property.property,
+    [],
+    property.shape,
+    value,
+    options?.tokens,
+    variants
+  );
+  return { property: property.property, controls, variants };
 }

--- a/packages/builder/src/style-controls.ts
+++ b/packages/builder/src/style-controls.ts
@@ -189,7 +189,19 @@ function variantForValue(
   const found = variants.findIndex(variant =>
     variantHolds(variant, value, tokens)
   );
-  return found === -1 ? 0 : found;
+  if (found !== -1) return found;
+  // A token whose kind no arm declares is still ACCEPTED: the engine reports
+  // `token-kind-mismatch` at WARNING severity and writes the value through the
+  // arm that admits tokens at all — measured. Falling through to arm 0 would
+  // draw a keyword select for a stored token that control cannot represent, so
+  // the arm that takes tokens is the honest one to show.
+  if (isTokenRef(value)) {
+    const admits = variants.findIndex(
+      variant => isStyleLeaf(variant) && variant.tokenKinds.length > 0
+    );
+    if (admits !== -1) return admits;
+  }
+  return 0;
 }
 
 /**

--- a/packages/builder/src/style-controls.ts
+++ b/packages/builder/src/style-controls.ts
@@ -219,6 +219,14 @@ function variantHolds(
   value: StyleValue,
   tokens: TokenLookup | undefined
 ): boolean {
+  // A union can be an ARM of a union, and it is neither a leaf nor a record of
+  // named fields — `fieldsOf` answers with nothing for one whose arms are all
+  // scalars, and "no fields declared" is read below as "any record fits". So a
+  // nested scalar union would swallow every composite value beside it. Asking
+  // its own arms is the only reading that matches what the engine would accept.
+  if (!isStyleLeaf(variant) && variant.kind === "union") {
+    return variant.of.some(arm => variantHolds(arm, value, tokens));
+  }
   if (!isStyleLeaf(variant)) {
     return isCompositeValue(value) && addressesAnyField(variant, value);
   }

--- a/packages/builder/src/style-controls.ts
+++ b/packages/builder/src/style-controls.ts
@@ -1,0 +1,286 @@
+/**
+ * Which controls a style property offers, derived from the catalog alone.
+ *
+ * Pure, for the reason `inspector.ts` is: which controls a property offers, in
+ * what order, carrying which value shape, is derivation — and a component test
+ * in jsdom cannot separate a correct answer from a plausible wrong one, because
+ * both render a column of inputs.
+ *
+ * **The catalog decides, and nothing here holds a second list.** A property's
+ * `shape` names its value form; this walks that shape and answers with one
+ * descriptor per editable leaf. Adding a property to `catalog.ts` gives it
+ * controls with no edit here, which is the whole of D-05.1 — and the mapping
+ * from leaf kind to control kind is a mapped type, so a leaf kind added to the
+ * engine is a compile error in exactly one place rather than a silent
+ * fallthrough at runtime.
+ *
+ * **What this module does NOT do.** It does not decide which properties a block
+ * offers (that is `supports`, read through the catalog's own group helpers), it
+ * does not hold the active state or breakpoint, and it does not validate. A
+ * control's value is written through `style-values.ts`, which delegates every
+ * check to `validateStyleValues`.
+ *
+ * @module style-controls
+ */
+
+import {
+  isStyleLeaf,
+  type StyleLeaf,
+  type StyleProperty,
+  type StyleShape,
+  type StyleValue,
+} from "@nextlyhq/blocks-engine";
+
+/**
+ * The editor kind a leaf resolves to.
+ *
+ * Named separately from `StyleLeaf["kind"]` rather than reused, because the two
+ * answer different questions and will not stay parallel: `dimension` and
+ * `number` are distinct storage shapes that both draw a numeric field with a
+ * scrub affordance, and a future leaf kind may reuse an existing control
+ * outright. Collapsing them onto one name would make that a breaking rename.
+ */
+export type StyleControlKind =
+  | "select"
+  | "length"
+  | "number"
+  | "color"
+  | "css"
+  | "url";
+
+/**
+ * The control each leaf kind draws with.
+ *
+ * A MAPPED TYPE over the engine's own union, so a leaf kind added there fails
+ * to compile here until it is given a control. The alternative — a `switch` with
+ * a `default` — accepts the new kind silently and draws nothing, which presents
+ * an incomplete property as a complete one.
+ */
+const CONTROL_KIND_BY_LEAF: {
+  readonly [K in StyleLeaf["kind"]]: StyleControlKind;
+} = {
+  keyword: "select",
+  dimension: "length",
+  number: "number",
+  color: "color",
+  cssValue: "css",
+  url: "url",
+};
+
+/**
+ * The leaf kinds this build can draw.
+ *
+ * Named as a set rather than inferred from the mapping's keys, so the answer
+ * survives a document written by a NEWER engine: a catalog carrying a leaf kind
+ * this build has never heard of resolves to an unsupported descriptor rather
+ * than to `undefined` flowing into a renderer. Same policy as `inspector.ts`'s
+ * `SUPPORTED_PROP_TYPES`, and for the same reason — the author is told the
+ * property exists and is not editable here, because omitting it entirely would
+ * present an incomplete property as a complete one.
+ */
+export const SUPPORTED_LEAF_KINDS: readonly StyleLeaf["kind"][] = [
+  "keyword",
+  "dimension",
+  "number",
+  "color",
+  "cssValue",
+  "url",
+];
+
+/**
+ * One editable position inside a property's value, with everything a control
+ * needs to draw itself and nothing about how it is drawn.
+ */
+export interface StyleControl {
+  /** The catalog key this belongs to, as stored in a `StyleValues` record. */
+  readonly property: string;
+  /**
+   * Where inside the property's value this control writes, outermost first.
+   *
+   * Empty for a property stored as a scalar. `["blockEnd"]` for the bottom
+   * margin, `["startStart"]` for the top-left corner radius. A control writes
+   * by handing this path back to `style-values.ts`, which is what keeps the
+   * addressing in one place rather than in every control.
+   */
+  readonly path: readonly string[];
+  /** The leaf the catalog declares at this path, carrying units, bounds and token kinds. */
+  readonly leaf: StyleLeaf;
+  /**
+   * The control to draw, or `undefined` when this build has no control for the
+   * leaf's kind.
+   *
+   * Carried rather than recomputed by the panel, for the reason `EditableProp`
+   * carries `supported`: the panel would have to repeat the membership test, and
+   * the two would disagree the first time the set gained a member.
+   */
+  readonly kind: StyleControlKind | undefined;
+  /** Whether {@link kind} is present. */
+  readonly supported: boolean;
+}
+
+/**
+ * A union's variants, when the shape at a path accepts more than one form.
+ *
+ * `borderRadius` stores either one measurement or four corners, and an editor
+ * offers a way to move between them. Recorded here so that affordance reads the
+ * catalog's own list instead of re-deriving which forms exist.
+ */
+export interface StyleControlVariants {
+  /** Which variant the returned controls describe, as an index into the union. */
+  readonly active: number;
+  /** How many variants the catalog declares at this position. */
+  readonly count: number;
+}
+
+/** A property's controls, and the variant they describe when it is a union. */
+export interface StyleControlSet {
+  readonly property: string;
+  readonly controls: readonly StyleControl[];
+  /** Absent when the property's shape is not a union. */
+  readonly variants?: StyleControlVariants;
+}
+
+/**
+ * Which union variant a stored value is shown in.
+ *
+ * A PRESENTATION choice and never a validity judgement: it decides which
+ * control to draw, and `validateStyleValues` remains the only thing that
+ * decides whether a value may be written. Drawing the wrong control is a
+ * legibility bug that the next keystroke corrects; the write is gated
+ * elsewhere either way, so this deliberately does not re-implement the
+ * validator's arm-matching in order to agree with it.
+ *
+ * The test is structural and shallow because that is the distinction that
+ * separates the variants in practice — a scalar is stored as a string, a number
+ * or a token reference, and a composite is stored as a record. Absent a value,
+ * the FIRST variant wins, which is the same order the engine tries them in and
+ * therefore the canonical spelling of the property.
+ */
+function variantForValue(
+  variants: readonly StyleShape[],
+  value: StyleValue | undefined
+): number {
+  if (value === undefined) return 0;
+  const stored = isCompositeValue(value);
+  const found = variants.findIndex(variant => !isStyleLeaf(variant) === stored);
+  return found === -1 ? 0 : found;
+}
+
+/** A stored value holding named sub-values, as a composite shape addresses. */
+type CompositeValue = { readonly [key: string]: StyleValue };
+
+/**
+ * Whether a stored value is a record of sub-values rather than a scalar.
+ *
+ * A token reference is a RECORD and is nonetheless a scalar: `{ $token }` is one
+ * value that happens to be spelled as an object, so a shape test that went by
+ * `typeof` alone would show a token-valued radius in the four-corner control
+ * with the token in none of them.
+ *
+ * A type predicate rather than a boolean, so the narrowing it establishes is
+ * the one the caller reads the value through. Returning a plain boolean would
+ * leave every read behind it needing an assertion to say what this already
+ * decided.
+ */
+function isCompositeValue(value: StyleValue): value is CompositeValue {
+  if (typeof value !== "object" || value === null) return false;
+  return !("$token" in value);
+}
+
+/** One descriptor for a leaf, resolving the control it draws with. */
+function controlForLeaf(
+  property: string,
+  path: readonly string[],
+  leaf: StyleLeaf
+): StyleControl {
+  // Read through the runtime set rather than off the mapping directly. A
+  // catalog from a newer engine can carry a kind absent from both, and indexing
+  // a mapped type with it returns `undefined` while the type says otherwise.
+  const known = SUPPORTED_LEAF_KINDS.includes(leaf.kind);
+  const kind = known ? CONTROL_KIND_BY_LEAF[leaf.kind] : undefined;
+  return { property, path, leaf, kind, supported: kind !== undefined };
+}
+
+/**
+ * Every editable position inside a shape, depth-first, carrying its path.
+ *
+ * Parallel to the engine's `shapeLeaves` but path-aware and union-aware:
+ * `shapeLeaves` flattens every arm of a union because a documentation generator
+ * wants all of them, and a control layer that did the same would draw two
+ * controls for one stored value.
+ */
+function walk(
+  property: string,
+  path: readonly string[],
+  shape: StyleShape,
+  value: StyleValue | undefined
+): StyleControl[] {
+  if (isStyleLeaf(shape)) return [controlForLeaf(property, path, shape)];
+  switch (shape.kind) {
+    case "logicalSides":
+      return entriesOf(shape.sides).flatMap(([side, leaf]) =>
+        walk(property, [...path, side], leaf, childValue(value, side))
+      );
+    case "logicalCorners":
+      return entriesOf(shape.corners).flatMap(([corner, leaf]) =>
+        walk(property, [...path, corner], leaf, childValue(value, corner))
+      );
+    case "object":
+      return entriesOf(shape.fields).flatMap(([field, child]) =>
+        walk(property, [...path, field], child, childValue(value, field))
+      );
+    case "union":
+      return walk(
+        property,
+        path,
+        shape.of[variantForValue(shape.of, value)],
+        value
+      );
+  }
+}
+
+/**
+ * A shape's named children, typed.
+ *
+ * `Object.entries` widens the key to `string`, and the widened key then flows
+ * into a control's `path` where it is the address a write is applied at. The
+ * narrowing is local because the shapes' key sets are declared, not open.
+ */
+function entriesOf<T>(record: Readonly<Record<string, T>>): [string, T][] {
+  return Object.entries(record);
+}
+
+/** The stored sub-value at a name, when the parent holds a record. */
+function childValue(
+  value: StyleValue | undefined,
+  name: string
+): StyleValue | undefined {
+  if (value === undefined || !isCompositeValue(value)) return undefined;
+  return value[name];
+}
+
+/**
+ * The controls one catalog property offers.
+ *
+ * `value` is optional and affects exactly one thing: which arm of a union the
+ * controls describe. Every other answer is a property of the catalog alone,
+ * which is what lets a caller derive a panel before any value is loaded.
+ */
+export function styleControlsFor(
+  property: StyleProperty,
+  value?: StyleValue
+): StyleControlSet {
+  const { shape } = property;
+  const controls = walk(property.property, [], shape, value);
+  if (shape.kind !== "union") {
+    return { property: property.property, controls };
+  }
+  return {
+    property: property.property,
+    controls,
+    variants: {
+      active: variantForValue(shape.of, value),
+      count: shape.of.length,
+    },
+  };
+}

--- a/packages/builder/src/style-controls.ts
+++ b/packages/builder/src/style-controls.ts
@@ -219,8 +219,46 @@ function variantHolds(
   value: StyleValue,
   tokens: TokenLookup | undefined
 ): boolean {
-  if (!isStyleLeaf(variant)) return isCompositeValue(value);
+  if (!isStyleLeaf(variant)) {
+    return isCompositeValue(value) && addressesAnyField(variant, value);
+  }
   return !isCompositeValue(value) && leafHolds(variant, value, tokens);
+}
+
+/** The field names a composite shape addresses. */
+function fieldsOf(shape: StyleShape): readonly string[] {
+  if (isStyleLeaf(shape)) return [];
+  switch (shape.kind) {
+    case "logicalSides":
+      return Object.keys(shape.sides);
+    case "logicalCorners":
+      return Object.keys(shape.corners);
+    case "object":
+      return Object.keys(shape.fields);
+    case "union":
+      return shape.of.flatMap(fieldsOf);
+  }
+}
+
+/**
+ * Whether a stored record names anything this composite arm declares.
+ *
+ * "Is it a record" is not enough to tell two composite arms apart: a union of
+ * `{ first }` and `{ second }` would take every record through the first, and
+ * the controls returned would address fields the value does not have. No union
+ * the catalog ships has two composite arms today, so nothing reaches that
+ * case — which is exactly why it would be silent if one arrived.
+ *
+ * ANY overlap rather than all, because a stored value is sparse: a radius with
+ * only its top-left corner set is still the four-corner form.
+ */
+function addressesAnyField(
+  variant: StyleShape,
+  value: CompositeValue
+): boolean {
+  const fields = fieldsOf(variant);
+  if (fields.length === 0) return true;
+  return Object.keys(value).some(key => fields.includes(key));
 }
 
 /**
@@ -323,7 +361,12 @@ const NEGATIVE_CACHE_LIMIT = 64;
  * probe answers it, and a keyword this engine learns is picked up with no edit.
  */
 function isUniversallyAccepted(value: string): boolean {
-  const cached = UNIVERSALLY_ACCEPTED.get(value);
+  // Keyed by the CANONICAL spelling, so every case, whitespace and escape
+  // variant of one keyword shares an entry. Keying by the raw string leaves the
+  // ACCEPTED side unbounded too — `inherit`, `INHERIT`, ` Inherit ` and an
+  // escaped spelling are all distinct raw keys for one closed-set answer.
+  const key = keywordKey(value);
+  const cached = UNIVERSALLY_ACCEPTED.get(key);
   if (cached !== undefined) return cached;
   const probe = getStyleProperty(UNIVERSAL_PROBE_PROPERTY);
   if (probe === undefined || probe.shape.kind !== "keyword") {
@@ -334,9 +377,8 @@ function isUniversallyAccepted(value: string): boolean {
   }
   // A value inside the probe's OWN vocabulary would be accepted for the wrong
   // reason, and would report every such word as universal.
-  const key = keywordKey(value);
   if (probe.shape.values.some(keyword => keywordKey(keyword) === key)) {
-    remember(value, false);
+    remember(key, false);
     return false;
   }
   const compiled = compileStyleValues(
@@ -346,14 +388,14 @@ function isUniversallyAccepted(value: string): boolean {
   const accepted =
     compiled.declarations.length > 0 &&
     !compiled.warnings.some(issue => issue.severity === "error");
-  remember(value, accepted);
+  remember(key, accepted);
   return accepted;
 }
 
 /** Keep an answer, bounding what the refusals can grow to. */
-function remember(value: string, accepted: boolean): void {
+function remember(key: string, accepted: boolean): void {
   if (!accepted && UNIVERSALLY_ACCEPTED.size >= NEGATIVE_CACHE_LIMIT) return;
-  UNIVERSALLY_ACCEPTED.set(value, accepted);
+  UNIVERSALLY_ACCEPTED.set(key, accepted);
 }
 
 /**

--- a/packages/builder/src/style-controls.ts
+++ b/packages/builder/src/style-controls.ts
@@ -24,6 +24,8 @@
  */
 
 import {
+  asciiLower,
+  decodeIdentifier,
   isStyleLeaf,
   isTokenRef,
   type StyleLeaf,
@@ -239,15 +241,39 @@ function numberLeafHolds(leaf: StyleLeaf, value: number): boolean {
 }
 
 /**
+ * A keyword in the spelling the engine compares keywords in.
+ *
+ * CSS keywords are ASCII case-insensitive and surrounding whitespace is
+ * discarded by parsing, so the validator accepts `"Italic"` and `" italic "`
+ * exactly as it accepts `"italic"` — and it decodes escapes before comparing,
+ * because an escape can spell an ordinary letter. An exact `includes` therefore
+ * misses valid stored values and sends them to the free-form arm, which draws a
+ * text box where a select belongs.
+ *
+ * Normalized with the engine's OWN primitives rather than a lowercase-and-trim
+ * written here, so the two cannot disagree about what an escape means.
+ */
+function keywordKey(value: string): string {
+  return asciiLower(decodeIdentifier(value.trim()));
+}
+
+/**
  * Whether a leaf stores this string.
  *
  * A keyword leaf claims one only when the string is one of ITS keywords. Every
  * other scalar leaf stores its value as a string, so the catalog's arm order
  * decides between those exactly as the engine's own order does.
+ *
+ * Compares the value WHOLE rather than splitting it, so a multi-part keyword
+ * shorthand — `overflow: hidden auto` — is not recognised as its own vocabulary.
+ * No union the catalog ships declares a multi-part keyword arm, so nothing
+ * reaches that case today; if one appears, the arm order decides, which is the
+ * engine's own fallback and not a wrong answer.
  */
 function stringLeafHolds(leaf: StyleLeaf, value: string): boolean {
-  if (leaf.kind === "keyword") return leaf.values.includes(value);
-  return leaf.kind !== "number";
+  if (leaf.kind !== "keyword") return leaf.kind !== "number";
+  const key = keywordKey(value);
+  return leaf.values.some(keyword => keywordKey(keyword) === key);
 }
 
 /**

--- a/packages/builder/src/style-provenance.test.ts
+++ b/packages/builder/src/style-provenance.test.ts
@@ -1,0 +1,124 @@
+import type { StyleTraceEntry } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import { styleProvenance, type StyleProvenanceQuery } from "./style-provenance";
+
+/** One declaration the compiler wrote, with the fields the trace records. */
+function entry(over: Partial<StyleTraceEntry> = {}): StyleTraceEntry {
+  return {
+    origin: { kind: "node", id: "n1" },
+    property: "margin-block-end",
+    value: "24px",
+    state: "base",
+    breakpoint: "desktop",
+    ...over,
+  };
+}
+
+/** Asking about `n1`'s bottom margin at the desktop breakpoint. */
+function query(
+  trace: readonly StyleTraceEntry[],
+  over: Partial<StyleProvenanceQuery> = {}
+): StyleProvenanceQuery {
+  return {
+    trace,
+    subject: { nodeId: "n1", classIds: ["c1"] },
+    cssProperty: "margin-block-end",
+    state: "base",
+    breakpoint: "desktop",
+    liveBreakpoints: ["desktop"],
+    ...over,
+  };
+}
+
+describe("a property nothing wrote", () => {
+  it("is unset, which is a real answer rather than a failure", () => {
+    expect(styleProvenance(query([]))).toEqual({ kind: "unset" });
+  });
+
+  it("is unset when the trace holds only OTHER properties", () => {
+    // The separating property against a dot that lit up for any trace entry at
+    // all: a node with a colour and no margin must show an empty margin dot.
+    const trace = [entry({ property: "color", value: "red" })];
+    expect(styleProvenance(query(trace)).kind).toBe("unset");
+  });
+});
+
+describe("a value this node authored at the position being edited", () => {
+  it("is authored, which is the control's own value", () => {
+    const result = styleProvenance(query([entry()]));
+    expect(result.kind).toBe("authored");
+  });
+
+  it("is INHERITED when the same node wrote it at another breakpoint", () => {
+    // The case the three-state answer exists for. A desktop value showing while
+    // the author edits mobile is not this control's own value, and a dot that
+    // said otherwise would invite editing mobile through a control that then
+    // silently changes desktop.
+    const trace = [entry()];
+    const result = styleProvenance(
+      query(trace, {
+        breakpoint: "mobile",
+        liveBreakpoints: ["desktop", "mobile"],
+      })
+    );
+    expect(result.kind).toBe("inherited");
+  });
+
+  it("does not reach a value written in another state", () => {
+    // States are asked about separately: the trace records which state each
+    // declaration came from, and a base value is not a hover value. So editing
+    // hover with only a base entry recorded reports unset rather than showing
+    // the base value as something hover inherited.
+    const trace = [entry({ state: "base" })];
+    const result = styleProvenance(query(trace, { state: "hover" }));
+    expect(result.kind).toBe("unset");
+  });
+
+  it("is not authored when the winning entry belongs to a DIFFERENT node", () => {
+    const trace = [entry({ origin: { kind: "node", id: "other" } })];
+    expect(styleProvenance(query(trace)).kind).not.toBe("authored");
+  });
+});
+
+describe("a value from another tier", () => {
+  it("names the class it came from, with the id a panel opens it by", () => {
+    const trace = [
+      entry({ origin: { kind: "class", id: "c1", slug: "card" } }),
+    ];
+    const result = styleProvenance(query(trace));
+    expect(result.kind).toBe("inherited");
+    if (result.kind !== "inherited") return;
+    expect(result.from).toEqual({ kind: "class", id: "c1", slug: "card" });
+  });
+
+  it("reports a block type's default as inherited", () => {
+    const trace = [entry({ origin: { kind: "blockType", type: "heading" } })];
+    expect(
+      styleProvenance(
+        query(trace, { subject: { nodeId: "n1", blockType: "heading" } })
+      ).kind
+    ).toBe("inherited");
+  });
+
+  it("prefers the node's own value over a class's, as the cascade does", () => {
+    // Order in the trace is emission order, and the node tier is emitted last.
+    const trace = [
+      entry({ origin: { kind: "class", id: "c1", slug: "card" } }),
+      entry(),
+    ];
+    expect(styleProvenance(query(trace)).kind).toBe("authored");
+  });
+});
+
+describe("matching the property", () => {
+  it("matches the CSS property the trace records, not the catalog key", () => {
+    // `margin` is the catalog key and `margin-block-end` is what was written.
+    // Asking with the catalog key finds nothing, which is why the query takes
+    // the leaf's own `cssProperty`.
+    expect(
+      styleProvenance(query([entry()], { cssProperty: "margin" })).kind
+    ).toBe("unset");
+    expect(styleProvenance(query([entry()])).kind).toBe("authored");
+  });
+});

--- a/packages/builder/src/style-provenance.test.ts
+++ b/packages/builder/src/style-provenance.test.ts
@@ -328,3 +328,51 @@ describe("ranking a base rule against an interaction rule", () => {
     expect(result.entry.value).toBe("#ff0000");
   });
 });
+
+describe("several interaction states matching at once", () => {
+  // A pressed pointer matches `:active` AND `:hover`. Both are wrapped in
+  // `:where()`, so neither outranks the other and emission order decides — a
+  // winner can therefore come from a state other than the one being edited.
+
+  it("reports a later hover rule while the active state is being edited", () => {
+    const trace = [
+      entry({
+        state: "active",
+        origin: { kind: "class", id: "c1", slug: "card" },
+        value: "#00ff00",
+      }),
+      entry({ state: "hover", value: "#ff0000" }),
+    ];
+    const result = styleProvenance(
+      query(trace, { state: "active", liveStates: ["active", "hover"] })
+    );
+    expect(result.kind).toBe("inherited");
+    if (result.kind !== "inherited") return;
+    expect(result.entry.value).toBe("#ff0000");
+    expect(result.entry.state).toBe("hover");
+  });
+
+  it("keeps the active rule when IT is the later one", () => {
+    // The control: ranking must not simply prefer whichever state is listed
+    // last, or the answer would depend on the caller's array order.
+    const trace = [
+      entry({ state: "hover", value: "#ff0000" }),
+      entry({ state: "active", value: "#00ff00" }),
+    ];
+    const result = styleProvenance(
+      query(trace, { state: "active", liveStates: ["active", "hover"] })
+    );
+    expect(result.kind).toBe("authored");
+    if (result.kind !== "authored") return;
+    expect(result.entry.value).toBe("#00ff00");
+  });
+
+  it("ignores a state the caller did not say was matching", () => {
+    // Without `liveStates`, only the edited state and base match — a hover rule
+    // is not showing while nothing is hovered.
+    const trace = [entry({ state: "hover", value: "#ff0000" })];
+    expect(styleProvenance(query(trace, { state: "active" })).kind).toBe(
+      "unset"
+    );
+  });
+});

--- a/packages/builder/src/style-provenance.test.ts
+++ b/packages/builder/src/style-provenance.test.ts
@@ -122,3 +122,56 @@ describe("matching the property", () => {
     expect(styleProvenance(query([entry()])).kind).toBe("authored");
   });
 });
+
+describe("controls that share a CSS property but style different things", () => {
+  // The catalog writes `color` from three properties: `color` on the block
+  // itself, `linkColor` on ` a`, and `linkColorHover` on ` a:hover`. The CSS
+  // property alone therefore does not identify a control.
+
+  /** A link colour written by the node, which is the confounding entry. */
+  const linkEntry = entry({ property: "color", descendant: "a" });
+
+  it("does not report the plain text colour as authored from a link rule", () => {
+    const result = styleProvenance(
+      query([linkEntry], { cssProperty: "color" })
+    );
+    expect(result.kind).toBe("unset");
+  });
+
+  it("finds the link colour when the control asks for its own descendant", () => {
+    // The positive control for the absence above: without this, a query that
+    // matched nothing at all would satisfy the assertion just as well.
+    const result = styleProvenance(
+      query([linkEntry], { cssProperty: "color", descendant: "a" })
+    );
+    expect(result.kind).toBe("authored");
+  });
+
+  it("keeps hover links separate from ordinary links", () => {
+    const hoverEntry = entry({ property: "color", descendant: "a:hover" });
+    expect(
+      styleProvenance(
+        query([hoverEntry], { cssProperty: "color", descendant: "a" })
+      ).kind
+    ).toBe("unset");
+    expect(
+      styleProvenance(
+        query([hoverEntry], { cssProperty: "color", descendant: "a:hover" })
+      ).kind
+    ).toBe("authored");
+  });
+
+  it("still ranks the tiers within one control's own declarations", () => {
+    // Narrowing removes other controls' entries; it must not disturb how the
+    // remaining ones are ranked.
+    const fromClass = entry({
+      property: "color",
+      descendant: "a",
+      origin: { kind: "class", id: "c1", slug: "card" },
+    });
+    const result = styleProvenance(
+      query([fromClass, linkEntry], { cssProperty: "color", descendant: "a" })
+    );
+    expect(result.kind).toBe("authored");
+  });
+});

--- a/packages/builder/src/style-provenance.test.ts
+++ b/packages/builder/src/style-provenance.test.ts
@@ -1,4 +1,10 @@
-import type { StyleTraceEntry } from "@nextlyhq/blocks-engine";
+import {
+  compilePageCss,
+  nodeClassName,
+  type BlockDocument,
+  type NodeStyles,
+  type StyleTraceEntry,
+} from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
 
 import { styleProvenance, type StyleProvenanceQuery } from "./style-provenance";
@@ -123,55 +129,143 @@ describe("matching the property", () => {
   });
 });
 
-describe("controls that share a CSS property but style different things", () => {
-  // The catalog writes `color` from three properties: `color` on the block
-  // itself, `linkColor` on ` a`, and `linkColorHover` on ` a:hover`. The CSS
-  // property alone therefore does not identify a control.
+describe("against a trace the compiler actually produced", () => {
+  // The fixtures above are hand-written, and a hand-written descendant is
+  // whatever this file believes the compiler emits. It emits the selector as
+  // GROUPED — `" a"`, with the leading combinator — while the catalog declares
+  // `"a"`. Comparing those two spellings directly matches nothing, and a
+  // fixture that mirrors the wrong belief agrees with itself.
+  //
+  // So these compile a real document and query the trace it returns.
 
-  /** A link colour written by the node, which is the confounding entry. */
-  const linkEntry = entry({ property: "color", descendant: "a" });
-
-  it("does not report the plain text colour as authored from a link rule", () => {
-    const result = styleProvenance(
-      query([linkEntry], { cssProperty: "color" })
-    );
-    expect(result.kind).toBe("unset");
-  });
-
-  it("finds the link colour when the control asks for its own descendant", () => {
-    // The positive control for the absence above: without this, a query that
-    // matched nothing at all would satisfy the assertion just as well.
-    const result = styleProvenance(
-      query([linkEntry], { cssProperty: "color", descendant: "a" })
-    );
-    expect(result.kind).toBe("authored");
-  });
-
-  it("keeps hover links separate from ordinary links", () => {
-    const hoverEntry = entry({ property: "color", descendant: "a:hover" });
-    expect(
-      styleProvenance(
-        query([hoverEntry], { cssProperty: "color", descendant: "a" })
-      ).kind
-    ).toBe("unset");
-    expect(
-      styleProvenance(
-        query([hoverEntry], { cssProperty: "color", descendant: "a:hover" })
-      ).kind
-    ).toBe("authored");
-  });
-
-  it("still ranks the tiers within one control's own declarations", () => {
-    // Narrowing removes other controls' entries; it must not disturb how the
-    // remaining ones are ranked.
-    const fromClass = entry({
-      property: "color",
-      descendant: "a",
-      origin: { kind: "class", id: "c1", slug: "card" },
+  /** The trace `compilePageCss` records for one node's styles. */
+  function traceFor(styles: NodeStyles): readonly StyleTraceEntry[] {
+    const document: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "n1", type: "core/box", version: 1, props: {}, styles }],
+    };
+    const compiled = compilePageCss(document, {
+      breakpoints: {
+        viewport: [{ id: "base", label: "Desktop" }],
+        container: [],
+      },
+      trace: true,
     });
-    const result = styleProvenance(
-      query([fromClass, linkEntry], { cssProperty: "color", descendant: "a" })
+    expect(compiled.warnings).toEqual([]);
+    return compiled.trace ?? [];
+  }
+
+  /** Asking about `n1` at the base state and breakpoint. */
+  function ask(
+    trace: readonly StyleTraceEntry[],
+    cssProperty: string,
+    descendant?: string
+  ) {
+    return styleProvenance({
+      trace,
+      subject: { nodeId: "n1" },
+      cssProperty,
+      ...(descendant === undefined ? {} : { descendant }),
+      state: "base",
+      breakpoint: "base",
+      liveBreakpoints: ["base"],
+    });
+  }
+
+  it("records the descendant WITH its combinator, which is why comparison normalizes", () => {
+    // The measurement this whole block exists for, pinned so a change to the
+    // compiler's spelling fails here rather than silently in every dot.
+    const trace = traceFor({ base: { base: { linkColor: "#ff0000" } } });
+    expect(trace.map(entry => entry.descendant)).toEqual([" a"]);
+    expect(nodeClassName("n1")).toBeTypeOf("string");
+  });
+
+  it("finds a link colour asked for by the catalog's own spelling", () => {
+    const trace = traceFor({ base: { base: { linkColor: "#ff0000" } } });
+    expect(ask(trace, "color", "a").kind).toBe("authored");
+  });
+
+  it("keeps the three colour controls apart on a real trace", () => {
+    const trace = traceFor({
+      base: {
+        base: {
+          color: "#0000ff",
+          linkColor: "#ff0000",
+          linkColorHover: "#00ff00",
+        },
+      },
+    });
+    expect(ask(trace, "color").kind).toBe("authored");
+    expect(ask(trace, "color", "a").kind).toBe("authored");
+    expect(ask(trace, "color", "a:hover").kind).toBe("authored");
+    // Each control reads its OWN declaration rather than a shared winner.
+    const plain = ask(trace, "color");
+    const link = ask(trace, "color", "a");
+    expect(plain.kind === "authored" && plain.entry.value).toBe("#0000ff");
+    expect(link.kind === "authored" && link.entry.value).toBe("#ff0000");
+  });
+
+  it("reports a text colour as unset when only the link colour is stored", () => {
+    // The defect the descendant filter exists for, on a real trace: without it
+    // the link rule wins the plain control and reports an unset one as authored.
+    const trace = traceFor({ base: { base: { linkColor: "#ff0000" } } });
+    expect(ask(trace, "color").kind).toBe("unset");
+  });
+
+  it("reports a hover link as unset when only the plain link is stored", () => {
+    const trace = traceFor({ base: { base: { linkColor: "#ff0000" } } });
+    expect(ask(trace, "color", "a:hover").kind).toBe("unset");
+  });
+});
+
+describe("two catalog properties writing one declaration", () => {
+  // `background.url` and `backgroundGradient` both emit `background-image` on
+  // the node itself, and the trace records neither's catalog identity. Which
+  // control wrote the winning declaration therefore cannot be told from it.
+
+  it("says so rather than attributing the value to one of them", () => {
+    const trace: readonly StyleTraceEntry[] = [
+      {
+        origin: { kind: "node", id: "n1" },
+        property: "background-image",
+        value: "linear-gradient(red, blue)",
+        state: "base",
+        breakpoint: "base",
+      },
+    ];
+    const result = styleProvenance({
+      trace,
+      subject: { nodeId: "n1" },
+      cssProperty: "background-image",
+      state: "base",
+      breakpoint: "base",
+      liveBreakpoints: ["base"],
+    });
+    expect(result.kind).toBe("ambiguous");
+    if (result.kind !== "ambiguous") return;
+    expect(result.sharedWith).toEqual(
+      expect.arrayContaining(["background", "backgroundGradient"])
     );
-    expect(result.kind).toBe("authored");
+  });
+
+  it("does not call an ordinary property ambiguous", () => {
+    // The negative control: a check that answered "ambiguous" for everything
+    // would satisfy the assertion above while telling a caller nothing.
+    expect(styleProvenance(query([entry()])).kind).toBe("authored");
+  });
+
+  it("is unset rather than ambiguous when nothing wrote the declaration", () => {
+    // Ambiguity is about attributing a WINNER. With no winner there is nothing
+    // to attribute, and "unset" is the honest answer.
+    const result = styleProvenance({
+      trace: [],
+      subject: { nodeId: "n1" },
+      cssProperty: "background-image",
+      state: "base",
+      breakpoint: "base",
+      liveBreakpoints: ["base"],
+    });
+    expect(result.kind).toBe("unset");
   });
 });

--- a/packages/builder/src/style-provenance.test.ts
+++ b/packages/builder/src/style-provenance.test.ts
@@ -291,3 +291,40 @@ describe("two catalog properties writing one declaration", () => {
     expect(result.kind).toBe("unset");
   });
 });
+
+describe("ranking a base rule against an interaction rule", () => {
+  // A state selector is wrapped in `:where()`, which adds NO specificity — so a
+  // base rule emitted LATER beats an earlier interaction rule. Measured: a
+  // class's hover colour followed by the node's base colour leaves the node's
+  // base colour showing while hovered.
+
+  it("reports the value the browser is showing, not the earlier hover rule", () => {
+    const trace = [
+      entry({
+        state: "hover",
+        origin: { kind: "class", id: "c1", slug: "card" },
+        value: "#ff0000",
+      }),
+      entry({ state: "base", value: "#0000ff" }),
+    ];
+    const result = styleProvenance(query(trace, { state: "hover" }));
+    // Inherited rather than authored: the winner is the node's BASE entry, and
+    // the control being asked about is hover.
+    expect(result.kind).toBe("inherited");
+    if (result.kind !== "inherited") return;
+    expect(result.entry.value).toBe("#0000ff");
+    expect(result.entry.state).toBe("base");
+  });
+
+  it("keeps the hover rule when IT is the later one", () => {
+    // The control: always preferring base would be the same defect mirrored.
+    const trace = [
+      entry({ state: "base", value: "#0000ff" }),
+      entry({ state: "hover", value: "#ff0000" }),
+    ];
+    const result = styleProvenance(query(trace, { state: "hover" }));
+    expect(result.kind).toBe("authored");
+    if (result.kind !== "authored") return;
+    expect(result.entry.value).toBe("#ff0000");
+  });
+});

--- a/packages/builder/src/style-provenance.test.ts
+++ b/packages/builder/src/style-provenance.test.ts
@@ -71,14 +71,36 @@ describe("a value this node authored at the position being edited", () => {
     expect(result.kind).toBe("inherited");
   });
 
-  it("does not reach a value written in another state", () => {
-    // States are asked about separately: the trace records which state each
-    // declaration came from, and a base value is not a hover value. So editing
-    // hover with only a base entry recorded reports unset rather than showing
-    // the base value as something hover inherited.
+  it("shows an interaction state the base value it is displaying", () => {
+    // Hovering a node whose colour is set only on base displays that colour, so
+    // a hover control reporting `unset` would claim the browser's own default
+    // applies — which is not what the author is looking at. The base entry
+    // reaches this control the same way a wider breakpoint's value does.
     const trace = [entry({ state: "base" })];
     const result = styleProvenance(query(trace, { state: "hover" }));
-    expect(result.kind).toBe("unset");
+    expect(result.kind).toBe("inherited");
+    if (result.kind !== "inherited") return;
+    expect(result.entry.state).toBe("base");
+  });
+
+  it("prefers the state's OWN value over the base one", () => {
+    // The control for the fallback: it must not shadow a value the state holds.
+    const trace = [entry({ state: "base" }), entry({ state: "hover" })];
+    const result = styleProvenance(query(trace, { state: "hover" }));
+    expect(result.kind).toBe("authored");
+    if (result.kind !== "authored") return;
+    expect(result.entry.state).toBe("hover");
+  });
+
+  it("is still unset when neither the state nor base wrote anything", () => {
+    expect(styleProvenance(query([], { state: "hover" })).kind).toBe("unset");
+  });
+
+  it("does not fall back from base to anywhere", () => {
+    // Base has nothing beneath it, so an empty answer there is genuinely the
+    // browser's default — the meaning `unset` carries.
+    const trace = [entry({ state: "hover" })];
+    expect(styleProvenance(query(trace, { state: "base" })).kind).toBe("unset");
   });
 
   it("is not authored when the winning entry belongs to a DIFFERENT node", () => {

--- a/packages/builder/src/style-provenance.test.ts
+++ b/packages/builder/src/style-provenance.test.ts
@@ -235,9 +235,35 @@ describe("against a trace the compiler actually produced", () => {
     expect(ask(trace, "color").kind).toBe("unset");
   });
 
-  it("reports a hover link as unset when only the plain link is stored", () => {
+  it("shows a hover link the plain-link value it is displaying", () => {
+    // A hovered anchor matches `a` as well as `a:hover`, so a hover control
+    // with only `linkColor` stored is displaying that rule. Reporting unset
+    // would claim the browser's default applies. Link hover lives in the
+    // catalog's DESCENDANT rather than in `StyleState`, which is why the
+    // interaction-state fallback does not cover it.
     const trace = traceFor({ base: { base: { linkColor: "#ff0000" } } });
-    expect(ask(trace, "color", "a:hover").kind).toBe("unset");
+    const result = ask(trace, "color", "a:hover");
+    expect(result.kind).toBe("inherited");
+    if (result.kind !== "inherited") return;
+    expect(result.entry.value).toBe("#ff0000");
+    expect(result.entry.descendant).toBe(" a");
+  });
+
+  it("prefers the hover rule when the document has one", () => {
+    const trace = traceFor({
+      base: { base: { linkColor: "#ff0000", linkColorHover: "#00ff00" } },
+    });
+    const result = ask(trace, "color", "a:hover");
+    expect(result.kind).toBe("authored");
+    if (result.kind !== "authored") return;
+    expect(result.entry.value).toBe("#00ff00");
+  });
+
+  it("does not show a plain link a rule that needs hovering", () => {
+    // The other direction, which must NOT fall back: an anchor that is not
+    // hovered does not match `a:hover`.
+    const trace = traceFor({ base: { base: { linkColorHover: "#00ff00" } } });
+    expect(ask(trace, "color", "a").kind).toBe("unset");
   });
 });
 

--- a/packages/builder/src/style-provenance.ts
+++ b/packages/builder/src/style-provenance.ts
@@ -36,7 +36,17 @@ import {
 
 /** What a control's dot reports. */
 export type StyleProvenance =
-  /** Nothing wrote this property; the browser's own default applies. */
+  /**
+   * Nothing in this document's own cascade wrote this property for this node.
+   *
+   * NOT the same as "the browser's default applies". `styleOrigin` considers an
+   * ancestor's declaration only when it carries a descendant selector, so an
+   * inheritable property — `color`, the font properties — set on an ancestor is
+   * visibly active on this node and reported here as unset. Modelling CSS
+   * inheritance needs to know which properties inherit, which the catalog does
+   * not declare, so it belongs to the engine that owns the cascade rather than
+   * to a reading of its output.
+   */
   | { readonly kind: "unset" }
   /** This node's own value, at the state and breakpoint being edited. */
   | { readonly kind: "authored"; readonly entry: StyleTraceEntry }

--- a/packages/builder/src/style-provenance.ts
+++ b/packages/builder/src/style-provenance.ts
@@ -24,6 +24,8 @@
  */
 
 import {
+  shapeLeaves,
+  STYLE_CATALOG,
   styleOrigin,
   type BreakpointId,
   type StyleOrigin,
@@ -46,6 +48,27 @@ export type StyleProvenance =
       readonly kind: "inherited";
       readonly entry: StyleTraceEntry;
       readonly from: StyleOrigin;
+    }
+  /**
+   * A declaration reached this control, and which control wrote it cannot be
+   * told from what the trace records.
+   *
+   * The trace identifies a declaration by its CSS property and the selector it
+   * attached to, and that pair does not always identify a CONTROL: the catalog
+   * writes `background-image` from both `background.url` and
+   * `backgroundGradient`, on the node itself, with nothing to separate them.
+   * With one of the two stored, both controls would otherwise be classified
+   * from the same winning entry and the unset one would report as authored.
+   *
+   * Reported rather than guessed, because a dot that claims a value the control
+   * does not hold is worse than one that says it cannot tell. Resolving it needs
+   * the catalog property carried in the trace, which is the engine's to record.
+   */
+  | {
+      readonly kind: "ambiguous";
+      readonly entry: StyleTraceEntry;
+      /** Every catalog property that writes this declaration, this one included. */
+      readonly sharedWith: readonly string[];
     };
 
 /** Everything needed to place one control's dot. */
@@ -92,6 +115,48 @@ export interface StyleProvenanceQuery {
   readonly liveBreakpoints: readonly BreakpointId[];
 }
 
+/**
+ * A descendant selector in the one spelling both sides can be compared in.
+ *
+ * The trace stores the selector as the compiler GROUPED it — `" a"`, with the
+ * leading combinator — while `StyleLeaf.descendant` declares `"a"`. Measured:
+ * compiling a node with `linkColor` and `linkColorHover` produces trace entries
+ * carrying `" a"` and `" a:hover"`. Comparing the two spellings directly
+ * matches nothing, so every link-colour control would report unset.
+ *
+ * Trimmed rather than re-joined with a space, so this does not depend on which
+ * separator the compiler happens to use — only that the two differ by
+ * surrounding whitespace, which is what a descendant combinator is.
+ */
+function normalizeDescendant(value: string | undefined): string {
+  return value === undefined ? "" : value.trim();
+}
+
+/**
+ * Every catalog property that writes one CSS property at one descendant.
+ *
+ * Derived from the catalog rather than listed, so a property added there is
+ * covered without an edit here.
+ */
+function propertiesWriting(
+  cssProperty: string,
+  descendant: string | undefined
+): string[] {
+  const names: string[] = [];
+  for (const entry of STYLE_CATALOG) {
+    for (const leaf of shapeLeaves(entry.shape)) {
+      if (leaf.cssProperty !== cssProperty) continue;
+      if (
+        normalizeDescendant(leaf.descendant) !== normalizeDescendant(descendant)
+      ) {
+        continue;
+      }
+      if (!names.includes(entry.property)) names.push(entry.property);
+    }
+  }
+  return names;
+}
+
 /** Whether an entry is this node's own value at the position being edited. */
 function isAuthoredHere(
   entry: StyleTraceEntry,
@@ -117,8 +182,9 @@ export function styleProvenance(query: StyleProvenanceQuery): StyleProvenance {
   // `styleOrigin` still decides which of the candidates a node is showing —
   // this only removes the declarations that belong to a different control, so
   // nothing here re-implements tier order, breakpoint axes or specificity.
+  const wanted = normalizeDescendant(query.descendant);
   const candidates = query.trace.filter(
-    entry => entry.descendant === query.descendant
+    entry => normalizeDescendant(entry.descendant) === wanted
   );
   const entry = styleOrigin(candidates, query.subject, {
     property: query.cssProperty,
@@ -126,6 +192,10 @@ export function styleProvenance(query: StyleProvenanceQuery): StyleProvenance {
     breakpoints: query.liveBreakpoints,
   });
   if (entry === undefined) return { kind: "unset" };
+  // Asked only once a declaration has won: nothing wrote this position is an
+  // unambiguous answer whatever else could have written it.
+  const sharedWith = propertiesWriting(query.cssProperty, query.descendant);
+  if (sharedWith.length > 1) return { kind: "ambiguous", entry, sharedWith };
   if (isAuthoredHere(entry, query)) return { kind: "authored", entry };
   return { kind: "inherited", entry, from: entry.origin };
 }

--- a/packages/builder/src/style-provenance.ts
+++ b/packages/builder/src/style-provenance.ts
@@ -1,0 +1,110 @@
+/**
+ * Whether a control's value was authored here, inherited, or never set.
+ *
+ * This is the question the has-value dot beside every control exists to answer,
+ * and the answer is READ rather than re-derived. `styleOrigin` already decides
+ * which recorded declaration a node is showing, having settled tier order, both
+ * breakpoint axes, states joining the base rules, refused values, descendant
+ * selectors and specificity. Walking the cascade again here would be a second
+ * implementation of that, and the two would disagree on exactly the cases that
+ * made the first one hard.
+ *
+ * **Three states, following the affordance Webflow established.** A property
+ * nothing set is empty; one set on this node at the breakpoint and state being
+ * edited is authored here; anything else is inherited — from a named class, a
+ * block type's defaults, the page, or this same node at a wider breakpoint. The
+ * distinction is what stops an author editing a class through a control that
+ * looks like it belongs to one node.
+ *
+ * **The inherited answer carries its ORIGIN, not just a colour.** A class origin
+ * holds both the id and the slug, so a panel can name the class it came from and
+ * offer to open it without looking anything up.
+ *
+ * @module style-provenance
+ */
+
+import {
+  styleOrigin,
+  type BreakpointId,
+  type StyleOrigin,
+  type StyleState,
+  type StyleSubject,
+  type StyleTraceEntry,
+} from "@nextlyhq/blocks-engine";
+
+/** What a control's dot reports. */
+export type StyleProvenance =
+  /** Nothing wrote this property; the browser's own default applies. */
+  | { readonly kind: "unset" }
+  /** This node's own value, at the state and breakpoint being edited. */
+  | { readonly kind: "authored"; readonly entry: StyleTraceEntry }
+  /**
+   * A value from somewhere else — another tier, or this node at another
+   * breakpoint or state. Editing the control writes HERE and takes over.
+   */
+  | {
+      readonly kind: "inherited";
+      readonly entry: StyleTraceEntry;
+      readonly from: StyleOrigin;
+    };
+
+/** Everything needed to place one control's dot. */
+export interface StyleProvenanceQuery {
+  /** The declarations the compiler wrote, in emission order. */
+  readonly trace: readonly StyleTraceEntry[];
+  /** The node the control belongs to, and the ancestors whose rules reach it. */
+  readonly subject: StyleSubject;
+  /**
+   * The CSS property, as the trace records it.
+   *
+   * Taken from the control's own leaf (`StyleLeaf.cssProperty`) rather than from
+   * the catalog key: two catalog keys can write one CSS property, and the trace
+   * records what was written.
+   */
+  readonly cssProperty: string;
+  /** The state being edited. */
+  readonly state: StyleState;
+  /** The breakpoint being edited, which is what "authored here" is measured against. */
+  readonly breakpoint: BreakpointId;
+  /**
+   * Every breakpoint live at the width being viewed.
+   *
+   * Distinct from {@link breakpoint}, and both are needed: the live set decides
+   * which declarations are in play at all, while the edited one decides whether
+   * the winner among them belongs to this control. An editor simulating a narrow
+   * viewport inside a wide window is the ordinary case, so neither can be
+   * derived from the other.
+   */
+  readonly liveBreakpoints: readonly BreakpointId[];
+}
+
+/** Whether an entry is this node's own value at the position being edited. */
+function isAuthoredHere(
+  entry: StyleTraceEntry,
+  query: StyleProvenanceQuery
+): boolean {
+  return (
+    entry.origin.kind === "node" &&
+    entry.origin.id === query.subject.nodeId &&
+    entry.breakpoint === query.breakpoint &&
+    entry.state === query.state
+  );
+}
+
+/**
+ * Where the value a control is showing came from.
+ *
+ * Undefined from `styleOrigin` is a real answer rather than a failure — a
+ * property no tier set is one the browser takes from its own defaults, and a
+ * control over it is genuinely empty.
+ */
+export function styleProvenance(query: StyleProvenanceQuery): StyleProvenance {
+  const entry = styleOrigin(query.trace, query.subject, {
+    property: query.cssProperty,
+    state: query.state,
+    breakpoints: query.liveBreakpoints,
+  });
+  if (entry === undefined) return { kind: "unset" };
+  if (isAuthoredHere(entry, query)) return { kind: "authored", entry };
+  return { kind: "inherited", entry, from: entry.origin };
+}

--- a/packages/builder/src/style-provenance.ts
+++ b/packages/builder/src/style-provenance.ts
@@ -159,6 +159,28 @@ function normalizeDescendant(value: string | undefined): string {
 }
 
 /**
+ * Whether a recorded declaration reaches the element this control addresses.
+ *
+ * Exact equality is too narrow, because a descendant selector carries the
+ * pseudo-classes with it: link hover is `a:hover` in the CATALOG rather than a
+ * `StyleState`, so a hovered anchor matches both `a:hover` and the plain `a`
+ * beside it. A control on `a:hover` with only `a` stored is displaying the `a`
+ * rule, and filtering it out reported the browser's default instead.
+ *
+ * Less-specific only, and never the reverse: an anchor that is NOT hovered does
+ * not match `a:hover`, so a plain-link control must not see a hover rule.
+ * Which of the two wins is left to `styleOrigin`, whose ranking already counts
+ * pseudo-classes as specificity.
+ */
+function reachesControl(entry: string, query: string): boolean {
+  if (entry === query) return true;
+  if (entry === "" || query === "") return false;
+  const [entryBase] = entry.split(":");
+  const [queryBase] = query.split(":");
+  return entryBase === queryBase && !entry.includes(":") && query.includes(":");
+}
+
+/**
  * Every catalog property that writes one CSS property at one descendant.
  *
  * Derived from the catalog rather than listed, so a property added there is
@@ -216,7 +238,14 @@ function isAuthoredHere(
     entry.origin.kind === "node" &&
     entry.origin.id === query.subject.nodeId &&
     entry.breakpoint === query.breakpoint &&
-    entry.state === query.state
+    entry.state === query.state &&
+    // The DESCENDANT too, because a candidate can reach this control without
+    // belonging to it: a plain `a` rule is what a hovered link displays, and it
+    // is this node's own value at this breakpoint and state — but the control
+    // that wrote it is the plain-link one. Calling that authored would offer to
+    // reset a value this control never set.
+    normalizeDescendant(entry.descendant) ===
+      normalizeDescendant(query.descendant)
   );
 }
 
@@ -233,8 +262,8 @@ export function styleProvenance(query: StyleProvenanceQuery): StyleProvenance {
   // this only removes the declarations that belong to a different control, so
   // nothing here re-implements tier order, breakpoint axes or specificity.
   const wanted = normalizeDescendant(query.descendant);
-  const candidates = query.trace.filter(
-    entry => normalizeDescendant(entry.descendant) === wanted
+  const candidates = query.trace.filter(entry =>
+    reachesControl(normalizeDescendant(entry.descendant), wanted)
   );
   const ask = (state: StyleState): StyleTraceEntry | undefined =>
     styleOrigin(candidates, query.subject, {

--- a/packages/builder/src/style-provenance.ts
+++ b/packages/builder/src/style-provenance.ts
@@ -62,6 +62,20 @@ export interface StyleProvenanceQuery {
    * records what was written.
    */
   readonly cssProperty: string;
+  /**
+   * The selector inside the block this control's declaration attaches to, from
+   * the control's own leaf (`StyleLeaf.descendant`), and `undefined` for the
+   * ordinary case of styling the block itself.
+   *
+   * Load-bearing, because a CSS property does not identify a control on its
+   * own. The catalog writes `color` from THREE properties: `color` on the block,
+   * `linkColor` on ` a`, and `linkColorHover` on ` a:hover`. `styleOrigin` reads
+   * the descendant for SPECIFICITY and does not filter on it, so a query
+   * carrying only the property lets a link rule win the plain text-colour
+   * control — reporting an unset control as authored, and all three controls as
+   * showing the same value.
+   */
+  readonly descendant?: string;
   /** The state being edited. */
   readonly state: StyleState;
   /** The breakpoint being edited, which is what "authored here" is measured against. */
@@ -99,7 +113,14 @@ function isAuthoredHere(
  * control over it is genuinely empty.
  */
 export function styleProvenance(query: StyleProvenanceQuery): StyleProvenance {
-  const entry = styleOrigin(query.trace, query.subject, {
+  // NARROWED before the question is asked, rather than re-ranked afterwards.
+  // `styleOrigin` still decides which of the candidates a node is showing —
+  // this only removes the declarations that belong to a different control, so
+  // nothing here re-implements tier order, breakpoint axes or specificity.
+  const candidates = query.trace.filter(
+    entry => entry.descendant === query.descendant
+  );
+  const entry = styleOrigin(candidates, query.subject, {
     property: query.cssProperty,
     state: query.state,
     breakpoints: query.liveBreakpoints,

--- a/packages/builder/src/style-provenance.ts
+++ b/packages/builder/src/style-provenance.ts
@@ -157,6 +157,23 @@ function propertiesWriting(
   return names;
 }
 
+/**
+ * Whichever of two winning entries the browser is actually showing.
+ *
+ * Both reach the node at the same specificity, so the one written later wins.
+ * The trace records declarations in emission order, so its index IS that
+ * ordering and nothing here re-derives it.
+ */
+function later(
+  trace: readonly StyleTraceEntry[],
+  a: StyleTraceEntry | undefined,
+  b: StyleTraceEntry | undefined
+): StyleTraceEntry | undefined {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  return trace.indexOf(b) > trace.indexOf(a) ? b : a;
+}
+
 /** Whether an entry is this node's own value at the position being edited. */
 function isAuthoredHere(
   entry: StyleTraceEntry,
@@ -192,15 +209,22 @@ export function styleProvenance(query: StyleProvenanceQuery): StyleProvenance {
       state,
       breakpoints: query.liveBreakpoints,
     });
-  const entry = ask(query.state);
-  // An interaction state with nothing of its own still SHOWS the base rule —
-  // hovering a node whose colour is set only on base displays that colour. So
-  // reporting `unset` there would say the browser's own default applies, which
-  // is not what the author is looking at. The base entry is what they see, and
-  // it reaches this control the same way a wider breakpoint's value does.
-  const fallback =
-    entry === undefined && query.state !== "base" ? ask("base") : undefined;
-  const winner = entry ?? fallback;
+  // An interaction state and the base state are asked SEPARATELY, because
+  // `styleOrigin` ranks within one state — and then ranked against each other
+  // here, because the browser does not keep them apart. A state selector is
+  // wrapped in `:where()`, which adds NO specificity, so a base rule emitted
+  // later beats an earlier interaction rule: measured, a class's hover colour
+  // followed by the node's base colour leaves the node's base colour showing
+  // while hovered. Preferring any interaction winner would report a value the
+  // browser is not displaying.
+  //
+  // Ranked by position in the trace, which is emission order — the same thing
+  // the cascade is settling — rather than by a second idea of tier order.
+  const winner = later(
+    candidates,
+    ask(query.state),
+    query.state === "base" ? undefined : ask("base")
+  );
   if (winner === undefined) return { kind: "unset" };
   // Asked only once a declaration has won: nothing wrote this position is an
   // unambiguous answer whatever else could have written it.

--- a/packages/builder/src/style-provenance.ts
+++ b/packages/builder/src/style-provenance.ts
@@ -186,16 +186,28 @@ export function styleProvenance(query: StyleProvenanceQuery): StyleProvenance {
   const candidates = query.trace.filter(
     entry => normalizeDescendant(entry.descendant) === wanted
   );
-  const entry = styleOrigin(candidates, query.subject, {
-    property: query.cssProperty,
-    state: query.state,
-    breakpoints: query.liveBreakpoints,
-  });
-  if (entry === undefined) return { kind: "unset" };
+  const ask = (state: StyleState): StyleTraceEntry | undefined =>
+    styleOrigin(candidates, query.subject, {
+      property: query.cssProperty,
+      state,
+      breakpoints: query.liveBreakpoints,
+    });
+  const entry = ask(query.state);
+  // An interaction state with nothing of its own still SHOWS the base rule —
+  // hovering a node whose colour is set only on base displays that colour. So
+  // reporting `unset` there would say the browser's own default applies, which
+  // is not what the author is looking at. The base entry is what they see, and
+  // it reaches this control the same way a wider breakpoint's value does.
+  const fallback =
+    entry === undefined && query.state !== "base" ? ask("base") : undefined;
+  const winner = entry ?? fallback;
+  if (winner === undefined) return { kind: "unset" };
   // Asked only once a declaration has won: nothing wrote this position is an
   // unambiguous answer whatever else could have written it.
   const sharedWith = propertiesWriting(query.cssProperty, query.descendant);
-  if (sharedWith.length > 1) return { kind: "ambiguous", entry, sharedWith };
-  if (isAuthoredHere(entry, query)) return { kind: "authored", entry };
-  return { kind: "inherited", entry, from: entry.origin };
+  if (sharedWith.length > 1) {
+    return { kind: "ambiguous", entry: winner, sharedWith };
+  }
+  if (isAuthoredHere(winner, query)) return { kind: "authored", entry: winner };
+  return { kind: "inherited", entry: winner, from: winner.origin };
 }

--- a/packages/builder/src/style-provenance.ts
+++ b/packages/builder/src/style-provenance.ts
@@ -123,6 +123,22 @@ export interface StyleProvenanceQuery {
    * derived from the other.
    */
   readonly liveBreakpoints: readonly BreakpointId[];
+  /**
+   * Every state whose rules are matching right now.
+   *
+   * A fact about the viewer, exactly as {@link liveBreakpoints} is: an element
+   * under a pressed pointer matches `:active` AND `:hover`, and a focused one
+   * being hovered matches two more. All of their rules apply at once, and
+   * because each is wrapped in `:where()` none outranks another — so emission
+   * order alone decides, and a winner can come from a state other than the one
+   * being edited.
+   *
+   * Omitted means the state being edited plus base, which is right when the
+   * canvas simulates exactly the state under the cursor. A canvas that
+   * simulates several should say so, or a control will report a value the
+   * browser is not showing.
+   */
+  readonly liveStates?: readonly StyleState[];
 }
 
 /**
@@ -168,20 +184,27 @@ function propertiesWriting(
 }
 
 /**
- * Whichever of two winning entries the browser is actually showing.
+ * Whichever of several winning entries the browser is actually showing.
  *
- * Both reach the node at the same specificity, so the one written later wins.
- * The trace records declarations in emission order, so its index IS that
+ * They all reach the node at the same specificity, so the one written last
+ * wins. The trace records declarations in emission order, so its index IS that
  * ordering and nothing here re-derives it.
  */
-function later(
+function lastWritten(
   trace: readonly StyleTraceEntry[],
-  a: StyleTraceEntry | undefined,
-  b: StyleTraceEntry | undefined
+  winners: readonly (StyleTraceEntry | undefined)[]
 ): StyleTraceEntry | undefined {
-  if (a === undefined) return b;
-  if (b === undefined) return a;
-  return trace.indexOf(b) > trace.indexOf(a) ? b : a;
+  let best: StyleTraceEntry | undefined;
+  let bestIndex = -1;
+  for (const winner of winners) {
+    if (winner === undefined) continue;
+    const index = trace.indexOf(winner);
+    if (best === undefined || index > bestIndex) {
+      best = winner;
+      bestIndex = index;
+    }
+  }
+  return best;
 }
 
 /** Whether an entry is this node's own value at the position being edited. */
@@ -230,10 +253,16 @@ export function styleProvenance(query: StyleProvenanceQuery): StyleProvenance {
   //
   // Ranked by position in the trace, which is emission order — the same thing
   // the cascade is settling — rather than by a second idea of tier order.
-  const winner = later(
+  // Every state matching right now, base included: base always matches, and the
+  // state being edited is the one the canvas is simulating.
+  const live = new Set<StyleState>([
+    ...(query.liveStates ?? []),
+    query.state,
+    "base",
+  ]);
+  const winner = lastWritten(
     candidates,
-    ask(query.state),
-    query.state === "base" ? undefined : ask("base")
+    [...live].map(state => ask(state))
   );
   if (winner === undefined) return { kind: "unset" };
   // Asked only once a declaration has won: nothing wrote this position is an

--- a/packages/builder/src/style-scrub.test.ts
+++ b/packages/builder/src/style-scrub.test.ts
@@ -416,3 +416,56 @@ describe("the selector at each state the catalog supports", () => {
     }
   });
 });
+
+describe("a scope the compiler refuses", () => {
+  // `scopeSelector` refuses an empty scope and one carrying ASCII whitespace —
+  // `a b` in a class attribute is two classes, and no escaping makes it the one
+  // class the renderer attached — so it warns and emits unscoped rules.
+
+  function compiledWith(scope: string): string {
+    const document: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/box",
+          version: 1,
+          props: {},
+          styles: { base: { base: { margin: { blockEnd: "24px" } } } },
+        },
+      ],
+    };
+    return compilePageCss(document, {
+      breakpoints: {
+        viewport: [{ id: "base", label: "Desktop" }],
+        container: [],
+      },
+      scope,
+    })
+      .css.split("{")[0]
+      .trim();
+  }
+
+  it("falls back to the unscoped root exactly as the compiler does", () => {
+    // Escaping the whitespace instead would require a class the DOM cannot
+    // hold, so the preview would show nothing while the commit produced
+    // working CSS.
+    for (const scope of ["a b", " ", "one\ttwo"]) {
+      const preview = scrubPreviewCss({ ...TARGET, scope }, "32px");
+      expect(preview.ok).toBe(true);
+      if (!preview.ok) return;
+      expect(preview.css.split("{")[0].trim()).toBe(compiledWith(scope));
+    }
+  });
+
+  it("still scopes a scope the compiler accepts", () => {
+    // The control: falling back for everything would make the assertion above
+    // pass while the scoped case silently lost its class.
+    const preview = scrubPreviewCss({ ...TARGET, scope: "region-one" }, "32px");
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    expect(preview.css.split("{")[0].trim()).toBe(compiledWith("region-one"));
+    expect(preview.css).toContain(".region-one");
+  });
+});

--- a/packages/builder/src/style-scrub.test.ts
+++ b/packages/builder/src/style-scrub.test.ts
@@ -586,9 +586,15 @@ describe("a breakpoint set edited in place", () => {
     expect(after.css).not.toContain("640px");
   });
 
-  it("still answers from cache when nothing moved", () => {
-    // The control: dropping the cache on every call would satisfy the test
-    // above while making the probe compile run per pointer frame.
+  it("derives the same query twice when nothing moved", () => {
+    // NOT a test of cache reuse. Removing the cache entirely recompiles and
+    // produces the same CSS, so this passes either way — and a spurious
+    // invalidation would also be invisible, because a re-derivation returns the
+    // same answer. What it covers is that the derivation is deterministic and
+    // the invalidation above does not change the ANSWER when nothing moved.
+    //
+    // That the second lookup avoids a compile is untested: it would need a seam
+    // through `compilePageCss` that exists only for the test.
     const breakpoints = {
       viewport: [
         { id: "base", label: "Desktop" },
@@ -606,5 +612,32 @@ describe("a breakpoint set edited in place", () => {
     expect(first.ok && second.ok).toBe(true);
     if (!first.ok || !second.ok) return;
     expect(first.css.split("{")[0]).toBe(second.css.split("{")[0]);
+  });
+});
+
+describe("committing at a breakpoint the site no longer defines", () => {
+  const BREAKPOINTS = {
+    viewport: [{ id: "base", label: "Desktop" }],
+    container: [],
+  };
+
+  it("refuses the commit for exactly what the preview refuses", () => {
+    // A breakpoint removed while a drag was in flight: the preview refuses, and
+    // a commit that ignored the set would persist a value the compiler never
+    // emits — the drag would end by storing something the page cannot show.
+    const stale: ScrubTarget = {
+      ...TARGET,
+      breakpoints: BREAKPOINTS,
+      address: { ...TARGET.address, breakpoint: "mobile" },
+    };
+    expect(scrubPreviewCss(stale, "32px").ok).toBe(false);
+    expect(scrubCommitOp(stale, undefined, "32px").ok).toBe(false);
+  });
+
+  it("still commits at a breakpoint the site does define", () => {
+    // The control: refusing on the set's mere presence would block every write.
+    const live: ScrubTarget = { ...TARGET, breakpoints: BREAKPOINTS };
+    expect(scrubPreviewCss(live, "32px").ok).toBe(true);
+    expect(scrubCommitOp(live, undefined, "32px").ok).toBe(true);
   });
 });

--- a/packages/builder/src/style-scrub.test.ts
+++ b/packages/builder/src/style-scrub.test.ts
@@ -1,7 +1,9 @@
 import {
+  compilePageCss,
   escapeIdentifier,
   nodeClassName,
   PAGE_ROOT_SELECTOR,
+  type BlockDocument,
 } from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
 
@@ -218,5 +220,71 @@ describe("preview and commit judge the same thing", () => {
     // The negative half: scoping validation to one property must not stop it
     // judging that property.
     expect(scrubCommitOp(TARGET, undefined, "notalength").ok).toBe(false);
+  });
+});
+
+describe("against the selector the compiler actually emits", () => {
+  // The assertions above build the expected selector the same way the code
+  // does, so they agree with it whatever it spells. These compile a real
+  // document and compare against the rule that comes out, which is the only
+  // thing that can tell a correct construction from a plausible wrong one.
+
+  /** The selector `compilePageCss` writes for one styled node. */
+  function compiledSelector(scope?: string): string {
+    const document: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/box",
+          version: 1,
+          props: {},
+          styles: { base: { base: { margin: { blockEnd: "24px" } } } },
+        },
+      ],
+    };
+    const compiled = compilePageCss(document, {
+      breakpoints: {
+        viewport: [{ id: "base", label: "Desktop" }],
+        container: [],
+      },
+      ...(scope === undefined ? {} : { scope }),
+    });
+    expect(compiled.warnings).toEqual([]);
+    return compiled.css.split("{")[0].trim();
+  }
+
+  /** The selector the preview writes for the same node. */
+  function previewSelector(scope?: string): string {
+    const target: ScrubTarget = {
+      nodeId: "n1",
+      nodeClass: nodeClassName("n1"),
+      ...(scope === undefined ? {} : { scope }),
+      address: {
+        state: "base",
+        breakpoint: "base",
+        property: "margin",
+        path: ["blockEnd"],
+      },
+    };
+    const preview = scrubPreviewCss(target, "32px");
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) throw new Error("expected a preview");
+    return preview.css.split("{")[0].trim();
+  }
+
+  it("matches on an unscoped document", () => {
+    expect(previewSelector()).toBe(compiledSelector());
+  });
+
+  it("matches on a scoped document", () => {
+    expect(previewSelector("region-one")).toBe(compiledSelector("region-one"));
+  });
+
+  it("matches on a scope that needs escaping", () => {
+    // `a.b` would otherwise read as two classes. The preview and the compiler
+    // must escape it identically or they address different elements.
+    expect(previewSelector("a.b")).toBe(compiledSelector("a.b"));
   });
 });

--- a/packages/builder/src/style-scrub.test.ts
+++ b/packages/builder/src/style-scrub.test.ts
@@ -288,3 +288,56 @@ describe("against the selector the compiler actually emits", () => {
     expect(previewSelector("a.b")).toBe(compiledSelector("a.b"));
   });
 });
+
+describe("a compiler setting the engine recovered from", () => {
+  // An invalid `tokenPrefix` does not stop the compiler: it writes the
+  // declarations under the default prefix and says so. Measured — a plain
+  // `24px` compiles to one declaration and one `severity: "warning"` issue.
+  // Reading the issue list's LENGTH conflates that with a refusal.
+  const BAD_PREFIX: ScrubTarget = { ...TARGET, tokenPrefix: "notaprefix" };
+
+  it("still previews a literal value that has nothing to do with tokens", () => {
+    const preview = scrubPreviewCss(BAD_PREFIX, "32px");
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    expect(preview.css).toContain("margin-block-end: 32px");
+  });
+
+  it("carries the remark rather than dropping it", () => {
+    // A warning is the compiler explaining something about output it wrote. A
+    // preview that discarded it would present a recovered-from setting as an
+    // unremarkable one.
+    const preview = scrubPreviewCss(BAD_PREFIX, "32px");
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    expect(preview.warnings.length).toBeGreaterThan(0);
+    expect(preview.warnings.every(issue => issue.severity !== "error")).toBe(
+      true
+    );
+  });
+
+  it("previews a token under the prefix the compiler fell back to", () => {
+    const preview = scrubPreviewCss(BAD_PREFIX, { $token: "space.large" });
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    expect(preview.css).toContain("var(--site-space-large)");
+  });
+
+  it("still refuses a value the compiler wrote nothing for", () => {
+    // The other half of the pair: separating warnings from errors must not
+    // stop a real refusal being a refusal.
+    const refused = scrubPreviewCss(BAD_PREFIX, "notalength");
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.issues.some(issue => issue.severity === "error")).toBe(true);
+  });
+
+  it("reports no warnings on a well-configured site", () => {
+    // The control that keeps the assertions above meaningful: if every preview
+    // carried warnings, "warnings.length > 0" would say nothing.
+    const preview = scrubPreviewCss(TARGET, "32px");
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    expect(preview.warnings).toEqual([]);
+  });
+});

--- a/packages/builder/src/style-scrub.test.ts
+++ b/packages/builder/src/style-scrub.test.ts
@@ -22,7 +22,7 @@ const TARGET: ScrubTarget = {
   nodeClass: nodeClassName("n1"),
   address: {
     state: "base",
-    breakpoint: "desktop",
+    breakpoint: "base",
     property: "margin",
     path: ["blockEnd"],
   },
@@ -95,7 +95,7 @@ describe("the commit that ends a drag", () => {
     if (!result.ok) return;
     const op = result.op as { patch: { styles?: unknown } };
     expect(op.patch.styles).toEqual({
-      base: { desktop: { margin: { blockEnd: "32px" } } },
+      base: { base: { margin: { blockEnd: "32px" } } },
     });
   });
 
@@ -150,7 +150,7 @@ describe("the site's URL policy", () => {
     nodeClass: nodeClassName("n1"),
     address: {
       state: "base",
-      breakpoint: "desktop",
+      breakpoint: "base",
       property: "background",
       path: ["url"],
     },
@@ -533,5 +533,23 @@ describe("a breakpoint the compiler wraps in a query", () => {
     // preview would show a value the published page will never carry.
     expect(compiledAt("tablet")).toBe("");
     expect(previewAt("tablet").ok).toBe(false);
+  });
+});
+
+describe("a caller that did not say where the preview goes", () => {
+  it("refuses a non-base breakpoint when no breakpoint set was supplied", () => {
+    // Without the set this cannot know which query the committed rule lands in,
+    // and an unconditional preview would show the value at every width.
+    const preview = scrubPreviewCss(
+      { ...TARGET, address: { ...TARGET.address, breakpoint: "mobile" } },
+      "32px"
+    );
+    expect(preview.ok).toBe(false);
+  });
+
+  it("still previews the base breakpoint, which is unconditional", () => {
+    // The control: refusing everything would pass the assertion above while
+    // making the SDK unusable for the ordinary case.
+    expect(scrubPreviewCss(TARGET, "32px").ok).toBe(true);
   });
 });

--- a/packages/builder/src/style-scrub.test.ts
+++ b/packages/builder/src/style-scrub.test.ts
@@ -1,4 +1,8 @@
-import { nodeClassName, PAGE_ROOT_SELECTOR } from "@nextlyhq/blocks-engine";
+import {
+  escapeIdentifier,
+  nodeClassName,
+  PAGE_ROOT_SELECTOR,
+} from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -98,5 +102,78 @@ describe("the commit that ends a drag", () => {
         scrubPreviewCss(TARGET, value).ok
       );
     }
+  });
+});
+
+describe("a document with a compile scope", () => {
+  const SCOPED: ScrubTarget = { ...TARGET, scope: "region-one" };
+
+  it("anchors the preview to the SAME root the compiled sheet uses", () => {
+    // `compilePageCss` emits `${PAGE_ROOT_SELECTOR}.${scope}`. A preview at the
+    // unscoped root carries one class fewer, so the stored rule outranks it and
+    // the drag shows nothing move.
+    const preview = scrubPreviewCss(SCOPED, "32px");
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    expect(preview.css.startsWith(`${PAGE_ROOT_SELECTOR}.region-one `)).toBe(
+      true
+    );
+  });
+
+  it("escapes a scope through the engine's own escaper", () => {
+    // A scope needing escapes must be spelled here exactly as the compiler
+    // spells it, or the two selectors address different elements.
+    const preview = scrubPreviewCss({ ...TARGET, scope: "a.b" }, "32px");
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    expect(preview.css).toContain(escapeIdentifier("a.b"));
+    expect(preview.css).not.toContain(`${PAGE_ROOT_SELECTOR}.a.b `);
+  });
+
+  it("stays unscoped when the document has no scope", () => {
+    const preview = scrubPreviewCss(TARGET, "32px");
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    expect(preview.css.startsWith(`${PAGE_ROOT_SELECTOR} `)).toBe(true);
+  });
+});
+
+describe("the site's URL policy", () => {
+  /** Scrubbing `background.url`, which is the catalog's only URL leaf. */
+  const IMAGE: ScrubTarget = {
+    nodeId: "n1",
+    nodeClass: nodeClassName("n1"),
+    address: {
+      state: "base",
+      breakpoint: "desktop",
+      property: "background",
+      path: ["url"],
+    },
+  };
+
+  it("refuses a host the site does not allow, so it never previews or fetches", () => {
+    const preview = scrubPreviewCss(
+      { ...IMAGE, policy: { mayFetchUrl: () => false } },
+      "https://elsewhere.example/x.png"
+    );
+    expect(preview.ok).toBe(false);
+  });
+
+  it("accepts the same URL when the site allows the host", () => {
+    // The pair is what makes the refusal evidence: without this, a preview that
+    // refused every URL would satisfy the assertion above.
+    const preview = scrubPreviewCss(
+      { ...IMAGE, policy: { mayFetchUrl: () => true } },
+      "https://elsewhere.example/x.png"
+    );
+    expect(preview.ok).toBe(true);
+  });
+
+  it("forwards the same policy to the commit, so preview and write agree", () => {
+    const policy = { mayFetchUrl: () => false };
+    const url = "https://elsewhere.example/x.png";
+    expect(scrubCommitOp({ ...IMAGE, policy }, undefined, url).ok).toBe(
+      scrubPreviewCss({ ...IMAGE, policy }, url).ok
+    );
   });
 });

--- a/packages/builder/src/style-scrub.test.ts
+++ b/packages/builder/src/style-scrub.test.ts
@@ -177,3 +177,46 @@ describe("the site's URL policy", () => {
     );
   });
 });
+
+describe("the site's token prefix", () => {
+  const TOKENED: ScrubTarget = { ...TARGET, tokenPrefix: "--acme-" };
+
+  it("emits tokens under the prefix the site publishes with", () => {
+    // A preview compiled with the default reads `var(--site-…)` while the
+    // published sheet reads `var(--acme-…)`, so the token resolves to nothing —
+    // or to something else — for exactly as long as the drag lasts.
+    const preview = scrubPreviewCss(TOKENED, { $token: "space.large" });
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    expect(preview.css).toContain("var(--acme-space-large)");
+    expect(preview.css).not.toContain("--site-");
+  });
+
+  it("uses the engine's default when the site configured none", () => {
+    const preview = scrubPreviewCss(TARGET, { $token: "space.large" });
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    expect(preview.css).toContain("var(--site-space-large)");
+  });
+});
+
+describe("preview and commit judge the same thing", () => {
+  it("is not blocked by an unrelated invalid value at the same breakpoint", () => {
+    // Validating the whole breakpoint map would let one bad value — a URL a
+    // changed site policy now refuses, say — block every other control on that
+    // breakpoint, with the preview still showing the drag as fine.
+    const withBadSibling = {
+      base: { desktop: { margin: { blockEnd: "24px" }, height: "notalength" } },
+    };
+    const preview = scrubPreviewCss(TARGET, "32px");
+    const commit = scrubCommitOp(TARGET, withBadSibling, "32px");
+    expect(preview.ok).toBe(true);
+    expect(commit.ok).toBe(true);
+  });
+
+  it("still refuses when the scrubbed value itself is invalid", () => {
+    // The negative half: scoping validation to one property must not stop it
+    // judging that property.
+    expect(scrubCommitOp(TARGET, undefined, "notalength").ok).toBe(false);
+  });
+});

--- a/packages/builder/src/style-scrub.test.ts
+++ b/packages/builder/src/style-scrub.test.ts
@@ -3,13 +3,16 @@ import {
   escapeIdentifier,
   nodeClassName,
   PAGE_ROOT_SELECTOR,
+  STYLE_STATES,
   type BlockDocument,
+  type StyleState,
 } from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
 
 import {
   scrubCommitOp,
   scrubPreviewCss,
+  scrubStateFragments,
   type ScrubTarget,
 } from "./style-scrub";
 
@@ -339,5 +342,77 @@ describe("a compiler setting the engine recovered from", () => {
     expect(preview.ok).toBe(true);
     if (!preview.ok) return;
     expect(preview.warnings).toEqual([]);
+  });
+});
+
+describe("the selector at each state the catalog supports", () => {
+  // A preview that ignored the state would match the node in ALL of them:
+  // dragging a hover value would repaint the resting appearance, and releasing
+  // would reveal behaviour the drag never showed.
+
+  /** The selector `compilePageCss` writes for one node styled at `state`. */
+  function compiledAt(state: StyleState): string {
+    const document: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/box",
+          version: 1,
+          props: {},
+          styles: { [state]: { base: { margin: { blockEnd: "24px" } } } },
+        },
+      ],
+    };
+    const compiled = compilePageCss(document, {
+      breakpoints: {
+        viewport: [{ id: "base", label: "Desktop" }],
+        container: [],
+      },
+    });
+    expect(compiled.warnings).toEqual([]);
+    return compiled.css.split("{")[0].trim();
+  }
+
+  /** The selector the preview writes for the same node at the same state. */
+  function previewAt(state: StyleState): string {
+    const preview = scrubPreviewCss(
+      {
+        nodeId: "n1",
+        nodeClass: nodeClassName("n1"),
+        address: {
+          state,
+          breakpoint: "base",
+          property: "margin",
+          path: ["blockEnd"],
+        },
+      },
+      "32px"
+    );
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) throw new Error("expected a preview");
+    return preview.css.split("{")[0].trim();
+  }
+
+  it("matches the compiler on every state, not just base", () => {
+    // Swept over the engine's own list, so a state added there is covered here
+    // without an edit.
+    expect(STYLE_STATES.length).toBeGreaterThan(1);
+    for (const state of STYLE_STATES) {
+      expect(previewAt(state)).toBe(compiledAt(state));
+    }
+  });
+
+  it("constrains a non-base state and leaves base unconstrained", () => {
+    // The control that keeps the sweep meaningful: if every fragment were
+    // empty, matching the compiler would be trivially true and the preview
+    // would still repaint the resting appearance.
+    const fragments = scrubStateFragments();
+    expect(fragments.get("base")).toBe("");
+    for (const state of STYLE_STATES.filter(s => s !== "base")) {
+      expect(fragments.get(state)).not.toBe("");
+      expect(fragments.get(state)).toContain(":where(");
+    }
   });
 });

--- a/packages/builder/src/style-scrub.test.ts
+++ b/packages/builder/src/style-scrub.test.ts
@@ -553,3 +553,58 @@ describe("a caller that did not say where the preview goes", () => {
     expect(scrubPreviewCss(TARGET, "32px").ok).toBe(true);
   });
 });
+
+describe("a breakpoint set edited in place", () => {
+  it("re-derives the query rather than answering with the old one", () => {
+    // A host that mutates a definition keeps the same object, so a cache keyed
+    // on identity alone keeps emitting the query the set no longer describes —
+    // and the preview then sits at a width where the committed value is absent.
+    const breakpoints = {
+      viewport: [
+        { id: "base", label: "Desktop" },
+        { id: "mobile", label: "Mobile", maxWidth: 640 },
+      ],
+      container: [],
+    };
+    const target: ScrubTarget = {
+      ...TARGET,
+      breakpoints,
+      address: { ...TARGET.address, breakpoint: "mobile" },
+    };
+
+    const before = scrubPreviewCss(target, "32px");
+    expect(before.ok).toBe(true);
+    if (!before.ok) return;
+    expect(before.css).toContain("@media (max-width: 640px)");
+
+    breakpoints.viewport[1].maxWidth = 320;
+
+    const after = scrubPreviewCss(target, "32px");
+    expect(after.ok).toBe(true);
+    if (!after.ok) return;
+    expect(after.css).toContain("@media (max-width: 320px)");
+    expect(after.css).not.toContain("640px");
+  });
+
+  it("still answers from cache when nothing moved", () => {
+    // The control: dropping the cache on every call would satisfy the test
+    // above while making the probe compile run per pointer frame.
+    const breakpoints = {
+      viewport: [
+        { id: "base", label: "Desktop" },
+        { id: "mobile", label: "Mobile", maxWidth: 640 },
+      ],
+      container: [],
+    };
+    const target: ScrubTarget = {
+      ...TARGET,
+      breakpoints,
+      address: { ...TARGET.address, breakpoint: "mobile" },
+    };
+    const first = scrubPreviewCss(target, "32px");
+    const second = scrubPreviewCss(target, "40px");
+    expect(first.ok && second.ok).toBe(true);
+    if (!first.ok || !second.ok) return;
+    expect(first.css.split("{")[0]).toBe(second.css.split("{")[0]);
+  });
+});

--- a/packages/builder/src/style-scrub.test.ts
+++ b/packages/builder/src/style-scrub.test.ts
@@ -469,3 +469,69 @@ describe("a scope the compiler refuses", () => {
     expect(preview.css).toContain(".region-one");
   });
 });
+
+describe("a breakpoint the compiler wraps in a query", () => {
+  const BREAKPOINTS = {
+    viewport: [
+      { id: "base", label: "Desktop" },
+      { id: "mobile", label: "Mobile", maxWidth: 640 },
+    ],
+    container: [],
+  };
+
+  /** The compiled sheet for one node styled at `breakpoint`. */
+  function compiledAt(breakpoint: string): string {
+    const document: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/box",
+          version: 1,
+          props: {},
+          styles: { base: { [breakpoint]: { margin: { blockEnd: "24px" } } } },
+        },
+      ],
+    };
+    return compilePageCss(document, { breakpoints: BREAKPOINTS }).css.trim();
+  }
+
+  function previewAt(breakpoint: string) {
+    return scrubPreviewCss(
+      {
+        ...TARGET,
+        breakpoints: BREAKPOINTS,
+        address: { ...TARGET.address, breakpoint },
+      },
+      "32px"
+    );
+  }
+
+  it("wraps the preview in the same query the committed rule gets", () => {
+    // Without this the value appears at every width and vanishes on release.
+    expect(compiledAt("mobile")).toContain("@media (max-width: 640px)");
+    const preview = previewAt("mobile");
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    expect(preview.css).toContain("@media (max-width: 640px)");
+    expect(preview.css).toContain("margin-block-end: 32px");
+  });
+
+  it("leaves an unconditional breakpoint unwrapped", () => {
+    // The control: wrapping everything would pass the assertion above while
+    // burying base values in a query they never had.
+    expect(compiledAt("base")).not.toContain("@media");
+    const preview = previewAt("base");
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    expect(preview.css).not.toContain("@media");
+  });
+
+  it("refuses a breakpoint this site does not define", () => {
+    // The compiler writes NO rule for an unknown id, so an unconditional
+    // preview would show a value the published page will never carry.
+    expect(compiledAt("tablet")).toBe("");
+    expect(previewAt("tablet").ok).toBe(false);
+  });
+});

--- a/packages/builder/src/style-scrub.test.ts
+++ b/packages/builder/src/style-scrub.test.ts
@@ -1,0 +1,102 @@
+import { nodeClassName, PAGE_ROOT_SELECTOR } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import {
+  scrubCommitOp,
+  scrubPreviewCss,
+  type ScrubTarget,
+} from "./style-scrub";
+
+/** Scrubbing the bottom margin of one node. */
+const TARGET: ScrubTarget = {
+  nodeId: "n1",
+  nodeClass: nodeClassName("n1"),
+  address: {
+    state: "base",
+    breakpoint: "desktop",
+    property: "margin",
+    path: ["blockEnd"],
+  },
+};
+
+describe("the CSS a drag shows", () => {
+  it("emits the property the catalog maps this path to", () => {
+    const preview = scrubPreviewCss(TARGET, "32px");
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    expect(preview.css).toContain("margin-block-end: 32px");
+  });
+
+  it("anchors to the compiler's own root selector rather than a stronger one", () => {
+    // The number of repetitions in that selector IS the override contract. A
+    // preview that outranked the committed rule would land where the stored
+    // value will not, and the difference would only appear on release.
+    const preview = scrubPreviewCss(TARGET, "32px");
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    expect(preview.css.startsWith(PAGE_ROOT_SELECTOR)).toBe(true);
+    expect(preview.css).toContain(`.${nodeClassName("n1")}`);
+  });
+
+  it("emits ONLY the property being scrubbed", () => {
+    // Everything else the node carries still comes from the sheet underneath,
+    // so previewing one side must not restate — or drop — the other three.
+    const preview = scrubPreviewCss(TARGET, "32px");
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    expect(preview.css).not.toContain("margin-block-start");
+    expect(preview.css).not.toContain("margin-inline");
+  });
+
+  it("compiles a token reference the way the published sheet does", () => {
+    // The separating property against a preview that formatted the value
+    // itself: a token is a `var()` on the page, and a hand-written preview
+    // would show the literal `[object Object]` or the raw name.
+    const preview = scrubPreviewCss(TARGET, { $token: "space.large" });
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    expect(preview.css).toContain("var(--site-space-large)");
+  });
+
+  it("refuses a value the compiler would not write, so it never reaches the screen", () => {
+    const preview = scrubPreviewCss(TARGET, "notalength");
+    expect(preview.ok).toBe(false);
+  });
+
+  it("accepts the values the compiler accepts", () => {
+    // The vacuity control for the refusal above: a preview that refused
+    // everything would satisfy that test while showing nothing ever.
+    for (const value of ["0", "1.5rem", "24px", "10%"]) {
+      expect(scrubPreviewCss(TARGET, value).ok).toBe(true);
+    }
+  });
+});
+
+describe("the commit that ends a drag", () => {
+  it("is exactly one op", () => {
+    const result = scrubCommitOp(TARGET, undefined, "32px");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.op).toMatchObject({ kind: "update", id: "n1" });
+  });
+
+  it("stores the value at the address, not the CSS the preview showed", () => {
+    const result = scrubCommitOp(TARGET, undefined, "32px");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const op = result.op as { patch: { styles?: unknown } };
+    expect(op.patch.styles).toEqual({
+      base: { desktop: { margin: { blockEnd: "32px" } } },
+    });
+  });
+
+  it("refuses exactly what the preview refuses", () => {
+    // Preview and commit agree by construction because both go through the
+    // catalog. This pins that they have not drifted apart.
+    for (const value of ["notalength", "24px", "1.5rem", "red"]) {
+      expect(scrubCommitOp(TARGET, undefined, value).ok).toBe(
+        scrubPreviewCss(TARGET, value).ok
+      );
+    }
+  });
+});

--- a/packages/builder/src/style-scrub.ts
+++ b/packages/builder/src/style-scrub.ts
@@ -164,9 +164,25 @@ export function scrubStateFragments(): ReadonlyMap<StyleState, string> {
   return STATE_FRAGMENTS;
 }
 
-/** The root every rule for this document is anchored to. */
+/**
+ * The root every rule for this document is anchored to.
+ *
+ * A scope the compiler REFUSES falls back to the unscoped root here too. It
+ * refuses an empty scope and one carrying ASCII whitespace, because `a b` in a
+ * class attribute is two classes and no escaping makes it the single class the
+ * renderer attached — so it warns and emits unscoped rules. Escaping the
+ * whitespace instead would produce a selector requiring a class the DOM cannot
+ * hold, and the preview would show nothing while the commit produced working
+ * CSS.
+ *
+ * The whitespace set is ASCII only, matching what HTML splits a class attribute
+ * on: `\s` in JavaScript also matches NBSP and the Unicode spaces, and those do
+ * NOT split a class, so rejecting them would drop a scope the compiler kept.
+ */
 function rootSelector(scope: string | undefined): string {
-  if (scope === undefined || scope === "") return PAGE_ROOT_SELECTOR;
+  if (scope === undefined || scope === "" || /[ \t\n\f\r]/.test(scope)) {
+    return PAGE_ROOT_SELECTOR;
+  }
   return `${PAGE_ROOT_SELECTOR}.${escapeIdentifier(scope)}`;
 }
 

--- a/packages/builder/src/style-scrub.ts
+++ b/packages/builder/src/style-scrub.ts
@@ -25,9 +25,18 @@
  * that contract for the duration of a drag, so the preview would land where the
  * committed value will not; spelling a weaker one loses to the rule being
  * previewed over, and the drag shows nothing move. The consequence for the host
- * is that the element holding this text must come AFTER the compiled sheet —
- * later of two equals wins — and removing it on commit reveals the real rule
- * underneath with no visible change.
+ * is that the element holding this text must come after the compiled sheet's
+ * rules for the SAME state — later of two equals wins — and removing it on
+ * commit reveals the real rule underneath with no visible change.
+ *
+ * **Mounting it after the WHOLE sheet is wrong for a base-state preview**, and
+ * this module cannot prevent that on its own. The compiler emits interaction
+ * states after base at equal specificity, so a base rule placed last also
+ * outranks an existing hover, focus or active declaration: the element shows
+ * the scrubbed base value while hovered, and reverts on release. Placing the
+ * preview beside the rules for its own state is the host's part of this
+ * contract; which states carry a declaration for the property is in the trace
+ * the provenance query already reads.
  *
  * @module style-scrub
  */

--- a/packages/builder/src/style-scrub.ts
+++ b/packages/builder/src/style-scrub.ts
@@ -47,6 +47,7 @@ import {
   type ValidationIssue,
 } from "@nextlyhq/blocks-engine";
 
+import { BASE_BREAKPOINT } from "./breakpoints";
 import type { StyleAddress, StylePolicy, StyleWrite } from "./style-values";
 import { styleValueAtPath, styleWriteOp } from "./style-values";
 
@@ -226,6 +227,23 @@ function breakpointAtRule(
 }
 
 /**
+ * The at-rule this target's declarations belong inside, or `null` to refuse.
+ *
+ * Omitting the breakpoint set is only safe for the BASE breakpoint, which the
+ * compiler writes unconditionally. For any other id the committed value is
+ * wrapped in a query — or dropped entirely, when the site does not define it —
+ * and an unconditional preview would show the value at every width and lose it
+ * on release. Refusing says the preview cannot be placed, which is the honest
+ * answer when the caller has not said where it goes.
+ */
+function atRuleFor(target: ScrubTarget): string | null {
+  if (target.breakpoints !== undefined) {
+    return breakpointAtRule(target.breakpoints, target.address.breakpoint);
+  }
+  return target.address.breakpoint === BASE_BREAKPOINT ? "" : null;
+}
+
+/**
  * The root every rule for this document is anchored to.
  *
  * A scope the compiler REFUSES falls back to the unscoped root here too. It
@@ -313,10 +331,7 @@ export function scrubPreviewCss(
   // Resolved BEFORE compiling the value: a breakpoint the site does not define
   // is one the published sheet carries no rule for, so previewing it would show
   // an author a result the page will never have.
-  const atRule =
-    target.breakpoints === undefined
-      ? ""
-      : breakpointAtRule(target.breakpoints, target.address.breakpoint);
+  const atRule = atRuleFor(target);
   if (atRule === null) return { ok: false, issues: [] };
   const compiled = compileStyleValues(
     { [property]: styleValueAtPath(path, value) },

--- a/packages/builder/src/style-scrub.ts
+++ b/packages/builder/src/style-scrub.ts
@@ -93,7 +93,22 @@ function rootSelector(scope: string | undefined): string {
 
 /** CSS for the value under the pointer, or the reasons it was refused. */
 export type ScrubPreview =
-  | { readonly ok: true; readonly css: string }
+  | {
+      readonly ok: true;
+      readonly css: string;
+      /**
+       * What the compiler remarked on while writing this declaration.
+       *
+       * Emitting and objecting are not the same outcome. A site whose
+       * `tokenPrefix` is invalid gets its declarations written under the
+       * engine's default prefix WITH a warning saying so — measured: a plain
+       * `24px` compiles to one declaration and one `severity: "warning"`
+       * issue. Treating that as a refusal would blank every preview on that
+       * site, including values with no token in them, while the commit
+       * succeeded and the published page rendered normally.
+       */
+      readonly warnings: readonly ValidationIssue[];
+    }
   | { readonly ok: false; readonly issues: readonly ValidationIssue[] };
 
 /**
@@ -145,17 +160,23 @@ export function scrubPreviewCss(
     undefined,
     { mayFetchUrl: target.policy?.mayFetchUrl }
   );
-  // The compiler reports only what it REFUSED, and refuses the whole map when
-  // it cannot check it. So anything reported means this value is not one the
-  // published page would carry, and previewing it would show the author a
-  // result they cannot keep.
-  if (compiled.warnings.length > 0) {
+  // Two different outcomes wear one field. An ERROR means the compiler refused
+  // the value, and nothing was written; a warning can accompany a declaration
+  // it wrote anyway. Reading the field's length alone conflates them, so a
+  // setting the compiler recovered from would blank the preview while the
+  // published page rendered fine.
+  const errors = compiled.warnings.filter(issue => issue.severity === "error");
+  if (errors.length > 0) return { ok: false, issues: errors };
+  // Nothing written is a refusal however it was reported: previewing a value
+  // the page will not carry shows the author a result they cannot keep.
+  if (compiled.declarations.length === 0) {
     return { ok: false, issues: compiled.warnings };
   }
-  if (compiled.declarations.length === 0) {
-    return { ok: false, issues: [] };
-  }
-  return { ok: true, css: ruleText(target, compiled.declarations) };
+  return {
+    ok: true,
+    css: ruleText(target, compiled.declarations),
+    warnings: compiled.warnings,
+  };
 }
 
 /**

--- a/packages/builder/src/style-scrub.ts
+++ b/packages/builder/src/style-scrub.ts
@@ -40,6 +40,7 @@ import {
   PAGE_ROOT_SELECTOR,
   STYLE_STATES,
   type BlockDocument,
+  type BreakpointSet,
   type Declaration,
   type StyleState,
   type StyleValue,
@@ -74,6 +75,20 @@ export interface ScrubTarget {
    * compiled sheet cannot disagree about a scope needing escapes.
    */
   readonly scope?: string;
+  /**
+   * The site's breakpoint definitions, as the canvas compiles with.
+   *
+   * `compilePageCss` wraps a non-base breakpoint's rules in `@media` or
+   * `@container` — measured, a `mobile` value comes out inside
+   * `@media (max-width: 640px)`. A preview that ignored the address's
+   * breakpoint would show the value at every width and lose it on release, and
+   * for a breakpoint id this site does not define the compiler writes no rule
+   * at all while an unconditional preview still showed one.
+   *
+   * Omitted means every value previews unconditionally, which is right only for
+   * a site whose breakpoints are all unconditional.
+   */
+  readonly breakpoints?: BreakpointSet;
   readonly address: StyleAddress;
   /**
    * The custom-property prefix this site emits tokens under.
@@ -164,6 +179,52 @@ export function scrubStateFragments(): ReadonlyMap<StyleState, string> {
   return STATE_FRAGMENTS;
 }
 
+/** At-rules already derived, per breakpoint set and id. */
+const AT_RULES = new WeakMap<BreakpointSet, Map<string, string | null>>();
+
+/**
+ * The at-rule the compiler wraps one breakpoint's declarations in.
+ *
+ * `null` means the compiler writes NO rule for this id — which is what it does
+ * for an id the site does not define, and is a refusal rather than an
+ * unconditional rule. `""` means it writes one with no wrapper, as base does.
+ *
+ * READ from a probe compile rather than rebuilt from the definitions. Turning a
+ * breakpoint into a media query is the compiler's own arithmetic — which axis,
+ * which bound, how a container query differs — and it does not export it, so a
+ * copy here would drift from the sheet the preview is meant to sit beside.
+ */
+function breakpointAtRule(
+  breakpoints: BreakpointSet,
+  id: string
+): string | null {
+  let perId = AT_RULES.get(breakpoints);
+  if (perId === undefined) {
+    perId = new Map();
+    AT_RULES.set(breakpoints, perId);
+  }
+  const cached = perId.get(id);
+  if (cached !== undefined) return cached;
+  const document: BlockDocument = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      {
+        id: PROBE_ID,
+        type: "core/box",
+        version: 1,
+        props: {},
+        styles: { base: { [id]: { height: "1px" } } },
+      },
+    ],
+  };
+  const css = compilePageCss(document, { breakpoints }).css.trim();
+  const wrapper = /^@[a-z-]+[^{]*/.exec(css);
+  const derived = css === "" ? null : wrapper === null ? "" : wrapper[0].trim();
+  perId.set(id, derived);
+  return derived;
+}
+
 /**
  * The root every rule for this document is anchored to.
  *
@@ -218,7 +279,8 @@ export type ScrubPreview =
  */
 function ruleText(
   target: ScrubTarget,
-  declarations: readonly Declaration[]
+  declarations: readonly Declaration[],
+  atRule: string
 ): string {
   const root = rootSelector(target.scope);
   const state = stateFragment(target.address.state);
@@ -228,10 +290,10 @@ function ruleText(
         declaration.descendant === undefined
           ? ""
           : ` ${declaration.descendant}`;
-      return (
+      const rule =
         `${root} .${target.nodeClass}${state}${descendant} ` +
-        `{ ${declaration.property}: ${declaration.value} }`
-      );
+        `{ ${declaration.property}: ${declaration.value} }`;
+      return atRule === "" ? rule : `${atRule} {\n  ${rule}\n}`;
     })
     .join("\n");
 }
@@ -248,6 +310,14 @@ export function scrubPreviewCss(
   value: StyleValue
 ): ScrubPreview {
   const { property, path } = target.address;
+  // Resolved BEFORE compiling the value: a breakpoint the site does not define
+  // is one the published sheet carries no rule for, so previewing it would show
+  // an author a result the page will never have.
+  const atRule =
+    target.breakpoints === undefined
+      ? ""
+      : breakpointAtRule(target.breakpoints, target.address.breakpoint);
+  if (atRule === null) return { ok: false, issues: [] };
   const compiled = compileStyleValues(
     { [property]: styleValueAtPath(path, value) },
     "",
@@ -270,7 +340,7 @@ export function scrubPreviewCss(
   }
   return {
     ok: true,
-    css: ruleText(target, compiled.declarations),
+    css: ruleText(target, compiled.declarations, atRule),
     warnings: compiled.warnings,
   };
 }

--- a/packages/builder/src/style-scrub.ts
+++ b/packages/builder/src/style-scrub.ts
@@ -1,0 +1,149 @@
+/**
+ * Previewing a value while the pointer is still down, and committing once.
+ *
+ * A scrub is two different operations wearing one gesture. Dragging must show
+ * the result immediately and cost nothing per frame; releasing must produce a
+ * single undoable edit. Doing both through the document would recompile a
+ * stylesheet on every pointer move and push an undo entry for each — so the
+ * drag writes CSS and only the release writes the document.
+ *
+ * **The preview is compiled, not formatted.** `compileStyleValues` is the same
+ * function the published stylesheet is emitted through, so a token reference
+ * becomes the same `var()`, a composite expands to the same logical properties,
+ * and a value the compiler refuses produces no declarations here either. Writing
+ * `${property}: ${value}` by hand would be a second emission path, and the two
+ * would disagree exactly where emission is interesting.
+ *
+ * **A refused value never reaches the screen.** The compiler validates before it
+ * writes, so the preview and the commit accept exactly the same values — by
+ * construction rather than by both remembering to check.
+ *
+ * **The rule sits at the compiler's own specificity and wins on ORDER.** It is
+ * anchored to `PAGE_ROOT_SELECTOR`, which is where the override contract lives;
+ * spelling a stronger selector here would quietly raise that contract for the
+ * duration of a drag, so the preview would land where the committed value will
+ * not. The consequence for the host is that the element holding this text must
+ * come AFTER the compiled sheet — later of two equals wins — and removing it on
+ * commit reveals the real rule underneath with no visible change.
+ *
+ * @module style-scrub
+ */
+
+import {
+  compileStyleValues,
+  PAGE_ROOT_SELECTOR,
+  type Declaration,
+  type StyleValue,
+  type ValidationIssue,
+} from "@nextlyhq/blocks-engine";
+
+import type { StyleAddress, StyleWrite } from "./style-values";
+import { styleWriteOp } from "./style-values";
+
+/** The node a scrub is previewing against. */
+export interface ScrubTarget {
+  readonly nodeId: string;
+  /**
+   * The class the compiler emitted for this node.
+   *
+   * Supplied rather than derived from the id. `nodeClassName` cannot see a hash
+   * collision — only `nodeClassNames`, which reads the whole document, can — so
+   * a target that hashed the id itself would preview against the wrong node on
+   * exactly the documents where the compiler had already disambiguated.
+   */
+  readonly nodeClass: string;
+  readonly address: StyleAddress;
+}
+
+/** CSS for the value under the pointer, or the reasons it was refused. */
+export type ScrubPreview =
+  | { readonly ok: true; readonly css: string }
+  | { readonly ok: false; readonly issues: readonly ValidationIssue[] };
+
+/**
+ * The rule text for one node's declarations, one rule per declaration.
+ *
+ * Deliberately NOT grouped by descendant. The compiler groups because it
+ * serializes a whole document and a stable, compact sheet matters there; a
+ * preview carries the declarations of a single leaf, which share one selector
+ * anyway, and separate rules at equal specificity cascade identically to one
+ * merged rule. Repeating the grouping here would be a second copy of a function
+ * the engine already has, kept in step by nothing.
+ */
+function ruleText(
+  nodeClass: string,
+  declarations: readonly Declaration[]
+): string {
+  return declarations
+    .map(declaration => {
+      const descendant =
+        declaration.descendant === undefined
+          ? ""
+          : ` ${declaration.descendant}`;
+      return (
+        `${PAGE_ROOT_SELECTOR} .${nodeClass}${descendant} ` +
+        `{ ${declaration.property}: ${declaration.value} }`
+      );
+    })
+    .join("\n");
+}
+
+/**
+ * The stylesheet text that shows `value` without touching the document.
+ *
+ * Only the scrubbed property is compiled. Everything else the node carries
+ * still comes from the sheet underneath, so a preview of one side of a margin
+ * does not restate — and cannot accidentally drop — the other three.
+ */
+export function scrubPreviewCss(
+  target: ScrubTarget,
+  value: StyleValue
+): ScrubPreview {
+  const { property, path } = target.address;
+  const compiled = compileStyleValues(
+    { [property]: valueAtPath(path, value) },
+    ""
+  );
+  // The compiler reports only what it REFUSED, and refuses the whole map when
+  // it cannot check it. So anything reported means this value is not one the
+  // published page would carry, and previewing it would show the author a
+  // result they cannot keep.
+  if (compiled.warnings.length > 0) {
+    return { ok: false, issues: compiled.warnings };
+  }
+  if (compiled.declarations.length === 0) {
+    return { ok: false, issues: [] };
+  }
+  return { ok: true, css: ruleText(target.nodeClass, compiled.declarations) };
+}
+
+/**
+ * A value wrapped in the containers its path names.
+ *
+ * A control scrubbing one side of a margin holds a length and an address; the
+ * compiler takes the property's whole value. Building the containers here keeps
+ * the preview compiling the same shape the commit will store.
+ */
+function valueAtPath(path: readonly string[], value: StyleValue): StyleValue {
+  let wrapped = value;
+  for (let index = path.length - 1; index >= 0; index -= 1) {
+    wrapped = { [path[index]]: wrapped };
+  }
+  return wrapped;
+}
+
+/**
+ * The single op that ends a scrub.
+ *
+ * Separate from the preview and deliberately not derived from it: the preview
+ * is CSS the canvas throws away, and the commit is a document edit. Passing one
+ * through the other would make the stored value a function of a string that was
+ * built for display.
+ */
+export function scrubCommitOp(
+  target: ScrubTarget,
+  styles: Parameters<typeof styleWriteOp>[1],
+  value: StyleValue
+): StyleWrite {
+  return styleWriteOp(target.nodeId, styles, target.address, value);
+}

--- a/packages/builder/src/style-scrub.ts
+++ b/packages/builder/src/style-scrub.ts
@@ -70,6 +70,17 @@ export interface ScrubTarget {
    */
   readonly scope?: string;
   readonly address: StyleAddress;
+  /**
+   * The custom-property prefix this site emits tokens under.
+   *
+   * `compilePageCss` takes it from `StyleCompileContext.tokenPrefix`, so a site
+   * that configured `--acme-` would have its published sheet read
+   * `var(--acme-brand)` while a preview compiled with the default read
+   * `var(--site-brand)` — a token that resolves to nothing, or to a different
+   * value, for exactly as long as the drag lasts. Omitted means the engine's
+   * own default, which is what the compiler falls back to.
+   */
+  readonly tokenPrefix?: string;
   /** The site policy, forwarded to the compile so a refused URL never previews. */
   readonly policy?: StylePolicy;
 }
@@ -129,7 +140,7 @@ export function scrubPreviewCss(
   const compiled = compileStyleValues(
     { [property]: valueAtPath(path, value) },
     "",
-    undefined,
+    target.tokenPrefix,
     undefined,
     undefined,
     { mayFetchUrl: target.policy?.mayFetchUrl }

--- a/packages/builder/src/style-scrub.ts
+++ b/packages/builder/src/style-scrub.ts
@@ -189,8 +189,27 @@ export function scrubStateFragments(): ReadonlyMap<StyleState, string> {
   return STATE_FRAGMENTS;
 }
 
-/** At-rules already derived, per breakpoint set and id. */
-const AT_RULES = new WeakMap<BreakpointSet, Map<string, string | null>>();
+/**
+ * At-rules already derived, per breakpoint set and id.
+ *
+ * Held against the set OBJECT, and checked against its CONTENT. Identity alone
+ * is not enough: a host that edits a definition in place keeps the same object,
+ * so a cache keyed on identity keeps answering with the old query — measured, a
+ * `mobile` breakpoint previewed at 640px still emitted `@media (max-width:
+ * 640px)` after its `maxWidth` became 320, while the next compile used 320.
+ * The preview would then sit at a width where the committed value is absent.
+ *
+ * The content key is recomputed per lookup and the entries dropped when it
+ * moves, which keeps this bounded by the number of live sets rather than by how
+ * often one is edited. Serializing a handful of definitions costs far less than
+ * the probe compile it saves.
+ */
+interface AtRuleCache {
+  content: string;
+  perId: Map<string, string | null>;
+}
+
+const AT_RULES = new WeakMap<BreakpointSet, AtRuleCache>();
 
 /**
  * The at-rule the compiler wraps one breakpoint's declarations in.
@@ -208,12 +227,13 @@ function breakpointAtRule(
   breakpoints: BreakpointSet,
   id: string
 ): string | null {
-  let perId = AT_RULES.get(breakpoints);
-  if (perId === undefined) {
-    perId = new Map();
-    AT_RULES.set(breakpoints, perId);
+  const content = JSON.stringify(breakpoints);
+  let entry = AT_RULES.get(breakpoints);
+  if (entry === undefined || entry.content !== content) {
+    entry = { content, perId: new Map() };
+    AT_RULES.set(breakpoints, entry);
   }
-  const cached = perId.get(id);
+  const cached = entry.perId.get(id);
   if (cached !== undefined) return cached;
   const document: BlockDocument = {
     formatVersion: 1,
@@ -231,7 +251,7 @@ function breakpointAtRule(
   const css = compilePageCss(document, { breakpoints }).css.trim();
   const wrapper = /^@[a-z-]+[^{]*/.exec(css);
   const derived = css === "" ? null : wrapper === null ? "" : wrapper[0].trim();
-  perId.set(id, derived);
+  entry.perId.set(id, derived);
   return derived;
 }
 

--- a/packages/builder/src/style-scrub.ts
+++ b/packages/builder/src/style-scrub.ts
@@ -19,25 +19,29 @@
  * construction rather than by both remembering to check.
  *
  * **The rule sits at the compiler's own specificity and wins on ORDER.** It is
- * anchored to `PAGE_ROOT_SELECTOR`, which is where the override contract lives;
- * spelling a stronger selector here would quietly raise that contract for the
- * duration of a drag, so the preview would land where the committed value will
- * not. The consequence for the host is that the element holding this text must
- * come AFTER the compiled sheet — later of two equals wins — and removing it on
- * commit reveals the real rule underneath with no visible change.
+ * anchored to the same root the compiled sheet uses — `PAGE_ROOT_SELECTOR`,
+ * plus the document's scope class when it has one — because that is where the
+ * override contract lives. Spelling a stronger selector would quietly raise
+ * that contract for the duration of a drag, so the preview would land where the
+ * committed value will not; spelling a weaker one loses to the rule being
+ * previewed over, and the drag shows nothing move. The consequence for the host
+ * is that the element holding this text must come AFTER the compiled sheet —
+ * later of two equals wins — and removing it on commit reveals the real rule
+ * underneath with no visible change.
  *
  * @module style-scrub
  */
 
 import {
   compileStyleValues,
+  escapeIdentifier,
   PAGE_ROOT_SELECTOR,
   type Declaration,
   type StyleValue,
   type ValidationIssue,
 } from "@nextlyhq/blocks-engine";
 
-import type { StyleAddress, StyleWrite } from "./style-values";
+import type { StyleAddress, StylePolicy, StyleWrite } from "./style-values";
 import { styleWriteOp } from "./style-values";
 
 /** The node a scrub is previewing against. */
@@ -52,7 +56,28 @@ export interface ScrubTarget {
    * exactly the documents where the compiler had already disambiguated.
    */
   readonly nodeClass: string;
+  /**
+   * The document's compile scope, when it has one.
+   *
+   * `compilePageCss` anchors every rule to `${PAGE_ROOT_SELECTOR}.${scope}`, so
+   * a preview that spelled the unscoped root would sit one class BELOW the rule
+   * it is previewing over — the stored value would win and the drag would show
+   * nothing move. It would also reach a same-class node in another document
+   * rendered beside this one.
+   *
+   * Escaped through the engine's own `escapeIdentifier`, so the preview and the
+   * compiled sheet cannot disagree about a scope needing escapes.
+   */
+  readonly scope?: string;
   readonly address: StyleAddress;
+  /** The site policy, forwarded to the compile so a refused URL never previews. */
+  readonly policy?: StylePolicy;
+}
+
+/** The root every rule for this document is anchored to. */
+function rootSelector(scope: string | undefined): string {
+  if (scope === undefined || scope === "") return PAGE_ROOT_SELECTOR;
+  return `${PAGE_ROOT_SELECTOR}.${escapeIdentifier(scope)}`;
 }
 
 /** CSS for the value under the pointer, or the reasons it was refused. */
@@ -71,9 +96,10 @@ export type ScrubPreview =
  * the engine already has, kept in step by nothing.
  */
 function ruleText(
-  nodeClass: string,
+  target: ScrubTarget,
   declarations: readonly Declaration[]
 ): string {
+  const root = rootSelector(target.scope);
   return declarations
     .map(declaration => {
       const descendant =
@@ -81,7 +107,7 @@ function ruleText(
           ? ""
           : ` ${declaration.descendant}`;
       return (
-        `${PAGE_ROOT_SELECTOR} .${nodeClass}${descendant} ` +
+        `${root} .${target.nodeClass}${descendant} ` +
         `{ ${declaration.property}: ${declaration.value} }`
       );
     })
@@ -102,7 +128,11 @@ export function scrubPreviewCss(
   const { property, path } = target.address;
   const compiled = compileStyleValues(
     { [property]: valueAtPath(path, value) },
-    ""
+    "",
+    undefined,
+    undefined,
+    undefined,
+    { mayFetchUrl: target.policy?.mayFetchUrl }
   );
   // The compiler reports only what it REFUSED, and refuses the whole map when
   // it cannot check it. So anything reported means this value is not one the
@@ -114,7 +144,7 @@ export function scrubPreviewCss(
   if (compiled.declarations.length === 0) {
     return { ok: false, issues: [] };
   }
-  return { ok: true, css: ruleText(target.nodeClass, compiled.declarations) };
+  return { ok: true, css: ruleText(target, compiled.declarations) };
 }
 
 /**
@@ -145,5 +175,11 @@ export function scrubCommitOp(
   styles: Parameters<typeof styleWriteOp>[1],
   value: StyleValue
 ): StyleWrite {
-  return styleWriteOp(target.nodeId, styles, target.address, value);
+  return styleWriteOp(
+    target.nodeId,
+    styles,
+    target.address,
+    value,
+    target.policy
+  );
 }

--- a/packages/builder/src/style-scrub.ts
+++ b/packages/builder/src/style-scrub.ts
@@ -33,16 +33,21 @@
  */
 
 import {
+  compilePageCss,
   compileStyleValues,
   escapeIdentifier,
+  nodeClassName,
   PAGE_ROOT_SELECTOR,
+  STYLE_STATES,
+  type BlockDocument,
   type Declaration,
+  type StyleState,
   type StyleValue,
   type ValidationIssue,
 } from "@nextlyhq/blocks-engine";
 
 import type { StyleAddress, StylePolicy, StyleWrite } from "./style-values";
-import { styleWriteOp } from "./style-values";
+import { styleValueAtPath, styleWriteOp } from "./style-values";
 
 /** The node a scrub is previewing against. */
 export interface ScrubTarget {
@@ -83,6 +88,80 @@ export interface ScrubTarget {
   readonly tokenPrefix?: string;
   /** The site policy, forwarded to the compile so a refused URL never previews. */
   readonly policy?: StylePolicy;
+}
+
+/**
+ * The fragment the compiler constrains one state's rules with, per state.
+ *
+ * READ from the compiler rather than restated here. `compilePageCss` appends
+ * `:where(:hover)` and its siblings from a table it does not export, so a copy
+ * would be a second statement of which pseudo-class each state means — and the
+ * two would agree until the engine moved, at which point a hover preview would
+ * land somewhere the committed rule does not. Compiling one probe per state and
+ * taking the fragment out of the selector it produced cannot drift.
+ *
+ * Without it a preview matches the node in EVERY state: dragging a hover value
+ * would repaint the resting appearance too, and releasing would reveal
+ * behaviour the drag never showed.
+ *
+ * Four states, computed once.
+ */
+const STATE_FRAGMENTS = new Map<StyleState, string>();
+
+/** The probe node's id, used only to derive the fragments above. */
+const PROBE_ID = "scrub-state-probe";
+
+/** Compile one probe document and return the selector it wrote. */
+function probeSelector(state: StyleState): string {
+  const document: BlockDocument = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      {
+        id: PROBE_ID,
+        type: "core/box",
+        version: 1,
+        props: {},
+        // A property with no descendant, so the selector carries the state
+        // fragment and nothing else after the node class.
+        styles: { [state]: { base: { height: "1px" } } },
+      },
+    ],
+  };
+  const compiled = compilePageCss(document, {
+    breakpoints: { viewport: [{ id: "base", label: "Base" }], container: [] },
+  });
+  return compiled.css.split("{")[0].trim();
+}
+
+/**
+ * What a state adds to a node's selector.
+ *
+ * Falls back to constraining nothing only for `base`, which genuinely adds
+ * nothing. For any other state a fragment that could not be derived would mean
+ * previewing in the wrong place, so this throws rather than emitting a rule
+ * that silently repaints the resting appearance.
+ */
+function stateFragment(state: StyleState): string {
+  const cached = STATE_FRAGMENTS.get(state);
+  if (cached !== undefined) return cached;
+  const prefix = `${PAGE_ROOT_SELECTOR} .${nodeClassName(PROBE_ID)}`;
+  const selector = probeSelector(state);
+  if (!selector.startsWith(prefix)) {
+    throw new Error(
+      `the compiler's selector for the ${state} state no longer starts with ` +
+        `the node's own selector, so a preview cannot be placed beside it`
+    );
+  }
+  const fragment = selector.slice(prefix.length);
+  STATE_FRAGMENTS.set(state, fragment);
+  return fragment;
+}
+
+/** Every state's fragment, for a caller that wants them warmed or asserted. */
+export function scrubStateFragments(): ReadonlyMap<StyleState, string> {
+  for (const state of STYLE_STATES) stateFragment(state);
+  return STATE_FRAGMENTS;
 }
 
 /** The root every rule for this document is anchored to. */
@@ -126,6 +205,7 @@ function ruleText(
   declarations: readonly Declaration[]
 ): string {
   const root = rootSelector(target.scope);
+  const state = stateFragment(target.address.state);
   return declarations
     .map(declaration => {
       const descendant =
@@ -133,7 +213,7 @@ function ruleText(
           ? ""
           : ` ${declaration.descendant}`;
       return (
-        `${root} .${target.nodeClass}${descendant} ` +
+        `${root} .${target.nodeClass}${state}${descendant} ` +
         `{ ${declaration.property}: ${declaration.value} }`
       );
     })
@@ -153,7 +233,7 @@ export function scrubPreviewCss(
 ): ScrubPreview {
   const { property, path } = target.address;
   const compiled = compileStyleValues(
-    { [property]: valueAtPath(path, value) },
+    { [property]: styleValueAtPath(path, value) },
     "",
     target.tokenPrefix,
     undefined,
@@ -177,21 +257,6 @@ export function scrubPreviewCss(
     css: ruleText(target, compiled.declarations),
     warnings: compiled.warnings,
   };
-}
-
-/**
- * A value wrapped in the containers its path names.
- *
- * A control scrubbing one side of a margin holds a length and an address; the
- * compiler takes the property's whole value. Building the containers here keeps
- * the preview compiling the same shape the commit will store.
- */
-function valueAtPath(path: readonly string[], value: StyleValue): StyleValue {
-  let wrapped = value;
-  for (let index = path.length - 1; index >= 0; index -= 1) {
-    wrapped = { [path[index]]: wrapped };
-  }
-  return wrapped;
 }
 
 /**

--- a/packages/builder/src/style-scrub.ts
+++ b/packages/builder/src/style-scrub.ts
@@ -402,6 +402,13 @@ export function scrubCommitOp(
   styles: Parameters<typeof styleWriteOp>[1],
   value: StyleValue
 ): StyleWrite {
+  // The SAME breakpoint decision the preview makes. A breakpoint removed while
+  // a drag was in flight makes `scrubPreviewCss` refuse, and a commit that
+  // ignored the set would persist a value `compilePageCss` never emits — the
+  // drag would end by storing something the page cannot show.
+  if (atRuleFor(target) === null) {
+    return { ok: false, issues: [] };
+  }
   return styleWriteOp(
     target.nodeId,
     styles,

--- a/packages/builder/src/style-values.test.ts
+++ b/packages/builder/src/style-values.test.ts
@@ -1,5 +1,12 @@
-import type { NodeStyles } from "@nextlyhq/blocks-engine";
+import {
+  DOCUMENT_FORMAT_VERSION,
+  type BlockDocument,
+  type BlockNode,
+  type NodeStyles,
+} from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
+
+import { applyOp, type BuilderOp } from "./ops";
 
 import {
   readStyleValue,
@@ -22,10 +29,24 @@ const WITH_MARGIN: NodeStyles = {
 };
 
 /** The `styles` a write op carries, for asserting on the resulting envelope. */
-function patchedStyles(op: {
-  patch: { styles?: NodeStyles };
-}): NodeStyles | undefined {
-  return op.patch.styles;
+function patchedStyles(op: BuilderOp | null): NodeStyles | undefined {
+  if (op === null || op.kind !== "update") return undefined;
+  return (op.patch as { styles?: NodeStyles }).styles;
+}
+
+/** One node carrying the styles under test, in a document `applyOp` accepts. */
+function documentWith(styles: NodeStyles | undefined): BlockDocument {
+  const node: BlockNode = {
+    id: "n1",
+    type: "core/box",
+    version: 1,
+    props: {},
+  };
+  return {
+    formatVersion: DOCUMENT_FORMAT_VERSION,
+    kind: "page",
+    nodes: [styles === undefined ? node : { ...node, styles }],
+  };
 }
 
 describe("reading a control's value", () => {
@@ -71,7 +92,7 @@ describe("writing a control's value", () => {
     const result = styleWriteOp("n1", both, BOTTOM, "32px");
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(patchedStyles(result.op as never)).toEqual({
+    expect(patchedStyles(result.op)).toEqual({
       base: { desktop: { margin: { blockStart: "8px", blockEnd: "32px" } } },
     });
   });
@@ -83,9 +104,7 @@ describe("writing a control's value", () => {
     const result = styleWriteOp("n1", withHeight, BOTTOM, "32px");
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(patchedStyles(result.op as never)?.base?.desktop?.height).toBe(
-      "48px"
-    );
+    expect(patchedStyles(result.op)?.base?.desktop?.height).toBe("48px");
   });
 
   it("leaves the envelope it was handed untouched", () => {
@@ -129,7 +148,7 @@ describe("clearing a control's value", () => {
     const result = styleClearOp("n1", both, BOTTOM);
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(patchedStyles(result.op as never)).toEqual({
+    expect(patchedStyles(result.op)).toEqual({
       base: { desktop: { margin: { blockStart: "8px" } } },
     });
   });
@@ -144,7 +163,7 @@ describe("clearing a control's value", () => {
     const result = styleClearOp("n1", two, BOTTOM);
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(patchedStyles(result.op as never)).toEqual({
+    expect(patchedStyles(result.op)).toEqual({
       base: { mobile: { height: "10px" } },
     });
   });
@@ -157,18 +176,75 @@ describe("clearing a control's value", () => {
     const result = styleClearOp("n1", two, BOTTOM);
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(patchedStyles(result.op as never)).toEqual({
+    expect(patchedStyles(result.op)).toEqual({
       hover: { desktop: { height: "10px" } },
     });
   });
 
-  it("is a no-op envelope when the value was not set to begin with", () => {
+  it("answers with NO op when the value was not set to begin with", () => {
+    // `applyOp` refuses an update that changes nothing, so handing back an op
+    // here would advertise one that throws — and resetting an already-unset
+    // control is an ordinary thing for an author to do.
     const result = styleClearOp("n1", WITH_MARGIN, {
       ...BOTTOM,
       path: ["blockStart"],
     });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(patchedStyles(result.op as never)).toEqual(WITH_MARGIN);
+    expect(result.op).toBeNull();
+  });
+
+  it("answers with NO op when the node has no styles at all", () => {
+    const result = styleClearOp("n1", undefined, BOTTOM);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.op).toBeNull();
+  });
+});
+
+describe("every op this SDK hands back can actually be applied", () => {
+  // The property the assertions above cannot reach: they inspect the op's
+  // PATCH, and a patch of the right shape still throws at `applyOp` when it
+  // changes nothing. Applying it is the only thing that separates the two.
+
+  it("applies a write to a node with no styles", () => {
+    const result = styleWriteOp("n1", undefined, BOTTOM, "32px");
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.op === null) throw new Error("expected an op");
+    const applied = applyOp(documentWith(undefined), result.op);
+    expect(applied.document.nodes[0].styles).toEqual({
+      base: { desktop: { margin: { blockEnd: "32px" } } },
+    });
+  });
+
+  it("applies a clear that removes the last style", () => {
+    const result = styleClearOp("n1", WITH_MARGIN, BOTTOM);
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.op === null) throw new Error("expected an op");
+    const applied = applyOp(documentWith(WITH_MARGIN), result.op);
+    expect(applied.document.nodes[0].styles).toBeUndefined();
+  });
+
+  it("answers with NO op when the node already holds the value being written", () => {
+    // Retyping the value a control already shows. An op here would carry a
+    // patch identical to what the node holds, which `applyOp` refuses.
+    const result = styleWriteOp("n1", WITH_MARGIN, BOTTOM, "24px");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.op).toBeNull();
+  });
+
+  it("throws if a no-op op were handed back, which is why null is", () => {
+    // The positive control for the two null answers above: it demonstrates
+    // that the refusal being avoided is real, so `toBeNull()` is evidence of
+    // something rather than an assertion about an arbitrary choice.
+    const noOp: BuilderOp = {
+      kind: "update",
+      id: "n1",
+      patch: { styles: WITH_MARGIN },
+    };
+    expect(() => applyOp(documentWith(WITH_MARGIN), noOp)).toThrow(
+      /changes nothing/
+    );
   });
 });

--- a/packages/builder/src/style-values.test.ts
+++ b/packages/builder/src/style-values.test.ts
@@ -248,3 +248,65 @@ describe("every op this SDK hands back can actually be applied", () => {
     );
   });
 });
+
+describe("what a write is judged against", () => {
+  it("is not blocked by an invalid SIBLING of the same composite", () => {
+    // Narrowing to the catalog property is not enough: a malformed top margin
+    // would block every other side, and the control could not be edited until
+    // a sibling nobody is touching is repaired.
+    const badSibling: NodeStyles = {
+      base: {
+        desktop: { margin: { blockStart: "notalength", blockEnd: "24px" } },
+      },
+    };
+    const result = styleWriteOp("n1", badSibling, BOTTOM, "32px");
+    expect(result.ok).toBe(true);
+  });
+
+  it("still judges the leaf being written", () => {
+    // The other half: scoping to the leaf must not stop that leaf being checked.
+    expect(styleWriteOp("n1", undefined, BOTTOM, "notalength").ok).toBe(false);
+  });
+
+  it("lets a reset through even when a sibling is invalid", () => {
+    const badSibling: NodeStyles = {
+      base: {
+        desktop: { margin: { blockStart: "notalength", blockEnd: "24px" } },
+      },
+    };
+    const result = styleClearOp("n1", badSibling, BOTTOM);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.op).not.toBeNull();
+  });
+
+  it("reports a token the site does not define, when given the table", () => {
+    // Without a lookup the validator cannot report `unknown-token`, so a
+    // control silently accepts a reference that renders as nothing.
+    const unknown = styleWriteOp(
+      "n1",
+      undefined,
+      BOTTOM,
+      { $token: "space.nosuch" },
+      { tokens: { kindOf: () => undefined } }
+    );
+    expect(unknown.ok).toBe(true);
+    if (!unknown.ok) return;
+    expect(unknown.warnings.length).toBeGreaterThan(0);
+  });
+
+  it("reports nothing for a token the site DOES define", () => {
+    // The control that makes the warning above evidence: if every token warned,
+    // the assertion would say nothing about the lookup being consulted.
+    const known = styleWriteOp(
+      "n1",
+      undefined,
+      BOTTOM,
+      { $token: "space.large" },
+      { tokens: { kindOf: () => "dimension" } }
+    );
+    expect(known.ok).toBe(true);
+    if (!known.ok) return;
+    expect(known.warnings).toEqual([]);
+  });
+});

--- a/packages/builder/src/style-values.test.ts
+++ b/packages/builder/src/style-values.test.ts
@@ -347,3 +347,51 @@ describe("a breakpoint id JavaScript treats specially", () => {
     );
   });
 });
+
+describe("values reached only through a prototype", () => {
+  // The engine reads style maps by OWN keys — `validateStyleValues` guards with
+  // `Object.hasOwn` in three places — so a document carrying prototype-bearing
+  // maps is validated and compiled from own keys alone. Reading any wider shows
+  // an author a value the page will not carry, and spreads it into the op.
+
+  /** A margin whose sibling side exists only on the prototype. */
+  function inheritedSibling(): NodeStyles {
+    const margin = Object.create({ blockStart: "999px" }) as Record<
+      string,
+      unknown
+    >;
+    margin.blockEnd = "24px";
+    return { base: { desktop: { margin } } } as NodeStyles;
+  }
+
+  it("does not read a side that is only inherited", () => {
+    const address: StyleAddress = { ...BOTTOM, path: ["blockStart"] };
+    expect(readStyleValue(inheritedSibling(), address)).toBeUndefined();
+  });
+
+  it("still reads the side the map owns", () => {
+    // The control: guarding must not hide own values.
+    expect(readStyleValue(inheritedSibling(), BOTTOM)).toBe("24px");
+  });
+
+  it("does not persist an inherited side into the stored op", () => {
+    const result = styleWriteOp("n1", inheritedSibling(), BOTTOM, "32px");
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.op === null) throw new Error("expected an op");
+    expect(patchedStyles(result.op)).toEqual({
+      base: { desktop: { margin: { blockEnd: "32px" } } },
+    });
+  });
+
+  it("does not read a breakpoint reached through a prototype", () => {
+    const breakpoints = Object.create({
+      desktop: { margin: { blockEnd: "999px" } },
+    }) as Record<string, unknown>;
+    breakpoints.mobile = { margin: { blockEnd: "8px" } };
+    const styles = { base: breakpoints } as NodeStyles;
+    expect(readStyleValue(styles, BOTTOM)).toBeUndefined();
+    expect(readStyleValue(styles, { ...BOTTOM, breakpoint: "mobile" })).toBe(
+      "8px"
+    );
+  });
+});

--- a/packages/builder/src/style-values.test.ts
+++ b/packages/builder/src/style-values.test.ts
@@ -310,3 +310,40 @@ describe("what a write is judged against", () => {
     expect(known.warnings).toEqual([]);
   });
 });
+
+describe("a breakpoint id JavaScript treats specially", () => {
+  // Nothing in `validateBreakpoints` restricts a breakpoint id's characters, so
+  // a site may define `__proto__`. Assigning it on an ordinary object reaches
+  // the legacy prototype setter instead of creating a key — measured: after
+  // `obj["__proto__"] = v`, `Object.keys(obj)` is empty.
+  const PROTO: StyleAddress = { ...BOTTOM, breakpoint: "__proto__" };
+
+  it("authors a first value there instead of reporting nothing to do", () => {
+    const result = styleWriteOp("n1", undefined, PROTO, "32px");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.op).not.toBeNull();
+  });
+
+  it("stores it as an own key the document can carry", () => {
+    const result = styleWriteOp("n1", undefined, PROTO, "32px");
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.op === null) throw new Error("expected an op");
+    const styles = patchedStyles(result.op);
+    const breakpoints = styles?.base as Record<string, unknown> | undefined;
+    expect(breakpoints).toBeDefined();
+    expect(Object.prototype.hasOwnProperty.call(breakpoints, "__proto__")).toBe(
+      true
+    );
+    expect(Object.keys(breakpoints ?? {})).toContain("__proto__");
+  });
+
+  it("applies, and reads back through the ordinary accessor", () => {
+    const result = styleWriteOp("n1", undefined, PROTO, "32px");
+    if (!result.ok || result.op === null) throw new Error("expected an op");
+    const applied = applyOp(documentWith(undefined), result.op);
+    expect(readStyleValue(applied.document.nodes[0].styles, PROTO)).toBe(
+      "32px"
+    );
+  });
+});

--- a/packages/builder/src/style-values.test.ts
+++ b/packages/builder/src/style-values.test.ts
@@ -1,0 +1,174 @@
+import type { NodeStyles } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import {
+  readStyleValue,
+  styleClearOp,
+  styleWriteOp,
+  type StyleAddress,
+} from "./style-values";
+
+/** The bottom margin at the base state and breakpoint, the worked example throughout. */
+const BOTTOM: StyleAddress = {
+  state: "base",
+  breakpoint: "desktop",
+  property: "margin",
+  path: ["blockEnd"],
+};
+
+/** A node carrying one authored bottom margin. */
+const WITH_MARGIN: NodeStyles = {
+  base: { desktop: { margin: { blockEnd: "24px" } } },
+};
+
+/** The `styles` a write op carries, for asserting on the resulting envelope. */
+function patchedStyles(op: {
+  patch: { styles?: NodeStyles };
+}): NodeStyles | undefined {
+  return op.patch.styles;
+}
+
+describe("reading a control's value", () => {
+  it("reads through the path the descriptor gave it", () => {
+    expect(readStyleValue(WITH_MARGIN, BOTTOM)).toBe("24px");
+  });
+
+  it("answers undefined where nothing is set, which is a real answer", () => {
+    expect(
+      readStyleValue(WITH_MARGIN, { ...BOTTOM, path: ["blockStart"] })
+    ).toBeUndefined();
+    expect(readStyleValue(undefined, BOTTOM)).toBeUndefined();
+    expect(
+      readStyleValue(WITH_MARGIN, { ...BOTTOM, breakpoint: "mobile" })
+    ).toBeUndefined();
+    expect(
+      readStyleValue(WITH_MARGIN, { ...BOTTOM, state: "hover" })
+    ).toBeUndefined();
+  });
+
+  it("does not descend into a token reference looking for a side", () => {
+    // `{ $token }` is one value spelled as an object. Descending into it would
+    // report the token's own key as though it were a box side.
+    const tokenised: NodeStyles = {
+      base: { desktop: { margin: { $token: "Space.Large" } } },
+    };
+    expect(readStyleValue(tokenised, BOTTOM)).toBeUndefined();
+  });
+});
+
+describe("writing a control's value", () => {
+  it("produces exactly ONE update op, which is one undo step", () => {
+    const result = styleWriteOp("n1", undefined, BOTTOM, "32px");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.op).toMatchObject({ kind: "update", id: "n1" });
+  });
+
+  it("keeps the siblings a composite already held", () => {
+    const both: NodeStyles = {
+      base: { desktop: { margin: { blockStart: "8px", blockEnd: "24px" } } },
+    };
+    const result = styleWriteOp("n1", both, BOTTOM, "32px");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(patchedStyles(result.op as never)).toEqual({
+      base: { desktop: { margin: { blockStart: "8px", blockEnd: "32px" } } },
+    });
+  });
+
+  it("keeps the other properties at the same breakpoint", () => {
+    const withHeight: NodeStyles = {
+      base: { desktop: { height: "48px", margin: { blockEnd: "24px" } } },
+    };
+    const result = styleWriteOp("n1", withHeight, BOTTOM, "32px");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(patchedStyles(result.op as never)?.base?.desktop?.height).toBe(
+      "48px"
+    );
+  });
+
+  it("leaves the envelope it was handed untouched", () => {
+    // The editor renders from the document it holds, so a write that mutated a
+    // nested level would change a value the current render is still showing.
+    const before = JSON.stringify(WITH_MARGIN);
+    styleWriteOp("n1", WITH_MARGIN, BOTTOM, "32px");
+    expect(JSON.stringify(WITH_MARGIN)).toBe(before);
+  });
+
+  it("refuses a value the catalog rejects, and says why", () => {
+    const result = styleWriteOp("n1", WITH_MARGIN, BOTTOM, "notalength");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues.length).toBeGreaterThan(0);
+    expect(result.issues.every(issue => issue.severity === "error")).toBe(true);
+  });
+
+  it("does not re-check the grammar itself — a value the catalog accepts is written", () => {
+    // The separating property against a control that carried its own unit list:
+    // `rem` is legal and a hand-kept list of units is exactly what omits it.
+    const result = styleWriteOp("n1", undefined, BOTTOM, "1.5rem");
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("clearing a control's value", () => {
+  it("removes the entry rather than storing an empty one", () => {
+    // A stored empty value pins the property to nothing here and beats the tier
+    // the author was asking to see again.
+    const result = styleClearOp("n1", WITH_MARGIN, BOTTOM);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.op).toMatchObject({ unset: ["styles"] });
+  });
+
+  it("keeps a sibling side and the property with it", () => {
+    const both: NodeStyles = {
+      base: { desktop: { margin: { blockStart: "8px", blockEnd: "24px" } } },
+    };
+    const result = styleClearOp("n1", both, BOTTOM);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(patchedStyles(result.op as never)).toEqual({
+      base: { desktop: { margin: { blockStart: "8px" } } },
+    });
+  });
+
+  it("prunes the breakpoint when its last property goes", () => {
+    const two: NodeStyles = {
+      base: {
+        desktop: { margin: { blockEnd: "24px" } },
+        mobile: { height: "10px" },
+      },
+    };
+    const result = styleClearOp("n1", two, BOTTOM);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(patchedStyles(result.op as never)).toEqual({
+      base: { mobile: { height: "10px" } },
+    });
+  });
+
+  it("prunes the state when its last breakpoint goes", () => {
+    const two: NodeStyles = {
+      base: { desktop: { margin: { blockEnd: "24px" } } },
+      hover: { desktop: { height: "10px" } },
+    };
+    const result = styleClearOp("n1", two, BOTTOM);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(patchedStyles(result.op as never)).toEqual({
+      hover: { desktop: { height: "10px" } },
+    });
+  });
+
+  it("is a no-op envelope when the value was not set to begin with", () => {
+    const result = styleClearOp("n1", WITH_MARGIN, {
+      ...BOTTOM,
+      path: ["blockStart"],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(patchedStyles(result.op as never)).toEqual(WITH_MARGIN);
+  });
+});

--- a/packages/builder/src/style-values.ts
+++ b/packages/builder/src/style-values.ts
@@ -121,6 +121,20 @@ function isComposite(value: StyleValue | undefined): value is CompositeValue {
   return typeof value === "object" && value !== null && !isTokenRef(value);
 }
 
+/**
+ * A value's OWN entry at a name, ignoring anything reached through a prototype.
+ *
+ * The engine reads style maps this way — `validateStyleValues` and the shape
+ * walk beside it both guard with `Object.hasOwn` — so a document carrying
+ * prototype-bearing maps, or running under a polluted `Object.prototype`, is
+ * validated and compiled from own keys alone. Reading any wider here would show
+ * an author a value the page will not carry, and spread it into the op that
+ * stores it; an inherited accessor would also RUN during the read.
+ */
+function ownValue(value: CompositeValue, name: string): StyleValue | undefined {
+  return Object.hasOwn(value, name) ? value[name] : undefined;
+}
+
 /** The value at a path inside one property's stored value. */
 function readAtPath(
   value: StyleValue | undefined,
@@ -129,7 +143,7 @@ function readAtPath(
   let at = value;
   for (const step of path) {
     if (!isComposite(at)) return undefined;
-    at = at[step];
+    at = ownValue(at, step);
   }
   return at;
 }
@@ -154,7 +168,7 @@ function writeAtPath(
   // stored as one measurement, then edited per corner — and preserving the
   // scalar would leave a value that is neither arm.
   const parent: CompositeValue = isComposite(value) ? value : {};
-  return { ...parent, [step]: writeAtPath(parent[step], rest, next) };
+  return { ...parent, [step]: writeAtPath(ownValue(parent, step), rest, next) };
 }
 
 /**
@@ -172,8 +186,11 @@ function clearAtPath(
   if (path.length === 0) return undefined;
   if (!isComposite(value)) return value;
   const [step, ...rest] = path;
-  if (!(step in value)) return value;
-  const next = clearAtPath(value[step], rest);
+  // `in` walks the prototype chain, so an inherited name would be "cleared"
+  // from an own map that never held it — materialising the inherited value as
+  // an own key on the way.
+  if (!Object.hasOwn(value, step)) return value;
+  const next = clearAtPath(ownValue(value, step), rest);
   const remaining: Record<string, StyleValue> = { ...value };
   if (next === undefined) delete remaining[step];
   else remaining[step] = next;
@@ -204,8 +221,29 @@ export function readStyleValue(
   styles: NodeStyles | undefined,
   address: StyleAddress
 ): StyleValue | undefined {
-  const values = styles?.[address.state]?.[address.breakpoint];
-  return readAtPath(values?.[address.property], address.path);
+  const values = valuesAt(styles, address.state, address.breakpoint);
+  if (values === undefined) return undefined;
+  return readAtPath(ownValue(values, address.property), address.path);
+}
+
+/**
+ * The stored values at one state × breakpoint, by own keys at every level.
+ *
+ * Both levels are guarded for the reason the path walk is: the envelope is a
+ * plain object, and a state or breakpoint name reached through a prototype is
+ * one the compiler will not read.
+ */
+function valuesAt(
+  styles: NodeStyles | undefined,
+  state: StyleState,
+  breakpoint: BreakpointId
+): StyleValues | undefined {
+  if (styles === undefined || !Object.hasOwn(styles, state)) return undefined;
+  const breakpoints = styles[state];
+  if (breakpoints === undefined || !Object.hasOwn(breakpoints, breakpoint)) {
+    return undefined;
+  }
+  return breakpoints[breakpoint];
 }
 
 /** The whole envelope with one state × breakpoint replaced, pruning what empties. */
@@ -327,11 +365,11 @@ export function styleWriteOp(
   value: StyleValue,
   policy?: StylePolicy
 ): StyleWrite {
-  const current = styles?.[address.state]?.[address.breakpoint];
+  const current = valuesAt(styles, address.state, address.breakpoint);
   const values: StyleValues = {
     ...current,
     [address.property]: writeAtPath(
-      current?.[address.property],
+      current === undefined ? undefined : ownValue(current, address.property),
       address.path,
       value
     ),
@@ -361,9 +399,14 @@ export function styleClearOp(
   address: StyleAddress,
   policy?: StylePolicy
 ): StyleWrite {
-  const current = styles?.[address.state]?.[address.breakpoint];
+  const current = valuesAt(styles, address.state, address.breakpoint);
   const values: StyleValues = { ...current };
-  const remaining = clearAtPath(values[address.property], address.path);
+  const remaining = clearAtPath(
+    Object.hasOwn(values, address.property)
+      ? values[address.property]
+      : undefined,
+    address.path
+  );
   if (remaining === undefined) delete values[address.property];
   else values[address.property] = remaining;
   // Nothing is being written, so there is nothing to judge: removing a value

--- a/packages/builder/src/style-values.ts
+++ b/packages/builder/src/style-values.ts
@@ -29,6 +29,7 @@ import {
   type StyleState,
   type StyleValue,
   type StyleValues,
+  type TokenLookup,
   type ValidationIssue,
 } from "@nextlyhq/blocks-engine";
 
@@ -46,6 +47,16 @@ import { sameStoredValue, type BuilderOp } from "./ops";
  */
 export interface StylePolicy {
   readonly mayFetchUrl?: MayFetchUrl;
+  /**
+   * The site's token table.
+   *
+   * Without it the validator cannot report `unknown-token` or
+   * `token-kind-mismatch`, so a control silently accepts a reference that
+   * renders as nothing. `styleControlsFor` already takes one for choosing a
+   * union arm; carrying it here is what gives a caller one route to supply it
+   * to both.
+   */
+  readonly tokens?: TokenLookup;
 }
 
 /** Where a control reads and writes. */
@@ -169,6 +180,25 @@ function clearAtPath(
   return Object.keys(remaining).length === 0 ? undefined : remaining;
 }
 
+/**
+ * A value wrapped in the containers its path names.
+ *
+ * A control holds a scalar and an address; both the validator and the compiler
+ * take the property's WHOLE value. Building the containers in one place is what
+ * lets the commit judge exactly the shape the preview compiled — two copies
+ * would agree until either moved.
+ */
+export function styleValueAtPath(
+  path: readonly string[],
+  value: StyleValue
+): StyleValue {
+  let wrapped = value;
+  for (let index = path.length - 1; index >= 0; index -= 1) {
+    wrapped = { [path[index]]: wrapped };
+  }
+  return wrapped;
+}
+
 /** The value a control is currently showing, or `undefined` when nothing set it. */
 export function readStyleValue(
   styles: NodeStyles | undefined,
@@ -234,24 +264,24 @@ function writeResult(
   before: NodeStyles | undefined,
   after: NodeStyles,
   values: StyleValues,
-  property: string,
+  subject: StyleValues,
   policy: StylePolicy | undefined
 ): StyleWrite {
-  // ONLY the property this edit writes, for two reasons that point the same
-  // way. A pre-existing invalid value elsewhere in the breakpoint is not this
-  // edit's fault, and validating the whole map would let one bad value block
-  // every other control on that breakpoint with no way to fix it. And the scrub
-  // preview compiles this one property, so validating anything wider here would
-  // make preview and commit disagree — a drag that previewed cleanly and then
-  // snapped back on release. The document validator still checks the whole map
-  // where completeness is the question.
+  // ONLY the leaf this edit writes. A sibling that is already invalid is not
+  // this edit's fault, and judging anything wider lets one bad value block the
+  // controls around it with no way to fix them: a breakpoint-wide check blocks
+  // every control on the breakpoint, and a property-wide one blocks every side
+  // of a margin whose top is malformed. It is also what keeps the commit
+  // judging exactly what the preview compiled, so a clean drag cannot snap
+  // back on release. The document validator still reads the whole map where
+  // completeness is the question.
   const issues = validateStyleValues(
-    { ...(property in values ? { [property]: values[property] } : {}) },
+    subject,
     "",
     "strict",
     undefined,
     false,
-    undefined,
+    policy?.tokens,
     { mayFetchUrl: policy?.mayFetchUrl }
   );
   const errors = errorsIn(issues);
@@ -296,7 +326,7 @@ export function styleWriteOp(
     styles,
     withValues(styles, address.state, address.breakpoint, values),
     values,
-    address.property,
+    { [address.property]: styleValueAtPath(address.path, value) },
     policy
   );
 }
@@ -321,12 +351,15 @@ export function styleClearOp(
   const remaining = clearAtPath(values[address.property], address.path);
   if (remaining === undefined) delete values[address.property];
   else values[address.property] = remaining;
+  // Nothing is being written, so there is nothing to judge: removing a value
+  // cannot make a document invalid, and validating what REMAINS would refuse a
+  // reset because of a sibling the author is not touching.
   return writeResult(
     nodeId,
     styles,
     withValues(styles, address.state, address.breakpoint, values),
     values,
-    address.property,
+    {},
     policy
   );
 }

--- a/packages/builder/src/style-values.ts
+++ b/packages/builder/src/style-values.ts
@@ -24,6 +24,7 @@ import {
   isTokenRef,
   validateStyleValues,
   type BreakpointId,
+  type MayFetchUrl,
   type NodeStyles,
   type StyleState,
   type StyleValue,
@@ -31,7 +32,21 @@ import {
   type ValidationIssue,
 } from "@nextlyhq/blocks-engine";
 
-import type { BuilderOp } from "./ops";
+import { sameStoredValue, type BuilderOp } from "./ops";
+
+/**
+ * The site policy a value is judged against.
+ *
+ * Carried rather than defaulted, because the engine ships no host list of its
+ * own: which hosts a site will fetch from is the operator's decision. Omitting
+ * it from a validation run does not mean "allow" — it means the question was
+ * never asked — so a control that never forwarded it would accept a URL the
+ * published compiler refuses, show it in the preview, fetch it from the editor,
+ * and let the author save a value that then vanishes from the page.
+ */
+export interface StylePolicy {
+  readonly mayFetchUrl?: MayFetchUrl;
+}
 
 /** Where a control reads and writes. */
 export interface StyleAddress {
@@ -60,7 +75,16 @@ export interface StyleAddress {
 export type StyleWrite =
   | {
       readonly ok: true;
-      readonly op: BuilderOp;
+      /**
+       * The op to apply, or `null` when the document already holds this value.
+       *
+       * `applyOp` REFUSES an update that changes nothing — "a history entry for
+       * it would undo to no visible effect" — so an SDK that always handed back
+       * an op would advertise one that throws on the ordinary cases: resetting
+       * a control that was already unset, or retyping the value a node already
+       * holds. Null says the ask was valid and there is nothing to do.
+       */
+      readonly op: BuilderOp | null;
       /**
        * Findings the catalog reported that do not refuse the write.
        *
@@ -207,15 +231,36 @@ function errorsIn(
  */
 function writeResult(
   nodeId: string,
-  styles: NodeStyles,
-  values: StyleValues
+  before: NodeStyles | undefined,
+  after: NodeStyles,
+  values: StyleValues,
+  policy: StylePolicy | undefined
 ): StyleWrite {
-  const issues = validateStyleValues(values, "", "strict");
+  const issues = validateStyleValues(
+    values,
+    "",
+    "strict",
+    undefined,
+    false,
+    undefined,
+    { mayFetchUrl: policy?.mayFetchUrl }
+  );
   const errors = errorsIn(issues);
   if (errors.length > 0) return { ok: false, issues: errors };
+  // Asked with the op layer's OWN comparison rather than a second one, so the
+  // answer here and the answer `applyOp` would give cannot differ. An empty
+  // envelope stands in for an absent one: a node with no styles and a node
+  // whose styles cleared to nothing are the same document.
+  if (sameStoredValue(before ?? {}, after)) {
+    return {
+      ok: true,
+      op: null,
+      warnings: issues.filter(issue => issue.severity !== "error"),
+    };
+  }
   return {
     ok: true,
-    op: patchOp(nodeId, styles),
+    op: patchOp(nodeId, after),
     warnings: issues.filter(issue => issue.severity !== "error"),
   };
 }
@@ -225,7 +270,8 @@ export function styleWriteOp(
   nodeId: string,
   styles: NodeStyles | undefined,
   address: StyleAddress,
-  value: StyleValue
+  value: StyleValue,
+  policy?: StylePolicy
 ): StyleWrite {
   const current = styles?.[address.state]?.[address.breakpoint];
   const values: StyleValues = {
@@ -238,8 +284,10 @@ export function styleWriteOp(
   };
   return writeResult(
     nodeId,
+    styles,
     withValues(styles, address.state, address.breakpoint, values),
-    values
+    values,
+    policy
   );
 }
 
@@ -255,7 +303,8 @@ export function styleWriteOp(
 export function styleClearOp(
   nodeId: string,
   styles: NodeStyles | undefined,
-  address: StyleAddress
+  address: StyleAddress,
+  policy?: StylePolicy
 ): StyleWrite {
   const current = styles?.[address.state]?.[address.breakpoint];
   const values: StyleValues = { ...current };
@@ -264,7 +313,9 @@ export function styleClearOp(
   else values[address.property] = remaining;
   return writeResult(
     nodeId,
+    styles,
     withValues(styles, address.state, address.breakpoint, values),
-    values
+    values,
+    policy
   );
 }

--- a/packages/builder/src/style-values.ts
+++ b/packages/builder/src/style-values.ts
@@ -234,10 +234,19 @@ function writeResult(
   before: NodeStyles | undefined,
   after: NodeStyles,
   values: StyleValues,
+  property: string,
   policy: StylePolicy | undefined
 ): StyleWrite {
+  // ONLY the property this edit writes, for two reasons that point the same
+  // way. A pre-existing invalid value elsewhere in the breakpoint is not this
+  // edit's fault, and validating the whole map would let one bad value block
+  // every other control on that breakpoint with no way to fix it. And the scrub
+  // preview compiles this one property, so validating anything wider here would
+  // make preview and commit disagree — a drag that previewed cleanly and then
+  // snapped back on release. The document validator still checks the whole map
+  // where completeness is the question.
   const issues = validateStyleValues(
-    values,
+    { ...(property in values ? { [property]: values[property] } : {}) },
     "",
     "strict",
     undefined,
@@ -287,6 +296,7 @@ export function styleWriteOp(
     styles,
     withValues(styles, address.state, address.breakpoint, values),
     values,
+    address.property,
     policy
   );
 }
@@ -316,6 +326,7 @@ export function styleClearOp(
     styles,
     withValues(styles, address.state, address.breakpoint, values),
     values,
+    address.property,
     policy
   );
 }

--- a/packages/builder/src/style-values.ts
+++ b/packages/builder/src/style-values.ts
@@ -1,0 +1,270 @@
+/**
+ * Reading and writing one control's value inside a node's style envelope.
+ *
+ * The envelope is `state × breakpoint × property`, both outer levels sparse, and
+ * a control addresses one position in it. Every control goes through here rather
+ * than reaching into `node.styles` itself, so the addressing exists once: a
+ * control that spelled the path itself would be a second answer to "where does
+ * this value live", and the two disagree the first time the envelope moves.
+ *
+ * **Validation is DELEGATED, never repeated.** `validateStyleValues` is the
+ * catalog's own grammar check, and this calls it on the values that would
+ * result. A control that re-checked units or ranges would be a second
+ * implementation of the same question — and the one that drifted would be this
+ * one, because the catalog is where new properties arrive.
+ *
+ * **A write is ONE op.** `editorState.apply` pushes exactly one undo entry per
+ * call, so a control that commits through a single `update` op is a single step
+ * of undo by construction rather than by remembering to batch.
+ *
+ * @module style-values
+ */
+
+import {
+  isTokenRef,
+  validateStyleValues,
+  type BreakpointId,
+  type NodeStyles,
+  type StyleState,
+  type StyleValue,
+  type StyleValues,
+  type ValidationIssue,
+} from "@nextlyhq/blocks-engine";
+
+import type { BuilderOp } from "./ops";
+
+/** Where a control reads and writes. */
+export interface StyleAddress {
+  readonly state: StyleState;
+  readonly breakpoint: BreakpointId;
+  /** The catalog key, as stored in a `StyleValues` record. */
+  readonly property: string;
+  /**
+   * The position inside the property's value, from `StyleControl.path`.
+   *
+   * Empty addresses the property itself. A control never builds this by hand:
+   * it carries the path the descriptor gave it, which is what keeps the two
+   * from disagreeing about where a side or a corner lives.
+   */
+  readonly path: readonly string[];
+}
+
+/**
+ * The outcome of asking for a write.
+ *
+ * A discriminated union rather than a thrown error, because a refused value is
+ * an ordinary thing for a control to encounter — a half-typed length is invalid
+ * for as long as it takes to type the unit — and an exception on every keystroke
+ * is not a control flow anyone wants to write against.
+ */
+export type StyleWrite =
+  | {
+      readonly ok: true;
+      readonly op: BuilderOp;
+      /**
+       * Findings the catalog reported that do not refuse the write.
+       *
+       * Carried rather than dropped: a warning is the validator explaining
+       * something about a value it accepted, and a control that discarded them
+       * would present an accepted-with-reservations value as an unremarkable
+       * one.
+       */
+      readonly warnings: readonly ValidationIssue[];
+    }
+  | { readonly ok: false; readonly issues: readonly ValidationIssue[] };
+
+/** A stored value holding named sub-values. */
+type CompositeValue = { readonly [key: string]: StyleValue };
+
+/**
+ * Whether a value addresses sub-values.
+ *
+ * A token reference is an object and is nonetheless a scalar, so `typeof` alone
+ * would descend into `{ $token }` looking for a side that is not there.
+ */
+function isComposite(value: StyleValue | undefined): value is CompositeValue {
+  return typeof value === "object" && value !== null && !isTokenRef(value);
+}
+
+/** The value at a path inside one property's stored value. */
+function readAtPath(
+  value: StyleValue | undefined,
+  path: readonly string[]
+): StyleValue | undefined {
+  let at = value;
+  for (const step of path) {
+    if (!isComposite(at)) return undefined;
+    at = at[step];
+  }
+  return at;
+}
+
+/**
+ * One property's value with `next` written at `path`.
+ *
+ * Rebuilt rather than mutated at every level, because the document the editor
+ * holds is the one React renders from: writing through a nested reference
+ * changes a value the previous render is still displaying, and the two states
+ * differ with nothing having re-rendered.
+ */
+function writeAtPath(
+  value: StyleValue | undefined,
+  path: readonly string[],
+  next: StyleValue
+): StyleValue {
+  if (path.length === 0) return next;
+  const [step, ...rest] = path;
+  // A scalar standing where a composite is addressed is REPLACED rather than
+  // descended into. It happens when a union moves between its arms — a radius
+  // stored as one measurement, then edited per corner — and preserving the
+  // scalar would leave a value that is neither arm.
+  const parent: CompositeValue = isComposite(value) ? value : {};
+  return { ...parent, [step]: writeAtPath(parent[step], rest, next) };
+}
+
+/**
+ * One property's value with `path` removed, or `undefined` when nothing is left.
+ *
+ * Pruning upward matters because an emptied container is not the same as an
+ * absent one to anything that reads the envelope: an empty record still counts
+ * as a value set at this breakpoint, so a reset that left one behind would show
+ * a control as authored-here with nothing in it.
+ */
+function clearAtPath(
+  value: StyleValue | undefined,
+  path: readonly string[]
+): StyleValue | undefined {
+  if (path.length === 0) return undefined;
+  if (!isComposite(value)) return value;
+  const [step, ...rest] = path;
+  if (!(step in value)) return value;
+  const next = clearAtPath(value[step], rest);
+  const remaining: Record<string, StyleValue> = { ...value };
+  if (next === undefined) delete remaining[step];
+  else remaining[step] = next;
+  return Object.keys(remaining).length === 0 ? undefined : remaining;
+}
+
+/** The value a control is currently showing, or `undefined` when nothing set it. */
+export function readStyleValue(
+  styles: NodeStyles | undefined,
+  address: StyleAddress
+): StyleValue | undefined {
+  const values = styles?.[address.state]?.[address.breakpoint];
+  return readAtPath(values?.[address.property], address.path);
+}
+
+/** The whole envelope with one state × breakpoint replaced, pruning what empties. */
+function withValues(
+  styles: NodeStyles | undefined,
+  state: StyleState,
+  breakpoint: BreakpointId,
+  values: StyleValues | undefined
+): NodeStyles {
+  const states: NodeStyles = { ...styles };
+  const breakpoints = { ...states[state] };
+  if (values === undefined || Object.keys(values).length === 0) {
+    delete breakpoints[breakpoint];
+  } else {
+    breakpoints[breakpoint] = values;
+  }
+  if (Object.keys(breakpoints).length === 0) delete states[state];
+  else states[state] = breakpoints;
+  return states;
+}
+
+/** The op that writes an envelope, removing the field outright when it empties. */
+function patchOp(nodeId: string, styles: NodeStyles): BuilderOp {
+  if (Object.keys(styles).length > 0) {
+    return { kind: "update", id: nodeId, patch: { styles } };
+  }
+  // Named for removal rather than set to `undefined`. An op is persisted, and
+  // `JSON.stringify` drops an undefined value — so the inverse of an edit that
+  // ADDED the first style would arrive back from storage as an empty patch and
+  // undo nothing.
+  return { kind: "update", id: nodeId, patch: {}, unset: ["styles"] };
+}
+
+/**
+ * The issues that refuse a write, as distinct from those that annotate it.
+ *
+ * Severity is read off each issue rather than assumed from the list being
+ * non-empty: a value the catalog accepts while remarking on it would otherwise
+ * be refused, and the control would show an error for a value that is fine.
+ */
+function errorsIn(
+  issues: readonly ValidationIssue[]
+): readonly ValidationIssue[] {
+  return issues.filter(issue => issue.severity === "error");
+}
+
+/**
+ * Validate the values that would result, and answer with the op or the reasons.
+ *
+ * `strict` because the author is writing this value right now: a property this
+ * build does not know is a mistake to report at the keystroke, not a document
+ * from a newer engine to be forgiving about.
+ */
+function writeResult(
+  nodeId: string,
+  styles: NodeStyles,
+  values: StyleValues
+): StyleWrite {
+  const issues = validateStyleValues(values, "", "strict");
+  const errors = errorsIn(issues);
+  if (errors.length > 0) return { ok: false, issues: errors };
+  return {
+    ok: true,
+    op: patchOp(nodeId, styles),
+    warnings: issues.filter(issue => issue.severity !== "error"),
+  };
+}
+
+/** The op that sets one control's value, or the reasons the value was refused. */
+export function styleWriteOp(
+  nodeId: string,
+  styles: NodeStyles | undefined,
+  address: StyleAddress,
+  value: StyleValue
+): StyleWrite {
+  const current = styles?.[address.state]?.[address.breakpoint];
+  const values: StyleValues = {
+    ...current,
+    [address.property]: writeAtPath(
+      current?.[address.property],
+      address.path,
+      value
+    ),
+  };
+  return writeResult(
+    nodeId,
+    withValues(styles, address.state, address.breakpoint, values),
+    values
+  );
+}
+
+/**
+ * The op that clears one control's value at this state × breakpoint.
+ *
+ * Clearing is not writing an empty string: a property with no entry falls back
+ * through the cascade to whatever a class, a block default or a wider
+ * breakpoint set, which is what an author asking to reset a control means. A
+ * stored empty value would instead pin the property to nothing here and win
+ * over the tier the author wanted back.
+ */
+export function styleClearOp(
+  nodeId: string,
+  styles: NodeStyles | undefined,
+  address: StyleAddress
+): StyleWrite {
+  const current = styles?.[address.state]?.[address.breakpoint];
+  const values: StyleValues = { ...current };
+  const remaining = clearAtPath(values[address.property], address.path);
+  if (remaining === undefined) delete values[address.property];
+  else values[address.property] = remaining;
+  return writeResult(
+    nodeId,
+    withValues(styles, address.state, address.breakpoint, values),
+    values
+  );
+}

--- a/packages/builder/src/style-values.ts
+++ b/packages/builder/src/style-values.ts
@@ -216,11 +216,26 @@ function withValues(
   values: StyleValues | undefined
 ): NodeStyles {
   const states: NodeStyles = { ...styles };
-  const breakpoints = { ...states[state] };
+  const breakpoints: Partial<Record<BreakpointId, StyleValues>> = {
+    ...states[state],
+  };
   if (values === undefined || Object.keys(values).length === 0) {
     delete breakpoints[breakpoint];
   } else {
-    breakpoints[breakpoint] = values;
+    // DEFINED rather than assigned. A breakpoint id is site-supplied free text
+    // — nothing in `validateBreakpoints` restricts its characters — and the id
+    // `__proto__` reaches JavaScript's legacy prototype setter through an
+    // ordinary assignment: the key never becomes an own property, the map reads
+    // as empty, the state is pruned, and the write reports success with nothing
+    // to do. Every control at that breakpoint would be unable to author its
+    // first value, silently. The spread above is safe on its own, because
+    // spreading DEFINES own properties rather than setting them.
+    Object.defineProperty(breakpoints, breakpoint, {
+      value: values,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
   }
   if (Object.keys(breakpoints).length === 0) delete states[state];
   else states[state] = breakpoints;


### PR DESCRIPTION
The contract the page builder's style controls will be built on. **No control renders yet** — this is the SDK the inspector, the core control set, the colour controls and the classes UI all sit on.

## What it does

**Controls are derived from `catalog.ts`, not listed.** The leaf-kind-to-control mapping is a mapped type over the engine's own union, so a leaf kind added there fails to compile here until it is given a control. A kind a *newer* engine carries that this build has no control for resolves to a known gap rather than reaching a renderer as `undefined` — same policy as `inspector.ts`'s `SUPPORTED_PROP_TYPES`, because omitting it would present an incomplete property as a complete one. A union shows the arm its stored value is in, with the alternatives recorded so an editor can offer the other.

**One address for reads and writes** — state, breakpoint, property, and the path inside the property's value — so nothing spells that path twice. Every write goes through `validateStyleValues`; no control re-checks the grammar. Clearing prunes upward, because an emptied breakpoint still counts as a value set here and would show a reset control as authored.

**Scrub previews through `compileStyleValues`** — the same function the published sheet is emitted through. A token resolves to the same `var()`, and a value the compiler refuses produces no declarations and never reaches the screen, so preview and commit accept exactly the same values by construction. The rule is anchored to `PAGE_ROOT_SELECTOR` rather than a stronger selector, so it wins on document order and the committed value lands where the preview did. Release writes one op, which is one undo step.

**Provenance is read, never re-derived.** `styleOrigin` already settles tier order, both breakpoint axes, states, refused values and specificity. This classifies its answer into unset / authored-here / inherited, and the inherited answer carries the origin — a class origin holds the id and the slug, so a panel can name the class and offer to open it.

**Custom behaviour is referenced by name.** `catalog.ts` is read by validation, the compiler, the inspector *and* the generated reference docs; a function stored in it could not be serialized, reasoned about, or documented. Behaviour is registered under a key derived from the catalog's own identity, so nothing is added to the catalog. It ships with zero entries — the shape is settled, the behaviour is not invented ahead of a consumer.

## The colour boundary

`packages/ui`'s contrast implementation is unreachable from the editor by export map, by the root barrel, and by a relative path climbing out of the package. The test asserts all three, with a positive control on the walk and a negative control on the predicate.

It also says **in the file** what it cannot prove: relative luminance is arithmetic over numbers already in hand, so a fourth implementation written inside `packages/builder` would import nothing and every assertion would pass. `layering.test.ts` records the same limit about rendering. This is therefore not a control for "no third colour parser" — that stays a review-time design constraint, and claiming otherwise would be a control that is present and inert.

The two WCAG implementations stay unshared and unconsolidated: importing ui's into the engine would end its runtime-free guarantee, and importing the engine's into ui would point the design system at the page builder. Both are anchored to the specification's reference values rather than to each other.

## Verification

- 57 new tests across 6 suites; `@nextlyhq/builder` at 917 passing, 48 files
- `check-types` clean, `lint` clean at `--max-warnings 0`
- `fallow audit` verdict `pass`, zero introduced findings — it caught a real clone of the engine's declaration grouping, which is now gone rather than suppressed
- Break-verified: union variant selection, and the relative-import sweep against a planted `../../ui/src/styles/contrast/color` import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added APIs for reading, updating, clearing, and comparing individual style values.
  - Added adaptive style controls for nested values, tokens, unions, and selectable variants.
  - Added previews and commits for style adjustments across interaction states and breakpoints.
  - Added validation feedback, accessibility labels, URL policies, and compiler warnings.
  - Added style provenance reporting for authored, inherited, unset, and ambiguous values.
  - Avoided updates when values are unchanged and exposed the style-control APIs for integration.

- **Tests**
  - Expanded coverage for controls, tokens, validation, inheritance, scrubbing, and package boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->