### PR TITLE
fix(builder): read composite fields by own key, and keep an empty record composite

### DIFF
--- a/.changeset/controls-read-composites-by-own-key.md
+++ b/.changeset/controls-read-composites-by-own-key.md
@@ -1,0 +1,36 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Two reads in the page builder's control derivation are corrected. A composite's
+nested field is read by OWN key, as the engine reads style maps everywhere else,
+so a field reached through a prototype no longer decides which control is drawn
+and an inherited accessor no longer runs during a read taken only to draw a
+panel. And an empty record stays on the composite arm: the validator accepts
+`{}` there, so requiring at least one named field sent a stored
+`borderRadius: {}` to the scalar variant and drew a single length control for a
+value the document holds in the four-corner form.

--- a/packages/builder/src/style-controls.test.ts
+++ b/packages/builder/src/style-controls.test.ts
@@ -608,11 +608,25 @@ describe("reading a composite's fields", () => {
     // The same own-key rule the engine reads style maps by. A field the
     // compiler will not emit must not decide which control is drawn, and an
     // inherited accessor must not run during a read taken to draw a panel.
+    //
+    // The inherited field is an ACCESSOR because that is the only shape which
+    // separates the two claims: a read ordered BEFORE the own-key check runs
+    // the getter and still returns undefined, which a plain data property
+    // cannot tell apart from a read that never happened. The getter returns a
+    // value the keyword arm accepts, so a read with no own-key check at all
+    // moves `active` too, and the two assertions fail independently.
     const position = getStyleProperty("position");
-    const value = Object.create({ zIndex: "auto" }) as Record<string, unknown>;
+    let inheritedReads = 0;
+    const value = Object.create({
+      get zIndex() {
+        inheritedReads += 1;
+        return "auto";
+      },
+    }) as Record<string, unknown>;
     value.inset = { blockStart: "0px" };
     const set = styleControlsFor(position as StyleProperty, value as never);
     const zIndex = set.variants.find(v => v.path.join(".") === "zIndex");
+    expect(inheritedReads).toBe(0);
     expect(zIndex?.active).toBe(0);
   });
 

--- a/packages/builder/src/style-controls.test.ts
+++ b/packages/builder/src/style-controls.test.ts
@@ -602,3 +602,27 @@ describe("composite arms sharing a field name", () => {
     );
   });
 });
+
+describe("reading a composite's fields", () => {
+  it("ignores a nested field reached only through a prototype", () => {
+    // The same own-key rule the engine reads style maps by. A field the
+    // compiler will not emit must not decide which control is drawn, and an
+    // inherited accessor must not run during a read taken to draw a panel.
+    const position = getStyleProperty("position");
+    const value = Object.create({ zIndex: "auto" }) as Record<string, unknown>;
+    value.inset = { blockStart: "0px" };
+    const set = styleControlsFor(position as StyleProperty, value as never);
+    const zIndex = set.variants.find(v => v.path.join(".") === "zIndex");
+    expect(zIndex?.active).toBe(0);
+  });
+
+  it("keeps an empty record on the composite arm", () => {
+    // `{}` names nothing and is still the four-corner form: the validator
+    // accepts it there, so sending it to the scalar arm drew one control for a
+    // value stored in the other.
+    const radius = getStyleProperty("borderRadius");
+    const set = styleControlsFor(radius as StyleProperty, {});
+    expect(set.variants[0].active).toBe(1);
+    expect(set.controls).toHaveLength(4);
+  });
+});

--- a/packages/builder/src/style-controls.ts
+++ b/packages/builder/src/style-controls.ts
@@ -289,7 +289,13 @@ function fieldsHold(
 ): boolean {
   const fields = fieldsOf(variant);
   if (fields.length === 0) return true;
-  const named = Object.keys(value).filter(key => fields.includes(key));
+  const keys = Object.keys(value);
+  // An EMPTY record names nothing and is still this form: the validator accepts
+  // `{}` against a composite with no issues, so rejecting it here sent a stored
+  // `borderRadius: {}` to the scalar arm and drew one length control for a
+  // value the document holds in the four-corner form.
+  if (keys.length === 0) return true;
+  const named = keys.filter(key => fields.includes(key));
   if (named.length === 0) return false;
   return named.every(name => {
     const shape = shapeAt(variant, name);
@@ -581,7 +587,12 @@ function childValue(
   name: string
 ): StyleValue | undefined {
   if (value === undefined || !isCompositeValue(value)) return undefined;
-  return value[name];
+  // OWN keys only, as `validateStyleValues` and the declaration walk both read
+  // them. A nested field reached through a prototype is one the compiler will
+  // not emit, so deriving a control from it shows an active variant the stored
+  // document does not have — and an inherited accessor would RUN during a read
+  // taken only to draw a panel.
+  return Object.hasOwn(value, name) ? value[name] : undefined;
 }
 
 /**


### PR DESCRIPTION
Re-lands the commit that PR #1128 merged without.

## Why this exists

#1128 merged from head `59dad99b0` while its branch tip was `bb387e223` — the push-a-fix-then-merge window `.claude/rules/verifying-merged-work.md` describes. Confirmed by content rather than by the range screen, with two markers unique to the stranded commit, each scoped to the file it changed and each run against the branch head as a positive control:

```
'return Object.hasOwn(value, name) ? value[name] : undefined;'   ABSENT from cb61a5cfa, PRESENT in bb387e223
'if (keys.length === 0) return true;'                            ABSENT from cb61a5cfa, PRESENT in bb387e223
```

`git log 59dad99b0..bb387e223` lists exactly one commit. Both changes below were found in review, fixed and break-verified before that push, and neither reached `main`.

## What it restores

**A composite's nested field is read by OWN key.** `style-values.ts` was guarded one commit earlier and this path was not, so a field reached through a prototype still decided which control is drawn — showing an active variant the stored document does not have — and an inherited accessor would run during a read taken only to draw a panel. The engine reads style maps this way throughout: `validateStyleValues` and the shape walk beside it guard with `Object.hasOwn` in three places.

**An empty record stays on the composite arm.** The validator accepts `{}` against a composite with no issues, so requiring at least one named field sent a stored `borderRadius: {}` to the scalar arm and drew one length control for a value the document holds in the four-corner form.

## Verification

- 1021 tests passing across 48 files in `@nextlyhq/builder`
- `check-types` 0, `lint` 0 at `--max-warnings 0`, comment convention 0
- `fallow audit` verdict `pass`, every `*_introduced` at 0
- Both changes break-verified individually: reverting the own-key guard fails the prototype test, and removing the empty-record branch fails the composite-arm test
- Changeset generated from `.changeset/config.json` rather than copied from a pending one, and checked with `check-changesets.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved composite style value detection when the stored value is empty.
  * Prevented inherited properties from affecting which style variant is displayed.
  * Avoided reading unintended inherited values while rendering style controls.

* **Tests**
  * Added coverage for empty composite values and inherited properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->