### PR TITLE
fix(plugin-page-builder): let a permission decide who reads Site Style

### DIFF
--- a/.changeset/site-style-read-permission.md
+++ b/.changeset/site-style-read-permission.md
@@ -1,0 +1,43 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(plugin-page-builder): let a permission decide who reads Site Style
+
+The Site Style single declared `access: { read: () => true }`, which cannot
+serve the anonymous page render it was written for and does reach every
+authenticated principal. `checkAccess` refuses an absent user before
+consulting any rule, singles are not public endpoints, and a published page
+never uses the route — `loadSiteStyle` reads through the Direct API, whose
+`overrideAccess` default returns before a rule is evaluated. What the rule
+did do was return ahead of the `read-site-style` permission lookup, and the
+`read` action covers the version list, a version, a version diff and the
+autosave recovery point as well as the published document.
+
+The access block is gone, so read and update alike fall through to the
+permissions seeded with the single. A published render is unchanged; a role
+that should read this document is granted `read-site-style`.

--- a/packages/plugin-page-builder/src/site-style-storage.test.ts
+++ b/packages/plugin-page-builder/src/site-style-storage.test.ts
@@ -1,0 +1,57 @@
+import { defineSingle, json } from "nextly/config";
+import { describe, expect, it } from "vitest";
+
+import { siteStyleSingle } from "./site-style-storage";
+
+/**
+ * The operations a config declares a code-defined rule for.
+ *
+ * This is the shape the RBAC service reads, not a second copy of its decision:
+ * it looks up `codeAccess?.[operation]` and, whenever that is anything other
+ * than `undefined`, answers from it and never reaches the permission lookup.
+ * So the list of declared keys IS the list of operations that would bypass a
+ * permission, whatever each rule goes on to return.
+ */
+function declaredRules(config: { access?: unknown }): string[] {
+  const { access } = config;
+  if (access === null || access === undefined) return [];
+  if (typeof access !== "object") return ["<access is not an object>"];
+  const rules = access as Record<string, unknown>;
+  return Object.keys(rules).filter(name => rules[name] !== undefined);
+}
+
+describe("the Site Style single's access", () => {
+  it("finds a declared rule on a single that has one", () => {
+    // The positive control. Every assertion below is an ABSENCE, and an
+    // absence is only evidence once the search is known to find the thing when
+    // it is there — `defineSingle` validates and rebuilds its input, so a
+    // version that dropped `access` on the floor would satisfy them all
+    // forever.
+    const control = defineSingle({
+      slug: "control-single",
+      label: { singular: "Control" },
+      access: { read: () => true },
+      fields: [json({ name: "payload" })],
+    });
+
+    expect(declaredRules(control)).toEqual(["read"]);
+  });
+
+  it("declares no code-defined rule, so a permission decides every operation", () => {
+    // Not "declares no READ rule": a rule under any operation returns ahead of
+    // the permission lookup, so naming one operation would guard one member of
+    // the family and let the next one through.
+    expect(declaredRules(siteStyleSingle())).toEqual([]);
+  });
+
+  it("keeps versions, which is what widens the read action past the document", () => {
+    // Why the rule above is load-bearing rather than tidy. `versions: true` is
+    // what gives this slug a version list, a version, a version diff and an
+    // autosave recovery point — all of which the route resolves to the SAME
+    // `read` action on the same slug. A permissive read rule would hand over
+    // the edit history and unpublished in-progress work along with the
+    // published document, and only the published document is emitted into a
+    // public page.
+    expect(siteStyleSingle().versions).toBe(true);
+  });
+});

--- a/packages/plugin-page-builder/src/site-style-storage.ts
+++ b/packages/plugin-page-builder/src/site-style-storage.ts
@@ -56,10 +56,10 @@ const refusing =
  * - `versions: true`, because a site's whole look changes in one write and a
  *   restorable history is the difference between an experiment and an
  *   accident.
- * - Public read, because every anonymous page render is styled by this
- *   document — its contents are emitted into the CSS of every public page,
- *   so there is nothing to protect on the read side. Updates stay with the
- *   role/permission checks every single falls back to.
+ * - NO code-defined access block, so read and update alike fall through to the
+ *   `read-site-style` / `update-site-style` permissions seeded with the single.
+ *   A published render is unaffected: it reads through the Direct API, whose
+ *   `overrideAccess` default returns before any rule is consulted.
  * - Plain `json` fields rather than structured ones, because the shapes are
  *   the ENGINE's contracts and the style studios that will edit them write
  *   whole sections at a time; a field-per-property schema here would be a
@@ -70,13 +70,21 @@ export function siteStyleSingle() {
     slug: SITE_STYLE_SLUG,
     label: { singular: "Site Style" },
     versions: true,
-    // A function rather than a boolean: the single config validator accepts
-    // only functions for access rules. Public read is the intent — every
-    // anonymous page render is styled by this document, and its contents are
-    // emitted into the CSS of every public page, so there is nothing to
-    // protect on the read side. Updates stay with the role/permission checks
-    // every single falls back to.
-    access: { read: () => true },
+    // No `access` block, deliberately: read and update both fall through to
+    // the `read-site-style` / `update-site-style` permissions seeded with the
+    // single and granted to super_admin, so a role reaches this document only
+    // by being given one.
+    //
+    // A code-defined read rule cannot serve the anonymous render it would be
+    // written for. `checkAccess` refuses an absent user before consulting any
+    // rule, singles are not public endpoints, and the published page does not
+    // use the route at all — `loadSiteStyle` reads through the Direct API,
+    // whose `overrideAccess` default returns from `checkSingleAccess` before
+    // the rule is reached. What such a rule DOES reach is every authenticated
+    // principal, returning ahead of the permission lookup, and the `read`
+    // action spans more than the published document: the version list, a
+    // version, a version diff and the autosave recovery point all resolve to
+    // `read` on this slug. None of those is emitted into a public page.
     admin: {
       icon: "Palette",
       description:


### PR DESCRIPTION
Remediates `finding:pb-site-style-read-rule-bypasses-permission` against the already-merged #1116. First of nine open findings on that PR, taken highest-severity first.

## The defect

`site-style-storage.ts` declared `access: { read: () => true }` on the Site Style single, justified in its own comment as public read, *"every anonymous page render is styled by this document"*. The rule does not do that, and it does do something else.

**It cannot serve the anonymous render on any path.** Three independent reasons, each verified against current `main`:

- `RBACAccessControlService.checkAccess` returns `false` for `!userId` before it looks at any code-defined rule.
- Singles are absent from `isPublicEndpoint` (`route-parser.ts:49-64` covers only `auth` and `forms`), so `requireCollectionAccess` sends an anonymous REST caller through `requireAuthentication` and 401s first.
- The published page never uses the route. `loadSiteStyle` calls `nextly.findSingle` through the Direct API, whose constructor default is `overrideAccess: true`, and `checkSingleAccess` returns `null` at its first branch on exactly that.

**What it did reach is every authenticated principal.** `checkAccess` returns the rule’s `true` and never falls through to `hasPermission`, so the seeded `read-site-style` permission — assigned to `super_admin` only — was skipped for every logged-in caller regardless of role.

**And `read` spans more than the published document.** `routeHandler.ts:725-732` resolves `listSingleVersions`, `getSingleVersion`, `getSingleVersionDiff` and `getSingleAutosave` to action `read` on the same slug. The single sets `versions: true`, so those are real surfaces: the full edit history with authors, and an autosave recovery point holding unpublished in-progress work. Neither is emitted into a public page, so the stated justification never covered them.

## The fix

Drop the access block. Read and update alike fall through to the permissions seeded with the single. The published render is unchanged, being `overrideAccess`. A role that should read this document is granted `read-site-style`.

This also closes an asymmetry: `update` was already left to the permission system, and only `read` had been singled out.

## Evidence

`site-style-storage.ts` had **no test file at all** before this. The new one asserts the absence of a code-defined rule under **any** operation — not just `read`, since a rule under any key returns ahead of the permission lookup.

An absence assertion is only evidence once the search is known to find the thing when it is there, so the first test is a positive control: a single built through the same `defineSingle`, carrying a rule, must be reported as carrying one. `defineSingle` validates and rebuilds its input, and a version that dropped `access` would otherwise satisfy every assertion here forever.

Break-verified, three ways:

| break | result |
|---|---|
| re-add `access: { read: () => true }` | `expected [ "read" ] to deeply equal []` |
| add `access: { update: () => true }` instead | `expected [ "update" ] to deeply equal []` — the assertion is not read-specific |
| remove the rule from the positive control | `expected [] to deeply equal [ "read" ]` — the reader is not blind |

## Gates

build 0 · vitest 103 tests / 17 files · `check-types` 0 (including `tsconfig.tests.json`) · `lint` 0 with `--max-warnings 0` · comment convention 0 new · `fallow audit` verdict `pass`, every `*_introduced` at 0.

Changeset generated from `.changeset/config.json` (25 packages) and verified with `scripts/release/check-changesets.mjs` → *all cover the group*.