### PR TITLE
fix(plugin-page-builder): judge a stored class's values under the site's host policy

### DIFF
--- a/.changeset/site-style-class-url-write-gate.md
+++ b/.changeset/site-style-class-url-write-gate.md
@@ -38,9 +38,22 @@ the site sheet.
 
 The classes field now runs each entry's values through the engine's own
 `validateStyleValues` with the site's `remotePatterns` predicate, derived through
-the same `isFetchableUrl` the published page and the canvas use. Forgiving mode,
-errors only: a property a newer engine wrote stays a warning, and a warning is a
-value the engine accepts and emits.
+the same `isFetchableUrl` the published page and the canvas use. Only errors
+refuse a write: a warning is a value the engine accepts and emits.
 
-A site that configured no `remotePatterns` is unchanged — the engine treats an
-absent policy as unasked, not as an empty allowlist.
+How strictly an unrecognised property is judged now depends on whether the site
+configured a host policy, because the validator does not look INSIDE one.
+
+- **No `remotePatterns`: forgiving, and nothing changes.** A property written by
+  a newer engine stays a warning, and an absent policy is treated as unasked
+  rather than as an empty allowlist.
+- **`remotePatterns` configured: strict.** An unrecognised property is an error
+  and the write is refused, because a value the gate cannot judge could carry a
+  `url()` it will never see. Such a site can no longer store a property this
+  engine does not know, and is told which one.
+
+Validation is also bounded now. One issue budget covers the whole classes
+section rather than each property map, and the walk stops once it is spent —
+between maps inside a class and between classes. A payload spreading invalid
+properties across many maps could otherwise ask for work proportional to the
+map count, which the document byte cap alone does not limit.

--- a/.changeset/site-style-class-url-write-gate.md
+++ b/.changeset/site-style-class-url-write-gate.md
@@ -1,0 +1,46 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(plugin-page-builder): judge a stored class's values under the site's host policy
+
+A named class is emitted verbatim into the sheet of every public page, and the
+Site Style write gate never read inside its `styles`. `isUsableNamedClass` types
+the envelope and stops there, so a class carrying
+`background: { url: "https://tracker.example/p.png" }` was stored, compiled and
+served to every visitor of every page — while the identical value written on a
+node was refused, because the renderer polices node styles and nothing policed
+the site sheet.
+
+The classes field now runs each entry's values through the engine's own
+`validateStyleValues` with the site's `remotePatterns` predicate, derived through
+the same `isFetchableUrl` the published page and the canvas use. Forgiving mode,
+errors only: a property a newer engine wrote stays a warning, and a warning is a
+value the engine accepts and emits.
+
+A site that configured no `remotePatterns` is unchanged — the engine treats an
+absent policy as unasked, not as an empty allowlist.

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -15,7 +15,7 @@ import {
   registerDeclaredBlocks,
 } from "./blocks/registration-service";
 import { pagesCollection } from "./collections/pages";
-import type { RemotePattern } from "./core/url-policy";
+import { isFetchableUrl, type RemotePattern } from "./core/url-policy";
 import { blocksFieldType } from "./fields/blocksField";
 import { resolveSiteStyle, siteBreakpoints } from "./site-style";
 import type { SiteStyleData } from "./site-style";
@@ -120,6 +120,27 @@ export interface PageBuilderOptions {
 }
 
 /**
+ * The host-fetch policy the Site Style write gate judges stored classes by.
+ *
+ * Derived from the SAME `remotePatterns` list the published page and the
+ * canvas are given, through `isFetchableUrl` — the engine's matcher, which
+ * this package re-exports. One implementation of "may this be fetched" is the
+ * point: a class refused on the canvas and served from the site sheet is the
+ * disagreement a second matcher would produce.
+ *
+ * No patterns means no policy rather than an empty allowlist, because the two
+ * are opposite answers. An empty list refuses every remote URL, which would
+ * break every site that has not configured one; absent leaves the engine's
+ * scheme allowlist as the only limit, which is what those sites have today.
+ */
+function siteStyleWritePolicy(patterns: readonly RemotePattern[] | undefined): {
+  mayFetchUrl?: (url: string) => boolean;
+} {
+  if (patterns === undefined) return {};
+  return { mayFetchUrl: (url: string) => isFetchableUrl(url, patterns) };
+}
+
+/**
  * The Page Builder plugin factory. Call it in a host app's
  * `defineConfig({ plugins: [pageBuilder()] })`.
  */
@@ -192,7 +213,14 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
       // stored style tier lives in. Registered whether or not the host stated
       // defaults, because the storage existing is what the style studios and
       // the API write against.
-      singles: [siteStyleSingle()],
+      // Given the SAME host list the published sheet and the canvas are given,
+      // through the same predicate: a named class is emitted verbatim into
+      // every public page, so a `url()` stored here is a request every visitor
+      // makes. `isFetchableUrl` is the engine's, re-exported by this package's
+      // url-policy module, so there is one answer to "may this be fetched"
+      // rather than one per surface. A host that configured no patterns gets
+      // today's behaviour: the engine treats an absent policy as unasked.
+      singles: [siteStyleSingle(siteStyleWritePolicy(opts.remotePatterns))],
       // One field type, where there were two. The other named the previous
       // editor's document — a shape this package defined itself, stored under a
       // synthetic root, and validated with its own rules. A site that declared

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -1,3 +1,4 @@
+import { isFetchableUrl, type RemotePattern } from "@nextlyhq/blocks-engine";
 import { definePlugin } from "@nextlyhq/plugin-sdk";
 
 // Imported rather than read at runtime so it can never drift from the published
@@ -15,7 +16,6 @@ import {
   registerDeclaredBlocks,
 } from "./blocks/registration-service";
 import { pagesCollection } from "./collections/pages";
-import { isFetchableUrl, type RemotePattern } from "./core/url-policy";
 import { blocksFieldType } from "./fields/blocksField";
 import { resolveSiteStyle, siteBreakpoints } from "./site-style";
 import type { SiteStyleData } from "./site-style";

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -258,6 +258,33 @@ describe("checkStoredClasses", () => {
     expect(statesRead).toBeLessThan(5);
   });
 
+  it("enumerates state keys lazily, so stopping stops the enumeration too", () => {
+    // The accessor test above counts VALUE reads, and key enumeration reads no
+    // values — so it cannot see a walk that materialises every key before the
+    // budget has a chance to stop it. A proxy counting descriptor lookups can:
+    // measured, breaking after the first entry costs one lookup in total with
+    // `for...in` and one PER KEY with `Object.keys`.
+    let descriptorLookups = 0;
+    const target: Record<string, unknown> = {};
+    const exhausting: Record<string, unknown> = {};
+    for (let k = 0; k < 300; k += 1) exhausting[`bad${k}`] = "x";
+    target.state0 = { base: exhausting };
+    for (let m = 1; m < 2000; m += 1) {
+      target[`state${m}`] = { base: { color: "#111111" } };
+    }
+    const styles = new Proxy(target, {
+      getOwnPropertyDescriptor(t, key) {
+        descriptorLookups += 1;
+        return Reflect.getOwnPropertyDescriptor(t, key);
+      },
+    });
+
+    const result = checkStoredClasses(tracker(styles), REFUSING);
+
+    expect(result.issues.join(" ")).toContain("not checked");
+    expect(descriptorLookups).toBeLessThan(10);
+  });
+
   it("stops judging later classes once the section budget is spent", () => {
     // The stop inside one class does not imply the stop between classes, and
     // neither is visible in the issue count. `MAX_NAMED_CLASSES` is 2000 and

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -176,17 +176,51 @@ describe("checkStoredClasses", () => {
     expect(result.issues.join(" ")).toContain("does not allow");
   });
 
-  it("does not refuse a value the engine only WARNS about", () => {
-    // Forgiving, errors only. A property this engine has not learned is a
-    // warning rather than an error, because a document written by a newer
-    // engine is not something the author can fix here — and a warning is a
-    // value the engine accepts and emits, so refusing on one would refuse a
-    // write whose result the sheet would render.
+  it("does not refuse an unknown property when NO policy is configured", () => {
+    // Forgiving there, and errors only everywhere: a property this engine has
+    // not learned is a warning, a document written by a newer engine is not
+    // something the author can fix, and there is no host rule to enforce.
+    const result = checkStoredClasses(
+      tracker({ base: { base: { notAProperty: "x" } } })
+    );
+    expect(result.issues).toEqual([]);
+  });
+
+  it("refuses an unknown property once a policy IS configured", () => {
+    // Strict there, because the validator never looks INSIDE an unknown
+    // property. A gate that cannot judge a value must not pass it.
     const result = checkStoredClasses(
       tracker({ base: { base: { notAProperty: "x" } } }),
       REFUSING
     );
-    expect(result.issues).toEqual([]);
+    expect(result.issues).not.toEqual([]);
+  });
+
+  it("refuses a url() hidden under a property this engine has not learned", () => {
+    // Why the mode follows the policy rather than being fixed. Measured:
+    // `{ futureBackground: { url: ... } }` yields `unknown-style-property`
+    // ALONE — the value is never inspected — so a forgiving read would store
+    // the URL, and it becomes live the moment an engine learns that property,
+    // with no further validating write to stop it.
+    const result = checkStoredClasses(
+      tracker({ base: { base: { futureBackground: { url: TRACKER } } } }),
+      REFUSING
+    );
+    expect(result.issues).not.toEqual([]);
+  });
+
+  it("refuses a property map too large to check through", () => {
+    // A budget per entry. Given none, the validator walks an unbounded map and
+    // allocates a diagnostic per key. Truncation needs no handling of its own:
+    // `style-issues-truncated` is itself an error, so a map the gate could not
+    // read to the end refuses rather than passing on a partial read.
+    const huge: Record<string, unknown> = {};
+    for (let i = 0; i < 5000; i += 1) huge[`p${i}`] = "x";
+    const result = checkStoredClasses(
+      tracker({ base: { base: huge } }),
+      REFUSING
+    );
+    expect(result.issues.join(" ")).toContain("not checked");
   });
 
   it("still returns the entry it reported on, so a READ narrows rather than drops", () => {

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -17,6 +17,9 @@ function token(name: string, light: string, dark?: string) {
   };
 }
 
+/** A host no site in these tests allows. */
+const TRACKER = "https://tracker.example/p.png";
+
 describe("checkStoredTokens", () => {
   it("reports nothing for an absent section", () => {
     expect(checkStoredTokens(undefined)).toEqual({ issues: [] });
@@ -128,6 +131,70 @@ describe("checkStoredClasses", () => {
   it("refuses a class with no numeric orderIndex", () => {
     const result = checkStoredClasses([{ ...usable, orderIndex: "first" }]);
     expect(result.issues).toHaveLength(1);
+  });
+
+  // A named class is emitted VERBATIM into the sheet of every public page, so
+  // a url() stored in one is a request every visitor makes. Unlike a token,
+  // which reaches the page as a var() substitution, there is no later
+  // substitution step where a policy could still see it.
+  const REFUSING = { mayFetchUrl: () => false };
+  const ALLOWING = { mayFetchUrl: () => true };
+  const tracker = (styles: unknown) => [{ ...usable, styles }];
+  const AT_BASE = { base: { base: { background: { url: TRACKER } } } };
+
+  it("refuses a url() the site's host policy does not allow", () => {
+    const result = checkStoredClasses(tracker(AT_BASE), REFUSING);
+    expect(result.issues.join(" ")).toContain("does not allow");
+  });
+
+  it("accepts the same url() when the policy allows the host", () => {
+    // The control that separates "the policy refused it" from "the walk
+    // refuses every url()". Without this the test above passes on a gate that
+    // rejects the shape and never consults the predicate at all.
+    expect(checkStoredClasses(tracker(AT_BASE), ALLOWING).issues).toEqual([]);
+  });
+
+  it("accepts it when NO policy is configured, which the engine calls unasked", () => {
+    // Deliberate and worth pinning: absent is not the same as an empty
+    // allowlist. A site that configured no remotePatterns keeps exactly the
+    // behaviour it has, and the engine's scheme allowlist stays the only
+    // limit. Closing that is the renderer's half, not this gate's.
+    expect(checkStoredClasses(tracker(AT_BASE)).issues).toEqual([]);
+  });
+
+  it("reaches a state and a breakpoint the compiler would emit nothing for", () => {
+    // The property a compiler-as-validator gate could not have. A breakpoint
+    // this site has not defined compiles to no rule TODAY and to a real rule
+    // the moment someone defines it, so a gate that only judged what compiles
+    // now would let the value through and serve it later.
+    const result = checkStoredClasses(
+      tracker({
+        hover: { "not-a-defined-breakpoint": { background: { url: TRACKER } } },
+      }),
+      REFUSING
+    );
+    expect(result.issues.join(" ")).toContain("does not allow");
+  });
+
+  it("does not refuse a value the engine only WARNS about", () => {
+    // Forgiving, errors only. A property this engine has not learned is a
+    // warning rather than an error, because a document written by a newer
+    // engine is not something the author can fix here — and a warning is a
+    // value the engine accepts and emits, so refusing on one would refuse a
+    // write whose result the sheet would render.
+    const result = checkStoredClasses(
+      tracker({ base: { base: { notAProperty: "x" } } }),
+      REFUSING
+    );
+    expect(result.issues).toEqual([]);
+  });
+
+  it("still returns the entry it reported on, so a READ narrows rather than drops", () => {
+    // The module's two postures: the write refuses the section on any issue,
+    // the read keeps what the compiler can narrow for itself.
+    const result = checkStoredClasses(tracker(AT_BASE), REFUSING);
+    expect(result.issues).not.toEqual([]);
+    expect(result.value).toHaveLength(1);
   });
 });
 

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -209,6 +209,85 @@ describe("checkStoredClasses", () => {
     expect(result.issues).not.toEqual([]);
   });
 
+  it("bounds the whole section, not each map inside it", () => {
+    // The single-map test below cannot see this. A budget created per map
+    // bounds each map and nothing else, and the number of maps is limited only
+    // by the document's byte cap — measured, the same payload spread over 200
+    // maps produced 40,200 diagnostics that way against 201 with one budget for
+    // the section. The write is refused either way; what differs is how much
+    // work refusing it costs.
+    const byState: Record<string, unknown> = {};
+    for (let m = 0; m < 200; m += 1) {
+      const values: Record<string, unknown> = {};
+      for (let k = 0; k < 300; k += 1) values[`bad${k}`] = "x";
+      byState[`state${m}`] = { base: values };
+    }
+
+    const result = checkStoredClasses(tracker(byState), REFUSING);
+
+    expect(result.issues.join(" ")).toContain("not checked");
+    expect(result.issues.length).toBeLessThan(1000);
+  });
+
+  it("stops reading states once the section budget is spent", () => {
+    // The bound above is visible in the issue COUNT; stopping the walk is not,
+    // because the budget caps the issues either way. So the states are
+    // accessors and the test counts how many were read: what the early stop
+    // buys is work not done, and work not done is only observable if something
+    // records the doing.
+    let statesRead = 0;
+    const byState: Record<string, unknown> = {};
+    for (let m = 0; m < 200; m += 1) {
+      Object.defineProperty(byState, `state${m}`, {
+        enumerable: true,
+        get() {
+          statesRead += 1;
+          const values: Record<string, unknown> = {};
+          for (let k = 0; k < 300; k += 1) values[`bad${k}`] = "x";
+          return { base: values };
+        },
+      });
+    }
+
+    const result = checkStoredClasses(tracker(byState), REFUSING);
+
+    expect(result.issues.join(" ")).toContain("not checked");
+    expect(statesRead).toBeLessThan(5);
+  });
+
+  it("stops judging later classes once the section budget is spent", () => {
+    // The stop inside one class does not imply the stop between classes, and
+    // neither is visible in the issue count. `MAX_NAMED_CLASSES` is 2000 and
+    // the count check reports without stopping the walk, so without this the
+    // cost of refusing scales with the array a caller sends.
+    let laterRead = 0;
+    const exhausting: Record<string, unknown> = {};
+    for (let m = 0; m < 200; m += 1) {
+      const values: Record<string, unknown> = {};
+      for (let k = 0; k < 300; k += 1) values[`bad${k}`] = "x";
+      exhausting[`state${m}`] = { base: values };
+    }
+    const later: Record<string, unknown> = {};
+    Object.defineProperty(later, "base", {
+      enumerable: true,
+      get() {
+        laterRead += 1;
+        return { base: { color: "#111111" } };
+      },
+    });
+
+    const result = checkStoredClasses(
+      [
+        { id: "a", slug: "a", orderIndex: 0, styles: exhausting },
+        { id: "b", slug: "b", orderIndex: 1, styles: later },
+      ],
+      REFUSING
+    );
+
+    expect(result.issues.join(" ")).toContain("not checked");
+    expect(laterRead).toBe(0);
+  });
+
   it("refuses a property map too large to check through", () => {
     // A budget per entry. Given none, the validator walks an unbounded map and
     // allocates a diagnostic per key. Truncation needs no handling of its own:

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -193,7 +193,10 @@ describe("checkStoredClasses", () => {
       tracker({ base: { base: { notAProperty: "x" } } }),
       REFUSING
     );
-    expect(result.issues).not.toEqual([]);
+    // The property NAME, not merely a non-empty array: a fixture typo trips the
+    // shape check and produces an issue too, which would keep this green while
+    // the rule it names stopped working.
+    expect(result.issues.join(" ")).toContain("notAProperty");
   });
 
   it("refuses a url() hidden under a property this engine has not learned", () => {
@@ -206,7 +209,7 @@ describe("checkStoredClasses", () => {
       tracker({ base: { base: { futureBackground: { url: TRACKER } } } }),
       REFUSING
     );
-    expect(result.issues).not.toEqual([]);
+    expect(result.issues.join(" ")).toContain("futureBackground");
   });
 
   it("bounds the whole section, not each map inside it", () => {
@@ -306,7 +309,11 @@ describe("checkStoredClasses", () => {
     // The module's two postures: the write refuses the section on any issue,
     // the read keeps what the compiler can narrow for itself.
     const result = checkStoredClasses(tracker(AT_BASE), REFUSING);
-    expect(result.issues).not.toEqual([]);
+    // The host refusal specifically. Any issue at all would satisfy a
+    // non-empty check, including one from the shape gate, which reports AND
+    // excludes the entry — so the two assertions would then contradict each
+    // other while both passed.
+    expect(result.issues.join(" ")).toContain("does not allow");
     expect(result.value).toHaveLength(1);
   });
 });

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -40,6 +40,7 @@ import {
   type NamedClass,
   type SiteToken,
   type SiteTokenSet,
+  type StyleIssueBudget,
   type TokenKind,
 } from "@nextlyhq/blocks-engine";
 
@@ -236,8 +237,8 @@ function readFontFace(entry: unknown): FontFaceDef | undefined {
  * Every property map inside a class envelope, with the address it sits at.
  *
  * `NodeStyles` is state × breakpoint × property, and the engine's value
- * validator judges ONE state × breakpoint's properties — so the two levels
- * above it are flattened here, by OWN key as the engine reads style maps.
+ * validator judges ONE state × breakpoint's properties, so the two levels above
+ * it are flattened here, by OWN key as the engine reads style maps.
  *
  * Every key is descended rather than only the states and breakpoints this
  * package knows. A breakpoint the site has not defined compiles to no rule
@@ -245,21 +246,23 @@ function readFontFace(entry: unknown): FontFaceDef | undefined {
  * visited only what compiles now would gate less than the sheet eventually
  * serves. A level that is not a record is skipped rather than reported: the
  * envelope's SHAPE is `isUsableNamedClass`'s question, already asked.
+ *
+ * A generator, so a caller that has seen enough stops the walk rather than
+ * receiving a list that was built in full first. The number of maps is bounded
+ * only by the document's byte cap, and a payload can spend that cap on maps as
+ * easily as on values.
  */
-function styleMapsIn(
+function* styleMapsIn(
   styles: Readonly<Record<string, unknown>>
-): { at: string; values: Readonly<Record<string, unknown>> }[] {
-  const maps: { at: string; values: Readonly<Record<string, unknown>> }[] = [];
+): Generator<{ at: string; values: Readonly<Record<string, unknown>> }> {
   for (const state of Object.keys(styles)) {
     const byBreakpoint = styles[state];
     if (!isPlainRecord(byBreakpoint)) continue;
     for (const breakpoint of Object.keys(byBreakpoint)) {
       const values = byBreakpoint[breakpoint];
-      if (isPlainRecord(values))
-        maps.push({ at: `${state}.${breakpoint}`, values });
+      if (isPlainRecord(values)) yield { at: `${state}.${breakpoint}`, values };
     }
   }
-  return maps;
 }
 
 /**
@@ -291,38 +294,47 @@ function styleMapsIn(
  * learns that property, with no further validating write. A gate that cannot
  * judge a value must not pass it: this package's own url-policy module states
  * the same rule for the same reason, that a security control should fail
- * toward the annoyance. The cost is that a site WITH a host policy cannot
- * store a property this engine does not know, and is told which one.
+ * toward the annoyance. The cost is that a site WITH a host policy cannot store
+ * a property this engine does not know, and is told which one.
  *
- * A BUDGET per entry, because `validateStyleValues` walks an unbounded map
- * when given none and allocates a diagnostic per key — measured at 5000 issues
- * for a 5000-key map, against 201 with a budget. Truncation needs no handling
- * of its own: `style-issues-truncated` is itself an error, so a map too large
- * to check through refuses the write rather than passing on a partial read.
+ * The BUDGET is the caller's, spanning the whole section, and the walk stops
+ * when it is spent. One budget per MAP would bound each map and nothing else:
+ * measured, a class spreading bad properties over 200 maps produced 40,200
+ * diagnostics that way against 201 with one budget, and the map count is
+ * limited only by the document's byte cap. Per CLASS has the same shape one
+ * level up — `MAX_NAMED_CLASSES` is 2000, and the count check reports without
+ * stopping the walk, so the array is not bounded at all.
  */
 function classValueIssues(
   entry: NamedClass,
   index: number,
-  policy: SectionPolicy
+  policy: SectionPolicy,
+  budget: StyleIssueBudget
 ): string[] {
   const options =
     policy.mayFetchUrl === undefined
       ? undefined
       : { mayFetchUrl: policy.mayFetchUrl };
   const mode = policy.mayFetchUrl === undefined ? "forgiving" : "strict";
-  return styleMapsIn(entry.styles).flatMap(({ at, values }) =>
-    validateStyleValues(
+  const issues: string[] = [];
+  for (const { at, values } of styleMapsIn(entry.styles)) {
+    for (const issue of validateStyleValues(
       values,
       `classes[${index}].styles.${at}`,
       mode,
-      newStyleIssueBudget(),
+      budget,
       false,
       undefined,
       options
-    )
-      .filter(issue => issue.severity === "error")
-      .map(issue => issue.message)
-  );
+    )) {
+      if (issue.severity === "error") issues.push(issue.message);
+    }
+    // Truncation is itself an error, so it is already among the messages above
+    // and the write is refused. What stopping adds is that the refusal costs a
+    // bounded amount of work rather than one batch per remaining map.
+    if (budget.truncated) break;
+  }
+  return issues;
 }
 
 /**
@@ -360,6 +372,9 @@ export function checkStoredClasses(
       `The class library holds ${raw.length} entries; the compiler reads at most ${MAX_NAMED_CLASSES}.`
     );
   }
+  // ONE for the whole section: see `classValueIssues` for why neither per map
+  // nor per class bounds the work a single write can ask for.
+  const budget = newStyleIssueBudget();
   const classes: NamedClass[] = [];
   const ids = new Set<string>();
   const slugs = new Set<string>();
@@ -383,7 +398,9 @@ export function checkStoredClasses(
     // Reported but still returned, as this module's two postures require: a
     // write refuses the section on any issue, while a read keeps the entry the
     // compiler will narrow for itself.
-    issues.push(...classValueIssues(entry, index, policy));
+    if (!budget.truncated) {
+      issues.push(...classValueIssues(entry, index, policy, budget));
+    }
     classes.push(entry);
   });
   return { value: classes, issues };

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -31,9 +31,11 @@ import {
   isPlainRecord,
   isUsableNamedClass,
   validateFontFace,
+  validateStyleValues,
   type BreakpointDef,
   type BreakpointSet,
   type FontFaceDef,
+  type MayFetchUrl,
   type NamedClass,
   type SiteToken,
   type SiteTokenSet,
@@ -60,6 +62,22 @@ export interface SectionCheck<T> {
 
 /** An absent section: nothing stored, nothing wrong. */
 const EMPTY: SectionCheck<never> = { issues: [] };
+
+/**
+ * What a checker needs from the SITE, beyond the value being checked.
+ *
+ * A predicate rather than the host list it is derived from, so this module
+ * keeps importing only the engine and one implementation of host matching
+ * answers for every channel — the published sheet, the canvas and this gate.
+ */
+export interface SectionPolicy {
+  /**
+   * Which hosts this site will fetch from. Absent means unasked rather than
+   * allowed, exactly as the engine treats it: with no policy the scheme
+   * allowlist is the only limit on a `url()`.
+   */
+  mayFetchUrl?: MayFetchUrl;
+}
 
 /** Shared shape guard: a string, when the slot allows one. */
 const optionalString = (value: unknown): value is string | undefined =>
@@ -214,6 +232,75 @@ function readFontFace(entry: unknown): FontFaceDef | undefined {
 }
 
 /**
+ * Every property map inside a class envelope, with the address it sits at.
+ *
+ * `NodeStyles` is state × breakpoint × property, and the engine's value
+ * validator judges ONE state × breakpoint's properties — so the two levels
+ * above it are flattened here, by OWN key as the engine reads style maps.
+ *
+ * Every key is descended rather than only the states and breakpoints this
+ * package knows. A breakpoint the site has not defined compiles to no rule
+ * today and to a real rule the moment someone defines it, so a walk that
+ * visited only what compiles now would gate less than the sheet eventually
+ * serves. A level that is not a record is skipped rather than reported: the
+ * envelope's SHAPE is `isUsableNamedClass`'s question, already asked.
+ */
+function styleMapsIn(
+  styles: Readonly<Record<string, unknown>>
+): { at: string; values: Readonly<Record<string, unknown>> }[] {
+  const maps: { at: string; values: Readonly<Record<string, unknown>> }[] = [];
+  for (const state of Object.keys(styles)) {
+    const byBreakpoint = styles[state];
+    if (!isPlainRecord(byBreakpoint)) continue;
+    for (const breakpoint of Object.keys(byBreakpoint)) {
+      const values = byBreakpoint[breakpoint];
+      if (isPlainRecord(values))
+        maps.push({ at: `${state}.${breakpoint}`, values });
+    }
+  }
+  return maps;
+}
+
+/**
+ * The values inside one class, judged by the engine's own validator.
+ *
+ * `isUsableNamedClass` types the envelope and stops at it: it never reads
+ * inside `styles`. So the section's only value-level limit used to be whatever
+ * the compiler drops at render, which is too late for a `url()` — the sheet is
+ * already serving it to every visitor of every page. The token section has
+ * never had that gap, because its gate IS its emitter.
+ *
+ * FORGIVING, reporting errors only, and both halves are deliberate. Under
+ * strict a property this engine has not learned is an error, and a document
+ * written by a newer engine is not something the author can fix here. A
+ * warning is a value the engine ACCEPTS and emits, so refusing on one would
+ * refuse writes whose result the sheet would render happily.
+ */
+function classValueIssues(
+  entry: NamedClass,
+  index: number,
+  policy: SectionPolicy
+): string[] {
+  const options =
+    policy.mayFetchUrl === undefined
+      ? undefined
+      : { mayFetchUrl: policy.mayFetchUrl };
+  return styleMapsIn(entry.styles).flatMap(({ at, values }) =>
+    validateStyleValues(
+      values,
+      `classes[${index}].styles.${at}`,
+      "forgiving",
+      undefined,
+      false,
+      undefined,
+      options
+    )
+      .filter(issue => issue.severity === "error")
+      .map(issue => issue.message)
+  );
+}
+
+/**
  * The stored class library.
  *
  * Usability per entry is the engine's `isUsableNamedClass` — the same
@@ -227,9 +314,16 @@ function readFontFace(entry: unknown): FontFaceDef | undefined {
  * makes a node's reference ambiguous. Both are cheaper to reject while the
  * writer is present than to explain after a page styles itself with the
  * wrong preset.
+ *
+ * The VALUES inside each entry are judged too, under the site's host policy —
+ * see `classValueIssues`. A class is emitted into the sheet of every public
+ * page, so a `url()` here reaches every visitor, and it is emitted verbatim
+ * rather than through the `var()` substitution that makes a token's own gate
+ * the last chance to stop one.
  */
 export function checkStoredClasses(
-  raw: unknown
+  raw: unknown,
+  policy: SectionPolicy = {}
 ): SectionCheck<readonly NamedClass[]> {
   if (raw === undefined || raw === null) return EMPTY;
   if (!Array.isArray(raw)) {
@@ -261,6 +355,10 @@ export function checkStoredClasses(
     }
     ids.add(entry.id);
     slugs.add(entry.slug);
+    // Reported but still returned, as this module's two postures require: a
+    // write refuses the section on any issue, while a read keeps the entry the
+    // compiler will narrow for itself.
+    issues.push(...classValueIssues(entry, index, policy));
     classes.push(entry);
   });
   return { value: classes, issues };

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -30,6 +30,7 @@ import {
   emitTokenBlocks,
   isPlainRecord,
   isUsableNamedClass,
+  newStyleIssueBudget,
   validateFontFace,
   validateStyleValues,
   type BreakpointDef,
@@ -270,11 +271,34 @@ function styleMapsIn(
  * already serving it to every visitor of every page. The token section has
  * never had that gap, because its gate IS its emitter.
  *
- * FORGIVING, reporting errors only, and both halves are deliberate. Under
- * strict a property this engine has not learned is an error, and a document
- * written by a newer engine is not something the author can fix here. A
- * warning is a value the engine ACCEPTS and emits, so refusing on one would
- * refuse writes whose result the sheet would render happily.
+ * Errors only. A warning is a value the engine ACCEPTS and emits, so refusing
+ * on one would refuse writes whose result the sheet would render happily.
+ *
+ * The MODE follows the policy, and it decides exactly one thing: whether a
+ * property this engine has not learned is an error or a warning. Measured —
+ * `mode === "strict" ? "error" : "warning"` occurs once in the whole validator,
+ * in the unknown-property branch — so this switch cannot over-refuse anything
+ * else.
+ *
+ * With no policy the answer is FORGIVING: a document written by a newer engine
+ * is not something the author can fix here, and there is no host rule to
+ * enforce anyway.
+ *
+ * With a policy it is STRICT, because the validator does not look INSIDE an
+ * unknown property. `{ futureBackground: { url: "https://tracker.example" } }`
+ * yields `unknown-style-property` alone — no value check at all — so a
+ * forgiving read would store a URL that becomes live the moment an engine
+ * learns that property, with no further validating write. A gate that cannot
+ * judge a value must not pass it: this package's own url-policy module states
+ * the same rule for the same reason, that a security control should fail
+ * toward the annoyance. The cost is that a site WITH a host policy cannot
+ * store a property this engine does not know, and is told which one.
+ *
+ * A BUDGET per entry, because `validateStyleValues` walks an unbounded map
+ * when given none and allocates a diagnostic per key — measured at 5000 issues
+ * for a 5000-key map, against 201 with a budget. Truncation needs no handling
+ * of its own: `style-issues-truncated` is itself an error, so a map too large
+ * to check through refuses the write rather than passing on a partial read.
  */
 function classValueIssues(
   entry: NamedClass,
@@ -285,12 +309,13 @@ function classValueIssues(
     policy.mayFetchUrl === undefined
       ? undefined
       : { mayFetchUrl: policy.mayFetchUrl };
+  const mode = policy.mayFetchUrl === undefined ? "forgiving" : "strict";
   return styleMapsIn(entry.styles).flatMap(({ at, values }) =>
     validateStyleValues(
       values,
       `classes[${index}].styles.${at}`,
-      "forgiving",
-      undefined,
+      mode,
+      newStyleIssueBudget(),
       false,
       undefined,
       options

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -255,10 +255,20 @@ function readFontFace(entry: unknown): FontFaceDef | undefined {
 function* styleMapsIn(
   styles: Readonly<Record<string, unknown>>
 ): Generator<{ at: string; values: Readonly<Record<string, unknown>> }> {
-  for (const state of Object.keys(styles)) {
+  // `for...in` with an own-key guard rather than `Object.keys`, which is the
+  // idiom `validateStyleValues` iterates its own property map by, for the
+  // reason its comment gives: a map with a hundred thousand keys would
+  // otherwise be materialised in full before anything downstream can stop.
+  // Measured through a proxy counting descriptor lookups, breaking after the
+  // first entry: `Object.keys` costs one per key up front, `for...in` one in
+  // total. The guard is what keeps this to OWN keys, which the engine reads
+  // style maps by.
+  for (const state in styles) {
+    if (!Object.hasOwn(styles, state)) continue;
     const byBreakpoint = styles[state];
     if (!isPlainRecord(byBreakpoint)) continue;
-    for (const breakpoint of Object.keys(byBreakpoint)) {
+    for (const breakpoint in byBreakpoint) {
+      if (!Object.hasOwn(byBreakpoint, breakpoint)) continue;
       const values = byBreakpoint[breakpoint];
       if (isPlainRecord(values)) yield { at: `${state}.${breakpoint}`, values };
     }

--- a/packages/plugin-page-builder/src/site-style-storage.test.ts
+++ b/packages/plugin-page-builder/src/site-style-storage.test.ts
@@ -1,7 +1,40 @@
 import { defineSingle, json } from "nextly/config";
 import { describe, expect, it } from "vitest";
 
+import { pageBuilder } from "./plugin";
 import { siteStyleSingle } from "./site-style-storage";
+
+/** A host no site in these tests allows. */
+const TRACKER = "https://tracker.example/p.png";
+
+/** One stored class carrying a url() at the base state and breakpoint. */
+const CLASSES = [
+  {
+    id: "c1",
+    slug: "card",
+    orderIndex: 0,
+    styles: { base: { base: { background: { url: TRACKER } } } },
+  },
+];
+
+/**
+ * The `validate` the Site Style single puts in front of a classes write.
+ *
+ * Reached through the field list rather than by calling the checker, because
+ * what is being tested is the WIRING: a checker that judges perfectly and a
+ * single that never hands it the policy produce identical unit tests and a
+ * site that still serves the tracker.
+ */
+function classesValidate(single: {
+  fields: readonly { name?: string; validate?: unknown }[];
+}): (value: unknown) => string | true {
+  const field = single.fields.find(f => f.name === "classes");
+  if (field === undefined) throw new Error("no classes field on the single");
+  if (typeof field.validate !== "function") {
+    throw new Error("the classes field declares no validate");
+  }
+  return field.validate as (value: unknown) => string | true;
+}
 
 /**
  * The operations a config declares a code-defined rule for.
@@ -53,5 +86,77 @@ describe("the Site Style single's access", () => {
     // published document, and only the published document is emitted into a
     // public page.
     expect(siteStyleSingle().versions).toBe(true);
+  });
+});
+
+describe("the Site Style single's class write gate", () => {
+  it("refuses a stored class whose url() the policy disallows", () => {
+    const verdict = classesValidate(
+      siteStyleSingle({ mayFetchUrl: () => false })
+    )(CLASSES);
+
+    expect(verdict).not.toBe(true);
+    expect(String(verdict)).toContain("does not allow");
+  });
+
+  it("accepts it when the policy allows the host", () => {
+    // Separates "the single threaded the policy" from "the single refuses
+    // every url()", which would pass the assertion above while consulting
+    // nothing.
+    expect(
+      classesValidate(siteStyleSingle({ mayFetchUrl: () => true }))(CLASSES)
+    ).toBe(true);
+  });
+
+  it("accepts it with no policy, the behaviour a site without remotePatterns keeps", () => {
+    expect(classesValidate(siteStyleSingle())(CLASSES)).toBe(true);
+  });
+});
+
+describe("the policy the plugin derives from remotePatterns", () => {
+  /** The Site Style single as the plugin actually registers it. */
+  function registeredSingle(opts: Parameters<typeof pageBuilder>[0]) {
+    const singles = pageBuilder(opts).contributes?.singles;
+    if (singles === undefined || singles.length === 0) {
+      throw new Error("the plugin registered no singles");
+    }
+    return singles[0] as {
+      fields: readonly { name?: string; validate?: unknown }[];
+    };
+  }
+
+  it("refuses a class url() from a host the patterns do not name", () => {
+    const verdict = classesValidate(
+      registeredSingle({ remotePatterns: [{ hostname: "cdn.example.com" }] })
+    )(CLASSES);
+
+    expect(verdict).not.toBe(true);
+    expect(String(verdict)).toContain("does not allow");
+  });
+
+  it("accepts one from a host they do name", () => {
+    // The positive control for the derivation: the same patterns, a URL inside
+    // them. Without it, a predicate that refused everything would satisfy the
+    // test above.
+    const allowed = [
+      {
+        ...CLASSES[0],
+        styles: {
+          base: {
+            base: { background: { url: "https://cdn.example.com/a.png" } },
+          },
+        },
+      },
+    ];
+
+    expect(
+      classesValidate(
+        registeredSingle({ remotePatterns: [{ hostname: "cdn.example.com" }] })
+      )(allowed)
+    ).toBe(true);
+  });
+
+  it("asks nothing when the host configured no patterns", () => {
+    expect(classesValidate(registeredSingle({}))(CLASSES)).toBe(true);
   });
 });

--- a/packages/plugin-page-builder/src/site-style-storage.ts
+++ b/packages/plugin-page-builder/src/site-style-storage.ts
@@ -28,6 +28,7 @@ import {
   checkStoredTokens,
   readSiteStyleRecord,
   type SectionCheck,
+  type SectionPolicy,
 } from "./site-style-record";
 
 /** The single the stored tier lives in. One document per site, by design. */
@@ -65,7 +66,7 @@ const refusing =
  *   whole sections at a time; a field-per-property schema here would be a
  *   third statement of shapes two packages already agree on.
  */
-export function siteStyleSingle() {
+export function siteStyleSingle(policy: SectionPolicy = {}) {
   return defineSingle({
     slug: SITE_STYLE_SLUG,
     label: { singular: "Site Style" },
@@ -112,7 +113,12 @@ export function siteStyleSingle() {
       json({
         name: "classes",
         label: "Named classes",
-        validate: refusing(checkStoredClasses),
+        // The one section whose gate is given the site's host policy: a class
+        // is emitted verbatim into every public page's sheet, so a `url()`
+        // stored here is fetched by every visitor. Tokens reach the page as a
+        // `var()` substitution, which is why their own gate is the last place
+        // a URL can be stopped and this one is the last place a class's can.
+        validate: refusing(raw => checkStoredClasses(raw, policy)),
         admin: {
           description:
             "Reusable style presets: [{ id, slug, orderIndex, styles }]. Documents reference a class by id; a later orderIndex overrides an earlier one.",


### PR DESCRIPTION
Remediates the write half of `finding:pb-stored-class-urls-escape-host-fetch-policy` (P1) against the merged #1116. Second of the nine findings on that PR; the first landed as #1130.

## The defect

A named class is emitted **verbatim** into the sheet of every public page, and the Site Style write gate never read inside its `styles`. `isUsableNamedClass` types the envelope — id, slug, orderIndex, `isPlainRecord(styles)` — and stops there.

So this write was accepted:

```json
{ "id": "x", "slug": "x", "orderIndex": 0,
  "styles": { "base": { "base": { "background": { "url": "https://tracker.example/p.png" } } } } }
```

and every public page then served `.nx-page .nx-c-x{background-image:url(https://tracker.example/p.png)}` — so every visitor of every page requested a host the site had explicitly refused.

**The identical value written on a node is refused.** That asymmetry is the tell that a control exists and this path sat outside it: `PageRenderer` passes `remotePatterns` into `effectiveCompile` for node styles and passes nothing to `compileSiteSheet`. `SiteSheetInput` has no `mayFetchUrl` member at all, and `checkUrlValue` says what that means itself — *"A caller with no host policy leaves this undefined and nothing changes: the scheme allowlist above is then the only limit"* — which is `["http","https"]`. The site sheet is emitted **first**, and a page sheet that merely omits a declaration cannot retract one.

The token section never had this gap, because its gate **is** its emitter. A token also reaches the page as a `var()` substitution; a class declaration does not, so there is no later step where a policy could still see the URL.

## The fix

The classes field runs each entry through the engine's own `validateStyleValues` with a predicate derived from `remotePatterns` via `isFetchableUrl` — the engine's matcher, which this package already re-exports precisely so there is one answer to "may this be fetched" rather than one per surface.

Two choices, both measured before being made and both break-verified:

**Forgiving mode, errors only.** Measured: `unknown-style-property` is `error` under strict and `warning` under forgiving, while a disallowed URL is `error` under both. Refusing on warnings would refuse writes whose result the sheet renders happily; strict would refuse a document a newer engine wrote.

**Every state and breakpoint key is descended**, not only what compiles today. A breakpoint the site has not defined emits no rule now and a real rule the moment someone defines it — so a compiler-as-validator gate would have let that through and served it later. There is a test for exactly that.

**A site with no `remotePatterns` is unchanged.** The engine treats an absent policy as unasked, not as an empty allowlist — an empty list would refuse every remote URL and break every unconfigured site. Pinned by a test.

## Evidence

Five breaks, each failing a distinct set — which is what makes the three wiring layers separately covered rather than one assertion repeated:

| break | fails |
|---|---|
| the value walk never runs | 5 tests, across both files |
| the single drops the policy | **only** the 2 wiring tests |
| the plugin derives no policy | **only** the 1 derivation test |
| report warnings too | only the "does not refuse a warning" test |
| `strict` instead of `forgiving` | only the "does not refuse a warning" test |

Each refusal test is paired with a positive control on the same input with an allowing policy, so none of them can pass on a gate that simply rejects every `url()` without consulting the predicate.

## Not in this PR

The **render half** — adding `mayFetchUrl` to `SiteSheetInput` so `compileSiteSheet` threads the predicate `PageRenderer` already derived. That is the one-implementation shape and it also covers classes stored before this change, but it lands in `blocks-engine` and `blocks-react`, outside this lane's territory. It is the next PR; the finding stays open until it lands.

## Gates

build 0 · vitest 115 tests / 17 files · `check-types` 0 (including `tsconfig.tests.json`) · `lint` 0 with `--max-warnings 0` · comment convention 0 new · `fallow audit` verdict `pass`, every `*_introduced` at 0.

Fallow initially failed this branch with `complexity_introduced=1` (cognitive 16 on the nested walk); the envelope walk and the judgement are now separate functions, and the break was re-verified after the refactor rather than assumed to survive it.

Changeset generated from `.changeset/config.json` (25 packages), checker-verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Site Style URL values now respect configured remote URL patterns.
  - URLs from unapproved hosts are rejected, while matching hosts remain allowed.
  - When no remote URL patterns are configured, URL values continue to be accepted.
  - Validation now covers Site Style classes across states and responsive breakpoints.

- **Bug Fixes**
  - Invalid URL references are surfaced as style validation errors without removing associated entries from stored values.
  - Validation now limits reported issues while preserving usable style classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->