### PR TITLE
fix(blocks-engine): compile the site sheet under the host-fetch policy

### DIFF
--- a/.changeset/site-sheet-fetch-policy.md
+++ b/.changeset/site-sheet-fetch-policy.md
@@ -1,0 +1,51 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(blocks-engine, blocks-react): give the site sheet the host-fetch policy the page sheet already had
+
+`SiteSheetInput` had no `mayFetchUrl` member, so `compileSiteSheet` compiled the
+named-class and block-default tiers with no host question asked — while
+`PageRenderer` passed `remotePatterns` into the page compile for node styles.
+A stored class naming a host the site refuses was therefore emitted into the
+sheet of every page, and the site sheet is emitted first, where a page sheet
+that merely omits a declaration cannot retract one.
+
+`SiteSheetInput` now accepts `mayFetchUrl` and threads it into its
+`compilePageCss` call. `effectiveCompile` returns the predicate it derives so
+`PageRenderer` hands the same function to both sheets: reading it off the
+reconciled compile context would have asked nothing on the ordinary production
+path, where a consumer rendering a stored artifact supplies no style context and
+that context is `undefined`.
+
+No `fetchPolicyId` counterpart on this input. That stamp exists so a reader can
+tell whether a stored sheet predates the current rules; this artifact is
+compiled per render and addressed by the hash of its own bytes, so a policy that
+changes what is emitted changes the name.
+
+A site that configured no `remotePatterns` is unchanged — absent is unasked, not
+an empty allowlist.

--- a/packages/blocks-engine/src/style/site-sheet.test.ts
+++ b/packages/blocks-engine/src/style/site-sheet.test.ts
@@ -269,3 +269,59 @@ describe("what the sheet declines to write", () => {
     expect(warnings.length).toBeGreaterThan(0);
   });
 });
+
+describe("the site sheet's host-fetch policy", () => {
+  // The class and block-default tiers are emitted VERBATIM into every page of
+  // the site, so a stored `url()` here is a request every visitor of every page
+  // makes. A page's own sheet has been compiled under a host policy since that
+  // existed; this sheet had no way to be given one, and it is emitted FIRST —
+  // a page sheet that merely omits a declaration cannot retract one.
+  const TRACKER = "https://tracker.example/p.png";
+  const tracking: NamedClass = {
+    id: "c9",
+    slug: "tracked",
+    orderIndex: 1,
+    styles: styles({ background: { url: TRACKER } }),
+  };
+
+  it("emits the url when no policy is given, which is unasked rather than allowed", () => {
+    // Pinned deliberately. Absent is not an empty allowlist: an empty list
+    // refuses every remote URL, and a site that configured none keeps exactly
+    // what it has today.
+    expect(sheet({ classes: [tracking] }).css).toContain(TRACKER);
+  });
+
+  it("emits it when the policy allows the host", () => {
+    // The positive control. Without it the refusal below passes just as well on
+    // a compile that dropped the declaration for some unrelated reason.
+    const allowed = sheet({ classes: [tracking], mayFetchUrl: () => true });
+    expect(allowed.css).toContain(TRACKER);
+  });
+
+  it("withholds it when the policy refuses the host", () => {
+    const refused = sheet({ classes: [tracking], mayFetchUrl: () => false });
+    expect(refused.css).not.toContain(TRACKER);
+    expect(refused.warnings).not.toHaveLength(0);
+  });
+
+  it("still emits the tiers around the withheld declaration", () => {
+    // A policy narrows one declaration; it does not cost the site its sheet.
+    const refused = sheet({
+      classes: [card, tracking],
+      mayFetchUrl: () => false,
+    });
+    expect(refused.css).toContain("blue");
+    expect(refused.css).toContain("green");
+  });
+
+  it("changes the content hash, so a cached sheet cannot be mistaken for it", () => {
+    // Why this input needs no `fetchPolicyId` counterpart. A stored PAGE sheet
+    // carries a stamp because a predicate is opaque and a reader has to decide
+    // whether the artifact predates the current rules. This artifact is
+    // compiled per render and addressed by the hash of its own bytes, so a
+    // policy that changes what is emitted changes the name.
+    const open = sheet({ classes: [tracking] });
+    const closed = sheet({ classes: [tracking], mayFetchUrl: () => false });
+    expect(closed.contentHash).not.toBe(open.contentHash);
+  });
+});

--- a/packages/blocks-engine/src/style/site-sheet.ts
+++ b/packages/blocks-engine/src/style/site-sheet.ts
@@ -17,6 +17,7 @@ import type { BlockDocument, BreakpointSet, NodeStyles } from "../document";
 import type { ValidationIssue } from "../validation";
 
 import { compilePageCss } from "./compile-page";
+import type { MayFetchUrl } from "./css-value";
 import type { NamedClass } from "./named-class";
 import { hashId } from "./node-class";
 import type { FontFaceDef, SiteTokenSet } from "./site-tokens";
@@ -36,6 +37,28 @@ export interface SiteSheetInput {
   breakpoints: BreakpointSet;
   /** The custom-property prefix tokens are written under. */
   tokenPrefix?: string;
+  /**
+   * Which hosts this site will fetch from.
+   *
+   * The class and block-default tiers are emitted VERBATIM into every page of
+   * the site, and a declaration is a fetching surface: one stored
+   * `background-image: url(...)` is a request every visitor of every page
+   * makes. A page's own sheet is compiled with this policy already; without it
+   * here, the two sheets judged the same value differently, and the site sheet
+   * is emitted FIRST — a page sheet that merely omits a declaration cannot
+   * retract one.
+   *
+   * Left undefined, no host question is asked and the compile behaves as it
+   * did before this existed. That is unasked rather than allowed: an empty
+   * allowlist would be the opposite answer.
+   *
+   * No `fetchPolicyId` counterpart, unlike the page compile. That stamp exists
+   * so a reader can tell whether a STORED sheet was compiled under other
+   * rules; this artifact is compiled per render and addressed by the hash of
+   * its own bytes, so a policy that changes what is emitted changes the hash
+   * and cannot be mistaken for the old sheet.
+   */
+  mayFetchUrl?: MayFetchUrl;
 }
 
 /** The shared sheet and the name it is addressed by. */
@@ -134,6 +157,9 @@ export function compileSiteSheet(input: SiteSheetInput): SiteSheetArtifact {
     blockBases,
     namedClasses: input.classes ?? [],
     ...(tokenPrefix === undefined ? {} : { tokenPrefix }),
+    ...(input.mayFetchUrl === undefined
+      ? {}
+      : { mayFetchUrl: input.mayFetchUrl }),
   });
   warnings.push(...tiers.warnings);
   if (tiers.css !== "") blocks.push(tiers.css);

--- a/packages/blocks-react/src/host-fetch-policy.test.tsx
+++ b/packages/blocks-react/src/host-fetch-policy.test.tsx
@@ -1,10 +1,16 @@
 /**
- * One host list, asked by both channels a page fetches through.
+ * One host list, asked by every channel a page fetches through.
  *
- * A block writes an `<iframe src>`; a compiled stylesheet writes `url(...)` into
- * a rule that fires wherever it applies. Both turn a stored value into a
- * request, so a policy answered by only one of them is not a policy — and the
- * failure would be invisible, because the channel still working looks correct.
+ * A block writes an `<iframe src>`; a page's compiled stylesheet writes
+ * `url(...)` into a rule that fires wherever it applies; and the SITE sheet
+ * writes the same thing for the named-class and block-default tiers, on every
+ * page of the site at once. All three turn a stored value into a request, so a
+ * policy answered by only some of them is not a policy — and the failure would
+ * be invisible, because the channels still working look correct.
+ *
+ * The site sheet is the one that was missing, and it is the widest: it is
+ * emitted on every page and it is emitted FIRST, so a page sheet that merely
+ * omits a declaration cannot retract one it already carried.
  */
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
@@ -13,7 +19,7 @@ import {
   DOCUMENT_FORMAT_VERSION,
   type BlockDocument,
 } from "@nextlyhq/blocks-engine";
-import type { RemotePattern } from "@nextlyhq/blocks-engine";
+import type { NodeStyles, RemotePattern } from "@nextlyhq/blocks-engine";
 
 import { renderEmbed } from "./blocks/embed";
 import { renderImage } from "./blocks/image";
@@ -81,6 +87,84 @@ async function pageCss(
   );
   return markup;
 }
+
+/**
+ * The markup for a page whose SITE sheet carries a stored class with a `url()`.
+ *
+ * Deliberately renders with NO `styleContext`, which is the ordinary production
+ * path — a consumer showing a stored artifact supplies none — and is exactly
+ * where reading the predicate off the reconciled compile context would have
+ * found `undefined` and asked nothing.
+ */
+function siteSheetMarkup(
+  url: string,
+  hostPolicy?: BlockHostPolicy,
+  ownPredicate?: (candidate: string) => boolean
+): string {
+  return renderToStaticMarkup(
+    <PageRenderer
+      document={{
+        formatVersion: DOCUMENT_FORMAT_VERSION,
+        kind: "page",
+        nodes: [
+          { id: "n1", type: "core/text", version: 1, props: { text: "body" } },
+        ],
+      }}
+      blocks={createBlockResolver(coreBlocks)}
+      siteStyles={{
+        breakpoints: { viewport: [], container: [] },
+        classes: [
+          {
+            id: "c1",
+            slug: "tracked",
+            orderIndex: 0,
+            styles: {
+              base: { base: { background: { url } } },
+            } as unknown as NodeStyles,
+          },
+        ],
+        ...(ownPredicate === undefined ? {} : { mayFetchUrl: ownPredicate }),
+      }}
+      {...(hostPolicy === undefined ? {} : { hostPolicy })}
+    />
+  );
+}
+
+describe("the site sheet's share of the host fetch list", () => {
+  it("emits an allowed host, which is the control for every absence below", () => {
+    expect(
+      siteSheetMarkup("https://player.allowed.test/a.png", {
+        remotePatterns: ALLOWED,
+      })
+    ).toContain("player.allowed.test");
+  });
+
+  it("refuses an unlisted host in the SITE sheet, with no style context at all", () => {
+    expect(
+      siteSheetMarkup("https://cdn.other.test/a.png", {
+        remotePatterns: ALLOWED,
+      })
+    ).not.toContain("cdn.other.test");
+  });
+
+  it("asks nothing when the host configured no list", () => {
+    expect(siteSheetMarkup("https://cdn.other.test/a.png")).toContain(
+      "cdn.other.test"
+    );
+  });
+
+  it("keeps a predicate set on siteStyles over one derived from the list", () => {
+    // The same precedence the style context gets: a caller who passed one meant
+    // it, and deriving one here would silently replace it.
+    expect(
+      siteSheetMarkup(
+        "https://cdn.other.test/a.png",
+        { remotePatterns: ALLOWED },
+        () => true
+      )
+    ).toContain("cdn.other.test");
+  });
+});
 
 describe("the host fetch list", () => {
   it("lets an allowed origin through both channels", async () => {

--- a/packages/blocks-react/src/host-fetch-policy.test.tsx
+++ b/packages/blocks-react/src/host-fetch-policy.test.tsx
@@ -26,7 +26,7 @@ import { renderImage } from "./blocks/image";
 import type { BlockHostPolicy, BlockRenderArgs, PageContext } from "./context";
 import type { PageStyles } from "./styles";
 import { PageRenderer } from "./page-renderer";
-import { fetchPolicyLabel } from "./styles";
+import { effectiveCompile, fetchPolicyLabel } from "./styles";
 import { createBlockResolver } from "./resolver";
 import { coreBlocks } from "./blocks";
 
@@ -129,6 +129,52 @@ function siteSheetMarkup(
     />
   );
 }
+
+describe("the one derived fetch predicate", () => {
+  // Identity, not equivalence. Two closures over the same pattern list behave
+  // alike today and are two implementations of one policy — the shape this
+  // module exists to prevent — so the property worth asserting is that the site
+  // sheet and the page context receive the SAME function object.
+  it("hands the page context the same function it hands the site sheet", () => {
+    const result = effectiveCompile({
+      styleContext: { breakpoints: { viewport: [], container: [] } },
+      styles: undefined,
+      limits: undefined,
+      remotePatterns: ALLOWED,
+    });
+
+    expect(result.mayFetchUrl).toBeTypeOf("function");
+    expect(result.context?.mayFetchUrl).toBe(result.mayFetchUrl);
+  });
+
+  it("keeps a caller's own predicate as that one function", () => {
+    const own = (): boolean => true;
+    const result = effectiveCompile({
+      styleContext: {
+        breakpoints: { viewport: [], container: [] },
+        mayFetchUrl: own,
+      },
+      styles: undefined,
+      limits: undefined,
+      remotePatterns: ALLOWED,
+    });
+
+    expect(result.mayFetchUrl).toBe(own);
+    expect(result.context?.mayFetchUrl).toBe(own);
+  });
+
+  it("derives nothing when the host configured no list", () => {
+    const result = effectiveCompile({
+      styleContext: { breakpoints: { viewport: [], container: [] } },
+      styles: undefined,
+      limits: undefined,
+      remotePatterns: undefined,
+    });
+
+    expect(result.mayFetchUrl).toBeUndefined();
+    expect(result.context?.mayFetchUrl).toBeUndefined();
+  });
+});
 
 describe("the site sheet's share of the host fetch list", () => {
   it("emits an allowed host, which is the control for every absence below", () => {

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -404,7 +404,11 @@ export function PageRenderer({
       ? { ...styleContext, namedClasses: siteStyles.classes }
       : styleContext;
 
-  const { context: compileContext, fetchPolicyId } = effectiveCompile({
+  const {
+    context: compileContext,
+    fetchPolicyId,
+    mayFetchUrl,
+  } = effectiveCompile({
     styleContext: pageStyleContext,
     styles,
     limits,
@@ -456,6 +460,17 @@ export function PageRenderer({
           ...siteInput,
           breakpoints: siteBreakpoints,
           tokens: resolveSiteTokens(siteInput?.tokens),
+          // The SAME predicate the page sheet is compiled with, taken from the
+          // one place it is derived rather than derived again here. The class
+          // and block-default tiers are emitted verbatim into every page, so
+          // without this a stored class could name a host the node styles
+          // beside it are refused for — and this sheet is emitted first, where
+          // a later omission cannot retract it. A caller who put a predicate on
+          // `siteStyles` keeps it, matching how `effectiveCompile` treats one
+          // on the style context.
+          ...(mayFetchUrl === undefined || siteInput?.mayFetchUrl !== undefined
+            ? {}
+            : { mayFetchUrl }),
         });
 
   return (

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -724,9 +724,13 @@ export function effectiveCompile(args: {
     context: {
       ...args.styleContext,
       limits: args.limits ?? args.styleContext.limits ?? DEFAULT_LIMITS,
-      ...(patterns === undefined || args.styleContext.mayFetchUrl !== undefined
-        ? {}
-        : { mayFetchUrl: (url: string) => isFetchableUrl(url, patterns) }),
+      // `derived` itself, not a second closure over the same list. It already
+      // encodes both rules: a caller's own predicate is what it resolved to,
+      // and no list with no caller predicate leaves it undefined. Rebuilding
+      // one here would hand the two sheets different functions while this
+      // module promised them one, which is the divergence the promise exists
+      // to prevent.
+      ...(derived === undefined ? {} : { mayFetchUrl: derived }),
       ...(args.styleContext.scope === undefined &&
       typeof args.styles?.scope === "string"
         ? { scope: args.styles.scope }

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -10,6 +10,7 @@ import {
   type BlockNode,
   type CompiledPageCss,
   type DocumentLimits,
+  type MayFetchUrl,
   type RemotePatternInput,
   type NodeStyles,
   type StyleCompileContext,
@@ -651,6 +652,17 @@ export interface EffectiveCompile {
   context: StyleCompileContext | undefined;
   /** The policy label to compare a stored sheet's stamp against. */
   fetchPolicyId: string | undefined;
+  /**
+   * The host-fetch predicate in force for this render — the caller's own when
+   * they supplied one, otherwise the one derived from the pattern list.
+   *
+   * Returned in its own right because the SITE sheet needs it and cannot read
+   * it off `context`: that is `undefined` whenever the caller gave no style
+   * context, while the site sheet is compiled regardless. Deriving it a second
+   * time at the other call site is how one sheet comes to refuse a host the
+   * other serves.
+   */
+  mayFetchUrl: MayFetchUrl | undefined;
 }
 
 /**
@@ -697,9 +709,18 @@ export function effectiveCompile(args: {
     args.styleContext?.mayFetchUrl === undefined
       ? fetchPolicyLabel(patterns)
       : (args.styleContext.fetchPolicyId ?? UNIDENTIFIED_FETCH_POLICY);
+  // Derived ONCE, here, and handed back so both sheets are judged by the same
+  // function. The caller's own predicate wins for the same reason it does
+  // below; a pattern list with no caller predicate becomes one.
+  const derived =
+    args.styleContext?.mayFetchUrl ??
+    (patterns === undefined
+      ? undefined
+      : (url: string) => isFetchableUrl(url, patterns));
   if (args.styleContext === undefined)
-    return { context: undefined, fetchPolicyId };
+    return { context: undefined, fetchPolicyId, mayFetchUrl: derived };
   return {
+    mayFetchUrl: derived,
     context: {
       ...args.styleContext,
       limits: args.limits ?? args.styleContext.limits ?? DEFAULT_LIMITS,


### PR DESCRIPTION
The **render half** of `finding:pb-stored-class-urls-escape-host-fetch-policy`. The write half landed in #1131; this is the durable control, and the two are not redundant.

## The gap

`SiteSheetInput` had **no `mayFetchUrl` member at all**. `compileSiteSheet` called `compilePageCss` with only `breakpoints`, `blockBases`, `namedClasses` and `tokenPrefix` — while `compilePageCss` has always read a policy off its context and threaded it into the named-class tier. So:

- `PageRenderer` passed `remotePatterns` into `effectiveCompile` for **node styles**, and passed nothing to `compileSiteSheet`.
- The class and block-default tiers were compiled with no host question asked, on every page of the site.
- The site sheet is emitted **first**, so a page sheet that merely omits a declaration cannot retract one it already carried.

## The fix

`SiteSheetInput` accepts `mayFetchUrl` and threads it into its `compilePageCss` call.

`effectiveCompile` now returns the predicate it derives, and `PageRenderer` hands that same function to both sheets. **That last part is the load-bearing choice**, and there is a test that fails on the obvious alternative: reading `compileContext?.mayFetchUrl` looks equivalent and is not, because `effectiveCompile` returns `context: undefined` whenever the caller supplied no style context — which is the ordinary production path, since a consumer rendering a stored artifact supplies none, and the site sheet is compiled anyway.

Deriving it a second time at the site-sheet call site would have been the other option. It is the same defect one layer down: two derivations of one policy agree until someone edits one.

## No `fetchPolicyId` counterpart

Asked and answered rather than skipped. The page compile carries that stamp because a predicate is opaque and a reader has to decide whether a **stored** sheet predates the current rules. This artifact is compiled per render and addressed by the hash of its own bytes, so a policy that changes what is emitted changes the name. There is a test asserting the hash actually differs.

## Evidence

Every refusal is paired with a positive control on the same input under an allowing policy, so none can pass on a compile that dropped the declaration for an unrelated reason. Break-verified:

| break | fails |
|---|---|
| `compileSiteSheet` declares the field but never threads it | the withholding test **and** the content-hash test; the "allowed" and "unasked" controls still pass |
| `PageRenderer` does not pass the predicate | the site-sheet refusal test |
| `PageRenderer` reads it off `compileContext` instead | **the same test** — this is the plausible-but-wrong implementation |

`host-fetch-policy.test.tsx` opened with the premise *"one host list, asked by both channels a page fetches through… a policy answered by only one of them is not a policy."* There were three channels, not two. The docblock now says so and the third is covered.

## Unchanged behaviour

A site that configured no `remotePatterns` renders exactly as before — the engine treats an absent policy as **unasked**, not as an empty allowlist, which would be the opposite answer and would refuse every remote URL on every unconfigured site. Pinned by a test on both sides.

## Gates

build 0 · blocks-engine 1291 tests / 31 files · blocks-react 678 tests / 28 files · plugin-page-builder 103 tests / 17 files (downstream, unaffected) · `check-types` 0 on all three including `tsconfig.tests.json` · `lint` 0 with `--max-warnings 0` · comment convention 0 new · `fallow audit` verdict `pass`, every `*_introduced` at 0.

Changeset generated from `.changeset/config.json` (25 packages), checker-verified.