### PR TITLE
fix(blocks-react): resolve every shared site-style input once per render

### DIFF
--- a/.changeset/site-style-remediation-rest.md
+++ b/.changeset/site-style-remediation-rest.md
@@ -1,0 +1,55 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(blocks-react): resolve every shared site-style input once per render
+
+A render carries two style inputs — the route's `styleContext` and the site's
+`siteStyles` — and compiles twice from them: the shared sheet, and the page's
+own values. Only the class library was reconciled between them. `breakpoints`,
+`tokenPrefix` and `blockBases` were each computed twice, so a stored value that
+reached the sheet never reached the page compile.
+
+The consequences were silent, because each sheet is internally consistent and
+neither reports anything. A stored breakpoint set replaces the config one
+whole, so a node's value stored under an id the route's set lacks was dropped
+outright; a stored token prefix left every `{ $token }` reference pointing at a
+custom property nothing declared, and an unresolved custom property invalidates
+the declaration rather than reporting.
+
+`PageRenderer` now resolves the shared inputs once and gives the same values to
+both compiles. Precedence is unchanged for every field — the defect was two
+computations of one question, not the wrong answer to it. A table typed over
+every `SiteSheetInput` key records which side each belongs on, so a field added
+there is a compile error until someone says.
+
+`BlocksPageConfig` also gains `siteStyleSingles`. A `siteStyles` provider is
+called per render, which on a pre-rendered route is not the same as being read
+per render: the whole render is cached and only a tag the page carries rebuilds
+it, and a Direct API read contributes none. Naming the single puts
+`nextly:single:<slug>` on the route, so an admin's save reaches the next page
+view as the documentation already promised.

--- a/.changeset/site-style-remediation-rest.md
+++ b/.changeset/site-style-remediation-rest.md
@@ -71,9 +71,19 @@ when a caller states its config tier. Token collisions are reported as the
 DIFFERENCE the write introduces, so a site whose own config already emits an
 issue does not have someone else's mistake charged to the admin saving a token.
 
-The configured breakpoint set threaded into the blocks field validator was
-inert: an unknown breakpoint is a warning under forgiving validation and the
-error filter dropped it, so no document was judged differently by the set. It is
-reported once a set has actually been wired in, and stays silent against the
-empty fallback, where every id would be unknown and every styled document would
-be refused.
+The configured breakpoint set threaded into the blocks field validator judges no
+document, and that is now recorded as the deliberate limit it is rather than
+left looking like an oversight. Making it strict was tried and is wrong while
+the set reaching that call is the config tier alone, resolved at config time
+where there is no database: a page styled at a breakpoint an admin STORED would
+be refused on save while the published renderer compiles it. The parameter keeps
+deciding the one property that is true of the set alone — ids colliding across
+axes — and becomes load-bearing for documents once something can reach the
+stored tier.
+
+Class writes are judged through `resolveSiteStyle` rather than against the two
+tiers concatenated. The merge is keyed by class ID, so a stored class sharing an
+id with a configured one REPLACES it — modelling that as a concatenation refuses
+a deliberate override as a duplicate and counts a replacement twice against the
+cap. What survives the merge and still breaks is one slug held by two different
+ids, and the cap is the merged length.

--- a/.changeset/site-style-remediation-rest.md
+++ b/.changeset/site-style-remediation-rest.md
@@ -53,3 +53,20 @@ per render: the whole render is cached and only a tag the page carries rebuilds
 it, and a Direct API read contributes none. Naming the single puts
 `nextly:single:<slug>` on the route, so an admin's save reaches the next page
 view as the documentation already promised.
+
+The Site Style write validators also judged the stored tier alone, while every
+consumer compiles the merge. Config entries are inserted first and both engine
+resolutions are first-wins, so a stored class whose slug a config class already
+holds was accepted, then dropped at render, leaving the node that referenced it
+with no rule — and `MAX_NAMED_CLASSES` was counted over the stored array while
+the compiler truncates the merged one. Both are judged against the merge now,
+when a caller states its config tier. Token collisions are reported as the
+DIFFERENCE the write introduces, so a site whose own config already emits an
+issue does not have someone else's mistake charged to the admin saving a token.
+
+The configured breakpoint set threaded into the blocks field validator was
+inert: an unknown breakpoint is a warning under forgiving validation and the
+error filter dropped it, so no document was judged differently by the set. It is
+reported once a set has actually been wired in, and stays silent against the
+empty fallback, where every id would be unknown and every styled document would
+be refused.

--- a/.changeset/site-style-remediation-rest.md
+++ b/.changeset/site-style-remediation-rest.md
@@ -81,9 +81,20 @@ deciding the one property that is true of the set alone — ids colliding across
 axes — and becomes load-bearing for documents once something can reach the
 stored tier.
 
-Class writes are judged through `resolveSiteStyle` rather than against the two
-tiers concatenated. The merge is keyed by class ID, so a stored class sharing an
-id with a configured one REPLACES it — modelling that as a concatenation refuses
-a deliberate override as a duplicate and counts a replacement twice against the
-cap. What survives the merge and still breaks is one slug held by two different
-ids, and the cap is the merged length.
+`blocks-engine` now exports `usableNamedClasses` and `usableNamedClassPositions`
+— the list the compiler writes and the renderer is handed, ordering and claim
+rules included.
+
+The Site Style write gate uses it to answer the only question an author cares
+about: will the class I just wrote render? It compares the ids that resolve
+before and after the write, so it reports a class the write adds that cannot
+render, and a class the site used to render that the write displaces — whether
+by claiming its slug, taking its id, reordering it behind another, or pushing
+it past the cap.
+
+Modelling that instead of asking was wrong four separate ways in review, each a
+different rule: the merge is keyed by id so a shared id REPLACES rather than
+duplicates, a config tier's own problems are not the writer's to fix, two
+collisions on one slug read identically as messages, and the compiler claims
+slugs after sorting by `orderIndex` rather than in array order. Asking cannot be
+wrong in any of them.

--- a/.changeset/site-style-remediation-rest.md
+++ b/.changeset/site-style-remediation-rest.md
@@ -47,12 +47,19 @@ computations of one question, not the wrong answer to it. A table typed over
 every `SiteSheetInput` key records which side each belongs on, so a field added
 there is a compile error until someone says.
 
-`BlocksPageConfig` also gains `siteStyleSingles`. A `siteStyles` provider is
-called per render, which on a pre-rendered route is not the same as being read
-per render: the whole render is cached and only a tag the page carries rebuilds
-it, and a Direct API read contributes none. Naming the single puts
+**Breaking, alpha:** a `siteStyles` PROVIDER is now `{ read, singles }` rather
+than a bare function. Being called per render is not the same as being read per
+render — on a pre-rendered route the whole render is cached and only a tag the
+page carries rebuilds it, while a Direct API read inside the provider
+contributes none. `singles` names the slugs that read consults, which puts
 `nextly:single:<slug>` on the route, so an admin's save reaches the next page
 view as the documentation already promised.
+
+The two are one type rather than a value and a separate optional property,
+because an optional one leaves the unsafe configuration legal: a provider with
+no declared dependencies compiles, serves a stale sheet, and looks exactly like
+a correct route. `singles: []` states that a provider reads no singles. A plain
+value needs none of this — it cannot change after the module loaded.
 
 The Site Style write validators also judged the stored tier alone, while every
 consumer compiles the merge. Config entries are inserted first and both engine

--- a/apps/playground/src/app/(frontend)/[...slug]/page.tsx
+++ b/apps/playground/src/app/(frontend)/[...slug]/page.tsx
@@ -39,7 +39,7 @@
 import { createBlockResolver } from "@nextlyhq/blocks-react";
 import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
 import { createBlocksPage } from "@nextlyhq/blocks-react/next";
-import { loadSiteStyle } from "@nextlyhq/plugin-page-builder";
+import { loadSiteStyle, SITE_STYLE_SLUG } from "@nextlyhq/plugin-page-builder";
 
 import { siteReader, SITE_STYLE_CONTEXT } from "../../../lib/site-content";
 import { SITE_STYLE_DEFAULTS } from "../../../lib/site-style-defaults";
@@ -87,8 +87,16 @@ const { ContentPage, generateMetadata } = createBlocksPage({
   // admin saves reaches the next page view rather than the next deploy. The
   // defaults are the same object `pageBuilder({ siteStyle })` was handed, so
   // the canvas, the validator and this route agree by construction.
-  siteStyles: () =>
-    loadSiteStyle({ nextly: siteReader, defaults: SITE_STYLE_DEFAULTS }),
+  siteStyles: {
+    read: () =>
+      loadSiteStyle({ nextly: siteReader, defaults: SITE_STYLE_DEFAULTS }),
+    // What that read depends on. This route is cacheable, so the whole render
+    // is what is cached and only a tag it carries rebuilds it — and the Direct
+    // API read inside `read` contributes none. Without naming the single, an
+    // admin's save would invalidate a tag no cache entry here holds and the
+    // page would keep serving the old sheet.
+    singles: [SITE_STYLE_SLUG],
+  },
   metadata: (entry, context, derived) => ({
     title: derived.title ?? (entry.title as string | undefined),
     description: derived.description,

--- a/apps/playground/src/app/blocks/[[...slug]]/page.tsx
+++ b/apps/playground/src/app/blocks/[[...slug]]/page.tsx
@@ -24,7 +24,7 @@
 import { createBlockResolver } from "@nextlyhq/blocks-react";
 import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
 import { createBlocksPage } from "@nextlyhq/blocks-react/next";
-import { loadSiteStyle } from "@nextlyhq/plugin-page-builder";
+import { loadSiteStyle, SITE_STYLE_SLUG } from "@nextlyhq/plugin-page-builder";
 
 import { siteReader, SITE_STYLE_CONTEXT } from "../../../lib/site-content";
 import { SITE_STYLE_DEFAULTS } from "../../../lib/site-style-defaults";
@@ -89,8 +89,16 @@ const { ContentPage, generateMetadata } = createBlocksPage({
   // The same statement the page-builder route makes, because both routes serve
   // documents of one engine and a site sheet that differed between them would
   // style one page two ways depending on its URL.
-  siteStyles: () =>
-    loadSiteStyle({ nextly: siteReader, defaults: SITE_STYLE_DEFAULTS }),
+  siteStyles: {
+    read: () =>
+      loadSiteStyle({ nextly: siteReader, defaults: SITE_STYLE_DEFAULTS }),
+    // What that read depends on. This route is cacheable, so the whole render
+    // is what is cached and only a tag it carries rebuilds it — and the Direct
+    // API read inside `read` contributes none. Without naming the single, an
+    // admin's save would invalidate a tag no cache entry here holds and the
+    // page would keep serving the old sheet.
+    singles: [SITE_STYLE_SLUG],
+  },
   metadata: (entry, context, derived) => ({
     title: derived.title ?? (entry.title as string | undefined),
     description: derived.description,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -342,6 +342,14 @@ export {
   isUsableNamedClass,
   namedClassName,
   orderedNamedClasses,
+  // Which classes a library actually RESOLVES to, ordering and claim rules
+  // included. The compiler writes exactly this list and the renderer is handed
+  // exactly this list, so a caller that needs to tell an author whether the
+  // class they wrote will render asks this rather than modelling it: the
+  // ordering is `orderIndex` then `id`, and a slug or id already claimed drops
+  // the later entry, which is four separate rules to get right by hand.
+  usableNamedClasses,
+  usableNamedClassPositions,
   NAMED_CLASS_PREFIX,
   NAMED_CLASS_SLUG_RE,
 } from "./style/named-class";

--- a/packages/blocks-react/src/next.tags.test.ts
+++ b/packages/blocks-react/src/next.tags.test.ts
@@ -103,4 +103,21 @@ describe("createBlocksPage cache tags", () => {
 
     expect(tags.some(tag => tag.startsWith("nextly:single:"))).toBe(false);
   });
+
+  it("refuses a bare function rather than reading it as a style value", () => {
+    // TypeScript rejects it, so this is for the JavaScript caller following
+    // older documentation. Falling through to the style-value branch would
+    // treat the provider as configuration: never invoked, its singles never
+    // tagged, and the page quietly serving config defaults for ever. Throwing
+    // at boot is the one outcome that cannot be mistaken for working.
+    created.mockClear();
+
+    expect(() =>
+      createBlocksPage({
+        collections: ["pages"],
+        field: "content",
+        siteStyles: (() => undefined) as never,
+      })
+    ).toThrow(/singles/);
+  });
 });

--- a/packages/blocks-react/src/next.tags.test.ts
+++ b/packages/blocks-react/src/next.tags.test.ts
@@ -63,4 +63,41 @@ describe("createBlocksPage cache tags", () => {
 
     expect(tags.some(tag => tag.includes("photos"))).toBe(true);
   });
+
+  it("tags the single a siteStyles provider reads", () => {
+    // A provider is called per render, which is not the same as being read per
+    // render: on a pre-rendered route the whole render is cached, and only a
+    // tag the page carries rebuilds it. The Direct API read inside the provider
+    // contributes none, so without this an admin's save invalidates
+    // `nextly:single:site-style` and no cache entry anywhere names it — the
+    // page keeps serving the old sheet, which looks exactly like the style
+    // never saving.
+    created.mockClear();
+    createBlocksPage({
+      collections: ["pages"],
+      field: "content",
+      siteStyles: () => undefined,
+      siteStyleSingles: ["site-style"],
+    });
+
+    const tags = (created.mock.calls[0][0] as { tags: string[] }).tags;
+
+    expect(tags).toContain("nextly:single:site-style");
+  });
+
+  it("adds no single tag when the route names none", () => {
+    // The control: the tag must come from the slug the route stated, not from
+    // the helper deciding that any route using siteStyles reads one particular
+    // single. A host can store its style anywhere.
+    created.mockClear();
+    createBlocksPage({
+      collections: ["pages"],
+      field: "content",
+      siteStyles: () => undefined,
+    });
+
+    const tags = (created.mock.calls[0][0] as { tags: string[] }).tags;
+
+    expect(tags.some(tag => tag.startsWith("nextly:single:"))).toBe(false);
+  });
 });

--- a/packages/blocks-react/src/next.tags.test.ts
+++ b/packages/blocks-react/src/next.tags.test.ts
@@ -76,8 +76,7 @@ describe("createBlocksPage cache tags", () => {
     createBlocksPage({
       collections: ["pages"],
       field: "content",
-      siteStyles: () => undefined,
-      siteStyleSingles: ["site-style"],
+      siteStyles: { read: () => undefined, singles: ["site-style"] },
     });
 
     const tags = (created.mock.calls[0][0] as { tags: string[] }).tags;
@@ -85,15 +84,19 @@ describe("createBlocksPage cache tags", () => {
     expect(tags).toContain("nextly:single:site-style");
   });
 
-  it("adds no single tag when the route names none", () => {
-    // The control: the tag must come from the slug the route stated, not from
-    // the helper deciding that any route using siteStyles reads one particular
+  it("adds no single tag when the provider declares it reads none", () => {
+    // The control: the tag comes from the slug the route stated, not from the
+    // helper deciding that any route using siteStyles reads one particular
     // single. A host can store its style anywhere.
+    //
+    // An empty array is a STATEMENT here, not an omission — the provider and
+    // its dependencies are one type, so a provider without them does not
+    // compile and the unsafe configuration is no longer expressible.
     created.mockClear();
     createBlocksPage({
       collections: ["pages"],
       field: "content",
-      siteStyles: () => undefined,
+      siteStyles: { read: () => undefined, singles: [] },
     });
 
     const tags = (created.mock.calls[0][0] as { tags: string[] }).tags;

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -103,6 +103,17 @@ export type SiteStylesInput = Omit<SiteSheetInput, "breakpoints"> &
 function isSiteStylesProvider(
   value: SiteStylesInput | SiteStylesProvider | undefined
 ): value is SiteStylesProvider {
+  // A function is refused rather than falling through to the style-value
+  // branch. TypeScript already rejects it, but a JavaScript caller following
+  // older documentation would otherwise have their provider treated as
+  // configuration: never invoked, its singles never tagged, and the page
+  // quietly serving config defaults for ever. Failing at boot is the one
+  // outcome that cannot be mistaken for working.
+  if (typeof value === "function") {
+    throw new TypeError(
+      "siteStyles must be a value or { read, singles }; a bare function no longer states the singles its read depends on, so a cached page could not be invalidated."
+    );
+  }
   return typeof value === "object" && value !== null && "read" in value;
 }
 
@@ -194,21 +205,33 @@ export interface BlocksPageConfig
    * "what are this site's breakpoints" is how the shared sheet and the page
    * sheet come to disagree about which at-rules a tier is emitted under.
    *
-   * **A function is called per render**, exactly as `styles` is, for a site
-   * whose style inputs live in storage: a route module's config is captured
-   * once per server process, so a plain value here freezes an admin's saved
-   * tokens at whatever they were when the module loaded — the edit would reach
-   * the next deploy instead of the next page view. Returning `undefined`
-   * means what omitting the value means.
+   * **A PROVIDER is read per render**, for a site whose style inputs live in
+   * storage: a route module's config is captured once per server process, so a
+   * plain value here freezes an admin's saved tokens at whatever they were when
+   * the module loaded, and the edit would reach the next deploy instead of the
+   * next page view.
    *
-   * **On a PRE-RENDERED route that promise needs `siteStyleSingles`.** Being
-   * called per render is not the same as being read per render: a public
-   * blocks page is cacheable, so the whole render is the thing cached, and it
-   * is only rebuilt when one of the page's TAGS is invalidated. A provider
-   * reading through the Direct API contributes no tag, so without naming the
-   * single it reads, an admin's save invalidates a tag no cache entry carries
-   * and the page keeps serving the old sheet — the same gap the media
-   * collection is in the tag list for.
+   * ```ts
+   * siteStyles: {
+   *   read: () => loadSiteStyle({ nextly, defaults }),
+   *   singles: [SITE_STYLE_SLUG],
+   * }
+   * ```
+   *
+   * `read` returning `undefined` means what omitting the value means. `singles`
+   * is required rather than optional, and that is the whole point: being called
+   * per render is not the same as being READ per render. A public blocks page
+   * is cacheable, so the whole render is what is cached and only a tag the page
+   * carries rebuilds it — and a Direct API read inside `read` contributes none.
+   * Without naming the single, an admin's save invalidates a tag no cache entry
+   * holds and the page keeps serving the old sheet, which is the same gap the
+   * media collection is in the tag list for. State `singles: []` for a provider
+   * that genuinely reads no singles.
+   *
+   * A bare function is NOT a provider and is refused at boot rather than read
+   * as a style value, because a JavaScript caller passing one would otherwise
+   * have it silently treated as configuration and lose both the stored styles
+   * and their invalidation.
    */
   siteStyles?: SiteStylesInput | SiteStylesProvider;
   /**

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -35,6 +35,7 @@ import {
   createSingleRoute,
   getNextly,
   nextlyTags,
+  nextlySingleTags,
   slugToStaticParam,
 } from "nextly/runtime";
 import type {
@@ -161,6 +162,15 @@ export interface BlocksPageConfig
    * tokens at whatever they were when the module loaded — the edit would reach
    * the next deploy instead of the next page view. Returning `undefined`
    * means what omitting the value means.
+   *
+   * **On a PRE-RENDERED route that promise needs `siteStyleSingles`.** Being
+   * called per render is not the same as being read per render: a public
+   * blocks page is cacheable, so the whole render is the thing cached, and it
+   * is only rebuilt when one of the page's TAGS is invalidated. A provider
+   * reading through the Direct API contributes no tag, so without naming the
+   * single it reads, an admin's save invalidates a tag no cache entry carries
+   * and the page keeps serving the old sheet — the same gap the media
+   * collection is in the tag list for.
    */
   siteStyles?:
     | SiteStylesInput
@@ -168,6 +178,23 @@ export interface BlocksPageConfig
         | SiteStylesInput
         | undefined
         | Promise<SiteStylesInput | undefined>);
+  /**
+   * The single slugs a `siteStyles` provider reads, so a write to one busts
+   * this page.
+   *
+   * A cacheable route is rebuilt only when a tag it carries is invalidated,
+   * and a Direct API read contributes no tag. Nextly's write path revalidates
+   * `nextly:single:<slug>`; naming the slug here is what puts that tag on the
+   * page, exactly as `mediaCollection` does for the media reader.
+   *
+   * Only pre-rendered routes need it — an access-enforced `createBlocksPage`
+   * is marked dynamic and re-reads every request — but stating it there is
+   * harmless, which is why this is one option rather than two.
+   *
+   * A page builder route reads the plugin's Site Style single:
+   * `siteStyleSingles: [SITE_STYLE_SLUG]`.
+   */
+  siteStyleSingles?: readonly string[];
   /**
    * A dynamic collection to resolve media ids against, for a site storing its
    * images in one of its own.
@@ -1008,6 +1035,13 @@ function blocksRouteConfig(
       ...(routeConfig.tags ?? []),
       ...nextlyTags(config.mediaCollection ?? MEDIA_TAG_COLLECTION),
       ...routeConfig.collections.flatMap(collection => nextlyTags(collection)),
+      // The singles a `siteStyles` provider reads, for the same reason the
+      // media collection is above: that read goes through the Direct API and
+      // contributes no tag of its own, so a write to the single would otherwise
+      // invalidate nothing this page carries.
+      ...(config.siteStyleSingles ?? []).flatMap(slug =>
+        nextlySingleTags(slug)
+      ),
     ],
     // Supplied only when asked for, so a route without it keeps whatever
     // `buildMetadata` the caller passed straight through to the content route.

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -99,6 +99,44 @@ const MEDIA_TAG_COLLECTION = "media";
 export type SiteStylesInput = Omit<SiteSheetInput, "breakpoints"> &
   Partial<Pick<SiteSheetInput, "breakpoints">>;
 
+/** A provider rather than a plain value: it states what its read depends on. */
+function isSiteStylesProvider(
+  value: SiteStylesInput | SiteStylesProvider | undefined
+): value is SiteStylesProvider {
+  return typeof value === "object" && value !== null && "read" in value;
+}
+
+/**
+ * A per-render site-style read, together with what it depends on.
+ *
+ * ONE unit, deliberately. Being called per render is not the same as being read
+ * per render: a public blocks route is cacheable, so the whole render is what
+ * is cached and only a tag the page carries rebuilds it — while a Direct API
+ * read inside `read` contributes no tag at all. A provider whose dependencies
+ * were a separate optional property left the unsafe configuration legal, and an
+ * omission that silently serves a stale sheet is the kind of rule this codebase
+ * asks to be enforced rather than documented.
+ *
+ * A plain value needs none of this: it cannot change after the module loaded,
+ * so there is nothing for a write to invalidate.
+ */
+export interface SiteStylesProvider {
+  /** Called once per render. Returning `undefined` means what omitting means. */
+  read: () =>
+    | SiteStylesInput
+    | undefined
+    | Promise<SiteStylesInput | undefined>;
+  /**
+   * The single slugs `read` consults, so a write to one busts this page.
+   *
+   * Nextly's write path revalidates `nextly:single:<slug>`; naming the slug
+   * here is what puts that tag on the route, exactly as `mediaCollection` does
+   * for the media reader. An empty array is a statement rather than an
+   * omission: this provider reads no singles.
+   */
+  singles: readonly string[];
+}
+
 /**
  * Config for {@link createBlocksPage}.
  *
@@ -172,29 +210,7 @@ export interface BlocksPageConfig
    * and the page keeps serving the old sheet — the same gap the media
    * collection is in the tag list for.
    */
-  siteStyles?:
-    | SiteStylesInput
-    | (() =>
-        | SiteStylesInput
-        | undefined
-        | Promise<SiteStylesInput | undefined>);
-  /**
-   * The single slugs a `siteStyles` provider reads, so a write to one busts
-   * this page.
-   *
-   * A cacheable route is rebuilt only when a tag it carries is invalidated,
-   * and a Direct API read contributes no tag. Nextly's write path revalidates
-   * `nextly:single:<slug>`; naming the slug here is what puts that tag on the
-   * page, exactly as `mediaCollection` does for the media reader.
-   *
-   * Only pre-rendered routes need it — an access-enforced `createBlocksPage`
-   * is marked dynamic and re-reads every request — but stating it there is
-   * harmless, which is why this is one option rather than two.
-   *
-   * A page builder route reads the plugin's Site Style single:
-   * `siteStyleSingles: [SITE_STYLE_SLUG]`.
-   */
-  siteStyleSingles?: readonly string[];
+  siteStyles?: SiteStylesInput | SiteStylesProvider;
   /**
    * A dynamic collection to resolve media ids against, for a site storing its
    * images in one of its own.
@@ -1039,9 +1055,10 @@ function blocksRouteConfig(
       // media collection is above: that read goes through the Direct API and
       // contributes no tag of its own, so a write to the single would otherwise
       // invalidate nothing this page carries.
-      ...(config.siteStyleSingles ?? []).flatMap(slug =>
-        nextlySingleTags(slug)
-      ),
+      ...(isSiteStylesProvider(config.siteStyles)
+        ? config.siteStyles.singles
+        : []
+      ).flatMap(slug => nextlySingleTags(slug)),
     ],
     // Supplied only when asked for, so a route without it keeps whatever
     // `buildMetadata` the caller passed straight through to the content route.
@@ -1116,10 +1133,9 @@ function blocksRouteConfig(
       // Resolved per render when the config states a provider, so style
       // inputs living in storage reach the next page view rather than the
       // next deploy; a plain value passes through unchanged.
-      const configuredSiteStyles =
-        typeof config.siteStyles === "function"
-          ? await config.siteStyles()
-          : config.siteStyles;
+      const configuredSiteStyles = isSiteStylesProvider(config.siteStyles)
+        ? await config.siteStyles.read()
+        : config.siteStyles;
       // Derived ONCE, from the breakpoints the site already stated. A second
       // answer to "what are this site's breakpoints" is how the shared sheet
       // and the page sheet come to disagree about which at-rules a tier is

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -155,9 +155,6 @@ function pruneRenderedPlaceholders(
   return pruneNodes(document, node => rendersOwnMarkup(node, resolver));
 }
 
-/** Where a site-level input is reconciled, if it is reconciled at all. */
-type SiteInputRole = "reconciled-here" | "reconciled-elsewhere" | "sheet-only";
-
 /**
  * Which side of the render each site-level input belongs to.
  *
@@ -165,58 +162,53 @@ type SiteInputRole = "reconciled-here" | "reconciled-elsewhere" | "sheet-only";
  * both read it, one render must resolve it once or the two disagree invisibly,
  * each internally consistent and neither reporting anything.
  *
- * `satisfies` rather than a type annotation, so the literal values survive:
- * `ReconciledHere` below reads them back, and an annotation would widen every
- * entry to the whole union and derive nothing. The mapped key set is what makes
- * a field added to `SiteSheetInput` a compile error here until it is
- * classified, and `ReconciledHere` is what makes classifying it "reconciled
- * here" an obligation on the resolver rather than a comment.
+ * - `breakpoints` decides which at-rules every tier is emitted under, and is
+ *   required on the compile context. A set that reached only the sheet puts the
+ *   block-default and class tiers under at-rules the page's own values never
+ *   use, and drops any value stored under an id the other set omits.
+ * - `classes` is reconciled onto the PAGE context only. The sheet always writes
+ *   the site's library; the page compile attributes from the context's list
+ *   when it states one, because a context stating its own defers ATTRIBUTION
+ *   while the rules stay in the sheet. Resolving it back onto the sheet drops
+ *   the library whenever a context defers.
+ * - `blockBases` is the same shape one level along: the sheet emits the
+ *   `.nx-bt-*` rules and the page compile decides which of them a node
+ *   inherits, and the page sheet is appended after the shared one.
+ * - `tokenPrefix` separates declaration from reference. The sheet DECLARES the
+ *   custom properties and the page compile REFERENCES them, so a prefix that
+ *   reaches only one leaves every reference pointing at a property nothing
+ *   declared — and an unresolved custom property invalidates the declaration
+ *   rather than reporting.
+ * - `mayFetchUrl` is reconciled a level up, in `effectiveCompile`, which
+ *   derives one predicate and hands the same object to both. It has its own
+ *   role rather than sharing one, so nothing here promises a reconciliation
+ *   that happens elsewhere.
+ * - `fonts` and `tokens` are the sheet's alone: it emits `@font-face` and the
+ *   token blocks, and the page compile emits neither and reads neither.
  */
-// Only ever read as a type, by `ReconciledHere` below. It has to be a VALUE
-// anyway: `satisfies` checks a value against a type, and it is what preserves
-// the literal roles that a plain annotation would widen to the whole union —
-// which is the difference between a table that derives an obligation and a
-// table that documents an intention.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const SITE_INPUT_ROLE = {
-  // Decides which at-rules every tier is emitted under. Required on the compile
-  // context, so a stored set that reached only the sheet would put the
-  // block-default and class tiers under at-rules the page's own values never
-  // use, and drop any value stored under an id the route's set does not define.
-  breakpoints: "reconciled-here",
-  // Reconciled onto the PAGE context only. The sheet always writes the site's
-  // library, and the page compile attributes from the context's list when it
-  // states one — a context stating its own defers ATTRIBUTION while the rules
-  // stay in the sheet. Feeding the resolved list back to the sheet as well
-  // drops the library whenever a context defers.
-  classes: "reconciled-here",
-  // The sheet emits the `.nx-bt-*` rules and the page compile decides which of
-  // them a node inherits; the page sheet is appended after the shared one, so
-  // two sets means one default silently overwriting the other.
-  blockBases: "reconciled-here",
-  // The sheet DECLARES the custom properties; the page compile REFERENCES
-  // them. A prefix that reached only the sheet leaves every `{ $token }` on
-  // every page pointing at a property nothing declared, and an unresolved
-  // custom property invalidates the declaration rather than reporting.
-  tokenPrefix: "reconciled-here",
-  // Reconciled a level up, by `effectiveCompile`, which derives one predicate
-  // and hands the same object to both. Classified rather than omitted so it is
-  // not mistaken for an oversight — and it is the reason this table has three
-  // roles instead of two, since calling it "shared" would promise a
-  // reconciliation here that does not happen here.
-  mayFetchUrl: "reconciled-elsewhere",
-  // The sheet emits `@font-face` and the token blocks; the page compile emits
-  // neither and reads neither.
-  fonts: "sheet-only",
-  tokens: "sheet-only",
-} as const satisfies { [K in keyof Required<SiteSheetInput>]: SiteInputRole };
+interface SiteInputRoles {
+  breakpoints: "reconciled-here";
+  classes: "reconciled-here";
+  blockBases: "reconciled-here";
+  tokenPrefix: "reconciled-here";
+  mayFetchUrl: "reconciled-elsewhere";
+  fonts: "sheet-only";
+  tokens: "sheet-only";
+}
 
-/** The inputs the resolver below must produce, taken from the table itself. */
+/**
+ * The inputs the resolver below must produce, taken from the table itself.
+ *
+ * Indexed by every `SiteSheetInput` key rather than by the table's own keys,
+ * which is what makes the table exhaustive: a field added there and not
+ * classified here cannot index `SiteInputRoles` and the type fails to compile.
+ * Purely a type, so nothing exists at runtime to be unused.
+ */
 type ReconciledHere = {
-  [K in keyof typeof SITE_INPUT_ROLE]: (typeof SITE_INPUT_ROLE)[K] extends "reconciled-here"
+  [K in keyof Required<SiteSheetInput>]: SiteInputRoles[K] extends "reconciled-here"
     ? K
     : never;
-}[keyof typeof SITE_INPUT_ROLE];
+}[keyof Required<SiteSheetInput>];
 
 /** The name an input takes on the compile context, where it differs. */
 type ContextKey<K> = K extends "classes" ? "namedClasses" : K;
@@ -225,7 +217,7 @@ type ContextKey<K> = K extends "classes" ? "namedClasses" : K;
  * What `sharedStyleInputs` must return: every reconciled-here key, present.
  *
  * Required rather than optional on purpose. An optional key can be left out
- * silently, which is exactly the gap this table is supposed to close — a field
+ * silently, which is exactly the gap this table is meant to close — a field
  * classified as reconciled here and then never reconciled.
  */
 type ResolvedShared = {

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -4,7 +4,10 @@ import {
   PAGE_ROOT_CLASS,
   resolveSiteTokens,
   type BlockDocument,
+  type BreakpointSet,
   type DocumentLimits,
+  type NamedClass,
+  type NodeStyles,
   type SiteSheetInput,
   type StyleCompileContext,
 } from "@nextlyhq/blocks-engine";
@@ -153,6 +156,122 @@ function pruneRenderedPlaceholders(
   resolver: BlockResolver
 ): BlockDocument {
   return pruneNodes(document, node => rendersOwnMarkup(node, resolver));
+}
+
+/**
+ * Which side of the render each site-level input belongs to.
+ *
+ * A `SiteSheetInput` field is either SHARED — the shared sheet and the page's
+ * own compile both read it, so one render must resolve it once or the two
+ * disagree invisibly, each internally consistent — or SHEET-ONLY, meaning the
+ * page compile has no use for it.
+ *
+ * Typed over every key of `SiteSheetInput` on purpose: adding a field there is
+ * a compile error here until someone says which side it is on. Three of these
+ * were found divergent one at a time, and the fourth would have been found the
+ * same way. This is the list that makes that unnecessary.
+ */
+const SITE_INPUT_ROLE: {
+  [K in keyof Required<SiteSheetInput>]: "shared" | "sheet-only";
+} = {
+  // Decides which at-rules every tier is emitted under. Required on the compile
+  // context, so a stored set that reached only the sheet would put the
+  // block-default and class tiers under at-rules the page's own values never
+  // use, and drop any value stored under an id the route's set does not define.
+  breakpoints: "shared",
+  // Shared, but NOT one value: the sheet always writes the site's library, and
+  // the page compile attributes from the context's list when it states one.
+  // That asymmetry is deliberate — a context stating its own list defers
+  // ATTRIBUTION while the rules stay in the sheet — so the resolution below
+  // reaches the page context only. Feeding it back to the sheet as well drops
+  // the library whenever a context defers, which the deferral test catches.
+  classes: "shared",
+  // Same shape one level along: the sheet emits the `.nx-bt-*` rules and the
+  // page compile decides which of them a node inherits.
+  blockBases: "shared",
+  // The sheet DECLARES the custom properties; the page compile REFERENCES
+  // them. A prefix that reached only the sheet leaves every `{ $token }` on
+  // every page pointing at a property nothing declared, and an unresolved
+  // custom property invalidates the declaration rather than reporting.
+  tokenPrefix: "shared",
+  // Reconciled a level up, by `effectiveCompile`, which hands one predicate
+  // object to both. Named here so it is not mistaken for an omission.
+  mayFetchUrl: "shared",
+  // The sheet emits `@font-face` and the token blocks; the page compile emits
+  // neither and reads neither.
+  fonts: "sheet-only",
+  tokens: "sheet-only",
+};
+
+/** The shared inputs a render must resolve once, and give to both compiles. */
+interface SharedStyleInputs {
+  breakpoints?: BreakpointSet;
+  namedClasses?: readonly NamedClass[];
+  blockBases?: Readonly<Record<string, NodeStyles>>;
+  tokenPrefix?: string;
+}
+
+/**
+ * Resolve every shared input once, so the two compiles cannot disagree.
+ *
+ * The defect this exists to prevent is not a wrong precedence — it is two
+ * computations of one question. Each field therefore keeps the precedence it
+ * already had, and only the number of places that decide changes:
+ *
+ * - `breakpoints` and `blockBases` take the site's when it has one. The site
+ *   tier is the stored one, and stored overrides code, which is the layering
+ *   every global-styles system uses.
+ * - `namedClasses` lets a context that states its own outrank the site's, the
+ *   rule this render already applied. This one is applied to the PAGE context
+ *   only: the sheet keeps emitting the site's library, because deferring means
+ *   deferring attribution, not losing the rules.
+ * - `tokenPrefix` follows the sheet, which reads `tokenPrefix` then the token
+ *   set's own `prefix`; the context's is the last fallback rather than the
+ *   first, because the declaration site is what a reference has to match.
+ *
+ * Only defined values are returned, so spreading this over a context adds no
+ * key the caller did not have.
+ */
+function sharedStyleInputs(
+  styleContext: StyleCompileContext | undefined,
+  site: SiteSheetInput | undefined
+): SharedStyleInputs {
+  void SITE_INPUT_ROLE;
+  // Both tiers normalised once. Every field below would otherwise repeat the
+  // same two absence checks, and the resolution is easier to read as a list of
+  // precedences than as a list of optional chains.
+  const route: Partial<StyleCompileContext> = styleContext ?? {};
+  const stored: Partial<SiteSheetInput> = site ?? {};
+  return defined({
+    breakpoints: firstStated(stored.breakpoints, route.breakpoints),
+    namedClasses: firstStated(route.namedClasses, stored.classes),
+    blockBases: firstStated(stored.blockBases, route.blockBases),
+    tokenPrefix: firstStated(
+      stored.tokenPrefix,
+      stored.tokens?.prefix,
+      route.tokenPrefix
+    ),
+  });
+}
+
+/** The first tier that stated this input, in the precedence its field has. */
+function firstStated<T>(...tiers: readonly (T | undefined)[]): T | undefined {
+  return tiers.find(tier => tier !== undefined);
+}
+
+/**
+ * The same object without its unstated keys.
+ *
+ * Spreading a key whose value is `undefined` is not the same as omitting it:
+ * the context would then carry the key, and a reader asking whether it was
+ * stated gets the wrong answer.
+ */
+function defined(value: {
+  [K in keyof SharedStyleInputs]: SharedStyleInputs[K] | undefined;
+}): SharedStyleInputs {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, stated]) => stated !== undefined)
+  );
 }
 
 /**
@@ -388,21 +507,12 @@ export function PageRenderer({
   // the scope lives on the artifact, the caps come from this prop, and a
   // caller's own fetch predicate needs an identity before a stored sheet can be
   // judged against it.
-  // The site's class library reaches the PAGE compile from the same value the
-  // shared sheet reads. The sheet writes the `.nx-c-<slug>` rule from
-  // `siteStyles.classes`, but a node's stored class IDS resolve to class NAMES
-  // during the page's own compile, from the context's `namedClasses` — two
-  // inputs that must be one list, or a stored class emits a rule no element
-  // ever carries and each half looks internally consistent. A context that
-  // states its own `namedClasses` outranks this, exactly as a context carrying
-  // its own `blockBases` does.
+  const siteInput = siteStyles === false ? undefined : siteStyles;
+  // Every site-level input BOTH compiles read, resolved once. See
+  // `sharedStyleInputs` for why one resolution rather than one per consumer.
+  const shared = sharedStyleInputs(styleContext, siteInput);
   const pageStyleContext =
-    styleContext !== undefined &&
-    styleContext.namedClasses === undefined &&
-    siteStyles !== false &&
-    siteStyles?.classes !== undefined
-      ? { ...styleContext, namedClasses: siteStyles.classes }
-      : styleContext;
+    styleContext === undefined ? undefined : { ...styleContext, ...shared };
 
   const {
     context: compileContext,
@@ -442,11 +552,7 @@ export function PageRenderer({
   // with no sheet. Two answers to "what are this site's breakpoints" is also how
   // the shared sheet and the page sheet come to disagree about which at-rules a
   // tier is emitted under, invisibly, since each sheet is consistent on its own.
-  const siteInput = siteStyles === false ? undefined : siteStyles;
-  const siteBreakpoints =
-    siteStyles === false
-      ? undefined
-      : (siteInput?.breakpoints ?? compileContext?.breakpoints);
+  const siteBreakpoints = siteStyles === false ? undefined : shared.breakpoints;
   // A sheet by DEFAULT. Without one a block cannot reference a token at all —
   // a default reading `color.surface` would resolve on a route and resolve to
   // nothing here — which is why `core/card` shipped with no background.
@@ -458,7 +564,16 @@ export function PageRenderer({
       ? undefined
       : compileSiteSheet({
           ...siteInput,
+          // The RESOLVED values, the same objects the page context above was
+          // given. Spreading `siteInput` alone would leave each consumer
+          // computing its own answer, which is the defect this closes.
           breakpoints: siteBreakpoints,
+          ...(shared.blockBases === undefined
+            ? {}
+            : { blockBases: shared.blockBases }),
+          ...(shared.tokenPrefix === undefined
+            ? {}
+            : { tokenPrefix: shared.tokenPrefix }),
           tokens: resolveSiteTokens(siteInput?.tokens),
           // The SAME predicate the page sheet is compiled with, taken from the
           // one place it is derived rather than derived again here. The class

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -4,10 +4,7 @@ import {
   PAGE_ROOT_CLASS,
   resolveSiteTokens,
   type BlockDocument,
-  type BreakpointSet,
   type DocumentLimits,
-  type NamedClass,
-  type NodeStyles,
   type SiteSheetInput,
   type StyleCompileContext,
 } from "@nextlyhq/blocks-engine";
@@ -158,58 +155,87 @@ function pruneRenderedPlaceholders(
   return pruneNodes(document, node => rendersOwnMarkup(node, resolver));
 }
 
+/** Where a site-level input is reconciled, if it is reconciled at all. */
+type SiteInputRole = "reconciled-here" | "reconciled-elsewhere" | "sheet-only";
+
 /**
  * Which side of the render each site-level input belongs to.
  *
- * A `SiteSheetInput` field is either SHARED — the shared sheet and the page's
- * own compile both read it, so one render must resolve it once or the two
- * disagree invisibly, each internally consistent — or SHEET-ONLY, meaning the
- * page compile has no use for it.
+ * A `SiteSheetInput` field is read by both compiles or by the sheet alone. When
+ * both read it, one render must resolve it once or the two disagree invisibly,
+ * each internally consistent and neither reporting anything.
  *
- * Typed over every key of `SiteSheetInput` on purpose: adding a field there is
- * a compile error here until someone says which side it is on. Three of these
- * were found divergent one at a time, and the fourth would have been found the
- * same way. This is the list that makes that unnecessary.
+ * `satisfies` rather than a type annotation, so the literal values survive:
+ * `ReconciledHere` below reads them back, and an annotation would widen every
+ * entry to the whole union and derive nothing. The mapped key set is what makes
+ * a field added to `SiteSheetInput` a compile error here until it is
+ * classified, and `ReconciledHere` is what makes classifying it "reconciled
+ * here" an obligation on the resolver rather than a comment.
  */
-const SITE_INPUT_ROLE: {
-  [K in keyof Required<SiteSheetInput>]: "shared" | "sheet-only";
-} = {
+// Only ever read as a type, by `ReconciledHere` below. It has to be a VALUE
+// anyway: `satisfies` checks a value against a type, and it is what preserves
+// the literal roles that a plain annotation would widen to the whole union —
+// which is the difference between a table that derives an obligation and a
+// table that documents an intention.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const SITE_INPUT_ROLE = {
   // Decides which at-rules every tier is emitted under. Required on the compile
   // context, so a stored set that reached only the sheet would put the
   // block-default and class tiers under at-rules the page's own values never
   // use, and drop any value stored under an id the route's set does not define.
-  breakpoints: "shared",
-  // Shared, but NOT one value: the sheet always writes the site's library, and
-  // the page compile attributes from the context's list when it states one.
-  // That asymmetry is deliberate — a context stating its own list defers
-  // ATTRIBUTION while the rules stay in the sheet — so the resolution below
-  // reaches the page context only. Feeding it back to the sheet as well drops
-  // the library whenever a context defers, which the deferral test catches.
-  classes: "shared",
-  // Same shape one level along: the sheet emits the `.nx-bt-*` rules and the
-  // page compile decides which of them a node inherits.
-  blockBases: "shared",
+  breakpoints: "reconciled-here",
+  // Reconciled onto the PAGE context only. The sheet always writes the site's
+  // library, and the page compile attributes from the context's list when it
+  // states one — a context stating its own defers ATTRIBUTION while the rules
+  // stay in the sheet. Feeding the resolved list back to the sheet as well
+  // drops the library whenever a context defers.
+  classes: "reconciled-here",
+  // The sheet emits the `.nx-bt-*` rules and the page compile decides which of
+  // them a node inherits; the page sheet is appended after the shared one, so
+  // two sets means one default silently overwriting the other.
+  blockBases: "reconciled-here",
   // The sheet DECLARES the custom properties; the page compile REFERENCES
   // them. A prefix that reached only the sheet leaves every `{ $token }` on
   // every page pointing at a property nothing declared, and an unresolved
   // custom property invalidates the declaration rather than reporting.
-  tokenPrefix: "shared",
-  // Reconciled a level up, by `effectiveCompile`, which hands one predicate
-  // object to both. Named here so it is not mistaken for an omission.
-  mayFetchUrl: "shared",
+  tokenPrefix: "reconciled-here",
+  // Reconciled a level up, by `effectiveCompile`, which derives one predicate
+  // and hands the same object to both. Classified rather than omitted so it is
+  // not mistaken for an oversight — and it is the reason this table has three
+  // roles instead of two, since calling it "shared" would promise a
+  // reconciliation here that does not happen here.
+  mayFetchUrl: "reconciled-elsewhere",
   // The sheet emits `@font-face` and the token blocks; the page compile emits
   // neither and reads neither.
   fonts: "sheet-only",
   tokens: "sheet-only",
+} as const satisfies { [K in keyof Required<SiteSheetInput>]: SiteInputRole };
+
+/** The inputs the resolver below must produce, taken from the table itself. */
+type ReconciledHere = {
+  [K in keyof typeof SITE_INPUT_ROLE]: (typeof SITE_INPUT_ROLE)[K] extends "reconciled-here"
+    ? K
+    : never;
+}[keyof typeof SITE_INPUT_ROLE];
+
+/** The name an input takes on the compile context, where it differs. */
+type ContextKey<K> = K extends "classes" ? "namedClasses" : K;
+
+/**
+ * What `sharedStyleInputs` must return: every reconciled-here key, present.
+ *
+ * Required rather than optional on purpose. An optional key can be left out
+ * silently, which is exactly the gap this table is supposed to close — a field
+ * classified as reconciled here and then never reconciled.
+ */
+type ResolvedShared = {
+  [K in ReconciledHere as ContextKey<K>]:
+    | NonNullable<Required<SiteSheetInput>[K]>
+    | undefined;
 };
 
-/** The shared inputs a render must resolve once, and give to both compiles. */
-interface SharedStyleInputs {
-  breakpoints?: BreakpointSet;
-  namedClasses?: readonly NamedClass[];
-  blockBases?: Readonly<Record<string, NodeStyles>>;
-  tokenPrefix?: string;
-}
+/** The same inputs as a context patch: unstated keys absent rather than undefined. */
+type SharedStyleInputs = Partial<ResolvedShared>;
 
 /**
  * Resolve every shared input once, so the two compiles cannot disagree.
@@ -236,7 +262,6 @@ function sharedStyleInputs(
   styleContext: StyleCompileContext | undefined,
   site: SiteSheetInput | undefined
 ): SharedStyleInputs {
-  void SITE_INPUT_ROLE;
   // Both tiers normalised once. Every field below would otherwise repeat the
   // same two absence checks, and the resolution is easier to read as a list of
   // precedences than as a list of optional chains.
@@ -266,9 +291,7 @@ function firstStated<T>(...tiers: readonly (T | undefined)[]): T | undefined {
  * the context would then carry the key, and a reader asking whether it was
  * stated gets the wrong answer.
  */
-function defined(value: {
-  [K in keyof SharedStyleInputs]: SharedStyleInputs[K] | undefined;
-}): SharedStyleInputs {
+function defined(value: ResolvedShared): SharedStyleInputs {
   return Object.fromEntries(
     Object.entries(value).filter(([, stated]) => stated !== undefined)
   );

--- a/packages/blocks-react/src/site-sheet.test.tsx
+++ b/packages/blocks-react/src/site-sheet.test.tsx
@@ -285,5 +285,11 @@ describe("a node's named-class references", () => {
     // The sheet still carries the library's rule; what the deferral changes
     // is ATTRIBUTION, so the element must not carry the name.
     expect(out).not.toMatch(/class="[^"]*\bnx-c-accent\b/);
+    // The separating property. The absence above is satisfied just as well by a
+    // render that lost the class library altogether — measured, dropping
+    // `siteStyles.classes` produces the same missing attribute — so on its own
+    // it cannot tell deferred attribution from a lost library. The sheet still
+    // carrying the rule is what makes it the former.
+    expect(out).toContain(".nx-c-accent");
   });
 });

--- a/packages/blocks-react/src/site-style-reconciliation.test.tsx
+++ b/packages/blocks-react/src/site-style-reconciliation.test.tsx
@@ -37,7 +37,7 @@ const STORED_BREAKPOINTS: BreakpointSet = {
   container: [],
 };
 
-function documentWith(styles: unknown): BlockDocument {
+function documentWith(styles: unknown, classes?: string[]): BlockDocument {
   return {
     formatVersion: DOCUMENT_FORMAT_VERSION,
     kind: "page",
@@ -48,6 +48,7 @@ function documentWith(styles: unknown): BlockDocument {
         version: 1,
         props: { text: "body" },
         styles,
+        ...(classes === undefined ? {} : { classes }),
       },
     ],
   } as unknown as BlockDocument;
@@ -55,15 +56,18 @@ function documentWith(styles: unknown): BlockDocument {
 
 function render(args: {
   styles?: unknown;
+  classes?: string[];
   styleContext: StyleCompileContext;
-  siteStyles: SiteSheetInput;
+  siteStyles?: SiteSheetInput;
 }): string {
   return renderToStaticMarkup(
     <PageRenderer
-      document={documentWith(args.styles ?? {})}
+      document={documentWith(args.styles ?? {}, args.classes)}
       blocks={createBlockResolver(coreBlocks)}
       styleContext={args.styleContext}
-      siteStyles={args.siteStyles}
+      {...(args.siteStyles === undefined
+        ? {}
+        : { siteStyles: args.siteStyles })}
     />
   );
 }
@@ -85,13 +89,15 @@ describe("breakpoints", () => {
     expect(out).toContain("#ff0000");
   });
 
-  it("still uses the route's set when the site states none", () => {
-    // The control: the site tier winning must not mean the route tier is
+  it("still uses the route's set when there is no site tier at all", () => {
+    // The control, and it has to leave `siteStyles` OUT rather than pass the
+    // same set through it: `SiteSheetInput.breakpoints` is required, so a site
+    // tier always states one, and passing it means the fallback under test is
+    // never reached. The site tier winning must not mean the route tier is
     // ignored when there is nothing to win with.
     const out = render({
       styles: { base: { base: { color: "#00ff00" } } },
       styleContext: { breakpoints: ROUTE_BREAKPOINTS },
-      siteStyles: { breakpoints: ROUTE_BREAKPOINTS },
     });
 
     expect(out).toContain("#00ff00");
@@ -158,31 +164,44 @@ describe("block bases", () => {
 });
 
 describe("named classes", () => {
+  const ACCENT = {
+    id: "c1",
+    slug: "accent",
+    orderIndex: 0,
+    styles: { base: { base: { color: "#fedcba" } } },
+  } as unknown as never;
+
+  it("attributes the site's library to a node that references it", () => {
+    // The positive control, and the reason it comes first. The assertion below
+    // is that an element does NOT carry a class name, and an element whose node
+    // never referenced the class could not carry it under any implementation —
+    // so without this the deferral case passes on a fixture that proves
+    // nothing. `node.classes` holds class IDS, so the reference has to be there
+    // for either assertion to mean anything.
+    const out = render({
+      classes: ["c1"],
+      styleContext: { breakpoints: ROUTE_BREAKPOINTS },
+      siteStyles: { breakpoints: ROUTE_BREAKPOINTS, classes: [ACCENT] },
+    });
+
+    expect(out).toMatch(/class="[^"]*\bnx-c-accent\b/);
+  });
+
   it("keeps letting a context that states its own outrank the site's", () => {
     // Precedence is NOT what this change is about — the defect was two
     // computations of one question, so each input keeps the rule it had. A
     // context stating an empty list means "no classes", and the site's library
     // must not override that.
-    const out = render({
-      styleContext: { breakpoints: ROUTE_BREAKPOINTS, namedClasses: [] },
-      siteStyles: {
-        breakpoints: ROUTE_BREAKPOINTS,
-        classes: [
-          {
-            id: "c1",
-            slug: "accent",
-            orderIndex: 0,
-            styles: { base: { base: { color: "#fedcba" } } },
-          } as unknown as never,
-        ],
-      },
-    });
-
+    //
     // Deferral is about ATTRIBUTION, not about losing the rules: the sheet
     // still carries the library, and what the context's own list changes is
-    // whether an element is given the class name. Asserting the colour's
-    // absence would demand the sheet drop the library, which is a different
-    // and wrong behaviour.
+    // whether the element is given the class name.
+    const out = render({
+      classes: ["c1"],
+      styleContext: { breakpoints: ROUTE_BREAKPOINTS, namedClasses: [] },
+      siteStyles: { breakpoints: ROUTE_BREAKPOINTS, classes: [ACCENT] },
+    });
+
     expect(out).toContain(".nx-c-accent");
     expect(out).not.toMatch(/class="[^"]*\bnx-c-accent\b/);
   });

--- a/packages/blocks-react/src/site-style-reconciliation.test.tsx
+++ b/packages/blocks-react/src/site-style-reconciliation.test.tsx
@@ -134,11 +134,10 @@ describe("token prefix", () => {
 
 describe("block bases", () => {
   it("gives both compiles the same block-default set", () => {
-    // The same shape as the two above, and the one no finding named. BOTH
-    // compiles emit a block-type tier from their own `blockBases`, and the page
-    // sheet is appended after the shared one — so two different sets means the
-    // shared sheet writes one default and the page sheet overwrites it with
-    // another, each internally consistent.
+    // BOTH compiles emit a block-type tier from their own `blockBases`, and
+    // the page sheet is appended after the shared one — so two different sets
+    // means the shared sheet writes one default and the page sheet overwrites
+    // it with another, each internally consistent.
     //
     // The route's colour is what must NOT survive: asserting only that the
     // site's appears passes either way, because the shared sheet emitted it

--- a/packages/blocks-react/src/site-style-reconciliation.test.tsx
+++ b/packages/blocks-react/src/site-style-reconciliation.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * One render, one answer per site-level input.
+ *
+ * A render carries two style inputs — the route's `styleContext` and the site's
+ * `siteStyles` — and compiles twice from them: the shared sheet, and the page's
+ * own values. Every input both compiles read has to be resolved once. Two
+ * computations of one question disagree silently, because each sheet is
+ * internally consistent and neither reports anything.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  DOCUMENT_FORMAT_VERSION,
+  type BlockDocument,
+  type BreakpointSet,
+  type SiteSheetInput,
+  type StyleCompileContext,
+} from "@nextlyhq/blocks-engine";
+
+import { coreBlocks } from "./blocks";
+import { PageRenderer } from "./page-renderer";
+import { createBlockResolver } from "./resolver";
+
+/** The route's tier: what the config states in code. */
+const ROUTE_BREAKPOINTS: BreakpointSet = {
+  viewport: [{ id: "base", label: "Base" }],
+  container: [],
+};
+
+/** The site's tier: what an admin stored, which the route's tier does not know. */
+const STORED_BREAKPOINTS: BreakpointSet = {
+  viewport: [
+    { id: "base", label: "Base" },
+    { id: "sm", label: "Small", maxWidth: 600 },
+  ],
+  container: [],
+};
+
+function documentWith(styles: unknown): BlockDocument {
+  return {
+    formatVersion: DOCUMENT_FORMAT_VERSION,
+    kind: "page",
+    nodes: [
+      {
+        id: "n1",
+        type: "core/text",
+        version: 1,
+        props: { text: "body" },
+        styles,
+      },
+    ],
+  } as unknown as BlockDocument;
+}
+
+function render(args: {
+  styles?: unknown;
+  styleContext: StyleCompileContext;
+  siteStyles: SiteSheetInput;
+}): string {
+  return renderToStaticMarkup(
+    <PageRenderer
+      document={documentWith(args.styles ?? {})}
+      blocks={createBlockResolver(coreBlocks)}
+      styleContext={args.styleContext}
+      siteStyles={args.siteStyles}
+    />
+  );
+}
+
+describe("breakpoints", () => {
+  it("compiles a node's own value under a breakpoint only the SITE defines", () => {
+    // The stored tier replaces the set as a whole, so an id the route's tier
+    // lacks is an ordinary consequence of an admin adding one. Compiled against
+    // the route's set the value is DROPPED — the engine reports
+    // "so these values were not written", and a published render surfaces no
+    // warnings — so the page silently loses the style.
+    const out = render({
+      styles: { base: { sm: { color: "#ff0000" } } },
+      styleContext: { breakpoints: ROUTE_BREAKPOINTS },
+      siteStyles: { breakpoints: STORED_BREAKPOINTS },
+    });
+
+    expect(out).toContain("max-width: 600px");
+    expect(out).toContain("#ff0000");
+  });
+
+  it("still uses the route's set when the site states none", () => {
+    // The control: the site tier winning must not mean the route tier is
+    // ignored when there is nothing to win with.
+    const out = render({
+      styles: { base: { base: { color: "#00ff00" } } },
+      styleContext: { breakpoints: ROUTE_BREAKPOINTS },
+      siteStyles: { breakpoints: ROUTE_BREAKPOINTS },
+    });
+
+    expect(out).toContain("#00ff00");
+  });
+});
+
+describe("token prefix", () => {
+  const TOKENS = {
+    tokens: [
+      {
+        name: "color.brand",
+        kind: "color" as const,
+        values: { light: "#123456" },
+      },
+    ],
+    prefix: "--brand-",
+  };
+
+  it("references the property the sheet declared, not the default prefix", () => {
+    // The sheet DECLARES the custom properties and the page compile REFERENCES
+    // them. A stored prefix reaching only the sheet leaves every reference
+    // pointing at a property nothing declared, and an unresolved custom
+    // property invalidates the declaration rather than reporting.
+    const out = render({
+      styles: { base: { base: { color: { $token: "color.brand" } } } },
+      styleContext: { breakpoints: ROUTE_BREAKPOINTS },
+      siteStyles: { breakpoints: ROUTE_BREAKPOINTS, tokens: TOKENS },
+    });
+
+    expect(out).toContain("--brand-color-brand");
+    expect(out).not.toContain("var(--site-color-brand)");
+  });
+});
+
+describe("block bases", () => {
+  it("gives both compiles the same block-default set", () => {
+    // The same shape as the two above, and the one no finding named. BOTH
+    // compiles emit a block-type tier from their own `blockBases`, and the page
+    // sheet is appended after the shared one — so two different sets means the
+    // shared sheet writes one default and the page sheet overwrites it with
+    // another, each internally consistent.
+    //
+    // The route's colour is what must NOT survive: asserting only that the
+    // site's appears passes either way, because the shared sheet emitted it
+    // before this change too.
+    const out = render({
+      styleContext: {
+        breakpoints: ROUTE_BREAKPOINTS,
+        blockBases: {
+          "core/text": { base: { base: { color: "#111111" } } },
+        } as unknown as Record<string, never>,
+      },
+      siteStyles: {
+        breakpoints: ROUTE_BREAKPOINTS,
+        blockBases: {
+          "core/text": { base: { base: { color: "#abcdef" } } },
+        } as unknown as Record<string, never>,
+      },
+    });
+
+    expect(out).toContain("#abcdef");
+    expect(out).not.toContain("#111111");
+  });
+});
+
+describe("named classes", () => {
+  it("keeps letting a context that states its own outrank the site's", () => {
+    // Precedence is NOT what this change is about — the defect was two
+    // computations of one question, so each input keeps the rule it had. A
+    // context stating an empty list means "no classes", and the site's library
+    // must not override that.
+    const out = render({
+      styleContext: { breakpoints: ROUTE_BREAKPOINTS, namedClasses: [] },
+      siteStyles: {
+        breakpoints: ROUTE_BREAKPOINTS,
+        classes: [
+          {
+            id: "c1",
+            slug: "accent",
+            orderIndex: 0,
+            styles: { base: { base: { color: "#fedcba" } } },
+          } as unknown as never,
+        ],
+      },
+    });
+
+    // Deferral is about ATTRIBUTION, not about losing the rules: the sheet
+    // still carries the library, and what the context's own list changes is
+    // whether an element is given the class name. Asserting the colour's
+    // absence would demand the sheet drop the library, which is a different
+    // and wrong behaviour.
+    expect(out).toContain(".nx-c-accent");
+    expect(out).not.toMatch(/class="[^"]*\bnx-c-accent\b/);
+  });
+});

--- a/packages/plugin-page-builder/src/fields/blocks-validator.test.ts
+++ b/packages/plugin-page-builder/src/fields/blocks-validator.test.ts
@@ -235,9 +235,6 @@ describe("the breakpoint set a blocks field is validated against", () => {
     container: [],
   };
 
-  /** What an unwired caller falls back to: `siteBreakpoints()` with nothing. */
-  const UNWIRED: BreakpointSet = { viewport: [], container: [] };
-
   function styledAt(breakpoint: string, value: unknown): unknown {
     return page([
       {
@@ -251,34 +248,37 @@ describe("the breakpoint set a blocks field is validated against", () => {
     validateBlocksValue(doc, "content", "Content", {}, breakpoints);
 
   it("reaches the breakpoint level of the walk at all", () => {
-    // The positive control, and it comes first because every assertion below is
-    // about which issues survive a filter — and a fixture that never reached
-    // the breakpoint level would return an empty list for a reason that has
-    // nothing to do with the filter.
+    // The positive control for the two absences below: a fixture that never
+    // reached the breakpoint level would return an empty list for a reason
+    // that has nothing to do with what is being asserted.
     const issues = check(styledAt("wide", "not-an-object"), WIRED);
 
     expect(issues.map(issue => issue.message).join(" ")).toContain("wide");
   });
 
-  it("reports a breakpoint the site's set does not define", () => {
-    // A node styled at an id no set defines compiles to nothing, and a
-    // published render surfaces no warnings, so the write is the only place an
-    // author can be told.
-    const issues = check(styledAt("wide", { color: "#000000" }), BASE_ONLY);
-
-    expect(issues.map(issue => issue.message).join(" ")).toContain("wide");
-  });
-
-  it("accepts the same document once the set defines that breakpoint", () => {
-    // The separating control: without it the assertion above passes just as
-    // well on a validator that refuses every styled document.
+  it("does NOT judge a document by the set it is given", () => {
+    // Pinned as the deliberate behaviour it is. The set reaching this call is
+    // the config tier alone, resolved once at config time where there is no
+    // database, so a page styled at a breakpoint an ADMIN stored would be
+    // refused on save while the published renderer compiles it. Rejecting
+    // valid pages is worse than judging none, so an unknown breakpoint stays a
+    // warning and the error filter drops it.
+    expect(check(styledAt("wide", { color: "#000000" }), BASE_ONLY)).toEqual(
+      []
+    );
     expect(check(styledAt("wide", { color: "#000000" }), WIRED)).toEqual([]);
   });
 
-  it("stays permissive when no set was wired in", () => {
-    // Every id is unknown to an empty set, so reporting there would refuse
-    // every document that styles anything at a breakpoint. Staying quiet is the
-    // fallback's whole purpose.
-    expect(check(styledAt("wide", { color: "#000000" }), UNWIRED)).toEqual([]);
+  it("does decide the one thing that is a property of the SET", () => {
+    // Not inert in every direction, and this is the direction that needs no
+    // stored tier to be correct: an id repeated across the two axes makes a
+    // node's style key ambiguous, which is true of the set alone.
+    const clashing: BreakpointSet = {
+      viewport: [{ id: "base", label: "Base" }],
+      container: [{ id: "base", label: "Base" }],
+    };
+
+    expect(check(page([]), clashing)).not.toEqual([]);
+    expect(check(page([]), WIRED)).toEqual([]);
   });
 });

--- a/packages/plugin-page-builder/src/fields/blocks-validator.test.ts
+++ b/packages/plugin-page-builder/src/fields/blocks-validator.test.ts
@@ -1,3 +1,4 @@
+import type { BreakpointSet } from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
 
 import { validateBlocksValue } from "./blocks-validator";
@@ -215,5 +216,69 @@ describe("validateBlocksValue", () => {
     expect(() =>
       validateBlocksValue(hostile, "content", "Content", {})
     ).not.toThrow();
+  });
+});
+
+describe("the breakpoint set a blocks field is validated against", () => {
+  /** A set that declares one breakpoint beyond the base one. */
+  const WIRED: BreakpointSet = {
+    viewport: [
+      { id: "base", label: "Base" },
+      { id: "wide", label: "Wide", maxWidth: 1200 },
+    ],
+    container: [],
+  };
+
+  /** A set that knows the base breakpoint and not `wide`. */
+  const BASE_ONLY: BreakpointSet = {
+    viewport: [{ id: "base", label: "Base" }],
+    container: [],
+  };
+
+  /** What an unwired caller falls back to: `siteBreakpoints()` with nothing. */
+  const UNWIRED: BreakpointSet = { viewport: [], container: [] };
+
+  function styledAt(breakpoint: string, value: unknown): unknown {
+    return page([
+      {
+        ...node("core/heading", "11111111-1111-4111-8111-111111111111"),
+        styles: { base: { [breakpoint]: value } },
+      },
+    ]);
+  }
+
+  const check = (doc: unknown, breakpoints: BreakpointSet) =>
+    validateBlocksValue(doc, "content", "Content", {}, breakpoints);
+
+  it("reaches the breakpoint level of the walk at all", () => {
+    // The positive control, and it comes first because every assertion below is
+    // about which issues survive a filter — and a fixture that never reached
+    // the breakpoint level would return an empty list for a reason that has
+    // nothing to do with the filter.
+    const issues = check(styledAt("wide", "not-an-object"), WIRED);
+
+    expect(issues.map(issue => issue.message).join(" ")).toContain("wide");
+  });
+
+  it("reports a breakpoint the site's set does not define", () => {
+    // A node styled at an id no set defines compiles to nothing, and a
+    // published render surfaces no warnings, so the write is the only place an
+    // author can be told.
+    const issues = check(styledAt("wide", { color: "#000000" }), BASE_ONLY);
+
+    expect(issues.map(issue => issue.message).join(" ")).toContain("wide");
+  });
+
+  it("accepts the same document once the set defines that breakpoint", () => {
+    // The separating control: without it the assertion above passes just as
+    // well on a validator that refuses every styled document.
+    expect(check(styledAt("wide", { color: "#000000" }), WIRED)).toEqual([]);
+  });
+
+  it("stays permissive when no set was wired in", () => {
+    // Every id is unknown to an empty set, so reporting there would refuse
+    // every document that styles anything at a breakpoint. Staying quiet is the
+    // fallback's whole purpose.
+    expect(check(styledAt("wide", { color: "#000000" }), UNWIRED)).toEqual([]);
   });
 });

--- a/packages/plugin-page-builder/src/fields/blocks-validator.ts
+++ b/packages/plugin-page-builder/src/fields/blocks-validator.ts
@@ -144,8 +144,24 @@ export function validateBlocksValue(
     // refused for a declaration nobody made.
     nesting: registryNestingSource(),
   });
+  // An unknown breakpoint is a WARNING under forgiving validation, so the
+  // severity filter alone drops it — and dropping it is what made the set
+  // threaded into this call change no document's verdict at all. It is real
+  // information the moment a site has actually declared its breakpoints: a node
+  // styled at an id no set defines compiles to nothing, silently, and the
+  // author is the only one who can fix it.
+  //
+  // Against an EMPTY set it is not information. An unwired caller falls back to
+  // `siteBreakpoints()` with nothing, and every id a document mentions is
+  // unknown to that — so reporting there would refuse every document that
+  // styles anything at a breakpoint, which is the hostility the fallback exists
+  // to avoid. Permissive when unwired, strict once wired.
+  const wired =
+    breakpoints.viewport.length > 0 || breakpoints.container.length > 0;
   const documentIssues = allDocumentIssues.filter(
-    issue => issue.severity === "error"
+    issue =>
+      issue.severity === "error" ||
+      (wired && issue.code === "unknown-breakpoint")
   );
   const structuralIssues = documentIssues.filter(
     issue => !NON_STRUCTURAL.has(issue.code)

--- a/packages/plugin-page-builder/src/fields/blocks-validator.ts
+++ b/packages/plugin-page-builder/src/fields/blocks-validator.ts
@@ -144,25 +144,28 @@ export function validateBlocksValue(
     // refused for a declaration nobody made.
     nesting: registryNestingSource(),
   });
-  // An unknown breakpoint is a WARNING under forgiving validation, so the
-  // severity filter alone drops it — and dropping it is what made the set
-  // threaded into this call change no document's verdict at all. It is real
-  // information the moment a site has actually declared its breakpoints: a node
-  // styled at an id no set defines compiles to nothing, silently, and the
-  // author is the only one who can fix it.
+  // Errors only, which means the breakpoint set threaded in here decides
+  // nothing about a document — and that is the correct behaviour today, not an
+  // oversight.
   //
-  // Against an EMPTY set it is not information. An unwired caller falls back to
-  // `siteBreakpoints()` with nothing, and every id a document mentions is
-  // unknown to that — so reporting there would refuse every document that
-  // styles anything at a breakpoint, which is the hostility the fallback exists
-  // to avoid. Permissive when unwired, strict once wired.
-  const wired =
-    breakpoints.viewport.length > 0 || breakpoints.container.length > 0;
+  // An unknown breakpoint is a warning under forgiving validation. Promoting it
+  // was tried and is WRONG while the set reaching this call is the config tier
+  // alone: `plugin.ts` builds the field from `siteBreakpoints(configStyle)` at
+  // config time, where there is no database to read, so a page styled at a
+  // breakpoint an admin STORED would be refused on save while the published
+  // renderer compiles it happily — and a reference to a config breakpoint the
+  // stored set removed would still be accepted. Rejecting valid pages is worse
+  // than judging none.
+  //
+  // What it needs is the MERGED set, which is the same thing the canvas needs
+  // and for the same reason: nothing here can reach stored site style yet. The
+  // parameter stays for the one property it genuinely decides — a set whose
+  // ids collide across axes — and becomes load-bearing for documents when a
+  // client path to the stored tier exists.
   const documentIssues = allDocumentIssues.filter(
-    issue =>
-      issue.severity === "error" ||
-      (wired && issue.code === "unknown-breakpoint")
+    issue => issue.severity === "error"
   );
+
   const structuralIssues = documentIssues.filter(
     issue => !NON_STRUCTURAL.has(issue.code)
   );

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -220,7 +220,16 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
       // url-policy module, so there is one answer to "may this be fetched"
       // rather than one per surface. A host that configured no patterns gets
       // today's behaviour: the engine treats an absent policy as unasked.
-      singles: [siteStyleSingle(siteStyleWritePolicy(opts.remotePatterns))],
+      singles: [
+        siteStyleSingle({
+          ...siteStyleWritePolicy(opts.remotePatterns),
+          // The CONFIG tier this site states in code, so the write gate judges
+          // what consumers actually compile. Without it a stored class whose
+          // slug a config class already holds is accepted and then dropped at
+          // render, and the node referencing it gets no rule at all.
+          ...(opts.siteStyle === undefined ? {} : { defaults: configStyle }),
+        }),
+      ],
       // One field type, where there were two. The other named the previous
       // editor's document — a shape this package defined itself, stored under a
       // synthetic root, and validated with its own rules. A site that declared

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -407,10 +407,9 @@ describe("readSiteStyleRecord", () => {
 
 describe("judging the write against the tier it will be merged with", () => {
   // A checker seeing only the stored array judges something no consumer ever
-  // compiles. Every consumer reads the merge, config inserted first, and both
-  // engine resolutions are first-wins — so a stored entry colliding with a
-  // config one is accepted here and dropped at render, and the node referencing
-  // it gets no rule at all.
+  // compiles. What it must NOT do is model the merge as a concatenation:
+  // `resolveSiteStyle` merges classes keyed by ID, so a stored class sharing an
+  // id with a config one REPLACES it.
   const stored = {
     id: "stored-1",
     slug: "hero",
@@ -425,13 +424,14 @@ describe("judging the write against the tier it will be merged with", () => {
     styles: { base: { base: { color: "#222222" } } },
   };
 
-  it("refuses a stored class whose slug the config tier already holds", () => {
+  it("refuses a slug two different classes would hold once merged", () => {
+    // Survives the merge and still breaks: two ids on one selector means the
+    // compiler keeps the first and the node referencing the other gets no rule.
     const result = checkStoredClasses([stored], {
       defaults: { classes: [CONFIG_CLASS] as never },
     });
 
-    expect(result.issues.join(" ")).toContain("config");
-    expect(result.value).toEqual([]);
+    expect(result.issues.join(" ")).toContain("merged");
   });
 
   it("accepts the same class when the caller states no config tier", () => {
@@ -440,29 +440,38 @@ describe("judging the write against the tier it will be merged with", () => {
     expect(checkStoredClasses([stored]).issues).toEqual([]);
   });
 
-  it("refuses a stored class whose id the config tier already holds", () => {
-    const result = checkStoredClasses([{ ...stored, slug: "unique" }], {
-      defaults: { classes: [{ ...CONFIG_CLASS, id: "stored-1" }] as never },
+  it("ACCEPTS a stored class that overrides a config one by id", () => {
+    // The case a concatenation model gets wrong. Sharing an id is how an
+    // override is expressed — `mergeByKey(defaults, stored, c => c.id)` — so
+    // refusing it as a duplicate refuses the feature.
+    const result = checkStoredClasses([{ ...stored, id: "config-1" }], {
+      defaults: { classes: [CONFIG_CLASS] as never },
     });
 
-    expect(result.issues.join(" ")).toContain("config");
+    expect(result.issues).toEqual([]);
   });
 
-  it("counts the cap over the MERGED library, which is what the compiler truncates", () => {
-    // The compiler takes an array PREFIX, so config entries first means the
-    // stored entries past the cap are the ones that vanish. Counting the stored
-    // array alone accepts a write whose entries are already unreachable.
+  it("counts the cap over the MERGED library, replacements included", () => {
+    // The compiler truncates the merged library by array PREFIX. Counting the
+    // two tiers added together would refuse a write that only replaces.
     const many = Array.from({ length: MAX_NAMED_CLASSES }, (_, i) => ({
       ...stored,
       id: `config-${i}`,
       slug: `config-${i}`,
     }));
 
-    const result = checkStoredClasses([stored], {
+    const overflowing = checkStoredClasses([stored], {
       defaults: { classes: many as never },
     });
+    expect(overflowing.issues.join(" ")).toContain("merged");
 
-    expect(result.issues.join(" ")).toContain("merged");
+    // And a pure replacement of one of them does not overflow, because the
+    // merge is the same length it was.
+    const replacing = checkStoredClasses(
+      [{ ...stored, id: "config-0", slug: "config-0" }],
+      { defaults: { classes: many as never } }
+    );
+    expect(replacing.issues).toEqual([]);
   });
 
   it("refuses a stored token colliding with a config one on a custom property", () => {

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -505,6 +505,34 @@ describe("judging the write against the tier it will be merged with", () => {
     ).toEqual([]);
   });
 
+  it("reports a NEW collision on a slug the config tier already collided on", () => {
+    // Two different collisions on one slug read identically, so a filter keyed
+    // on the rendered message accepts the second as though it were the first.
+    // Config holds `x` and `y` both on `dup`. The write moves `x` off it and
+    // adds `z` onto it: the merge now drops `z` rather than `y`, which is a
+    // different pair and a class the author just wrote that will never render.
+    const config = [
+      { ...stored, id: "x", slug: "dup" },
+      { ...stored, id: "y", slug: "dup" },
+    ];
+    const write = [
+      { ...stored, id: "x", slug: "moved" },
+      { ...stored, id: "z", slug: "dup" },
+    ];
+
+    const result = checkStoredClasses(write, {
+      defaults: { classes: config as never },
+    });
+
+    // BOTH participants, because naming them is what makes one collision
+    // distinguishable from another. A message saying only that "two different
+    // classes" hold the slug reads identically for either pair, and a
+    // difference keyed on it accepts the second as though it were the first.
+    const reported = result.issues.join(" ");
+    expect(reported).toContain('"y"');
+    expect(reported).toContain('"z"');
+  });
+
   it("refuses a stored token colliding with a config one on a custom property", () => {
     const result = checkStoredTokens(
       { tokens: [token("color.primary", "#111111")] },

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -604,6 +604,27 @@ describe("judging the write against the tier it will be merged with", () => {
     expect(result.issues).not.toEqual([]);
   });
 
+  it("accepts a write that only changes the prefix over a colliding config tier", () => {
+    // A collision message renders the custom property the two names both
+    // become, so the prefix is inside the string. Emitting the baseline under
+    // its own prefix makes a prefix change look like a brand new collision and
+    // refuses a write for a clash it did not cause and cannot reach — the
+    // stored tier holds no tokens here at all.
+    const colliding = {
+      tokens: [
+        token("color.primary-dark", "#111111"),
+        token("color-primary.dark", "#222222"),
+      ],
+    };
+
+    const result = checkStoredTokens(
+      { tokens: [], prefix: "--brand-" },
+      { defaults: { tokens: colliding } }
+    );
+
+    expect(result.issues).toEqual([]);
+  });
+
   it("does not report a problem the CONFIG tier already had on its own", () => {
     // Reported as a difference. A site whose own config emits an issue has a
     // problem, but it is not one this write introduced and not one the writer

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -570,9 +570,16 @@ describe("judging the write against the tier it will be merged with", () => {
   });
 
   it("refuses a stored token colliding with a config one on a custom property", () => {
+    // Names the engine does not define, so the collision under test is between
+    // the two SITE tiers rather than with a default. `color.primary` is itself
+    // an engine default, which would attribute the clash a level lower.
     const result = checkStoredTokens(
-      { tokens: [token("color.primary", "#111111")] },
-      { defaults: { tokens: { tokens: [token("color-primary", "#222222")] } } }
+      { tokens: [token("brand.accent-hover", "#111111")] },
+      {
+        defaults: {
+          tokens: { tokens: [token("brand-accent.hover", "#222222")] },
+        },
+      }
     );
 
     expect(result.issues).not.toEqual([]);
@@ -625,6 +632,19 @@ describe("judging the write against the tier it will be merged with", () => {
     expect(result.issues).toEqual([]);
   });
 
+  it("refuses a stored token that collides with an ENGINE default", () => {
+    // A page layers the site's tokens over the engine's defaults before
+    // compiling, so the tier stack a write is judged against has three levels
+    // and not two. `color-primary` emits nothing on its own and collides with
+    // the guaranteed default `color.primary` on `--site-color-primary`, where
+    // the emitter keeps the default and silently drops the saved value.
+    const result = checkStoredTokens({
+      tokens: [token("color-primary", "#111111")],
+    });
+
+    expect(result.issues.join(" ")).toContain("--site-color-primary");
+  });
+
   it("does not report a problem the CONFIG tier already had on its own", () => {
     // Reported as a difference. A site whose own config emits an issue has a
     // problem, but it is not one this write introduced and not one the writer
@@ -632,13 +652,13 @@ describe("judging the write against the tier it will be merged with", () => {
     // else's mistake.
     const brokenConfig = {
       tokens: [
-        token("color.primary", "#111111"),
-        token("color-primary", "#222222"),
+        token("brand.accent-hover", "#111111"),
+        token("brand-accent.hover", "#222222"),
       ],
     };
 
     const result = checkStoredTokens(
-      { tokens: [token("color.accent", "#333333")] },
+      { tokens: [token("brand.other", "#333333")] },
       { defaults: { tokens: brokenConfig } }
     );
 

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -578,6 +578,32 @@ describe("judging the write against the tier it will be merged with", () => {
     expect(result.issues).not.toEqual([]);
   });
 
+  it("reports the stored set's OWN issue even when config emits the same message", () => {
+    // A token issue names the token and not the offending value, so a config
+    // token that already emits one and a stored override that emits a
+    // different one produce identical strings. Comparing merged against config
+    // then accepts a value the compiler drops. What the writer wrote is theirs
+    // whatever the config tier says.
+    const fetching = (name: string, url: string) => ({
+      name,
+      kind: "color" as const,
+      values: { light: `url(${url})` },
+    });
+
+    const result = checkStoredTokens(
+      { tokens: [fetching("brand.image", "https://b.example/2.png")] },
+      {
+        defaults: {
+          tokens: {
+            tokens: [fetching("brand.image", "https://a.example/1.png")],
+          },
+        },
+      }
+    );
+
+    expect(result.issues).not.toEqual([]);
+  });
+
   it("does not report a problem the CONFIG tier already had on its own", () => {
     // Reported as a difference. A site whose own config emits an issue has a
     // problem, but it is not one this write introduced and not one the writer

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -488,6 +488,23 @@ describe("judging the write against the tier it will be merged with", () => {
     expect(checkStoredClasses(tooMany).issues.join(" ")).toContain("at most");
   });
 
+  it("does not charge the writer for a class problem the CONFIG tier already had", () => {
+    // The merge only ever adds to or replaces within the config tier, never
+    // removes from it — so a config tier that already exceeds the cap, or
+    // already holds one slug on two ids, is a problem the writer cannot reach
+    // from the admin. Charging it to their save leaves them unable to store
+    // anything at all, including an empty library.
+    const brokenConfig = [
+      { ...stored, id: "x", slug: "dup" },
+      { ...stored, id: "y", slug: "dup" },
+    ];
+
+    expect(
+      checkStoredClasses([], { defaults: { classes: brokenConfig as never } })
+        .issues
+    ).toEqual([]);
+  });
+
   it("refuses a stored token colliding with a config one on a custom property", () => {
     const result = checkStoredTokens(
       { tokens: [token("color.primary", "#111111")] },

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -485,7 +485,11 @@ describe("judging the write against the tier it will be merged with", () => {
       slug: `c-${i}`,
     }));
 
-    expect(checkStoredClasses(tooMany).issues.join(" ")).toContain("at most");
+    // Named by the id that will not render, which is what a node references and
+    // the only thing the author can act on.
+    expect(checkStoredClasses(tooMany).issues.join(" ")).toContain(
+      `"c-${MAX_NAMED_CLASSES}"`
+    );
   });
 
   it("does not charge the writer for a class problem the CONFIG tier already had", () => {
@@ -524,13 +528,45 @@ describe("judging the write against the tier it will be merged with", () => {
       defaults: { classes: config as never },
     });
 
-    // BOTH participants, because naming them is what makes one collision
-    // distinguishable from another. A message saying only that "two different
-    // classes" hold the slug reads identically for either pair, and a
-    // difference keyed on it accepts the second as though it were the first.
-    const reported = result.issues.join(" ");
-    expect(reported).toContain('"y"');
-    expect(reported).toContain('"z"');
+    // `z` is the class that will not render, and naming it is the whole point:
+    // the pre-existing collision dropped `y`, this one drops `z`, and a check
+    // that could not tell those apart accepted the write.
+    expect(result.issues.join(" ")).toContain('"z"');
+  });
+
+  it("reports a class the write pushes past the cap, over an already-full config", () => {
+    // Config alone is over the cap, which the writer cannot fix. Adding one
+    // more is still their doing, and the class they just added is guaranteed
+    // not to render — so the overflow being inherited must not suppress it.
+    const overfull = Array.from({ length: MAX_NAMED_CLASSES + 1 }, (_, i) => ({
+      ...stored,
+      id: `cfg-${i}`,
+      slug: `cfg-${i}`,
+    }));
+
+    const result = checkStoredClasses([{ ...stored, id: "new", slug: "new" }], {
+      defaults: { classes: overfull as never },
+    });
+
+    expect(result.issues.join(" ")).toContain('"new"');
+  });
+
+  it("reports a config class the write reorders out of rendering", () => {
+    // The compiler claims slugs AFTER sorting by orderIndex, so a write that
+    // only changes precedence changes which of two colliding classes survives.
+    // Config renders `a` and drops `b`; moving `b` in front makes it render and
+    // drops `a`, which used to be on the page.
+    const config = [
+      { ...stored, id: "a", slug: "same", orderIndex: 0 },
+      { ...stored, id: "b", slug: "same", orderIndex: 1 },
+    ];
+
+    const result = checkStoredClasses(
+      [{ ...stored, id: "b", slug: "same", orderIndex: -1 }],
+      { defaults: { classes: config as never } }
+    );
+
+    expect(result.issues.join(" ")).toContain('"a"');
   });
 
   it("refuses a stored token colliding with a config one on a custom property", () => {

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -474,6 +474,20 @@ describe("judging the write against the tier it will be merged with", () => {
     expect(replacing.issues).toEqual([]);
   });
 
+  it("still caps the library when there is no config tier at all", () => {
+    // The merge of nothing and the stored array is the stored array, so the cap
+    // applies either way. A site on the plain `pageBuilder()` configuration
+    // states no defaults, which is the common case — skipping the merged checks
+    // for it would let the compiler silently drop everything past the cap.
+    const tooMany = Array.from({ length: MAX_NAMED_CLASSES + 1 }, (_, i) => ({
+      ...stored,
+      id: `c-${i}`,
+      slug: `c-${i}`,
+    }));
+
+    expect(checkStoredClasses(tooMany).issues.join(" ")).toContain("at most");
+  });
+
   it("refuses a stored token colliding with a config one on a custom property", () => {
     const result = checkStoredTokens(
       { tokens: [token("color.primary", "#111111")] },

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { MAX_NAMED_CLASSES } from "@nextlyhq/blocks-engine";
+
 import {
   checkStoredBreakpoints,
   checkStoredClasses,
@@ -400,5 +402,95 @@ describe("readSiteStyleRecord", () => {
     expect(style.tokens?.tokens.map(t => t.name)).toEqual(["color.primary"]);
     expect(style.classes).toBeUndefined();
     expect(style.breakpoints?.viewport).toHaveLength(1);
+  });
+});
+
+describe("judging the write against the tier it will be merged with", () => {
+  // A checker seeing only the stored array judges something no consumer ever
+  // compiles. Every consumer reads the merge, config inserted first, and both
+  // engine resolutions are first-wins — so a stored entry colliding with a
+  // config one is accepted here and dropped at render, and the node referencing
+  // it gets no rule at all.
+  const stored = {
+    id: "stored-1",
+    slug: "hero",
+    orderIndex: 0,
+    styles: { base: { base: { color: "#111111" } } },
+  };
+
+  const CONFIG_CLASS = {
+    id: "config-1",
+    slug: "hero",
+    orderIndex: 0,
+    styles: { base: { base: { color: "#222222" } } },
+  };
+
+  it("refuses a stored class whose slug the config tier already holds", () => {
+    const result = checkStoredClasses([stored], {
+      defaults: { classes: [CONFIG_CLASS] as never },
+    });
+
+    expect(result.issues.join(" ")).toContain("config");
+    expect(result.value).toEqual([]);
+  });
+
+  it("accepts the same class when the caller states no config tier", () => {
+    // The separating control. Without it the refusal above passes just as well
+    // on a checker that rejects the slug for some reason of its own.
+    expect(checkStoredClasses([stored]).issues).toEqual([]);
+  });
+
+  it("refuses a stored class whose id the config tier already holds", () => {
+    const result = checkStoredClasses([{ ...stored, slug: "unique" }], {
+      defaults: { classes: [{ ...CONFIG_CLASS, id: "stored-1" }] as never },
+    });
+
+    expect(result.issues.join(" ")).toContain("config");
+  });
+
+  it("counts the cap over the MERGED library, which is what the compiler truncates", () => {
+    // The compiler takes an array PREFIX, so config entries first means the
+    // stored entries past the cap are the ones that vanish. Counting the stored
+    // array alone accepts a write whose entries are already unreachable.
+    const many = Array.from({ length: MAX_NAMED_CLASSES }, (_, i) => ({
+      ...stored,
+      id: `config-${i}`,
+      slug: `config-${i}`,
+    }));
+
+    const result = checkStoredClasses([stored], {
+      defaults: { classes: many as never },
+    });
+
+    expect(result.issues.join(" ")).toContain("merged");
+  });
+
+  it("refuses a stored token colliding with a config one on a custom property", () => {
+    const result = checkStoredTokens(
+      { tokens: [token("color.primary", "#111111")] },
+      { defaults: { tokens: { tokens: [token("color-primary", "#222222")] } } }
+    );
+
+    expect(result.issues).not.toEqual([]);
+  });
+
+  it("does not report a problem the CONFIG tier already had on its own", () => {
+    // Reported as a difference. A site whose own config emits an issue has a
+    // problem, but it is not one this write introduced and not one the writer
+    // can fix from here — refusing their save for it tells them about somebody
+    // else's mistake.
+    const brokenConfig = {
+      tokens: [
+        token("color.primary", "#111111"),
+        token("color-primary", "#222222"),
+      ],
+    };
+
+    const result = checkStoredTokens(
+      { tokens: [token("color.accent", "#333333")] },
+      { defaults: { tokens: brokenConfig } }
+    );
+
+    expect(result.issues).toEqual([]);
   });
 });

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -394,10 +394,14 @@ function classValueIssues(
 /**
  * What the stored classes do once merged with the tier they will be merged with.
  *
- * Asked of `resolveSiteStyle` rather than modelled here. The merge is keyed by
- * class ID, so a stored class sharing an id with a config one REPLACES it —
- * concatenating the two tiers instead would refuse a deliberate override as a
- * duplicate, and would count a replacement twice against the cap.
+ * Asked of `resolveSiteStyle` rather than modelled here, and asked even when
+ * there is no config tier: the merge of nothing and the stored array is the
+ * stored array, so one path covers both and the cap cannot be lost with it.
+ *
+ * The merge is keyed by class ID, so a stored class sharing an id with a config
+ * one REPLACES it — concatenating the two tiers instead would refuse a
+ * deliberate override as a duplicate, and would count a replacement twice
+ * against the cap.
  *
  * What survives the merge and still breaks is a SLUG held by two different
  * ids: the compiler drops the later one, so a node referencing it gets no rule.
@@ -408,7 +412,10 @@ function mergedLibraryIssues(
   classes: readonly NamedClass[],
   policy: SectionPolicy
 ): string[] {
-  if (policy.defaults === undefined) return [];
+  // Run whether or not a config tier was stated. With none, the merge is the
+  // stored array itself and the cap below is the only check that applies — but
+  // it applies, and skipping it here would let a site with no config defaults
+  // store more classes than the compiler reads.
   const merged = resolveSiteStyle(policy.defaults, { classes }).classes ?? [];
   const issues: string[] = [];
   if (merged.length > MAX_NAMED_CLASSES) {

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -44,7 +44,11 @@ import {
   type TokenKind,
 } from "@nextlyhq/blocks-engine";
 
-import { siteStyleOf, type SiteStyleData } from "./site-style";
+import {
+  resolveSiteStyle,
+  siteStyleOf,
+  type SiteStyleData,
+} from "./site-style";
 
 /**
  * One section's verdict: the narrowed value a reader may use, and the issues
@@ -79,6 +83,21 @@ export interface SectionPolicy {
    * allowlist is the only limit on a `url()`.
    */
   mayFetchUrl?: MayFetchUrl;
+  /**
+   * The CONFIG tier this write will be merged with, when the caller has one.
+   *
+   * A checker seeing only the stored array judges something no consumer ever
+   * compiles. Every consumer reads the merge, config first, and both engine
+   * resolutions are first-wins — so a stored class whose slug a config class
+   * already holds is accepted here and then dropped at render, and the node
+   * referencing it gets no rule at all. Judging the merge is what makes the
+   * refusal happen while the writer is present.
+   *
+   * Absent means the caller stated no defaults, not that there are none to
+   * consider; a checker with no config tier judges the stored one, which is
+   * exactly what it did before.
+   */
+  defaults?: SiteStyleData;
 }
 
 /** Shared shape guard: a string, when the slot allows one. */
@@ -97,7 +116,10 @@ const optionalString = (value: unknown): value is string | undefined =>
  * write time the author is present to fix it, and accepting a value the
  * browser will drop stores a defect for someone else to debug at render time.
  */
-export function checkStoredTokens(raw: unknown): SectionCheck<SiteTokenSet> {
+export function checkStoredTokens(
+  raw: unknown,
+  policy: SectionPolicy = {}
+): SectionCheck<SiteTokenSet> {
   if (raw === undefined || raw === null) return EMPTY;
   if (!isPlainRecord(raw) || !Array.isArray(raw.tokens)) {
     return {
@@ -158,8 +180,30 @@ export function checkStoredTokens(raw: unknown): SectionCheck<SiteTokenSet> {
   // The emitter is the validator: it is what will read this set on every
   // page render, so its report is the one that counts. The selector is
   // irrelevant to validation; the CSS is discarded.
-  for (const issue of emitTokenBlocks(set, ":root").issues) {
-    issues.push(issue.message);
+  //
+  // Emitted over the MERGE, because that is what every consumer compiles. A
+  // stored token colliding with a config one on a single custom property is
+  // refused by the emitter, and config is inserted first, so without this the
+  // write is accepted and the token silently never applies.
+  //
+  // Reported as a DIFFERENCE against the config tier alone. A site whose own
+  // config already emits an issue has a problem, but it is not one this write
+  // introduced and not one the writer can fix from here — refusing their save
+  // for it would be telling them about somebody else's mistake.
+  //
+  // `resolveSiteStyle` does the merging rather than a local one: it is the one
+  // answer to what the merged style is, and a second one here would drift from
+  // the render it is meant to predict.
+  const merged = resolveSiteStyle(policy.defaults, { tokens: set }).tokens;
+  const already = new Set(
+    policy.defaults?.tokens === undefined
+      ? []
+      : emitTokenBlocks(policy.defaults.tokens, ":root").issues.map(
+          issue => issue.message
+        )
+  );
+  for (const issue of emitTokenBlocks(merged ?? set, ":root").issues) {
+    if (!already.has(issue.message)) issues.push(issue.message);
   }
   return { value: set, issues };
 }
@@ -377,17 +421,29 @@ export function checkStoredClasses(
     return { issues: ["Classes must be an array of named classes."] };
   }
   const issues: string[] = [];
-  if (raw.length > MAX_NAMED_CLASSES) {
+  // Counted over the MERGE, because that is what the compiler truncates: it
+  // takes an array PREFIX, so config entries first means the stored entries
+  // past the cap are the ones that vanish.
+  const configCount = (policy.defaults?.classes ?? []).length;
+  if (raw.length + configCount > MAX_NAMED_CLASSES) {
     issues.push(
-      `The class library holds ${raw.length} entries; the compiler reads at most ${MAX_NAMED_CLASSES}.`
+      `The class library holds ${raw.length + configCount} entries once merged with this site's config; the compiler reads at most ${MAX_NAMED_CLASSES}.`
     );
   }
   // ONE for the whole section: see `classValueIssues` for why neither per map
   // nor per class bounds the work a single write can ask for.
   const budget = newStyleIssueBudget();
   const classes: NamedClass[] = [];
-  const ids = new Set<string>();
-  const slugs = new Set<string>();
+  // Seeded with the CONFIG tier, so a collision across tiers is reported by the
+  // same check that reports one within the stored array. Every consumer reads
+  // the merge and both engine resolutions are first-wins with config inserted
+  // first, so a stored entry colliding with a config one is dropped at render
+  // and the node referencing it gets no rule.
+  const configClasses = policy.defaults?.classes ?? [];
+  const configIds = new Set(configClasses.map(entry => entry.id));
+  const configSlugs = new Set(configClasses.map(entry => entry.slug));
+  const ids = new Set<string>(configIds);
+  const slugs = new Set<string>(configSlugs);
   raw.forEach((entry: unknown, index) => {
     if (!isUsableNamedClass(entry) || !Number.isFinite(entry.orderIndex)) {
       issues.push(
@@ -396,11 +452,19 @@ export function checkStoredClasses(
       return;
     }
     if (ids.has(entry.id)) {
-      issues.push(`classes[${index}] repeats the id "${entry.id}".`);
+      issues.push(
+        configIds.has(entry.id)
+          ? `classes[${index}] repeats the id "${entry.id}", which this site already states in its config. The config entry wins the merge, so this one would be dropped at render.`
+          : `classes[${index}] repeats the id "${entry.id}".`
+      );
       return;
     }
     if (slugs.has(entry.slug)) {
-      issues.push(`classes[${index}] repeats the slug "${entry.slug}".`);
+      issues.push(
+        configSlugs.has(entry.slug)
+          ? `classes[${index}] repeats the slug "${entry.slug}", which this site already states in its config. The config entry wins the merge, so this one would be dropped at render.`
+          : `classes[${index}] repeats the slug "${entry.slug}".`
+      );
       return;
     }
     ids.add(entry.id);

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -412,20 +412,31 @@ function mergedLibraryIssues(
   classes: readonly NamedClass[],
   policy: SectionPolicy
 ): string[] {
-  // Run whether or not a config tier was stated. With none, the merge is the
-  // stored array itself and the cap below is the only check that applies — but
-  // it applies, and skipping it here would let a site with no config defaults
-  // store more classes than the compiler reads.
+  // Reported as a DIFFERENCE against the config tier alone, the same way token
+  // issues are. A site whose own config already exceeds the cap, or already
+  // holds one slug on two ids, has a problem the writer cannot fix from the
+  // admin and cannot even reach — the merge only ever adds to or replaces
+  // within the config tier, never removes from it — so charging it to their
+  // save would leave them unable to store anything at all.
+  const already = new Set(libraryIssues(policy.defaults?.classes ?? []));
+  // Run whether or not a config tier was stated: the merge of nothing and the
+  // stored array is the stored array, so one path covers both and the cap
+  // cannot be lost along with the tier.
   const merged = resolveSiteStyle(policy.defaults, { classes }).classes ?? [];
+  return libraryIssues(merged).filter(issue => !already.has(issue));
+}
+
+/** What a class library, as a whole, would cost the compiler. */
+function libraryIssues(library: readonly NamedClass[]): string[] {
   const issues: string[] = [];
-  if (merged.length > MAX_NAMED_CLASSES) {
+  if (library.length > MAX_NAMED_CLASSES) {
     issues.push(
-      `The class library holds ${merged.length} entries once merged with this site's config; the compiler reads at most ${MAX_NAMED_CLASSES}.`
+      `The class library holds ${library.length} entries once merged with this site's config; the compiler reads at most ${MAX_NAMED_CLASSES}.`
     );
   }
   const owner = new Map<string, string>();
   const reported = new Set<string>();
-  for (const entry of merged) {
+  for (const entry of library) {
     const held = owner.get(entry.slug);
     if (held === undefined) {
       owner.set(entry.slug, entry.id);

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -392,6 +392,49 @@ function classValueIssues(
 }
 
 /**
+ * What the stored classes do once merged with the tier they will be merged with.
+ *
+ * Asked of `resolveSiteStyle` rather than modelled here. The merge is keyed by
+ * class ID, so a stored class sharing an id with a config one REPLACES it —
+ * concatenating the two tiers instead would refuse a deliberate override as a
+ * duplicate, and would count a replacement twice against the cap.
+ *
+ * What survives the merge and still breaks is a SLUG held by two different
+ * ids: the compiler drops the later one, so a node referencing it gets no rule.
+ * The cap is the merged length for the same reason — the compiler truncates the
+ * merged library by array prefix.
+ */
+function mergedLibraryIssues(
+  classes: readonly NamedClass[],
+  policy: SectionPolicy
+): string[] {
+  if (policy.defaults === undefined) return [];
+  const merged = resolveSiteStyle(policy.defaults, { classes }).classes ?? [];
+  const issues: string[] = [];
+  if (merged.length > MAX_NAMED_CLASSES) {
+    issues.push(
+      `The class library holds ${merged.length} entries once merged with this site's config; the compiler reads at most ${MAX_NAMED_CLASSES}.`
+    );
+  }
+  const owner = new Map<string, string>();
+  const reported = new Set<string>();
+  for (const entry of merged) {
+    const held = owner.get(entry.slug);
+    if (held === undefined) {
+      owner.set(entry.slug, entry.id);
+      continue;
+    }
+    if (held !== entry.id && !reported.has(entry.slug)) {
+      reported.add(entry.slug);
+      issues.push(
+        `The slug "${entry.slug}" is held by two different classes once merged with this site's config; the compiler keeps the first, so the other is dropped at render.`
+      );
+    }
+  }
+  return issues;
+}
+
+/**
  * The stored class library.
  *
  * Usability per entry is the engine's `isUsableNamedClass` — the same
@@ -421,29 +464,13 @@ export function checkStoredClasses(
     return { issues: ["Classes must be an array of named classes."] };
   }
   const issues: string[] = [];
-  // Counted over the MERGE, because that is what the compiler truncates: it
-  // takes an array PREFIX, so config entries first means the stored entries
-  // past the cap are the ones that vanish.
-  const configCount = (policy.defaults?.classes ?? []).length;
-  if (raw.length + configCount > MAX_NAMED_CLASSES) {
-    issues.push(
-      `The class library holds ${raw.length + configCount} entries once merged with this site's config; the compiler reads at most ${MAX_NAMED_CLASSES}.`
-    );
-  }
+
   // ONE for the whole section: see `classValueIssues` for why neither per map
   // nor per class bounds the work a single write can ask for.
   const budget = newStyleIssueBudget();
   const classes: NamedClass[] = [];
-  // Seeded with the CONFIG tier, so a collision across tiers is reported by the
-  // same check that reports one within the stored array. Every consumer reads
-  // the merge and both engine resolutions are first-wins with config inserted
-  // first, so a stored entry colliding with a config one is dropped at render
-  // and the node referencing it gets no rule.
-  const configClasses = policy.defaults?.classes ?? [];
-  const configIds = new Set(configClasses.map(entry => entry.id));
-  const configSlugs = new Set(configClasses.map(entry => entry.slug));
-  const ids = new Set<string>(configIds);
-  const slugs = new Set<string>(configSlugs);
+  const ids = new Set<string>();
+  const slugs = new Set<string>();
   raw.forEach((entry: unknown, index) => {
     if (!isUsableNamedClass(entry) || !Number.isFinite(entry.orderIndex)) {
       issues.push(
@@ -452,19 +479,11 @@ export function checkStoredClasses(
       return;
     }
     if (ids.has(entry.id)) {
-      issues.push(
-        configIds.has(entry.id)
-          ? `classes[${index}] repeats the id "${entry.id}", which this site already states in its config. The config entry wins the merge, so this one would be dropped at render.`
-          : `classes[${index}] repeats the id "${entry.id}".`
-      );
+      issues.push(`classes[${index}] repeats the id "${entry.id}".`);
       return;
     }
     if (slugs.has(entry.slug)) {
-      issues.push(
-        configSlugs.has(entry.slug)
-          ? `classes[${index}] repeats the slug "${entry.slug}", which this site already states in its config. The config entry wins the merge, so this one would be dropped at render.`
-          : `classes[${index}] repeats the slug "${entry.slug}".`
-      );
+      issues.push(`classes[${index}] repeats the slug "${entry.slug}".`);
       return;
     }
     ids.add(entry.id);
@@ -477,6 +496,7 @@ export function checkStoredClasses(
     }
     classes.push(entry);
   });
+  issues.push(...mergedLibraryIssues(classes, policy));
   return { value: classes, issues };
 }
 

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -31,6 +31,7 @@ import {
   isPlainRecord,
   isUsableNamedClass,
   newStyleIssueBudget,
+  usableNamedClasses,
   validateFontFace,
   validateStyleValues,
   type BreakpointDef,
@@ -412,70 +413,49 @@ function mergedLibraryIssues(
   classes: readonly NamedClass[],
   policy: SectionPolicy
 ): string[] {
-  // Reported as a DIFFERENCE against the config tier alone. A site whose own
-  // config exceeds the cap, or already holds one slug on two ids, has a problem
-  // the writer cannot reach from the admin — the merge adds to and replaces
-  // within that tier, never removes from it — so charging it to their save
-  // would leave them unable to store anything at all.
+  // Asked of the engine, never modelled. `usableNamedClasses` is the list the
+  // compiler writes and the renderer is handed, so it already applies the
+  // ordering (`orderIndex`, then `id`) and the claim rules (a slug or an id
+  // already taken drops the later entry). Reproducing those here was wrong four
+  // separate ways, each a different rule; asking cannot be wrong in any of
+  // them.
   //
-  // Compared by IDENTITY, not by the rendered message. Two different collisions
-  // on one slug read identically: config holding `x` and `y` both on `dup`
-  // produces the same sentence as `y` and a newly stored `z` on `dup`, so a
-  // message-keyed filter would accept a write whose new class never renders.
-  // The participants are what make one collision a different collision.
-  const already = new Set(
-    libraryViolations(policy.defaults?.classes ?? []).map(v => v.identity)
-  );
-  // Run whether or not a config tier was stated: the merge of nothing and the
-  // stored array is the stored array, so one path covers both and the cap
-  // cannot be lost along with the tier.
+  // The cap is applied BEFORE resolution, as an array prefix on the whole
+  // library, so it is applied that way here too.
   const merged = resolveSiteStyle(policy.defaults, { classes }).classes ?? [];
-  return libraryViolations(merged)
-    .filter(violation => !already.has(violation.identity))
-    .map(violation => violation.message);
-}
+  const before = renderedIds(policy.defaults?.classes ?? []);
+  const after = renderedIds(merged);
 
-/**
- * One thing a class library would cost the compiler, and what makes it that one.
- *
- * `identity` names the participants rather than describing the outcome, so two
- * violations are the same violation only when the same entries cause them.
- *
- * The message names them too, and that is what the tests can observe: keying
- * the difference on the message alone is only unsafe while the message says
- * "two different classes" instead of which two. Comparing `identity` is
- * therefore belt and braces — it keeps the comparison correct if the wording
- * is ever shortened, and no test distinguishes it from comparing the message
- * as that message stands today.
- */
-interface LibraryViolation {
-  identity: string;
-  message: string;
-}
-
-/** What a class library, as a whole, would cost the compiler. */
-function libraryViolations(library: readonly NamedClass[]): LibraryViolation[] {
-  const violations: LibraryViolation[] = [];
-  if (library.length > MAX_NAMED_CLASSES) {
-    violations.push({
-      identity: "cap",
-      message: `The class library holds ${library.length} entries once merged with this site's config; the compiler reads at most ${MAX_NAMED_CLASSES}.`,
-    });
-  }
-  const owner = new Map<string, string>();
-  for (const entry of library) {
-    const held = owner.get(entry.slug);
-    if (held === undefined) {
-      owner.set(entry.slug, entry.id);
-      continue;
+  const issues: string[] = [];
+  // A class the site used to render and no longer does. This write caused it,
+  // whether by claiming its slug, taking its id, reordering it behind another,
+  // or pushing it past the cap.
+  for (const id of before) {
+    if (!after.has(id)) {
+      issues.push(
+        `Saving this would stop the class "${id}" rendering: once merged with this site's config it is no longer one of the ${MAX_NAMED_CLASSES} the compiler reads, or another class claims its slug or id first.`
+      );
     }
-    if (held === entry.id) continue;
-    violations.push({
-      identity: `slug:${entry.slug}|kept:${held}|dropped:${entry.id}`,
-      message: `The slug "${entry.slug}" is held by both "${held}" and "${entry.id}" once merged with this site's config; the compiler keeps the first, so "${entry.id}" is dropped at render.`,
-    });
   }
-  return violations;
+  // A class in this write that will not render. Reported by id, because that is
+  // what a node references and what the author can act on.
+  for (const entry of classes) {
+    if (!after.has(entry.id)) {
+      issues.push(
+        `The class "${entry.id}" would not render: once merged with this site's config another class claims its slug or id first, or it falls past the ${MAX_NAMED_CLASSES} the compiler reads.`
+      );
+    }
+  }
+  return issues;
+}
+
+/** The ids a library actually renders, as the compiler resolves it. */
+function renderedIds(library: readonly NamedClass[]): Set<string> {
+  const read =
+    library.length > MAX_NAMED_CLASSES
+      ? library.slice(0, MAX_NAMED_CLASSES)
+      : library;
+  return new Set(usableNamedClasses(read).map(entry => entry.id));
 }
 
 /**

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -211,12 +211,18 @@ function tokenEmissionIssues(
   policy: SectionPolicy
 ): string[] {
   const own = emittedMessages(set);
+  const merged = resolveSiteStyle(policy.defaults, { tokens: set }).tokens;
+  // The config tier emitted under the MERGED prefix, so the two runs are
+  // comparable. A collision message renders the custom property the two names
+  // both become, and the prefix is part of that rendering rather than part of
+  // the collision — emitting the baseline under its own prefix makes a write
+  // that changes only the prefix look like a brand new collision, and refuses
+  // it for a clash it did not cause and cannot reach.
   const inherited = new Set(
     policy.defaults?.tokens === undefined
       ? []
-      : emittedMessages(policy.defaults.tokens)
+      : emittedMessages(withPrefixOf(policy.defaults.tokens, merged))
   );
-  const merged = resolveSiteStyle(policy.defaults, { tokens: set }).tokens;
   const reported = new Set(own);
   const issues = [...own];
   for (const message of emittedMessages(merged ?? set)) {
@@ -225,6 +231,16 @@ function tokenEmissionIssues(
     issues.push(message);
   }
   return issues;
+}
+
+/** One token set as it would render under another's prefix. */
+function withPrefixOf(
+  tokens: SiteTokenSet,
+  under: SiteTokenSet | undefined
+): SiteTokenSet {
+  return under?.prefix === undefined
+    ? tokens
+    : { ...tokens, prefix: under.prefix };
 }
 
 /** What emitting one token set reports, as plain messages. */

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -31,6 +31,7 @@ import {
   isPlainRecord,
   isUsableNamedClass,
   newStyleIssueBudget,
+  resolveSiteTokens,
   usableNamedClasses,
   validateFontFace,
   validateStyleValues,
@@ -243,9 +244,23 @@ function withPrefixOf(
     : { ...tokens, prefix: under.prefix };
 }
 
-/** What emitting one token set reports, as plain messages. */
+/**
+ * What emitting one token set reports, as plain messages, AS RENDERED.
+ *
+ * Resolved through `resolveSiteTokens` first, because that is what a page does:
+ * `PageRenderer` layers the site's tokens over the engine's defaults before
+ * compiling, so a stored name that collides with a default is dropped at render
+ * while a gate judging the stored and config tiers alone sees nothing at all.
+ * Measured: `color-primary` emits no issue on its own and collides with the
+ * default `color.primary` on `--site-color-primary` once resolved.
+ *
+ * Applied here rather than at each call so all three emissions — the stored set,
+ * the config baseline and the merge — are judged against the same tier stack.
+ */
 function emittedMessages(tokens: SiteTokenSet): string[] {
-  return emitTokenBlocks(tokens, ":root").issues.map(issue => issue.message);
+  return emitTokenBlocks(resolveSiteTokens(tokens), ":root").issues.map(
+    issue => issue.message
+  );
 }
 
 /** The stored font faces, each checked by the engine's own face validator. */

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -412,44 +412,70 @@ function mergedLibraryIssues(
   classes: readonly NamedClass[],
   policy: SectionPolicy
 ): string[] {
-  // Reported as a DIFFERENCE against the config tier alone, the same way token
-  // issues are. A site whose own config already exceeds the cap, or already
-  // holds one slug on two ids, has a problem the writer cannot fix from the
-  // admin and cannot even reach — the merge only ever adds to or replaces
-  // within the config tier, never removes from it — so charging it to their
-  // save would leave them unable to store anything at all.
-  const already = new Set(libraryIssues(policy.defaults?.classes ?? []));
+  // Reported as a DIFFERENCE against the config tier alone. A site whose own
+  // config exceeds the cap, or already holds one slug on two ids, has a problem
+  // the writer cannot reach from the admin — the merge adds to and replaces
+  // within that tier, never removes from it — so charging it to their save
+  // would leave them unable to store anything at all.
+  //
+  // Compared by IDENTITY, not by the rendered message. Two different collisions
+  // on one slug read identically: config holding `x` and `y` both on `dup`
+  // produces the same sentence as `y` and a newly stored `z` on `dup`, so a
+  // message-keyed filter would accept a write whose new class never renders.
+  // The participants are what make one collision a different collision.
+  const already = new Set(
+    libraryViolations(policy.defaults?.classes ?? []).map(v => v.identity)
+  );
   // Run whether or not a config tier was stated: the merge of nothing and the
   // stored array is the stored array, so one path covers both and the cap
   // cannot be lost along with the tier.
   const merged = resolveSiteStyle(policy.defaults, { classes }).classes ?? [];
-  return libraryIssues(merged).filter(issue => !already.has(issue));
+  return libraryViolations(merged)
+    .filter(violation => !already.has(violation.identity))
+    .map(violation => violation.message);
+}
+
+/**
+ * One thing a class library would cost the compiler, and what makes it that one.
+ *
+ * `identity` names the participants rather than describing the outcome, so two
+ * violations are the same violation only when the same entries cause them.
+ *
+ * The message names them too, and that is what the tests can observe: keying
+ * the difference on the message alone is only unsafe while the message says
+ * "two different classes" instead of which two. Comparing `identity` is
+ * therefore belt and braces — it keeps the comparison correct if the wording
+ * is ever shortened, and no test distinguishes it from comparing the message
+ * as that message stands today.
+ */
+interface LibraryViolation {
+  identity: string;
+  message: string;
 }
 
 /** What a class library, as a whole, would cost the compiler. */
-function libraryIssues(library: readonly NamedClass[]): string[] {
-  const issues: string[] = [];
+function libraryViolations(library: readonly NamedClass[]): LibraryViolation[] {
+  const violations: LibraryViolation[] = [];
   if (library.length > MAX_NAMED_CLASSES) {
-    issues.push(
-      `The class library holds ${library.length} entries once merged with this site's config; the compiler reads at most ${MAX_NAMED_CLASSES}.`
-    );
+    violations.push({
+      identity: "cap",
+      message: `The class library holds ${library.length} entries once merged with this site's config; the compiler reads at most ${MAX_NAMED_CLASSES}.`,
+    });
   }
   const owner = new Map<string, string>();
-  const reported = new Set<string>();
   for (const entry of library) {
     const held = owner.get(entry.slug);
     if (held === undefined) {
       owner.set(entry.slug, entry.id);
       continue;
     }
-    if (held !== entry.id && !reported.has(entry.slug)) {
-      reported.add(entry.slug);
-      issues.push(
-        `The slug "${entry.slug}" is held by two different classes once merged with this site's config; the compiler keeps the first, so the other is dropped at render.`
-      );
-    }
+    if (held === entry.id) continue;
+    violations.push({
+      identity: `slug:${entry.slug}|kept:${held}|dropped:${entry.id}`,
+      message: `The slug "${entry.slug}" is held by both "${held}" and "${entry.id}" once merged with this site's config; the compiler keeps the first, so "${entry.id}" is dropped at render.`,
+    });
   }
-  return issues;
+  return violations;
 }
 
 /**

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -178,44 +178,58 @@ export function checkStoredTokens(
     ...(typeof raw.prefix === "string" ? { prefix: raw.prefix } : {}),
     ...(darkMode === "attribute" || darkMode === "media" ? { darkMode } : {}),
   };
-  // The emitter is the validator: it is what will read this set on every page
-  // render, so its report is the one that counts. The selector is irrelevant to
-  // validation; the CSS is discarded.
-  //
-  // Three runs, because "did this write cause it" and "is this new" are
-  // different questions and only one of them can be answered by comparing
-  // merged against config.
-  //
-  // The stored set's OWN issues are always reported. A message names the token
-  // and not the offending value, so a config token that already emits one and a
-  // stored override that emits a different one produce the same string — and
-  // suppressing on that accepts a value the compiler drops. What the writer
-  // wrote is theirs whatever the config tier says.
-  //
-  // Only issues the MERGE creates are compared against the config tier, and
-  // suppressed when it already had them. A collision between the two tiers that
-  // predates this write is not something the writer can fix from the admin.
-  //
-  // `resolveSiteStyle` does the merging rather than a second implementation
-  // here: it is the one answer to what the merged style is, and a local copy
-  // would drift from the render it exists to predict.
-  const own = emitTokenBlocks(set, ":root").issues.map(issue => issue.message);
+  issues.push(...tokenEmissionIssues(set, policy));
+  return { value: set, issues };
+}
+
+/**
+ * What emitting this token set would report, minus what the config tier already
+ * reported on its own.
+ *
+ * The emitter is the validator: it is what will read the set on every page
+ * render, so its report is the one that counts. The selector is irrelevant to
+ * validation; the CSS is discarded.
+ *
+ * Three runs, because "did this write cause it" and "is this new" are different
+ * questions and only the second can be answered by comparing merged against
+ * config.
+ *
+ * The stored set's OWN issues are always reported. A message names the token
+ * and not the offending value, so a config token that already emits one and a
+ * stored override emitting a different one produce byte-identical strings — and
+ * suppressing on that accepts a value the compiler drops. What the writer wrote
+ * is theirs whatever the config tier says.
+ *
+ * Only issues the MERGE creates are compared and suppressed when the config
+ * tier already had them, because a collision that predates this write is not
+ * reachable from the admin. `resolveSiteStyle` does the merging rather than a
+ * second implementation here: it is the one answer to what the merged style is,
+ * and a local copy would drift from the render it exists to predict.
+ */
+function tokenEmissionIssues(
+  set: SiteTokenSet,
+  policy: SectionPolicy
+): string[] {
+  const own = emittedMessages(set);
   const inherited = new Set(
     policy.defaults?.tokens === undefined
       ? []
-      : emitTokenBlocks(policy.defaults.tokens, ":root").issues.map(
-          issue => issue.message
-        )
+      : emittedMessages(policy.defaults.tokens)
   );
   const merged = resolveSiteStyle(policy.defaults, { tokens: set }).tokens;
   const reported = new Set(own);
-  issues.push(...own);
-  for (const issue of emitTokenBlocks(merged ?? set, ":root").issues) {
-    if (inherited.has(issue.message) || reported.has(issue.message)) continue;
-    reported.add(issue.message);
-    issues.push(issue.message);
+  const issues = [...own];
+  for (const message of emittedMessages(merged ?? set)) {
+    if (inherited.has(message) || reported.has(message)) continue;
+    reported.add(message);
+    issues.push(message);
   }
-  return { value: set, issues };
+  return issues;
+}
+
+/** What emitting one token set reports, as plain messages. */
+function emittedMessages(tokens: SiteTokenSet): string[] {
+  return emitTokenBlocks(tokens, ":root").issues.map(issue => issue.message);
 }
 
 /** The stored font faces, each checked by the engine's own face validator. */

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -178,33 +178,42 @@ export function checkStoredTokens(
     ...(typeof raw.prefix === "string" ? { prefix: raw.prefix } : {}),
     ...(darkMode === "attribute" || darkMode === "media" ? { darkMode } : {}),
   };
-  // The emitter is the validator: it is what will read this set on every
-  // page render, so its report is the one that counts. The selector is
-  // irrelevant to validation; the CSS is discarded.
+  // The emitter is the validator: it is what will read this set on every page
+  // render, so its report is the one that counts. The selector is irrelevant to
+  // validation; the CSS is discarded.
   //
-  // Emitted over the MERGE, because that is what every consumer compiles. A
-  // stored token colliding with a config one on a single custom property is
-  // refused by the emitter, and config is inserted first, so without this the
-  // write is accepted and the token silently never applies.
+  // Three runs, because "did this write cause it" and "is this new" are
+  // different questions and only one of them can be answered by comparing
+  // merged against config.
   //
-  // Reported as a DIFFERENCE against the config tier alone. A site whose own
-  // config already emits an issue has a problem, but it is not one this write
-  // introduced and not one the writer can fix from here — refusing their save
-  // for it would be telling them about somebody else's mistake.
+  // The stored set's OWN issues are always reported. A message names the token
+  // and not the offending value, so a config token that already emits one and a
+  // stored override that emits a different one produce the same string — and
+  // suppressing on that accepts a value the compiler drops. What the writer
+  // wrote is theirs whatever the config tier says.
   //
-  // `resolveSiteStyle` does the merging rather than a local one: it is the one
-  // answer to what the merged style is, and a second one here would drift from
-  // the render it is meant to predict.
-  const merged = resolveSiteStyle(policy.defaults, { tokens: set }).tokens;
-  const already = new Set(
+  // Only issues the MERGE creates are compared against the config tier, and
+  // suppressed when it already had them. A collision between the two tiers that
+  // predates this write is not something the writer can fix from the admin.
+  //
+  // `resolveSiteStyle` does the merging rather than a second implementation
+  // here: it is the one answer to what the merged style is, and a local copy
+  // would drift from the render it exists to predict.
+  const own = emitTokenBlocks(set, ":root").issues.map(issue => issue.message);
+  const inherited = new Set(
     policy.defaults?.tokens === undefined
       ? []
       : emitTokenBlocks(policy.defaults.tokens, ":root").issues.map(
           issue => issue.message
         )
   );
+  const merged = resolveSiteStyle(policy.defaults, { tokens: set }).tokens;
+  const reported = new Set(own);
+  issues.push(...own);
   for (const issue of emitTokenBlocks(merged ?? set, ":root").issues) {
-    if (!already.has(issue.message)) issues.push(issue.message);
+    if (inherited.has(issue.message) || reported.has(issue.message)) continue;
+    reported.add(issue.message);
+    issues.push(issue.message);
   }
   return { value: set, issues };
 }

--- a/packages/plugin-page-builder/src/site-style-storage.ts
+++ b/packages/plugin-page-builder/src/site-style-storage.ts
@@ -95,7 +95,7 @@ export function siteStyleSingle(policy: SectionPolicy = {}) {
       json({
         name: "tokens",
         label: "Design tokens",
-        validate: refusing(checkStoredTokens),
+        validate: refusing(raw => checkStoredTokens(raw, policy)),
         admin: {
           description:
             'A token set: { tokens: [{ name, kind, values: { light, dark? } }], prefix?, darkMode? }. Values are per mode; "light" is what a reader with no mode set resolves.',

--- a/packages/plugin-page-builder/src/site-style.test.ts
+++ b/packages/plugin-page-builder/src/site-style.test.ts
@@ -51,8 +51,8 @@ const VIEWPORT_ONLY: BreakpointSet = {
 
 describe("resolveSiteStyle", () => {
   it("answers the empty style when nothing is stated on either tier", () => {
-    expect(resolveSiteStyle()).toEqual({});
-    expect(resolveSiteStyle({}, {})).toEqual({});
+    expect(resolveSiteStyle()).toStrictEqual({});
+    expect(resolveSiteStyle({}, {})).toStrictEqual({});
   });
 
   it("passes a lone tier through, whichever side states it", () => {
@@ -155,7 +155,7 @@ describe("siteSheet", () => {
   it("omits undefined sections rather than defaulting them", () => {
     // An invented section would preview a design no published page has; the
     // sheet compiler treats an absent key as "the site defines none".
-    expect(siteSheet()).toEqual({
+    expect(siteSheet()).toStrictEqual({
       breakpoints: { viewport: [], container: [] },
     });
   });
@@ -167,7 +167,7 @@ describe("siteSheet", () => {
       fonts: [face("Geist")],
       breakpoints: VIEWPORT_ONLY,
     };
-    expect(siteSheet(style)).toEqual({
+    expect(siteSheet(style)).toStrictEqual({
       tokens: style.tokens,
       classes: style.classes,
       fonts: style.fonts,


### PR DESCRIPTION
Closes the remaining findings against the merged #1116. **Work in progress on this branch** — five of seven are in the first commit; the write-gate tier and the inert breakpoint validator follow on this same PR.

## One render was answering one question twice

A render carries two style inputs — the route's `styleContext` and the site's `siteStyles` — and compiles twice from them: the shared sheet, and the page's own values. **Only the class library was reconciled.** `breakpoints`, `tokenPrefix` and `blockBases` were each computed twice.

Every consequence is silent, because each sheet is internally consistent and neither reports anything:

- A stored breakpoint set replaces the config one *whole*, so a node value stored under an id the route's set lacks is **dropped outright** — the engine says *"so these values were not written"* and a published render surfaces no warnings.
- A stored token prefix leaves every `{ $token }` reference pointing at a custom property nothing declared, and an unresolved custom property invalidates the declaration rather than reporting.

**`blockBases` is the same defect and no finding named it.** Both compiles emit a block-type tier from their own set and the page sheet is appended after the shared one, so two sets means one default silently overwriting the other. A fix in one path is not a fix in the class.

### The shape of the fix

Precedence is **unchanged for every field**. The defect was two computations of one question, not the wrong answer to it — so each field keeps the rule it had and only the number of places that decide changes.

`SITE_INPUT_ROLE` is typed over every `SiteSheetInput` key, so adding a field there is a compile error until someone classifies it. Three of these were found one at a time; the fourth would have been.

Prior art checked rather than assumed: [WordPress global styles](https://developer.wordpress.org/block-editor/how-to-guides/themes/global-settings-and-styles/) resolves core → theme → **user/database over theme** → per-block, which is exactly `resolveSiteStyle`'s layering. So there was no precedence question to reopen.

### Classes are the deliberate exception

The reconciliation reaches the page context only. A context stating its own list defers **attribution** while the rules stay in the sheet — so feeding the resolved list back to the sheet drops the library whenever a context defers.

I know because **it happened**: the deferral test caught it one commit after I gave that test the assertion which made it able to. That is the finding paying for itself immediately.

## Cache invalidation

`BlocksPageConfig` gains `siteStyleSingles`. A provider is called per render, which on a pre-rendered route is **not** the same as being read per render: the whole render is cached and only a tag the page carries rebuilds it, while a Direct API read contributes none. Naming the single puts `nextly:single:<slug>` on the route.

This is the same gap, and the same remedy, as the media collection one line above it in the tag list. It matches [Next.js on-demand revalidation](https://nextjs.org/docs/app/guides/how-revalidation-works) and uses `nextlySingleTags`, which this repo already supplies and already applies at `single-route.ts:190`.

## Two evidence findings

- The absence guards were asserted with `toEqual`, which **ignores undefined-valued keys** — deleting all seven spread guards left the suite green. Four assertions are `toStrictEqual` now.
- The deferral test asserted only that an element lacks the class, which a render that dropped the library satisfies identically. It now also asserts the sheet still carries the rule.

## Evidence

Break-verified. Reverting the page context to its previous namedClasses-only form fails exactly three tests — breakpoints, token prefix, block bases — while both controls (site states none; context outranks for classes) still pass. Dropping the single tags fails exactly the tag test and not its control.

One test was **vacuous on first writing** and I caught it with the same break: the original block-bases assertion checked only that the site's colour appears, which the shared sheet emitted before this change too. It now asserts the route's colour is absent, which is what separates the implementations.

## Not in this PR

`apps/playground/**` is outside this lane's two territories, so both playground routes still need `siteStyleSingles: [SITE_STYLE_SLUG]` — the slot and its plumbing are here, that one line is not. Filed as `finding:playground-blocks-routes-lack-site-style-tags`.

## Gates

build 0 · blocks-react 688 tests / 29 files · plugin-page-builder 122 tests / 17 files · `check-types` 0 on both including `tsconfig.tests.json` · `lint` 0 with `--max-warnings 0` · comment convention 0 new · `fallow audit` verdict `pass`, every `*_introduced` at 0.

Fallow first failed this branch with `complexity_introduced=1` (`sharedStyleInputs`, cyclomatic 19). Normalising both tiers once instead of repeating optional chains per field took it to a passing figure without changing behaviour.

Changeset generated from `.changeset/config.json` (25 packages), checker-verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved site-wide styling consistency across pages, including breakpoints, block styles, named classes, and token prefixes.
  * Site styles now support per-request loading and explicit cache invalidation dependencies.
  * Site-style defaults are applied consistently during registration and rendering.
  * Added reusable named-class utilities.

* **Bug Fixes**
  * Preserved site class-library styles during page-level class attribution.
  * Improved fallback behavior for unavailable breakpoint settings.
  * Strengthened validation for merged styles, tokens, classes, breakpoints, duplicate IDs, and configured limits.
  * Invalid legacy site-style configurations now fail clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->