### PR TITLE
feat(builder): export the engine's union arm choice, and add the Style tab

### DIFF
--- a/.changeset/style-tab-and-arm-selection-export.md
+++ b/.changeset/style-tab-and-arm-selection-export.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Export the engine’s union arm selection and delete the copy of it the style-controls SDK carried, so a control and the error message beside it describe one arm by construction. When no arm accepts a value the engine now reports through the arm the value was written in — `fontWeight: 5000` says it is above the maximum of 1000 rather than that it is not one of `normal, bold, lighter, bolder`.
+
+Add the Style tab to the page-builder inspector: Content|Style tabs, one-open accordion sections derived from the catalog’s groups and the block’s own `supports`, and an editable control for every property those allow.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -239,12 +239,18 @@ export {
   MAX_SITE_LOOKUPS,
   tokenKindAllowedAt,
   tokenKindsForProperty,
-  // Which arm of a union a stored value belongs to. Public because the compiler
-  // and an editor ask the same question of it — one to decide which arm's rules
-  // to emit and which complaint to report, the other to decide which control to
-  // draw. A second answer to it drifts silently, because both surfaces look
-  // right on their own: the disagreement is only visible to an author holding a
-  // control for one arm while reading an error written about another.
+  // Which arm of a union a stored value belongs to. Public because more than one
+  // surface asks it: validation picks the arm it judges a value against, and an
+  // editor picks the control to draw for it. A second answer drifts silently,
+  // because both surfaces look right on their own — the disagreement is visible
+  // only to an author holding a control for one arm while reading an error
+  // written about another.
+  //
+  // `style/declarations.ts` still selects an arm its OWN way while emitting, by
+  // taking the first that writes bytes. Measured, the two already disagree:
+  // `fontWeight: 700` resolves here to the number arm and emits through the
+  // keyword one, because `scalarText` reads no leaf kind. Nothing is visibly
+  // wrong today only because both arms write `font-weight`.
   styleUnionVariant,
 } from "./style/validate-style-value";
 export type {

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -226,6 +226,11 @@ export {
   // at-rule to a browser. Public because every surface deciding what a keyword
   // IS has to fold it the same way.
   asciiLower,
+  // What CSS discards around a value, which is NOT what `String.trim` discards:
+  // JavaScript strips NBSP and the Unicode spaces and CSS does not, so an editor
+  // trimming with the language's own function normalises spellings the engine
+  // then refuses — or worse, converts one into a value it accepts.
+  trimCssWhitespace,
 } from "./style/css-value";
 export type { CssValueRejection, MayFetchUrl } from "./style/css-value";
 export type { StyleValueOptions } from "./style/validate-style-value";

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -239,8 +239,18 @@ export {
   MAX_SITE_LOOKUPS,
   tokenKindAllowedAt,
   tokenKindsForProperty,
+  // Which arm of a union a stored value belongs to. Public because the compiler
+  // and an editor ask the same question of it — one to decide which arm's rules
+  // to emit and which complaint to report, the other to decide which control to
+  // draw. A second answer to it drifts silently, because both surfaces look
+  // right on their own: the disagreement is only visible to an author holding a
+  // control for one arm while reading an error written about another.
+  styleUnionVariant,
 } from "./style/validate-style-value";
-export type { StyleIssueBudget } from "./style/validate-style-value";
+export type {
+  StyleIssueBudget,
+  StyleUnionVariantOptions,
+} from "./style/validate-style-value";
 export { compilePageCss, BASE_BREAKPOINT } from "./style/compile-page";
 // The one rule for how a document-global CSS name wears its scope. Public
 // because more than one place has to produce it and they must agree exactly:

--- a/packages/blocks-engine/src/style/validate-style-value.test.ts
+++ b/packages/blocks-engine/src/style/validate-style-value.test.ts
@@ -675,8 +675,8 @@ describe("styleUnionVariant", () => {
     // Both arms take records, so the kind rule ties and depth is what decides.
     // The shape is BUILT rather than taken from the catalog because the catalog
     // ships no union of two composites: measured, removing the depth rule
-    // entirely left all 1306 engine tests green. This is a public entry point,
-    // so a caller can hand it the shape the catalog cannot express, and a rule
+    // entirely left every engine test green. This is a public entry point, so a
+    // caller can hand it the shape the catalog cannot express, and a rule
     // nothing exercises is one nobody would notice going wrong.
     //
     // An unknown key is NOT the discriminator — it reports at the key's own

--- a/packages/blocks-engine/src/style/validate-style-value.test.ts
+++ b/packages/blocks-engine/src/style/validate-style-value.test.ts
@@ -695,6 +695,34 @@ describe("styleUnionVariant", () => {
     expect(styleUnionVariant(both, { startStart: { blockStart: 5 } })).toBe(1);
   });
 
+  it("ranks a deeper complaint by pointer SEGMENTS, not by string length", () => {
+    // `path` is a JSON Pointer STRING, so measuring its length lets a property
+    // NAME decide which arm a value is judged under. Both arms here take
+    // records, so the kind rule ties and depth is what answers — and the
+    // shallow arm's complaint is the LONGER string, which is the case a
+    // character count gets backwards.
+    const leaf = leafOf("letterSpacing");
+    const shallow: ObjectShape = {
+      kind: "object",
+      fields: { aVeryLongKeyNameIndeed: leaf, s: leaf },
+    };
+    const deep: ObjectShape = {
+      kind: "object",
+      fields: {
+        aVeryLongKeyNameIndeed: leafOf("opacity"),
+        s: { kind: "object", fields: { t: leafOf("opacity") } },
+      },
+    };
+    const both: UnionShape = { kind: "union", of: [shallow, deep] };
+    // `0.5` is a length nowhere and a valid opacity, so against `shallow` the
+    // first key refuses at `/aVeryLongKeyNameIndeed` — 23 characters, ONE
+    // segment — while against `deep` it is accepted and the refusal falls to
+    // `/s/t`, 4 characters and TWO segments.
+    expect(
+      styleUnionVariant(both, { aVeryLongKeyNameIndeed: 0.5, s: { t: "x" } })
+    ).toBe(1);
+  });
+
   it("chooses by the value's form rather than by the catalog's order", () => {
     // Every union the catalog ships happens to list the arm a malformed STRING
     // belongs to first, so order and the rule agree on all of them and a test

--- a/packages/blocks-engine/src/style/validate-style-value.test.ts
+++ b/packages/blocks-engine/src/style/validate-style-value.test.ts
@@ -723,6 +723,29 @@ describe("styleUnionVariant", () => {
     ).toBe(1);
   });
 
+  it("ranks by the DEEPEST complaint, so key order cannot change the answer", () => {
+    // Issues arrive in the stored object's key order, so reading only the first
+    // one makes the arm depend on insertion order — and `{ a, x }` and
+    // `{ x, a }` are the same value. Both arms take records, so the kind rule
+    // ties and depth decides; only the second arm can complain below `x`.
+    const leaf = leafOf("letterSpacing");
+    const shallow: ObjectShape = {
+      kind: "object",
+      fields: { a: leaf, x: leaf },
+    };
+    const deep: ObjectShape = {
+      kind: "object",
+      fields: {
+        a: leaf,
+        x: { kind: "object", fields: { y: leafOf("opacity") } },
+      },
+    };
+    const both: UnionShape = { kind: "union", of: [shallow, deep] };
+
+    expect(styleUnionVariant(both, { a: 5, x: { y: "bad" } })).toBe(1);
+    expect(styleUnionVariant(both, { x: { y: "bad" }, a: 5 })).toBe(1);
+  });
+
   it("chooses by the value's form rather than by the catalog's order", () => {
     // Every union the catalog ships happens to list the arm a malformed STRING
     // belongs to first, so order and the rule agree on all of them and a test

--- a/packages/blocks-engine/src/style/validate-style-value.test.ts
+++ b/packages/blocks-engine/src/style/validate-style-value.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import type { StyleValues } from "../document";
 import { ISSUE_CODES } from "../validation";
+import { getStyleProperty } from "./catalog";
+import { isStyleLeaf } from "./catalog-types";
+import type {
+  ObjectShape,
+  StyleLeaf,
+  StyleShape,
+  UnionShape,
+} from "./catalog-types";
 import { checkColorValue, checkCssValue, checkUrlValue } from "./css-value";
 import {
   MAX_SITE_ISSUES,
@@ -10,6 +18,7 @@ import {
   memoizeTokenLookup,
   newStyleIssueBudget,
   speculativeBudget,
+  styleUnionVariant,
   validateStyleValues,
 } from "./validate-style-value";
 
@@ -20,6 +29,39 @@ function check(values: StyleValues) {
 
 function codes(values: StyleValues): string[] {
   return check(values).map(issue => issue.code);
+}
+
+function messages(values: StyleValues): string[] {
+  return check(values).map(issue => issue.message);
+}
+
+/**
+ * The union a catalog property declares.
+ *
+ * Narrowed rather than asserted, so a catalog change that stops a property
+ * being a union fails HERE, naming the property, instead of leaving a test
+ * asserting arm indices against a shape that has no arms.
+ */
+function unionShapeOf(property: string): UnionShape {
+  const shape = shapeOf(property);
+  if (isStyleLeaf(shape) || shape.kind !== "union") {
+    throw new Error(`${property} is no longer a union`);
+  }
+  return shape;
+}
+
+/** The shape a catalog property declares. */
+function shapeOf(property: string): StyleShape {
+  const entry = getStyleProperty(property);
+  if (entry === undefined) throw new Error(`no catalog property ${property}`);
+  return entry.shape;
+}
+
+/** The leaf a catalog property declares, for tests that vary one field of it. */
+function leafOf(property: string): StyleLeaf {
+  const shape = shapeOf(property);
+  if (!isStyleLeaf(shape)) throw new Error(`${property} is not a leaf`);
+  return shape;
 }
 
 describe("a design token reference is checked against the site", () => {
@@ -525,6 +567,193 @@ describe("union shapes", () => {
       "invalid-style-value",
     ]);
     expect(codes({ fontWeight: "heavy" })).toEqual(["invalid-style-value"]);
+  });
+});
+
+describe("the arm a union reports through is the one the value was written in", () => {
+  // Every value here is refused by BOTH arms, so which complaint comes back is
+  // a choice between them rather than the only one on offer. Ranking by issue
+  // depth alone cannot make that choice for two SCALAR arms, because both
+  // report at the property's own path — so the catalog's first arm used to win
+  // whatever had been stored.
+
+  it("names the numeric bound rather than the keyword arm's vocabulary", () => {
+    // `fontWeight` is a keyword or a number bounded to 1-1000. A number is not
+    // a spelling of a keyword, so the vocabulary is not what the author broke.
+    expect(messages({ fontWeight: 5000 })).toEqual([
+      "5000 is above the maximum of 1000.",
+    ]);
+    expect(messages({ fontWeight: 0 })).toEqual([
+      "0 is below the minimum of 1.",
+    ]);
+  });
+
+  it("names the length arm for a string a number arm could only read as a keyword", () => {
+    // `lineHeight` is a number or a dimension. A string reaches the number arm
+    // only as a CSS-wide keyword, so a string that is not one is a length that
+    // failed to parse rather than a number that was misspelled.
+    expect(messages({ lineHeight: "nonsense" })).toEqual([
+      "nonsense is not a length.",
+    ]);
+  });
+
+  it("names the keyword arm for a string where the other arm takes numbers", () => {
+    // `position.zIndex` is an integer or `auto`, and it is a union nested one
+    // level down — so this also covers the choice being made at depth.
+    expect(messages({ position: { zIndex: "top" } })).toEqual([
+      "top is not one of the allowed values.",
+    ]);
+  });
+
+  it("reports a record through the composite arm, however the record is spelled", () => {
+    // `borderRadius` is one length or four corners, and only the corners arm
+    // stores a record — so this is the KIND rule, not the depth rule below it.
+    // Measured: removing depth entirely left both of these passing.
+    expect(messages({ borderRadius: { bogus: "4px" } })).toEqual([
+      '"bogus" is not a known corner.',
+    ]);
+    expect(messages({ borderRadius: { startStart: "-4px" } })).toEqual([
+      "-4px is not a length.",
+    ]);
+  });
+
+  // The rule that an ACCEPTING arm's warning outranks a refusing arm's error is
+  // deliberately not asserted here, because nothing can reach it: every warning
+  // an arm produces comes from a leaf's token branch, which runs only where the
+  // leaf declares token kinds — and that is the same fact the kind rule reads,
+  // so the two never disagree. A test over a token would be answered by the
+  // union's own kind shortcut before any arm was ranked, which is covered
+  // already by "a union says which kinds it really accepts". Saying so beats a
+  // green that reads as coverage; the code carries the same note.
+});
+
+describe("styleUnionVariant", () => {
+  const fontWeight = unionShapeOf("fontWeight");
+  const lineHeight = unionShapeOf("lineHeight");
+  const borderRadius = unionShapeOf("borderRadius");
+
+  it("answers with the catalog's first arm when there is no value yet", () => {
+    // A panel is drawn before anything is loaded, and the arm the catalog lists
+    // first is the property's canonical spelling.
+    expect(styleUnionVariant(fontWeight, undefined)).toBe(0);
+    expect(styleUnionVariant(borderRadius, undefined)).toBe(0);
+  });
+
+  it("answers with the arm that accepts the value", () => {
+    expect(styleUnionVariant(fontWeight, "bold")).toBe(0);
+    expect(styleUnionVariant(fontWeight, 700)).toBe(1);
+    expect(styleUnionVariant(lineHeight, 1.5)).toBe(0);
+    expect(styleUnionVariant(lineHeight, "1.5rem")).toBe(1);
+    expect(styleUnionVariant(borderRadius, "4px")).toBe(0);
+    expect(styleUnionVariant(borderRadius, { startStart: "4px" })).toBe(1);
+  });
+
+  it("reads a keyword as CSS does, through case, whitespace and escapes", () => {
+    expect(styleUnionVariant(fontWeight, "BOLD")).toBe(0);
+    expect(styleUnionVariant(fontWeight, "  bold  ")).toBe(0);
+    expect(styleUnionVariant(fontWeight, "bol\\64 ")).toBe(0);
+  });
+
+  it("puts a CSS-wide keyword on the arm that accepts it first", () => {
+    // `inherit` is legal wherever a value is, so every arm takes it and the
+    // catalog's order decides — which is the engine's own answer, not a rule
+    // stated here.
+    expect(styleUnionVariant(fontWeight, "inherit")).toBe(0);
+    expect(styleUnionVariant(lineHeight, "inherit")).toBe(0);
+  });
+
+  it("answers with the arm a value NO arm accepts was written in", () => {
+    // The whole point of returning an arm for a refused value: the author is
+    // looking at something, and the control to show is the one whose complaint
+    // they will read.
+    expect(styleUnionVariant(fontWeight, 5000)).toBe(1);
+    expect(styleUnionVariant(lineHeight, "nonsense")).toBe(1);
+    expect(styleUnionVariant(borderRadius, "not-a-length")).toBe(0);
+  });
+
+  it("separates two arms that both store records by which issue points deeper", () => {
+    // Both arms take records, so the kind rule ties and depth is what decides.
+    // The shape is BUILT rather than taken from the catalog because the catalog
+    // ships no union of two composites: measured, removing the depth rule
+    // entirely left all 1306 engine tests green. This is a public entry point,
+    // so a caller can hand it the shape the catalog cannot express, and a rule
+    // nothing exercises is one nobody would notice going wrong.
+    //
+    // An unknown key is NOT the discriminator — it reports at the key's own
+    // path, exactly as a bad value at a known key does. What differs is how far
+    // each arm has to descend before something refuses.
+    const shallow = unionShapeOf("borderRadius").of[1];
+    const deep: ObjectShape = {
+      kind: "object",
+      fields: { startStart: shapeOf("padding") },
+    };
+    const both: UnionShape = { kind: "union", of: [shallow, deep] };
+    // Against the corners arm, `startStart` is a length and the record handed
+    // to it refuses one level down. Against the deep arm the same record is a
+    // set of logical sides, and the refusal is a further level in — at the leaf
+    // that actually holds the offending value.
+    expect(styleUnionVariant(both, { startStart: { blockStart: 5 } })).toBe(1);
+  });
+
+  it("chooses by the value's form rather than by the catalog's order", () => {
+    // Every union the catalog ships happens to list the arm a malformed STRING
+    // belongs to first, so order and the rule agree on all of them and a test
+    // over a real property cannot say which one answered. Reversing
+    // `fontWeight`'s arms separates the two: the keyword arm is now second, and
+    // "heavy" is a keyword outside its vocabulary rather than a badly written
+    // number, so order alone would answer 0.
+    const reversed: UnionShape = {
+      kind: "union",
+      of: [...fontWeight.of].reverse(),
+    };
+    expect(styleUnionVariant(reversed, "heavy")).toBe(1);
+  });
+
+  it("keeps a record on the composite arm, however it is spelled", () => {
+    // An EMPTY record names nothing and is still the four-corner form: the
+    // validator accepts `{}` there, so sending it to the scalar arm would draw
+    // one length control for a value the document holds as a record. A record
+    // naming only UNKNOWN fields is the same form with a mistake in it.
+    expect(styleUnionVariant(borderRadius, {})).toBe(1);
+    expect(styleUnionVariant(borderRadius, { bogus: "4px" })).toBe(1);
+  });
+
+  it("uses the site's table to place a token between two arms that take one", () => {
+    // `lineHeight` accepts a number token on one arm and a dimension token on
+    // the other, so the NAME alone cannot separate them.
+    const kinds = { kindOf: () => "dimension" as const };
+    expect(styleUnionVariant(lineHeight, { $token: "space.4" })).toBe(0);
+    expect(
+      styleUnionVariant(lineHeight, { $token: "space.4" }, { tokens: kinds })
+    ).toBe(1);
+  });
+
+  it("puts a token on the arm that admits tokens at all", () => {
+    // `fontWeight`'s keyword arm declares no token kinds, so a reference there
+    // is refused outright while the number arm takes it.
+    expect(styleUnionVariant(fontWeight, { $token: "weight.bold" })).toBe(1);
+  });
+
+  it("keeps a token no arm accepts on a scalar arm rather than a composite", () => {
+    // A reference is one value spelled as an object. To a COMPOSITE arm that
+    // spelling reads as an unknown field one level down, which looks like the
+    // deeper — and therefore better — match, so the token would be shown in a
+    // four-corner control that cannot hold it in any of them.
+    const noTokensAnywhere: UnionShape = {
+      kind: "union",
+      of: [
+        { ...leafOf("letterSpacing"), tokenKinds: [] },
+        unionShapeOf("borderRadius").of[1],
+      ],
+    };
+    expect(styleUnionVariant(noTokensAnywhere, { $token: "r.card" })).toBe(0);
+  });
+
+  it("answers undefined for a union that declares no arms", () => {
+    // Nothing to draw and nothing it can refuse. The catalog ships none, and a
+    // caller indexing `of` with a number this did not return would read
+    // `undefined` as a shape.
+    expect(styleUnionVariant({ kind: "union", of: [] }, "4px")).toBeUndefined();
   });
 });
 

--- a/packages/blocks-engine/src/style/validate-style-value.ts
+++ b/packages/blocks-engine/src/style/validate-style-value.ts
@@ -1040,8 +1040,23 @@ interface VariantRank {
   readonly accepts: boolean;
   /** Whether the value is written in a form this arm stores at all. */
   readonly stores: boolean;
-  /** How deep the arm's first complaint points. */
+  /** How deep the arm's first complaint points, in pointer SEGMENTS. */
   readonly depth: number;
+}
+
+/**
+ * How far into a value a JSON Pointer reaches.
+ *
+ * Segments, not characters. `path.length` is the length of the STRING, so
+ * `/veryLongField` would outrank `/x/y` and a property's NAME would decide
+ * which arm of a union a value is judged under.
+ */
+function pointerDepth(path: string): number {
+  let depth = 0;
+  for (let index = 0; index < path.length; index += 1) {
+    if (path[index] === "/") depth += 1;
+  }
+  return depth;
 }
 
 function variantRank(
@@ -1052,7 +1067,7 @@ function variantRank(
   return {
     accepts: !issues.some(issue => issue.severity === "error"),
     stores: shapeStoresKindOf(variant, value),
-    depth: issues[0]?.path.length ?? 0,
+    depth: pointerDepth(issues[0]?.path ?? ""),
   };
 }
 

--- a/packages/blocks-engine/src/style/validate-style-value.ts
+++ b/packages/blocks-engine/src/style/validate-style-value.ts
@@ -20,7 +20,12 @@ import type {
 
 import { getStyleProperty } from "./catalog";
 import { isStyleLeaf, shapeLeaves } from "./catalog-types";
-import type { StyleLeaf, StyleShape, TokenKind } from "./catalog-types";
+import type {
+  StyleLeaf,
+  StyleShape,
+  TokenKind,
+  UnionShape,
+} from "./catalog-types";
 import {
   checkColorValue,
   checkCssValue,
@@ -847,6 +852,224 @@ function partIssues(
   return issues;
 }
 
+/**
+ * Whether a leaf STORES values of this one's runtime kind.
+ *
+ * Not "would this leaf accept this value" — {@link leafIssues} answers that,
+ * and asking it twice would be two implementations of one question. This is the
+ * coarser question of whether the value is written in a form the leaf reads at
+ * all, which is what separates two arms that both REFUSED a value: `fontWeight`
+ * is a keyword or a number, `5000` is refused by each, and only one of them is
+ * the form the author was writing in.
+ *
+ * A string is a value form for every leaf kind except `number`, where it is
+ * only ever the CSS-wide-keyword escape hatch: `inherit` is legal in a numeric
+ * position, and `"nonsense"` is not a number spelled differently. Counting a
+ * string as fitting a number leaf would send `lineHeight: "nonsense"` there and
+ * report that it is not a number, where not being a LENGTH is what the author
+ * got wrong.
+ */
+function leafStoresKindOf(leaf: StyleLeaf, value: unknown): boolean {
+  // A token reference is a scalar spelled as an object, so it is a form every
+  // LEAF reads and no composite does. Whether THIS leaf accepts tokens is a
+  // validity question that `leafIssues` answers; folding it in here would rank
+  // a token no arm accepts onto a composite arm, because `$token` reads to a
+  // composite as an unknown field one level down and so looks like the deeper
+  // match — and that arm's controls cannot hold a token at all.
+  if (isTokenRef(value)) return true;
+  if (typeof value === "number") {
+    if (leaf.kind === "number") return true;
+    // The same pair `leafIssues` reads: a dimension takes a bare number only
+    // where the catalog allows one, and zero regardless, because zero is the
+    // one measurement that is a complete length without a unit.
+    return (
+      leaf.kind === "dimension" && (leaf.allowNumber === true || value === 0)
+    );
+  }
+  if (typeof value === "string") return leaf.kind !== "number";
+  return false;
+}
+
+/**
+ * Whether a shape stores values of this one's runtime kind.
+ *
+ * A composite addresses named sub-values, so it stores records and nothing
+ * else — and a token reference is a record that is nonetheless a scalar, so it
+ * is excluded rather than counted as one. Counting it would report both arms of
+ * a scalar-versus-composite union as fitting a token, and the tie would fall to
+ * the catalog's order rather than to the arm that admits tokens at all.
+ */
+function shapeStoresKindOf(shape: StyleShape, value: unknown): boolean {
+  if (isStyleLeaf(shape)) return leafStoresKindOf(shape, value);
+  if (shape.kind === "union") {
+    return shape.of.some(arm => shapeStoresKindOf(arm, value));
+  }
+  return !isTokenRef(value) && isPlainRecord(value);
+}
+
+/**
+ * A union's verdict on a token reference, judged against EVERY arm's kinds at
+ * once, or `undefined` when the question does not arise and the arms decide.
+ *
+ * Asked before the arms are tried, because reporting the first refusing arm's
+ * list names a subset: `lineHeight` takes a number OR a dimension token, and a
+ * colour token there would be told the property takes only numbers, steering
+ * the author away from a spelling that works.
+ *
+ * The allowance is asked BEFORE the lookup, not after: `kindOf` is the caller's
+ * code and may be expensive, and a run that has already said name checking
+ * stopped must stop calling it rather than call it and discard the answer. The
+ * lookup and reporting allowances are distinct — a name already answered this
+ * run costs the caller nothing — so the same guard the leaf reference uses
+ * bounds the ask here too.
+ */
+function unionTokenKindIssues(
+  shape: UnionShape,
+  value: unknown,
+  path: string,
+  budget: ReadyStyleIssueBudget | undefined,
+  check: ValueCheckContext
+): ValidationIssue[] | undefined {
+  const { tokens } = check;
+  if (!isTokenRef(value) || tokens === undefined) return undefined;
+  if (extraTokenKeys(value)) return undefined;
+  const kinds = unionTokenKinds(shape);
+  if (kinds.length === 0) return undefined;
+  if (!canResolveName(tokens, value.$token, budget)) {
+    return siteTruncationNotice(budget, path);
+  }
+  const kind = tokens.kindOf(value.$token);
+  if (kind === undefined || kinds.includes(kind)) return undefined;
+  return reportSiteIssue(budget, {
+    path,
+    code: "token-kind-mismatch",
+    severity: "warning",
+    message: `The design token "${describeValue(value.$token)}" is a ${kind}, and this value takes ${kinds.join(" or ")}.`,
+    suggestion: `Use a token of kind ${kinds.join(" or ")}.`,
+  });
+}
+
+/** The arm of a union a value belongs to, and whether that arm accepted it. */
+interface UnionVariantChoice {
+  /** Which arm, as an index into the union's own `of`. */
+  readonly index: number;
+  /** The arm itself, so a caller does not index `of` a second time. */
+  readonly variant: StyleShape;
+  /**
+   * Whether the arm reported nothing at all.
+   *
+   * Distinct from "reported no errors": an arm can accept a value and remark on
+   * it, and that remark is the one worth reporting.
+   */
+  readonly clean: boolean;
+}
+
+/**
+ * Which arm of a union a value belongs to.
+ *
+ * Arms are tried in the catalog's order and the first reporting nothing wins,
+ * so the catalog decides the canonical spelling. When none accepts, the arm
+ * chosen is the one whose issues describe what the author actually got wrong,
+ * ranked on three properties in this order:
+ *
+ * 1. **An arm that only WARNED beats one that ERRORED.** A warning is an arm
+ *    accepting a value and remarking on it; an error is a refusal. Without
+ *    this, a refusal wins a tie against an advisory note and turns it into
+ *    something that blocks a publish.
+ * 2. **An arm that STORES this kind of value beats one that does not.** Two
+ *    scalar arms report at the same path, so rule 3 cannot separate them and
+ *    the catalog's first arm won whatever the value was — `fontWeight: 5000`
+ *    was told it is not one of `normal, bold, lighter, bolder` rather than that
+ *    it is outside 1-1000.
+ * 3. **A deeper first issue beats a shallower one.** Within one kind-fit, an
+ *    arm the value structurally matches points at the offending leaf while a
+ *    mismatched one reports only that the whole value is the wrong shape. This
+ *    is what separates two COMPOSITE arms, which rule 2 cannot.
+ *
+ * `undefined` only for a union declaring no arms: it holds no shape to check
+ * against, so there is nothing it can refuse.
+ */
+function chooseUnionVariant(
+  shape: UnionShape,
+  value: unknown,
+  path: string,
+  budget?: ReadyStyleIssueBudget,
+  spent = 0,
+  spentBytes = 0,
+  check: ValueCheckContext = {}
+): UnionVariantChoice | undefined {
+  let chosen: UnionVariantChoice | undefined;
+  let bestRank: VariantRank | undefined;
+  for (let index = 0; index < shape.of.length; index += 1) {
+    const variant = shape.of[index];
+    // Tried against a COPY of the allowances, because trying is speculative and
+    // spending is not. The copy still gates, so an arm cannot allocate past the
+    // cap; nothing it charges outlives it, so a value is not billed once per arm
+    // and a discarded arm's truncation marker cannot suppress one a later
+    // reference was going to get. The winner is re-run by the caller against
+    // the real budget, unless it was clean.
+    const issues = shapeIssues(
+      variant,
+      value,
+      path,
+      speculativeBudget(budget),
+      spent,
+      spentBytes,
+      check
+    );
+    if (issues.length === 0) return { index, variant, clean: true };
+    const rank = variantRank(variant, value, issues);
+    if (bestRank !== undefined && !outranks(rank, bestRank)) continue;
+    chosen = { index, variant, clean: false };
+    bestRank = rank;
+  }
+  return chosen;
+}
+
+/** How well one refusing arm describes what the author actually wrote. */
+interface VariantRank {
+  /**
+   * Whether the arm ACCEPTED the value and merely remarked on it.
+   *
+   * Not separately observable today: every warning an arm can produce comes
+   * from the token branch of `leafIssues`, which runs only where the leaf
+   * declares token kinds — and a reference is a form every leaf stores, so
+   * {@link VariantRank.stores} is true wherever this is. Kept because a warning
+   * IS an acceptance, so the ordering is right whatever comes to reach it.
+   */
+  readonly accepts: boolean;
+  /** Whether the value is written in a form this arm stores at all. */
+  readonly stores: boolean;
+  /** How deep the arm's first complaint points. */
+  readonly depth: number;
+}
+
+function variantRank(
+  variant: StyleShape,
+  value: unknown,
+  issues: readonly ValidationIssue[]
+): VariantRank {
+  return {
+    accepts: !issues.some(issue => issue.severity === "error"),
+    stores: shapeStoresKindOf(variant, value),
+    depth: issues[0]?.path.length ?? 0,
+  };
+}
+
+/**
+ * Whether one arm's refusal describes the value better than another's.
+ *
+ * Lexicographic over the three properties in {@link VariantRank}'s order, which
+ * is what makes each one a tie-break for the one above rather than a vote: a
+ * deeper complaint from an arm that cannot hold the value at all must never
+ * beat a shallower one from the arm the author was writing in.
+ */
+function outranks(candidate: VariantRank, best: VariantRank): boolean {
+  if (candidate.accepts !== best.accepts) return candidate.accepts;
+  if (candidate.stores !== best.stores) return candidate.stores;
+  return candidate.depth > best.depth;
+}
+
 /** Validate a value against any shape, leaf or composite. */
 function shapeIssues(
   shape: StyleShape,
@@ -893,90 +1116,41 @@ function shapeIssues(
         check
       );
     case "union": {
-      // A token is judged against every arm's kinds at once. Reporting the
-      // first refusing arm's list names a subset: `lineHeight` takes a number
-      // OR a dimension token, and a colour token there would be told the
-      // property takes only numbers, steering the author away from a spelling
-      // that works.
-      // The allowance is asked BEFORE the lookup, not after: `kindOf` is the
-      // caller's code and may be expensive, and a run that has already said
-      // name checking stopped must stop calling it rather than call it and
-      // discard the answer. The lookup and reporting allowances are distinct
-      // (a name already answered this run costs the caller nothing), so the
-      // same guard the leaf reference uses bounds the ask here too.
-      const { tokens } = check;
-      if (isTokenRef(value) && tokens !== undefined && !extraTokenKeys(value)) {
-        const kinds = unionTokenKinds(shape);
-        if (kinds.length > 0) {
-          if (!canResolveName(tokens, value.$token, budget)) {
-            return siteTruncationNotice(budget, path);
-          }
-          const kind = tokens.kindOf(value.$token);
-          if (kind !== undefined && !kinds.includes(kind)) {
-            return reportSiteIssue(budget, {
-              path,
-              code: "token-kind-mismatch",
-              severity: "warning",
-              message: `The design token "${describeValue(value.$token)}" is a ${kind}, and this value takes ${kinds.join(" or ")}.`,
-              suggestion: `Use a token of kind ${kinds.join(" or ")}.`,
-            });
-          }
-        }
-      }
-      // A union accepts the value if any variant does. Variants are tried in
-      // order and the first clean one wins; when none accepts, the first
-      // variant's issues are reported, because it is the shape the catalog
-      // lists first and therefore the one an author most likely intended.
-      let best: ValidationIssue[] | undefined;
-      let bestVariant: StyleShape | undefined;
-      let bestRejects = true;
-      for (const variant of shape.of) {
-        // Tried against a COPY of the allowances, because trying is
-        // speculative and spending is not. The copy still gates, so an arm
-        // cannot allocate past the cap; nothing it charges outlives it, so a
-        // value is not billed once per arm and a discarded arm's truncation
-        // marker cannot suppress one a later reference was going to get. The
-        // winner is re-run below against the real budget.
-        const issues = shapeIssues(
-          variant,
-          value,
-          path,
-          speculativeBudget(budget),
-          spent,
-          spentBytes,
-          check
-        );
-        if (issues.length === 0) return [];
-        // A variant that reports only warnings has ACCEPTED the value and
-        // remarked on it. One that reports an error has refused it. Ranking by
-        // path depth alone cannot tell those apart, so a value the catalog
-        // lists two ways — a keyword or a number — could be refused by the arm
-        // that structurally forbids it while the other arm merely warned, and
-        // the refusal would win on a tie. That would turn an advisory note into
-        // something that blocks a publish.
-        const rejects = issues.some(issue => issue.severity === "error");
-        if (bestRejects && !rejects) {
-          best = issues;
-          bestVariant = variant;
-          bestRejects = false;
-          continue;
-        }
-        if (rejects !== bestRejects) continue;
-        // Within the same verdict, prefer whichever variant the value
-        // structurally resembles: its issues point at the offending leaf, while
-        // a mismatched variant only reports that the whole value is the wrong
-        // shape.
-        const deeper =
-          best === undefined ||
-          (issues[0]?.path.length ?? 0) > (best[0]?.path.length ?? 0);
-        if (deeper) {
-          best = issues;
-          bestVariant = variant;
-        }
-      }
-      if (bestVariant === undefined) return [];
+      const kindMismatch = unionTokenKindIssues(
+        shape,
+        value,
+        path,
+        budget,
+        check
+      );
+      if (kindMismatch !== undefined) return kindMismatch;
+      // Which arm the value belongs to is decided in ONE place and read from
+      // here. It is also the question an editor asks to decide which control to
+      // draw, so it is exported rather than kept private: a caller that had to
+      // predict this answer would be maintaining a second copy of every rule
+      // below, and the two would agree on the day they were written.
+      const chosen = chooseUnionVariant(
+        shape,
+        value,
+        path,
+        budget,
+        spent,
+        spentBytes,
+        check
+      );
+      // A union declaring no arms holds no shape to check against, so there is
+      // nothing it can refuse.
+      if (chosen === undefined) return [];
+      // A clean arm is NOT re-run against the real budget, which is the
+      // behaviour this refactor had to preserve rather than an optimisation it
+      // introduced. Re-running would return the same nothing and cost a second
+      // walk of the arm — and it would NOT double-charge the site allowance,
+      // which is what it looks like it would do: name resolution is memoized
+      // per run and `canResolveName` answers a cached name without spending, so
+      // the second pass asks the caller nothing. Measured, not assumed.
+      if (chosen.clean) return [];
       return shapeIssues(
-        bestVariant,
+        chosen.variant,
         value,
         path,
         budget,
@@ -1080,4 +1254,53 @@ export function validateStyleValues(
     );
   }
   return issues;
+}
+
+/** What a caller can tell the arm resolver about the site it is resolving for. */
+export interface StyleUnionVariantOptions extends StyleValueOptions {
+  /**
+   * The site's token table.
+   *
+   * Which arm a token belongs to is a fact about the TOKEN, and a stored
+   * reference carries only its name: `lineHeight` takes tokens on both arms,
+   * numbers on one and dimensions on the other, so without the table the name
+   * alone cannot separate them and the catalog's order decides.
+   */
+  tokens?: TokenLookup;
+}
+
+/**
+ * Which arm of a union a stored value belongs to, as an index into `of`.
+ *
+ * Exported because more than one surface asks it and they must not answer it
+ * separately. The compiler asks it to decide which arm's rules to emit and
+ * which arm's complaint to report; an editor asks it to decide which control to
+ * draw for a stored value. Those are the same question, and a second
+ * implementation of it drifts silently — a control drawn for one arm while
+ * validation judges the value under another leaves an author looking at a
+ * keyword select and reading an error about a number.
+ *
+ * `undefined` only for a union declaring no arms, which has no shape to draw
+ * and nothing to refuse.
+ *
+ * This is a PRESENTATION answer as much as a validation one, and it is not a
+ * verdict: {@link validateStyleValues} remains the only thing deciding whether
+ * a value may be written. An arm is returned for a value every arm refuses,
+ * because the author is looking at something and the honest control to show is
+ * the one whose complaint they will read.
+ */
+export function styleUnionVariant(
+  shape: UnionShape,
+  value: unknown,
+  options?: StyleUnionVariantOptions
+): number | undefined {
+  // Its own allowance, because this run reports nothing: the issues an arm
+  // produces are read only to rank the arms and are then discarded, so charging
+  // them to a caller's budget would spend a document's reporting allowance on a
+  // question about a control.
+  const budget = newStyleIssueBudget();
+  return chooseUnionVariant(shape, value, "", budget, 0, 0, {
+    tokens: memoizeTokenLookup(options?.tokens, budget),
+    mayFetchUrl: options?.mayFetchUrl,
+  })?.index;
 }

--- a/packages/blocks-engine/src/style/validate-style-value.ts
+++ b/packages/blocks-engine/src/style/validate-style-value.ts
@@ -1040,7 +1040,7 @@ interface VariantRank {
   readonly accepts: boolean;
   /** Whether the value is written in a form this arm stores at all. */
   readonly stores: boolean;
-  /** How deep the arm's first complaint points, in pointer SEGMENTS. */
+  /** How deep the arm's DEEPEST complaint points, in pointer SEGMENTS. */
   readonly depth: number;
 }
 
@@ -1067,7 +1067,15 @@ function variantRank(
   return {
     accepts: !issues.some(issue => issue.severity === "error"),
     stores: shapeStoresKindOf(variant, value),
-    depth: pointerDepth(issues[0]?.path ?? ""),
+    // The DEEPEST complaint, not the first one enumerated. Issues arrive in the
+    // stored object's key order, so reading `issues[0]` makes the answer depend
+    // on insertion order: `{ a, x }` and `{ x, a }` hold the same value and
+    // would be judged under different arms, producing different diagnostics and
+    // different controls for one document.
+    depth: issues.reduce(
+      (deepest, issue) => Math.max(deepest, pointerDepth(issue.path)),
+      0
+    ),
   };
 }
 

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -449,3 +449,20 @@ export {
   type StyleControlBehaviour,
   type StyleControlBehaviours,
 } from "./style-control-behaviour";
+
+/**
+ * @experimental What the selected block offers on the Style tab.
+ *
+ * From this entry because it is a plain function over a document and the
+ * registry. A host drawing its own style surface — or an agent asked "what can
+ * I set on this block" — needs the same answer the panel draws from, which is
+ * `supports` read through the engine rather than a second reading of it. The
+ * panel itself is behind the client banner in `./shell`.
+ */
+export {
+  inspectStyle,
+  type InspectedStyleProperty,
+  type StyleInspection,
+  type StyleInspectionOptions,
+  type StyleSection,
+} from "./style-inspector";

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -23,7 +23,11 @@
  * @module inspector-panel
  */
 
-import { findNode } from "@nextlyhq/blocks-engine";
+import {
+  findNode,
+  type BreakpointId,
+  type StyleState,
+} from "@nextlyhq/blocks-engine";
 import {
   Checkbox,
   Input,
@@ -33,12 +37,17 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
   Textarea,
 } from "@nextlyhq/ui";
 import * as React from "react";
 
 import type { EditorState } from "./editor-state";
 import {
+  fieldLabel,
   inspectSelection,
   lockOp,
   lockStateOf,
@@ -49,6 +58,8 @@ import {
   type LockState,
 } from "./inspector";
 import { selectionLock } from "./selection-ops";
+import { StyleInspectorPanel } from "./style-inspector-panel";
+import type { StylePolicy } from "./style-values";
 
 export interface InspectorPanelProps {
   /**
@@ -60,19 +71,36 @@ export interface InspectorPanelProps {
    * writes a merged props object assembled from a stale node.
    */
   editor: EditorState;
+  /**
+   * What the site allows, forwarded to the Style tab.
+   *
+   * Carried rather than defaulted: the engine ships no host list of its own, so
+   * omitting it does not mean "allow" — it means the question was never asked.
+   */
+  policy?: StylePolicy;
+  /** The interaction state the Style tab edits. `base` when the host says nothing. */
+  styleState?: StyleState;
+  /** The breakpoint the Style tab edits. The unconditional one by default. */
+  breakpoint?: BreakpointId;
 }
 
-/** A prop name as a human reads it: `backgroundColor` becomes "Background color". */
-function labelFor(name: string): string {
-  const spaced = name
-    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-    .replace(/[-_]+/g, " ")
-    .trim();
-  return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
-}
+/**
+ * Which half of the inspector is showing.
+ *
+ * Two tabs rather than a second rail: two rails meaning different things is the
+ * ambiguity this editor's layout rulings have consistently removed, and the
+ * inspector is already the region that answers "what is selected".
+ */
+const INSPECTOR_TABS = [
+  { value: "content", label: "Content" },
+  { value: "style", label: "Style" },
+] as const;
 
 export function InspectorPanel({
   editor,
+  policy,
+  styleState,
+  breakpoint,
 }: InspectorPanelProps): React.JSX.Element {
   // Recomputed each render rather than memoised: an inspection is only valid
   // against the document it was read from, and an edit anywhere changes both
@@ -116,6 +144,15 @@ export function InspectorPanel({
     );
   }
 
+  /*
+   * Nothing selected: one note, and no tabs.
+   *
+   * The entry's OWN fields are not drawn here. They already ship as a left
+   * panel the host renders, and reproducing them in this region would be the
+   * second surface-meaning-two-things the layout ruling removed, wearing a
+   * different shape. Tabs are withheld too: a Style tab over no selection would
+   * offer an author somewhere to click that can never show anything.
+   */
   if (inspection === null) {
     return (
       <div className="nx-inspector" data-empty="no-selection">
@@ -130,11 +167,15 @@ export function InspectorPanel({
 
       {/*
         What the block IS, above what it holds.
-        
+
         First because it answers "which block am I looking at" — a page with six
         headings gives an author six identical inspector titles, and the name is
         the only thing that tells them apart. Both fields are also the two the
         layers panel already shows, so this is where that display gets a writer.
+
+        Above the tabs rather than inside Content, because it describes the block
+        under both of them: an author on the Style tab still needs to know which
+        of six headings they are looking at.
       */}
       <IdentityFields
         // Keyed by node so the name input does not carry an uncommitted edit
@@ -145,24 +186,52 @@ export function InspectorPanel({
         editor={editor}
       />
 
-      {inspection.props.length === 0 ? (
-        <p className="nx-inspector__note">
-          This block has no editable properties.
-        </p>
-      ) : (
-        <div className="nx-inspector__fields">
-          {inspection.props.map(prop => (
-            <PropField
-              // Keyed by node AND prop: a bare prop name would let React reuse
-              // one block's field for the next block's same-named prop, so the
-              // input would keep the previous block's uncommitted text.
-              key={`${inspection.nodeId}:${prop.name}`}
-              prop={prop}
-              onCommit={commit}
-            />
+      {/*
+        Uncontrolled, so the chosen tab survives a change of selection — an
+        author styling one block after another means to stay on Style. React
+        keeps that state because this element's position does not change; a
+        `key` on the node id here would reset it on every click.
+      */}
+      <Tabs defaultValue="content" className="nx-inspector__tabs">
+        <TabsList>
+          {INSPECTOR_TABS.map(tab => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.label}
+            </TabsTrigger>
           ))}
-        </div>
-      )}
+        </TabsList>
+
+        <TabsContent value="content">
+          {inspection.props.length === 0 ? (
+            <p className="nx-inspector__note">
+              This block has no editable properties.
+            </p>
+          ) : (
+            <div className="nx-inspector__fields">
+              {inspection.props.map(prop => (
+                <PropField
+                  // Keyed by node AND prop: a bare prop name would let React
+                  // reuse one block's field for the next block's same-named
+                  // prop, so the input would keep the previous block's
+                  // uncommitted text.
+                  key={`${inspection.nodeId}:${prop.name}`}
+                  prop={prop}
+                  onCommit={commit}
+                />
+              ))}
+            </div>
+          )}
+        </TabsContent>
+
+        <TabsContent value="style">
+          <StyleInspectorPanel
+            editor={editor}
+            policy={policy}
+            state={styleState}
+            breakpoint={breakpoint}
+          />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }
@@ -246,7 +315,7 @@ function PropField({
   if (!prop.supported) {
     return (
       <div className="nx-inspector__field" data-unsupported="">
-        <Label htmlFor={id}>{labelFor(prop.name)}</Label>
+        <Label htmlFor={id}>{fieldLabel(prop.name)}</Label>
         {/*
           Listed rather than omitted. A block declaring a prop this panel cannot
           draw is still a block with that prop, and hiding it presents an
@@ -268,7 +337,7 @@ function PropField({
           checked={prop.value === true}
           onCheckedChange={checked => onCommit(prop.name, checked === true)}
         />
-        <Label htmlFor={id}>{labelFor(prop.name)}</Label>
+        <Label htmlFor={id}>{fieldLabel(prop.name)}</Label>
       </div>
     );
   }
@@ -276,7 +345,7 @@ function PropField({
   if (prop.schema.type === "select") {
     return (
       <div className="nx-inspector__field">
-        <Label htmlFor={id}>{labelFor(prop.name)}</Label>
+        <Label htmlFor={id}>{fieldLabel(prop.name)}</Label>
         <Select
           value={typeof prop.value === "string" ? prop.value : undefined}
           onValueChange={next => onCommit(prop.name, next)}
@@ -369,7 +438,7 @@ function TextishField({
 
   return (
     <div className="nx-inspector__field">
-      <Label htmlFor={id}>{labelFor(prop.name)}</Label>
+      <Label htmlFor={id}>{fieldLabel(prop.name)}</Label>
       {prop.schema.type === "textarea" ? (
         <Textarea {...shared} rows={3} />
       ) : (

--- a/packages/builder/src/inspector.ts
+++ b/packages/builder/src/inspector.ts
@@ -18,6 +18,7 @@
 import {
   getBlock,
   findNode,
+  type AnyBlockDefinition,
   type BlockDocument,
   type BlockNode,
   type PropSchema,
@@ -97,6 +98,58 @@ export interface BlockInspection {
   readonly props: readonly EditableProp[];
 }
 
+/** The selected node together with the definition that describes it. */
+export interface SelectedBlock {
+  readonly node: BlockNode;
+  readonly definition: AnyBlockDefinition;
+}
+
+/**
+ * The block an inspector is describing, or `null` when there is none.
+ *
+ * One answer for both tabs, because both ask the same question and would
+ * otherwise answer it separately: the content tab needs `props` and the style
+ * tab needs `supports`, and each lives on the definition.
+ *
+ * `null` for no selection, for an id the document no longer holds, and for a
+ * block the REGISTRY does not know. The last is the one worth stating, because
+ * it is a policy rather than a lookup failing:
+ *
+ * - an unregistered block's props have no schemas, so every content control
+ *   would have to be guessed from the stored value's runtime type — which
+ *   produces a text box for a number and silently rewrites the value on save;
+ * - and it has no `supports`, so the style tab would either offer nothing or
+ *   offer the whole catalog, and the second lets an author write styles the
+ *   compiler then drops.
+ */
+export function selectedBlock(
+  document: BlockDocument,
+  selectedId: string | null
+): SelectedBlock | null {
+  if (selectedId === null) return null;
+  const node = findNode(document.nodes, selectedId);
+  if (node === undefined) return null;
+  const definition = getBlock(node.type);
+  if (definition === undefined) return null;
+  return { node, definition };
+}
+
+/**
+ * A stored key as a human reads it: `backgroundColor` becomes "Background color".
+ *
+ * Here rather than in a panel because both panels label the same way and from
+ * the same kind of key — a prop name on the content tab, a catalog key on the
+ * style tab — and two spellings of one rule would drift the first time either
+ * learned about an acronym or a digit.
+ */
+export function fieldLabel(name: string): string {
+  const spaced = name
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[-_]+/g, " ")
+    .trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
+}
+
 /** Read a schema's `options`, which is untyped by construction. */
 function optionsOf(schema: PropSchema): readonly string[] {
   const declared = schema.options;
@@ -145,25 +198,15 @@ export function lockStateOf(
 
 /**
  * Describe the selected block for editing, or `null` when there is nothing to
- * edit.
- *
- * `null` for no selection, for an id the document no longer holds, and for a
- * block the registry does not know — the last because an unregistered block's
- * props have no schemas, so every control would have to be guessed from the
- * stored value's runtime type. Guessing produces a text box for a number and
- * silently rewrites the value on save.
+ * edit. See {@link selectedBlock} for what "nothing" covers and why.
  */
 export function inspectSelection(
   document: BlockDocument,
   selectedId: string | null
 ): BlockInspection | null {
-  if (selectedId === null) return null;
-
-  const node = findNode(document.nodes, selectedId);
-  if (node === undefined) return null;
-
-  const definition = getBlock(node.type);
-  if (definition === undefined) return null;
+  const selected = selectedBlock(document, selectedId);
+  if (selected === null) return null;
+  const { node, definition } = selected;
 
   const declared = definition.props ?? {};
   const props = Object.entries(declared).flatMap<EditableProp>(

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -84,6 +84,18 @@ export type { CanvasProps } from "./canvas";
 export { InspectorPanel } from "./inspector-panel";
 export type { InspectorPanelProps } from "./inspector-panel";
 
+/**
+ * The Style half of the same inspector.
+ *
+ * Exported beside it rather than only through it, because a host embedding the
+ * editor in a surface of its own may have somewhere else to put styling — and
+ * withholding it would invite exactly the second implementation the note above
+ * is about. Mounting BOTH is the ordinary case and needs nothing here:
+ * `InspectorPanel` already renders this one under its Style tab.
+ */
+export { StyleInspectorPanel } from "./style-inspector-panel";
+export type { StyleInspectorPanelProps } from "./style-inspector-panel";
+
 export { InsertPanel } from "./insert-panel";
 export type { InsertPanelProps } from "./insert-panel";
 

--- a/packages/builder/src/style-controls.test.ts
+++ b/packages/builder/src/style-controls.test.ts
@@ -17,12 +17,12 @@ import {
 /*
  * The union-arm assertions below no longer describe a rule this package holds.
  * Arm selection is `styleUnionVariant`'s, in the engine, where it is also
- * tested — and each case here is one of the eight spellings review found a
- * local matcher getting wrong. They are kept rather than moved because what
- * they now cover is the SEAM: that this module asks, that it passes the site's
- * options through, and that it walks the arm it was handed. A change
- * reintroducing a local answer, or dropping `tokens` on the way down, fails
- * here and nowhere in the engine's own suite.
+ * tested. They are kept rather than moved because what they now cover is the
+ * SEAM: that this module asks, that it passes the site's options through, and
+ * that it walks the arm it was handed. A change reintroducing a local answer,
+ * or dropping `tokens` on the way down, fails here and nowhere in the engine's
+ * own suite — and each case is a spelling that is easy to get wrong, which is
+ * why they are worth keeping pointed at the seam rather than deleted.
  */
 
 /**

--- a/packages/builder/src/style-controls.test.ts
+++ b/packages/builder/src/style-controls.test.ts
@@ -14,6 +14,17 @@ import {
   type StyleControlKind,
 } from "./style-controls";
 
+/*
+ * The union-arm assertions below no longer describe a rule this package holds.
+ * Arm selection is `styleUnionVariant`'s, in the engine, where it is also
+ * tested — and each case here is one of the eight spellings review found a
+ * local matcher getting wrong. They are kept rather than moved because what
+ * they now cover is the SEAM: that this module asks, that it passes the site's
+ * options through, and that it walks the arm it was handed. A change
+ * reintroducing a local answer, or dropping `tokens` on the way down, fails
+ * here and nowhere in the engine's own suite.
+ */
+
 /**
  * A VALID leaf of one kind.
  *

--- a/packages/builder/src/style-controls.test.ts
+++ b/packages/builder/src/style-controls.test.ts
@@ -155,7 +155,16 @@ describe("a union, which stores one value in more than one form", () => {
   it("shows the FIRST variant when nothing is stored, which is the form the engine tries first", () => {
     const set = styleControlsFor(radius);
     expect(paths(set.controls)).toEqual([[]]);
-    expect(set.variants).toEqual([{ path: [], active: 0, count: 2 }]);
+    // The arms' own shape kinds travel with the choice, so a renderer offering
+    // it can name the forms from the catalog rather than numbering them.
+    expect(set.variants).toEqual([
+      {
+        path: [],
+        active: 0,
+        count: 2,
+        kinds: ["dimension", "logicalCorners"],
+      },
+    ]);
   });
 
   it("shows the composite variant when a record is stored", () => {
@@ -176,6 +185,43 @@ describe("a union, which stores one value in more than one form", () => {
     const set = styleControlsFor(radius, { $token: "Radius.Card" });
     expect(paths(set.controls)).toEqual([[]]);
     expect(set.variants[0].active).toBe(0);
+  });
+
+  it("shows the form a caller asked for, but only where nothing is stored", () => {
+    // The engine answers with the catalog's FIRST arm for an unset position, and
+    // that answer is right precisely because the author has not spoken yet — so
+    // without this an unset `borderRadius` could only ever be the single radius.
+    const chosen = styleControlsFor(radius, undefined, {
+      variantAt: () => 1,
+    });
+    expect(chosen.variants[0]?.active).toBe(1);
+    expect(paths(chosen.controls)).toEqual([
+      ["startStart"],
+      ["startEnd"],
+      ["endStart"],
+      ["endEnd"],
+    ]);
+  });
+
+  it("lets a STORED value override the form a caller asked for", () => {
+    // A stored value decides its own arm, and the engine decides that. Honouring
+    // a preference here would draw one arm while validation judged the value
+    // under another, which is the disagreement this module exists to remove.
+    const set = styleControlsFor(radius, "4px", { variantAt: () => 1 });
+    expect(set.variants[0]?.active).toBe(0);
+  });
+
+  it("ignores a form outside the union's own arms rather than clamping", () => {
+    // Clamping would draw arm 0 for a caller asking for arm 7, which reads as
+    // the choice having been honoured.
+    expect(
+      styleControlsFor(radius, undefined, { variantAt: () => 7 }).variants[0]
+        ?.active
+    ).toBe(0);
+    expect(
+      styleControlsFor(radius, undefined, { variantAt: () => -1 }).variants[0]
+        ?.active
+    ).toBe(0);
   });
 
   it("records how many variants exist, so an editor can offer the other one", () => {

--- a/packages/builder/src/style-controls.ts
+++ b/packages/builder/src/style-controls.ts
@@ -39,12 +39,11 @@ import {
   isStyleLeaf,
   isTokenRef,
   styleUnionVariant,
-  type MayFetchUrl,
   type StyleLeaf,
   type StyleProperty,
   type StyleShape,
+  type StyleUnionVariantOptions,
   type StyleValue,
-  type TokenLookup,
 } from "@nextlyhq/blocks-engine";
 
 /**
@@ -156,36 +155,51 @@ export interface StyleControlVariants {
   readonly active: number;
   /** How many variants the catalog declares at this position. */
   readonly count: number;
+  /**
+   * Each arm's own shape kind, in the catalog's order.
+   *
+   * Carried so an affordance offering the choice can NAME the forms from the
+   * catalog rather than numbering them: `borderRadius` is a length or four
+   * corners, and "Form 1 / Form 2" tells an author nothing about which is
+   * which. The arms have no names of their own, so their shape kind is the
+   * most specific thing the catalog actually says about them.
+   */
+  readonly kinds: readonly StyleShape["kind"][];
 }
 
 /**
  * What a caller can tell the resolver about the site.
  *
- * Structurally the engine's own `StyleUnionVariantOptions`, and handed to it
- * unchanged: a field this named and the engine did not would be silently
- * dropped, and one the engine reads and this omits would make the arm shown
- * disagree with the arm a write is judged under.
+ * DERIVED from the engine's own option type rather than restated beside it.
+ * Both this and `StylePolicy` in `style-values.ts` are the same contract — what
+ * this site allows — read at two moments, and three structural copies of it
+ * would all keep compiling while the next field was added to one: arm selection
+ * and write validation would then disagree about a value, which is the failure
+ * the module docblock above describes from the other direction.
+ *
+ * Kept as a NAME rather than making callers import the engine's, because it is
+ * this package's public surface and a rename there should not be one here.
  */
-export interface StyleControlOptions {
+export type StyleControlOptions = StyleUnionVariantOptions;
+
+/**
+ * Everything {@link styleControlsFor} accepts.
+ *
+ * The site policy, plus the one thing the engine has no opinion about: which
+ * form an AUTHOR has chosen to write a value in. A union's arm is decided by
+ * the stored value wherever there is one, so this is consulted only where the
+ * position is unset — which is exactly when the engine has nothing to read and
+ * answers with the catalog's first arm for every caller alike.
+ */
+export interface StyleControlInput extends StyleControlOptions {
   /**
-   * The site's token table, for choosing between union arms that both accept
-   * tokens.
+   * The arm an author picked at one position inside the value, if any.
    *
-   * Optional: without it the catalog's arm order decides, which is the engine's
-   * own fallback for a name it cannot resolve.
+   * Addressed by the same path a control carries, so a union nested below the
+   * property root is answerable too — `position.zIndex` is a number OR `auto`,
+   * and a caller that could only speak about the root could never offer it.
    */
-  readonly tokens?: TokenLookup;
-  /**
-   * Which hosts this site will fetch from.
-   *
-   * Carried because the arm choice is the engine's, and the engine asks this
-   * question of a `url` or free-form leaf. No union the catalog ships has such
-   * an arm today, so nothing measurable changes by supplying it — which is the
-   * moment to wire it, rather than after a catalog change makes its absence a
-   * defect. Absent means UNASKED rather than allowed, exactly as everywhere
-   * else the policy travels.
-   */
-  readonly mayFetchUrl?: MayFetchUrl;
+  readonly variantAt?: (path: readonly string[]) => number | undefined;
 }
 
 /** A property's controls, and every choice of form its shape offers. */
@@ -246,7 +260,7 @@ function walk(
   path: readonly string[],
   shape: StyleShape,
   value: StyleValue | undefined,
-  options: StyleControlOptions | undefined,
+  options: StyleControlInput | undefined,
   // Collected as the walk descends rather than returned alongside, so a union
   // at ANY depth is recorded by the same line that resolves it.
   variants: StyleControlVariants[]
@@ -278,15 +292,54 @@ function walk(
       // arm to judge that value against, so reading its answer makes the
       // control and the error message beside it describe one arm by
       // construction. The module docblock lists what predicting it would cost.
-      const active = styleUnionVariant(shape, value, options);
+      const active = activeVariant(shape, path, value, options);
       // A union declaring no arms offers no choice and has nothing to draw. The
       // catalog ships none; the matcher this replaced answered 0 regardless and
       // handed `undefined` down as though it were a shape.
       if (active === undefined) return [];
-      variants.push({ path, active, count: shape.of.length });
+      variants.push({
+        path,
+        active,
+        count: shape.of.length,
+        kinds: shape.of.map(arm => arm.kind),
+      });
       return walk(property, path, shape.of[active], value, options, variants);
     }
   }
+}
+
+/**
+ * Which arm of a union to draw at one position.
+ *
+ * A STORED value settles it, and the engine settles that — so a caller's
+ * preference cannot make the panel show one arm while validation judges the
+ * value under another. Where nothing is stored there is no such value to
+ * disagree with: the engine answers with the catalog's first arm for everyone,
+ * and an author who wants to write the four-corner radius rather than the
+ * single one has no other way to say so.
+ *
+ * A preference outside the union's own arms is ignored rather than clamped.
+ * Clamping would silently draw arm 0 for a caller asking for arm 7, which reads
+ * as the choice having been honoured.
+ */
+function activeVariant(
+  shape: Extract<StyleShape, { kind: "union" }>,
+  path: readonly string[],
+  value: StyleValue | undefined,
+  options: StyleControlInput | undefined
+): number | undefined {
+  if (value === undefined) {
+    const preferred = options?.variantAt?.(path);
+    if (
+      preferred !== undefined &&
+      Number.isInteger(preferred) &&
+      preferred >= 0 &&
+      preferred < shape.of.length
+    ) {
+      return preferred;
+    }
+  }
+  return styleUnionVariant(shape, value, options);
 }
 
 /**
@@ -324,7 +377,7 @@ function childValue(
 export function styleControlsFor(
   property: StyleProperty,
   value?: StyleValue,
-  options?: StyleControlOptions
+  options?: StyleControlInput
 ): StyleControlSet {
   const variants: StyleControlVariants[] = [];
   const controls = walk(

--- a/packages/builder/src/style-controls.ts
+++ b/packages/builder/src/style-controls.ts
@@ -14,6 +14,18 @@
  * to the engine is a compile error in exactly one place rather than a silent
  * fallthrough at runtime.
  *
+ * **Which arm of a union a value is shown in is ASKED, not decided.**
+ * `styleUnionVariant` is the engine's own arm selection — the same answer
+ * validation uses to pick the arm it judges a value against — so the control an
+ * author sees and the error they read describe one arm by construction.
+ * Predicting it here instead means restating every rule the engine applies, and
+ * each of these is a rule that is easy to miss and invisible when missed: the
+ * three all-scalar unions, the site's token kind table, a token kind no arm
+ * declares, keyword case and ASCII whitespace and CSS escapes, the CSS-wide
+ * keywords that every leaf accepts, a union nested as another union's arm,
+ * composite arms that share a field name, and a record naming no known field at
+ * all. Nothing here holds any of them.
+ *
  * **What this module does NOT do.** It does not decide which properties a block
  * offers (that is `supports`, read through the catalog's own group helpers), it
  * does not hold the active state or breakpoint, and it does not validate. A
@@ -24,12 +36,10 @@
  */
 
 import {
-  asciiLower,
-  compileStyleValues,
-  decodeIdentifier,
-  getStyleProperty,
   isStyleLeaf,
   isTokenRef,
+  styleUnionVariant,
+  type MayFetchUrl,
   type StyleLeaf,
   type StyleProperty,
   type StyleShape,
@@ -148,7 +158,14 @@ export interface StyleControlVariants {
   readonly count: number;
 }
 
-/** What a caller can tell the resolver about the site. */
+/**
+ * What a caller can tell the resolver about the site.
+ *
+ * Structurally the engine's own `StyleUnionVariantOptions`, and handed to it
+ * unchanged: a field this named and the engine did not would be silently
+ * dropped, and one the engine reads and this omits would make the arm shown
+ * disagree with the arm a write is judged under.
+ */
 export interface StyleControlOptions {
   /**
    * The site's token table, for choosing between union arms that both accept
@@ -158,6 +175,17 @@ export interface StyleControlOptions {
    * own fallback for a name it cannot resolve.
    */
   readonly tokens?: TokenLookup;
+  /**
+   * Which hosts this site will fetch from.
+   *
+   * Carried because the arm choice is the engine's, and the engine asks this
+   * question of a `url` or free-form leaf. No union the catalog ships has such
+   * an arm today, so nothing measurable changes by supplying it — which is the
+   * moment to wire it, rather than after a catalog change makes its absence a
+   * defect. Absent means UNASKED rather than allowed, exactly as everywhere
+   * else the policy travels.
+   */
+  readonly mayFetchUrl?: MayFetchUrl;
 }
 
 /** A property's controls, and every choice of form its shape offers. */
@@ -166,324 +194,6 @@ export interface StyleControlSet {
   readonly controls: readonly StyleControl[];
   /** Empty when the property's shape holds no union at any depth. */
   readonly variants: readonly StyleControlVariants[];
-}
-
-/**
- * Which union variant a stored value is shown in.
- *
- * A PRESENTATION choice and never a validity judgement: it decides which
- * control to draw, and `validateStyleValues` remains the only thing that
- * decides whether a value may be written.
- *
- * Absent a value the FIRST variant wins, which is the order the engine tries
- * them in and therefore the canonical spelling of the property. With a value,
- * the arm that HOLDS it wins — see {@link variantHolds}, which reads the
- * catalog's own declarations rather than restating any grammar.
- */
-function variantForValue(
-  variants: readonly StyleShape[],
-  value: StyleValue | undefined,
-  tokens: TokenLookup | undefined
-): number {
-  if (value === undefined) return 0;
-  const found = variants.findIndex(variant =>
-    variantHolds(variant, value, tokens)
-  );
-  if (found !== -1) return found;
-  // A token whose kind no arm declares is still ACCEPTED: the engine reports
-  // `token-kind-mismatch` at WARNING severity and writes the value through the
-  // arm that admits tokens at all — measured. Falling through to arm 0 would
-  // draw a keyword select for a stored token that control cannot represent, so
-  // the arm that takes tokens is the honest one to show.
-  if (isTokenRef(value)) {
-    const admits = variants.findIndex(
-      variant => isStyleLeaf(variant) && variant.tokenKinds.length > 0
-    );
-    if (admits !== -1) return admits;
-  }
-  return 0;
-}
-
-/**
- * Whether a variant is the shape a stored value is written in.
- *
- * Composite against scalar is not enough on its own, and three of the four
- * unions the catalog ships are the case it misses: `fontWeight` is a keyword OR
- * a number, `lineHeight` a number OR a dimension, `fontStyle` a keyword OR a
- * free-form value. Every arm of those is a leaf, so a composite test picks the
- * first one every time — a numeric weight would draw the keyword select, and a
- * `1.5rem` line height the unitless number field.
- */
-function variantHolds(
-  variant: StyleShape,
-  value: StyleValue,
-  tokens: TokenLookup | undefined
-): boolean {
-  // A union can be an ARM of a union, and it is neither a leaf nor a record of
-  // named fields — `fieldsOf` answers with nothing for one whose arms are all
-  // scalars, and "no fields declared" is read below as "any record fits". So a
-  // nested scalar union would swallow every composite value beside it. Asking
-  // its own arms is the only reading that matches what the engine would accept.
-  if (!isStyleLeaf(variant) && variant.kind === "union") {
-    return variant.of.some(arm => variantHolds(arm, value, tokens));
-  }
-  if (!isStyleLeaf(variant)) {
-    return isCompositeValue(value) && fieldsHold(variant, value, tokens);
-  }
-  return !isCompositeValue(value) && leafHolds(variant, value, tokens);
-}
-
-/** The field names a composite shape addresses. */
-function fieldsOf(shape: StyleShape): readonly string[] {
-  if (isStyleLeaf(shape)) return [];
-  switch (shape.kind) {
-    case "logicalSides":
-      return Object.keys(shape.sides);
-    case "logicalCorners":
-      return Object.keys(shape.corners);
-    case "object":
-      return Object.keys(shape.fields);
-    case "union":
-      return shape.of.flatMap(fieldsOf);
-  }
-}
-
-/** The shape a composite declares at one of its field names. */
-function shapeAt(variant: StyleShape, name: string): StyleShape | undefined {
-  if (isStyleLeaf(variant)) return undefined;
-  switch (variant.kind) {
-    case "logicalSides":
-      return Object.hasOwn(variant.sides, name)
-        ? variant.sides[name as keyof typeof variant.sides]
-        : undefined;
-    case "logicalCorners":
-      return Object.hasOwn(variant.corners, name)
-        ? variant.corners[name as keyof typeof variant.corners]
-        : undefined;
-    case "object":
-      return Object.hasOwn(variant.fields, name)
-        ? variant.fields[name]
-        : undefined;
-    case "union":
-      return undefined;
-  }
-}
-
-/**
- * Whether a composite arm holds the fields a stored record names.
- *
- * Field NAMES alone do not tell two composite arms apart when they share one:
- * `{ value: keyword }` beside `{ value: number }` both claim `{ value: 2 }`, and
- * the controls returned would describe a form that cannot hold it. So each named
- * field is checked against the shape this arm declares for it, recursively,
- * which is the same walk the leaf matching already performs one level down.
- *
- * Only the fields the value NAMES are checked, because a stored value is
- * sparse: a radius with just its top-left corner set is still the four-corner
- * form, and requiring every field would push it to the scalar arm.
- */
-function fieldsHold(
-  variant: StyleShape,
-  value: CompositeValue,
-  tokens: TokenLookup | undefined
-): boolean {
-  const fields = fieldsOf(variant);
-  if (fields.length === 0) return true;
-  const keys = Object.keys(value);
-  // An EMPTY record names nothing and is still this form: the validator accepts
-  // `{}` against a composite with no issues, so rejecting it here sent a stored
-  // `borderRadius: {}` to the scalar arm and drew one length control for a
-  // value the document holds in the four-corner form.
-  if (keys.length === 0) return true;
-  const named = keys.filter(key => fields.includes(key));
-  if (named.length === 0) return false;
-  return named.every(name => {
-    const shape = shapeAt(variant, name);
-    const held = value[name];
-    if (shape === undefined || held === undefined) return false;
-    return variantHolds(shape, held, tokens);
-  });
-}
-
-/**
- * Whether a leaf admits this token reference.
- *
- * Which arm a token belongs to is a fact about the TOKEN, and the stored
- * reference carries only its name. `lineHeight` accepts tokens on both its arms
- * — numbers on one, dimensions on the other — so without the site's table the
- * name alone cannot separate them, and the catalog's arm order decides exactly
- * as the engine's own union check falls back to it.
- */
-function tokenLeafHolds(
-  leaf: StyleLeaf,
-  name: string,
-  tokens: TokenLookup | undefined
-): boolean {
-  if (leaf.tokenKinds.length === 0) return false;
-  const kind = tokens?.kindOf(name);
-  return kind === undefined || leaf.tokenKinds.includes(kind);
-}
-
-/**
- * Whether a leaf stores this number.
- *
- * `0` is the one measurement that needs no unit, which is why a dimension
- * accepts it without `allowNumber`.
- */
-function numberLeafHolds(leaf: StyleLeaf, value: number): boolean {
-  if (leaf.kind === "number") return true;
-  if (leaf.kind !== "dimension") return false;
-  return leaf.allowNumber === true || value === 0;
-}
-
-/**
- * A keyword in the spelling the engine compares keywords in.
- *
- * CSS keywords are ASCII case-insensitive and surrounding whitespace is
- * discarded by parsing, so the validator accepts `"Italic"` and `" italic "`
- * exactly as it accepts `"italic"` — and it decodes escapes before comparing,
- * because an escape can spell an ordinary letter. An exact `includes` therefore
- * misses valid stored values and sends them to the free-form arm, which draws a
- * text box where a select belongs.
- *
- * Normalized with the engine's OWN primitives rather than a lowercase-and-trim
- * written here, so the two cannot disagree about what an escape means.
- *
- * The whitespace stripped is ASCII only, which is what CSS discards.
- * JavaScript's `trim()` also removes NBSP and the Unicode spaces, and the engine
- * does NOT — measured, a value carrying NBSP is refused where the same value
- * with an ordinary space is accepted. Trimming it here would match a closed
- * keyword control to a value that control cannot represent.
- */
-const CSS_TRIM = /^[ \t\n\f\r]+|[ \t\n\f\r]+$/g;
-
-/**
- * A keyword in the spelling the engine compares keywords in.
- */
-function keywordKey(value: string): string {
-  return asciiLower(decodeIdentifier(value.replace(CSS_TRIM, "")));
-}
-
-/**
- * A plain keyword property, used to ask the engine what any leaf would accept.
- *
- * `textAlign` is a single keyword leaf with a closed vocabulary. A value it
- * accepts that is NOT in that vocabulary is accepted for a reason that has
- * nothing to do with this property — it is legal wherever a value is — which is
- * exactly the question below.
- */
-const UNIVERSAL_PROBE_PROPERTY = "textAlign";
-
-/**
- * Answers already derived, so a repeated value costs one lookup.
- *
- * The values that ARE universal are a closed, tiny set, so caching those costs
- * nothing. A NEGATIVE answer is any author-supplied string that reached a
- * scalar union — free-form `fontStyle` input, half-typed values, rejected ones —
- * so caching every one of those in a long-lived editor grows without bound, and
- * each key can be as long as the style-value limit allows. Negatives are
- * therefore capped: past the cap they are recomputed rather than retained.
- */
-const UNIVERSALLY_ACCEPTED = new Map<string, boolean>();
-
-/** How many refusals to remember before recomputing them instead. */
-const NEGATIVE_CACHE_LIMIT = 64;
-
-/**
- * Whether every leaf accepts this string whatever its own vocabulary says.
- *
- * The CSS-wide keywords — `inherit`, `initial` and their siblings — are legal
- * wherever a value is, so a keyword leaf accepts them alongside its own list and
- * a number leaf accepts them despite taking numbers. Without this, a stored
- * `fontStyle: "inherit"` misses the keyword arm and lands on the free-form one,
- * and `lineHeight: "inherit"` misses the number arm — in both cases disagreeing
- * with the arm the engine itself would accept the value through.
- *
- * ASKED of the engine rather than listed here. The engine holds that set and
- * does not export it, so a copy would be a second statement of which keywords
- * are universal, and the two would agree until either moved. Compiling one
- * probe answers it, and a keyword this engine learns is picked up with no edit.
- */
-function isUniversallyAccepted(value: string): boolean {
-  // Keyed by the CANONICAL spelling, so every case, whitespace and escape
-  // variant of one keyword shares an entry. Keying by the raw string leaves the
-  // ACCEPTED side unbounded too — `inherit`, `INHERIT`, ` Inherit ` and an
-  // escaped spelling are all distinct raw keys for one closed-set answer.
-  const key = keywordKey(value);
-  const cached = UNIVERSALLY_ACCEPTED.get(key);
-  if (cached !== undefined) return cached;
-  const probe = getStyleProperty(UNIVERSAL_PROBE_PROPERTY);
-  if (probe === undefined || probe.shape.kind !== "keyword") {
-    throw new Error(
-      `${UNIVERSAL_PROBE_PROPERTY} is no longer a plain keyword property, so ` +
-        `the engine cannot be asked which values are legal everywhere`
-    );
-  }
-  // A value inside the probe's OWN vocabulary would be accepted for the wrong
-  // reason, and would report every such word as universal.
-  if (probe.shape.values.some(keyword => keywordKey(keyword) === key)) {
-    remember(key, false);
-    return false;
-  }
-  const compiled = compileStyleValues(
-    { [UNIVERSAL_PROBE_PROPERTY]: value },
-    ""
-  );
-  const accepted =
-    compiled.declarations.length > 0 &&
-    !compiled.warnings.some(issue => issue.severity === "error");
-  remember(key, accepted);
-  return accepted;
-}
-
-/** Keep an answer, bounding what the refusals can grow to. */
-function remember(key: string, accepted: boolean): void {
-  if (!accepted && UNIVERSALLY_ACCEPTED.size >= NEGATIVE_CACHE_LIMIT) return;
-  UNIVERSALLY_ACCEPTED.set(key, accepted);
-}
-
-/**
- * Whether a leaf stores this string.
- *
- * A keyword leaf claims one only when the string is one of ITS keywords. Every
- * other scalar leaf stores its value as a string, so the catalog's arm order
- * decides between those exactly as the engine's own order does.
- *
- * Compares the value WHOLE rather than splitting it, so a multi-part keyword
- * shorthand — `overflow: hidden auto` — is not recognised as its own vocabulary.
- * No union the catalog ships declares a multi-part keyword arm, so nothing
- * reaches that case today; if one appears, the arm order decides, which is the
- * engine's own fallback and not a wrong answer.
- */
-function stringLeafHolds(leaf: StyleLeaf, value: string): boolean {
-  // Checked FIRST and for every kind, because a value legal everywhere is one
-  // the engine accepts through the earliest arm — including a number arm that
-  // otherwise takes no strings at all.
-  if (isUniversallyAccepted(value)) return true;
-  if (leaf.kind !== "keyword") return leaf.kind !== "number";
-  const key = keywordKey(value);
-  return leaf.values.some(keyword => keywordKey(keyword) === key);
-}
-
-/**
- * Whether a leaf is the one a scalar is stored under.
- *
- * Reads the catalog's own declarations — a keyword leaf's `values`, a
- * dimension's `allowNumber`, an arm's `tokenKinds` — rather than restating any
- * grammar. It stays a PRESENTATION choice: `validateStyleValues` remains the
- * only thing deciding whether a value may be written, and it owes this no
- * agreement. Drawing the wrong control is a legibility bug the next keystroke
- * corrects; the write is gated either way.
- */
-function leafHolds(
-  leaf: StyleLeaf,
-  value: StyleValue,
-  tokens: TokenLookup | undefined
-): boolean {
-  if (isTokenRef(value)) return tokenLeafHolds(leaf, value.$token, tokens);
-  if (typeof value === "number") return numberLeafHolds(leaf, value);
-  if (typeof value === "string") return stringLeafHolds(leaf, value);
-  return false;
 }
 
 /** A stored value holding named sub-values, as a composite shape addresses. */
@@ -536,7 +246,7 @@ function walk(
   path: readonly string[],
   shape: StyleShape,
   value: StyleValue | undefined,
-  tokens: TokenLookup | undefined,
+  options: StyleControlOptions | undefined,
   // Collected as the walk descends rather than returned alongside, so a union
   // at ANY depth is recorded by the same line that resolves it.
   variants: StyleControlVariants[]
@@ -547,7 +257,7 @@ function walk(
       [...path, step],
       child,
       childValue(value, step),
-      tokens,
+      options,
       variants
     );
   if (isStyleLeaf(shape)) return [controlForLeaf(property, path, shape)];
@@ -563,9 +273,18 @@ function walk(
         down(field, child)
       );
     case "union": {
-      const active = variantForValue(shape.of, value, tokens);
+      // ASKED of the engine rather than decided here. Which arm a stored value
+      // belongs to is the same question validation answers when it picks the
+      // arm to judge that value against, so reading its answer makes the
+      // control and the error message beside it describe one arm by
+      // construction. The module docblock lists what predicting it would cost.
+      const active = styleUnionVariant(shape, value, options);
+      // A union declaring no arms offers no choice and has nothing to draw. The
+      // catalog ships none; the matcher this replaced answered 0 regardless and
+      // handed `undefined` down as though it were a shape.
+      if (active === undefined) return [];
       variants.push({ path, active, count: shape.of.length });
-      return walk(property, path, shape.of[active], value, tokens, variants);
+      return walk(property, path, shape.of[active], value, options, variants);
     }
   }
 }
@@ -613,7 +332,7 @@ export function styleControlsFor(
     [],
     property.shape,
     value,
-    options?.tokens,
+    options,
     variants
   );
   return { property: property.property, controls, variants };

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -538,6 +538,26 @@ describe("controls", () => {
     expect(editor.apply).toHaveBeenCalledTimes(1);
   });
 
+  it("names a read-only value through its label, which `for` cannot reach", () => {
+    // HTML's `for` associates a label only with a LABELABLE element — input,
+    // select, textarea, button, output, meter, progress. These branches render
+    // a paragraph, so the association is dropped silently and the value has no
+    // accessible name at all.
+    const styles = {
+      base: {
+        [BASE_BREAKPOINT]: { padding: { blockStart: { $token: "space.4" } } },
+      },
+    } as NodeStyles;
+    mount({ spacing: true }, styles);
+
+    const value = fieldsOf("padding").getByText("space.4").closest("p");
+    const labelledBy = value?.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+    expect(document.getElementById(labelledBy as string)?.textContent).toBe(
+      "Block start"
+    );
+  });
+
   it("names a token's clear action for its property, not just 'Clear'", () => {
     // Several token-valued properties on one panel would otherwise be a column
     // of identical buttons, and the label pointed at an id nothing carried.

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -325,6 +325,34 @@ describe("controls", () => {
     expect(screen.getByRole("alert").textContent).toContain("is not a length");
   });
 
+  it("drops a refusal once the document holds a different value here", () => {
+    // A refusal describes the draft that produced it. An undo, or an edit
+    // applied from somewhere else, leaves the SELECTION alone — so the remount
+    // key does not change and nothing else would clear the message, leaving an
+    // error under a field that now shows a different value.
+    register({ spacing: true });
+    const editor = editorFor(documentOf());
+    const { rerender } = render(<StyleInspectorPanel editor={editor} />);
+
+    const field = fieldsOf("padding").getByLabelText("Block start");
+    fireEvent.change(field, { target: { value: "12 furlongs" } });
+    fireEvent.blur(field);
+    expect(screen.getByRole("alert")).toBeDefined();
+
+    const repaired = editorFor(
+      documentOf({
+        base: { [BASE_BREAKPOINT]: { padding: { blockStart: "4px" } } },
+      } as NodeStyles)
+    );
+    rerender(<StyleInspectorPanel editor={repaired} />);
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(
+      (fieldsOf("padding").getByLabelText("Block start") as HTMLInputElement)
+        .value
+    ).toBe("4px");
+  });
+
   it("shows a stored token by name rather than as editable text", () => {
     // `{ $token }` is one value spelled as an object. Typing over it would
     // store the token's NAME as a literal — a value that looks right in the

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -376,7 +376,7 @@ describe("controls", () => {
     // engine answers with the catalog's first arm when nothing is stored.
     mount({ border: { radius: true } });
 
-    const trigger = screen.getByLabelText("Form");
+    const trigger = screen.getByLabelText("Border radius form");
     fireEvent.click(trigger);
     // Named from the arms' own shape kinds rather than numbered.
     expect(screen.getByRole("option", { name: "Per corner" })).toBeDefined();
@@ -397,7 +397,7 @@ describe("controls", () => {
     } as NodeStyles;
     const editor = mount({ border: { radius: true } }, styles);
 
-    fireEvent.click(screen.getByLabelText("Form"));
+    fireEvent.click(screen.getByLabelText("Border radius form"));
     fireEvent.click(screen.getByRole("option", { name: "Per corner" }));
 
     expect(editor.apply).toHaveBeenCalledTimes(1);
@@ -536,6 +536,32 @@ describe("controls", () => {
 
     fireEvent.click(fontSize.getByRole("button", { name: "Clear Font size" }));
     expect(editor.apply).toHaveBeenCalledTimes(1);
+  });
+
+  it("names every ROOT form selector for its own property", () => {
+    // A property whose shape is a union at the top draws one control and so no
+    // heading. `fontWeight`, `lineHeight` and `fontStyle` are all such unions,
+    // and a selector called "Form" three times over tells a screen-reader user
+    // nothing about which property it changes.
+    mount({ typography: true });
+
+    expect(screen.getByLabelText("Font weight form")).toBeDefined();
+    expect(screen.getByLabelText("Line height form")).toBeDefined();
+    expect(screen.getByLabelText("Font style form")).toBeDefined();
+  });
+
+  it("leaves a trailing decimal point for the catalog, rather than reading it as a number", () => {
+    // CSS requires a digit AFTER a decimal point, so `1.` is a number followed
+    // by a stray delimiter rather than a number. `Number("1.")` answers 1
+    // regardless, which would store a value the author never spelled validly.
+    const editor = mount({ effects: true });
+    const field = screen.getByLabelText("Opacity");
+
+    fireEvent.change(field, { target: { value: "1." } });
+    fireEvent.blur(field);
+
+    expect(editor.apply).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toBeDefined();
   });
 
   it("names a read-only value through its label, which `for` cannot reach", () => {

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -440,7 +440,9 @@ describe("controls", () => {
     const editor = mount({ effects: true }, styles);
 
     fireEvent.click(
-      fieldsOf("mixBlendMode").getByRole("button", { name: "Clear" })
+      fieldsOf("mixBlendMode").getByRole("button", {
+        name: "Clear Mix blend mode",
+      })
     );
 
     expect(editor.apply.mock.calls[0]?.[0]).toEqual({
@@ -558,6 +560,40 @@ describe("controls", () => {
     expect(
       screen.getByRole("button", { name: "Clear Margin block start" })
     ).toBeDefined();
+  });
+
+  it("names every keyword clear action for its own property", () => {
+    // Two keyword properties set at once would otherwise offer two buttons
+    // both called "Clear", and a screen-reader user cannot tell which
+    // declaration each removes.
+    // One section, so both controls are in the OPEN accordion: a closed section
+    // hides its buttons and `getByRole` would report them missing rather than
+    // unnamed, which is a different failure wearing the same message.
+    const styles = {
+      base: { [BASE_BREAKPOINT]: { mixBlendMode: "multiply", filter: "none" } },
+    } as NodeStyles;
+    mount({ effects: true }, styles);
+
+    expect(
+      screen.getByRole("button", { name: "Clear Mix blend mode" })
+    ).toBeDefined();
+  });
+
+  it("does not read NBSP-only text as an empty field, which would DELETE the value", () => {
+    // `String.prototype.trim` strips NBSP; CSS does not. Reading it as empty
+    // turns a value the engine refuses into a silent clear of the declaration.
+    const styles = {
+      base: { [BASE_BREAKPOINT]: { padding: { blockStart: "12px" } } },
+    } as NodeStyles;
+    const editor = mount({ spacing: true }, styles);
+    const field = fieldsOf("padding").getByLabelText("Block start");
+
+    fireEvent.change(field, { target: { value: "\u00a0" } });
+    fireEvent.blur(field);
+
+    // Refused as a value, not treated as a request to clear.
+    expect(editor.apply).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toBeDefined();
   });
 
   it("trims the whitespace CSS trims, not the whitespace JavaScript trims", () => {

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -576,12 +576,13 @@ describe("controls", () => {
     } as NodeStyles;
     mount({ spacing: true }, styles);
 
-    const value = fieldsOf("padding").getByText("space.4").closest("p");
-    const labelledBy = value?.getAttribute("aria-labelledby");
-    expect(labelledBy).toBeTruthy();
-    expect(document.getElementById(labelledBy as string)?.textContent).toBe(
-      "Block start"
-    );
+    // The COMPUTED accessible name, not the raw attribute. Asserting
+    // `aria-labelledby` and resolving the id by hand passes even when the
+    // element's role prohibits a name — which a bare paragraph's does — so it
+    // would have reported this association as working while it was dropped.
+    expect(
+      fieldsOf("padding").getByRole("group", { name: "Block start" })
+    ).toBeDefined();
   });
 
   it("names a token's clear action for its property, not just 'Clear'", () => {

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -200,6 +200,24 @@ describe("sections", () => {
     expect(screen.getAllByLabelText("1 set")).toHaveLength(2);
   });
 
+  it("keeps a section collapsed when the author closes it", () => {
+    // The accordion sends "" on collapse. Treating that as "not chosen" made
+    // the first section impossible to close, and closing any later one opened
+    // the first instead.
+    mount({ spacing: true, effects: true });
+    const spacing = screen.getByRole("button", { name: /Spacing/ });
+    expect(spacing.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(spacing);
+
+    expect(spacing.getAttribute("aria-expanded")).toBe("false");
+    expect(
+      screen
+        .getByRole("button", { name: /Effects/ })
+        .getAttribute("aria-expanded")
+    ).toBe("false");
+  });
+
   it("says so when a block offers no style properties at all", () => {
     mount({});
 
@@ -457,6 +475,21 @@ describe("controls", () => {
       screen.getByText("2 blocks selected. Select one to style it.")
     ).toBeDefined();
     expect(screen.queryByLabelText("Block start")).toBeNull();
+  });
+
+  it("stores only the numeric grammar CSS accepts, leaving other spellings alone", () => {
+    // `Number` reads spellings CSS does not: `0x10` is 16, `0b10` is 2, `0o10`
+    // is 8. Converting those would store a number the author never typed and
+    // pass validation on the way through.
+    const editor = mount({ effects: true });
+    const field = screen.getByLabelText("Opacity");
+
+    fireEvent.change(field, { target: { value: "0x10" } });
+    fireEvent.blur(field);
+
+    // Left as text, so the catalog refuses it and says why.
+    expect(editor.apply).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert").textContent).toContain("is not a number");
   });
 
   it("shows a stored token by name rather than as editable text", () => {

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -1,0 +1,347 @@
+// @vitest-environment jsdom
+
+/**
+ * The Style tab, driven through a host that renders it against a real editor.
+ *
+ * `style-inspector.ts` decides which sections a block offers and what each
+ * property carries, and asserts that without a DOM. What is only true HERE is
+ * the wiring: that a control shows the stored value, that an edit reaches
+ * `editor.apply` as the op the store owns, that an emptied field CLEARS rather
+ * than writing an empty value, and that a refusal is shown rather than
+ * swallowed.
+ *
+ * @module style-inspector-panel.test
+ */
+import {
+  BASE_BREAKPOINT,
+  clearBlocks,
+  registerBlocks,
+  type BlockDocument,
+  type BlockNode,
+  type NodeStyles,
+} from "@nextlyhq/blocks-engine";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import * as React from "react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { EditorState } from "./editor-state";
+import { InspectorPanel } from "./inspector-panel";
+import { StyleInspectorPanel } from "./style-inspector-panel";
+
+afterEach(() => {
+  cleanup();
+  clearBlocks();
+});
+
+beforeAll(() => {
+  // Radix measures and scrolls; jsdom provides neither, and a missing one
+  // throws during render rather than failing an assertion.
+  const element = window.Element.prototype as unknown as Record<
+    string,
+    unknown
+  >;
+  element.scrollIntoView = function scrollIntoView(): void {};
+  (window as unknown as Record<string, unknown>).ResizeObserver =
+    class ResizeObserver {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    };
+});
+
+function register(
+  supports: Record<string, boolean | Record<string, boolean>>
+): void {
+  registerBlocks(
+    [
+      {
+        name: "acme/box",
+        version: 1,
+        description: "A box.",
+        example: { props: {} },
+        editor: { label: "Box" },
+        props: { text: { type: "text" } },
+        supports,
+        render: () => null,
+      },
+    ] as never,
+    { source: "style-inspector-panel-test" }
+  );
+}
+
+function documentOf(styles?: NodeStyles): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      { id: "a", type: "acme/box", version: 1, props: {}, styles },
+    ] as BlockNode[],
+  } as BlockDocument;
+}
+
+function editorFor(
+  document: BlockDocument,
+  selectedId: string | null = "a"
+): EditorState & { apply: ReturnType<typeof vi.fn> } {
+  return {
+    document,
+    selectedId,
+    selection: {
+      ids: selectedId === null ? [] : [selectedId],
+      primary: selectedId,
+    },
+    applyAll: vi.fn(() => document),
+    select: vi.fn(),
+    apply: vi.fn(() => document),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+    undoDepth: 0,
+  } as unknown as EditorState & { apply: ReturnType<typeof vi.fn> };
+}
+
+function mount(
+  supports: Record<string, boolean | Record<string, boolean>>,
+  styles?: NodeStyles
+) {
+  register(supports);
+  const editor = editorFor(documentOf(styles));
+  render(<StyleInspectorPanel editor={editor} />);
+  return editor;
+}
+
+/** The fields of one property, scoped so two properties sharing a side name do not collide. */
+function fieldsOf(property: string) {
+  return within(
+    document.querySelector(`[data-property="${property}"]`) as HTMLElement
+  );
+}
+
+describe("the Style tab beside Content", () => {
+  it("offers both tabs and shows Content first", () => {
+    register({ effects: true });
+    render(<InspectorPanel editor={editorFor(documentOf())} />);
+
+    expect(screen.getByRole("tab", { name: "Content" })).toHaveProperty(
+      "ariaSelected",
+      "true"
+    );
+    expect(screen.getByRole("tab", { name: "Style" })).toHaveProperty(
+      "ariaSelected",
+      "false"
+    );
+    // The content half is still what it was: the block's props.
+    expect(screen.getByLabelText("Text")).toBeDefined();
+  });
+
+  it("shows the style sections once the Style tab is chosen", () => {
+    register({ effects: true });
+    render(<InspectorPanel editor={editorFor(documentOf())} />);
+
+    // `mouseDown` rather than `click`: the trigger activates on pointer-down,
+    // and a synthetic click leaves it unselected — which would let every
+    // assertion below run against the Content tab.
+    const style = screen.getByRole("tab", { name: "Style" });
+    fireEvent.mouseDown(style);
+
+    expect(style.getAttribute("aria-selected")).toBe("true");
+    // Queried by ROLE, which ignores the hidden panel: both panels are in the
+    // DOM and the inactive one is hidden, so a query that read hidden nodes
+    // would pass whether or not the tab ever changed.
+    expect(screen.getByRole("button", { name: /Effects/ })).toBeDefined();
+    expect(screen.getByRole("textbox", { name: "Opacity" })).toBeDefined();
+  });
+
+  it("offers no tabs at all when nothing is selected", () => {
+    // A Style tab over no selection would offer somewhere to click that can
+    // never show anything, and the entry's own fields are a left panel rather
+    // than this region.
+    register({ effects: true });
+    render(<InspectorPanel editor={editorFor(documentOf(), null)} />);
+
+    expect(screen.queryByRole("tab", { name: "Style" })).toBeNull();
+    expect(screen.getByText("Select a block to edit it.")).toBeDefined();
+  });
+});
+
+describe("sections", () => {
+  it("opens one section at a time", () => {
+    mount({ spacing: true, effects: true });
+
+    // The first section is open and the second is not, without either being
+    // clicked: an accordion that opened nothing would show a block's style
+    // surface as a column of headings.
+    const spacing = screen.getByRole("button", { name: /Spacing/ });
+    const effects = screen.getByRole("button", { name: /Effects/ });
+    expect(spacing.getAttribute("aria-expanded")).toBe("true");
+    expect(effects.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(effects);
+
+    expect(spacing.getAttribute("aria-expanded")).toBe("false");
+    expect(effects.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("counts the properties this node sets in each section", () => {
+    const styles = {
+      base: { [BASE_BREAKPOINT]: { margin: "8px", opacity: 0.5 } },
+    } as NodeStyles;
+    mount({ spacing: true, effects: true }, styles);
+
+    // One of two in spacing, one of five in effects — so an author can see
+    // which sections they have touched without opening each one.
+    expect(screen.getAllByLabelText("1 set")).toHaveLength(2);
+  });
+
+  it("says so when a block offers no style properties at all", () => {
+    mount({});
+
+    expect(
+      screen.getByText("This block does not offer style properties.")
+    ).toBeDefined();
+  });
+});
+
+describe("controls", () => {
+  it("shows the value stored at this address", () => {
+    const styles = {
+      base: { [BASE_BREAKPOINT]: { padding: { blockStart: "12px" } } },
+    } as NodeStyles;
+    mount({ spacing: true }, styles);
+
+    expect(
+      (fieldsOf("padding").getByLabelText("Block start") as HTMLInputElement)
+        .value
+    ).toBe("12px");
+    // The same side of a DIFFERENT property is empty, which is what says the
+    // read is addressed rather than by leaf name.
+    expect(
+      (fieldsOf("margin").getByLabelText("Block start") as HTMLInputElement)
+        .value
+    ).toBe("");
+  });
+
+  it("draws a keyword leaf as a select over the catalog's own vocabulary", () => {
+    mount({ effects: true });
+
+    const trigger = screen.getByLabelText("Mix blend mode");
+    fireEvent.click(trigger);
+
+    // `multiply` is the catalog's, not a list written here — a value absent
+    // from `mix-blend-mode` would fail to appear.
+    expect(screen.getByRole("option", { name: "multiply" })).toBeDefined();
+  });
+
+  it("writes through the store on blur, not on every keystroke", () => {
+    const editor = mount({ spacing: true });
+    const field = fieldsOf("padding").getByLabelText("Block start");
+
+    fireEvent.change(field, { target: { value: "12px" } });
+    expect(editor.apply).not.toHaveBeenCalled();
+
+    fireEvent.blur(field);
+
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+    expect(editor.apply.mock.calls[0]?.[0]).toMatchObject({
+      kind: "update",
+      id: "a",
+      patch: {
+        styles: {
+          base: { [BASE_BREAKPOINT]: { padding: { blockStart: "12px" } } },
+        },
+      },
+    });
+  });
+
+  it("CLEARS on an emptied field rather than storing an empty value", () => {
+    // A stored `""` would pin the property to nothing here and beat the tier an
+    // author is asking to get back — and the validator refuses it anyway.
+    const styles = {
+      base: { [BASE_BREAKPOINT]: { padding: { blockStart: "12px" } } },
+    } as NodeStyles;
+    const editor = mount({ spacing: true }, styles);
+    const field = fieldsOf("padding").getByLabelText("Block start");
+
+    fireEvent.change(field, { target: { value: "" } });
+    fireEvent.blur(field);
+
+    // Named for REMOVAL rather than set to an empty object: an op is
+    // persisted, and `JSON.stringify` drops an undefined value, so the inverse
+    // of the edit that added the first style has to say which key goes.
+    expect(editor.apply.mock.calls[0]?.[0]).toEqual({
+      kind: "update",
+      id: "a",
+      patch: {},
+      unset: ["styles"],
+    });
+  });
+
+  it("stores a numeric draft as a NUMBER where the leaf takes one", () => {
+    // Measured: `opacity: "0.5"` is refused and `opacity: 0.5` is accepted, so
+    // passing the draft through unchanged would refuse every numeric edit.
+    const editor = mount({ effects: true });
+    const field = screen.getByLabelText("Opacity");
+
+    fireEvent.change(field, { target: { value: "0.5" } });
+    fireEvent.blur(field);
+
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+    expect(editor.apply.mock.calls[0]?.[0]).toMatchObject({
+      patch: { styles: { base: { [BASE_BREAKPOINT]: { opacity: 0.5 } } } },
+    });
+  });
+
+  it("passes a non-numeric draft through, so a CSS-wide keyword reaches a number leaf", () => {
+    const editor = mount({ effects: true });
+    const field = screen.getByLabelText("Opacity");
+
+    fireEvent.change(field, { target: { value: "inherit" } });
+    fireEvent.blur(field);
+
+    expect(editor.apply.mock.calls[0]?.[0]).toMatchObject({
+      patch: {
+        styles: { base: { [BASE_BREAKPOINT]: { opacity: "inherit" } } },
+      },
+    });
+  });
+
+  it("shows the catalog's own refusal and applies nothing", () => {
+    const editor = mount({ spacing: true });
+    const field = fieldsOf("padding").getByLabelText("Block start");
+
+    fireEvent.change(field, { target: { value: "12 furlongs" } });
+    fireEvent.blur(field);
+
+    expect(editor.apply).not.toHaveBeenCalled();
+    // The message is the validator's rather than one written here, so a change
+    // to how the catalog explains a length is carried straight to the author.
+    expect(screen.getByRole("alert").textContent).toContain("is not a length");
+  });
+
+  it("shows a stored token by name rather than as editable text", () => {
+    // `{ $token }` is one value spelled as an object. Typing over it would
+    // store the token's NAME as a literal — a value that looks right in the
+    // field and compiles to nothing.
+    const styles = {
+      base: {
+        [BASE_BREAKPOINT]: { padding: { blockStart: { $token: "space.4" } } },
+      },
+    } as NodeStyles;
+    const editor = mount({ spacing: true }, styles);
+    const padding = fieldsOf("padding");
+
+    expect(padding.getByText("space.4")).toBeDefined();
+    expect(padding.queryByDisplayValue("space.4")).toBeNull();
+
+    fireEvent.click(padding.getByRole("button", { name: "Clear" }));
+
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -677,6 +677,25 @@ describe("controls", () => {
     ).toBe("");
   });
 
+  it("ties a refusal to the control that produced it", () => {
+    // `role="alert"` announces once and is then gone. Without the relationship
+    // being stated, a screen-reader user returning to the field — or meeting
+    // several rejected controls — cannot tell which message belongs to which.
+    const editor = mount({ spacing: true });
+    const field = fieldsOf("padding").getByLabelText("Block start");
+
+    fireEvent.change(field, { target: { value: "12 furlongs" } });
+    fireEvent.blur(field);
+    expect(editor.apply).not.toHaveBeenCalled();
+
+    const describedBy = field.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    expect(
+      document.getElementById(describedBy as string)?.textContent
+    ).toContain("is not a length");
+    expect(field.getAttribute("aria-invalid")).toBe("true");
+  });
+
   it("shows a stored token by name rather than as editable text", () => {
     // `{ $token }` is one value spelled as an object. Typing over it would
     // store the token's NAME as a literal — a value that looks right in the

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -409,6 +409,30 @@ describe("controls", () => {
     });
   });
 
+  it("clears only the union position when a NESTED form changes", () => {
+    // `position` holds a type, an inset and a zIndex, and only the last is a
+    // union. Clearing the property root to change the zIndex form would delete
+    // the author's positioning scheme and offsets with it.
+    const styles = {
+      base: {
+        [BASE_BREAKPOINT]: { position: { type: "relative", zIndex: 3 } },
+      },
+    } as NodeStyles;
+    const editor = mount({ position: true }, styles);
+
+    fireEvent.click(screen.getByLabelText("Z index form"));
+    fireEvent.click(screen.getByRole("option", { name: "Keyword" }));
+
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+    expect(editor.apply.mock.calls[0]?.[0]).toMatchObject({
+      patch: {
+        styles: {
+          base: { [BASE_BREAKPOINT]: { position: { type: "relative" } } },
+        },
+      },
+    });
+  });
+
   it("lets a keyword selection be cleared, which a select cannot offer as an item", () => {
     const styles = {
       base: { [BASE_BREAKPOINT]: { mixBlendMode: "multiply" } },

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -516,6 +516,85 @@ describe("controls", () => {
     expect(screen.getByRole("alert").textContent).toContain("is not a number");
   });
 
+  it("makes a retained but unsupported value clear-only, not editable", () => {
+    // The value is live on the page — nothing in validation or compilation
+    // reads `supports` — so it must be removable. Letting it go on being EDITED
+    // is the other error: that writes new values through a capability the block
+    // has withdrawn.
+    const styles = {
+      base: { [BASE_BREAKPOINT]: { fontSize: "20px" } },
+    } as NodeStyles;
+    const editor = mount({ spacing: true, typography: false }, styles);
+
+    fireEvent.click(screen.getByRole("button", { name: /Typography/ }));
+    const fontSize = fieldsOf("fontSize");
+
+    expect(fontSize.queryByRole("textbox")).toBeNull();
+    expect(fontSize.getByText("20px")).toBeDefined();
+
+    fireEvent.click(fontSize.getByRole("button", { name: "Clear Font size" }));
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+  });
+
+  it("names a token's clear action for its property, not just 'Clear'", () => {
+    // Several token-valued properties on one panel would otherwise be a column
+    // of identical buttons, and the label pointed at an id nothing carried.
+    const styles = {
+      base: {
+        [BASE_BREAKPOINT]: {
+          padding: { blockStart: { $token: "space.4" } },
+          margin: { blockStart: { $token: "space.2" } },
+        },
+      },
+    } as NodeStyles;
+    mount({ spacing: true }, styles);
+
+    // Each names the PROPERTY it clears, not just the side: `padding` and
+    // `margin` both have a block start, so a name built from the side alone
+    // says the same thing twice.
+    expect(
+      screen.getByRole("button", { name: "Clear Padding block start" })
+    ).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: "Clear Margin block start" })
+    ).toBeDefined();
+  });
+
+  it("trims the whitespace CSS trims, not the whitespace JavaScript trims", () => {
+    // `String.prototype.trim` strips NBSP and the Unicode spaces where CSS
+    // strips neither, so trimming with it would turn a spelling the engine
+    // refuses into a number it accepts.
+    const editor = mount({ effects: true });
+    const field = screen.getByLabelText("Opacity");
+
+    fireEvent.change(field, { target: { value: "\u00a00.5" } });
+    fireEvent.blur(field);
+
+    expect(editor.apply).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toBeDefined();
+  });
+
+  it("gives a field an identity that includes the address it writes to", () => {
+    // A host switching state or breakpoint leaves this field mounted, and where
+    // both addresses hold the same value the synchronisation effect does not
+    // run — so an unfinished draft would commit into the new address.
+    register({ spacing: true });
+    const editor = editorFor(documentOf());
+    const { rerender } = render(<StyleInspectorPanel editor={editor} />);
+
+    fireEvent.change(fieldsOf("padding").getByLabelText("Block start"), {
+      target: { value: "99px" },
+    });
+
+    rerender(<StyleInspectorPanel editor={editor} state="hover" />);
+
+    // A fresh field for the new address, not the base breakpoint's draft.
+    expect(
+      (fieldsOf("padding").getByLabelText("Block start") as HTMLInputElement)
+        .value
+    ).toBe("");
+  });
+
   it("shows a stored token by name rather than as editable text", () => {
     // `{ $token }` is one value spelled as an object. Typing over it would
     // store the token's NAME as a literal — a value that looks right in the
@@ -531,7 +610,9 @@ describe("controls", () => {
     expect(padding.getByText("space.4")).toBeDefined();
     expect(padding.queryByDisplayValue("space.4")).toBeNull();
 
-    fireEvent.click(padding.getByRole("button", { name: "Clear" }));
+    fireEvent.click(
+      padding.getByRole("button", { name: "Clear Padding block start" })
+    );
 
     expect(editor.apply).toHaveBeenCalledTimes(1);
   });

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -353,6 +353,112 @@ describe("controls", () => {
     ).toBe("4px");
   });
 
+  it("offers every form the catalog declares, so an unset union is authorable", () => {
+    // Without this, an unset `borderRadius` could only ever be one radius: the
+    // engine answers with the catalog's first arm when nothing is stored.
+    mount({ border: { radius: true } });
+
+    const trigger = screen.getByLabelText("Form");
+    fireEvent.click(trigger);
+    // Named from the arms' own shape kinds rather than numbered.
+    expect(screen.getByRole("option", { name: "Per corner" })).toBeDefined();
+
+    fireEvent.click(screen.getByRole("option", { name: "Per corner" }));
+
+    expect(
+      fieldsOf("borderRadius").getByLabelText("Start start")
+    ).toBeDefined();
+  });
+
+  it("clears the stored value when the form changes under it", () => {
+    // One radius is not four corners, so there is nothing to carry across — and
+    // leaving the value would snap the panel straight back, because a stored
+    // value decides its own arm.
+    const styles = {
+      base: { [BASE_BREAKPOINT]: { borderRadius: "4px" } },
+    } as NodeStyles;
+    const editor = mount({ border: { radius: true } }, styles);
+
+    fireEvent.click(screen.getByLabelText("Form"));
+    fireEvent.click(screen.getByRole("option", { name: "Per corner" }));
+
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+    expect(editor.apply.mock.calls[0]?.[0]).toEqual({
+      kind: "update",
+      id: "a",
+      patch: {},
+      unset: ["styles"],
+    });
+  });
+
+  it("lets a keyword selection be cleared, which a select cannot offer as an item", () => {
+    const styles = {
+      base: { [BASE_BREAKPOINT]: { mixBlendMode: "multiply" } },
+    } as NodeStyles;
+    const editor = mount({ effects: true }, styles);
+
+    fireEvent.click(
+      fieldsOf("mixBlendMode").getByRole("button", { name: "Clear" })
+    );
+
+    expect(editor.apply.mock.calls[0]?.[0]).toEqual({
+      kind: "update",
+      id: "a",
+      patch: {},
+      unset: ["styles"],
+    });
+  });
+
+  it("shows a stored keyword the catalog does not list verbatim, rather than blank", () => {
+    // The validator accepts keywords case-insensitively and accepts the CSS-wide
+    // keywords everywhere, so `inherit` is live and compiles while matching no
+    // catalog item — and a select showing nothing over a working value reads as
+    // an unset property.
+    const styles = {
+      base: { [BASE_BREAKPOINT]: { mixBlendMode: "inherit" } },
+    } as NodeStyles;
+    mount({ effects: true }, styles);
+
+    expect(fieldsOf("mixBlendMode").getByText("inherit")).toBeDefined();
+  });
+
+  it("reports an edit the op store refused, which the validator cannot anticipate", () => {
+    // `styleWriteOp` judges the edited leaf; `applyOp` judges the whole
+    // document. A page at its byte limit refuses an edit whose value is valid,
+    // and an unreported refusal leaves the field reading as saved.
+    register({ spacing: true });
+    const editor = editorFor(documentOf());
+    editor.apply.mockReturnValue(null);
+    render(<StyleInspectorPanel editor={editor} />);
+
+    const field = fieldsOf("padding").getByLabelText("Block start");
+    fireEvent.change(field, { target: { value: "12px" } });
+    fireEvent.blur(field);
+
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("alert").textContent).toContain(
+      "could not be applied"
+    );
+  });
+
+  it("refuses to style a multi-selection rather than editing its primary", () => {
+    // Exported standalone, so a host can mount it with no wrapper to make this
+    // refusal for it — and `selectedId` is the PRIMARY, so it would silently
+    // change one block while the canvas outlines six.
+    register({ spacing: true });
+    const editor = editorFor(documentOf());
+    const many = {
+      ...editor,
+      selection: { ids: ["a", "b"], primary: "a" },
+    } as unknown as EditorState;
+    render(<StyleInspectorPanel editor={many} />);
+
+    expect(
+      screen.getByText("2 blocks selected. Select one to style it.")
+    ).toBeDefined();
+    expect(screen.queryByLabelText("Block start")).toBeNull();
+  });
+
   it("shows a stored token by name rather than as editable text", () => {
     // `{ $token }` is one value spelled as an object. Typing over it would
     // store the token's NAME as a literal — a value that looks right in the

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -1,0 +1,566 @@
+"use client";
+
+/**
+ * The Style tab: editing the selected block's style values.
+ *
+ * Draws what `style-inspector` decides and decides nothing itself — which
+ * sections a block offers, which properties sit in each, and which control each
+ * property draws all live there, where they can be asserted without a DOM.
+ *
+ * **One section open at a time.** The choice is remembered across selections
+ * rather than reset, because an author working on spacing selects one block
+ * after another and means to stay on spacing; it falls back to the first
+ * section only when the newly selected block does not offer the open one.
+ *
+ * **Text commits on blur, discrete controls immediately**, the same rule the
+ * content tab follows and for the same reason: undo is built from op inverses,
+ * so an op per keystroke would make one undo remove one character.
+ *
+ * **Clearing is not writing an empty value.** An emptied field removes the
+ * entry, so the property falls back through the cascade to whatever a class, a
+ * block default or a wider breakpoint set — which is what an author asking to
+ * reset a control means. Writing `""` would instead pin the property to nothing
+ * here and beat the tier they wanted back.
+ *
+ * **A refused value is shown, not swallowed.** The catalog's own message sits
+ * under the control that produced it, because a field that silently keeps its
+ * old value after an edit reads as an editor that dropped the keystroke.
+ *
+ * @module style-inspector-panel
+ */
+
+import {
+  findNode,
+  isTokenRef,
+  type BreakpointId,
+  type StyleLeaf,
+  type StyleState,
+  type StyleValue,
+} from "@nextlyhq/blocks-engine";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@nextlyhq/ui";
+import * as React from "react";
+
+import type { EditorState } from "./editor-state";
+import { fieldLabel } from "./inspector";
+import type { StyleControl, StyleControlKind } from "./style-controls";
+import {
+  inspectStyle,
+  type InspectedStyleProperty,
+  type StyleSection,
+} from "./style-inspector";
+import {
+  readStyleValue,
+  styleClearOp,
+  styleWriteOp,
+  type StyleAddress,
+  type StylePolicy,
+} from "./style-values";
+
+export interface StyleInspectorPanelProps {
+  /**
+   * The editor whose selected block this styles.
+   *
+   * The whole state rather than a document and an `apply` separately, for the
+   * reason the content tab takes it: a write is built from the node in a
+   * particular document, and passing them apart lets a caller hand a node from
+   * one render to an `apply` bound to another.
+   */
+  editor: EditorState;
+  /**
+   * What the site allows, forwarded to both the arm choice and the write.
+   *
+   * Carried rather than defaulted: the engine ships no host list of its own, so
+   * omitting it does not mean "allow" — it means the question was never asked.
+   */
+  policy?: StylePolicy;
+  /** The interaction state being edited. `base` when the host says nothing. */
+  state?: StyleState;
+  /** The breakpoint being edited. The unconditional one when the host says nothing. */
+  breakpoint?: BreakpointId;
+}
+
+export function StyleInspectorPanel({
+  editor,
+  policy,
+  state,
+  breakpoint,
+}: StyleInspectorPanelProps): React.JSX.Element {
+  // Recomputed each render rather than memoised, as the content tab is: an
+  // inspection is only valid against the document it was read from, and an edit
+  // anywhere changes both the document and the values shown.
+  const inspection = inspectStyle(editor.document, editor.selectedId, {
+    ...policy,
+    state,
+    breakpoint,
+  });
+
+  const [openGroup, setOpenGroup] = React.useState("");
+
+  if (inspection === null) {
+    return (
+      <div className="nx-style-inspector" data-empty="no-selection">
+        <p className="nx-inspector__note">Select a block to style it.</p>
+      </div>
+    );
+  }
+
+  if (inspection.sections.length === 0) {
+    return (
+      <div className="nx-style-inspector" data-empty="no-style-support">
+        <p className="nx-inspector__note">
+          This block does not offer style properties.
+        </p>
+      </div>
+    );
+  }
+
+  const groups = inspection.sections.map(section => section.group);
+  // Held rather than left to the accordion, so the open section survives a
+  // change of selection. Falling back to the first is what keeps it valid when
+  // the newly selected block does not offer the section that was open — an
+  // accordion asked to open a section it does not have shows nothing open at
+  // all, which reads as the panel having failed to load.
+  //
+  // Compared as strings because that is what the accordion hands back, and
+  // narrowing its argument to a catalog group would be this file claiming to
+  // know the vocabulary rather than reading it off the sections in hand.
+  const offered = new Set<string>(groups);
+  const open = offered.has(openGroup) ? openGroup : (groups[0] ?? "");
+
+  return (
+    <div className="nx-style-inspector">
+      <Accordion
+        type="single"
+        collapsible
+        value={open}
+        onValueChange={setOpenGroup}
+      >
+        {inspection.sections.map(section => (
+          <StyleSectionItem
+            // Keyed by node AND group: a bare group would let React reuse one
+            // block's inputs for the next block's same-named section, so a field
+            // would keep the previous block's uncommitted text.
+            key={`${inspection.nodeId}:${section.group}`}
+            section={section}
+            nodeId={inspection.nodeId}
+            state={inspection.state}
+            breakpoint={inspection.breakpoint}
+            editor={editor}
+            policy={policy}
+          />
+        ))}
+      </Accordion>
+    </div>
+  );
+}
+
+/** One catalog group, as a section that opens onto its properties. */
+function StyleSectionItem({
+  section,
+  nodeId,
+  state,
+  breakpoint,
+  editor,
+  policy,
+}: {
+  section: StyleSection;
+  nodeId: string;
+  state: StyleState;
+  breakpoint: BreakpointId;
+  editor: EditorState;
+  policy: StylePolicy | undefined;
+}): React.JSX.Element {
+  // How many of this section's properties this node sets HERE, so an author can
+  // see which sections they have touched without opening each one.
+  const setCount = section.properties.filter(property => property.set).length;
+  return (
+    <AccordionItem value={section.group}>
+      <AccordionTrigger>
+        <span className="nx-style-inspector__section-label">
+          {section.label}
+        </span>
+        {setCount > 0 ? (
+          <span
+            className="nx-style-inspector__section-count"
+            aria-label={`${setCount} set`}
+          >
+            {setCount}
+          </span>
+        ) : null}
+      </AccordionTrigger>
+      <AccordionContent>
+        <div className="nx-inspector__fields">
+          {section.properties.map(property => (
+            <StylePropertyFields
+              key={`${nodeId}:${property.property}`}
+              property={property}
+              nodeId={nodeId}
+              state={state}
+              breakpoint={breakpoint}
+              editor={editor}
+              policy={policy}
+            />
+          ))}
+        </div>
+      </AccordionContent>
+    </AccordionItem>
+  );
+}
+
+/**
+ * One catalog property, which is one control or several.
+ *
+ * `margin` is four logical sides and `position` is a scheme, four offsets and a
+ * stacking order, so a property is a GROUP of controls rather than a field. The
+ * heading is drawn only when there is more than one, because a lone control
+ * already carries the property's name.
+ */
+function StylePropertyFields({
+  property,
+  nodeId,
+  state,
+  breakpoint,
+  editor,
+  policy,
+}: {
+  property: InspectedStyleProperty;
+  nodeId: string;
+  state: StyleState;
+  breakpoint: BreakpointId;
+  editor: EditorState;
+  policy: StylePolicy | undefined;
+}): React.JSX.Element {
+  const many = property.controls.length > 1;
+  return (
+    <div
+      className="nx-style-inspector__property"
+      data-property={property.property}
+    >
+      {many ? (
+        <p
+          className="nx-style-inspector__property-label"
+          title={property.summary}
+        >
+          {property.label}
+        </p>
+      ) : null}
+      {property.controls.map(control => (
+        <StyleControlField
+          key={[property.property, ...control.path].join(".")}
+          control={control}
+          label={
+            many
+              ? fieldLabel(control.path[control.path.length - 1] ?? "")
+              : property.label
+          }
+          summary={many ? undefined : property.summary}
+          nodeId={nodeId}
+          state={state}
+          breakpoint={breakpoint}
+          editor={editor}
+          policy={policy}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** One editable position, drawn as the control its leaf kind resolves to. */
+function StyleControlField({
+  control,
+  label,
+  summary,
+  nodeId,
+  state,
+  breakpoint,
+  editor,
+  policy,
+}: {
+  control: StyleControl;
+  label: string;
+  summary: string | undefined;
+  nodeId: string;
+  state: StyleState;
+  breakpoint: BreakpointId;
+  editor: EditorState;
+  policy: StylePolicy | undefined;
+}): React.JSX.Element {
+  const id = React.useId();
+  const address: StyleAddress = {
+    state,
+    breakpoint,
+    property: control.property,
+    path: control.path,
+  };
+  const node = findNode(editor.document.nodes, nodeId);
+  const stored = readStyleValue(node?.styles, address);
+  const [issue, setIssue] = React.useState<string | null>(null);
+
+  /*
+   * Read the node at commit time rather than closing over one. A field
+   * committing on blur can fire after another edit has already replaced the
+   * node, and writing from the older copy would resurrect its styles.
+   */
+  const commit = (value: StyleValue | null) => {
+    const current = findNode(editor.document.nodes, nodeId);
+    if (current === undefined) return;
+    const write =
+      value === null
+        ? styleClearOp(nodeId, current.styles, address, policy)
+        : styleWriteOp(nodeId, current.styles, address, value, policy);
+    if (!write.ok) {
+      setIssue(write.issues[0]?.message ?? "This value cannot be used here.");
+      return;
+    }
+    setIssue(null);
+    // Null is the store saying the document already holds this value, which is
+    // the ordinary case for a field blurred without being changed. Applying it
+    // would ask the op store for a history entry that undoes to no visible
+    // effect, which it refuses.
+    if (write.op !== null) editor.apply(write.op);
+  };
+
+  if (!control.supported) {
+    return (
+      <div className="nx-inspector__field" data-unsupported={control.leaf.kind}>
+        <Label htmlFor={id}>{label}</Label>
+        <p className="nx-inspector__note">
+          This build has no control for {control.leaf.kind} values.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="nx-inspector__field" data-control={control.kind}>
+      <Label htmlFor={id} title={summary}>
+        {label}
+      </Label>
+      {isTokenRef(stored) ? (
+        <TokenValue name={stored.$token} onClear={() => commit(null)} />
+      ) : (
+        <ValueField
+          id={id}
+          control={control}
+          stored={stored}
+          onCommit={commit}
+        />
+      )}
+      {issue === null ? null : (
+        <p className="nx-inspector__error" role="alert">
+          {issue}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * A stored design-token reference, which is a value no text field can edit.
+ *
+ * Shown by name with a way to remove it rather than as editable text: `{$token}`
+ * is one value spelled as an object, and typing over it would store the token's
+ * NAME as a literal — a value that looks right in the field and compiles to
+ * nothing. Choosing a token is the token picker's job and it does not exist
+ * yet, so what is offered here is the honest half: see it, or clear it.
+ */
+function TokenValue({
+  name,
+  onClear,
+}: {
+  name: string;
+  onClear: () => void;
+}): React.JSX.Element {
+  return (
+    <p className="nx-style-inspector__token">
+      <span>{name}</span>
+      <button type="button" onClick={onClear}>
+        Clear
+      </button>
+    </p>
+  );
+}
+
+/**
+ * The control a leaf's kind resolves to.
+ *
+ * A keyword leaf carries a closed vocabulary and gets a select over it. Every
+ * other kind is drawn as a text field in this build: `length`, `number`,
+ * `color`, `css` and `url` all store a scalar the catalog judges, and the
+ * affordances that tell them apart — a unit stepper, a colour surface, a token
+ * picker — are the control set's, not this panel's. Drawing a text field for
+ * them is what makes each editable now, rather than presenting an incomplete
+ * property as a complete one.
+ */
+function ValueField({
+  id,
+  control,
+  stored,
+  onCommit,
+}: {
+  id: string;
+  control: StyleControl;
+  stored: StyleValue | undefined;
+  onCommit: (value: StyleValue | null) => void;
+}): React.JSX.Element {
+  if (control.kind === "select" && control.leaf.kind === "keyword") {
+    return (
+      <Select
+        value={typeof stored === "string" ? stored : ""}
+        onValueChange={value => onCommit(value)}
+      >
+        <SelectTrigger id={id}>
+          <SelectValue placeholder="Not set" />
+        </SelectTrigger>
+        <SelectContent>
+          {control.leaf.values.map(option => (
+            <SelectItem key={option} value={option}>
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  }
+  return (
+    <TextField id={id} control={control} stored={stored} onCommit={onCommit} />
+  );
+}
+
+/**
+ * A text field over one stored value.
+ *
+ * The draft is local so a half-typed value — `16` on the way to `16px` — is not
+ * sent to the validator on every keystroke and refused four times while the
+ * author is still typing.
+ */
+function TextField({
+  id,
+  control,
+  stored,
+  onCommit,
+}: {
+  id: string;
+  control: StyleControl;
+  stored: StyleValue | undefined;
+  onCommit: (value: StyleValue | null) => void;
+}): React.JSX.Element {
+  const [draft, setDraft] = React.useState(() => storedText(stored));
+
+  // The stored value wins whenever it changes underneath the field — an undo, a
+  // scrub, an edit applied from somewhere else. Without this the input would go
+  // on showing a value the document no longer has.
+  React.useEffect(() => {
+    setDraft(storedText(stored));
+  }, [stored]);
+
+  const commit = () => {
+    if (draft === storedText(stored)) return;
+    onCommit(draft.trim() === "" ? null : committedValue(control.kind, draft));
+  };
+
+  return (
+    <Input
+      id={id}
+      value={draft}
+      placeholder={placeholderFor(control)}
+      // Committed on blur and on Enter, matching the content tab: an op per
+      // keystroke would make one undo remove one character.
+      onChange={event => setDraft(event.target.value)}
+      onBlur={commit}
+      onKeyDown={event => {
+        if (event.key !== "Enter") return;
+        event.preventDefault();
+        commit();
+      }}
+    />
+  );
+}
+
+/** A stored value as a text field shows it. */
+function storedText(value: StyleValue | undefined): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  return "";
+}
+
+/**
+ * What a typed string is stored as.
+ *
+ * A `number` leaf takes a NUMBER, and accepts a string only as one of the
+ * CSS-wide keywords — measured: `opacity: "0.5"` is refused where `opacity: 0.5`
+ * is accepted. So a numeric-looking draft is converted and anything else is
+ * passed through, which is what lets `inherit` reach a numeric property and
+ * lets every other refusal carry the catalog's own message.
+ *
+ * Every other kind stores its value as written: a `dimension` accepts the
+ * string `"0"` as readily as the number, so converting there would change what
+ * is stored without changing what is valid.
+ */
+function committedValue(
+  kind: StyleControlKind | undefined,
+  draft: string
+): StyleValue {
+  if (kind !== "number") return draft;
+  const trimmed = draft.trim();
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : draft;
+}
+
+/**
+ * The hint for a kind whose form does not vary with the leaf's own fields.
+ *
+ * Partial on purpose, and the one place in this lane where a fallthrough is the
+ * right answer: a placeholder is advisory text, so a leaf kind this build has
+ * not learned about gets a generic hint rather than a compile error. Whether
+ * the kind can be DRAWN at all is a different question, and `style-controls.ts`
+ * already answers it with a mapped type that does fail to compile.
+ */
+const FIXED_PLACEHOLDER: Partial<Record<StyleLeaf["kind"], string>> = {
+  keyword: "Not set",
+  cssValue: "Not set",
+  // The FORM rather than an example, as the length and number hints are. A
+  // literal here would also be a hardcoded colour, which this repository bans
+  // outright — the rule reads source, not intent, and it is right to: a hex in
+  // a placeholder is one copy away from a hex in a style.
+  color: "hex, rgb(), or a colour name",
+  url: "https://…",
+};
+
+/** A length's hint, which depends on what the catalog lets this one hold. */
+function dimensionHint(
+  leaf: Extract<StyleLeaf, { kind: "dimension" }>
+): string {
+  const units = leaf.allowPercentage === true ? "16px or 50%" : "16px";
+  // The catalog's helper always writes this field, and the TYPE leaves it
+  // optional — so a leaf assembled by hand, which every fixture in this package
+  // is, legitimately arrives without one.
+  const keywords = leaf.keywords ?? [];
+  return keywords.length > 0 ? `${units}, or ${keywords.join(", ")}` : units;
+}
+
+/** A number's hint, which names its bounds when the catalog gives it both. */
+function numberHint(leaf: Extract<StyleLeaf, { kind: "number" }>): string {
+  if (leaf.min === undefined || leaf.max === undefined) return "a number";
+  return `${leaf.min} to ${leaf.max}`;
+}
+
+/** A hint at the form this leaf takes, from the catalog rather than a list here. */
+function placeholderFor(control: StyleControl): string {
+  const { leaf } = control;
+  if (leaf.kind === "dimension") return dimensionHint(leaf);
+  if (leaf.kind === "number") return numberHint(leaf);
+  return FIXED_PLACEHOLDER[leaf.kind] ?? "Not set";
+}

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -34,6 +34,7 @@ import {
   isTokenRef,
   type BreakpointId,
   type StyleLeaf,
+  type StyleShape,
   type StyleState,
   type StyleValue,
 } from "@nextlyhq/blocks-engine";
@@ -54,7 +55,11 @@ import * as React from "react";
 
 import type { EditorState } from "./editor-state";
 import { fieldLabel } from "./inspector";
-import type { StyleControl, StyleControlKind } from "./style-controls";
+import type {
+  StyleControl,
+  StyleControlKind,
+  StyleControlVariants,
+} from "./style-controls";
 import {
   inspectStyle,
   type InspectedStyleProperty,
@@ -97,6 +102,15 @@ export function StyleInspectorPanel({
   state,
   breakpoint,
 }: StyleInspectorPanelProps): React.JSX.Element {
+  const [openGroup, setOpenGroup] = React.useState("");
+  // The form an author chose at a union position, keyed by property and path.
+  // Panel state rather than document state: it is only consulted where nothing
+  // is stored, so there is nothing to persist — the moment a value exists, the
+  // value decides its own form.
+  const [chosenForms, setChosenForms] = React.useState<Record<string, number>>(
+    {}
+  );
+
   // Recomputed each render rather than memoised, as the content tab is: an
   // inspection is only valid against the document it was read from, and an edit
   // anywhere changes both the document and the values shown.
@@ -104,9 +118,34 @@ export function StyleInspectorPanel({
     ...policy,
     state,
     breakpoint,
+    variantAt: (property, path) => chosenForms[formKey(property, path)],
   });
 
-  const [openGroup, setOpenGroup] = React.useState("");
+  const chooseForm = (property: string, path: readonly string[], arm: number) =>
+    setChosenForms(current => ({ ...current, [formKey(property, path)]: arm }));
+
+  /*
+   * Several blocks selected: a different panel, not a thinner one.
+   *
+   * `selectedId` is the PRIMARY of the selection, so inspecting it would draw
+   * writable controls that change one block while the canvas outlines six —
+   * two surfaces answering different questions with the same words. The
+   * inspector wrapper makes the same refusal for the content half; this one
+   * makes it for itself because it is exported standalone, and a host mounting
+   * it directly gets no wrapper.
+   *
+   * Per-property batch editing is Plan 05's batch edit and is deliberately not
+   * here.
+   */
+  if (editor.selection.ids.length > 1) {
+    return (
+      <div className="nx-style-inspector" data-empty="many-selected">
+        <p className="nx-inspector__note">
+          {editor.selection.ids.length} blocks selected. Select one to style it.
+        </p>
+      </div>
+    );
+  }
 
   if (inspection === null) {
     return (
@@ -159,6 +198,7 @@ export function StyleInspectorPanel({
             breakpoint={inspection.breakpoint}
             editor={editor}
             policy={policy}
+            onChooseForm={chooseForm}
           />
         ))}
       </Accordion>
@@ -174,6 +214,7 @@ function StyleSectionItem({
   breakpoint,
   editor,
   policy,
+  onChooseForm,
 }: {
   section: StyleSection;
   nodeId: string;
@@ -181,6 +222,7 @@ function StyleSectionItem({
   breakpoint: BreakpointId;
   editor: EditorState;
   policy: StylePolicy | undefined;
+  onChooseForm: ChooseForm;
 }): React.JSX.Element {
   // How many of this section's properties this node sets HERE, so an author can
   // see which sections they have touched without opening each one.
@@ -211,6 +253,7 @@ function StyleSectionItem({
               breakpoint={breakpoint}
               editor={editor}
               policy={policy}
+              onChooseForm={onChooseForm}
             />
           ))}
         </div>
@@ -234,6 +277,7 @@ function StylePropertyFields({
   breakpoint,
   editor,
   policy,
+  onChooseForm,
 }: {
   property: InspectedStyleProperty;
   nodeId: string;
@@ -241,6 +285,7 @@ function StylePropertyFields({
   breakpoint: BreakpointId;
   editor: EditorState;
   policy: StylePolicy | undefined;
+  onChooseForm: ChooseForm;
 }): React.JSX.Element {
   const many = property.controls.length > 1;
   return (
@@ -256,6 +301,28 @@ function StylePropertyFields({
           {property.label}
         </p>
       ) : null}
+      {/*
+        The forms the catalog offers at each union position, so every one is
+        reachable. Without this an unset `borderRadius` could only ever be
+        authored as a single radius and `position.zIndex` only as a number: the
+        engine answers with the catalog's first arm when nothing is stored, and
+        that answer is right precisely because the author has not spoken yet.
+      */}
+      {property.variants
+        .filter(variant => variant.count > 1)
+        .map(variant => (
+          <FormChoice
+            key={variant.path.join(".")}
+            property={property}
+            variant={variant}
+            nodeId={nodeId}
+            state={state}
+            breakpoint={breakpoint}
+            editor={editor}
+            policy={policy}
+            onChooseForm={onChooseForm}
+          />
+        ))}
       {property.controls.map(control => (
         <StyleControlField
           key={[property.property, ...control.path].join(".")}
@@ -273,6 +340,108 @@ function StylePropertyFields({
           policy={policy}
         />
       ))}
+    </div>
+  );
+}
+
+/** How an author says which form they mean to write a value in. */
+type ChooseForm = (
+  property: string,
+  path: readonly string[],
+  arm: number
+) => void;
+
+/** The panel-state key for one union position. */
+function formKey(property: string, path: readonly string[]): string {
+  return [property, ...path].join(".");
+}
+
+/**
+ * What each form is called, from the arm's own shape kind.
+ *
+ * The catalog gives arms no names, so their shape kind is the most specific
+ * thing it says about them — and "Form 1 / Form 2" tells an author nothing
+ * about which is which. Partial for the same reason the placeholders are: this
+ * is a label, so a kind this build has not learned about gets the kind itself
+ * rather than a compile error.
+ */
+const FORM_LABEL: Partial<Record<StyleShape["kind"], string>> = {
+  dimension: "Length",
+  number: "Number",
+  keyword: "Keyword",
+  color: "Colour",
+  cssValue: "Custom",
+  url: "URL",
+  logicalSides: "Per side",
+  logicalCorners: "Per corner",
+  object: "Fields",
+  union: "Mixed",
+};
+
+/**
+ * The choice of form at one union position.
+ *
+ * Choosing a form while a value is stored CLEARS it. The two forms hold
+ * different things — one radius is not four corners — so there is nothing to
+ * carry across, and leaving the value in place would be worse than clearing:
+ * the stored value decides its own arm, so the panel would snap straight back
+ * to the form the author just moved away from.
+ */
+function FormChoice({
+  property,
+  variant,
+  nodeId,
+  state,
+  breakpoint,
+  editor,
+  policy,
+  onChooseForm,
+}: {
+  property: InspectedStyleProperty;
+  variant: StyleControlVariants;
+  nodeId: string;
+  state: StyleState;
+  breakpoint: BreakpointId;
+  editor: EditorState;
+  policy: StylePolicy | undefined;
+  onChooseForm: ChooseForm;
+}): React.JSX.Element {
+  const id = React.useId();
+  const choose = (raw: string) => {
+    const arm = Number(raw);
+    if (!Number.isInteger(arm)) return;
+    onChooseForm(property.property, variant.path, arm);
+    if (!property.set) return;
+    const current = findNode(editor.document.nodes, nodeId);
+    if (current === undefined) return;
+    const cleared = styleClearOp(
+      nodeId,
+      current.styles,
+      { state, breakpoint, property: property.property, path: [] },
+      policy
+    );
+    if (cleared.ok && cleared.op !== null) editor.apply(cleared.op);
+  };
+
+  return (
+    <div className="nx-inspector__field" data-form-choice={property.property}>
+      <Label htmlFor={id}>
+        {variant.path.length === 0
+          ? "Form"
+          : `${fieldLabel(variant.path[variant.path.length - 1] ?? "")} form`}
+      </Label>
+      <Select value={String(variant.active)} onValueChange={choose}>
+        <SelectTrigger id={id}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {variant.kinds.map((kind, index) => (
+            <SelectItem key={`${index}:${kind}`} value={String(index)}>
+              {FORM_LABEL[kind] ?? kind}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
     </div>
   );
 }
@@ -338,7 +507,15 @@ function StyleControlField({
     // the ordinary case for a field blurred without being changed. Applying it
     // would ask the op store for a history entry that undoes to no visible
     // effect, which it refuses.
-    if (write.op !== null) editor.apply(write.op);
+    if (write.op === null) return;
+    // The store's own refusal, which the validator cannot anticipate: it judges
+    // the edited leaf, while `applyOp` judges the whole document — a page at
+    // its byte limit rejects an edit whose value is perfectly valid. Unreported,
+    // the field goes on showing the draft and reads as saved while neither the
+    // document nor the undo history moved.
+    if (editor.apply(write.op) === null) {
+      setIssue("This edit could not be applied to the document.");
+    }
   };
 
   if (!control.supported) {
@@ -437,22 +614,45 @@ function ValueField({
   onCommit: (value: StyleValue | null) => void;
 }): React.JSX.Element {
   if (control.kind === "select" && control.leaf.kind === "keyword") {
+    const current = typeof stored === "string" ? stored : "";
+    // The validator accepts a keyword case-insensitively, with surrounding CSS
+    // whitespace and escapes, and accepts the CSS-wide keywords everywhere — so
+    // a stored `Bold` or `inherit` is live and compiles while matching no item
+    // here, and the select would render empty over a value that is doing
+    // something. Offered VERBATIM as its own item rather than normalised: any
+    // rule written here to fold spellings would be a second copy of the
+    // engine's, and the stored string is the one thing that needs no rule.
+    const extra =
+      current !== "" && !control.leaf.values.includes(current) ? current : null;
     return (
-      <Select
-        value={typeof stored === "string" ? stored : ""}
-        onValueChange={value => onCommit(value)}
-      >
-        <SelectTrigger id={id}>
-          <SelectValue placeholder="Not set" />
-        </SelectTrigger>
-        <SelectContent>
-          {control.leaf.values.map(option => (
-            <SelectItem key={option} value={option}>
-              {option}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      <div className="nx-style-inspector__select">
+        <Select value={current} onValueChange={value => onCommit(value)}>
+          <SelectTrigger id={id}>
+            <SelectValue placeholder="Not set" />
+          </SelectTrigger>
+          <SelectContent>
+            {extra === null ? null : (
+              <SelectItem value={extra}>{extra}</SelectItem>
+            )}
+            {control.leaf.values.map(option => (
+              <SelectItem key={option} value={option}>
+                {option}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {/*
+          A select cannot offer "unset" as an item: an empty value is not a
+          choice the list can carry, and a sentinel standing for it would mean
+          two things at once. A button beside it clears, which is the same act
+          an emptied text field performs.
+        */}
+        {current === "" ? null : (
+          <button type="button" onClick={() => onCommit(null)}>
+            Clear
+          </button>
+        )}
+      </div>
     );
   }
   return (

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -597,21 +597,29 @@ function StyleControlField({
     );
   }
 
+  // A value that cannot be typed into is shown, not edited — and HTML's `for`
+  // only associates a label with a LABELABLE element (input, select, textarea,
+  // button, output, meter, progress). Pointing it at the paragraph those
+  // branches render drops the association silently, so the label carries an id
+  // of its own and the value points back at it instead.
+  const readOnly = clearOnly || isTokenRef(stored);
+  const labelId = `${id}-label`;
+
   return (
     <div className="nx-inspector__field" data-control={control.kind}>
-      <Label htmlFor={id} title={summary}>
+      <Label id={labelId} htmlFor={readOnly ? undefined : id} title={summary}>
         {label}
       </Label>
       {clearOnly ? (
         <RetainedValue
-          id={id}
+          labelledBy={labelId}
           label={actionName}
           stored={stored}
           onClear={() => commit(null)}
         />
       ) : isTokenRef(stored) ? (
         <TokenValue
-          id={id}
+          labelledBy={labelId}
           label={actionName}
           name={stored.$token}
           onClear={() => commit(null)}
@@ -644,12 +652,13 @@ function StyleControlField({
  * yet, so what is offered here is the honest half: see it, or clear it.
  */
 function TokenValue({
-  id,
+  labelledBy,
   label,
   name,
   onClear,
 }: {
-  id: string;
+  /** The id of the label element that names this value. */
+  labelledBy: string;
   label: string;
   name: string;
   onClear: () => void;
@@ -660,7 +669,11 @@ function TokenValue({
     // PROPERTY, because a panel with several token-valued properties otherwise
     // offers a column of buttons all called "Clear" and a screen-reader user
     // cannot tell which style each one removes.
-    <p className="nx-style-inspector__token" id={id} tabIndex={-1}>
+    <p
+      className="nx-style-inspector__token"
+      aria-labelledby={labelledBy}
+      tabIndex={-1}
+    >
       <span>{name}</span>
       <button type="button" onClick={onClear} aria-label={`Clear ${label}`}>
         Clear
@@ -676,18 +689,23 @@ function TokenValue({
  * these on one panel would otherwise be a column of identical "Clear" buttons.
  */
 function RetainedValue({
-  id,
+  labelledBy,
   label,
   stored,
   onClear,
 }: {
-  id: string;
+  /** The id of the label element that names this value. */
+  labelledBy: string;
   label: string;
   stored: StyleValue | undefined;
   onClear: () => void;
 }): React.JSX.Element {
   return (
-    <p className="nx-style-inspector__token" id={id} tabIndex={-1}>
+    <p
+      className="nx-style-inspector__token"
+      aria-labelledby={labelledBy}
+      tabIndex={-1}
+    >
       <span>{isTokenRef(stored) ? stored.$token : storedText(stored)}</span>
       <button type="button" onClick={onClear} aria-label={`Clear ${label}`}>
         Clear

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -621,6 +621,7 @@ function StyleControlField({
           id={id}
           control={control}
           stored={stored}
+          actionName={actionName}
           onCommit={commit}
         />
       )}
@@ -710,11 +711,14 @@ function ValueField({
   id,
   control,
   stored,
+  actionName,
   onCommit,
 }: {
   id: string;
   control: StyleControl;
   stored: StyleValue | undefined;
+  /** What this control's clear action removes, named for the property. */
+  actionName: string;
   onCommit: (value: StyleValue | null) => void;
 }): React.JSX.Element {
   if (control.kind === "select" && control.leaf.kind === "keyword") {
@@ -752,7 +756,11 @@ function ValueField({
           an emptied text field performs.
         */}
         {current === "" ? null : (
-          <button type="button" onClick={() => onCommit(null)}>
+          <button
+            type="button"
+            onClick={() => onCommit(null)}
+            aria-label={`Clear ${actionName}`}
+          >
             Clear
           </button>
         )}
@@ -793,7 +801,12 @@ function TextField({
 
   const commit = () => {
     if (draft === storedText(stored)) return;
-    onCommit(draft.trim() === "" ? null : committedValue(control.kind, draft));
+    // CSS whitespace here too, not JavaScript's. `String.prototype.trim` also
+    // strips NBSP and the Unicode spaces, so a draft of nothing but a
+    // non-breaking space would read as empty and DELETE the declaration —
+    // where the engine treats it as a value and refuses it.
+    const emptied = trimCssWhitespace(draft) === "";
+    onCommit(emptied ? null : committedValue(control.kind, draft));
   };
 
   return (

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -415,15 +415,22 @@ function FormChoice({
     const arm = Number(raw);
     if (!Number.isInteger(arm)) return;
     onChooseForm(property.property, variant.path, arm);
-    if (!property.set) return;
     const current = findNode(editor.document.nodes, nodeId);
     if (current === undefined) return;
-    const cleared = styleClearOp(
-      nodeId,
-      current.styles,
-      { state, breakpoint, property: property.property, path: [] },
-      policy
-    );
+    // The union's OWN position, not the property's root. A union can sit below
+    // it — `position` holds a type, an inset and a zIndex, and only the last is
+    // a union — so clearing the root to change the zIndex form would delete the
+    // author's positioning scheme and offsets along with it.
+    const address: StyleAddress = {
+      state,
+      breakpoint,
+      property: property.property,
+      path: variant.path,
+    };
+    // Read at this position for the same reason: `property.set` answers for the
+    // whole property, which is true whenever any sibling holds a value.
+    if (readStyleValue(current.styles, address) === undefined) return;
+    const cleared = styleClearOp(nodeId, current.styles, address, policy);
     if (cleared.ok && cleared.op !== null) editor.apply(cleared.op);
   };
 

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -139,8 +139,9 @@ export function StyleInspectorPanel({
    * makes it for itself because it is exported standalone, and a host mounting
    * it directly gets no wrapper.
    *
-   * Per-property batch editing is Plan 05's batch edit and is deliberately not
-   * here.
+   * Editing one property across a whole selection — one field showing "Mixed"
+   * and writing to every block — is a different surface with its own rules
+   * about what a shared value means, and it does not exist yet.
    */
   if (editor.selection.ids.length > 1) {
     return (
@@ -524,6 +525,11 @@ function StyleControlField({
   policy: StylePolicy | undefined;
 }): React.JSX.Element {
   const id = React.useId();
+  // The message's own id, so the control can point at it. A `role="alert"`
+  // announces once and then it is gone: a screen-reader user who returns to the
+  // field, or meets several rejected controls, has no way to tell which message
+  // belongs to which without the relationship being stated.
+  const errorId = `${id}-error`;
   const address: StyleAddress = {
     state,
     breakpoint,
@@ -617,35 +623,81 @@ function StyleControlField({
       <Label id={labelId} htmlFor={readOnly ? undefined : id} title={summary}>
         {label}
       </Label>
-      {clearOnly ? (
-        <RetainedValue
-          labelledBy={labelId}
-          label={actionName}
-          stored={stored}
-          onClear={() => commit(null)}
-        />
-      ) : isTokenRef(stored) ? (
-        <TokenValue
-          labelledBy={labelId}
-          label={actionName}
-          name={stored.$token}
-          onClear={() => commit(null)}
-        />
-      ) : (
-        <ValueField
-          id={id}
-          control={control}
-          stored={stored}
-          actionName={actionName}
-          onCommit={commit}
-        />
-      )}
+      <ControlValue
+        id={id}
+        labelledBy={labelId}
+        control={control}
+        stored={stored}
+        actionName={actionName}
+        clearOnly={clearOnly}
+        describedBy={issue === null ? undefined : errorId}
+        onCommit={commit}
+      />
       {issue === null ? null : (
-        <p className="nx-inspector__error" role="alert">
+        <p className="nx-inspector__error" id={errorId} role="alert">
           {issue}
         </p>
       )}
     </div>
+  );
+}
+
+/**
+ * The surface one value is shown through: read-only, a token, or editable.
+ *
+ * Its own component rather than a chain of conditionals inside the field,
+ * because the three are genuinely different surfaces — one of them cannot be
+ * typed into at all — and reading them as early returns says that, where a
+ * nested ternary reads as one control with two exceptions.
+ */
+function ControlValue({
+  id,
+  labelledBy,
+  control,
+  stored,
+  actionName,
+  clearOnly,
+  describedBy,
+  onCommit,
+}: {
+  id: string;
+  labelledBy: string;
+  control: StyleControl;
+  stored: StyleValue | undefined;
+  actionName: string;
+  clearOnly: boolean;
+  describedBy: string | undefined;
+  onCommit: (value: StyleValue | null) => void;
+}): React.JSX.Element {
+  if (clearOnly) {
+    return (
+      <RetainedValue
+        labelledBy={labelledBy}
+        label={actionName}
+        stored={stored}
+        onClear={() => onCommit(null)}
+      />
+    );
+  }
+  if (isTokenRef(stored)) {
+    return (
+      <TokenValue
+        labelledBy={labelledBy}
+        label={actionName}
+        name={stored.$token}
+        onClear={() => onCommit(null)}
+      />
+    );
+  }
+  return (
+    <ValueField
+      id={id}
+      control={control}
+      stored={stored}
+      actionName={actionName}
+      describedBy={describedBy}
+      onCommit={onCommit}
+    />
   );
 }
 
@@ -737,6 +789,7 @@ function ValueField({
   control,
   stored,
   actionName,
+  describedBy,
   onCommit,
 }: {
   id: string;
@@ -744,6 +797,13 @@ function ValueField({
   stored: StyleValue | undefined;
   /** What this control's clear action removes, named for the property. */
   actionName: string;
+  /**
+   * The id of the message explaining why this control's last value was refused,
+   * or `undefined` when nothing was. Also what marks the control invalid: the
+   * two travel together because a control described by an error message and not
+   * marked invalid reads as one carrying a hint.
+   */
+  describedBy: string | undefined;
   onCommit: (value: StyleValue | null) => void;
 }): React.JSX.Element {
   if (control.kind === "select" && control.leaf.kind === "keyword") {
@@ -760,7 +820,11 @@ function ValueField({
     return (
       <div className="nx-style-inspector__select">
         <Select value={current} onValueChange={value => onCommit(value)}>
-          <SelectTrigger id={id}>
+          <SelectTrigger
+            id={id}
+            aria-describedby={describedBy}
+            aria-invalid={describedBy === undefined ? undefined : true}
+          >
             <SelectValue placeholder="Not set" />
           </SelectTrigger>
           <SelectContent>
@@ -793,7 +857,13 @@ function ValueField({
     );
   }
   return (
-    <TextField id={id} control={control} stored={stored} onCommit={onCommit} />
+    <TextField
+      id={id}
+      control={control}
+      stored={stored}
+      describedBy={describedBy}
+      onCommit={onCommit}
+    />
   );
 }
 
@@ -808,11 +878,14 @@ function TextField({
   id,
   control,
   stored,
+  describedBy,
   onCommit,
 }: {
   id: string;
   control: StyleControl;
   stored: StyleValue | undefined;
+  /** The id of the message explaining a refusal, and what marks this invalid. */
+  describedBy: string | undefined;
   onCommit: (value: StyleValue | null) => void;
 }): React.JSX.Element {
   const [draft, setDraft] = React.useState(() => storedText(stored));
@@ -839,6 +912,8 @@ function TextField({
       id={id}
       value={draft}
       placeholder={placeholderFor(control)}
+      aria-describedby={describedBy}
+      aria-invalid={describedBy === undefined ? undefined : true}
       // Committed on blur and on Enter, matching the content tab: an op per
       // keystroke would make one undo remove one character.
       onChange={event => setDraft(event.target.value)}

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -308,6 +308,15 @@ function StyleControlField({
   const stored = readStyleValue(node?.styles, address);
   const [issue, setIssue] = React.useState<string | null>(null);
 
+  // A refusal describes the draft that produced it, so it stops describing
+  // anything the moment the document holds a different value here. Clearing on
+  // the stored value rather than only on the next commit is what covers an undo
+  // or an edit applied from elsewhere: the remount key changes with the
+  // SELECTION, and neither of those changes the selection.
+  React.useEffect(() => {
+    setIssue(null);
+  }, [stored]);
+
   /*
    * Read the node at commit time rather than closing over one. A field
    * committing on blur can fire after another edit has already replaced the
@@ -335,7 +344,19 @@ function StyleControlField({
   if (!control.supported) {
     return (
       <div className="nx-inspector__field" data-unsupported={control.leaf.kind}>
-        <Label htmlFor={id}>{label}</Label>
+        {/*
+          Plain text, not a `<label>`. This branch renders no control, so a
+          label would carry `htmlFor` to an id nothing has — which a screen
+          reader announces as a field that cannot be reached, worse than the
+          note below saying plainly that there is nothing to reach.
+
+          UNTESTED, and stated rather than left to be assumed: every leaf kind
+          the engine ships resolves to a control, so nothing reaches this branch
+          today. It exists for a catalog written by a NEWER engine, and the
+          catalog is compiled in rather than registered, so no fixture can hand
+          this panel an unknown kind.
+        */}
+        <p className="nx-style-inspector__property-label">{label}</p>
         <p className="nx-inspector__note">
           This build has no control for {control.leaf.kind} values.
         </p>

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -32,6 +32,7 @@
 import {
   findNode,
   isTokenRef,
+  trimCssWhitespace,
   type BreakpointId,
   type StyleLeaf,
   type StyleShape,
@@ -327,9 +328,22 @@ function StylePropertyFields({
             onChooseForm={onChooseForm}
           />
         ))}
+      {property.offered ? null : (
+        <p className="nx-inspector__note" data-not-offered={property.property}>
+          This block no longer offers {property.label}. The value is still on
+          the page and can be cleared.
+        </p>
+      )}
       {property.controls.map(control => (
         <StyleControlField
-          key={[property.property, ...control.path].join(".")}
+          // The ADDRESS, not just the position: a host switching state or
+          // breakpoint leaves this field mounted, and where the old and new
+          // addresses hold the same value — both unset, most often — the
+          // synchronisation effect does not run either. An unfinished draft
+          // from the base breakpoint would then commit into the hover state.
+          key={[state, breakpoint, property.property, ...control.path].join(
+            "."
+          )}
           control={control}
           label={
             many
@@ -337,6 +351,8 @@ function StylePropertyFields({
               : property.label
           }
           summary={many ? undefined : property.summary}
+          propertyLabel={property.label}
+          clearOnly={!property.offered}
           nodeId={nodeId}
           state={state}
           breakpoint={breakpoint}
@@ -462,6 +478,8 @@ function StyleControlField({
   control,
   label,
   summary,
+  propertyLabel,
+  clearOnly,
   nodeId,
   state,
   breakpoint,
@@ -471,6 +489,27 @@ function StyleControlField({
   control: StyleControl;
   label: string;
   summary: string | undefined;
+  /**
+   * The whole property's name, for naming an ACTION rather than a field.
+   *
+   * A field is labelled by its position — "Block start" — which is enough
+   * beside its own property's heading and not enough on a button: `padding` and
+   * `margin` both have a block start, so two buttons called "Clear block start"
+   * name the same thing twice and a screen-reader user cannot tell which style
+   * each removes.
+   */
+  propertyLabel: string;
+  /**
+   * Whether this value may only be REMOVED, not changed.
+   *
+   * True for a property the block's `supports` no longer declares. The value is
+   * still emitted — nothing in validation or compilation reads `supports` — so
+   * withholding the control entirely would leave styling on the page that the
+   * author can see and cannot remove. Letting them go on EDITING it is the
+   * other error: it writes new values through a capability the block has
+   * withdrawn, which is the definition the panel is supposed to be reading.
+   */
+  clearOnly: boolean;
   nodeId: string;
   state: StyleState;
   breakpoint: BreakpointId;
@@ -486,6 +525,12 @@ function StyleControlField({
   };
   const node = findNode(editor.document.nodes, nodeId);
   const stored = readStyleValue(node?.styles, address);
+  // The property alone where a property draws one control, and the property
+  // plus the position where it draws several.
+  const actionName =
+    propertyLabel === label
+      ? propertyLabel
+      : `${propertyLabel} ${label.toLowerCase()}`;
   const [issue, setIssue] = React.useState<string | null>(null);
 
   // A refusal describes the draft that produced it, so it stops describing
@@ -557,8 +602,20 @@ function StyleControlField({
       <Label htmlFor={id} title={summary}>
         {label}
       </Label>
-      {isTokenRef(stored) ? (
-        <TokenValue name={stored.$token} onClear={() => commit(null)} />
+      {clearOnly ? (
+        <RetainedValue
+          id={id}
+          label={actionName}
+          stored={stored}
+          onClear={() => commit(null)}
+        />
+      ) : isTokenRef(stored) ? (
+        <TokenValue
+          id={id}
+          label={actionName}
+          name={stored.$token}
+          onClear={() => commit(null)}
+        />
       ) : (
         <ValueField
           id={id}
@@ -586,16 +643,52 @@ function StyleControlField({
  * yet, so what is offered here is the honest half: see it, or clear it.
  */
 function TokenValue({
+  id,
+  label,
   name,
   onClear,
 }: {
+  id: string;
+  label: string;
   name: string;
   onClear: () => void;
 }): React.JSX.Element {
   return (
-    <p className="nx-style-inspector__token">
+    // The id lands on the value, so the property's own label names it: without
+    // that the label points at nothing. And the button is named for the
+    // PROPERTY, because a panel with several token-valued properties otherwise
+    // offers a column of buttons all called "Clear" and a screen-reader user
+    // cannot tell which style each one removes.
+    <p className="nx-style-inspector__token" id={id} tabIndex={-1}>
       <span>{name}</span>
-      <button type="button" onClick={onClear}>
+      <button type="button" onClick={onClear} aria-label={`Clear ${label}`}>
+        Clear
+      </button>
+    </p>
+  );
+}
+
+/**
+ * A value the block no longer supports: shown, and removable, not editable.
+ *
+ * Named for the property for the same reason the token control is — several of
+ * these on one panel would otherwise be a column of identical "Clear" buttons.
+ */
+function RetainedValue({
+  id,
+  label,
+  stored,
+  onClear,
+}: {
+  id: string;
+  label: string;
+  stored: StyleValue | undefined;
+  onClear: () => void;
+}): React.JSX.Element {
+  return (
+    <p className="nx-style-inspector__token" id={id} tabIndex={-1}>
+      <span>{isTokenRef(stored) ? stored.$token : storedText(stored)}</span>
+      <button type="button" onClick={onClear} aria-label={`Clear ${label}`}>
         Clear
       </button>
     </p>
@@ -772,7 +865,11 @@ function committedValue(
   draft: string
 ): StyleValue {
   if (kind !== "number") return draft;
-  const trimmed = draft.trim();
+  // The engine's own trim, not `String.prototype.trim`, which also strips NBSP
+  // and the Unicode spaces where CSS strips neither. Trimming wider than CSS
+  // does turns a spelling the engine REFUSES into a number it accepts: pasting
+  // a non-breaking space before a digit would silently store the digit.
+  const trimmed = trimCssWhitespace(draft);
   // `Number` reads spellings CSS does not: `0x10` becomes 16, `0b10` becomes 2,
   // `0o10` becomes 8. Converting those would store a number the author never
   // typed and pass validation, so only the grammar CSS calls a <number> is

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -723,13 +723,15 @@ function TokenValue({
   onClear: () => void;
 }): React.JSX.Element {
   return (
-    // The id lands on the value, so the property's own label names it: without
-    // that the label points at nothing. And the button is named for the
-    // PROPERTY, because a panel with several token-valued properties otherwise
-    // offers a column of buttons all called "Clear" and a screen-reader user
-    // cannot tell which style each one removes.
+    // Named by the property's own label, and given a role that can CARRY a
+    // name: a bare paragraph maps to the ARIA `paragraph` role, which prohibits
+    // one, so `aria-labelledby` on it may be dropped outright. The button is
+    // named for the PROPERTY as well, because a panel with several
+    // token-valued properties otherwise offers a column of buttons all called
+    // "Clear" and a screen-reader user cannot tell which style each removes.
     <p
       className="nx-style-inspector__token"
+      role="group"
       aria-labelledby={labelledBy}
       tabIndex={-1}
     >
@@ -760,8 +762,11 @@ function RetainedValue({
   onClear: () => void;
 }): React.JSX.Element {
   return (
+    // `group` for the reason {@link TokenValue} carries one: the ARIA
+    // `paragraph` role a bare paragraph maps to prohibits an accessible name.
     <p
       className="nx-style-inspector__token"
+      role="group"
       aria-labelledby={labelledBy}
       tabIndex={-1}
     >

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -453,8 +453,15 @@ function FormChoice({
   return (
     <div className="nx-inspector__field" data-form-choice={property.property}>
       <Label htmlFor={id}>
+        {/*
+          The PROPERTY's name at the root, because a property whose shape is a
+          union at the top draws one control and therefore no heading — so
+          `fontWeight`, `lineHeight` and `fontStyle` would all offer a selector
+          called "Form". Below the root the heading is rendered, so the position
+          is enough to tell them apart.
+        */}
         {variant.path.length === 0
-          ? "Form"
+          ? `${property.label} form`
           : `${fieldLabel(variant.path[variant.path.length - 1] ?? "")} form`}
       </Label>
       <Select value={String(variant.active)} onValueChange={choose}>
@@ -866,10 +873,16 @@ function openSection(
 
 /**
  * The grammar CSS calls a `<number>`: an optional sign, digits with an optional
- * decimal part, and an optional exponent. Deliberately narrower than
- * `Number` — see {@link committedValue}.
+ * decimal part, and an optional exponent.
+ *
+ * Deliberately narrower than `Number` in both directions. `Number` reads
+ * spellings CSS does not (`0x10`, `0b10`, `0o10`), and it also accepts a
+ * trailing point: CSS requires at least one digit AFTER a decimal point, so
+ * `1.` is a number followed by a stray delimiter rather than a number, and
+ * `Number("1.")` quietly answering `1` would store a value the author never
+ * wrote a valid spelling of.
  */
-const CSS_NUMBER = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+const CSS_NUMBER = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?$/;
 
 /** A stored value as a text field shows it. */
 function storedText(value: StyleValue | undefined): string {

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -102,7 +102,11 @@ export function StyleInspectorPanel({
   state,
   breakpoint,
 }: StyleInspectorPanelProps): React.JSX.Element {
-  const [openGroup, setOpenGroup] = React.useState("");
+  // `null` is "the author has not chosen yet", which is NOT the same as the
+  // empty string the accordion sends when they collapse the open section. The
+  // two collapsed onto one value made the first section impossible to close,
+  // and closing any later one silently opened the first.
+  const [openGroup, setOpenGroup] = React.useState<string | null>(null);
   // The form an author chose at a union position, keyed by property and path.
   // Panel state rather than document state: it is only consulted where nothing
   // is stored, so there is nothing to persist — the moment a value exists, the
@@ -175,8 +179,8 @@ export function StyleInspectorPanel({
   // Compared as strings because that is what the accordion hands back, and
   // narrowing its argument to a catalog group would be this file claiming to
   // know the vocabulary rather than reading it off the sections in hand.
-  const offered = new Set<string>(groups);
-  const open = offered.has(openGroup) ? openGroup : (groups[0] ?? "");
+  const available = new Set<string>(groups);
+  const open = openSection(openGroup, available, groups[0] ?? "");
 
   return (
     <div className="nx-style-inspector">
@@ -710,6 +714,32 @@ function TextField({
   );
 }
 
+/**
+ * Which section is open, given what the author has said.
+ *
+ * Three states, not two: not yet chosen falls back to the first section so the
+ * panel never opens onto a column of headings; the empty string is an explicit
+ * collapse and is honoured; and a section the newly selected block does not
+ * offer falls back, because an accordion asked to open one it does not have
+ * shows nothing open at all.
+ */
+function openSection(
+  chosen: string | null,
+  available: ReadonlySet<string>,
+  first: string
+): string {
+  if (chosen === null) return first;
+  if (chosen === "") return "";
+  return available.has(chosen) ? chosen : first;
+}
+
+/**
+ * The grammar CSS calls a `<number>`: an optional sign, digits with an optional
+ * decimal part, and an optional exponent. Deliberately narrower than
+ * `Number` — see {@link committedValue}.
+ */
+const CSS_NUMBER = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+
 /** A stored value as a text field shows it. */
 function storedText(value: StyleValue | undefined): string {
   if (typeof value === "string") return value;
@@ -736,6 +766,11 @@ function committedValue(
 ): StyleValue {
   if (kind !== "number") return draft;
   const trimmed = draft.trim();
+  // `Number` reads spellings CSS does not: `0x10` becomes 16, `0b10` becomes 2,
+  // `0o10` becomes 8. Converting those would store a number the author never
+  // typed and pass validation, so only the grammar CSS calls a <number> is
+  // converted and everything else is left for the catalog to judge.
+  if (!CSS_NUMBER.test(trimmed)) return draft;
   const parsed = Number(trimmed);
   return Number.isFinite(parsed) ? parsed : draft;
 }

--- a/packages/builder/src/style-inspector.test.ts
+++ b/packages/builder/src/style-inspector.test.ts
@@ -241,6 +241,27 @@ describe("a property the block no longer supports", () => {
     expect(typography?.properties[0]?.set).toBe(true);
   });
 
+  it("lists a retained property in the CATALOG's order, not discovery order", () => {
+    // The allowed set is built in two passes — supported, then retained — and a
+    // `Set` iterates in insertion order, so a group holding both listed the
+    // supported one first however the catalog declares them. `border` is
+    // declared before `borderRadius`, and only the second is supported here.
+    register({ border: { radius: true } });
+    const styles = {
+      base: { [BASE_BREAKPOINT]: { border: "1px solid red" } },
+    } as NodeStyles;
+
+    const inspection = inspectStyle(documentOf(styles), "a");
+    const border = inspection?.sections.find(
+      section => section.group === "border"
+    );
+
+    expect(border?.properties.map(p => p.property)).toEqual([
+      "border",
+      "borderRadius",
+    ]);
+  });
+
   it("marks a property the block does support as offered", () => {
     register({ spacing: true });
 

--- a/packages/builder/src/style-inspector.test.ts
+++ b/packages/builder/src/style-inspector.test.ts
@@ -220,6 +220,50 @@ describe("what a property carries", () => {
   });
 });
 
+describe("a property the block no longer supports", () => {
+  it("still offers a stored property outside supports, marked as not offered", () => {
+    // Measured: neither validation nor compilation consults `supports`, so a
+    // value written before a block update removed the capability — or written
+    // through the API, which never had one — is still valid and still emitted.
+    // Hiding it would show an author styling they can see and cannot clear.
+    register({ spacing: true });
+    const styles = {
+      base: { [BASE_BREAKPOINT]: { fontSize: "20px" } },
+    } as NodeStyles;
+
+    const inspection = inspectStyle(documentOf(styles), "a");
+    const typography = inspection?.sections.find(
+      section => section.group === "typography"
+    );
+
+    expect(typography?.properties.map(p => p.property)).toEqual(["fontSize"]);
+    expect(typography?.properties[0]?.offered).toBe(false);
+    expect(typography?.properties[0]?.set).toBe(true);
+  });
+
+  it("marks a property the block does support as offered", () => {
+    register({ spacing: true });
+
+    const inspection = inspectStyle(documentOf(), "a");
+
+    expect(inspection?.sections[0]?.properties.every(p => p.offered)).toBe(
+      true
+    );
+  });
+
+  it("does not offer an unsupported property the node does not store", () => {
+    // The reachability rule is about values that EXIST. Without that bound the
+    // panel would list the whole catalog for every block.
+    register({ spacing: true });
+
+    const inspection = inspectStyle(documentOf(), "a");
+
+    expect(inspection?.sections.map(section => section.group)).toEqual([
+      "spacing",
+    ]);
+  });
+});
+
 describe("when there is nothing to style", () => {
   it("answers null with no selection", () => {
     register({ spacing: true });

--- a/packages/builder/src/style-inspector.test.ts
+++ b/packages/builder/src/style-inspector.test.ts
@@ -1,0 +1,240 @@
+/**
+ * What the Style tab offers, asserted without a DOM.
+ *
+ * Every question here is derivation — which sections a block offers, in what
+ * order, holding which properties, and which of them this node sets — and a
+ * component test could not separate a correct answer from a plausible wrong one
+ * because both render a column of inputs.
+ *
+ * @module style-inspector.test
+ */
+import {
+  BASE_BREAKPOINT,
+  clearBlocks,
+  registerBlocks,
+  STYLE_GROUP_DEFS,
+  stylePropertiesForSupports,
+  type BlockDocument,
+  type BlockNode,
+  type NodeStyles,
+} from "@nextlyhq/blocks-engine";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { inspectStyle } from "./style-inspector";
+
+afterEach(() => {
+  clearBlocks();
+});
+
+/** A block declaring exactly the supports a test needs. */
+function register(
+  supports: Record<string, boolean | Record<string, boolean>>
+): void {
+  registerBlocks(
+    [
+      {
+        name: "acme/box",
+        version: 1,
+        description: "A box.",
+        example: { props: {} },
+        supports,
+        render: () => null,
+      },
+    ] as never,
+    { source: "style-inspector-test" }
+  );
+}
+
+function documentOf(styles?: NodeStyles): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      { id: "a", type: "acme/box", version: 1, props: {}, styles },
+    ] as BlockNode[],
+  } as BlockDocument;
+}
+
+/** The properties one section offers, by catalog key. */
+function propertiesOf(
+  inspection: ReturnType<typeof inspectStyle>,
+  group: string
+): readonly string[] {
+  const section = inspection?.sections.find(entry => entry.group === group);
+  return (section?.properties ?? []).map(property => property.property);
+}
+
+describe("which sections a block offers", () => {
+  it("offers a section per group the block supports, and no others", () => {
+    register({ spacing: true, typography: true });
+
+    const inspection = inspectStyle(documentOf(), "a");
+
+    expect(inspection?.sections.map(section => section.group)).toEqual([
+      "spacing",
+      "typography",
+    ]);
+  });
+
+  it("orders sections as the catalog presents them, not as supports lists them", () => {
+    // Declared in the opposite order to the catalog's, so an implementation
+    // walking `supports` would produce the reverse of this.
+    register({ border: true, layout: true, spacing: true });
+
+    const inspection = inspectStyle(documentOf(), "a");
+    const order = STYLE_GROUP_DEFS.map(group => group.key).filter(key =>
+      ["border", "layout", "spacing"].includes(key)
+    );
+
+    expect(inspection?.sections.map(section => section.group)).toEqual(order);
+  });
+
+  it("offers no section for a group the block supports nothing in", () => {
+    // A sub-flag that enables nothing outside its own property leaves the rest
+    // of the group out — and a group left entirely out is not a heading.
+    register({ border: { radius: true } });
+
+    const inspection = inspectStyle(documentOf(), "a");
+
+    expect(propertiesOf(inspection, "border")).toEqual(["borderRadius"]);
+    expect(inspection?.sections).toHaveLength(1);
+  });
+
+  it("asks the engine which properties a supports declaration allows", () => {
+    // The expectation is the ENGINE's answer rather than a list written here:
+    // a list would agree with itself, and this is the one assertion that fails
+    // if the panel ever grows its own reading of `supports`.
+    register({ typography: true });
+
+    const inspection = inspectStyle(documentOf(), "a");
+
+    expect(propertiesOf(inspection, "typography")).toEqual(
+      stylePropertiesForSupports({ typography: true }).map(
+        entry => entry.property
+      )
+    );
+  });
+
+  it("answers with no sections at all for a block that opts into nothing", () => {
+    register({});
+
+    const inspection = inspectStyle(documentOf(), "a");
+
+    // An inspection, not null: the block IS selected and IS known, and the
+    // panel says it offers no style properties. Null would make it look
+    // unselected.
+    expect(inspection).not.toBeNull();
+    expect(inspection?.sections).toEqual([]);
+  });
+});
+
+describe("what a property carries", () => {
+  it("carries the controls the property's shape declares", () => {
+    register({ spacing: true });
+
+    const inspection = inspectStyle(documentOf(), "a");
+    const padding = inspection?.sections[0]?.properties.find(
+      property => property.property === "padding"
+    );
+
+    // Four logical sides, so four controls under one property rather than one
+    // control for the whole box.
+    expect(padding?.controls.map(control => control.path.join("."))).toEqual([
+      "blockStart",
+      "blockEnd",
+      "inlineStart",
+      "inlineEnd",
+    ]);
+  });
+
+  it("labels a property as a human reads it", () => {
+    register({ layout: true });
+
+    const inspection = inspectStyle(documentOf(), "a");
+    const labels = new Map(
+      (inspection?.sections[0]?.properties ?? []).map(property => [
+        property.property,
+        property.label,
+      ])
+    );
+
+    expect(labels.get("flexDirection")).toBe("Flex direction");
+    expect(labels.get("gridTemplateColumns")).toBe("Grid template columns");
+  });
+
+  it("reports which properties this node sets, and which it does not", () => {
+    register({ spacing: true });
+    const styles = {
+      base: { [BASE_BREAKPOINT]: { margin: { blockStart: "8px" } } },
+    } as NodeStyles;
+
+    const inspection = inspectStyle(documentOf(styles), "a");
+    const set = new Map(
+      (inspection?.sections[0]?.properties ?? []).map(property => [
+        property.property,
+        property.set,
+      ])
+    );
+
+    expect(set.get("margin")).toBe(true);
+    expect(set.get("padding")).toBe(false);
+  });
+
+  it("reports a value stored at ANOTHER breakpoint as unset here", () => {
+    // "Set" is about this address, not about what the element shows: a value
+    // inherited from a wider breakpoint is not one this panel would clear, so
+    // calling it set would offer a reset with nothing to reset.
+    register({ spacing: true });
+    const styles = {
+      base: { md: { margin: { blockStart: "8px" } } },
+    } as NodeStyles;
+
+    const inspection = inspectStyle(documentOf(styles), "a");
+    const margin = inspection?.sections[0]?.properties.find(
+      property => property.property === "margin"
+    );
+
+    expect(margin?.set).toBe(false);
+    expect(
+      inspectStyle(documentOf(styles), "a", {
+        breakpoint: "md",
+      })?.sections[0]?.properties.find(p => p.property === "margin")?.set
+    ).toBe(true);
+  });
+
+  it("reads the state and breakpoint it was given, defaulting to base", () => {
+    register({ spacing: true });
+    const styles = {
+      hover: { [BASE_BREAKPOINT]: { padding: "4px" } },
+    } as NodeStyles;
+
+    expect(inspectStyle(documentOf(styles), "a")?.state).toBe("base");
+    expect(inspectStyle(documentOf(styles), "a")?.breakpoint).toBe(
+      BASE_BREAKPOINT
+    );
+
+    const hover = inspectStyle(documentOf(styles), "a", { state: "hover" });
+    expect(
+      hover?.sections[0]?.properties.find(p => p.property === "padding")?.set
+    ).toBe(true);
+  });
+});
+
+describe("when there is nothing to style", () => {
+  it("answers null with no selection", () => {
+    register({ spacing: true });
+    expect(inspectStyle(documentOf(), null)).toBeNull();
+  });
+
+  it("answers null for an id the document no longer holds", () => {
+    register({ spacing: true });
+    expect(inspectStyle(documentOf(), "gone")).toBeNull();
+  });
+
+  it("answers null for a block the registry does not know", () => {
+    // Deliberately NOT registered. `supports` lives on the definition, so an
+    // unregistered block has no statement of what it may set — and offering the
+    // whole catalog would let an author write styles the compiler then drops.
+    expect(inspectStyle(documentOf(), "a")).toBeNull();
+  });
+});

--- a/packages/builder/src/style-inspector.ts
+++ b/packages/builder/src/style-inspector.ts
@@ -205,19 +205,24 @@ export function inspectStyle(
 }
 
 /**
- * The allowed properties of one group, in the catalog's order.
+ * The allowed properties of one group, in the CATALOG's order.
  *
- * Filtered from the allowed set rather than intersected with
- * `stylePropertiesInGroup`, so the ORDER is the one the engine emits in and not
- * an artefact of how the set was built.
+ * Read off `STYLE_CATALOG` rather than off the allowed set. A `Set` iterates in
+ * insertion order, and the set above is built in two passes — everything the
+ * block supports, then anything it merely retains — so a group holding both
+ * listed the supported one first however the catalog declares them. Measured:
+ * a block supporting `border: { radius: true }` while still storing `border`
+ * listed `borderRadius, border` where the catalog says `border, borderRadius`.
  */
 function propertiesInGroup(
   allowed: ReadonlySet<string>,
   group: StyleGroup
 ): readonly string[] {
   const rows: string[] = [];
-  for (const property of allowed) {
-    if (getStyleProperty(property)?.group === group) rows.push(property);
+  for (const entry of STYLE_CATALOG) {
+    if (entry.group === group && allowed.has(entry.property)) {
+      rows.push(entry.property);
+    }
   }
   return rows;
 }

--- a/packages/builder/src/style-inspector.ts
+++ b/packages/builder/src/style-inspector.ts
@@ -52,6 +52,18 @@ import { readStyleValue } from "./style-values";
 /** Which state × breakpoint the panel reads and writes, and what the site is. */
 export interface StyleInspectionOptions extends StyleControlOptions {
   /**
+   * The form an author picked for one union position, if any.
+   *
+   * Addressed by property AND path, because a union can sit below the property
+   * root — `position.zIndex` is a number or `auto`. Consulted only where
+   * nothing is stored: a stored value decides its own arm, and the engine
+   * decides that.
+   */
+  readonly variantAt?: (
+    property: string,
+    path: readonly string[]
+  ) => number | undefined;
+  /**
    * The interaction state being edited.
    *
    * `base` unless a caller says otherwise. The switcher that changes it does
@@ -204,7 +216,13 @@ function inspectProperty(
     property,
     path: [],
   });
-  const set = styleControlsFor(entry, value, options);
+  const set = styleControlsFor(entry, value, {
+    ...options,
+    // Bound to THIS property before it reaches the walk, which speaks only in
+    // paths: two properties can both hold a union at the root, and a resolver
+    // told only the path would answer for whichever asked first.
+    variantAt: path => options.variantAt?.(property, path),
+  });
   return {
     property,
     label: fieldLabel(property),

--- a/packages/builder/src/style-inspector.ts
+++ b/packages/builder/src/style-inspector.ts
@@ -1,0 +1,217 @@
+/**
+ * What the selected block offers on the Style tab.
+ *
+ * Pure, for the reason `inspector.ts` is: which sections a block offers, which
+ * properties sit in each, and which control each property draws is derivation —
+ * and a component test in jsdom cannot separate a correct answer from a
+ * plausible wrong one, because both render a column of inputs.
+ *
+ * **Nothing here holds a list of properties, groups or capabilities.** A
+ * block's `supports` decides which properties it may set and the engine answers
+ * that; the catalog decides which group each property belongs to and the order
+ * the groups appear in; a property's shape decides which controls it draws.
+ * Adding a property or a group to the engine gives every block that supports it
+ * an editor with no edit here — which is the property worth protecting, because
+ * a list written here would be a second answer to a question the engine already
+ * holds and the two would agree only on the day they were written.
+ *
+ * **Every supported property is offered, and the one-open accordion is what
+ * bounds the screen.** The alternative — render only the properties that
+ * already hold a value and put the rest behind an "add" menu — answers a
+ * problem this layout does not have: it exists for editors that expand every
+ * section at once, and here exactly one section is open. Measured against the
+ * catalog, the largest group is layout at twelve scalar controls, which is a
+ * panel rather than a wall. A control an author cannot see is one they cannot
+ * discover, and the content tab beside this one already lists every prop a
+ * block declares, including the ones it cannot draw.
+ *
+ * @module style-inspector
+ */
+
+import {
+  BASE_BREAKPOINT,
+  getStyleProperty,
+  STYLE_GROUP_DEFS,
+  stylePropertiesForSupports,
+  type BlockDocument,
+  type BreakpointId,
+  type StyleGroup,
+  type StyleState,
+  type StyleValue,
+} from "@nextlyhq/blocks-engine";
+
+import { fieldLabel, selectedBlock } from "./inspector";
+import {
+  styleControlsFor,
+  type StyleControl,
+  type StyleControlOptions,
+  type StyleControlVariants,
+} from "./style-controls";
+import { readStyleValue } from "./style-values";
+
+/** Which state × breakpoint the panel reads and writes, and what the site is. */
+export interface StyleInspectionOptions extends StyleControlOptions {
+  /**
+   * The interaction state being edited.
+   *
+   * `base` unless a caller says otherwise. The switcher that changes it does
+   * not exist yet, and defaulting to anything else would write hover styles
+   * from a panel with no way to say so.
+   */
+  readonly state?: StyleState;
+  /**
+   * The breakpoint being edited.
+   *
+   * The engine's unconditional context unless a caller says otherwise, for the
+   * same reason: a panel with no breakpoint switcher must write the rules that
+   * apply at every width, not a narrow band an author never chose.
+   */
+  readonly breakpoint?: BreakpointId;
+}
+
+/** One catalog property as the Style tab offers it. */
+export interface InspectedStyleProperty {
+  /** The catalog key, as stored in a `StyleValues` record. */
+  readonly property: string;
+  /** The property's name as a human reads it. */
+  readonly label: string;
+  /** The catalog's own one-line description, for a tooltip or a hint. */
+  readonly summary: string;
+  /** One descriptor per editable position inside the property's value. */
+  readonly controls: readonly StyleControl[];
+  /** Every choice of form the property's shape offers, empty when it holds no union. */
+  readonly variants: readonly StyleControlVariants[];
+  /** What this node stores for the property at this address, if anything. */
+  readonly value: StyleValue | undefined;
+  /**
+   * Whether this node sets the property HERE.
+   *
+   * At this state and breakpoint only, and deliberately: a value inherited from
+   * the base breakpoint is not one this panel would clear, so reporting it as
+   * set would put a reset affordance on a control that has nothing to reset.
+   * Where the value visibly comes from is `styleProvenance`'s question, and it
+   * needs the compiler's trace rather than the document.
+   */
+  readonly set: boolean;
+}
+
+/** One accordion section: a catalog group, and the properties this block has in it. */
+export interface StyleSection {
+  readonly group: StyleGroup;
+  readonly label: string;
+  /** Never empty — a group this block supports nothing in is not a section. */
+  readonly properties: readonly InspectedStyleProperty[];
+}
+
+/** The selected block, as something to style. */
+export interface StyleInspection {
+  readonly nodeId: string;
+  readonly state: StyleState;
+  readonly breakpoint: BreakpointId;
+  /**
+   * Sections in the catalog's own order, each holding at least one property.
+   *
+   * Empty for a block that opts into no style groups at all, which is a real
+   * answer rather than a failure: the panel says the block offers none, exactly
+   * as the content tab says when a block declares no props.
+   */
+  readonly sections: readonly StyleSection[];
+}
+
+/**
+ * Describe the selected block's style surface, or `null` when there is none.
+ *
+ * `null` under exactly the conditions the content tab returns null under, which
+ * is why they share one answer — see {@link selectedBlock}.
+ */
+export function inspectStyle(
+  document: BlockDocument,
+  selectedId: string | null,
+  options?: StyleInspectionOptions
+): StyleInspection | null {
+  const selected = selectedBlock(document, selectedId);
+  if (selected === null) return null;
+  const { node, definition } = selected;
+
+  const state = options?.state ?? "base";
+  const breakpoint = options?.breakpoint ?? BASE_BREAKPOINT;
+  // ASKED of the engine. `supports` is a capability declaration whose meaning —
+  // `true` for a whole group, an object naming sub-flags — is the registry's,
+  // and a second reading of it here would offer a property the compiler
+  // silently drops, or withhold one the block really has.
+  const allowed = new Set(
+    stylePropertiesForSupports(definition.supports).map(entry => entry.property)
+  );
+
+  const sections: StyleSection[] = [];
+  for (const group of STYLE_GROUP_DEFS) {
+    const properties = propertiesInGroup(allowed, group.key).map(property =>
+      inspectProperty(property, node.styles, {
+        ...options,
+        state,
+        breakpoint,
+      })
+    );
+    // A group the block supports nothing in is not a section. Rendering an
+    // empty accordion would offer an author somewhere to click that opens onto
+    // nothing, and every block would show all eleven headings whatever it does.
+    if (properties.length > 0) {
+      sections.push({ group: group.key, label: group.label, properties });
+    }
+  }
+
+  return { nodeId: node.id, state, breakpoint, sections };
+}
+
+/**
+ * The allowed properties of one group, in the catalog's order.
+ *
+ * Filtered from the allowed set rather than intersected with
+ * `stylePropertiesInGroup`, so the ORDER is the one the engine emits in and not
+ * an artefact of how the set was built.
+ */
+function propertiesInGroup(
+  allowed: ReadonlySet<string>,
+  group: StyleGroup
+): readonly string[] {
+  const rows: string[] = [];
+  for (const property of allowed) {
+    if (getStyleProperty(property)?.group === group) rows.push(property);
+  }
+  return rows;
+}
+
+/** One property's controls and the value they are showing. */
+function inspectProperty(
+  property: string,
+  styles: Parameters<typeof readStyleValue>[0],
+  options: StyleInspectionOptions & {
+    state: StyleState;
+    breakpoint: BreakpointId;
+  }
+): InspectedStyleProperty {
+  // Present by construction: the name came out of `stylePropertiesForSupports`,
+  // which reads the same catalog. Asked again rather than threaded through so
+  // this function takes a name, which is what makes it callable from a test
+  // without assembling a catalog row.
+  const entry = getStyleProperty(property);
+  if (entry === undefined) {
+    throw new Error(`${property} is not a style property`);
+  }
+  const value = readStyleValue(styles, {
+    state: options.state,
+    breakpoint: options.breakpoint,
+    property,
+    path: [],
+  });
+  const set = styleControlsFor(entry, value, options);
+  return {
+    property,
+    label: fieldLabel(property),
+    summary: entry.summary,
+    controls: set.controls,
+    variants: set.variants,
+    value,
+    set: value !== undefined,
+  };
+}

--- a/packages/builder/src/style-inspector.ts
+++ b/packages/builder/src/style-inspector.ts
@@ -31,6 +31,7 @@
 import {
   BASE_BREAKPOINT,
   getStyleProperty,
+  STYLE_CATALOG,
   STYLE_GROUP_DEFS,
   stylePropertiesForSupports,
   type BlockDocument,
@@ -105,6 +106,17 @@ export interface InspectedStyleProperty {
    * needs the compiler's trace rather than the document.
    */
   readonly set: boolean;
+  /**
+   * Whether the block's `supports` still declares this property.
+   *
+   * False only for a property this node STORES and the block no longer offers —
+   * a capability removed by a block update, or a value written through the API,
+   * which never consults `supports` at all. Carried rather than dropped so the
+   * panel can say why a control is there: the value is live on the page, and an
+   * author looking at styling they cannot explain needs the control that clears
+   * it more than they need it hidden.
+   */
+  readonly offered: boolean;
 }
 
 /** One accordion section: a catalog group, and the properties this block has in it. */
@@ -149,16 +161,33 @@ export function inspectStyle(
   const breakpoint = options?.breakpoint ?? BASE_BREAKPOINT;
   // ASKED of the engine. `supports` is a capability declaration whose meaning —
   // `true` for a whole group, an object naming sub-flags — is the registry's,
-  // and a second reading of it here would offer a property the compiler
-  // silently drops, or withhold one the block really has.
-  const allowed = new Set(
+  // and a second reading of it here would withhold a property the block really
+  // has, or offer one it does not.
+  const offered = new Set(
     stylePropertiesForSupports(definition.supports).map(entry => entry.property)
   );
+  // Plus anything this node ALREADY stores here, whether the block still
+  // supports it or not. Measured: neither `validation.ts` nor `compile-page.ts`
+  // consults `supports`, so a value written before a block update removed the
+  // capability — or written by the API, which never had one — stays valid and
+  // is still emitted on the page. Filtering on `supports` alone would show the
+  // author styling that is visibly active with no control able to clear it.
+  const allowed = new Set(offered);
+  for (const entry of STYLE_CATALOG) {
+    if (allowed.has(entry.property)) continue;
+    const stored = readStyleValue(node.styles, {
+      state,
+      breakpoint,
+      property: entry.property,
+      path: [],
+    });
+    if (stored !== undefined) allowed.add(entry.property);
+  }
 
   const sections: StyleSection[] = [];
   for (const group of STYLE_GROUP_DEFS) {
     const properties = propertiesInGroup(allowed, group.key).map(property =>
-      inspectProperty(property, node.styles, {
+      inspectProperty(property, node.styles, offered.has(property), {
         ...options,
         state,
         breakpoint,
@@ -197,6 +226,7 @@ function propertiesInGroup(
 function inspectProperty(
   property: string,
   styles: Parameters<typeof readStyleValue>[0],
+  offered: boolean,
   options: StyleInspectionOptions & {
     state: StyleState;
     breakpoint: BreakpointId;
@@ -231,5 +261,6 @@ function inspectProperty(
     variants: set.variants,
     value,
     set: value !== undefined,
+    offered,
   };
 }

--- a/packages/builder/src/style-values.ts
+++ b/packages/builder/src/style-values.ts
@@ -24,16 +24,15 @@ import {
   isTokenRef,
   validateStyleValues,
   type BreakpointId,
-  type MayFetchUrl,
   type NodeStyles,
   type StyleState,
   type StyleValue,
   type StyleValues,
-  type TokenLookup,
   type ValidationIssue,
 } from "@nextlyhq/blocks-engine";
 
 import { sameStoredValue, type BuilderOp } from "./ops";
+import type { StyleControlOptions } from "./style-controls";
 
 /**
  * The site policy a value is judged against.
@@ -44,20 +43,13 @@ import { sameStoredValue, type BuilderOp } from "./ops";
  * never asked — so a control that never forwarded it would accept a URL the
  * published compiler refuses, show it in the preview, fetch it from the editor,
  * and let the author save a value that then vanishes from the page.
+ *
+ * DERIVED rather than restated. This and `StyleControlOptions` are the same
+ * contract read at two moments — choosing which arm to draw, and judging the
+ * write — and they must never disagree about a field. Both trace to the
+ * engine's own option type, so a field added there reaches all three at once.
  */
-export interface StylePolicy {
-  readonly mayFetchUrl?: MayFetchUrl;
-  /**
-   * The site's token table.
-   *
-   * Without it the validator cannot report `unknown-token` or
-   * `token-kind-mismatch`, so a control silently accepts a reference that
-   * renders as nothing. `styleControlsFor` already takes one for choosing a
-   * union arm; carrying it here is what gives a caller one route to supply it
-   * to both.
-   */
-  readonly tokens?: TokenLookup;
-}
+export type StylePolicy = StyleControlOptions;
 
 /** Where a control reads and writes. */
 export interface StyleAddress {

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -380,6 +380,105 @@
 }
 
 /*
+ * A refused value, under the control that produced it. Kept in the flow rather
+ * than floated: a message overlaying the field below it hides the next control
+ * exactly when an author is working through several.
+ */
+.nx-inspector__error {
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--nx-destructive);
+}
+
+.nx-inspector__tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 0;
+}
+
+.nx-style-inspector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-height: 0;
+}
+
+/*
+ * The section heading carries its name and, when this node sets anything in it,
+ * how many — so an author can see which sections they have touched without
+ * opening each one in turn.
+ */
+.nx-style-inspector__section-label {
+  flex: 1;
+  text-align: start;
+  font-size: 0.8125rem;
+  font-weight: 500;
+}
+
+.nx-style-inspector__section-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  padding: 0 0.375rem;
+  border-radius: 999px;
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--nx-primary-foreground);
+  background: var(--nx-primary);
+}
+
+/*
+ * A property that draws several controls — a margin's four sides — is grouped
+ * under one heading, so the sides read as one property rather than four.
+ */
+.nx-style-inspector__property {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.nx-style-inspector__property-label {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--nx-muted-foreground);
+}
+
+/*
+ * A stored design token, which is a value no text field can edit: shown by name
+ * with a way to remove it, because typing over it would store the token's NAME
+ * as a literal.
+ */
+.nx-style-inspector__token {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--nx-border);
+  border-radius: var(--nx-radius-sm, 0.25rem);
+  font-size: 0.8125rem;
+  background: var(--nx-muted);
+}
+
+.nx-style-inspector__token button {
+  font-size: 0.75rem;
+  color: var(--nx-muted-foreground);
+  cursor: pointer;
+}
+
+.nx-style-inspector__token button:hover {
+  color: var(--nx-foreground);
+}
+
+/*
  * The canvas root is the positioning context for editor chrome drawn over the
  * page.
  *


### PR DESCRIPTION
Closes `finding:builder-reimplements-union-arm-selection`, `finding:engine-union-tiebreak-picks-first-arm`, and `task:pb-inspector-style-tab` (Plan 05 C-2).

## 1. The engine's union arm choice, exported — and the copy deleted

`packages/builder/src/style-controls.ts` decided which arm of a union a stored value belonged to, so it could draw the right control. **The engine already decides that**, in `shapeIssues`' union branch, to pick the arm it judges the value against. Two answers to one question, and they could disagree.

Extracted into one function, `shapeIssues` derives from it, exported as `styleUnionVariant`, and **318 of `style-controls.ts`'s 620 lines deleted** — `variantForValue`, `variantHolds`, `fieldsOf`, `shapeAt`, `fieldsHold`, `tokenLeafHolds`, `numberLeafHolds`, `stringLeafHolds`, `leafHolds`, the keyword normaliser and the CSS-wide-keyword probe cache.

**Measured before doing it**, by running both answers over every catalog union:

| stored value | builder showed | engine judged under | who was right |
|---|---|---|---|
| `fontWeight: 5000` | number | keyword | builder |
| `fontWeight: 0` | number | keyword | builder |
| `lineHeight: "nonsense"` | dimension | number | builder |
| `borderRadius: {bogus:"4px"}` | **scalar** | corners | **engine** |

That last row is a defect in the deleted matcher that no review round found: `fieldsHold` returned false when a record named no known field, so a composite value was drawn in the scalar arm — one length control for a value stored as a record.

## 2. The tie-break the export depends on

The first three rows were an **engine** defect. When no arm accepts a value the arms are ranked by how deep their first complaint points, which cannot separate two *scalar* arms — both report at the property's own path — so the catalog's first arm always won. Exporting the answer as-is would have regressed the builder.

Ranking now prefers an arm that stores the value's runtime form before falling back to depth:

```
fontWeight 5000        "not one of the allowed values"  →  "above the maximum of 1000"
fontWeight 0           "not one of the allowed values"  →  "below the minimum of 1"
lineHeight "nonsense"  "is not a number"                →  "is not a length"
position.zIndex "top"  "is not a number"                →  "not one of the allowed values"  (the arm offering `auto`)
```

Better diagnostics for every consumer, not only the editor. **All 1291 pre-existing engine tests passed both before and after, so nothing covered this.**

A token reference is a scalar spelled as an object, so it fits every leaf and no composite — to a composite arm `$token` reads as an unknown field one level down and would win on depth, drawing a token in a four-corner control that cannot hold one. That case was caught by the builder's own suite during the swap, not by inspection.

## 3. C-2 — the Style tab

Content|Style tabs, one-open accordion sections, per `decision:pb-inspector-style-layout`. No second rail.

Nothing in the builder holds a list of properties, groups or capabilities: `supports` → `stylePropertiesForSupports`, group and order → `STYLE_GROUP_DEFS`, controls → the property's shape. Adding a property to the engine gives every block that supports it an editor with no edit in the builder.

**Every supported property is drawn** rather than hidden behind an add-menu. Gutenberg's `ToolsPanel` pattern exists for editors that expand every section at once; here exactly one section is open, and the largest catalog group is twelve scalar controls. Recorded in `research:pb-style-inspector-prior-art` alongside Elementor V4, which shipped this same architecture in March 2026.

Control-layer behaviour, each measured rather than assumed:

- an emptied field **clears** rather than storing `""` — a stored empty value would pin the property to nothing here and beat the tier the author wants back;
- a numeric draft is stored as a **number** where the leaf takes one (`opacity: "0.5"` is refused, `opacity: 0.5` is accepted), and anything else passes through so `inherit` still reaches a numeric property;
- a refused value shows **the catalog's own message** under its control;
- a stored token is shown by name with a way to clear it, never as editable text.

## Evidence

- **Break-verified**: 11 breaks run, each read. Three found problems rather than confirming coverage — a vacuous test of mine (right by catalog order, not by the rule), the depth rule having **no coverage at all** across 1306 engine tests, and the warning-first rule being **unreachable**, which is now stated in both the code and the test file rather than left reading as covered.
- **A comment claim I had to correct**: I wrote that re-running a clean arm would double-charge site lookups. Memoization makes that false; the comment now says the narrower true thing.
- Tests: blocks-engine 1291 → 1307, builder 1021 → 1048. Files 48 → 50.
- Gates: build, vitest, check-types, lint (both the package config and the root one lint-staged uses), comment convention, and `fallow audit` at `pass` with `changed_files_count: 15` and every gated `*_introduced` at 0. `styling_introduced: 6` is reported and is not in the gated set.

## Out of territory, filed not fixed

`finding:pb-style-tab-mounted-without-the-host-fetch-policy` — `InspectorPanel` now takes a `policy`, and `BlocksField.tsx:478` mounts it without one, so a URL naming a host the site disallows is accepted while authoring and dropped by the published compiler. The policy already exists in that package (`plugin.ts:137-140`); nothing carries it to the client. The fix is in `packages/plugin-page-builder/**`, outside both claimed territories.

## Not in this PR

`finding:style-origin-ignores-css-inheritance` — measured as the larger half: it needs a CSS-inheritance table keyed by *CSS* property (the catalog is keyed by catalog key), a return-shape change so `styleOrigin` can distinguish "reached this node" from "inherited from ancestor X", and changes in `packages/builder`'s `style-provenance.ts` where a second finding already sits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Style tab to the inspector with organized sections, property counts, controls, token support, validation messages, and responsive state/breakpoint handling.
  - Added style inspection APIs for retrieving supported properties, current values, and control metadata.
  - Added public APIs for consistent style-variant selection.
  - Added support for clearing, editing, and committing style values through the inspector, including retained unsupported values.
  - Added accessible labels, descriptions, error messaging, and catalog-based input guidance.

- **Bug Fixes**
  - Improved union-value selection and validation for ambiguous style values.
  - Preserved catalog ordering for supported and retained properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->