### PR TITLE
feat(blocks-engine): give a site token a stable identity so a rename moves nothing that resolves

### DIFF
--- a/.changeset/site-token-stable-identity.md
+++ b/.changeset/site-token-stable-identity.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Give a site token a stable identity, so renaming one moves neither the custom property a compiled page references nor the `$token` a stored document holds.
+
+`SiteToken` gains an optional `id`. A token identity is its `id` when it has one and its `name` otherwise, and both the emitted custom property and the config/stored tier merge key on that identity rather than on the name. Every token stored before the field existed carries no id, so its identity is its name and it emits exactly the property it emitted before — nothing migrates. Renaming pins the identity at the name the token already had and moves only the label, which is what keeps existing references resolving.
+
+Because an id and a name share one custom-property space, renaming frees the label but not the property behind it: a new token claiming the freed name is refused and named rather than allowed to shadow the token that left it.
+
+DTCG import and export carry the identity under the `com.nextlyhq.nextly` extension key, which is the only place the format allows it — DTCG has no token id of its own and reserves the `$` prefix. A file from another tool carries no such key and imports with its names for identities rather than having one invented for it.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -284,6 +284,13 @@ export {
   emitFontFaces,
   emitTokenBlocks,
   isTokenName,
+  // Both halves of token identity, public for the same reason the types are:
+  // an editor that offers rename has to pin the identity the way this package
+  // pins it, and one that cannot reach these has no way to do that except to
+  // reimplement the rule or to write `name` directly — which moves the custom
+  // property every compiled page references, silently.
+  renameSiteToken,
+  tokenIdentity,
   resolveTokenPrefix,
   validateFontFace,
 } from "./style/site-tokens";

--- a/packages/blocks-engine/src/style/dtcg.test.ts
+++ b/packages/blocks-engine/src/style/dtcg.test.ts
@@ -7,8 +7,10 @@
  */
 import { describe, expect, it } from "vitest";
 
+import type { DtcgNode } from "./dtcg";
 import { NEXTLY_EXTENSION, dtcgToTokens, tokensToDtcg } from "./dtcg";
 import type { SiteToken } from "./site-tokens";
+import { renameSiteToken } from "./site-tokens";
 
 const tokens = (list: SiteToken[]) => ({ tokens: list });
 
@@ -656,5 +658,123 @@ describe("the round trip", () => {
       carried = dtcgToTokens(tokensToDtcg(tokens(carried)).document).tokens;
     }
     expect(carried).toEqual(original);
+  });
+});
+
+describe("a token's stable identity across the format", () => {
+  // The identity DTCG itself cannot express: the format knows a token by its
+  // path, so this rides in `$extensions` under the vendor key the spec asks
+  // for and the spec guarantees other tools preserve.
+  const renamed = renameSiteToken(
+    { name: "color.primary", kind: "color", values: { light: "#2563eb" } },
+    "brand.main"
+  );
+
+  const own = (
+    document: DtcgNode,
+    ...path: string[]
+  ): Record<string, unknown> => {
+    let node: Record<string, unknown> = document;
+    for (const segment of path) node = node[segment] as Record<string, unknown>;
+    const extensions = node.$extensions as Record<string, unknown>;
+    return extensions[NEXTLY_EXTENSION] as Record<string, unknown>;
+  };
+
+  it("nests under the CURRENT name and carries the identity in the extension", () => {
+    // Both halves matter and they pull apart. The path is what a designer reads
+    // in Figma, so it has to be the name the author sees; the identity is what
+    // a document and a compiled sheet key off, so it cannot be the path.
+    const { document, issues } = tokensToDtcg(tokens([renamed]));
+
+    expect(issues).toEqual([]);
+    expect(Object.keys(document)).toEqual(["brand"]);
+    expect(own(document, "brand", "main").id).toBe("color.primary");
+  });
+
+  it("reads the identity back, so a rename survives a trip through the format", () => {
+    // Exporting to Style Dictionary and importing the result must not quietly
+    // re-point a token at its own label — every reference written against the
+    // old identity would stop resolving, and stop resolving silently.
+    const { tokens: read } = dtcgToTokens(
+      tokensToDtcg(tokens([renamed])).document
+    );
+
+    expect(read).toEqual([renamed]);
+    expect(read[0]?.id).toBe("color.primary");
+    expect(read[0]?.name).toBe("brand.main");
+  });
+
+  it("writes no id at all for a token that never moved", () => {
+    // A field present on every token says nothing about identity and everything
+    // about which exporter ran, and it is data another tool must then carry.
+    const { document } = tokensToDtcg(
+      tokens([
+        { name: "color.primary", kind: "color", values: { light: "#2563eb" } },
+      ])
+    );
+
+    expect(own(document, "color", "primary")).not.toHaveProperty("id");
+  });
+
+  it("invents no identity for a file that came from somewhere else", () => {
+    // A file from Figma carries no vendor key of ours to read one out of.
+    // Minting one here would be this importer deciding what a token IS on the
+    // strength of nothing, and the honest answer — the name — is what an absent
+    // id already means everywhere else in the model.
+    const { tokens: read } = dtcgToTokens({
+      color: {
+        primary: {
+          $type: "color",
+          $value: { colorSpace: "srgb", components: [0, 0, 0], hex: "#000000" },
+        },
+      },
+    });
+
+    expect(read[0]).not.toHaveProperty("id");
+    expect(read[0]?.name).toBe("color.primary");
+  });
+
+  it("normalises away an id that merely repeats the name", () => {
+    // `id === name` states exactly what an absent id states. Keeping it would
+    // leave the model with two spellings of one fact, and a reader deciding
+    // which of them means "never renamed".
+    const { tokens: read } = dtcgToTokens({
+      brand: {
+        $type: "color",
+        $value: { colorSpace: "srgb", components: [0, 0, 0], hex: "#000000" },
+        $extensions: {
+          [NEXTLY_EXTENSION]: {
+            css: { light: "#000" },
+            kind: "color",
+            id: "brand",
+          },
+        },
+      },
+    });
+
+    expect(read[0]).not.toHaveProperty("id");
+  });
+
+  it("skips a token whose stated id could never be written, rather than dropping the id", () => {
+    // Importing it WITHOUT the id is the tempting repair and it is the wrong
+    // one: the token would arrive with its name for an identity, emit a
+    // different custom property from the one the file describes, and every
+    // reference written against the stated identity would resolve to nothing.
+    const { tokens: read, issues } = dtcgToTokens({
+      brand: {
+        $type: "color",
+        $value: { colorSpace: "srgb", components: [0, 0, 0], hex: "#000000" },
+        $extensions: {
+          [NEXTLY_EXTENSION]: {
+            css: { light: "#000" },
+            kind: "color",
+            id: "color}primary",
+          },
+        },
+      },
+    });
+
+    expect(read).toEqual([]);
+    expect(issues.some(i => i.message.includes("id"))).toBe(true);
   });
 });

--- a/packages/blocks-engine/src/style/dtcg.test.ts
+++ b/packages/blocks-engine/src/style/dtcg.test.ts
@@ -755,6 +755,29 @@ describe("a token's stable identity across the format", () => {
     expect(read[0]).not.toHaveProperty("id");
   });
 
+  it("refuses to EXPORT an id it would refuse to import, so a file survives its own round trip", () => {
+    // The three readers of a token have to agree about what an unusable id
+    // means. `emitTokenBlocks` refuses the token and the importer below refuses
+    // it; an exporter that wrote it anyway would produce a document this very
+    // module rejects on the way back in — and reject the WHOLE token, because
+    // an id it cannot read is an identity it cannot honour.
+    const bad: SiteToken[] = [
+      {
+        id: "color}primary",
+        name: "brand.main",
+        kind: "color",
+        values: { light: "#2563eb" },
+      },
+    ];
+    const { document, issues } = tokensToDtcg(tokens(bad));
+
+    expect(Object.keys(document)).toEqual([]);
+    expect(issues.some(i => i.message.includes("id"))).toBe(true);
+    // The round trip is the property, so it is asserted as one rather than
+    // inferred from the export being empty.
+    expect(dtcgToTokens(document).tokens).toEqual([]);
+  });
+
   it("skips a token whose stated id could never be written, rather than dropping the id", () => {
     // Importing it WITHOUT the id is the tempting repair and it is the wrong
     // one: the token would arrive with its name for an identity, emit a

--- a/packages/blocks-engine/src/style/dtcg.ts
+++ b/packages/blocks-engine/src/style/dtcg.ts
@@ -136,49 +136,101 @@ export function tokensToDtcg(set: SiteTokenSet): {
   const issues: ValidationIssue[] = [];
 
   for (const token of set.tokens) {
-    if (!isTokenName(token.name)) {
-      issues.push(
-        issue(`"${token.name}" is not a token name, so it was not exported.`)
-      );
-      continue;
-    }
-
-    const type = DTCG_TYPE[token.kind];
-    const value = type === undefined ? undefined : toDtcgValue(token);
-    if (type === undefined || value === undefined) {
-      issues.push(
-        issue(
-          `"${token.name}" holds a value the design-token format cannot express, so it was not exported. Its value is still here in Nextly.`
-        )
-      );
-      continue;
-    }
-
-    const extension: NextlyExtension = {
-      css:
-        token.values.dark === undefined
-          ? { light: token.values.light }
-          : { light: token.values.light, dark: token.values.dark },
-      kind: token.kind,
-      // Written only when the token carries one. Exporting `id: name` for every
-      // token that never moved would make the field say nothing about identity
-      // and everything about which version of this exporter ran.
-      ...(token.id === undefined ? {} : { id: token.id }),
-    };
-    const entry: DtcgNode = {
-      $type: type,
-      $value: value,
-      $extensions: {
-        ...(token.extensions ?? {}),
-        [NEXTLY_EXTENSION]: extension,
-      },
-    };
-    if (token.description !== undefined) entry.$description = token.description;
-
+    const entry = dtcgEntry(token, issues);
+    // Skipped rather than placed: `dtcgEntry` has already said why, and a name
+    // it refused is one `place` would split into a path anyway.
+    if (entry === undefined) continue;
     place(document, token.name.split("."), entry, issues);
   }
 
   return { document, issues };
+}
+
+/**
+ * One token as the format holds it, or nothing when it cannot be written.
+ *
+ * Split from the checks the way {@link readToken} is split from its assembly,
+ * and for the same reason: deciding whether a token can cross the boundary and
+ * building the node that crosses it are separate jobs, and a guard added to the
+ * builder would be a second place that answers the first question.
+ */
+function dtcgEntry(
+  token: SiteToken,
+  issues: ValidationIssue[]
+): DtcgNode | undefined {
+  const writable = exportableValue(token, issues);
+  if (writable === undefined) return undefined;
+  return entryFor(token, writable.type, writable.value);
+}
+
+/**
+ * What this token becomes in the format, or nothing with the reason reported.
+ *
+ * Returns the converted value rather than merely approving the token, so the
+ * caller does not convert it a second time — two conversions of one value is
+ * the shape that lets an approval and an emission disagree about what was
+ * approved.
+ */
+function exportableValue(
+  token: SiteToken,
+  issues: ValidationIssue[]
+): { type: string; value: unknown } | undefined {
+  if (!isTokenName(token.name)) {
+    issues.push(
+      issue(`"${token.name}" is not a token name, so it was not exported.`)
+    );
+    return undefined;
+  }
+  // The id is held to the grammar too, and refused rather than written. Writing
+  // it produces a file this module's own importer refuses on the way back in —
+  // and it refuses the WHOLE token, because an id it cannot read is an identity
+  // it cannot honour. An exporter emitting a document that fails its own round
+  // trip is the one shape this module exists to prevent.
+  if (token.id !== undefined && !isTokenName(token.id)) {
+    issues.push(
+      issue(
+        `"${token.name}" has an id that is not a token name, so it was not exported. Its value is still here in Nextly.`
+      )
+    );
+    return undefined;
+  }
+
+  const type = DTCG_TYPE[token.kind];
+  const value = type === undefined ? undefined : toDtcgValue(token);
+  if (type === undefined || value === undefined) {
+    issues.push(
+      issue(
+        `"${token.name}" holds a value the design-token format cannot express, so it was not exported. Its value is still here in Nextly.`
+      )
+    );
+    return undefined;
+  }
+  return { type, value };
+}
+
+/** The node for a token already established as writable. */
+function entryFor(token: SiteToken, type: string, value: unknown): DtcgNode {
+  const extension: NextlyExtension = {
+    css:
+      token.values.dark === undefined
+        ? { light: token.values.light }
+        : { light: token.values.light, dark: token.values.dark },
+    kind: token.kind,
+    // Written only when the token carries one. Exporting `id: name` for every
+    // token that never moved would make the field say nothing about identity
+    // and everything about which version of this exporter ran.
+    ...(token.id === undefined ? {} : { id: token.id }),
+  };
+  const entry: DtcgNode = {
+    $type: type,
+    $value: value,
+    $extensions: {
+      ...(token.extensions ?? {}),
+      [NEXTLY_EXTENSION]: extension,
+    },
+  };
+  if (token.description !== undefined) entry.$description = token.description;
+  return entry;
 }
 
 /** Put a token at its path, creating the groups it passes through. */

--- a/packages/blocks-engine/src/style/dtcg.ts
+++ b/packages/blocks-engine/src/style/dtcg.ts
@@ -36,6 +36,20 @@
  * format requires it: "Tools that process design token files MUST preserve any
  * extension data they do not themselves understand."
  *
+ * ## A token's identity travels in the extension, because DTCG has none
+ *
+ * The format knows a token by its path and nothing else — there is no id, and
+ * an alias `{color.primary}` resolves by name. A `SiteToken`'s identity is
+ * therefore not expressible in the format's own vocabulary, and inventing a
+ * `$id` for it would take a prefix the spec reserves for itself. So it rides in
+ * `$extensions` beside the exact CSS, which is both the conformant place for it
+ * and a preserved one.
+ *
+ * That leaves the two directions asymmetric, deliberately. A file this wrote
+ * comes back with the identity it left with. A file from anywhere else has no
+ * identity to read, and gets none invented for it: its tokens arrive with their
+ * names as identities, which is what a token with no id means everywhere else.
+ *
  * @module style/dtcg
  */
 import type { ValidationIssue } from "../validation";
@@ -59,6 +73,22 @@ interface NextlyExtension {
   /** The exact CSS per mode, which is what makes a round trip exact. */
   css: { light: string; dark?: string };
   kind: TokenKind;
+  /**
+   * The token's stable identity, when it has one distinct from its name.
+   *
+   * It rides HERE because the format leaves nowhere else for it. DTCG has no
+   * concept of a token id — a name is the only identity it knows, and `{a.b}`
+   * aliases resolve by path — while every property the format defines is
+   * `$`-prefixed and that prefix is reserved for future versions of the spec,
+   * so a `$id` of this system's invention would squat on it. `$extensions`
+   * under a reverse-domain key is what the spec offers instead, and what it
+   * guarantees: extension data a tool does not understand MUST be preserved,
+   * so an identity that leaves through Figma or Style Dictionary comes back.
+   *
+   * Omitted when the name IS the identity, so a file this exports carries no
+   * field a reader has to interpret to arrive at the token that was written.
+   */
+  id?: string;
 }
 
 /** A DTCG group or token; the format is a tree of plain JSON. */
@@ -130,6 +160,10 @@ export function tokensToDtcg(set: SiteTokenSet): {
           ? { light: token.values.light }
           : { light: token.values.light, dark: token.values.dark },
       kind: token.kind,
+      // Written only when the token carries one. Exporting `id: name` for every
+      // token that never moved would make the field say nothing about identity
+      // and everything about which version of this exporter ran.
+      ...(token.id === undefined ? {} : { id: token.id }),
     };
     const entry: DtcgNode = {
       $type: type,
@@ -555,6 +589,52 @@ function readToken(
     typeof node.$description === "string" ? node.$description : undefined;
   const carried = Object.keys(extensions).length > 0 ? extensions : undefined;
 
+  // Read ahead of the branch below, because identity does not depend on which
+  // value path is taken: an extension whose `css` is unreadable still says
+  // which token this is, and the native `$value` beside it is that same token's
+  // value. A file from Figma carries no such key and arrives with no id, which
+  // is the same thing as arriving with its name for an identity.
+  const stated = isPlainObject(own) ? own.id : undefined;
+  if (
+    stated !== undefined &&
+    !(typeof stated === "string" && isTokenName(stated))
+  ) {
+    issues.push(
+      issue(
+        `"${name}" carries an id that is not a usable token name, so it was skipped. Importing it without the id would give it a different identity from the one the file states, and every reference written against that identity would stop resolving.`
+      )
+    );
+    return undefined;
+  }
+  // A stated id equal to the name says exactly what an absent one says, so it
+  // is normalised away — `id === undefined` then means one thing everywhere in
+  // the model rather than two spellings of it.
+  const id = stated === name ? undefined : stated;
+
+  // Both value paths below finish identically — same identity, same label, same
+  // description, same carried extensions — and differ only in the kind and
+  // values they arrived at. Assembled once so the two cannot drift into
+  // disagreeing about what a token read from a file IS, which is a
+  // disagreement with no symptom: whichever path a given file happens to take
+  // is the only one anyone sees.
+  const assemble = (
+    kind: TokenKind,
+    values: { light: string; dark?: string }
+  ): SiteToken | undefined => {
+    // The guard lives here rather than at each call, so the shorter extension
+    // path cannot be the one that skips it: its CSS is arbitrary JSON from a
+    // file exactly as `$value` is, and is trusted no further.
+    if (!isWritableValue(values, name, issues)) return undefined;
+    return {
+      ...(id !== undefined ? { id } : {}),
+      name,
+      kind,
+      values,
+      ...(description !== undefined ? { description } : {}),
+      ...(carried !== undefined ? { extensions: carried } : {}),
+    };
+  };
+
   // The exact CSS this system wrote, when the file came from here. Read field
   // by field rather than asserted: the extension is arbitrary JSON from a file,
   // and a cast would be this function agreeing to whatever shape it found.
@@ -567,17 +647,7 @@ function readToken(
         typeof dark === "string"
           ? { light: css.light, dark }
           : { light: css.light };
-      // The extension is arbitrary JSON from a file, so its CSS gets the same
-      // guards a value read from `$value` does. It is the shorter path, not the
-      // trusted one.
-      if (!isWritableValue(values, name, issues)) return undefined;
-      return {
-        name,
-        kind,
-        values,
-        ...(description !== undefined ? { description } : {}),
-        ...(carried !== undefined ? { extensions: carried } : {}),
-      };
+      return assemble(kind, values);
     }
   }
 
@@ -600,15 +670,7 @@ function readToken(
     return undefined;
   }
 
-  const values = { light };
-  if (!isWritableValue(values, name, issues)) return undefined;
-  return {
-    name,
-    kind,
-    values,
-    ...(description !== undefined ? { description } : {}),
-    ...(carried !== undefined ? { extensions: carried } : {}),
-  };
+  return assemble(kind, { light });
 }
 
 /**

--- a/packages/blocks-engine/src/style/site-tokens.test.ts
+++ b/packages/blocks-engine/src/style/site-tokens.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, it } from "vitest";
 
 import { compileStyleValues } from "./declarations";
+import type { SiteToken } from "./site-tokens";
 import {
   checkTokenKind,
   DARK_MODE_ATTRIBUTE,
@@ -16,6 +17,8 @@ import {
   emitFontFaces,
   emitTokenBlocks,
   isTokenName,
+  renameSiteToken,
+  tokenIdentity,
   tokenValueFetches,
   resolveTokenPrefix,
   validateFontFace,
@@ -739,5 +742,138 @@ describe("the surface, border and muted tokens", () => {
 
     expect(surface?.light).not.toBe(background?.light);
     expect(surface?.dark).not.toBe(background?.dark);
+  });
+});
+
+describe("a token's stable identity", () => {
+  // `color.primary` under a name an author has since moved away from. Written
+  // once because every case below is about what does NOT move with the label.
+  const renamed = (): SiteToken =>
+    renameSiteToken(
+      { name: "color.primary", kind: "color", values: { light: "#2563eb" } },
+      "brand.main"
+    );
+
+  it("is the name while a token carries no id", () => {
+    // The continuity case, and the one that decides whether any of this can
+    // reach an existing site: every token stored before the field existed has
+    // no id, so the identity has to fall back to the thing those sites already
+    // reference. A separate default here — anything but the name — would move
+    // the custom property under every already-compiled page at once.
+    const stored: SiteToken = {
+      name: "color.primary",
+      kind: "color",
+      values: { light: "#2563eb" },
+    };
+
+    expect(tokenIdentity(stored)).toBe("color.primary");
+    const { css } = emitTokenBlocks({ tokens: [stored] }, SCOPE);
+    expect(css).toContain("--site-color-primary:#2563eb");
+  });
+
+  it("keeps the custom property and the stored reference in step across a rename", () => {
+    // The whole point of the field, asserted from BOTH sides at once. A page
+    // compiled before the rename holds `var(--site-color-primary)` in its CSS,
+    // and a stored document holds `{ $token: "color.primary" }`. Neither is
+    // rewritten by a rename, so both have to keep meaning what they meant —
+    // and an unresolved custom property invalidates the declaration rather
+    // than reporting, so the failure this guards has no symptom on the page.
+    const token = renamed();
+    expect(token.name).toBe("brand.main");
+
+    const { css } = emitTokenBlocks({ tokens: [token] }, SCOPE);
+    expect(css).toContain("--site-color-primary:#2563eb");
+    expect(css).not.toContain("--site-brand-main");
+
+    const reference = compileStyleValues(
+      { color: { $token: "color.primary" } },
+      "/styles",
+      undefined
+    );
+    expect(reference.declarations[0]?.value).toBe("var(--site-color-primary)");
+  });
+
+  it("pins the identity ONCE, so a second rename does not move it either", () => {
+    // A rename that read the CURRENT name each time would pin the identity to
+    // whatever the token was called just before the latest edit, which moves
+    // the custom property on every rename after the first — the same defect,
+    // one rename later, and no louder.
+    const twice = renameSiteToken(renamed(), "palette.hero");
+
+    expect(twice.name).toBe("palette.hero");
+    expect(tokenIdentity(twice)).toBe("color.primary");
+    expect(emitTokenBlocks({ tokens: [twice] }, SCOPE).css).toContain(
+      "--site-color-primary:"
+    );
+  });
+
+  it("lets a renamed override replace the default it came from, rather than joining it", () => {
+    // A tier merge keyed on the NAME stops matching the moment an author
+    // renames a default, so the default survives beside the override — two
+    // entries where the author edited one, both keying off the single custom
+    // property they share. The COUNT is the assertion: a set one larger than
+    // the defaults is that failure.
+    const override = renameSiteToken(
+      { name: "color.primary", kind: "color", values: { light: "#ff0000" } },
+      "brand.main"
+    );
+    const resolved = resolveSiteTokens({ tokens: [override] });
+
+    expect(resolved.tokens.length).toBe(defaultSiteTokens().length);
+    const matches = resolved.tokens.filter(
+      t => tokenIdentity(t) === "color.primary"
+    );
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.name).toBe("brand.main");
+    expect(matches[0]?.values.light).toBe("#ff0000");
+  });
+
+  it("refuses a new token claiming the name a renamed one still holds as its id", () => {
+    // Renaming frees the LABEL and not the custom property behind it, because
+    // ids and names share that one space. Writing both would let a page that
+    // still references the old name resolve to the new token's value, which is
+    // a wrong colour rather than a missing one — so the second is refused and
+    // named instead.
+    const { css, issues } = emitTokenBlocks(
+      {
+        tokens: [
+          renamed(),
+          {
+            name: "color.primary",
+            kind: "color",
+            values: { light: "#ff0000" },
+          },
+        ],
+      },
+      SCOPE
+    );
+
+    expect(css).toContain("--site-color-primary:#2563eb");
+    expect(css).not.toContain("#ff0000");
+    expect(issues.some(i => i.message.includes("--site-color-primary"))).toBe(
+      true
+    );
+  });
+
+  it("refuses an id that cannot be written as a custom property", () => {
+    // An id reaches the selector by the same route a name does, so it is held
+    // to the same grammar: one holding `}` would close the rule this opened and
+    // everything after it becomes CSS the site never wrote.
+    const { css, issues } = emitTokenBlocks(
+      {
+        tokens: [
+          {
+            id: "color}primary;color:red",
+            name: "brand.main",
+            kind: "color",
+            values: { light: "#2563eb" },
+          },
+        ],
+      },
+      SCOPE
+    );
+
+    expect(css).toBe("");
+    expect(issues.some(i => i.message.includes("id"))).toBe(true);
   });
 });

--- a/packages/blocks-engine/src/style/site-tokens.test.ts
+++ b/packages/blocks-engine/src/style/site-tokens.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, expect, it } from "vitest";
 
+import * as publicEntry from "../index";
 import { compileStyleValues } from "./declarations";
 import type { SiteToken } from "./site-tokens";
 import {
@@ -853,6 +854,21 @@ describe("a token's stable identity", () => {
     expect(issues.some(i => i.message.includes("--site-color-primary"))).toBe(
       true
     );
+  });
+
+  it("reaches an editor through the package's public entry", () => {
+    // Imported from `../index` rather than from `./site-tokens`, because the
+    // module resolving is not the surface a consumer resolves: `packages/builder`
+    // sees only the `.` export, and a helper absent from it is a helper the
+    // rename UI cannot call. Left unexported, the pinning rule gets reimplemented
+    // or `name` is written directly — which moves the custom property every
+    // compiled page references, which is the defect the rule exists to prevent.
+    //
+    // Identity rather than mere presence: a re-declaration at the entry would
+    // satisfy a `toBeDefined`, and would be the second implementation this is
+    // asserting does not exist.
+    expect(publicEntry.tokenIdentity).toBe(tokenIdentity);
+    expect(publicEntry.renameSiteToken).toBe(renameSiteToken);
   });
 
   it("refuses an id that cannot be written as a custom property", () => {

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -23,6 +23,29 @@
  * document, and it may already have a theme toggle — so this emits the values
  * under a strategy and takes no position on who flips it.
  *
+ * ## Identity is `id` when there is one, and the name otherwise
+ *
+ * A name is a label an author edits. Two things key off a token's IDENTITY and
+ * neither can move when that label does: the custom property emitted into every
+ * compiled sheet, and the `$token` string every stored document holds. So the
+ * identity is a separate field, exactly as `NamedClass` splits `id` from
+ * `slug` — and for the same reason, since an unresolved custom property
+ * invalidates the declaration rather than reporting, so a moved one loses the
+ * style with no symptom to follow.
+ *
+ * `id` is OPTIONAL, and that is the whole continuity argument rather than a
+ * convenience. Every token stored before the field existed has none, so its
+ * identity is its name, so it emits the property it already emitted and the
+ * documents referencing it already resolve. Nothing migrates. A rename then
+ * FREEZES the identity at the name it had — {@link renameSiteToken} is the one
+ * place that rule lives — and moves only the label.
+ *
+ * One consequence is worth stating because it is not obvious: ids and names
+ * share one custom-property space, so renaming `color.primary` does not fully
+ * free that name. A new token claiming it collides with the frozen id of the
+ * token that left it, and {@link emitTokenBlocks} refuses the second rather
+ * than letting one token resolve to the other's value.
+ *
  * @module style/site-tokens
  */
 import { isPlainRecord } from "../plain-record";
@@ -62,7 +85,18 @@ export type DarkModeStrategy = "attribute" | "media";
 
 /** One site token: a name, what kind of value it holds, and that value. */
 export interface SiteToken {
-  /** Dot-path name, as authors read and write it. */
+  /**
+   * Stable identity, when the token has been given one.
+   *
+   * What the emitted custom property and a document's `$token` key off, and
+   * what a rename never changes. Held to the same grammar as a name, because it
+   * reaches CSS through the same `tokenCustomProperty` call.
+   *
+   * Absent means the name IS the identity, which is what every token stored
+   * before this field existed relies on — see the module note.
+   */
+  id?: string;
+  /** Dot-path name, as authors read and write it. Free to change. */
   name: string;
   kind: TokenKind;
   /**
@@ -92,6 +126,36 @@ export interface SiteTokenSet {
   /** Custom-property prefix; `--site-` when unset. */
   prefix?: string;
   darkMode?: DarkModeStrategy;
+}
+
+/**
+ * What this token is, as against what it is called.
+ *
+ * The one answer to that question, because three things ask it — the custom
+ * property the emitter writes, the key a tier merge overrides on, and the
+ * string a document stores — and they have to agree by construction. Two of
+ * them agreeing today and drifting later has no symptom: a token whose
+ * identity moved emits a property nothing references, which reads exactly like
+ * a token whose value did not apply.
+ */
+export function tokenIdentity(token: SiteToken): string {
+  return token.id ?? token.name;
+}
+
+/**
+ * The token under a new name, with its identity pinned where it already was.
+ *
+ * The rename rule lives here rather than in each editor that offers one,
+ * because getting it wrong is silent in the direction that loses work: setting
+ * `id` to the NEW name moves the custom property and every stored `$token`
+ * stops resolving, which is the defect the field exists to prevent, and the
+ * page still renders — just without the style.
+ *
+ * Idempotent across repeated renames: the second one reads the id the first
+ * froze, so an identity is pinned once and never again.
+ */
+export function renameSiteToken(token: SiteToken, name: string): SiteToken {
+  return { ...token, id: tokenIdentity(token), name };
 }
 
 /** One file a font face can be loaded from. */
@@ -444,8 +508,11 @@ export function checkTokenKind(
  *
  * The three-tier arrangement this implements is the one Gutenberg's
  * `theme.json` reaches: core defaults, then the theme's file, then the user's
- * saved styles, each overriding the last by name. This function is the first
- * two tiers; a stored per-site override is the third and layers the same way.
+ * saved styles, each overriding the last by identity. This function is the
+ * first two tiers; a stored per-site override is the third and layers the same
+ * way. Gutenberg keys that override on a preset's `slug` rather than on its
+ * display `name` for the reason this does: the machine key is the one that
+ * must not move when an author edits the label.
  *
  * **ONE implementation of "what tokens does this site have", deliberately.** The
  * emitter and any future editor must not answer it separately — two answers
@@ -459,15 +526,27 @@ export function checkTokenKind(
  * reason.
  */
 export function resolveSiteTokens(override?: SiteTokenSet): SiteTokenSet {
-  const byName = new Map<string, SiteToken>();
-  for (const token of defaultSiteTokens()) byName.set(token.name, token);
-  // Second, so a site's own definition wins the name. Iterated rather than
+  // Keyed on IDENTITY rather than on the name, because a tier overrides the
+  // token and not the label. A site that renamed a default holds it under the
+  // default's identity with a name of its own, and keying on the name would
+  // leave the default in place beside it — two entries where the author edited
+  // one, colliding on the single custom property they both key off.
+  //
+  // For a set where nothing carries an id this is the same map it always was:
+  // every identity is a name, so no existing token changes tier or slot.
+  const byIdentity = new Map<string, SiteToken>();
+  for (const token of defaultSiteTokens()) {
+    byIdentity.set(tokenIdentity(token), token);
+  }
+  // Second, so a site's own definition wins the identity. Iterated rather than
   // spread, because a later duplicate WITHIN the override must also win — an
   // imported DTCG file can carry one, and taking the first would apply a value
   // the author replaced.
-  for (const token of override?.tokens ?? []) byName.set(token.name, token);
+  for (const token of override?.tokens ?? []) {
+    byIdentity.set(tokenIdentity(token), token);
+  }
   return {
-    tokens: [...byName.values()],
+    tokens: [...byIdentity.values()],
     ...(override?.prefix === undefined ? {} : { prefix: override.prefix }),
     ...(override?.darkMode === undefined
       ? {}
@@ -719,6 +798,19 @@ export function emitTokenBlocks(
       );
       continue;
     }
+    // An id reaches the same selector by the same route, so it is held to the
+    // same grammar. Checked separately from the name rather than through the
+    // identity alone, so the report names the field the author has to repair —
+    // a token whose id is unwritable and whose name is fine reads as a good
+    // token otherwise, and "rename it" would be advice that fixes nothing.
+    if (token.id !== undefined && !isTokenName(token.id)) {
+      issues.push(
+        tokenIssue(
+          `"${token.name}" has an id that is not a token name, so it was not written. An id is dot-separated words of letters, digits and dashes, like "color.primary".`
+        )
+      );
+      continue;
+    }
     // A token with no values record at all. Site tokens are one settings row read on every page
     // render and reach here whether or not anything validated them, so a missing field has to
     // cost the token rather than the render: reading through it throws, and one corrupt row would
@@ -766,16 +858,22 @@ export function emitTokenBlocks(
       );
       continue;
     }
-    const property = tokenCustomProperty(token.name, prefix);
-    // Two names can land on one property — `color.primary-dark` and
+    // Composed from the IDENTITY, which is the name until a rename pins one.
+    // That is what keeps an already-compiled page working: its CSS references
+    // the property this token emitted when the page was built, and only a moved
+    // identity moves it.
+    const property = tokenCustomProperty(tokenIdentity(token), prefix);
+    // Two identities can land on one property — `color.primary-dark` and
     // `color-primary.dark` both give `--site-color-primary-dark`. Emitting both
     // would let one silently resolve to the other's value, so the second is
-    // refused and named.
+    // refused and named. Ids share this space with names, so the other way to
+    // arrive here is a new token claiming a name that a renamed token still
+    // holds as its id.
     const previous = seen.get(property);
     if (previous !== undefined) {
       issues.push(
         tokenIssue(
-          `"${token.name}" and "${previous}" both become "${property}", so "${token.name}" was not written. Rename one of them.`
+          `"${token.name}" and "${previous}" both become "${property}", so "${token.name}" was not written. Two tokens cannot share one custom property: rename one of them, or give one a different id.`
         )
       );
       continue;


### PR DESCRIPTION
## What

`SiteToken` gains an optional `id`. A token's **identity** is its `id` when it has one and its `name` otherwise, and two things now key on that identity rather than on the name:

- the emitted custom property (`tokenCustomProperty(tokenIdentity(token), prefix)`)
- the config/stored tier merge in `resolveSiteTokens`

Implements `decision:site-token-stable-identity` (founder-ruled, `add-the-id-before-c7`). Closes `finding:site-token-has-no-stable-identity`. Research: `research:site-token-identity-shape`.

## Why the shape is "optional id", not "required id"

Two properties had to hold at once and they pull against each other:

1. **Existing data must keep working.** Every token stored today has no id, every document references one *by name* via `TokenRef { $token }`, and every already-compiled page's CSS references `--site-<name>`.
2. **After the change a rename must move nothing** a document or a compiled sheet depends on.

"Required id, custom property keys off id" satisfies (2) and breaks (1) for every existing site. Optional-with-name-fallback satisfies both: an id-less token's identity *is* its name, so it emits precisely the property it emitted before and every stored reference still resolves. **It is a pure field addition — no stored-format change, nothing to migrate**, so it is not the category `decision:pb-tokens-modes` was escalated for.

The load-bearing fact that makes this sufficient: `declarations.ts` turns `{ $token: "x" }` into `var(--site-x)` **lexically, with no lookup against the token table** — the file says so itself. So continuity does not require re-resolving old refs; it requires only that the same string keeps deriving the same property, and that the token keeps emitting it.

`renameSiteToken` pins the identity at the name the token already had and moves only the label. It is idempotent, so the pin happens once and never again.

## Prior art

| | machine identity | human label | rename safe? |
|---|---|---|---|
| Figma variables | `id`/`key`, stable for the variable's lifetime; `boundVariables` holds the id | `name` | yes |
| WordPress `theme.json` | `slug` → `--wp--preset--color--{slug}`, `var:preset\|color\|{slug}` | `name` | yes |
| Webflow | *derives the custom property from the current variable name* | — | **no** — its own community warns against late renames |
| Nextly, before this | *the name is both* | — | **no** |

WordPress is the closest analogue: like us, its machine key is also the CSS custom-property segment rather than an opaque handle. `NamedClass` in this same package already has exactly this split.

## DTCG

The spec has **no concept of a token id** — names are the sole identity, `{a.b}` aliases resolve by path, and every spec-defined property is `$`-prefixed with that prefix reserved for future versions. So a `$id` of our invention would squat on reserved space. `$extensions` under a reverse-domain key is the conformant home, and the spec guarantees it survives: *"Tools that process design token files MUST preserve any extension data they do not themselves understand."* Tokens Studio does the same thing at `$extensions['studio.tokens']`.

The two directions are deliberately asymmetric:
- a file we wrote comes back with the identity it left with;
- a file from Figma has no such key and **gets no identity invented for it** — its tokens arrive with names for identities, which is what an absent id means everywhere else.

## One consequence worth knowing

Ids and names share one custom-property space, so **renaming frees the label but not the property behind it**. A new token claiming the freed name collides with the departed token's frozen id, and `emitTokenBlocks` refuses the second and names it. That is deliberate: letting it through means an old reference resolves to a *new* value — a wrong colour, which is worse than a missing one.

## Evidence

12 new tests, **each seen failing for its intended reason** before being kept:

| test | break applied | observed failure |
|---|---|---|
| identity is the name with no id | `id ?? "x.unknown"` | `expected 'x.unknown' to be 'color.primary'` |
| rename moves neither property nor ref | emit keys on `token.name` | emitted `--site-brand-main` |
| identity pinned once | `id: token.name` | `expected 'brand.main' to be 'color.primary'` |
| renamed override replaces its default | merge keys on `token.name` | `expected 10 to be 9` |
| freed name refused | emit keys on `token.name` | no collision, `#ff0000` emitted |
| bad id refused | guard removed | `--site-color}primary;...` reached the CSS |
| export carries the id | export drops id | `expected undefined to be 'color.primary'` |
| round trip keeps it | import drops id | token returned without `id` |
| no id when never renamed | `id: token.id ?? token.name` | extension had `id` |
| invents none for a foreign file | `stated ?? name` | token gained `id: 'color.primary'` |
| normalises `id === name` away | normalisation removed | token kept `id: 'brand'` |
| bad stated id skips the token | guard removed | imported `id: 'color}primary'` |

Suite: **1314 → 1326**, no drops. The existing round-trip tests use strict `toEqual` and already guard against inventing identity; they pass unchanged, which is the corroboration that nothing moved for id-less data.

## Territory

`packages/blocks-engine/**` only. Nothing spilled — the diff is 5 files, zero of them outside this package, and two peer sessions verified that independently rather than taking it on trust.

**Three defects are left unfixed because they are outside this territory**, filed as `finding:pb-stored-token-write-drops-identity`, which now blocks `task:pb-tokens-studio`:

- **(a)** `plugin-page-builder/src/site-style-record.ts` — `checkStoredTokens` rebuilds each token from a field allowlist and **silently drops** unknown keys, so an id written through the editor never persists.
- **(b)** `plugin-page-builder/src/site-style.ts:166` — `mergeTokens` keys the config/stored merge on `token.name`.
- **(c)** and this one **this PR introduces**, so it should not read as a pre-existing gap. `site-style-record.ts:215` calls `resolveSiteStyle` — a **name**-keyed merge — and feeds the result to `emittedMessages`, which calls `resolveSiteTokens`, now **identity**-keyed. One pipeline, two tier merges, two different keys. Before this PR both were name-keyed and agreed. The module note added here at `site-tokens.ts:131-138` says three things ask "what is this token" and must agree by construction; this is a fourth asker that now does not.

**The fix order matters, because (a) and (c) mask each other.** The divergence is unreachable today: no stored token can carry an id, because (a) strips it on the way in. So fixing (a) alone does not merely leave (c) unfixed — it **unmasks** it, turning a latent disagreement into a live one where a renamed stored token stops overriding its config counterpart, both survive the merge, and the emitter refuses one on a custom-property collision. **(a) and (b)/(c) must land together, or (b) first.** Landing (a) first is strictly worse than landing neither.

`plugin-page-builder` compiles and its suite passes against this branch, and **that green is satisfied by absence** — nothing in that package exercises a renamed token end to end, and nothing could have, since the field did not exist. It shows only that an optional field cannot break a compile. The fix needs a test that writes a renamed token through `checkStoredTokens`, reads it back, and asserts both that the emitted custom property is unchanged *and* that the config-tier default was **replaced rather than joined** — the second half is what catches (b)/(c), and the first half alone passes with them still broken. Seen failing first, or it proves nothing.

None of this is reachable from the admin today, which is why it is filed rather than rushed. It must land before C-7 ships a rename UI, which is what the ledger edge enforces.

## Gates

`build` ✅ · `vitest` 1326/1326 ✅ · `check-types` ✅ · package `lint` ✅ · root `eslint` ✅ (41 files read, both changed files among them) · `check-comment-convention` ✅ · `fallow audit` **pass**, 5 changed files, all `*_introduced` counters 0.

The first fallow run reported `duplication_introduced: 1` — my change had made the importer's two return paths identical enough to clone. Fixed properly by assembling the token in one place, which also puts the writability guard on one path instead of two.
