### PR TITLE
feat(builder): step a measurement with the arrow keys, swap its unit, and toggle a two-value keyword

### DIFF
--- a/.changeset/pb-core-style-controls.md
+++ b/.changeset/pb-core-style-controls.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Give the page-builder style inspector unit-aware numeric editing and a two-state toggle, without narrowing what a style value may be.
+
+Arrow keys step a measurement and keep its unit — Shift steps by ten, matching what Figma, Framer and Webflow all do — and a menu beside the field swaps the unit, offering only units the property itself accepts. A keyword property with exactly two values is drawn as a pair of buttons instead of a menu, so both options are visible and each is one click.
+
+Every one of these is layered ON the existing text field rather than replacing it. A style value is stored as a string and may legitimately be `auto`, `clamp(1rem, 2vw, 3rem)`, a two-part shorthand like `10px 20px`, a CSS-wide keyword, or a design-token reference — so a control that modelled a length as a number plus a unit would write five of those six away the first time the field was touched. The affordances engage only where the stored value is a single simple measurement and disengage silently everywhere else, and whether a stepped or unit-swapped result is legal is decided by asking the engine with the property's own rules rather than by restating them.

--- a/.changeset/pb-core-style-controls.md
+++ b/.changeset/pb-core-style-controls.md
@@ -28,6 +28,8 @@
 
 Give the page-builder style inspector unit-aware numeric editing and a two-state toggle, without narrowing what a style value may be.
 
-Arrow keys step a measurement and keep its unit — Shift steps by ten, matching what Figma, Framer and Webflow all do — and a menu beside the field swaps the unit, offering only units the property itself accepts. A keyword property with exactly two values is drawn as a pair of buttons instead of a menu, so both options are visible and each is one click.
+Arrow keys step a measurement and keep its unit — Shift steps by ten, matching what Figma, Framer and Webflow all do — and a menu beside the field swaps the unit, offering only units the property itself accepts.
+
+A keyword property with exactly two values draws a pair of buttons instead of a menu, so both options are visible and each is one click. No property in the style catalog declares a two-value keyword today, so this changes nothing an author currently sees; it takes effect for the first property that does, with no further editor change.
 
 Every one of these is layered ON the existing text field rather than replacing it. A style value is stored as a string and may legitimately be `auto`, `clamp(1rem, 2vw, 3rem)`, a two-part shorthand like `10px 20px`, a CSS-wide keyword, or a design-token reference — so a control that modelled a length as a number plus a unit would write five of those six away the first time the field was touched. The affordances engage only where the stored value is a single simple measurement and disengage silently everywhere else, and whether a stepped or unit-swapped result is legal is decided by asking the engine with the property's own rules rather than by restating them.

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -1181,6 +1181,31 @@ describe("what the arrow keys do and do not claim", () => {
     }
   );
 
+  it("points a refusal at the unit menu as well as the field", () => {
+    // A unit change can be refused, and the message explaining it is rendered
+    // once for the whole field. A screen-reader user who returns to the MENU is
+    // otherwise sitting on the control that failed with nothing saying so.
+    mount({ spacing: true }, withPadding("12px"), {
+      // A prefix the engine reserves, so any write from this field is refused.
+      allowedTokenKinds: undefined,
+    } as never);
+    const padding = fieldsOf("padding");
+    const field = padding.getByLabelText("Block start");
+
+    fireEvent.change(field, { target: { value: "not a length" } });
+    fireEvent.blur(field);
+
+    // Asserted unconditionally. Guarding this on the menu being present would
+    // pass in the world where it is absent — which is the world the assertion
+    // is supposed to rule out — so the menu is required first and described
+    // second.
+    const unit = padding.getByLabelText("Unit for Padding block start");
+    const description = field.getAttribute("aria-describedby");
+    expect(description).not.toBeNull();
+    expect(unit.getAttribute("aria-describedby")).toBe(description);
+    expect(unit.getAttribute("aria-invalid")).toBe("true");
+  });
+
   it("declines precision the formatter cannot round, rather than throwing", () => {
     // The engine accepts more fractional digits than `toFixed` takes, so
     // composing one would raise a RangeError in the middle of a keystroke.

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -1166,6 +1166,18 @@ describe("what the arrow keys do and do not claim", () => {
     expect(field).toHaveProperty("value", "21px");
   });
 
+  it("leaves an arrow to the IME while a composition is in progress", () => {
+    // An IME uses the arrows to move through conversion candidates. Stepping
+    // there edits the style AND suppresses the candidate move, so the author
+    // loses the keystroke twice over. The shortcut manager states the same rule.
+    const editor = mount({ spacing: true }, withPadding("12px"));
+    const field = fieldsOf("padding").getByLabelText("Block start");
+
+    fireEvent.keyDown(field, { key: "ArrowUp", isComposing: true });
+
+    expect(editor.apply).not.toHaveBeenCalled();
+  });
+
   it.each(["altKey", "ctrlKey", "metaKey"])(
     "leaves %s+Arrow to the platform",
     modifier => {

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -1076,7 +1076,7 @@ describe("the numeric affordances a simple measurement earns", () => {
   it("offers a unit menu only where the value is one measurement", () => {
     mount({ spacing: true }, withPadding("12px"));
     expect(
-      fieldsOf("padding").getByLabelText("Unit for Padding")
+      fieldsOf("padding").getByLabelText("Unit for Padding block start")
     ).toBeDefined();
 
     cleanup();
@@ -1084,6 +1084,55 @@ describe("the numeric affordances a simple measurement earns", () => {
     mount({ spacing: true }, withPadding("auto"));
     // A menu rendered over `auto` could only offer no-ops, and a control that
     // silently does nothing is worse than one that is not drawn.
-    expect(fieldsOf("padding").queryByLabelText("Unit for Padding")).toBeNull();
+    expect(
+      fieldsOf("padding").queryByLabelText("Unit for Padding block start")
+    ).toBeNull();
+  });
+
+  it("names each side's unit menu for that side, not for the property", () => {
+    // A composite draws one menu per side. Named from the property alone, all
+    // four would announce "Unit for Padding" and a screen-reader user could not
+    // tell which side a menu edits, so the distinctness is asserted by naming
+    // two of them rather than by matching one string.
+    mount({ spacing: true }, {
+      base: {
+        [BASE_BREAKPOINT]: {
+          padding: { blockStart: "12px", blockEnd: "4px" },
+        },
+      },
+    } as NodeStyles);
+    const padding = fieldsOf("padding");
+
+    expect(
+      padding.getByLabelText("Unit for Padding block start")
+    ).toBeDefined();
+    expect(padding.getByLabelText("Unit for Padding block end")).toBeDefined();
+  });
+
+  it("keeps a stored unit the menu does not offer, rather than showing an empty one", () => {
+    // `ch` is a valid length this build does not put in the menu. A controlled
+    // select with no matching item renders a BLANK trigger over a value that is
+    // doing something, so the stored unit is carried as its own item.
+    mount({ spacing: true }, withPadding("12ch"));
+
+    expect(
+      fieldsOf("padding").getByLabelText("Unit for Padding block start")
+    ).toHaveProperty("textContent", "ch");
+  });
+
+  it("leaves scientific notation to the plain field", () => {
+    // `1e-3rem` is a legal value with no decimal count that both preserves it
+    // and survives a step: composing one back rounds it to `0`. Declining is
+    // what keeps it intact, so neither affordance is offered.
+    const editor = mount({ spacing: true }, withPadding("1e-3rem"));
+    const field = fieldsOf("padding").getByLabelText("Block start");
+
+    fireEvent.keyDown(field, { key: "ArrowUp" });
+
+    expect(editor.apply).not.toHaveBeenCalled();
+    expect(field).toHaveProperty("value", "1e-3rem");
+    expect(
+      fieldsOf("padding").queryByLabelText("Unit for Padding block start")
+    ).toBeNull();
   });
 });

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -1181,18 +1181,45 @@ describe("what the arrow keys do and do not claim", () => {
     }
   );
 
+  it("swaps the unit on the quantity the AUTHOR is looking at", () => {
+    // Two controls edit one value. With the draft private to the text field,
+    // the menu read `stored` instead — so typing `20` over `12px` and then
+    // picking `rem` committed `12rem`, silently discarding the 20 on screen.
+    // `20` alone is refused on blur (padding takes no unitless number), which
+    // is exactly why the stale value was still there to be composed from.
+    const editor = mount({ spacing: true }, withPadding("12px"));
+    const padding = fieldsOf("padding");
+    const field = padding.getByLabelText("Block start");
+
+    fireEvent.change(field, { target: { value: "20" } });
+    fireEvent.blur(field);
+    fireEvent.click(padding.getByLabelText("Unit for Padding block start"));
+    fireEvent.click(screen.getByRole("option", { name: "rem" }));
+
+    const written = editor.apply.mock.calls.at(-1)?.[0] as {
+      patch?: {
+        styles?: Record<string, Record<string, Record<string, unknown>>>;
+      };
+    };
+    const side = written.patch?.styles?.base?.[BASE_BREAKPOINT]?.padding as
+      | { blockStart?: unknown }
+      | undefined;
+    expect(side?.blockStart).toBe("20rem");
+  });
+
   it("points a refusal at the unit menu as well as the field", () => {
     // A unit change can be refused, and the message explaining it is rendered
     // once for the whole field. A screen-reader user who returns to the MENU is
     // otherwise sitting on the control that failed with nothing saying so.
-    mount({ spacing: true }, withPadding("12px"), {
-      // A prefix the engine reserves, so any write from this field is refused.
-      allowedTokenKinds: undefined,
-    } as never);
+    // `-5px` is refused because `padding` takes no negative measurement, and it
+    // is still A MEASUREMENT — which matters, because the menu follows the
+    // draft. A refusal that leaves unparseable text behind removes the menu
+    // legitimately, so it could not carry a description at all.
+    mount({ spacing: true }, withPadding("12px"));
     const padding = fieldsOf("padding");
     const field = padding.getByLabelText("Block start");
 
-    fireEvent.change(field, { target: { value: "not a length" } });
+    fireEvent.change(field, { target: { value: "-5px" } });
     fireEvent.blur(field);
 
     // Asserted unconditionally. Guarding this on the menu being present would

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -1136,3 +1136,61 @@ describe("the numeric affordances a simple measurement earns", () => {
     ).toBeNull();
   });
 });
+
+describe("what the arrow keys do and do not claim", () => {
+  const withPadding = (value: string): NodeStyles =>
+    ({
+      base: { [BASE_BREAKPOINT]: { padding: { blockStart: value } } },
+    }) as NodeStyles;
+
+  it("steps the DRAFT an author is mid-edit on, not the stored value", () => {
+    // A text input has no numeric fallback, so declining here would leave the
+    // arrow doing nothing precisely while the field is being used — and reading
+    // `stored` instead would step from a value the author has already moved on
+    // from, discarding what they typed.
+    const editor = mount({ spacing: true }, withPadding("12px"));
+    const field = fieldsOf("padding").getByLabelText("Block start");
+
+    fireEvent.change(field, { target: { value: "20px" } });
+    fireEvent.keyDown(field, { key: "ArrowUp" });
+
+    expect(editor.apply.mock.calls[0]?.[0]).toMatchObject({
+      patch: {
+        styles: {
+          base: { [BASE_BREAKPOINT]: { padding: { blockStart: "21px" } } },
+        },
+      },
+    });
+    // One op, not a commit of the draft followed by a step of the result.
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+    expect(field).toHaveProperty("value", "21px");
+  });
+
+  it.each(["altKey", "ctrlKey", "metaKey"])(
+    "leaves %s+Arrow to the platform",
+    modifier => {
+      // These chords are OS, browser and assistive-navigation shortcuts.
+      // Claiming one mutates a style and adds an undo entry from a keystroke
+      // the author aimed somewhere else entirely.
+      const editor = mount({ spacing: true }, withPadding("12px"));
+      const field = fieldsOf("padding").getByLabelText("Block start");
+
+      fireEvent.keyDown(field, { key: "ArrowUp", [modifier]: true });
+
+      expect(editor.apply).not.toHaveBeenCalled();
+    }
+  );
+
+  it("declines precision the formatter cannot round, rather than throwing", () => {
+    // The engine accepts more fractional digits than `toFixed` takes, so
+    // composing one would raise a RangeError in the middle of a keystroke.
+    const editor = mount(
+      { spacing: true },
+      withPadding(`0.${"1".repeat(101)}px`)
+    );
+    const field = fieldsOf("padding").getByLabelText("Block start");
+
+    expect(() => fireEvent.keyDown(field, { key: "ArrowUp" })).not.toThrow();
+    expect(editor.apply).not.toHaveBeenCalled();
+  });
+});

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -998,3 +998,92 @@ describe("naming a value the panel cannot edit", () => {
     );
   });
 });
+
+describe("the numeric affordances a simple measurement earns", () => {
+  const withPadding = (value: string): NodeStyles =>
+    ({
+      base: { [BASE_BREAKPOINT]: { padding: { blockStart: value } } },
+    }) as NodeStyles;
+
+  it("steps a measurement with the arrow keys, keeping its unit", () => {
+    const editor = mount({ spacing: true }, withPadding("12px"));
+    const field = fieldsOf("padding").getByLabelText("Block start");
+
+    fireEvent.keyDown(field, { key: "ArrowUp" });
+
+    expect(editor.apply.mock.calls[0]?.[0]).toMatchObject({
+      kind: "update",
+      id: "a",
+      patch: {
+        styles: {
+          base: { [BASE_BREAKPOINT]: { padding: { blockStart: "13px" } } },
+        },
+      },
+    });
+  });
+
+  it("steps by ten with Shift, which is what every comparable editor does", () => {
+    const editor = mount({ spacing: true }, withPadding("12px"));
+    const field = fieldsOf("padding").getByLabelText("Block start");
+
+    fireEvent.keyDown(field, { key: "ArrowDown", shiftKey: true });
+
+    expect(editor.apply.mock.calls[0]?.[0]).toMatchObject({
+      patch: {
+        styles: {
+          base: { [BASE_BREAKPOINT]: { padding: { blockStart: "2px" } } },
+        },
+      },
+    });
+  });
+
+  it("LEAVES a value it cannot decompose entirely alone", () => {
+    // The property the whole design exists for. A field that modelled the value
+    // as a number and a unit would answer this keystroke with `0px` and destroy
+    // an expression the author spent real effort on — silently, because the
+    // result is a perfectly valid declaration.
+    const editor = mount(
+      { spacing: true },
+      withPadding("clamp(1rem, 2vw, 3rem)")
+    );
+    const field = fieldsOf("padding").getByLabelText("Block start");
+
+    fireEvent.keyDown(field, { key: "ArrowUp" });
+    fireEvent.keyDown(field, { key: "ArrowDown", shiftKey: true });
+
+    expect(editor.apply).not.toHaveBeenCalled();
+    expect(field).toHaveProperty("value", "clamp(1rem, 2vw, 3rem)");
+  });
+
+  it("declines a step the property would reject, rather than writing and being refused", () => {
+    // `padding` takes no negative measurement, so stepping `0px` down has no
+    // legal answer. The distinction the assertions draw is between DECLINING
+    // and writing something the validator then rejects: both leave the document
+    // untouched, so `apply` alone cannot tell them apart. A rejected write also
+    // raises the refusal message beside the field, so its ABSENCE is what says
+    // the step never happened — the author gets a key that quietly does
+    // nothing, not an error for a value they never typed.
+    const editor = mount({ spacing: true }, withPadding("0px"));
+    const field = fieldsOf("padding").getByLabelText("Block start");
+
+    fireEvent.keyDown(field, { key: "ArrowDown" });
+
+    expect(editor.apply).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(field).toHaveProperty("value", "0px");
+  });
+
+  it("offers a unit menu only where the value is one measurement", () => {
+    mount({ spacing: true }, withPadding("12px"));
+    expect(
+      fieldsOf("padding").getByLabelText("Unit for Padding")
+    ).toBeDefined();
+
+    cleanup();
+    clearBlocks();
+    mount({ spacing: true }, withPadding("auto"));
+    // A menu rendered over `auto` could only offer no-ops, and a control that
+    // silently does nothing is worse than one that is not drawn.
+    expect(fieldsOf("padding").queryByLabelText("Unit for Padding")).toBeNull();
+  });
+});

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -1189,10 +1189,13 @@ function NumericField({
       />
       {showUnits ? (
         <Select
-          // `undefined` rather than the empty string for a unitless draft: an
-          // empty value is not a choice the list can carry, so it is shown as
-          // no selection and the placeholder names what the menu is for.
-          value={measurement.unit === "" ? undefined : measurement.unit}
+          // The empty string, never `undefined`. Radix reads `""` as "no
+          // selection" and shows the placeholder, while `undefined` switches it
+          // from controlled to UNCONTROLLED — where it keeps whatever was last
+          // picked, so a unit added and then undone leaves the trigger still
+          // displaying it while the draft has none. The draft is the only unit
+          // state, and passing `undefined` would give it a second one.
+          value={measurement.unit}
           onValueChange={unit => {
             // Composed from the draft, which is what the author is looking at.
             const next = withUnit(control.leaf, draft, unit);
@@ -1349,6 +1352,12 @@ function TextField({
  * style and add an undo entry from a keystroke aimed somewhere else entirely.
  */
 function arrowStep(event: React.KeyboardEvent): number | null {
+  // A keystroke arriving mid-composition belongs to the IME, which uses the
+  // arrows to move through conversion candidates. Stepping there would edit the
+  // style AND suppress the candidate move, so the author loses both. The
+  // shortcut manager states the same rule for the same reason, and this is the
+  // second reader of a keyboard event in this repository that has to know it.
+  if (event.nativeEvent.isComposing) return null;
   if (event.altKey || event.ctrlKey || event.metaKey) return null;
   const direction =
     event.key === "ArrowUp" ? 1 : event.key === "ArrowDown" ? -1 : 0;

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -1146,14 +1146,14 @@ function NumericField({
         stored={stored}
         describedBy={describedBy}
         onCommit={onCommit}
-        onStep={delta => {
-          const next = steppedValue(control.leaf, stored, delta);
+        onStep={(draft, delta) => {
+          const next = steppedValue(control.leaf, draft, delta);
           // `undefined` means this value cannot be stepped or the result would
           // be refused, so the key does nothing rather than writing a value the
           // document then rejects.
-          if (next === undefined) return false;
+          if (next === undefined) return null;
           onCommit(next);
-          return true;
+          return String(next);
         }}
       />
       {showUnits ? (
@@ -1205,13 +1205,15 @@ function TextField({
   describedBy: string | undefined;
   onCommit: (value: StyleValue | null) => CommitOutcome;
   /**
-   * Applies one arrow-key step, answering whether it did.
+   * Applies one arrow-key step to the text currently shown, answering the text
+   * that was written or `null` when nothing was.
    *
-   * `false` leaves the key to its default behaviour, which is what keeps a
-   * value that is not a single measurement — a shorthand, a function, a
-   * keyword — behaving like ordinary text under the caret.
+   * `null` leaves the key to its default behaviour, which is what keeps a value
+   * that is not a single measurement — a shorthand, a function, a keyword —
+   * behaving like ordinary text under the caret. The DRAFT is passed rather
+   * than read from the store, so a step lands on what the author is looking at.
    */
-  onStep?: (delta: number) => boolean;
+  onStep?: (draft: string, delta: number) => string | null;
 }): React.JSX.Element {
   const [draft, setDraft] = React.useState(() => storedText(stored));
 
@@ -1259,24 +1261,49 @@ function TextField({
           return;
         }
         if (onStep === undefined) return;
-        // Arrow steps by one and Shift by ten, which is what Figma, Framer and
-        // Webflow all do — an author arrives already knowing it, and a
-        // different scale here would cost them for no gain.
-        const direction =
-          event.key === "ArrowUp" ? 1 : event.key === "ArrowDown" ? -1 : 0;
-        if (direction === 0) return;
-        // A draft the author has typed but not committed is what they mean by
-        // "this value", so stepping a stale STORED number would discard it.
-        // Committing first is deliberately not done: it would make one arrow
-        // key produce two ops and two undo steps.
-        if (draft !== storedText(stored)) return;
-        if (!onStep(direction * (event.shiftKey ? 10 : 1))) return;
+        const delta = arrowStep(event);
+        if (delta === null) return;
+        // Stepped from the DRAFT rather than from what is stored, so the key
+        // works while an author is mid-edit — which is most of when they reach
+        // for it. Reading `stored` instead would either discard an uncommitted
+        // edit or, if it declined to act, leave the arrow doing nothing in a
+        // text input that has no numeric fallback: an affordance that appears
+        // broken exactly while it is being used.
+        const next = onStep(draft, delta);
+        if (next === null) return;
+        // The draft follows the value that was written, so the field shows the
+        // step immediately rather than waiting for `stored` to come back.
+        setDraft(next);
         // Only once the step was applied, so an unsteppable value keeps the
         // caret movement the key would otherwise perform.
         event.preventDefault();
       }}
     />
   );
+}
+
+/**
+ * The step one key press asks for, or `null` when it asks for none.
+ *
+ * Separated from the handler so that WHICH keys are claimed is one readable
+ * answer rather than a run of early returns inside an event callback — and so
+ * the two rules it encodes sit together, since they are easy to change apart
+ * and wrong apart.
+ *
+ * Arrow steps by one and Shift by ten, which is what Figma, Framer and Webflow
+ * all do: an author arrives already knowing it, and a different scale here
+ * would cost them for no gain.
+ *
+ * Alt, Control and Meta are refused outright. Those chords are platform,
+ * browser and assistive-navigation shortcuts, so claiming one would mutate a
+ * style and add an undo entry from a keystroke aimed somewhere else entirely.
+ */
+function arrowStep(event: React.KeyboardEvent): number | null {
+  if (event.altKey || event.ctrlKey || event.metaKey) return null;
+  const direction =
+    event.key === "ArrowUp" ? 1 : event.key === "ArrowDown" ? -1 : 0;
+  if (direction === 0) return null;
+  return direction * (event.shiftKey ? 10 : 1);
 }
 
 /**

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -67,6 +67,14 @@ import {
   type StyleSection,
 } from "./style-inspector";
 import {
+  measurementOf,
+  steppedValue,
+  toggleOptionsFor,
+  toggleShows,
+  unitChoicesFor,
+  withUnit,
+} from "./style-numeric";
+import {
   readStyleValue,
   styleClearOp,
   styleWriteOp,
@@ -744,6 +752,7 @@ function ControlValue({
   return (
     <ValueField
       id={id}
+      labelledBy={labelledBy}
       control={control}
       stored={stored}
       actionName={actionName}
@@ -864,17 +873,14 @@ function RetainedValue({
 }
 
 /**
- * The control a leaf's kind resolves to.
+ * A closed vocabulary of more than two keywords, as a menu.
  *
- * A keyword leaf carries a closed vocabulary and gets a select over it. Every
- * other kind is drawn as a text field in this build: `length`, `number`,
- * `color`, `css` and `url` all store a scalar the catalog judges, and the
- * affordances that tell them apart — a unit stepper, a colour surface, a token
- * picker — are the control set's, not this panel's. Drawing a text field for
- * them is what makes each editable now, rather than presenting an incomplete
- * property as a complete one.
+ * Its own component rather than a branch inside the router, so that deciding
+ * WHICH surface a leaf gets and drawing one are separate readings: the router
+ * is then short enough to see all three choices at once, which is the thing a
+ * reader comes to it for.
  */
-function ValueField({
+function SelectField({
   id,
   control,
   stored,
@@ -883,6 +889,90 @@ function ValueField({
   onCommit,
 }: {
   id: string;
+  control: StyleControl & { leaf: Extract<StyleLeaf, { kind: "keyword" }> };
+  stored: StyleValue | undefined;
+  actionName: string;
+  describedBy: string | undefined;
+  onCommit: (value: StyleValue | null) => CommitOutcome;
+}): React.JSX.Element {
+  const current = typeof stored === "string" ? stored : "";
+  // The validator accepts a keyword case-insensitively, with surrounding CSS
+  // whitespace and escapes, and accepts the CSS-wide keywords everywhere — so
+  // a stored `Bold` or `inherit` is live and compiles while matching no item
+  // here, and the select would render empty over a value that is doing
+  // something. Offered VERBATIM as its own item rather than normalised: any
+  // rule written here to fold spellings would be a second copy of the
+  // engine's, and the stored string is the one thing that needs no rule.
+  const extra =
+    current !== "" && !control.leaf.values.includes(current) ? current : null;
+  return (
+    <div className="nx-style-inspector__select">
+      <Select value={current} onValueChange={value => onCommit(value)}>
+        <SelectTrigger
+          id={id}
+          aria-describedby={describedBy}
+          aria-invalid={describedBy === undefined ? undefined : true}
+        >
+          <SelectValue placeholder="Not set" />
+        </SelectTrigger>
+        <SelectContent>
+          {extra === null ? null : (
+            <SelectItem value={extra}>{extra}</SelectItem>
+          )}
+          {control.leaf.values.map(option => (
+            <SelectItem key={option} value={option}>
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {/*
+          A select cannot offer "unset" as an item: an empty value is not a
+          choice the list can carry, and a sentinel standing for it would mean
+          two things at once. A button beside it clears, which is the same act
+          an emptied text field performs.
+        */}
+      {current === "" ? null : (
+        <button
+          type="button"
+          onClick={() => onCommit(null)}
+          aria-label={`Clear ${actionName}`}
+        >
+          Clear
+        </button>
+      )}
+    </div>
+  );
+}
+/**
+ * The control a leaf's kind resolves to.
+ *
+ * A keyword leaf carries a closed vocabulary: two values get a toggle and more
+ * than two get a select over them. Every other kind is drawn as a text field
+ * that accepts whatever the catalog judges — `length`, `number`, `color`, `css`
+ * and `url` all store a scalar — with the numeric affordances layered on top
+ * where the stored value is a single measurement.
+ *
+ * Layered rather than substituted, which is the decision worth keeping. A field
+ * that MODELLED a length as a number and a unit could not hold `auto`,
+ * `clamp(...)`, a two-part shorthand or a token, and would write each of them
+ * away on the first edit. So the text field remains the control and the stepper
+ * and unit menu are affordances it grows when the value is simple enough to
+ * carry them; `style-numeric.ts` decides when that is, and answers `undefined`
+ * rather than guessing.
+ */
+function ValueField({
+  id,
+  labelledBy,
+  control,
+  stored,
+  actionName,
+  describedBy,
+  onCommit,
+}: {
+  id: string;
+  /** The field label's id, so a group of buttons can be named by it. */
+  labelledBy: string;
   control: StyleControl;
   stored: StyleValue | undefined;
   /** What this control's clear action removes, named for the property. */
@@ -896,64 +986,175 @@ function ValueField({
   describedBy: string | undefined;
   onCommit: (value: StyleValue | null) => CommitOutcome;
 }): React.JSX.Element {
+  // A keyword vocabulary too wide for a toggle is a menu. Narrowed here rather
+  // than inside the component so the leaf carries its own kind through.
   if (control.kind === "select" && control.leaf.kind === "keyword") {
-    const current = typeof stored === "string" ? stored : "";
-    // The validator accepts a keyword case-insensitively, with surrounding CSS
-    // whitespace and escapes, and accepts the CSS-wide keywords everywhere — so
-    // a stored `Bold` or `inherit` is live and compiles while matching no item
-    // here, and the select would render empty over a value that is doing
-    // something. Offered VERBATIM as its own item rather than normalised: any
-    // rule written here to fold spellings would be a second copy of the
-    // engine's, and the stored string is the one thing that needs no rule.
-    const extra =
-      current !== "" && !control.leaf.values.includes(current) ? current : null;
     return (
-      <div className="nx-style-inspector__select">
-        <Select value={current} onValueChange={value => onCommit(value)}>
-          <SelectTrigger
-            id={id}
-            aria-describedby={describedBy}
-            aria-invalid={describedBy === undefined ? undefined : true}
-          >
-            <SelectValue placeholder="Not set" />
-          </SelectTrigger>
-          <SelectContent>
-            {extra === null ? null : (
-              <SelectItem value={extra}>{extra}</SelectItem>
-            )}
-            {control.leaf.values.map(option => (
-              <SelectItem key={option} value={option}>
-                {option}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        {/*
-          A select cannot offer "unset" as an item: an empty value is not a
-          choice the list can carry, and a sentinel standing for it would mean
-          two things at once. A button beside it clears, which is the same act
-          an emptied text field performs.
-        */}
-        {current === "" ? null : (
-          <button
-            type="button"
-            onClick={() => onCommit(null)}
-            aria-label={`Clear ${actionName}`}
-          >
-            Clear
-          </button>
-        )}
-      </div>
+      <SelectField
+        id={id}
+        control={{ ...control, leaf: control.leaf }}
+        stored={stored}
+        actionName={actionName}
+        describedBy={describedBy}
+        onCommit={onCommit}
+      />
     );
   }
+  // A two-value keyword is drawn as a pair of buttons rather than a menu: both
+  // options are visible and each is one click, where a select costs two and
+  // hides the alternative until it is opened. Offered only where the whole
+  // vocabulary fits — `toggleOptionsFor` declines a shorthand — and only where
+  // the STORED value is one of the two, so a CSS-wide keyword or a token keeps
+  // the field that can actually show it.
+  const toggle = toggleOptionsFor(control.leaf);
+  if (toggle !== undefined && toggleShows(toggle, stored)) {
+    return (
+      <ToggleField
+        id={id}
+        labelledBy={labelledBy}
+        options={toggle}
+        stored={stored}
+        describedBy={describedBy}
+        onCommit={onCommit}
+      />
+    );
+  }
+
   return (
-    <TextField
+    <NumericField
       id={id}
       control={control}
       stored={stored}
       describedBy={describedBy}
       onCommit={onCommit}
     />
+  );
+}
+
+/**
+ * Two keywords as two buttons, with the current one pressed.
+ *
+ * `aria-pressed` rather than a radio group: these are two states of one
+ * property rather than a choice among options that includes "neither", and the
+ * clear affordance beside them is what expresses unset. Labelled by the field's
+ * own label, so a screen reader reads the property name before the state.
+ */
+function ToggleField({
+  id,
+  labelledBy,
+  options,
+  stored,
+  describedBy,
+  onCommit,
+}: {
+  id: string;
+  labelledBy: string;
+  options: readonly [string, string];
+  stored: StyleValue | undefined;
+  describedBy: string | undefined;
+  onCommit: (value: StyleValue | null) => CommitOutcome;
+}): React.JSX.Element {
+  return (
+    <div
+      className="nx-style-inspector__toggle"
+      role="group"
+      aria-labelledby={labelledBy}
+      aria-describedby={describedBy}
+    >
+      {options.map((option, index) => {
+        const pressed = stored === option;
+        return (
+          <button
+            key={option}
+            // Only the first carries the field's id, because a label points at
+            // one control and the group is what the label names.
+            id={index === 0 ? id : undefined}
+            type="button"
+            aria-pressed={pressed}
+            // Pressing the pressed option CLEARS rather than re-writing it,
+            // which is the only way a two-button group can reach unset without
+            // a third button standing for "neither".
+            onClick={() => onCommit(pressed ? null : option)}
+          >
+            {option}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * The text field, plus the affordances a value that is one measurement earns.
+ *
+ * The input stays a TEXT field whatever the value is, which is the whole design:
+ * `auto`, `clamp(...)`, a shorthand and a token all remain typeable and none is
+ * rewritten. The numeric behaviour is LAYERED on — arrow keys step the quantity
+ * and a menu swaps the unit — and both disengage silently when the current value
+ * is not a single measurement, so nothing an author can express is taken away by
+ * the field being clever about the common case.
+ */
+function NumericField({
+  id,
+  control,
+  stored,
+  describedBy,
+  onCommit,
+}: {
+  id: string;
+  control: StyleControl;
+  stored: StyleValue | undefined;
+  describedBy: string | undefined;
+  onCommit: (value: StyleValue | null) => CommitOutcome;
+}): React.JSX.Element {
+  const units = unitChoicesFor(control.leaf);
+  const measurement = measurementOf(stored);
+  // The menu is shown only where it can act. Rendered against a value it cannot
+  // decompose, every choice in it would be a no-op, and a disabled-looking
+  // control that silently does nothing is worse than one that is not there.
+  const showUnits = units.length > 0 && measurement !== undefined;
+
+  return (
+    <div className="nx-style-inspector__numeric">
+      <TextField
+        id={id}
+        control={control}
+        stored={stored}
+        describedBy={describedBy}
+        onCommit={onCommit}
+        onStep={delta => {
+          const next = steppedValue(control.leaf, stored, delta);
+          // `undefined` means this value cannot be stepped or the result would
+          // be refused, so the key does nothing rather than writing a value the
+          // document then rejects.
+          if (next === undefined) return false;
+          onCommit(next);
+          return true;
+        }}
+      />
+      {showUnits ? (
+        <Select
+          value={measurement.unit}
+          onValueChange={unit => {
+            const next = withUnit(control.leaf, stored, unit);
+            if (next !== undefined) onCommit(next);
+          }}
+        >
+          <SelectTrigger
+            aria-label={`Unit for ${fieldLabel(control.property)}`}
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {units.map(unit => (
+              <SelectItem key={unit} value={unit}>
+                {unit}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      ) : null}
+    </div>
   );
 }
 
@@ -970,6 +1171,7 @@ function TextField({
   stored,
   describedBy,
   onCommit,
+  onStep,
 }: {
   id: string;
   control: StyleControl;
@@ -977,6 +1179,14 @@ function TextField({
   /** The id of the message explaining a refusal, and what marks this invalid. */
   describedBy: string | undefined;
   onCommit: (value: StyleValue | null) => CommitOutcome;
+  /**
+   * Applies one arrow-key step, answering whether it did.
+   *
+   * `false` leaves the key to its default behaviour, which is what keeps a
+   * value that is not a single measurement — a shorthand, a function, a
+   * keyword — behaving like ordinary text under the caret.
+   */
+  onStep?: (delta: number) => boolean;
 }): React.JSX.Element {
   const [draft, setDraft] = React.useState(() => storedText(stored));
 
@@ -1018,9 +1228,27 @@ function TextField({
       onChange={event => setDraft(event.target.value)}
       onBlur={commit}
       onKeyDown={event => {
-        if (event.key !== "Enter") return;
+        if (event.key === "Enter") {
+          event.preventDefault();
+          commit();
+          return;
+        }
+        if (onStep === undefined) return;
+        // Arrow steps by one and Shift by ten, which is what Figma, Framer and
+        // Webflow all do — an author arrives already knowing it, and a
+        // different scale here would cost them for no gain.
+        const direction =
+          event.key === "ArrowUp" ? 1 : event.key === "ArrowDown" ? -1 : 0;
+        if (direction === 0) return;
+        // A draft the author has typed but not committed is what they mean by
+        // "this value", so stepping a stale STORED number would discard it.
+        // Committing first is deliberately not done: it would make one arrow
+        // key produce two ops and two undo steps.
+        if (draft !== storedText(stored)) return;
+        if (!onStep(direction * (event.shiftKey ? 10 : 1))) return;
+        // Only once the step was applied, so an unsteppable value keeps the
+        // caret movement the key would otherwise perform.
         event.preventDefault();
-        commit();
       }}
     />
   );

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -67,6 +67,7 @@ import {
   type StyleSection,
 } from "./style-inspector";
 import {
+  CSS_NUMBER,
   measurementOf,
   steppedValue,
   toggleOptionsFor,
@@ -986,26 +987,9 @@ function ValueField({
   describedBy: string | undefined;
   onCommit: (value: StyleValue | null) => CommitOutcome;
 }): React.JSX.Element {
-  // A keyword vocabulary too wide for a toggle is a menu. Narrowed here rather
-  // than inside the component so the leaf carries its own kind through.
-  if (control.kind === "select" && control.leaf.kind === "keyword") {
-    return (
-      <SelectField
-        id={id}
-        control={{ ...control, leaf: control.leaf }}
-        stored={stored}
-        actionName={actionName}
-        describedBy={describedBy}
-        onCommit={onCommit}
-      />
-    );
-  }
-  // A two-value keyword is drawn as a pair of buttons rather than a menu: both
-  // options are visible and each is one click, where a select costs two and
-  // hides the alternative until it is opened. Offered only where the whole
-  // vocabulary fits — `toggleOptionsFor` declines a shorthand — and only where
-  // the STORED value is one of the two, so a CSS-wide keyword or a token keeps
-  // the field that can actually show it.
+  // Decided BEFORE the menu, because every keyword leaf resolves to the
+  // `select` control kind — so a branch on that kind placed first would return
+  // for all of them and the toggle could never be reached.
   const toggle = toggleOptionsFor(control.leaf);
   if (toggle !== undefined && toggleShows(toggle, stored)) {
     return (
@@ -1020,11 +1004,26 @@ function ValueField({
     );
   }
 
+  // A keyword vocabulary too wide for a toggle is a menu. Narrowed here rather
+  // than inside the component so the leaf carries its own kind through.
+  if (control.kind === "select" && control.leaf.kind === "keyword") {
+    return (
+      <SelectField
+        id={id}
+        control={{ ...control, leaf: control.leaf }}
+        stored={stored}
+        actionName={actionName}
+        describedBy={describedBy}
+        onCommit={onCommit}
+      />
+    );
+  }
   return (
     <NumericField
       id={id}
       control={control}
       stored={stored}
+      actionName={actionName}
       describedBy={describedBy}
       onCommit={onCommit}
     />
@@ -1098,12 +1097,22 @@ function NumericField({
   id,
   control,
   stored,
+  actionName,
   describedBy,
   onCommit,
 }: {
   id: string;
   control: StyleControl;
   stored: StyleValue | undefined;
+  /**
+   * This control's own name, position included.
+   *
+   * Taken from the caller rather than derived from the property here: a
+   * composite draws one of these per side, and a name built from the property
+   * alone would give all four of `padding`'s menus the same accessible name,
+   * leaving a screen reader no way to tell which side one edits.
+   */
+  actionName: string;
   describedBy: string | undefined;
   onCommit: (value: StyleValue | null) => CommitOutcome;
 }): React.JSX.Element {
@@ -1112,7 +1121,22 @@ function NumericField({
   // The menu is shown only where it can act. Rendered against a value it cannot
   // decompose, every choice in it would be a no-op, and a disabled-looking
   // control that silently does nothing is worse than one that is not there.
-  const showUnits = units.length > 0 && measurement !== undefined;
+  //
+  // A UNITLESS measurement is excluded for a different reason: `line-height: 1.5`
+  // has no unit to swap, and adding one changes what the property means rather
+  // than how it is spelled. The menu has no way to offer "no unit" back either,
+  // so showing one would be a one-way door.
+  const showUnits =
+    units.length > 0 && measurement !== undefined && measurement.unit !== "";
+  // A stored unit the candidate list does not carry — `ch`, or an uppercase
+  // `PX` the validator folds — is live and compiles while matching no item, and
+  // a controlled select over it renders an EMPTY trigger above a value that is
+  // doing something. Offered verbatim as its own item, which is what the
+  // keyword select above already does for a value outside its vocabulary.
+  const extraUnit =
+    measurement !== undefined && !units.includes(measurement.unit)
+      ? measurement.unit
+      : null;
 
   return (
     <div className="nx-style-inspector__numeric">
@@ -1140,12 +1164,13 @@ function NumericField({
             if (next !== undefined) onCommit(next);
           }}
         >
-          <SelectTrigger
-            aria-label={`Unit for ${fieldLabel(control.property)}`}
-          >
+          <SelectTrigger aria-label={`Unit for ${actionName}`}>
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
+            {extraUnit === null ? null : (
+              <SelectItem value={extraUnit}>{extraUnit}</SelectItem>
+            )}
             {units.map(unit => (
               <SelectItem key={unit} value={unit}>
                 {unit}
@@ -1272,19 +1297,6 @@ function openSection(
   if (chosen === "") return "";
   return available.has(chosen) ? chosen : first;
 }
-
-/**
- * The grammar CSS calls a `<number>`: an optional sign, digits with an optional
- * decimal part, and an optional exponent.
- *
- * Deliberately narrower than `Number` in both directions. `Number` reads
- * spellings CSS does not (`0x10`, `0b10`, `0o10`), and it also accepts a
- * trailing point: CSS requires at least one digit AFTER a decimal point, so
- * `1.` is a number followed by a stray delimiter rather than a number, and
- * `Number("1.")` quietly answering `1` would store a value the author never
- * wrote a valid spelling of.
- */
-const CSS_NUMBER = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?$/;
 
 /** A stored value as a text field shows it. */
 function storedText(value: StyleValue | undefined): string {

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -68,7 +68,7 @@ import {
 } from "./style-inspector";
 import {
   CSS_NUMBER,
-  measurementOf,
+  measurementOfText,
   steppedValue,
   toggleOptionsFor,
   toggleShows,
@@ -1129,24 +1129,41 @@ function NumericField({
   onCommit: (value: StyleValue | null) => CommitOutcome;
 }): React.JSX.Element {
   const units = unitChoicesFor(control.leaf);
-  const measurement = measurementOf(stored);
+  // The draft lives HERE rather than inside the text field, because two
+  // controls edit one value and the unit menu was reading the other copy. An
+  // author who types `20` over `12px` and then picks `rem` had the blur refuse
+  // the unitless draft, leaving `12px` stored — and the menu composed from
+  // THAT, committing `12rem` and discarding the 20 they were looking at.
+  const [draft, setDraft] = React.useState(() => storedText(stored));
+  // The stored value wins whenever it changes underneath — an undo, an edit
+  // applied from elsewhere. Without this both controls go on showing a value
+  // the document no longer has.
+  React.useEffect(() => {
+    setDraft(storedText(stored));
+  }, [stored]);
+  // Read from the DRAFT, so the menu offers units for the quantity on screen
+  // and swaps the unit on that quantity rather than on a superseded one.
+  const measurement = measurementOfText(draft);
   // The menu is shown only where it can act. Rendered against a value it cannot
   // decompose, every choice in it would be a no-op, and a disabled-looking
   // control that silently does nothing is worse than one that is not there.
   //
-  // A UNITLESS measurement is excluded for a different reason: `line-height: 1.5`
-  // has no unit to swap, and adding one changes what the property means rather
-  // than how it is spelled. The menu has no way to offer "no unit" back either,
-  // so showing one would be a one-way door.
-  const showUnits =
-    units.length > 0 && measurement !== undefined && measurement.unit !== "";
+  // A UNITLESS draft keeps the menu rather than losing it, because typing the
+  // quantity and then choosing the unit is an ordinary way to write one — and a
+  // control that vanishes mid-edit is worse than one showing no selection. A
+  // leaf with no units to offer never reaches this: `unitChoicesFor` answers
+  // empty for anything that is not a dimension, so `line-height` as a number
+  // has no menu to gain a unit from.
+  const showUnits = units.length > 0 && measurement !== undefined;
   // A stored unit the candidate list does not carry — `ch`, or an uppercase
   // `PX` the validator folds — is live and compiles while matching no item, and
   // a controlled select over it renders an EMPTY trigger above a value that is
   // doing something. Offered verbatim as its own item, which is what the
   // keyword select above already does for a value outside its vocabulary.
   const extraUnit =
-    measurement !== undefined && !units.includes(measurement.unit)
+    measurement !== undefined &&
+    measurement.unit !== "" &&
+    !units.includes(measurement.unit)
       ? measurement.unit
       : null;
 
@@ -1156,6 +1173,8 @@ function NumericField({
         id={id}
         control={control}
         stored={stored}
+        draft={draft}
+        setDraft={setDraft}
         describedBy={describedBy}
         onCommit={onCommit}
         onStep={(draft, delta) => {
@@ -1170,10 +1189,15 @@ function NumericField({
       />
       {showUnits ? (
         <Select
-          value={measurement.unit}
+          // `undefined` rather than the empty string for a unitless draft: an
+          // empty value is not a choice the list can carry, so it is shown as
+          // no selection and the placeholder names what the menu is for.
+          value={measurement.unit === "" ? undefined : measurement.unit}
           onValueChange={unit => {
-            const next = withUnit(control.leaf, stored, unit);
-            if (next !== undefined) onCommit(next);
+            // Composed from the draft, which is what the author is looking at.
+            const next = withUnit(control.leaf, draft, unit);
+            if (next === undefined) return;
+            if (onCommit(next) !== "refused") setDraft(next);
           }}
         >
           <SelectTrigger
@@ -1188,7 +1212,7 @@ function NumericField({
             aria-describedby={describedBy}
             aria-invalid={describedBy === undefined ? undefined : true}
           >
-            <SelectValue />
+            <SelectValue placeholder="unit" />
           </SelectTrigger>
           <SelectContent>
             {extraUnit === null ? null : (
@@ -1217,6 +1241,8 @@ function TextField({
   id,
   control,
   stored,
+  draft,
+  setDraft,
   describedBy,
   onCommit,
   onStep,
@@ -1224,6 +1250,16 @@ function TextField({
   id: string;
   control: StyleControl;
   stored: StyleValue | undefined;
+  /**
+   * The text being edited, owned by the caller.
+   *
+   * Lifted because a numeric row has TWO controls over one value — the field
+   * and the unit menu — and a draft private to this one leaves the other
+   * reading the stored value instead, which is a different and usually older
+   * answer to what the author is editing.
+   */
+  draft: string;
+  setDraft: (value: string) => void;
   /** The id of the message explaining a refusal, and what marks this invalid. */
   describedBy: string | undefined;
   onCommit: (value: StyleValue | null) => CommitOutcome;
@@ -1238,15 +1274,6 @@ function TextField({
    */
   onStep?: (draft: string, delta: number) => string | null;
 }): React.JSX.Element {
-  const [draft, setDraft] = React.useState(() => storedText(stored));
-
-  // The stored value wins whenever it changes underneath the field — an undo, a
-  // scrub, an edit applied from somewhere else. Without this the input would go
-  // on showing a value the document no longer has.
-  React.useEffect(() => {
-    setDraft(storedText(stored));
-  }, [stored]);
-
   const commit = () => {
     if (draft === storedText(stored)) return;
     // CSS whitespace here too, not JavaScript's. `String.prototype.trim` also

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -1075,6 +1075,13 @@ function ToggleField({
             key={option}
             type="button"
             aria-pressed={pressed}
+            // Marked on the BUTTONS rather than on the group, which carries the
+            // description. `aria-invalid` is not a state `role="group"`
+            // supports, so setting it there would be an attribute a screen
+            // reader is entitled to ignore — and the file's own rule is that a
+            // control described by a refusal must also read as invalid, or it
+            // announces the message as a hint rather than as a failure.
+            aria-invalid={describedBy === undefined ? undefined : true}
             // Pressing the pressed option CLEARS rather than re-writing it,
             // which is the only way a two-button group can reach unset without
             // a third button standing for "neither".

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -1055,19 +1055,24 @@ function ToggleField({
 }): React.JSX.Element {
   return (
     <div
+      // The field's id sits on the GROUP rather than on either button. The
+      // field label carries `htmlFor`, and a label pointing at a button
+      // forwards a click to it — so naming the first option that way would make
+      // clicking the property label press it, or clear it when already pressed,
+      // and write an edit the author never asked for. A `div` is not labelable,
+      // so the association is inert and the group is named by `aria-labelledby`
+      // instead, which is what a screen reader reads either way.
+      id={id}
       className="nx-style-inspector__toggle"
       role="group"
       aria-labelledby={labelledBy}
       aria-describedby={describedBy}
     >
-      {options.map((option, index) => {
+      {options.map(option => {
         const pressed = stored === option;
         return (
           <button
             key={option}
-            // Only the first carries the field's id, because a label points at
-            // one control and the group is what the label names.
-            id={index === 0 ? id : undefined}
             type="button"
             aria-pressed={pressed}
             // Pressing the pressed option CLEARS rather than re-writing it,
@@ -1164,7 +1169,18 @@ function NumericField({
             if (next !== undefined) onCommit(next);
           }}
         >
-          <SelectTrigger aria-label={`Unit for ${actionName}`}>
+          <SelectTrigger
+            className="nx-style-inspector__unit"
+            aria-label={`Unit for ${actionName}`}
+            // A unit change can be refused — a document at its byte limit, a
+            // value the validator rejects — and the message that explains it is
+            // rendered once for the field. Pointed at from HERE as well as from
+            // the text input, because a screen-reader user who returns to the
+            // menu is otherwise on the control that failed with nothing saying
+            // so and no way to reach the reason.
+            aria-describedby={describedBy}
+            aria-invalid={describedBy === undefined ? undefined : true}
+          >
             <SelectValue />
           </SelectTrigger>
           <SelectContent>

--- a/packages/builder/src/style-numeric.test.ts
+++ b/packages/builder/src/style-numeric.test.ts
@@ -145,6 +145,18 @@ describe("stepping a dimension", () => {
     }
   );
 
+  it.each([
+    ["9007199254740992", "a step a double cannot represent at all"],
+    ["9007199254740994", "a step a double turns into two"],
+  ])("declines to step %s (%s)", digits => {
+    // The round-trip guard proves the STARTING value survives a double and
+    // says nothing about the step. Near the safe-integer boundary the two come
+    // apart: the first value plus one is the same double, so the arrow is
+    // consumed and nothing happens — a key that looks dead — and the second
+    // lands two away. Neither is what the author asked for.
+    expect(steppedValue(PADDING, `${digits}px`, 1)).toBeUndefined();
+  });
+
   it("rounds at the author's own precision", () => {
     // Rounded at the two decimals the value was written with. Ignored, the
     // step would round to the whole number and answer `1rem`.

--- a/packages/builder/src/style-numeric.test.ts
+++ b/packages/builder/src/style-numeric.test.ts
@@ -95,6 +95,19 @@ describe("what a measurement is", () => {
     expect(measurementOf(stringifies)).toBeUndefined();
   });
 
+  it.each([
+    ["9007199254740993", "an integer past the safe range"],
+    ["1e-3", "exponent notation"],
+    [".5", "a leading point"],
+    ["+5", "an explicit plus"],
+  ])("declines %s (%s), which does not survive a number round trip", digits => {
+    // The engine accepts all four. A double changes each of them — the first
+    // comes back SMALLER than it started — so composing one writes a value the
+    // author never typed. Asserted as one family rather than one case, because
+    // they were found one at a time and nothing says the list is closed.
+    expect(measurementOf(`${digits}px`)).toBeUndefined();
+  });
+
   it("keeps the author's precision rather than the double's", () => {
     expect(measurementOf("1.50rem")).toMatchObject({
       number: 1.5,
@@ -128,8 +141,15 @@ describe("stepping a dimension", () => {
     }
   );
 
-  it("answers in the author's own precision", () => {
+  it("rounds at the author's own precision", () => {
+    // Rounded at two decimals because the value was written with two. Read at
+    // the double's apparent one, this would answer `1.8rem`.
     expect(steppedValue(PADDING, "1.50rem", 0.25)).toBe("1.75rem");
+    // The count governs ROUNDING and not spelling: the trailing zero does not
+    // come back, because the composed text is re-parsed to drop the zeros that
+    // rounding introduces. Asserted so the distinction is written down rather
+    // than left for a reader to infer from a comment.
+    expect(steppedValue(PADDING, "1.50rem", 0.1)).toBe("1.6rem");
   });
 
   it("does not answer in floating point", () => {

--- a/packages/builder/src/style-numeric.test.ts
+++ b/packages/builder/src/style-numeric.test.ts
@@ -65,6 +65,16 @@ describe("what a measurement is", () => {
     expect(measurementOf("-4px")).toMatchObject({ number: -4, unit: "px" });
   });
 
+  it("holds a stored NUMBER to the same round trip as a written one", () => {
+    // `line-height` stores a number, and `1e-7` printed back is `"1e-7"` —
+    // which the text path declines because composing it yields `0`. Read
+    // directly, the number branch answered `decimals: 0` and a step discarded
+    // the quantity entirely. The two paths must agree because they are one
+    // question.
+    expect(measurementOf(1e-7)).toBeUndefined();
+    expect(measurementOf("1e-7")).toBeUndefined();
+  });
+
   it("reads a stored NUMBER as a measurement with no unit", () => {
     // `number` leaves store numbers rather than strings, so reading only
     // strings would leave every opacity and line-height unsteppable while

--- a/packages/builder/src/style-numeric.test.ts
+++ b/packages/builder/src/style-numeric.test.ts
@@ -47,6 +47,17 @@ const PADDING = side("padding");
 const MARGIN = side("margin");
 const OPACITY = entry("opacity").shape as unknown as StyleLeaf;
 
+/** `position.zIndex` is a union; its number arm is an UNBOUNDED integer. */
+const Z_INDEX: StyleLeaf = (() => {
+  const fields = entry("position").shape.fields as Record<
+    string,
+    { of?: readonly Record<string, unknown>[] }
+  >;
+  const arm = fields.zIndex?.of?.find(candidate => candidate.kind === "number");
+  if (arm === undefined) throw new Error("position.zIndex has no number arm");
+  return arm as unknown as StyleLeaf;
+})();
+
 describe("what a measurement is", () => {
   it("decomposes a single measurement into its number and unit", () => {
     expect(measurementOf("16px")).toMatchObject({ number: 16, unit: "px" });
@@ -186,6 +197,25 @@ describe("stepping a number leaf", () => {
 
   it("steps within the bounds", () => {
     expect(steppedValue(OPACITY, 0.5, 0.1)).toBe(0.6);
+  });
+
+  it.each([
+    [9007199254740992, "a step a double cannot represent"],
+    [9007199254740994, "a step a double turns into two"],
+  ])("declines to step %s (%s) on a number leaf too", stored => {
+    // `z-index` is an unbounded integer leaf, so the same arithmetic that
+    // defeats a dimension defeats it — and the dimension path's guard does not
+    // run here. Asserted against a REAL catalog leaf rather than the bounded
+    // `opacity`, because a min/max would clamp before the arithmetic showed.
+    expect(steppedValue(Z_INDEX, stored, 1)).toBeUndefined();
+  });
+
+  it("still rests at a declared bound, which is not a failed step", () => {
+    // Clamping must stay exempt: resting at the maximum is the right answer to
+    // a step, and requiring movement there would kill the arrow exactly at the
+    // ends, where a spinbutton is most often held.
+    expect(steppedValue(OPACITY, 0.9, 0.2)).toBe(1);
+    expect(steppedValue(OPACITY, 0.1, -0.5)).toBe(0);
   });
 
   it("refuses a value carrying a unit, which is not a number", () => {

--- a/packages/builder/src/style-numeric.test.ts
+++ b/packages/builder/src/style-numeric.test.ts
@@ -98,9 +98,11 @@ describe("what a measurement is", () => {
   it.each([
     ["9007199254740993", "an integer past the safe range"],
     ["1e-3", "exponent notation"],
+    ["1e-7", "an exponent JavaScript itself prints back"],
     [".5", "a leading point"],
     ["+5", "an explicit plus"],
-  ])("declines %s (%s), which does not survive a number round trip", digits => {
+    ["1.50", "a trailing zero"],
+  ])("declines %s (%s), which the composer cannot reproduce", digits => {
     // The engine accepts all four. A double changes each of them — the first
     // comes back SMALLER than it started — so composing one writes a value the
     // author never typed. Asserted as one family rather than one case, because
@@ -109,8 +111,10 @@ describe("what a measurement is", () => {
   });
 
   it("keeps the author's precision rather than the double's", () => {
-    expect(measurementOf("1.50rem")).toMatchObject({
-      number: 1.5,
+    // Two decimals because two were written. The double alone reports one, so
+    // a step of `0.05` read from it would round to `1.3` instead of `1.25`.
+    expect(measurementOf("1.25rem")).toMatchObject({
+      number: 1.25,
       decimals: 2,
     });
   });
@@ -142,14 +146,9 @@ describe("stepping a dimension", () => {
   );
 
   it("rounds at the author's own precision", () => {
-    // Rounded at two decimals because the value was written with two. Read at
-    // the double's apparent one, this would answer `1.8rem`.
-    expect(steppedValue(PADDING, "1.50rem", 0.25)).toBe("1.75rem");
-    // The count governs ROUNDING and not spelling: the trailing zero does not
-    // come back, because the composed text is re-parsed to drop the zeros that
-    // rounding introduces. Asserted so the distinction is written down rather
-    // than left for a reader to infer from a comment.
-    expect(steppedValue(PADDING, "1.50rem", 0.1)).toBe("1.6rem");
+    // Rounded at the two decimals the value was written with. Ignored, the
+    // step would round to the whole number and answer `1rem`.
+    expect(steppedValue(PADDING, "1.25rem", 0.1)).toBe("1.35rem");
   });
 
   it("does not answer in floating point", () => {
@@ -210,6 +209,13 @@ describe("units offered", () => {
 });
 
 describe("a toggle is a projection of a keyword leaf", () => {
+  // NO CATALOG PROPERTY DECLARES A TWO-VALUE KEYWORD LEAF, verified by walking
+  // every entry in `STYLE_CATALOG` including nested shapes. So the leaf below
+  // is constructed, and what these assertions cover is the PROJECTION —
+  // whether a vocabulary of this shape is offered as a toggle — and not that a
+  // toggle reaches the panel for any block a site can use, which today it does
+  // not. Said here rather than left to be inferred: a reader meeting a green
+  // suite is entitled to know which half of the claim it stands behind.
   const two: StyleLeaf = {
     kind: "keyword",
     cssProperty: "font-style",

--- a/packages/builder/src/style-numeric.test.ts
+++ b/packages/builder/src/style-numeric.test.ts
@@ -1,0 +1,227 @@
+/**
+ * What a numeric affordance may do to a stored value, and — mostly — what it
+ * may not.
+ *
+ * The leaves come from `STYLE_CATALOG` rather than being written here, because
+ * the property under test is that the ENGINE decides. A hand-made leaf asserting
+ * `allowNegative: false` would pass against a hardcoded rule in the module just
+ * as happily as against the engine being asked, and those are the two
+ * implementations that have to be told apart.
+ */
+import { STYLE_CATALOG, type StyleLeaf } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import {
+  measurementOf,
+  steppedValue,
+  toggleOptionsFor,
+  toggleShows,
+  unitChoicesFor,
+  withUnit,
+} from "./style-numeric";
+
+/** One catalog entry, as the array actually stores them. */
+interface CatalogEntry {
+  readonly property: string;
+  readonly shape: Record<string, unknown>;
+}
+
+const entry = (property: string): CatalogEntry => {
+  const found = (STYLE_CATALOG as unknown as readonly CatalogEntry[]).find(
+    candidate => candidate.property === property
+  );
+  if (found === undefined) throw new Error(`no catalog entry for ${property}`);
+  return found;
+};
+
+/** The leaf on one logical side of a box property. */
+const side = (property: string): StyleLeaf => {
+  const sides = entry(property).shape.sides as Record<string, StyleLeaf>;
+  const leaf = sides.blockStart;
+  if (leaf === undefined) throw new Error(`${property} has no blockStart side`);
+  return leaf;
+};
+
+/** `padding` refuses a negative measurement; `margin` allows one. */
+const PADDING = side("padding");
+const MARGIN = side("margin");
+const OPACITY = entry("opacity").shape as unknown as StyleLeaf;
+
+describe("what a measurement is", () => {
+  it("decomposes a single measurement into its number and unit", () => {
+    expect(measurementOf("16px")).toMatchObject({ number: 16, unit: "px" });
+    expect(measurementOf("50%")).toMatchObject({ number: 50, unit: "%" });
+    expect(measurementOf("-4px")).toMatchObject({ number: -4, unit: "px" });
+  });
+
+  it("reads a stored NUMBER as a measurement with no unit", () => {
+    // `number` leaves store numbers rather than strings, so reading only
+    // strings would leave every opacity and line-height unsteppable while
+    // looking supported.
+    expect(measurementOf(0.5)).toMatchObject({ number: 0.5, unit: "" });
+  });
+
+  it.each([
+    ["auto", "a keyword"],
+    ["inherit", "a CSS-wide keyword"],
+    ["10px 20px", "a two-part shorthand"],
+    ["clamp(1rem, 2vw, 3rem)", "a function"],
+    ["calc(100% - 2rem)", "an expression"],
+    ["", "nothing"],
+    ["1.", "a number CSS does not spell"],
+  ])("refuses to decompose %s (%s)", text => {
+    // Each of these is a value the engine accepts somewhere, so answering with
+    // a number would let a numeric field claim it and write it away.
+    expect(measurementOf(text)).toBeUndefined();
+  });
+
+  it("refuses to decompose any object at a scalar position", () => {
+    // A token reference is the one that matters — `{ $token }` is one value
+    // spelled as a record — but the guard that stops it is the plain
+    // not-a-string test, which is why an imported `{ value: "12px" }` is
+    // refused by the same line. Asserted together rather than as a token case
+    // alone: a token-shaped assertion here would pass whether or not anything
+    // in the module knew what a token was.
+    expect(measurementOf({ $token: "space.4" })).toBeUndefined();
+    expect(measurementOf({ value: "12px" } as never)).toBeUndefined();
+    // The two above are refused by the REGEX as much as by the type test —
+    // both stringify to "[object Object]", which matches nothing — so neither
+    // can tell a guard that branches on type from one that does not. This one
+    // can: it stringifies to a value the regex would accept, so it decomposes
+    // the moment the type test stops being made. Without it the assertions
+    // above are a regression guard on the outcome and no coverage of the line
+    // that produces it.
+    const stringifies = { toString: () => "16px" } as never;
+    expect(measurementOf(stringifies)).toBeUndefined();
+  });
+
+  it("keeps the author's precision rather than the double's", () => {
+    expect(measurementOf("1.50rem")).toMatchObject({
+      number: 1.5,
+      decimals: 2,
+    });
+  });
+});
+
+describe("stepping a dimension", () => {
+  it("keeps the unit, so a step is an edit and not a change of kind", () => {
+    expect(steppedValue(PADDING, "8px", 1)).toBe("9px");
+    expect(steppedValue(PADDING, "2rem", -1)).toBe("1rem");
+  });
+
+  it("asks the ENGINE whether the result is legal, per property", () => {
+    // The separating assertion of this file. Same value, same step, opposite
+    // answers — and the only thing that differs is what the catalog says about
+    // negatives. A rule written into the module would have to answer both the
+    // same way.
+    expect(steppedValue(PADDING, "0px", -1)).toBeUndefined();
+    expect(steppedValue(MARGIN, "0px", -1)).toBe("-1px");
+  });
+
+  it.each(["auto", "clamp(1rem, 2vw, 3rem)", "10px 20px", "inherit"])(
+    "leaves %s alone rather than replacing it",
+    stored => {
+      // The defect this module exists to prevent: a numeric control that
+      // modelled the value would answer with a number here and overwrite the
+      // author's value on the first keystroke.
+      expect(steppedValue(PADDING, stored, 1)).toBeUndefined();
+    }
+  );
+
+  it("answers in the author's own precision", () => {
+    expect(steppedValue(PADDING, "1.50rem", 0.25)).toBe("1.75rem");
+  });
+
+  it("does not answer in floating point", () => {
+    // `0.1 + 0.2` is `0.30000000000000004`, a valid CSS number and a value
+    // nobody would choose to store.
+    expect(steppedValue(PADDING, "0.1rem", 0.2)).toBe("0.3rem");
+  });
+
+  it("widens precision for a fine step off a whole number", () => {
+    // Rounded to the value's own zero decimals, a 0.1 step off `1rem` would
+    // land back on `1rem` and the key would appear dead.
+    expect(steppedValue(PADDING, "1rem", 0.1)).toBe("1.1rem");
+  });
+});
+
+describe("stepping a number leaf", () => {
+  it("rests at the declared bounds rather than going past them", () => {
+    // `opacity` declares min 0 and max 1. Clamping rather than refusing is what
+    // a spinbutton does: holding an arrow at the maximum should rest there.
+    expect(steppedValue(OPACITY, 0.9, 0.2)).toBe(1);
+    expect(steppedValue(OPACITY, 0.1, -0.5)).toBe(0);
+  });
+
+  it("steps within the bounds", () => {
+    expect(steppedValue(OPACITY, 0.5, 0.1)).toBe(0.6);
+  });
+
+  it("refuses a value carrying a unit, which is not a number", () => {
+    // `opacity: 5px` is stored text the engine refuses; stepping it would
+    // answer `6px`, which it also refuses.
+    expect(steppedValue(OPACITY, "5px", 1)).toBeUndefined();
+  });
+});
+
+describe("units offered", () => {
+  it("offers only units the property accepts", () => {
+    const units = unitChoicesFor(PADDING);
+    expect(units).toContain("px");
+    expect(units).toContain("rem");
+    // `padding` resolves percentages, so `%` earns its place.
+    expect(units).toContain("%");
+  });
+
+  it("offers none for a leaf that is not a dimension", () => {
+    expect(unitChoicesFor(OPACITY)).toEqual([]);
+  });
+
+  it("carries the number across a unit change rather than converting it", () => {
+    // A conversion would need the font size and the viewport, neither knowable
+    // from here. `16px` becoming `16rem` is what was asked for; inventing
+    // `1rem` would be a guess dressed as help.
+    expect(withUnit(PADDING, "16px", "rem")).toBe("16rem");
+  });
+
+  it("refuses a unit swap on a value it cannot decompose", () => {
+    expect(withUnit(PADDING, "clamp(1rem, 2vw, 3rem)", "px")).toBeUndefined();
+  });
+});
+
+describe("a toggle is a projection of a keyword leaf", () => {
+  const two: StyleLeaf = {
+    kind: "keyword",
+    cssProperty: "font-style",
+    tokenKinds: [],
+    values: ["normal", "italic"],
+    maxParts: 1,
+  } as unknown as StyleLeaf;
+
+  it("offers both options when the whole vocabulary is two keywords", () => {
+    expect(toggleOptionsFor(two)).toEqual(["normal", "italic"]);
+  });
+
+  it("declines a vocabulary that does not fit in two buttons", () => {
+    // `display` has many values; drawing two of them would hide the rest.
+    const display = entry("display").shape as unknown as StyleLeaf;
+    expect(toggleOptionsFor(display)).toBeUndefined();
+  });
+
+  it("declines a leaf taking a shorthand of two keywords", () => {
+    // `overflow: hidden auto` sets two axes. Two buttons can say one thing.
+    const shorthand = { ...two, maxParts: 2 } as unknown as StyleLeaf;
+    expect(toggleOptionsFor(shorthand)).toBeUndefined();
+  });
+
+  it("declines to show a stored value outside its two options", () => {
+    // A CSS-wide keyword is live and compiles while matching neither button. A
+    // toggle drawn over it would show one side selected and replace the value
+    // on the first click.
+    const options = ["normal", "italic"] as const;
+    expect(toggleShows(options, "italic")).toBe(true);
+    expect(toggleShows(options, undefined)).toBe(true);
+    expect(toggleShows(options, "inherit")).toBe(false);
+    expect(toggleShows(options, { $token: "x.y" })).toBe(false);
+  });
+});

--- a/packages/builder/src/style-numeric.ts
+++ b/packages/builder/src/style-numeric.ts
@@ -230,42 +230,22 @@ function composeMeasurement(
 }
 
 /**
- * The rules the engine judges this leaf's values by.
+ * Whether the engine accepts this text as a value for this leaf.
  *
- * Read off the leaf rather than assembled from defaults, so a property that
- * declares nothing is judged by the engine's own defaults rather than by a
- * guess made here about what they are.
+ * The LEAF is handed over whole rather than having its rule fields copied into
+ * a fresh object. A dimension leaf already carries everything
+ * `checkDimensionValue` reads, so passing it through means the preflight this
+ * module performs and the validation the write path performs are judged by
+ * literally the same values — including any the engine adds later, which an
+ * enumeration here would silently omit while continuing to compile. A control
+ * that offered a unit the write path then refused would be the visible half of
+ * that drift; the invisible half is a restriction quietly not applied.
  */
-function rulesOf(leaf: Extract<StyleLeaf, { kind: "dimension" }>): {
-  keywords?: readonly string[];
-  maxParts?: number;
-  allowNegative?: boolean;
-  allowPercentage?: boolean;
-  functions?: readonly string[];
-  allowNumber?: boolean;
-} {
-  return {
-    ...(leaf.keywords === undefined ? {} : { keywords: leaf.keywords }),
-    ...(leaf.maxParts === undefined ? {} : { maxParts: leaf.maxParts }),
-    ...(leaf.allowNegative === undefined
-      ? {}
-      : { allowNegative: leaf.allowNegative }),
-    ...(leaf.allowPercentage === undefined
-      ? {}
-      : { allowPercentage: leaf.allowPercentage }),
-    ...(leaf.functions === undefined ? {} : { functions: leaf.functions }),
-    ...(leaf.allowNumber === undefined
-      ? {}
-      : { allowNumber: leaf.allowNumber }),
-  };
-}
-
-/** Whether the engine accepts this text as a value for this leaf. */
 function accepts(
   leaf: Extract<StyleLeaf, { kind: "dimension" }>,
   text: string
 ): boolean {
-  return checkDimensionValue(text, rulesOf(leaf)) === null;
+  return checkDimensionValue(text, leaf) === null;
 }
 
 /**

--- a/packages/builder/src/style-numeric.ts
+++ b/packages/builder/src/style-numeric.ts
@@ -94,8 +94,12 @@ export interface Measurement {
  * trailing text fails to match rather than matching its first part and
  * presenting a shorthand as though it were one measurement.
  */
-const MEASUREMENT =
-  /^([+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?)([a-zA-Z]+|%)?$/;
+const MEASUREMENT = new RegExp(
+  // Composed from the one grammar rather than spelled again: a second copy of
+  // the number rule would let a draft this accepts and `committedValue`
+  // rejects — or the reverse — pass every test either side owns.
+  `^(${CSS_NUMBER.source.replace(/^\^|\$$/g, "")})([a-zA-Z]+|%)?$`
+);
 
 /**
  * The measurement a stored value holds, when it holds exactly one.
@@ -134,6 +138,13 @@ export function measurementOfText(text: string): Measurement | undefined {
   const match = MEASUREMENT.exec(trimmed);
   if (match === null) return undefined;
   const [, digits = "", unit = ""] = match;
+  // Exponent notation is DECLINED rather than decomposed. It is a legal CSS
+  // number, and the affordances cannot carry it: there is no decimal count that
+  // both preserves `1e-3` and survives a step, so composing one back rounds a
+  // real value to `0` — which is the silent destruction this module exists to
+  // prevent, committed by the module itself. Declining keeps the plain field,
+  // where the value stays exactly as written and remains editable.
+  if (/[eE]/.test(digits)) return undefined;
   const number = Number(digits);
   if (!Number.isFinite(number)) return undefined;
   return { number, unit, decimals: decimalsOf(digits) };
@@ -146,12 +157,10 @@ export function measurementOfText(text: string): Measurement | undefined {
  * a step applied to `1.50` answers `1.60` rather than `1.6`, so a field does
  * not reformat itself under an author who was mid-edit.
  *
- * An exponent abandons the question — `1e-3` written back at three decimals
- * would be `0.001`, a different spelling of the same value, and rewriting a
- * spelling nobody asked to change is the thing this module exists to avoid.
+ * Exponent notation never reaches here, because {@link measurementOf} declines
+ * it — see the note there for why rounding it was the wrong answer.
  */
 function decimalsOf(digits: string): number {
-  if (/[eE]/.test(digits)) return 0;
   const point = digits.indexOf(".");
   return point === -1 ? 0 : digits.length - point - 1;
 }

--- a/packages/builder/src/style-numeric.ts
+++ b/packages/builder/src/style-numeric.ts
@@ -74,12 +74,20 @@ export interface Measurement {
   /** The unit as WRITTEN, or `""` for a unitless value. */
   readonly unit: string;
   /**
-   * How many digits followed the decimal point, so a step can answer in the
+   * How many digits followed the decimal point, so a step ROUNDS at the
    * author's own precision.
    *
-   * Carried rather than recovered from {@link number}, because the number has
-   * already lost it: `1.50` and `1.5` parse to the same double, and stepping
-   * the first should not silently reformat it to the second.
+   * Carried rather than recovered from {@link number}, which has already lost
+   * it: `1.50` and `1.5` parse to the same double, so without this a step of
+   * `0.25` on `1.50rem` would round to the value's apparent one decimal and
+   * answer `1.8rem` instead of `1.75rem`.
+   *
+   * It governs ROUNDING and not spelling. A trailing zero is not preserved
+   * through a step — `1.50` stepped by `0.1` answers `1.6`, not `1.60` —
+   * because the composed text is re-parsed to drop the zeros that rounding
+   * introduces. Stated because the two are easy to conflate, and a reader
+   * expecting the spelling back would find the value correct and the text
+   * changed.
    */
   readonly decimals: number;
 }
@@ -147,34 +155,47 @@ export function measurementOfText(text: string): Measurement | undefined {
   const match = MEASUREMENT.exec(trimmed);
   if (match === null) return undefined;
   const [, digits = "", unit = ""] = match;
-  // Exponent notation is DECLINED rather than decomposed. It is a legal CSS
-  // number, and the affordances cannot carry it: there is no decimal count that
-  // both preserves `1e-3` and survives a step, so composing one back rounds a
-  // real value to `0` — which is the silent destruction this module exists to
-  // prevent, committed by the module itself. Declining keeps the plain field,
-  // where the value stays exactly as written and remains editable.
-  if (/[eE]/.test(digits)) return undefined;
   const number = Number(digits);
   if (!Number.isFinite(number)) return undefined;
   const decimals = decimalsOf(digits);
   // Precision the formatter cannot round to is DECLINED, not truncated. The
   // engine accepts a length with more fractional digits than `toFixed` takes,
-  // and composing one would throw mid-keystroke — so the affordances step aside
-  // and the plain field keeps the value, which is what it does for every other
-  // spelling it cannot decompose.
+  // and composing one would throw mid-keystroke. Checked BEFORE the round trip
+  // below, which would be the thing that throws.
   if (decimals > MAX_FRACTION_DIGITS) return undefined;
+  // THE PROJECTION MUST REPRODUCE ITS OWN INPUT, or it does not get to edit it.
+  //
+  // A `number` is a double, and three separate spellings the engine accepts
+  // survive the trip through one changed: `1e-3` comes back `0.001`,
+  // `9007199254740993` comes back `9007199254740992` — smaller than it started
+  // — and `.5` comes back `0.5`. Composing any of them writes a value the
+  // author never typed, which is the silent rewrite this module exists to
+  // prevent, committed by the module itself.
+  //
+  // Asked as one question rather than as a guard per spelling, because the
+  // three above were found one at a time and there is no reason to think the
+  // list is closed. Anything that does not round-trip keeps the plain field,
+  // where it stays exactly as written and fully editable.
+  //
+  // Conservative by design: `+5` and `05` are legal and do not round-trip
+  // either, so they lose the affordances too. For an editing aid that is the
+  // cheap direction to be wrong in — the value still works and can still be
+  // typed, which is not true of the alternative.
+  const rewritten = decimals === 0 ? String(number) : number.toFixed(decimals);
+  if (rewritten !== digits) return undefined;
   return { number, unit, decimals };
 }
 
 /**
  * How many digits follow the decimal point in a written number.
  *
- * Read from the TEXT rather than from the parsed double, which no longer knows:
- * a step applied to `1.50` answers `1.60` rather than `1.6`, so a field does
- * not reformat itself under an author who was mid-edit.
+ * Read from the TEXT rather than from the parsed double, which no longer knows
+ * the difference between `1.50` and `1.5` — and the count is what a step rounds
+ * at, so losing it coarsens the result rather than merely reformatting it.
  *
- * Exponent notation never reaches here, because {@link measurementOf} declines
- * it — see the note there for why rounding it was the wrong answer.
+ * Exponent notation reaches here and answers 0, which is correct for what this
+ * measures: it never survives the round-trip check in {@link measurementOfText}
+ * regardless, so no caller sees the count.
  */
 function decimalsOf(digits: string): number {
   const point = digits.indexOf(".");

--- a/packages/builder/src/style-numeric.ts
+++ b/packages/builder/src/style-numeric.ts
@@ -1,0 +1,380 @@
+/**
+ * The numeric view of a stored style value, and the choices a control may offer
+ * over it.
+ *
+ * Pure, for the reason `style-controls.ts` is: what a value decomposes into,
+ * whether it may be stepped, and which units are worth offering are all
+ * derivation, and a jsdom test of the rendered field cannot separate a correct
+ * answer from a plausible wrong one — both draw an input with a number in it.
+ *
+ * ## A measurement is a PROJECTION over the string, never a model of it
+ *
+ * A `dimension` is stored as a string, and the catalog lets one hold far more
+ * than a number and a unit: per-property `keywords` (`auto` centres a margin
+ * and is discarded on padding), `maxParts` (four corners, or a row and a column
+ * gap), `functions` (`clamp()`, `fit-content()`), a unitless number where the
+ * property says so, the CSS-wide keywords everywhere, and a `{ $token }`
+ * reference that is a record and nonetheless a scalar.
+ *
+ * So `16px`, `auto`, `10px 20px`, `clamp(1rem, 2vw, 3rem)`, `inherit` and a
+ * token are all legal in one position. A control that MODELLED the value as a
+ * number plus a unit could represent one of those six, and would write the
+ * other five away the moment a field was focused and blurred — the author's
+ * `clamp()` replaced by `0px`, with nothing to say it happened.
+ *
+ * Everything here therefore answers with `undefined` rather than with a guess.
+ * A caller that gets `undefined` keeps the plain text field it already had,
+ * which accepts every one of those spellings; a caller that gets a measurement
+ * may additionally offer stepping and a unit. Nothing here ever rewrites a
+ * value it could not decompose.
+ *
+ * ## The engine decides, and this asks it
+ *
+ * No grammar is restated here. Whether a composed string is a legal value for a
+ * property is `checkDimensionValue`'s question, asked with the leaf's own rules,
+ * and a step or a unit swap that would produce something the engine refuses is
+ * answered `undefined` instead of being offered. Predicting it here would mean
+ * a second copy of the rules for negatives, percentages, functions and unitless
+ * numbers — the copy that keeps compiling while the two drift apart, which is
+ * invisible because a refused value and an unoffered one look identical.
+ *
+ * @module style-numeric
+ */
+
+import {
+  checkDimensionValue,
+  trimCssWhitespace,
+  type StyleLeaf,
+  type StyleValue,
+} from "@nextlyhq/blocks-engine";
+
+/**
+ * The grammar CSS calls a `<number>`: an optional sign, digits with an optional
+ * decimal part, and an optional exponent.
+ *
+ * Deliberately narrower than `Number` in both directions. `Number` reads
+ * spellings CSS does not (`0x10`, `0b10`, `0o10`), and it also accepts a
+ * trailing point: CSS requires at least one digit AFTER a decimal point, so
+ * `1.` is a number followed by a stray delimiter rather than a number, and
+ * `Number("1.")` quietly answering `1` would store a value the author never
+ * wrote a valid spelling of.
+ */
+export const CSS_NUMBER = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+
+/**
+ * One measurement split into the parts a control edits separately.
+ *
+ * A unit can be absent — `line-height: 1.5` is unitless and `0` is legal
+ * everywhere — so the empty string means "no unit" rather than "unknown", and a
+ * caller composing a new value joins the two with nothing between them.
+ */
+export interface Measurement {
+  /** The numeric part, as CSS reads it. */
+  readonly number: number;
+  /** The unit as WRITTEN, or `""` for a unitless value. */
+  readonly unit: string;
+  /**
+   * How many digits followed the decimal point, so a step can answer in the
+   * author's own precision.
+   *
+   * Carried rather than recovered from {@link number}, because the number has
+   * already lost it: `1.50` and `1.5` parse to the same double, and stepping
+   * the first should not silently reformat it to the second.
+   */
+  readonly decimals: number;
+}
+
+/**
+ * A number followed by an optional unit, and nothing else.
+ *
+ * The unit is matched as letters or a single `%` rather than by a list, because
+ * a list here would be a second copy of the engine's — this only has to SPLIT
+ * the string; whether the unit means anything is decided by asking. Anchored at
+ * both ends so a value with a second term (`10px 20px`), a function, or any
+ * trailing text fails to match rather than matching its first part and
+ * presenting a shorthand as though it were one measurement.
+ */
+const MEASUREMENT =
+  /^([+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?)([a-zA-Z]+|%)?$/;
+
+/**
+ * The measurement a stored value holds, when it holds exactly one.
+ *
+ * Answers `undefined` for everything a numeric affordance cannot represent —
+ * a keyword, a shorthand, a function, a token reference, an object at a scalar
+ * position — so the caller keeps its text field rather than narrowing what the
+ * author can express.
+ *
+ * A stored NUMBER is a measurement with no unit. `number` leaves store numbers
+ * rather than strings, so reading only strings would leave every `opacity` and
+ * `line-height` unsteppable while looking supported.
+ */
+export function measurementOf(
+  value: StyleValue | undefined
+): Measurement | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value)
+      ? { number: value, unit: "", decimals: decimalsOf(String(value)) }
+      : undefined;
+  }
+  // Every remaining non-string is refused by the same test, and a token
+  // reference is one of them: `{ $token }` is one value spelled as a record, so
+  // it arrives here as an object and is never decomposed. A control that
+  // offered to step it would be offering to replace the reference with a
+  // literal. Named because the shape is easy to mistake for a composite —
+  // `isTokenRef` is deliberately NOT called, since it could only ever agree
+  // with the test already made.
+  if (typeof value !== "string") return undefined;
+  return measurementOfText(value);
+}
+
+/** The measurement a typed draft holds, when it holds exactly one. */
+export function measurementOfText(text: string): Measurement | undefined {
+  const trimmed = trimCssWhitespace(text);
+  const match = MEASUREMENT.exec(trimmed);
+  if (match === null) return undefined;
+  const [, digits = "", unit = ""] = match;
+  const number = Number(digits);
+  if (!Number.isFinite(number)) return undefined;
+  return { number, unit, decimals: decimalsOf(digits) };
+}
+
+/**
+ * How many digits follow the decimal point in a written number.
+ *
+ * Read from the TEXT rather than from the parsed double, which no longer knows:
+ * a step applied to `1.50` answers `1.60` rather than `1.6`, so a field does
+ * not reformat itself under an author who was mid-edit.
+ *
+ * An exponent abandons the question — `1e-3` written back at three decimals
+ * would be `0.001`, a different spelling of the same value, and rewriting a
+ * spelling nobody asked to change is the thing this module exists to avoid.
+ */
+function decimalsOf(digits: string): number {
+  if (/[eE]/.test(digits)) return 0;
+  const point = digits.indexOf(".");
+  return point === -1 ? 0 : digits.length - point - 1;
+}
+
+/**
+ * The value written back after a measurement is composed, in the author's own
+ * precision.
+ *
+ * Rounded rather than left to floating point, because the arithmetic is not
+ * exact in the base the author is typing in: stepping `0.1` by `0.2` answers
+ * `0.30000000000000004`, which is a valid CSS number and a value no one would
+ * choose to store.
+ */
+function composeMeasurement(
+  number: number,
+  unit: string,
+  decimals: number
+): string {
+  // `toFixed` rather than a multiply-round-divide, which reintroduces the error
+  // it was meant to remove at the magnitudes a length actually takes.
+  const rounded = Number(number.toFixed(decimals));
+  return `${String(rounded)}${unit}`;
+}
+
+/**
+ * The rules the engine judges this leaf's values by.
+ *
+ * Read off the leaf rather than assembled from defaults, so a property that
+ * declares nothing is judged by the engine's own defaults rather than by a
+ * guess made here about what they are.
+ */
+function rulesOf(leaf: Extract<StyleLeaf, { kind: "dimension" }>): {
+  keywords?: readonly string[];
+  maxParts?: number;
+  allowNegative?: boolean;
+  allowPercentage?: boolean;
+  functions?: readonly string[];
+  allowNumber?: boolean;
+} {
+  return {
+    ...(leaf.keywords === undefined ? {} : { keywords: leaf.keywords }),
+    ...(leaf.maxParts === undefined ? {} : { maxParts: leaf.maxParts }),
+    ...(leaf.allowNegative === undefined
+      ? {}
+      : { allowNegative: leaf.allowNegative }),
+    ...(leaf.allowPercentage === undefined
+      ? {}
+      : { allowPercentage: leaf.allowPercentage }),
+    ...(leaf.functions === undefined ? {} : { functions: leaf.functions }),
+    ...(leaf.allowNumber === undefined
+      ? {}
+      : { allowNumber: leaf.allowNumber }),
+  };
+}
+
+/** Whether the engine accepts this text as a value for this leaf. */
+function accepts(
+  leaf: Extract<StyleLeaf, { kind: "dimension" }>,
+  text: string
+): boolean {
+  return checkDimensionValue(text, rulesOf(leaf)) === null;
+}
+
+/**
+ * The units a control may OFFER for this leaf, in the order an author meets
+ * them.
+ *
+ * Every candidate is tried against the engine before being offered, so the list
+ * is filtered by the property's own rules rather than by a belief about them: a
+ * leaf that refuses percentages never shows `%`, and no offered unit can
+ * produce a value the write path then rejects.
+ *
+ * **The candidate list is a discoverability aid and NOT a grammar, which is the
+ * honest description of its limits.** A unit missing from it is still typeable,
+ * because the field it sits beside accepts any text the engine does; a unit
+ * wrongly present is filtered out by the check above. So the failure mode is a
+ * shorter menu, which an author routes around, rather than an offered value the
+ * document then refuses. That asymmetry is why a fixed list is acceptable here
+ * and would not be in the write path — the engine's own unit sets are private
+ * to it, and reaching for them would put a second copy in this package.
+ */
+export function unitChoicesFor(leaf: StyleLeaf): readonly string[] {
+  if (leaf.kind !== "dimension") return [];
+  return UNIT_CANDIDATES.filter(unit => accepts(leaf, `1${unit}`));
+}
+
+/**
+ * Units common enough in authoring to be worth a menu entry.
+ *
+ * Absolute first, then the two font-relative units, then the viewport pair,
+ * then the percentage — the order an author reaches for them rather than
+ * alphabetical, which would open the menu on `%`. `ch` and the container-query
+ * units are omitted deliberately: they are typeable, and a menu long enough to
+ * scroll costs every author to serve a few.
+ */
+const UNIT_CANDIDATES: readonly string[] = ["px", "rem", "em", "vw", "vh", "%"];
+
+/**
+ * The same value carrying a different unit, or `undefined` when the swap would
+ * produce something this property refuses.
+ *
+ * The NUMBER is carried across unchanged rather than converted. A conversion
+ * would have to know the font size and the viewport to be correct, and neither
+ * is knowable from here — so `16px` becoming `16rem` is what the author asked
+ * for and is what a design tool does; inventing `1rem` instead would be a
+ * guess dressed as help.
+ */
+export function withUnit(
+  leaf: StyleLeaf,
+  value: StyleValue | undefined,
+  unit: string
+): string | undefined {
+  if (leaf.kind !== "dimension") return undefined;
+  const current = measurementOf(value);
+  if (current === undefined) return undefined;
+  const next = composeMeasurement(current.number, unit, current.decimals);
+  return accepts(leaf, next) ? next : undefined;
+}
+
+/**
+ * The value one step away, or `undefined` when this value cannot be stepped or
+ * the result would be refused.
+ *
+ * The unit is preserved, so stepping is an edit to the quantity and never a
+ * change of kind. A result the property refuses — a negative margin on a
+ * padding, a percentage where none resolves — answers `undefined` so the key
+ * does nothing visible, rather than writing a value the document then rejects
+ * and leaving the field holding text that was never stored.
+ */
+export function steppedValue(
+  leaf: StyleLeaf,
+  value: StyleValue | undefined,
+  delta: number
+): string | number | undefined {
+  if (leaf.kind === "number") return steppedNumber(leaf, value, delta);
+  if (leaf.kind !== "dimension") return undefined;
+  const current = measurementOf(value);
+  if (current === undefined) return undefined;
+  const next = composeMeasurement(
+    current.number + delta,
+    current.unit,
+    stepDecimals(current.decimals, delta)
+  );
+  return accepts(leaf, next) ? next : undefined;
+}
+
+/**
+ * A `number` leaf stepped within its declared bounds.
+ *
+ * Separate from the dimension path because the two are judged by different
+ * things: a number carries `min`, `max` and `integer` on the leaf itself, where
+ * a dimension's legality is a question only the engine can answer. Clamped
+ * rather than refused at the ends, which is what a spinbutton does — holding an
+ * arrow key at the maximum should rest there rather than stop responding.
+ */
+function steppedNumber(
+  leaf: Extract<StyleLeaf, { kind: "number" }>,
+  value: StyleValue | undefined,
+  delta: number
+): number | undefined {
+  const current = measurementOf(value);
+  // A unit on a number leaf is not a number: `opacity: 5px` is stored text the
+  // engine refuses, and stepping it would answer `6px`, which it also refuses.
+  if (current === undefined || current.unit !== "") return undefined;
+  const stepped =
+    leaf.integer === true
+      ? Math.round(current.number + delta)
+      : current.number + delta;
+  const decimals =
+    leaf.integer === true ? 0 : stepDecimals(current.decimals, delta);
+  const rounded = Number(stepped.toFixed(decimals));
+  if (leaf.min !== undefined && rounded < leaf.min) return leaf.min;
+  if (leaf.max !== undefined && rounded > leaf.max) return leaf.max;
+  return rounded;
+}
+
+/**
+ * How many decimals the stepped result keeps.
+ *
+ * The wider of the value's own precision and the step's, so a fine step off a
+ * whole number lands on `0.1` rather than being rounded straight back to `0`,
+ * and a coarse step off `1.50` does not drop the trailing zero the author
+ * typed.
+ */
+function stepDecimals(valueDecimals: number, delta: number): number {
+  return Math.max(valueDecimals, decimalsOf(String(Math.abs(delta))));
+}
+
+/**
+ * The two options a keyword leaf offers, when offering both at once is
+ * possible.
+ *
+ * A toggle is a PROJECTION of a keyword leaf and not a shape of its own — the
+ * engine has no boolean — so it is offered only where the whole vocabulary fits
+ * in it: exactly two values, and one keyword per value. A leaf taking a
+ * shorthand of two keywords (`overflow: hidden auto`) has more to say than two
+ * buttons can, and drawing one would hide the second axis entirely.
+ */
+export function toggleOptionsFor(
+  leaf: StyleLeaf
+): readonly [string, string] | undefined {
+  if (leaf.kind !== "keyword") return undefined;
+  if ((leaf.maxParts ?? 1) !== 1) return undefined;
+  const [first, second, ...rest] = leaf.values;
+  if (first === undefined || second === undefined || rest.length > 0) {
+    return undefined;
+  }
+  return [first, second];
+}
+
+/**
+ * Whether a toggle may show this stored value as one of its two options.
+ *
+ * A stored value outside the pair — a CSS-wide keyword, a token, a spelling the
+ * validator folds — is live and compiles while matching neither button, and a
+ * toggle rendered over it would show one side selected and silently replace the
+ * value on the first click. Answering `false` keeps the text field, which can
+ * show what is actually stored.
+ */
+export function toggleShows(
+  options: readonly [string, string],
+  value: StyleValue | undefined
+): boolean {
+  if (value === undefined) return true;
+  return typeof value === "string" && options.includes(value);
+}

--- a/packages/builder/src/style-numeric.ts
+++ b/packages/builder/src/style-numeric.ts
@@ -408,10 +408,37 @@ function steppedNumber(
       : current.number + delta;
   const decimals =
     leaf.integer === true ? 0 : stepDecimals(current.decimals, delta);
-  const rounded = Number(stepped.toFixed(decimals));
-  if (leaf.min !== undefined && rounded < leaf.min) return leaf.min;
-  if (leaf.max !== undefined && rounded > leaf.max) return leaf.max;
+  const rounded = roundedTo(stepped, decimals);
+  // Clamping comes FIRST and is exempt from the check below. Resting at a
+  // declared bound is the correct answer to a step rather than a step that
+  // failed to happen, so requiring movement there would make the arrow go dead
+  // exactly at the ends, which is where a spinbutton is most often held.
+  const bound = boundFor(leaf, rounded);
+  if (bound !== undefined) return bound;
+  // Everywhere else a number leaf is subject to the same arithmetic as a
+  // dimension, and was not asking the same question of it: `z-index` is an
+  // unbounded integer, so `9007199254740992` plus one is the same double and
+  // `9007199254740994` plus one lands two away — a dead key and a doubled step,
+  // in a branch the dimension path's guard never reached.
+  if (!movedBy(current.number, rounded, delta, decimals)) return undefined;
   return rounded;
+}
+
+/**
+ * The bound this leaf holds a value to, when the value has passed one.
+ *
+ * Its own answer rather than two conditionals inside the step, because "has
+ * this left the declared range" and "did this move by what was asked" are
+ * different questions with opposite answers at the ends: one says the value is
+ * correct, the other would say the step failed.
+ */
+function boundFor(
+  leaf: Extract<StyleLeaf, { kind: "number" }>,
+  value: number
+): number | undefined {
+  if (leaf.min !== undefined && value < leaf.min) return leaf.min;
+  if (leaf.max !== undefined && value > leaf.max) return leaf.max;
+  return undefined;
 }
 
 /**

--- a/packages/builder/src/style-numeric.ts
+++ b/packages/builder/src/style-numeric.ts
@@ -134,8 +134,15 @@ export function measurementOf(
   value: StyleValue | undefined
 ): Measurement | undefined {
   if (typeof value === "number") {
+    // DELEGATED to the text path rather than decomposed here, so the
+    // round-trip guard applies to a stored number too. Read directly, this
+    // branch answered `{ number: 1e-7, decimals: 0 }` for a value the text path
+    // declines — and `line-height: 1e-7` then stepped to `1`, discarding the
+    // quantity. Two paths to one answer is the defect this module keeps
+    // producing; the number branch simply prints its value and asks the same
+    // question of it.
     return Number.isFinite(value)
-      ? { number: value, unit: "", decimals: decimalsOf(String(value)) }
+      ? measurementOfText(String(value))
       : undefined;
   }
   // Every remaining non-string is refused by the same test, and a token

--- a/packages/builder/src/style-numeric.ts
+++ b/packages/builder/src/style-numeric.ts
@@ -85,6 +85,15 @@ export interface Measurement {
 }
 
 /**
+ * The most fractional digits `Number.prototype.toFixed` accepts.
+ *
+ * Named rather than inlined because it is a limit of the FORMATTER and not a
+ * judgement about how precise a length may be: the engine accepts more, and
+ * anything beyond this is declined rather than truncated for that reason.
+ */
+const MAX_FRACTION_DIGITS = 100;
+
+/**
  * A number followed by an optional unit, and nothing else.
  *
  * The unit is matched as letters or a single `%` rather than by a list, because
@@ -147,7 +156,14 @@ export function measurementOfText(text: string): Measurement | undefined {
   if (/[eE]/.test(digits)) return undefined;
   const number = Number(digits);
   if (!Number.isFinite(number)) return undefined;
-  return { number, unit, decimals: decimalsOf(digits) };
+  const decimals = decimalsOf(digits);
+  // Precision the formatter cannot round to is DECLINED, not truncated. The
+  // engine accepts a length with more fractional digits than `toFixed` takes,
+  // and composing one would throw mid-keystroke — so the affordances step aside
+  // and the plain field keeps the value, which is what it does for every other
+  // spelling it cannot decompose.
+  if (decimals > MAX_FRACTION_DIGITS) return undefined;
+  return { number, unit, decimals };
 }
 
 /**
@@ -346,7 +362,13 @@ function steppedNumber(
  * typed.
  */
 function stepDecimals(valueDecimals: number, delta: number): number {
-  return Math.max(valueDecimals, decimalsOf(String(Math.abs(delta))));
+  // Bounded as well as widened. A measurement reaching here is already within
+  // the formatter's range, but the step's own precision is a caller's value and
+  // widening past the limit would throw where the measurement alone would not.
+  return Math.min(
+    MAX_FRACTION_DIGITS,
+    Math.max(valueDecimals, decimalsOf(String(Math.abs(delta))))
+  );
 }
 
 /**

--- a/packages/builder/src/style-numeric.ts
+++ b/packages/builder/src/style-numeric.ts
@@ -165,24 +165,25 @@ export function measurementOfText(text: string): Measurement | undefined {
   if (decimals > MAX_FRACTION_DIGITS) return undefined;
   // THE PROJECTION MUST REPRODUCE ITS OWN INPUT, or it does not get to edit it.
   //
-  // A `number` is a double, and three separate spellings the engine accepts
-  // survive the trip through one changed: `1e-3` comes back `0.001`,
-  // `9007199254740993` comes back `9007199254740992` — smaller than it started
-  // — and `.5` comes back `0.5`. Composing any of them writes a value the
-  // author never typed, which is the silent rewrite this module exists to
-  // prevent, committed by the module itself.
+  // A `number` is a double and several spellings the engine accepts do not
+  // survive the trip through one: `9007199254740993` comes back smaller than it
+  // started, `1e-7` composes to `0`, `.5` becomes `0.5`. Composing any of them
+  // writes a value the author never typed, which is the silent rewrite this
+  // module exists to prevent, committed by the module itself.
   //
-  // Asked as one question rather than as a guard per spelling, because the
-  // three above were found one at a time and there is no reason to think the
-  // list is closed. Anything that does not round-trip keeps the plain field,
-  // where it stays exactly as written and fully editable.
+  // Asked by CALLING THE COMPOSER rather than by re-deriving what it would do.
+  // That is the whole point of the check and not an implementation detail: a
+  // guard written as its own expression is a second answer to "what will this
+  // become", and the two drifted apart at exactly one input — `String(1e-7)` is
+  // `"1e-7"` and round-trips, while `toFixed(0)` on the same value is `"0"`. So
+  // the guard admitted a value the composer then destroyed. Sharing the
+  // function makes that disagreement unrepresentable.
   //
-  // Conservative by design: `+5` and `05` are legal and do not round-trip
-  // either, so they lose the affordances too. For an editing aid that is the
-  // cheap direction to be wrong in — the value still works and can still be
-  // typed, which is not true of the alternative.
-  const rewritten = decimals === 0 ? String(number) : number.toFixed(decimals);
-  if (rewritten !== digits) return undefined;
+  // Conservative by design: `1.50`, `+5`, `05` and `.5` are all legal and none
+  // reproduces itself, so they lose the affordances too. For an editing aid
+  // that is the cheap direction to be wrong in — the value still works and can
+  // still be typed, which is not true of the alternative.
+  if (composeMeasurement(number, "", decimals) !== digits) return undefined;
   return { number, unit, decimals };
 }
 

--- a/packages/builder/src/style-numeric.ts
+++ b/packages/builder/src/style-numeric.ts
@@ -219,8 +219,7 @@ function composeMeasurement(
 ): string {
   // `toFixed` rather than a multiply-round-divide, which reintroduces the error
   // it was meant to remove at the magnitudes a length actually takes.
-  const rounded = Number(number.toFixed(decimals));
-  return `${String(rounded)}${unit}`;
+  return `${String(roundedTo(number, decimals))}${unit}`;
 }
 
 /**
@@ -337,12 +336,52 @@ export function steppedValue(
   if (leaf.kind !== "dimension") return undefined;
   const current = measurementOf(value);
   if (current === undefined) return undefined;
+  const decimals = stepDecimals(current.decimals, delta);
+  const stepped = roundedTo(current.number + delta, decimals);
+  if (!movedBy(current.number, stepped, delta, decimals)) return undefined;
   const next = composeMeasurement(
     current.number + delta,
     current.unit,
-    stepDecimals(current.decimals, delta)
+    decimals
   );
   return accepts(leaf, next) ? next : undefined;
+}
+
+/**
+ * Whether the composed result actually moved by the step that was asked for.
+ *
+ * The round-trip guard in {@link measurementOfText} proves the STARTING value
+ * survives a double. It says nothing about the step, and near the safe-integer
+ * boundary the two come apart: `9007199254740992` plus one is the same double,
+ * so the arrow is consumed and nothing happens, and `9007199254740994` plus one
+ * lands on `...996` — a silent step of two. Neither is a value the author asked
+ * for, and the first is worse than an error because it looks like a dead key.
+ *
+ * Measured at the composition's own precision rather than exactly, because
+ * binary arithmetic does not land on decimal boundaries: `1.25 + 0.1` differs
+ * from `1.25` by `0.10000000000000009`, which is the correct step and is not
+ * `0.1`. Rounding both sides at the digits the value is written to compares
+ * what an author would read rather than what a double holds.
+ */
+function movedBy(
+  from: number,
+  stepped: number,
+  delta: number,
+  decimals: number
+): boolean {
+  return roundedTo(stepped - from, decimals) === roundedTo(delta, decimals);
+}
+
+/**
+ * A number as it reads at a given precision.
+ *
+ * The one rounding used by both the composer and the check above, so what gets
+ * written and what gets verified cannot be two different roundings — which is
+ * the disagreement this module has already produced once, between a guard and
+ * the composer it was guarding.
+ */
+function roundedTo(value: number, decimals: number): number {
+  return Number(value.toFixed(decimals));
 }
 
 /**

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -393,13 +393,14 @@
  * or three characters and the quantity is what an author edits, so an even
  * split would take space from the half that needs it.
  *
- * `:not(:first-child)` is load-bearing rather than defensive. Most fields draw
- * NO unit menu — every colour, URL, free-CSS, unitless number and non-simple
- * dimension — and there the input is the first and last child at once, so a
- * bare `:last-child` would override the design system's full-width input and
- * shrink ordinary inspector rows to their intrinsic width.
+ * Named on the control rather than found by position. A positional selector
+ * has to be read against how many children the row happens to have, and most
+ * rows draw NO unit menu — every colour, URL, free-CSS, unitless number and
+ * non-simple dimension — so one written for the trigger claimed the lone input
+ * instead and shrank ordinary inspector rows to their intrinsic width. A class
+ * cannot match the wrong element however the row is composed.
  */
-.nx-style-inspector__numeric > :last-child:not(:first-child) {
+.nx-style-inspector__unit {
   flex: 0 0 auto;
   width: auto;
   min-width: 4.5rem;

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -392,8 +392,14 @@
  * Sized to its content rather than shared evenly with the field: a unit is two
  * or three characters and the quantity is what an author edits, so an even
  * split would take space from the half that needs it.
+ *
+ * `:not(:first-child)` is load-bearing rather than defensive. Most fields draw
+ * NO unit menu — every colour, URL, free-CSS, unitless number and non-simple
+ * dimension — and there the input is the first and last child at once, so a
+ * bare `:last-child` would override the design system's full-width input and
+ * shrink ordinary inspector rows to their intrinsic width.
  */
-.nx-style-inspector__numeric > :last-child {
+.nx-style-inspector__numeric > :last-child:not(:first-child) {
   flex: 0 0 auto;
   width: auto;
   min-width: 4.5rem;

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -372,6 +372,75 @@
 }
 
 /*
+ * A measurement and its unit read as one control, so they sit on one line with
+ * the field taking the space the unit does not. Without this both are block
+ * elements at full width and the unit menu lands under the input as a second
+ * row, which reads as two separate controls for one value.
+ */
+.nx-style-inspector__numeric {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.nx-style-inspector__numeric > :first-child {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/*
+ * Sized to its content rather than shared evenly with the field: a unit is two
+ * or three characters and the quantity is what an author edits, so an even
+ * split would take space from the half that needs it.
+ */
+.nx-style-inspector__numeric > :last-child {
+  flex: 0 0 auto;
+  width: auto;
+  min-width: 4.5rem;
+}
+
+/*
+ * Two states of one property, drawn as one segmented control rather than two
+ * buttons that happen to be adjacent: they share a border and split the width,
+ * so the pair reads as a single choice with one side taken.
+ */
+.nx-style-inspector__toggle {
+  display: flex;
+}
+
+.nx-style-inspector__toggle > button {
+  flex: 1 1 0;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--nx-border);
+  background: var(--nx-background);
+  color: var(--nx-foreground);
+  font: inherit;
+  cursor: pointer;
+}
+
+.nx-style-inspector__toggle > button:first-child {
+  border-start-start-radius: var(--radius-md);
+  border-end-start-radius: var(--radius-md);
+}
+
+.nx-style-inspector__toggle > button:last-child {
+  border-start-end-radius: var(--radius-md);
+  border-end-end-radius: var(--radius-md);
+  /* The shared edge is drawn once, by the first button. */
+  border-inline-start-width: 0;
+}
+
+/*
+ * The taken side is filled rather than merely outlined. `aria-pressed` is the
+ * state a screen reader reads, so styling from that attribute keeps what is
+ * seen and what is announced reading off one value.
+ */
+.nx-style-inspector__toggle > button[aria-pressed="true"] {
+  background: var(--nx-accent);
+  color: var(--nx-accent-foreground);
+}
+
+/*
  * A prop the panel cannot draw is dimmed rather than hidden — present, and
  * visibly not one of the things an author can change here.
  */


### PR DESCRIPTION
Implements `task:pb-core-style-controls` (C-4). Research: `research:pb-core-style-controls-shape`. Branched from `249506a69`.

## What an author gets

- **Arrow keys step a measurement** and keep its unit; **Shift steps by ten**.
- **A unit menu** beside the field, offering only units the property accepts.
- **A two-value keyword renders as a pair of buttons** rather than a menu — both options visible, one click each, and pressing the pressed one clears.

Keyboard scale follows Figma, Framer and Webflow rather than being invented: an author arrives already knowing arrow-one and shift-ten.

## The decision worth reviewing: these are layered ON the text field, not a replacement

The obvious build is a number input plus a unit dropdown. **It would silently destroy data.** A style value is stored as a *string*, and the catalog lets one hold far more than a number and a unit:

| stored value | why it's legal |
|---|---|
| `16px` | the simple case |
| `auto` | per-property `keywords` — `auto` centres a margin, and is discarded on padding |
| `10px 20px` | `maxParts` — four corners, or a row and column gap |
| `clamp(1rem, 2vw, 3rem)` | declared `functions` |
| `inherit` | CSS-wide keywords, accepted everywhere |
| `{ $token: "space.4" }` | a record that is nonetheless a scalar |

A control that *modelled* the value as `(number, unit)` can represent one of those six and would overwrite the other five the first time a field was focused and blurred — `clamp(...)` replaced by `0px`, **silently**, because the result is a perfectly valid declaration.

So the text field remains the control. [`style-numeric.ts`](packages/builder/src/style-numeric.ts) decides whether a value is a single simple measurement and answers `undefined` when it is not; every caller keeps the plain field on `undefined` rather than narrowing what can be typed. **Nothing rewrites a value it could not decompose.**

## No grammar is restated

Whether a stepped or unit-swapped result is legal is `checkDimensionValue`'s question, asked with the leaf's own rules. `padding` refuses a step below zero and `margin` allows one **without either rule being written down twice** — that pair is the separating test in the suite.

The offered units are filtered the same way, which is why a property resolving no percentage never shows `%`. The candidate list behind that filter is a **discoverability aid, not a grammar**, and the module says so: a unit missing from it stays typeable, one wrongly in it is filtered out, so the failure mode is a shorter menu rather than an offered value the document then refuses. The engine's own unit sets are private to it and reaching for them would put a second copy in this package.

A `number` leaf keeps its own path — `min`/`max`/`integer` live on the leaf where a dimension's legality is only the engine's to judge — and stepping clamps at the bounds rather than refusing, which is what a spinbutton does.

## Evidence

**12 properties break-verified** — each seen failing for its intended reason. Three of those breaks initially *did not fail*, and each was a real defect in my own work rather than a formality:

| break | what it exposed |
|---|---|
| remove `isTokenRef` guard | **dead code** — `typeof value !== "string"` already rejected it. Guard removed. |
| remove the object guard | test was **satisfied by absence** — `String({...})` is `"[object Object]"`, which the regex rejects anyway. Added a `{ toString: () => "16px" }` control that makes the guard observable. |
| make the step write an illegal value | test asserted on `apply`, so it was proving the **validator** refuses, not that the step declined. Now also asserts no refusal message appears — declining and writing-then-refused are different things. |

The headline test is `LEAVES a value it cannot decompose entirely alone`: arrow and shift-arrow on a stored `clamp(1rem, 2vw, 3rem)` reach `editor.apply` zero times and leave the field's value byte-identical.

Fixtures come from `STYLE_CATALOG` rather than being hand-written, because the property under test is *that the engine decides* — a hand-made leaf asserting `allowNegative: false` would pass against a hardcoded rule just as happily.

**Suite: 1092 → 1128**, no drops.

## Gates

`build` ✅ · `vitest` 1128/1128 ✅ · `check-types` ✅ · package `lint` ✅ · root `eslint` ✅ (50 files read, `style-numeric.ts` among them) · `check-comment-convention` ✅ · `fallow audit` **pass**, 5 files, all `*_introduced` counters 0.

Fallow first reported `complexity_introduced: 1` on `ValueField`, which had become a router over three surfaces with the keyword menu still inline. Extracted `SelectField`, so deciding *which* surface a leaf gets and *drawing* one are separate readings.

## Scope

`packages/builder/**` only. Confirmed unclaimed before starting: no `claim` op has ever been written for this task in the ledger — checked directly rather than by polling sessions, since the claim ops are the only enumeration that includes lanes nobody has spoken to. Four branches that diff against the style-control surface all carry merged PRs (#1128, #1129, #1134, #1135); a squash preserves none of a branch's commits, so both `ahead` counts and ancestry lie afterwards.

This unblocks `pb-colour-controls`, `pb-breakpoint-badges`, `pb-batch-style-edit` and `pb-canvas-spacing-values` — and through the first, the path to C-7.

## Review round 1 — six findings, all confirmed and fixed in `c96d62757`

Codex found six and every one was real. Two are worth reading:

- **The toggle could not be reached.** Every keyword leaf resolves to the `select` control kind, so the branch testing that kind returned first and the two-value case below it was dead. Fixed by deciding the toggle before the menu. **Latent rather than live** — I walked the catalog and *no property declares a two-value keyword*, so nothing rendered wrongly; it would have failed silently the first time one was added.
- **Scientific notation was rounded away.** `withUnit("1e-3rem", "px")` returned `"0px"` — the exact silent destruction this module exists to prevent, committed by the module itself. Declined outright rather than given a derived precision, because no decimal count both preserves `1e-3` and survives a step.

The other four: three copies of the CSS-number grammar with the exported one dead (now one, three readers); every unit menu on a composite announcing "Unit for Padding" (now position-aware); a stored `12ch`/`12PX` rendering an empty trigger (now carried verbatim, and unitless shows no menu since there is no way back); and no layout CSS at all, so the row wrapped into two (now a flex line, with a segmented toggle styled from `aria-pressed`).

Suite 1128 → 1131, each new test break-verified.

**Not done here:** D-05.7 asks that every control be proven end to end in a browser — set in the inspector, publish, assert on the served page. These are covered by unit and jsdom tests only. Saying so plainly rather than letting the green read as more than it is.

**The toggle has no panel-level test and cannot have one yet.** No catalog property declares a two-value keyword leaf, so the projection is unit-tested against a synthetic leaf and the rendering is exercised by nothing. It will engage the moment such a property is added — which is D-05.1 working as intended, a catalog change reaching the controls with no control-code edit — but today it is forward-looking rather than proven.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unit selectors for supported numeric style properties.
  * Added arrow-key value adjustments, including larger Shift-based increments.
  * Added segmented toggles and multi-option controls for applicable style settings.
  * Improved keyboard accessibility with labeled controls and Enter-to-commit editing.

* **Bug Fixes**
  * Prevented invalid, unsupported, or imprecise values from being applied.
  * Preserved measurement units and decimal precision during edits.
  * Enforced valid bounds and engine-specific negative-value rules.
  * Ensured edits consistently reflect the current draft value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->