### PR TITLE
fix(admin): read a validation payload once, and check the whole error shape

### DIFF
--- a/.changeset/one-validation-issue-reader.md
+++ b/.changeset/one-validation-issue-reader.md
@@ -1,0 +1,43 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+One reading of a validation payload, and a guard that answers for the whole shape.
+
+`parseServerErrors` traversed `data.errors` independently of `validationIssues`,
+so the entry form and the SDK disagreed about a partial issue: one dropped it,
+the other kept it with missing fields. Both now read through one normalizer and
+the form derives its stricter subset from the result.
+
+A blank message is reported as absent rather than carried, so a surface keying
+issues by field falls back to its own wording instead of showing an author a
+refusal with nothing in it.
+
+`isApiError` checks every present field rather than `status` alone. It narrows
+`unknown` across the SDK boundary, where another client's error carrying a
+numeric status would otherwise be handed over as an `ApiError` whose `code` is
+declared `string` and is not.

--- a/packages/admin/src/lib/api/parseApiError.test.ts
+++ b/packages/admin/src/lib/api/parseApiError.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 import {
   apiErrorMessage,
   isApiError,
+  normalizeValidationIssues,
   parseApiError,
   validationIssues,
 } from "./parseApiError";
@@ -77,6 +78,48 @@ describe("isApiError", () => {
   it("says no to values that are not errors at all", () => {
     expect(isApiError({ status: 400 })).toBe(false);
     expect(isApiError(undefined)).toBe(false);
+  });
+
+  // This narrows `unknown` across the published SDK boundary, so a numeric
+  // `status` alone is not proof of the shape: another client's error that
+  // records one would be handed to a plugin author as an `ApiError` whose
+  // `code` is declared `string` and is not.
+  describe("a present field of the wrong type", () => {
+    it.each([
+      ["code", { status: 400, code: 42 }],
+      ["requestId", { status: 400, requestId: 7 }],
+      ["data", { status: 400, data: "not an object" }],
+    ])("rejects a wrong %s", (_field, extra) => {
+      expect(isApiError(Object.assign(new Error("x"), extra))).toBe(false);
+    });
+
+    it("still accepts them absent, because the type says optional", () => {
+      expect(isApiError(Object.assign(new Error("x"), { status: 400 }))).toBe(
+        true
+      );
+    });
+  });
+});
+
+describe("normalizeValidationIssues", () => {
+  // The blankness rule lives HERE and nowhere else, so a consumer keying by
+  // field and a consumer showing a sentence cannot disagree about whether ""
+  // counts as a message.
+  it.each([
+    ["an empty string", ""],
+    ["whitespace only", "   "],
+  ])("reports %s as absent rather than carrying it", (_name, message) => {
+    expect(normalizeValidationIssues([{ path: "name", message }])).toEqual([
+      { path: "name", code: undefined, message: undefined },
+    ]);
+  });
+
+  it("keeps a message that merely has surrounding space", () => {
+    // Blank is absent; padded is not. Trimming the retained value would be a
+    // separate decision about presentation.
+    expect(
+      normalizeValidationIssues([{ path: "name", message: " Need it. " }])
+    ).toEqual([{ path: "name", code: undefined, message: " Need it. " }]);
   });
 });
 
@@ -191,6 +234,18 @@ describe("apiErrorMessage", () => {
   // A malformed payload should not produce "undefined" on screen.
   it("ignores field errors that carry no message", () => {
     const err = parseApiError(validationBody([{ path: "name" }]), 400);
+
+    expect(apiErrorMessage(err)).toBe("Validation failed.");
+  });
+
+  it("ignores a field error whose message is blank", () => {
+    // Same case as the one above by the time it reaches here, and it has to be:
+    // a message with nothing in it explains nothing, so falling back to the
+    // top-level sentence is what leaves a reader with something to read.
+    const err = parseApiError(
+      validationBody([{ path: "name", code: "REQUIRED", message: "   " }]),
+      400
+    );
 
     expect(apiErrorMessage(err)).toBe("Validation failed.");
   });

--- a/packages/admin/src/lib/api/parseApiError.ts
+++ b/packages/admin/src/lib/api/parseApiError.ts
@@ -75,21 +75,63 @@ export interface ValidationIssue {
  *
  * Keyed on `status` being a NUMBER rather than merely present, because the
  * absent-status case is the one this exists to separate.
+ *
+ * Every OTHER field is checked too, and only when present. This narrows
+ * `unknown` across a published SDK boundary, so it has to answer for the whole
+ * shape rather than for the field that motivated it: another client's error —
+ * an axios-style one, or any wrapper that also records a numeric `status` —
+ * would otherwise be handed to a caller as an `ApiError` whose `code` is
+ * declared `string` and is not. Absent stays legal because the type says
+ * optional; present-and-wrong is what fails.
  */
 export function isApiError(reason: unknown): reason is ApiError {
-  return (
-    reason instanceof Error &&
-    typeof (reason as Partial<ApiError>).status === "number"
-  );
+  if (!(reason instanceof Error)) return false;
+
+  const { status, code, requestId, data } = reason as Partial<ApiError>;
+  if (typeof status !== "number") return false;
+  if (code !== undefined && typeof code !== "string") return false;
+  if (requestId !== undefined && typeof requestId !== "string") return false;
+  return data === undefined || isObject(data);
+}
+
+/** A wire field kept only when it is a string with something in it. */
+function readable(value: unknown): string | undefined {
+  // An empty or blank string is treated as ABSENT rather than carried, because
+  // every consumer wants the same thing from it and none of them wants "".
+  // Keying an issue under a blank message shows an author a failed save with
+  // no reason, and it does so while looking like a populated result — the
+  // caller's own "did I get any issues" test passes. Deciding it here is what
+  // stops each consumer having its own opinion about blankness.
+  if (typeof value !== "string") return undefined;
+  return value.trim() === "" ? undefined : value;
+}
+
+/**
+ * Normalize the wire's `errors` array into typed issues.
+ *
+ * Separate from `validationIssues` because the payload arrives at two
+ * different boundaries: a caller narrowing a REJECTION reaches it through
+ * `validationIssues`, and `parseServerErrors` reaches it from a raw response
+ * body that has never been an `Error`. Both need the same normalization and
+ * neither should own it.
+ */
+export function normalizeValidationIssues(
+  errors: unknown
+): readonly ValidationIssue[] {
+  if (!Array.isArray(errors)) return [];
+
+  // Rebuilt field by field rather than asserted, because this is the point the
+  // wire shape becomes a typed one. Anything the server sent that is not a
+  // usable string arrives here as `undefined`, which every caller handles.
+  return errors.filter(isObject).map(issue => ({
+    path: readable(issue.path),
+    code: readable(issue.code),
+    message: readable(issue.message),
+  }));
 }
 
 /**
  * The per-field complaints a rejection carries, or none.
- *
- * The one reading of `data.errors`, so a consumer keying by field and a
- * consumer showing a sentence agree about what is in there. Each applies its
- * own requirement to the result — which fields it needs present — rather than
- * restating how to find them.
  *
  * Empty for every rejection that is not a validation failure, a transport
  * error included, which is why this answers with an array rather than a
@@ -99,17 +141,7 @@ export function isApiError(reason: unknown): reason is ApiError {
 export function validationIssues(reason: unknown): readonly ValidationIssue[] {
   if (!isApiError(reason)) return [];
 
-  const errors = reason.data?.errors;
-  if (!Array.isArray(errors)) return [];
-
-  // Rebuilt field by field rather than asserted, because this is the point the
-  // wire shape becomes a typed one. Anything the server sent that is not a
-  // string arrives here as `undefined`, which every caller already handles.
-  return errors.filter(isObject).map(issue => ({
-    path: typeof issue.path === "string" ? issue.path : undefined,
-    code: typeof issue.code === "string" ? issue.code : undefined,
-    message: typeof issue.message === "string" ? issue.message : undefined,
-  }));
+  return normalizeValidationIssues(reason.data?.errors);
 }
 
 /**
@@ -132,9 +164,13 @@ export function apiErrorMessage(
   // field cannot disagree about where the reasons live. What differs between
   // them is the requirement, not the lookup: this one needs a message and does
   // not care which field produced it.
+  //
+  // No emptiness test of its own. `normalizeValidationIssues` already reports a
+  // blank message as absent, and re-testing here would be a second opinion
+  // about blankness that could drift from the one the other consumers see.
   const reasons = validationIssues(err)
     .map(issue => issue.message)
-    .filter((m): m is string => m !== undefined && m.length > 0);
+    .filter((m): m is string => m !== undefined);
 
   if (reasons.length > 0) return reasons.join(" ");
 

--- a/packages/admin/src/lib/errors/error-mapping.test.ts
+++ b/packages/admin/src/lib/errors/error-mapping.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Turning a server's field errors into something a form can point at.
+ *
+ * The subject here is the NARROWING, not the reading. `parseServerErrors` wants
+ * a path, a code and a message on every issue, because it names a form control
+ * with them and an issue missing any of the three cannot address one. That is a
+ * stricter requirement than a consumer showing a sentence has — and the two
+ * used to be expressed as two separate traversals of `data.errors`, which is
+ * how they came to disagree.
+ *
+ * So what this file asserts is that the strict view is DERIVED from the shared
+ * one: same reading, different requirement.
+ *
+ * @module lib/errors/error-mapping.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { validationIssues, parseApiError } from "../api/parseApiError";
+import { parseServerErrors } from "./error-mapping";
+
+/** A canonical validation body, as the wire carries it. */
+const body = (errors: unknown[]) => ({
+  error: {
+    code: "VALIDATION_ERROR",
+    message: "Validation failed.",
+    requestId: "req_x",
+    data: { errors },
+  },
+});
+
+const COMPLETE = {
+  path: "email",
+  code: "INVALID_FORMAT",
+  message: "Must be a valid email address.",
+};
+
+describe("parseServerErrors", () => {
+  it("keeps an issue that can name a field", () => {
+    expect(parseServerErrors(body([COMPLETE]))).toEqual([COMPLETE]);
+  });
+
+  it("returns null for anything that is not a canonical error body", () => {
+    expect(parseServerErrors({ oops: true })).toBeNull();
+    expect(parseServerErrors(null)).toBeNull();
+    expect(parseServerErrors("nope")).toBeNull();
+  });
+
+  it("unwraps a fetch/axios-style response before reading it", () => {
+    // The wrapper case the function has always accepted, asserted because the
+    // derivation below must not quietly drop it.
+    expect(parseServerErrors({ response: { data: body([COMPLETE]) } })).toEqual(
+      [COMPLETE]
+    );
+  });
+
+  describe("the requirement it adds on top of the shared reading", () => {
+    it.each([
+      ["no path", { code: "REQUIRED", message: "Need it." }],
+      ["no code", { path: "email", message: "Need it." }],
+      ["no message", { path: "email", code: "REQUIRED" }],
+      ["a blank message", { path: "email", code: "REQUIRED", message: "  " }],
+    ])("drops an issue with %s", (_name, issue) => {
+      expect(parseServerErrors(body([issue]))).toEqual([]);
+    });
+
+    it("drops only the unusable one, keeping the rest", () => {
+      expect(parseServerErrors(body([COMPLETE, { path: "name" }]))).toEqual([
+        COMPLETE,
+      ]);
+    });
+  });
+
+  // The property the derivation exists for. Two independent traversals of
+  // `data.errors` agreed on the day they were written and disagreed on partial
+  // issues; anything this file can assert about one reading has to hold for the
+  // other, on the same input.
+  describe("agrees with the shared reading", () => {
+    it("is exactly the subset of validationIssues that names all three", () => {
+      const errors = [
+        COMPLETE,
+        { path: "name" },
+        { path: "slug", code: "REQUIRED", message: "" },
+        { code: "REQUIRED", message: "Orphaned." },
+        "not an object",
+      ];
+
+      const shared = validationIssues(parseApiError(body(errors), 400));
+      const strict = parseServerErrors(body(errors));
+
+      expect(strict).toEqual(
+        shared.filter(
+          i =>
+            i.path !== undefined &&
+            i.code !== undefined &&
+            i.message !== undefined
+        )
+      );
+      // And the shared reading really did see more than the strict one, or the
+      // assertion above is satisfied by both being empty.
+      expect(shared.length).toBeGreaterThan((strict ?? []).length);
+    });
+  });
+});

--- a/packages/admin/src/lib/errors/error-mapping.ts
+++ b/packages/admin/src/lib/errors/error-mapping.ts
@@ -28,6 +28,8 @@
 
 import type { UseFormSetError, FieldPath, FieldValues } from "react-hook-form";
 
+import { normalizeValidationIssues } from "../api/parseApiError";
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -118,16 +120,17 @@ export function parseServerErrors(
     ) {
       const data = errorObj.data as Record<string, unknown>;
       if (Array.isArray(data.errors)) {
-        return data.errors.filter(
-          (e): e is ServerFieldError =>
-            typeof e === "object" &&
-            e !== null &&
-            "path" in e &&
-            "code" in e &&
-            "message" in e &&
-            typeof (e as ServerFieldError).path === "string" &&
-            typeof (e as ServerFieldError).code === "string" &&
-            typeof (e as ServerFieldError).message === "string"
+        // Normalized once, in `parseApiError`, then NARROWED here. Traversing
+        // `data.errors` a second time would be a second answer to what the
+        // wire carries, and the two drifted the moment they existed: this
+        // form needs all three fields to name a form control, which is a
+        // stricter requirement than a consumer showing a sentence has. The
+        // requirement belongs here; the reading does not.
+        return normalizeValidationIssues(data.errors).filter(
+          (issue): issue is ServerFieldError =>
+            issue.path !== undefined &&
+            issue.code !== undefined &&
+            issue.message !== undefined
         );
       }
     }


### PR DESCRIPTION
Closes the three Codex findings that merged **unresolved** with #1136. All three were real; all three were mine.

They merged because I measured threads at 18:05:38Z, reported zero unresolved, and Codex posted these at **18:07:22Z**. I pushed again at 18:19 and re-read check-runs twice afterwards but never re-read threads, so my last thread measurement was 14 minutes stale at merge time. A thread count is a photograph, exactly as `reading-a-ci-verdict.md` says about jobs.

## One reading of `data.errors` (P1)

`parseServerErrors` traversed the array on its own while `validationIssues` read the same one, and they already disagreed on real input: the form dropped an issue missing any field, the SDK kept it with those fields `undefined`.

This is **live code**, not a latent duplicate — `parseServerErrors` is reached through `createServerErrorHandler`, which `useCreateEntry` and `useUpdateEntry` both import, so it sits on the entry-form error path every content editor hits. (`hasFieldErrors` also calls it and is itself unused; that is pre-existing and untouched here.)

The reading now happens once in `normalizeValidationIssues`, and the form derives its stricter subset — all three fields present — from the result. **The requirement belongs at the form; the reading does not.**

My own comment shipped in #1136 claimed `validationIssues` was *"the one reading of `data.errors`"*. It was not. I folded `apiErrorMessage` in because it sat in the same file and never grepped the package.

## A blank message no longer suppresses the fallback (P2)

An issue with a `path` and `message: ""` was stored, so `Object.keys(issues).length` was non-zero, the section-level fallback was skipped, and a studio rendered `{ saved: false, issues: { section: "" } }` — a failed save with no explanation, which *looks* like a populated result to the caller's own emptiness test.

Fixed in the normalizer rather than at the call site, so every consumer sees the same answer. `apiErrorMessage` consequently drops its own `length > 0` test — that would have been a second opinion about blankness, free to drift. Whitespace-only counts as blank; a message with surrounding space is kept, since trimming displayed text is a separate decision.

No change was needed in `plugin-page-builder` — its guard is already `!== undefined`, and a blank never reaches it now.

## `isApiError` answers for the whole shape (P1)

It checked `status` and nothing else, while being exported specifically to narrow `unknown` across the SDK boundary. Another client's error carrying a numeric `status` was handed over as an `ApiError` whose `code` is declared `string` and is not. Now every **present** field is checked; absent stays legal, because the type says optional.

## Evidence

`error-mapping.ts` had **no tests at all** and I changed it, so it has them now — including that its strict view *equals* the shared reading filtered, with an assertion that the shared reading really did see more, so the comparison is not satisfied by both being empty.

Break-verified, each failing only its intended tests:

| break | what failed |
|---|---|
| `isApiError` back to status-only | the three present-but-wrong-type cases |
| blank strings carried, not reported absent | 4 tests across both files |
| the second traversal restored | the agreement test, and the blank-message drop |

The last one prints the disagreement directly: `expected [ {…}, …(1) ] to deeply equal [ {…} ]`.

Gates: build, check-types, lint, root eslint, comment convention all clean. Admin suite **2591 passing** with its documented 15-test baseline unchanged across the same 4 files (+17 new). `fallow audit` **pass**, 5 changed files, every `*_introduced` at 0. Changeset generated from `.changeset/config.json`, 25/25, verified with `check-changesets.mjs`.
