### PR TITLE
fix(plugin-page-builder): keep a token's identity across a save and a tier merge

### DIFF
--- a/.changeset/pb-token-identity-survives-a-save.md
+++ b/.changeset/pb-token-identity-survives-a-save.md
@@ -1,0 +1,39 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A design token's stable identity now survives a save, and the tier merge keys on it.
+
+The stored-tokens write validator rebuilt each token from a field allowlist, so
+an `id` written through the editor was dropped on every save — a rename appeared
+to work while the identity keeping existing references resolving was gone. The
+id is carried through, and refused rather than dropped when it is not a string.
+
+`resolveSiteStyle` merged the config and stored token tiers by name while the
+engine resolves by identity. A renamed stored token therefore stopped matching
+its config counterpart and the default survived beside it, leaving a stale entry
+in the list every studio reads. Both stages now key on `tokenIdentity`.

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -98,6 +98,29 @@ describe("checkStoredTokens", () => {
       expect(result.issues.join(" ")).toContain("id that is not a token name");
     });
 
+    it("REFUSES a new token that takes a renamed token's identity", () => {
+      // The identity a rename freezes stays claimed, and the name it freed does
+      // not carry the claim with it. So a new token named `color.primary` and a
+      // renamed token still holding `color.primary` as its id both key off one
+      // custom property, and one of them silently loses — the value every
+      // document referencing that identity resolves to.
+      //
+      // The engine anticipates this and cannot see it from here: the gate emits
+      // through `resolveSiteTokens`, which is a Map on identity, so the pair is
+      // deduplicated before `emitTokenBlocks` is handed the set. Judging the set
+      // AS AUTHORED is what puts the two in front of the check at once.
+      const result = checkStoredTokens({
+        tokens: [
+          { ...token("color.brand", "#111111"), id: "color.primary" },
+          token("color.primary", "#222222"),
+        ],
+      });
+
+      expect(result.issues.join(" ")).toContain(
+        'both become "--site-color-primary"'
+      );
+    });
+
     it("leaves a token with no id exactly as it was", () => {
       // Every token stored before the field existed relies on the name BEING
       // the identity, so an absent id must stay absent rather than becoming one.

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -52,6 +52,64 @@ describe("checkStoredTokens", () => {
     expect(result.value?.tokens.map(t => t.name)).toEqual(["color.primary"]);
   });
 
+  // A token's identity is what a document's `$token` and the emitted custom
+  // property key off, so a save that does not carry it forward undoes the
+  // guarantee the field exists for — silently, and in the worst direction: the
+  // rename appears to have worked.
+  describe("a token's stable identity", () => {
+    it("carries an id through the write", () => {
+      const result = checkStoredTokens({
+        tokens: [{ ...token("color.brand", "#111111"), id: "color.primary" }],
+      });
+
+      expect(result.issues).toEqual([]);
+      expect(result.value?.tokens[0]?.id).toBe("color.primary");
+    });
+
+    it("REFUSES an id that is not a string rather than dropping it", () => {
+      // Dropping is what the allowlist did to every unrecognised field, and it
+      // is the shape of the defect this repairs: the write succeeds, the author
+      // is told nothing, and the identity is gone.
+      const result = checkStoredTokens({
+        tokens: [{ ...token("color.brand", "#111111"), id: 42 }],
+      });
+
+      expect(result.issues).toHaveLength(1);
+      expect(result.value?.tokens).toEqual([]);
+    });
+
+    it("reports the ENGINE's refusal of an id that cannot become a property", () => {
+      // Grammar is not re-checked here. The emitter already holds an id to the
+      // token-name grammar because it reaches CSS by the same route, and this
+      // gate refuses on the emitter's whole report — so carrying the field is
+      // what makes that check reachable, and a second one here would be a
+      // second answer to the same question.
+      //
+      // Reported, not excluded, and that is this module's stated split: a
+      // shape the checker cannot type is dropped from `value`, while a
+      // VALUE-level refusal is reported and left in place, because the engine
+      // already drops that entry per-token at compile time. The issue is what
+      // matters — `refusing` in site-style-storage turns any issue into a
+      // rejected write, so this never reaches storage.
+      const result = checkStoredTokens({
+        tokens: [{ ...token("color.brand", "#111111"), id: "not a name!" }],
+      });
+
+      expect(result.issues.join(" ")).toContain("id that is not a token name");
+    });
+
+    it("leaves a token with no id exactly as it was", () => {
+      // Every token stored before the field existed relies on the name BEING
+      // the identity, so an absent id must stay absent rather than becoming one.
+      const result = checkStoredTokens({
+        tokens: [token("color.primary", "#111111")],
+      });
+
+      expect(result.issues).toEqual([]);
+      expect(result.value?.tokens[0]).not.toHaveProperty("id");
+    });
+  });
+
   it("reports what the engine's emitter refuses: a value that would fetch", () => {
     const result = checkStoredTokens({
       tokens: [token("color.primary", "url(https://evil.example/a.png)")],

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -223,7 +223,14 @@ function tokenEmissionIssues(
   set: SiteTokenSet,
   policy: SectionPolicy
 ): string[] {
-  const own = emittedMessages(set);
+  // Two runs over the stored set, and the second is not redundant with the
+  // first. AS RENDERED is what a page produces. AS AUTHORED is the only view in
+  // which two entries sharing one identity are both still present — resolving
+  // keys them into a Map and keeps one, so the emitter's collision check cannot
+  // observe the pair it names in its own comment. Without this run, an author
+  // can rename a token and then create a new one under the freed name, and the
+  // save succeeds while one of the two silently stops existing.
+  const own = [...new Set([...emittedMessages(set), ...authoredMessages(set)])];
   const merged = resolveSiteStyle(policy.defaults, { tokens: set }).tokens;
   // The config tier emitted under the MERGED prefix, so the two runs are
   // comparable. A collision message renders the custom property the two names
@@ -273,6 +280,23 @@ function emittedMessages(tokens: SiteTokenSet): string[] {
   return emitTokenBlocks(resolveSiteTokens(tokens), ":root").issues.map(
     issue => issue.message
   );
+}
+
+/**
+ * What emitting one token set reports AS AUTHORED, without resolving it.
+ *
+ * The un-resolved run exists for one class the resolved one cannot reach.
+ * `resolveSiteTokens` is a Map keyed on identity, so two stored entries sharing
+ * an identity — a token renamed away from a name, and a new token that claims
+ * it — are reduced to one before `emitTokenBlocks` is handed the set. The
+ * emitter holds the check for exactly that pair and names it in its own
+ * comment; it simply is never shown both.
+ *
+ * Nothing is restated here. It is the same emitter answering the same question
+ * about a set that has not had one of the two removed from it.
+ */
+function authoredMessages(tokens: SiteTokenSet): string[] {
+  return emitTokenBlocks(tokens, ":root").issues.map(issue => issue.message);
 }
 
 /** The stored font faces, each checked by the engine's own face validator. */

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -139,14 +139,26 @@ export function checkStoredTokens(
       !isPlainRecord(entry.values) ||
       typeof entry.values.light !== "string" ||
       !optionalString(entry.values.dark) ||
-      !optionalString(entry.description)
+      !optionalString(entry.description) ||
+      // Shape only. Whether the id can become a custom property is the
+      // emitter's question and it already asks it, holding an id to the same
+      // grammar as a name because it reaches CSS by the same route. What has
+      // to happen HERE is that a non-string is refused rather than skipped:
+      // this identity is what a document's `$token` resolves through, so
+      // letting an unusable one fall out of the object would lose it on a save
+      // the author is told succeeded.
+      !optionalString(entry.id)
     ) {
       issues.push(
-        `tokens[${index}] is not a token: it needs a string name, a kind (${TOKEN_KINDS.join(", ")}), and values with a light string (dark optional).`
+        `tokens[${index}] is not a token: it needs a string name, a kind (${TOKEN_KINDS.join(", ")}), and values with a light string (dark optional). An id, when present, must be a string.`
       );
       return;
     }
     tokens.push({
+      // Carried, not rebuilt. The id is the whole point of the field: it is
+      // what a rename leaves alone, so a write that does not preserve it turns
+      // every rename into a silent break of every reference.
+      ...(entry.id === undefined ? {} : { id: entry.id }),
       name: entry.name,
       kind: entry.kind as TokenKind,
       values: {

--- a/packages/plugin-page-builder/src/site-style-storage.ts
+++ b/packages/plugin-page-builder/src/site-style-storage.ts
@@ -98,7 +98,7 @@ export function siteStyleSingle(policy: SectionPolicy = {}) {
         validate: refusing(raw => checkStoredTokens(raw, policy)),
         admin: {
           description:
-            'A token set: { tokens: [{ name, kind, values: { light, dark? } }], prefix?, darkMode? }. Values are per mode; "light" is what a reader with no mode set resolves.',
+            'A token set: { tokens: [{ id?, name, kind, values: { light, dark? } }], prefix?, darkMode? }. Values are per mode; "light" is what a reader with no mode set resolves. `id` is the token\'s stable identity — set it once and a later rename of `name` leaves every page that references the token working; omit it and the name is the identity.',
         },
       }),
       json({

--- a/packages/plugin-page-builder/src/site-style.test.ts
+++ b/packages/plugin-page-builder/src/site-style.test.ts
@@ -83,6 +83,60 @@ describe("resolveSiteStyle", () => {
     expect(byName.get("content.width")).toBe("60rem");
   });
 
+  it("keys the tier merge on IDENTITY, so a rename replaces its default", () => {
+    // The property the whole stable-identity field rests on. An author renames
+    // a config-stated token in the studio; the stored entry keeps the id and
+    // takes a new name. Keyed on the name, the two tiers stop matching and the
+    // default survives BESIDE the override — two entries for one token, with
+    // the stale one earlier in the list.
+    //
+    // That is not a collision. `resolveSiteTokens` is a Map keyed on identity,
+    // so it deduplicates and the stored token wins; what leaks is the list
+    // itself, which is what a tokens studio and `useSiteStyle` both read.
+    const merged = resolveSiteStyle(
+      {
+        tokens: {
+          tokens: [
+            {
+              name: "color.primary",
+              kind: "color" as const,
+              values: { light: "#111111" },
+            },
+          ],
+        },
+      },
+      {
+        tokens: {
+          tokens: [
+            {
+              id: "color.primary",
+              name: "color.brand",
+              kind: "color" as const,
+              values: { light: "#222222" },
+            },
+          ],
+        },
+      }
+    );
+
+    expect(merged.tokens?.tokens).toHaveLength(1);
+    expect(merged.tokens?.tokens[0]?.name).toBe("color.brand");
+    expect(merged.tokens?.tokens[0]?.values.light).toBe("#222222");
+  });
+
+  it("still merges by name when no token states an id", () => {
+    // The continuity case. `tokenIdentity` falls back to the name, so every
+    // token stored before the field existed keys exactly as it did — a change
+    // to the merge key must not move data that has no id to move.
+    const merged = resolveSiteStyle(
+      { tokens: tokens([{ name: "color.primary", light: "#111111" }]) },
+      { tokens: tokens([{ name: "color.primary", light: "#222222" }]) }
+    );
+
+    expect(merged.tokens?.tokens).toHaveLength(1);
+    expect(merged.tokens?.tokens[0]?.values.light).toBe("#222222");
+  });
+
   it("takes prefix and darkMode from the stored tier when stated", () => {
     const merged = resolveSiteStyle(
       { tokens: { tokens: [], prefix: "--acme-", darkMode: "media" } },

--- a/packages/plugin-page-builder/src/site-style.ts
+++ b/packages/plugin-page-builder/src/site-style.ts
@@ -33,6 +33,7 @@
  *
  * @module @nextlyhq/plugin-page-builder/site-style
  */
+import { tokenIdentity } from "@nextlyhq/blocks-engine";
 import type {
   BreakpointSet,
   FontFaceDef,
@@ -154,16 +155,27 @@ function mergeByKey<T>(
   return [...byKey.values()];
 }
 
-/** Token sets merged by token name; `prefix`/`darkMode` from the override. */
+/** Token sets merged by token identity; `prefix`/`darkMode` from the override. */
 function mergeTokens(
   defaults: SiteTokenSet | undefined,
   stored: SiteTokenSet | undefined
 ): SiteTokenSet | undefined {
   if (defaults === undefined && stored === undefined) return undefined;
+  // `tokenIdentity`, not the name, and imported rather than restated. The
+  // engine names three things that have to agree by construction — the custom
+  // property the emitter writes, the key a tier merge overrides on, and the
+  // string a document stores — and this is the second of them. Keyed on the
+  // name, a renamed stored token stops matching its config counterpart and the
+  // default survives beside the override: not a collision, because the engine's
+  // own resolution deduplicates on identity and the stored token wins, but a
+  // stale entry in the LIST that every studio and `useSiteStyle` read.
+  //
+  // Tokens with no id key exactly as they did, because the identity falls back
+  // to the name.
   const tokens = mergeByKey<SiteToken>(
     defaults?.tokens,
     stored?.tokens,
-    token => token.name
+    tokenIdentity
   );
   const prefix = stored?.prefix ?? defaults?.prefix;
   const darkMode = stored?.darkMode ?? defaults?.darkMode;


### PR DESCRIPTION
Closes `finding:pb-stored-token-write-drops-identity`, which blocks C-7 (`task:pb-tokens-studio`). Two defects in one pipeline, both latent until `SiteToken.id` landed with #1137 and both live on main since.

## The id did not survive a save

`checkStoredTokens` rebuilds each token field-by-field from an allowlist, so anything not on the list is silently absent from the object it pushes. An `id` written through the editor was dropped on **every** save.

The identity was durable in memory and across a DTCG round trip, and not across a save — the worst direction available: the author renames a token, the editor shows the rename applied, the write succeeds, and the id that was keeping every existing reference resolving is gone. The next emit keys the custom property off the new name and every already-compiled page loses that declaration with no report.

The id is now carried through, and a **non-string** one refuses the entry rather than falling out of it — dropping is the exact shape of the defect, one level down.

**Its grammar is deliberately not re-checked here.** `site-tokens.ts:806` already holds an id to the token-name grammar, because it reaches CSS by the same route, with a message that names the id specifically rather than telling the author to rename. This gate refuses on the emitter's whole report, so **carrying the field is what makes that check reachable**. A second `isTokenName` call here would be a second answer to a question the emitter already owns.

## The two merge stages keyed differently

`resolveSiteStyle` merged the config and stored tiers on `token.name` while the engine's `resolveSiteTokens` keys on `tokenIdentity`. A renamed stored token therefore stopped matching its config counterpart, so the default was **not replaced** and survived beside the override.

**That is not a collision, and the finding's original text said it was.** The prediction was retracted on the node after three sessions independently ran the falsifier: `resolveSiteTokens` is a `Map` keyed on identity, so it *deduplicates* and the stored token wins, emitting the right custom property with zero issues. What leaks is a stale duplicate in the **list** — which `site-style-storage.ts`, the public `index.ts` export, and now `useSiteStyle` (landed in #1136) all read. A tokens studio would render it in its picker.

Both stages now key on `tokenIdentity`, which the engine's own docblock names as one of three things that must agree by construction: *"the custom property the emitter writes, the key a tier merge overrides on, and the string a document stores"*.

Two consequences worth stating:

- **Tokens with no id key exactly as they did**, because the identity falls back to the name. Asserted, because a change to a merge key must not move data that has no id to move.
- **Position is now stable across a rename.** Re-setting an existing `Map` key keeps the original position and replaces the value — measured, not assumed — so a matched token holds its config-tier slot instead of being appended. That matters because `compile-page.ts` truncates a merged library by array **prefix**, so a stale leading entry can push a live token past the limit.

## The write gate's prediction is corrected too

`tokenEmissionIssues` calls `resolveSiteStyle` rather than a local copy, deliberately — so changing the merge key changes what the gate predicts at write time as well as what happens at render, and the two stay in agreement because both go through the one merge.

## Evidence

6 new tests, each seen failing first for its intended reason, then break-verified:

| break | what failed |
|---|---|
| stop carrying the id | `carries an id through the write`, and the engine-refusal test |
| drop the id from the shape guard | `REFUSES an id that is not a string rather than dropping it` |
| merge back on the name | `keys the tier merge on IDENTITY` |

One test in the set is a regression guard that passed before the change (`leaves a token with no id exactly as it was`) — stated rather than counted as coverage.

I also **corrected one of my own assertions rather than the code**: I had asserted an ungrammatical id is excluded from `value`. It is not, and should not be — this module's stated split is that a shape it cannot type is dropped from `value` while a value-level refusal is reported and left in place, since the engine drops that entry per-token at compile time. `refusing` turns any issue into a rejected write, so it never reaches storage.

**Type-checked including the test files**, which no gate here does — this package excludes `**/*.test.ts(x)` from `tsconfig.json` and again from `tsconfig.tests.json`. Result: 16 errors, all pre-existing, none in anything I touched (`finding:test-files-read-by-no-typechecker-and-no-linter` has the population).

Gates: build, vitest **173 passed**, check-types, lint, root eslint, comment convention all clean. `fallow audit` **pass**, 6 changed files, every `*_introduced` at 0. Changeset generated from `.changeset/config.json`, 25/25, verified.

@codex please review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stable token identities, allowing tokens to be renamed without breaking pages that reference them.
  - Tokens without an explicit identity continue to use their names for matching.
  - Duplicate or invalid token identities are now detected and reported.

- **Documentation**
  - Updated token field guidance to describe optional stable IDs and rename behavior.

- **Tests**
  - Added coverage for identity preservation, renamed tokens, invalid IDs, collisions, and legacy tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->