### PR TITLE
feat(builder): colour controls with a token picker and a contrast readout

### DIFF
--- a/.changeset/tidy-colours-arrive.md
+++ b/.changeset/tidy-colours-arrive.md
@@ -1,0 +1,33 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Colour controls in the page-builder style inspector: a swatch that opens a picker beside the field that owns the value, a token picker over the site's colour tokens, and a WCAG contrast readout for a text-and-background pair.
+
+The text field remains the control. A stored colour may be `oklch()`, `color-mix()`, a named colour, `currentcolor`, a CSS-wide keyword or a `var()`, and none of them is rewritten by opening the picker — the swatch and the readout offer themselves only where the value can be resolved here, and show nothing where it cannot.
+
+Choosing a token stores the token's IDENTITY rather than the name shown, so a reference keeps resolving after the token is renamed; a stored reference is displayed under the token's current name.

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -78,13 +78,10 @@
   //   @nextlyhq/ui/color = the same shape again, and the same measurement. It
   //     is a declared exports subpath resolving to `./dist/color.mjs`, so a
   //     local audit after `pnpm build` reports nothing while CI, which audits
-  //     after install and before build, reports it unresolved — measured on
-  //     PR #1143, where it was the single dead-code finding against 37
-  //     inherited dependency ones. The editor's colour control cannot drop the
-  //     import: it is the WRITING half of hex and the engine owns the reading
-  //     half, so composing the notation in `packages/builder` instead would be
-  //     the third colour parser `decision:pb-colour-parser-boundary` exists to
-  //     keep out.
+  //     after install and before build, reports it unresolved. The editor's
+  //     colour control cannot drop the import: it is the WRITING half of hex
+  //     and `blocks-engine` owns the reading half, so composing the notation
+  //     inside `packages/builder` would put a third colour parser in the tree.
   //
   // Every entry is an exact specifier rather than a prefix. These match the
   // raw import string, so `../dist/**` would also swallow a typo like

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -75,6 +75,16 @@
   //     sheet ships neither the `--nx-*` tokens nor the base reset, because the
   //     host owns both, so without them the shell renders with its colours
   //     resolving to nothing — which is a bug the shell suite has a test for.
+  //   @nextlyhq/ui/color = the same shape again, and the same measurement. It
+  //     is a declared exports subpath resolving to `./dist/color.mjs`, so a
+  //     local audit after `pnpm build` reports nothing while CI, which audits
+  //     after install and before build, reports it unresolved — measured on
+  //     PR #1143, where it was the single dead-code finding against 37
+  //     inherited dependency ones. The editor's colour control cannot drop the
+  //     import: it is the WRITING half of hex and the engine owns the reading
+  //     half, so composing the notation in `packages/builder` instead would be
+  //     the third colour parser `decision:pb-colour-parser-boundary` exists to
+  //     keep out.
   //
   // Every entry is an exact specifier rather than a prefix. These match the
   // raw import string, so `../dist/**` would also swallow a typo like
@@ -86,6 +96,7 @@
     "../dist/cli.mjs",
     "../dist/render/index.js",
     "@nextlyhq/ui/styles.css",
+    "@nextlyhq/ui/color",
     "@nextlyhq/builder/styles.css",
   ],
 

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -26,6 +26,7 @@
 import {
   findNode,
   type BreakpointId,
+  type SiteTokenSet,
   type StyleState,
 } from "@nextlyhq/blocks-engine";
 import {
@@ -82,6 +83,15 @@ export interface InspectorPanelProps {
   styleState?: StyleState;
   /** The breakpoint the Style tab edits. The unconditional one by default. */
   breakpoint?: BreakpointId;
+  /**
+   * The site's design tokens, forwarded to the Style tab's colour controls.
+   *
+   * Carried rather than defaulted, as `policy` is: omitting it means the
+   * question was never asked, not that the site defines none. See
+   * {@link StyleInspectorPanelProps.tokens} for why `policy.tokens` cannot
+   * serve this.
+   */
+  tokens?: SiteTokenSet;
 }
 
 /**
@@ -101,6 +111,7 @@ export function InspectorPanel({
   policy,
   styleState,
   breakpoint,
+  tokens,
 }: InspectorPanelProps): React.JSX.Element {
   // Recomputed each render rather than memoised: an inspection is only valid
   // against the document it was read from, and an edit anywhere changes both
@@ -229,6 +240,7 @@ export function InspectorPanel({
             policy={policy}
             state={styleState}
             breakpoint={breakpoint}
+            tokens={tokens}
           />
         </TabsContent>
       </Tabs>

--- a/packages/builder/src/layering.test.ts
+++ b/packages/builder/src/layering.test.ts
@@ -82,6 +82,17 @@ const ALLOWED_RUNTIME_IMPORTS = [
   // The `cn` helper only. A separate subpath because the root barrel carries a
   // `"use client"` banner and this one is plain string joining.
   "@nextlyhq/ui/utils",
+  // Colour conversion only, and a separate subpath for the same reason `utils`
+  // is: `ui` publishes it away from the root barrel precisely because it is
+  // arithmetic on numbers with no React in it, so importing it does not pull a
+  // client boundary into a pure module.
+  //
+  // It is the writing half of hex, and the engine owns the reading half — so
+  // this entry is what keeps `style-colour.ts` from growing a hex composer of
+  // its own. Note what it deliberately does NOT admit: `ui/styles/contrast` is
+  // a different subpath, is not listed here, and is not published at all;
+  // `style-colour-boundary.test.ts` is the guard that says why.
+  "@nextlyhq/ui/color",
   // The `/admin` subpath ONLY, and not the SDK root. The root re-exports runtime
   // values from `nextly` (`export { definePlugin } from "nextly"`), which that
   // package's build leaves external, so importing it loads the CMS runtime this

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -1,0 +1,310 @@
+// @vitest-environment jsdom
+
+/**
+ * The colour control, driven through the Style tab against a real editor.
+ *
+ * `style-colour.ts` decides what a value resolves to and whether a pair can be
+ * measured, and asserts that without a DOM. What is only true HERE is the
+ * wiring: that a colour leaf draws a swatch rather than a bare text field, that
+ * a stored TOKEN reaches this control instead of the read-only surface, that
+ * the name shown is the token's current one while the document keeps its
+ * identity, and that a readout appears only where both halves of a pair can be
+ * read.
+ *
+ * @module style-colour-panel.test
+ */
+import {
+  clearBlocks,
+  registerBlocks,
+  type BlockDocument,
+  type BlockNode,
+  type NodeStyles,
+  type SiteTokenSet,
+} from "@nextlyhq/blocks-engine";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { EditorState } from "./editor-state";
+import { StyleInspectorPanel } from "./style-inspector-panel";
+
+afterEach(() => {
+  cleanup();
+  clearBlocks();
+});
+
+beforeAll(() => {
+  // Radix measures and scrolls; jsdom provides neither, and a missing one
+  // throws during render rather than failing an assertion.
+  const element = window.Element.prototype as unknown as Record<
+    string,
+    unknown
+  >;
+  element.scrollIntoView = function scrollIntoView(): void {};
+  (window as unknown as Record<string, unknown>).ResizeObserver =
+    class ResizeObserver {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    };
+});
+
+/**
+ * A site whose second token is RENAMED, so identity and name differ.
+ *
+ * The panel must show one and store the other, and a fixture where they match
+ * cannot tell a correct control from one that has them the wrong way round.
+ */
+const TOKENS: SiteTokenSet = {
+  tokens: [
+    { name: "color.ink", kind: "color", values: { light: "#111111" } },
+    {
+      id: "color.primary",
+      name: "brand.main",
+      kind: "color",
+      values: { light: "#ffffff" },
+    },
+  ],
+};
+
+function register(): void {
+  registerBlocks(
+    [
+      {
+        name: "acme/box",
+        version: 1,
+        description: "A box.",
+        example: { props: {} },
+        editor: { label: "Box" },
+        props: { text: { type: "text" } },
+        supports: { color: { text: true }, background: { color: true } },
+        render: () => null,
+      },
+    ] as never,
+    { source: "style-colour-panel-test" }
+  );
+}
+
+function editorFor(
+  document: BlockDocument
+): EditorState & { apply: ReturnType<typeof vi.fn> } {
+  return {
+    document,
+    selectedId: "a",
+    selection: { ids: ["a"], primary: "a" },
+    applyAll: vi.fn(() => document),
+    select: vi.fn(),
+    apply: vi.fn(() => document),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+    undoDepth: 0,
+  } as unknown as EditorState & { apply: ReturnType<typeof vi.fn> };
+}
+
+/**
+ * Mount the Style tab over one node's stored styles.
+ *
+ * `null` means the host supplied NO table, and is spelled that way rather than
+ * as `undefined` because a default parameter cannot tell an omitted argument
+ * from an explicit `undefined` — measured: `mount(styles, undefined)` silently
+ * took the default and the no-table test asserted against the full fixture.
+ */
+function mount(styles?: NodeStyles, tokens: SiteTokenSet | null = TOKENS) {
+  register();
+  const document_: BlockDocument = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      { id: "a", type: "acme/box", version: 1, props: {}, styles },
+    ] as BlockNode[],
+  } as BlockDocument;
+  const editor = editorFor(document_);
+  render(
+    <StyleInspectorPanel
+      editor={editor}
+      {...(tokens === null ? {} : { tokens })}
+    />
+  );
+  return editor;
+}
+
+/** Styles holding a text colour, and optionally a background, at base/base. */
+function styles(color?: unknown, backgroundColor?: unknown): NodeStyles {
+  return {
+    base: {
+      base: {
+        ...(color === undefined ? {} : { color }),
+        ...(backgroundColor === undefined ? {} : { backgroundColor }),
+      },
+    },
+  } as unknown as NodeStyles;
+}
+
+const swatch = (name: string): HTMLElement =>
+  screen.getByRole("button", { name });
+
+describe("a colour leaf draws a colour control", () => {
+  it("offers a swatch beside the field, where before there was only a field", () => {
+    mount(styles("#3b82f6"));
+    // The gap C-5 fills: this leaf used to fall through to a plain text field.
+    expect(swatch("Colour for Color")).toBeDefined();
+    expect(screen.getByRole("textbox", { name: "Color" })).toHaveProperty(
+      "value",
+      "#3b82f6"
+    );
+  });
+
+  it("paints the swatch with the colour the value resolves to", () => {
+    mount(styles("#3b82f6"));
+    expect(
+      swatch("Colour for Color").style.getPropertyValue("--nx-swatch")
+    ).toBe("#3b82f6");
+  });
+
+  it("paints NOTHING for a colour it cannot resolve, and keeps the value", () => {
+    // `oklch()` is a valid colour the engine stores and `parseColor` declines.
+    // The swatch must not guess, and the text must not be rewritten.
+    mount(styles("oklch(0.7 0.1 200)"));
+    const button = swatch("Colour for Color");
+    expect(button.style.getPropertyValue("--nx-swatch")).toBe("");
+    expect(button.getAttribute("data-empty")).toBe("");
+    expect(screen.getByRole("textbox", { name: "Color" })).toHaveProperty(
+      "value",
+      "oklch(0.7 0.1 200)"
+    );
+  });
+
+  it("paints nothing for a value that resolves somewhere else", () => {
+    // `var()` in the panel would resolve against the PANEL's custom properties
+    // rather than the canvas's, so a painted swatch would show a colour the
+    // page does not have.
+    mount(styles("var(--site-color-primary)"));
+    expect(
+      swatch("Colour for Color").style.getPropertyValue("--nx-swatch")
+    ).toBe("");
+  });
+
+  it("commits a typed colour on blur", () => {
+    const editor = mount(styles("#3b82f6"));
+    const field = screen.getByRole("textbox", { name: "Color" });
+    fireEvent.change(field, { target: { value: "#ff0000" } });
+    expect(editor.apply).not.toHaveBeenCalled();
+    fireEvent.blur(field);
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+  });
+
+  it("CLEARS rather than storing an empty colour", () => {
+    const editor = mount(styles("#3b82f6"));
+    const field = screen.getByRole("textbox", { name: "Color" });
+    fireEvent.change(field, { target: { value: "" } });
+    fireEvent.blur(field);
+    const op = editor.apply.mock.calls[0]?.[0] as { patch?: unknown };
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+    // The entry is removed, so the property falls back through the cascade.
+    // Written as an empty string it would instead pin the property to nothing.
+    expect(JSON.stringify(op.patch)).not.toContain('"color":""');
+  });
+});
+
+describe("a stored token reference", () => {
+  it("reaches the colour control rather than the read-only surface", () => {
+    // Before this control, `ControlValue` returned the generic token surface for
+    // every reference — see-it-or-clear-it, with no way to choose another. The
+    // swatch is what says a colour reference is now editable.
+    mount(styles({ $token: "color.ink" }));
+    expect(swatch("Colour for Color")).toBeDefined();
+  });
+
+  it("shows the token's CURRENT name, not the identity the document holds", () => {
+    // The renamed token: stored as `color.primary`, displayed as `brand.main`.
+    // A control reading the stored string straight onto the screen shows an
+    // author a name they already changed.
+    mount(styles({ $token: "color.primary" }));
+    expect(screen.getByText("brand.main")).toBeDefined();
+    expect(screen.queryByText("color.primary")).toBeNull();
+  });
+
+  it("paints the swatch with the colour the token resolves to", () => {
+    mount(styles({ $token: "color.ink" }));
+    expect(
+      swatch("Colour for Color").style.getPropertyValue("--nx-swatch")
+    ).toBe("#111111");
+  });
+
+  it("falls back to the stored identity when the site defines no such token", () => {
+    // A dangling reference still compiles — an unknown token is a warning, not
+    // an error — so the author is shown the string their document holds rather
+    // than an empty space.
+    mount(styles({ $token: "color.missing" }));
+    expect(screen.getByText("color.missing")).toBeDefined();
+  });
+
+  it("shows the identity when the host supplied no table at all", () => {
+    // Omitting `tokens` means the question was never asked, so there is no name
+    // to resolve to and the identity is the only string available.
+    mount(styles({ $token: "color.primary" }), null);
+    expect(screen.getByText("color.primary")).toBeDefined();
+  });
+
+  it("offers a clear that removes the reference", () => {
+    const editor = mount(styles({ $token: "color.ink" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear Color" }));
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("the contrast readout", () => {
+  it("reports a ratio when both halves of the pair can be read", () => {
+    mount(styles("#000000", "#ffffff"));
+    expect(screen.getAllByText(/Contrast 21\.0:1/).length).toBeGreaterThan(0);
+  });
+
+  it("says a failing pair fails, without refusing the value", () => {
+    mount(styles("#777777", "#888888"));
+    expect(
+      screen.getAllByText(/below AA for body text/).length
+    ).toBeGreaterThan(0);
+    // Still editable: a low ratio is a warning about a valid value, never a
+    // refusal. The same position Gutenberg's contrast checker takes.
+    expect(screen.getByRole("textbox", { name: "Color" })).toHaveProperty(
+      "value",
+      "#777777"
+    );
+  });
+
+  it("measures a pair written as TOKENS, by resolving both sides", () => {
+    mount(styles({ $token: "color.ink" }, { $token: "color.primary" }));
+    expect(
+      screen.getAllByText(/Contrast 1[0-9]\.[0-9]:1/).length
+    ).toBeGreaterThan(0);
+  });
+
+  it("reports NOTHING when the partner is unset", () => {
+    // The honest half. A colour on its own has no contrast, and inventing a
+    // background to measure against would be a number an author acts on.
+    mount(styles("#000000"));
+    expect(screen.queryByText(/Contrast/)).toBeNull();
+  });
+
+  it("reports nothing when either half cannot be read", () => {
+    mount(styles("var(--brand)", "#ffffff"));
+    expect(screen.queryByText(/Contrast/)).toBeNull();
+  });
+
+  it("appears on the BACKGROUND control too, not only the foreground", () => {
+    // Each control answers for the pair it is part of, so an author editing the
+    // background sees the same verdict as one editing the text. The two sit in
+    // different accordion sections and Radix renders only the open one, so this
+    // has to open Background rather than counting two readouts at once — which
+    // is itself worth knowing: an author never sees both controls together.
+    mount(styles("#000000", "#ffffff"));
+    fireEvent.click(screen.getByRole("button", { name: /^Background/ }));
+    expect(
+      screen.getByRole("textbox", { name: "Background color" })
+    ).toHaveProperty("value", "#ffffff");
+    expect(swatch("Colour for Background color")).toBeDefined();
+    expect(screen.getAllByText(/Contrast 21\.0:1/).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -518,3 +518,39 @@ describe("the picker can replace a stored token with a literal", () => {
     ).toBe("#ff0000");
   });
 });
+
+describe("a picker gesture survives the field being replaced", () => {
+  it("writes an unwritten adjustment when the control unmounts", () => {
+    // The popover commits on close, and a close is not the only way an author
+    // leaves: selecting another block in the canvas iframe cannot reach the
+    // popover's outside-dismiss handler, and the selection change remounts this
+    // field without firing `onOpenChange`. Unflushed, the whole gesture is
+    // discarded silently.
+    const editor = mount(styles("#3b82f6"));
+    fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
+    // The PICKER's hex field, not the control's own. Taking the first textbox
+    // picks up the main field, whose draft commits on blur and never reaches
+    // the pending gesture — so the assertion below would hold whether or not
+    // the flush exists.
+    const hex = screen
+      .getAllByRole("textbox")
+      .find(input => input !== screen.getByRole("textbox", { name: "Color" }));
+    expect(hex).toBeDefined();
+    if (hex === undefined) return;
+    fireEvent.change(hex, { target: { value: "#ff0000" } });
+    expect(editor.apply).not.toHaveBeenCalled();
+
+    // Unmount without ever closing the popover.
+    cleanup();
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes nothing when the picker was opened and not moved", () => {
+    // The positive control: unmounting must not manufacture an edit, or every
+    // click through the inspector would write a history entry.
+    const editor = mount(styles("#3b82f6"));
+    fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
+    cleanup();
+    expect(editor.apply).not.toHaveBeenCalled();
+  });
+});

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -767,3 +767,53 @@ describe("a dismissal that is NOT a superseding control", () => {
  * because the suppression worked. It was deleted rather than left as a green
  * that reported nothing.
  */
+
+describe("an ancestor's effects reach the readout", () => {
+  /** Mount the Style tab over a node nested inside a styled wrapper. */
+  function mountNested(wrapper: unknown) {
+    register();
+    const document_: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "wrap",
+          type: "acme/box",
+          version: 1,
+          props: {},
+          styles: wrapper,
+          slots: {
+            children: [
+              {
+                id: "a",
+                type: "acme/box",
+                version: 1,
+                props: {},
+                styles: styles("#000000", "#ffffff"),
+              },
+            ],
+          },
+        },
+      ] as unknown as BlockNode[],
+    } as BlockDocument;
+    const editor = editorFor(document_);
+    render(<StyleInspectorPanel editor={editor} tokens={TOKENS} />);
+    return editor;
+  }
+
+  it("reports the ratio when nothing above the node alters it", () => {
+    // The control. Without it the assertion below passes for any panel that
+    // never shows a readout at all.
+    mountNested(undefined);
+    expect(screen.getAllByText(/Contrast 21\.0:1/).length).toBeGreaterThan(0);
+  });
+
+  it("withholds it when a PARENT fades the whole subtree", () => {
+    // Black on white measures 21:1 from the node's own styles alone, and
+    // reaches the eye at a fraction of that. A readout scoped to the selected
+    // node reports the figure and is wrong — the one direction this guard
+    // must not fail in.
+    mountNested({ base: { base: { opacity: "0.1" } } });
+    expect(screen.queryByText(/Contrast/)).toBeNull();
+  });
+});

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -554,3 +554,46 @@ describe("a picker gesture survives the field being replaced", () => {
     expect(editor.apply).not.toHaveBeenCalled();
   });
 });
+
+describe("a discrete choice supersedes an unfinished gesture", () => {
+  it("does not let a pending literal overwrite a token chosen after it", () => {
+    // Choosing a preset does not close the popover, so the pending gesture
+    // survives it. Unflushed correctly, the unmount write then lands the older
+    // hex on top of the token the author just picked — the reference silently
+    // becoming a literal.
+    const editor = mount(styles("#3b82f6"));
+    fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
+
+    const hex = screen
+      .getAllByRole("textbox")
+      .find(input => input !== screen.getByRole("textbox", { name: "Color" }));
+    expect(hex).toBeDefined();
+    if (hex === undefined) return;
+    fireEvent.change(hex, { target: { value: "#ff0000" } });
+
+    // Now pick a token preset, which commits immediately.
+    fireEvent.click(screen.getByRole("button", { name: "color.ink" }));
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+
+    // Leave without closing the popover.
+    cleanup();
+
+    // Still one write, and it is the token.
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(editor.apply.mock.calls[0])).toContain("$token");
+  });
+
+  it("does not let one overwrite a CLEAR either", () => {
+    const editor = mount(styles({ $token: "color.ink" }));
+    fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
+    const hex = screen.getAllByRole("textbox")[0];
+    expect(hex).toBeDefined();
+    if (hex === undefined) return;
+    fireEvent.change(hex, { target: { value: "#ff0000" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear Color" }));
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+    cleanup();
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -396,3 +396,64 @@ describe("a picker gesture is ONE editor operation", () => {
     expect(editor.apply).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("the contrast readout keeps up with the picker", () => {
+  it("measures what the field is SHOWING, not what the document holds", () => {
+    // The readout deferred to `stored` while the draft moved, so throughout a
+    // picker gesture the verdict described the old colour — stale exactly while
+    // an author is choosing, which is when a contrast readout is for. It also
+    // put the swatch and the figure beside it on two different colours.
+    mount(styles("#000000", "#ffffff"));
+    expect(screen.getAllByText(/Contrast 21\.0:1/).length).toBeGreaterThan(0);
+
+    // Type a low-contrast colour without committing it.
+    fireEvent.change(screen.getByRole("textbox", { name: "Color" }), {
+      target: { value: "#f0f0f0" },
+    });
+
+    // The verdict follows immediately, and the old one is gone.
+    expect(screen.queryByText(/Contrast 21\.0:1/)).toBeNull();
+    expect(
+      screen.getAllByText(/below AA for body text/).length
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe("a contrast verdict is not a complaint", () => {
+  it("does NOT mark a valid colour invalid just for describing it", () => {
+    // The field is described by the contrast note, and a field that inferred
+    // invalidity from having a description announced a perfectly good colour
+    // with a passing 21:1 result as invalid.
+    mount(styles("#000000", "#ffffff"));
+    const field = screen.getByRole("textbox", { name: "Color" });
+    // Described...
+    expect(field.getAttribute("aria-describedby")).toBeTruthy();
+    // ...and still valid.
+    expect(field.getAttribute("aria-invalid")).toBeNull();
+    expect(
+      screen
+        .getByRole("button", { name: "Colour for Color" })
+        .getAttribute("aria-invalid")
+    ).toBeNull();
+  });
+});
+
+describe("opening the picker on a reference it cannot show", () => {
+  it("warns before a movement would replace the reference", () => {
+    // `storedText` answers "" for a reference, so a predicate reading the draft
+    // alone missed every one of them. Opening the picker on a token the site no
+    // longer defines starts its controls at black, and the first adjustment
+    // replaces the reference with an unrelated near-black literal.
+    mount(styles({ $token: "color.missing" }));
+    fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
+    expect(screen.getByText(/cannot be shown on the picker/)).toBeDefined();
+  });
+
+  it("stays quiet for a reference it CAN show", () => {
+    // The positive control: the warning must be about being unresolvable, not
+    // about being a reference.
+    mount(styles({ $token: "color.ink" }));
+    fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
+    expect(screen.queryByText(/cannot be shown on the picker/)).toBeNull();
+  });
+});

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -598,9 +598,14 @@ describe("a discrete choice supersedes an unfinished gesture", () => {
     expect(JSON.stringify(editor.apply.mock.calls[0])).toContain("$token");
   });
 
-  it("does not let one overwrite a CLEAR either", () => {
+  it("does not let one overwrite a CLEAR either", async () => {
     const editor = mount(styles({ $token: "color.ink" }));
     fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
+    // Radix attaches its outside-pointerdown listener inside a `setTimeout`, so
+    // nothing can dismiss the popover until that has run. Without this the
+    // popover never closes, the close path never runs, and the assertions below
+    // hold for a reason that has nothing to do with what they name.
+    await settle();
     const hex = screen.getAllByRole("textbox")[0];
     expect(hex).toBeDefined();
     if (hex === undefined) return;
@@ -655,6 +660,11 @@ describe("clearing a token while the picker is open", () => {
     // author never chose. The pointer-down supersede drops the gesture first.
     const editor = mount(styles({ $token: "color.ink" }));
     fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
+    // Radix attaches its outside-pointerdown listener inside a `setTimeout`, so
+    // nothing can dismiss the popover until that has run. Without this the
+    // popover never closes, the close path never runs, and the assertions below
+    // hold for a reason that has nothing to do with what they name.
+    await settle();
     const hex = screen.getAllByRole("textbox")[0];
     expect(hex).toBeDefined();
     if (hex === undefined) return;
@@ -662,13 +672,11 @@ describe("clearing a token while the picker is open", () => {
 
     // The real order: React's handler on the button, then the document
     // dismissal Radix listens for, then the click.
-    // The dismissal and the activation are one interaction, whichever event
-    // Radix noticed it through. Escape stands in for the dismissal here; the
-    // click that follows is what the author meant.
+    // The real interaction: a pointer press on the button dismisses the popover
+    // — Radix listens for that on the document — and the click follows. One
+    // intent, however many events it takes.
     const clear = screen.getByRole("button", { name: "Clear Color" });
-    fireEvent.keyDown(document.activeElement ?? document.body, {
-      key: "Escape",
-    });
+    fireEvent.pointerDown(clear);
     fireEvent.click(clear);
     await settle();
 
@@ -718,30 +726,40 @@ describe("the route a real editor takes to the colour control", () => {
   });
 });
 
-describe("clearing a token from the KEYBOARD while the picker is open", () => {
-  it("records one operation, as the pointer route does", async () => {
-    // The route the pointer-down fix could not cover. Moving focus to the Clear
-    // button dismisses the popover through `focusin` rather than `pointerdown`,
-    // and the activation arrives afterwards — so a control that dropped the
-    // gesture on pointer-down handled a mouse and left a keyboard writing the
-    // literal first and clearing it second.
-    const editor = mount(styles({ $token: "color.ink" }));
+describe("a dismissal that is NOT a superseding control", () => {
+  it("still writes the gesture", async () => {
+    // The control for the suppression, and the direction that loses work. If
+    // every outside interaction suppressed, clicking anywhere off the picker
+    // would silently discard what the author had just done.
+    const editor = mount(styles("#3b82f6"));
     fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
-    const hex = screen.getAllByRole("textbox")[0];
+    await settle();
+    const hex = screen
+      .getAllByRole("textbox")
+      .find(input => input !== screen.getByRole("textbox", { name: "Color" }));
     expect(hex).toBeDefined();
     if (hex === undefined) return;
     fireEvent.change(hex, { target: { value: "#ff0000" } });
+    expect(editor.apply).not.toHaveBeenCalled();
 
-    // Focus moves out — the dismissal — and only then is the button activated.
-    const clear = screen.getByRole("button", { name: "Clear Color" });
-    fireEvent.focus(clear);
-    fireEvent.keyDown(document.activeElement ?? document.body, {
-      key: "Escape",
-    });
-    fireEvent.click(clear);
+    // Somewhere outside the picker that commits nothing of its own.
+    fireEvent.pointerDown(document.body);
     await settle();
 
     expect(editor.apply).toHaveBeenCalledTimes(1);
-    expect(JSON.stringify(editor.apply.mock.calls[0])).not.toContain("#ff0000");
+    expect(JSON.stringify(editor.apply.mock.calls[0])).toContain("#ff0000");
   });
 });
+
+/*
+ * The FOCUS route is not driven here, and that is a limit of jsdom rather than
+ * a gap in the guard.
+ *
+ * Radix dismisses on `focusin` as well as `pointerdown`, and both arrive at the
+ * one `onInteractOutside` callback the suppression reads — so the route above
+ * exercises the same branch this one would. Attempting it directly was
+ * measured and abandoned: `fireEvent.focusIn` on the clear button leaves the
+ * popover OPEN, so the test passed because only the click ever committed, not
+ * because the suppression worked. It was deleted rather than left as a green
+ * that reported nothing.
+ */

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -169,7 +169,9 @@ function render_with(all: unknown) {
 describe("a colour leaf draws a colour control", () => {
   it("offers a swatch beside the field, where before there was only a field", () => {
     mount(styles("#3b82f6"));
-    // The gap C-5 fills: this leaf used to fall through to a plain text field.
+    // A colour leaf used to fall through to a plain text field, so the swatch
+    // beside it is the regression this holds: the control is a colour surface
+    // rather than a string box that happens to hold a colour.
     expect(swatch("Colour for Color")).toBeDefined();
     expect(screen.getByRole("textbox", { name: "Color" })).toHaveProperty(
       "value",

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -817,3 +817,76 @@ describe("an ancestor's effects reach the readout", () => {
     expect(screen.queryByText(/Contrast/)).toBeNull();
   });
 });
+
+describe("the readout announces itself while the picker moves", () => {
+  it("keeps the note in the document with nothing to say", () => {
+    // A live region only speaks when its contents CHANGE, so one that mounts
+    // with the verdict already in place is silent — which is every time a
+    // colour first becomes measurable. Rendering it empty is what makes the
+    // first verdict an announcement rather than an arrival.
+    render_with({ base: { base: { color: "#000000" } } });
+    const note = document.querySelector(".nx-style-inspector__contrast");
+    expect(note).not.toBeNull();
+    expect(note?.getAttribute("aria-live")).toBe("polite");
+    expect(note?.textContent).toBe("");
+  });
+
+  it("announces the verdict from the same region once a pair is readable", () => {
+    render_with({
+      base: { base: { color: "#000000", backgroundColor: "#ffffff" } },
+    });
+    const notes = Array.from(
+      document.querySelectorAll(".nx-style-inspector__contrast")
+    );
+    const spoken = notes.filter(note => note.textContent !== "");
+    expect(spoken.length).toBeGreaterThan(0);
+    for (const note of spoken) {
+      expect(note.getAttribute("aria-live")).toBe("polite");
+      expect(note.textContent).toContain("Contrast 21.0:1");
+    }
+  });
+});
+
+describe("two tokens under one name are told apart", () => {
+  it("qualifies the preset labels with the identity that differs", () => {
+    // A rename freezes the old name as the identity, so a second token can
+    // take the name the first left. Both emit and both are offered.
+    const clashing: SiteTokenSet = {
+      tokens: [
+        {
+          id: "color.primary",
+          name: "brand.main",
+          kind: "color",
+          values: { light: "#111111" },
+        },
+        { name: "brand.main", kind: "color", values: { light: "#111111" } },
+      ],
+    };
+    register();
+    const document_: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "a",
+          type: "acme/box",
+          version: 1,
+          props: {},
+          styles: styles("#3b82f6"),
+        },
+      ] as BlockNode[],
+    } as BlockDocument;
+    render(
+      <StyleInspectorPanel editor={editorFor(document_)} tokens={clashing} />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
+
+    // Identical colours, so the swatches themselves cannot tell them apart.
+    expect(
+      screen.queryByRole("button", { name: "brand.main (color.primary)" })
+    ).not.toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "brand.main (brand.main)" })
+    ).not.toBeNull();
+  });
+});

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -26,6 +26,7 @@ import * as React from "react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import type { EditorState } from "./editor-state";
+import { InspectorPanel } from "./inspector-panel";
 import { StyleInspectorPanel } from "./style-inspector-panel";
 
 afterEach(() => {
@@ -656,5 +657,45 @@ describe("clearing a token while the picker is open", () => {
     expect(editor.apply).toHaveBeenCalledTimes(1);
     // A clear removes the entry rather than writing one.
     expect(JSON.stringify(editor.apply.mock.calls[0])).not.toContain("#ff0000");
+  });
+});
+
+describe("the route a real editor takes to the colour control", () => {
+  it("carries the site's tokens through the inspector into the Style tab", () => {
+    /*
+     * Mounted through `InspectorPanel`, which is what the page builder renders,
+     * rather than through `StyleInspectorPanel` directly.
+     *
+     * Every other case in this file constructs the Style tab by hand and hands
+     * it a token set, so all of them stay green with the forwarding through the
+     * inspector deleted — measured: removing `tokens={tokens}` from
+     * `InspectorPanel` moved ZERO of 1424 tests. The host-side test cannot see
+     * it either, because it mocks `InspectorPanel` to record its props. This is
+     * the one link production depends on and nothing exercised it.
+     */
+    register();
+    const document_: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "a",
+          type: "acme/box",
+          version: 1,
+          props: {},
+          styles: styles("#3b82f6"),
+        },
+      ] as BlockNode[],
+    } as BlockDocument;
+    render(<InspectorPanel editor={editorFor(document_)} tokens={TOKENS} />);
+
+    // `mouseDown`, not `click`: the trigger activates on pointer-down, and a
+    // synthetic click leaves the Content tab selected — which would make every
+    // assertion below run against the wrong panel.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Style" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
+    // The site's own token, reachable only if the set travelled the whole way.
+    expect(screen.getByRole("button", { name: "color.ink" })).toBeDefined();
   });
 });

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -145,6 +145,11 @@ function styles(color?: unknown, backgroundColor?: unknown): NodeStyles {
 const swatch = (name: string): HTMLElement =>
   screen.getByRole("button", { name });
 
+/** Mount over a whole `NodeStyles` envelope, for properties `styles()` omits. */
+function render_with(all: unknown) {
+  return mount(all as NodeStyles);
+}
+
 describe("a colour leaf draws a colour control", () => {
   it("offers a swatch beside the field, where before there was only a field", () => {
     mount(styles("#3b82f6"));
@@ -455,5 +460,61 @@ describe("opening the picker on a reference it cannot show", () => {
     mount(styles({ $token: "color.ink" }));
     fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
     expect(screen.queryByText(/cannot be shown on the picker/)).toBeNull();
+  });
+});
+
+describe("a verdict is withheld while something else decides the pixels", () => {
+  it("reports nothing when a gradient covers the background colour", () => {
+    // Black text on white with an opaque black gradient over it reports 21:1
+    // and renders black on black. The two colour properties are no longer what
+    // reaches the eye, so there is no honest figure to give.
+    render_with({
+      base: {
+        base: {
+          color: "#000000",
+          backgroundColor: "#ffffff",
+          backgroundGradient: "linear-gradient(#000, #000)",
+        },
+      },
+    });
+    expect(screen.queryByText(/Contrast/)).toBeNull();
+  });
+
+  it("reports the pair when nothing stands between them", () => {
+    // The positive control: the same pair without the gradient is measured, so
+    // the silence above is the gradient rather than the pair being unreadable.
+    render_with({
+      base: { base: { color: "#000000", backgroundColor: "#ffffff" } },
+    });
+    expect(screen.getAllByText(/Contrast 21\.0:1/).length).toBeGreaterThan(0);
+  });
+});
+
+describe("the picker can replace a stored token with a literal", () => {
+  it("follows the draft once a token-reference picker has been moved", () => {
+    // Pinned to the stored token, `ColorPicker` was handed the token's own hex
+    // again on every render and its prop-sync effect reset the surface to it —
+    // the controls snapped back mid-drag and a token could not be replaced with
+    // a literal through the picker at all.
+    mount(styles({ $token: "color.ink" }));
+    // Before any movement the surface shows the token's colour.
+    expect(
+      screen
+        .getByRole("button", { name: "Colour for Color" })
+        .style.getPropertyValue("--nx-swatch")
+    ).toBe("#111111");
+
+    fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
+    const hex = screen.getAllByRole("textbox")[0];
+    expect(hex).toBeDefined();
+    if (hex === undefined) return;
+    fireEvent.change(hex, { target: { value: "#ff0000" } });
+
+    // The swatch now follows the draft rather than snapping back to the token.
+    expect(
+      screen
+        .getByRole("button", { name: "Colour for Color" })
+        .style.getPropertyValue("--nx-swatch")
+    ).toBe("#ff0000");
   });
 });

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -146,6 +146,19 @@ function styles(color?: unknown, backgroundColor?: unknown): NodeStyles {
 const swatch = (name: string): HTMLElement =>
   screen.getByRole("button", { name });
 
+/**
+ * Let a deferred write land.
+ *
+ * The picker's close does not write during the dismissal — it schedules, so a
+ * discrete choice arriving in the same interaction can cancel it. A test
+ * asserting synchronously after a close therefore sees nothing yet, which is
+ * the behaviour rather than a failure.
+ */
+const settle = (): Promise<void> =>
+  new Promise(resolve => {
+    setTimeout(resolve, 0);
+  });
+
 /** Mount over a whole `NodeStyles` envelope, for properties `styles()` omits. */
 function render_with(all: unknown) {
   return mount(all as NodeStyles);
@@ -371,7 +384,7 @@ describe("the contrast verdict is reachable from the control it describes", () =
 });
 
 describe("a picker gesture is ONE editor operation", () => {
-  it("does not write while the picker is being moved, and writes once on close", () => {
+  it("does not write while the picker is being moved, and writes once on close", async () => {
     // The UI picker fires `onColorChange` on every pointer event, so committing
     // each one turns a single drag into dozens of undo entries — and
     // `MAX_HISTORY` is 100, so one drag can evict unrelated earlier edits and
@@ -399,6 +412,7 @@ describe("a picker gesture is ONE editor operation", () => {
     fireEvent.keyDown(document.activeElement ?? document.body, {
       key: "Escape",
     });
+    await settle();
     expect(editor.apply).toHaveBeenCalledTimes(1);
   });
 });
@@ -600,7 +614,7 @@ describe("a discrete choice supersedes an unfinished gesture", () => {
 });
 
 describe("a superseded gesture stays superseded even when the choice is refused", () => {
-  it("does not write the older literal after a REFUSED token commit", () => {
+  it("does not write the older literal after a REFUSED token commit", async () => {
     // The close path is separate from the unmount one. A token commit that the
     // store refuses — a document at its byte limit, say — leaves the picker's
     // earlier literal sitting in the draft, and a close that decided from the
@@ -627,12 +641,13 @@ describe("a superseded gesture stays superseded even when the choice is refused"
     fireEvent.keyDown(document.activeElement ?? document.body, {
       key: "Escape",
     });
+    await settle();
     expect(editor.apply.mock.calls.length).toBe(afterToken);
   });
 });
 
 describe("clearing a token while the picker is open", () => {
-  it("records ONE operation, and it is the clear", () => {
+  it("records ONE operation, and it is the clear", async () => {
     // The Clear button sits outside the popover, so pressing it is an outside
     // interaction: Radix dismisses on a document `pointerdown`, which closes the
     // picker and commits its gesture, and only then does the click clear. That
@@ -647,12 +662,15 @@ describe("clearing a token while the picker is open", () => {
 
     // The real order: React's handler on the button, then the document
     // dismissal Radix listens for, then the click.
+    // The dismissal and the activation are one interaction, whichever event
+    // Radix noticed it through. Escape stands in for the dismissal here; the
+    // click that follows is what the author meant.
     const clear = screen.getByRole("button", { name: "Clear Color" });
-    fireEvent.pointerDown(clear);
     fireEvent.keyDown(document.activeElement ?? document.body, {
       key: "Escape",
     });
     fireEvent.click(clear);
+    await settle();
 
     expect(editor.apply).toHaveBeenCalledTimes(1);
     // A clear removes the entry rather than writing one.
@@ -697,5 +715,33 @@ describe("the route a real editor takes to the colour control", () => {
     fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
     // The site's own token, reachable only if the set travelled the whole way.
     expect(screen.getByRole("button", { name: "color.ink" })).toBeDefined();
+  });
+});
+
+describe("clearing a token from the KEYBOARD while the picker is open", () => {
+  it("records one operation, as the pointer route does", async () => {
+    // The route the pointer-down fix could not cover. Moving focus to the Clear
+    // button dismisses the popover through `focusin` rather than `pointerdown`,
+    // and the activation arrives afterwards — so a control that dropped the
+    // gesture on pointer-down handled a mouse and left a keyboard writing the
+    // literal first and clearing it second.
+    const editor = mount(styles({ $token: "color.ink" }));
+    fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
+    const hex = screen.getAllByRole("textbox")[0];
+    expect(hex).toBeDefined();
+    if (hex === undefined) return;
+    fireEvent.change(hex, { target: { value: "#ff0000" } });
+
+    // Focus moves out — the dismissal — and only then is the button activated.
+    const clear = screen.getByRole("button", { name: "Clear Color" });
+    fireEvent.focus(clear);
+    fireEvent.keyDown(document.activeElement ?? document.body, {
+      key: "Escape",
+    });
+    fireEvent.click(clear);
+    await settle();
+
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(editor.apply.mock.calls[0])).not.toContain("#ff0000");
   });
 });

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -629,3 +629,32 @@ describe("a superseded gesture stays superseded even when the choice is refused"
     expect(editor.apply.mock.calls.length).toBe(afterToken);
   });
 });
+
+describe("clearing a token while the picker is open", () => {
+  it("records ONE operation, and it is the clear", () => {
+    // The Clear button sits outside the popover, so pressing it is an outside
+    // interaction: Radix dismisses on a document `pointerdown`, which closes the
+    // picker and commits its gesture, and only then does the click clear. That
+    // is two history entries, and one undo returns an intermediate literal the
+    // author never chose. The pointer-down supersede drops the gesture first.
+    const editor = mount(styles({ $token: "color.ink" }));
+    fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
+    const hex = screen.getAllByRole("textbox")[0];
+    expect(hex).toBeDefined();
+    if (hex === undefined) return;
+    fireEvent.change(hex, { target: { value: "#ff0000" } });
+
+    // The real order: React's handler on the button, then the document
+    // dismissal Radix listens for, then the click.
+    const clear = screen.getByRole("button", { name: "Clear Color" });
+    fireEvent.pointerDown(clear);
+    fireEvent.keyDown(document.activeElement ?? document.body, {
+      key: "Escape",
+    });
+    fireEvent.click(clear);
+
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+    // A clear removes the entry rather than writing one.
+    expect(JSON.stringify(editor.apply.mock.calls[0])).not.toContain("#ff0000");
+  });
+});

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -557,10 +557,10 @@ describe("a picker gesture survives the field being replaced", () => {
 
 describe("a discrete choice supersedes an unfinished gesture", () => {
   it("does not let a pending literal overwrite a token chosen after it", () => {
-    // Choosing a preset does not close the popover, so the pending gesture
-    // survives it. Unflushed correctly, the unmount write then lands the older
-    // hex on top of the token the author just picked — the reference silently
-    // becoming a literal.
+    // Choosing a preset does not close the popover, so the control is still
+    // holding an unfinished gesture when the author leaves. Unless that gesture
+    // is dropped as the preset commits, the unmount write lands the older hex
+    // on top of the token just picked and the reference becomes a literal.
     const editor = mount(styles("#3b82f6"));
     fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
 
@@ -595,5 +595,37 @@ describe("a discrete choice supersedes an unfinished gesture", () => {
     expect(editor.apply).toHaveBeenCalledTimes(1);
     cleanup();
     expect(editor.apply).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("a superseded gesture stays superseded even when the choice is refused", () => {
+  it("does not write the older literal after a REFUSED token commit", () => {
+    // The close path is separate from the unmount one. A token commit that the
+    // store refuses — a document at its byte limit, say — leaves the picker's
+    // earlier literal sitting in the draft, and a close that decided from the
+    // draft wrote that literal even though choosing the token was meant to
+    // replace it. Both paths now read the one pending value.
+    const editor = mount(styles("#3b82f6"));
+    // Every write is refused: `apply` answering null is the store declining.
+    editor.apply.mockReturnValue(null);
+
+    fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
+    const hex = screen
+      .getAllByRole("textbox")
+      .find(input => input !== screen.getByRole("textbox", { name: "Color" }));
+    expect(hex).toBeDefined();
+    if (hex === undefined) return;
+    fireEvent.change(hex, { target: { value: "#ff0000" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "color.ink" }));
+    const afterToken = editor.apply.mock.calls.length;
+    expect(afterToken).toBe(1);
+    expect(JSON.stringify(editor.apply.mock.calls[0])).toContain("$token");
+
+    // Closing must not resurrect the literal the token choice replaced.
+    fireEvent.keyDown(document.activeElement ?? document.body, {
+      key: "Escape",
+    });
+    expect(editor.apply.mock.calls.length).toBe(afterToken);
   });
 });

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -147,12 +147,14 @@ const swatch = (name: string): HTMLElement =>
   screen.getByRole("button", { name });
 
 /**
- * Let a deferred write land.
+ * Let Radix arm the listener that makes a dismissal possible.
  *
- * The picker's close does not write during the dismissal — it schedules, so a
- * discrete choice arriving in the same interaction can cancel it. A test
- * asserting synchronously after a close therefore sees nothing yet, which is
- * the behaviour rather than a failure.
+ * Not a wait for the write, which happens synchronously inside the close. Radix
+ * attaches its outside-pointerdown listener inside a `setTimeout`, so until
+ * that has run NOTHING can dismiss the popover — and a test that opens the
+ * picker and immediately acts outside it asserts against a popover that never
+ * closed, passing for a reason unrelated to what it names. Measured: three such
+ * tests were green while the close path had never run.
  */
 const settle = (): Promise<void> =>
   new Promise(resolve => {

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -308,3 +308,91 @@ describe("the contrast readout", () => {
     expect(screen.getAllByText(/Contrast 21\.0:1/).length).toBeGreaterThan(0);
   });
 });
+
+describe("a value no colour surface can represent", () => {
+  it("keeps the read-only surface rather than an empty colour field", () => {
+    // An object at a scalar position, from an import or the API. Routed to the
+    // colour control it projects to an empty draft and reads as UNSET while the
+    // value goes on compiling — and the one action that would remove it, Clear,
+    // is the one the field does not offer.
+    mount(styles({ value: "#fff" }));
+    expect(screen.queryByRole("textbox", { name: "Color" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Colour for Color" })
+    ).toBeNull();
+    // Shown, and removable.
+    expect(screen.getByRole("button", { name: "Clear Color" })).toBeDefined();
+    expect(screen.getByText(/"value"/)).toBeDefined();
+  });
+
+  it("still routes an ordinary literal and a reference to the colour control", () => {
+    // The positive control for the guard: it must refuse the shape above and
+    // nothing else, or every colour would fall back to read-only.
+    mount(styles("#3b82f6"));
+    expect(
+      screen.getByRole("button", { name: "Colour for Color" })
+    ).toBeDefined();
+  });
+});
+
+describe("the contrast verdict is reachable from the control it describes", () => {
+  it("points the field and the swatch at the readout", () => {
+    // Without this the verdict is rendered and announced to nobody: focusing
+    // the colour control says nothing about the WCAG result beside it.
+    mount(styles("#000000", "#ffffff"));
+    const note = document.querySelector(".nx-style-inspector__contrast");
+    expect(note).not.toBeNull();
+    const noteId = note?.getAttribute("id");
+    expect(noteId).toBeTruthy();
+    const field = screen.getByRole("textbox", { name: "Color" });
+    const swatchButton = screen.getByRole("button", {
+      name: "Colour for Color",
+    });
+    expect(field.getAttribute("aria-describedby")).toContain(noteId as string);
+    expect(swatchButton.getAttribute("aria-describedby")).toContain(
+      noteId as string
+    );
+  });
+
+  it("describes nothing when there is no verdict to describe", () => {
+    mount(styles("#000000"));
+    expect(
+      screen
+        .getByRole("textbox", { name: "Color" })
+        .getAttribute("aria-describedby")
+    ).toBeNull();
+  });
+});
+
+describe("a picker gesture is ONE editor operation", () => {
+  it("does not write while the picker is being moved, and writes once on close", () => {
+    // The UI picker fires `onColorChange` on every pointer event, so committing
+    // each one turns a single drag into dozens of undo entries — and
+    // `MAX_HISTORY` is 100, so one drag can evict unrelated earlier edits and
+    // leave undo walking intermediate colours instead of reverting the gesture.
+    // The same rule the text fields follow: an op per keystroke would make one
+    // undo remove one character.
+    const editor = mount(styles("#3b82f6"));
+    fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
+
+    // The picker's own hex field stands in for the drag: it reaches the same
+    // `onColorChange` the surface and sliders do.
+    const hex = screen
+      .getAllByRole("textbox")
+      .find(input => input !== screen.getByRole("textbox", { name: "Color" }));
+    expect(hex).toBeDefined();
+    if (hex === undefined) return;
+    fireEvent.change(hex, { target: { value: "#ff0000" } });
+    fireEvent.change(hex, { target: { value: "#00ff00" } });
+    fireEvent.change(hex, { target: { value: "#0000ff" } });
+
+    // Three moves, no writes.
+    expect(editor.apply).not.toHaveBeenCalled();
+
+    // Closing ends the gesture and writes once.
+    fireEvent.keyDown(document.activeElement ?? document.body, {
+      key: "Escape",
+    });
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/builder/src/style-colour-roundtrip.test.ts
+++ b/packages/builder/src/style-colour-roundtrip.test.ts
@@ -1,0 +1,166 @@
+/**
+ * What the colour control writes, carried through the real compilers.
+ *
+ * `style-colour.test.ts` asserts the projection and `style-colour-panel.test.tsx`
+ * asserts the wiring, and between them they establish that choosing a token
+ * stores `{ $token: <identity> }`. Neither shows that the value so stored
+ * RESOLVES: the page compiler turns a reference into `var(--<prefix><name>)`
+ * lexically, with no lookup against the table, and the site sheet declares its
+ * custom properties from a different function. The two agree only if the string
+ * the control stored is the one the emitter keyed on.
+ *
+ * That join is the whole reason `SiteToken.id` exists, and it is the failure
+ * with no symptom: a reference to a property nothing declares invalidates the
+ * declaration rather than reporting, so the page renders with the style simply
+ * absent. Nothing above this file could see it, because both halves are correct
+ * in isolation.
+ *
+ * So this compiles a page and a site sheet from the SAME token set the picker
+ * offered, and requires the property the page references to be one the sheet
+ * declares. It is not a browser — D-05.7 asks for that and this is not it — but
+ * it is the whole road from the control's output to the bytes a visitor's
+ * stylesheet would contain.
+ *
+ * @module style-colour-roundtrip.test
+ */
+import {
+  compilePageCss,
+  compileSiteSheet,
+  type BlockDocument,
+  type BlockNode,
+  type SiteTokenSet,
+  type StyleLeaf,
+  STYLE_CATALOG,
+} from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import { colourTokensFor } from "./style-colour";
+
+/** The `color` property's leaf, from the catalog rather than written here. */
+const COLOR = (
+  STYLE_CATALOG as unknown as readonly {
+    property: string;
+    shape: StyleLeaf;
+  }[]
+).find(entry => entry.property === "color")?.shape as StyleLeaf;
+
+/**
+ * A site whose token has been RENAMED, so identity and name differ.
+ *
+ * The only state in which storing the wrong one of the two has a symptom. With
+ * a fixture where every id equals its name, both spellings compile to the same
+ * property and this file would pass against the defect it exists to catch.
+ */
+const TOKENS: SiteTokenSet = {
+  tokens: [
+    {
+      id: "color.primary",
+      name: "brand.main",
+      kind: "color",
+      values: { light: "#3b82f6" },
+    },
+  ],
+};
+
+const BREAKPOINTS = { base: { id: "base", label: "Base" } } as never;
+
+/** A one-node page whose text colour holds whatever is passed. */
+function pageWith(colour: unknown): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      {
+        id: "a",
+        type: "acme/box",
+        version: 1,
+        props: {},
+        styles: { base: { base: { color: colour } } },
+      },
+    ] as BlockNode[],
+  } as BlockDocument;
+}
+
+/** Every `--custom-property` the page's CSS REFERENCES through `var()`. */
+function referenced(css: string): string[] {
+  return [...css.matchAll(/var\((--[a-zA-Z0-9_-]+)/g)].map(
+    match => match[1] ?? ""
+  );
+}
+
+/** Every `--custom-property` the site sheet DECLARES. */
+function declared(css: string): string[] {
+  return [...css.matchAll(/(--[a-zA-Z0-9_-]+)\s*:/g)].map(
+    match => match[1] ?? ""
+  );
+}
+
+describe("a token chosen in the picker resolves on the page", () => {
+  const offered = colourTokensFor(COLOR, TOKENS);
+  const brand = offered.find(token => token.name === "brand.main");
+
+  it("offers the renamed token under its current name", () => {
+    // The control for the fixture: if the picker did not offer this token at
+    // all, every assertion below would be about a token nobody could choose.
+    expect(brand).toBeDefined();
+    expect(brand?.name).toBe("brand.main");
+    expect(brand?.identity).toBe("color.primary");
+  });
+
+  it("references a property the site sheet declares", () => {
+    expect(brand).toBeDefined();
+    if (brand === undefined) return;
+
+    // Exactly what the control commits when the preset is chosen.
+    const page = compilePageCss(pageWith({ $token: brand.identity }), {
+      breakpoints: BREAKPOINTS,
+    });
+    const sheet = compileSiteSheet({
+      tokens: TOKENS,
+      breakpoints: BREAKPOINTS,
+    });
+
+    const uses = referenced(page.css);
+    const has = declared(sheet.css);
+
+    // Positive controls first: an empty page or an empty sheet would satisfy
+    // the subset assertion below without either compiler having done anything.
+    expect(uses.length).toBeGreaterThan(0);
+    expect(has.length).toBeGreaterThan(0);
+
+    for (const property of uses) expect(has).toContain(property);
+  });
+
+  it("does NOT resolve when the name is stored instead of the identity", () => {
+    // The separating case, and the defect `SiteToken.id` exists to prevent.
+    // This is what a control storing the label would produce, and the failure
+    // has no symptom on the page: the declaration is invalid, so the style is
+    // absent and everything still renders.
+    expect(brand).toBeDefined();
+    if (brand === undefined) return;
+
+    const page = compilePageCss(pageWith({ $token: brand.name }), {
+      breakpoints: BREAKPOINTS,
+    });
+    const sheet = compileSiteSheet({
+      tokens: TOKENS,
+      breakpoints: BREAKPOINTS,
+    });
+
+    const uses = referenced(page.css);
+    const has = declared(sheet.css);
+
+    expect(uses.length).toBeGreaterThan(0);
+    // The page asks for something the sheet never declares.
+    expect(uses.some(property => !has.includes(property))).toBe(true);
+  });
+
+  it("carries a literal through unchanged", () => {
+    // The other thing the control writes. Asserted so a compiler that dropped
+    // every colour would not pass the token cases by emitting nothing at all.
+    const page = compilePageCss(pageWith("#ff0000"), {
+      breakpoints: BREAKPOINTS,
+    });
+    expect(page.css).toContain("#ff0000");
+  });
+});

--- a/packages/builder/src/style-colour-roundtrip.test.ts
+++ b/packages/builder/src/style-colour-roundtrip.test.ts
@@ -17,9 +17,9 @@
  *
  * So this compiles a page and a site sheet from the SAME token set the picker
  * offered, and requires the property the page references to be one the sheet
- * declares. It is not a browser — D-05.7 asks for that and this is not it — but
- * it is the whole road from the control's output to the bytes a visitor's
- * stylesheet would contain.
+ * declares. No browser is involved, so this does not show the declaration taking
+ * effect on a rendered page — but it is the whole road from the control's output
+ * to the bytes a visitor's stylesheet would contain.
  *
  * @module style-colour-roundtrip.test
  */

--- a/packages/builder/src/style-colour.test.ts
+++ b/packages/builder/src/style-colour.test.ts
@@ -22,6 +22,7 @@ import {
   colourShowable,
   colourTokenFor,
   colourTokensFor,
+  contrastObscuredBy,
   contrastOf,
   contrastPartnerOf,
   contrastRatioText,
@@ -509,5 +510,80 @@ describe("which mode a token resolves in", () => {
     const bg = { $token: "color.primary" };
     expect(contrastOf(fg, bg, media, "light")?.passesBodyText).toBe(true);
     expect(contrastOf(fg, bg, media, "dark")?.passesBodyText).toBe(false);
+  });
+});
+
+describe("only tokens the canvas will declare are offered", () => {
+  it("withholds a token whose NAME cannot become a custom property", () => {
+    // `emitTokenBlocks` drops it and names the issue, so a reference stored
+    // from the picker would point at a property nothing declares — the style
+    // vanishes and the page still renders.
+    const set: SiteTokenSet = {
+      tokens: [
+        { name: "color.ok", kind: "color", values: { light: "#111111" } },
+        { name: "color primary!", kind: "color", values: { light: "#222222" } },
+      ],
+    };
+    expect(colourTokensFor(COLOR, set).map(t => t.name)).toEqual(["color.ok"]);
+  });
+
+  it("withholds the SECOND of two identities that collide on one property", () => {
+    // `color.primary-dark` and `color-primary.dark` both become
+    // `--site-color-primary-dark`. The engine emits the first and refuses the
+    // second rather than letting one resolve to the other's value.
+    const set: SiteTokenSet = {
+      tokens: [
+        {
+          name: "color.primary-dark",
+          kind: "color",
+          values: { light: "#111111" },
+        },
+        {
+          name: "color-primary.dark",
+          kind: "color",
+          values: { light: "#222222" },
+        },
+      ],
+    };
+    const offered = colourTokensFor(COLOR, set);
+    expect(offered.map(t => t.name)).toEqual(["color.primary-dark"]);
+  });
+
+  it("offers a set with no collisions untouched", () => {
+    // The positive control: the filter must remove those two shapes and
+    // nothing else, or every picker would come back empty.
+    expect(colourTokensFor(COLOR, TOKENS).length).toBe(3);
+  });
+});
+
+describe("what stands between a contrast pair", () => {
+  const none = () => undefined;
+
+  it("names a property that puts something over the colours", () => {
+    // Black text on `#ffffff` with an opaque black gradient over it reports
+    // 21:1 and renders black on black.
+    expect(
+      contrastObscuredBy(p => (p === "backgroundGradient" ? "x" : undefined))
+    ).toBe("backgroundGradient");
+    expect(contrastObscuredBy(p => (p === "opacity" ? 0.5 : undefined))).toBe(
+      "opacity"
+    );
+    expect(
+      contrastObscuredBy(p => (p === "filter" ? "blur(2px)" : undefined))
+    ).toBe("filter");
+    expect(
+      contrastObscuredBy(p => (p === "mixBlendMode" ? "multiply" : undefined))
+    ).toBe("mixBlendMode");
+    expect(contrastObscuredBy(p => (p === "background" ? {} : undefined))).toBe(
+      "background"
+    );
+  });
+
+  it("names nothing when the pair is drawn plainly", () => {
+    expect(contrastObscuredBy(none)).toBeUndefined();
+    // And is not fooled by an unrelated property being set.
+    expect(
+      contrastObscuredBy(p => (p === "padding" ? "4px" : undefined))
+    ).toBeUndefined();
   });
 });

--- a/packages/builder/src/style-colour.test.ts
+++ b/packages/builder/src/style-colour.test.ts
@@ -11,6 +11,7 @@
 import {
   STYLE_CATALOG,
   emitTokenBlocks,
+  type BlockNode,
   type NodeStyles,
   type ContrastResult,
   type SiteTokenSet,
@@ -20,6 +21,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   activeTokenMode,
+  contrastObscuredAbove,
   colourHexOf,
   colourShowable,
   colourTokenFor,
@@ -822,5 +824,63 @@ describe("what obscures a pair anywhere on the node", () => {
     } as unknown as NodeStyles;
     expect(contrastObscuredIn(styles)).toBeUndefined();
     expect(contrastObscuredIn(undefined)).toBeUndefined();
+  });
+});
+
+describe("what an ancestor puts over a pair", () => {
+  /** A parent holding `styles`, wrapping one child in a slot. */
+  const treeWith = (parentStyles: unknown, depth = 1): BlockNode[] => {
+    let node = { id: "leaf", type: "acme/box", version: 1, props: {} };
+    for (let level = 0; level < depth; level += 1) {
+      node = {
+        id: `wrap${level}`,
+        type: "acme/box",
+        version: 1,
+        props: {},
+        // Only the OUTERMOST wrapper carries the styles, so a walk that stops
+        // at the immediate parent fails the deep case.
+        ...(level === depth - 1 ? { styles: parentStyles } : {}),
+        slots: { children: [node] },
+      } as never;
+    }
+    return [node] as unknown as BlockNode[];
+  };
+
+  it("names an ancestor's opacity, which composites the whole subtree", () => {
+    // The failing-open case: the leaf's own styles are spotless, so a
+    // node-scoped look reports 21:1 for text the parent has faded to a tenth.
+    const nodes = treeWith({ base: { base: { opacity: "0.1" } } });
+    expect(contrastObscuredAbove(nodes, "leaf")).toBe("opacity");
+  });
+
+  it("keeps walking past a clean parent to a grandparent", () => {
+    const nodes = treeWith({ base: { base: { filter: "blur(2px)" } } }, 3);
+    expect(contrastObscuredAbove(nodes, "leaf")).toBe("filter");
+  });
+
+  it("names a blend mode, whose result depends on what is under the ancestor", () => {
+    const nodes = treeWith({ base: { base: { mixBlendMode: "multiply" } } });
+    expect(contrastObscuredAbove(nodes, "leaf")).toBe("mixBlendMode");
+  });
+
+  it("IGNORES an ancestor background, which an opaque child paints over", () => {
+    // The reason the ancestor list is a subset. A section with a background
+    // colour is the ordinary case, and treating it as obscuring would silence
+    // the readout for every control on the page.
+    const nodes = treeWith({
+      base: { base: { background: "#ff0000", boxShadow: "0 0 2px #000" } },
+    });
+    expect(contrastObscuredAbove(nodes, "leaf")).toBeUndefined();
+  });
+
+  it("sees an ancestor rule set only at a hover state or a breakpoint", () => {
+    const nodes = treeWith({ hover: { md: { opacity: "0.2" } } });
+    expect(contrastObscuredAbove(nodes, "leaf")).toBe("opacity");
+  });
+
+  it("answers undefined at the top level, and for an id not in the tree", () => {
+    const nodes = treeWith({ base: { base: { opacity: "0.1" } } });
+    expect(contrastObscuredAbove(nodes, "wrap0")).toBeUndefined();
+    expect(contrastObscuredAbove(nodes, "absent")).toBeUndefined();
   });
 });

--- a/packages/builder/src/style-colour.test.ts
+++ b/packages/builder/src/style-colour.test.ts
@@ -620,6 +620,23 @@ describe("what stands between a contrast pair", () => {
     );
   });
 
+  it("names an inset shadow, which paints over the background", () => {
+    // Black text on white under an opaque black inset shadow renders black on
+    // black and reported 21:1. Counted whether or not the value says `inset`:
+    // a `cssValue` leaf is validated for syntax only, so nothing here decides
+    // what a shadow means.
+    expect(
+      contrastObscuredBy(prop =>
+        prop === "boxShadow" ? "inset 0 0 0 99px #000" : undefined
+      )
+    ).toBe("boxShadow");
+    expect(
+      contrastObscuredBy(prop =>
+        prop === "boxShadow" ? "0 1px 2px #0003" : undefined
+      )
+    ).toBe("boxShadow");
+  });
+
   it("names nothing when the pair is drawn plainly", () => {
     expect(contrastObscuredBy(none)).toBeUndefined();
     // And is not fooled by an unrelated property being set.

--- a/packages/builder/src/style-colour.test.ts
+++ b/packages/builder/src/style-colour.test.ts
@@ -17,6 +17,7 @@ import {
 import { describe, expect, it } from "vitest";
 
 import {
+  activeTokenMode,
   colourHexOf,
   colourShowable,
   colourTokenFor,
@@ -452,5 +453,61 @@ describe("a translucent background withholds the verdict", () => {
 
   it("refuses an alpha hex background as readily as an rgba() one", () => {
     expect(contrastOf("#ffffff", "#00000080", TOKENS)).toBeUndefined();
+  });
+});
+
+describe("which mode a token resolves in", () => {
+  const media: SiteTokenSet = { ...TOKENS, darkMode: "media" };
+  const attribute: SiteTokenSet = { ...TOKENS, darkMode: "attribute" };
+
+  it("follows the system only where the site said to", () => {
+    // `emitTokenBlocks` wraps the dark block in
+    // `@media (prefers-color-scheme:dark)` for the media strategy, so the
+    // canvas switches with the system and nothing tells the panel.
+    expect(activeTokenMode(media, true)).toBe("dark");
+    expect(activeTokenMode(media, false)).toBe("light");
+  });
+
+  it("stays light on the attribute strategy, which the panel cannot observe", () => {
+    // The dark block is written under `[data-nx-theme="dark"]`, set by the HOST
+    // on an ancestor of its choosing. A stated limit, not a claim.
+    expect(activeTokenMode(attribute, true)).toBe("light");
+    // And the default, when a site names no strategy at all.
+    expect(activeTokenMode(TOKENS, true)).toBe("light");
+    expect(activeTokenMode(undefined, true)).toBe("light");
+  });
+
+  it("resolves a reference to the value the canvas is actually showing", () => {
+    // The separating case: this token differs between modes, so a resolution
+    // pinned to light would paint a swatch the canvas contradicts.
+    const ref = { $token: "color.primary" };
+    expect(colourHexOf(ref, media, "light")).toBe("#ffffff");
+    expect(colourHexOf(ref, media, "dark")).toBe("#000000");
+  });
+
+  it("falls back to light for a token defined only for light", () => {
+    // Which is what the canvas does too: no dark declaration is emitted for it,
+    // so the light one goes on applying.
+    const ink = TOKENS.tokens.find(token => token.name === "color.ink");
+    expect(ink?.values.dark).toBeUndefined();
+    expect(colourHexOf({ $token: "color.ink" }, media, "dark")).toBe("#111111");
+  });
+
+  it("paints preset swatches in the same mode", () => {
+    const dark = colourTokensFor(COLOR, media, "dark").find(
+      token => token.name === "brand.main"
+    );
+    expect(dark?.colour).toBe("#000000");
+    expect(dark?.swatch).toBe("#000000");
+  });
+
+  it("measures contrast in that mode too", () => {
+    // Light: #111111 on #ffffff, high. Dark: #111111 on #000000, low. A readout
+    // pinned to light would report a passing pair while the canvas shows a
+    // failing one.
+    const fg = { $token: "color.ink" };
+    const bg = { $token: "color.primary" };
+    expect(contrastOf(fg, bg, media, "light")?.passesBodyText).toBe(true);
+    expect(contrastOf(fg, bg, media, "dark")?.passesBodyText).toBe(false);
   });
 });

--- a/packages/builder/src/style-colour.test.ts
+++ b/packages/builder/src/style-colour.test.ts
@@ -740,6 +740,45 @@ describe("the emitter decides which tokens are offered", () => {
     );
   });
 
+  it("does not hand a claimed property to the token the engine REFUSED", () => {
+    // The two verdicts have different scopes, and the ORDER they are asked in
+    // decides who owns a contested property. The engine skips a refused token
+    // before the collision check and writes an accepted one even when its kind
+    // is wrong — so a kind-mismatched token still takes the property, and the
+    // token colliding with it is refused.
+    //
+    // Asking the kind first inverts that: the mismatched token is dropped here,
+    // the refused one inherits the property, and the picker offers it painted
+    // with its OWN colour while the page resolves the other's value.
+    const set: SiteTokenSet = {
+      // Both compose "--site-color-primary-dark"; only the spelling differs.
+      tokens: [
+        {
+          name: "color.primary-dark",
+          kind: "color",
+          values: { light: "16px" },
+        },
+        {
+          name: "color-primary.dark",
+          kind: "color",
+          values: { light: "#123456" },
+        },
+      ],
+    };
+
+    // Ground truth from the emitter: the FIRST token takes the property, with
+    // the value that does nothing, and the second is refused outright.
+    const emitted = emitTokenBlocks(set, ":root");
+    expect(emitted.css).toContain("--site-color-primary-dark:16px");
+    expect(emitted.css).not.toContain("#123456");
+
+    // So neither is choosable: one resolves to nothing, and the other is not
+    // declared at all.
+    const names = colourTokensFor(COLOR, set).map(t => t.name);
+    expect(names).not.toContain("color-primary.dark");
+    expect(names).not.toContain("color.primary-dark");
+  });
+
   it("withholds a token with no usable light value", () => {
     const set = {
       tokens: [

--- a/packages/builder/src/style-colour.test.ts
+++ b/packages/builder/src/style-colour.test.ts
@@ -684,6 +684,29 @@ describe("the emitter decides which tokens are offered", () => {
     expect(names).not.toContain("color.wrong");
   });
 
+  it("KEEPS a token whose other mode is broken but whose active one is not", () => {
+    // A token that renders perfectly well in light, and badly in dark. Judged
+    // across both modes at once it looks unusable; judged in the mode the
+    // canvas is showing it is fine. Removing it from a light-mode picker takes
+    // away a token that works from an author who cannot see the problem.
+    const set: SiteTokenSet = {
+      tokens: [
+        {
+          name: "color.half",
+          kind: "color",
+          values: { light: "#ffffff", dark: "16px" },
+        },
+      ],
+    };
+    expect(colourTokensFor(COLOR, set, "light").map(t => t.name)).toContain(
+      "color.half"
+    );
+    // And withheld in the mode where it really is broken.
+    expect(colourTokensFor(COLOR, set, "dark").map(t => t.name)).not.toContain(
+      "color.half"
+    );
+  });
+
   it("withholds a token with no usable light value", () => {
     const set = {
       tokens: [

--- a/packages/builder/src/style-colour.test.ts
+++ b/packages/builder/src/style-colour.test.ts
@@ -667,6 +667,23 @@ describe("the emitter decides which tokens are offered", () => {
     expect(names).not.toContain("color.bad");
   });
 
+  it("withholds a token whose value CONTRADICTS its declared kind", () => {
+    // The engine emits this one deliberately, with a warning, because refusing
+    // it would cost the author the token on a verdict it is not certain enough
+    // to act on. The browser then drops `color: var(...)` where the token is
+    // used — so a picker offering it hands over a reference that does nothing.
+    // A filter reading only the declared kind cannot see this.
+    const set: SiteTokenSet = {
+      tokens: [
+        { name: "color.ok", kind: "color", values: { light: "#111111" } },
+        { name: "color.wrong", kind: "color", values: { light: "16px" } },
+      ],
+    };
+    const names = colourTokensFor(COLOR, set).map(t => t.name);
+    expect(names).toContain("color.ok");
+    expect(names).not.toContain("color.wrong");
+  });
+
   it("withholds a token with no usable light value", () => {
     const set = {
       tokens: [

--- a/packages/builder/src/style-colour.test.ts
+++ b/packages/builder/src/style-colour.test.ts
@@ -10,6 +10,7 @@
  */
 import {
   STYLE_CATALOG,
+  emitTokenBlocks,
   type NodeStyles,
   type ContrastResult,
   type SiteTokenSet,
@@ -704,6 +705,38 @@ describe("the emitter decides which tokens are offered", () => {
     // And withheld in the mode where it really is broken.
     expect(colourTokensFor(COLOR, set, "dark").map(t => t.name)).not.toContain(
       "color.half"
+    );
+  });
+
+  it("WITHHOLDS one whose other mode is refused, which costs both modes", () => {
+    // The other half of the rule above, and the one that reverses it. A kind
+    // mismatch is mode-local: the emitter reports it and writes the value
+    // anyway, so a bad dark value leaves a good light one resolving. A refusal
+    // is not: the emitter scans BOTH values for anything unsafe or fetching and
+    // skips the whole token, so a dark `url(...)` leaves the light value with
+    // no custom property either. Scoping the whole question to the active mode
+    // therefore offers a preset whose reference resolves to nothing, in the
+    // very mode that looked fine.
+    const set: SiteTokenSet = {
+      tokens: [
+        {
+          name: "color.fetches",
+          kind: "color",
+          values: { light: "#ffffff", dark: "url(https://example.com/a.png)" },
+        },
+      ],
+    };
+
+    // Ground truth from the emitter itself, so this asserts the engine's real
+    // behaviour rather than a belief about it: nothing is written for the token
+    // at all, in either mode.
+    expect(emitTokenBlocks(set, ":root").css).toBe("");
+
+    expect(colourTokensFor(COLOR, set, "light").map(t => t.name)).not.toContain(
+      "color.fetches"
+    );
+    expect(colourTokensFor(COLOR, set, "dark").map(t => t.name)).not.toContain(
+      "color.fetches"
     );
   });
 

--- a/packages/builder/src/style-colour.test.ts
+++ b/packages/builder/src/style-colour.test.ts
@@ -10,6 +10,7 @@
  */
 import {
   STYLE_CATALOG,
+  type NodeStyles,
   type ContrastResult,
   type SiteTokenSet,
   type StyleLeaf,
@@ -23,6 +24,7 @@ import {
   colourTokenFor,
   colourTokensFor,
   contrastObscuredBy,
+  contrastObscuredIn,
   contrastOf,
   contrastPartnerOf,
   contrastRatioText,
@@ -585,5 +587,68 @@ describe("what stands between a contrast pair", () => {
     expect(
       contrastObscuredBy(p => (p === "padding" ? "4px" : undefined))
     ).toBeUndefined();
+  });
+});
+
+describe("the emitter decides which tokens are offered", () => {
+  it("withholds a token whose VALUE the canvas will not write", () => {
+    // The reason a partial copy of the emitter's rules is worse than none: the
+    // name here is fine and the identity collides with nothing, so a check that
+    // knew only those two rules would offer this token — and the canvas emits
+    // no property for it, so a stored reference loses the style silently.
+    const set: SiteTokenSet = {
+      tokens: [
+        { name: "color.ok", kind: "color", values: { light: "#111111" } },
+        {
+          name: "color.bad",
+          kind: "color",
+          values: { light: "url(https://example.com/a.png)" },
+        },
+      ],
+    };
+    expect(colourTokensFor(COLOR, set).map(t => t.name)).toEqual(["color.ok"]);
+  });
+
+  it("withholds a token with no usable light value", () => {
+    const set = {
+      tokens: [
+        { name: "color.ok", kind: "color", values: { light: "#111111" } },
+        { name: "color.empty", kind: "color", values: { light: 4 } },
+      ],
+    } as unknown as SiteTokenSet;
+    expect(colourTokensFor(COLOR, set).map(t => t.name)).toEqual(["color.ok"]);
+  });
+});
+
+describe("what obscures a pair anywhere on the node", () => {
+  it("sees a base-state gradient while a hover rule is being edited", () => {
+    // The cascade is why this cannot be address-scoped: a base gradient goes on
+    // covering the background when a hover rule sets only the two colours, so
+    // an address-scoped look reports a ratio for pixels the gradient hides.
+    const styles = {
+      base: { base: { backgroundGradient: "linear-gradient(#000, #000)" } },
+      hover: { base: { color: "#000000", backgroundColor: "#ffffff" } },
+    } as unknown as NodeStyles;
+    expect(contrastObscuredIn(styles)).toBe("backgroundGradient");
+  });
+
+  it("sees one set at another breakpoint", () => {
+    const styles = {
+      base: {
+        base: { color: "#000000", backgroundColor: "#ffffff" },
+        mobile: { opacity: 0.5 },
+      },
+    } as unknown as NodeStyles;
+    expect(contrastObscuredIn(styles)).toBe("opacity");
+  });
+
+  it("names nothing for a node carrying only the pair", () => {
+    // The positive control: it must find those and nothing else, or every
+    // verdict would be withheld.
+    const styles = {
+      base: { base: { color: "#000000", backgroundColor: "#ffffff" } },
+    } as unknown as NodeStyles;
+    expect(contrastObscuredIn(styles)).toBeUndefined();
+    expect(contrastObscuredIn(undefined)).toBeUndefined();
   });
 });

--- a/packages/builder/src/style-colour.test.ts
+++ b/packages/builder/src/style-colour.test.ts
@@ -91,15 +91,43 @@ const TOKENS: SiteTokenSet = {
 
 describe("which tokens a colour control offers", () => {
   it("offers the site's colour tokens and withholds the others", () => {
-    const offered = colourTokensFor(COLOR, TOKENS);
-    expect(offered.map(token => token.name)).toEqual([
-      "color.ink",
-      "color.themed",
-      "brand.main",
-    ]);
-    // The positive control for the filter: the site DOES define a token of
-    // another kind, so an empty exclusion list would show here.
+    const offered = colourTokensFor(COLOR, TOKENS).map(token => token.name);
+    expect(offered).toContain("color.ink");
+    expect(offered).toContain("color.themed");
+    expect(offered).toContain("brand.main");
+    // The positive control for the KIND filter: the site defines a dimension
+    // token, and the engine's defaults carry two more, so an empty exclusion
+    // list would show every one of them here.
     expect(TOKENS.tokens.some(token => token.kind === "dimension")).toBe(true);
+    expect(offered).not.toContain("space.4");
+    expect(offered).not.toContain("content.width");
+    expect(offered).not.toContain("font.body");
+  });
+
+  it("offers the ENGINE's default colour tokens, which every page emits", () => {
+    // `PageRenderer` compiles with `resolveSiteTokens`, which layers these
+    // underneath whatever the site defines — so a page emits them whether or
+    // not the site has any tokens of its own. A picker reading the raw override
+    // set offered none of them, and could not resolve a document referencing
+    // one.
+    const bare = colourTokensFor(COLOR, { tokens: [] }).map(t => t.name);
+    expect(bare).toContain("color.text");
+    expect(bare).toContain("color.background");
+    expect(bare).toContain("color.primary");
+    // Still only colours.
+    expect(bare).not.toContain("space.4");
+  });
+
+  it("still offers nothing when the question was never asked", () => {
+    // `undefined` is not "the site has the defaults" — it is "no host has said
+    // what this site holds", and answering with the defaults would be a claim.
+    expect(colourTokensFor(COLOR, undefined)).toEqual([]);
+  });
+
+  it("resolves a stored reference to a DEFAULT token", () => {
+    expect(colourTokenFor("color.primary", { tokens: [] })?.name).toBe(
+      "color.primary"
+    );
   });
 
   it("offers nothing at a leaf whose catalog entry admits no colour token", () => {
@@ -408,9 +436,14 @@ describe("what a preset swatch may be painted with", () => {
     expect(themed?.swatch).toBeUndefined();
   });
 
-  it("agrees with the main swatch about what can be painted", () => {
+  it("paints only hex, or nothing", () => {
+    // Stated as a property the RESOLVER does not decide, rather than by calling
+    // the same function that produced the field: comparing `swatch` against
+    // `colourHexOf(colour)` is the expression that built it, so it holds for
+    // any implementation including a wrong one.
     for (const token of colourTokensFor(COLOR, TOKENS)) {
-      expect(token.swatch).toBe(colourHexOf(token.colour, undefined));
+      if (token.swatch === undefined) continue;
+      expect(token.swatch).toMatch(/^#[0-9a-f]{6}([0-9a-f]{2})?$/);
     }
   });
 });
@@ -526,7 +559,9 @@ describe("only tokens the canvas will declare are offered", () => {
         { name: "color primary!", kind: "color", values: { light: "#222222" } },
       ],
     };
-    expect(colourTokensFor(COLOR, set).map(t => t.name)).toEqual(["color.ok"]);
+    const names = colourTokensFor(COLOR, set).map(t => t.name);
+    expect(names).toContain("color.ok");
+    expect(names).not.toContain("color primary!");
   });
 
   it("withholds the SECOND of two identities that collide on one property", () => {
@@ -547,14 +582,18 @@ describe("only tokens the canvas will declare are offered", () => {
         },
       ],
     };
-    const offered = colourTokensFor(COLOR, set);
-    expect(offered.map(t => t.name)).toEqual(["color.primary-dark"]);
+    const names = colourTokensFor(COLOR, set).map(t => t.name);
+    expect(names).toContain("color.primary-dark");
+    expect(names).not.toContain("color-primary.dark");
   });
 
   it("offers a set with no collisions untouched", () => {
     // The positive control: the filter must remove those two shapes and
     // nothing else, or every picker would come back empty.
-    expect(colourTokensFor(COLOR, TOKENS).length).toBe(3);
+    const names = colourTokensFor(COLOR, TOKENS).map(t => t.name);
+    expect(names).toContain("color.ink");
+    expect(names).toContain("brand.main");
+    expect(names).toContain("color.themed");
   });
 });
 
@@ -606,7 +645,9 @@ describe("the emitter decides which tokens are offered", () => {
         },
       ],
     };
-    expect(colourTokensFor(COLOR, set).map(t => t.name)).toEqual(["color.ok"]);
+    const names = colourTokensFor(COLOR, set).map(t => t.name);
+    expect(names).toContain("color.ok");
+    expect(names).not.toContain("color.bad");
   });
 
   it("withholds a token with no usable light value", () => {
@@ -616,7 +657,9 @@ describe("the emitter decides which tokens are offered", () => {
         { name: "color.empty", kind: "color", values: { light: 4 } },
       ],
     } as unknown as SiteTokenSet;
-    expect(colourTokensFor(COLOR, set).map(t => t.name)).toEqual(["color.ok"]);
+    const names = colourTokensFor(COLOR, set).map(t => t.name);
+    expect(names).toContain("color.ok");
+    expect(names).not.toContain("color.empty");
   });
 });
 

--- a/packages/builder/src/style-colour.test.ts
+++ b/packages/builder/src/style-colour.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   colourHexOf,
+  colourShowable,
   colourTokenFor,
   colourTokensFor,
   contrastOf,
@@ -71,6 +72,9 @@ const OPACITY = leaf("opacity");
 const TOKENS: SiteTokenSet = {
   tokens: [
     { name: "color.ink", kind: "color", values: { light: "#111111" } },
+    // A token whose value resolves somewhere else. Valid, storable, and not
+    // paintable by this package.
+    { name: "color.themed", kind: "color", values: { light: "var(--brand)" } },
     {
       id: "color.primary",
       name: "brand.main",
@@ -86,6 +90,7 @@ describe("which tokens a colour control offers", () => {
     const offered = colourTokensFor(COLOR, TOKENS);
     expect(offered.map(token => token.name)).toEqual([
       "color.ink",
+      "color.themed",
       "brand.main",
     ]);
     // The positive control for the filter: the site DOES define a token of
@@ -371,5 +376,81 @@ describe("how a ratio reads", () => {
     };
     expect(contrastRatioText(near)).toBe("4.5:1");
     expect(near.passesBodyText).toBe(false);
+  });
+});
+
+describe("what a preset swatch may be painted with", () => {
+  it("carries a RESOLVED colour, not the token's raw value", () => {
+    // A preset button paints what it is handed, so the resolution has to happen
+    // before the value reaches it.
+    const offered = colourTokensFor(COLOR, TOKENS);
+    const ink = offered.find(token => token.name === "color.ink");
+    expect(ink?.colour).toBe("#111111");
+    expect(ink?.swatch).toBe("#111111");
+  });
+
+  it("paints NOTHING for a token that resolves somewhere else", () => {
+    // The separating case, and the one that made this a defect: `var(--brand)`
+    // is a valid colour a site may store in a token, and painted raw into the
+    // inspector it resolves against the PANEL rather than the canvas.
+    const themed = colourTokensFor(COLOR, TOKENS).find(
+      token => token.name === "color.themed"
+    );
+    // Still offered, so the reference stays choosable.
+    expect(themed).toBeDefined();
+    // And still truthful about what the site stores.
+    expect(themed?.colour).toBe("var(--brand)");
+    // But not paintable.
+    expect(themed?.swatch).toBeUndefined();
+  });
+
+  it("agrees with the main swatch about what can be painted", () => {
+    for (const token of colourTokensFor(COLOR, TOKENS)) {
+      expect(token.swatch).toBe(colourHexOf(token.colour, undefined));
+    }
+  });
+});
+
+describe("which stored values a colour control can show", () => {
+  it("shows a literal, a reference, and nothing set", () => {
+    expect(colourShowable(undefined)).toBe(true);
+    expect(colourShowable("#3b82f6")).toBe(true);
+    expect(colourShowable("oklch(0.7 0.1 200)")).toBe(true);
+    expect(colourShowable({ $token: "color.ink" })).toBe(true);
+  });
+
+  it("REFUSES a value no colour surface can represent", () => {
+    // An object at a scalar position, from an import or the API. Routed to a
+    // colour control it would project to an empty field and read as unset while
+    // the value goes on compiling — so it has to keep the read-only surface.
+    expect(colourShowable({ value: "#fff" } as never)).toBe(false);
+    expect(colourShowable(16)).toBe(false);
+  });
+});
+
+describe("a translucent background withholds the verdict", () => {
+  it("reports nothing when the background carries alpha", () => {
+    // `checkContrast` composites a background over WHITE, which is wrong for a
+    // block sitting on a dark backdrop — and wrong in the direction that
+    // matters: this pair reports as passing after white compositing while
+    // rendering nearly invisible over black.
+    const overWhite = contrastOf("#ffffff", "rgba(0, 0, 0, 0.5)", TOKENS);
+    expect(overWhite).toBeUndefined();
+    // The positive control: the SAME pair opaque is measured, so the refusal
+    // above is the alpha and not the parser declining the notation.
+    const opaque = contrastOf("#ffffff", "rgba(0, 0, 0, 1)", TOKENS);
+    expect(opaque?.ratio).toBeCloseTo(21, 5);
+  });
+
+  it("still measures a translucent FOREGROUND, which composites over a known colour", () => {
+    // Not refused: what sits behind the foreground is the background, and that
+    // is a colour this does know.
+    const result = contrastOf("rgba(0, 0, 0, 0.5)", "#ffffff", TOKENS);
+    expect(result).toBeDefined();
+    expect(result?.ratio).toBeGreaterThan(1);
+  });
+
+  it("refuses an alpha hex background as readily as an rgba() one", () => {
+    expect(contrastOf("#ffffff", "#00000080", TOKENS)).toBeUndefined();
   });
 });

--- a/packages/builder/src/style-colour.test.ts
+++ b/packages/builder/src/style-colour.test.ts
@@ -1,0 +1,375 @@
+/**
+ * What a colour affordance may do with a stored value, and — mostly — what it
+ * may not.
+ *
+ * The leaves come from `STYLE_CATALOG` rather than being written here, for the
+ * reason `style-numeric.test.ts` gives: a hand-made leaf asserting
+ * `tokenKinds: ["color"]` would pass against a hardcoded rule in the module
+ * just as happily as against the catalog being asked, and those are the two
+ * implementations that have to be told apart.
+ */
+import {
+  STYLE_CATALOG,
+  type ContrastResult,
+  type SiteTokenSet,
+  type StyleLeaf,
+} from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import {
+  colourHexOf,
+  colourTokenFor,
+  colourTokensFor,
+  contrastOf,
+  contrastPartnerOf,
+  contrastRatioText,
+  contrastRoleOf,
+  emitsContrastPartner,
+} from "./style-colour";
+
+/** One catalog entry, as the array actually stores them. */
+interface CatalogEntry {
+  readonly property: string;
+  readonly shape: Record<string, unknown>;
+}
+
+const entry = (property: string): CatalogEntry => {
+  const found = (STYLE_CATALOG as unknown as readonly CatalogEntry[]).find(
+    candidate => candidate.property === property
+  );
+  if (found === undefined) throw new Error(`no catalog entry for ${property}`);
+  return found;
+};
+
+const leaf = (property: string): StyleLeaf =>
+  entry(property).shape as unknown as StyleLeaf;
+
+/** The leaf at one field of an object-shaped property. */
+const field = (property: string, name: string): StyleLeaf => {
+  const fields = entry(property).shape.fields as Record<string, StyleLeaf>;
+  const found = fields[name];
+  if (found === undefined) throw new Error(`${property} has no ${name} field`);
+  return found;
+};
+
+const COLOR = leaf("color");
+const LINK_COLOR = leaf("linkColor");
+const LINK_COLOR_HOVER = leaf("linkColorHover");
+const BACKGROUND_COLOR = leaf("backgroundColor");
+const BORDER_COLOR = field("border", "color");
+/** A leaf that is not a colour at all, and admits no colour token. */
+const OPACITY = leaf("opacity");
+
+/**
+ * A site whose second token has been RENAMED, so its identity and its name
+ * differ.
+ *
+ * That divergence is the only state in which storing the wrong one of the two
+ * has a symptom, so a fixture where every id equals its name would let the
+ * defect this module exists to prevent pass every assertion below.
+ */
+const TOKENS: SiteTokenSet = {
+  tokens: [
+    { name: "color.ink", kind: "color", values: { light: "#111111" } },
+    {
+      id: "color.primary",
+      name: "brand.main",
+      kind: "color",
+      values: { light: "#ffffff", dark: "#000000" },
+    },
+    { name: "space.4", kind: "dimension", values: { light: "1rem" } },
+  ],
+};
+
+describe("which tokens a colour control offers", () => {
+  it("offers the site's colour tokens and withholds the others", () => {
+    const offered = colourTokensFor(COLOR, TOKENS);
+    expect(offered.map(token => token.name)).toEqual([
+      "color.ink",
+      "brand.main",
+    ]);
+    // The positive control for the filter: the site DOES define a token of
+    // another kind, so an empty exclusion list would show here.
+    expect(TOKENS.tokens.some(token => token.kind === "dimension")).toBe(true);
+  });
+
+  it("offers nothing at a leaf whose catalog entry admits no colour token", () => {
+    // Asked of the leaf rather than of its kind: `opacity` is a number leaf and
+    // the reason it offers no colour token is that the CATALOG gives it no
+    // colour in `tokenKinds`, which is the fact a control must read.
+    expect(OPACITY.tokenKinds).not.toContain("color");
+    expect(colourTokensFor(OPACITY, TOKENS)).toEqual([]);
+  });
+
+  it("offers nothing when the host supplied no table", () => {
+    expect(colourTokensFor(COLOR, undefined)).toEqual([]);
+  });
+
+  it("carries the IDENTITY to store and the NAME to read, which differ", () => {
+    // The load-bearing assertion of this file. A stored `{ $token }` holds the
+    // identity, because `emitTokenBlocks` writes each custom property from
+    // `tokenIdentity` while the compiler composes `var(...)` from the stored
+    // string verbatim. Offering the NAME would store a reference to a property
+    // nothing declares — the style vanishes and the page still renders.
+    const renamed = colourTokensFor(COLOR, TOKENS).find(
+      token => token.name === "brand.main"
+    );
+    expect(renamed).toBeDefined();
+    expect(renamed?.identity).toBe("color.primary");
+    expect(renamed?.identity).not.toBe(renamed?.name);
+  });
+
+  it("falls back to the name as identity for a token that has no id", () => {
+    // The continuity half of the same rule, and what every token stored before
+    // `id` existed relies on.
+    const original = colourTokensFor(COLOR, TOKENS).find(
+      token => token.name === "color.ink"
+    );
+    expect(original?.identity).toBe("color.ink");
+  });
+});
+
+describe("resolving a stored reference back to its token", () => {
+  it("finds a renamed token by the identity a document stores", () => {
+    const found = colourTokenFor("color.primary", TOKENS);
+    expect(found?.name).toBe("brand.main");
+    expect(found?.colour).toBe("#ffffff");
+  });
+
+  it("does NOT find it by the name an author now reads", () => {
+    // The separating case. A lookup keyed on the name would answer here, and
+    // would answer nothing for the identity above — reversing which references
+    // resolve.
+    expect(colourTokenFor("brand.main", TOKENS)).toBeUndefined();
+  });
+
+  it("answers undefined for a token this site does not define", () => {
+    expect(colourTokenFor("color.nothing", TOKENS)).toBeUndefined();
+  });
+});
+
+describe("the hex a stored colour denotes", () => {
+  it("reads the notations the engine's contrast parser reads", () => {
+    expect(colourHexOf("#3b82f6", TOKENS)).toBe("#3b82f6");
+    expect(colourHexOf("rgb(59 130 246)", TOKENS)).toBe("#3b82f6");
+    expect(colourHexOf("rgba(59, 130, 246, 0.5)", TOKENS)).toBe("#3b82f680");
+  });
+
+  it("expands a short hex the way CSS does", () => {
+    expect(colourHexOf("#fff", TOKENS)).toBe("#ffffff");
+  });
+
+  it("keeps channels on the ENGINE's scale rather than the picker's", () => {
+    // The separating test for the one place two `Rgb` types meet. The engine's
+    // channels are 0-255 and `@nextlyhq/ui`'s are [0, 1], and `toHex` CLAMPS —
+    // so handing it the engine's shape does not throw or warn, it silently
+    // answers `#ffffff` for every colour but black. These three channels are
+    // each above 1 and below 4, which is the range where the two scales are
+    // furthest apart in effect.
+    expect(colourHexOf("rgb(1 2 3)", TOKENS)).toBe("#010203");
+    expect(colourHexOf("rgb(1 2 3)", TOKENS)).not.toBe("#ffffff");
+  });
+
+  it("resolves a token reference through the site's table", () => {
+    expect(colourHexOf({ $token: "color.ink" }, TOKENS)).toBe("#111111");
+    // By identity, so a renamed token still paints.
+    expect(colourHexOf({ $token: "color.primary" }, TOKENS)).toBe("#ffffff");
+  });
+
+  it("answers undefined for a reference the site does not define", () => {
+    expect(colourHexOf({ $token: "color.nothing" }, TOKENS)).toBeUndefined();
+    expect(colourHexOf({ $token: "color.ink" }, undefined)).toBeUndefined();
+  });
+
+  it("REFUSES every value that means resolve-this-somewhere-else", () => {
+    // These are the values a swatch must not be painted with: each is a valid
+    // colour the engine accepts, and each resolves against the surface it is
+    // drawn on — so painted in the inspector they would show the author a
+    // colour their page does not have.
+    expect(colourHexOf("var(--site-color-primary)", TOKENS)).toBeUndefined();
+    expect(colourHexOf("currentcolor", TOKENS)).toBeUndefined();
+    expect(colourHexOf("inherit", TOKENS)).toBeUndefined();
+    expect(colourHexOf("initial", TOKENS)).toBeUndefined();
+    expect(colourHexOf("unset", TOKENS)).toBeUndefined();
+  });
+
+  it("refuses the notations the engine's parser declines, rather than guessing", () => {
+    // Valid CSS colours that `parseColor` deliberately does not read. The
+    // control keeps its text field for them and rewrites nothing.
+    expect(colourHexOf("red", TOKENS)).toBeUndefined();
+    expect(colourHexOf("oklch(0.7 0.1 200)", TOKENS)).toBeUndefined();
+    expect(
+      colourHexOf("color-mix(in srgb, red, blue)", TOKENS)
+    ).toBeUndefined();
+    expect(colourHexOf("hsl(210 90% 60%)", TOKENS)).toBeUndefined();
+  });
+
+  it("refuses a value that is not a colour at all", () => {
+    expect(colourHexOf(undefined, TOKENS)).toBeUndefined();
+    expect(colourHexOf(16, TOKENS)).toBeUndefined();
+    expect(colourHexOf("16px", TOKENS)).toBeUndefined();
+    // An object at a scalar position, from an import or the API. Refused rather
+    // than coerced: offering to edit it would offer to replace it.
+    expect(colourHexOf({ value: "#fff" } as never, TOKENS)).toBeUndefined();
+    // A token key holding something that is not a name.
+    expect(colourHexOf({ $token: 4 } as never, TOKENS)).toBeUndefined();
+  });
+});
+
+describe("which side of a contrast pair a leaf sits on", () => {
+  it("reads the CSS property, so the link colours are covered unnamed", () => {
+    // The property under test is that the role is DERIVED. `linkColor` and
+    // `linkColorHover` are separate catalog keys that both write `color`, and a
+    // rule listing catalog keys would have to name them; this covers them
+    // because it reads what they emit.
+    expect(LINK_COLOR.cssProperty).toBe("color");
+    expect(LINK_COLOR_HOVER.cssProperty).toBe("color");
+    expect(contrastRoleOf(COLOR)).toBe("foreground");
+    expect(contrastRoleOf(LINK_COLOR)).toBe("foreground");
+    expect(contrastRoleOf(LINK_COLOR_HOVER)).toBe("foreground");
+  });
+
+  it("names the background", () => {
+    expect(contrastRoleOf(BACKGROUND_COLOR)).toBe("background");
+  });
+
+  it("puts a border on neither side", () => {
+    // A border is a colour leaf and still has no place in a text-contrast pair:
+    // reporting it against the block's background would answer a question
+    // nobody asked, against a threshold that does not apply.
+    expect(BORDER_COLOR.kind).toBe("color");
+    expect(contrastRoleOf(BORDER_COLOR)).toBeUndefined();
+  });
+
+  it("puts a leaf that is not a colour on neither side", () => {
+    expect(contrastRoleOf(OPACITY)).toBeUndefined();
+  });
+});
+
+describe("which property holds the other half of the pair", () => {
+  it("finds the partner in the catalog rather than naming it", () => {
+    expect(contrastPartnerOf(COLOR)).toBe("backgroundColor");
+    expect(contrastPartnerOf(BACKGROUND_COLOR)).toBe("color");
+  });
+
+  it("pairs a link colour against the block's own background", () => {
+    expect(contrastPartnerOf(LINK_COLOR)).toBe("backgroundColor");
+    expect(contrastPartnerOf(LINK_COLOR_HOVER)).toBe("backgroundColor");
+  });
+
+  it("refuses a leaf that styles a DESCENDANT as a partner", () => {
+    // Asserted on the PREDICATE rather than through `contrastPartnerOf`, and
+    // the reason is worth recording: `color` precedes `linkColor` in
+    // `STYLE_CATALOG`, so the search returns "color" by array order whether or
+    // not the selector is read. Measured — deleting the descendant rule and
+    // re-running this file changed nothing at all. Through the search, this
+    // property has NO coverage; here it has some.
+    expect(LINK_COLOR.descendant).toBeDefined();
+    expect(LINK_COLOR_HOVER.descendant).toBeDefined();
+    expect(emitsContrastPartner(LINK_COLOR, "color")).toBe(false);
+    expect(emitsContrastPartner(LINK_COLOR_HOVER, "color")).toBe(false);
+    // The positive control: the same call on the block's own colour accepts,
+    // so the `false` above is the selector being read rather than the predicate
+    // refusing everything.
+    expect(emitsContrastPartner(COLOR, "color")).toBe(true);
+    expect(emitsContrastPartner(BACKGROUND_COLOR, "background-color")).toBe(
+      true
+    );
+  });
+
+  it("refuses a leaf that emits a different property, or is not a colour", () => {
+    expect(emitsContrastPartner(COLOR, "background-color")).toBe(false);
+    expect(emitsContrastPartner(OPACITY, "color")).toBe(false);
+  });
+
+  it("gives a leaf outside the pairing no partner", () => {
+    expect(contrastPartnerOf(BORDER_COLOR)).toBeUndefined();
+    expect(contrastPartnerOf(OPACITY)).toBeUndefined();
+  });
+});
+
+describe("the contrast a pair reports", () => {
+  it("reports the specification's own extreme", () => {
+    // Black on white is 21:1 exactly, which is a value WCAG states rather than
+    // one this repository chose — so it separates a correct implementation from
+    // a plausible one.
+    const result = contrastOf("#000000", "#ffffff", TOKENS);
+    expect(result?.ratio).toBeCloseTo(21, 5);
+    expect(result?.level).toBe("AAA");
+    expect(result?.passesBodyText).toBe(true);
+  });
+
+  it("measures a pair written as tokens, by resolving both sides first", () => {
+    // The improvement over checking literals only, and the reason resolution
+    // happens before the engine is asked: in a design system the ordinary pair
+    // is two token references, and declining those would leave the readout
+    // silent exactly where it is most wanted.
+    const result = contrastOf(
+      { $token: "color.ink" },
+      { $token: "color.primary" },
+      TOKENS
+    );
+    // `#111111` on `#ffffff`.
+    expect(result?.ratio).toBeGreaterThan(18);
+    expect(result?.passesBodyText).toBe(true);
+  });
+
+  it("reports a failing pair as failing", () => {
+    const result = contrastOf("#777777", "#888888", TOKENS);
+    expect(result?.level).toBe("fail");
+    expect(result?.passesBodyText).toBe(false);
+  });
+
+  it("answers undefined when EITHER side cannot be read", () => {
+    // Not a default, and not an approximation. A ratio computed from a colour
+    // that was misread is a number an author will act on.
+    expect(contrastOf("var(--brand)", "#ffffff", TOKENS)).toBeUndefined();
+    expect(contrastOf("#000000", "var(--brand)", TOKENS)).toBeUndefined();
+    expect(contrastOf("#000000", undefined, TOKENS)).toBeUndefined();
+    expect(contrastOf(undefined, "#ffffff", TOKENS)).toBeUndefined();
+    // A named colour is a colour the engine accepts and this cannot measure.
+    expect(contrastOf("red", "#ffffff", TOKENS)).toBeUndefined();
+  });
+
+  it("agrees with the swatch about which values are readable", () => {
+    // The two must not disagree: a value the panel painted a swatch for and
+    // then reported no figure about — or the reverse — reads as a broken
+    // control. They share `colourHexOf`, and this is what would fail if a
+    // second resolution were introduced.
+    for (const value of [
+      "#3b82f6",
+      "rgb(1 2 3)",
+      "red",
+      "var(--x)",
+      "currentcolor",
+      { $token: "color.primary" },
+      { $token: "color.nothing" },
+    ]) {
+      const readable = colourHexOf(value, TOKENS) !== undefined;
+      const measured = contrastOf(value, "#ffffff", TOKENS) !== undefined;
+      expect(measured).toBe(readable);
+    }
+  });
+});
+
+describe("how a ratio reads", () => {
+  it("reports one decimal place, as the thresholds are written", () => {
+    const result = contrastOf("#000000", "#ffffff", TOKENS);
+    expect(result).toBeDefined();
+    if (result !== undefined) expect(contrastRatioText(result)).toBe("21.0:1");
+  });
+
+  it("rounds the DISPLAY without moving the verdict", () => {
+    // A ratio just under the body-text threshold displays as the threshold and
+    // still reports as failing. That pair looks contradictory and is the honest
+    // reading: the rule is on the ratio, not on its rendering. Constructed
+    // rather than searched for, so the case is stated rather than hoped for.
+    const near: ContrastResult = {
+      ratio: 4.49,
+      level: "AA-large",
+      passesBodyText: false,
+    };
+    expect(contrastRatioText(near)).toBe("4.5:1");
+    expect(near.passesBodyText).toBe(false);
+  });
+});

--- a/packages/builder/src/style-colour.test.ts
+++ b/packages/builder/src/style-colour.test.ts
@@ -25,6 +25,7 @@ import {
   colourHexOf,
   colourShowable,
   colourTokenFor,
+  colourTokenLabel,
   colourTokensFor,
   contrastObscuredBy,
   contrastObscuredIn,
@@ -33,6 +34,7 @@ import {
   contrastRatioText,
   contrastRoleOf,
   emitsContrastPartner,
+  type ColourToken,
 } from "./style-colour";
 
 /** One catalog entry, as the array actually stores them. */
@@ -882,5 +884,46 @@ describe("what an ancestor puts over a pair", () => {
     const nodes = treeWith({ base: { base: { opacity: "0.1" } } });
     expect(contrastObscuredAbove(nodes, "wrap0")).toBeUndefined();
     expect(contrastObscuredAbove(nodes, "absent")).toBeUndefined();
+  });
+});
+
+describe("what a token is CALLED where two share a name", () => {
+  const of = (identity: string, name: string): ColourToken =>
+    ({
+      identity,
+      name,
+      kind: "color",
+      colour: "#000000",
+      swatch: "#000000",
+    }) as ColourToken;
+
+  it("shows the plain name when nothing else offered carries it", () => {
+    const list = [of("color.primary", "brand.main"), of("color.ink", "text")];
+    expect(colourTokenLabel(list[0] as ColourToken, list)).toBe("brand.main");
+  });
+
+  it("qualifies BOTH entries when two identities share one name", () => {
+    // Reachable because a rename freezes the old name as the identity and
+    // moves only the label, so a second token may take the name the first
+    // left. Both go on emitting — their identities still differ — so both are
+    // offered, under one label, and choosing either stores an identity the
+    // author could not have predicted.
+    const list = [
+      of("color.primary", "brand.main"),
+      of("brand.main", "brand.main"),
+    ];
+    expect(colourTokenLabel(list[0] as ColourToken, list)).toBe(
+      "brand.main (color.primary)"
+    );
+    expect(colourTokenLabel(list[1] as ColourToken, list)).toBe(
+      "brand.main (brand.main)"
+    );
+  });
+
+  it("does not qualify a token against ITSELF", () => {
+    // The same token appearing once must not read as a collision with its own
+    // entry, which an identity-blind comparison would produce.
+    const one = of("color.primary", "brand.main");
+    expect(colourTokenLabel(one, [one])).toBe("brand.main");
   });
 });

--- a/packages/builder/src/style-colour.ts
+++ b/packages/builder/src/style-colour.ts
@@ -69,6 +69,7 @@ import {
   type Rgb,
   type SiteToken,
   type SiteTokenSet,
+  type TokenMode,
   type StyleLeaf,
   type StyleValue,
 } from "@nextlyhq/blocks-engine";
@@ -113,6 +114,30 @@ export interface ColourToken {
 }
 
 /**
+ * Which mode's value a token resolves to on the canvas right now.
+ *
+ * `emitTokenBlocks` writes a second block for every token carrying a dark
+ * value, and WHEN it applies is the site's strategy: `media` wraps it in
+ * `@media (prefers-color-scheme:dark)`, so a viewer whose system prefers dark
+ * sees the dark value with nothing else having to happen. A control resolving
+ * `values.light` regardless would then paint a swatch and report a ratio for a
+ * colour the canvas is not showing — the one failure this module exists to
+ * prevent, reached through the mode rather than through the notation.
+ *
+ * `attribute` — the default — answers `light`, and that is a STATED LIMIT
+ * rather than a claim. The dark block is written under
+ * `[data-nx-theme="dark"]`, which the HOST sets on an ancestor of its choosing;
+ * nothing tells this panel whether it did. Reading the DOM to find out would
+ * make a pure projection depend on where the canvas happens to be mounted.
+ */
+export function activeTokenMode(
+  tokens: SiteTokenSet | undefined,
+  prefersDark: boolean
+): TokenMode {
+  return tokens?.darkMode === "media" && prefersDark ? "dark" : "light";
+}
+
+/**
  * The tokens a colour control may offer at this leaf.
  *
  * Both halves of the filter are the ENGINE's answer rather than this module's.
@@ -135,12 +160,13 @@ export interface ColourToken {
  */
 export function colourTokensFor(
   leaf: StyleLeaf,
-  tokens: SiteTokenSet | undefined
+  tokens: SiteTokenSet | undefined,
+  mode: TokenMode = "light"
 ): readonly ColourToken[] {
   if (tokens === undefined) return [];
   return tokens.tokens
     .filter(token => leaf.tokenKinds.includes(token.kind))
-    .map(colourTokenOf);
+    .map(token => colourTokenOf(token, mode));
 }
 
 /**
@@ -151,17 +177,21 @@ export function colourTokensFor(
  * NAME, which compiles to a custom property nothing declares and loses the
  * style with no symptom.
  */
-function colourTokenOf(token: SiteToken): ColourToken {
+function colourTokenOf(token: SiteToken, mode: TokenMode): ColourToken {
+  // `light` is required and `dark` is not, so a token defined only for light
+  // resolves to it in either mode — which is what the canvas does too: no dark
+  // declaration is emitted for it, so the light one goes on applying.
+  const colour = token.values[mode] ?? token.values.light;
   return {
     identity: tokenIdentity(token),
     name: token.name,
-    colour: token.values.light,
+    colour,
     // Resolved with NO table, which is what stops this recursing: a token whose
     // value is itself a reference would otherwise re-enter the lookup that is
     // building this record. Without a table a reference resolves to nothing and
     // the swatch is simply unpainted, which is the honest answer for a value
     // this package cannot follow.
-    swatch: colourHexOf(token.values.light, undefined),
+    swatch: colourHexOf(colour, undefined),
   };
 }
 
@@ -180,11 +210,12 @@ function colourTokenOf(token: SiteToken): ColourToken {
  */
 export function colourTokenFor(
   identity: string,
-  tokens: SiteTokenSet | undefined
+  tokens: SiteTokenSet | undefined,
+  mode: TokenMode = "light"
 ): ColourToken | undefined {
   if (tokens === undefined) return undefined;
   const token = tokens.tokens.find(entry => tokenIdentity(entry) === identity);
-  return token === undefined ? undefined : colourTokenOf(token);
+  return token === undefined ? undefined : colourTokenOf(token, mode);
 }
 
 /**
@@ -204,9 +235,10 @@ export function colourTokenFor(
  */
 function colourChannelsOf(
   value: StyleValue | undefined,
-  tokens: SiteTokenSet | undefined
+  tokens: SiteTokenSet | undefined,
+  mode: TokenMode
 ): Rgb | undefined {
-  const literal = resolvedColourOf(value, tokens);
+  const literal = resolvedColourOf(value, tokens, mode);
   return literal === undefined ? undefined : parseColor(literal);
 }
 
@@ -224,13 +256,16 @@ function colourChannelsOf(
  */
 function resolvedColourOf(
   value: StyleValue | undefined,
-  tokens: SiteTokenSet | undefined
+  tokens: SiteTokenSet | undefined,
+  mode: TokenMode
 ): string | undefined {
   if (typeof value === "string") return value;
   // The ENGINE's own test for a reference, which is also what
   // {@link colourShowable} routes on — so what counts as a token here and what
   // the panel sends to a colour control cannot drift apart.
-  if (isTokenRef(value)) return colourTokenFor(value.$token, tokens)?.colour;
+  if (isTokenRef(value)) {
+    return colourTokenFor(value.$token, tokens, mode)?.colour;
+  }
   return undefined;
 }
 
@@ -252,9 +287,10 @@ function resolvedColourOf(
  */
 export function colourHexOf(
   value: StyleValue | undefined,
-  tokens: SiteTokenSet | undefined
+  tokens: SiteTokenSet | undefined,
+  mode: TokenMode = "light"
 ): string | undefined {
-  const channels = colourChannelsOf(value, tokens);
+  const channels = colourChannelsOf(value, tokens, mode);
   return channels === undefined ? undefined : hexOf(channels);
 }
 
@@ -399,15 +435,16 @@ export function emitsContrastPartner(
 export function contrastOf(
   foreground: StyleValue | undefined,
   background: StyleValue | undefined,
-  tokens: SiteTokenSet | undefined
+  tokens: SiteTokenSet | undefined,
+  mode: TokenMode = "light"
 ): ContrastResult | undefined {
   // Through the same function the swatch is painted from, so a pair the panel
   // drew two swatches for is a pair this can measure — and a value that shows
   // no swatch shows no figure. Asking `parseColor` separately here would be a
   // second answer to what a value resolves to, and the two would disagree first
   // on tokens, where one of them consults the table and the other does not.
-  const fg = colourHexOf(foreground, tokens);
-  const back = colourChannelsOf(background, tokens);
+  const fg = colourHexOf(foreground, tokens, mode);
+  const back = colourChannelsOf(background, tokens, mode);
   if (fg === undefined || back === undefined) return undefined;
   // A TRANSLUCENT background has no contrast this can compute, because what
   // shows through it is not known here. `checkContrast` composites the
@@ -439,13 +476,14 @@ export function contrastAtLeaf(
   leaf: StyleLeaf,
   own: StyleValue | undefined,
   partner: StyleValue | undefined,
-  tokens: SiteTokenSet | undefined
+  tokens: SiteTokenSet | undefined,
+  mode: TokenMode = "light"
 ): ContrastResult | undefined {
   const role = contrastRoleOf(leaf);
   if (role === undefined) return undefined;
   return role === "background"
-    ? contrastOf(partner, own, tokens)
-    : contrastOf(own, partner, tokens);
+    ? contrastOf(partner, own, tokens, mode)
+    : contrastOf(own, partner, tokens, mode);
 }
 
 /**

--- a/packages/builder/src/style-colour.ts
+++ b/packages/builder/src/style-colour.ts
@@ -260,49 +260,49 @@ function emittableTokens(
 /**
  * Whether the canvas will declare a custom property for this token.
  *
- * ASKED, by emitting the token on its own and seeing whether anything came out.
- * `emitTokenBlocks` returns empty CSS when it wrote no light declaration, which
- * is exactly its own verdict — and it refuses for an unusable id, a missing or
- * non-string light value, a value that is not safe CSS, and a value that would
- * make the page fetch something, as well as for an unusable name.
+ * ASKED, by emitting the token and seeing what comes out, rather than by
+ * restating the emitter's rules here where they would drift from it.
  *
- * The whole SET is passed rather than a bare token, because a token's
- * acceptance can depend on the set's own prefix.
+ * Asked TWICE, because the emitter reaches two kinds of verdict and they have
+ * different scopes. A refusal — an unusable name or id, a missing or non-string
+ * light value, a value that is not safe CSS, a value that would make the page
+ * fetch a file — costs the token in EVERY mode: the emitter scans both values
+ * and skips the whole token, so a dark `url(…)` leaves the light value
+ * undeclared too. A kind mismatch is the opposite: it is reported and the value
+ * is written anyway, so it costs only the mode whose value is wrong.
+ *
+ * Judging the whole token by its active value alone would miss the first kind,
+ * and offer a preset whose reference resolves to nothing. Judging it by both
+ * values would apply the second kind too widely, and withhold a token whose
+ * light value is a perfectly good colour.
  */
 function emits(token: SiteToken, mode: TokenMode): boolean {
-  // Asked about a token carrying ONLY the value the canvas is currently
-  // showing. Emitting the whole token would report the other mode too, and a
-  // token whose light value is a colour and whose dark value is not renders
-  // perfectly well in light — rejecting it there would remove a token that
-  // works from the picker of an author who cannot see the problem.
+  // The refusals, asked of the WHOLE token. Nothing WRITTEN is the emitter's
+  // own verdict, read from its output rather than from its commentary: a future
+  // refusal that forgot to report would otherwise arrive here as an accepted
+  // token that declares nothing.
+  //
+  // The set's prefix is deliberately not passed. It cannot decide any of these
+  // rules, and supplying an unusable one would add an issue about the SET to
+  // every token in it — turning one bad prefix into an empty picker.
+  if (emitTokenBlocks({ tokens: [token] }, ":root").css === "") return false;
+
+  // The kind mismatch, asked of the ACTIVE value alone. Every other objection
+  // was ruled out above, so anything said about a token carrying only this one
+  // value is that check — which is why the question can be asked without
+  // matching the message text, wording nobody promised to keep, and without
+  // `checkTokenKind`, which the engine does not export.
+  //
+  // It matters because the browser drops the declaration where the token is
+  // USED, not where it is defined: a colour token holding `16px` is written,
+  // resolves, and does nothing, so a picker offering it hands over a reference
+  // with no symptom to follow.
   const active = token.values[mode] ?? token.values.light;
   const alone = emitTokenBlocks(
     { tokens: [{ ...token, values: { light: active } }] },
     ":root"
   );
-  // Nothing WRITTEN means refused outright. Nothing SAID means the engine had
-  // no objection to what it wrote, which is a different and equally necessary
-  // question: a value that contradicts its kind — `16px` on a colour — is
-  // emitted deliberately, with a warning, because refusing it would cost the
-  // author the token on a verdict the engine is not certain enough to act on.
-  // The browser then drops the declaration where it is USED, so a picker
-  // offering it hands over a reference that does nothing.
-  //
-  // Read as issues rather than by asking `checkTokenKind`, which the engine
-  // does not export, and rather than by matching the message text, which would
-  // be a copy of wording nobody promised to keep.
-  //
-  // The set's prefix is deliberately not passed. It cannot decide any of these
-  // rules, and supplying an unusable one would add an issue about the SET to
-  // every token in it — turning one bad prefix into an empty picker.
-  //
-  // Measured: every refusal the emitter makes today also reports an issue, so
-  // the emptiness check is currently implied by the silence one and removing it
-  // moves no test. Kept because it is the DIRECT question — did anything get
-  // written — asked of a value already in hand, and because a future silent
-  // skip in that package would otherwise arrive here as an accepted token that
-  // emits nothing.
-  return alone.css !== "" && alone.issues.length === 0;
+  return alone.issues.length === 0;
 }
 
 /**
@@ -554,9 +554,12 @@ export function emitsContrastPartner(
  * How a foreground fares against a background, or `undefined` when either
  * cannot be read.
  *
- * The verdict is the ENGINE's — `checkContrast` — per D-05.4. What this adds is
- * only the resolution step in front of it, so a pair written as tokens is
- * judged rather than declined: both sides go through
+ * The verdict is the ENGINE's — `checkContrast` — and is never recomputed here.
+ * A contrast ratio is a property of two colours rather than of this panel, and a
+ * second implementation would drift from the one the compiler and the validator
+ * already answer with, silently, because both spellings look correct. What this
+ * adds is only the resolution step in front of it, so a pair written as tokens
+ * is judged rather than declined: both sides go through
  * {@link colourChannelsOf} first, which is the same resolution the swatch used.
  *
  * `undefined` propagates rather than being softened, and the caller is expected

--- a/packages/builder/src/style-colour.ts
+++ b/packages/builder/src/style-colour.ts
@@ -63,11 +63,13 @@ import {
   checkContrast,
   emitTokenBlocks,
   isTokenRef,
+  locateNode,
   parseColor,
   resolveSiteTokens,
   STYLE_CATALOG,
   tokenCustomProperty,
   tokenIdentity,
+  type BlockNode,
   type ContrastResult,
   type Rgb,
   type NodeStyles,
@@ -655,6 +657,29 @@ const OBSCURING_PROPERTIES: readonly string[] = [
 ];
 
 /**
+ * The obscuring properties whose effect reaches every DESCENDANT.
+ *
+ * A subset, because most of the list above is local: an ancestor's background
+ * or gradient is painted BEHIND this node and stops mattering the moment this
+ * node paints an opaque one of its own, and a shadow is drawn within the box
+ * that declares it. These three are different — `opacity` and `filter`
+ * composite the whole rendered subtree, and `mixBlendMode` makes it depend on
+ * whatever lies beneath the ancestor — so both of the colours a control is
+ * comparing arrive at the eye altered, and the ratio between the two stored
+ * values describes a rendering that does not happen.
+ *
+ * Split from the list rather than reusing it whole, because applying the local
+ * entries to ancestors would withhold a verdict for a background nothing can
+ * see, on almost every page: a section with a background colour is the ordinary
+ * case, and every control inside it would go quiet.
+ */
+const SUBTREE_OBSCURING_PROPERTIES: readonly string[] = [
+  "opacity",
+  "filter",
+  "mixBlendMode",
+];
+
+/**
  * The property standing between this pair, or `undefined` when none is set.
  *
  * Takes a READER rather than the stored values, so the caller keeps ownership
@@ -693,18 +718,70 @@ export function contrastObscuredBy(
 export function contrastObscuredIn(
   styles: NodeStyles | undefined
 ): string | undefined {
+  return obscuringAnywhereIn(styles, OBSCURING_PROPERTIES);
+}
+
+/**
+ * Any of `properties` set at any address on one node, or `undefined`.
+ *
+ * The sweep both callers need, written once: the node's own verdict asks it
+ * over the whole list, and the ancestor walk asks it over the propagating
+ * subset. Two copies differing only in which list they close over is the shape
+ * that drifts, and the drift would be silent in the failing-open direction.
+ */
+function obscuringAnywhereIn(
+  styles: NodeStyles | undefined,
+  properties: readonly string[]
+): string | undefined {
   if (styles === undefined) return undefined;
   for (const breakpoints of Object.values(styles)) {
     if (breakpoints === undefined) continue;
     for (const values of Object.values(breakpoints)) {
       if (values === undefined) continue;
-      const found = contrastObscuredBy(property =>
-        Object.hasOwn(values, property) ? values[property] : undefined
+      const found = properties.find(property =>
+        Object.hasOwn(values, property) ? values[property] !== undefined : false
       );
       if (found !== undefined) return found;
     }
   }
   return undefined;
+}
+
+/**
+ * An ANCESTOR putting something over this node's pair, or `undefined`.
+ *
+ * The node's own styles are not the whole rendering. `opacity`, `filter` and
+ * `mixBlendMode` on any ancestor composite this node along with everything else
+ * inside it, so black text on white beneath a parent at `opacity: 0.1` still
+ * measures 21:1 here and reaches the eye at a small fraction of it. That is the
+ * guard failing OPEN — reporting a figure that is wrong rather than withholding
+ * one — which is the single direction the rest of this file refuses to fail in.
+ *
+ * Walks by repeated {@link locateNode} rather than by a second traversal of the
+ * tree. Children live in named slots rather than one list, so a hand-written
+ * walk would be a second implementation of the engine's own descent, and the
+ * copy that drifts here goes quiet about an ancestor instead of reporting.
+ */
+export function contrastObscuredAbove(
+  nodes: readonly BlockNode[],
+  nodeId: string
+): string | undefined {
+  // The ids already visited. A document holding a cycle would otherwise spin
+  // here forever, and this costs a set membership over values in hand — the
+  // guard is cheap precisely because it never has to look anything up.
+  const seen = new Set<string>([nodeId]);
+  let current = nodeId;
+  for (;;) {
+    const parent = locateNode(nodes as BlockNode[], current)?.parent;
+    if (parent === undefined || seen.has(parent.id)) return undefined;
+    seen.add(parent.id);
+    const found = obscuringAnywhereIn(
+      parent.styles,
+      SUBTREE_OBSCURING_PROPERTIES
+    );
+    if (found !== undefined) return found;
+    current = parent.id;
+  }
 }
 
 /**

--- a/packages/builder/src/style-colour.ts
+++ b/packages/builder/src/style-colour.ts
@@ -325,6 +325,37 @@ function kindMatches(token: SiteToken, mode: TokenMode): boolean {
 }
 
 /**
+ * What to CALL a token in a list where two of them may share a name.
+ *
+ * A rename FREEZES the old name as the identity and moves only the label, so
+ * nothing stops a second token taking the name the first one left — and both go
+ * on emitting, because they compose their properties from identities that still
+ * differ. Two choices then arrive with one label, and if their colours match or
+ * neither resolves to a swatch there is nothing at all to tell them apart. The
+ * author picks one and the document stores an identity they could not have
+ * predicted.
+ *
+ * Qualified only where the collision is REAL, so the ordinary list stays
+ * readable: a name unique among the tokens offered beside it is shown as the
+ * author wrote it, and the identity appears only when it is the sole thing that
+ * distinguishes two entries.
+ *
+ * Judged against the list the reader is actually looking at rather than the
+ * whole site, because that is where the ambiguity exists. A token qualified for
+ * a collision the reader cannot see would be explaining a distinction that is
+ * not on screen.
+ */
+export function colourTokenLabel(
+  token: ColourToken,
+  among: readonly ColourToken[]
+): string {
+  const shared = among.some(
+    other => other.name === token.name && other.identity !== token.identity
+  );
+  return shared ? `${token.name} (${token.identity})` : token.name;
+}
+
+/**
  * One site token in the forms a control needs it in.
  *
  * Shared by every reader rather than written at each, so the identity rule is

--- a/packages/builder/src/style-colour.ts
+++ b/packages/builder/src/style-colour.ts
@@ -1,0 +1,425 @@
+/**
+ * The colour view of a stored style value, and the choices a control may offer
+ * over it.
+ *
+ * Pure, for the reason `style-numeric.ts` is: which tokens a leaf may hold,
+ * what a value resolves to, and whether a pair has enough contrast are all
+ * derivation, and a jsdom test of the rendered field cannot separate a correct
+ * answer from a plausible wrong one — both draw a swatch with a colour in it.
+ *
+ * ## A colour is a PROJECTION over the string, never a model of it
+ *
+ * A `color` leaf carries no rules of its own, but the value it holds is far
+ * wider than a hex: `checkColorValue` accepts the CSS named colours, the system
+ * colours, `transparent`, `currentcolor`, the CSS-wide keywords, and sixteen
+ * functions including `oklch()`, `color-mix()`, `light-dark()` and `var()` — as
+ * well as a `{ $token }` reference, which is a record and nonetheless a scalar.
+ *
+ * A picker that MODELLED the value as RGBA could represent one of those and
+ * would write the rest away the moment it opened. So the text field remains the
+ * control and the swatch, the picker and the readout are affordances layered on
+ * it, each answering `undefined` rather than guessing.
+ *
+ * ## Three questions, three domains, and they genuinely differ
+ *
+ * Conflating them would be the tempting simplification and the wrong one:
+ *
+ * - what may be STORED is `checkColorValue`'s question, and the write path
+ *   already asks it;
+ * - what a contrast figure may be computed from is `parseColor`'s, which reads
+ *   hex and `rgb()`/`rgba()` ONLY and says why: a figure from a colour it
+ *   misread "is worse than no figure, because it is a number somebody will act
+ *   on";
+ * - what the PICKER can open on is narrower still, because it is seeded from a
+ *   hex.
+ *
+ * Nothing here restates any of them. The engine is asked in every case.
+ *
+ * ## What a swatch may be painted with, and why it is narrower than CSS
+ *
+ * A swatch is painted only with a colour this module resolved ITSELF — a token
+ * looked up in the site's table, or a literal `parseColor` reads. That is
+ * narrower than what a browser can paint, and the exclusion is principled
+ * rather than incidental: every value it leaves out means "resolve this
+ * somewhere else", and the inspector is not that somewhere.
+ *
+ * `var(--site-color-primary)` painted into the panel resolves against the
+ * PANEL's custom properties rather than the canvas's, so it lands on a
+ * different colour or on none. `currentcolor` takes the panel's own text
+ * colour. `inherit` takes the swatch's parent. Each would show an author a
+ * colour their page does not have, which is the one failure a colour control
+ * must not have. Telling those apart from `oklch()` and the named colours —
+ * which a browser would paint correctly — needs a grammar this package has no
+ * business owning, so the honest line is drawn at what can be resolved here.
+ *
+ * The cost is a named colour showing no swatch. The value is still displayed,
+ * still typeable and never rewritten, which is the cheap direction to be wrong
+ * in.
+ *
+ * @module style-colour
+ */
+
+import {
+  checkContrast,
+  parseColor,
+  STYLE_CATALOG,
+  tokenIdentity,
+  type ContrastResult,
+  type Rgb,
+  type SiteToken,
+  type SiteTokenSet,
+  type StyleLeaf,
+  type StyleValue,
+} from "@nextlyhq/blocks-engine";
+import { toHex } from "@nextlyhq/ui/color";
+
+/**
+ * One token a colour control may offer, in the three forms it is needed in.
+ *
+ * The split between {@link identity} and {@link name} is the whole point of the
+ * type and is not a convenience. A stored `{ $token }` holds the IDENTITY:
+ * `emitTokenBlocks` writes each token's custom property from
+ * `tokenCustomProperty(tokenIdentity(token), prefix)`, while the compiler turns
+ * a reference into `var(...)` from the stored string verbatim, with no lookup
+ * against the table. So the two agree only when the stored string is the
+ * identity — and after a rename an identity and a name differ.
+ *
+ * Storing the name instead would compile to a custom property nothing declares.
+ * That invalidates the declaration rather than reporting, so the page keeps
+ * rendering with the style missing and nothing says what happened: exactly the
+ * failure `SiteToken.id` was added to prevent, reintroduced by the control that
+ * writes the reference.
+ */
+export interface ColourToken {
+  /** What a reference STORES, and what a rename never changes. */
+  readonly identity: string;
+  /** What the author reads and edits. Free to change. */
+  readonly name: string;
+  /** The literal this token holds, for painting and for measuring. */
+  readonly colour: string;
+}
+
+/**
+ * The tokens a colour control may offer at this leaf.
+ *
+ * Both halves of the filter are the ENGINE's answer rather than this module's.
+ * Which kinds a leaf admits is `leaf.tokenKinds`, taken from the catalog, so a
+ * leaf that admits no token offers no picker without a rule being written here;
+ * and a token's own `kind` is what the site recorded. A control that offered a
+ * token the write path then refused would be the visible half of a drift, and
+ * the invisible half is a token wrongly withheld.
+ *
+ * `undefined` tokens means the question was never asked — the host supplied no
+ * table — and answers empty, which is the same shape a site with no colour
+ * tokens produces. The two are deliberately not distinguished HERE: what
+ * differs is what the panel should SAY about an empty list, and that is the
+ * panel's to decide from the same `undefined` it already has.
+ *
+ * The light-mode value is what a swatch carries, because `values.light` is the
+ * one a token is guaranteed to have and the one a document with no mode
+ * resolves. A dark-only preview would be a second question and is not this
+ * control's.
+ */
+export function colourTokensFor(
+  leaf: StyleLeaf,
+  tokens: SiteTokenSet | undefined
+): readonly ColourToken[] {
+  if (tokens === undefined) return [];
+  return tokens.tokens
+    .filter(token => leaf.tokenKinds.includes(token.kind))
+    .map(colourTokenOf);
+}
+
+/**
+ * One site token in the three forms a control needs it in.
+ *
+ * Shared by the list and the single lookup rather than written at each, so the
+ * identity rule is applied once: a second copy is one edit from storing the
+ * NAME, which compiles to a custom property nothing declares and loses the
+ * style with no symptom.
+ */
+function colourTokenOf(token: SiteToken): ColourToken {
+  return {
+    identity: tokenIdentity(token),
+    name: token.name,
+    colour: token.values.light,
+  };
+}
+
+/**
+ * The token a stored reference names, or `undefined` when the site defines
+ * none by that identity.
+ *
+ * Looked up by identity because that is what the reference holds. A site that
+ * renamed the token still answers, and answers with its CURRENT name — which is
+ * what makes a renamed token readable in the panel rather than showing the
+ * label it carried when the reference was written.
+ *
+ * `undefined` for a reference to a token this site does not define. That is a
+ * warning rather than an error in the engine's own issue table, so the value
+ * goes on compiling and the control must go on showing it.
+ */
+export function colourTokenFor(
+  identity: string,
+  tokens: SiteTokenSet | undefined
+): ColourToken | undefined {
+  if (tokens === undefined) return undefined;
+  const token = tokens.tokens.find(entry => tokenIdentity(entry) === identity);
+  return token === undefined ? undefined : colourTokenOf(token);
+}
+
+/**
+ * The channels a stored colour resolves to, or `undefined` when nothing here
+ * can read it.
+ *
+ * The one place a value becomes channels, so the swatch, the picker seed and
+ * the contrast readout cannot disagree about what a value IS — they differ only
+ * in what they do with the answer. A token is resolved through the table first,
+ * so a reference is as readable as the literal it points at; everything else is
+ * handed to the engine.
+ *
+ * A non-string that is not a token reference — an object at a scalar position
+ * from an import or the API — is refused here rather than coerced, for the
+ * reason `measurementOf` refuses one: a control that offered to edit it would
+ * be offering to replace it with something else entirely.
+ */
+function colourChannelsOf(
+  value: StyleValue | undefined,
+  tokens: SiteTokenSet | undefined
+): Rgb | undefined {
+  const literal = resolvedColourOf(value, tokens);
+  return literal === undefined ? undefined : parseColor(literal);
+}
+
+/**
+ * The literal CSS colour a stored value denotes, as far as this package can
+ * resolve it.
+ *
+ * A token reference becomes the colour the site's table holds for it. A string
+ * is already a literal and is returned as written — including the spellings
+ * `parseColor` cannot read, because whether a value can be MEASURED is a
+ * different question from what it says, and the two have different callers.
+ *
+ * Not exported: every caller wants one of the two narrower answers below, and a
+ * third caller taking the raw literal would be a fourth domain to keep straight.
+ */
+function resolvedColourOf(
+  value: StyleValue | undefined,
+  tokens: SiteTokenSet | undefined
+): string | undefined {
+  if (typeof value === "string") return value;
+  // A token reference is one value spelled as a record, so it arrives as an
+  // object. Matched on the `$token` key rather than through `isTokenRef`, which
+  // could only ever agree with the test already made here, and which would then
+  // be a second place this module decides what a reference looks like.
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "$token" in value &&
+    typeof value.$token === "string"
+  ) {
+    return colourTokenFor(value.$token, tokens)?.colour;
+  }
+  return undefined;
+}
+
+/**
+ * The hex a stored colour denotes, or `undefined` when nothing here can read it.
+ *
+ * ONE function for the swatch, the picker seed and the contrast readout, rather
+ * than one named for each. They are three uses of a single question — what hex
+ * is this value — and giving each its own function would be three expressions
+ * that agree today: the shape that produced six of the twenty-four findings on
+ * the control that came before this one. A use that genuinely diverges gets its
+ * own function THEN, when there is a difference to express.
+ *
+ * Composed as hex from the channels rather than passed through as written, and
+ * that is what makes the module note's rule hold by construction rather than by
+ * a check that could be forgotten: `var()`, `currentcolor` and the CSS-wide
+ * keywords all fail to become channels, so none of them can reach a `style`
+ * attribute through here and resolve against the panel instead of the canvas.
+ */
+export function colourHexOf(
+  value: StyleValue | undefined,
+  tokens: SiteTokenSet | undefined
+): string | undefined {
+  const channels = colourChannelsOf(value, tokens);
+  return channels === undefined ? undefined : hexOf(channels);
+}
+
+/**
+ * The engine's channels as the hex notation the picker reads and writes.
+ *
+ * THE ONE PLACE THE TWO SCALES MEET, and the reason it is a function rather
+ * than an expression at each call site. `@nextlyhq/blocks-engine`'s `Rgb` is
+ * 0-255 and `@nextlyhq/ui`'s is [0, 1] — two types with the same name, both in
+ * scope in this file. `toHex` CLAMPS to [0, 1], so handing it the engine's
+ * shape does not fail: every channel above 1 becomes 255 and the answer is
+ * `#ffffff`, silently, for every colour but black. A scale factor written twice
+ * is one edit away from that.
+ *
+ * Alpha crosses as it is, since both packages already carry it as [0, 1], and
+ * `toHex` omits the pair at 1 so an opaque colour comes back in the six-digit
+ * form an author typed.
+ */
+function hexOf(rgb: Rgb): string {
+  return toHex({ r: rgb.r / 255, g: rgb.g / 255, b: rgb.b / 255 }, rgb.a);
+}
+
+/**
+ * Which side of a contrast pair a leaf sits on, or `undefined` when it sits on
+ * neither.
+ *
+ * Read from the leaf's own `cssProperty` rather than from a list of catalog
+ * keys, which is what makes it cover `linkColor` and `linkColorHover` — both of
+ * which write `color`, at ` a` and ` a:hover` — without naming them, and what
+ * keeps a sixth colour property working with no edit here.
+ *
+ * `border-color` is deliberately neither. A border is not text and has no
+ * background of its own in this pairing, so reporting it against the block's
+ * background would answer a question nobody asked with a threshold that does
+ * not apply to it.
+ */
+export function contrastRoleOf(
+  leaf: StyleLeaf
+): "foreground" | "background" | undefined {
+  if (leaf.kind !== "color") return undefined;
+  if (leaf.cssProperty === "color") return "foreground";
+  if (leaf.cssProperty === "background-color") return "background";
+  return undefined;
+}
+
+/**
+ * The catalog property holding the other half of this leaf's contrast pair, or
+ * `undefined` when it has none.
+ *
+ * FOUND in the catalog rather than named here. Writing `"backgroundColor"` as a
+ * string would be this package asserting a catalog key it does not own — the
+ * proxy `derived-checks.md` warns about — and it would go on compiling after a
+ * rename while quietly pairing against nothing. Searching for the leaf that
+ * emits the partner CSS property asks the structural question instead.
+ *
+ * Only a leaf with no `descendant` is eligible. `linkColor` emits `color` at
+ * ` a`, so a search that ignored the selector could pair the block's background
+ * against a link's colour, or return `linkColor` as the partner OF the
+ * background — reporting a ratio for two things that are not drawn on top of
+ * each other.
+ */
+export function contrastPartnerOf(leaf: StyleLeaf): string | undefined {
+  const role = contrastRoleOf(leaf);
+  if (role === undefined) return undefined;
+  const wanted = role === "foreground" ? "background-color" : "color";
+  const entries = STYLE_CATALOG as unknown as readonly {
+    property: string;
+    shape: StyleLeaf;
+  }[];
+  const found = entries.find(candidate =>
+    emitsContrastPartner(candidate.shape, wanted)
+  );
+  return found?.property;
+}
+
+/**
+ * Whether a leaf is the one a contrast pair should read its partner from.
+ *
+ * Exported so the descendant rule can be OBSERVED. Inside
+ * {@link contrastPartnerOf} it is invisible: `color` precedes `linkColor` in
+ * `STYLE_CATALOG`, so the search returns the right property by array order
+ * whether or not the selector is considered, and removing the rule changes no
+ * result. A guard nothing can see is one a later edit removes as redundant.
+ *
+ * The rule itself is worth keeping despite that. Three catalog entries emit
+ * `color` and two of them attach to ` a` and ` a:hover`, so the correct answer
+ * depends on catalog ORDER unless the selector is read — and order is not
+ * something this package should be relying on.
+ *
+ * A leaf with a descendant styles something INSIDE the block. A block's
+ * background and a link's colour are not drawn on top of one another in any
+ * way this pairing models, so a ratio between them describes nothing.
+ */
+export function emitsContrastPartner(
+  leaf: StyleLeaf,
+  cssProperty: string
+): boolean {
+  return (
+    leaf.kind === "color" &&
+    leaf.cssProperty === cssProperty &&
+    leaf.descendant === undefined
+  );
+}
+
+/**
+ * How a foreground fares against a background, or `undefined` when either
+ * cannot be read.
+ *
+ * The verdict is the ENGINE's — `checkContrast` — per D-05.4. What this adds is
+ * only the resolution step in front of it, so a pair written as tokens is
+ * judged rather than declined: both sides go through
+ * {@link colourChannelsOf} first, which is the same resolution the swatch used.
+ *
+ * `undefined` propagates rather than being softened, and the caller is expected
+ * to render NOTHING for it. That is the engine's own reasoning applied one
+ * level up: a ratio computed from a colour that was misread, or defaulted, is a
+ * number an author will act on. There is no honest approximation of a contrast
+ * against `var(--brand)`, whose value is not known until the page renders.
+ *
+ * Measured against the LIGHT mode value of any token involved, because that is
+ * the mode a document with no mode resolves. A site whose dark values differ
+ * has a second answer this does not give.
+ */
+export function contrastOf(
+  foreground: StyleValue | undefined,
+  background: StyleValue | undefined,
+  tokens: SiteTokenSet | undefined
+): ContrastResult | undefined {
+  // Through the same function the swatch is painted from, so a pair the panel
+  // drew two swatches for is a pair this can measure — and a value that shows
+  // no swatch shows no figure. Asking `parseColor` separately here would be a
+  // second answer to what a value resolves to, and the two would disagree first
+  // on tokens, where one of them consults the table and the other does not.
+  const fg = colourHexOf(foreground, tokens);
+  const bg = colourHexOf(background, tokens);
+  if (fg === undefined || bg === undefined) return undefined;
+  return checkContrast(fg, bg);
+}
+
+/**
+ * The contrast at one leaf against its partner, in the order the two are drawn.
+ *
+ * A control knows its own value and its partner's; which of them is the
+ * FOREGROUND is a fact about the leaf. Kept here with {@link contrastRoleOf}
+ * rather than at the call site, because the order is not cosmetic:
+ * `checkContrast` composites the background over white and then the foreground
+ * over that, so passing a translucent pair the wrong way round produces a
+ * different number rather than the same one.
+ */
+export function contrastAtLeaf(
+  leaf: StyleLeaf,
+  own: StyleValue | undefined,
+  partner: StyleValue | undefined,
+  tokens: SiteTokenSet | undefined
+): ContrastResult | undefined {
+  const role = contrastRoleOf(leaf);
+  if (role === undefined) return undefined;
+  return role === "background"
+    ? contrastOf(partner, own, tokens)
+    : contrastOf(own, partner, tokens);
+}
+
+/**
+ * How a ratio reads to an author, at the precision the figure supports.
+ *
+ * One decimal place, which is what every accessibility tool reports and what
+ * the thresholds themselves are written to: 4.5 and 3 and 7. More digits would
+ * imply a precision the input does not have, since the ratio moves with the
+ * eighth of a percent that rounding a channel introduces.
+ *
+ * Rounded rather than truncated, so a figure is never reported below what it
+ * is — but the LEVEL beside it is the engine's, computed from the unrounded
+ * ratio, so a value at 4.49 reads as "4.5" and still reports as failing body
+ * text. That pair looks contradictory and is the honest reading: the threshold
+ * is on the ratio, not on its display.
+ */
+export function contrastRatioText(result: ContrastResult): string {
+  return `${result.ratio.toFixed(1)}:1`;
+}

--- a/packages/builder/src/style-colour.ts
+++ b/packages/builder/src/style-colour.ts
@@ -205,7 +205,7 @@ function offeredTokens(
   const hit = byMode.get(mode);
   if (hit !== undefined) return hit;
   const resolved = resolveSiteTokens(tokens);
-  const built = emittableTokens(resolved).map(token =>
+  const built = emittableTokens(resolved, mode).map(token =>
     colourTokenOf(token, mode)
   );
   byMode.set(mode, built);
@@ -233,11 +233,14 @@ const cache = new WeakMap<SiteTokenSet, Map<TokenMode, ColourToken[]>>();
  * a token the canvas silently drops for any case they did not — which stores a
  * reference to a property nothing declares and loses the style with no symptom.
  */
-function emittableTokens(set: SiteTokenSet): readonly SiteToken[] {
+function emittableTokens(
+  set: SiteTokenSet,
+  mode: TokenMode
+): readonly SiteToken[] {
   const seen = new Set<string>();
   const emittable: SiteToken[] = [];
   for (const token of set.tokens) {
-    if (!emits(set, token)) continue;
+    if (!emits(token, mode)) continue;
     // Which of two ACCEPTED tokens actually gets the property is the one thing
     // the emitter cannot be asked, because both are individually fine and only
     // their order decides. `tokenCustomProperty` composes the key, so the
@@ -266,15 +269,24 @@ function emittableTokens(set: SiteTokenSet): readonly SiteToken[] {
  * The whole SET is passed rather than a bare token, because a token's
  * acceptance can depend on the set's own prefix.
  */
-function emits(set: SiteTokenSet, token: SiteToken): boolean {
-  const alone = emitTokenBlocks({ tokens: [token] }, ":root");
+function emits(token: SiteToken, mode: TokenMode): boolean {
+  // Asked about a token carrying ONLY the value the canvas is currently
+  // showing. Emitting the whole token would report the other mode too, and a
+  // token whose light value is a colour and whose dark value is not renders
+  // perfectly well in light — rejecting it there would remove a token that
+  // works from the picker of an author who cannot see the problem.
+  const active = token.values[mode] ?? token.values.light;
+  const alone = emitTokenBlocks(
+    { tokens: [{ ...token, values: { light: active } }] },
+    ":root"
+  );
   // Nothing WRITTEN means refused outright. Nothing SAID means the engine had
-  // no objection to what was written, which is a different and equally
-  // necessary question: a token whose value contradicts its kind — `16px` on a
-  // colour — is emitted deliberately, with a warning, because refusing it would
-  // cost the author the token on a verdict the engine is not certain enough to
-  // act on. The browser then drops the declaration where it is USED, so a
-  // picker offering it hands over a reference that does nothing.
+  // no objection to what it wrote, which is a different and equally necessary
+  // question: a value that contradicts its kind — `16px` on a colour — is
+  // emitted deliberately, with a warning, because refusing it would cost the
+  // author the token on a verdict the engine is not certain enough to act on.
+  // The browser then drops the declaration where it is USED, so a picker
+  // offering it hands over a reference that does nothing.
   //
   // Read as issues rather than by asking `checkTokenKind`, which the engine
   // does not export, and rather than by matching the message text, which would

--- a/packages/builder/src/style-colour.ts
+++ b/packages/builder/src/style-colour.ts
@@ -621,7 +621,10 @@ export function contrastObscuredBy(
  * absent and a verdict that is sometimes wrong, this takes the first.
  *
  * A named class carrying one of these is still not seen, for the same reason,
- * and that limit is not closed here.
+ * and that limit is not closed here. Nor is a stored breakpoint the site no
+ * longer defines: its values never compile, so counting them withholds a
+ * verdict that would have been correct. Both err the same way as the rest of
+ * this function, which is why neither is treated as urgent.
  */
 export function contrastObscuredIn(
   styles: NodeStyles | undefined

--- a/packages/builder/src/style-colour.ts
+++ b/packages/builder/src/style-colour.ts
@@ -61,9 +61,11 @@
 
 import {
   checkContrast,
+  isTokenName,
   isTokenRef,
   parseColor,
   STYLE_CATALOG,
+  tokenCustomProperty,
   tokenIdentity,
   type ContrastResult,
   type Rgb,
@@ -164,9 +166,44 @@ export function colourTokensFor(
   mode: TokenMode = "light"
 ): readonly ColourToken[] {
   if (tokens === undefined) return [];
-  return tokens.tokens
+  return emittableTokens(tokens)
     .filter(token => leaf.tokenKinds.includes(token.kind))
     .map(token => colourTokenOf(token, mode));
+}
+
+/**
+ * The tokens the canvas will actually declare a custom property for.
+ *
+ * `emitTokenBlocks` DROPS two kinds of token, and a picker that offered them
+ * would let an author store a reference to a property nothing declares — which
+ * invalidates the declaration rather than reporting, so the style is simply
+ * absent and the page still renders. That is the failure this whole control
+ * exists around, reached through the token list instead of through the name.
+ *
+ * Both rules are applied with the ENGINE's own primitives rather than restated:
+ * `isTokenName` decides whether a name can become a property, and
+ * `tokenCustomProperty` composes the property that two identities can collide
+ * on. Only the ORDER is repeated — first one wins — which is a single line and
+ * the one thing the engine does not export a way to ask.
+ *
+ * The prefix is deliberately omitted from the collision key. A prefix is the
+ * same string in front of every property, so it cannot make two identities
+ * collide or stop them colliding; asking for the site's real prefix would need
+ * `resolveTokenPrefix`, which the engine keeps private.
+ */
+function emittableTokens(set: SiteTokenSet): readonly SiteToken[] {
+  const seen = new Set<string>();
+  const emittable: SiteToken[] = [];
+  for (const token of set.tokens) {
+    // The NAME, matching the engine: it checks the name and then composes the
+    // property from the identity.
+    if (!isTokenName(token.name)) continue;
+    const property = tokenCustomProperty(tokenIdentity(token), "");
+    if (seen.has(property)) continue;
+    seen.add(property);
+    emittable.push(token);
+  }
+  return emittable;
 }
 
 /**
@@ -460,6 +497,46 @@ export function contrastOf(
   // background, which is a colour this does know.
   if (back.a < 1) return undefined;
   return checkContrast(fg, hexOf(back));
+}
+
+/**
+ * Catalog properties whose value changes what colour actually reaches the eye.
+ *
+ * A contrast figure is about two colours drawn on top of each other. Each of
+ * these puts something else between them or over them: a background image or
+ * gradient covers the background colour, `opacity` and `filter` change both,
+ * and `mixBlendMode` makes the result depend on what is underneath the node
+ * entirely. A ratio computed from the two colour properties alone is then a
+ * number about a rendering that does not happen — black text on `#ffffff` with
+ * an opaque black gradient over it reports 21:1 and renders black on black.
+ *
+ * A list rather than a catalog-derived set, and the honest reason is that the
+ * catalog does not record this: nothing marks a property as pixel-altering, so
+ * there is no structural question to ask. It is therefore a floor rather than a
+ * proof — a property added later that also obscures will not appear here until
+ * someone adds it — and it errs toward WITHHOLDING, which is the safe direction
+ * for a figure an author acts on.
+ */
+const OBSCURING_PROPERTIES: readonly string[] = [
+  "background",
+  "backgroundGradient",
+  "opacity",
+  "filter",
+  "mixBlendMode",
+];
+
+/**
+ * The property standing between this pair, or `undefined` when none is set.
+ *
+ * Takes a READER rather than the stored values, so the caller keeps ownership
+ * of which node, state and breakpoint is being asked about — the same address
+ * the control is reading its own value at — and this stays a pure question
+ * about a set of property names.
+ */
+export function contrastObscuredBy(
+  valueAt: (property: string) => StyleValue | undefined
+): string | undefined {
+  return OBSCURING_PROPERTIES.find(property => valueAt(property) !== undefined);
 }
 
 /**

--- a/packages/builder/src/style-colour.ts
+++ b/packages/builder/src/style-colour.ts
@@ -61,6 +61,7 @@
 
 import {
   checkContrast,
+  isTokenRef,
   parseColor,
   STYLE_CATALOG,
   tokenIdentity,
@@ -95,8 +96,20 @@ export interface ColourToken {
   readonly identity: string;
   /** What the author reads and edits. Free to change. */
   readonly name: string;
-  /** The literal this token holds, for painting and for measuring. */
+  /** The literal this token holds, as the site recorded it. */
   readonly colour: string;
+  /**
+   * The colour a preset swatch may be PAINTED with, or `undefined` when this
+   * package cannot resolve one.
+   *
+   * Carried rather than left to the call site, because a token's value is a
+   * string like any other and may be `var(--brand)`, `currentcolor` or a
+   * CSS-wide keyword. Painted raw into a preset button those resolve against
+   * the INSPECTOR rather than the canvas — the exact failure
+   * {@link colourHexOf} exists to prevent for the main swatch, arrived at by a
+   * second route. Resolving here means both swatches answer the same way.
+   */
+  readonly swatch: string | undefined;
 }
 
 /**
@@ -143,6 +156,12 @@ function colourTokenOf(token: SiteToken): ColourToken {
     identity: tokenIdentity(token),
     name: token.name,
     colour: token.values.light,
+    // Resolved with NO table, which is what stops this recursing: a token whose
+    // value is itself a reference would otherwise re-enter the lookup that is
+    // building this record. Without a table a reference resolves to nothing and
+    // the swatch is simply unpainted, which is the honest answer for a value
+    // this package cannot follow.
+    swatch: colourHexOf(token.values.light, undefined),
   };
 }
 
@@ -208,18 +227,10 @@ function resolvedColourOf(
   tokens: SiteTokenSet | undefined
 ): string | undefined {
   if (typeof value === "string") return value;
-  // A token reference is one value spelled as a record, so it arrives as an
-  // object. Matched on the `$token` key rather than through `isTokenRef`, which
-  // could only ever agree with the test already made here, and which would then
-  // be a second place this module decides what a reference looks like.
-  if (
-    typeof value === "object" &&
-    value !== null &&
-    "$token" in value &&
-    typeof value.$token === "string"
-  ) {
-    return colourTokenFor(value.$token, tokens)?.colour;
-  }
+  // The ENGINE's own test for a reference, which is also what
+  // {@link colourShowable} routes on — so what counts as a token here and what
+  // the panel sends to a colour control cannot drift apart.
+  if (isTokenRef(value)) return colourTokenFor(value.$token, tokens)?.colour;
   return undefined;
 }
 
@@ -264,6 +275,24 @@ export function colourHexOf(
  */
 function hexOf(rgb: Rgb): string {
   return toHex({ r: rgb.r / 255, g: rgb.g / 255, b: rgb.b / 255 }, rgb.a);
+}
+
+/**
+ * Whether a colour control can show this stored value at all.
+ *
+ * A colour surface has two shapes — a literal string it puts in a text field,
+ * and a `{ $token }` reference it names — plus the unset case. Anything else is
+ * a value no colour control can represent: an object at a scalar position from
+ * an import or the API, or a number. Those keep the panel's own read-only
+ * surface, which shows the value and offers to clear it, rather than being
+ * projected to an empty field that reads as unset while the value goes on
+ * compiling.
+ *
+ * Asked HERE rather than in the panel so that the routing question and the
+ * resolution below cannot disagree about what a colour value is.
+ */
+export function colourShowable(value: StyleValue | undefined): boolean {
+  return value === undefined || typeof value === "string" || isTokenRef(value);
 }
 
 /**
@@ -378,9 +407,22 @@ export function contrastOf(
   // second answer to what a value resolves to, and the two would disagree first
   // on tokens, where one of them consults the table and the other does not.
   const fg = colourHexOf(foreground, tokens);
-  const bg = colourHexOf(background, tokens);
-  if (fg === undefined || bg === undefined) return undefined;
-  return checkContrast(fg, bg);
+  const back = colourChannelsOf(background, tokens);
+  if (fg === undefined || back === undefined) return undefined;
+  // A TRANSLUCENT background has no contrast this can compute, because what
+  // shows through it is not known here. `checkContrast` composites the
+  // background over WHITE, which is a reasonable default for a page and wrong
+  // for a block sitting on another block, on a site background, or on a dark
+  // canvas — and it fails in the direction that matters: white text on
+  // `rgba(0,0,0,.5)` reports as PASSING after white compositing while
+  // rendering nearly invisible over a dark backdrop. Withheld rather than
+  // reported, for the same reason the engine withholds a figure for a colour it
+  // cannot read.
+  //
+  // A translucent FOREGROUND is fine and is not refused: it composites over the
+  // background, which is a colour this does know.
+  if (back.a < 1) return undefined;
+  return checkContrast(fg, hexOf(back));
 }
 
 /**

--- a/packages/builder/src/style-colour.ts
+++ b/packages/builder/src/style-colour.ts
@@ -240,7 +240,16 @@ function emittableTokens(
   const seen = new Set<string>();
   const emittable: SiteToken[] = [];
   for (const token of set.tokens) {
-    if (!emits(token, mode)) continue;
+    // The REFUSAL decides who takes the property, because it is the emitter's
+    // own rule for the same question: the engine skips a refused token before
+    // it reaches the collision check, and writes an accepted one even when its
+    // kind is wrong. Asking the kind here instead would drop a token the engine
+    // wrote, hand its property to the token the engine REFUSED as a collision,
+    // and offer that one — painted with its own colour, resolving to the
+    // other's. Measured: `color.primary-dark` holding `16px` and
+    // `color-primary.dark` holding `#123456` compose one property, the engine
+    // writes `16px`, and the picker offered `#123456`.
+    if (!written(token)) continue;
     // Which of two ACCEPTED tokens actually gets the property is the one thing
     // the emitter cannot be asked, because both are individually fine and only
     // their order decides. `tokenCustomProperty` composes the key, so the
@@ -252,57 +261,65 @@ function emittableTokens(
     const property = tokenCustomProperty(tokenIdentity(token), "");
     if (seen.has(property)) continue;
     seen.add(property);
+    // Asked only once the property is claimed. A kind mismatch is mode-local
+    // and does NOT stop the engine writing the declaration, so it withholds the
+    // token from this picker without releasing the property to anything else.
+    if (!kindMatches(token, mode)) continue;
     emittable.push(token);
   }
   return emittable;
 }
 
 /**
- * Whether the canvas will declare a custom property for this token.
+ * Whether the emitter writes anything at all for this token.
  *
- * ASKED, by emitting the token and seeing what comes out, rather than by
- * restating the emitter's rules here where they would drift from it.
+ * The REFUSALS, and the reason they are a separate question from the kind
+ * check: an unusable name or id, a missing or non-string light value, a value
+ * that is not safe CSS, a value that would make the page fetch a file. Each is
+ * scanned across BOTH mode values and skips the whole token, so a dark `url(…)`
+ * leaves the light value with no custom property either.
  *
- * Asked TWICE, because the emitter reaches two kinds of verdict and they have
- * different scopes. A refusal — an unusable name or id, a missing or non-string
- * light value, a value that is not safe CSS, a value that would make the page
- * fetch a file — costs the token in EVERY mode: the emitter scans both values
- * and skips the whole token, so a dark `url(…)` leaves the light value
- * undeclared too. A kind mismatch is the opposite: it is reported and the value
- * is written anyway, so it costs only the mode whose value is wrong.
+ * ASKED, by emitting the token and seeing whether anything came out, rather
+ * than by restating that list here where it would drift from the engine's. The
+ * OUTPUT is read rather than the issue list, because a future refusal that
+ * forgot to report would otherwise arrive as an accepted token declaring
+ * nothing.
  *
- * Judging the whole token by its active value alone would miss the first kind,
- * and offer a preset whose reference resolves to nothing. Judging it by both
- * values would apply the second kind too widely, and withhold a token whose
- * light value is a perfectly good colour.
+ * The set's prefix is deliberately not passed. It cannot decide any of these
+ * rules, and supplying an unusable one would add an issue about the SET to
+ * every token in it — turning one bad prefix into an empty picker.
  */
-function emits(token: SiteToken, mode: TokenMode): boolean {
-  // The refusals, asked of the WHOLE token. Nothing WRITTEN is the emitter's
-  // own verdict, read from its output rather than from its commentary: a future
-  // refusal that forgot to report would otherwise arrive here as an accepted
-  // token that declares nothing.
-  //
-  // The set's prefix is deliberately not passed. It cannot decide any of these
-  // rules, and supplying an unusable one would add an issue about the SET to
-  // every token in it — turning one bad prefix into an empty picker.
-  if (emitTokenBlocks({ tokens: [token] }, ":root").css === "") return false;
+function written(token: SiteToken): boolean {
+  return emitTokenBlocks({ tokens: [token] }, ":root").css !== "";
+}
 
-  // The kind mismatch, asked of the ACTIVE value alone. Every other objection
-  // was ruled out above, so anything said about a token carrying only this one
-  // value is that check — which is why the question can be asked without
-  // matching the message text, wording nobody promised to keep, and without
-  // `checkTokenKind`, which the engine does not export.
-  //
-  // It matters because the browser drops the declaration where the token is
-  // USED, not where it is defined: a colour token holding `16px` is written,
-  // resolves, and does nothing, so a picker offering it hands over a reference
-  // with no symptom to follow.
+/**
+ * Whether the value this mode resolves is the kind the token claims.
+ *
+ * The other verdict the emitter reaches, and the one with the narrower scope.
+ * A mismatch is reported and the value written ANYWAY — deliberately, because
+ * refusing it would cost the author the token on a judgement the engine is not
+ * certain enough to act on — so it costs only the mode whose value is wrong,
+ * and never the token's claim on its custom property.
+ *
+ * It still withholds the token here, because the browser drops the declaration
+ * where the token is USED rather than where it is defined: a colour token
+ * holding `16px` is written, resolves, and does nothing, so a picker offering
+ * it hands over a reference with no symptom to follow.
+ *
+ * Asked by emitting the active value alone and reading the silence. Every other
+ * objection belongs to {@link written}, which runs first — and the emptiness
+ * check is kept even so, cheap and over a value already in hand, so that a
+ * caller reaching here in the other order gets a wrong answer rather than a
+ * confident misattribution.
+ */
+function kindMatches(token: SiteToken, mode: TokenMode): boolean {
   const active = token.values[mode] ?? token.values.light;
   const alone = emitTokenBlocks(
     { tokens: [{ ...token, values: { light: active } }] },
     ":root"
   );
-  return alone.issues.length === 0;
+  return alone.css !== "" && alone.issues.length === 0;
 }
 
 /**

--- a/packages/builder/src/style-colour.ts
+++ b/packages/builder/src/style-colour.ts
@@ -267,7 +267,30 @@ function emittableTokens(set: SiteTokenSet): readonly SiteToken[] {
  * acceptance can depend on the set's own prefix.
  */
 function emits(set: SiteTokenSet, token: SiteToken): boolean {
-  return emitTokenBlocks({ ...set, tokens: [token] }, ":root").css !== "";
+  const alone = emitTokenBlocks({ tokens: [token] }, ":root");
+  // Nothing WRITTEN means refused outright. Nothing SAID means the engine had
+  // no objection to what was written, which is a different and equally
+  // necessary question: a token whose value contradicts its kind — `16px` on a
+  // colour — is emitted deliberately, with a warning, because refusing it would
+  // cost the author the token on a verdict the engine is not certain enough to
+  // act on. The browser then drops the declaration where it is USED, so a
+  // picker offering it hands over a reference that does nothing.
+  //
+  // Read as issues rather than by asking `checkTokenKind`, which the engine
+  // does not export, and rather than by matching the message text, which would
+  // be a copy of wording nobody promised to keep.
+  //
+  // The set's prefix is deliberately not passed. It cannot decide any of these
+  // rules, and supplying an unusable one would add an issue about the SET to
+  // every token in it — turning one bad prefix into an empty picker.
+  //
+  // Measured: every refusal the emitter makes today also reports an issue, so
+  // the emptiness check is currently implied by the silence one and removing it
+  // moves no test. Kept because it is the DIRECT question — did anything get
+  // written — asked of a value already in hand, and because a future silent
+  // skip in that package would otherwise arrive here as an accepted token that
+  // emits nothing.
+  return alone.css !== "" && alone.issues.length === 0;
 }
 
 /**

--- a/packages/builder/src/style-colour.ts
+++ b/packages/builder/src/style-colour.ts
@@ -377,9 +377,9 @@ function resolvedColourOf(
  * ONE function for the swatch, the picker seed and the contrast readout, rather
  * than one named for each. They are three uses of a single question — what hex
  * is this value — and giving each its own function would be three expressions
- * that agree today: the shape that produced six of the twenty-four findings on
- * the control that came before this one. A use that genuinely diverges gets its
- * own function THEN, when there is a difference to express.
+ * that agree today and drift apart silently, because each looks correct on its
+ * own. A use that genuinely diverges gets its own function THEN, when there is
+ * a difference to express.
  *
  * Composed as hex from the channels rather than passed through as written, and
  * that is what makes the module note's rule hold by construction rather than by

--- a/packages/builder/src/style-colour.ts
+++ b/packages/builder/src/style-colour.ts
@@ -588,6 +588,15 @@ const OBSCURING_PROPERTIES: readonly string[] = [
   "opacity",
   "filter",
   "mixBlendMode",
+  // An INSET shadow is painted over the background and can replace the colour
+  // behind the text entirely — black text on `#ffffff` under an opaque black
+  // inset shadow reports 21:1 and renders black on black. Counted whether or
+  // not the value says `inset`, because telling the two apart means reading
+  // the grammar of a shadow, and a `cssValue` leaf is validated for SYNTAX
+  // only: the catalog does not decide what a shadow means, so neither can
+  // this. An outer shadow therefore withholds a verdict it need not, which is
+  // the direction everything else in this list errs in.
+  "boxShadow",
 ];
 
 /**

--- a/packages/builder/src/style-colour.ts
+++ b/packages/builder/src/style-colour.ts
@@ -64,6 +64,7 @@ import {
   emitTokenBlocks,
   isTokenRef,
   parseColor,
+  resolveSiteTokens,
   STYLE_CATALOG,
   tokenCustomProperty,
   tokenIdentity,
@@ -72,6 +73,7 @@ import {
   type NodeStyles,
   type SiteToken,
   type SiteTokenSet,
+  type TokenKind,
   type TokenMode,
   type StyleLeaf,
   type StyleValue,
@@ -100,6 +102,8 @@ export interface ColourToken {
   readonly identity: string;
   /** What the author reads and edits. Free to change. */
   readonly name: string;
+  /** What the token holds, so a leaf can be asked whether it admits one. */
+  readonly kind: TokenKind;
   /** The literal this token holds, as the site recorded it. */
   readonly colour: string;
   /**
@@ -166,31 +170,68 @@ export function colourTokensFor(
   tokens: SiteTokenSet | undefined,
   mode: TokenMode = "light"
 ): readonly ColourToken[] {
-  if (tokens === undefined) return [];
-  return emittableTokens(tokens)
-    .filter(token => leaf.tokenKinds.includes(token.kind))
-    .map(token => colourTokenOf(token, mode));
+  return offeredTokens(tokens, mode).filter(token =>
+    leaf.tokenKinds.includes(token.kind)
+  );
 }
+
+/**
+ * Every token the canvas will resolve, in the mode it is showing.
+ *
+ * THE one projection, and everything else here reads it. Which tokens exist,
+ * which of them the canvas actually declares, and what each resolves to are one
+ * question asked once — so the list a picker offers, the table a stored
+ * reference is looked up in, and the colours a contrast figure is measured from
+ * cannot disagree. Each of those was a separate search before, and each was
+ * wrong in a different way.
+ *
+ * `resolveSiteTokens` FIRST, because that is what the renderer does:
+ * `PageRenderer` compiles with `resolveSiteTokens(siteInput?.tokens)`, which
+ * layers the engine's own defaults under the site's overrides. A site that
+ * defines nothing still emits `color.text`, `color.primary` and the rest, so a
+ * picker reading the raw override set offered none of them and could not
+ * resolve a document that referenced one.
+ *
+ * `undefined` still means the question was never asked and answers empty — NOT
+ * the defaults. A host that has not said what the site holds has not said that
+ * it holds the defaults either.
+ */
+function offeredTokens(
+  tokens: SiteTokenSet | undefined,
+  mode: TokenMode
+): readonly ColourToken[] {
+  if (tokens === undefined) return [];
+  const byMode = cache.get(tokens) ?? new Map<TokenMode, ColourToken[]>();
+  const hit = byMode.get(mode);
+  if (hit !== undefined) return hit;
+  const resolved = resolveSiteTokens(tokens);
+  const built = emittableTokens(resolved).map(token =>
+    colourTokenOf(token, mode)
+  );
+  byMode.set(mode, built);
+  cache.set(tokens, byMode);
+  return built;
+}
+
+/**
+ * Built projections, by the set they came from.
+ *
+ * Held because building one emits every token individually to ask the engine
+ * whether it accepts it, and a control rebuilds on every render of every colour
+ * field. Keyed on the set's identity, which is safe for the same reason the
+ * engine's own `memoizeTokenLookup` is: these are immutable props, so a set
+ * that is the same object is the same data.
+ */
+const cache = new WeakMap<SiteTokenSet, Map<TokenMode, ColourToken[]>>();
 
 /**
  * The tokens the canvas will actually declare a custom property for.
  *
- * `emitTokenBlocks` DROPS two kinds of token, and a picker that offered them
- * would let an author store a reference to a property nothing declares — which
- * invalidates the declaration rather than reporting, so the style is simply
- * absent and the page still renders. That is the failure this whole control
- * exists around, reached through the token list instead of through the name.
- *
- * Both rules are applied with the ENGINE's own primitives rather than restated:
- * `isTokenName` decides whether a name can become a property, and
- * `tokenCustomProperty` composes the property that two identities can collide
- * on. Only the ORDER is repeated — first one wins — which is a single line and
- * the one thing the engine does not export a way to ask.
- *
- * The prefix is deliberately omitted from the collision key. A prefix is the
- * same string in front of every property, so it cannot make two identities
- * collide or stop them colliding; asking for the site's real prefix would need
- * `resolveTokenPrefix`, which the engine keeps private.
+ * `emitTokenBlocks` drops a token for more reasons than are obvious from
+ * outside, and a partial copy of that list is worse than none: it reads as
+ * complete, agrees with the engine on the cases someone thought of, and offers
+ * a token the canvas silently drops for any case they did not — which stores a
+ * reference to a property nothing declares and loses the style with no symptom.
  */
 function emittableTokens(set: SiteTokenSet): readonly SiteToken[] {
   const seen = new Set<string>();
@@ -218,15 +259,9 @@ function emittableTokens(set: SiteTokenSet): readonly SiteToken[] {
  *
  * ASKED, by emitting the token on its own and seeing whether anything came out.
  * `emitTokenBlocks` returns empty CSS when it wrote no light declaration, which
- * is exactly its own verdict on the token — and it refuses for more reasons
- * than are obvious from outside: a name that cannot become a property, an
- * unusable id, a missing or non-string light value, a value that is not safe
- * CSS, and a value that would make the page fetch something.
- *
- * A partial copy of that list is worse than none. It reads as complete, agrees
- * with the engine on the cases someone thought of, and offers a token the
- * canvas silently drops for any case they did not — which stores a reference to
- * a property nothing declares and loses the style with no symptom.
+ * is exactly its own verdict — and it refuses for an unusable id, a missing or
+ * non-string light value, a value that is not safe CSS, and a value that would
+ * make the page fetch something, as well as for an unusable name.
  *
  * The whole SET is passed rather than a bare token, because a token's
  * acceptance can depend on the set's own prefix.
@@ -236,12 +271,11 @@ function emits(set: SiteTokenSet, token: SiteToken): boolean {
 }
 
 /**
- * One site token in the three forms a control needs it in.
+ * One site token in the forms a control needs it in.
  *
- * Shared by the list and the single lookup rather than written at each, so the
- * identity rule is applied once: a second copy is one edit from storing the
- * NAME, which compiles to a custom property nothing declares and loses the
- * style with no symptom.
+ * Shared by every reader rather than written at each, so the identity rule is
+ * applied once: a second copy is one edit from storing the NAME, which compiles
+ * to a custom property nothing declares and loses the style with no symptom.
  */
 function colourTokenOf(token: SiteToken, mode: TokenMode): ColourToken {
   // `light` is required and `dark` is not, so a token defined only for light
@@ -251,12 +285,12 @@ function colourTokenOf(token: SiteToken, mode: TokenMode): ColourToken {
   return {
     identity: tokenIdentity(token),
     name: token.name,
+    kind: token.kind,
     colour,
-    // Resolved with NO table, which is what stops this recursing: a token whose
-    // value is itself a reference would otherwise re-enter the lookup that is
-    // building this record. Without a table a reference resolves to nothing and
-    // the swatch is simply unpainted, which is the honest answer for a value
-    // this package cannot follow.
+    // Resolved with an EMPTY table, which is what stops this recursing: a token
+    // whose value is itself a reference would otherwise re-enter the lookup that
+    // is building this record. Unresolvable then means unpainted, which is the
+    // honest answer for a value this package cannot follow.
     swatch: colourHexOf(colour, undefined),
   };
 }
@@ -279,9 +313,11 @@ export function colourTokenFor(
   tokens: SiteTokenSet | undefined,
   mode: TokenMode = "light"
 ): ColourToken | undefined {
-  if (tokens === undefined) return undefined;
-  const token = tokens.tokens.find(entry => tokenIdentity(entry) === identity);
-  return token === undefined ? undefined : colourTokenOf(token, mode);
+  // The OFFERED projection, not the raw set. Searching the raw set resolved a
+  // reference the canvas never declares — an imported document naming a token
+  // the emitter rejects painted its value anyway — and, for two identities that
+  // collide, showed the loser while the page resolves the winner's declaration.
+  return offeredTokens(tokens, mode).find(token => token.identity === identity);
 }
 
 /**

--- a/packages/builder/src/style-colour.ts
+++ b/packages/builder/src/style-colour.ts
@@ -61,7 +61,7 @@
 
 import {
   checkContrast,
-  isTokenName,
+  emitTokenBlocks,
   isTokenRef,
   parseColor,
   STYLE_CATALOG,
@@ -69,6 +69,7 @@ import {
   tokenIdentity,
   type ContrastResult,
   type Rgb,
+  type NodeStyles,
   type SiteToken,
   type SiteTokenSet,
   type TokenMode,
@@ -195,15 +196,43 @@ function emittableTokens(set: SiteTokenSet): readonly SiteToken[] {
   const seen = new Set<string>();
   const emittable: SiteToken[] = [];
   for (const token of set.tokens) {
-    // The NAME, matching the engine: it checks the name and then composes the
-    // property from the identity.
-    if (!isTokenName(token.name)) continue;
+    if (!emits(set, token)) continue;
+    // Which of two ACCEPTED tokens actually gets the property is the one thing
+    // the emitter cannot be asked, because both are individually fine and only
+    // their order decides. `tokenCustomProperty` composes the key, so the
+    // normalisation is still the engine's; only first-one-wins is repeated.
+    //
+    // The prefix is omitted deliberately: it is the same string in front of
+    // every property, so it can neither create a collision nor prevent one, and
+    // the site's real prefix is resolved by a function the engine keeps private.
     const property = tokenCustomProperty(tokenIdentity(token), "");
     if (seen.has(property)) continue;
     seen.add(property);
     emittable.push(token);
   }
   return emittable;
+}
+
+/**
+ * Whether the canvas will declare a custom property for this token.
+ *
+ * ASKED, by emitting the token on its own and seeing whether anything came out.
+ * `emitTokenBlocks` returns empty CSS when it wrote no light declaration, which
+ * is exactly its own verdict on the token — and it refuses for more reasons
+ * than are obvious from outside: a name that cannot become a property, an
+ * unusable id, a missing or non-string light value, a value that is not safe
+ * CSS, and a value that would make the page fetch something.
+ *
+ * A partial copy of that list is worse than none. It reads as complete, agrees
+ * with the engine on the cases someone thought of, and offers a token the
+ * canvas silently drops for any case they did not — which stores a reference to
+ * a property nothing declares and loses the style with no symptom.
+ *
+ * The whole SET is passed rather than a bare token, because a token's
+ * acceptance can depend on the set's own prefix.
+ */
+function emits(set: SiteTokenSet, token: SiteToken): boolean {
+  return emitTokenBlocks({ ...set, tokens: [token] }, ":root").css !== "";
 }
 
 /**
@@ -537,6 +566,42 @@ export function contrastObscuredBy(
   valueAt: (property: string) => StyleValue | undefined
 ): string | undefined {
   return OBSCURING_PROPERTIES.find(property => valueAt(property) !== undefined);
+}
+
+/**
+ * The property standing between a pair anywhere on this node, or `undefined`.
+ *
+ * Every state and every breakpoint, not the one address being edited. A base
+ * `backgroundGradient` goes on covering the background while a hover rule sets
+ * only the two colours, so an address-scoped look sees no gradient and reports
+ * a ratio for pixels the gradient hides — the guard failing OPEN, which is the
+ * one direction it must not fail in.
+ *
+ * This OVER-withholds, and that is the deliberate trade: a gradient set only at
+ * a narrow breakpoint suppresses the verdict at every width. Answering exactly
+ * needs `styleOrigin`, which has already settled tier order, both breakpoint
+ * axes, states and specificity — and needs a trace of compiled declarations
+ * that nothing supplies to this panel. Between a verdict that is sometimes
+ * absent and a verdict that is sometimes wrong, this takes the first.
+ *
+ * A named class carrying one of these is still not seen, for the same reason,
+ * and that limit is not closed here.
+ */
+export function contrastObscuredIn(
+  styles: NodeStyles | undefined
+): string | undefined {
+  if (styles === undefined) return undefined;
+  for (const breakpoints of Object.values(styles)) {
+    if (breakpoints === undefined) continue;
+    for (const values of Object.values(breakpoints)) {
+      if (values === undefined) continue;
+      const found = contrastObscuredBy(property =>
+        Object.hasOwn(values, property) ? values[property] : undefined
+      );
+      if (found !== undefined) return found;
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -65,6 +65,7 @@ import type { EditorState } from "./editor-state";
 import { fieldLabel } from "./inspector";
 import {
   colourHexOf,
+  colourShowable,
   colourTokenFor,
   colourTokensFor,
   contrastAtLeaf,
@@ -729,8 +730,15 @@ function ControlValue({
    * Narrowed on the LEAF rather than on `control.kind`, because the leaf is what
    * carries `tokenKinds` and `cssProperty` — the two facts the colour surface
    * asks the catalog for — so passing it narrowed means neither is re-derived.
+   *
+   * Guarded by {@link colourShowable}, so a value NO colour control can
+   * represent — an object at a scalar position from an import or the API — does
+   * not take this branch and skip the read-only surface below. Without it the
+   * field projects that object to an empty draft and reads as unset while the
+   * value goes on compiling, which is the failure the surface below exists to
+   * prevent.
    */
-  if (control.leaf.kind === "color") {
+  if (control.leaf.kind === "color" && colourShowable(stored)) {
     return (
       <ColourField
         id={id}
@@ -1202,6 +1210,12 @@ function ColourField({
 
   const reference = isTokenRef(stored) ? stored.$token : null;
   const choices = colourTokensFor(control.leaf, tokens);
+  // What the picker composed, written once the gesture is over. Compared
+  // against the stored text so closing a picker nobody moved writes nothing.
+  const commitDraft = (): void => {
+    if (draft === storedText(stored)) return;
+    if (onCommit(draft) === "unchanged") setDraft(storedText(stored));
+  };
   // What the surface is currently SHOWING: the draft while a literal is being
   // typed, so the swatch follows the field, and the stored value for a
   // reference, which no field is editing. Named once and resolved once, rather
@@ -1210,6 +1224,14 @@ function ColourField({
   const showing = reference === null ? draft : stored;
   const shown = colourHexOf(showing, tokens);
   const contrast = contrastAtLeaf(control.leaf, stored, pairedColour, tokens);
+  // Both descriptions, not one. A control pointed only at the refusal message
+  // never announces the contrast verdict, and one pointed only at the verdict
+  // drops the reason its last value was refused — so a screen-reader user gets
+  // whichever happens to be listed and no way to reach the other.
+  const describes =
+    [describedBy, contrast === undefined ? undefined : noteId]
+      .filter(part => part !== undefined)
+      .join(" ") || undefined;
 
   return (
     <>
@@ -1226,15 +1248,25 @@ function ColourField({
           shown={shown}
           choices={choices}
           actionName={actionName}
-          describedBy={describedBy}
+          describedBy={describes}
           // A warning is only worth showing where there is something to lose:
           // an empty field has nothing, and a value the picker CAN show needs
           // no notice. A reference falls out of the first test on its own,
           // since it is displayed by name and never as draft text.
           unrepresented={shown === undefined && draft !== ""}
-          onColour={value => {
-            if (onCommit(value) !== "refused") setDraft(value);
-          }}
+          // The draft moves with the pointer and the DOCUMENT does not. A drag
+          // across the saturation surface fires `onColorChange` on every
+          // pointer event, and committing each one writes an editor op each
+          // time: one gesture becomes dozens of undo entries, and `MAX_HISTORY`
+          // is 100, so a single drag can evict unrelated earlier edits and
+          // leave undo walking intermediate colours instead of reverting the
+          // gesture. This is the rule the text fields already follow — an op
+          // per keystroke would make one undo remove one character.
+          onColour={setDraft}
+          // Committed when the picker CLOSES, which is where the gesture ends.
+          onClosed={commitDraft}
+          // A preset is one discrete choice rather than a gesture, so it
+          // commits immediately, exactly as the select and toggle controls do.
           onToken={identity => onCommit({ $token: identity })}
         />
         {reference === null ? (
@@ -1250,7 +1282,7 @@ function ColourField({
             stored={stored}
             draft={draft}
             setDraft={setDraft}
-            describedBy={describedBy}
+            describedBy={describes}
             onCommit={onCommit}
           />
         ) : (
@@ -1288,6 +1320,7 @@ function ColourPicker({
   describedBy,
   unrepresented,
   onColour,
+  onClosed,
   onToken,
 }: {
   /** The resolved colour, or `undefined` when nothing here can resolve one. */
@@ -1297,11 +1330,14 @@ function ColourPicker({
   describedBy: string | undefined;
   /** Whether the stored value is one the picker cannot show. */
   unrepresented: boolean;
+  /** The picker moved. Fires on every pointer event during a drag. */
   onColour: (hex: string) => void;
+  /** The picker closed, which is where a gesture ends and a write belongs. */
+  onClosed: () => void;
   onToken: (identity: string) => void;
 }): React.JSX.Element {
   return (
-    <Popover>
+    <Popover onOpenChange={open => !open && onClosed()}>
       <PopoverTrigger asChild>
         <button
           type="button"
@@ -1340,7 +1376,14 @@ function ColourPicker({
             // token and a new one that took its old name.
             id: choice.identity,
             label: choice.name,
-            color: choice.colour,
+            // The RESOLVED colour, never the token's raw value. A preset button
+            // paints what it is handed, so a token holding `var(--brand)`,
+            // `currentcolor` or a CSS-wide keyword would resolve against the
+            // inspector rather than the canvas and show a colour the page does
+            // not have — the same failure the main swatch refuses. A token this
+            // package cannot resolve paints nothing and stays choosable, which
+            // is what keeps the reference reachable.
+            color: choice.swatch ?? "transparent",
             value: choice,
           }))}
           onColorChange={onColour}

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -1359,6 +1359,10 @@ function ColourField({
   // in state because the unmount flush below reads it from a cleanup that runs
   // once, where the closed-over `draft` would be the value at first render.
   const pending = React.useRef<string | null>(null);
+  // The clear beside a token reference. It sits OUTSIDE the popover, so pressing
+  // it dismisses the picker and then commits — two writes for one intent unless
+  // the close knows the press belongs to it.
+  const clear = React.useRef<HTMLButtonElement | null>(null);
   /*
    * A discrete choice, which SUPERSEDES anything the picker was mid-way through.
    *
@@ -1373,42 +1377,23 @@ function ColourField({
     onCommit(value);
   };
   /*
-   * The gesture, written a beat after the picker closes rather than during it.
+   * The gesture, written when the picker closes.
    *
-   * Deferred because CLOSING and CHOOSING can be one interaction. The controls
-   * that supersede a gesture — the token presets, the clear — sit outside the
-   * popover, so pressing one dismisses it first: the close wrote the picker's
-   * literal and the choice then replaced it, two history entries where one undo
-   * returns an intermediate colour the author never picked.
+   * Synchronous, because an author can leave the editor entirely in the same
+   * interaction that dismisses this popover: the page builder hands the current
+   * document to its host form and unmounts, and a write scheduled for after
+   * that lands on an editor nobody is reading any more. The gesture is simply
+   * gone from the document handed over.
    *
-   * Deferring rather than hooking the dismissal is what makes that hold for
-   * EVERY cause. Radix dismisses on `pointerdown`, `focusin`, `keydown`,
-   * `click`, `pointerup`, `mousedown` and `mouseup`, so a control clearing the
-   * gesture on pointer-down covered a mouse and missed a keyboard — where focus
-   * reaches the button first and the activation follows. Enumerating that list
-   * here would be a copy of someone else's, kept in step by hand.
-   *
-   * A timeout rather than a microtask: a dismissal and the activation that
-   * caused it are separate tasks, so a microtask would still run between them.
+   * Which is why the supersede below is decided by WHERE the interaction went
+   * rather than by giving a later handler time to cancel a scheduled write. A
+   * timer bought that cancellation and paid for it with this race.
    */
   const commitDraft = (): void => {
-    if (pending.current === null) return;
-    cancelWrite();
-    scheduled.current = window.setTimeout(flush, 0);
-  };
-  /** Write whatever the picker produced and has not had written yet. */
-  const flush = (): void => {
-    scheduled.current = null;
     const unwritten = pending.current;
     pending.current = null;
     if (unwritten === null) return;
-    if (write.current(unwritten) === "unchanged") reset();
-  };
-  const scheduled = React.useRef<number | null>(null);
-  const cancelWrite = (): void => {
-    if (scheduled.current === null) return;
-    window.clearTimeout(scheduled.current);
-    scheduled.current = null;
+    if (onCommit(unwritten) === "unchanged") reset();
   };
   // The current writer, held so the teardown below depends on nothing. A
   // teardown listing `onCommit` would re-run its cleanup on every render that
@@ -1430,7 +1415,6 @@ function ColourField({
    */
   React.useEffect(
     () => () => {
-      cancelWrite();
       const unwritten = pending.current;
       pending.current = null;
       if (unwritten !== null) write.current(unwritten);
@@ -1495,6 +1479,11 @@ function ColourField({
           }}
           // Committed when the picker CLOSES, which is where the gesture ends.
           onClosed={commitDraft}
+          commitsItself={target =>
+            clear.current !== null &&
+            target instanceof Node &&
+            clear.current.contains(target)
+          }
           // A preset is one discrete choice rather than a gesture, so it
           // commits immediately, exactly as the select and toggle controls do.
           onToken={identity => commitInstead({ $token: identity })}
@@ -1520,6 +1509,7 @@ function ColourField({
           />
         ) : (
           <TokenName
+            buttonRef={clear}
             identity={reference}
             token={colourTokenFor(reference, tokens, mode)}
             actionName={actionName}
@@ -1555,6 +1545,7 @@ function ColourPicker({
   unrepresented,
   onColour,
   onClosed,
+  commitsItself,
   onToken,
 }: {
   /** The resolved colour, or `undefined` when nothing here can resolve one. */
@@ -1571,10 +1562,32 @@ function ColourPicker({
   onColour: (hex: string) => void;
   /** The picker closed, which is where a gesture ends and a write belongs. */
   onClosed: () => void;
+  /**
+   * Whether an interaction outside the popover will write for itself.
+   *
+   * Asked before the dismissal is turned into a write, so a control that both
+   * closes this picker and commits something of its own does not produce two
+   * edits for one intent. `onInteractOutside` is the single callback Radix
+   * fires for EVERY cause it dismisses on — pointer, focus and the rest — which
+   * is why the question is asked here rather than by hooking the causes one at
+   * a time and missing whichever is added next.
+   */
+  commitsItself: (target: EventTarget | null) => boolean;
   onToken: (identity: string) => void;
 }): React.JSX.Element {
+  // Whether the dismissal in progress belongs to a control that writes for
+  // itself. Read once by the close below and reset there, so it cannot leak
+  // into the next open.
+  const superseded = React.useRef(false);
   return (
-    <Popover onOpenChange={open => !open && onClosed()}>
+    <Popover
+      onOpenChange={open => {
+        if (open) return;
+        const own = superseded.current;
+        superseded.current = false;
+        if (!own) onClosed();
+      }}
+    >
       <PopoverTrigger asChild>
         <button
           type="button"
@@ -1594,7 +1607,12 @@ function ColourPicker({
           data-empty={shown === undefined ? "" : undefined}
         />
       </PopoverTrigger>
-      <PopoverContent className="nx-style-inspector__picker">
+      <PopoverContent
+        className="nx-style-inspector__picker"
+        onInteractOutside={event => {
+          superseded.current = commitsItself(event.target);
+        }}
+      >
         {unrepresented ? (
           <p className="nx-inspector__note">
             This value cannot be shown on the picker. Choosing here replaces it.
@@ -1644,11 +1662,14 @@ function ColourPicker({
  * rather than an empty space.
  */
 function TokenName({
+  buttonRef,
   identity,
   token,
   actionName,
   onClear,
 }: {
+  /** Handed up so the picker can tell its own clear from any other dismissal. */
+  buttonRef: React.RefObject<HTMLButtonElement | null>;
   /** What the document stores, and the fallback when nothing resolves it. */
   identity: string;
   /** The site's token of that identity, when it defines one. */
@@ -1662,6 +1683,7 @@ function TokenName({
         {token?.name ?? identity}
       </span>
       <button
+        ref={buttonRef}
         type="button"
         onClick={onClear}
         aria-label={`Clear ${actionName}`}

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -37,6 +37,7 @@ import {
   type ContrastResult,
   type NodeStyles,
   type SiteTokenSet,
+  type TokenMode,
   type StyleLeaf,
   type StyleShape,
   type StyleState,
@@ -68,6 +69,7 @@ import {
   colourHexOf,
   colourShowable,
   colourTokenFor,
+  colourTokenLabel,
   colourTokensFor,
   contrastAtLeaf,
   contrastObscuredAbove,
@@ -1449,6 +1451,7 @@ function ColourField({
   // token's own hex again on every render, and its prop-sync effect reset the
   // surface to it: the controls snapped back mid-drag and a token could not be
   // replaced with a literal by using the picker at all.
+  const storedLabel = storedTokenLabel(reference, tokens, mode, choices);
   const showing = reference === null || edited ? draft : stored;
   const shown = colourHexOf(showing, tokens, mode);
   // Measured from what the surface is SHOWING, which is the same value the
@@ -1528,8 +1531,7 @@ function ColourField({
         ) : (
           <TokenName
             buttonRef={clear}
-            identity={reference}
-            token={colourTokenFor(reference, tokens, mode)}
+            label={storedLabel}
             actionName={actionName}
             onClear={() => commitInstead(null)}
           />
@@ -1649,7 +1651,11 @@ function ColourPicker({
             // every renamed token's swatch, and would collide between a renamed
             // token and a new one that took its old name.
             id: choice.identity,
-            label: choice.name,
+            // Qualified with the identity only where another offered token
+            // shares this name. Two presets under one label with equal or
+            // unresolvable colours are indistinguishable, and choosing either
+            // stores an identity the author could not have predicted.
+            label: colourTokenLabel(choice, choices),
             // The RESOLVED colour, never the token's raw value. A preset button
             // paints what it is handed, so a token holding `var(--brand)`,
             // `currentcolor` or a CSS-wide keyword would resolve against the
@@ -1671,6 +1677,32 @@ function ColourPicker({
 }
 
 /**
+ * What a STORED reference is called, for the row that displays it.
+ *
+ * Three answers to one question, which is why it is asked in one place: a
+ * reference the site still defines reads as that token's current name; one
+ * whose name another offered token shares is qualified with its identity, so
+ * the two rows cannot be confused; and one the site no longer defines at all
+ * reads as the raw identity the document holds. That last case is a warning
+ * rather than an error — the value goes on compiling — so showing the stored
+ * string is more use than showing an empty space.
+ *
+ * Separate from {@link colourTokenLabel} because that one answers about a token
+ * in hand, and this one has to find the token first, or account for there being
+ * none.
+ */
+function storedTokenLabel(
+  reference: string | null,
+  tokens: SiteTokenSet | undefined,
+  mode: TokenMode,
+  among: readonly ColourToken[]
+): string {
+  if (reference === null) return "";
+  const token = colourTokenFor(reference, tokens, mode);
+  return token === undefined ? reference : colourTokenLabel(token, among);
+}
+
+/**
  * A stored token, by the name an author reads, with the way to remove it.
  *
  * The name is resolved by the caller and the fallback is the stored identity,
@@ -1681,25 +1713,25 @@ function ColourPicker({
  */
 function TokenName({
   buttonRef,
-  identity,
-  token,
+  label,
   actionName,
   onClear,
 }: {
   /** Handed up so the picker can tell its own clear from any other dismissal. */
   buttonRef: React.RefObject<HTMLButtonElement | null>;
-  /** What the document stores, and the fallback when nothing resolves it. */
-  identity: string;
-  /** The site's token of that identity, when it defines one. */
-  token: ColourToken | undefined;
+  /**
+   * What to show: the token's current name, qualified with its identity where
+   * another offered token shares that name, and the identity alone when the
+   * site defines no token for it. Resolved by the caller, which is the only
+   * place that holds the list the collision would be against.
+   */
+  label: string;
   actionName: string;
   onClear: () => void;
 }): React.JSX.Element {
   return (
     <>
-      <span className="nx-style-inspector__colour-token">
-        {token?.name ?? identity}
-      </span>
+      <span className="nx-style-inspector__colour-token">{label}</span>
       <button
         ref={buttonRef}
         type="button"
@@ -1731,19 +1763,34 @@ function ContrastNote({
 }: {
   id: string;
   contrast: ContrastResult | undefined;
-}): React.JSX.Element | null {
-  if (contrast === undefined) return null;
+}): React.JSX.Element {
   return (
     <p
       className="nx-style-inspector__contrast"
       id={id}
-      data-level={contrast.level}
+      // Announced as it changes, because the verdict moves while focus is
+      // INSIDE the picker — on the saturation square, the hue strip, the alpha
+      // strip or the hex field — and none of those controls is described by
+      // this note. `aria-describedby` is read when a control receives focus, so
+      // a figure that changes during the interaction is never spoken. Polite
+      // rather than assertive: it coalesces while a drag is moving and speaks
+      // once the author pauses, which is when the number is wanted.
+      aria-live="polite"
+      // Mounted even with nothing to say. A live region announces CHANGES to
+      // its contents, so one that arrives with its text already in place is not
+      // a change and is silent — the state this note is in every time a colour
+      // first becomes measurable. Empty it occupies no space; `:empty` drops
+      // the margin rather than the box, because `display: none` would take it
+      // out of the accessibility tree and stop it announcing at all.
+      {...(contrast === undefined ? {} : { "data-level": contrast.level })}
     >
-      {`Contrast ${contrastRatioText(contrast)} — ${
-        contrast.passesBodyText
-          ? `passes AA for body text (${contrast.level})`
-          : "below AA for body text"
-      }`}
+      {contrast === undefined
+        ? ""
+        : `Contrast ${contrastRatioText(contrast)} — ${
+            contrast.passesBodyText
+              ? `passes AA for body text (${contrast.level})`
+              : "below AA for body text"
+          }`}
     </p>
   );
 }

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -70,7 +70,7 @@ import {
   colourTokenFor,
   colourTokensFor,
   contrastAtLeaf,
-  contrastObscuredBy,
+  contrastObscuredIn,
   contrastPartnerOf,
   contrastRatioText,
   type ColourToken,
@@ -664,11 +664,7 @@ function StyleControlField({
   const styles = findNode(editor.document.nodes, nodeId)?.styles;
   const stored = readStyleValue(styles, address);
   const pairedColour = partnerColour(control.leaf, styles, address);
-  // Asked at the SAME address the control reads its own value at, so a gradient
-  // set at another breakpoint does not withhold a verdict that is correct here.
-  const obscuredBy = contrastObscuredBy(property =>
-    readStyleValue(styles, { ...address, property, path: [] })
-  );
+  const obscuredBy = contrastObscuredIn(styles);
   const actionName = actionNameFor(propertyLabel, label);
   const [issue, setIssue] = React.useState<string | null>(null);
 
@@ -1359,10 +1355,43 @@ function ColourField({
   const choices = colourTokensFor(control.leaf, tokens, mode);
   // What the picker composed, written once the gesture is over. Compared
   // against the stored text so closing a picker nobody moved writes nothing.
+  // What the picker has produced and not yet written. Held in a ref as well as
+  // in state because the unmount flush below reads it from a cleanup that runs
+  // once, where the closed-over `draft` would be the value at first render.
+  const pending = React.useRef<string | null>(null);
   const commitDraft = (): void => {
+    pending.current = null;
     if (!edited) return;
     if (onCommit(draft) === "unchanged") reset();
   };
+  /*
+   * Flush an unwritten gesture when this field goes away.
+   *
+   * The popover commits on close, and a close is not the only way an author
+   * leaves: selecting another block in the canvas iframe cannot reach the
+   * popover's outside-dismiss handler, and the selection change remounts this
+   * field — which does not fire `onOpenChange`. Without this the adjustment,
+   * and the whole gesture behind it, is discarded silently.
+   *
+   * Written through a ref and an empty dependency list so it runs exactly once,
+   * at teardown. `onCommit` reads the node from the store at call time, so a
+   * write from here lands on the current document rather than a captured one.
+   */
+  // The current writer, held so the teardown below depends on nothing. A
+  // teardown listing `onCommit` would re-run its cleanup on every render that
+  // gives the field a new callback — which is every render — and flush a
+  // gesture the author is still making.
+  const write = React.useRef(onCommit);
+  React.useEffect(() => {
+    write.current = onCommit;
+  });
+  React.useEffect(
+    () => () => {
+      const unwritten = pending.current;
+      if (unwritten !== null) write.current(unwritten);
+    },
+    []
+  );
   // What the surface is currently SHOWING: the draft while a literal is being
   // typed, so the swatch follows the field, and the stored value for a
   // reference, which no field is editing. Named once and resolved once, rather
@@ -1415,7 +1444,10 @@ function ColourField({
           // leave undo walking intermediate colours instead of reverting the
           // gesture. This is the rule the text fields already follow — an op
           // per keystroke would make one undo remove one character.
-          onColour={setDraft}
+          onColour={value => {
+            pending.current = value;
+            setDraft(value);
+          }}
           // Committed when the picker CLOSES, which is where the gesture ends.
           onClosed={commitDraft}
           // A preset is one discrete choice rather than a gesture, so it

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -1374,10 +1374,21 @@ function ColourField({
     pending.current = null;
     onCommit(value);
   };
+  /*
+   * The gesture, written once, when the picker closes.
+   *
+   * Reads the SAME pending value the unmount flush and `commitInstead` do, so
+   * the three cannot disagree about whether there is anything to write. Deciding
+   * from `edited` instead let a superseded gesture through: a token commit that
+   * was REFUSED — a document at its byte limit, say — cleared the pending value
+   * and left the older literal in the draft, and closing the popover then wrote
+   * that literal even though choosing the token was meant to replace it.
+   */
   const commitDraft = (): void => {
+    const unwritten = pending.current;
     pending.current = null;
-    if (!edited) return;
-    if (onCommit(draft) === "unchanged") reset();
+    if (unwritten === null) return;
+    if (onCommit(unwritten) === "unchanged") reset();
   };
   /*
    * Flush an unwritten gesture when this field goes away.

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -64,6 +64,7 @@ import * as React from "react";
 import type { EditorState } from "./editor-state";
 import { fieldLabel } from "./inspector";
 import {
+  activeTokenMode,
   colourHexOf,
   colourShowable,
   colourTokenFor,
@@ -157,6 +158,7 @@ export function StyleInspectorPanel({
   const [chosenForms, setChosenForms] = React.useState<Record<string, number>>(
     {}
   );
+  const prefersDark = usePrefersDark();
 
   // Recomputed each render rather than memoised, as the content tab is: an
   // inspection is only valid against the document it was read from, and an edit
@@ -247,12 +249,51 @@ export function StyleInspectorPanel({
             editor={editor}
             policy={policy}
             tokens={tokens}
+            prefersDark={prefersDark}
             onChooseForm={chooseForm}
           />
         ))}
       </Accordion>
     </div>
   );
+}
+
+/**
+ * Whether the viewer's system asks for a dark colour scheme.
+ *
+ * Read because a site on the `media` dark-mode strategy has its dark token
+ * block wrapped in `@media (prefers-color-scheme:dark)`, so the canvas switches
+ * with the system and nothing tells the panel. Resolving every token to its
+ * light value regardless would paint swatches and report ratios for colours the
+ * canvas is not showing.
+ *
+ * Starts `false` and subscribes after mount, so a server render and the first
+ * client render agree — React discards a subtree whose two renders disagree,
+ * which would take the whole Style tab with it. A viewer already in dark mode
+ * sees one frame of light-mode swatches; the alternative is a hydration
+ * mismatch, which is worse and harder to see.
+ */
+function usePrefersDark(): boolean {
+  const [prefersDark, setPrefersDark] = React.useState(false);
+  React.useEffect(() => {
+    // Detected by CALLABILITY, not by presence. `"matchMedia" in window` is
+    // true under jsdom while the value is not a function, so the property test
+    // passes and the call throws — measured, and it took 85 tests down. A
+    // capability check has to ask the question the caller will ask.
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return;
+    }
+    const query = window.matchMedia("(prefers-color-scheme: dark)");
+    setPrefersDark(query.matches);
+    const listen = (event: MediaQueryListEvent): void =>
+      setPrefersDark(event.matches);
+    query.addEventListener("change", listen);
+    return () => query.removeEventListener("change", listen);
+  }, []);
+  return prefersDark;
 }
 
 /** One catalog group, as a section that opens onto its properties. */
@@ -264,6 +305,7 @@ function StyleSectionItem({
   editor,
   policy,
   tokens,
+  prefersDark,
   onChooseForm,
 }: {
   section: StyleSection;
@@ -273,6 +315,7 @@ function StyleSectionItem({
   editor: EditorState;
   policy: StylePolicy | undefined;
   tokens: SiteTokenSet | undefined;
+  prefersDark: boolean;
   onChooseForm: ChooseForm;
 }): React.JSX.Element {
   // How many of this section's properties this node sets HERE, so an author can
@@ -305,6 +348,7 @@ function StyleSectionItem({
               editor={editor}
               policy={policy}
               tokens={tokens}
+              prefersDark={prefersDark}
               onChooseForm={onChooseForm}
             />
           ))}
@@ -330,6 +374,7 @@ function StylePropertyFields({
   editor,
   policy,
   tokens,
+  prefersDark,
   onChooseForm,
 }: {
   property: InspectedStyleProperty;
@@ -339,6 +384,7 @@ function StylePropertyFields({
   editor: EditorState;
   policy: StylePolicy | undefined;
   tokens: SiteTokenSet | undefined;
+  prefersDark: boolean;
   onChooseForm: ChooseForm;
 }): React.JSX.Element {
   const many = property.controls.length > 1;
@@ -417,6 +463,7 @@ function StylePropertyFields({
           editor={editor}
           policy={policy}
           tokens={tokens}
+          prefersDark={prefersDark}
         />
       ))}
     </div>
@@ -565,6 +612,7 @@ function StyleControlField({
   editor,
   policy,
   tokens,
+  prefersDark,
 }: {
   control: StyleControl;
   label: string;
@@ -596,6 +644,7 @@ function StyleControlField({
   editor: EditorState;
   policy: StylePolicy | undefined;
   tokens: SiteTokenSet | undefined;
+  prefersDark: boolean;
 }): React.JSX.Element {
   const id = React.useId();
   // The message's own id, so the control can point at it. A `role="alert"`
@@ -663,6 +712,7 @@ function StyleControlField({
         actionName={actionName}
         clearOnly={clearOnly}
         tokens={tokens}
+        prefersDark={prefersDark}
         pairedColour={pairedColour}
         describedBy={describedBy}
         onCommit={commit}
@@ -692,6 +742,7 @@ function ControlValue({
   actionName,
   clearOnly,
   tokens,
+  prefersDark,
   pairedColour,
   describedBy,
   onCommit,
@@ -703,6 +754,8 @@ function ControlValue({
   actionName: string;
   clearOnly: boolean;
   tokens: SiteTokenSet | undefined;
+  /** Whether the viewer's system asks for dark, for a site on the media strategy. */
+  prefersDark: boolean;
   /** The other half of this control's contrast pair, when its leaf has one. */
   pairedColour: StyleValue | undefined;
   describedBy: string | undefined;
@@ -747,6 +800,7 @@ function ControlValue({
         stored={stored}
         actionName={actionName}
         tokens={tokens}
+        prefersDark={prefersDark}
         pairedColour={pairedColour}
         describedBy={describedBy}
         onCommit={onCommit}
@@ -1185,6 +1239,7 @@ function ColourField({
   stored,
   actionName,
   tokens,
+  prefersDark,
   pairedColour,
   describedBy,
   onCommit,
@@ -1195,6 +1250,7 @@ function ColourField({
   stored: StyleValue | undefined;
   actionName: string;
   tokens: SiteTokenSet | undefined;
+  prefersDark: boolean;
   pairedColour: StyleValue | undefined;
   describedBy: string | undefined;
   onCommit: (value: StyleValue | null) => CommitOutcome;
@@ -1209,7 +1265,8 @@ function ColourField({
   }, [stored]);
 
   const reference = isTokenRef(stored) ? stored.$token : null;
-  const choices = colourTokensFor(control.leaf, tokens);
+  const mode = activeTokenMode(tokens, prefersDark);
+  const choices = colourTokensFor(control.leaf, tokens, mode);
   // What the picker composed, written once the gesture is over. Compared
   // against the stored text so closing a picker nobody moved writes nothing.
   const commitDraft = (): void => {
@@ -1222,8 +1279,19 @@ function ColourField({
   // than resolved in each branch — two calls to the same resolver is the shape
   // that drifts.
   const showing = reference === null ? draft : stored;
-  const shown = colourHexOf(showing, tokens);
-  const contrast = contrastAtLeaf(control.leaf, stored, pairedColour, tokens);
+  const shown = colourHexOf(showing, tokens, mode);
+  // Measured from what the surface is SHOWING, which is the same value the
+  // swatch is painted from. Reading `stored` instead left the verdict describing
+  // the old colour for the whole of a picker gesture — stale exactly while an
+  // author is choosing, which is when a contrast readout is for — and put the
+  // swatch and the figure beside it on two different colours.
+  const contrast = contrastAtLeaf(
+    control.leaf,
+    showing,
+    pairedColour,
+    tokens,
+    mode
+  );
   // Both descriptions, not one. A control pointed only at the refusal message
   // never announces the contrast verdict, and one pointed only at the verdict
   // drops the reason its last value was refused — so a screen-reader user gets
@@ -1249,11 +1317,16 @@ function ColourField({
           choices={choices}
           actionName={actionName}
           describedBy={describes}
-          // A warning is only worth showing where there is something to lose:
-          // an empty field has nothing, and a value the picker CAN show needs
-          // no notice. A reference falls out of the first test on its own,
-          // since it is displayed by name and never as draft text.
-          unrepresented={shown === undefined && draft !== ""}
+          invalid={describedBy !== undefined}
+          // A warning wherever there is something to LOSE, which is a stored
+          // reference or non-empty text. Tested on the draft alone this missed
+          // every reference — `storedText` answers `""` for one — so opening
+          // the picker on a token the site no longer defines, or one holding
+          // `var(...)`, started its controls at black and the first movement
+          // replaced the reference with a near-black literal, unwarned.
+          unrepresented={
+            shown === undefined && (reference !== null || draft !== "")
+          }
           // The draft moves with the pointer and the DOCUMENT does not. A drag
           // across the saturation surface fires `onColorChange` on every
           // pointer event, and committing each one writes an editor op each
@@ -1283,12 +1356,15 @@ function ColourField({
             draft={draft}
             setDraft={setDraft}
             describedBy={describes}
+            // The REFUSAL alone. `describes` also carries the contrast verdict,
+            // which is supplementary text and never a complaint.
+            invalid={describedBy !== undefined}
             onCommit={onCommit}
           />
         ) : (
           <TokenName
             identity={reference}
-            token={colourTokenFor(reference, tokens)}
+            token={colourTokenFor(reference, tokens, mode)}
             actionName={actionName}
             onClear={() => onCommit(null)}
           />
@@ -1318,6 +1394,7 @@ function ColourPicker({
   choices,
   actionName,
   describedBy,
+  invalid,
   unrepresented,
   onColour,
   onClosed,
@@ -1327,7 +1404,10 @@ function ColourPicker({
   shown: string | undefined;
   choices: readonly ColourToken[];
   actionName: string;
+  /** Everything describing the control: a refusal, a contrast verdict, or both. */
   describedBy: string | undefined;
+  /** Whether the last value was refused. A contrast verdict is not a refusal. */
+  invalid: boolean;
   /** Whether the stored value is one the picker cannot show. */
   unrepresented: boolean;
   /** The picker moved. Fires on every pointer event during a drag. */
@@ -1344,6 +1424,7 @@ function ColourPicker({
           className="nx-style-inspector__swatch"
           aria-label={`Colour for ${actionName}`}
           aria-describedby={describedBy}
+          aria-invalid={invalid ? true : undefined}
           // Painted through a custom property rather than `background-color`
           // directly, so the chequerboard beneath a translucent colour stays
           // visible through it. `undefined` leaves the class's own "nothing
@@ -1701,6 +1782,7 @@ function NumericField({
         draft={draft}
         setDraft={setDraft}
         describedBy={describedBy}
+        invalid={describedBy !== undefined}
         onCommit={onCommit}
         onStep={(draft, delta) => {
           const next = steppedValue(control.leaf, draft, delta);
@@ -1772,6 +1854,7 @@ function TextField({
   draft,
   setDraft,
   describedBy,
+  invalid,
   onCommit,
   onStep,
 }: {
@@ -1788,8 +1871,18 @@ function TextField({
    */
   draft: string;
   setDraft: (value: string) => void;
-  /** The id of the message explaining a refusal, and what marks this invalid. */
+  /**
+   * Everything describing this field: a refusal message, a contrast verdict, or
+   * both.
+   *
+   * Separate from {@link invalid}, and that separation is the point. A
+   * description is not a complaint — a passing 21:1 contrast note is
+   * supplementary text — so a field that inferred invalidity from having a
+   * description would announce a perfectly good colour as invalid.
+   */
   describedBy: string | undefined;
+  /** Whether the LAST value was refused, which is the only thing that invalidates. */
+  invalid: boolean;
   onCommit: (value: StyleValue | null) => CommitOutcome;
   /**
    * Applies one arrow-key step to the text currently shown, answering the text
@@ -1827,7 +1920,7 @@ function TextField({
       value={draft}
       placeholder={placeholderFor(control)}
       aria-describedby={describedBy}
-      aria-invalid={describedBy === undefined ? undefined : true}
+      aria-invalid={invalid ? true : undefined}
       // Committed on blur and on Enter, matching the content tab: an op per
       // keystroke would make one undo remove one character.
       onChange={event => setDraft(event.target.value)}

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -1366,11 +1366,11 @@ function ColourField({
   /*
    * A discrete choice, which SUPERSEDES anything the picker was mid-way through.
    *
-   * Dropping the pending value is the whole of it. A write scheduled by the
-   * dismissal this control caused reads that same value when it runs, so
-   * clearing it leaves the scheduled call with nothing to write — cancelling
-   * the timer as well was measured to change no outcome, and a second
-   * expression for one rule is what drifts.
+   * Dropping the pending value is the whole of it. Pressing this control also
+   * dismisses the picker, and the close reads `pending.current` to decide what
+   * the gesture produced — so clearing it first leaves that close with nothing
+   * to write, and the discrete choice is the only edit. One rule expressed
+   * once: a second expression of it is what drifts.
    */
   const commitInstead = (value: StyleValue | null): void => {
     pending.current = null;

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -70,6 +70,7 @@ import {
   colourTokenFor,
   colourTokensFor,
   contrastAtLeaf,
+  contrastObscuredBy,
   contrastPartnerOf,
   contrastRatioText,
   type ColourToken,
@@ -663,6 +664,11 @@ function StyleControlField({
   const styles = findNode(editor.document.nodes, nodeId)?.styles;
   const stored = readStyleValue(styles, address);
   const pairedColour = partnerColour(control.leaf, styles, address);
+  // Asked at the SAME address the control reads its own value at, so a gradient
+  // set at another breakpoint does not withhold a verdict that is correct here.
+  const obscuredBy = contrastObscuredBy(property =>
+    readStyleValue(styles, { ...address, property, path: [] })
+  );
   const actionName = actionNameFor(propertyLabel, label);
   const [issue, setIssue] = React.useState<string | null>(null);
 
@@ -714,6 +720,7 @@ function StyleControlField({
         tokens={tokens}
         prefersDark={prefersDark}
         pairedColour={pairedColour}
+        obscuredBy={obscuredBy}
         describedBy={describedBy}
         onCommit={commit}
       />
@@ -744,6 +751,7 @@ function ControlValue({
   tokens,
   prefersDark,
   pairedColour,
+  obscuredBy,
   describedBy,
   onCommit,
 }: {
@@ -758,6 +766,11 @@ function ControlValue({
   prefersDark: boolean;
   /** The other half of this control's contrast pair, when its leaf has one. */
   pairedColour: StyleValue | undefined;
+  /**
+   * A property on this node that puts something between the pair, or
+   * `undefined` when none does. A verdict is withheld while one is set.
+   */
+  obscuredBy: string | undefined;
   describedBy: string | undefined;
   onCommit: (value: StyleValue | null) => CommitOutcome;
 }): React.JSX.Element {
@@ -802,6 +815,7 @@ function ControlValue({
         tokens={tokens}
         prefersDark={prefersDark}
         pairedColour={pairedColour}
+        obscuredBy={obscuredBy}
         describedBy={describedBy}
         onCommit={onCommit}
       />
@@ -1200,6 +1214,80 @@ function partnerColour(
 }
 
 /**
+ * Every id describing one control, or `undefined` when nothing does.
+ *
+ * A refusal message and a contrast verdict are both descriptions and neither
+ * replaces the other: a control pointed only at the refusal never announces the
+ * verdict, and one pointed only at the verdict drops the reason its last value
+ * was refused. Joined here so the two cannot be traded off at a call site.
+ *
+ * Note what this deliberately does NOT decide: whether the control is INVALID.
+ * A passing 21:1 contrast note is supplementary text, and a control inferring
+ * invalidity from having a description announced a perfectly good colour as an
+ * error.
+ */
+function describedByAll(
+  refusal: string | undefined,
+  verdict: string | undefined
+): string | undefined {
+  return (
+    [refusal, verdict].filter(part => part !== undefined).join(" ") || undefined
+  );
+}
+
+/**
+ * Whether opening the picker here would REPLACE something the author has.
+ *
+ * True when the surface cannot show the stored value and there is a stored
+ * value to lose — a reference, or non-empty text. The picker then starts at its
+ * fallback rather than at the value, so the first movement writes something
+ * unrelated to what was there, and the author is owed a warning first.
+ *
+ * The reference has to be tested explicitly: `storedText` answers `""` for one,
+ * so a predicate reading the draft alone missed every token — including the two
+ * that most need the warning, a token the site no longer defines and one whose
+ * value this package cannot resolve.
+ */
+function wouldReplace(
+  shown: string | undefined,
+  reference: string | null,
+  draft: string
+): boolean {
+  if (shown !== undefined) return false;
+  return reference !== null || draft !== "";
+}
+
+/**
+ * The text a control is editing, over the value the document holds.
+ *
+ * One implementation for both fields that need it. A draft is not just local
+ * state: it has to be REPLACED whenever the stored value moves underneath — an
+ * undo, an edit applied from elsewhere — or the control goes on showing a value
+ * the document no longer has, and the remount key changes with the SELECTION,
+ * which neither of those changes.
+ *
+ * `edited` is the same comparison every caller was making to decide whether a
+ * commit is worth attempting, so it is answered here rather than at each.
+ */
+function useDraft(stored: StyleValue | undefined): {
+  draft: string;
+  setDraft: (value: string) => void;
+  edited: boolean;
+  reset: () => void;
+} {
+  const [draft, setDraft] = React.useState(() => storedText(stored));
+  React.useEffect(() => {
+    setDraft(storedText(stored));
+  }, [stored]);
+  return {
+    draft,
+    setDraft,
+    edited: draft !== storedText(stored),
+    reset: () => setDraft(storedText(stored)),
+  };
+}
+
+/**
  * The hex a picker opens on when the stored value cannot be decomposed.
  *
  * Black, and it is never WRITTEN by being shown: the picker reports a colour
@@ -1241,6 +1329,7 @@ function ColourField({
   tokens,
   prefersDark,
   pairedColour,
+  obscuredBy,
   describedBy,
   onCommit,
 }: {
@@ -1252,17 +1341,18 @@ function ColourField({
   tokens: SiteTokenSet | undefined;
   prefersDark: boolean;
   pairedColour: StyleValue | undefined;
+  /**
+   * A property on this node that puts something between the pair, or
+   * `undefined` when none does. A verdict is withheld while one is set.
+   */
+  obscuredBy: string | undefined;
   describedBy: string | undefined;
   onCommit: (value: StyleValue | null) => CommitOutcome;
 }): React.JSX.Element {
   const noteId = React.useId();
-  // The draft lives here for the reason it does in `NumericField`: two controls
-  // edit one value, so a draft private to the text field would leave the swatch
-  // painting a superseded one.
-  const [draft, setDraft] = React.useState(() => storedText(stored));
-  React.useEffect(() => {
-    setDraft(storedText(stored));
-  }, [stored]);
+  // Lifted out of the text field because two controls edit one value: a draft
+  // private to the field would leave the swatch painting a superseded one.
+  const { draft, setDraft, edited, reset } = useDraft(stored);
 
   const reference = isTokenRef(stored) ? stored.$token : null;
   const mode = activeTokenMode(tokens, prefersDark);
@@ -1270,36 +1360,34 @@ function ColourField({
   // What the picker composed, written once the gesture is over. Compared
   // against the stored text so closing a picker nobody moved writes nothing.
   const commitDraft = (): void => {
-    if (draft === storedText(stored)) return;
-    if (onCommit(draft) === "unchanged") setDraft(storedText(stored));
+    if (!edited) return;
+    if (onCommit(draft) === "unchanged") reset();
   };
   // What the surface is currently SHOWING: the draft while a literal is being
   // typed, so the swatch follows the field, and the stored value for a
   // reference, which no field is editing. Named once and resolved once, rather
   // than resolved in each branch — two calls to the same resolver is the shape
   // that drifts.
-  const showing = reference === null ? draft : stored;
+  // Once the draft has MOVED, it is what the surface shows — including over a
+  // stored token. Pinned to `stored` for a reference, the picker was handed the
+  // token's own hex again on every render, and its prop-sync effect reset the
+  // surface to it: the controls snapped back mid-drag and a token could not be
+  // replaced with a literal by using the picker at all.
+  const showing = reference === null || edited ? draft : stored;
   const shown = colourHexOf(showing, tokens, mode);
   // Measured from what the surface is SHOWING, which is the same value the
   // swatch is painted from. Reading `stored` instead left the verdict describing
   // the old colour for the whole of a picker gesture — stale exactly while an
   // author is choosing, which is when a contrast readout is for — and put the
   // swatch and the figure beside it on two different colours.
-  const contrast = contrastAtLeaf(
-    control.leaf,
-    showing,
-    pairedColour,
-    tokens,
-    mode
+  const contrast =
+    obscuredBy === undefined
+      ? contrastAtLeaf(control.leaf, showing, pairedColour, tokens, mode)
+      : undefined;
+  const describes = describedByAll(
+    describedBy,
+    contrast === undefined ? undefined : noteId
   );
-  // Both descriptions, not one. A control pointed only at the refusal message
-  // never announces the contrast verdict, and one pointed only at the verdict
-  // drops the reason its last value was refused — so a screen-reader user gets
-  // whichever happens to be listed and no way to reach the other.
-  const describes =
-    [describedBy, contrast === undefined ? undefined : noteId]
-      .filter(part => part !== undefined)
-      .join(" ") || undefined;
 
   return (
     <>
@@ -1318,15 +1406,7 @@ function ColourField({
           actionName={actionName}
           describedBy={describes}
           invalid={describedBy !== undefined}
-          // A warning wherever there is something to LOSE, which is a stored
-          // reference or non-empty text. Tested on the draft alone this missed
-          // every reference — `storedText` answers `""` for one — so opening
-          // the picker on a token the site no longer defines, or one holding
-          // `var(...)`, started its controls at black and the first movement
-          // replaced the reference with a near-black literal, unwarned.
-          unrepresented={
-            shown === undefined && (reference !== null || draft !== "")
-          }
+          unrepresented={wouldReplace(shown, reference, draft)}
           // The draft moves with the pointer and the DOCUMENT does not. A drag
           // across the saturation surface fires `onColorChange` on every
           // pointer event, and committing each one writes an editor op each
@@ -1740,13 +1820,7 @@ function NumericField({
   // author who types `20` over `12px` and then picks `rem` had the blur refuse
   // the unitless draft, leaving `12px` stored — and the menu composed from
   // THAT, committing `12rem` and discarding the 20 they were looking at.
-  const [draft, setDraft] = React.useState(() => storedText(stored));
-  // The stored value wins whenever it changes underneath — an undo, an edit
-  // applied from elsewhere. Without this both controls go on showing a value
-  // the document no longer has.
-  React.useEffect(() => {
-    setDraft(storedText(stored));
-  }, [stored]);
+  const { draft, setDraft } = useDraft(stored);
   // Read from the DRAFT, so the menu offers units for the quantity on screen
   // and swaps the unit on that quantity rather than on a superseded one.
   const measurement = measurementOfText(draft);

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -34,6 +34,9 @@ import {
   isTokenRef,
   trimCssWhitespace,
   type BreakpointId,
+  type ContrastResult,
+  type NodeStyles,
+  type SiteTokenSet,
   type StyleLeaf,
   type StyleShape,
   type StyleState,
@@ -44,8 +47,12 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
+  ColorPicker,
   Input,
   Label,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   Select,
   SelectContent,
   SelectItem,
@@ -56,6 +63,15 @@ import * as React from "react";
 
 import type { EditorState } from "./editor-state";
 import { fieldLabel } from "./inspector";
+import {
+  colourHexOf,
+  colourTokenFor,
+  colourTokensFor,
+  contrastAtLeaf,
+  contrastPartnerOf,
+  contrastRatioText,
+  type ColourToken,
+} from "./style-colour";
 import type {
   StyleControl,
   StyleControlKind,
@@ -104,11 +120,27 @@ export interface StyleInspectorPanelProps {
   state?: StyleState;
   /** The breakpoint being edited. The unconditional one when the host says nothing. */
   breakpoint?: BreakpointId;
+  /**
+   * The site's design tokens, so a colour control can offer them and resolve
+   * one it is shown.
+   *
+   * Separate from `policy.tokens`, which cannot serve this: a `TokenLookup` is
+   * `{ kindOf(name) }` and answers ABOUT a name the caller already has. It can
+   * confirm a reference and cannot enumerate one, so a picker sourced from it
+   * would have nothing to list.
+   *
+   * Carried rather than defaulted, exactly as `policy` is: omitting it does not
+   * mean the site has no tokens, it means the question was never asked. A
+   * control with no table offers no token picker and shows a stored reference
+   * by the identity the document holds, because that is the only name it has.
+   */
+  tokens?: SiteTokenSet;
 }
 
 export function StyleInspectorPanel({
   editor,
   policy,
+  tokens,
   state,
   breakpoint,
 }: StyleInspectorPanelProps): React.JSX.Element {
@@ -213,6 +245,7 @@ export function StyleInspectorPanel({
             breakpoint={inspection.breakpoint}
             editor={editor}
             policy={policy}
+            tokens={tokens}
             onChooseForm={chooseForm}
           />
         ))}
@@ -229,6 +262,7 @@ function StyleSectionItem({
   breakpoint,
   editor,
   policy,
+  tokens,
   onChooseForm,
 }: {
   section: StyleSection;
@@ -237,6 +271,7 @@ function StyleSectionItem({
   breakpoint: BreakpointId;
   editor: EditorState;
   policy: StylePolicy | undefined;
+  tokens: SiteTokenSet | undefined;
   onChooseForm: ChooseForm;
 }): React.JSX.Element {
   // How many of this section's properties this node sets HERE, so an author can
@@ -268,6 +303,7 @@ function StyleSectionItem({
               breakpoint={breakpoint}
               editor={editor}
               policy={policy}
+              tokens={tokens}
               onChooseForm={onChooseForm}
             />
           ))}
@@ -292,6 +328,7 @@ function StylePropertyFields({
   breakpoint,
   editor,
   policy,
+  tokens,
   onChooseForm,
 }: {
   property: InspectedStyleProperty;
@@ -300,6 +337,7 @@ function StylePropertyFields({
   breakpoint: BreakpointId;
   editor: EditorState;
   policy: StylePolicy | undefined;
+  tokens: SiteTokenSet | undefined;
   onChooseForm: ChooseForm;
 }): React.JSX.Element {
   const many = property.controls.length > 1;
@@ -377,6 +415,7 @@ function StylePropertyFields({
           breakpoint={breakpoint}
           editor={editor}
           policy={policy}
+          tokens={tokens}
         />
       ))}
     </div>
@@ -524,6 +563,7 @@ function StyleControlField({
   breakpoint,
   editor,
   policy,
+  tokens,
 }: {
   control: StyleControl;
   label: string;
@@ -554,6 +594,7 @@ function StyleControlField({
   breakpoint: BreakpointId;
   editor: EditorState;
   policy: StylePolicy | undefined;
+  tokens: SiteTokenSet | undefined;
 }): React.JSX.Element {
   const id = React.useId();
   // The message's own id, so the control can point at it. A `role="alert"`
@@ -567,14 +608,12 @@ function StyleControlField({
     property: control.property,
     path: control.path,
   };
-  const node = findNode(editor.document.nodes, nodeId);
-  const stored = readStyleValue(node?.styles, address);
-  // The property alone where a property draws one control, and the property
-  // plus the position where it draws several.
-  const actionName =
-    propertyLabel === label
-      ? propertyLabel
-      : `${propertyLabel} ${label.toLowerCase()}`;
+  // Read ONCE and shared by both lookups below, so the control's own value and
+  // its contrast partner cannot come from two different reads of the document.
+  const styles = findNode(editor.document.nodes, nodeId)?.styles;
+  const stored = readStyleValue(styles, address);
+  const pairedColour = partnerColour(control.leaf, styles, address);
+  const actionName = actionNameFor(propertyLabel, label);
   const [issue, setIssue] = React.useState<string | null>(null);
 
   // A refusal describes the draft that produced it, so it stops describing
@@ -586,80 +625,27 @@ function StyleControlField({
     setIssue(null);
   }, [stored]);
 
-  /*
-   * Read the node at commit time rather than closing over one. A field
-   * committing on blur can fire after another edit has already replaced the
-   * node, and writing from the older copy would resurrect its styles.
-   */
-  const commit = (value: StyleValue | null): CommitOutcome => {
-    const current = findNode(editor.document.nodes, nodeId);
-    if (current === undefined) return "refused";
-    const write =
-      value === null
-        ? styleClearOp(nodeId, current.styles, address, policy)
-        : styleWriteOp(nodeId, current.styles, address, value, policy);
-    if (!write.ok) {
-      setIssue(write.issues[0]?.message ?? "This value cannot be used here.");
-      return "refused";
-    }
-    setIssue(null);
-    // Null is the store saying the document already holds this value, which is
-    // the ordinary case for a field blurred without being changed. Applying it
-    // would ask the op store for a history entry that undoes to no visible
-    // effect, which it refuses.
-    if (write.op === null) return "unchanged";
-    // The store's own refusal, which the validator cannot anticipate: it judges
-    // the edited leaf, while `applyOp` judges the whole document — a page at
-    // its byte limit rejects an edit whose value is perfectly valid. Unreported,
-    // the field goes on showing the draft and reads as saved while neither the
-    // document nor the undo history moved.
-    if (editor.apply(write.op) === null) {
-      setIssue("This edit could not be applied to the document.");
-      return "refused";
-    }
-    return "applied";
-  };
+  const commit = (value: StyleValue | null): CommitOutcome =>
+    writeStyleValue({ editor, nodeId, address, policy, value, setIssue });
 
-  // A value that cannot be typed into is shown, not edited — and HTML's `for`
-  // only associates a label with a LABELABLE element (input, select, textarea,
-  // button, output, meter, progress). Pointing it at the paragraph those
-  // branches render drops the association silently, so the label carries an id
-  // of its own and the value points back at it instead.
-  //
-  // `control.supported` is NOT a term here: the branch below returns before
-  // this is read, so including it would be a condition that can never be true
-  // where it is used.
-  const readOnly =
-    clearOnly ||
-    isTokenRef(stored) ||
-    editableText(control, stored) === undefined;
+  const readOnly = showsNoField(control, stored, clearOnly);
   const labelId = `${id}-label`;
+  // Computed once and used by both the control and its message: two spellings
+  // of "is there an error" is the shape that drifts into a control described by
+  // a message it is not marked invalid for.
+  const describedBy = issue === null ? undefined : errorId;
 
   if (!control.supported) {
     return (
-      <div className="nx-inspector__field" data-unsupported={control.leaf.kind}>
-        {/*
-          The label carries no `htmlFor`, for the reason stated above: this
-          branch renders no labelable element.
-
-          UNTESTED as a CATALOG case, and stated rather than left to be assumed:
-          every leaf kind the engine ships resolves to a control, so a catalog
-          written by a newer engine is the only thing that reaches this — and
-          the catalog is compiled in rather than registered, so no fixture can
-          hand this panel an unknown kind. What IS reachable and IS covered is
-          the value: a node can store one at such a leaf, and it compiles.
-        */}
-        <Label id={labelId} title={summary}>
-          {label}
-        </Label>
-        <RetainedValue
-          labelledBy={labelId}
-          label={actionName}
-          stored={stored}
-          note={`This build has no control for ${control.leaf.kind} values.`}
-          onClear={() => commit(null)}
-        />
-      </div>
+      <UnsupportedField
+        labelId={labelId}
+        label={label}
+        summary={summary}
+        actionName={actionName}
+        leafKind={control.leaf.kind}
+        stored={stored}
+        onClear={() => commit(null)}
+      />
     );
   }
 
@@ -675,7 +661,9 @@ function StyleControlField({
         stored={stored}
         actionName={actionName}
         clearOnly={clearOnly}
-        describedBy={issue === null ? undefined : errorId}
+        tokens={tokens}
+        pairedColour={pairedColour}
+        describedBy={describedBy}
         onCommit={commit}
       />
       {issue === null ? null : (
@@ -702,6 +690,8 @@ function ControlValue({
   stored,
   actionName,
   clearOnly,
+  tokens,
+  pairedColour,
   describedBy,
   onCommit,
 }: {
@@ -711,6 +701,9 @@ function ControlValue({
   stored: StyleValue | undefined;
   actionName: string;
   clearOnly: boolean;
+  tokens: SiteTokenSet | undefined;
+  /** The other half of this control's contrast pair, when its leaf has one. */
+  pairedColour: StyleValue | undefined;
   describedBy: string | undefined;
   onCommit: (value: StyleValue | null) => CommitOutcome;
 }): React.JSX.Element {
@@ -721,6 +714,34 @@ function ControlValue({
         label={actionName}
         stored={stored}
         onClear={() => onCommit(null)}
+      />
+    );
+  }
+  /*
+   * A colour draws its own surface, INCLUDING for a stored token reference.
+   *
+   * Placed before the token branch below rather than after it, because that one
+   * returns for every reference and a colour control would never see one. It
+   * exists for controls that cannot offer a token picker, and says so: choosing
+   * a token was "the token picker's job and it does not exist yet". For a
+   * colour it now does, so a reference here is editable rather than read-only.
+   *
+   * Narrowed on the LEAF rather than on `control.kind`, because the leaf is what
+   * carries `tokenKinds` and `cssProperty` — the two facts the colour surface
+   * asks the catalog for — so passing it narrowed means neither is re-derived.
+   */
+  if (control.leaf.kind === "color") {
+    return (
+      <ColourField
+        id={id}
+        labelledBy={labelledBy}
+        control={{ ...control, leaf: control.leaf }}
+        stored={stored}
+        actionName={actionName}
+        tokens={tokens}
+        pairedColour={pairedColour}
+        describedBy={describedBy}
+        onCommit={onCommit}
       />
     );
   }
@@ -945,6 +966,467 @@ function SelectField({
     </div>
   );
 }
+/**
+ * What this control's clear action removes, named for the author.
+ *
+ * The property alone where a property draws one control, and the property plus
+ * the position where it draws several: `padding` and `margin` both have a block
+ * start, so two buttons called "Clear block start" name the same thing twice
+ * and a screen-reader user cannot tell which style each removes.
+ */
+function actionNameFor(propertyLabel: string, label: string): string {
+  return propertyLabel === label
+    ? propertyLabel
+    : `${propertyLabel} ${label.toLowerCase()}`;
+}
+
+/**
+ * Whether this position renders no element a label can be attached to.
+ *
+ * HTML's `for` only associates a label with a LABELABLE element — input,
+ * select, textarea, button, output, meter, progress. Pointing it at the
+ * paragraph the read-only surfaces render drops the association SILENTLY, so
+ * the label carries an id of its own and the value points back at it instead.
+ *
+ * `control.supported` is not a term here: the caller returns before this is
+ * read, so including it would be a condition that can never be true where it
+ * is used.
+ */
+function showsNoField(
+  control: StyleControl,
+  stored: StyleValue | undefined,
+  clearOnly: boolean
+): boolean {
+  if (clearOnly) return true;
+  // Every reference, whatever the control. The colour surface reaches this the
+  // same way the others do: it draws a name and a button for a reference and a
+  // text field only for a literal, so a reference has no field there either.
+  if (isTokenRef(stored)) return true;
+  return editableText(control, stored) === undefined;
+}
+
+/**
+ * A position this build has no control for: shown by value, and removable.
+ *
+ * Its own component because it is a different SURFACE rather than a variation
+ * of one — nothing here is editable, so no labelable element exists and the
+ * label has to name the value by id instead of pointing at a field.
+ *
+ * UNTESTED as a CATALOG case, and stated rather than left to be assumed: every
+ * leaf kind the engine ships resolves to a control, so only a catalog written
+ * by a newer engine reaches this — and the catalog is compiled in rather than
+ * registered, so no fixture can hand this panel an unknown kind. What IS
+ * reachable and IS covered is the value: a node can store one at such a leaf,
+ * and it compiles.
+ */
+function UnsupportedField({
+  labelId,
+  label,
+  summary,
+  actionName,
+  leafKind,
+  stored,
+  onClear,
+}: {
+  labelId: string;
+  label: string;
+  summary: string | undefined;
+  actionName: string;
+  leafKind: StyleLeaf["kind"];
+  stored: StyleValue | undefined;
+  onClear: () => void;
+}): React.JSX.Element {
+  return (
+    <div className="nx-inspector__field" data-unsupported={leafKind}>
+      {/* No `htmlFor`: this branch renders no labelable element. */}
+      <Label id={labelId} title={summary}>
+        {label}
+      </Label>
+      <RetainedValue
+        labelledBy={labelId}
+        label={actionName}
+        stored={stored}
+        note={`This build has no control for ${leafKind} values.`}
+        onClear={onClear}
+      />
+    </div>
+  );
+}
+
+/**
+ * Apply one control's edit to the document, and say what happened to it.
+ *
+ * Lifted out of the field because it is a different question from drawing one:
+ * the field owns what the author is looking at, and this owns the write — which
+ * of two ops to build, which refusals are reportable, and which of the three
+ * outcomes each produces.
+ *
+ * Read the node at COMMIT TIME rather than closing over one. A field committing
+ * on blur can fire after another edit has already replaced the node, and
+ * writing from the older copy would resurrect its styles.
+ */
+function writeStyleValue({
+  editor,
+  nodeId,
+  address,
+  policy,
+  value,
+  setIssue,
+}: {
+  editor: EditorState;
+  nodeId: string;
+  address: StyleAddress;
+  policy: StylePolicy | undefined;
+  /** `null` clears, which is not the same as writing an empty value. */
+  value: StyleValue | null;
+  setIssue: (message: string | null) => void;
+}): CommitOutcome {
+  const current = findNode(editor.document.nodes, nodeId);
+  if (current === undefined) return "refused";
+  const write =
+    value === null
+      ? styleClearOp(nodeId, current.styles, address, policy)
+      : styleWriteOp(nodeId, current.styles, address, value, policy);
+  if (!write.ok) {
+    setIssue(write.issues[0]?.message ?? "This value cannot be used here.");
+    return "refused";
+  }
+  setIssue(null);
+  // Null is the store saying the document already holds this value, which is
+  // the ordinary case for a field blurred without being changed. Applying it
+  // would ask the op store for a history entry that undoes to no visible
+  // effect, which it refuses.
+  if (write.op === null) return "unchanged";
+  // The store's own refusal, which the validator cannot anticipate: it judges
+  // the edited leaf, while `applyOp` judges the whole document — a page at its
+  // byte limit rejects an edit whose value is perfectly valid. Unreported, the
+  // field goes on showing the draft and reads as saved while neither the
+  // document nor the undo history moved.
+  if (editor.apply(write.op) === null) {
+    setIssue("This edit could not be applied to the document.");
+    return "refused";
+  }
+  return "applied";
+}
+
+/**
+ * The other half of a contrast pair, for a leaf that has one.
+ *
+ * Read from THIS node at the same state and breakpoint the control edits,
+ * which is narrower than the cascade and is the honest limit of what this panel
+ * can answer today: a background arriving from a named class, a block default
+ * or a wider breakpoint is not seen, so the readout reports nothing rather than
+ * measuring against a background that is not the one on the page.
+ *
+ * Answering it properly means asking `styleProvenance`, which has already
+ * settled tier order, both breakpoint axes, states and specificity — and which
+ * needs a `trace` of compiled declarations that nothing supplies to this panel.
+ * Walking the cascade a second time HERE is the thing that must not happen.
+ *
+ * The address is reused rather than rebuilt so the state and breakpoint cannot
+ * drift from the ones the control is reading its own value at — a pair measured
+ * across two breakpoints is two colours that are never drawn together.
+ */
+function partnerColour(
+  leaf: StyleLeaf,
+  styles: NodeStyles | undefined,
+  address: StyleAddress
+): StyleValue | undefined {
+  const property = contrastPartnerOf(leaf);
+  if (property === undefined) return undefined;
+  return readStyleValue(styles, { ...address, property, path: [] });
+}
+
+/**
+ * The hex a picker opens on when the stored value cannot be decomposed.
+ *
+ * Black, and it is never WRITTEN by being shown: the picker reports a colour
+ * only when the author moves something. So this is where the surface starts for
+ * a value it cannot represent, not a value substituted for one.
+ */
+const PICKER_FALLBACK = "#000000";
+
+/**
+ * A colour: a swatch that opens a picker, beside the field that owns the value.
+ *
+ * **The text field remains the control**, exactly as it does for a length. A
+ * stored colour may be `oklch()`, `color-mix()`, a named colour, `currentcolor`,
+ * a CSS-wide keyword or a `var()`, and a control that modelled the value as
+ * RGBA would write every one of them away the moment it opened. The picker is
+ * an affordance on top, and it reports nothing until the author moves it.
+ *
+ * **A token reference is EDITABLE here rather than read-only**, which is the
+ * other half of what this control adds. `TokenValue` shows a reference and
+ * offers only Clear because choosing a token had nowhere to happen; a colour
+ * control has the site's table, so it shows the token's CURRENT name and lets
+ * the author swap it, replace it with a literal, or remove it.
+ *
+ * **A token is stored by IDENTITY, never by the name shown.** The two differ
+ * after a rename, and `ColourToken` carries both for that reason — the picker
+ * hands back the swatch it was given, so the identity travels with it and the
+ * label never reaches the document.
+ *
+ * **Literal and token are exclusive**, which is what the two layouts express.
+ * The same rule Gutenberg's palette follows: a value is a reference or a
+ * colour, and nothing sensible reads as both at once.
+ */
+function ColourField({
+  id,
+  labelledBy,
+  control,
+  stored,
+  actionName,
+  tokens,
+  pairedColour,
+  describedBy,
+  onCommit,
+}: {
+  id: string;
+  labelledBy: string;
+  control: StyleControl & { leaf: Extract<StyleLeaf, { kind: "color" }> };
+  stored: StyleValue | undefined;
+  actionName: string;
+  tokens: SiteTokenSet | undefined;
+  pairedColour: StyleValue | undefined;
+  describedBy: string | undefined;
+  onCommit: (value: StyleValue | null) => CommitOutcome;
+}): React.JSX.Element {
+  const noteId = React.useId();
+  // The draft lives here for the reason it does in `NumericField`: two controls
+  // edit one value, so a draft private to the text field would leave the swatch
+  // painting a superseded one.
+  const [draft, setDraft] = React.useState(() => storedText(stored));
+  React.useEffect(() => {
+    setDraft(storedText(stored));
+  }, [stored]);
+
+  const reference = isTokenRef(stored) ? stored.$token : null;
+  const choices = colourTokensFor(control.leaf, tokens);
+  // What the surface is currently SHOWING: the draft while a literal is being
+  // typed, so the swatch follows the field, and the stored value for a
+  // reference, which no field is editing. Named once and resolved once, rather
+  // than resolved in each branch — two calls to the same resolver is the shape
+  // that drifts.
+  const showing = reference === null ? draft : stored;
+  const shown = colourHexOf(showing, tokens);
+  const contrast = contrastAtLeaf(control.leaf, stored, pairedColour, tokens);
+
+  return (
+    <>
+      <div
+        className="nx-style-inspector__colour"
+        // Named as a GROUP only where there is no field to carry the name: with
+        // a text input present the label points at it directly, and a group
+        // wrapping a named control announces the property twice.
+        {...(reference === null
+          ? {}
+          : { role: "group", "aria-labelledby": labelledBy })}
+      >
+        <ColourPicker
+          shown={shown}
+          choices={choices}
+          actionName={actionName}
+          describedBy={describedBy}
+          // A warning is only worth showing where there is something to lose:
+          // an empty field has nothing, and a value the picker CAN show needs
+          // no notice. A reference falls out of the first test on its own,
+          // since it is displayed by name and never as draft text.
+          unrepresented={shown === undefined && draft !== ""}
+          onColour={value => {
+            if (onCommit(value) !== "refused") setDraft(value);
+          }}
+          onToken={identity => onCommit({ $token: identity })}
+        />
+        {reference === null ? (
+          // The SAME field every other text control uses, rather than one
+          // written here. Commit on blur, Enter, the empty draft that clears
+          // instead of storing `""`, and the `unchanged` case that puts back
+          // what the document holds are one contract — and a second copy of it
+          // beside the first is what drifts, silently, in the direction of
+          // losing an edit.
+          <TextField
+            id={id}
+            control={control}
+            stored={stored}
+            draft={draft}
+            setDraft={setDraft}
+            describedBy={describedBy}
+            onCommit={onCommit}
+          />
+        ) : (
+          <TokenName
+            identity={reference}
+            token={colourTokenFor(reference, tokens)}
+            actionName={actionName}
+            onClear={() => onCommit(null)}
+          />
+        )}
+      </div>
+      <ContrastNote id={noteId} contrast={contrast} />
+    </>
+  );
+}
+
+/**
+ * The swatch, and the surface it opens onto.
+ *
+ * Its own component because CHOOSING a colour is a different question from
+ * showing one: the row below owns the stored value and its text, and this owns
+ * the picker, the token swatches and what the trigger is painted with. Kept
+ * together here because all three read the one resolved colour, and split from
+ * the row because neither half needs the other's state.
+ *
+ * The two callbacks stay separate for the reason `ColorPicker` keeps them
+ * separate: only the host knows what a swatch MEANS. A token hands back its
+ * identity and never the colour it currently resolves to — storing that would
+ * turn a reference into a literal and stop the page following the token.
+ */
+function ColourPicker({
+  shown,
+  choices,
+  actionName,
+  describedBy,
+  unrepresented,
+  onColour,
+  onToken,
+}: {
+  /** The resolved colour, or `undefined` when nothing here can resolve one. */
+  shown: string | undefined;
+  choices: readonly ColourToken[];
+  actionName: string;
+  describedBy: string | undefined;
+  /** Whether the stored value is one the picker cannot show. */
+  unrepresented: boolean;
+  onColour: (hex: string) => void;
+  onToken: (identity: string) => void;
+}): React.JSX.Element {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="nx-style-inspector__swatch"
+          aria-label={`Colour for ${actionName}`}
+          aria-describedby={describedBy}
+          // Painted through a custom property rather than `background-color`
+          // directly, so the chequerboard beneath a translucent colour stays
+          // visible through it. `undefined` leaves the class's own "nothing
+          // here" appearance rather than a colour this cannot vouch for.
+          style={
+            shown === undefined
+              ? undefined
+              : ({ "--nx-swatch": shown } as React.CSSProperties)
+          }
+          data-empty={shown === undefined ? "" : undefined}
+        />
+      </PopoverTrigger>
+      <PopoverContent className="nx-style-inspector__picker">
+        {unrepresented ? (
+          <p className="nx-inspector__note">
+            This value cannot be shown on the picker. Choosing here replaces it.
+          </p>
+        ) : null}
+        <ColorPicker<ColourToken>
+          // A fallback only where nothing could be resolved, and it is never
+          // WRITTEN by being shown: the picker reports a colour only once the
+          // author moves something, so opening it over a value it cannot
+          // represent changes nothing.
+          color={shown ?? PICKER_FALLBACK}
+          showAlpha
+          swatches={choices.map(choice => ({
+            // The IDENTITY as the swatch id, which is what keeps the list
+            // stable across a rename: a key built from the label would remount
+            // every renamed token's swatch, and would collide between a renamed
+            // token and a new one that took its old name.
+            id: choice.identity,
+            label: choice.name,
+            color: choice.colour,
+            value: choice,
+          }))}
+          onColorChange={onColour}
+          onSwatchSelect={swatch => {
+            if (swatch.value !== undefined) onToken(swatch.value.identity);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/**
+ * A stored token, by the name an author reads, with the way to remove it.
+ *
+ * The name is resolved by the caller and the fallback is the stored identity,
+ * which is the honest answer for a reference to a token the site no longer
+ * defines: an unknown token is a warning rather than an error, so the value
+ * goes on compiling and the author is shown the string their document holds
+ * rather than an empty space.
+ */
+function TokenName({
+  identity,
+  token,
+  actionName,
+  onClear,
+}: {
+  /** What the document stores, and the fallback when nothing resolves it. */
+  identity: string;
+  /** The site's token of that identity, when it defines one. */
+  token: ColourToken | undefined;
+  actionName: string;
+  onClear: () => void;
+}): React.JSX.Element {
+  return (
+    <>
+      <span className="nx-style-inspector__colour-token">
+        {token?.name ?? identity}
+      </span>
+      <button
+        type="button"
+        onClick={onClear}
+        aria-label={`Clear ${actionName}`}
+      >
+        Clear
+      </button>
+    </>
+  );
+}
+
+/**
+ * How a colour pair fares, or nothing at all.
+ *
+ * `undefined` renders NOTHING rather than a placeholder, an approximation or a
+ * last-known figure. That is the engine's own reasoning carried up one level:
+ * a ratio computed from a colour that was misread "is worse than no figure,
+ * because it is a number somebody will act on", and there is no honest estimate
+ * of the contrast against a `var()` whose value the page decides at render.
+ *
+ * A failing pair is a WARNING and never a refusal — the value is valid, stored
+ * and compiling, and the author may have a reason. The same position
+ * Gutenberg's contrast checker takes.
+ */
+function ContrastNote({
+  id,
+  contrast,
+}: {
+  id: string;
+  contrast: ContrastResult | undefined;
+}): React.JSX.Element | null {
+  if (contrast === undefined) return null;
+  return (
+    <p
+      className="nx-style-inspector__contrast"
+      id={id}
+      data-level={contrast.level}
+    >
+      {`Contrast ${contrastRatioText(contrast)} — ${
+        contrast.passesBodyText
+          ? `passes AA for body text (${contrast.level})`
+          : "below AA for body text"
+      }`}
+    </p>
+  );
+}
+
 /**
  * The control a leaf's kind resolves to.
  *

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -1417,6 +1417,17 @@ function ColourField({
     () => () => {
       const unwritten = pending.current;
       pending.current = null;
+      // The outcome is DROPPED, and that is the honest limit rather than an
+      // oversight. A refusal here — a document at its byte limit, say — is
+      // reported through state belonging to a component that is going away, so
+      // there is nobody left to show it to and nowhere to keep the value: the
+      // ref does not survive the remount either. Writing when the document
+      // accepts strictly improves on not writing at all, and cannot improve the
+      // case where it does not.
+      //
+      // Closing it properly means the pending edit living somewhere that
+      // outlives one field, which is the same thing undo and the unsaved-work
+      // guard need and is tracked with them.
       if (unwritten !== null) write.current(unwritten);
     },
     []

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -1359,6 +1359,21 @@ function ColourField({
   // in state because the unmount flush below reads it from a cleanup that runs
   // once, where the closed-over `draft` would be the value at first render.
   const pending = React.useRef<string | null>(null);
+  /*
+   * A discrete choice, which SUPERSEDES anything the picker was mid-way through.
+   *
+   * Choosing a preset or clearing does not close the popover, so without
+   * dropping the pending gesture the unmount flush below would write the older
+   * literal over the choice just made — an author picks a token and the token
+   * is silently replaced by the hex they had been dragging past.
+   *
+   * One function for both, because "this supersedes the gesture" is one rule
+   * and two copies of it is one edit away from covering only one path.
+   */
+  const commitInstead = (value: StyleValue | null): void => {
+    pending.current = null;
+    onCommit(value);
+  };
   const commitDraft = (): void => {
     pending.current = null;
     if (!edited) return;
@@ -1452,7 +1467,7 @@ function ColourField({
           onClosed={commitDraft}
           // A preset is one discrete choice rather than a gesture, so it
           // commits immediately, exactly as the select and toggle controls do.
-          onToken={identity => onCommit({ $token: identity })}
+          onToken={identity => commitInstead({ $token: identity })}
         />
         {reference === null ? (
           // The SAME field every other text control uses, rather than one
@@ -1478,7 +1493,7 @@ function ColourField({
             identity={reference}
             token={colourTokenFor(reference, tokens, mode)}
             actionName={actionName}
-            onClear={() => onCommit(null)}
+            onClear={() => commitInstead(null)}
           />
         )}
       </div>

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -1504,6 +1504,9 @@ function ColourField({
             identity={reference}
             token={colourTokenFor(reference, tokens, mode)}
             actionName={actionName}
+            onSupersede={() => {
+              pending.current = null;
+            }}
             onClear={() => commitInstead(null)}
           />
         )}
@@ -1628,6 +1631,7 @@ function TokenName({
   identity,
   token,
   actionName,
+  onSupersede,
   onClear,
 }: {
   /** What the document stores, and the fallback when nothing resolves it. */
@@ -1635,6 +1639,19 @@ function TokenName({
   /** The site's token of that identity, when it defines one. */
   token: ColourToken | undefined;
   actionName: string;
+  /**
+   * The clear has begun, before anything around it can react to the pointer.
+   *
+   * Separate from {@link onClear} because of WHEN it runs rather than what it
+   * does. This button sits outside the picker'"'"'s popover, so pressing it is an
+   * outside interaction: Radix dismisses on a `pointerdown` listener attached
+   * to the document, and React'"'"'s handlers are attached to the root container
+   * inside it — so this fires first, and the surrounding control can drop an
+   * unfinished gesture before the dismissal commits it. Without that the close
+   * writes the picker'"'"'s literal and the clear removes it, two history entries
+   * where one undo returns an intermediate value the author never chose.
+   */
+  onSupersede: () => void;
   onClear: () => void;
 }): React.JSX.Element {
   return (
@@ -1644,6 +1661,7 @@ function TokenName({
       </span>
       <button
         type="button"
+        onPointerDown={onSupersede}
         onClick={onClear}
         aria-label={`Clear ${actionName}`}
       >

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -1362,47 +1362,54 @@ function ColourField({
   /*
    * A discrete choice, which SUPERSEDES anything the picker was mid-way through.
    *
-   * Choosing a preset or clearing does not close the popover, so without
-   * dropping the pending gesture the unmount flush below would write the older
-   * literal over the choice just made — an author picks a token and the token
-   * is silently replaced by the hex they had been dragging past.
-   *
-   * One function for both, because "this supersedes the gesture" is one rule
-   * and two copies of it is one edit away from covering only one path.
+   * Dropping the pending value is the whole of it. A write scheduled by the
+   * dismissal this control caused reads that same value when it runs, so
+   * clearing it leaves the scheduled call with nothing to write — cancelling
+   * the timer as well was measured to change no outcome, and a second
+   * expression for one rule is what drifts.
    */
   const commitInstead = (value: StyleValue | null): void => {
     pending.current = null;
     onCommit(value);
   };
   /*
-   * The gesture, written once, when the picker closes.
+   * The gesture, written a beat after the picker closes rather than during it.
    *
-   * Reads the SAME pending value the unmount flush and `commitInstead` do, so
-   * the three cannot disagree about whether there is anything to write. Deciding
-   * from `edited` instead let a superseded gesture through: a token commit that
-   * was REFUSED — a document at its byte limit, say — cleared the pending value
-   * and left the older literal in the draft, and closing the popover then wrote
-   * that literal even though choosing the token was meant to replace it.
+   * Deferred because CLOSING and CHOOSING can be one interaction. The controls
+   * that supersede a gesture — the token presets, the clear — sit outside the
+   * popover, so pressing one dismisses it first: the close wrote the picker's
+   * literal and the choice then replaced it, two history entries where one undo
+   * returns an intermediate colour the author never picked.
+   *
+   * Deferring rather than hooking the dismissal is what makes that hold for
+   * EVERY cause. Radix dismisses on `pointerdown`, `focusin`, `keydown`,
+   * `click`, `pointerup`, `mousedown` and `mouseup`, so a control clearing the
+   * gesture on pointer-down covered a mouse and missed a keyboard — where focus
+   * reaches the button first and the activation follows. Enumerating that list
+   * here would be a copy of someone else's, kept in step by hand.
+   *
+   * A timeout rather than a microtask: a dismissal and the activation that
+   * caused it are separate tasks, so a microtask would still run between them.
    */
   const commitDraft = (): void => {
+    if (pending.current === null) return;
+    cancelWrite();
+    scheduled.current = window.setTimeout(flush, 0);
+  };
+  /** Write whatever the picker produced and has not had written yet. */
+  const flush = (): void => {
+    scheduled.current = null;
     const unwritten = pending.current;
     pending.current = null;
     if (unwritten === null) return;
-    if (onCommit(unwritten) === "unchanged") reset();
+    if (write.current(unwritten) === "unchanged") reset();
   };
-  /*
-   * Flush an unwritten gesture when this field goes away.
-   *
-   * The popover commits on close, and a close is not the only way an author
-   * leaves: selecting another block in the canvas iframe cannot reach the
-   * popover's outside-dismiss handler, and the selection change remounts this
-   * field — which does not fire `onOpenChange`. Without this the adjustment,
-   * and the whole gesture behind it, is discarded silently.
-   *
-   * Written through a ref and an empty dependency list so it runs exactly once,
-   * at teardown. `onCommit` reads the node from the store at call time, so a
-   * write from here lands on the current document rather than a captured one.
-   */
+  const scheduled = React.useRef<number | null>(null);
+  const cancelWrite = (): void => {
+    if (scheduled.current === null) return;
+    window.clearTimeout(scheduled.current);
+    scheduled.current = null;
+  };
   // The current writer, held so the teardown below depends on nothing. A
   // teardown listing `onCommit` would re-run its cleanup on every render that
   // gives the field a new callback — which is every render — and flush a
@@ -1411,9 +1418,21 @@ function ColourField({
   React.useEffect(() => {
     write.current = onCommit;
   });
+  /*
+   * Write an unfinished gesture when this field goes away, and do it NOW.
+   *
+   * Two ways to leave without closing the popover: selecting another block in
+   * the canvas iframe cannot reach the outside-dismiss handler, and the
+   * selection change remounts this field without firing `onOpenChange`. A
+   * scheduled write would not survive either, so the timer is cancelled and the
+   * value written synchronously rather than left to a callback whose component
+   * has gone.
+   */
   React.useEffect(
     () => () => {
+      cancelWrite();
       const unwritten = pending.current;
+      pending.current = null;
       if (unwritten !== null) write.current(unwritten);
     },
     []
@@ -1504,9 +1523,6 @@ function ColourField({
             identity={reference}
             token={colourTokenFor(reference, tokens, mode)}
             actionName={actionName}
-            onSupersede={() => {
-              pending.current = null;
-            }}
             onClear={() => commitInstead(null)}
           />
         )}
@@ -1631,7 +1647,6 @@ function TokenName({
   identity,
   token,
   actionName,
-  onSupersede,
   onClear,
 }: {
   /** What the document stores, and the fallback when nothing resolves it. */
@@ -1639,19 +1654,6 @@ function TokenName({
   /** The site's token of that identity, when it defines one. */
   token: ColourToken | undefined;
   actionName: string;
-  /**
-   * The clear has begun, before anything around it can react to the pointer.
-   *
-   * Separate from {@link onClear} because of WHEN it runs rather than what it
-   * does. This button sits outside the picker'"'"'s popover, so pressing it is an
-   * outside interaction: Radix dismisses on a `pointerdown` listener attached
-   * to the document, and React'"'"'s handlers are attached to the root container
-   * inside it — so this fires first, and the surrounding control can drop an
-   * unfinished gesture before the dismissal commits it. Without that the close
-   * writes the picker'"'"'s literal and the clear removes it, two history entries
-   * where one undo returns an intermediate value the author never chose.
-   */
-  onSupersede: () => void;
   onClear: () => void;
 }): React.JSX.Element {
   return (
@@ -1661,7 +1663,6 @@ function TokenName({
       </span>
       <button
         type="button"
-        onPointerDown={onSupersede}
         onClick={onClear}
         aria-label={`Clear ${actionName}`}
       >

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -70,6 +70,7 @@ import {
   colourTokenFor,
   colourTokensFor,
   contrastAtLeaf,
+  contrastObscuredAbove,
   contrastObscuredIn,
   contrastPartnerOf,
   contrastRatioText,
@@ -664,7 +665,13 @@ function StyleControlField({
   const styles = findNode(editor.document.nodes, nodeId)?.styles;
   const stored = readStyleValue(styles, address);
   const pairedColour = partnerColour(control.leaf, styles, address);
-  const obscuredBy = contrastObscuredIn(styles);
+  // This node's own styles first, then every ancestor's. An ancestor's
+  // `opacity`, `filter` or `mixBlendMode` composites this node along with the
+  // rest of the subtree, so both colours reach the eye altered and the ratio
+  // between the two stored values describes a rendering that does not happen.
+  const obscuredBy =
+    contrastObscuredIn(styles) ??
+    contrastObscuredAbove(editor.document.nodes, nodeId);
   const actionName = actionNameFor(propertyLabel, label);
   const [issue, setIssue] = React.useState<string | null>(null);
 

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -407,6 +407,93 @@
 }
 
 /*
+ * A colour row: the swatch that opens the picker, then whatever holds the value.
+ *
+ * Laid out like the numeric row and named as its own class for the reason that
+ * one records — the second child is an input for a literal and a name plus a
+ * Clear button for a token reference, so a positional rule would size two
+ * different things.
+ */
+.nx-style-inspector__colour {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.nx-style-inspector__colour > :nth-child(2) {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/*
+ * The swatch, over a chequerboard so a translucent colour reads as translucent
+ * rather than as a lighter opaque one.
+ *
+ * The colour arrives as `--nx-swatch` rather than as `background-color` so it
+ * can be layered over that chequerboard in one declaration. A swatch with no
+ * colour set paints nothing and shows the chequerboard alone, which is the
+ * honest appearance for a value this panel cannot resolve.
+ *
+ * design-lint-ok: the chequerboard greys are the standard rendering of "no
+ * colour here" and must not move with the theme, exactly as the picker's own
+ * are.
+ */
+.nx-style-inspector__swatch {
+  flex: 0 0 auto;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  cursor: pointer;
+  border: 1px solid var(--nx-border);
+  border-radius: var(--radius-sm);
+  background-image:
+    linear-gradient(
+      var(--nx-swatch, transparent),
+      var(--nx-swatch, transparent)
+    ),
+    repeating-conic-gradient(#c8c8c8 0% 25%, #ffffff 0% 50%); /* design-lint-ok: the chequerboard is the standard rendering of "no colour", and must not move with the theme — the same fixed greys ui's own ColorPicker uses */
+  background-size:
+    100% 100%,
+    0.5rem 0.5rem;
+}
+
+.nx-style-inspector__swatch:focus-visible {
+  outline: 2px solid var(--nx-accent);
+  outline-offset: 1px;
+}
+
+/* The token's name, beside the swatch, where a literal would show its field. */
+.nx-style-inspector__colour-token {
+  overflow: hidden;
+  font-size: 0.8125rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/*
+ * The contrast readout, under the row it describes.
+ *
+ * Coloured by VERDICT rather than by ratio, so the three thresholds the
+ * specification names are what the eye reads — and a failing pair is not made
+ * to look like an error the panel refused, because it is a warning about a
+ * value that is stored and valid.
+ */
+.nx-style-inspector__contrast {
+  margin: 0.25rem 0 0;
+  font-size: 0.75rem;
+  color: var(--nx-muted-foreground);
+}
+
+.nx-style-inspector__contrast[data-level="fail"] {
+  color: var(--nx-destructive);
+}
+
+/* Sized to the picker rather than to the trigger it hangs from. */
+.nx-style-inspector__picker {
+  width: auto;
+}
+
+/*
  * Two states of one property, drawn as one segmented control rather than two
  * buttons that happen to be adjacent: they share a border and split the width,
  * so the pair reads as a single choice with one side taken.
@@ -539,7 +626,7 @@
   margin: 0;
   padding: 0.375rem 0.5rem;
   border: 1px solid var(--nx-border);
-  border-radius: var(--nx-radius-sm, 0.25rem);
+  border-radius: var(--radius-sm);
   font-size: 0.8125rem;
   background: var(--nx-muted);
 }

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -409,10 +409,11 @@
 /*
  * A colour row: the swatch that opens the picker, then whatever holds the value.
  *
- * Laid out like the numeric row and named as its own class for the reason that
- * one records — the second child is an input for a literal and a name plus a
- * Clear button for a token reference, so a positional rule would size two
- * different things.
+ * The two things that can hold it are named rather than found by position, for
+ * the reason the unit menu above records: a literal puts an input here and a
+ * token reference puts a name and a Clear button, so `:nth-child(2)` sizes
+ * whichever happens to be second and matches the wrong element as soon as the
+ * row is composed differently.
  */
 .nx-style-inspector__colour {
   display: flex;
@@ -420,7 +421,8 @@
   gap: 0.375rem;
 }
 
-.nx-style-inspector__colour > :nth-child(2) {
+.nx-style-inspector__colour input,
+.nx-style-inspector__colour-token {
   flex: 1 1 auto;
   min-width: 0;
 }
@@ -439,6 +441,14 @@
  * are.
  */
 .nx-style-inspector__swatch {
+  /*
+   * Declared here, and OVERRIDDEN from the element's own style attribute when
+   * the panel has a colour to paint. Declaring it means the stylesheet is
+   * self-contained — a rule referencing a property nothing in CSS defines reads
+   * as a broken reference to anything analysing the sheet on its own, and the
+   * JavaScript that sets it is not visible from there.
+   */
+  --nx-swatch: transparent;
   flex: 0 0 auto;
   width: 1.75rem;
   height: 1.75rem;
@@ -447,10 +457,7 @@
   border: 1px solid var(--nx-border);
   border-radius: var(--radius-sm);
   background-image:
-    linear-gradient(
-      var(--nx-swatch, transparent),
-      var(--nx-swatch, transparent)
-    ),
+    linear-gradient(var(--nx-swatch), var(--nx-swatch)),
     repeating-conic-gradient(#c8c8c8 0% 25%, #ffffff 0% 50%); /* design-lint-ok: the chequerboard is the standard rendering of "no colour", and must not move with the theme — the same fixed greys ui's own ColorPicker uses */
   background-size:
     100% 100%,
@@ -465,7 +472,7 @@
 /* The token's name, beside the swatch, where a literal would show its field. */
 .nx-style-inspector__colour-token {
   overflow: hidden;
-  font-size: 0.8125rem;
+  font-size: var(--text-sm);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -480,7 +487,7 @@
  */
 .nx-style-inspector__contrast {
   margin: 0.25rem 0 0;
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--nx-muted-foreground);
 }
 

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -491,6 +491,16 @@
   color: var(--nx-muted-foreground);
 }
 
+/*
+ * Nothing to say yet. The element stays in the document so it can announce a
+ * verdict that appears later — a live region only speaks when its contents
+ * CHANGE — and `display: none` would remove it from the accessibility tree
+ * instead. Dropping the margin is all that is needed to make it take no room.
+ */
+.nx-style-inspector__contrast:empty {
+  margin: 0;
+}
+
 .nx-style-inspector__contrast[data-level="fail"] {
   color: var(--nx-destructive);
 }

--- a/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
@@ -255,3 +255,64 @@ describe("when the stored style cannot be read at all", () => {
     expect(document.querySelector('[data-canvas-state="failed"]')).toBeNull();
   });
 });
+
+describe("what the token picker waits for", () => {
+  /**
+   * A site whose config defines a colour token.
+   *
+   * Required by every case here, including the negatives: with no token defined
+   * anywhere, `tokens` is undefined whatever the gate does, and the two
+   * withholding assertions would pass on the fixture rather than on the gate.
+   * Measured — the control below failed until this was supplied.
+   */
+  beforeEach(() => {
+    clientConfig = {
+      siteStyle: {
+        tokens: {
+          tokens: [
+            { name: "color.ink", kind: "color", values: { light: "#111111" } },
+          ],
+        },
+      },
+    };
+  });
+
+  it("offers no tokens while the stored style is still arriving", () => {
+    // The same reasoning that holds the canvas back, one surface over. The
+    // defaults `useSiteStyle` answers with meanwhile are a real design, so a
+    // picker fed from them offers a token by a name and colour the site may
+    // have overridden — and the identity an author chose then resolves to
+    // something else on the published page.
+    siteStyleRead = { data: undefined, isPending: true, error: null };
+
+    openEditor();
+
+    expect(seen.inspector).toBeDefined();
+    expect(seen.inspector?.tokens).toBeUndefined();
+  });
+
+  it("offers no tokens when the stored style cannot be read at all", () => {
+    // `pending` is false on this path while the merged value falls back to the
+    // config defaults, so gating on `pending` alone would hand the picker a
+    // tier nobody has read.
+    siteStyleRead = {
+      data: undefined,
+      isPending: false,
+      error: new Error("Forbidden"),
+    };
+
+    openEditor();
+
+    expect(seen.inspector?.tokens).toBeUndefined();
+  });
+
+  it("offers the merged tokens once the read has answered", () => {
+    // The control. Without it a build that never passed tokens at all would
+    // pass both tests above.
+    siteStyleRead = { data: undefined, isPending: false, error: null };
+
+    openEditor();
+
+    expect(seen.inspector?.tokens).toBeDefined();
+  });
+});

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -38,6 +38,7 @@ import {
   registerBlocks,
   registryNestingSource,
   type BlockDocument,
+  type SiteTokenSet,
 } from "@nextlyhq/blocks-engine";
 import { CORE_CATEGORIES, coreBlocks } from "@nextlyhq/blocks-react/blocks";
 import { registrySlotSource } from "@nextlyhq/builder";
@@ -76,7 +77,7 @@ import {
 
 import { emptyBlockDocument } from "../fields/blocks-document";
 import { hostFetchPolicy, readRemotePatterns } from "../host-policy";
-import { siteBreakpoints, siteSheet } from "../site-style";
+import { siteBreakpoints, siteSheet, type SiteStyleData } from "../site-style";
 import { readSiteStyleRecord } from "../site-style-record";
 
 import { BlocksSummary } from "./BlocksSummary";
@@ -327,6 +328,31 @@ function useCheckpoints<TFieldValues extends FieldValues>({
  * ask the admin to hide its navigation for every entry form holding a blocks
  * field, open or not.
  */
+/**
+ * The tokens an inspector may offer, or `undefined` while the site's own tier
+ * is still unknown.
+ *
+ * Withheld on exactly the two states that hold the CANVAS back, and for the
+ * same reason. Until the stored read answers, the merged value is the config
+ * defaults alone — a real design rather than a placeholder — so a picker fed
+ * from it offers a token by a name and a colour the site may have overridden,
+ * and the identity an author chooses then resolves to something else on the
+ * published page. The error path matters as much as the pending one: `pending`
+ * is false there while the value has still fallen back to defaults.
+ *
+ * `undefined` rather than an empty set, because the control reads absence as
+ * "the question was never asked" and offers no picker at all — which is the
+ * truth here, and is different from a site that defines no tokens.
+ */
+function offerableTokens(
+  style: SiteStyleData | undefined,
+  pending: boolean,
+  error: unknown
+): SiteTokenSet | undefined {
+  if (pending || error !== null) return undefined;
+  return style?.tokens;
+}
+
 function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   initialValue,
   onCommit,
@@ -582,7 +608,11 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
           <InspectorPanel
             editor={editor}
             policy={stylePolicy}
-            tokens={canvasSiteStyle?.tokens}
+            tokens={offerableTokens(
+              canvasSiteStyle,
+              siteStylePending,
+              siteStyleError
+            )}
           />
         }
         // Switched on the panel id rather than rendering the inserter for

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -570,7 +570,21 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
         // The policy travels with the panel because the Style tab judges a
         // written value at the keystroke and has to reach the same verdict the
         // published compiler will.
-        inspector={<InspectorPanel editor={editor} policy={stylePolicy} />}
+        //
+        // The tokens travel with it for the same reason one step further: a
+        // colour control offers the site's tokens and resolves a stored
+        // reference to the name an author currently reads, and `policy.tokens`
+        // cannot serve either — a `TokenLookup` answers ABOUT a name the caller
+        // already holds and cannot enumerate one. This is the MERGED set the
+        // canvas compiles with, so the picker offers exactly the tokens the
+        // page will resolve.
+        inspector={
+          <InspectorPanel
+            editor={editor}
+            policy={stylePolicy}
+            tokens={canvasSiteStyle?.tokens}
+          />
+        }
         // Switched on the panel id rather than rendering the inserter for
         // whatever the rail reports open. The shell asks for the panel it
         // opened, and a renderer ignoring that argument would draw the inserter

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -350,7 +350,13 @@ function offerableTokens(
   error: unknown
 ): SiteTokenSet | undefined {
   if (pending || error !== null) return undefined;
-  return style?.tokens;
+  // A SET even when the site defines nothing, because the renderer compiles
+  // with `resolveSiteTokens`, which layers the engine's own defaults underneath.
+  // A site with no tokens of its own still emits `color.text`, `color.primary`
+  // and the rest, so handing over `undefined` here would have the picker offer
+  // none of them — and `undefined` already means something else to the control:
+  // that the question was never asked.
+  return style?.tokens ?? { tokens: [] };
 }
 
 function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({


### PR DESCRIPTION
Closes the C-5 gate on the tokens studio (`task:pb-colour-controls`). A colour
leaf used to fall through to a plain text field; it now draws a swatch that
opens a picker, offers the site's colour tokens, and reports WCAG contrast for a
text-and-background pair.

## The design, and why it is a projection rather than a model

A stored colour is a **string**, and `checkColorValue` accepts far more than a
hex: the ~148 named colours, the system colours, `transparent`, `currentcolor`,
the five CSS-wide keywords, and **sixteen** functions including `oklch()`,
`color-mix()`, `light-dark()` and `var()` — plus a `{ $token }` reference, which
is a record and nonetheless a scalar. A picker that modelled the value as RGBA
could represent one of those and would write the rest away the moment it opened.

So the **text field remains the control**, exactly as it does for a length in
#1139. `style-colour.ts` answers `undefined` for anything it cannot resolve and
every caller keeps the plain field. **The picker reports nothing until the
author moves something**, so opening it over a value it cannot represent changes
nothing.

### Three domains disagree, and are kept apart rather than merged

| question | answered by | domain |
|---|---|---|
| what may be STORED | `checkColorValue` | hex, named + system colours, CSS-wide keywords, 16 functions |
| what contrast may be computed FROM | engine `parseColor` | **hex and `rgb()`/`rgba()` only** |
| what the picker can open on | `parseHex` | hex |

The engine's own docblock gives the reason for the middle row: a figure from a
colour it misread "is worse than no figure, because it is a number somebody will
act on". `var()` is unjudgeable in principle rather than by omission — its value
is not known until the page renders.

**A swatch is painted only with a colour resolved here.** That is narrower than
what a browser can paint, and the exclusion is principled: every value it leaves
out means *resolve this somewhere else*, and the inspector is not that
somewhere. `var(--site-color-primary)` painted into the panel resolves against
the PANEL's custom properties; `currentcolor` takes the panel's text colour;
`inherit` takes the swatch's parent. Each would show an author a colour their
page does not have.

### A token is stored by IDENTITY, never by the name shown

`emitTokenBlocks` writes each custom property from `tokenIdentity(token)` while
the compiler composes `var(...)` from the stored string **verbatim**, with no
lookup against the table. So the two agree only when the stored string is the
identity — and after a rename they differ. Storing the label would reference a
property nothing declares, which invalidates the declaration rather than
reporting: the page keeps rendering with the style missing. That is precisely
the failure `SiteToken.id` was landed in #1137 to prevent.

A stored reference is displayed under the token's **current** name, falling back
to the stored identity when the site defines no token by it (a dangling
reference is a warning, not an error, so it still compiles and must still be
shown).

### Contrast

Calls the **engine's** `style/contrast.ts` per `decision:pb-colour-parser-boundary`
(D-05.4), and resolves a token on both sides first — so a pair written as two
references is measured rather than declined, which is the ordinary case in a
design system. A pair it cannot read reports **nothing at all**: not a greyed
estimate, not a `~`, not a last-known value. It **warns and never blocks**, the
position Gutenberg's `ContrastChecker` takes.

## Prior art

Read at source, recorded as `research:pb-colour-controls-shape`. **Gutenberg**
stores a slug for a theme colour and a hex for a custom one, mutually exclusive
— the same shape as `{ $token }` vs a literal — and its contrast checker is a
warning that never blocks. **Figma** binds a variable from the fill swatch's
Libraries tab, replacing the raw value with a reference. **Webflow** binds one
from a dot on the colour field. All three keep the field as the control and make
the token an affordance on it.

`packages/ui`'s `ColorPicker` (#717) was **built for this**: `swatches` carry an
opaque `value` "unread by this component", and `onSwatchSelect` is deliberately
separate from `onColorChange` because "collapsing them is what loses a token
reference". Nothing new was invented.

## Layering

`@nextlyhq/ui/color` joins the allowlist in `layering.test.ts` beside
`@nextlyhq/ui/utils`, for the same reason: it is arithmetic published away from
the `"use client"` root barrel. It is the **writing** half of hex and the engine
owns the **reading** half, which is what keeps a third colour parser out of this
package. `ui/styles/contrast` remains unreachable and unlisted;
`style-colour-boundary.test.ts` is the guard that says why.

One trap worth naming: the engine's `Rgb` is **0-255** and ui's is **[0, 1]** —
two types with the same name, both in scope in one file — and `toHex` CLAMPS, so
handing it the engine's shape does not fail, it silently answers `#ffffff` for
every colour but black. There is exactly one conversion function, and a test
that fails on it.

## Review

Codex found **seven** findings at `8b45b4aee`; every one was verified against the
code and every one was real. All seven are fixed in `cce09e255`, and the three
behavioural ones are break-verified: committing per pointer event, dropping the
`colourShowable` guard, and pointing the controls only at the error message each
fail exactly one test.

The most serious was a drag writing one editor op per pointer event against a
`MAX_HISTORY` of 100 — a single gesture could evict unrelated undo history. The
draft now moves with the pointer and the document is written once, on close,
which is the rule the text fields already follow.

Greptile reviewed at `8b45b4aee`: 5/5, no inline comments. CodeRabbit has been
rate-limited throughout and has produced **no review** — that is absence, not a
clean verdict.

## Evidence

- **1201 unit tests pass**, 53 files. 57 of them are this change's, across
  `style-colour.test.ts` (39) and `style-colour-panel.test.tsx` (18).
- **Every mechanism break-verified**, with the diff shown each time: storing the
  name instead of the identity fails 1; displaying the identity instead of the
  current name fails 1; handing `toHex` the engine's channels fails 7; removing
  the colour route fails 11; painting from the raw value fails 3; dropping the
  descendant rule fails 1; hardcoding the partner key fails 2.
- **One break changed nothing and was repaired rather than left.** The
  descendant filter in `contrastPartnerOf` is invisible through the search,
  because `color` precedes `linkColor` in `STYLE_CATALOG` and `.find()` returns
  the right answer by array order either way. The rule is worth keeping — three
  entries emit `color` and two attach to ` a` — so the predicate is exported as
  `emitsContrastPartner` and asserted directly, with a positive control. That is
  stated in the test file too.
- Gates: build, `vitest`, `check-types`, package `lint`, root `eslint`
  (51 files read, both new modules among them, 0 problems), `lint:design`
  (968 files), `check-comment-convention`, and `fallow audit` — **verdict
  `pass`**, every `*_introduced` counter at 0.

`fallow` failed three times on `complexity_introduced` and each fix was a real
separation, not metric gaming: `ColourPicker`, `ContrastNote`, `TokenName`,
`UnsupportedField`, `writeStyleValue`, `partnerColour`, `actionNameFor`,
`showsNoField`. One of them removed an actual defect — `ColourField` had
hand-written commit-on-blur logic that `TextField` already owned, which is a
second representation of one contract and the dominant defect class on #1139.

## What this does NOT do — stated rather than left to be found

1. **D-05.7 is NOT met.** Coverage is unit and jsdom only. No control here has
   been proven end to end in a browser — set in inspector, publish, assert on
   the served page. #1139 carried the same gap and said so.
2. **The readout does not read the cascade.** The partner colour is read from
   THIS node at the same state and breakpoint. A background arriving from a
   named class, a block default or a wider breakpoint is not seen, and the
   readout reports nothing rather than measuring against the wrong background.
   Doing it properly means asking `styleProvenance` — which already settles tier
   order, both breakpoint axes, states and specificity — and that needs a
   `trace` of compiled declarations which nothing supplies to this panel yet.
   Walking the cascade a second time here is the thing that must not happen.
3. **Crossing a territory line, stated rather than buried.** The `tokens` prop
   is now wired at `packages/plugin-page-builder/src/admin/BlocksField.tsx`,
   which is OUTSIDE this task's declared territory of `packages/builder/**`.
   Codex raised the unwired prop as P1 and the argument is right: the task says
   "token picker in every colour control", and a picker that can never list a
   token does not meet it — shipping it inert would have been scoping the
   deliverable down without being asked. The change is one prop passing the
   MERGED token set the canvas already compiles with. I verified the package was
   unclaimed first (three outstanding claims, none covering it). **Revert that
   one hunk if you would rather it landed separately** — everything else in this
   PR stands without it.

4. **The two halves of a contrast pair sit in different accordion sections**
   (`color` and `background`) and Radix renders only the open one, so an author
   never sees both controls at once. The readout appears on each, so the verdict
   is reachable from either — but this is a layout question C-5 does not answer.
5. **Only mode `light` is measured.** A site whose dark values differ has a
   second answer this does not give.
6. Drive-by: two `var(--nx-radius-sm, 0.25rem)` references named a token that
   does not exist and survived on the fallback. Replaced with `--radius-sm`;
   measured identical at 0.25rem.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added design-token support to the style inspector, including token selection, resolution, replacement, and clearing.
  * Added color swatches, a color picker, and support for literal and token-based colors.
  * Added contrast ratio information with accessibility-focused status messaging.
  * Added support for light and dark theme color modes.
  * Improved color controls with responsive layouts, focus states, token-name handling, and clearer descriptions.

* **Bug Fixes**
  * Tokens are withheld while site styles are loading or unavailable.
  * Prevented outdated color-picker drafts from being restored after clearing or cancelled changes.
  * Contrast results are suppressed when styling prevents an accurate assessment.
  * Improved color-token reference handling to preserve the correct token identity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->