### PR TITLE
feat(builder): draw the selected block's margin and padding on the canvas

### DIFF
--- a/.changeset/spacing-values-on-canvas.md
+++ b/.changeset/spacing-values-on-canvas.md
@@ -1,0 +1,47 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+feat(builder): draw the selected block's margin and padding on the canvas
+
+An author sets spacing in the inspector and looks at the canvas, where until now
+nothing said what a value did — the only way to see it was to change it and watch
+the layout move. The selected block now carries a band over each side that has
+spacing, with the value written on it: amber outside for margin, green inside for
+padding, which is the palette browser developer tools have used for years.
+
+The values are read from the RENDERED element rather than from the stored style
+tier, because that tier cannot answer the question. The catalog stores spacing per
+LOGICAL side and a band is drawn on a physical one; `auto` has no value until
+layout runs; a percentage resolves against the containing block; and a named
+class, a block-type default or a breakpoint override can win the cascade. Asking
+the page what it is doing keeps one answer where there would otherwise be two.
+
+Only the primary selection is measured — spacing belongs to a node, and a
+multi-block selection has no margin of its own. Sides with no value draw nothing.
+The bands take no pointer events and are hidden from assistive technology, whose
+route to the same numbers is the inspector's Spacing section.

--- a/apps/playground/src/app/builder-canvas/harness.tsx
+++ b/apps/playground/src/app/builder-canvas/harness.tsx
@@ -10,6 +10,7 @@ import { registrySlotSource } from "@nextlyhq/builder";
 import {
   Canvas,
   DropIndicator,
+  SpacingOverlay,
   useCanvasDrag,
   useEditorState,
 } from "@nextlyhq/builder/shell";
@@ -129,7 +130,17 @@ export function BuilderCanvasHarness() {
         selectedIds={editor.selection.ids}
         onSelect={editor.select}
         dragHandlers={drag.handlers}
-        overlay={<DropIndicator target={drag.target} />}
+        /*
+         * Both overlays, because the spacing bands are only measurable where the
+         * canvas is laid out for real. jsdom reports every element as zero-sized,
+         * so the geometry this draws has no other place it can be certified.
+         */
+        overlay={
+          <>
+            <DropIndicator target={drag.target} />
+            <SpacingOverlay editor={editor} hidden={drag.draggingId !== null} />
+          </>
+        }
       />
     </div>
   );

--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -232,6 +232,153 @@ test.describe("spacing values on the canvas", () => {
     await expect(page.locator(BAND)).toHaveCount(0);
   });
 
+  test("bands FOLLOW the block when the ROOT's size does not change", async ({
+    page,
+  }) => {
+    /*
+     * The position-only reflow, asserted as a REDRAW and with a fixture that can
+     * tell the two implementations apart.
+     *
+     * A sibling above the selection is grown and a sibling BELOW it shrunk by the
+     * same amount, in one evaluation so the layout settles once. The selected
+     * block moves down; the page's total height does not change; and
+     * `.nx-canvas` is `min-height: 100%` sizing to that content, so the ROOT
+     * emits no `ResizeObserver` entry at all.
+     *
+     * That is what makes this a separating test rather than another green. Growing
+     * a sibling ALONE also moves the block, but it changes the page height too, so
+     * the root reports it and an overlay watching only the root passes — measured,
+     * by removing the per-node observation and watching this test stay green. The
+     * unselected sibling that changed is the only element with anything to report,
+     * so it has to be the one observed.
+     */
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(block).toBeVisible();
+    await block.click();
+
+    const before = await page.locator(band("margin", "bottom")).boundingBox();
+    const rootBefore = await page.locator(".nx-canvas").boundingBox();
+    if (before === null || rootBefore === null) {
+      throw new Error("no margin band or canvas root before the reflow");
+    }
+
+    const SHIFT = 200;
+    await page.evaluate(shift => {
+      const above = document.querySelector(
+        '[data-nx-node="hx-heading"]'
+      ) as HTMLElement;
+      const below = document.querySelector(
+        '[data-nx-node="hx-spacer"]'
+      ) as HTMLElement;
+      above.style.height = `${above.getBoundingClientRect().height + shift}px`;
+      below.style.height = `${below.getBoundingClientRect().height - shift}px`;
+    }, SHIFT);
+
+    await expect
+      .poll(async () => {
+        const box = await page.locator(band("margin", "bottom")).boundingBox();
+        return box === null ? null : Math.round(box.y - before.y);
+      })
+      .toBeGreaterThan(SHIFT - 5);
+
+    // The control for the claim above: the root really did not resize, so the
+    // redraw cannot be credited to the root's own entry.
+    const rootAfter = await page.locator(".nx-canvas").boundingBox();
+    expect(Math.abs((rootAfter?.height ?? 0) - rootBefore.height)).toBeLessThan(
+      TOLERANCE
+    );
+  });
+
+  test("a fractional untransformed box is NOT treated as scaled", async ({
+    page,
+  }) => {
+    /*
+     * The rounding defect, as a separating test rather than a claim that the new
+     * code cannot have it.
+     *
+     * `offsetHeight` is integer-rounded and a bounding rectangle is not, so
+     * deriving the scale from their ratio makes a block of fractional height
+     * report a scale it does not have — worst at small sizes, where the rounding
+     * is a large fraction of the value. Measured on this fixture: `offsetHeight`
+     * reports `1` against a drawn height of `0.594`, so the ratio reads `0.594`
+     * and the seeded `24px` margin band is drawn near `14px` on a block nobody
+     * transformed.
+     *
+     * Composing the real transform has no rounded input: `transform: none` is the
+     * identity whatever size the block happens to be.
+     *
+     * `height`, `minHeight` and `padding` are all catalog properties, so the
+     * shape being set up here is one an author can author.
+     */
+    await page.goto(ROUTE);
+    const spacer = page.locator('[data-nx-node="hx-spacer"]');
+    await expect(spacer).toBeVisible();
+
+    await spacer.evaluate(node => {
+      const el = node as HTMLElement;
+      el.style.height = "0.6px";
+      el.style.minHeight = "0";
+      el.style.padding = "0";
+    });
+    await spacer.click();
+
+    const bandBox = await page.locator(band("margin", "bottom")).boundingBox();
+    if (bandBox === null) throw new Error("no margin band on the spacer");
+
+    // The seeded gap, undistorted. The ratio implementation lands near 14.3.
+    expect(Math.abs(bandBox.height - MARGIN_BOTTOM)).toBeLessThan(TOLERANCE);
+  });
+
+  test.describe("a box axis-aligned bands cannot describe", () => {
+    /*
+     * One rule, not three patches. A band is an axis-aligned rectangle pinned to
+     * a physical side, and that representation has no meaning for a rotated,
+     * skewed or MIRRORED box — a mirrored block renders its left margin on the
+     * right — nor for one collapsed to nothing, where the unclipped value chips
+     * would pile up at the transform origin over an invisible block.
+     */
+    for (const [name, transform] of [
+      ["collapsed by scale(0)", "scale(0)"],
+      ["mirrored by scaleX(-1)", "scaleX(-1)"],
+      ["rotated", "rotate(30deg)"],
+      ["skewed", "skewX(20deg)"],
+    ] as const) {
+      test(`draws nothing for a block ${name}`, async ({ page }) => {
+        await page.goto(ROUTE);
+        const block = page.locator(`[data-nx-node="${PADDED}"]`);
+        await expect(block).toBeVisible();
+
+        /*
+         * Selected while it is still clickable, and asserted — the POSITIVE
+         * CONTROL, so the emptiness at the end is the refusal rather than a
+         * selection that never took. `scale(0)` in particular leaves nothing to
+         * click, so selecting afterwards is not available for every case here.
+         */
+        await block.click();
+        await expect(page.locator(BAND)).not.toHaveCount(0);
+
+        await block.evaluate((node, value) => {
+          (node as HTMLElement).style.transform = value;
+        }, transform);
+
+        /*
+         * A transform changes no LAYOUT size, so it emits no `ResizeObserver`
+         * entry of its own. Growing a sibling does, which re-measures the
+         * selection and re-evaluates the refusal — the same path an author takes,
+         * since editing a transform in the inspector changes the document and
+         * re-measures on that.
+         */
+        await page.locator('[data-nx-node="hx-heading"]').evaluate(node => {
+          const el = node as HTMLElement;
+          el.style.height = `${el.getBoundingClientRect().height + 40}px`;
+        });
+
+        await expect(page.locator(BAND)).toHaveCount(0);
+      });
+    }
+  });
+
   test("the bands take no pointer events, so a covered block stays clickable", async ({
     page,
   }) => {

--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -489,6 +489,129 @@ test.describe("spacing values on the canvas", () => {
     await expect(page.locator(BAND)).toHaveCount(0);
   });
 
+  test("bands catch up when a CSS transition finishes", async ({ page }) => {
+    /*
+     * `transition` is a catalog property, and a transition emits nothing an
+     * observer sees: the frames resize nothing and mutate nothing.
+     *
+     * TRANSFORM rather than margin, and that choice is what makes this separate.
+     * A transitioning margin grows the page, so the canvas root resizes on every
+     * frame and its own observer does the work — measured, by removing the
+     * completion listeners and watching a margin version of this test stay green.
+     * A transform changes no layout at all, so nothing resizes and nothing
+     * mutates after the style is set, and the only route to the final geometry is
+     * the completion event.
+     *
+     * The mutation that starts it measures at frame zero, where the computed
+     * transform is still `none` and the bands are full size. Arriving at half can
+     * only come from `transitionend`.
+     */
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(block).toBeVisible();
+    await block.click();
+
+    const before = await page.locator(band("padding", "bottom")).boundingBox();
+    if (before === null)
+      throw new Error("no padding band before the transition");
+    expect(Math.abs(before.height - PADDING_BOTTOM)).toBeLessThan(TOLERANCE);
+
+    await block.evaluate(node => {
+      const el = node as HTMLElement;
+      el.style.transformOrigin = "top left";
+      el.style.transition = "transform 400ms linear";
+      el.style.transform = "scale(0.5)";
+    });
+
+    await expect
+      .poll(
+        async () => {
+          const box = await page
+            .locator(band("padding", "bottom"))
+            .boundingBox();
+          return box === null ? null : Math.round(box.height);
+        },
+        { timeout: 5000 }
+      )
+      .toBeLessThan(PADDING_BOTTOM / 2 + 5);
+
+    // The label never moved: the author still typed 120.
+    await expect(page.locator(band("padding", "bottom"))).toHaveText(
+      String(PADDING_BOTTOM)
+    );
+  });
+
+  test("a scroll container with NO scrollbar still draws its bands", async ({
+    page,
+  }) => {
+    /*
+     * A REGRESSION GUARD, and not a separating test — stated so it is not read as
+     * coverage of the threshold itself.
+     *
+     * It pins that an ordinary scroll container is not refused. It does NOT
+     * exercise the rounding residue the two-pixel bound exists for: that needs
+     * `offsetWidth` and `clientWidth` to round apart, and measured on this
+     * platform a `0.333px` border computes to `1px` — Chrome snaps border widths
+     * to device pixels — leaving a residue of exactly zero. Setting the bound to
+     * `0.001` leaves this test green, which is the honest statement of what it
+     * covers. The bound is derived from the arithmetic instead: half a pixel of
+     * rounding from each reading against an exact border, so a whole pixel is
+     * reachable with no scrollbar present.
+     */
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(block).toBeVisible();
+
+    await block.evaluate(node => {
+      const el = node as HTMLElement;
+      el.style.overflow = "auto";
+      el.style.scrollbarGutter = "auto";
+    });
+    await block.click();
+
+    await expect(page.locator(band("padding", "bottom"))).toHaveText(
+      String(PADDING_BOTTOM)
+    );
+  });
+
+  test("still draws a top margin that collapsed out of the canvas", async ({
+    page,
+  }) => {
+    /*
+     * Neither `.nx-pb-page` nor `.nx-canvas` establishes a formatting context, so
+     * the first block's top margin collapses THROUGH both and out of the canvas.
+     * Measured: setting `margin-top: 40px` on the first block moves the canvas
+     * root down by 40 while the block's offset inside it stays 0 — the border box
+     * starts at the root's top edge and the margin band belongs above it.
+     *
+     * What this asserts is that the overlay still DRAWS it, at a negative offset,
+     * rather than dropping a band it cannot place inside the layer. Whether those
+     * pixels paint is the stylesheet's half — `overflow: clip` with an
+     * `overflow-clip-margin` allowance, which paints outside the layer without
+     * contributing to the scroll extent — and a layout assertion cannot see paint,
+     * so this does not claim to cover it.
+     */
+    await page.goto(ROUTE);
+    const first = page.locator('[data-nx-node="hx-heading"]');
+    await expect(first).toBeVisible();
+
+    await first.evaluate(node => {
+      (node as HTMLElement).style.marginTop = "40px";
+    });
+    await first.click();
+
+    const layerBox = await page.locator(".nx-spacing-overlay").boundingBox();
+    const bandBox = await page.locator(band("margin", "top")).boundingBox();
+    if (layerBox === null || bandBox === null) {
+      throw new Error("no overlay layer or top margin band");
+    }
+
+    await expect(page.locator(band("margin", "top"))).toHaveText("40");
+    expect(Math.abs(bandBox.height - 40)).toBeLessThan(TOLERANCE);
+    // Above the layer's own top edge, which is the escaped-margin case.
+    expect(bandBox.y).toBeLessThan(layerBox.y);
+  });
+
   test("the bands take no pointer events, so a covered block stays clickable", async ({
     page,
   }) => {

--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -763,6 +763,126 @@ test.describe("spacing values on the canvas", () => {
     await expect(page.locator(BAND)).toHaveCount(0);
   });
 
+  test("an ancestor clipping ONE axis does not refuse overflow on the other", async ({
+    page,
+  }) => {
+    /*
+     * `overflow` is a two-value catalog keyword, so the axes can clip
+     * differently — and `clip visible` is the only mixed pair that survives
+     * computation: measured in Chromium, pairing `visible` with `hidden`, `auto`
+     * or `scroll` resolves the `visible` side to `auto`, while `clip visible`
+     * stays exactly as written.
+     *
+     * A block overflowing only the axis that is still `visible` is not cut at
+     * all, and its overflow is rendered. Comparing all four edges whenever
+     * EITHER axis clips refuses it, and a refusal costs every band on the block.
+     *
+     * The control comes first and is the same geometry under `clip` on BOTH
+     * axes, where the refusal is correct — so the bands returning afterwards are
+     * the axis being respected rather than the block having stopped overflowing.
+     */
+    await page.goto(ROUTE);
+    const target = page.locator('[data-nx-node="hx-nested-text"]');
+    await expect(target).toBeVisible();
+
+    await page.evaluate(() => {
+      (
+        document.querySelector('[data-nx-node="hx-nested-text"]') as HTMLElement
+      ).style.marginBottom = "24px";
+      const section = document.querySelector(
+        '[data-nx-node="hx-section"]'
+      ) as HTMLElement;
+      section.style.overflow = "clip";
+    });
+    // Selected while the container still shows it. Shrinking first would clip
+    // the target out of reach and the click would land on the page instead.
+    await target.click();
+
+    // CONTROL: a clipping ancestor that does not cut still draws.
+    await expect(page.locator(BAND)).not.toHaveCount(0);
+
+    await page.evaluate(() => {
+      (
+        document.querySelector('[data-nx-node="hx-section"]') as HTMLElement
+      ).style.height = "10px";
+    });
+
+    // CONTROL: clipped on BOTH axes, that same vertical overflow IS a cut.
+    await expect(page.locator(BAND)).toHaveCount(0);
+
+    await page.evaluate(() => {
+      const section = document.querySelector(
+        '[data-nx-node="hx-section"]'
+      ) as HTMLElement;
+      section.style.overflow = "clip visible";
+      /*
+       * Asserted rather than assumed. If the engine collapsed this pair the way
+       * it collapses every other mixed pair, the fixture would be testing two
+       * fully-clipped containers and the bands would stay absent for a reason
+       * that has nothing to do with the axis rule.
+       */
+      const computed = getComputedStyle(section);
+      if (computed.overflowX !== "clip" || computed.overflowY !== "visible") {
+        throw new Error(
+          `expected clip/visible, got ${computed.overflowX}/${computed.overflowY}`
+        );
+      }
+    });
+
+    await expect(page.locator(BAND)).not.toHaveCount(0);
+  });
+
+  test("a SCALED bordered ancestor clips at its rendered padding edge", async ({
+    page,
+  }) => {
+    /*
+     * `getBoundingClientRect` reports post-transform pixels while a computed
+     * border width is unscaled CSS pixels, so the two are only comparable once
+     * the ancestor's own scale is applied. Under `scale(2)` a 20px border
+     * renders 40px thick, and insetting the rectangle by 20 puts the clip edge
+     * half way through the border — accepting a child the container visibly cuts
+     * and painting its bands over the hidden area.
+     *
+     * The margin is deliberately SMALL. At `-15px` the child clears the
+     * unscaled inset as well, so both implementations refuse it and the fixture
+     * separates nothing; `-5px` scales to ten rendered pixels and lands the
+     * child between the two answers — inside the rendered border, outside the
+     * unscaled one.
+     */
+    await page.goto(ROUTE);
+    const target = page.locator('[data-nx-node="hx-nested-text"]');
+    await expect(target).toBeVisible();
+    await target.click();
+
+    await page.evaluate(() => {
+      (
+        document.querySelector('[data-nx-node="hx-nested-text"]') as HTMLElement
+      ).style.marginBottom = "24px";
+      const section = document.querySelector(
+        '[data-nx-node="hx-section"]'
+      ) as HTMLElement;
+      section.style.overflow = "hidden";
+      section.style.border = "20px solid transparent";
+      // From the top left, so the border's rendered thickness is a plain
+      // doubling rather than a function of where the box happens to sit.
+      section.style.transformOrigin = "0 0";
+      section.style.transform = "scale(2)";
+    });
+
+    // CONTROL: the scaled bordered container that does NOT cut still draws, so
+    // the emptiness below is the clip edge moving rather than the transform or
+    // the border refusing the block outright.
+    await expect(page.locator(BAND)).not.toHaveCount(0);
+
+    await page.evaluate(() => {
+      (
+        document.querySelector('[data-nx-node="hx-nested-text"]') as HTMLElement
+      ).style.marginTop = "-5px";
+    });
+
+    await expect(page.locator(BAND)).toHaveCount(0);
+  });
+
   test("the bands take no pointer events, so a covered block stays clickable", async ({
     page,
   }) => {

--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -883,6 +883,91 @@ test.describe("spacing values on the canvas", () => {
     await expect(page.locator(BAND)).toHaveCount(0);
   });
 
+  test("declines a clipping ancestor that is not axis-aligned", async ({
+    page,
+  }) => {
+    /*
+     * A rotated ancestor's `getBoundingClientRect` is an axis-aligned BOUNDING
+     * box whose edges are not the clip edges — the real clip is a slanted
+     * rectangle inside it — so a child cut by that clip still reads as
+     * contained, and its bands paint over ground the container hides.
+     *
+     * The block's OWN describability check does not cover this, which is the
+     * whole point of the fixture: the block carries the inverse rotation, so the
+     * composition from block to root is axis-aligned and passes. Measured, that
+     * composition comes back `a=0.999999, b=0, c=0, d=0.999999` while the
+     * ancestor's own matrix carries `b=0.5, c=-0.5`.
+     *
+     * The control is therefore load-bearing rather than decorative: it shows the
+     * counter-rotated block still draws while the ancestor merely rotates, so
+     * the emptiness afterwards is the CLIP being declined and not the rotation
+     * being refused by the guard that was already there.
+     */
+    await page.goto(ROUTE);
+    const target = page.locator('[data-nx-node="hx-nested-text"]');
+    await expect(target).toBeVisible();
+    await target.click();
+
+    await page.evaluate(() => {
+      const section = document.querySelector(
+        '[data-nx-node="hx-section"]'
+      ) as HTMLElement;
+      const text = document.querySelector(
+        '[data-nx-node="hx-nested-text"]'
+      ) as HTMLElement;
+      text.style.marginBottom = "24px";
+      section.style.position = "relative";
+      section.style.width = "200px";
+      section.style.height = "200px";
+      section.style.transform = "rotate(30deg)";
+      /*
+       * Placed so the block is INSIDE the ancestor's axis-aligned bounding box
+       * while hanging past its rotated right edge. That is what makes this
+       * fixture separate the decline from the four-edge comparison: a block
+       * that also escapes the bounding box is refused by that comparison, and
+       * removing the decline changes nothing.
+       */
+      text.style.position = "absolute";
+      text.style.left = "180px";
+      text.style.top = "90px";
+      text.style.width = "60px";
+      text.style.height = "20px";
+      text.style.transform = "rotate(-30deg)";
+    });
+
+    // The fixture's separating property, asserted rather than assumed: layout
+    // that drifted so the block escaped the bounding box would leave this test
+    // passing on the comparison below the decline.
+    const contained = await page.evaluate(() => {
+      const outer = (
+        document.querySelector('[data-nx-node="hx-section"]') as HTMLElement
+      ).getBoundingClientRect();
+      const box = (
+        document.querySelector('[data-nx-node="hx-nested-text"]') as HTMLElement
+      ).getBoundingClientRect();
+      const slack = 0.5;
+      return !(
+        box.top < outer.top - slack ||
+        box.left < outer.left - slack ||
+        box.bottom > outer.bottom + slack ||
+        box.right > outer.right + slack
+      );
+    });
+    expect(contained).toBe(true);
+
+    // CONTROL: the composition is axis-aligned, so the block is describable and
+    // still draws under a rotated — but not yet clipping — ancestor.
+    await expect(page.locator(BAND)).not.toHaveCount(0);
+
+    await page.evaluate(() => {
+      (
+        document.querySelector('[data-nx-node="hx-section"]') as HTMLElement
+      ).style.overflow = "hidden";
+    });
+
+    await expect(page.locator(BAND)).toHaveCount(0);
+  });
+
   test("the bands take no pointer events, so a covered block stays clickable", async ({
     page,
   }) => {

--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -1,0 +1,203 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * The spacing overlay, measured in a browser because nowhere else can measure it.
+ *
+ * `spacing-bands.test.ts` decides where a band goes given numbers, and
+ * `spacing-overlay.test.tsx` decides which numbers it is given. Neither can say
+ * whether the result lands on the space it names: jsdom lays nothing out and
+ * reports every element as zero-sized, so a rectangle asserted there is a
+ * statement about jsdom and passes against an overlay drawn wrongly for a real
+ * author.
+ *
+ * Two properties are ONLY observable here:
+ *
+ * 1. **A logical value is reported on the physical edge it renders at.** The
+ *    seed authors `padding: { blockEnd }` and `margin: { blockEnd }`; nothing in
+ *    the document says "bottom". The browser resolves that, and this asserts the
+ *    band came out on the bottom with the authored number on it — which is the
+ *    whole argument for reading the rendered page rather than the stored tier.
+ * 2. **The band covers the space.** A number drawn beside the wrong rectangle is
+ *    worse than no overlay, because it reads as a measurement.
+ */
+
+const ROUTE = "/builder-canvas";
+const NODE = "[data-nx-node]";
+
+/**
+ * The seeded block that carries both kinds of spacing, and the only one that
+ * carries a padding at all.
+ *
+ * `padding: { blockEnd: "120px" }` and `margin: { blockEnd: "24px" }`. The two
+ * differ so no assertion below can be satisfied by reading the wrong box.
+ */
+const PADDED = "hx-columns";
+const PADDING_BOTTOM = 120;
+const MARGIN_BOTTOM = 24;
+
+const BAND = ".nx-spacing-overlay__band";
+const band = (box: string, side: string) =>
+  `${BAND}[data-box="${box}"][data-side="${side}"]`;
+
+/** Layout is fractional, and a whole-pixel claim about it would be flaky. */
+const TOLERANCE = 1.5;
+
+test.describe("spacing values on the canvas", () => {
+  test("draws nothing until a block is selected", async ({ page }) => {
+    await page.goto(ROUTE);
+    // The population first: an empty canvas would satisfy the assertion below
+    // for a reason that has nothing to do with the overlay.
+    await expect(page.locator(NODE).first()).toBeVisible();
+    await expect(page.locator("[data-nx-selected]")).toHaveCount(0);
+
+    await expect(page.locator(BAND)).toHaveCount(0);
+  });
+
+  test("reports a logical blockEnd on the PHYSICAL bottom edge", async ({
+    page,
+  }) => {
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(block).toBeVisible();
+
+    await block.click();
+    await expect(block).toHaveAttribute("data-nx-selected", "primary");
+
+    /*
+     * The document never says "bottom" — it says `blockEnd`, and the value
+     * arrives on the bottom edge with the authored number on it.
+     *
+     * This is the END-TO-END case, not the separating one. In a horizontal
+     * left-to-right document `margin-block-end` and `margin-bottom` compute to
+     * the same value, so an implementation reading the LOGICAL property would
+     * pass this too. The test below changes the writing mode, where the two
+     * disagree and only one answer is right.
+     */
+    await expect(page.locator(band("padding", "bottom"))).toHaveText(
+      String(PADDING_BOTTOM)
+    );
+    await expect(page.locator(band("margin", "bottom"))).toHaveText(
+      String(MARGIN_BOTTOM)
+    );
+
+    // And the sides the seed did NOT author report nothing, which is what
+    // separates this from an overlay that draws all eight sides always.
+    await expect(page.locator(band("padding", "top"))).toHaveCount(0);
+    await expect(page.locator(band("margin", "top"))).toHaveCount(0);
+  });
+
+  test("a vertical writing mode moves the band to the edge it RENDERS at", async ({
+    page,
+  }) => {
+    /*
+     * The separating property, and the only place it can be observed.
+     *
+     * `writing-mode: vertical-rl` puts the block axis horizontal, so the seed's
+     * authored `padding: { blockEnd }` computes to `padding-left`. An overlay
+     * reading the LOGICAL property still sees `padding-block-end: 120px` and
+     * draws the band along the bottom, where there is no padding at all; one
+     * reading the physical longhands follows the browser to the left edge.
+     *
+     * The mode is applied here rather than in the seed because that fixture is
+     * shared, and other suites pin geometry that a writing mode would move.
+     */
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(block).toBeVisible();
+
+    await block.evaluate(node => {
+      (node as HTMLElement).style.writingMode = "vertical-rl";
+    });
+    await block.click();
+    await expect(block).toHaveAttribute("data-nx-selected", "primary");
+
+    await expect(page.locator(band("padding", "left"))).toHaveText(
+      String(PADDING_BOTTOM)
+    );
+    await expect(page.locator(band("padding", "bottom"))).toHaveCount(0);
+  });
+
+  test("the padding band covers the padding, at the bottom of the block", async ({
+    page,
+  }) => {
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(block).toBeVisible();
+    await block.click();
+
+    const blockBox = await block.boundingBox();
+    const bandBox = await page.locator(band("padding", "bottom")).boundingBox();
+    if (blockBox === null || bandBox === null) {
+      throw new Error("the selected block or its padding band has no box");
+    }
+
+    // The extent is the authored padding, in real laid-out pixels.
+    expect(Math.abs(bandBox.height - PADDING_BOTTOM)).toBeLessThan(TOLERANCE);
+
+    // And it sits at the block's bottom INSIDE it, which is where padding is.
+    // An overlay that drew padding outward would land this below the block and
+    // still report the right height.
+    const blockBottom = blockBox.y + blockBox.height;
+    expect(Math.abs(bandBox.y + bandBox.height - blockBottom)).toBeLessThan(
+      TOLERANCE
+    );
+    expect(bandBox.y).toBeGreaterThan(blockBox.y);
+  });
+
+  test("the margin band sits OUTSIDE the block, below its border edge", async ({
+    page,
+  }) => {
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(block).toBeVisible();
+    await block.click();
+
+    const blockBox = await block.boundingBox();
+    const bandBox = await page.locator(band("margin", "bottom")).boundingBox();
+    if (blockBox === null || bandBox === null) {
+      throw new Error("the selected block or its margin band has no box");
+    }
+
+    expect(Math.abs(bandBox.height - MARGIN_BOTTOM)).toBeLessThan(TOLERANCE);
+
+    // Its TOP is the block's bottom: margin begins where the border box ends.
+    const blockBottom = blockBox.y + blockBox.height;
+    expect(Math.abs(bandBox.y - blockBottom)).toBeLessThan(TOLERANCE);
+  });
+
+  test("the bands take no pointer events, so a covered block stays clickable", async ({
+    page,
+  }) => {
+    await page.goto(ROUTE);
+    const padded = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(padded).toBeVisible();
+    await padded.click();
+
+    // The margin band is drawn over the gap below the block, which is where a
+    // neighbour begins. If the overlay could be hit, the author would meet this
+    // as a canvas that stops responding once anything is selected.
+    await expect(page.locator(band("margin", "bottom"))).toHaveCount(1);
+
+    const neighbour = page.locator('[data-nx-node="hx-text-last"]');
+    await neighbour.click();
+
+    await expect(neighbour).toHaveAttribute("data-nx-selected", "primary");
+    await expect(padded).not.toHaveAttribute("data-nx-selected", "primary");
+  });
+
+  test("the bands follow the selection to another block", async ({ page }) => {
+    await page.goto(ROUTE);
+    const padded = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(padded).toBeVisible();
+
+    await padded.click();
+    await expect(page.locator(band("padding", "bottom"))).toHaveCount(1);
+
+    // A block the seed gives a margin but no padding. The padding band has to
+    // GO — an overlay that only ever added bands would keep the old one and
+    // report one block's padding while naming another.
+    await page.locator('[data-nx-node="hx-heading"]').click();
+    await expect(page.locator(band("margin", "bottom"))).toHaveCount(1);
+    await expect(page.locator(band("padding", "bottom"))).toHaveCount(0);
+  });
+});

--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -165,6 +165,73 @@ test.describe("spacing values on the canvas", () => {
     expect(Math.abs(bandBox.y - blockBottom)).toBeLessThan(TOLERANCE);
   });
 
+  test("a scaled block gets scaled BANDS and an unscaled LABEL", async ({
+    page,
+  }) => {
+    /*
+     * `transform` is a catalog property, so this is reachable by an author today
+     * rather than a hypothetical about a future canvas zoom.
+     *
+     * The two halves pull apart under a transform and only one of them moves.
+     * `getBoundingClientRect` reports the DRAWN box, so a block at half size has
+     * half the padding on screen and the band has to match it. `getComputedStyle`
+     * reports unscaled CSS pixels, and that is what the author typed — a band
+     * reading `60` would name a value that appears nowhere in their document.
+     */
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(block).toBeVisible();
+
+    await block.evaluate(node => {
+      (node as HTMLElement).style.transform = "scale(0.5)";
+      (node as HTMLElement).style.transformOrigin = "top left";
+    });
+    await block.click();
+
+    const bandBox = await page.locator(band("padding", "bottom")).boundingBox();
+    if (bandBox === null) throw new Error("the padding band has no box");
+
+    expect(Math.abs(bandBox.height - PADDING_BOTTOM / 2)).toBeLessThan(
+      TOLERANCE
+    );
+    await expect(page.locator(band("padding", "bottom"))).toHaveText(
+      String(PADDING_BOTTOM)
+    );
+  });
+
+  test("a block with no layout box draws no bands at all", async ({ page }) => {
+    /*
+     * `display: none` keeps the element in the DOM and keeps its computed margin,
+     * while every rectangle it reports reads zero. Without a guard the bands land
+     * at the canvas origin naming space that is nowhere on screen — and the
+     * author reaches this by selecting a hidden node in the Layers panel.
+     */
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(block).toBeVisible();
+
+    // Selected FIRST, so the bands demonstrably exist and their later absence is
+    // the guard firing rather than a selection that never took.
+    await block.click();
+    await expect(page.locator(band("padding", "bottom"))).toHaveCount(1);
+
+    /*
+     * Hidden WITHOUT touching the selection, so the block under test is still
+     * the one the overlay answers for. Clicking elsewhere would empty the bands
+     * for the unrelated reason that the new selection has no padding, and the
+     * assertion would pass against the guard being absent.
+     *
+     * Losing its box is a size change, so the block's own ResizeObserver entry
+     * is what drives the re-measure — no extra nudge needed.
+     */
+    await block.evaluate(node => {
+      (node as HTMLElement).style.display = "none";
+    });
+
+    await expect(page.locator(`${BAND}[data-box="padding"]`)).toHaveCount(0);
+    await expect(page.locator(BAND)).toHaveCount(0);
+  });
+
   test("the bands take no pointer events, so a covered block stays clickable", async ({
     page,
   }) => {

--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -343,6 +343,13 @@ test.describe("spacing values on the canvas", () => {
       ["mirrored by scaleX(-1)", "scaleX(-1)"],
       ["rotated", "rotate(30deg)"],
       ["skewed", "skewX(20deg)"],
+      /*
+       * A 3D projection can flatten to a matrix with zero off-diagonal terms and
+       * positive `a` and `d`, so the 2D tests alone call it describable. It
+       * renders as a trapezoid whose scale varies across the box, which no
+       * uniformly scaled rectangle covers.
+       */
+      ["projected in 3D", "perspective(500px) rotateY(30deg)"],
     ] as const) {
       test(`draws nothing for a block ${name}`, async ({ page }) => {
         await page.goto(ROUTE);
@@ -377,6 +384,109 @@ test.describe("spacing values on the canvas", () => {
         await expect(page.locator(BAND)).toHaveCount(0);
       });
     }
+  });
+
+  test.describe("a box the canvas coordinates cannot hold", () => {
+    /*
+     * These are not transforms — they are blocks whose rendered geometry is not
+     * a single upright rectangle sitting in the canvas's own coordinate space,
+     * so the same refusal applies for the same reason.
+     */
+    for (const [name, apply] of [
+      [
+        "positioned fixed",
+        (el: HTMLElement) => {
+          el.style.position = "fixed";
+        },
+      ],
+      [
+        "positioned sticky",
+        (el: HTMLElement) => {
+          el.style.position = "sticky";
+          el.style.top = "0px";
+        },
+      ],
+      [
+        "a scroll container reserving a scrollbar gutter",
+        (el: HTMLElement) => {
+          el.style.overflow = "scroll";
+        },
+      ],
+    ] as const) {
+      test(`draws nothing for ${name}`, async ({ page }) => {
+        await page.goto(ROUTE);
+        const block = page.locator(`[data-nx-node="${PADDED}"]`);
+        await expect(block).toBeVisible();
+
+        // The positive control, in this test: bands exist before the change.
+        await block.click();
+        await expect(page.locator(BAND)).not.toHaveCount(0);
+
+        await block.evaluate((node, key) => {
+          const el = node as HTMLElement;
+          if (key === "positioned fixed") el.style.position = "fixed";
+          if (key === "positioned sticky") {
+            el.style.position = "sticky";
+            el.style.top = "0px";
+          }
+          if (key === "a scroll container reserving a scrollbar gutter") {
+            /*
+             * `scrollbar-gutter: stable` reserves the space deterministically.
+             * Left to the platform this is a coin toss — macOS uses overlay
+             * scrollbars that reserve nothing, so the defect only appears on
+             * Windows and Linux, and a test that depended on that would pass
+             * locally while covering nothing.
+             */
+            el.style.overflow = "scroll";
+            el.style.scrollbarGutter = "stable";
+          }
+        }, name);
+
+        // A style change emits no resize of its own, so a sibling is grown to
+        // force the re-measure that re-evaluates the refusal.
+        await page.locator('[data-nx-node="hx-heading"]').evaluate(node => {
+          const el = node as HTMLElement;
+          el.style.height = `${el.getBoundingClientRect().height + 40}px`;
+        });
+
+        await expect(page.locator(BAND)).toHaveCount(0);
+      });
+    }
+  });
+
+  test("draws nothing for an inline box fragmented across lines", async ({
+    page,
+  }) => {
+    /*
+     * An inline box that wraps produces one rectangle PER LINE, and its padding
+     * and margins belong to those fragments individually — while
+     * `getBoundingClientRect` reports their union. Bands drawn from the union run
+     * through the whitespace between lines and put the start and end padding on
+     * the union's edges rather than on the first and last fragment.
+     *
+     * The canvas is narrowed to force the wrap. `width` does NOT apply to an
+     * inline box, so constraining the element itself changes nothing — measured:
+     * `display: inline` alone reports one rectangle, adding `width: 40px` still
+     * reports one, and narrowing the canvas to 120px reports four.
+     */
+    await page.goto(ROUTE);
+    const text = page.locator('[data-nx-node="hx-text-short"]');
+    await expect(text).toBeVisible();
+
+    await text.click();
+    await expect(page.locator(BAND)).not.toHaveCount(0);
+
+    await page.evaluate(() => {
+      const el = document.querySelector(
+        '[data-nx-node="hx-text-short"]'
+      ) as HTMLElement;
+      el.style.display = "inline";
+      el.textContent = "wrap this text across several lines please and again";
+      (document.querySelector(".nx-canvas") as HTMLElement).style.width =
+        "120px";
+    });
+
+    await expect(page.locator(BAND)).toHaveCount(0);
   });
 
   test("the bands take no pointer events, so a covered block stays clickable", async ({

--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -612,6 +612,112 @@ test.describe("spacing values on the canvas", () => {
     expect(bandBox.y).toBeLessThan(layerBox.y);
   });
 
+  test("bands follow a block inside a scrolling container", async ({
+    page,
+  }) => {
+    /*
+     * `overflow: auto` and `overflow: scroll` are catalog values, so a block can
+     * sit inside a container the author scrolls. Scrolling it moves the block
+     * relative to the canvas while resizing nothing, mutating nothing and
+     * finishing no transition — every other subscription is silent. A scroll
+     * event does not bubble either, which is why the listener is registered in
+     * the CAPTURE phase on the root.
+     *
+     * The nested block is given a margin here because the seed gives it none —
+     * measured, it carries no `styles` key at all, so without this the test would
+     * assert against an overlay that correctly had nothing to draw.
+     *
+     * It is parked MID-SCROLL on purpose. A scroller has content outside its box
+     * by definition, and a block at that boundary is genuinely cut off — which
+     * the clipping guard refuses, correctly. Both scroll positions here keep the
+     * block wholly inside its container, so what moves is the block and not its
+     * visibility.
+     */
+    await page.goto(ROUTE);
+    const target = page.locator('[data-nx-node="hx-nested-text"]');
+    await expect(target).toBeVisible();
+
+    await page.evaluate(() => {
+      (
+        document.querySelector('[data-nx-node="hx-nested-text"]') as HTMLElement
+      ).style.marginBottom = "24px";
+      const section = document.querySelector(
+        '[data-nx-node="hx-section"]'
+      ) as HTMLElement;
+      /*
+       * `box-sizing: border-box` with generous padding is what makes this scroll
+       * at all. Padding counts INSIDE `clientHeight`, so a fixed height smaller
+       * than the padding is raised to fit it — measured, this configuration gives
+       * a `scrollHeight` of 848 against a `clientHeight` of 800, so the scrollable
+       * range is 48px and a request beyond that is silently clamped. An earlier
+       * version asked for 320, got 48, and asserted a movement that never
+       * happened.
+       */
+      section.style.boxSizing = "border-box";
+      section.style.overflow = "auto";
+      section.style.height = "200px";
+      section.style.paddingTop = "400px";
+      section.style.paddingBottom = "400px";
+    });
+
+    await target.click({ force: true });
+    const before = await page.locator(band("margin", "bottom")).boundingBox();
+    if (before === null) throw new Error("no band before the scroll");
+
+    await page.evaluate(() => {
+      (
+        document.querySelector('[data-nx-node="hx-section"]') as HTMLElement
+      ).scrollTop = 40;
+    });
+
+    await expect
+      .poll(async () => {
+        const box = await page.locator(band("margin", "bottom")).boundingBox();
+        return box === null ? null : Math.round(before.y - box.y);
+      })
+      .toBeGreaterThan(25);
+  });
+
+  test("draws nothing for a block CUT OFF by a clipping ancestor", async ({
+    page,
+  }) => {
+    /*
+     * The block's own rectangle is reported UNCLIPPED, and the overlay draws as a
+     * sibling of the page rather than inside the container — so bands taken from
+     * that rectangle escape the clip and paint over ground where the block is not
+     * rendered.
+     *
+     * Only a clip that ACTUALLY cuts is refused, and the control below is what
+     * pins that: a block wholly inside an `overflow: hidden` container still
+     * draws. Refusing on the mere presence of a clipping ancestor would blank the
+     * overlay for most well-built pages.
+     */
+    await page.goto(ROUTE);
+    const target = page.locator('[data-nx-node="hx-nested-text"]');
+    await expect(target).toBeVisible();
+
+    await page.evaluate(() => {
+      (
+        document.querySelector('[data-nx-node="hx-nested-text"]') as HTMLElement
+      ).style.marginBottom = "24px";
+      (
+        document.querySelector('[data-nx-node="hx-section"]') as HTMLElement
+      ).style.overflow = "hidden";
+    });
+    await target.click();
+
+    // CONTROL: a clipping ancestor that does not cut still draws.
+    await expect(page.locator(BAND)).not.toHaveCount(0);
+
+    await page.evaluate(() => {
+      (
+        document.querySelector('[data-nx-node="hx-section"]') as HTMLElement
+      ).style.height = "10px";
+    });
+
+    await expect(page.locator(BAND)).toHaveCount(0);
+  });
+
   test("the bands take no pointer events, so a covered block stays clickable", async ({
     page,
   }) => {

--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -718,6 +718,51 @@ test.describe("spacing values on the canvas", () => {
     await expect(page.locator(BAND)).toHaveCount(0);
   });
 
+  test("a BORDERED clipping ancestor clips at its padding edge", async ({
+    page,
+  }) => {
+    /*
+     * Overflow clips at the PADDING edge while `getBoundingClientRect` reports
+     * the BORDER box, so on a bordered container the two differ by its width —
+     * measured, a 20px border puts the border box at 217 and the clip edge at
+     * 237. A child pulled into that border is visibly cut while a border-box
+     * comparison reports it contained, and the bands paint over the cut region.
+     *
+     * The control comes first: the same bordered container that does NOT cut
+     * still draws, so the emptiness afterwards is the padding edge being used
+     * rather than any border at all refusing the block.
+     */
+    await page.goto(ROUTE);
+    const target = page.locator('[data-nx-node="hx-nested-text"]');
+    await expect(target).toBeVisible();
+
+    await page.evaluate(() => {
+      (
+        document.querySelector('[data-nx-node="hx-nested-text"]') as HTMLElement
+      ).style.marginBottom = "24px";
+      const section = document.querySelector(
+        '[data-nx-node="hx-section"]'
+      ) as HTMLElement;
+      section.style.overflow = "hidden";
+      section.style.border = "20px solid transparent";
+    });
+    await target.click();
+    await expect(page.locator(BAND)).not.toHaveCount(0);
+
+    /*
+     * Pulled UP into the border by a negative margin. The child is now above the
+     * padding edge and below the border-box top, so it is genuinely cut — and a
+     * border-box comparison would still call it contained.
+     */
+    await page.evaluate(() => {
+      (
+        document.querySelector('[data-nx-node="hx-nested-text"]') as HTMLElement
+      ).style.marginTop = "-15px";
+    });
+
+    await expect(page.locator(BAND)).toHaveCount(0);
+  });
+
   test("the bands take no pointer events, so a covered block stays clickable", async ({
     page,
   }) => {

--- a/packages/builder/src/block-toolbar.tsx
+++ b/packages/builder/src/block-toolbar.tsx
@@ -42,7 +42,6 @@
  * @module block-toolbar
  */
 
-import { NODE_ID_ATTRIBUTE } from "@nextlyhq/blocks-react";
 import {
   ArrowDown,
   ArrowUp,
@@ -53,7 +52,7 @@ import {
 } from "lucide-react";
 import * as React from "react";
 
-import { CANVAS_ROOT_CLASS, CHROME_ATTRIBUTE } from "./canvas";
+import { CANVAS_ROOT_CLASS, CHROME_ATTRIBUTE, nodeElement } from "./canvas";
 import type { EditorState } from "./editor-state";
 import type { Rect } from "./geometry";
 import { canvasContentRect } from "./geometry-dom";
@@ -87,32 +86,6 @@ export interface BlockToolbarProps {
    * hidden bar would still be in the tab order.
    */
   hidden?: boolean;
-}
-
-/**
- * The selected block's element, found by comparing ids rather than by selector.
- *
- * A node id reaches this from stored data, and interpolating it into
- * `querySelector` makes any character CSS treats specially either throw or,
- * worse, match something else. The canvas resolves the same question the same
- * way for the same reason.
- *
- * Deliberately NOT the `data-nx-selected` marker the canvas writes. That marker
- * is applied in a passive effect, and this measurement runs in a layout effect
- * of a DESCENDANT — so on the render where the selection changes, the marker is
- * still on the previously selected element. The bar would spend one frame
- * measuring the wrong block, which is visible as a jump.
- */
-function selectedElement(root: HTMLElement, id: string): Element | null {
-  let found: Element | null = null;
-  // `forEach` rather than `for…of`: a `NodeList` is only iterable under a lib
-  // that declares its iterator, and this package compiles without one.
-  root.querySelectorAll(`[${NODE_ID_ATTRIBUTE}]`).forEach(element => {
-    if (found === null && element.getAttribute(NODE_ID_ATTRIBUTE) === id) {
-      found = element;
-    }
-  });
-  return found;
 }
 
 export function BlockToolbar({
@@ -188,7 +161,7 @@ export function BlockToolbar({
      */
     const rects: Rect[] = [];
     for (const id of selectedIds) {
-      const element = selectedElement(root, id);
+      const element = nodeElement(root, id);
       if (element !== null) rects.push(canvasContentRect(element, root));
     }
     const block = unionRect(rects);
@@ -247,7 +220,7 @@ export function BlockToolbar({
      * happens while an image loads or a webfont swaps.
      */
     for (const id of selectedIds) {
-      const block = selectedElement(root, id);
+      const block = nodeElement(root, id);
       if (block !== null) observer.observe(block);
     }
     observer.observe(root);

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -150,6 +150,26 @@ export function nodeElement(root: HTMLElement, id: string): Element | null {
   return found;
 }
 
+/**
+ * Every element the renderer marked as a node, in document order.
+ *
+ * Beside {@link nodeElement} because both answer from the same marker, and a
+ * caller that needs all of them should not walk the tree with its own selector.
+ *
+ * Chrome drawn INSIDE the canvas root carries no node marker, so it is excluded
+ * by construction rather than by a filter that would have to be kept in step
+ * with whatever chrome arrives next.
+ */
+export function nodeElements(root: HTMLElement): readonly Element[] {
+  const found: Element[] = [];
+  // `forEach` for the reason given in `nodeElement`: a `NodeList` is only
+  // iterable under a lib this package does not compile with.
+  root.querySelectorAll(`[${NODE_ID_ATTRIBUTE}]`).forEach(element => {
+    found.push(element);
+  });
+  return found;
+}
+
 export interface CanvasProps {
   /** The document being edited. */
   document: BlockDocument;

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -122,6 +122,34 @@ export function nodeIdFromEvent(target: EventTarget | null): string | null {
   return owner.getAttribute(NODE_ID_ATTRIBUTE);
 }
 
+/**
+ * The element a node id was rendered as, or `null` when it is not on screen.
+ *
+ * The inverse of {@link nodeIdFromEvent}, and beside it because the two are one
+ * mapping read in two directions — separated, they become two answers to what a
+ * node id means in the DOM.
+ *
+ * Ids are COMPARED rather than interpolated into a selector. A node id reaches
+ * here from stored data, so any character CSS treats specially makes
+ * `querySelector` either throw or match something else entirely.
+ *
+ * Deliberately not the {@link SELECTED_ATTRIBUTE} marker. That marker is applied
+ * in a passive effect, so on the render where the selection changes it is still
+ * on the previously selected element, and any chrome measuring in a layout
+ * effect would spend a frame measuring the wrong block.
+ */
+export function nodeElement(root: HTMLElement, id: string): Element | null {
+  let found: Element | null = null;
+  // `forEach` rather than `for…of`: a `NodeList` is only iterable under a lib
+  // that declares its iterator, and this package compiles without one.
+  root.querySelectorAll(`[${NODE_ID_ATTRIBUTE}]`).forEach(element => {
+    if (found === null && element.getAttribute(NODE_ID_ATTRIBUTE) === id) {
+      found = element;
+    }
+  });
+  return found;
+}
+
 export interface CanvasProps {
   /** The document being edited. */
   document: BlockDocument;

--- a/packages/builder/src/geometry-dom.test.ts
+++ b/packages/builder/src/geometry-dom.test.ts
@@ -21,6 +21,7 @@ import {
   canvasContentPoint,
   canvasContentRect,
   frameInsetOf,
+  canvasRootFrom,
 } from "./geometry-dom";
 
 /**
@@ -192,5 +193,51 @@ describe("canvasContentPoint", () => {
       x: rect.x,
       y: rect.y,
     });
+  });
+});
+
+describe("finding the canvas root across realms", () => {
+  it("finds the root in the ordinary same-realm case", () => {
+    const root = document.createElement("div");
+    root.className = "nx-canvas";
+    const child = document.createElement("p");
+    root.appendChild(child);
+    document.body.appendChild(root);
+
+    expect(canvasRootFrom(child, "nx-canvas")).toBe(root);
+    root.remove();
+  });
+
+  it("returns null when nothing above the element is a canvas root", () => {
+    const lone = document.createElement("p");
+    document.body.appendChild(lone);
+    expect(canvasRootFrom(lone, "nx-canvas")).toBeNull();
+    lone.remove();
+  });
+
+  it("accepts a root built by ANOTHER realm", () => {
+    /*
+     * The separating case. `instanceof HTMLElement` compares against the
+     * constructor of the realm doing the asking, so a root created inside an
+     * iframe is not an instance of THIS realm's `HTMLElement` — and chrome
+     * checking it that way returns early and draws nothing on a perfectly good
+     * canvas. The control below is the same object failing that naive check.
+     */
+    const frame = document.createElement("iframe");
+    document.body.appendChild(frame);
+    const inner = frame.contentDocument;
+    if (inner === null) throw new Error("the iframe has no document");
+
+    const root = inner.createElement("div");
+    root.className = "nx-canvas";
+    const child = inner.createElement("p");
+    root.appendChild(child);
+    inner.body.appendChild(root);
+
+    // The naive check fails on it — which is what the helper exists to survive.
+    expect(root instanceof HTMLElement).toBe(false);
+    expect(canvasRootFrom(child, "nx-canvas")).toBe(root);
+
+    frame.remove();
   });
 });

--- a/packages/builder/src/geometry-dom.test.ts
+++ b/packages/builder/src/geometry-dom.test.ts
@@ -22,6 +22,7 @@ import {
   canvasContentRect,
   frameInsetOf,
   canvasRootFrom,
+  hasScrollbarGutter,
 } from "./geometry-dom";
 
 /**
@@ -237,6 +238,74 @@ describe("finding the canvas root across realms", () => {
     // The naive check fails on it — which is what the helper exists to survive.
     expect(root instanceof HTMLElement).toBe(false);
     expect(canvasRootFrom(child, "nx-canvas")).toBe(root);
+
+    frame.remove();
+  });
+});
+
+describe("hasScrollbarGutter", () => {
+  /**
+   * A scroll container with a known gutter, in whichever realm is asked for.
+   *
+   * `offsetWidth` and `clientWidth` are DEFINED rather than styled, for the
+   * reason `frameWith` defines its borders: jsdom lays nothing out, so both read
+   * zero from real styles and the subtraction below would measure nothing.
+   *
+   * The LONGHANDS are set rather than the `overflow` shorthand, because jsdom
+   * does not expand it: after `style.overflow = "auto"`, its `getComputedStyle`
+   * answers `auto` for `overflow` and the empty string for `overflowX` and
+   * `overflowY` — so a fixture written the natural way reads as a container that
+   * does not scroll, and every assertion here would pass on an implementation
+   * that never measured anything.
+   */
+  function scroller(
+    doc: Document,
+    { offset, client }: { offset: number; client: number }
+  ): HTMLElement {
+    const element = doc.createElement("div");
+    element.style.overflowX = "auto";
+    element.style.overflowY = "auto";
+    doc.body.appendChild(element);
+    Object.defineProperty(element, "offsetWidth", { value: offset });
+    Object.defineProperty(element, "clientWidth", { value: client });
+    Object.defineProperty(element, "offsetHeight", { value: 100 });
+    Object.defineProperty(element, "clientHeight", { value: 100 });
+    return element;
+  }
+
+  it("reports a reserved gutter", () => {
+    // The control for the cross-realm case below: it pins the measurement as
+    // actually happening, so a function that returned `false` unconditionally
+    // would pass that one and fail this.
+    const element = scroller(document, { offset: 200, client: 185 });
+    expect(hasScrollbarGutter(element, { x: 0, y: 0 })).toBe(true);
+  });
+
+  it("reports no gutter on a container that reserves none", () => {
+    // The mirror control. Without it, an implementation answering `true` for
+    // every scroll container satisfies the two tests around this one.
+    const element = scroller(document, { offset: 200, client: 200 });
+    expect(hasScrollbarGutter(element, { x: 0, y: 0 })).toBe(false);
+  });
+
+  it("measures a scroll container built by ANOTHER realm", () => {
+    /*
+     * The separating case, and the one that fails silently in production: an
+     * `instanceof HTMLElement` against the asking realm rejects a perfectly good
+     * element from an iframe canvas BEFORE any measurement, so the gutter
+     * refusal never fires and the block draws its padding bands across the
+     * reserved scrollbar. The naive check is asserted below so the fixture
+     * cannot quietly stop being cross-realm.
+     */
+    const frame = document.createElement("iframe");
+    document.body.appendChild(frame);
+    const inner = frame.contentDocument;
+    if (inner === null) throw new Error("the iframe has no document");
+
+    const element = scroller(inner, { offset: 200, client: 185 });
+
+    expect(element instanceof HTMLElement).toBe(false);
+    expect(hasScrollbarGutter(element, { x: 0, y: 0 })).toBe(true);
 
     frame.remove();
   });

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -220,6 +220,9 @@ export interface RenderedScale {
 
 const IDENTITY_SCALE: RenderedScale = { x: 1, y: 1, describable: true };
 
+/** Below this, an off-diagonal matrix term is serialization noise, not a rotation. */
+const AXIS_ALIGNED_TOLERANCE = 1e-9;
+
 export function renderedScale(element: Element, root: Element): RenderedScale {
   const view = element.ownerDocument.defaultView;
   // Absent in jsdom, which lays nothing out and so has no transform to compose.
@@ -253,13 +256,26 @@ export function renderedScale(element: Element, root: Element): RenderedScale {
    * translations and axis-aligned scales, non-zero the moment a rotation or a
    * skew enters.
    *
+   * Compared against a TOLERANCE rather than to zero exactly. A transform that is
+   * geometrically the identity can be written as one that is not —
+   * `rotate(360deg)`, `rotate(1turn)` — and an engine is free to serialize the
+   * sine residue rather than normalize it away. Measured in Chromium, both of
+   * those come back exactly zero, so this guards an engine that behaves
+   * differently rather than a failure anyone has seen here.
+   *
+   * The bound rejects nothing real: the off-diagonal term of a thousandth of a
+   * degree of rotation is about 1.7e-5, four orders of magnitude above it.
+   *
    * `is2D` is a separate question and a 2D check does not imply it. A
    * `perspective(500px) rotateY(30deg)` projects the box as a trapezoid whose
    * scale varies across it, and the flattened matrix can still show zero
    * off-diagonal terms with positive `a` and `d` — describable by those tests
    * and describable by nothing that draws rectangles.
    */
-  const axisAligned = matrix.is2D && matrix.b === 0 && matrix.c === 0;
+  const axisAligned =
+    matrix.is2D &&
+    Math.abs(matrix.b) < AXIS_ALIGNED_TOLERANCE &&
+    Math.abs(matrix.c) < AXIS_ALIGNED_TOLERANCE;
   return {
     x: matrix.a,
     y: matrix.d,
@@ -346,6 +362,12 @@ export function hasScrollbarGutter(
  * that clipping applies to the bands and the page alike, so it produces no
  * mismatch; only a clip between the block and the root does.
  */
+/** A computed border width in pixels, or zero when the browser reports no number. */
+function edgeWidth(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
 export function clippedByAncestor(element: Element, root: Element): boolean {
   const view = element.ownerDocument.defaultView;
   if (view === null) return false;
@@ -359,7 +381,20 @@ export function clippedByAncestor(element: Element, root: Element): boolean {
     const style = view.getComputedStyle(node);
     if (style.overflowX === "visible" && style.overflowY === "visible")
       continue;
-    const clip = node.getBoundingClientRect();
+    /*
+     * Overflow clips at the PADDING edge, and `getBoundingClientRect` reports the
+     * BORDER box. On a container with a border the two differ by its width, so a
+     * child pulled into the border by a negative margin or a transform is
+     * visibly cut while a border-box comparison reports it contained — measured,
+     * a 20px border puts the border box at 217 and the clip edge at 237.
+     */
+    const outer = node.getBoundingClientRect();
+    const clip = {
+      top: outer.top + edgeWidth(style.borderTopWidth),
+      left: outer.left + edgeWidth(style.borderLeftWidth),
+      bottom: outer.bottom - edgeWidth(style.borderBottomWidth),
+      right: outer.right - edgeWidth(style.borderRightWidth),
+    };
     // Half a pixel, because both rectangles are fractional and a block laid out
     // flush against its container's edge is not clipped by rounding.
     const slack = 0.5;
@@ -373,4 +408,28 @@ export function clippedByAncestor(element: Element, root: Element): boolean {
     }
   }
   return false;
+}
+
+/**
+ * The canvas root an element sits inside, as an `HTMLElement` of its OWN realm.
+ *
+ * `instanceof HTMLElement` compares against the constructor of the realm doing
+ * the asking. A host that mounts the canvas into a same-origin iframe through a
+ * portal gets a root built by that iframe's realm, and the check fails for a
+ * perfectly good element — so chrome would return early and draw nothing,
+ * silently, on exactly the iframe canvas `geometry.ts` documents.
+ *
+ * Here rather than at each caller because two of them ask the same question, and
+ * the realm-safe spelling is the kind of detail that gets written correctly once
+ * and copied wrongly afterwards.
+ */
+export function canvasRootFrom(
+  element: Element,
+  rootClass: string
+): HTMLElement | null {
+  const root = element.closest(`.${rootClass}`);
+  if (root === null) return null;
+  const realm = root.ownerDocument.defaultView;
+  if (realm === null) return null;
+  return root instanceof realm.HTMLElement ? root : null;
 }

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -142,3 +142,54 @@ export function containerEdges(root: HTMLElement): {
   const box = root.getBoundingClientRect();
   return { top: box.top, bottom: box.bottom };
 }
+
+/**
+ * Whether an element generates a layout box at all.
+ *
+ * `display: none` and `display: contents` are both catalog values, and an
+ * element carrying either can still be SELECTED — the Layers panel addresses
+ * nodes by id and does not require them to be visible. Neither generates a box,
+ * so every rectangle read from one is the zero rectangle, while its computed
+ * margin and padding stay whatever the author set. Chrome positioned from that
+ * pair lands at the canvas origin describing spacing that is nowhere on screen.
+ *
+ * `getClientRects` is the direct question rather than a proxy: a zero-sized
+ * rectangle is also what a genuinely empty block reports, and `core/spacer`
+ * legitimately has one. An element that generates no box returns no rectangles
+ * at all, which is the property that separates the two.
+ *
+ * Here because this module is the one place allowed to read a rectangle from the
+ * DOM, and a sibling guard enforces it by name.
+ */
+export function hasLayoutBox(element: Element): boolean {
+  return element.getClientRects().length > 0;
+}
+
+/**
+ * How much larger an element RENDERS than it was laid out, per axis.
+ *
+ * `transform` is a catalog property, so an author can scale a block. Everything
+ * measured through `getBoundingClientRect` is then post-transform while every
+ * length from `getComputedStyle` stays in unscaled CSS pixels, and anything
+ * combining the two is wrong by exactly this factor.
+ *
+ * Derived by COMPARING the two rather than by parsing a transform: `offsetWidth`
+ * is the untransformed border-box width and the bounding rectangle is the drawn
+ * one, so their ratio carries the whole ancestor chain's scaling with it. A
+ * parser would see only the element's own `transform` and would miss a scaled
+ * parent entirely.
+ *
+ * Returns `1` on an axis with no layout extent, where the ratio is `0/0` and
+ * there is nothing to scale. Note what this does NOT represent: a rotation or a
+ * skew inflates the bounding box without being a scale, so the ratio is larger
+ * than any real factor. Axis-aligned chrome cannot describe a rotated element in
+ * any case, which is a limit of the drawing rather than of this measurement.
+ */
+export function renderedScale(element: Element): { x: number; y: number } {
+  if (!(element instanceof HTMLElement)) return { x: 1, y: 1 };
+  const box = element.getBoundingClientRect();
+  return {
+    x: element.offsetWidth > 0 ? box.width / element.offsetWidth : 1,
+    y: element.offsetHeight > 0 ? box.height / element.offsetHeight : 1,
+  };
+}

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -321,9 +321,18 @@ export function hasScrollbarGutter(
   element: Element,
   borders: { x: number; y: number }
 ): boolean {
-  if (!(element instanceof HTMLElement)) return false;
   const view = element.ownerDocument.defaultView;
   if (view === null) return false;
+  /*
+   * The ELEMENT's realm, not the one asking — see `canvasRootFrom` for why the
+   * ambient `HTMLElement` is the wrong constructor to compare against.
+   *
+   * Getting it wrong here fails SILENTLY and in the unsafe direction. A canvas
+   * mounted into a same-origin iframe answers `false` before measuring
+   * anything, so the refusal below never fires and every scrolling block in
+   * that canvas draws its padding bands across the reserved scrollbar.
+   */
+  if (!(element instanceof view.HTMLElement)) return false;
 
   /*
    * Only a scroll container can reserve one, and asking anything else is not
@@ -346,8 +355,9 @@ export function hasScrollbarGutter(
 /**
  * Whether an ancestor between this element and the canvas root clips it.
  *
- * `overflow` is a catalog keyword taking `hidden`, `clip`, `scroll` or `auto`, so
- * an author can put a block inside a container that cuts part of it off. The
+ * `overflow` is a catalog keyword taking `hidden`, `clip`, `scroll` or `auto` —
+ * and taking TWO of them, so the axes can clip differently — so an author can
+ * put a block inside a container that cuts part of it off. The
  * element's own bounding rectangle is reported UNCLIPPED, and the overlay draws
  * as a sibling of the page rather than inside that container — so bands derived
  * from the full rectangle escape the ancestor's clip and paint over ground where
@@ -379,8 +389,21 @@ export function clippedByAncestor(element: Element, root: Element): boolean {
     node = node.parentElement
   ) {
     const style = view.getComputedStyle(node);
-    if (style.overflowX === "visible" && style.overflowY === "visible")
-      continue;
+    /*
+     * PER AXIS, because the two can differ and the catalog ships the shorthand
+     * that makes them differ: `overflow` takes two values, so `clip visible` is
+     * a declaration an author can store. Measured in Chromium it is also the
+     * ONLY mixed pair that survives computation — pairing `visible` with
+     * `hidden`, `auto` or `scroll` resolves the `visible` side to `auto`, while
+     * `clip visible` stays exactly as written.
+     *
+     * Asking whether EITHER axis clips and then comparing all four edges
+     * refuses a block that overflows only the axis still rendering it, and a
+     * refusal costs every band on the block.
+     */
+    const clipsX = style.overflowX !== "visible";
+    const clipsY = style.overflowY !== "visible";
+    if (!clipsX && !clipsY) continue;
     /*
      * Overflow clips at the PADDING edge, and `getBoundingClientRect` reports the
      * BORDER box. On a container with a border the two differ by its width, so a
@@ -389,21 +412,37 @@ export function clippedByAncestor(element: Element, root: Element): boolean {
      * a 20px border puts the border box at 217 and the clip edge at 237.
      */
     const outer = node.getBoundingClientRect();
+    /*
+     * Scaled, because the two readings are in different units: `outer` is
+     * post-transform and a computed border width is unscaled CSS pixels. Under
+     * `scale(2)` a 20px border renders 40px thick, so insetting by 20 puts the
+     * clip edge half way through the border and accepts a child the container
+     * visibly cuts — measured, the real padding edge sat at 40 while this
+     * arithmetic answered 20 and a child at exactly 20 was let through.
+     *
+     * `x` and `y` are used without consulting `describable` on purpose. A
+     * rotated, mirrored or collapsed ancestor makes the composition from the
+     * BLOCK to the root non-describable too — it passes through this same node —
+     * so the caller has already refused the overlay by the time such a factor
+     * could be read. Declining here as well would be a branch nothing reaches.
+     */
+    const scale = renderedScale(node, root);
     const clip = {
-      top: outer.top + edgeWidth(style.borderTopWidth),
-      left: outer.left + edgeWidth(style.borderLeftWidth),
-      bottom: outer.bottom - edgeWidth(style.borderBottomWidth),
-      right: outer.right - edgeWidth(style.borderRightWidth),
+      top: outer.top + edgeWidth(style.borderTopWidth) * scale.y,
+      left: outer.left + edgeWidth(style.borderLeftWidth) * scale.x,
+      bottom: outer.bottom - edgeWidth(style.borderBottomWidth) * scale.y,
+      right: outer.right - edgeWidth(style.borderRightWidth) * scale.x,
     };
     // Half a pixel, because both rectangles are fractional and a block laid out
     // flush against its container's edge is not clipped by rounding.
     const slack = 0.5;
-    if (
-      box.top < clip.top - slack ||
-      box.left < clip.left - slack ||
-      box.bottom > clip.bottom + slack ||
-      box.right > clip.right + slack
-    ) {
+    const cutVertically =
+      clipsY &&
+      (box.top < clip.top - slack || box.bottom > clip.bottom + slack);
+    const cutHorizontally =
+      clipsX &&
+      (box.left < clip.left - slack || box.right > clip.right + slack);
+    if (cutVertically || cutHorizontally) {
       return true;
     }
   }

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -144,7 +144,7 @@ export function containerEdges(root: HTMLElement): {
 }
 
 /**
- * Whether an element generates a layout box at all.
+ * How many layout boxes an element generates.
  *
  * `display: none` and `display: contents` are both catalog values, and an
  * element carrying either can still be SELECTED — the Layers panel addresses
@@ -153,16 +153,23 @@ export function containerEdges(root: HTMLElement): {
  * margin and padding stay whatever the author set. Chrome positioned from that
  * pair lands at the canvas origin describing spacing that is nowhere on screen.
  *
- * `getClientRects` is the direct question rather than a proxy: a zero-sized
- * rectangle is also what a genuinely empty block reports, and `core/spacer`
- * legitimately has one. An element that generates no box returns no rectangles
- * at all, which is the property that separates the two.
+ * ZERO means the element generates no box: `display: none` and
+ * `display: contents` both reach it. `getClientRects` is the direct question
+ * rather than a proxy, because a zero-SIZED rectangle is also what a genuinely
+ * empty block reports and `core/spacer` legitimately has one — an element that
+ * generates no box returns no rectangles at all.
+ *
+ * MORE THAN ONE means an inline box fragmented across lines. Its padding and
+ * margins belong to the individual fragments while `getBoundingClientRect`
+ * reports their union, so a band drawn from that union runs through the
+ * whitespace between lines and puts the start and end padding on the union's
+ * edges rather than on the first and last fragment.
  *
  * Here because this module is the one place allowed to read a rectangle from the
  * DOM, and a sibling guard enforces it by name.
  */
-export function hasLayoutBox(element: Element): boolean {
-  return element.getClientRects().length > 0;
+export function layoutFragments(element: Element): number {
+  return element.getClientRects().length;
 }
 
 /**
@@ -223,24 +230,85 @@ export function renderedScale(element: Element, root: Element): RenderedScale {
   }
 
   let matrix = new view.DOMMatrix();
+  /*
+   * Stops BELOW the root, which is not an off-by-one.
+   *
+   * The overlay is a child of the root, so it is inside whatever transform the
+   * root carries and is drawn through it already. Composing the root's own
+   * transform here would apply it a second time — the bands would be scaled by
+   * its square while the page was scaled by it once.
+   */
   for (
     let node: Element | null = element;
-    node !== null && node !== root.parentElement;
+    node !== null && node !== root;
     node = node.parentElement
   ) {
     const declared = view.getComputedStyle(node).transform;
     if (declared === "" || declared === "none") continue;
     matrix = new view.DOMMatrix(declared).multiply(matrix);
-    if (node === root) break;
   }
 
-  // `b` and `c` are the off-diagonal terms: zero for any composition of
-  // translations and axis-aligned scales, non-zero the moment a rotation or a
-  // skew enters.
-  const axisAligned = matrix.b === 0 && matrix.c === 0;
+  /*
+   * `b` and `c` are the off-diagonal terms: zero for any composition of
+   * translations and axis-aligned scales, non-zero the moment a rotation or a
+   * skew enters.
+   *
+   * `is2D` is a separate question and a 2D check does not imply it. A
+   * `perspective(500px) rotateY(30deg)` projects the box as a trapezoid whose
+   * scale varies across it, and the flattened matrix can still show zero
+   * off-diagonal terms with positive `a` and `d` — describable by those tests
+   * and describable by nothing that draws rectangles.
+   */
+  const axisAligned = matrix.is2D && matrix.b === 0 && matrix.c === 0;
   return {
     x: matrix.a,
     y: matrix.d,
     describable: axisAligned && matrix.a > 0 && matrix.d > 0,
   };
+}
+
+/**
+ * Whether a classic scrollbar reserves space inside the element's border box.
+ *
+ * `overflow: auto` and `overflow: scroll` are catalog values, and on a platform
+ * without overlay scrollbars the scrollbar takes its width from BETWEEN the
+ * padding box and the border — so a padding box derived by removing only the
+ * borders is too wide by the gutter, and the right or bottom padding band is
+ * drawn over the scrollbar instead of over the padding. Which side it takes is
+ * a function of the writing direction, so a right-hand assumption is wrong in
+ * RTL.
+ *
+ * `clientWidth` excludes both the border and the gutter while `offsetWidth`
+ * excludes neither, so their difference beyond the borders IS the gutter. Both
+ * are integer-rounded, hence the half-pixel threshold: a real scrollbar is
+ * around fifteen pixels and sub-pixel layout noise is never that.
+ *
+ * Reported rather than corrected. The caller declines a block whose padding
+ * geometry cannot be represented, which is one rule it already applies to
+ * several other shapes.
+ */
+export function hasScrollbarGutter(
+  element: Element,
+  borders: { x: number; y: number }
+): boolean {
+  if (!(element instanceof HTMLElement)) return false;
+  const view = element.ownerDocument.defaultView;
+  if (view === null) return false;
+
+  /*
+   * Only a scroll container can reserve one, and asking anything else is not
+   * merely wasted — it is WRONG. `clientWidth` and `clientHeight` are defined as
+   * zero for an element with no CSS layout box in the usual sense, which
+   * includes every inline box, so the subtraction below reports the element's
+   * whole width as a gutter and an ordinary inline block is refused for a
+   * scrollbar it could not have.
+   */
+  const style = view.getComputedStyle(element);
+  const scrolls = (overflow: string): boolean =>
+    overflow === "auto" || overflow === "scroll";
+  if (!scrolls(style.overflowX) && !scrolls(style.overflowY)) return false;
+
+  const gutterX = element.offsetWidth - element.clientWidth - borders.x;
+  const gutterY = element.offsetHeight - element.clientHeight - borders.y;
+  return gutterX > 0.5 || gutterY > 0.5;
 }

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -166,30 +166,81 @@ export function hasLayoutBox(element: Element): boolean {
 }
 
 /**
- * How much larger an element RENDERS than it was laid out, per axis.
+ * The cumulative transform between an element and the canvas root, reduced to
+ * the two things axis-aligned chrome can use.
  *
- * `transform` is a catalog property, so an author can scale a block. Everything
- * measured through `getBoundingClientRect` is then post-transform while every
- * length from `getComputedStyle` stays in unscaled CSS pixels, and anything
- * combining the two is wrong by exactly this factor.
+ * `transform` is a catalog property taking a free-form CSS value, so an author
+ * can scale, rotate, skew or MIRROR a block. Everything measured through
+ * `getBoundingClientRect` is post-transform while every length from
+ * `getComputedStyle` stays in unscaled CSS pixels, and anything combining the
+ * two is wrong by whatever sits between them.
  *
- * Derived by COMPARING the two rather than by parsing a transform: `offsetWidth`
- * is the untransformed border-box width and the bounding rectangle is the drawn
- * one, so their ratio carries the whole ancestor chain's scaling with it. A
- * parser would see only the element's own `transform` and would miss a scaled
- * parent entirely.
+ * ## Read from the matrix rather than inferred from a ratio
  *
- * Returns `1` on an axis with no layout extent, where the ratio is `0/0` and
- * there is nothing to scale. Note what this does NOT represent: a rotation or a
- * skew inflates the bounding box without being a scale, so the ratio is larger
- * than any real factor. Axis-aligned chrome cannot describe a rotated element in
- * any case, which is a limit of the drawing rather than of this measurement.
+ * Comparing the drawn box against `offsetWidth` looks equivalent and is not, in
+ * three ways that all read as ordinary code:
+ *
+ * - `offsetWidth` is INTEGER-ROUNDED and a bounding rectangle is not, so an
+ *   untransformed block of fractional width reports a scale it does not have —
+ *   worst at exactly the small sizes where a band is hardest to judge by eye.
+ * - A bounding rectangle is never negative, so `scaleX(-1)` divides out to an
+ *   ordinary positive factor and the mirroring vanishes from the answer.
+ * - A rotation or skew inflates the bounding box, so the ratio reports a scale
+ *   that describes no axis at all.
+ *
+ * The matrix has none of those: it is exact, it is signed, and its off-diagonal
+ * terms are what a rotation or skew shows up in.
+ *
+ * ## `describable` is a refusal, not a detail
+ *
+ * A band is an axis-aligned rectangle pinned to a physical side. That
+ * representation has no meaning for a rotated, skewed or mirrored box — a left
+ * margin on a mirrored element renders on the RIGHT — and no choice of scale
+ * factor rescues it. So the answer carries whether the question is askable, and
+ * chrome that cannot draw the truth draws nothing rather than something
+ * confident and wrong.
+ *
+ * Composed up to the ROOT rather than read off the element, because a scaled
+ * ancestor moves and resizes its descendants while their own transform stays
+ * `none`.
  */
-export function renderedScale(element: Element): { x: number; y: number } {
-  if (!(element instanceof HTMLElement)) return { x: 1, y: 1 };
-  const box = element.getBoundingClientRect();
+export interface RenderedScale {
+  readonly x: number;
+  readonly y: number;
+  /** False for a rotation, a skew, a reflection, or a collapse to zero. */
+  readonly describable: boolean;
+}
+
+const IDENTITY_SCALE: RenderedScale = { x: 1, y: 1, describable: true };
+
+export function renderedScale(element: Element, root: Element): RenderedScale {
+  const view = element.ownerDocument.defaultView;
+  // Absent in jsdom, which lays nothing out and so has no transform to compose.
+  // Identity is the honest answer there: nothing is scaled because nothing is
+  // laid out, and every caller still measures.
+  if (view === null || typeof view.DOMMatrix === "undefined") {
+    return IDENTITY_SCALE;
+  }
+
+  let matrix = new view.DOMMatrix();
+  for (
+    let node: Element | null = element;
+    node !== null && node !== root.parentElement;
+    node = node.parentElement
+  ) {
+    const declared = view.getComputedStyle(node).transform;
+    if (declared === "" || declared === "none") continue;
+    matrix = new view.DOMMatrix(declared).multiply(matrix);
+    if (node === root) break;
+  }
+
+  // `b` and `c` are the off-diagonal terms: zero for any composition of
+  // translations and axis-aligned scales, non-zero the moment a rotation or a
+  // skew enters.
+  const axisAligned = matrix.b === 0 && matrix.c === 0;
   return {
-    x: element.offsetWidth > 0 ? box.width / element.offsetWidth : 1,
-    y: element.offsetHeight > 0 ? box.height / element.offsetHeight : 1,
+    x: matrix.a,
+    y: matrix.d,
+    describable: axisAligned && matrix.a > 0 && matrix.d > 0,
   };
 }

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -326,3 +326,51 @@ export function hasScrollbarGutter(
   const gutterY = element.offsetHeight - element.clientHeight - borders.y;
   return gutterX > ROUNDING_BOUND_PX || gutterY > ROUNDING_BOUND_PX;
 }
+
+/**
+ * Whether an ancestor between this element and the canvas root clips it.
+ *
+ * `overflow` is a catalog keyword taking `hidden`, `clip`, `scroll` or `auto`, so
+ * an author can put a block inside a container that cuts part of it off. The
+ * element's own bounding rectangle is reported UNCLIPPED, and the overlay draws
+ * as a sibling of the page rather than inside that container — so bands derived
+ * from the full rectangle escape the ancestor's clip and paint over ground where
+ * the block is not rendered.
+ *
+ * Only a clip that ACTUALLY cuts is reported. A block sitting wholly inside an
+ * `overflow: hidden` card is not clipped by it, and that is the ordinary case —
+ * refusing on the presence of a clipping ancestor rather than on the fact of
+ * being clipped would blank the overlay for most well-built pages.
+ *
+ * The walk stops BELOW the root. The shell scrolls the canvas from above, and
+ * that clipping applies to the bands and the page alike, so it produces no
+ * mismatch; only a clip between the block and the root does.
+ */
+export function clippedByAncestor(element: Element, root: Element): boolean {
+  const view = element.ownerDocument.defaultView;
+  if (view === null) return false;
+  const box = element.getBoundingClientRect();
+
+  for (
+    let node: Element | null = element.parentElement;
+    node !== null && node !== root;
+    node = node.parentElement
+  ) {
+    const style = view.getComputedStyle(node);
+    if (style.overflowX === "visible" && style.overflowY === "visible")
+      continue;
+    const clip = node.getBoundingClientRect();
+    // Half a pixel, because both rectangles are fractional and a block laid out
+    // flush against its container's edge is not clipped by rounding.
+    const slack = 0.5;
+    if (
+      box.top < clip.top - slack ||
+      box.left < clip.left - slack ||
+      box.bottom > clip.bottom + slack ||
+      box.right > clip.right + slack
+    ) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -279,14 +279,28 @@ export function renderedScale(element: Element, root: Element): RenderedScale {
  * RTL.
  *
  * `clientWidth` excludes both the border and the gutter while `offsetWidth`
- * excludes neither, so their difference beyond the borders IS the gutter. Both
- * are integer-rounded, hence the half-pixel threshold: a real scrollbar is
- * around fifteen pixels and sub-pixel layout noise is never that.
+ * excludes neither, so their difference beyond the borders IS the gutter.
+ *
+ * THE THRESHOLD IS A ROUNDING BOUND, not a guess. Both readings are integer
+ * rounded INDEPENDENTLY while the border subtracted from them is exact and may
+ * be fractional, so the residue on a container with no scrollbar at all can
+ * reach a whole pixel — half from each — and a fractional border on a high-DPI
+ * display is enough to produce it. Two pixels clears that bound with room, and
+ * clears nothing real: the narrowest scrollbar a platform draws is `thin`, which
+ * is eight pixels at its slimmest, and a classic one is around fifteen.
  *
  * Reported rather than corrected. The caller declines a block whose padding
  * geometry cannot be represented, which is one rule it already applies to
  * several other shapes.
  */
+/**
+ * The most two independently rounded readings can differ by, plus a margin.
+ *
+ * Half a pixel each, so a whole pixel of residue is reachable with no scrollbar
+ * present; two leaves room without reaching any real scrollbar width.
+ */
+const ROUNDING_BOUND_PX = 2;
+
 export function hasScrollbarGutter(
   element: Element,
   borders: { x: number; y: number }
@@ -310,5 +324,5 @@ export function hasScrollbarGutter(
 
   const gutterX = element.offsetWidth - element.clientWidth - borders.x;
   const gutterY = element.offsetHeight - element.clientHeight - borders.y;
-  return gutterX > 0.5 || gutterY > 0.5;
+  return gutterX > ROUNDING_BOUND_PX || gutterY > ROUNDING_BOUND_PX;
 }

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -419,14 +419,32 @@ export function clippedByAncestor(element: Element, root: Element): boolean {
      * clip edge half way through the border and accepts a child the container
      * visibly cuts — measured, the real padding edge sat at 40 while this
      * arithmetic answered 20 and a child at exactly 20 was let through.
-     *
-     * `x` and `y` are used without consulting `describable` on purpose. A
-     * rotated, mirrored or collapsed ancestor makes the composition from the
-     * BLOCK to the root non-describable too — it passes through this same node —
-     * so the caller has already refused the overlay by the time such a factor
-     * could be read. Declining here as well would be a branch nothing reaches.
      */
     const scale = renderedScale(node, root);
+    /*
+     * A clipping ancestor that is not axis-aligned is DECLINED rather than
+     * measured, because neither reading survives its transform: `a` and `d` are
+     * not scale factors once a rotation is present, and `getBoundingClientRect`
+     * answers with an axis-aligned BOUNDING box whose edges are not the clip
+     * edges at all. The real clip is a slanted rectangle sitting inside that
+     * box, so a child cut by it still reads as contained.
+     *
+     * It cannot be left to the caller's own describability check, which is what
+     * an earlier version of this assumed: a descendant carrying the INVERSE
+     * transform composes back to an axis-aligned matrix, so the block passes
+     * that check while this ancestor fails it. Measured — a block under
+     * `rotate(-30deg)` inside an ancestor under `rotate(30deg)` composes to
+     * `a=0.999999, b=0, c=0, d=0.999999` and is called describable, while its
+     * ancestor's own matrix carries `b=0.5, c=-0.5`; the block sat inside the
+     * ancestor's bounding box with a quarter of it beyond the clip.
+     *
+     * Refusing is deliberately broader than the defect: a block WHOLLY INSIDE a
+     * rotated clipping ancestor is not cut and loses its bands anyway. Deciding
+     * that needs the clip as an oriented rectangle, and drawing nothing is the
+     * same answer this module already gives for every other shape it cannot
+     * describe.
+     */
+    if (!scale.describable) return true;
     const clip = {
       top: outer.top + edgeWidth(style.borderTopWidth) * scale.y,
       left: outer.left + edgeWidth(style.borderLeftWidth) * scale.x,

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -144,6 +144,21 @@ export { BlockToolbar } from "./block-toolbar";
 export type { BlockToolbarProps } from "./block-toolbar";
 
 /**
+ * The selected block's margin and padding, drawn over the page.
+ *
+ * A canvas overlay like the drop indicator, and composed the same way — it goes
+ * in `Canvas`'s `overlay`, because it is positioned in the canvas's own content
+ * coordinates and the canvas root is what establishes them.
+ *
+ * It reads the RENDERED page rather than the stored style tier, so what it
+ * reports is what the author is looking at: the browser has already resolved the
+ * logical sides to physical ones, `auto` to a used value, percentages against
+ * the containing block, and the whole cascade to a winner.
+ */
+export { SpacingOverlay } from "./spacing-overlay";
+export type { SpacingOverlayProps } from "./spacing-overlay";
+
+/**
  * The editor's document state, published beside the canvas because it is a hook
  * and therefore client-only for the same reason the shell is.
  *

--- a/packages/builder/src/spacing-bands.test.ts
+++ b/packages/builder/src/spacing-bands.test.ts
@@ -121,6 +121,50 @@ describe("where a margin band lands", () => {
     });
   });
 
+  it("fills the outer CORNERS when two adjacent margins are set", () => {
+    /*
+     * Two adjacent margins leave a rectangle diagonally outside the border box
+     * that belongs to the margin area. Spanning only the border box paints
+     * nothing there, so the highlighted region is smaller than the margin box
+     * and the overlay under-reports the space it exists to show.
+     *
+     * The horizontal bands take it: top and bottom span the whole margin box
+     * while left and right span the border height, so each corner is assigned
+     * exactly once and no translucent band is drawn over another.
+     */
+    const bands = bandsFor({
+      margin: { top: 20, right: 8, bottom: 0, left: 12 },
+    });
+    expect(band(bands, "margin", "top")?.rect).toEqual({
+      x: 88, // border.x - left margin
+      y: 180,
+      width: 320, // border.width + left + right
+      height: 20,
+    });
+    // The vertical band is unchanged, which is what keeps the corner single.
+    expect(band(bands, "margin", "left")?.rect).toEqual({
+      x: 88,
+      y: 200,
+      width: 12,
+      height: 150,
+    });
+  });
+
+  it("does not widen a band for a NEGATIVE neighbour", () => {
+    // A negative margin makes the margin box SMALLER on that side, so there is
+    // no corner out there to fill and extending toward it would paint outside
+    // the margin area entirely.
+    const bands = bandsFor({
+      margin: { top: 20, right: 0, bottom: 0, left: -12 },
+    });
+    expect(band(bands, "margin", "top")?.rect).toEqual({
+      x: 100,
+      y: 180,
+      width: 300,
+      height: 20,
+    });
+  });
+
   it("puts a NEGATIVE margin inside the border edge, not outside it", () => {
     /*
      * The separating property. A negative margin pulls the element toward its
@@ -382,6 +426,9 @@ describe("comparing two band lists", () => {
 });
 
 describe("which spacing a generated box can have", () => {
+  const ALL = { top: true, right: true, bottom: true, left: true };
+  const NONE = { top: false, right: false, bottom: false, left: false };
+
   it.each([
     "table-row-group",
     "table-header-group",
@@ -400,25 +447,60 @@ describe("which spacing a generated box can have", () => {
      * reading it unconditionally draws bands for space that does not exist and
      * cannot be made to exist by changing the value.
      */
-    expect(spacingApplies(display)).toEqual({ margin: false, padding: false });
+    expect(spacingApplies(display, "horizontal-tb")).toEqual({
+      margin: NONE,
+      padding: NONE,
+    });
   });
 
   it("gives table-cell padding but not margin", () => {
     // The one internal table box padding applies to, and the common case an
     // author actually sets. Collapsing it into the group above would blank the
     // padding of every table cell on the page.
-    expect(spacingApplies("table-cell")).toEqual({
-      margin: false,
-      padding: true,
+    expect(spacingApplies("table-cell", "horizontal-tb")).toEqual({
+      margin: NONE,
+      padding: ALL,
     });
   });
 
   it.each(["block", "flex", "grid", "inline-block", "table", "table-caption"])(
-    "gives %s both",
+    "gives %s every side of both",
     display => {
       // `table-caption` is here deliberately: it is NOT an internal table box,
       // and its margins apply normally.
-      expect(spacingApplies(display)).toEqual({ margin: true, padding: true });
+      expect(spacingApplies(display, "horizontal-tb")).toEqual({
+        margin: ALL,
+        padding: ALL,
+      });
+    }
+  );
+
+  it("drops an inline box's BLOCK-axis margins and keeps the inline ones", () => {
+    /*
+     * A non-replaced inline box ignores its block-axis margins entirely while
+     * `getComputedStyle` reports whatever was declared, so a blanket answer
+     * draws bands for space the box does not create. Its padding is left alone:
+     * block-axis padding on an inline box does not affect layout but DOES
+     * render, and this overlay reports what renders.
+     */
+    expect(spacingApplies("inline", "horizontal-tb")).toEqual({
+      margin: { top: false, bottom: false, left: true, right: true },
+      padding: ALL,
+    });
+  });
+
+  it.each(["vertical-rl", "vertical-lr", "sideways-rl"])(
+    "follows the writing mode: %s puts the block axis sideways",
+    writingMode => {
+      // Which PHYSICAL sides the block axis lands on is a function of the
+      // writing mode, so a physical answer hard-coded to `horizontal-tb` is
+      // wrong on exactly the documents that need it most.
+      expect(spacingApplies("inline", writingMode).margin).toEqual({
+        top: true,
+        bottom: true,
+        left: false,
+        right: false,
+      });
     }
   );
 });

--- a/packages/builder/src/spacing-bands.test.ts
+++ b/packages/builder/src/spacing-bands.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { Rect } from "./geometry";
 import {
+  sameBands,
   spacingBands,
   type EdgeLengths,
   type SpacingBand,
@@ -211,6 +212,21 @@ describe("where a padding band lands", () => {
     expect(band(bands, "padding", "left")?.rect.height).toBe(0);
   });
 
+  it("clamps a single padding extent to the box, not just the remainder", () => {
+    /*
+     * `box-sizing: border-box` with a fixed height and a larger padding keeps
+     * the computed padding and collapses the content, so one side alone can
+     * exceed the box. An unclamped band runs past the border edge and is drawn
+     * over the neighbouring block — naming another block's space as this one's,
+     * which is worse than drawing nothing.
+     */
+    const bands = bandsFor({ padding: { ...NONE, top: 400 } });
+    const top = band(bands, "padding", "top")?.rect;
+    expect(top?.height).toBe(150);
+    // Still labelled with what the author set, which the clamp must not change.
+    expect(band(bands, "padding", "top")?.label).toBe("400");
+  });
+
   it("clamps the padding box when the borders exceed the border box", () => {
     /*
      * A separate clamp from the one above, on the inset rather than on the
@@ -318,5 +334,47 @@ describe("paint order", () => {
       padding: { ...NONE, top: 10 },
     });
     expect(bands.map(one => one.box)).toEqual(["margin", "padding"]);
+  });
+});
+
+describe("comparing two band lists", () => {
+  const one = (over: Partial<SpacingBand> = {}): SpacingBand => ({
+    box: "margin",
+    side: "top",
+    rect: { x: 1, y: 2, width: 3, height: 4 },
+    label: "16",
+    negative: false,
+    ...over,
+  });
+
+  it("says two identical lists are the same", () => {
+    expect(sameBands([one()], [one()])).toBe(true);
+  });
+
+  it("says an empty list matches an empty list", () => {
+    expect(sameBands([], [])).toBe(true);
+  });
+
+  it("notices a different length", () => {
+    expect(sameBands([one()], [one(), one({ side: "left" })])).toBe(false);
+  });
+
+  it.each<[string, Partial<SpacingBand>]>([
+    ["the box", { box: "padding" }],
+    ["the side", { side: "bottom" }],
+    ["the label", { label: "24" }],
+    ["the negative flag", { negative: true }],
+    ["the rectangle's x", { rect: { x: 9, y: 2, width: 3, height: 4 } }],
+    ["the rectangle's y", { rect: { x: 1, y: 9, width: 3, height: 4 } }],
+    ["the rectangle's width", { rect: { x: 1, y: 2, width: 9, height: 4 } }],
+    ["the rectangle's height", { rect: { x: 1, y: 2, width: 3, height: 9 } }],
+  ])("notices a change to %s", (_label, over) => {
+    /*
+     * Every field, not a subset. A band that MOVED without resizing and a label
+     * that changed while the geometry held are both real changes an author has
+     * to see, and a comparison skipping either would freeze the overlay in
+     * exactly the case it exists to report.
+     */
+    expect(sameBands([one()], [one(over)])).toBe(false);
   });
 });

--- a/packages/builder/src/spacing-bands.test.ts
+++ b/packages/builder/src/spacing-bands.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { Rect } from "./geometry";
 import {
+  overlayEscape,
   sameBands,
   spacingApplies,
   spacingBands,
@@ -420,4 +421,57 @@ describe("which spacing a generated box can have", () => {
       expect(spacingApplies(display)).toEqual({ margin: true, padding: true });
     }
   );
+});
+
+describe("how far the overlay must be allowed to paint outside itself", () => {
+  const LAYER = { width: 1000, height: 800 };
+  const CHIP = 24;
+  const at = (rect: Rect): SpacingBand => ({
+    box: "margin",
+    side: "top",
+    rect,
+    label: "40",
+    negative: false,
+  });
+
+  it("allows the chip alone when nothing escapes", () => {
+    // A band wholly inside still needs room: the chip is CENTRED on it and
+    // deliberately unclipped, so a band flush with an edge overflows by its own
+    // half-height even when the band escapes by nothing.
+    const bands = [at({ x: 10, y: 10, width: 100, height: 20 })];
+    expect(overlayEscape(bands, LAYER, CHIP)).toBe(CHIP);
+  });
+
+  it("measures a band that escapes ABOVE the layer", () => {
+    /*
+     * The collapsed-margin case: the first block's top margin escapes the canvas
+     * entirely, so its band is placed at a negative offset. A fixed allowance is
+     * what this replaces — `2rem` clipped an ordinary 64px spacing step.
+     */
+    const bands = [at({ x: 0, y: -64, width: 1000, height: 64 })];
+    expect(overlayEscape(bands, LAYER, CHIP)).toBe(64 + CHIP);
+  });
+
+  it.each<[string, Rect, number]>([
+    ["left", { x: -30, y: 10, width: 30, height: 50 }, 30],
+    ["right", { x: 980, y: 10, width: 60, height: 50 }, 40],
+    ["below", { x: 0, y: 780, width: 100, height: 45 }, 25],
+  ])("measures a band escaping to the %s", (_side, rect, expected) => {
+    expect(overlayEscape([at(rect)], LAYER, CHIP)).toBe(expected + CHIP);
+  });
+
+  it("takes the LARGEST escape across every band", () => {
+    // One allowance covers all four sides, so the widest escape decides it. A
+    // per-band answer would clip whichever band was not asked about.
+    const bands = [
+      at({ x: 0, y: -10, width: 100, height: 10 }),
+      at({ x: 0, y: -90, width: 100, height: 90 }),
+      at({ x: 0, y: 10, width: 100, height: 10 }),
+    ];
+    expect(overlayEscape(bands, LAYER, CHIP)).toBe(90 + CHIP);
+  });
+
+  it("never returns a negative allowance", () => {
+    expect(overlayEscape([], LAYER, CHIP)).toBe(CHIP);
+  });
 });

--- a/packages/builder/src/spacing-bands.test.ts
+++ b/packages/builder/src/spacing-bands.test.ts
@@ -623,6 +623,46 @@ describe("which spacing a generated box can have", () => {
     expect(replaced.padding).toEqual(ALL);
   });
 
+  it.each(["inline list-item", "ruby"])(
+    "treats the non-atomic inline %s the same as a bare inline",
+    display => {
+      /*
+       * `display` is a two-part value and the catalog ships the multi-keyword
+       * forms, so matching `"inline"` exactly is not enough. `inline list-item`
+       * is authorable eight ways — every ordering computes to this one string —
+       * and `ruby` is inline-level without the word appearing in it at all.
+       *
+       * Measured across the catalog's whole display list: these two move the
+       * content after them by nothing when given fifty pixels of margin above
+       * and below, exactly as a bare `inline` does.
+       */
+      expect(spacingApplies(display, "horizontal-tb", false).margin).toEqual({
+        top: false,
+        bottom: false,
+        left: true,
+        right: true,
+      });
+    }
+  );
+
+  it.each([
+    "inline flow-root list-item",
+    "inline-block",
+    "inline-flex",
+    "inline-table",
+    "block ruby",
+  ])("gives the ATOMIC inline-level %s every side", display => {
+    /*
+     * The separating set. Each of these is inline-LEVEL, and each of them takes
+     * its block-axis margins, so the question is not whether a box is inline
+     * but whether it is ATOMIC. A rule written as "starts with inline" or
+     * "contains inline" answers the tests above correctly and blanks all of
+     * these — `inline flow-root list-item` in particular differs from
+     * `inline list-item` by one keyword and goes the other way.
+     */
+    expect(spacingApplies(display, "horizontal-tb", false).margin).toEqual(ALL);
+  });
+
   it("still gives a replaced box in a MARGINLESS display no margins", () => {
     // Replaced-ness answers the inline question only. An author who sets
     // `display: table-row` on an image gets a box CSS applies no margin to, and

--- a/packages/builder/src/spacing-bands.test.ts
+++ b/packages/builder/src/spacing-bands.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from "vitest";
+
+import type { Rect } from "./geometry";
+import {
+  spacingBands,
+  type EdgeLengths,
+  type SpacingBand,
+  type SpacingBox,
+  type SpacingGeometry,
+  type SpacingSide,
+} from "./spacing-bands";
+
+/**
+ * A border box away from the origin and not square, so no assertion below can
+ * pass by coincidence: an implementation that dropped `x`, swapped an axis or
+ * confused width with height would land on the same numbers for a square at
+ * `0,0`.
+ */
+const BORDER: Rect = { x: 100, y: 200, width: 300, height: 150 };
+
+const NONE: EdgeLengths = { top: 0, right: 0, bottom: 0, left: 0 };
+
+function bandsFor(over: Partial<SpacingGeometry>): readonly SpacingBand[] {
+  return spacingBands({
+    border: BORDER,
+    borderWidths: NONE,
+    margin: NONE,
+    padding: NONE,
+    scale: 1,
+    ...over,
+  });
+}
+
+function band(
+  bands: readonly SpacingBand[],
+  box: SpacingBox,
+  side: SpacingSide
+): SpacingBand | undefined {
+  return bands.find(one => one.box === box && one.side === side);
+}
+
+describe("which sides report at all", () => {
+  it("draws nothing for a node with no spacing", () => {
+    expect(bandsFor({})).toEqual([]);
+  });
+
+  it("draws only the sides that carry a value", () => {
+    const bands = bandsFor({
+      margin: { top: 16, right: 0, bottom: 0, left: 0 },
+      padding: { top: 0, right: 0, bottom: 24, left: 0 },
+    });
+    expect(bands.map(one => `${one.box}-${one.side}`)).toEqual([
+      "margin-top",
+      "padding-bottom",
+    ]);
+  });
+
+  it("omits a side whose value rounds away to nothing", () => {
+    // The band and the label have to agree. A hair of a pixel reads as `0`, and
+    // a band drawn beside that text says nothing while occupying the overlay.
+    expect(bandsFor({ margin: { ...NONE, top: 0.001 } })).toEqual([]);
+  });
+
+  it("reports a side that rounds to a value, however small", () => {
+    const bands = bandsFor({ margin: { ...NONE, top: 0.4 } });
+    expect(bands).toHaveLength(1);
+    expect(bands[0]?.label).toBe("0.4");
+  });
+});
+
+describe("the label", () => {
+  it.each<[string, number, string]>([
+    ["a whole number carries no decimals", 16, "16"],
+    ["a fraction is kept", 16.5, "16.5"],
+    ["a long fraction is rounded to two places", 15.996, "16"],
+    ["a repeating fraction is truncated, not expanded", 33.333333, "33.33"],
+    ["a negative keeps its sign", -10, "-10"],
+  ])("%s", (_label, value, expected) => {
+    const bands = bandsFor({ margin: { ...NONE, top: value } });
+    expect(bands[0]?.label).toBe(expected);
+  });
+});
+
+describe("where a margin band lands", () => {
+  it("puts a positive margin OUTSIDE the border edge", () => {
+    const bands = bandsFor({ margin: { ...NONE, top: 20 } });
+    expect(band(bands, "margin", "top")?.rect).toEqual({
+      x: 100,
+      y: 180,
+      width: 300,
+      height: 20,
+    });
+  });
+
+  it("puts a positive bottom margin below the border box", () => {
+    const bands = bandsFor({ margin: { ...NONE, bottom: 24 } });
+    expect(band(bands, "margin", "bottom")?.rect).toEqual({
+      x: 100,
+      y: 350,
+      width: 300,
+      height: 24,
+    });
+  });
+
+  it("puts left and right margins beside the border box", () => {
+    const bands = bandsFor({ margin: { ...NONE, left: 12, right: 8 } });
+    expect(band(bands, "margin", "left")?.rect).toEqual({
+      x: 88,
+      y: 200,
+      width: 12,
+      height: 150,
+    });
+    expect(band(bands, "margin", "right")?.rect).toEqual({
+      x: 400,
+      y: 200,
+      width: 8,
+      height: 150,
+    });
+  });
+
+  it("puts a NEGATIVE margin inside the border edge, not outside it", () => {
+    /*
+     * The separating property. A negative margin pulls the element toward its
+     * neighbour, so the margin box is SMALLER than the border box on that side —
+     * and an implementation that only took the absolute value would draw the
+     * band in empty space on the far side, naming space that is not there.
+     */
+    const bands = bandsFor({ margin: { ...NONE, top: -30 } });
+    expect(band(bands, "margin", "top")?.rect).toEqual({
+      x: 100,
+      y: 200,
+      width: 300,
+      height: 30,
+    });
+  });
+
+  it("marks a negative margin, and does not mark a positive one", () => {
+    expect(bandsFor({ margin: { ...NONE, top: -30 } })[0]?.negative).toBe(true);
+    expect(bandsFor({ margin: { ...NONE, top: 30 } })[0]?.negative).toBe(false);
+  });
+
+  it("draws a negative bottom margin up from the bottom edge", () => {
+    const bands = bandsFor({ margin: { ...NONE, bottom: -40 } });
+    expect(band(bands, "margin", "bottom")?.rect).toEqual({
+      x: 100,
+      y: 310,
+      width: 300,
+      height: 40,
+    });
+  });
+});
+
+describe("where a padding band lands", () => {
+  it("puts padding inside the border box", () => {
+    const bands = bandsFor({ padding: { ...NONE, top: 10 } });
+    expect(band(bands, "padding", "top")?.rect).toEqual({
+      x: 100,
+      y: 200,
+      width: 300,
+      height: 10,
+    });
+  });
+
+  it("insets padding by the BORDER width", () => {
+    /*
+     * Padding is measured from the padding box, which is the border box less the
+     * border. Without the inset every band on a bordered block is drawn over the
+     * border by its width, which is the one case where the overlay is wrong
+     * about a block that looks ordinary.
+     */
+    const bands = bandsFor({
+      borderWidths: { top: 4, right: 4, bottom: 4, left: 4 },
+      padding: { ...NONE, top: 10 },
+    });
+    expect(band(bands, "padding", "top")?.rect).toEqual({
+      x: 104,
+      y: 204,
+      width: 292,
+      height: 10,
+    });
+  });
+
+  it("leaves the corners to top and bottom, so no two bands overlap", () => {
+    // Top and bottom span the full width; left and right take what is between
+    // them. Two translucent bands over one corner read as a heavier colour that
+    // means nothing.
+    const bands = bandsFor({
+      padding: { top: 10, right: 6, bottom: 20, left: 8 },
+    });
+    expect(band(bands, "padding", "left")?.rect).toEqual({
+      x: 100,
+      y: 210,
+      width: 8,
+      height: 120,
+    });
+    expect(band(bands, "padding", "right")?.rect).toEqual({
+      x: 394,
+      y: 210,
+      width: 6,
+      height: 120,
+    });
+  });
+
+  it("clamps rather than inverting when padding exceeds the box", () => {
+    // Legal: a fixed-height element with more padding than height. The remainder
+    // between top and bottom is negative, and a rectangle with a negative height
+    // draws nothing at all.
+    const bands = bandsFor({
+      padding: { top: 100, right: 5, bottom: 100, left: 5 },
+    });
+    expect(band(bands, "padding", "left")?.rect.height).toBe(0);
+  });
+
+  it("clamps the padding box when the borders exceed the border box", () => {
+    /*
+     * A separate clamp from the one above, on the inset rather than on the
+     * remainder between two sides. A border box contains its own borders, so a
+     * DOM cannot currently produce this — which is exactly why it is asserted
+     * here: the function takes plain numbers, and a caller that is not the DOM
+     * must get a rectangle rather than an inverted one.
+     */
+    const bands = bandsFor({
+      borderWidths: { top: 100, right: 200, bottom: 100, left: 200 },
+      padding: { ...NONE, top: 10 },
+    });
+    expect(band(bands, "padding", "top")?.rect.width).toBe(0);
+  });
+});
+
+describe("scale", () => {
+  /*
+   * The rectangle arrives post-transform and the edge lengths do not, so the
+   * scale is what reconciles them. The label must NOT move with it: the author
+   * set sixteen pixels, and a canvas drawn at half size has not changed that.
+   */
+  it("scales a band's extent", () => {
+    const bands = bandsFor({ margin: { ...NONE, top: 20 }, scale: 0.5 });
+    expect(band(bands, "margin", "top")?.rect).toEqual({
+      x: 100,
+      y: 190,
+      width: 300,
+      height: 10,
+    });
+  });
+
+  it("leaves the LABEL in unscaled CSS pixels", () => {
+    const bands = bandsFor({ margin: { ...NONE, top: 20 }, scale: 0.5 });
+    expect(band(bands, "margin", "top")?.label).toBe("20");
+  });
+
+  it("scales the border inset that positions padding", () => {
+    const bands = bandsFor({
+      borderWidths: { top: 4, right: 4, bottom: 4, left: 4 },
+      padding: { ...NONE, top: 10 },
+      scale: 2,
+    });
+    expect(band(bands, "padding", "top")?.rect).toEqual({
+      x: 108,
+      y: 208,
+      width: 284,
+      height: 20,
+    });
+  });
+
+  it("is not satisfied by ignoring the argument", () => {
+    // The control for the three above, which an implementation that dropped
+    // `scale` entirely would pass at 1. At any other scale the extent has to
+    // differ from the unscaled one.
+    const plain = bandsFor({ margin: { ...NONE, top: 20 } });
+    const scaled = bandsFor({ margin: { ...NONE, top: 20 }, scale: 0.5 });
+    expect(scaled[0]?.rect.height).not.toBe(plain[0]?.rect.height);
+  });
+});
+
+describe("paint order", () => {
+  it("emits margin before padding", () => {
+    /*
+     * A negative margin band lies over the same pixels a padding band occupies,
+     * and inside the box the padding is the more useful of the two. Emitting
+     * margin first is what puts padding on top.
+     */
+    const bands = bandsFor({
+      margin: { ...NONE, top: -30 },
+      padding: { ...NONE, top: 10 },
+    });
+    expect(bands.map(one => one.box)).toEqual(["margin", "padding"]);
+  });
+});

--- a/packages/builder/src/spacing-bands.test.ts
+++ b/packages/builder/src/spacing-bands.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { Rect } from "./geometry";
 import {
   sameBands,
+  spacingApplies,
   spacingBands,
   type EdgeLengths,
   type SpacingBand,
@@ -377,4 +378,46 @@ describe("comparing two band lists", () => {
      */
     expect(sameBands([one()], [one(over)])).toBe(false);
   });
+});
+
+describe("which spacing a generated box can have", () => {
+  it.each([
+    "table-row-group",
+    "table-header-group",
+    "table-footer-group",
+    "table-row",
+    "table-column-group",
+    "table-column",
+    "ruby-base",
+    "ruby-text",
+    "ruby-base-container",
+    "ruby-text-container",
+  ])("gives %s neither margin nor padding", display => {
+    /*
+     * CSS applies neither to an internal table or ruby box, but
+     * `getComputedStyle` still answers with whatever the author declared — so
+     * reading it unconditionally draws bands for space that does not exist and
+     * cannot be made to exist by changing the value.
+     */
+    expect(spacingApplies(display)).toEqual({ margin: false, padding: false });
+  });
+
+  it("gives table-cell padding but not margin", () => {
+    // The one internal table box padding applies to, and the common case an
+    // author actually sets. Collapsing it into the group above would blank the
+    // padding of every table cell on the page.
+    expect(spacingApplies("table-cell")).toEqual({
+      margin: false,
+      padding: true,
+    });
+  });
+
+  it.each(["block", "flex", "grid", "inline-block", "table", "table-caption"])(
+    "gives %s both",
+    display => {
+      // `table-caption` is here deliberately: it is NOT an internal table box,
+      // and its margins apply normally.
+      expect(spacingApplies(display)).toEqual({ margin: true, padding: true });
+    }
+  );
 });

--- a/packages/builder/src/spacing-bands.test.ts
+++ b/packages/builder/src/spacing-bands.test.ts
@@ -26,7 +26,7 @@ function bandsFor(over: Partial<SpacingGeometry>): readonly SpacingBand[] {
     borderWidths: NONE,
     margin: NONE,
     padding: NONE,
-    scale: 1,
+    scale: { x: 1, y: 1 },
     ...over,
   });
 }
@@ -234,7 +234,10 @@ describe("scale", () => {
    * set sixteen pixels, and a canvas drawn at half size has not changed that.
    */
   it("scales a band's extent", () => {
-    const bands = bandsFor({ margin: { ...NONE, top: 20 }, scale: 0.5 });
+    const bands = bandsFor({
+      margin: { ...NONE, top: 20 },
+      scale: { x: 0.5, y: 0.5 },
+    });
     expect(band(bands, "margin", "top")?.rect).toEqual({
       x: 100,
       y: 190,
@@ -244,7 +247,10 @@ describe("scale", () => {
   });
 
   it("leaves the LABEL in unscaled CSS pixels", () => {
-    const bands = bandsFor({ margin: { ...NONE, top: 20 }, scale: 0.5 });
+    const bands = bandsFor({
+      margin: { ...NONE, top: 20 },
+      scale: { x: 0.5, y: 0.5 },
+    });
     expect(band(bands, "margin", "top")?.label).toBe("20");
   });
 
@@ -252,7 +258,7 @@ describe("scale", () => {
     const bands = bandsFor({
       borderWidths: { top: 4, right: 4, bottom: 4, left: 4 },
       padding: { ...NONE, top: 10 },
-      scale: 2,
+      scale: { x: 2, y: 2 },
     });
     expect(band(bands, "padding", "top")?.rect).toEqual({
       x: 108,
@@ -262,12 +268,40 @@ describe("scale", () => {
     });
   });
 
+  it("scales each edge by the axis it runs along", () => {
+    /*
+     * `transform: scale(2, 0.5)` is one legal value, and a single factor is
+     * necessarily wrong on one of the two axes. A vertical margin follows the
+     * vertical scale and a horizontal one the horizontal scale.
+     */
+    const bands = bandsFor({
+      margin: { top: 20, right: 20, bottom: 0, left: 0 },
+      scale: { x: 2, y: 0.5 },
+    });
+    expect(band(bands, "margin", "top")?.rect.height).toBe(10);
+    expect(band(bands, "margin", "right")?.rect.width).toBe(40);
+  });
+
+  it("reports the same LABEL on both axes however they are scaled", () => {
+    // The author typed twenty on each side. Nothing about drawing the block at
+    // a different size changed what they typed.
+    const bands = bandsFor({
+      margin: { top: 20, right: 20, bottom: 0, left: 0 },
+      scale: { x: 2, y: 0.5 },
+    });
+    expect(band(bands, "margin", "top")?.label).toBe("20");
+    expect(band(bands, "margin", "right")?.label).toBe("20");
+  });
+
   it("is not satisfied by ignoring the argument", () => {
     // The control for the three above, which an implementation that dropped
     // `scale` entirely would pass at 1. At any other scale the extent has to
     // differ from the unscaled one.
     const plain = bandsFor({ margin: { ...NONE, top: 20 } });
-    const scaled = bandsFor({ margin: { ...NONE, top: 20 }, scale: 0.5 });
+    const scaled = bandsFor({
+      margin: { ...NONE, top: 20 },
+      scale: { x: 0.5, y: 0.5 },
+    });
     expect(scaled[0]?.rect.height).not.toBe(plain[0]?.rect.height);
   });
 });

--- a/packages/builder/src/spacing-bands.test.ts
+++ b/packages/builder/src/spacing-bands.test.ts
@@ -195,6 +195,105 @@ describe("where a margin band lands", () => {
       height: 40,
     });
   });
+
+  it("stops a negative margin LARGER than the block at the opposite edge", () => {
+    /*
+     * A negative margin has no bound in CSS and pulling an element further than
+     * its own size is the usual way an overlap is authored. Drawn unbounded,
+     * `-400` on a 150-tall block runs 250 pixels past the bottom edge and
+     * colours a neighbour's pixels as this block's margin.
+     *
+     * The existing fixtures above are all smaller than the border box, so they
+     * do not separate a clamped implementation from an unbounded one.
+     */
+    const bands = bandsFor({ margin: { ...NONE, top: -400 } });
+    expect(band(bands, "margin", "top")?.rect).toEqual({
+      x: 100,
+      y: 200,
+      width: 300,
+      height: 150,
+    });
+  });
+
+  it("reports the AUTHORED value on a band it had to clamp", () => {
+    // The bound moves the band, never the number. An author who wrote `-400`
+    // and reads `-150` off the canvas would go looking for a value that is not
+    // in the document.
+    const bands = bandsFor({ margin: { ...NONE, top: -400 } });
+    expect(band(bands, "margin", "top")?.label).toBe("-400");
+  });
+
+  it.each<[SpacingSide, Rect]>([
+    ["bottom", { x: 100, y: 200, width: 300, height: 150 }],
+    ["left", { x: 100, y: 200, width: 300, height: 150 }],
+    ["right", { x: 100, y: 200, width: 300, height: 150 }],
+  ])("stops an oversized negative %s margin too", (side, expected) => {
+    // Each side clamps against the dimension it runs along: top and bottom
+    // against the height, left and right against the width. A single clamp
+    // written against one dimension is wrong on the other axis, and this block
+    // is deliberately not square.
+    const bands = bandsFor({ margin: { ...NONE, [side]: -400 } });
+    expect(band(bands, "margin", side)?.rect).toEqual(expected);
+  });
+
+  it("shares the block between two negative sides that both overrun", () => {
+    /*
+     * Clamping each side to the border dimension ON ITS OWN still lets a pair
+     * overlap: `-200` and `-100` on a 150-tall block would each be cut to 150
+     * and cover the whole block twice. The fills are translucent, so the
+     * contested strip darkens and reads as a third value nobody wrote.
+     *
+     * Shared in proportion, the larger margin keeps the larger band — 200:100
+     * of 150 is 100 and 50 — and they meet at a single boundary.
+     */
+    const bands = bandsFor({
+      margin: { ...NONE, top: -200, bottom: -100 },
+    });
+    const top = band(bands, "margin", "top")?.rect;
+    const bottom = band(bands, "margin", "bottom")?.rect;
+    expect(top).toEqual({ x: 100, y: 200, width: 300, height: 100 });
+    expect(bottom).toEqual({ x: 100, y: 300, width: 300, height: 50 });
+    // Meeting exactly: no gap and no overlap.
+    expect((top?.y ?? 0) + (top?.height ?? 0)).toBe(bottom?.y);
+  });
+
+  it("steps an INWARD side band past the inward bands above and below it", () => {
+    /*
+     * The mirror of the outward rule. Outward, the top and bottom bands span the
+     * margin box's full width and the side bands stop at the border height, so
+     * each corner is painted exactly once. Inward, the horizontal bands lie
+     * inside the border box, so a side band spanning the full height would cross
+     * them and darken the corner.
+     */
+    const bands = bandsFor({
+      margin: { ...NONE, top: -40, left: -30 },
+    });
+    expect(band(bands, "margin", "top")?.rect).toEqual({
+      x: 100,
+      y: 200,
+      width: 300,
+      height: 40,
+    });
+    expect(band(bands, "margin", "left")?.rect).toEqual({
+      x: 100,
+      y: 240,
+      width: 30,
+      height: 110,
+    });
+  });
+
+  it("does NOT shorten an outward side band for an inward neighbour", () => {
+    // An outward side band sits beyond the border edge, where no inward band
+    // reaches — insetting it there would leave a strip of the margin area
+    // painted by nothing.
+    const bands = bandsFor({ margin: { ...NONE, top: -40, left: 20 } });
+    expect(band(bands, "margin", "left")?.rect).toEqual({
+      x: 80,
+      y: 200,
+      width: 20,
+      height: 150,
+    });
+  });
 });
 
 describe("where a padding band lands", () => {
@@ -447,7 +546,7 @@ describe("which spacing a generated box can have", () => {
      * reading it unconditionally draws bands for space that does not exist and
      * cannot be made to exist by changing the value.
      */
-    expect(spacingApplies(display, "horizontal-tb")).toEqual({
+    expect(spacingApplies(display, "horizontal-tb", false)).toEqual({
       margin: NONE,
       padding: NONE,
     });
@@ -457,7 +556,7 @@ describe("which spacing a generated box can have", () => {
     // The one internal table box padding applies to, and the common case an
     // author actually sets. Collapsing it into the group above would blank the
     // padding of every table cell on the page.
-    expect(spacingApplies("table-cell", "horizontal-tb")).toEqual({
+    expect(spacingApplies("table-cell", "horizontal-tb", false)).toEqual({
       margin: NONE,
       padding: ALL,
     });
@@ -468,14 +567,14 @@ describe("which spacing a generated box can have", () => {
     display => {
       // `table-caption` is here deliberately: it is NOT an internal table box,
       // and its margins apply normally.
-      expect(spacingApplies(display, "horizontal-tb")).toEqual({
+      expect(spacingApplies(display, "horizontal-tb", false)).toEqual({
         margin: ALL,
         padding: ALL,
       });
     }
   );
 
-  it("drops an inline box's BLOCK-axis margins and keeps the inline ones", () => {
+  it("drops a NON-REPLACED inline box's block-axis margins and keeps the inline ones", () => {
     /*
      * A non-replaced inline box ignores its block-axis margins entirely while
      * `getComputedStyle` reports whatever was declared, so a blanket answer
@@ -483,7 +582,7 @@ describe("which spacing a generated box can have", () => {
      * block-axis padding on an inline box does not affect layout but DOES
      * render, and this overlay reports what renders.
      */
-    expect(spacingApplies("inline", "horizontal-tb")).toEqual({
+    expect(spacingApplies("inline", "horizontal-tb", false)).toEqual({
       margin: { top: false, bottom: false, left: true, right: true },
       padding: ALL,
     });
@@ -495,7 +594,7 @@ describe("which spacing a generated box can have", () => {
       // Which PHYSICAL sides the block axis lands on is a function of the
       // writing mode, so a physical answer hard-coded to `horizontal-tb` is
       // wrong on exactly the documents that need it most.
-      expect(spacingApplies("inline", writingMode).margin).toEqual({
+      expect(spacingApplies("inline", writingMode, false).margin).toEqual({
         top: true,
         bottom: true,
         left: false,
@@ -503,6 +602,36 @@ describe("which spacing a generated box can have", () => {
       });
     }
   );
+
+  it("keeps a REPLACED inline box's block-axis margins", () => {
+    /*
+     * The captionless `core/image` case, which is the ordinary way an image is
+     * placed: the block's root is a bare `<img>` whose computed display is
+     * `inline`. A replaced box is sized by its own content, and the line box has
+     * to make room for its block-axis margins — measured in Chromium, fifty
+     * pixels above and below an inline `<img>` moves the following content by a
+     * hundred, where the same declaration on a `<span>` moves it by nothing.
+     *
+     * Compared against the non-replaced answer rather than asserted alone, so
+     * the pair is what separates them: an implementation that ignored
+     * `replaced` would satisfy either expectation on its own.
+     */
+    const replaced = spacingApplies("inline", "horizontal-tb", true);
+    const plain = spacingApplies("inline", "horizontal-tb", false);
+    expect(replaced.margin).toEqual(ALL);
+    expect(plain.margin).not.toEqual(ALL);
+    expect(replaced.padding).toEqual(ALL);
+  });
+
+  it("still gives a replaced box in a MARGINLESS display no margins", () => {
+    // Replaced-ness answers the inline question only. An author who sets
+    // `display: table-row` on an image gets a box CSS applies no margin to, and
+    // the replaced exception must not reach past the branch it belongs to.
+    expect(spacingApplies("table-row", "horizontal-tb", true)).toEqual({
+      margin: NONE,
+      padding: NONE,
+    });
+  });
 });
 
 describe("how far the overlay must be allowed to paint outside itself", () => {

--- a/packages/builder/src/spacing-bands.ts
+++ b/packages/builder/src/spacing-bands.ts
@@ -151,6 +151,8 @@ export function spacingBands(
   const padding = scaled(geometry.padding);
   const bands: SpacingBand[] = [];
 
+  const inward = inwardExtents(margin, border);
+
   for (const side of SIDES) {
     const value = geometry.margin[side];
     const label = labelFor(value);
@@ -158,7 +160,7 @@ export function spacingBands(
     bands.push({
       box: "margin",
       side,
-      rect: marginRect(border, side, margin),
+      rect: marginRect(border, side, margin, inward),
       label,
       negative: value < 0,
     });
@@ -199,6 +201,58 @@ function inset(rect: Rect, by: EdgeLengths): Rect {
 }
 
 /**
+ * How far each negative margin reaches INTO the border box.
+ *
+ * A negative margin has no bound in CSS: `margin-top: -100px` on a twenty-pixel
+ * block is legal, and pulling an element further than its own size is the usual
+ * way an overlap is authored. Drawn unbounded the band runs past the opposite
+ * edge and colours a neighbour's pixels as this block's margin — the one thing
+ * the overlay exists to answer, answered wrongly.
+ *
+ * Opposite sides are bounded TOGETHER, not one at a time. Clamping each to the
+ * border dimension on its own still lets a pair overlap in the middle, and the
+ * fills are translucent, so the contested strip darkens and reads as a third
+ * value that nobody wrote. Sharing the dimension in proportion keeps each side's
+ * band the larger of the two exactly when its margin is the larger, and lets
+ * them meet without either crossing.
+ *
+ * The bound moves the band, never the number: the label is taken from the
+ * authored value, so a margin clamped for want of room still reports what the
+ * author typed.
+ */
+function inwardExtents(margin: EdgeLengths, border: Rect): EdgeLengths {
+  const inwardPair = (
+    near: number,
+    far: number,
+    size: number
+  ): { near: number; far: number } => {
+    const total = near + far;
+    if (total <= size) return { near, far };
+    // `total` exceeds `size` and `size` is never negative, so `total` is
+    // positive here and the division is safe.
+    const share = size / total;
+    return { near: near * share, far: far * share };
+  };
+
+  const vertical = inwardPair(
+    Math.max(0, -margin.top),
+    Math.max(0, -margin.bottom),
+    border.height
+  );
+  const horizontal = inwardPair(
+    Math.max(0, -margin.left),
+    Math.max(0, -margin.right),
+    border.width
+  );
+  return {
+    top: vertical.near,
+    bottom: vertical.far,
+    left: horizontal.near,
+    right: horizontal.far,
+  };
+}
+
+/**
  * Where one margin band sits relative to the border box.
  *
  * A positive margin lies OUTSIDE the border edge, which is the case the box
@@ -207,70 +261,101 @@ function inset(rect: Rect, by: EdgeLengths): Rect {
  * toward its neighbour means. Drawing a negative margin outward would put the
  * band exactly where the space it removes is not.
  *
- * See {@link marginRect} for how the four meet at the corners.
+ * `inward` carries every side's bounded inward reach, not just this one's,
+ * because a band has to know where its neighbours stop — see
+ * {@link inwardExtents}.
+ *
+ * The two axes are separate functions rather than four arms of one switch: they
+ * follow DIFFERENT rules about the corners, and writing them together meant a
+ * reader had to hold both to be sure which applied.
  */
 function marginRect(
   border: Rect,
   side: SpacingSide,
-  margin: EdgeLengths
+  margin: EdgeLengths,
+  inward: EdgeLengths
 ): Rect {
   const value = margin[side];
-  const extent = Math.abs(value);
   const outward = value >= 0;
-  /*
-   * Top and bottom span the whole MARGIN box, not the border box.
-   *
-   * Spanning the border box leaves the outer corners painted by nothing: with a
-   * top and a left margin, the rectangle above-and-left of the border box
-   * belongs to the margin area and no band reached it. Extending the horizontal
-   * bands over the vertical margins assigns each corner exactly once — left and
-   * right still span the border height, so nothing is painted twice and no
-   * translucent overlap darkens a corner.
-   *
-   * Only OUTWARD neighbours extend it. A negative margin makes the margin box
-   * smaller on that side, so there is no corner out there to fill.
-   */
+  const extent = outward ? value : inward[side];
+  return side === "top" || side === "bottom"
+    ? horizontalMarginRect(border, side, { extent, outward, margin })
+    : verticalMarginRect(border, side, { extent, outward, inward });
+}
+
+/**
+ * The TOP or BOTTOM band, which runs across the box.
+ *
+ * Outward, it spans the whole MARGIN box rather than the border box. Spanning
+ * the border box leaves the outer corners painted by nothing: with a top and a
+ * left margin, the rectangle above-and-left of the border box belongs to the
+ * margin area and no band reached it. Extending the horizontal bands over the
+ * vertical margins assigns each corner exactly once — the side bands still stop
+ * at the border height, so nothing is painted twice and no translucent overlap
+ * darkens a corner.
+ *
+ * Only OUTWARD neighbours extend it. A negative margin makes the margin box
+ * smaller on that side, so there is no corner out there to fill.
+ */
+function horizontalMarginRect(
+  border: Rect,
+  side: "top" | "bottom",
+  {
+    extent,
+    outward,
+    margin,
+  }: { extent: number; outward: boolean; margin: EdgeLengths }
+): Rect {
   const leftOut = Math.max(0, margin.left);
   const rightOut = Math.max(0, margin.right);
-  switch (side) {
-    case "top":
-      return outward
-        ? {
-            x: border.x - leftOut,
-            y: border.y - extent,
-            width: border.width + leftOut + rightOut,
-            height: extent,
-          }
-        : { x: border.x, y: border.y, width: border.width, height: extent };
-    case "bottom":
-      return outward
-        ? {
-            x: border.x - leftOut,
-            y: border.y + border.height,
-            width: border.width + leftOut + rightOut,
-            height: extent,
-          }
-        : {
-            x: border.x,
-            y: border.y + border.height - extent,
-            width: border.width,
-            height: extent,
-          };
-    case "left":
-      return {
-        x: outward ? border.x - extent : border.x,
-        y: border.y,
-        width: extent,
-        height: border.height,
-      };
-    case "right":
-      return {
-        x: outward ? border.x + border.width : border.x + border.width - extent,
-        y: border.y,
-        width: extent,
-        height: border.height,
-      };
-  }
+  const span = outward
+    ? { x: border.x - leftOut, width: border.width + leftOut + rightOut }
+    : { x: border.x, width: border.width };
+
+  const top = border.y;
+  const bottom = border.y + border.height;
+  let y: number;
+  if (side === "top") y = outward ? top - extent : top;
+  else y = outward ? bottom : bottom - extent;
+
+  return { ...span, y, height: extent };
+}
+
+/**
+ * The LEFT or RIGHT band, which runs down the box.
+ *
+ * An INWARD one yields the corners to the horizontal bands, mirroring what
+ * {@link horizontalMarginRect} does outward: there the top and bottom bands
+ * span the margin box's full width and the side bands stop at the border
+ * height, so each corner is painted exactly once. Inward, the horizontal bands
+ * lie INSIDE the border box, and a side band spanning the full height would
+ * cross them — the fills are translucent, so the corner darkens and reads as a
+ * value nobody wrote.
+ *
+ * An outward side band needs no such inset: it sits beyond the border edge,
+ * where no inward band reaches.
+ */
+function verticalMarginRect(
+  border: Rect,
+  side: "left" | "right",
+  {
+    extent,
+    outward,
+    inward,
+  }: { extent: number; outward: boolean; inward: EdgeLengths }
+): Rect {
+  const y = outward ? border.y : border.y + inward.top;
+  const height = outward
+    ? border.height
+    : Math.max(0, border.height - inward.top - inward.bottom);
+
+  const left = border.x;
+  const right = border.x + border.width;
+  let x: number;
+  if (side === "left") x = outward ? left - extent : left;
+  else x = outward ? right : right - extent;
+
+  return { x, y, width: extent, height };
 }
 
 /**
@@ -439,14 +524,25 @@ function blockAxisIsVertical(writingMode: string): boolean {
  * vertical in `horizontal-tb` and horizontal in every `vertical-*` mode. Padding
  * is left alone — an inline box's block-axis padding does not affect layout, but
  * it DOES render, and this overlay reports what renders.
+ *
+ * `replaced` is the exception that makes the inline branch conditional, and it
+ * is not a detail of an obscure element: `core/image` renders a bare `<img>`
+ * whenever it has no caption, so the most ordinary image on a page IS an inline
+ * replaced root. A replaced box is sized by its own content rather than by the
+ * line, and its block-axis margins are part of what the line box has to make
+ * room for — measured in Chromium, fifty pixels above and below an inline
+ * `<img>` moves the following content by exactly a hundred, and the same
+ * declaration on a `<span>` moves it by nothing. It cannot be read off the
+ * computed style, which is why the caller passes it.
  */
 export function spacingApplies(
   display: string,
-  writingMode: string
+  writingMode: string,
+  replaced: boolean
 ): { margin: EdgeApplicability; padding: EdgeApplicability } {
   const padding = PADDINGLESS.has(display) ? NO_SIDES : ALL_SIDES;
   if (MARGINLESS.has(display)) return { margin: NO_SIDES, padding };
-  if (display !== "inline") return { margin: ALL_SIDES, padding };
+  if (display !== "inline" || replaced) return { margin: ALL_SIDES, padding };
 
   const acrossBlock = blockAxisIsVertical(writingMode);
   return {

--- a/packages/builder/src/spacing-bands.ts
+++ b/packages/builder/src/spacing-bands.ts
@@ -13,16 +13,21 @@
  * ## Two coordinate spaces meet here, and they are not the same space
  *
  * `border` arrives from `canvasContentRect`, which reads `getBoundingClientRect`
- * — a POST-transform measurement, so a canvas drawn at half size reports half
+ * — a POST-transform measurement, so an element drawn at half size reports half
  * the pixels. The edge lengths arrive from `getComputedStyle`, which reports
- * UNSCALED CSS pixels and knows nothing about a transform above it.
+ * UNSCALED CSS pixels and knows nothing about a transform on the element or on
+ * anything above it.
  *
- * `scale` is what reconciles them, and it is required rather than defaulted for
- * that reason. The two spaces coincide exactly while the canvas is drawn at 1:1,
- * which is every case today — so a default would be correct, silently, until the
- * day it was not, and nothing here would fail. A caller has to say which scale
- * its rectangle was measured at, and the label keeps reporting the CSS value the
- * author typed rather than the scaled one they can see.
+ * `scale` is what reconciles them, and it is required rather than defaulted
+ * because the mismatch is reachable TODAY: `transform` is a catalog property, so
+ * an author can scale a block and every band would otherwise be wrong by exactly
+ * that factor with nothing failing. It is per-axis because `scale(2, 0.5)` is
+ * one value, and a single factor would be right on one axis and wrong on the
+ * other.
+ *
+ * The LABEL never moves with it. The author typed sixteen pixels; drawing the
+ * block at half size did not change what they typed, and a band reading `8`
+ * would name a value that appears nowhere in their document.
  *
  * @module spacing-bands
  */
@@ -67,16 +72,27 @@ export interface SpacingBand {
   readonly negative: boolean;
 }
 
+/**
+ * How much bigger the measured rectangle is than the layout it came from.
+ *
+ * Per-axis because a transform scales the two independently. `{ x: 1, y: 1 }`
+ * for an untransformed element, which is the ordinary case.
+ */
+export interface Scale {
+  readonly x: number;
+  readonly y: number;
+}
+
 /** Everything the placement needs, and nothing that has to be read from a DOM. */
 export interface SpacingGeometry {
-  /** The node's border box, in canvas content coordinates. */
+  /** The node's border box, in canvas content coordinates, post-transform. */
   readonly border: Rect;
   /** Border widths, needed because padding is measured from the padding box. */
   readonly borderWidths: EdgeLengths;
   readonly margin: EdgeLengths;
   readonly padding: EdgeLengths;
-  /** The scale `border` was measured at; `1` while the canvas is drawn 1:1. */
-  readonly scale: number;
+  /** The scale `border` was measured at. See the module docblock. */
+  readonly scale: Scale;
 }
 
 const SIDES: readonly SpacingSide[] = ["top", "right", "bottom", "left"];
@@ -118,8 +134,21 @@ export function spacingBands(
   geometry: SpacingGeometry
 ): readonly SpacingBand[] {
   const { border, scale } = geometry;
-  const scaled = (value: number): number => value * scale;
+  /*
+   * Each edge scales by the axis it runs along: a left margin is a horizontal
+   * distance and a top margin a vertical one. Scaling both by one factor is
+   * right only while the transform is uniform, and `scale(2, 0.5)` is a single
+   * legal value that makes it wrong on one axis.
+   */
+  const scaled = (edges: EdgeLengths): EdgeLengths => ({
+    top: edges.top * scale.y,
+    right: edges.right * scale.x,
+    bottom: edges.bottom * scale.y,
+    left: edges.left * scale.x,
+  });
 
+  const margin = scaled(geometry.margin);
+  const padding = scaled(geometry.padding);
   const bands: SpacingBand[] = [];
 
   for (const side of SIDES) {
@@ -129,7 +158,7 @@ export function spacingBands(
     bands.push({
       box: "margin",
       side,
-      rect: marginRect(border, side, scaled(value)),
+      rect: marginRect(border, side, margin[side]),
       label,
       negative: value < 0,
     });
@@ -141,12 +170,7 @@ export function spacingBands(
    * costs the same, so there is no branch for it — a block that does carry a
    * border would otherwise draw every padding band offset by its width.
    */
-  const inner = inset(border, {
-    top: scaled(geometry.borderWidths.top),
-    right: scaled(geometry.borderWidths.right),
-    bottom: scaled(geometry.borderWidths.bottom),
-    left: scaled(geometry.borderWidths.left),
-  });
+  const inner = inset(border, scaled(geometry.borderWidths));
 
   for (const side of SIDES) {
     const value = geometry.padding[side];
@@ -155,12 +179,7 @@ export function spacingBands(
     bands.push({
       box: "padding",
       side,
-      rect: paddingRect(inner, side, {
-        top: scaled(geometry.padding.top),
-        right: scaled(geometry.padding.right),
-        bottom: scaled(geometry.padding.bottom),
-        left: scaled(geometry.padding.left),
-      }),
+      rect: paddingRect(inner, side, padding),
       label,
       negative: false,
     });

--- a/packages/builder/src/spacing-bands.ts
+++ b/packages/builder/src/spacing-bands.ts
@@ -329,3 +329,51 @@ export function sameBands(
     );
   });
 }
+
+/**
+ * Boxes that CSS gives no margin, whatever the computed style reports.
+ *
+ * `getComputedStyle` answers with the declared computed length for a property
+ * that does not apply to the generated box, so an author who sets a margin on a
+ * `table-row` gets a number back from a box that has none. Drawing it names
+ * space that does not exist and cannot be made to exist by changing the value.
+ *
+ * The internal table boxes and the internal ruby boxes, both of which the
+ * catalog's `display` keyword list ships. `table-caption` is deliberately absent
+ * — it is not an internal table box and its margins apply normally.
+ */
+const MARGINLESS: ReadonlySet<string> = new Set([
+  "table-row-group",
+  "table-header-group",
+  "table-footer-group",
+  "table-row",
+  "table-cell",
+  "table-column-group",
+  "table-column",
+  "ruby-base",
+  "ruby-text",
+  "ruby-base-container",
+  "ruby-text-container",
+]);
+
+/**
+ * Boxes that CSS gives no padding.
+ *
+ * The same set MINUS `table-cell`, which is the one internal table box padding
+ * does apply to — and the distinction is the point, because a cell's padding is
+ * the common case an author actually sets.
+ */
+const PADDINGLESS: ReadonlySet<string> = new Set(
+  [...MARGINLESS].filter(display => display !== "table-cell")
+);
+
+/** Which spacing a generated box of this display type can actually have. */
+export function spacingApplies(display: string): {
+  margin: boolean;
+  padding: boolean;
+} {
+  return {
+    margin: !MARGINLESS.has(display),
+    padding: !PADDINGLESS.has(display),
+  };
+}

--- a/packages/builder/src/spacing-bands.ts
+++ b/packages/builder/src/spacing-bands.ts
@@ -377,3 +377,39 @@ export function spacingApplies(display: string): {
     padding: !PADDINGLESS.has(display),
   };
 }
+
+/**
+ * How far outside its own box the overlay layer must be allowed to paint.
+ *
+ * A band can legitimately sit outside the canvas. The first block's top margin
+ * collapses through the page wrapper and the root — neither establishes a
+ * formatting context — so its band is placed above the layer entirely; a
+ * negative margin or an edge-flush block can do the same on any side.
+ *
+ * A FIXED allowance is the wrong shape and was the first attempt: any constant
+ * is too small for some legal value, and `2rem` clipped an ordinary `64px`
+ * spacing step. This measures what the bands actually need instead, so the clip
+ * is exactly as loose as the content requires and no looser.
+ *
+ * `chip` is added unconditionally because the value chip is CENTRED on its band
+ * and deliberately unclipped, so a band flush with an edge overflows by its own
+ * half-height even when the band itself escapes by nothing. It is bounded by the
+ * chip's own size, which this package controls.
+ */
+export function overlayEscape(
+  bands: readonly SpacingBand[],
+  layer: { readonly width: number; readonly height: number },
+  chip: number
+): number {
+  let escape = 0;
+  for (const band of bands) {
+    escape = Math.max(
+      escape,
+      -band.rect.y,
+      -band.rect.x,
+      band.rect.y + band.rect.height - layer.height,
+      band.rect.x + band.rect.width - layer.width
+    );
+  }
+  return Math.max(0, escape) + chip;
+}

--- a/packages/builder/src/spacing-bands.ts
+++ b/packages/builder/src/spacing-bands.ts
@@ -477,6 +477,38 @@ const PADDINGLESS: ReadonlySet<string> = new Set(
   [...MARGINLESS].filter(display => display !== "table-cell")
 );
 
+/**
+ * Computed displays that generate a NON-ATOMIC inline box.
+ *
+ * These are the boxes whose block-axis margins do not affect layout. An ATOMIC
+ * inline — `inline-block`, `inline-flex`, `inline-table`, `inline flow-root
+ * list-item` — is inline-level too, and its margins DO apply, so the question
+ * is not whether a box is inline-level but whether it is atomic.
+ *
+ * A set rather than an equality test, because `display` is a two-part value and
+ * the catalog ships the multi-keyword forms: `inline list-item` is authorable
+ * eight different ways, and `ruby` is inline-level without the word appearing in
+ * it at all. Matching `"inline"` exactly misses both.
+ *
+ * Written against the COMPUTED value, which is what makes a set sufficient. The
+ * browser normalises order and shorthand — every one of `list-item inline`,
+ * `flow inline list-item` and `inline flow list-item` computes to `inline
+ * list-item` — so the fifty-nine spellings the catalog ships collapse to
+ * twenty-seven computed values, and these are the three of them that are
+ * inline and non-atomic.
+ *
+ * Measured, every catalog display value at once, by declaring fifty pixels of
+ * margin above and below and reading how far the following content moved: these
+ * three moved it by zero. `contents` and `none` did too and are deliberately
+ * absent — they generate no box at all, which the caller refuses outright
+ * before asking this.
+ */
+const NON_ATOMIC_INLINE: ReadonlySet<string> = new Set([
+  "inline",
+  "inline list-item",
+  "ruby",
+]);
+
 /** Whether each physical side of one box can carry spacing at all. */
 export interface EdgeApplicability {
   readonly top: boolean;
@@ -514,11 +546,15 @@ function blockAxisIsVertical(writingMode: string): boolean {
 /**
  * Which spacing a generated box of this display type can actually have.
  *
- * PER SIDE rather than per box, because `display: inline` is not all-or-nothing:
- * a non-replaced inline box takes its INLINE-axis margins and ignores its
+ * PER SIDE rather than per box, because an inline box is not all-or-nothing: a
+ * non-replaced, non-atomic one takes its INLINE-axis margins and ignores its
  * BLOCK-axis ones entirely, while `getComputedStyle` reports whatever the author
  * declared on all four. A blanket answer draws top and bottom bands for space an
  * inline box does not create.
+ *
+ * Which displays those are is {@link NON_ATOMIC_INLINE}, and it is more than the
+ * `inline` keyword: the catalog ships the multi-keyword forms, so `inline
+ * list-item` and `ruby` reach here as well.
  *
  * Which physical sides those are depends on the writing mode: the block axis is
  * vertical in `horizontal-tb` and horizontal in every `vertical-*` mode. Padding
@@ -542,7 +578,8 @@ export function spacingApplies(
 ): { margin: EdgeApplicability; padding: EdgeApplicability } {
   const padding = PADDINGLESS.has(display) ? NO_SIDES : ALL_SIDES;
   if (MARGINLESS.has(display)) return { margin: NO_SIDES, padding };
-  if (display !== "inline" || replaced) return { margin: ALL_SIDES, padding };
+  if (!NON_ATOMIC_INLINE.has(display) || replaced)
+    return { margin: ALL_SIDES, padding };
 
   const acrossBlock = blockAxisIsVertical(writingMode);
   return {

--- a/packages/builder/src/spacing-bands.ts
+++ b/packages/builder/src/spacing-bands.ts
@@ -261,30 +261,71 @@ function marginRect(border: Rect, side: SpacingSide, value: number): Rect {
  * remainder between top and bottom is then negative.
  */
 function paddingRect(inner: Rect, side: SpacingSide, by: EdgeLengths): Rect {
-  const middle = Math.max(0, inner.height - by.top - by.bottom);
+  /*
+   * Every extent is clamped to the box, not only the remainder between two
+   * sides. Padding can exceed the box it is measured in — `box-sizing:
+   * border-box` with a fixed height and a larger padding keeps the computed
+   * padding and collapses the content — and an unclamped band then runs past the
+   * border edge and is drawn over the neighbouring block, which is worse than
+   * drawing nothing because it names another block's space as this one's.
+   */
+  const top = Math.min(by.top, inner.height);
+  const bottom = Math.min(by.bottom, inner.height);
+  const left = Math.min(by.left, inner.width);
+  const right = Math.min(by.right, inner.width);
+  const middle = Math.max(0, inner.height - top - bottom);
   switch (side) {
     case "top":
-      return { x: inner.x, y: inner.y, width: inner.width, height: by.top };
+      return { x: inner.x, y: inner.y, width: inner.width, height: top };
     case "bottom":
       return {
         x: inner.x,
-        y: inner.y + inner.height - by.bottom,
+        y: inner.y + inner.height - bottom,
         width: inner.width,
-        height: by.bottom,
+        height: bottom,
       };
     case "left":
-      return {
-        x: inner.x,
-        y: inner.y + by.top,
-        width: by.left,
-        height: middle,
-      };
+      return { x: inner.x, y: inner.y + top, width: left, height: middle };
     case "right":
       return {
-        x: inner.x + inner.width - by.right,
-        y: inner.y + by.top,
-        width: by.right,
+        x: inner.x + inner.width - right,
+        y: inner.y + top,
+        width: right,
         height: middle,
       };
   }
+}
+
+/**
+ * Whether two band lists say the same thing, by VALUE.
+ *
+ * The overlay re-measures whenever the canvas moves or mutates, which on a page
+ * being typed into is often. Handing React a fresh array each time re-renders
+ * the whole overlay for a layout that did not move, so the caller keeps the
+ * array it already has when the answer is unchanged.
+ *
+ * Every field is compared, not a subset. A rectangle that moved without changing
+ * size, or a label that changed while the geometry held, are both real changes
+ * an author must see — and a comparison that skipped either would freeze the
+ * overlay in exactly the case it exists to report.
+ */
+export function sameBands(
+  left: readonly SpacingBand[],
+  right: readonly SpacingBand[]
+): boolean {
+  if (left.length !== right.length) return false;
+  return left.every((one, index) => {
+    const other = right[index];
+    return (
+      other !== undefined &&
+      one.box === other.box &&
+      one.side === other.side &&
+      one.label === other.label &&
+      one.negative === other.negative &&
+      one.rect.x === other.rect.x &&
+      one.rect.y === other.rect.y &&
+      one.rect.width === other.rect.width &&
+      one.rect.height === other.rect.height
+    );
+  });
 }

--- a/packages/builder/src/spacing-bands.ts
+++ b/packages/builder/src/spacing-bands.ts
@@ -1,0 +1,271 @@
+/**
+ * Where a node's spacing bands land, as arithmetic over plain numbers.
+ *
+ * The canvas draws an author's margin and padding as coloured bands with the
+ * value written on them. Deciding WHERE each band goes is geometry, and it is
+ * kept here — away from the DOM — for the reason `geometry.ts` gives about
+ * itself: jsdom lays nothing out and reports every element as zero-sized, so a
+ * placement rule written against live elements can only be exercised in a
+ * browser. Written against numbers it can be exercised anywhere, and the browser
+ * is left to certify the one thing only it can: that the numbers handed in
+ * describe the element they claim to.
+ *
+ * ## Two coordinate spaces meet here, and they are not the same space
+ *
+ * `border` arrives from `canvasContentRect`, which reads `getBoundingClientRect`
+ * — a POST-transform measurement, so a canvas drawn at half size reports half
+ * the pixels. The edge lengths arrive from `getComputedStyle`, which reports
+ * UNSCALED CSS pixels and knows nothing about a transform above it.
+ *
+ * `scale` is what reconciles them, and it is required rather than defaulted for
+ * that reason. The two spaces coincide exactly while the canvas is drawn at 1:1,
+ * which is every case today — so a default would be correct, silently, until the
+ * day it was not, and nothing here would fail. A caller has to say which scale
+ * its rectangle was measured at, and the label keeps reporting the CSS value the
+ * author typed rather than the scaled one they can see.
+ *
+ * @module spacing-bands
+ */
+
+import type { Rect } from "./geometry";
+
+/** The four physical sides, in the order a CSS shorthand writes them. */
+export type SpacingSide = "top" | "right" | "bottom" | "left";
+
+/**
+ * Which box of the CSS model a band belongs to.
+ *
+ * Border is measured but never drawn: it is a different catalog group, and the
+ * padding box cannot be located without it.
+ */
+export type SpacingBox = "margin" | "padding";
+
+/** Four physical edge lengths, in unscaled CSS pixels. */
+export interface EdgeLengths {
+  readonly top: number;
+  readonly right: number;
+  readonly bottom: number;
+  readonly left: number;
+}
+
+/** One band to draw, with the text that goes on it. */
+export interface SpacingBand {
+  readonly box: SpacingBox;
+  readonly side: SpacingSide;
+  /** In the same space as the `border` rectangle it was derived from. */
+  readonly rect: Rect;
+  /** The CSS-pixel value, unscaled, as the author would recognise it. */
+  readonly label: string;
+  /**
+   * A margin that pulls the element toward the side rather than away from it.
+   *
+   * Kept as a flag rather than a negative extent because a rectangle with a
+   * negative height draws nothing: the band is laid out INSIDE the border edge
+   * instead, which is where the margin box genuinely is, and the caller styles
+   * it differently so it cannot be mistaken for padding.
+   */
+  readonly negative: boolean;
+}
+
+/** Everything the placement needs, and nothing that has to be read from a DOM. */
+export interface SpacingGeometry {
+  /** The node's border box, in canvas content coordinates. */
+  readonly border: Rect;
+  /** Border widths, needed because padding is measured from the padding box. */
+  readonly borderWidths: EdgeLengths;
+  readonly margin: EdgeLengths;
+  readonly padding: EdgeLengths;
+  /** The scale `border` was measured at; `1` while the canvas is drawn 1:1. */
+  readonly scale: number;
+}
+
+const SIDES: readonly SpacingSide[] = ["top", "right", "bottom", "left"];
+
+/**
+ * The value as the author would write it, to two decimals.
+ *
+ * A computed length is frequently fractional — a percentage, a `rem` against a
+ * non-integer root, a flex remainder — and the full expansion is noise on a
+ * band a few pixels tall. `String` drops the trailing zeros that `toFixed`
+ * keeps, so a whole number reads as `16` rather than `16.00`, and it renders
+ * negative zero as `0`.
+ */
+function labelFor(value: number): string {
+  return String(Math.round(value * 100) / 100);
+}
+
+/**
+ * Whether a side has anything to report, decided FROM the label.
+ *
+ * A band drawn beside the text `0` is worse than no band: eight of them appear
+ * on every selection and train the author to stop reading the overlay. Asking
+ * the label rather than the raw value keeps the two answers from disagreeing —
+ * a length of `0.001` rounds to `0`, and the version that tests the raw value
+ * draws a band that says nothing.
+ */
+function reports(label: string): boolean {
+  return label !== "0";
+}
+
+/**
+ * The bands for one node, in paint order.
+ *
+ * Margin first so padding paints over it. The two only overlap where a margin
+ * is negative — that band lies inside the border edge, across the same pixels
+ * padding occupies — and there the padding is the more useful of the two.
+ */
+export function spacingBands(
+  geometry: SpacingGeometry
+): readonly SpacingBand[] {
+  const { border, scale } = geometry;
+  const scaled = (value: number): number => value * scale;
+
+  const bands: SpacingBand[] = [];
+
+  for (const side of SIDES) {
+    const value = geometry.margin[side];
+    const label = labelFor(value);
+    if (!reports(label)) continue;
+    bands.push({
+      box: "margin",
+      side,
+      rect: marginRect(border, side, scaled(value)),
+      label,
+      negative: value < 0,
+    });
+  }
+
+  /*
+   * Padding is measured from the padding box, which is the border box inset by
+   * the border. Insetting by nothing is the common case and the general form
+   * costs the same, so there is no branch for it — a block that does carry a
+   * border would otherwise draw every padding band offset by its width.
+   */
+  const inner = inset(border, {
+    top: scaled(geometry.borderWidths.top),
+    right: scaled(geometry.borderWidths.right),
+    bottom: scaled(geometry.borderWidths.bottom),
+    left: scaled(geometry.borderWidths.left),
+  });
+
+  for (const side of SIDES) {
+    const value = geometry.padding[side];
+    const label = labelFor(value);
+    if (!reports(label)) continue;
+    bands.push({
+      box: "padding",
+      side,
+      rect: paddingRect(inner, side, {
+        top: scaled(geometry.padding.top),
+        right: scaled(geometry.padding.right),
+        bottom: scaled(geometry.padding.bottom),
+        left: scaled(geometry.padding.left),
+      }),
+      label,
+      negative: false,
+    });
+  }
+
+  return bands;
+}
+
+/** A rectangle reduced on each side, never past zero in either dimension. */
+function inset(rect: Rect, by: EdgeLengths): Rect {
+  return {
+    x: rect.x + by.left,
+    y: rect.y + by.top,
+    width: Math.max(0, rect.width - by.left - by.right),
+    height: Math.max(0, rect.height - by.top - by.bottom),
+  };
+}
+
+/**
+ * Where one margin band sits relative to the border box.
+ *
+ * A positive margin lies OUTSIDE the border edge, which is the case the box
+ * model makes obvious. A negative one lies inside it: the margin box is smaller
+ * than the border box on that side, because that is what pulling an element
+ * toward its neighbour means. Drawing a negative margin outward would put the
+ * band exactly where the space it removes is not.
+ *
+ * Top and bottom span the full width and left and right span the full height,
+ * so the four meet at the corners rather than leaving them blank. The overlap
+ * that produces is a corner drawn twice at the same colour, which is invisible.
+ */
+function marginRect(border: Rect, side: SpacingSide, value: number): Rect {
+  const extent = Math.abs(value);
+  const outward = value >= 0;
+  switch (side) {
+    case "top":
+      return {
+        x: border.x,
+        y: outward ? border.y - extent : border.y,
+        width: border.width,
+        height: extent,
+      };
+    case "bottom":
+      return {
+        x: border.x,
+        y: outward
+          ? border.y + border.height
+          : border.y + border.height - extent,
+        width: border.width,
+        height: extent,
+      };
+    case "left":
+      return {
+        x: outward ? border.x - extent : border.x,
+        y: border.y,
+        width: extent,
+        height: border.height,
+      };
+    case "right":
+      return {
+        x: outward ? border.x + border.width : border.x + border.width - extent,
+        y: border.y,
+        width: extent,
+        height: border.height,
+      };
+  }
+}
+
+/**
+ * Where one padding band sits inside the padding box.
+ *
+ * Top and bottom take the full width; left and right take what is left between
+ * them. The alternative — all four spanning fully — draws the corners twice,
+ * and padding bands are translucent, so a doubled corner reads as a heavier
+ * colour that means nothing.
+ *
+ * Clamped at zero because padding can exceed the box it is measured in: a
+ * fixed-height element with more padding than height is legal, and the
+ * remainder between top and bottom is then negative.
+ */
+function paddingRect(inner: Rect, side: SpacingSide, by: EdgeLengths): Rect {
+  const middle = Math.max(0, inner.height - by.top - by.bottom);
+  switch (side) {
+    case "top":
+      return { x: inner.x, y: inner.y, width: inner.width, height: by.top };
+    case "bottom":
+      return {
+        x: inner.x,
+        y: inner.y + inner.height - by.bottom,
+        width: inner.width,
+        height: by.bottom,
+      };
+    case "left":
+      return {
+        x: inner.x,
+        y: inner.y + by.top,
+        width: by.left,
+        height: middle,
+      };
+    case "right":
+      return {
+        x: inner.x + inner.width - by.right,
+        y: inner.y + by.top,
+        width: by.right,
+        height: middle,
+      };
+  }
+}

--- a/packages/builder/src/spacing-bands.ts
+++ b/packages/builder/src/spacing-bands.ts
@@ -158,7 +158,7 @@ export function spacingBands(
     bands.push({
       box: "margin",
       side,
-      rect: marginRect(border, side, margin[side]),
+      rect: marginRect(border, side, margin),
       label,
       negative: value < 0,
     });
@@ -207,30 +207,55 @@ function inset(rect: Rect, by: EdgeLengths): Rect {
  * toward its neighbour means. Drawing a negative margin outward would put the
  * band exactly where the space it removes is not.
  *
- * Top and bottom span the full width and left and right span the full height,
- * so the four meet at the corners rather than leaving them blank. The overlap
- * that produces is a corner drawn twice at the same colour, which is invisible.
+ * See {@link marginRect} for how the four meet at the corners.
  */
-function marginRect(border: Rect, side: SpacingSide, value: number): Rect {
+function marginRect(
+  border: Rect,
+  side: SpacingSide,
+  margin: EdgeLengths
+): Rect {
+  const value = margin[side];
   const extent = Math.abs(value);
   const outward = value >= 0;
+  /*
+   * Top and bottom span the whole MARGIN box, not the border box.
+   *
+   * Spanning the border box leaves the outer corners painted by nothing: with a
+   * top and a left margin, the rectangle above-and-left of the border box
+   * belongs to the margin area and no band reached it. Extending the horizontal
+   * bands over the vertical margins assigns each corner exactly once — left and
+   * right still span the border height, so nothing is painted twice and no
+   * translucent overlap darkens a corner.
+   *
+   * Only OUTWARD neighbours extend it. A negative margin makes the margin box
+   * smaller on that side, so there is no corner out there to fill.
+   */
+  const leftOut = Math.max(0, margin.left);
+  const rightOut = Math.max(0, margin.right);
   switch (side) {
     case "top":
-      return {
-        x: border.x,
-        y: outward ? border.y - extent : border.y,
-        width: border.width,
-        height: extent,
-      };
+      return outward
+        ? {
+            x: border.x - leftOut,
+            y: border.y - extent,
+            width: border.width + leftOut + rightOut,
+            height: extent,
+          }
+        : { x: border.x, y: border.y, width: border.width, height: extent };
     case "bottom":
-      return {
-        x: border.x,
-        y: outward
-          ? border.y + border.height
-          : border.y + border.height - extent,
-        width: border.width,
-        height: extent,
-      };
+      return outward
+        ? {
+            x: border.x - leftOut,
+            y: border.y + border.height,
+            width: border.width + leftOut + rightOut,
+            height: extent,
+          }
+        : {
+            x: border.x,
+            y: border.y + border.height - extent,
+            width: border.width,
+            height: extent,
+          };
     case "left":
       return {
         x: outward ? border.x - extent : border.x,
@@ -367,14 +392,84 @@ const PADDINGLESS: ReadonlySet<string> = new Set(
   [...MARGINLESS].filter(display => display !== "table-cell")
 );
 
-/** Which spacing a generated box of this display type can actually have. */
-export function spacingApplies(display: string): {
-  margin: boolean;
-  padding: boolean;
-} {
+/** Whether each physical side of one box can carry spacing at all. */
+export interface EdgeApplicability {
+  readonly top: boolean;
+  readonly right: boolean;
+  readonly bottom: boolean;
+  readonly left: boolean;
+}
+
+const ALL_SIDES: EdgeApplicability = {
+  top: true,
+  right: true,
+  bottom: true,
+  left: true,
+};
+const NO_SIDES: EdgeApplicability = {
+  top: false,
+  right: false,
+  bottom: false,
+  left: false,
+};
+
+/**
+ * Whether the writing mode puts the BLOCK axis vertically on screen.
+ *
+ * `horizontal-tb` and anything unrecognised count as horizontal, which is the
+ * initial value and the overwhelming case; every `vertical-*` and `sideways-*`
+ * mode turns the block axis sideways.
+ */
+function blockAxisIsVertical(writingMode: string): boolean {
+  return (
+    !writingMode.startsWith("vertical") && !writingMode.startsWith("sideways")
+  );
+}
+
+/**
+ * Which spacing a generated box of this display type can actually have.
+ *
+ * PER SIDE rather than per box, because `display: inline` is not all-or-nothing:
+ * a non-replaced inline box takes its INLINE-axis margins and ignores its
+ * BLOCK-axis ones entirely, while `getComputedStyle` reports whatever the author
+ * declared on all four. A blanket answer draws top and bottom bands for space an
+ * inline box does not create.
+ *
+ * Which physical sides those are depends on the writing mode: the block axis is
+ * vertical in `horizontal-tb` and horizontal in every `vertical-*` mode. Padding
+ * is left alone — an inline box's block-axis padding does not affect layout, but
+ * it DOES render, and this overlay reports what renders.
+ */
+export function spacingApplies(
+  display: string,
+  writingMode: string
+): { margin: EdgeApplicability; padding: EdgeApplicability } {
+  const padding = PADDINGLESS.has(display) ? NO_SIDES : ALL_SIDES;
+  if (MARGINLESS.has(display)) return { margin: NO_SIDES, padding };
+  if (display !== "inline") return { margin: ALL_SIDES, padding };
+
+  const acrossBlock = blockAxisIsVertical(writingMode);
   return {
-    margin: !MARGINLESS.has(display),
-    padding: !PADDINGLESS.has(display),
+    margin: {
+      top: !acrossBlock,
+      bottom: !acrossBlock,
+      left: acrossBlock,
+      right: acrossBlock,
+    },
+    padding,
+  };
+}
+
+/** Zero the edges a generated box cannot have, keeping the ones it can. */
+export function applicableEdges(
+  edges: EdgeLengths,
+  applies: EdgeApplicability
+): EdgeLengths {
+  return {
+    top: applies.top ? edges.top : 0,
+    right: applies.right ? edges.right : 0,
+    bottom: applies.bottom ? edges.bottom : 0,
+    left: applies.left ? edges.left : 0,
   };
 }
 

--- a/packages/builder/src/spacing-overlay.test.tsx
+++ b/packages/builder/src/spacing-overlay.test.tsx
@@ -283,22 +283,37 @@ describe("accessibility", () => {
 });
 
 describe("what it stays subscribed to", () => {
-  it("watches the canvas ROOT as well as the selected block", () => {
+  it("watches EVERY rendered node, not only the selected one", () => {
     /*
-     * A `ResizeObserver` reports a size change and never a position one, so a
-     * sibling above the selection finishing its load moves the block without
-     * resizing it and the block's own entry never fires. The root sizes to its
-     * content, which makes that reflow observable.
+     * A `ResizeObserver` reports a size change and never a position one, so the
+     * selected block's own entry stays silent while a sibling above it grows and
+     * pushes it down. The unselected sibling is the element that changed, so it
+     * is the one that has to be watched — block `b` here is never selected and
+     * must still be observed.
      */
     withFakeResizeObserver();
     stubComputedStyle({ a: { marginTop: "16px" } });
     const { container } = mount(editorOf("a"));
 
     const observer = FakeResizeObserver.instances.at(-1);
-    const root = container.querySelector(`.${CANVAS_ROOT_CLASS}`);
-    const block = container.querySelector('[data-nx-node="a"]');
-    expect(observer?.observed).toContain(root);
-    expect(observer?.observed).toContain(block);
+    expect(observer?.observed).toContain(
+      container.querySelector('[data-nx-node="a"]')
+    );
+    expect(observer?.observed).toContain(
+      container.querySelector('[data-nx-node="b"]')
+    );
+  });
+
+  it("watches the canvas root, which no node reports for", () => {
+    // The panels resizing around the canvas changes the frame without changing
+    // any node, so the root is not redundant with the node list above.
+    withFakeResizeObserver();
+    stubComputedStyle({ a: { marginTop: "16px" } });
+    const { container } = mount(editorOf("a"));
+
+    expect(FakeResizeObserver.instances.at(-1)?.observed).toContain(
+      container.querySelector(`.${CANVAS_ROOT_CLASS}`)
+    );
   });
 
   it("re-subscribes when the document changes under an unchanged selection", () => {

--- a/packages/builder/src/spacing-overlay.test.tsx
+++ b/packages/builder/src/spacing-overlay.test.tsx
@@ -101,8 +101,20 @@ function styleOf(values: Record<string, string>): CSSStyleDeclaration {
  * own layer is measured by nothing here, and replacing every style in the
  * document would change what the canvas itself renders.
  */
+/**
+ * jsdom's own implementation, captured ONCE at module load.
+ *
+ * Re-reading `window.getComputedStyle` inside the stub captures whatever is
+ * installed at that moment — which, on a second call, is the FIRST stub. The
+ * delegate then calls the spy that owns it and the stack overflows. That stayed
+ * invisible while the overlay only asked about the selected block, because a
+ * node id always hits the fake and never reaches the delegate; the ancestor
+ * walks added for the clip and gutter guards ask about elements that do.
+ */
+const REAL_COMPUTED_STYLE = window.getComputedStyle.bind(window);
+
 function stubComputedStyle(byNodeId: Record<string, Record<string, string>>) {
-  const real = window.getComputedStyle.bind(window);
+  const real = REAL_COMPUTED_STYLE;
   vi.spyOn(window, "getComputedStyle").mockImplementation(((
     element: Element,
     pseudo?: string | null

--- a/packages/builder/src/spacing-overlay.test.tsx
+++ b/packages/builder/src/spacing-overlay.test.tsx
@@ -47,6 +47,19 @@ function register() {
         example: { props: {} },
         render: () => React.createElement("p", null, "leaf"),
       },
+      {
+        /*
+         * A block whose ROOT is a replaced element, which `core/image` is
+         * whenever it has no caption. It renders an `<img>` rather than
+         * wrapping one, because what is being tested is the root's own
+         * replaced-ness — a wrapper would make the question about the wrapper.
+         */
+        name: "acme/replaced",
+        version: 1,
+        description: "A replaced leaf.",
+        example: { props: {} },
+        render: () => React.createElement("img", { alt: "" }),
+      },
     ] as never,
     { source: "spacing-overlay-test" }
   );
@@ -58,6 +71,7 @@ const DOCUMENT = {
   nodes: [
     { id: "a", type: "acme/leaf", version: 1, props: {} },
     { id: "b", type: "acme/leaf", version: 1, props: {} },
+    { id: "c", type: "acme/replaced", version: 1, props: {} },
   ],
 } as unknown as BlockDocument;
 
@@ -265,6 +279,42 @@ describe("which values it reports", () => {
     stubComputedStyle({ a: {} });
     const { container } = mount(editorOf("a"));
     expect(bandSides(container)).toEqual([]);
+  });
+
+  it("drops a NON-REPLACED inline root's block-axis margin", () => {
+    /*
+     * `spacing-bands.test.ts` decides what `spacingApplies` answers; what is
+     * only true here is that the overlay asks it about the ELEMENT it measured.
+     * A `<p>` at `display: inline` creates no block-axis margin, so reporting
+     * one would name space the author cannot see.
+     */
+    stubComputedStyle({
+      a: { display: "inline", writingMode: "horizontal-tb", marginTop: "16px" },
+    });
+    const { container } = mount(editorOf("a"));
+    expect(bandSides(container)).toEqual([]);
+  });
+
+  it("keeps a REPLACED inline root's block-axis margin", () => {
+    /*
+     * The captionless `core/image` case, and the pair that separates it from the
+     * test above: same display, same declared margin, different element. An
+     * overlay that read only the computed style cannot tell them apart, and it
+     * is the ordinary image on a page that loses its bands.
+     */
+    stubComputedStyle({
+      c: { display: "inline", writingMode: "horizontal-tb", marginTop: "16px" },
+    });
+    const { container } = mount(editorOf("c"));
+    // The fixture is only meaningful while the block's ROOT is the replaced
+    // element. A renderer that wrapped it would leave this test asserting the
+    // wrapper's applicability and quietly stop testing anything.
+    expect(
+      container
+        .querySelector(`.${CANVAS_ROOT_CLASS} [${NODE_ID_ATTRIBUTE}="c"]`)
+        ?.tagName.toLowerCase()
+    ).toBe("img");
+    expect(bandSides(container)).toEqual(["margin-top"]);
   });
 });
 

--- a/packages/builder/src/spacing-overlay.test.tsx
+++ b/packages/builder/src/spacing-overlay.test.tsx
@@ -21,7 +21,7 @@ import {
   type BlockDocument,
 } from "@nextlyhq/blocks-engine";
 import { NODE_ID_ATTRIBUTE } from "@nextlyhq/blocks-react";
-import { cleanup, render } from "@testing-library/react";
+import { act, cleanup, render } from "@testing-library/react";
 import * as React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -75,6 +75,9 @@ function editorOf(selectedId: string | null, ids?: string[]): EditorState {
 /** The properties the overlay reads, with everything else reported as zero. */
 function styleOf(values: Record<string, string>): CSSStyleDeclaration {
   const zeroed: Record<string, string> = {
+    // Neither is read as a length; both are read by the describability guard,
+    // and jsdom supplies no default for a fake style object.
+    position: "static",
     marginTop: "0px",
     marginRight: "0px",
     marginBottom: "0px",
@@ -346,5 +349,65 @@ describe("what it stays subscribed to", () => {
 
     expect(before?.disconnected).toBe(true);
     expect(FakeResizeObserver.instances.length).toBeGreaterThan(1);
+  });
+});
+
+/**
+ * Let the mutations React made while mounting reach the observer.
+ *
+ * Building the tree IS a mutation of the observed subtree, and the records are
+ * delivered on a microtask AFTER mount returns. Without draining them first, the
+ * next flush in a test re-measures because of the MOUNT rather than because of
+ * whatever the test just did — measured, by a probe that changed nothing at all
+ * and still saw the value move.
+ */
+async function settle(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("a computed style that changes with nothing else", () => {
+  it("re-measures when only the SHEET changed", async () => {
+    /*
+     * A site-style save changes a class-driven margin while the document, the
+     * selection and every element's SIZE stay as they were, so a resize observer
+     * has nothing to report and an effect keyed on document-and-selection never
+     * runs. What does change is the DOM: `PageRenderer` emits the compiled sheet
+     * as a `<style>` inside the page root, so the new bytes are a mutation in the
+     * canvas subtree.
+     */
+    stubComputedStyle({ a: { marginTop: "16px" } });
+    const { container } = mount(editorOf("a"));
+    await settle();
+    expect(labels(container)).toEqual(["16"]);
+
+    stubComputedStyle({ a: { marginTop: "48px" } });
+    const root = container.querySelector(`.${CANVAS_ROOT_CLASS}`);
+    root?.appendChild(window.document.createElement("style"));
+    await settle();
+
+    expect(labels(container)).toEqual(["48"]);
+  });
+
+  it("ignores a mutation the overlay itself made", async () => {
+    /*
+     * The bands are drawn INSIDE the observed subtree, so reacting to every
+     * mutation would let one measurement trigger the next. A mutation confined to
+     * the overlay's own layer has to be ignored — and the test above is the
+     * positive control that says this fixture CAN move when something outside
+     * changes.
+     */
+    stubComputedStyle({ a: { marginTop: "16px" } });
+    const { container } = mount(editorOf("a"));
+    await settle();
+
+    stubComputedStyle({ a: { marginTop: "48px" } });
+    container
+      .querySelector(".nx-spacing-overlay")
+      ?.appendChild(window.document.createElement("span"));
+    await settle();
+
+    expect(labels(container)).toEqual(["16"]);
   });
 });

--- a/packages/builder/src/spacing-overlay.test.tsx
+++ b/packages/builder/src/spacing-overlay.test.tsx
@@ -25,7 +25,7 @@ import { cleanup, render } from "@testing-library/react";
 import * as React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { Canvas } from "./canvas";
+import { CANVAS_ROOT_CLASS, Canvas } from "./canvas";
 import type { EditorState } from "./editor-state";
 import { SpacingOverlay } from "./spacing-overlay";
 
@@ -33,6 +33,7 @@ afterEach(() => {
   cleanup();
   clearBlocks();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 function register() {
@@ -109,17 +110,65 @@ function stubComputedStyle(byNodeId: Record<string, Record<string, string>>) {
   }) as typeof window.getComputedStyle);
 }
 
-function mount(editor: EditorState, hidden = false) {
+/**
+ * Give every element a layout box, which jsdom does not.
+ *
+ * The overlay refuses to draw for an element that generates none — `display:
+ * none` and `display: contents` both reach it — and jsdom reports NO client
+ * rectangles for anything, so without this every test here would assert against
+ * the refusal rather than against the overlay. Assigning layout in a test is the
+ * same allowance `geometry-ownership.test.ts` documents for itself.
+ */
+function stubLayoutBoxes(present: boolean) {
+  vi.spyOn(Element.prototype, "getClientRects").mockImplementation(() => {
+    const rects = present ? [new DOMRect(0, 0, 100, 50)] : [];
+    return Object.assign(rects, {
+      item: (index: number) => rects[index] ?? null,
+    }) as unknown as DOMRectList;
+  });
+}
+
+function mount(editor: EditorState, hidden = false, laidOut = true) {
+  stubLayoutBoxes(laidOut);
   register();
   return render(
     <Canvas
-      document={DOCUMENT}
+      document={editor.document}
       siteStyles={{ css: "", classes: {} } as never}
       selectedId={editor.selectedId}
       selectedIds={editor.selection.ids}
       overlay={<SpacingOverlay editor={editor} hidden={hidden} />}
     />
   );
+}
+
+/**
+ * A stand-in for `ResizeObserver`, which jsdom does not implement.
+ *
+ * These tests assert the SUBSCRIPTION rather than the redraw: what goes wrong is
+ * that the overlay stops being told, and whether it is told is the observable
+ * half. jsdom never reflows, so no fixture here can produce the resize the real
+ * observer would report.
+ */
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = [];
+  readonly observed: Element[] = [];
+  disconnected = false;
+  constructor(_callback: ResizeObserverCallback) {
+    FakeResizeObserver.instances.push(this);
+  }
+  observe(target: Element): void {
+    this.observed.push(target);
+  }
+  unobserve(): void {}
+  disconnect(): void {
+    this.disconnected = true;
+  }
+}
+
+function withFakeResizeObserver() {
+  FakeResizeObserver.instances = [];
+  vi.stubGlobal("ResizeObserver", FakeResizeObserver);
 }
 
 function labels(container: HTMLElement): string[] {
@@ -183,6 +232,20 @@ describe("which values it reports", () => {
     expect(labels(container)).toEqual(["16"]);
   });
 
+  it("draws nothing for a block that generates no layout box", () => {
+    /*
+     * `display: none` and `display: contents` are catalog values and stay
+     * selectable through the Layers panel. Their computed margin survives while
+     * every rectangle reads zero, so the bands would otherwise appear at the
+     * canvas origin naming space that is nowhere on screen. The identical
+     * fixture WITH a layout box is asserted above, which is what makes this
+     * emptiness mean the guard fired rather than the fixture being inert.
+     */
+    stubComputedStyle({ a: { marginTop: "16px" } });
+    const { container } = mount(editorOf("a"), false, false);
+    expect(bandSides(container)).toEqual([]);
+  });
+
   it("reports nothing for a block whose computed spacing is all zero", () => {
     stubComputedStyle({ a: {} });
     const { container } = mount(editorOf("a"));
@@ -216,5 +279,57 @@ describe("accessibility", () => {
     const { container } = mount(editorOf("a"));
     const layer = container.querySelector(".nx-spacing-overlay");
     expect(layer?.getAttribute("aria-hidden")).toBe("true");
+  });
+});
+
+describe("what it stays subscribed to", () => {
+  it("watches the canvas ROOT as well as the selected block", () => {
+    /*
+     * A `ResizeObserver` reports a size change and never a position one, so a
+     * sibling above the selection finishing its load moves the block without
+     * resizing it and the block's own entry never fires. The root sizes to its
+     * content, which makes that reflow observable.
+     */
+    withFakeResizeObserver();
+    stubComputedStyle({ a: { marginTop: "16px" } });
+    const { container } = mount(editorOf("a"));
+
+    const observer = FakeResizeObserver.instances.at(-1);
+    const root = container.querySelector(`.${CANVAS_ROOT_CLASS}`);
+    const block = container.querySelector('[data-nx-node="a"]');
+    expect(observer?.observed).toContain(root);
+    expect(observer?.observed).toContain(block);
+  });
+
+  it("re-subscribes when the document changes under an unchanged selection", () => {
+    /*
+     * An edit replaces the rendered tree while the selection survives, so the id
+     * resolves to a NEW element. An effect keyed on the selection alone keeps
+     * watching the detached old one, and every later resize of the real block
+     * reports to nobody.
+     */
+    withFakeResizeObserver();
+    stubComputedStyle({ a: { marginTop: "16px" } });
+    const first = editorOf("a");
+    const { rerender } = mount(first);
+    const before = FakeResizeObserver.instances.at(-1);
+
+    const edited = {
+      ...DOCUMENT,
+      nodes: [...(DOCUMENT.nodes as unknown[])],
+    } as unknown as BlockDocument;
+    const next = { ...first, document: edited } as unknown as EditorState;
+    rerender(
+      <Canvas
+        document={edited}
+        siteStyles={{ css: "", classes: {} } as never}
+        selectedId="a"
+        selectedIds={["a"]}
+        overlay={<SpacingOverlay editor={next} />}
+      />
+    );
+
+    expect(before?.disconnected).toBe(true);
+    expect(FakeResizeObserver.instances.length).toBeGreaterThan(1);
   });
 });

--- a/packages/builder/src/spacing-overlay.test.tsx
+++ b/packages/builder/src/spacing-overlay.test.tsx
@@ -1,0 +1,220 @@
+// @vitest-environment jsdom
+
+/**
+ * The overlay's wiring, which is the half `spacing-bands.test.ts` cannot see.
+ *
+ * That file decides where a band lands given numbers. What is only true HERE is
+ * WHICH numbers it is given: that they come from the rendered element's computed
+ * style rather than from the stored document, that the PHYSICAL longhands are
+ * the ones read, and that one block's values are never shown for another.
+ *
+ * The GEOMETRY is deliberately not asserted here. jsdom reports every element as
+ * zero-sized, so a rectangle in this file would be a statement about jsdom and
+ * would pass against a canvas drawn wrongly for a real author. That property is
+ * certified in a browser instead.
+ */
+
+import {
+  clearBlocks,
+  hasBlock,
+  registerBlocks,
+  type BlockDocument,
+} from "@nextlyhq/blocks-engine";
+import { NODE_ID_ATTRIBUTE } from "@nextlyhq/blocks-react";
+import { cleanup, render } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Canvas } from "./canvas";
+import type { EditorState } from "./editor-state";
+import { SpacingOverlay } from "./spacing-overlay";
+
+afterEach(() => {
+  cleanup();
+  clearBlocks();
+  vi.restoreAllMocks();
+});
+
+function register() {
+  if (hasBlock("acme/leaf")) return;
+  registerBlocks(
+    [
+      {
+        name: "acme/leaf",
+        version: 1,
+        description: "A leaf.",
+        example: { props: {} },
+        render: () => React.createElement("p", null, "leaf"),
+      },
+    ] as never,
+    { source: "spacing-overlay-test" }
+  );
+}
+
+const DOCUMENT = {
+  formatVersion: 1,
+  kind: "page",
+  nodes: [
+    { id: "a", type: "acme/leaf", version: 1, props: {} },
+    { id: "b", type: "acme/leaf", version: 1, props: {} },
+  ],
+} as unknown as BlockDocument;
+
+function editorOf(selectedId: string | null, ids?: string[]): EditorState {
+  return {
+    document: DOCUMENT,
+    selectedId,
+    selection: {
+      ids: ids ?? (selectedId === null ? [] : [selectedId]),
+      primary: selectedId,
+    },
+  } as unknown as EditorState;
+}
+
+/** The properties the overlay reads, with everything else reported as zero. */
+function styleOf(values: Record<string, string>): CSSStyleDeclaration {
+  const zeroed: Record<string, string> = {
+    marginTop: "0px",
+    marginRight: "0px",
+    marginBottom: "0px",
+    marginLeft: "0px",
+    paddingTop: "0px",
+    paddingRight: "0px",
+    paddingBottom: "0px",
+    paddingLeft: "0px",
+    borderTopWidth: "0px",
+    borderRightWidth: "0px",
+    borderBottomWidth: "0px",
+    borderLeftWidth: "0px",
+  };
+  return { ...zeroed, ...values } as unknown as CSSStyleDeclaration;
+}
+
+/**
+ * Report a style PER NODE, so a test can tell one block's values from another's.
+ *
+ * Anything that is not a rendered block keeps jsdom's own answer: the overlay's
+ * own layer is measured by nothing here, and replacing every style in the
+ * document would change what the canvas itself renders.
+ */
+function stubComputedStyle(byNodeId: Record<string, Record<string, string>>) {
+  const real = window.getComputedStyle.bind(window);
+  vi.spyOn(window, "getComputedStyle").mockImplementation(((
+    element: Element,
+    pseudo?: string | null
+  ) => {
+    const id = element.getAttribute?.(NODE_ID_ATTRIBUTE);
+    const values = id === null || id === undefined ? undefined : byNodeId[id];
+    return values === undefined ? real(element, pseudo) : styleOf(values);
+  }) as typeof window.getComputedStyle);
+}
+
+function mount(editor: EditorState, hidden = false) {
+  register();
+  return render(
+    <Canvas
+      document={DOCUMENT}
+      siteStyles={{ css: "", classes: {} } as never}
+      selectedId={editor.selectedId}
+      selectedIds={editor.selection.ids}
+      overlay={<SpacingOverlay editor={editor} hidden={hidden} />}
+    />
+  );
+}
+
+function labels(container: HTMLElement): string[] {
+  return Array.from(
+    container.querySelectorAll(".nx-spacing-overlay__value")
+  ).map(node => node.textContent ?? "");
+}
+
+function bandSides(container: HTMLElement): string[] {
+  return Array.from(
+    container.querySelectorAll(".nx-spacing-overlay__band")
+  ).map(
+    node => `${node.getAttribute("data-box")}-${node.getAttribute("data-side")}`
+  );
+}
+
+describe("when the overlay draws at all", () => {
+  it("draws no band when nothing is selected", () => {
+    stubComputedStyle({ a: { marginTop: "16px" } });
+    const { container } = mount(editorOf(null));
+    expect(bandSides(container)).toEqual([]);
+  });
+
+  it("draws no band while hidden", () => {
+    // The suppression a drag uses. Asserting the same fixture unhidden below is
+    // what separates this from a fixture that never produced a band at all.
+    stubComputedStyle({ a: { marginTop: "16px" } });
+    const { container } = mount(editorOf("a"), true);
+    expect(bandSides(container)).toEqual([]);
+  });
+
+  it("draws a band for the same fixture when not hidden", () => {
+    stubComputedStyle({ a: { marginTop: "16px" } });
+    const { container } = mount(editorOf("a"));
+    expect(bandSides(container)).toEqual(["margin-top"]);
+  });
+});
+
+describe("which values it reports", () => {
+  it("labels each band with the element's computed value", () => {
+    stubComputedStyle({
+      a: { marginTop: "16px", paddingBottom: "24px" },
+    });
+    const { container } = mount(editorOf("a"));
+    expect(bandSides(container)).toEqual(["margin-top", "padding-bottom"]);
+    expect(labels(container)).toEqual(["16", "24"]);
+  });
+
+  it("reads the PHYSICAL longhand rather than the logical one", () => {
+    /*
+     * The separating property for the whole design. The catalog stores spacing
+     * per logical side, and an implementation that reached for the logical
+     * computed property would report the same number in a left-to-right
+     * document and the wrong EDGE in a right-to-left one. Both spellings are
+     * present here and only the physical one is correct.
+     */
+    stubComputedStyle({
+      a: { marginTop: "16px", marginBlockStart: "99px" },
+    });
+    const { container } = mount(editorOf("a"));
+    expect(labels(container)).toEqual(["16"]);
+  });
+
+  it("reports nothing for a block whose computed spacing is all zero", () => {
+    stubComputedStyle({ a: {} });
+    const { container } = mount(editorOf("a"));
+    expect(bandSides(container)).toEqual([]);
+  });
+});
+
+describe("which block it answers for", () => {
+  it("measures the PRIMARY selection and not another selected block", () => {
+    /*
+     * Spacing belongs to a node, so a multi-block selection has no margin of its
+     * own. Both blocks carry a distinct value here: an implementation drawing
+     * bands per member would report both, and one anchored to the wrong member
+     * would report `40`.
+     */
+    stubComputedStyle({
+      a: { marginTop: "16px" },
+      b: { marginTop: "40px" },
+    });
+    const { container } = mount(editorOf("a", ["a", "b"]));
+    expect(labels(container)).toEqual(["16"]);
+  });
+});
+
+describe("accessibility", () => {
+  it("is hidden from assistive technology", () => {
+    // The values are in the inspector's Spacing section with real labels and
+    // controls. Announcing up to eight numbers on every selection change would
+    // bury that surface in the readers it exists for.
+    stubComputedStyle({ a: { marginTop: "16px" } });
+    const { container } = mount(editorOf("a"));
+    const layer = container.querySelector(".nx-spacing-overlay");
+    expect(layer?.getAttribute("aria-hidden")).toBe("true");
+  });
+});

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -70,6 +70,7 @@ import {
 } from "./geometry-dom";
 import {
   sameBands,
+  spacingApplies,
   spacingBands,
   type EdgeLengths,
   type SpacingBand,
@@ -137,6 +138,9 @@ function boxesOf(style: CSSStyleDeclaration): {
     },
   };
 }
+
+/** Four zero edges, for a box CSS gives no margin or no padding. */
+const NO_EDGES: EdgeLengths = { top: 0, right: 0, bottom: 0, left: 0 };
 
 /** One array identity for every empty result, so React can bail out of a render. */
 const NO_BANDS: readonly SpacingBand[] = [];
@@ -232,7 +236,20 @@ export function SpacingOverlay({
       return;
     }
 
-    const boxes = boxesOf(style);
+    /*
+     * Zeroed where the generated box cannot have them. `display: table-row` and
+     * the internal ruby boxes take no margin, and everything internal to a table
+     * except a cell takes no padding — but the computed style still answers with
+     * whatever the author declared, so reading it unconditionally draws bands
+     * for space that does not exist.
+     */
+    const applies = spacingApplies(style.display);
+    const measured = boxesOf(style);
+    const boxes = {
+      borderWidths: measured.borderWidths,
+      margin: applies.margin ? measured.margin : NO_EDGES,
+      padding: applies.padding ? measured.padding : NO_EDGES,
+    };
     const borders = {
       x: boxes.borderWidths.left + boxes.borderWidths.right,
       y: boxes.borderWidths.top + boxes.borderWidths.bottom,
@@ -349,9 +366,26 @@ export function SpacingOverlay({
       characterData: true,
     });
 
+    /*
+     * A transition moves geometry over time and emits nothing an observer sees:
+     * `transition` is a catalog property, a transform or margin animating past
+     * its first frame resizes nothing, and no DOM mutation accompanies the
+     * frames. The completion events are what the browser does offer, and they
+     * bubble, so one listener on the root covers every block.
+     *
+     * This corrects the FINAL geometry rather than following the animation.
+     * Tracking the frames between would mean measuring on every one, which costs
+     * more than a band being briefly behind a transition the author is watching.
+     */
+    const settled = (): void => measure();
+    root.addEventListener("transitionend", settled);
+    root.addEventListener("transitioncancel", settled);
+
     return () => {
       sizes?.disconnect();
       styles?.disconnect();
+      root.removeEventListener("transitionend", settled);
+      root.removeEventListener("transitioncancel", settled);
     };
     /*
      * `document` re-subscribes, and dropping it strands the observer on a

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -59,7 +59,7 @@
 
 import * as React from "react";
 
-import { CANVAS_ROOT_CLASS, nodeElement } from "./canvas";
+import { CANVAS_ROOT_CLASS, nodeElement, nodeElements } from "./canvas";
 import type { EditorState } from "./editor-state";
 import { canvasContentRect, hasLayoutBox, renderedScale } from "./geometry-dom";
 import {
@@ -188,6 +188,23 @@ export function SpacingOverlay({
       return;
     }
 
+    /*
+     * A block whose rendered box cannot be described by axis-aligned bands gets
+     * none. A rotation or skew has no left edge to pin a band to; a mirrored
+     * block renders its left margin on the RIGHT; and a `scale(0)` collapses
+     * every band to nothing while the value chips, which are deliberately
+     * unclipped so a thin band stays readable, would pile up at the transform
+     * origin over an invisible block.
+     *
+     * All four are one property — the representation does not fit — so they are
+     * refused in one place rather than patched one at a time.
+     */
+    const scale = renderedScale(block, root);
+    if (!scale.describable) {
+      setBands([]);
+      return;
+    }
+
     const boxes = boxesOf(style);
     setBands(
       spacingBands({
@@ -198,13 +215,9 @@ export function SpacingOverlay({
         borderWidths: boxes.borderWidths,
         margin: boxes.margin,
         padding: boxes.padding,
-        /*
-         * MEASURED from the element rather than assumed to be 1. `transform` is
-         * a catalog property, so a scaled block makes the rectangle above and
-         * the lengths beside it disagree — and asking the element carries any
-         * scaled ancestor with it, which parsing its own transform would miss.
-         */
-        scale: renderedScale(block),
+        // Composed from the real transform between the block and the root, so
+        // a scaled ancestor counts and no rounded layout value is involved.
+        scale: { x: scale.x, y: scale.y },
       })
     );
   }, [selectedId]);
@@ -224,15 +237,21 @@ export function SpacingOverlay({
    * Re-measure when the layout moves for a reason no render reports — an image
    * finishing, a webfont swapping, the panels being resized around the canvas.
    *
-   * BOTH the block and the canvas root are watched, and the root is not
-   * redundant. A `ResizeObserver` reports a size change, never a position one,
-   * so a sibling ABOVE the selection finishing its own load moves the block
-   * without resizing it and the block's own entry never fires. The root sizes to
-   * its content, so that same reflow changes the root's height — which is the
-   * observable event standing in for "something moved".
+   * EVERY rendered node is observed, not just the selected one, because what
+   * moves a block is another block changing size. A `ResizeObserver` reports a
+   * size change and never a position one, so the selected block's own entry
+   * stays silent while a sibling above it grows and pushes it down.
    *
-   * The overlay itself cannot drive that loop: it is `position: absolute` filling
-   * the root, so what it draws never contributes to the root's size.
+   * Watching the canvas root does not stand in for this. The root is
+   * `min-height: 100%`, so on a page shorter than the viewport it holds that
+   * height and reports nothing however much the content inside it reflows — the
+   * case where the bands would sit furthest from the block they name. The root
+   * is still observed, for the resize the nodes cannot report: the panels moving
+   * around the canvas, which changes the frame without changing any node.
+   *
+   * The overlay cannot drive its own loop: it is `position: absolute` filling the
+   * root and carries no node marker, so nothing it draws is observed here or
+   * contributes to the root's size.
    */
   React.useEffect(() => {
     if (hidden || selectedId === null) return;
@@ -245,14 +264,13 @@ export function SpacingOverlay({
     if (typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(() => measure());
     observer.observe(root);
-    const block = nodeElement(root, selectedId);
-    if (block !== null) observer.observe(block);
+    for (const node of nodeElements(root)) observer.observe(node);
     return () => observer.disconnect();
     /*
      * `document` re-subscribes, and dropping it strands the observer on a
      * DETACHED element. An edit replaces the rendered tree while the selection
-     * survives, so the id resolves to a NEW element and this effect — keyed on
-     * the selection alone — would keep watching the old one. Its later resizes
+     * survives, so every id resolves to a NEW element and this effect — keyed on
+     * the selection alone — would keep watching the old ones. Their later resizes
      * fire nothing, and the bands stay at the size the block had before the edit.
      */
   }, [measure, hidden, selectedId, document]);

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -144,6 +144,55 @@ function boxesOf(style: CSSStyleDeclaration): {
 }
 
 /**
+ * Elements whose box is REPLACED by content the CSS box model does not lay out.
+ *
+ * Asked because a replaced inline box keeps its block-axis margins where a
+ * non-replaced one drops them, and nothing in the computed style says which
+ * kind a box is — `display` answers `inline` for both. It is the element type
+ * that decides, so the element type is what this asks.
+ *
+ * Every member was measured, not assumed: forced to `display: inline` and given
+ * a top and bottom margin, each one below moves the content after it by the
+ * full amount, and `span`, `div` and `math` move it by nothing. `math` is the
+ * surprise — MathML Core lays its box out like any other, so it is deliberately
+ * absent rather than forgotten.
+ *
+ * A replaced element that is not currently rendering anything — an `<audio>`
+ * with no controls, an `<embed>` with no type — generates no replaced box and
+ * takes no block-axis margin, and this still calls it replaced. That is the
+ * safer of the two errors: it draws a band for spacing the box takes the moment
+ * it has something to show, where the other omits spacing that is in effect
+ * right now.
+ */
+const REPLACED_TAGS: ReadonlySet<string> = new Set([
+  "img",
+  "iframe",
+  "embed",
+  "object",
+  "video",
+  "audio",
+  "canvas",
+  "svg",
+  "input",
+  "select",
+  "textarea",
+  "button",
+  "progress",
+  "meter",
+]);
+
+/** Whether this element's box is replaced. See {@link REPLACED_TAGS}. */
+export function isReplaced(element: Element): boolean {
+  /*
+   * `localName` rather than `tagName`, which upper-cases an HTML element's name
+   * but leaves an SVG one alone — so `<svg>` inside HTML answers `svg` to one
+   * and `svg` to the other while `<img>` answers `img` and `IMG`. Comparing the
+   * lower-cased local name is the spelling that holds for both.
+   */
+  return REPLACED_TAGS.has(element.localName.toLowerCase());
+}
+
+/**
  * How far a value chip can overflow the band it is centred on.
  *
  * Bounded by the chip's own size, which this package sets: `0.6875rem` text on a
@@ -278,7 +327,11 @@ export function SpacingOverlay({
      * whatever the author declared, so reading it unconditionally draws bands
      * for space that does not exist.
      */
-    const applies = spacingApplies(style.display, style.writingMode);
+    const applies = spacingApplies(
+      style.display,
+      style.writingMode,
+      isReplaced(block)
+    );
     const measured = boxesOf(style);
     const boxes = {
       borderWidths: measured.borderWidths,

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -61,8 +61,15 @@ import * as React from "react";
 
 import { CANVAS_ROOT_CLASS, nodeElement, nodeElements } from "./canvas";
 import type { EditorState } from "./editor-state";
-import { canvasContentRect, hasLayoutBox, renderedScale } from "./geometry-dom";
 import {
+  canvasContentRect,
+  hasScrollbarGutter,
+  layoutFragments,
+  renderedScale,
+  type RenderedScale,
+} from "./geometry-dom";
+import {
+  sameBands,
   spacingBands,
   type EdgeLengths,
   type SpacingBand,
@@ -131,6 +138,53 @@ function boxesOf(style: CSSStyleDeclaration): {
   };
 }
 
+/** One array identity for every empty result, so React can bail out of a render. */
+const NO_BANDS: readonly SpacingBand[] = [];
+
+/**
+ * Whether axis-aligned bands can describe this block at all.
+ *
+ * One predicate rather than a guard per case, because every entry is the same
+ * property: the rendered box is not a single upright rectangle sitting in the
+ * canvas's own coordinates, so no rectangle pinned to a physical side describes
+ * it and no scale factor rescues one that tries.
+ *
+ * Drawing nothing is the right answer for all of them. A band is read as a
+ * MEASUREMENT, so one drawn in the wrong place is worse than an overlay that
+ * declines to draw.
+ */
+function describable(
+  fragments: number,
+  position: string,
+  gutter: boolean,
+  scale: RenderedScale
+): boolean {
+  // No box at all — `display: none`, `display: contents`.
+  if (fragments === 0) return false;
+  /*
+   * An inline box wrapped across lines. Its padding and margins belong to the
+   * individual fragments while the bounding rectangle is their union, so bands
+   * drawn from that union run through the whitespace between lines.
+   */
+  if (fragments > 1) return false;
+  /*
+   * Positioned against the viewport rather than the page. A sticky or fixed
+   * block stops moving with the canvas content the bands are drawn in, so they
+   * slide away from it on the first scroll — and scrolling emits no resize, so
+   * nothing re-measures.
+   */
+  if (position === "fixed" || position === "sticky") return false;
+  /*
+   * A classic scrollbar takes its width between the padding box and the border,
+   * so a padding box derived from the borders alone is too wide by the gutter
+   * and the band lands on the scrollbar. Which side it takes depends on the
+   * writing direction.
+   */
+  if (gutter) return false;
+  // A rotation, skew, reflection, perspective, or a collapse to zero.
+  return scale.describable;
+}
+
 export function SpacingOverlay({
   editor,
   hidden = false,
@@ -149,32 +203,22 @@ export function SpacingOverlay({
    * selection alone would keep describing the layout it used to have.
    */
   const measure = React.useCallback(() => {
+    const apply = (next: readonly SpacingBand[]): void => {
+      setBands(current => (sameBands(current, next) ? current : next));
+    };
     const element = layer.current;
     if (element === null || selectedId === null) {
-      setBands([]);
+      apply(NO_BANDS);
       return;
     }
     const root = element.closest(`.${CANVAS_ROOT_CLASS}`);
     if (!(root instanceof HTMLElement)) {
-      setBands([]);
+      apply(NO_BANDS);
       return;
     }
     const block = nodeElement(root, selectedId);
     if (block === null) {
-      setBands([]);
-      return;
-    }
-    /*
-     * A selected block that generates no box has nothing to draw around.
-     *
-     * `display: none` and `display: contents` are both catalog values and both
-     * remain selectable through the Layers panel, which addresses nodes by id.
-     * Their computed margin and padding stay whatever the author set while every
-     * rectangle reads zero, so without this the bands appear at the canvas
-     * origin describing space that is nowhere on screen.
-     */
-    if (!hasLayoutBox(block)) {
-      setBands([]);
+      apply(NO_BANDS);
       return;
     }
     /*
@@ -184,29 +228,29 @@ export function SpacingOverlay({
      */
     const style = block.ownerDocument.defaultView?.getComputedStyle(block);
     if (style === undefined) {
-      setBands([]);
-      return;
-    }
-
-    /*
-     * A block whose rendered box cannot be described by axis-aligned bands gets
-     * none. A rotation or skew has no left edge to pin a band to; a mirrored
-     * block renders its left margin on the RIGHT; and a `scale(0)` collapses
-     * every band to nothing while the value chips, which are deliberately
-     * unclipped so a thin band stays readable, would pile up at the transform
-     * origin over an invisible block.
-     *
-     * All four are one property — the representation does not fit — so they are
-     * refused in one place rather than patched one at a time.
-     */
-    const scale = renderedScale(block, root);
-    if (!scale.describable) {
-      setBands([]);
+      apply(NO_BANDS);
       return;
     }
 
     const boxes = boxesOf(style);
-    setBands(
+    const borders = {
+      x: boxes.borderWidths.left + boxes.borderWidths.right,
+      y: boxes.borderWidths.top + boxes.borderWidths.bottom,
+    };
+    const scale = renderedScale(block, root);
+    if (
+      !describable(
+        layoutFragments(block),
+        style.position,
+        hasScrollbarGutter(block, borders),
+        scale
+      )
+    ) {
+      apply(NO_BANDS);
+      return;
+    }
+
+    apply(
       spacingBands({
         // Through `canvasContentRect` rather than a rectangle read here: this
         // package reads a rectangle in one place, so chrome measured one way
@@ -224,7 +268,7 @@ export function SpacingOverlay({
 
   React.useLayoutEffect(() => {
     if (hidden) {
-      setBands([]);
+      setBands(current => (current.length === 0 ? current : NO_BANDS));
       return;
     }
     measure();
@@ -258,14 +302,57 @@ export function SpacingOverlay({
     const element = layer.current;
     const root = element?.closest(`.${CANVAS_ROOT_CLASS}`);
     if (!(root instanceof HTMLElement)) return;
-    // Absent in jsdom unless a test supplies one, and absent in older browsers.
-    // A missing observer costs a re-measure, not correctness — every render
-    // path above still measures.
-    if (typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(() => measure());
-    observer.observe(root);
-    for (const node of nodeElements(root)) observer.observe(node);
-    return () => observer.disconnect();
+    /*
+     * Each observer is guarded separately, and that is not tidiness. They answer
+     * different questions — sizes changed, and the DOM changed — so a runtime
+     * missing one must still get the other. Guarding both behind `ResizeObserver`
+     * would silently drop mutation tracking wherever it is absent.
+     *
+     * Absent in jsdom unless a test supplies one, and absent in older browsers.
+     * A missing observer costs a re-measure, not correctness — every render path
+     * above still measures.
+     */
+    const sizes =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(() => measure());
+    if (sizes !== null) {
+      sizes.observe(root);
+      for (const node of nodeElements(root)) sizes.observe(node);
+    }
+
+    /*
+     * The other half: a change that alters computed style without altering any
+     * size. A site-style save recompiles the sheet, and `PageRenderer` emits it
+     * as a `<style>` INSIDE the page root — so the bytes changing is a mutation
+     * in this subtree, where a resize observer has nothing to report because a
+     * class-driven margin moves blocks without resizing them.
+     *
+     * Mutations inside the overlay's own layer are ignored. Drawing the bands is
+     * itself a mutation of this subtree, so reacting to it would have the
+     * measurement trigger the next measurement.
+     */
+    const styles =
+      typeof MutationObserver === "undefined"
+        ? null
+        : new MutationObserver(records => {
+            const own = layer.current;
+            const outside = records.some(
+              record => own === null || !own.contains(record.target)
+            );
+            if (outside) measure();
+          });
+    styles?.observe(root, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      characterData: true,
+    });
+
+    return () => {
+      sizes?.disconnect();
+      styles?.disconnect();
+    };
     /*
      * `document` re-subscribes, and dropping it strands the observer on a
      * DETACHED element. An edit replaces the rendered tree while the selection

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+/**
+ * The selected block's spacing, drawn on the page it applies to.
+ *
+ * An author setting margin or padding in the inspector is looking at the
+ * canvas, not at the panel, and until now the only way to see what a value did
+ * was to change it and watch the layout move. This draws the space itself:
+ * a band over each side that has one, with the value written on it.
+ *
+ * ## The values come from the RENDERED page, not from the document
+ *
+ * `getComputedStyle` is the source, and the alternative — reading the stored
+ * style tier the inspector edits — is wrong here in four separate ways, any one
+ * of which is enough:
+ *
+ * - The catalog stores spacing per LOGICAL side (`margin-inline-start`), and a
+ *   band is drawn on a PHYSICAL one. Which physical edge an inline side lands on
+ *   depends on the element's inherited `direction` and `writing-mode`, so
+ *   deriving it from the document means reimplementing a resolution rule the
+ *   browser has already applied correctly.
+ * - `auto` is a legal margin and has no value at all until layout runs — it is
+ *   what centres a block.
+ * - A percentage resolves against the containing block, which the document
+ *   cannot see.
+ * - The tier the inspector edits is not the whole cascade. A named class, a
+ *   block-type default or a breakpoint override can win, and an overlay reading
+ *   one tier would confidently name a value the page does not use.
+ *
+ * So the page is asked what it is doing, rather than a second opinion being
+ * computed alongside it and drifting.
+ *
+ * ## The PRIMARY selection only
+ *
+ * Spacing belongs to a node; a multi-block selection has no margin of its own,
+ * and drawing a set of bands per member leaves the numbers ambiguous about which
+ * block each describes. The primary is the one the inspector answers for, so the
+ * two surfaces agree about whose value is on screen.
+ *
+ * @module spacing-overlay
+ */
+
+import * as React from "react";
+
+import { CANVAS_ROOT_CLASS, nodeElement } from "./canvas";
+import type { EditorState } from "./editor-state";
+import { canvasContentRect } from "./geometry-dom";
+import {
+  spacingBands,
+  type EdgeLengths,
+  type SpacingBand,
+} from "./spacing-bands";
+
+export interface SpacingOverlayProps {
+  /** The editor whose primary selection is measured. */
+  editor: EditorState;
+  /**
+   * Suppress the bands, for a host that is mid-gesture.
+   *
+   * A drag is the case this exists for: the bands describe a layout that is in
+   * the middle of changing, so every value on screen is about to be wrong.
+   */
+  hidden?: boolean;
+}
+
+/**
+ * A computed length in pixels, or zero where the browser reports no number.
+ *
+ * `auto` is the case that reaches this. A computed margin is normally the used
+ * value — a number even where the author wrote `auto` — but an element that is
+ * not laid out has nothing to resolve against, and the string comes back
+ * unresolved. Zero is the honest reading: there is no space to draw.
+ */
+function lengthOf(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * The four physical margins, paddings and border widths of one element.
+ *
+ * PHYSICAL longhands rather than the logical ones the catalog stores, because a
+ * band is drawn on a physical edge — and letting the browser resolve
+ * `inline-start` to a side is the point, not an oversight.
+ *
+ * Spelled out one property at a time rather than assembled from a side name.
+ * The computed style is a typed interface, and a name built at runtime turns
+ * every one of these reads into an index lookup the checker cannot verify.
+ */
+function boxesOf(style: CSSStyleDeclaration): {
+  margin: EdgeLengths;
+  padding: EdgeLengths;
+  borderWidths: EdgeLengths;
+} {
+  return {
+    margin: {
+      top: lengthOf(style.marginTop),
+      right: lengthOf(style.marginRight),
+      bottom: lengthOf(style.marginBottom),
+      left: lengthOf(style.marginLeft),
+    },
+    padding: {
+      top: lengthOf(style.paddingTop),
+      right: lengthOf(style.paddingRight),
+      bottom: lengthOf(style.paddingBottom),
+      left: lengthOf(style.paddingLeft),
+    },
+    borderWidths: {
+      top: lengthOf(style.borderTopWidth),
+      right: lengthOf(style.borderRightWidth),
+      bottom: lengthOf(style.borderBottomWidth),
+      left: lengthOf(style.borderLeftWidth),
+    },
+  };
+}
+
+export function SpacingOverlay({
+  editor,
+  hidden = false,
+}: SpacingOverlayProps): React.JSX.Element | null {
+  const layer = React.useRef<HTMLDivElement | null>(null);
+  const [bands, setBands] = React.useState<readonly SpacingBand[]>([]);
+
+  const { document, selectedId } = editor;
+
+  /*
+   * Measured before the browser paints, so the bands never appear over the
+   * position the block held on the previous render.
+   *
+   * Keyed on the document as well as the selection because an edit resizes the
+   * block — which is most of what the inspector does — and bands keyed on the
+   * selection alone would keep describing the layout it used to have.
+   */
+  const measure = React.useCallback(() => {
+    const element = layer.current;
+    if (element === null || selectedId === null) {
+      setBands([]);
+      return;
+    }
+    const root = element.closest(`.${CANVAS_ROOT_CLASS}`);
+    if (!(root instanceof HTMLElement)) {
+      setBands([]);
+      return;
+    }
+    const block = nodeElement(root, selectedId);
+    if (block === null) {
+      setBands([]);
+      return;
+    }
+    /*
+     * The element's own view rather than the ambient `window`, so a canvas
+     * rendered into another document is measured against the styles that
+     * actually apply to it rather than against this one's.
+     */
+    const style = block.ownerDocument.defaultView?.getComputedStyle(block);
+    if (style === undefined) {
+      setBands([]);
+      return;
+    }
+
+    const boxes = boxesOf(style);
+    setBands(
+      spacingBands({
+        // Through `canvasContentRect` rather than a rectangle read here: this
+        // package reads a rectangle in one place, so chrome measured one way
+        // cannot disagree with chrome measured another at a scroll offset.
+        border: canvasContentRect(block, root),
+        borderWidths: boxes.borderWidths,
+        margin: boxes.margin,
+        padding: boxes.padding,
+        /*
+         * The canvas is drawn at its natural size, so the rectangle above and
+         * the lengths beside it are in the same units.
+         *
+         * Stated rather than assumed: `canvasContentRect` reports POST-transform
+         * pixels and a computed length is unscaled, so the day the canvas gains
+         * a zoom this argument is what has to carry it — and every band would
+         * otherwise be wrong by exactly that factor with nothing failing.
+         */
+        scale: 1,
+      })
+    );
+  }, [selectedId]);
+
+  React.useLayoutEffect(() => {
+    if (hidden) {
+      setBands([]);
+      return;
+    }
+    measure();
+    // `document` is not read by `measure` and is listed anyway: an edit resizes
+    // the selected block, which is most of what the inspector does, and bands
+    // keyed on the selection alone would keep describing the layout it had.
+  }, [measure, hidden, document]);
+
+  /*
+   * Re-measure when the block changes size for a reason no render reports — an
+   * image finishing, a webfont swapping, the panels being resized around the
+   * canvas. Without this the bands describe the size the block had while it was
+   * still loading, which is the state most pages spend their first second in.
+   */
+  React.useEffect(() => {
+    if (hidden || selectedId === null) return;
+    const element = layer.current;
+    const root = element?.closest(`.${CANVAS_ROOT_CLASS}`);
+    if (!(root instanceof HTMLElement)) return;
+    // Absent in jsdom unless a test supplies one, and absent in older browsers.
+    // A missing observer costs a re-measure, not correctness — every render
+    // path above still measures.
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => measure());
+    const block = nodeElement(root, selectedId);
+    if (block !== null) observer.observe(block);
+    return () => observer.disconnect();
+  }, [measure, hidden, selectedId]);
+
+  return (
+    <div
+      ref={layer}
+      className="nx-spacing-overlay"
+      /*
+       * Not marked as chrome, for the reason the drop indicator is not: it takes
+       * no pointer events at all, so a press travels through to the block
+       * underneath and resolves to that node rather than to the overlay drawn
+       * over it.
+       *
+       * Hidden from assistive technology because the same values are in the
+       * inspector's Spacing section, with real labels and controls. Announcing
+       * up to eight numbers on every arrow-key move through the layer tree would
+       * bury that surface in exactly the readers it is for.
+       */
+      aria-hidden="true"
+    >
+      {bands.map(band => (
+        <div
+          key={`${band.box}-${band.side}`}
+          className="nx-spacing-overlay__band"
+          data-box={band.box}
+          data-side={band.side}
+          data-negative={band.negative ? "" : undefined}
+          style={{
+            left: band.rect.x,
+            top: band.rect.y,
+            width: band.rect.width,
+            height: band.rect.height,
+          }}
+        >
+          <span className="nx-spacing-overlay__value">{band.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -44,7 +44,7 @@ import * as React from "react";
 
 import { CANVAS_ROOT_CLASS, nodeElement } from "./canvas";
 import type { EditorState } from "./editor-state";
-import { canvasContentRect } from "./geometry-dom";
+import { canvasContentRect, hasLayoutBox, renderedScale } from "./geometry-dom";
 import {
   spacingBands,
   type EdgeLengths,
@@ -148,6 +148,19 @@ export function SpacingOverlay({
       return;
     }
     /*
+     * A selected block that generates no box has nothing to draw around.
+     *
+     * `display: none` and `display: contents` are both catalog values and both
+     * remain selectable through the Layers panel, which addresses nodes by id.
+     * Their computed margin and padding stay whatever the author set while every
+     * rectangle reads zero, so without this the bands appear at the canvas
+     * origin describing space that is nowhere on screen.
+     */
+    if (!hasLayoutBox(block)) {
+      setBands([]);
+      return;
+    }
+    /*
      * The element's own view rather than the ambient `window`, so a canvas
      * rendered into another document is measured against the styles that
      * actually apply to it rather than against this one's.
@@ -169,15 +182,12 @@ export function SpacingOverlay({
         margin: boxes.margin,
         padding: boxes.padding,
         /*
-         * The canvas is drawn at its natural size, so the rectangle above and
-         * the lengths beside it are in the same units.
-         *
-         * Stated rather than assumed: `canvasContentRect` reports POST-transform
-         * pixels and a computed length is unscaled, so the day the canvas gains
-         * a zoom this argument is what has to carry it — and every band would
-         * otherwise be wrong by exactly that factor with nothing failing.
+         * MEASURED from the element rather than assumed to be 1. `transform` is
+         * a catalog property, so a scaled block makes the rectangle above and
+         * the lengths beside it disagree — and asking the element carries any
+         * scaled ancestor with it, which parsing its own transform would miss.
          */
-        scale: 1,
+        scale: renderedScale(block),
       })
     );
   }, [selectedId]);
@@ -194,10 +204,18 @@ export function SpacingOverlay({
   }, [measure, hidden, document]);
 
   /*
-   * Re-measure when the block changes size for a reason no render reports — an
-   * image finishing, a webfont swapping, the panels being resized around the
-   * canvas. Without this the bands describe the size the block had while it was
-   * still loading, which is the state most pages spend their first second in.
+   * Re-measure when the layout moves for a reason no render reports — an image
+   * finishing, a webfont swapping, the panels being resized around the canvas.
+   *
+   * BOTH the block and the canvas root are watched, and the root is not
+   * redundant. A `ResizeObserver` reports a size change, never a position one,
+   * so a sibling ABOVE the selection finishing its own load moves the block
+   * without resizing it and the block's own entry never fires. The root sizes to
+   * its content, so that same reflow changes the root's height — which is the
+   * observable event standing in for "something moved".
+   *
+   * The overlay itself cannot drive that loop: it is `position: absolute` filling
+   * the root, so what it draws never contributes to the root's size.
    */
   React.useEffect(() => {
     if (hidden || selectedId === null) return;
@@ -209,10 +227,18 @@ export function SpacingOverlay({
     // path above still measures.
     if (typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(() => measure());
+    observer.observe(root);
     const block = nodeElement(root, selectedId);
     if (block !== null) observer.observe(block);
     return () => observer.disconnect();
-  }, [measure, hidden, selectedId]);
+    /*
+     * `document` re-subscribes, and dropping it strands the observer on a
+     * DETACHED element. An edit replaces the rendered tree while the selection
+     * survives, so the id resolves to a NEW element and this effect — keyed on
+     * the selection alone — would keep watching the old one. Its later resizes
+     * fire nothing, and the bands stay at the size the block had before the edit.
+     */
+  }, [measure, hidden, selectedId, document]);
 
   return (
     <div

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -63,6 +63,7 @@ import { CANVAS_ROOT_CLASS, nodeElement, nodeElements } from "./canvas";
 import type { EditorState } from "./editor-state";
 import {
   canvasContentRect,
+  canvasRootFrom,
   clippedByAncestor,
   hasScrollbarGutter,
   layoutFragments,
@@ -70,6 +71,7 @@ import {
   type RenderedScale,
 } from "./geometry-dom";
 import {
+  applicableEdges,
   overlayEscape,
   sameBands,
   spacingApplies,
@@ -150,9 +152,6 @@ function boxesOf(style: CSSStyleDeclaration): {
  * with room and keeps the clip allowance small.
  */
 const CHIP_OVERFLOW_PX = 24;
-
-/** Four zero edges, for a box CSS gives no margin or no padding. */
-const NO_EDGES: EdgeLengths = { top: 0, right: 0, bottom: 0, left: 0 };
 
 /** One array identity for every empty result, so React can bail out of a render. */
 const NO_BANDS: readonly SpacingBand[] = [];
@@ -249,8 +248,10 @@ export function SpacingOverlay({
       apply(NO_BANDS);
       return;
     }
-    const root = element.closest(`.${CANVAS_ROOT_CLASS}`);
-    if (!(root instanceof HTMLElement)) {
+    // Resolved through `canvasRootFrom`, which answers in the ROOT's own realm —
+    // see there for why `instanceof HTMLElement` is the wrong question.
+    const root = canvasRootFrom(element, CANVAS_ROOT_CLASS);
+    if (root === null) {
       apply(NO_BANDS);
       return;
     }
@@ -277,12 +278,12 @@ export function SpacingOverlay({
      * whatever the author declared, so reading it unconditionally draws bands
      * for space that does not exist.
      */
-    const applies = spacingApplies(style.display);
+    const applies = spacingApplies(style.display, style.writingMode);
     const measured = boxesOf(style);
     const boxes = {
       borderWidths: measured.borderWidths,
-      margin: applies.margin ? measured.margin : NO_EDGES,
-      padding: applies.padding ? measured.padding : NO_EDGES,
+      margin: applicableEdges(measured.margin, applies.margin),
+      padding: applicableEdges(measured.padding, applies.padding),
     };
     const borders = {
       x: boxes.borderWidths.left + boxes.borderWidths.right,
@@ -359,8 +360,9 @@ export function SpacingOverlay({
   React.useEffect(() => {
     if (hidden || selectedId === null) return;
     const element = layer.current;
-    const root = element?.closest(`.${CANVAS_ROOT_CLASS}`);
-    if (!(root instanceof HTMLElement)) return;
+    const root =
+      element === null ? null : canvasRootFrom(element, CANVAS_ROOT_CLASS);
+    if (root === null) return;
     /*
      * Each observer is guarded separately, and that is not tidiness. They answer
      * different questions — sizes changed, and the DOM changed — so a runtime

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -37,6 +37,23 @@
  * block each describes. The primary is the one the inspector answers for, so the
  * two surfaces agree about whose value is on screen.
  *
+ * ## When it re-measures, and the one case it cannot see
+ *
+ * A re-measure happens when the selection changes, when the document changes,
+ * when the selected block resizes, and when the canvas root resizes. Between
+ * them those cover an edit, an image or webfont arriving, the panels moving, and
+ * a breakpoint changing — a breakpoint is driven by the canvas's own width, so
+ * the root's resize is the event that reports it.
+ *
+ * What is NOT covered is a spacing change driven purely by a CSS STATE: a
+ * `:hover` or `:focus-visible` rule altering a margin repaints without mutating
+ * the DOM and without resizing anything, so there is no event for an observer to
+ * receive — a `MutationObserver` sees nothing either, because nothing mutates.
+ * Reaching it would mean re-measuring on pointer traffic across the canvas or
+ * polling every frame, and both cost more than the staleness they remove. Stated
+ * here rather than left to be discovered: while the pointer rests on a block
+ * whose hover rule moves it, the bands describe its resting state.
+ *
  * @module spacing-overlay
  */
 

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -63,12 +63,14 @@ import { CANVAS_ROOT_CLASS, nodeElement, nodeElements } from "./canvas";
 import type { EditorState } from "./editor-state";
 import {
   canvasContentRect,
+  clippedByAncestor,
   hasScrollbarGutter,
   layoutFragments,
   renderedScale,
   type RenderedScale,
 } from "./geometry-dom";
 import {
+  overlayEscape,
   sameBands,
   spacingApplies,
   spacingBands,
@@ -139,6 +141,16 @@ function boxesOf(style: CSSStyleDeclaration): {
   };
 }
 
+/**
+ * How far a value chip can overflow the band it is centred on.
+ *
+ * Bounded by the chip's own size, which this package sets: `0.6875rem` text on a
+ * `1.4` line box with two pixels of padding, so a little over twenty pixels tall
+ * and wider than that only for a value nobody authors. Twenty-four covers it
+ * with room and keeps the clip allowance small.
+ */
+const CHIP_OVERFLOW_PX = 24;
+
 /** Four zero edges, for a box CSS gives no margin or no padding. */
 const NO_EDGES: EdgeLengths = { top: 0, right: 0, bottom: 0, left: 0 };
 
@@ -161,6 +173,7 @@ function describable(
   fragments: number,
   position: string,
   gutter: boolean,
+  clipped: boolean,
   scale: RenderedScale
 ): boolean {
   // No box at all — `display: none`, `display: contents`.
@@ -185,6 +198,12 @@ function describable(
    * writing direction.
    */
   if (gutter) return false;
+  /*
+   * Cut off by an ancestor. The block's own rectangle is reported unclipped and
+   * the overlay draws outside that container, so bands taken from it would paint
+   * over ground where the block is not rendered.
+   */
+  if (clipped) return false;
   // A rotation, skew, reflection, perspective, or a collapse to zero.
   return scale.describable;
 }
@@ -195,6 +214,13 @@ export function SpacingOverlay({
 }: SpacingOverlayProps): React.JSX.Element | null {
   const layer = React.useRef<HTMLDivElement | null>(null);
   const [bands, setBands] = React.useState<readonly SpacingBand[]>([]);
+  /*
+   * How far the layer may paint outside itself, in pixels.
+   *
+   * Held beside the bands rather than derived at render because it needs the
+   * LAYER's size, which only the measurement has.
+   */
+  const [escape, setEscape] = React.useState(0);
 
   const { document, selectedId } = editor;
 
@@ -207,8 +233,16 @@ export function SpacingOverlay({
    * selection alone would keep describing the layout it used to have.
    */
   const measure = React.useCallback(() => {
-    const apply = (next: readonly SpacingBand[]): void => {
+    const apply = (
+      next: readonly SpacingBand[],
+      layerBox?: { width: number; height: number }
+    ): void => {
       setBands(current => (sameBands(current, next) ? current : next));
+      setEscape(
+        next.length === 0 || layerBox === undefined
+          ? 0
+          : overlayEscape(next, layerBox, CHIP_OVERFLOW_PX)
+      );
     };
     const element = layer.current;
     if (element === null || selectedId === null) {
@@ -260,6 +294,7 @@ export function SpacingOverlay({
         layoutFragments(block),
         style.position,
         hasScrollbarGutter(block, borders),
+        clippedByAncestor(block, root),
         scale
       )
     ) {
@@ -267,6 +302,12 @@ export function SpacingOverlay({
       return;
     }
 
+    /*
+     * The layer's own box, measured the same way every other rectangle here is.
+     * It fills the root, so the root's content rectangle IS the layer's, and
+     * asking for it separately would be a second answer to one question.
+     */
+    const layerBox = canvasContentRect(root, root);
     apply(
       spacingBands({
         // Through `canvasContentRect` rather than a rectangle read here: this
@@ -279,7 +320,8 @@ export function SpacingOverlay({
         // Composed from the real transform between the block and the root, so
         // a scaled ancestor counts and no rounded layout value is involved.
         scale: { x: scale.x, y: scale.y },
-      })
+      }),
+      layerBox
     );
   }, [selectedId]);
 
@@ -380,12 +422,23 @@ export function SpacingOverlay({
     const settled = (): void => measure();
     root.addEventListener("transitionend", settled);
     root.addEventListener("transitioncancel", settled);
+    /*
+     * `overflow: auto` and `overflow: scroll` are catalog values, so a block can
+     * sit inside a container the author scrolls. Scrolling it moves the block
+     * relative to the canvas while resizing nothing, mutating nothing and
+     * finishing no transition — none of the subscriptions above hear it.
+     *
+     * CAPTURE, because a scroll event does not bubble: listening on the root in
+     * the capture phase is what reaches a scroller nested anywhere inside it.
+     */
+    root.addEventListener("scroll", settled, true);
 
     return () => {
       sizes?.disconnect();
       styles?.disconnect();
       root.removeEventListener("transitionend", settled);
       root.removeEventListener("transitioncancel", settled);
+      root.removeEventListener("scroll", settled, true);
     };
     /*
      * `document` re-subscribes, and dropping it strands the observer on a
@@ -412,6 +465,14 @@ export function SpacingOverlay({
        * bury that surface in exactly the readers it is for.
        */
       aria-hidden="true"
+      /*
+       * How far the clip may extend, measured rather than fixed. A band can
+       * legitimately sit outside the canvas — a collapsed top margin does — and
+       * any constant allowance is too small for some legal value.
+       */
+      style={
+        { "--nx-spacing-escape": `${String(escape)}px` } as React.CSSProperties
+      }
     >
       {bands.map(band => (
         <div

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -933,7 +933,12 @@
    * region contributes no scrollable overflow.
    */
   overflow: clip;
-  overflow-clip-margin: 2rem;
+  /*
+   * Set by the component from the bands it actually measured, because a fixed
+   * allowance is too small for some legal value — `2rem` clipped an ordinary
+   * `64px` spacing step. Zero is the floor when nothing escapes.
+   */
+  overflow-clip-margin: var(--nx-spacing-escape, 0px);
 }
 
 .nx-spacing-overlay__band {

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -922,8 +922,18 @@
    *
    * `clip` rather than `hidden`: both contain the overflow, and `hidden` makes
    * the element a scroll container, which is the thing being avoided.
+   *
+   * `overflow-clip-margin` is what keeps the clip from being the wrong answer for
+   * a band that legitimately sits OUTSIDE the root. The first block's top margin
+   * can collapse through the page wrapper and the canvas — neither establishes a
+   * formatting context — so the block's border box starts at the root's top edge
+   * and its margin band is placed at a negative offset. A bare clip would remove
+   * that band while the gap it names is plainly visible. The allowance paints it
+   * without making it scrollable, which is the whole point: an extended clip
+   * region contributes no scrollable overflow.
    */
   overflow: clip;
+  overflow-clip-margin: 2rem;
 }
 
 .nx-spacing-overlay__band {

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -880,3 +880,90 @@
   color: var(--nx-builder-text);
   cursor: pointer;
 }
+
+/**
+ * The selected block's spacing, drawn over the page it applies to.
+ *
+ * Margin amber and padding green, which is the box-model palette browser
+ * developer tools have used for years — an author arrives already knowing which
+ * band is which, and a different pairing would cost that for nothing.
+ *
+ * BASE tokens rather than the `--nx-builder-*` set above. Those are declared on
+ * `.nx-builder-chrome`, and the canvas is mounted without the shell in the
+ * harness a browser drives it through, so a builder token would resolve to
+ * nothing exactly where the overlay is under test. The drop indicator reaches
+ * for `--nx-primary` for the same reason.
+ */
+.nx-spacing-overlay {
+  position: absolute;
+  inset: 0;
+  /*
+   * Under the drop indicator and the toolbar, both of which say what is about to
+   * happen; this only describes what already is.
+   */
+  z-index: 1;
+  /*
+   * Never a pointer target. The bands cover the block they measure — the margin
+   * ones cover its neighbours too — so a hit-test that could land here would
+   * make the selected block unclickable, and the author would meet that as a
+   * canvas that stops responding once anything is selected.
+   */
+  pointer-events: none;
+}
+
+.nx-spacing-overlay__band {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.nx-spacing-overlay__band[data-box="margin"] {
+  background-color: color-mix(in srgb, var(--nx-chart-4) 22%, transparent);
+}
+
+.nx-spacing-overlay__band[data-box="padding"] {
+  background-color: color-mix(in srgb, var(--nx-chart-3) 22%, transparent);
+}
+
+/*
+ * A negative margin is hatched rather than filled.
+ *
+ * It lies INSIDE the border edge, over the same pixels a padding band occupies,
+ * because that is where the space it removes is. A flat fill there reads as
+ * ordinary space and says the opposite of what is happening; a hatch reads as
+ * the element being pulled over its neighbour, which it is.
+ */
+.nx-spacing-overlay__band[data-box="margin"][data-negative] {
+  background-color: transparent;
+  background-image: repeating-linear-gradient(
+    45deg,
+    color-mix(in srgb, var(--nx-chart-4) 34%, transparent) 0 3px,
+    transparent 3px 7px
+  );
+}
+
+/**
+ * The value, on a chip rather than drawn straight onto the band.
+ *
+ * The band is translucent and whatever the author put on the page shows through
+ * it, so bare text lands on arbitrary content and is legible only by luck. The
+ * chip is opaque, which makes the number readable over any page at either theme.
+ *
+ * It is NOT clipped to the band. A four-pixel margin cannot contain a label, and
+ * the case where the value is hardest to guess from looking is exactly the case
+ * where the space is too small to hold it — so the chip overflows and stays
+ * centred on the band it names.
+ */
+.nx-spacing-overlay__value {
+  padding: 0 3px;
+  border-radius: 2px;
+  background-color: var(--nx-background);
+  color: var(--nx-foreground);
+  /* The smallest size already in this sheet, rather than a fourth one. */
+  font-size: 0.6875rem;
+  line-height: 1.4;
+  /* So a column of values does not jitter as digits change under a drag. */
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -909,6 +909,21 @@
    * canvas that stops responding once anything is selected.
    */
   pointer-events: none;
+
+  /*
+   * Clipped at the canvas, so chrome never joins the page's scroll extent.
+   *
+   * The value chips deliberately overflow their own band, because the case where
+   * a number is hardest to guess is the case where the space is too small to
+   * hold it. On a block flush with a canvas edge that overflow would otherwise
+   * enlarge the scrollable area — and the canvas is the surface a responsive
+   * layout is measured against, so selecting a block could change the width the
+   * page lays out in and move the very spacing being inspected.
+   *
+   * `clip` rather than `hidden`: both contain the overflow, and `hidden` makes
+   * the element a scroll container, which is the thing being avoided.
+   */
+  overflow: clip;
 }
 
 .nx-spacing-overlay__band {

--- a/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
@@ -79,6 +79,7 @@ vi.mock("@nextlyhq/builder/shell", () => {
     LayersPanel: nothing,
     OnboardingChecklist: nothing,
     SelectionBreadcrumb: nothing,
+    SpacingOverlay: nothing,
     useBuilderChecklist: () => ({
       visible: false,
       steps: [],

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -53,6 +53,7 @@ import {
   LayersPanel,
   OnboardingChecklist,
   SelectionBreadcrumb,
+  SpacingOverlay,
   useBuilderChecklist,
   useCanvasDrag,
   useEditorState,
@@ -687,6 +688,15 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                   that is in the middle of moving.
                 */}
                   <BlockToolbar
+                    editor={editor}
+                    hidden={drag.draggingId !== null}
+                  />
+                  {/*
+                  Suppressed for the same reason and by the same signal. The
+                  bands report a layout that is mid-change during a drag, so
+                  every value on them is about to be wrong.
+                */}
+                  <SpacingOverlay
                     editor={editor}
                     hidden={drag.draggingId !== null}
                   />


### PR DESCRIPTION
Closes C-17 (`task:pb-canvas-spacing-values`), Plan 05 stage 1. Drag handles are Phase 5 and are not here.

## What an author gets

Select a block and its spacing is drawn on the page it applies to: a band over each side that has margin or padding, with the value on it. Amber outside for margin, green inside for padding — the palette browser developer tools have used for years, so the mapping is one an author arrives already knowing.

Until now the only way to see what a spacing value did was to change it and watch the layout move.

## The decision that shaped everything: where the values come from

There were two candidate sources, and only one can answer the question the canvas is asking.

The **stored style tier** — what `readStyleValue` returns, what the inspector edits — is wrong in four independent ways, each sufficient on its own:

1. **The catalog is LOGICAL; the screen is PHYSICAL.** `STYLE_CATALOG` declares spacing through `logicalSides()` (`catalog.ts:285,296`), emitting `margin-inline-start` and friends. A band is drawn on top/right/bottom/left. Resolving one to the other depends on the element's inherited `direction` and `writing-mode` — a CSS rule the browser has already applied correctly, and re-implementing it is a second answer that drifts.
2. **`auto` has no value in the document.** The margin shape declares `keywords: ["auto"]` (`catalog.ts:286`). It resolves only after layout — it is what centres a block.
3. **Percentages resolve against the containing block.** Both margin and padding declare `allowPercentage: true`.
4. **A tier is not the cascade.** A named class, a block-type default or a breakpoint override can win, and an overlay reading one tier would confidently name a value the page does not use.

So the overlay asks the rendered element via `getComputedStyle`. This is the same move as #1138 (derive the sitemap URL from the route's own path answer), reached independently on a different surface.

## Shape

- **`spacing-bands.ts`** — pure. Rect + eight edge lengths + `scale` → the bands to draw. No DOM, no React.
- **`spacing-overlay.tsx`** — the DOM edge. Reads the four *physical* longhands and renders, following `BlockToolbar`'s lifecycle exactly (`useLayoutEffect`, `ResizeObserver`, every rectangle through `canvasContentRect`).
- Composed into `Canvas`'s existing `overlay` prop, beside `DropIndicator` and `BlockToolbar`.

The split is forced by the tooling, not aesthetic: **jsdom lays nothing out and reports every element as zero-sized**, so a placement rule written against live elements can only be exercised in a browser. Written against numbers it is exercisable anywhere.

### `scale` is required, not defaulted

`canvasContentRect` reads `getBoundingClientRect` — **post-transform** pixels. `getComputedStyle` reports **unscaled** CSS pixels. They coincide exactly while the canvas is drawn 1:1, which is every case today, so a default would be silently correct until it was not, with nothing failing. The call site passes `1` with a comment naming the day it changes. `builder-shell.test.tsx:465` says a page builder "acquires canvas zoom eventually"; `geometry.ts` already carries `scale` for the same reason.

## Product decisions

- **Primary selection only.** Spacing belongs to a node; a multi-block selection has no margin of its own, and two sets of bands leave the numbers ambiguous. `selectedId` is documented as the one the inspector edits, so the two surfaces agree.
- **Zero-valued sides draw nothing.** Eight bands reading `0` on every selection trains authors to ignore the overlay.
- **Negative margins are hatched, drawn INWARD.** A negative margin box is *smaller* than the border box on that side. Filling outward would draw the band exactly where the space it removes is not.
- **`aria-hidden`.** The same values are in the inspector's Spacing section with real labels and controls; announcing up to eight numbers on every arrow-key selection change would bury that surface in the readers it is for.
- **Used px, not the authored unit** — what the canvas is showing, comparable across siblings, and what DevTools and Webflow both display.

## D-05.7 is satisfied, in a browser

C-4 shipped disclosing that D-05.7 was unmet (unit and jsdom only). This meets it: **7 Playwright tests** against the real `Canvas` on `/builder-canvas`.

The one that matters most: **a vertical writing mode moves the band to the edge it RENDERS at.** With `writing-mode: vertical-rl`, the seed's authored `padding: { blockEnd: 120px }` computes to `padding-left`. A logical-reading implementation still sees `padding-block-end` and draws along the bottom, where there is no padding. This is the only place the physical-vs-logical choice is observable — in an ordinary LTR document the two compute to the same value.

## Evidence

**Every test was break-verified: 13 deliberate breaks, 13 reds, each failing its intended test for the intended reason.**

| layer | tests | breaks verified |
|---|---|---|
| `spacing-bands.test.ts` (node) | 25 | negative margin drawn outward · scale ignored · border inset dropped · filter on raw value · corner overlap · clamp removed |
| `spacing-overlay.test.tsx` (jsdom) | 8 | logical longhand read · `hidden` ignored · anchored to wrong selection member · `aria-hidden` dropped |
| `spacing-overlay.spec.ts` (chromium) | 7 | logical longhands · padding drawn outward · `pointer-events` removed |

Break 1 of the browser set failed **only** the writing-mode test, confirming it is the true separator.

One break initially stayed **green** — my clamp test exercised `paddingRect`'s clamp, not `inset()`'s, leaving a guard uncovered. Fixed by adding a test that reaches it.

### Gates

| gate | exit |
|---|---|
| `pnpm build` (19 tasks) | 0 |
| `pnpm check-types` (22 tasks) | 0 |
| `@nextlyhq/builder` test — 53 files, 1184 tests | 0 |
| `@nextlyhq/plugin-page-builder` test — 20 files, 175 tests | 0 |
| both packages' `lint` (`--max-warnings 0`) | 0 |
| root `npx eslint` on 11 changed files | 0 |
| `check-changesets.mjs` | 0 |
| `check-comment-convention.mjs` | 0 |
| `fallow audit` | `pass`, all four `*_introduced` at 0 |
| Playwright | 7 passed |

The changeset's 25-package list is generated from `.changeset/config.json`, not copied — and break-verified: removing `@nextlyhq/eslint-plugin` makes the gate exit 1.

## Incidental change, called out because it is not mine to make quietly

`selectedElement` moves from `block-toolbar.tsx` into `canvas.tsx` as **`nodeElement`**, beside its inverse `nodeIdFromEvent`. It encodes two non-obvious rules — ids are compared rather than interpolated into a selector (a stored id may contain CSS-special characters), and it deliberately avoids the `data-nx-selected` marker because that is applied in a passive effect and would be one frame stale. Copying it into a second overlay would have been a second implementation of "which element is this node id". No behaviour change; `BlockToolbar`'s suite is unchanged and passing.

## What this does NOT do

- **No toggle.** Bands show whenever a block is selected. Webflow ships the same feature opt-in (`Cmd+Shift+D`), which is evidence permanent bands can be visually expensive. If that proves true in use, the toggle sits above this component without changing its contract.
- **No drag handles** — Phase 5.
- **Border is measured but never drawn.** It is a different catalog group; the padding box cannot be located without it.
- **`scale` is proven by unit test, not in production.** Nothing passes anything but `1` today, because no zoom exists to pass.

## Coordination

`packages/builder/**` is contended. Agreed an explicit file boundary with `nextly-workspace-78` (holds C-5 / #1143) before starting: they verified zero hits on all eight files I might need and committed to messaging before touching any; I committed the same in return. `nextly-workspace-5d` (taking C-9 next) confirmed no overlap. My `builder-chrome.css` change is an append at line 880, clear of #1143's hunks at 406–506 and 539; my `BlocksField.tsx` hunks are at 53 and 690, clear of theirs at 570–591.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a visual spacing overlay for selected blocks, showing rendered margin and padding values.
  - Added color-coded bands and labels with support for borders, negative margins, writing modes, transforms, and responsive layout changes.
  - Overlay remains pointer-transparent and hides during dragging or when spacing cannot be measured reliably.

- **Bug Fixes**
  - Improved selected-block detection for more reliable toolbar and overlay positioning.

- **Tests**
  - Expanded coverage for spacing geometry, rendering, selection, resizing, clipping, and browser layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->