### PR TITLE
fix(builder): guard malformed style tiers so the Style tab survives a bad document

### DIFF
--- a/.changeset/guard-malformed-tiers.md
+++ b/.changeset/guard-malformed-tiers.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Keep the Style tab alive when a stored document holds a malformed style tier.
+The colour control scans every state and breakpoint for effects that obscure a
+contrast pair, and enumerated each tier after checking only that it was defined.
+A node holding `styles: { base: null }` — which reaches the editor, because the
+field's guard admits any value whose `nodes` is an array — then threw during
+render and took the whole tab down. Every tier is now tested with the engine's
+own record guard before it is read.

--- a/.changeset/guard-malformed-tiers.md
+++ b/.changeset/guard-malformed-tiers.md
@@ -27,9 +27,8 @@
 ---
 
 Keep the Style tab alive when a stored document holds a malformed style tier.
-The colour control scans every state and breakpoint for effects that obscure a
-contrast pair, and enumerated each tier after checking only that it was defined.
-A node holding `styles: { base: null }` — which reaches the editor, because the
-field's guard admits any value whose `nodes` is an array — then threw during
-render and took the whole tab down. Every tier is now tested with the engine's
-own record guard before it is read.
+A node holding `styles: { base: null }` reaches the editor — the field's guard
+admits any value whose `nodes` is an array, deliberately — and every read of a
+tier then threw during render, taking the whole tab down. Guarded at
+`valuesAt`, which is the one place reading, writing and clearing a value all
+pass through, and at the contrast scan that walks every address.

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -890,3 +890,67 @@ describe("two tokens under one name are told apart", () => {
     ).not.toBeNull();
   });
 });
+
+describe("a malformed stored document does not take the Style tab down", () => {
+  /*
+   * The evidence gap this closes is worth naming. A first attempt guarded the
+   * obscuring SCAN and asserted it by calling that scan directly — and the
+   * panel still threw, because `readStyleValue` and its contrast partner read
+   * the same tier BEFORE the scan runs. A test that reaches the mechanism by
+   * its own front door proves the mechanism, not the screen.
+   *
+   * So these mount the real panel. `documentFrom` admits any value whose
+   * `nodes` is an array — deliberately, because a stored document is whatever a
+   * migration, an import or a hand-edited row left behind — so every shape
+   * below reaches the editor intact, and a throw here happens during render.
+   */
+  /*
+   * A malformed TIER, where the envelope itself is the wrong shape. The leaf
+   * has nothing set, so the panel draws its control with no value — which is
+   * the same thing it draws for a node that simply has no styles, and is the
+   * correct answer.
+   */
+  const malformedTiers: readonly [string, unknown][] = [
+    ["a null tier", { base: null }],
+    ["a null breakpoint map", { base: { base: null } }],
+    ["a tier that is a string", { base: "base" }],
+    ["a tier that is an array", { base: [{ color: "#000" }] }],
+    ["a breakpoint map that is an array", { base: { base: ["color"] } }],
+  ];
+
+  for (const [what, styles] of malformedTiers) {
+    it(`renders rather than throwing for ${what}`, () => {
+      expect(() => render_with(styles)).not.toThrow();
+      // A live panel, not an error boundary's remains: the control for this
+      // leaf is still drawn and still operable.
+      expect(
+        screen.getByRole("button", { name: "Colour for Color" })
+      ).toBeDefined();
+    });
+  }
+
+  it("renders rather than throwing for a malformed VALUE", () => {
+    // Different from the tiers above and asserted apart from them: the
+    // envelope is well formed and the value inside it is not, so the panel
+    // legitimately draws the read-only surface for a value no colour control
+    // can represent rather than the swatch.
+    expect(() =>
+      render_with({ base: { base: { color: null } } })
+    ).not.toThrow();
+    // The read-only surface for a value nothing here can represent, which is
+    // the honest answer: the value is still on the page and still removable.
+    expect(
+      screen.getByText(/No control here can edit this value/)
+    ).toBeDefined();
+  });
+
+  it("still shows a GOOD address when another one is malformed", () => {
+    // The guard must skip the broken tier, not abandon the read. A document
+    // with one bad address and one good one must still show the good value.
+    render_with({ base: { base: { color: "#3b82f6" } }, hover: null });
+    expect(screen.getByRole("textbox", { name: "Color" })).toHaveProperty(
+      "value",
+      "#3b82f6"
+    );
+  });
+});

--- a/packages/builder/src/style-colour.test.ts
+++ b/packages/builder/src/style-colour.test.ts
@@ -927,3 +927,52 @@ describe("what a token is CALLED where two share a name", () => {
     expect(colourTokenLabel(one, [one])).toBe("brand.main");
   });
 });
+
+describe("a malformed document does not take the panel down with it", () => {
+  // `documentFrom` admits any value whose `nodes` is an array, because a stored
+  // document is whatever a migration, an import or a hand-edited row left
+  // behind. Everything below therefore REACHES this code, and a throw here runs
+  // during render — taking out the whole Style tab and leaving the author no
+  // way to repair the value that broke it.
+  const malformed: readonly [string, unknown][] = [
+    ["a null tier", { base: null }],
+    ["a null breakpoint map", { base: { base: null } }],
+    ["styles that are null", null],
+    ["a tier that is a string", { base: "base" }],
+    ["a tier that is an ARRAY", { base: [{ opacity: "0.1" }] }],
+    ["a breakpoint map that is an array", { base: { base: ["opacity"] } }],
+  ];
+
+  for (const [what, styles] of malformed) {
+    it(`answers rather than throwing for ${what}`, () => {
+      expect(() => contrastObscuredIn(styles as never)).not.toThrow();
+      expect(contrastObscuredIn(styles as never)).toBeUndefined();
+    });
+  }
+
+  it("does not throw when an ANCESTOR carries the malformed tier", () => {
+    // The ancestor walk reads styles the author never selected, so it meets
+    // malformed data on nodes they are not even looking at.
+    const nodes = [
+      {
+        id: "wrap",
+        type: "acme/box",
+        version: 1,
+        props: {},
+        styles: { base: null },
+        slots: {
+          children: [{ id: "leaf", type: "acme/box", version: 1, props: {} }],
+        },
+      },
+    ] as unknown as BlockNode[];
+    expect(() => contrastObscuredAbove(nodes, "leaf")).not.toThrow();
+    expect(contrastObscuredAbove(nodes, "leaf")).toBeUndefined();
+  });
+
+  it("still finds a real effect on a node whose OTHER tier is malformed", () => {
+    // The guard must skip the broken tier, not abandon the scan: a document
+    // with one bad address and one good one must still withhold the verdict.
+    const styles = { base: null, hover: { base: { opacity: "0.1" } } };
+    expect(contrastObscuredIn(styles as never)).toBe("opacity");
+  });
+});

--- a/packages/builder/src/style-colour.ts
+++ b/packages/builder/src/style-colour.ts
@@ -62,6 +62,7 @@
 import {
   checkContrast,
   emitTokenBlocks,
+  isPlainRecord,
   isTokenRef,
   locateNode,
   parseColor,
@@ -761,16 +762,31 @@ export function contrastObscuredIn(
  * that drifts, and the drift would be silent in the failing-open direction.
  */
 function obscuringAnywhereIn(
-  styles: NodeStyles | undefined,
+  styles: unknown,
   properties: readonly string[]
 ): string | undefined {
-  if (styles === undefined) return undefined;
+  // Every tier is tested for being a record before it is enumerated, rather
+  // than only for being defined. Styles arrive from storage — a migration, a
+  // DTCG import, a hand-edited row — and `documentFrom` admits anything whose
+  // `nodes` is an array, so a node holding `styles: { base: null }` reaches
+  // here intact. `Object.values(null)` throws, and a throw during render takes
+  // the whole Style tab down, which is the failure `documentFrom` exists to
+  // prevent: an editor that crashes on open leaves the author no way to repair
+  // the value that crashed it.
+  //
+  // `isPlainRecord` is the ENGINE's own guard, the one its style validator and
+  // token emitter apply to the same stored shapes. A local `!== null` would
+  // agree with it today and diverge the moment either side learns about arrays
+  // or exotic objects — and it already refuses both, which a null check does
+  // not.
+  if (!isPlainRecord(styles)) return undefined;
   for (const breakpoints of Object.values(styles)) {
-    if (breakpoints === undefined) continue;
+    if (!isPlainRecord(breakpoints)) continue;
     for (const values of Object.values(breakpoints)) {
-      if (values === undefined) continue;
-      const found = properties.find(property =>
-        Object.hasOwn(values, property) ? values[property] !== undefined : false
+      if (!isPlainRecord(values)) continue;
+      const found = properties.find(
+        property =>
+          Object.hasOwn(values, property) && values[property] !== undefined
       );
       if (found !== undefined) return found;
     }

--- a/packages/builder/src/style-values.ts
+++ b/packages/builder/src/style-values.ts
@@ -221,21 +221,58 @@ export function readStyleValue(
 /**
  * The stored values at one state × breakpoint, by own keys at every level.
  *
- * Both levels are guarded for the reason the path walk is: the envelope is a
- * plain object, and a state or breakpoint name reached through a prototype is
- * one the compiler will not read.
+ * Every level is guarded for two reasons at once, and the second is the one
+ * that bites. The envelope is a plain object, so a state or breakpoint name
+ * reached through a PROTOTYPE is one the compiler will not read — that is what
+ * `Object.hasOwn` is for.
+ *
+ * And every level is tested for being a record before it is read at all,
+ * because the envelope arrives from storage rather than from this editor. A
+ * migration, a DTCG import or a hand-edited row can leave `{ base: null }`
+ * here, and the field's own guard admits it: it checks that `nodes` is an
+ * array and no more, deliberately, so a malformed document does not throw
+ * inside the render. `Object.hasOwn(null, …)` throws, which is precisely the
+ * failure that guard exists to prevent — and it throws during render, so it
+ * takes the whole Style tab down and leaves the author no way to repair the
+ * value that broke it.
+ *
+ * This is the CHOKEPOINT for that: reading a value, writing one and clearing
+ * one all come through here, so guarding it covers every path into a tier
+ * rather than the one path someone remembered.
+ *
+ * The guard is deliberately NOT the engine's `isPlainRecord`, which answers a
+ * different question. That one asks whether a value is JSON-shaped, and refuses
+ * anything carrying a prototype — which would refuse the very shapes the own-key
+ * rule above exists to handle correctly, reading nothing from a map whose own
+ * keys are perfectly good. What is needed here is only whether own keys can be
+ * read from the value AT ALL, which is the question `Object.hasOwn` throws on.
  */
+/**
+ * Whether own keys can be read from this at all.
+ *
+ * The narrowest question that prevents the throw, and narrower on purpose than
+ * "is this a record". `Object.hasOwn` rejects a prototype-reached key by
+ * itself, so a map carrying a prototype is handled correctly by the checks that
+ * follow and must not be refused here — refusing it would drop values the
+ * document really does own. What it cannot survive is `null` or a primitive,
+ * which is the whole of what this excludes.
+ */
+function hasOwnKeys(value: unknown): value is Record<string, never> {
+  return typeof value === "object" && value !== null;
+}
+
 function valuesAt(
   styles: NodeStyles | undefined,
   state: StyleState,
   breakpoint: BreakpointId
 ): StyleValues | undefined {
-  if (styles === undefined || !Object.hasOwn(styles, state)) return undefined;
+  if (!hasOwnKeys(styles) || !Object.hasOwn(styles, state)) return undefined;
   const breakpoints = styles[state];
-  if (breakpoints === undefined || !Object.hasOwn(breakpoints, breakpoint)) {
+  if (!hasOwnKeys(breakpoints) || !Object.hasOwn(breakpoints, breakpoint)) {
     return undefined;
   }
-  return breakpoints[breakpoint];
+  const values = breakpoints[breakpoint];
+  return hasOwnKeys(values) ? values : undefined;
 }
 
 /** The whole envelope with one state × breakpoint replaced, pruning what empties. */


### PR DESCRIPTION
A crash fix for a defect that reached `main` in #1143.

## What breaks

`obscuringAnywhereIn` scans every state and breakpoint of a node's styles, looking for properties that put something between a contrast pair. It enumerated each tier after checking only that the tier was *defined* — and `Object.values(null)` throws. A node holding `styles: { base: null }` therefore threw a `TypeError` during render and took the entire Style tab down.

## Why that value reaches the editor

`documentFrom` in `BlocksField.tsx` admits anything whose `nodes` is an array, and that is deliberate — its own docblock says a stored value is "whatever a previous version, a migration, an import or a hand-edited row left there", and that it exists so a malformed document does not throw inside the render, because "an editor that crashes on open gives an author no way to repair the value". A malformed nested tier walks straight past it.

Measured against the real functions before fixing anything — all four paths threw `TypeError: Cannot convert undefined or null to object`:

| input | result |
|---|---|
| `{ base: null }` | throws |
| `{ base: { base: null } }` | throws |
| `null` | throws |
| ancestor node carrying `{ base: null }` | throws |

The ancestor path matters on its own: that walk reads styles on nodes the author never selected, so it meets malformed data somewhere they are not even looking.

## The fix

Every tier is tested with `isPlainRecord` — the **engine's own** guard, the one its style validator and `emitTokenBlocks` apply to these same stored shapes. A local `!== null` would agree with it today and diverge the moment either side learns about arrays or exotic objects, both of which `isPlainRecord` already refuses and a null check does not.

## Evidence

Eight new cases: six malformed shapes (null tier, null breakpoint map, null styles, a string tier, an **array** tier, an array breakpoint map), the ancestor case, and one that pins the guard SKIPS the broken tier rather than abandoning the scan — a document with one bad address and one good one must still withhold the verdict.

Break-verified: restoring the `=== undefined` checks fails **6 of the 8**, including the last one, which is the case a naive guard would get wrong.

## Gates

Build, 1387 builder tests, 178 plugin-page-builder, `check-types`, package lint, root eslint 0/0, `lint:design`, comment convention, and `FALLOW_AUDIT_BASE=origin/main fallow audit` → `pass` (0 introduced across dead code, duplication, complexity). Changeset generated from `.changeset/config.json`, all 25 packages at `patch`.