### PR TITLE
fix(blocks-react): narrow block bases by own properties, and bound a rejected style value

### DIFF
--- a/.changeset/block-base-ownership-and-value-bound.md
+++ b/.changeset/block-base-ownership-and-value-bound.md
@@ -108,3 +108,10 @@ The builder's rename gate follows the same rule, so the editor no longer refuses
 a label the engine accepts, and `EMITTABLE_STRING_BOUNDS` lists the literal
 style value — the largest bound of the set, and the one whose omission let a
 consumer verify every listed bound and still choose a limit below it.
+
+Renaming a token whose identity the new rules cannot emit re-pins the identity
+to the new name rather than carrying the unusable one forward. A site stored
+before these bounds existed can hold such a token, and carrying its identity
+through a rename left it permanently unrenderable with no way to repair it from
+the editor. A WORKING identity still never moves, which is what rename exists to
+protect.

--- a/.changeset/block-base-ownership-and-value-bound.md
+++ b/.changeset/block-base-ownership-and-value-bound.md
@@ -136,3 +136,15 @@ with no cap.
 `safeTokenPrefix` takes what actually reaches it. A persisted `null` is not the
 absent value its old signature described, and reading a length off it aborted
 the compile the fallback exists to keep going.
+
+A stored page stylesheet records the scope its selectors were actually written
+under rather than the one the caller asked for. A scope the compiler refuses is
+dropped and the sheet compiled global, so recording the request stored an
+artifact claiming an isolation its own selectors did not carry — and the
+renderer attaches that class, which is how one document's rules reach another
+rendered beside it. That held for any refused scope, not only an oversized one.
+
+A font format is bounded, and the token studio refuses a name that lands on a
+custom property another token already occupies. The name-to-property mapping is
+deliberately not injective, so two visibly different, individually legal names
+can collide and the compiler drops whichever it reaches second.

--- a/.changeset/block-base-ownership-and-value-bound.md
+++ b/.changeset/block-base-ownership-and-value-bound.md
@@ -1,0 +1,45 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+An inherited block-base entry is no longer turned into an emitted CSS rule.
+
+`compilePageCss` emits a block type's defaults only when `Object.hasOwn` finds
+the entry, because a node type reaches a SELECTOR and the compiler reads
+persisted data whether or not anything validated it. Narrowing a stated
+`blockBases` record to the types a page draws copied whatever the lookup
+answered — so a record reached through `Object.create`, or one whose prototype
+had been polluted, had its inherited entry made an OWN property of the narrowed
+record, and the compiler then emitted a rule it had deliberately declined to
+emit.
+
+A style value longer than `MAX_VALUE_LENGTH` is also read no further than the
+compiler reads it. The engine refuses such a value before parsing and emits no
+declaration, so two of them produce identical CSS — carrying both in full
+invalidated a byte-identical stored stylesheet over a suffix nothing reads, and
+put an arbitrarily large allocation into every cache check. `MAX_VALUE_LENGTH`
+is exported so a writer can honour the same number.

--- a/.changeset/block-base-ownership-and-value-bound.md
+++ b/.changeset/block-base-ownership-and-value-bound.md
@@ -54,3 +54,11 @@ names agreeing up to the truncation point and differing after it compiled apart
 under one identifier, and the stored sheet was then reused for the wrong one.
 The cap is deliberately larger than the one on a class name, because a token
 name is composed from a design-token file's nesting depth rather than typed.
+
+A block type is bounded at `MAX_BLOCK_TYPE_LENGTH` before its grammar runs, for
+the same reason and by the same measure. The engine now also exports
+`EMITTABLE_STRING_BOUNDS`: every bound on a string it can write into CSS, as
+data rather than as prose. A consumer that digests compiler inputs has to keep
+enough of each string to tell two apart whenever they compile differently, and
+the list of which strings those are had been kept twice as a comment — short by
+one both times.

--- a/.changeset/block-base-ownership-and-value-bound.md
+++ b/.changeset/block-base-ownership-and-value-bound.md
@@ -62,3 +62,15 @@ data rather than as prose. A consumer that digests compiler inputs has to keep
 enough of each string to tell two apart whenever they compile differently, and
 the list of which strings those are had been kept twice as a comment — short by
 one both times.
+
+Registration, document validation and compilation now share one block-type
+predicate, `isBlockType`, exported from the document model. The three carried
+identical copies of the grammar, so a bound added to one accepted a name the
+others rejected: a block could register and validate while the compiler omitted
+its declared defaults, rendering without the look it declares and reporting
+nothing.
+
+The shared-input stamp's encoding is bumped, and its contract now covers what
+the COMPILER emits as well as what the stamp serializes. A stamp keys on inputs,
+so it cannot see the compiler treating unchanged inputs differently — a stored
+stylesheet would otherwise be served for a compile that no longer produces it.

--- a/.changeset/block-base-ownership-and-value-bound.md
+++ b/.changeset/block-base-ownership-and-value-bound.md
@@ -115,3 +115,16 @@ before these bounds existed can hold such a token, and carrying its identity
 through a rename left it permanently unrenderable with no way to repair it from
 the editor. A WORKING identity still never moves, which is what rename exists to
 protect.
+
+A label and an identity are asked different questions by different functions
+rather than one function reading a string whose role the caller decides. Depth
+belongs to a label, because only a label becomes nested design-token groups;
+the emission cap belongs to an identity, because only an identity becomes a
+custom property. Conflating them cleared working identities on rename.
+
+Both fields are checked for being strings before the grammar runs, since
+`RegExp.test` coerces and a stored number satisfied it before reaching a place
+that assumed a string — one malformed settings entry aborted every page compile.
+
+The design-token reader bounds nesting before descending rather than at the
+leaf, so a deeply nested file is refused instead of exhausting the stack.

--- a/.changeset/block-base-ownership-and-value-bound.md
+++ b/.changeset/block-base-ownership-and-value-bound.md
@@ -74,3 +74,14 @@ The shared-input stamp's encoding is bumped, and its contract now covers what
 the COMPILER emits as well as what the stamp serializes. A stamp keys on inputs,
 so it cannot see the compiler treating unchanged inputs differently — a stored
 stylesheet would otherwise be served for a compile that no longer produces it.
+
+A custom-property prefix is bounded too, and the block-name cap now reaches the
+generated block manifest and its published JSON Schema. Without the second,
+`nextly generate` accepts a declaration `registerBlocks` refuses at boot, which
+is the opposite of what an artifact describing a plugin's declaration is for.
+The manifest restates the cap rather than importing it, as it already does for
+the block-version bound, and the engine-parity test holds the two equal.
+
+`isBlockType` and its cap are also exported from `@nextlyhq/blocks-engine/format`,
+so a generator reading the document format from the lightweight entry can apply
+the same rule instead of deciding independently what a node type may be.

--- a/.changeset/block-base-ownership-and-value-bound.md
+++ b/.changeset/block-base-ownership-and-value-bound.md
@@ -91,3 +91,8 @@ A token's identity is its id when it has one, so a renamed token emits under
 that id and its name reaches no stylesheet — capping the name would have deleted
 a working token from the site sheet the moment an author gave it a long label,
 and a rename is meant to cost nothing.
+
+Both DTCG gates follow the same identity rule as the emitter, through one shared
+answer rather than a third copy of it. Without that, a renamed token with a long
+label was silently dropped from an export and refused on the way back in, while
+Nextly went on rendering it.

--- a/.changeset/block-base-ownership-and-value-bound.md
+++ b/.changeset/block-base-ownership-and-value-bound.md
@@ -43,3 +43,14 @@ declaration, so two of them produce identical CSS — carrying both in full
 invalidated a byte-identical stored stylesheet over a suffix nothing reads, and
 put an arbitrarily large allocation into every cache check. `MAX_VALUE_LENGTH`
 is exported so a writer can honour the same number.
+
+A design token's name is now bounded at `MAX_TOKEN_NAME_LENGTH`, on both sides
+of a reference. The name grammar constrained the alphabet and not the length, so
+a name of megabytes of otherwise-valid characters was scanned in full by the
+pattern on every compile and copied into a `var()` on every rule that used it.
+Bounding it also makes the stamp above sound for every string it reads rather
+than for most of them: a token name reaches CSS through `scalarText`, so two
+names agreeing up to the truncation point and differing after it compiled apart
+under one identifier, and the stored sheet was then reused for the wrong one.
+The cap is deliberately larger than the one on a class name, because a token
+name is composed from a design-token file's nesting depth rather than typed.

--- a/.changeset/block-base-ownership-and-value-bound.md
+++ b/.changeset/block-base-ownership-and-value-bound.md
@@ -85,3 +85,9 @@ the block-version bound, and the engine-parity test holds the two equal.
 `isBlockType` and its cap are also exported from `@nextlyhq/blocks-engine/format`,
 so a generator reading the document format from the lightweight entry can apply
 the same rule instead of deciding independently what a node type may be.
+
+The emission cap applies to a token's IDENTITY rather than to its display name.
+A token's identity is its id when it has one, so a renamed token emits under
+that id and its name reaches no stylesheet — capping the name would have deleted
+a working token from the site sheet the moment an author gave it a long label,
+and a rename is meant to cost nothing.

--- a/.changeset/block-base-ownership-and-value-bound.md
+++ b/.changeset/block-base-ownership-and-value-bound.md
@@ -128,3 +128,11 @@ that assumed a string — one malformed settings entry aborted every page compil
 
 The design-token reader bounds nesting before descending rather than at the
 leaf, so a deeply nested file is refused instead of exhausting the stack.
+
+A page scope is bounded and listed too — it prefixes every rule a page emits, so
+an oversized one is copied once per rule, and it was the last emitted string
+with no cap.
+
+`safeTokenPrefix` takes what actually reaches it. A persisted `null` is not the
+absent value its old signature described, and reading a length off it aborted
+the compile the fallback exists to keep going.

--- a/.changeset/block-base-ownership-and-value-bound.md
+++ b/.changeset/block-base-ownership-and-value-bound.md
@@ -96,3 +96,15 @@ Both DTCG gates follow the same identity rule as the emitter, through one shared
 answer rather than a third copy of it. Without that, a renamed token with a long
 label was silently dropped from an export and refused on the way back in, while
 Nextly went on rendering it.
+
+A token name's DEPTH is bounded as well as its length. The DTCG exporter writes
+one nested group per dot-separated segment and the reader walks those groups, so
+a label deep enough produced a file this package could not read back — an
+exporter emitting a document that fails its own round trip. Bounded separately
+from length because depth is the property that breaks, and a renamed token's
+label is deliberately free of the length cap.
+
+The builder's rename gate follows the same rule, so the editor no longer refuses
+a label the engine accepts, and `EMITTABLE_STRING_BOUNDS` lists the literal
+style value — the largest bound of the set, and the one whose omission let a
+consumer verify every listed bound and still choose a limit below it.

--- a/.changeset/block-base-ownership-and-value-bound.md
+++ b/.changeset/block-base-ownership-and-value-bound.md
@@ -148,3 +148,10 @@ A font format is bounded, and the token studio refuses a name that lands on a
 custom property another token already occupies. The name-to-property mapping is
 deliberately not injective, so two visibly different, individually legal names
 can collide and the compiler drops whichever it reaches second.
+
+The selector `emitTokenBlocks` writes under is bounded, and the token studio no
+longer lets a new row claim an identity another row has frozen under a different
+display name — the compiler writes the older token and drops the new one.
+
+Both design-token gates name the depth limit when they refuse for it, instead of
+reporting a grammar problem the name does not have.

--- a/packages/blocks-engine/src/document.test.ts
+++ b/packages/blocks-engine/src/document.test.ts
@@ -173,10 +173,10 @@ describe("the block-type predicate", () => {
   // that registers and validates while the compiler omits its defaults renders
   // without the look it declared, and nothing reports why.
   //
-  // They agree by construction, because each calls this one function. The test
-  // is here for the change that reintroduces a second implementation: that is
-  // how the three came to hold identical copies of one grammar, and a copy
-  // agrees on the day it is written.
+  // They agree by construction, because each calls this one function, and the
+  // requirement is that they keep doing so. A second implementation of the
+  // grammar agrees with this one wherever it is exercised and diverges only at
+  // the edges, so the boundary cases below are what a divergence shows up in.
   const cases: [string, string, boolean][] = [
     ["a namespaced slug", "core/heading", true],
     [

--- a/packages/blocks-engine/src/document.test.ts
+++ b/packages/blocks-engine/src/document.test.ts
@@ -154,6 +154,7 @@ describe("the bounds a writer must honour are reachable from the entry", () => {
       MAX_NAMED_CLASSES: entry.MAX_NAMED_CLASSES,
       MAX_NAMED_CLASS_NAME_LENGTH: entry.MAX_NAMED_CLASS_NAME_LENGTH,
       MAX_SCANNED_KEYS: entry.MAX_SCANNED_KEYS,
+      MAX_VALUE_LENGTH: entry.MAX_VALUE_LENGTH,
     };
 
     for (const [name, value] of Object.entries(bounds)) {

--- a/packages/blocks-engine/src/document.test.ts
+++ b/packages/blocks-engine/src/document.test.ts
@@ -150,6 +150,7 @@ describe("the bounds a writer must honour are reachable from the entry", () => {
   it("exposes every limit that discards input rather than reporting it", () => {
     const bounds: Record<string, unknown> = {
       MAX_BREAKPOINTS_PER_AXIS: entry.MAX_BREAKPOINTS_PER_AXIS,
+      MAX_BLOCK_TYPE_LENGTH: entry.MAX_BLOCK_TYPE_LENGTH,
       MAX_BREAKPOINT_ID_LENGTH: entry.MAX_BREAKPOINT_ID_LENGTH,
       MAX_NAMED_CLASSES: entry.MAX_NAMED_CLASSES,
       MAX_NAMED_CLASS_NAME_LENGTH: entry.MAX_NAMED_CLASS_NAME_LENGTH,
@@ -162,5 +163,54 @@ describe("the bounds a writer must honour are reachable from the entry", () => {
         "number"
       );
     }
+  });
+});
+
+describe("the block-type predicate", () => {
+  // Three gates decide whether a string is a block type: registration
+  // (`isBlockName`), document validation (`isNodeType`) and compilation. One
+  // accepting what another rejects is not a cosmetic inconsistency — a block
+  // that registers and validates while the compiler omits its defaults renders
+  // without the look it declared, and nothing reports why.
+  //
+  // They agree by construction, because each calls this one function. The test
+  // is here for the change that reintroduces a second implementation: that is
+  // how the three came to hold identical copies of one grammar, and a copy
+  // agrees on the day it is written.
+  const cases: [string, string, boolean][] = [
+    ["a namespaced slug", "core/heading", true],
+    [
+      "a slug at the cap",
+      `core/${"a".repeat(entry.MAX_BLOCK_TYPE_LENGTH - 5)}`,
+      true,
+    ],
+    [
+      "a slug one past the cap",
+      `core/${"a".repeat(entry.MAX_BLOCK_TYPE_LENGTH - 4)}`,
+      false,
+    ],
+    ["no namespace", "heading", false],
+    ["a trailing slash", "core/columns/", false],
+    ["uppercase", "Core/Heading", false],
+  ];
+
+  it.each(cases)(
+    "agrees across all three gates on %s",
+    (_what, value, want) => {
+      expect(entry.isBlockType(value), "isBlockType").toBe(want);
+      expect(entry.isNodeType(value), "isNodeType").toBe(want);
+      expect(entry.isBlockName(value), "isBlockName").toBe(want);
+    }
+  );
+
+  it("puts the cap where the boundary cases say it is", () => {
+    // The pair above only means something if the two lengths really straddle
+    // the cap, which is a property of the fixtures rather than of the code.
+    expect(`core/${"a".repeat(entry.MAX_BLOCK_TYPE_LENGTH - 5)}`).toHaveLength(
+      entry.MAX_BLOCK_TYPE_LENGTH
+    );
+    expect(`core/${"a".repeat(entry.MAX_BLOCK_TYPE_LENGTH - 4)}`).toHaveLength(
+      entry.MAX_BLOCK_TYPE_LENGTH + 1
+    );
   });
 });

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -451,6 +451,48 @@ export const MAX_BREAKPOINTS_PER_AXIS = 7;
 export const MAX_BREAKPOINT_ID_LENGTH = 128;
 
 /**
+ * The grammar a block type follows: two lowercase slug segments around one `/`.
+ *
+ * Held here, in the document model, because a block type is a document-model
+ * fact rather than a property of any one consumer. Registration, validation and
+ * compilation all decide whether a value is a type, and each asking its own
+ * question is how they come to disagree about the same string.
+ */
+const BLOCK_TYPE_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/**
+ * The longest block type this engine accepts.
+ *
+ * The grammar constrains the alphabet and not the length, so a type of megabytes
+ * of otherwise-valid characters satisfies it, is scanned in full wherever it is
+ * checked, and is copied into a selector for every rule its defaults produce.
+ * The same reason `MAX_BREAKPOINT_ID_LENGTH` and `MAX_NAMED_CLASS_NAME_LENGTH`
+ * exist, and the same value: far above a namespaced slug anyone types, so it is
+ * only ever met by data that is already wrong.
+ */
+export const MAX_BLOCK_TYPE_LENGTH = 128;
+
+/**
+ * Whether a value is a usable block type.
+ *
+ * Length before the pattern, so the cheap test is what rejects an oversized
+ * value: the other way round, the regex scans the whole string first and the cap
+ * bounds nothing it exists to bound.
+ *
+ * This is the ONE answer. A consumer that bounds the type where another does not
+ * accepts a value its neighbour rejects — a block registers and validates while
+ * the compiler silently omits its defaults, so it renders without the look it
+ * declared and nothing reports why.
+ */
+export function isBlockType(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length <= MAX_BLOCK_TYPE_LENGTH &&
+    BLOCK_TYPE_RE.test(value)
+  );
+}
+
+/**
  * Maximum named classes read from the site library on one compile.
  *
  * The library is site settings, not part of a document, so the document's own byte cap does not

--- a/packages/blocks-engine/src/format.ts
+++ b/packages/blocks-engine/src/format.ts
@@ -33,6 +33,14 @@ export {
   type ComponentInstanceProps,
   DEFAULT_BINDING_SOURCE,
   isBindingSource,
+  // The rule for a valid `BlockNode.type`, beside the types it constrains. This
+  // entry exports `BlockNode`, so a generator or schema publisher reading the
+  // format from here decides what a type may be — and deciding it independently
+  // is how a manifest comes to accept a name registration and compilation
+  // refuse. Exported as the predicate AND the cap: a JSON Schema cannot call a
+  // function, so a publisher emitting `maxLength` needs the number.
+  isBlockType,
+  MAX_BLOCK_TYPE_LENGTH,
   DOCUMENT_FORMAT_VERSION,
   DOCUMENT_KINDS,
   type DocumentFormatVersion,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -421,6 +421,15 @@ export type { BreakpointAxis } from "./style/breakpoint-axes";
 
 // Where each emitted declaration came from, for an editor that has to tell an author which of
 // several tiers they are looking at. Produced only when `StyleCompileContext.trace` asks for it.
+// Every bound on a string the compiler can emit, as DATA. A consumer that
+// digests these inputs has to keep enough of each string to tell two apart
+// whenever they compile differently, and a hand-kept list of which strings
+// those are has been short by one twice.
+export {
+  EMITTABLE_STRING_BOUNDS,
+  MAX_BLOCK_TYPE_LENGTH,
+} from "./style/emittable-string-bounds";
+export type { EmittableStringBound } from "./style/emittable-string-bounds";
 export type { StyleOrigin, StyleTraceEntry } from "./style/style-trace";
 export type { StyleQuery, StyleSubject } from "./style/style-origin";
 

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -312,7 +312,9 @@ export {
   emitTokenBlocks,
   isAuthorableTokenName,
   isTokenName,
+  tokenNamingProblem,
   MAX_TOKEN_NAME_LENGTH,
+  MAX_TOKEN_NAME_SEGMENTS,
   MAX_TOKEN_PREFIX_LENGTH,
   // Both halves of token identity, public for the same reason the types are:
   // an editor that offers rename has to pin the identity the way this package

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -312,6 +312,7 @@ export {
   emitTokenBlocks,
   isTokenName,
   MAX_TOKEN_NAME_LENGTH,
+  MAX_TOKEN_PREFIX_LENGTH,
   // Both halves of token identity, public for the same reason the types are:
   // an editor that offers rename has to pin the identity the way this package
   // pins it, and one that cannot reach these has no way to do that except to

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -432,6 +432,7 @@ export type { BreakpointAxis } from "./style/breakpoint-axes";
 // two apart whenever they compile differently, and this is the set that decides
 // how much "enough" is.
 export { EMITTABLE_STRING_BOUNDS } from "./style/emittable-string-bounds";
+export { MAX_SCOPE_LENGTH } from "./style/compile-page";
 export type { EmittableStringBound } from "./style/emittable-string-bounds";
 export type { StyleOrigin, StyleTraceEntry } from "./style/style-trace";
 export type { StyleQuery, StyleSubject } from "./style/style-origin";

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -309,6 +309,7 @@ export {
   emitFontFaces,
   emitTokenBlocks,
   isTokenName,
+  MAX_TOKEN_NAME_LENGTH,
   // Both halves of token identity, public for the same reason the types are:
   // an editor that offers rename has to pin the identity the way this package
   // pins it, and one that cannot reach these has no way to do that except to

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -30,6 +30,8 @@ export {
   MAX_NAMED_CLASSES,
   isTokenRef,
   isBindingSource,
+  isBlockType,
+  MAX_BLOCK_TYPE_LENGTH,
   isComponentInstance,
 } from "./document";
 export type {
@@ -421,14 +423,11 @@ export type { BreakpointAxis } from "./style/breakpoint-axes";
 
 // Where each emitted declaration came from, for an editor that has to tell an author which of
 // several tiers they are looking at. Produced only when `StyleCompileContext.trace` asks for it.
-// Every bound on a string the compiler can emit, as DATA. A consumer that
-// digests these inputs has to keep enough of each string to tell two apart
-// whenever they compile differently, and a hand-kept list of which strings
-// those are has been short by one twice.
-export {
-  EMITTABLE_STRING_BOUNDS,
-  MAX_BLOCK_TYPE_LENGTH,
-} from "./style/emittable-string-bounds";
+// Every bound on a string the compiler can emit, as DATA rather than as prose.
+// A consumer that digests these inputs must keep enough of each string to tell
+// two apart whenever they compile differently, and this is the set that decides
+// how much "enough" is.
+export { EMITTABLE_STRING_BOUNDS } from "./style/emittable-string-bounds";
 export type { EmittableStringBound } from "./style/emittable-string-bounds";
 export type { StyleOrigin, StyleTraceEntry } from "./style/style-trace";
 export type { StyleQuery, StyleSubject } from "./style/style-origin";

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -310,6 +310,7 @@ export {
   resolveSiteTokens,
   emitFontFaces,
   emitTokenBlocks,
+  isAuthorableTokenName,
   isTokenName,
   MAX_TOKEN_NAME_LENGTH,
   MAX_TOKEN_PREFIX_LENGTH,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -238,6 +238,10 @@ export {
   // trimming with the language's own function normalises spellings the engine
   // then refuses — or worse, converts one into a value it accepts.
   trimCssWhitespace,
+  // The longest style value the compiler reads: anything past it is refused
+  // before parsing, so a writer honours it and a reader keyed on what the sheet
+  // contains stops reading where the compiler does.
+  MAX_VALUE_LENGTH,
 } from "./style/css-value";
 export type { CssValueRejection, MayFetchUrl } from "./style/css-value";
 export type { StyleValueOptions } from "./style/validate-style-value";

--- a/packages/blocks-engine/src/registry.ts
+++ b/packages/blocks-engine/src/registry.ts
@@ -10,7 +10,7 @@
  * at boot with a named error rather than producing broken pages later.
  */
 import type { AnyBlockDefinition, BlockSupports } from "./block";
-import { COMPONENT_INSTANCE_TYPE } from "./document";
+import { COMPONENT_INSTANCE_TYPE, isBlockType } from "./document";
 import type { MigrationSource } from "./migration";
 import { MAX_MIGRATION_STEPS, findMigrationGaps } from "./migration";
 import type { NestingSource } from "./nesting";
@@ -80,9 +80,6 @@ function supportStore(): Map<string, SupportDefinition> {
   return globalForBlocks.__nextly_blockSupports;
 }
 
-/** A block name is a namespaced slug, e.g. "core/heading". */
-const BLOCK_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
-
 /**
  * Whether a string is a well-formed block name: two lowercase slug segments around one `/`.
  *
@@ -92,7 +89,7 @@ const BLOCK_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
  * every instance of the declaring block becomes unsaveable with the declaration looking correct.
  */
 export function isBlockName(value: unknown): value is string {
-  return typeof value === "string" && BLOCK_NAME_RE.test(value);
+  return typeof value === "string" && isBlockType(value);
 }
 
 /**
@@ -138,7 +135,7 @@ function describeSupportValue(value: unknown): string {
  * caller can validate a definition without committing it to the registry.
  */
 function assertValidDefinition(def: AnyBlockDefinition): void {
-  if (typeof def.name !== "string" || !BLOCK_NAME_RE.test(def.name)) {
+  if (typeof def.name !== "string" || !isBlockType(def.name)) {
     fail(
       "NEXTLY_BLOCK_INVALID",
       `block name "${String(def.name)}" must be a namespaced slug like "core/heading".`
@@ -246,9 +243,7 @@ function assertValidDefinition(def: AnyBlockDefinition): void {
   if (def.parent !== undefined) {
     if (
       !Array.isArray(def.parent) ||
-      def.parent.some(
-        name => typeof name !== "string" || !BLOCK_NAME_RE.test(name)
-      )
+      def.parent.some(name => !isBlockType(name))
     ) {
       fail(
         "NEXTLY_BLOCK_INVALID",

--- a/packages/blocks-engine/src/style/compile-page.test.ts
+++ b/packages/blocks-engine/src/style/compile-page.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { BlockDocument, BlockNode } from "../document";
 import {
+  MAX_BLOCK_TYPE_LENGTH,
   MAX_BREAKPOINTS_PER_AXIS,
   MAX_BREAKPOINT_ID_LENGTH,
 } from "../document";
@@ -9,11 +10,7 @@ import { DEFAULT_LIMITS } from "../limits";
 import { validate } from "../validation";
 import { FIXTURE_BREAKPOINTS } from "../validation.fixtures";
 
-import {
-  compilePageCss,
-  MAX_BLOCK_TYPE_LENGTH,
-  MAX_SCANNED_KEYS,
-} from "./compile-page";
+import { compilePageCss, MAX_SCANNED_KEYS } from "./compile-page";
 import type { StyleCompileContext } from "./compile-page";
 import {
   nodeClassName,

--- a/packages/blocks-engine/src/style/compile-page.test.ts
+++ b/packages/blocks-engine/src/style/compile-page.test.ts
@@ -9,7 +9,11 @@ import { DEFAULT_LIMITS } from "../limits";
 import { validate } from "../validation";
 import { FIXTURE_BREAKPOINTS } from "../validation.fixtures";
 
-import { compilePageCss, MAX_SCANNED_KEYS } from "./compile-page";
+import {
+  compilePageCss,
+  MAX_BLOCK_TYPE_LENGTH,
+  MAX_SCANNED_KEYS,
+} from "./compile-page";
 import type { StyleCompileContext } from "./compile-page";
 import {
   nodeClassName,
@@ -258,6 +262,46 @@ describe("cascade tiers", () => {
         `${PAGE_ROOT_SELECTOR} .${nodeClassName("n1")} { color: #333 }`,
       ].join("\n")
     );
+  });
+
+  it("refuses a block type longer than the cap, so two cannot compile apart", () => {
+    // The type grammar constrains the ALPHABET and not the length, so a type of
+    // megabytes of valid characters satisfies it and is copied into a selector
+    // for every rule its defaults produce.
+    //
+    // The PAIR is what matters, not the single refusal. The page-artifact stamp
+    // keeps at most `MAX_VALUE_LENGTH` characters of any string it reads, and
+    // sends each block type through that same reduction — so two overlong types
+    // agreeing to the truncation point and differing after it once stamped
+    // alike while emitting DIFFERENT selectors, and a stored stylesheet built
+    // for one was served for the other. Under the cap both emit nothing, which
+    // makes identical output the honest answer rather than a collision.
+    const shared = `core/${"a".repeat(MAX_BLOCK_TYPE_LENGTH)}`;
+    // The document has to USE the type, or the base is narrowed away before the
+    // cap is ever consulted and both sides emit nothing whatever the cap says.
+    const cssFor = (type: string) =>
+      css(doc([node("n1", {}, { type })]), {
+        ...CTX,
+        blockBases: { [type]: { base: { base: { color: "#222" } } } },
+      });
+
+    const first = cssFor(`${shared}b`);
+    expect(first).toBe(cssFor(`${shared}c`));
+    expect(first).not.toContain("nx-bt-");
+  });
+
+  it("still writes a block type at the cap", () => {
+    // A cap that took the boundary with it would be a different rule from the
+    // one documented, and the off-by-one is invisible to any test supplying a
+    // type well clear of it.
+    const atCap = `core/${"a".repeat(MAX_BLOCK_TYPE_LENGTH - "core/".length)}`;
+    expect(atCap.length).toBe(MAX_BLOCK_TYPE_LENGTH);
+
+    const out = css(doc([node("n1", {}, { type: atCap })]), {
+      ...CTX,
+      blockBases: { [atCap]: { base: { base: { color: "#222" } } } },
+    });
+    expect(out).toContain("nx-bt-");
   });
 
   it("puts a whole tier before the next, so a node beats a wider default", () => {

--- a/packages/blocks-engine/src/style/compile-page.test.ts
+++ b/packages/blocks-engine/src/style/compile-page.test.ts
@@ -10,7 +10,11 @@ import { DEFAULT_LIMITS } from "../limits";
 import { validate } from "../validation";
 import { FIXTURE_BREAKPOINTS } from "../validation.fixtures";
 
-import { compilePageCss, MAX_SCANNED_KEYS } from "./compile-page";
+import {
+  compilePageCss,
+  MAX_SCANNED_KEYS,
+  MAX_SCOPE_LENGTH,
+} from "./compile-page";
 import type { StyleCompileContext } from "./compile-page";
 import {
   nodeClassName,
@@ -1657,5 +1661,30 @@ describe("the node walk is bounded by what it reads", () => {
     ];
     const out = compilePageCss(doc(nodes), CTX);
     expect(out.css).not.toContain("#f00");
+  });
+});
+
+describe("the page scope", () => {
+  // The scope prefixes every rule the page emits, so an oversized one is copied
+  // once per rule rather than once per sheet — and it was the last emitted
+  // string with no cap, which is what `EMITTABLE_STRING_BOUNDS` promises there
+  // are none of.
+  it("is refused past its bound, so the sheet is unscoped rather than enormous", () => {
+    const out = css(doc([node("n1", { base: { base: { color: "#111" } } })]), {
+      ...CTX,
+      scope: "s".repeat(MAX_SCOPE_LENGTH + 1),
+    });
+    expect(out).not.toContain("s".repeat(MAX_SCOPE_LENGTH + 1));
+  });
+
+  it("still writes a scope AT the bound, so the refusal is not blanket", () => {
+    // The control. A compiler that dropped every scope would satisfy the case
+    // above and silently unscope every page.
+    const atBound = "s".repeat(MAX_SCOPE_LENGTH);
+    const out = css(doc([node("n1", { base: { base: { color: "#111" } } })]), {
+      ...CTX,
+      scope: atBound,
+    });
+    expect(out).toContain(atBound);
   });
 });

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -206,6 +206,17 @@ function readClassSlug(value: unknown): unknown {
 export interface CompiledPageCss {
   css: string;
   /**
+   * The scope these selectors were actually written under, or `undefined` when
+   * they were written unscoped.
+   *
+   * Returned rather than assumed to equal the requested one, because a scope
+   * this compiler cannot write is dropped and the sheet compiled global. A
+   * caller recording the REQUESTED scope then stores an artifact claiming an
+   * isolation its CSS does not have — and the renderer attaches that class, so
+   * the rules reach whatever else is on the page.
+   */
+  scope?: string;
+  /**
    * What was not written, and why. Every entry names a value that is in the
    * document and absent from the stylesheet, so "my style did nothing" always
    * has an answer.
@@ -1144,6 +1155,11 @@ export function compilePageCss(
   const tokenPrefix = ctx.tokenPrefix ?? DEFAULT_TOKEN_PREFIX;
   const mayFetchUrl = ctx.mayFetchUrl;
   const scope = scopeSelector(ctx.scope, warnings);
+  // What was WRITTEN, which is not always what was asked for: a scope this
+  // compiler refuses is dropped and the sheet compiled global, and a caller that
+  // recorded the request would store an artifact claiming an isolation its own
+  // selectors do not carry.
+  const effectiveScope = scope === "" ? undefined : ctx.scope;
   const pageRoot = `${PAGE_ROOT_SELECTOR}${scope}`;
 
   const nodes = documentNodes(
@@ -1607,6 +1623,7 @@ export function compilePageCss(
   }
 
   return {
+    ...(effectiveScope === undefined ? {} : { scope: effectiveScope }),
     css: serializeRules(rules),
     warnings,
     classes: attributeClasses,

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -499,6 +499,16 @@ export function breakpointContexts(
   return contexts;
 }
 
+/**
+ * The longest page scope this compiler will write into a selector.
+ *
+ * A scope keeps two documents rendered into one DOM apart, so it prefixes every
+ * rule the page emits — an oversized one is therefore copied once per rule
+ * rather than once per sheet. Generous against anything a host would pass: a
+ * scope is an element id or a short generated token.
+ */
+export const MAX_SCOPE_LENGTH = 128;
+
 /** The breakpoint id meaning "no media query" in a stored style envelope. */
 export const BASE_BREAKPOINT = "base";
 
@@ -531,7 +541,15 @@ function scopeSelector(
   // NOT split a class: a renderer attaching `region\u00a0one` attaches one
   // valid class, so rejecting it here would drop the scope for a document whose
   // scope was fine and send it back to the selector every other document shares.
-  if (scope === "" || /[ \t\n\f\r]/.test(scope)) {
+  // Bounded as well as shaped. The scope is a caller's string and every rule
+  // this compiler writes carries it, so an oversized one is copied into the
+  // sheet once per rule — and it is the last emitted string with no cap, which
+  // `EMITTABLE_STRING_BOUNDS` is only honest about while none remain.
+  if (
+    scope === "" ||
+    scope.length > MAX_SCOPE_LENGTH ||
+    /[ \t\n\f\r]/.test(scope)
+  ) {
     warnings.push({
       path: "/scope",
       code: "invalid-scope",

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -31,6 +31,7 @@ import {
   MAX_CLASSES_PER_NODE,
   MAX_NAMED_CLASSES,
   STYLE_STATES,
+  isBlockType,
 } from "../document";
 import { describeValue, pointer } from "../issue-text";
 import { DEFAULT_LIMITS } from "../limits";
@@ -500,29 +501,6 @@ export function breakpointContexts(
 
 /** The breakpoint id meaning "no media query" in a stored style envelope. */
 export const BASE_BREAKPOINT = "base";
-
-/**
- * The grammar a block type has to match before it reaches a selector.
- *
- * The same shape document validation requires of `node.type`, restated here
- * because compilation is the path that does not assume validation ran.
- */
-const BLOCK_TYPE_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
-
-/**
- * The longest block type this engine will write into a selector.
- *
- * The grammar above constrains the ALPHABET and not the length, so a type of
- * megabytes of otherwise-valid characters satisfies it, is scanned in full on
- * every compile, and is copied into a selector for every rule the type's
- * defaults produce. The same reason `MAX_NAMED_CLASS_NAME_LENGTH` and
- * `MAX_TOKEN_NAME_LENGTH` exist.
- *
- * Generous against a namespaced slug a person types (`core/section`), for the
- * same reason those two are: the cap is only ever reached by data that is
- * already wrong, so it should not be near anything legitimate.
- */
-export const MAX_BLOCK_TYPE_LENGTH = 128;
 
 /**
  * The scope written as a class selector, or nothing when it cannot be one.
@@ -1224,7 +1202,7 @@ export function compilePageCss(
     // rather than escaped into something safe: a type that is not a namespaced
     // slug is not a type this engine can style, and quietly renaming it would
     // emit a class no renderer will ever put on an element.
-    if (type.length > MAX_BLOCK_TYPE_LENGTH || !BLOCK_TYPE_RE.test(type)) {
+    if (!isBlockType(type)) {
       pushBoundedWarning(warningAllowance, warnings, {
         path: pointer("/blockBases", type),
         code: "invalid-node-type",

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -510,6 +510,21 @@ export const BASE_BREAKPOINT = "base";
 const BLOCK_TYPE_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 /**
+ * The longest block type this engine will write into a selector.
+ *
+ * The grammar above constrains the ALPHABET and not the length, so a type of
+ * megabytes of otherwise-valid characters satisfies it, is scanned in full on
+ * every compile, and is copied into a selector for every rule the type's
+ * defaults produce. The same reason `MAX_NAMED_CLASS_NAME_LENGTH` and
+ * `MAX_TOKEN_NAME_LENGTH` exist.
+ *
+ * Generous against a namespaced slug a person types (`core/section`), for the
+ * same reason those two are: the cap is only ever reached by data that is
+ * already wrong, so it should not be near anything legitimate.
+ */
+export const MAX_BLOCK_TYPE_LENGTH = 128;
+
+/**
  * The scope written as a class selector, or nothing when it cannot be one.
  *
  * A scope is what keeps two documents rendered into one DOM apart, and node
@@ -1209,7 +1224,7 @@ export function compilePageCss(
     // rather than escaped into something safe: a type that is not a namespaced
     // slug is not a type this engine can style, and quietly renaming it would
     // emit a class no renderer will ever put on an element.
-    if (!BLOCK_TYPE_RE.test(type)) {
+    if (type.length > MAX_BLOCK_TYPE_LENGTH || !BLOCK_TYPE_RE.test(type)) {
       pushBoundedWarning(warningAllowance, warnings, {
         path: pointer("/blockBases", type),
         code: "invalid-node-type",

--- a/packages/blocks-engine/src/style/css-value.ts
+++ b/packages/blocks-engine/src/style/css-value.ts
@@ -1112,7 +1112,15 @@ export function isOverlongValue(value: string): boolean {
  * expensive parse: a flat value of a few hundred thousand tokens builds an AST
  * node for each. No real declaration approaches this.
  */
-const MAX_VALUE_LENGTH = 8192;
+/**
+ * The longest style value this engine will read.
+ *
+ * Public for the reason every other bound here is: a value past it is REFUSED
+ * before parsing, so a writer that wants its declaration emitted has to honour
+ * the same number, and anything walking the same stored values has to stop
+ * reading where the compiler stops.
+ */
+export const MAX_VALUE_LENGTH = 8192;
 
 /**
  * Deepest bracket nesting in a value.

--- a/packages/blocks-engine/src/style/declarations.ts
+++ b/packages/blocks-engine/src/style/declarations.ts
@@ -130,6 +130,20 @@ const RESERVED_TOKEN_PREFIXES = ["--nx-", "--tw-"] as const;
 const TOKEN_PREFIX_RE = /^--[a-z0-9-]*$/;
 
 /**
+ * The longest custom-property prefix this engine will write.
+ *
+ * The pattern above constrains the alphabet and not the length, and the prefix
+ * is copied into every token definition and every `var()` that reads one — so
+ * one oversized stored value is written once per token and once per reference,
+ * on every compile.
+ *
+ * Small because a prefix is small: `--site-` is seven characters and a vendor
+ * prefix is not much more. Set well clear of that and still far below anything
+ * a person would type by accident, so the cap is only met by data already wrong.
+ */
+export const MAX_TOKEN_PREFIX_LENGTH = 64;
+
+/**
  * The prefix to write tokens under, or the default when the supplied one cannot
  * be used. Reports rather than throwing, in keeping with everything else here:
  * one bad setting should cost the tokens, not the page.
@@ -139,7 +153,12 @@ export function safeTokenPrefix(prefix: string | undefined): {
   warning?: string;
 } {
   if (prefix === undefined) return { prefix: DEFAULT_TOKEN_PREFIX };
-  if (!TOKEN_PREFIX_RE.test(prefix)) {
+  // Length before the pattern, so the cheap test is what rejects an oversized
+  // value rather than the regex scanning it in full first.
+  if (
+    prefix.length > MAX_TOKEN_PREFIX_LENGTH ||
+    !TOKEN_PREFIX_RE.test(prefix)
+  ) {
     return {
       prefix: DEFAULT_TOKEN_PREFIX,
       warning: `"${describeValue(prefix)}" is not a custom-property prefix, so design tokens were written under "${DEFAULT_TOKEN_PREFIX}" instead. A prefix starts with "--" and holds only lowercase letters, digits and dashes.`,

--- a/packages/blocks-engine/src/style/declarations.ts
+++ b/packages/blocks-engine/src/style/declarations.ts
@@ -71,15 +71,40 @@ export interface CompiledDeclarations {
 const TOKEN_NAME_RE = /^[a-z0-9]+(?:[-.][a-z0-9]+)*$/;
 
 /**
+ * The longest name this engine will write as a token.
+ *
+ * The grammar above bounds the ALPHABET and not the length, so a name of
+ * megabytes of otherwise-valid characters satisfies it, is scanned in full by
+ * the regex on every compile, and is copied into a `var()` on every rule that
+ * references it. `MAX_NAMED_CLASS_NAME_LENGTH` exists for exactly this reason
+ * one file over; a token name reaches CSS the same way and had no equivalent.
+ *
+ * Deliberately NOT the 128 that bounds a class name, because the two are
+ * produced by different mechanisms. A class slug is typed by a person. A token
+ * name is composed — `readToken` joins a design-token file's nested group path
+ * with dots, so its length is set by how deeply an imported file nests rather
+ * than by anything anyone types. Real token paths run 30-65 characters
+ * (`md.sys.color.on-surface-variant`); 256 sits an order of magnitude above
+ * that, so no realistic import meets it, while still bounding both the scan and
+ * the copy. Inheriting the class-name number would have applied a limit
+ * calibrated for hand-typed input to a value nesting depth produces.
+ */
+export const MAX_TOKEN_NAME_LENGTH = 256;
+
+/**
  * Whether a name may be written as a token, on either side of the reference.
  *
  * One grammar for the table and for the `$token` that reads it. Two would
  * disagree the moment either moved, and the disagreement has no symptom to
  * follow: a table accepting `Color.Primary` while a reference refuses it leaves
  * a token that exists, resolves to nothing, and reports no reason.
+ *
+ * Length BEFORE the pattern, so the cheap test is what rejects an oversized
+ * name: run the other way round, the regex scans the whole string first and the
+ * cap bounds nothing it was added to bound.
  */
 export function isTokenName(name: string): boolean {
-  return TOKEN_NAME_RE.test(name);
+  return name.length <= MAX_TOKEN_NAME_LENGTH && TOKEN_NAME_RE.test(name);
 }
 
 /** The default custom-property prefix for site tokens. */

--- a/packages/blocks-engine/src/style/declarations.ts
+++ b/packages/blocks-engine/src/style/declarations.ts
@@ -104,7 +104,28 @@ export const MAX_TOKEN_NAME_LENGTH = 256;
  * cap bounds nothing it was added to bound.
  */
 export function isTokenName(name: string): boolean {
-  return name.length <= MAX_TOKEN_NAME_LENGTH && TOKEN_NAME_RE.test(name);
+  return name.length <= MAX_TOKEN_NAME_LENGTH && isAuthorableTokenName(name);
+}
+
+/**
+ * Whether a name may be WRITTEN as a token name, without asking whether it can
+ * be emitted.
+ *
+ * The grammar half of {@link isTokenName}, separated because the two answer
+ * different questions and one value can need only the first. A token's identity
+ * is `id ?? name`, so a renamed token emits under its id and its display name
+ * reaches no stylesheet at all — holding that name to the emission cap would
+ * refuse a token whose every emitted string is well within it, and the token
+ * would vanish from the site sheet on being renamed.
+ *
+ * So: this for a value that is only ever read by a person, {@link isTokenName}
+ * for one that reaches CSS. Bounded is the default and the wider name; a caller
+ * has to reach for this one deliberately, which is the safe direction — using
+ * the bounded predicate where the grammar alone was needed refuses a little too
+ * much, while the reverse writes an unbounded string into a stylesheet.
+ */
+export function isAuthorableTokenName(name: string): boolean {
+  return TOKEN_NAME_RE.test(name);
 }
 
 /** The default custom-property prefix for site tokens. */

--- a/packages/blocks-engine/src/style/declarations.ts
+++ b/packages/blocks-engine/src/style/declarations.ts
@@ -165,6 +165,20 @@ const TOKEN_PREFIX_RE = /^--[a-z0-9-]*$/;
 export const MAX_TOKEN_PREFIX_LENGTH = 64;
 
 /**
+ * The most dot-separated parts a token name may hold.
+ *
+ * A name's segments are structure rather than characters: the DTCG exporter
+ * writes one nested group per segment, and the reader walks those groups
+ * recursively, so a deep enough name produces a file this package cannot read
+ * back. Bounded separately from the length cap because depth is what breaks
+ * there, and because a renamed token's label is deliberately free of the length
+ * cap — it is not emitted.
+ *
+ * Well above any real token path: `md.sys.color.on-surface-variant` is five.
+ */
+export const MAX_TOKEN_NAME_SEGMENTS = 32;
+
+/**
  * The prefix to write tokens under, or the default when the supplied one cannot
  * be used. Reports rather than throwing, in keeping with everything else here:
  * one bad setting should cost the tokens, not the page.

--- a/packages/blocks-engine/src/style/declarations.ts
+++ b/packages/blocks-engine/src/style/declarations.ts
@@ -183,14 +183,19 @@ export const MAX_TOKEN_NAME_SEGMENTS = 32;
  * be used. Reports rather than throwing, in keeping with everything else here:
  * one bad setting should cost the tokens, not the page.
  */
-export function safeTokenPrefix(prefix: string | undefined): {
+export function safeTokenPrefix(prefix: unknown): {
   prefix: string;
   warning?: string;
 } {
   if (prefix === undefined) return { prefix: DEFAULT_TOKEN_PREFIX };
-  // Length before the pattern, so the cheap test is what rejects an oversized
-  // value rather than the regex scanning it in full first.
+  // TYPE before length before pattern, and the parameter is `unknown` because
+  // that is what actually arrives: this reads a persisted site setting, so a
+  // stored `null` is not the absent value handled above, and reading `.length`
+  // off it aborts the compile this function exists to keep going. Length then
+  // precedes the pattern so the cheap test rejects an oversized value rather
+  // than the regex scanning it in full first.
   if (
+    typeof prefix !== "string" ||
     prefix.length > MAX_TOKEN_PREFIX_LENGTH ||
     !TOKEN_PREFIX_RE.test(prefix)
   ) {

--- a/packages/blocks-engine/src/style/dtcg.test.ts
+++ b/packages/blocks-engine/src/style/dtcg.test.ts
@@ -10,7 +10,11 @@ import { describe, expect, it } from "vitest";
 import type { DtcgNode } from "./dtcg";
 import { NEXTLY_EXTENSION, dtcgToTokens, tokensToDtcg } from "./dtcg";
 import type { SiteToken } from "./site-tokens";
-import { MAX_TOKEN_NAME_LENGTH, renameSiteToken } from "./site-tokens";
+import {
+  MAX_TOKEN_NAME_LENGTH,
+  MAX_TOKEN_NAME_SEGMENTS,
+  renameSiteToken,
+} from "./site-tokens";
 
 const tokens = (list: SiteToken[]) => ({ tokens: list });
 
@@ -876,5 +880,52 @@ describe("a renamed token's long label", () => {
       ],
     });
     expect(issues.length).toBeGreaterThan(0);
+  });
+});
+
+describe("a label deep enough to break the reader", () => {
+  // The exporter writes one nested group per dot-separated segment and the
+  // reader walks those groups, so a deep label produces a file this package
+  // cannot read back. An exporter emitting a document that fails its own round
+  // trip is the shape this module exists to prevent, and a renamed token's
+  // label is free of the LENGTH cap — so depth needs its own bound.
+  const deepLabel = Array.from(
+    { length: MAX_TOKEN_NAME_SEGMENTS + 1 },
+    () => "a"
+  ).join(".");
+
+  it("is refused at export rather than written", () => {
+    const { issues } = tokensToDtcg({
+      tokens: [
+        {
+          id: "short.id",
+          name: deepLabel,
+          kind: "color",
+          values: { light: "#000000" },
+        },
+      ],
+    });
+    expect(issues.length).toBeGreaterThan(0);
+  });
+
+  it("still exports a label at the depth bound, so the refusal is not blanket", () => {
+    // The control. Without it a gate refusing every renamed token would satisfy
+    // the case above and look correct.
+    const atBound = Array.from(
+      { length: MAX_TOKEN_NAME_SEGMENTS },
+      () => "a"
+    ).join(".");
+    const { document, issues } = tokensToDtcg({
+      tokens: [
+        {
+          id: "short.id",
+          name: atBound,
+          kind: "color",
+          values: { light: "#000000" },
+        },
+      ],
+    });
+    expect(issues).toEqual([]);
+    expect(dtcgToTokens(document).tokens).toHaveLength(1);
   });
 });

--- a/packages/blocks-engine/src/style/dtcg.test.ts
+++ b/packages/blocks-engine/src/style/dtcg.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from "vitest";
 import type { DtcgNode } from "./dtcg";
 import { NEXTLY_EXTENSION, dtcgToTokens, tokensToDtcg } from "./dtcg";
 import type { SiteToken } from "./site-tokens";
-import { renameSiteToken } from "./site-tokens";
+import { MAX_TOKEN_NAME_LENGTH, renameSiteToken } from "./site-tokens";
 
 const tokens = (list: SiteToken[]) => ({ tokens: list });
 
@@ -799,5 +799,82 @@ describe("a token's stable identity across the format", () => {
 
     expect(read).toEqual([]);
     expect(issues.some(i => i.message.includes("id"))).toBe(true);
+  });
+});
+
+describe("a renamed token's long label", () => {
+  // A token's identity is its id, so a renamed token is written under that id
+  // and its display name reaches neither a stylesheet nor an exported file.
+  // Both DTCG gates therefore hold the label to the grammar and the identity to
+  // the emission cap — capping the label would drop a working token from an
+  // export and refuse it on the way back in, silently in both directions.
+  const longLabel = `label.${"a".repeat(MAX_TOKEN_NAME_LENGTH)}`;
+
+  it("straddles the cap, so the cases below mean what they say", () => {
+    expect(longLabel.length).toBeGreaterThan(MAX_TOKEN_NAME_LENGTH);
+    expect("color.primary".length).toBeLessThanOrEqual(MAX_TOKEN_NAME_LENGTH);
+  });
+
+  it("survives an export, because the id is what it is written under", () => {
+    const { document, issues } = tokensToDtcg({
+      tokens: [
+        {
+          id: "color.primary",
+          name: longLabel,
+          kind: "color",
+          values: { light: "#000000" },
+        },
+      ],
+    });
+    expect(issues).toEqual([]);
+    expect(JSON.stringify(document)).toContain("color.primary");
+  });
+
+  it("imports a token whose stated id is short, however deep its group path", () => {
+    // The import side of the same rule. A file may nest a token so deeply that
+    // its dot path exceeds the cap while stating a short id in the extension —
+    // that id is the identity, so the token is written under it and the path is
+    // only a label.
+    const deep = "g".repeat(MAX_TOKEN_NAME_LENGTH);
+    const { tokens: read, issues } = dtcgToTokens({
+      [deep]: {
+        primary: {
+          $type: "color",
+          $value: { colorSpace: "srgb", components: [0, 0, 0], hex: "#000000" },
+          $extensions: { [NEXTLY_EXTENSION]: { id: "color.primary" } },
+        },
+      },
+    });
+    expect(issues).toEqual([]);
+    expect(read[0]?.id).toBe("color.primary");
+  });
+
+  it("skips an imported token whose path is the identity and exceeds the cap", () => {
+    // With no stated id the path IS what the token is written under, so the cap
+    // applies to it. Without this the import gate has no coverage at all: the
+    // case above passes whether or not the cap is applied there.
+    const deep = "g".repeat(MAX_TOKEN_NAME_LENGTH);
+    const { tokens: read, issues } = dtcgToTokens({
+      [deep]: {
+        primary: {
+          $type: "color",
+          $value: { colorSpace: "srgb", components: [0, 0, 0], hex: "#000000" },
+        },
+      },
+    });
+    expect(read).toEqual([]);
+    expect(issues.length).toBeGreaterThan(0);
+  });
+
+  it("is refused when the LABEL is the identity, which is when it is written", () => {
+    // The control on the other side: with no id the label is the identity, so
+    // the same string is capped. Without this, a gate that accepted everything
+    // would satisfy the case above perfectly.
+    const { issues } = tokensToDtcg({
+      tokens: [
+        { name: longLabel, kind: "color", values: { light: "#000000" } },
+      ],
+    });
+    expect(issues.length).toBeGreaterThan(0);
   });
 });

--- a/packages/blocks-engine/src/style/dtcg.ts
+++ b/packages/blocks-engine/src/style/dtcg.ts
@@ -66,6 +66,7 @@ import type { SiteToken, SiteTokenSet } from "./site-tokens";
 import {
   isAuthorableTokenName,
   MAX_TOKEN_NAME_LENGTH,
+  MAX_TOKEN_NAME_SEGMENTS,
   tokenNamingProblem,
   tokenValueFetches,
 } from "./site-tokens";
@@ -189,7 +190,7 @@ function exportableValue(
     issues.push(
       issue(
         naming.reason === "length"
-          ? `"${token.name}" is written under ${naming.length} characters, so it was not exported. The ${naming.field} a token is written under is at most ${MAX_TOKEN_NAME_LENGTH} characters.`
+          ? `"${String(token.name)}" is written under more than ${MAX_TOKEN_NAME_LENGTH} characters, so it was not exported. The ${naming.field} a token is written under is at most ${MAX_TOKEN_NAME_LENGTH} characters.`
           : naming.field === "name"
             ? `"${token.name}" is not a token name, so it was not exported.`
             : `"${token.name}" has an id that is not a token name, so it was not exported. Its value is still here in Nextly.`
@@ -605,6 +606,20 @@ function read(
       if (token !== undefined) tokens.push(token);
       continue;
     }
+    // Bounded BEFORE descending. A group path becomes a token's dot-separated
+    // name, so the depth rule is the same one — but applying it at the leaf is
+    // too late: this walk reaches the leaf by recursing, so a document nested
+    // deeply enough exhausts the stack before any leaf is read. A file arrives
+    // from outside this package, so that is untrusted input deciding how deep
+    // this recursion goes.
+    if (here.length > MAX_TOKEN_NAME_SEGMENTS) {
+      issues.push(
+        issue(
+          `"${here.slice(0, 4).join(".")}..." is nested more than ${MAX_TOKEN_NAME_SEGMENTS} groups deep, so it and everything under it was skipped.`
+        )
+      );
+      continue;
+    }
     read(child, here, groupType, tokens, issues);
   }
 }
@@ -684,7 +699,7 @@ function readToken(
     issues.push(
       issue(
         naming.reason === "length"
-          ? `"${name}" is written under ${naming.length} characters, so it was skipped. The ${naming.field} a token is written under is at most ${MAX_TOKEN_NAME_LENGTH} characters.`
+          ? `"${name}" is written under more than ${MAX_TOKEN_NAME_LENGTH} characters, so it was skipped. The ${naming.field} a token is written under is at most ${MAX_TOKEN_NAME_LENGTH} characters.`
           : `"${name}" has a ${naming.field} that is not a usable token name, so it was skipped.`
       )
     );

--- a/packages/blocks-engine/src/style/dtcg.ts
+++ b/packages/blocks-engine/src/style/dtcg.ts
@@ -189,11 +189,13 @@ function exportableValue(
     // the file while Nextly went on rendering it.
     issues.push(
       issue(
-        naming.reason === "length"
-          ? `"${String(token.name)}" is written under more than ${MAX_TOKEN_NAME_LENGTH} characters, so it was not exported. The ${naming.field} a token is written under is at most ${MAX_TOKEN_NAME_LENGTH} characters.`
-          : naming.field === "name"
-            ? `"${token.name}" is not a token name, so it was not exported.`
-            : `"${token.name}" has an id that is not a token name, so it was not exported. Its value is still here in Nextly.`
+        naming.reason === "depth"
+          ? `"${String(token.name)}" is nested too deeply, so it was not exported. A token name holds at most ${MAX_TOKEN_NAME_SEGMENTS} dot-separated parts.`
+          : naming.reason === "length"
+            ? `"${String(token.name)}" is written under more than ${MAX_TOKEN_NAME_LENGTH} characters, so it was not exported. The ${naming.field} a token is written under is at most ${MAX_TOKEN_NAME_LENGTH} characters.`
+            : naming.field === "name"
+              ? `"${token.name}" is not a token name, so it was not exported.`
+              : `"${token.name}" has an id that is not a token name, so it was not exported. Its value is still here in Nextly.`
       )
     );
     return undefined;
@@ -698,9 +700,11 @@ function readToken(
   if (naming !== undefined) {
     issues.push(
       issue(
-        naming.reason === "length"
-          ? `"${name}" is written under more than ${MAX_TOKEN_NAME_LENGTH} characters, so it was skipped. The ${naming.field} a token is written under is at most ${MAX_TOKEN_NAME_LENGTH} characters.`
-          : `"${name}" has a ${naming.field} that is not a usable token name, so it was skipped.`
+        naming.reason === "depth"
+          ? `"${name}" is nested too deeply, so it was skipped. A token name holds at most ${MAX_TOKEN_NAME_SEGMENTS} dot-separated parts.`
+          : naming.reason === "length"
+            ? `"${name}" is written under more than ${MAX_TOKEN_NAME_LENGTH} characters, so it was skipped. The ${naming.field} a token is written under is at most ${MAX_TOKEN_NAME_LENGTH} characters.`
+            : `"${name}" has a ${naming.field} that is not a usable token name, so it was skipped.`
       )
     );
     return undefined;

--- a/packages/blocks-engine/src/style/dtcg.ts
+++ b/packages/blocks-engine/src/style/dtcg.ts
@@ -63,7 +63,12 @@ import { parseColor } from "./contrast";
 import type { Rgb } from "./contrast";
 import { asciiLower, checkCssValue, decodeIdentifier } from "./css-value";
 import type { SiteToken, SiteTokenSet } from "./site-tokens";
-import { isTokenName, tokenValueFetches } from "./site-tokens";
+import {
+  isAuthorableTokenName,
+  MAX_TOKEN_NAME_LENGTH,
+  tokenNamingProblem,
+  tokenValueFetches,
+} from "./site-tokens";
 
 /** The key this vendor's data lives under, in the notation the format asks for. */
 export const NEXTLY_EXTENSION = "com.nextlyhq.nextly";
@@ -175,25 +180,28 @@ function exportableValue(
   token: SiteToken,
   issues: ValidationIssue[]
 ): { type: string; value: unknown } | undefined {
-  if (!isTokenName(token.name)) {
-    issues.push(
-      issue(`"${token.name}" is not a token name, so it was not exported.`)
-    );
-    return undefined;
-  }
-  // The id is held to the grammar too, and refused rather than written. Writing
-  // it produces a file this module's own importer refuses on the way back in —
-  // and it refuses the WHOLE token, because an id it cannot read is an identity
-  // it cannot honour. An exporter emitting a document that fails its own round
-  // trip is the one shape this module exists to prevent.
-  if (token.id !== undefined && !isTokenName(token.id)) {
+  const naming = tokenNamingProblem(token);
+  if (naming !== undefined) {
+    // One rule, phrased for this gate. The identity carries the cap and the
+    // display name carries only the grammar, so a renamed token with a long
+    // label exports normally — refusing it here would drop a working token from
+    // the file while Nextly went on rendering it.
     issues.push(
       issue(
-        `"${token.name}" has an id that is not a token name, so it was not exported. Its value is still here in Nextly.`
+        naming.reason === "length"
+          ? `"${token.name}" is written under ${naming.length} characters, so it was not exported. The ${naming.field} a token is written under is at most ${MAX_TOKEN_NAME_LENGTH} characters.`
+          : naming.field === "name"
+            ? `"${token.name}" is not a token name, so it was not exported.`
+            : `"${token.name}" has an id that is not a token name, so it was not exported. Its value is still here in Nextly.`
       )
     );
     return undefined;
   }
+  // The id is covered by the same answer above, and refused rather than
+  // written: writing it produces a file this module's own importer refuses on
+  // the way back in — and it refuses the WHOLE token, because an id it cannot
+  // read is an identity it cannot honour. An exporter emitting a document that
+  // fails its own round trip is the one shape this module exists to prevent.
 
   const type = DTCG_TYPE[token.kind];
   const value = type === undefined ? undefined : toDtcgValue(token);
@@ -622,7 +630,11 @@ function readToken(
     return undefined;
   }
   const name = path.join(".");
-  if (!isTokenName(name)) {
+  // The grammar only, here. Whether this name is also the string the token is
+  // WRITTEN under depends on the id below, which has not been read yet — and a
+  // file may legitimately carry a long label for a token whose stated id is
+  // short. The cap is applied once the identity is known.
+  if (!isAuthorableTokenName(name)) {
     issues.push(
       issue(`"${name}" is not a usable token name, so it was skipped.`)
     );
@@ -649,7 +661,7 @@ function readToken(
   const stated = isPlainObject(own) ? own.id : undefined;
   if (
     stated !== undefined &&
-    !(typeof stated === "string" && isTokenName(stated))
+    !(typeof stated === "string" && isAuthorableTokenName(stated))
   ) {
     issues.push(
       issue(
@@ -662,6 +674,22 @@ function readToken(
   // is normalised away — `id === undefined` then means one thing everywhere in
   // the model rather than two spellings of it.
   const id = stated === name ? undefined : stated;
+
+  // The cap, now that the identity is settled. Held here rather than on either
+  // field alone because the identity is what a stylesheet is written under: a
+  // token whose stated id is short imports normally however long its label, and
+  // one with no id is capped by that label because the label IS the identity.
+  const naming = tokenNamingProblem({ name, id });
+  if (naming !== undefined) {
+    issues.push(
+      issue(
+        naming.reason === "length"
+          ? `"${name}" is written under ${naming.length} characters, so it was skipped. The ${naming.field} a token is written under is at most ${MAX_TOKEN_NAME_LENGTH} characters.`
+          : `"${name}" has a ${naming.field} that is not a usable token name, so it was skipped.`
+      )
+    );
+    return undefined;
+  }
 
   // Both value paths below finish identically — same identity, same label, same
   // description, same carried extensions — and differ only in the kind and

--- a/packages/blocks-engine/src/style/emittable-string-bounds.ts
+++ b/packages/blocks-engine/src/style/emittable-string-bounds.ts
@@ -31,6 +31,7 @@
  */
 import { MAX_BLOCK_TYPE_LENGTH, MAX_BREAKPOINT_ID_LENGTH } from "../document";
 
+import { MAX_VALUE_LENGTH } from "./css-value";
 import { MAX_TOKEN_NAME_LENGTH, MAX_TOKEN_PREFIX_LENGTH } from "./declarations";
 import { MAX_NAMED_CLASS_NAME_LENGTH } from "./named-class";
 
@@ -55,6 +56,10 @@ export interface EmittableStringBound {
  */
 export const EMITTABLE_STRING_BOUNDS: readonly EmittableStringBound[] =
   Object.freeze([
+    // The literal style value, and the largest bound here. A consumer choosing a
+    // truncation limit reads the whole set, so omitting the biggest lets it
+    // verify every listed bound and still cut below one the compiler emits.
+    Object.freeze({ what: "a literal style value", max: MAX_VALUE_LENGTH }),
     Object.freeze({
       what: "a named class id or slug",
       max: MAX_NAMED_CLASS_NAME_LENGTH,

--- a/packages/blocks-engine/src/style/emittable-string-bounds.ts
+++ b/packages/blocks-engine/src/style/emittable-string-bounds.ts
@@ -1,0 +1,68 @@
+/**
+ * Every bound on a string this compiler can write into CSS.
+ *
+ * ## Why this list exists rather than a comment saying the same thing
+ *
+ * A caller that digests compiler inputs has to keep enough of each string to
+ * tell two inputs apart whenever they compile differently. Keeping strings
+ * whole is unbounded, so such a caller truncates — and truncating is sound only
+ * while no string the compiler EMITS can be longer than what the caller keeps.
+ *
+ * That is a claim about this package, and it was made twice as a COMMENT
+ * enumerating the strings involved. Both enumerations were short by one: the
+ * first missed a token-reference name, and the second, written to fix the
+ * first, missed a block type. A list held beside the prose it justifies is a
+ * copy, and a copy of a set drifts from the set the moment either moves.
+ *
+ * So the list is data, it lives with the bounds it names, and the caller reads
+ * it. Adding a bounded string to the compiler means adding a line here, and a
+ * consumer's assertion over this array then covers it without being edited —
+ * which is the difference between a rule and a list of the cases someone
+ * remembered.
+ *
+ * ## What belongs here
+ *
+ * A string that reaches emitted CSS and whose length is bounded by this
+ * package. NOT every constant with a cap in its name: `MAX_NAMED_CLASSES`
+ * bounds how many entries are read and says nothing about their size, and a
+ * count in this array would make the assertion below meaningless.
+ *
+ * A string the compiler emits with NO bound belongs here least of all — it
+ * belongs in the compiler, as a bound. That is the point of the array: the
+ * missing member is the defect, and a consumer asserting over it can only
+ * catch what is listed, so the discipline is to add the bound rather than to
+ * add an exception.
+ *
+ * @module style/emittable-string-bounds
+ */
+import { MAX_BREAKPOINT_ID_LENGTH } from "../document";
+
+import { MAX_BLOCK_TYPE_LENGTH } from "./compile-page";
+import { MAX_TOKEN_NAME_LENGTH } from "./declarations";
+import { MAX_NAMED_CLASS_NAME_LENGTH } from "./named-class";
+
+// Re-exported so the bound and the list that names it arrive together: a
+// consumer asserting over the list usually also wants the constant by name.
+export { MAX_BLOCK_TYPE_LENGTH };
+
+/** One bounded string the compiler can write, named so a failure says which. */
+export interface EmittableStringBound {
+  /** What the string is, for a message that has to be read by a person. */
+  readonly what: string;
+  /** The longest the compiler will emit. */
+  readonly max: number;
+}
+
+/**
+ * Every string the compiler emits whose length this package bounds.
+ *
+ * Ordered by nothing in particular; a consumer reads all of them. Frozen
+ * because a caller mutating it would silently narrow what it then verifies.
+ */
+export const EMITTABLE_STRING_BOUNDS: readonly EmittableStringBound[] =
+  Object.freeze([
+    { what: "a named class id or slug", max: MAX_NAMED_CLASS_NAME_LENGTH },
+    { what: "a breakpoint id", max: MAX_BREAKPOINT_ID_LENGTH },
+    { what: "a design token name", max: MAX_TOKEN_NAME_LENGTH },
+    { what: "a block type", max: MAX_BLOCK_TYPE_LENGTH },
+  ]);

--- a/packages/blocks-engine/src/style/emittable-string-bounds.ts
+++ b/packages/blocks-engine/src/style/emittable-string-bounds.ts
@@ -31,7 +31,7 @@
  */
 import { MAX_BLOCK_TYPE_LENGTH, MAX_BREAKPOINT_ID_LENGTH } from "../document";
 
-import { MAX_TOKEN_NAME_LENGTH } from "./declarations";
+import { MAX_TOKEN_NAME_LENGTH, MAX_TOKEN_PREFIX_LENGTH } from "./declarations";
 import { MAX_NAMED_CLASS_NAME_LENGTH } from "./named-class";
 
 /** One bounded string the compiler can write, named so a failure says which. */
@@ -54,4 +54,5 @@ export const EMITTABLE_STRING_BOUNDS: readonly EmittableStringBound[] =
     { what: "a breakpoint id", max: MAX_BREAKPOINT_ID_LENGTH },
     { what: "a design token name", max: MAX_TOKEN_NAME_LENGTH },
     { what: "a block type", max: MAX_BLOCK_TYPE_LENGTH },
+    { what: "a custom-property prefix", max: MAX_TOKEN_PREFIX_LENGTH },
   ]);

--- a/packages/blocks-engine/src/style/emittable-string-bounds.ts
+++ b/packages/blocks-engine/src/style/emittable-string-bounds.ts
@@ -45,14 +45,25 @@ export interface EmittableStringBound {
 /**
  * Every string the compiler emits whose length this package bounds.
  *
- * Ordered by nothing in particular; a consumer reads all of them. Frozen
- * because a caller mutating it would silently narrow what it then verifies.
+ * Ordered by nothing in particular; a consumer reads all of them.
+ *
+ * Each ENTRY is frozen as well as the array. `Object.freeze` is shallow, so
+ * freezing the array alone leaves every `max` writable: a consumer in the same
+ * process could assign one and silently narrow the contract every later reader
+ * observes, while the array itself reported as frozen. `readonly` is a
+ * compile-time claim and reaches no JavaScript caller at all.
  */
 export const EMITTABLE_STRING_BOUNDS: readonly EmittableStringBound[] =
   Object.freeze([
-    { what: "a named class id or slug", max: MAX_NAMED_CLASS_NAME_LENGTH },
-    { what: "a breakpoint id", max: MAX_BREAKPOINT_ID_LENGTH },
-    { what: "a design token name", max: MAX_TOKEN_NAME_LENGTH },
-    { what: "a block type", max: MAX_BLOCK_TYPE_LENGTH },
-    { what: "a custom-property prefix", max: MAX_TOKEN_PREFIX_LENGTH },
+    Object.freeze({
+      what: "a named class id or slug",
+      max: MAX_NAMED_CLASS_NAME_LENGTH,
+    }),
+    Object.freeze({ what: "a breakpoint id", max: MAX_BREAKPOINT_ID_LENGTH }),
+    Object.freeze({ what: "a design token name", max: MAX_TOKEN_NAME_LENGTH }),
+    Object.freeze({ what: "a block type", max: MAX_BLOCK_TYPE_LENGTH }),
+    Object.freeze({
+      what: "a custom-property prefix",
+      max: MAX_TOKEN_PREFIX_LENGTH,
+    }),
   ]);

--- a/packages/blocks-engine/src/style/emittable-string-bounds.ts
+++ b/packages/blocks-engine/src/style/emittable-string-bounds.ts
@@ -35,6 +35,7 @@ import { MAX_SCOPE_LENGTH } from "./compile-page";
 import { MAX_VALUE_LENGTH } from "./css-value";
 import { MAX_TOKEN_NAME_LENGTH, MAX_TOKEN_PREFIX_LENGTH } from "./declarations";
 import { MAX_NAMED_CLASS_NAME_LENGTH } from "./named-class";
+import { MAX_FONT_FORMAT_LENGTH } from "./site-tokens";
 
 /** One bounded string the compiler can write, named so a failure says which. */
 export interface EmittableStringBound {
@@ -73,4 +74,5 @@ export const EMITTABLE_STRING_BOUNDS: readonly EmittableStringBound[] =
       max: MAX_TOKEN_PREFIX_LENGTH,
     }),
     Object.freeze({ what: "a page scope", max: MAX_SCOPE_LENGTH }),
+    Object.freeze({ what: "a font format", max: MAX_FONT_FORMAT_LENGTH }),
   ]);

--- a/packages/blocks-engine/src/style/emittable-string-bounds.ts
+++ b/packages/blocks-engine/src/style/emittable-string-bounds.ts
@@ -31,6 +31,7 @@
  */
 import { MAX_BLOCK_TYPE_LENGTH, MAX_BREAKPOINT_ID_LENGTH } from "../document";
 
+import { MAX_SCOPE_LENGTH } from "./compile-page";
 import { MAX_VALUE_LENGTH } from "./css-value";
 import { MAX_TOKEN_NAME_LENGTH, MAX_TOKEN_PREFIX_LENGTH } from "./declarations";
 import { MAX_NAMED_CLASS_NAME_LENGTH } from "./named-class";
@@ -71,4 +72,5 @@ export const EMITTABLE_STRING_BOUNDS: readonly EmittableStringBound[] =
       what: "a custom-property prefix",
       max: MAX_TOKEN_PREFIX_LENGTH,
     }),
+    Object.freeze({ what: "a page scope", max: MAX_SCOPE_LENGTH }),
   ]);

--- a/packages/blocks-engine/src/style/emittable-string-bounds.ts
+++ b/packages/blocks-engine/src/style/emittable-string-bounds.ts
@@ -1,49 +1,38 @@
 /**
  * Every bound on a string this compiler can write into CSS.
  *
- * ## Why this list exists rather than a comment saying the same thing
+ * ## What this is for
  *
- * A caller that digests compiler inputs has to keep enough of each string to
- * tell two inputs apart whenever they compile differently. Keeping strings
- * whole is unbounded, so such a caller truncates — and truncating is sound only
- * while no string the compiler EMITS can be longer than what the caller keeps.
+ * A caller that digests compiler inputs — a cache key over a page's style
+ * inputs, say — must keep enough of each string to tell two inputs apart
+ * whenever they compile differently. Keeping strings whole is unbounded, so such
+ * a caller truncates, and truncating is sound only while no string the compiler
+ * EMITS is longer than what the caller keeps.
  *
- * That is a claim about this package, and it was made twice as a COMMENT
- * enumerating the strings involved. Both enumerations were short by one: the
- * first missed a token-reference name, and the second, written to fix the
- * first, missed a block type. A list held beside the prose it justifies is a
- * copy, and a copy of a set drifts from the set the moment either moves.
- *
- * So the list is data, it lives with the bounds it names, and the caller reads
- * it. Adding a bounded string to the compiler means adding a line here, and a
- * consumer's assertion over this array then covers it without being edited —
- * which is the difference between a rule and a list of the cases someone
- * remembered.
+ * That is a claim about this package, so this package states it, as data a
+ * consumer can assert against rather than as prose a consumer has to trust.
+ * Prose describing a set is a second copy of that set: it agrees with the code
+ * when written and has nothing to keep it in step afterwards, and the member it
+ * falls out of step over is the member a consumer silently stops covering.
  *
  * ## What belongs here
  *
- * A string that reaches emitted CSS and whose length is bounded by this
- * package. NOT every constant with a cap in its name: `MAX_NAMED_CLASSES`
- * bounds how many entries are read and says nothing about their size, and a
- * count in this array would make the assertion below meaningless.
+ * A string that reaches emitted CSS and whose length this package bounds. NOT
+ * every constant with a cap in its name: `MAX_NAMED_CLASSES` bounds how many
+ * entries are read and says nothing about their size, and a count in this array
+ * would make a consumer's assertion meaningless.
  *
- * A string the compiler emits with NO bound belongs here least of all — it
- * belongs in the compiler, as a bound. That is the point of the array: the
- * missing member is the defect, and a consumer asserting over it can only
- * catch what is listed, so the discipline is to add the bound rather than to
- * add an exception.
+ * A string the compiler emits with NO bound belongs in the compiler as a bound,
+ * not here as an entry. A consumer asserting over this array covers what it
+ * lists, so the discipline is to bound the string rather than to record an
+ * exception to the invariant.
  *
  * @module style/emittable-string-bounds
  */
-import { MAX_BREAKPOINT_ID_LENGTH } from "../document";
+import { MAX_BLOCK_TYPE_LENGTH, MAX_BREAKPOINT_ID_LENGTH } from "../document";
 
-import { MAX_BLOCK_TYPE_LENGTH } from "./compile-page";
 import { MAX_TOKEN_NAME_LENGTH } from "./declarations";
 import { MAX_NAMED_CLASS_NAME_LENGTH } from "./named-class";
-
-// Re-exported so the bound and the list that names it arrive together: a
-// consumer asserting over the list usually also wants the constant by name.
-export { MAX_BLOCK_TYPE_LENGTH };
 
 /** One bounded string the compiler can write, named so a failure says which. */
 export interface EmittableStringBound {

--- a/packages/blocks-engine/src/style/emittable-string-bounds.ts
+++ b/packages/blocks-engine/src/style/emittable-string-bounds.ts
@@ -35,7 +35,10 @@ import { MAX_SCOPE_LENGTH } from "./compile-page";
 import { MAX_VALUE_LENGTH } from "./css-value";
 import { MAX_TOKEN_NAME_LENGTH, MAX_TOKEN_PREFIX_LENGTH } from "./declarations";
 import { MAX_NAMED_CLASS_NAME_LENGTH } from "./named-class";
-import { MAX_FONT_FORMAT_LENGTH } from "./site-tokens";
+import {
+  MAX_FONT_FORMAT_LENGTH,
+  MAX_TOKEN_SELECTOR_LENGTH,
+} from "./site-tokens";
 
 /** One bounded string the compiler can write, named so a failure says which. */
 export interface EmittableStringBound {
@@ -75,4 +78,8 @@ export const EMITTABLE_STRING_BOUNDS: readonly EmittableStringBound[] =
     }),
     Object.freeze({ what: "a page scope", max: MAX_SCOPE_LENGTH }),
     Object.freeze({ what: "a font format", max: MAX_FONT_FORMAT_LENGTH }),
+    Object.freeze({
+      what: "a token-block selector",
+      max: MAX_TOKEN_SELECTOR_LENGTH,
+    }),
   ]);

--- a/packages/blocks-engine/src/style/site-tokens.test.ts
+++ b/packages/blocks-engine/src/style/site-tokens.test.ts
@@ -19,6 +19,7 @@ import {
   emitTokenBlocks,
   isTokenName,
   MAX_TOKEN_NAME_LENGTH,
+  MAX_TOKEN_NAME_SEGMENTS,
   renameSiteToken,
   tokenIdentity,
   tokenValueFetches,
@@ -1023,6 +1024,55 @@ describe("renaming a token whose identity the rules have made unusable", () => {
     const { css, issues } = emitTokenBlocks({ tokens: [renamed] }, SCOPE);
     expect(issues).toEqual([]);
     expect(css).toContain("color-primary");
+  });
+
+  it("keeps a working DEEP identity pinned, because depth is a label rule", () => {
+    // An identity never becomes DTCG groups — only a label does — so the depth
+    // bound does not reach it. A legacy id with more parts than a label may
+    // carry is still emittable, and clearing it on rename would move an
+    // identity every stored reference reads.
+    const deepId = Array.from(
+      { length: MAX_TOKEN_NAME_SEGMENTS + 1 },
+      () => "a"
+    ).join(".");
+    expect(deepId.length).toBeLessThanOrEqual(MAX_TOKEN_NAME_LENGTH);
+
+    const renamed = renameSiteToken(
+      {
+        id: deepId,
+        name: "old.label",
+        kind: "color",
+        values: { light: "#000" },
+      },
+      "color.primary"
+    );
+    expect(renamed.id).toBe(deepId);
+  });
+
+  it("refuses a token whose id is not a string, rather than throwing", () => {
+    // Persisted settings arrive unvalidated and `RegExp.test` coerces, so a
+    // stored number satisfies the grammar and then travels on as a number —
+    // reaching a place that assumes a string and taking the whole compile with
+    // it. One malformed settings entry must cost its own token, not the page.
+    // The ID specifically, because that is what becomes the custom property: a
+    // non-string name travels only into a message, while a non-string id
+    // reaches the composer and throws there. A fixture with both wrong is
+    // caught by the identity guard and says nothing about which one ran.
+    const { css, issues } = emitTokenBlocks(
+      {
+        tokens: [
+          {
+            id: 123,
+            name: "color.primary",
+            kind: "color",
+            values: { light: "#000" },
+          } as never,
+        ],
+      },
+      SCOPE
+    );
+    expect(css).toBe("");
+    expect(issues.length).toBeGreaterThan(0);
   });
 
   it("still never moves a WORKING identity, which is what rename protects", () => {

--- a/packages/blocks-engine/src/style/site-tokens.test.ts
+++ b/packages/blocks-engine/src/style/site-tokens.test.ts
@@ -1004,3 +1004,36 @@ describe("a token's stable identity", () => {
     expect(issues.some(i => i.message.includes("id"))).toBe(true);
   });
 });
+
+describe("renaming a token whose identity the rules have made unusable", () => {
+  // The upgrade path. A site stored before the cap existed can hold a token
+  // with no id and an overlong name, so its identity is now unemittable and the
+  // token has stopped rendering. Carrying that identity through a rename pins
+  // it forever: the editor accepts the new label and the token still emits
+  // nothing, with no remaining way to repair it from the UI.
+  const overlong = "a".repeat(MAX_TOKEN_NAME_LENGTH + 1);
+
+  it("re-pins the identity to the new name, so the token can be repaired", () => {
+    const renamed = renameSiteToken(
+      { name: overlong, kind: "color", values: { light: "#000" } },
+      "color.primary"
+    );
+    expect(renamed.id).toBeUndefined();
+
+    const { css, issues } = emitTokenBlocks({ tokens: [renamed] }, SCOPE);
+    expect(issues).toEqual([]);
+    expect(css).toContain("color-primary");
+  });
+
+  it("still never moves a WORKING identity, which is what rename protects", () => {
+    // The control, and the property that matters more than the repair: every
+    // stored `$token` reads the identity, so moving one that resolves is the
+    // defect this function exists to prevent. Without this, a rename that
+    // always re-pinned would satisfy the case above and silently break renames.
+    const renamed = renameSiteToken(
+      { name: "color.brand", kind: "color", values: { light: "#000" } },
+      "color.primary"
+    );
+    expect(renamed.id).toBe("color.brand");
+  });
+});

--- a/packages/blocks-engine/src/style/site-tokens.test.ts
+++ b/packages/blocks-engine/src/style/site-tokens.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, it } from "vitest";
 
 import * as publicEntry from "../index";
-import { compileStyleValues } from "./declarations";
+import { compileStyleValues, safeTokenPrefix } from "./declarations";
 import type { SiteToken } from "./site-tokens";
 import {
   checkTokenKind,
@@ -1085,5 +1085,23 @@ describe("renaming a token whose identity the rules have made unusable", () => {
       "color.primary"
     );
     expect(renamed.id).toBe("color.brand");
+  });
+});
+
+describe("a stored prefix that is not a string", () => {
+  it("falls back with a warning rather than aborting the compile", () => {
+    // Persisted settings are JSON, so `null` reaches here as a value rather
+    // than as the absence the signature suggests — and this function's whole
+    // purpose is that one bad setting costs the tokens, not the page.
+    expect(safeTokenPrefix(null as never).prefix).toBe("--site-");
+    expect(safeTokenPrefix(null as never).warning).toBeDefined();
+  });
+
+  it("still returns the default for an ABSENT prefix, with no warning", () => {
+    // The control: absence is not a malformed setting, so it must not report
+    // one. Without this, a build that warned on everything would satisfy the
+    // case above.
+    expect(safeTokenPrefix(undefined).prefix).toBe("--site-");
+    expect(safeTokenPrefix(undefined).warning).toBeUndefined();
   });
 });

--- a/packages/blocks-engine/src/style/site-tokens.test.ts
+++ b/packages/blocks-engine/src/style/site-tokens.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import * as publicEntry from "../index";
 import { compileStyleValues, safeTokenPrefix } from "./declarations";
-import type { SiteToken } from "./site-tokens";
+import type { SiteToken, SiteTokenSet } from "./site-tokens";
 import {
   checkTokenKind,
   DARK_MODE_ATTRIBUTE,
@@ -20,6 +20,7 @@ import {
   isTokenName,
   MAX_TOKEN_NAME_LENGTH,
   MAX_TOKEN_NAME_SEGMENTS,
+  MAX_TOKEN_SELECTOR_LENGTH,
   renameSiteToken,
   tokenIdentity,
   tokenValueFetches,
@@ -1103,5 +1104,35 @@ describe("a stored prefix that is not a string", () => {
     // case above.
     expect(safeTokenPrefix(undefined).prefix).toBe("--site-");
     expect(safeTokenPrefix(undefined).warning).toBeUndefined();
+  });
+});
+
+describe("the selector token blocks are written under", () => {
+  const oneToken: SiteTokenSet = {
+    tokens: [
+      { name: "color.primary", kind: "color", values: { light: "#000" } },
+    ],
+  };
+
+  it("refuses an oversized selector rather than writing under a cut one", () => {
+    // The selector is the caller's and goes into the sheet verbatim, once per
+    // block. Truncating it would be worse than refusing: a selector cut in half
+    // is a different selector, so the site's values would land on whatever it
+    // happens to match.
+    const { css, issues } = emitTokenBlocks(
+      oneToken,
+      `.${"s".repeat(MAX_TOKEN_SELECTOR_LENGTH)}`
+    );
+    expect(css).toBe("");
+    expect(issues.length).toBeGreaterThan(0);
+  });
+
+  it("still writes under a selector at the bound", () => {
+    // The control. A guard refusing every selector would satisfy the case above
+    // and emit no tokens at all, anywhere.
+    const atBound = "s".repeat(MAX_TOKEN_SELECTOR_LENGTH);
+    const { css, issues } = emitTokenBlocks(oneToken, atBound);
+    expect(issues).toEqual([]);
+    expect(css).toContain(atBound);
   });
 });

--- a/packages/blocks-engine/src/style/site-tokens.test.ts
+++ b/packages/blocks-engine/src/style/site-tokens.test.ts
@@ -386,6 +386,49 @@ describe("the token name grammar", () => {
     expect(cssFor(first)).toBe("");
   });
 
+  it("still writes a renamed token whose DISPLAY name is past the cap", () => {
+    // A token's identity is `id ?? name`, so a renamed one emits under its id
+    // and its display name reaches no stylesheet. Holding that name to the
+    // emission cap would delete a working token from the sheet the moment an
+    // author gave it a long label — a rename is supposed to cost nothing, which
+    // is the whole reason identity is pinned separately from the name.
+    const longLabel = "a".repeat(MAX_TOKEN_NAME_LENGTH + 1);
+    const { css, issues } = emitTokenBlocks(
+      {
+        tokens: [
+          {
+            id: "color.primary",
+            name: longLabel,
+            kind: "color",
+            values: { light: "#000" },
+          },
+        ],
+      },
+      SCOPE
+    );
+    expect(issues).toEqual([]);
+    expect(css).toContain("color-primary");
+  });
+
+  it("refuses a token whose IDENTITY is past the cap", () => {
+    // The other side, and the one that reaches CSS: with no id the name IS the
+    // identity, so the cap applies to it here and to nothing else.
+    const { css, issues } = emitTokenBlocks(
+      {
+        tokens: [
+          {
+            name: "a".repeat(MAX_TOKEN_NAME_LENGTH + 1),
+            kind: "color",
+            values: { light: "#000" },
+          },
+        ],
+      },
+      SCOPE
+    );
+    expect(css).toBe("");
+    expect(issues.length).toBeGreaterThan(0);
+  });
+
   it("accepts a name exactly at the cap", () => {
     // A cap that took the boundary with it would be a different rule from the
     // one documented, and the off-by-one is invisible in any test that only

--- a/packages/blocks-engine/src/style/site-tokens.test.ts
+++ b/packages/blocks-engine/src/style/site-tokens.test.ts
@@ -18,6 +18,7 @@ import {
   emitFontFaces,
   emitTokenBlocks,
   isTokenName,
+  MAX_TOKEN_NAME_LENGTH,
   renameSiteToken,
   tokenIdentity,
   tokenValueFetches,
@@ -331,6 +332,73 @@ describe("the token name grammar", () => {
       "/styles"
     );
     expect(reference.declarations).toEqual([]);
+  });
+
+  it("refuses a name longer than the cap, on both sides of the reference", () => {
+    // The grammar bounds the ALPHABET and not the length, so without a cap a
+    // name of megabytes of valid characters is scanned in full on every compile
+    // and copied into a `var()` on every rule referencing it.
+    //
+    // Both sides are asserted because the whole value of one grammar is that the
+    // table and the reference agree: a table that refused an overlong name while
+    // a reference still emitted it would write `var(--site-...)` against a custom
+    // property nothing defines, and report nothing.
+    const overlong = "a".repeat(MAX_TOKEN_NAME_LENGTH + 1);
+    expect(isTokenName(overlong)).toBe(false);
+
+    const { css } = emitTokenBlocks(
+      {
+        tokens: [{ name: overlong, kind: "color", values: { light: "#000" } }],
+      },
+      SCOPE
+    );
+    expect(css).toBe("");
+
+    const reference = compileStyleValues(
+      { color: { $token: overlong } },
+      "/styles"
+    );
+    expect(reference.declarations).toEqual([]);
+  });
+
+  it("emits nothing for two different overlong names, so they cannot compile apart", () => {
+    // This is the property the page-artifact stamp depends on. That stamp keeps
+    // at most `MAX_VALUE_LENGTH` characters of any string it reads, which is
+    // sound only while no string the compiler EMITS can be longer. A token name
+    // is the one that could: it reaches CSS in full through `tokenCustomProperty`.
+    //
+    // So the pair matters, not the single case. Two names agreeing to the
+    // stamp's truncation point and differing after it once produced different
+    // CSS under one identifier, and the stored sheet was then reused for the
+    // wrong one indefinitely. Under the cap both emit nothing, so identical
+    // output is the honest answer rather than a collision.
+    const shared = "a".repeat(MAX_TOKEN_NAME_LENGTH + 1);
+    const first = `${shared}b`;
+    const second = `${shared}c`;
+
+    const cssFor = (name: string) =>
+      emitTokenBlocks(
+        { tokens: [{ name, kind: "color", values: { light: "#000" } }] },
+        SCOPE
+      ).css;
+
+    expect(cssFor(first)).toBe(cssFor(second));
+    expect(cssFor(first)).toBe("");
+  });
+
+  it("accepts a name exactly at the cap", () => {
+    // A cap that took the boundary with it would be a different rule from the
+    // one documented, and the off-by-one is invisible in any test that only
+    // supplies a name well clear of it.
+    const atCap = "a".repeat(MAX_TOKEN_NAME_LENGTH);
+    expect(atCap.length).toBe(MAX_TOKEN_NAME_LENGTH);
+    expect(isTokenName(atCap)).toBe(true);
+
+    const reference = compileStyleValues(
+      { color: { $token: atCap } },
+      "/styles"
+    );
+    expect(reference.declarations).not.toEqual([]);
   });
 
   it("keeps accepting the names the default set uses", () => {

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -159,7 +159,20 @@ export function tokenIdentity(token: SiteToken): string {
  * froze, so an identity is pinned once and never again.
  */
 export function renameSiteToken(token: SiteToken, name: string): SiteToken {
-  return { ...token, id: tokenIdentity(token), name };
+  const current = tokenIdentity(token);
+  // An identity this engine cannot write is not resolving for anything, so
+  // carrying it forward pins a token permanently unusable: the rename is
+  // accepted, the label changes, and the token still emits nothing with no
+  // remaining way to repair it.
+  //
+  // Re-pinning is safe in exactly that case and only there. A WORKING identity
+  // must never move, because every stored `$token` reads it — which is what
+  // this function exists to protect. One that cannot be emitted has no such
+  // references to lose, so the new name becomes the identity instead.
+  if (tokenNamingProblem({ name: current }) !== undefined) {
+    return { ...token, id: undefined, name };
+  }
+  return { ...token, id: current, name };
 }
 
 /** One file a font face can be loaded from. */
@@ -792,7 +805,9 @@ export function emitFontFaces(faces: readonly FontFaceDef[]): {
 export type TokenNamingProblem =
   | { field: "name" | "id"; reason: "grammar" }
   | { field: "name" | "id"; reason: "length"; length: number }
-  | { field: "name"; reason: "depth"; segments: number };
+  // No count: the scan stops once the answer is known, so any number it could
+  // carry would be the bound rather than the label's real depth.
+  | { field: "name"; reason: "depth" };
 
 export function tokenNamingProblem(token: {
   name: string;
@@ -817,9 +832,20 @@ export function tokenNamingProblem(token: {
   // the same answer — and bounded separately from LENGTH because depth is what
   // breaks, and capping the label's length again is what a renamed token's
   // identity exists to avoid.
-  const segments = token.name.split(".").length;
+  // Counted rather than split. `split(".")` materialises every segment of a
+  // label that is deliberately free of the length cap, so an oversized one is
+  // allocated in full on every compile only to be refused — and the count stops
+  // as soon as the answer is known.
+  let segments = 1;
+  for (
+    let at = 0;
+    at < token.name.length && segments <= MAX_TOKEN_NAME_SEGMENTS;
+    at++
+  ) {
+    if (token.name[at] === ".") segments++;
+  }
   if (segments > MAX_TOKEN_NAME_SEGMENTS) {
-    return { field: "name", reason: "depth", segments };
+    return { field: "name", reason: "depth" };
   }
   const identity = tokenIdentity(token as SiteToken);
   if (identity.length > MAX_TOKEN_NAME_LENGTH) {
@@ -837,7 +863,7 @@ function tokenNamingRefusal(token: SiteToken): string | undefined {
   const problem = tokenNamingProblem(token);
   if (problem === undefined) return undefined;
   if (problem.reason === "depth") {
-    return `"${token.name}" is ${problem.segments} names deep, so it was not written. A token name holds at most ${MAX_TOKEN_NAME_SEGMENTS} dot-separated parts.`;
+    return `"${token.name}" is nested too deeply, so it was not written. A token name holds at most ${MAX_TOKEN_NAME_SEGMENTS} dot-separated parts.`;
   }
   if (problem.reason === "length") {
     return `"${token.name}" is written under ${problem.length} characters, so it was not written. The ${problem.field} a token is written under is at most ${MAX_TOKEN_NAME_LENGTH} characters.`;

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -64,6 +64,7 @@ import {
 import {
   MAX_TOKEN_NAME_LENGTH,
   MAX_TOKEN_PREFIX_LENGTH,
+  isAuthorableTokenName,
   isTokenName,
   safeTokenPrefix,
   tokenCustomProperty,
@@ -236,7 +237,12 @@ function tokenIssue(
  * everything after it is CSS the site never wrote. `x:1}body{color` is the
  * whole attack.
  */
-export { isTokenName, MAX_TOKEN_NAME_LENGTH, MAX_TOKEN_PREFIX_LENGTH };
+export {
+  isAuthorableTokenName,
+  isTokenName,
+  MAX_TOKEN_NAME_LENGTH,
+  MAX_TOKEN_PREFIX_LENGTH,
+};
 
 /**
  * A font descriptor that goes inside a quoted CSS string, made safe to put
@@ -766,6 +772,39 @@ export function emitFontFaces(faces: readonly FontFaceDef[]): {
 }
 
 /**
+ * Why a token cannot be written under the name it carries, or nothing.
+ *
+ * Three refusals with one subject — what this token is CALLED — so they answer
+ * together rather than as separate branches inside the emitter, and each names
+ * the field an author has to repair rather than reporting "invalid token".
+ *
+ * The split between grammar and length is the point. A token's identity is
+ * `id ?? name`, so a renamed token emits under its id and its display name
+ * reaches no stylesheet: the grammar applies to both, because either can become
+ * the identity, while the EMISSION cap applies only to the one that actually
+ * does. Capping the display name instead would drop a working token from the
+ * sheet the moment an author gave it a long label.
+ */
+function tokenNamingRefusal(token: SiteToken): string | undefined {
+  // Grammar first, and on both fields. A name holding `}` closes the rule the
+  // emitter opened and everything after it is CSS the site never wrote, and an
+  // id reaches the same selector by the same route.
+  if (!isAuthorableTokenName(token.name)) {
+    return `"${token.name}" is not a token name, so it was not written. A name is dot-separated words of letters, digits and dashes, like "color.primary".`;
+  }
+  if (token.id !== undefined && !isAuthorableTokenName(token.id)) {
+    return `"${token.name}" has an id that is not a token name, so it was not written. An id is dot-separated words of letters, digits and dashes, like "color.primary".`;
+  }
+  // The cap, on the string `tokenCustomProperty` actually composes.
+  const identity = tokenIdentity(token);
+  if (identity.length > MAX_TOKEN_NAME_LENGTH) {
+    const field = token.id === undefined ? "name" : "id";
+    return `"${token.name}" emits under ${identity.length} characters, so it was not written. The ${field} a token is written under is at most ${MAX_TOKEN_NAME_LENGTH} characters.`;
+  }
+  return undefined;
+}
+
+/**
  * The custom-property blocks a site's tokens resolve in.
  *
  * Emitted onto a selector the caller supplies rather than `:root`, so a page's
@@ -789,28 +828,9 @@ export function emitTokenBlocks(
   const seen = new Map<string, string>();
 
   for (const token of set.tokens) {
-    // The name becomes the custom PROPERTY, so it is checked before it is
-    // composed: a name holding `}` closes the rule this opened, and everything
-    // after it is CSS the site never wrote.
-    if (!isTokenName(token.name)) {
-      issues.push(
-        tokenIssue(
-          `"${token.name}" is not a token name, so it was not written. A name is dot-separated words of letters, digits and dashes, like "color.primary".`
-        )
-      );
-      continue;
-    }
-    // An id reaches the same selector by the same route, so it is held to the
-    // same grammar. Checked separately from the name rather than through the
-    // identity alone, so the report names the field the author has to repair —
-    // a token whose id is unwritable and whose name is fine reads as a good
-    // token otherwise, and "rename it" would be advice that fixes nothing.
-    if (token.id !== undefined && !isTokenName(token.id)) {
-      issues.push(
-        tokenIssue(
-          `"${token.name}" has an id that is not a token name, so it was not written. An id is dot-separated words of letters, digits and dashes, like "color.primary".`
-        )
-      );
+    const naming = tokenNamingRefusal(token);
+    if (naming !== undefined) {
+      issues.push(tokenIssue(naming));
       continue;
     }
     // A token with no values record at all. Site tokens are one settings row read on every page

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -772,50 +772,62 @@ export function emitFontFaces(faces: readonly FontFaceDef[]): {
 }
 
 /**
- * Why a token cannot be written under the name it carries, or nothing.
+ * What is wrong with the name a token carries, or nothing.
  *
- * Three refusals with one subject — what this token is CALLED — so they answer
- * together rather than as separate branches inside the emitter, and each names
- * the field an author has to repair rather than reporting "invalid token".
+ * Answered once, for every gate that decides whether a token can be written —
+ * the emitter, the DTCG exporter and the DTCG importer all ask it, and each
+ * phrases its own message from the result. Returning the PROBLEM rather than a
+ * sentence is what lets them share the rule without sharing wording that would
+ * be wrong in two of the three.
  *
- * The split between grammar and length is the point. A token's identity is
- * `id ?? name`, so a renamed token emits under its id and its display name
- * reaches no stylesheet: the grammar applies to both, because either can become
- * the identity, while the EMISSION cap applies only to the one that actually
- * does. Capping the display name instead would drop a working token from the
- * sheet the moment an author gave it a long label.
+ * The split between grammar and length is the rule itself. A token's identity is
+ * `id ?? name`, so a renamed token is written under its id and its display name
+ * reaches no stylesheet and no exported file. Both fields meet the grammar,
+ * because either can BE the identity and either would reach a selector; only the
+ * identity meets the emission cap. Capping the display name instead drops a
+ * working token the moment an author gives it a long label.
  */
-function tokenNamingRefusal(token: SiteToken): string | undefined {
-  // Grammar first, and on both fields. A name holding `}` closes the rule the
-  // emitter opened and everything after it is CSS the site never wrote, and an
-  // id reaches the same selector by the same route.
+export type TokenNamingProblem =
+  | { field: "name" | "id"; reason: "grammar" }
+  | { field: "name" | "id"; reason: "length"; length: number };
+
+export function tokenNamingProblem(token: {
+  name: string;
+  id?: string | undefined;
+}): TokenNamingProblem | undefined {
+  // Grammar on both. A name holding `}` closes the rule an emitter opened and
+  // everything after it is CSS the site never wrote; an id reaches the same
+  // selector by the same route. Asked per field so a caller can name the one an
+  // author has to repair — "rename it" fixes nothing for a bad id.
   if (!isAuthorableTokenName(token.name)) {
-    return `"${token.name}" is not a token name, so it was not written. A name is dot-separated words of letters, digits and dashes, like "color.primary".`;
+    return { field: "name", reason: "grammar" };
   }
   if (token.id !== undefined && !isAuthorableTokenName(token.id)) {
-    return `"${token.name}" has an id that is not a token name, so it was not written. An id is dot-separated words of letters, digits and dashes, like "color.primary".`;
+    return { field: "id", reason: "grammar" };
   }
-  // The cap, on the string `tokenCustomProperty` actually composes.
-  const identity = tokenIdentity(token);
+  const identity = tokenIdentity(token as SiteToken);
   if (identity.length > MAX_TOKEN_NAME_LENGTH) {
-    const field = token.id === undefined ? "name" : "id";
-    return `"${token.name}" emits under ${identity.length} characters, so it was not written. The ${field} a token is written under is at most ${MAX_TOKEN_NAME_LENGTH} characters.`;
+    return {
+      field: token.id === undefined ? "name" : "id",
+      reason: "length",
+      length: identity.length,
+    };
   }
   return undefined;
 }
 
-/**
- * The custom-property blocks a site's tokens resolve in.
- *
- * Emitted onto a selector the caller supplies rather than `:root`, so a page's
- * tokens reach the page and stop there. Writing them at the document root would
- * make a site's values apply to a host's own markup, which is the collision
- * this styling layer spends its effort avoiding everywhere else.
- *
- * The dark block is only written when some token actually differs in dark. An
- * empty block is not free: it is a selector a host reads in devtools and takes
- * for a place where something should be happening.
- */
+/** The emitter's wording for {@link tokenNamingProblem}. */
+function tokenNamingRefusal(token: SiteToken): string | undefined {
+  const problem = tokenNamingProblem(token);
+  if (problem === undefined) return undefined;
+  if (problem.reason === "length") {
+    return `"${token.name}" is written under ${problem.length} characters, so it was not written. The ${problem.field} a token is written under is at most ${MAX_TOKEN_NAME_LENGTH} characters.`;
+  }
+  return problem.field === "name"
+    ? `"${token.name}" is not a token name, so it was not written. A name is dot-separated words of letters, digits and dashes, like "color.primary".`
+    : `"${token.name}" has an id that is not a token name, so it was not written. An id is dot-separated words of letters, digits and dashes, like "color.primary".`;
+}
+
 export function emitTokenBlocks(
   set: SiteTokenSet,
   selector: string

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -167,8 +167,15 @@ export function renameSiteToken(token: SiteToken, name: string): SiteToken {
   //
   // Re-pinning is safe in exactly that case and only there. A WORKING identity
   // must never move, because every stored `$token` reads it — which is what
-  // this function exists to protect. One that cannot be emitted has no such
-  // references to lose, so the new name becomes the identity instead.
+  // this function exists to protect. One that cannot be emitted resolves for
+  // nothing, so no reference that WORKS is lost by replacing it.
+  //
+  // What that does not mean is that no references exist. A name refused today
+  // may have been valid when a document was saved, so stored `$token` values
+  // can still name it — already resolving to nothing, and still doing so after
+  // the token is repaired under a new identity. This makes the TOKEN usable
+  // again; the documents pointing at the old name are a separate repair, and
+  // one this helper cannot make: it is handed a token and never sees them.
   if (
     identityProblem(current, token.id === undefined ? "name" : "id") !==
     undefined
@@ -218,6 +225,17 @@ export const DARK_MODE_ATTRIBUTE = "data-nx-theme";
  * and is only met by data already wrong.
  */
 export const MAX_FONT_FORMAT_LENGTH = 32;
+
+/**
+ * The longest selector `emitTokenBlocks` will write a token block under.
+ *
+ * The selector is supplied by the caller and inserted into the emitted CSS
+ * verbatim — once for the light block and once more for a dark one — so an
+ * oversized one is copied into the sheet rather than merely held.
+ *
+ * Generous against what a caller passes: a page-scope class or `:root`.
+ */
+export const MAX_TOKEN_SELECTOR_LENGTH = 256;
 
 const FONT_FORMAT = /^[a-z0-9-]+$/i;
 
@@ -1022,6 +1040,20 @@ export function emitTokenBlocks(
     }
   }
 
+  // Refused rather than truncated: a selector cut in half is a different
+  // selector, and writing tokens under it would put the site's values on
+  // whatever it happens to match.
+  if (
+    typeof selector !== "string" ||
+    selector.length > MAX_TOKEN_SELECTOR_LENGTH
+  ) {
+    issues.push(
+      tokenIssue(
+        `The selector these tokens would be written under is longer than ${MAX_TOKEN_SELECTOR_LENGTH} characters, so none were written.`
+      )
+    );
+    return { css: "", issues };
+  }
   if (light.length === 0) return { css: "", issues };
 
   let css = `${selector}{${light.join(";")}}`;

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -813,9 +813,13 @@ export type TokenNamingProblem =
 /**
  * Why a LABEL cannot be used, or nothing.
  *
- * A label is what an author reads. It is not written into CSS, so no length cap
- * applies — but the DTCG exporter turns each of its dot-separated parts into a
- * nested group, so its DEPTH is bounded.
+ * A label is what an author reads. It never becomes a custom property, so the
+ * emission cap does not reach it — that belongs to the identity.
+ *
+ * It does reach an exported file, though, and that is why it carries rules at
+ * all: the DTCG exporter splits it on dots and makes each part a key, so its
+ * grammar decides what those keys may contain and its DEPTH decides how far the
+ * reader has to descend to find the token underneath them.
  */
 export function labelProblem(name: unknown): TokenNamingProblem | undefined {
   // Persisted settings reach here unvalidated, and `RegExp.test` COERCES: a

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -209,6 +209,16 @@ export interface FontFaceDef {
 export const DARK_MODE_ATTRIBUTE = "data-nx-theme";
 
 /** The `format()` hints a face may declare: plain keywords, nothing else. */
+/**
+ * The longest font format this engine will write.
+ *
+ * The grammar below constrains the alphabet and not the length, and a format is
+ * emitted into `format("...")` on every source of every face. Real values are
+ * `woff2`, `truetype`, `opentype` — so this sits far above anything meaningful
+ * and is only met by data already wrong.
+ */
+export const MAX_FONT_FORMAT_LENGTH = 32;
+
 const FONT_FORMAT = /^[a-z0-9-]+$/i;
 
 /**
@@ -710,7 +720,12 @@ export function validateFontFace(
     }
   }
   for (const source of face.src) {
-    if (source.format !== undefined && !FONT_FORMAT.test(source.format)) {
+    if (
+      source.format !== undefined &&
+      (typeof source.format !== "string" ||
+        source.format.length > MAX_FONT_FORMAT_LENGTH ||
+        !FONT_FORMAT.test(source.format))
+    ) {
       fail(`"${face.family}" has a font format that cannot be used.`);
     }
   }

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -63,6 +63,7 @@ import {
 } from "./css-value";
 import {
   MAX_TOKEN_NAME_LENGTH,
+  MAX_TOKEN_PREFIX_LENGTH,
   isTokenName,
   safeTokenPrefix,
   tokenCustomProperty,
@@ -235,7 +236,7 @@ function tokenIssue(
  * everything after it is CSS the site never wrote. `x:1}body{color` is the
  * whole attack.
  */
-export { isTokenName, MAX_TOKEN_NAME_LENGTH };
+export { isTokenName, MAX_TOKEN_NAME_LENGTH, MAX_TOKEN_PREFIX_LENGTH };
 
 /**
  * A font descriptor that goes inside a quoted CSS string, made safe to put

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -63,6 +63,7 @@ import {
 } from "./css-value";
 import {
   MAX_TOKEN_NAME_LENGTH,
+  MAX_TOKEN_NAME_SEGMENTS,
   MAX_TOKEN_PREFIX_LENGTH,
   isAuthorableTokenName,
   isTokenName,
@@ -241,6 +242,7 @@ export {
   isAuthorableTokenName,
   isTokenName,
   MAX_TOKEN_NAME_LENGTH,
+  MAX_TOKEN_NAME_SEGMENTS,
   MAX_TOKEN_PREFIX_LENGTH,
 };
 
@@ -789,7 +791,8 @@ export function emitFontFaces(faces: readonly FontFaceDef[]): {
  */
 export type TokenNamingProblem =
   | { field: "name" | "id"; reason: "grammar" }
-  | { field: "name" | "id"; reason: "length"; length: number };
+  | { field: "name" | "id"; reason: "length"; length: number }
+  | { field: "name"; reason: "depth"; segments: number };
 
 export function tokenNamingProblem(token: {
   name: string;
@@ -804,6 +807,19 @@ export function tokenNamingProblem(token: {
   }
   if (token.id !== undefined && !isAuthorableTokenName(token.id)) {
     return { field: "id", reason: "grammar" };
+  }
+  // A name is dot-separated by grammar, and its SEGMENTS are structure rather
+  // than characters: the DTCG exporter turns each one into a nested group, and
+  // the reader walks those groups recursively. A label deep enough therefore
+  // produces a file this package cannot read back, which is the round trip the
+  // exporter exists to keep. Bounded here rather than at the exporter because
+  // the segment count is a property of the name, so every reader of a name gets
+  // the same answer — and bounded separately from LENGTH because depth is what
+  // breaks, and capping the label's length again is what a renamed token's
+  // identity exists to avoid.
+  const segments = token.name.split(".").length;
+  if (segments > MAX_TOKEN_NAME_SEGMENTS) {
+    return { field: "name", reason: "depth", segments };
   }
   const identity = tokenIdentity(token as SiteToken);
   if (identity.length > MAX_TOKEN_NAME_LENGTH) {
@@ -820,6 +836,9 @@ export function tokenNamingProblem(token: {
 function tokenNamingRefusal(token: SiteToken): string | undefined {
   const problem = tokenNamingProblem(token);
   if (problem === undefined) return undefined;
+  if (problem.reason === "depth") {
+    return `"${token.name}" is ${problem.segments} names deep, so it was not written. A token name holds at most ${MAX_TOKEN_NAME_SEGMENTS} dot-separated parts.`;
+  }
   if (problem.reason === "length") {
     return `"${token.name}" is written under ${problem.length} characters, so it was not written. The ${problem.field} a token is written under is at most ${MAX_TOKEN_NAME_LENGTH} characters.`;
   }

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -169,7 +169,10 @@ export function renameSiteToken(token: SiteToken, name: string): SiteToken {
   // must never move, because every stored `$token` reads it — which is what
   // this function exists to protect. One that cannot be emitted has no such
   // references to lose, so the new name becomes the identity instead.
-  if (tokenNamingProblem({ name: current }) !== undefined) {
+  if (
+    identityProblem(current, token.id === undefined ? "name" : "id") !==
+    undefined
+  ) {
     return { ...token, id: undefined, name };
   }
   return { ...token, id: current, name };
@@ -804,58 +807,76 @@ export function emitFontFaces(faces: readonly FontFaceDef[]): {
  */
 export type TokenNamingProblem =
   | { field: "name" | "id"; reason: "grammar" }
-  | { field: "name" | "id"; reason: "length"; length: number }
-  // No count: the scan stops once the answer is known, so any number it could
-  // carry would be the bound rather than the label's real depth.
+  | { field: "name" | "id"; reason: "length" }
   | { field: "name"; reason: "depth" };
 
-export function tokenNamingProblem(token: {
-  name: string;
-  id?: string | undefined;
-}): TokenNamingProblem | undefined {
-  // Grammar on both. A name holding `}` closes the rule an emitter opened and
-  // everything after it is CSS the site never wrote; an id reaches the same
-  // selector by the same route. Asked per field so a caller can name the one an
-  // author has to repair — "rename it" fixes nothing for a bad id.
-  if (!isAuthorableTokenName(token.name)) {
-    return { field: "name", reason: "grammar" };
+/**
+ * Why a LABEL cannot be used, or nothing.
+ *
+ * A label is what an author reads. It is not written into CSS, so no length cap
+ * applies — but the DTCG exporter turns each of its dot-separated parts into a
+ * nested group, so its DEPTH is bounded.
+ */
+export function labelProblem(name: unknown): TokenNamingProblem | undefined {
+  // Persisted settings reach here unvalidated, and `RegExp.test` COERCES: a
+  // stored `123` becomes "123" and satisfies the grammar, after which the value
+  // travels on as a number and throws where a string was assumed.
+  if (typeof name !== "string") return { field: "name", reason: "grammar" };
+  if (!isAuthorableTokenName(name)) return { field: "name", reason: "grammar" };
+  // Counted in place: a label carries no length cap, so splitting it
+  // materialises every part of an oversized one only to refuse it.
+  let parts = 1;
+  for (let at = 0; at < name.length && parts <= MAX_TOKEN_NAME_SEGMENTS; at++) {
+    if (name[at] === ".") parts++;
   }
-  if (token.id !== undefined && !isAuthorableTokenName(token.id)) {
-    return { field: "id", reason: "grammar" };
-  }
-  // A name is dot-separated by grammar, and its SEGMENTS are structure rather
-  // than characters: the DTCG exporter turns each one into a nested group, and
-  // the reader walks those groups recursively. A label deep enough therefore
-  // produces a file this package cannot read back, which is the round trip the
-  // exporter exists to keep. Bounded here rather than at the exporter because
-  // the segment count is a property of the name, so every reader of a name gets
-  // the same answer — and bounded separately from LENGTH because depth is what
-  // breaks, and capping the label's length again is what a renamed token's
-  // identity exists to avoid.
-  // Counted rather than split. `split(".")` materialises every segment of a
-  // label that is deliberately free of the length cap, so an oversized one is
-  // allocated in full on every compile only to be refused — and the count stops
-  // as soon as the answer is known.
-  let segments = 1;
-  for (
-    let at = 0;
-    at < token.name.length && segments <= MAX_TOKEN_NAME_SEGMENTS;
-    at++
-  ) {
-    if (token.name[at] === ".") segments++;
-  }
-  if (segments > MAX_TOKEN_NAME_SEGMENTS) {
+  if (parts > MAX_TOKEN_NAME_SEGMENTS)
     return { field: "name", reason: "depth" };
-  }
-  const identity = tokenIdentity(token as SiteToken);
-  if (identity.length > MAX_TOKEN_NAME_LENGTH) {
-    return {
-      field: token.id === undefined ? "name" : "id",
-      reason: "length",
-      length: identity.length,
-    };
-  }
   return undefined;
+}
+
+/**
+ * Why an IDENTITY cannot be used, or nothing.
+ *
+ * An identity is what a token is WRITTEN under — it becomes the custom property
+ * and every stored reference reads it — so the emission cap applies. Depth does
+ * not: an identity never becomes DTCG groups, and refusing one for its depth is
+ * what clears a working id and breaks every reference to it.
+ *
+ * Separate from {@link labelProblem} rather than a flag on it, because the two
+ * subjects take different rules and a caller holding a bare string cannot be
+ * relied on to say which it has.
+ */
+export function identityProblem(
+  identity: unknown,
+  field: "name" | "id"
+): TokenNamingProblem | undefined {
+  if (typeof identity !== "string") return { field, reason: "grammar" };
+  if (!isAuthorableTokenName(identity)) return { field, reason: "grammar" };
+  if (identity.length > MAX_TOKEN_NAME_LENGTH)
+    return { field, reason: "length" };
+  return undefined;
+}
+
+/**
+ * Why a token cannot be written, or nothing.
+ *
+ * Composed from the two rules above so each applies to its own subject: the
+ * label is checked as a label, the identity as an identity. A token with an id
+ * is checked as both, because the id is the identity and the name is the label.
+ */
+export function tokenNamingProblem(token: {
+  name: unknown;
+  id?: unknown;
+}): TokenNamingProblem | undefined {
+  const label = labelProblem(token.name);
+  if (label !== undefined) return label;
+  if (token.id !== undefined) {
+    const stated = identityProblem(token.id, "id");
+    if (stated !== undefined) return stated;
+    return undefined;
+  }
+  // With no id the label IS the identity, so it meets the emission cap too.
+  return identityProblem(token.name, "name");
 }
 
 /** The emitter's wording for {@link tokenNamingProblem}. */
@@ -863,10 +884,10 @@ function tokenNamingRefusal(token: SiteToken): string | undefined {
   const problem = tokenNamingProblem(token);
   if (problem === undefined) return undefined;
   if (problem.reason === "depth") {
-    return `"${token.name}" is nested too deeply, so it was not written. A token name holds at most ${MAX_TOKEN_NAME_SEGMENTS} dot-separated parts.`;
+    return `"${String(token.name)}" is nested too deeply, so it was not written. A token name holds at most ${MAX_TOKEN_NAME_SEGMENTS} dot-separated parts.`;
   }
   if (problem.reason === "length") {
-    return `"${token.name}" is written under ${problem.length} characters, so it was not written. The ${problem.field} a token is written under is at most ${MAX_TOKEN_NAME_LENGTH} characters.`;
+    return `"${String(token.name)}" is written under more than ${MAX_TOKEN_NAME_LENGTH} characters, so it was not written. The ${problem.field} a token is written under is at most ${MAX_TOKEN_NAME_LENGTH} characters.`;
   }
   return problem.field === "name"
     ? `"${token.name}" is not a token name, so it was not written. A name is dot-separated words of letters, digits and dashes, like "color.primary".`

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -62,6 +62,7 @@ import {
   unitCategory,
 } from "./css-value";
 import {
+  MAX_TOKEN_NAME_LENGTH,
   isTokenName,
   safeTokenPrefix,
   tokenCustomProperty,
@@ -234,7 +235,7 @@ function tokenIssue(
  * everything after it is CSS the site never wrote. `x:1}body{color` is the
  * whole attack.
  */
-export { isTokenName };
+export { isTokenName, MAX_TOKEN_NAME_LENGTH };
 
 /**
  * A font descriptor that goes inside a quoted CSS string, made safe to put

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -18,6 +18,7 @@ import {
   MAX_CLASSES_PER_NODE,
   STYLE_STATES,
   isBindingSource,
+  isBlockType,
 } from "./document";
 import { describeValue, pointer } from "./issue-text";
 import { DEFAULT_LIMITS, LIMIT_WARNING_RATIO } from "./limits";
@@ -256,9 +257,6 @@ export const ISSUE_CODES = {
 /** A stable validation issue code. */
 export type IssueCode = keyof typeof ISSUE_CODES;
 
-/** A node type is a namespaced slug, e.g. "core/heading". */
-const NODE_TYPE_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
-
 /**
  * Whether a value is a well-formed node type, independent of any registry.
  *
@@ -273,7 +271,7 @@ const NODE_TYPE_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
  * agree today.
  */
 export function isNodeType(value: unknown): value is string {
-  return typeof value === "string" && NODE_TYPE_RE.test(value);
+  return isBlockType(value);
 }
 
 /**

--- a/packages/blocks-react/src/shared-input-staleness.test.ts
+++ b/packages/blocks-react/src/shared-input-staleness.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, it } from "vitest";
 import type {
   BlockDocument,
   BlockNode,
+  NodeStyles,
   StyleCompileContext,
 } from "@nextlyhq/blocks-engine";
 
@@ -266,5 +267,52 @@ describe("the exported resolver, handed a site-wide block library", () => {
       resolvePageStyles(doc(), undefined, drawn("#020202"), blocks, false, {})
         .sharedInputsId
     );
+  });
+});
+
+describe("an INHERITED block base is not turned into an emitted one", () => {
+  // `compilePageCss` emits a base for a used type only when
+  // `Object.hasOwn(bases, type)` succeeds, and its comment says why the boundary
+  // is drawn there: a node type reaches a SELECTOR, and this compiler reads
+  // persisted data whether or not anything validated it.
+  //
+  // Narrowing a stated record walks the document and copies what it finds, so a
+  // lookup that answered from the prototype would make an inherited value an OWN
+  // property of the narrowed record — and the compiler, seeing an own property,
+  // would emit a rule it had deliberately declined to emit.
+  const inherited = (colour: string): Record<string, NodeStyles> =>
+    Object.create({
+      "test/text": { base: { base: { color: colour } } },
+    }) as Record<string, NodeStyles>;
+
+  it("emits nothing for a base reachable only through the prototype", () => {
+    const css = resolvePageStyles(
+      doc(),
+      undefined,
+      { ...context(), blockBases: inherited("#abcdef") },
+      blocks,
+      false,
+      {}
+    ).css;
+
+    expect(css).not.toContain("#abcdef");
+  });
+
+  it("CONTROL: emits it when the record owns the entry", () => {
+    // The separating property. A narrowing that dropped every stated base would
+    // satisfy the assertion above while going blind to the ordinary case.
+    const css = resolvePageStyles(
+      doc(),
+      undefined,
+      {
+        ...context(),
+        blockBases: { "test/text": { base: { base: { color: "#abcdef" } } } },
+      },
+      blocks,
+      false,
+      {}
+    ).css;
+
+    expect(css).toContain("#abcdef");
   });
 });

--- a/packages/blocks-react/src/shared-style-inputs.test.ts
+++ b/packages/blocks-react/src/shared-style-inputs.test.ts
@@ -59,12 +59,15 @@ describe("the stamp", () => {
     // can emit may be longer than the walk keeps, or two inputs agreeing to the
     // cut and differing after it stamp alike and compile apart.
     //
-    // Read from the ENGINE'S own list rather than named here. A copy of that
-    // set was written twice as prose and was short by one both times, and a
-    // copy in a test is the same copy with a green tick on it: it would assert
-    // over the members someone remembered while the member they forgot is
-    // exactly the one carrying the defect. Reading the array means a bound
-    // added to the compiler is covered here without this file being touched.
+    // Read from the ENGINE'S own list rather than named here, because a list
+    // restated at the consumer is a copy of the producer's set with nothing
+    // keeping the two in step — and it would assert over the members it names
+    // while the member it omits is the one whose bound nobody has written.
+    // Reading the array means a bound added to the compiler is covered without
+    // this file being edited.
+    //
+    // The length check is the population assertion: an empty set satisfies the
+    // loop below perfectly, so without it this passes by reading nothing.
     expect(EMITTABLE_STRING_BOUNDS.length).toBeGreaterThan(0);
     for (const bound of EMITTABLE_STRING_BOUNDS) {
       expect(bound.max, bound.what).toBeLessThanOrEqual(MAX_VALUE_LENGTH);

--- a/packages/blocks-react/src/shared-style-inputs.test.ts
+++ b/packages/blocks-react/src/shared-style-inputs.test.ts
@@ -16,6 +16,7 @@ import {
   MAX_NAMED_CLASSES,
   MAX_NAMED_CLASS_NAME_LENGTH,
   MAX_SCANNED_KEYS,
+  MAX_VALUE_LENGTH,
 } from "@nextlyhq/blocks-engine";
 
 import {
@@ -659,20 +660,49 @@ describe("what a corrupt or hostile settings row costs", () => {
     );
   });
 
-  it("notices a change DEEP inside an oversized envelope", () => {
-    // The case a truncating bound could not see. These two serialize to the
-    // same length and differ only far past any prefix a cut would keep, while
-    // the compiler emits different CSS for them.
+  it("notices a change DEEP inside a large envelope the compiler still reads", () => {
+    // The case a truncating bound could not see: these differ only far past any
+    // prefix a cut would keep, and the compiler emits different CSS for them.
+    //
+    // Sized UNDER `MAX_VALUE_LENGTH` on purpose, and this fixture was wrong
+    // before — it used 9000 characters, which the engine refuses outright before
+    // parsing, so both variants emitted nothing and the premise in its own
+    // comment was false. A value the compiler will not read cannot demonstrate
+    // sensitivity to a change inside it.
     const big = (tail: string) => ({
       id: "c1",
       slug: "hero",
       orderIndex: 0,
-      styles: { base: { base: { content: "x".repeat(9000) + tail } } },
+      styles: {
+        base: {
+          base: { content: "x".repeat(MAX_VALUE_LENGTH - 100) + tail },
+        },
+      },
     });
 
     expect(
       sharedStyleInputsId(inputs({ namedClasses: [big("aaa")] }))
     ).not.toBe(sharedStyleInputsId(inputs({ namedClasses: [big("bbb")] })));
+  });
+
+  it("holds still for two values the compiler refuses as too long", () => {
+    // The other side of the same bound. Past `MAX_VALUE_LENGTH` the engine
+    // rejects the value before parsing and emits no declaration, so two of them
+    // produce identical CSS — and carrying both in full invalidated a
+    // byte-identical sheet over a suffix nothing reads, with an arbitrarily
+    // large allocation on every cache check.
+    const rejected = (tail: string) => ({
+      id: "c1",
+      slug: "hero",
+      orderIndex: 0,
+      styles: {
+        base: { base: { content: "x".repeat(MAX_VALUE_LENGTH + 1) + tail } },
+      },
+    });
+
+    expect(
+      sharedStyleInputsId(inputs({ namedClasses: [rejected("aaa")] }))
+    ).toBe(sharedStyleInputsId(inputs({ namedClasses: [rejected("bbb")] })));
   });
 
   it("reads no further than the compiler does", () => {

--- a/packages/blocks-react/src/shared-style-inputs.test.ts
+++ b/packages/blocks-react/src/shared-style-inputs.test.ts
@@ -685,10 +685,10 @@ describe("what a corrupt or hostile settings row costs", () => {
     // The case a truncating bound could not see: these differ only far past any
     // prefix a cut would keep, and the compiler emits different CSS for them.
     //
-    // Sized UNDER `MAX_VALUE_LENGTH` on purpose, and this fixture was wrong
-    // before — it used 9000 characters, which the engine refuses outright before
-    // parsing, so both variants emitted nothing and the premise in its own
-    // comment was false. A value the compiler will not read cannot demonstrate
+    // Sized UNDER `MAX_VALUE_LENGTH`, which is what makes the case real: the
+    // engine refuses a longer value outright before parsing, so two variants of
+    // one would both emit nothing and agree for a reason that has nothing to do
+    // with the walk. A value the compiler will not read cannot demonstrate
     // sensitivity to a change inside it.
     const big = (tail: string) => ({
       id: "c1",

--- a/packages/blocks-react/src/shared-style-inputs.test.ts
+++ b/packages/blocks-react/src/shared-style-inputs.test.ts
@@ -13,11 +13,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  MAX_BREAKPOINT_ID_LENGTH,
+  EMITTABLE_STRING_BOUNDS,
   MAX_NAMED_CLASSES,
   MAX_NAMED_CLASS_NAME_LENGTH,
   MAX_SCANNED_KEYS,
-  MAX_TOKEN_NAME_LENGTH,
   MAX_VALUE_LENGTH,
 } from "@nextlyhq/blocks-engine";
 
@@ -60,16 +59,15 @@ describe("the stamp", () => {
     // can emit may be longer than the walk keeps, or two inputs agreeing to the
     // cut and differing after it stamp alike and compile apart.
     //
-    // Asserted between the CONSTANTS rather than by exercising a name of each
-    // length, because the relationship is what has to hold. A test that fed one
-    // oversized string through would pass just as well after someone raised a
-    // bound past `MAX_VALUE_LENGTH`, which is the change that breaks this.
-    for (const bound of [
-      MAX_NAMED_CLASS_NAME_LENGTH,
-      MAX_BREAKPOINT_ID_LENGTH,
-      MAX_TOKEN_NAME_LENGTH,
-    ]) {
-      expect(bound).toBeLessThanOrEqual(MAX_VALUE_LENGTH);
+    // Read from the ENGINE'S own list rather than named here. A copy of that
+    // set was written twice as prose and was short by one both times, and a
+    // copy in a test is the same copy with a green tick on it: it would assert
+    // over the members someone remembered while the member they forgot is
+    // exactly the one carrying the defect. Reading the array means a bound
+    // added to the compiler is covered here without this file being touched.
+    expect(EMITTABLE_STRING_BOUNDS.length).toBeGreaterThan(0);
+    for (const bound of EMITTABLE_STRING_BOUNDS) {
+      expect(bound.max, bound.what).toBeLessThanOrEqual(MAX_VALUE_LENGTH);
     }
   });
 

--- a/packages/blocks-react/src/shared-style-inputs.test.ts
+++ b/packages/blocks-react/src/shared-style-inputs.test.ts
@@ -868,8 +868,16 @@ describe("the label the stamp is taken over", () => {
   });
 
   it("carries its encoding version, so a later change invalidates rather than matches", () => {
-    expect(JSON.parse(sharedStyleInputsLabel(inputs()))[0]).toBe("v1");
-    expect(sharedStyleInputsId(inputs())).toMatch(/^v1:[0-9a-z]+$/);
+    // Pinned to a LITERAL rather than compared against the constant, which is
+    // the point of the test: reading the constant would agree with whatever it
+    // says and assert only that a string was copied. Written out, a bump cannot
+    // happen without someone editing this line and deciding it should.
+    //
+    // Both surfaces, because they can disagree — the label is what the stamp is
+    // taken over, so a version reaching one and not the other would key
+    // artifacts on a value the label never carried.
+    expect(JSON.parse(sharedStyleInputsLabel(inputs()))[0]).toBe("v2");
+    expect(sharedStyleInputsId(inputs())).toMatch(/^v2:[0-9a-z]+$/);
   });
 
   it("omits the label a breakpoint carries", () => {

--- a/packages/blocks-react/src/shared-style-inputs.test.ts
+++ b/packages/blocks-react/src/shared-style-inputs.test.ts
@@ -13,9 +13,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  MAX_BREAKPOINT_ID_LENGTH,
   MAX_NAMED_CLASSES,
   MAX_NAMED_CLASS_NAME_LENGTH,
   MAX_SCANNED_KEYS,
+  MAX_TOKEN_NAME_LENGTH,
   MAX_VALUE_LENGTH,
 } from "@nextlyhq/blocks-engine";
 
@@ -50,6 +52,27 @@ function inputs(over: Partial<SharedStyleInputs> = {}): SharedStyleInputs {
 }
 
 describe("the stamp", () => {
+  it("keeps every emittable string shorter than the length it truncates at", () => {
+    // The walk keeps at most `MAX_VALUE_LENGTH` characters of any string it
+    // reads, and carries no notion of WHERE it is — which is the property that
+    // stops it becoming a second reading of the envelope. Soundness therefore
+    // rests on one relationship rather than on the walk: no string the compiler
+    // can emit may be longer than the walk keeps, or two inputs agreeing to the
+    // cut and differing after it stamp alike and compile apart.
+    //
+    // Asserted between the CONSTANTS rather than by exercising a name of each
+    // length, because the relationship is what has to hold. A test that fed one
+    // oversized string through would pass just as well after someone raised a
+    // bound past `MAX_VALUE_LENGTH`, which is the change that breaks this.
+    for (const bound of [
+      MAX_NAMED_CLASS_NAME_LENGTH,
+      MAX_BREAKPOINT_ID_LENGTH,
+      MAX_TOKEN_NAME_LENGTH,
+    ]) {
+      expect(bound).toBeLessThanOrEqual(MAX_VALUE_LENGTH);
+    }
+  });
+
   it("is stable for the same inputs", () => {
     // Nothing else here means anything if this does not hold: a stamp that
     // varied run to run would recompile every page on every render.

--- a/packages/blocks-react/src/shared-style-inputs.ts
+++ b/packages/blocks-react/src/shared-style-inputs.ts
@@ -258,21 +258,23 @@ function leafText(value: unknown): string {
       // becoming a second reading of the envelope.
       //
       // That is sound only because no string the compiler emits can exceed the
-      // longest one this keeps. It is a claim about the COMPILER, not about the
-      // positions a string is reachable from — stated that way because the
-      // enumerated form of it was wrong: the list of positions read class id
-      // and slug, breakpoint id and token prefix, and omitted the `$token` of a
-      // reference, which `scalarText` writes into a `var()` in full. Until
-      // `MAX_TOKEN_NAME_LENGTH` bounded it, two names agreeing to the truncation
-      // point and differing after stamped alike and compiled differently, and
-      // the stored sheet was reused for the wrong one indefinitely.
+      // longest one this keeps. It is a claim about the COMPILER, and the
+      // engine states it as data: `EMITTABLE_STRING_BOUNDS` lists every bound
+      // on a string it can write, and `shared-style-inputs.test.ts` asserts
+      // each is at or under `MAX_VALUE_LENGTH`.
       //
-      // So the invariant is the general one, and it is about this walk rather
-      // than about the compiler at large: any string reaching HERE must be
-      // bounded at or under `MAX_VALUE_LENGTH`, or the stamp stops
-      // distinguishing two inputs that compile differently. The label's other
-      // fields are carried whole and are not subject to it — an unbounded one
-      // there costs allocation, not correctness.
+      // Read from that list rather than restated here, because the restated
+      // form was wrong TWICE. The first enumeration gave class id and slug,
+      // breakpoint id and token prefix, and missed the `$token` of a reference.
+      // The second, written to repair the first, missed a block type. Both
+      // failures were the same one: a copy of a set, kept beside the prose it
+      // justifies, drifts from the set the moment either moves — and the member
+      // that drifts out is the one carrying the defect, because a member nobody
+      // forgot is a member nobody had to bound.
+      //
+      // The label's other fields are carried whole and are not subject to any
+      // of this. An unbounded string there costs allocation, not correctness,
+      // which is why `TOKEN_PREFIX_RE` being unbounded is not a stamp defect.
       return JSON.stringify(value.slice(0, MAX_VALUE_LENGTH + 1));
     case "number":
     case "boolean":

--- a/packages/blocks-react/src/shared-style-inputs.ts
+++ b/packages/blocks-react/src/shared-style-inputs.ts
@@ -121,8 +121,8 @@ const ENCODING = "v2";
  * The identity of shared inputs that decline to identify themselves.
  *
  * Deliberately not valid digest output: every stamp this module produces is
- * `v1:` followed by hex, and this contains neither, so no stored stamp can
- * equal it. That makes "compiled when the inputs were unknowable" mean
+ * the encoding above followed by `:` and a base-36 digest, and this contains
+ * neither separator nor digest, so no stored stamp can equal it. That makes "compiled when the inputs were unknowable" mean
  * recompile every time.
  *
  * The asymmetry that forces a sentinel rather than absence is the one

--- a/packages/blocks-react/src/shared-style-inputs.ts
+++ b/packages/blocks-react/src/shared-style-inputs.ts
@@ -59,6 +59,7 @@ import {
   MAX_NAMED_CLASSES,
   MAX_NAMED_CLASS_NAME_LENGTH,
   MAX_SCANNED_KEYS,
+  MAX_VALUE_LENGTH,
   breakpointContexts,
   hashId,
   isPlainRecord,
@@ -241,7 +242,23 @@ function leafText(value: unknown): string {
   if (value === null) return "null";
   switch (typeof value) {
     case "string":
-      return JSON.stringify(value);
+      // Bounded where the compiler bounds it. A style value past
+      // `MAX_VALUE_LENGTH` is refused before parsing and emits no declaration,
+      // so two of them produce identical CSS — carrying both in full invalidated
+      // a byte-identical sheet over a suffix nothing reads, and put an
+      // arbitrarily large allocation into every cache check.
+      //
+      // One character past the limit, which is what separates a value AT it —
+      // emitted, and preserved here in full — from one over it. Written as a
+      // slice rather than a branch because `slice` returns the string unchanged
+      // when it is shorter, so the ordinary case pays nothing.
+      //
+      // Applied to every string rather than to declaration values alone: the
+      // walk carries no notion of where it is, and every other string that
+      // reaches it is already bounded more tightly — a class id and slug at
+      // `MAX_NAMED_CLASS_NAME_LENGTH`, a breakpoint id at
+      // `MAX_BREAKPOINT_ID_LENGTH`, the token prefix by `safeTokenPrefix`.
+      return JSON.stringify(value.slice(0, MAX_VALUE_LENGTH + 1));
     case "number":
     case "boolean":
       // `String`, not `JSON.stringify`, which writes `null` for NaN and for both

--- a/packages/blocks-react/src/shared-style-inputs.ts
+++ b/packages/blocks-react/src/shared-style-inputs.ts
@@ -254,10 +254,25 @@ function leafText(value: unknown): string {
       // when it is shorter, so the ordinary case pays nothing.
       //
       // Applied to every string rather than to declaration values alone: the
-      // walk carries no notion of where it is, and every other string that
-      // reaches it is already bounded more tightly — a class id and slug at
-      // `MAX_NAMED_CLASS_NAME_LENGTH`, a breakpoint id at
-      // `MAX_BREAKPOINT_ID_LENGTH`, the token prefix by `safeTokenPrefix`.
+      // walk carries no notion of where it is, which is what keeps it from
+      // becoming a second reading of the envelope.
+      //
+      // That is sound only because no string the compiler emits can exceed the
+      // longest one this keeps. It is a claim about the COMPILER, not about the
+      // positions a string is reachable from — stated that way because the
+      // enumerated form of it was wrong: the list of positions read class id
+      // and slug, breakpoint id and token prefix, and omitted the `$token` of a
+      // reference, which `scalarText` writes into a `var()` in full. Until
+      // `MAX_TOKEN_NAME_LENGTH` bounded it, two names agreeing to the truncation
+      // point and differing after stamped alike and compiled differently, and
+      // the stored sheet was reused for the wrong one indefinitely.
+      //
+      // So the invariant is the general one, and it is about this walk rather
+      // than about the compiler at large: any string reaching HERE must be
+      // bounded at or under `MAX_VALUE_LENGTH`, or the stamp stops
+      // distinguishing two inputs that compile differently. The label's other
+      // fields are carried whole and are not subject to it — an unbounded one
+      // there costs allocation, not correctness.
       return JSON.stringify(value.slice(0, MAX_VALUE_LENGTH + 1));
     case "number":
     case "boolean":

--- a/packages/blocks-react/src/shared-style-inputs.ts
+++ b/packages/blocks-react/src/shared-style-inputs.ts
@@ -96,14 +96,26 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * The encoding this module produces, carried inside every stamp.
+ * The generation of the input-to-CSS mapping this stamp identifies.
  *
- * A later change to what is serialized, or to how, makes old stamps describe a
- * different question — and comparing them would silently reuse artifacts nobody
- * re-judged. Bumping this invalidates them instead, which costs one recompile
- * each and is the safe direction.
+ * A stamp answers "would this compile to the same stylesheet". Two things decide
+ * that answer, and BOTH belong here:
+ *
+ * - what this module serializes, and how. A change makes old stamps describe a
+ *   different question, so comparing them reuses artifacts nobody re-judged.
+ * - what the COMPILER emits from that serialization. A stamp keys on inputs, so
+ *   it cannot see the compiler treating the same inputs differently — a value
+ *   the compiler starts refusing, a rule it stops writing, a selector it spells
+ *   another way. The inputs are unchanged, the stamp matches, and the stored
+ *   sheet is served for a compile that would no longer produce it.
+ *
+ * The second is the one with no other guard: nothing else in an artifact records
+ * which compiler wrote it. So bump this whenever a release changes what the
+ * compiler emits for inputs it already accepted, not only when this file
+ * changes. It costs one recompile per artifact, which is the safe direction —
+ * the unbumped alternative is a stale stylesheet served indefinitely, silently.
  */
-const ENCODING = "v1";
+const ENCODING = "v2";
 
 /**
  * The identity of shared inputs that decline to identify themselves.
@@ -258,23 +270,20 @@ function leafText(value: unknown): string {
       // becoming a second reading of the envelope.
       //
       // That is sound only because no string the compiler emits can exceed the
-      // longest one this keeps. It is a claim about the COMPILER, and the
-      // engine states it as data: `EMITTABLE_STRING_BOUNDS` lists every bound
-      // on a string it can write, and `shared-style-inputs.test.ts` asserts
-      // each is at or under `MAX_VALUE_LENGTH`.
+      // longest one this keeps. It is a claim about the COMPILER rather than
+      // about the positions a string is reachable from, and the engine states it
+      // as data: `EMITTABLE_STRING_BOUNDS` lists every bound on a string it can
+      // write, and `shared-style-inputs.test.ts` asserts each is at or under
+      // `MAX_VALUE_LENGTH`.
       //
-      // Read from that list rather than restated here, because the restated
-      // form was wrong TWICE. The first enumeration gave class id and slug,
-      // breakpoint id and token prefix, and missed the `$token` of a reference.
-      // The second, written to repair the first, missed a block type. Both
-      // failures were the same one: a copy of a set, kept beside the prose it
-      // justifies, drifts from the set the moment either moves — and the member
-      // that drifts out is the one carrying the defect, because a member nobody
-      // forgot is a member nobody had to bound.
+      // Read from that list rather than named here, so a bound added to the
+      // compiler is covered without this file or its test being edited. A list
+      // restated at the consumer is a copy of the producer's set with nothing
+      // keeping the two in step.
       //
-      // The label's other fields are carried whole and are not subject to any
-      // of this. An unbounded string there costs allocation, not correctness,
-      // which is why `TOKEN_PREFIX_RE` being unbounded is not a stamp defect.
+      // The label's other fields are carried whole and are subject to none of
+      // this: an unbounded string there costs allocation, not correctness,
+      // because it is never truncated and so can never make two inputs agree.
       return JSON.stringify(value.slice(0, MAX_VALUE_LENGTH + 1));
     case "number":
     case "boolean":

--- a/packages/blocks-react/src/styles.test.ts
+++ b/packages/blocks-react/src/styles.test.ts
@@ -14,9 +14,10 @@
 import { describe, expect, it } from "vitest";
 
 import type { BlockDocument, BlockNode } from "@nextlyhq/blocks-engine";
+import { compilePageCss } from "@nextlyhq/blocks-engine";
 
 import { createBlockResolver } from "./resolver";
-import { resolvePageStyles, type PageStyles } from "./styles";
+import { resolvePageStyles, toPageStyles, type PageStyles } from "./styles";
 
 const blocks = createBlockResolver([]);
 
@@ -193,5 +194,55 @@ describe("a stored artifact carrying gated rules", () => {
 
     expect(styles.css).toBe("");
     expect(styles.css).not.toContain("rebeccapurple");
+  });
+});
+
+describe("the scope an artifact records", () => {
+  // Declared here rather than imported: the engine's own fixture is internal to
+  // that package, and this file only needs one axis with a base.
+  const BREAKPOINTS = {
+    viewport: [{ id: "base", label: "Base" }],
+    container: [],
+  };
+
+  // A scope keeps two documents rendered into one DOM apart, and the renderer
+  // attaches whatever the artifact names. So an artifact recording a scope the
+  // COMPILER refused claims an isolation its own selectors do not carry, and
+  // the rules reach whatever else is on the page — which is the collision
+  // scoping exists to prevent, arriving with a scope class visibly present.
+  const doc = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      {
+        id: "n1",
+        type: "core/box",
+        version: 1,
+        props: {},
+        styles: { base: { base: { color: "#111" } } },
+      },
+    ],
+  } as BlockDocument;
+
+  it("records nothing when the compiler refused the scope", () => {
+    // Whitespace is refused by shape rather than by length, so this holds
+    // whatever the length bound is.
+    const compiled = compilePageCss(doc, {
+      breakpoints: BREAKPOINTS,
+      scope: "two words",
+    });
+    expect(compiled.css).not.toContain("two words");
+    expect(toPageStyles(compiled, "two words").scope).toBeUndefined();
+  });
+
+  it("records the scope when the compiler wrote it", () => {
+    // The control. Without it, dropping every scope would satisfy the case
+    // above and silently unscope every page in the product.
+    const compiled = compilePageCss(doc, {
+      breakpoints: BREAKPOINTS,
+      scope: "nx-doc-1",
+    });
+    expect(compiled.css).toContain("nx-doc-1");
+    expect(toPageStyles(compiled, "nx-doc-1").scope).toBe("nx-doc-1");
   });
 });

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -168,7 +168,17 @@ export function blockBasesFor(
     const baseStyles =
       stated === undefined
         ? blocks.get(node.type)?.baseStyles
-        : stated[node.type];
+        : // OWN properties only, because that is the boundary `compilePageCss`
+          // draws: it emits a base for a used type only when
+          // `Object.hasOwn(bases, type)` succeeds. A record reached through
+          // `Object.create` or a polluted prototype answers this lookup with an
+          // inherited value, and copying it here would make it an own property
+          // of the narrowed record — turning data the compiler deliberately
+          // ignores into a rule it emits, against a selector built from the node
+          // type.
+          Object.hasOwn(stated, node.type)
+          ? stated[node.type]
+          : undefined;
     if (baseStyles !== undefined) bases[node.type] = baseStyles;
   });
   return bases;

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -132,7 +132,17 @@ export function toPageStyles(
     compiled.gated === undefined
       ? styles
       : { ...styles, gated: compiled.gated };
-  return scope === undefined ? withGated : { ...withGated, scope };
+  // The scope the compiler WROTE, not the one the caller asked for. A scope the
+  // compiler cannot write is dropped and the sheet compiled global, so recording
+  // the request stores an artifact claiming an isolation its own selectors do
+  // not carry — and the renderer attaches that class, which is how one
+  // document's rules reach another rendered beside it.
+  //
+  // The parameter is no longer read for this: a caller cannot know whether the
+  // compiler accepted its scope, and only the compiler does.
+  return compiled.scope === undefined
+    ? withGated
+    : { ...withGated, scope: compiled.scope };
 }
 
 /**

--- a/packages/builder/src/tokens-studio.test.ts
+++ b/packages/builder/src/tokens-studio.test.ts
@@ -438,3 +438,30 @@ describe("a row key that survives a removal elsewhere in the list", () => {
     );
   });
 });
+
+describe("two names that land on one custom property", () => {
+  // The name-to-property mapping is deliberately not injective: a dot and a
+  // dash both become a dash. So two visibly different, individually legal names
+  // can be written under one property, and the compiler drops whichever it
+  // reaches second — leaving a token the author can see in the table and cannot
+  // find on the page.
+  const pair = {
+    tokens: [
+      {
+        name: "color.primary-dark",
+        kind: "color",
+        values: { light: "#111111" },
+      },
+    ],
+  } as SiteTokenSet;
+
+  it("refuses the spelling that collides, though the names differ", () => {
+    expect(tokenNameIssue(pair, 1, "color-primary.dark")).toBeDefined();
+  });
+
+  it("accepts a spelling that lands somewhere else", () => {
+    // The control. A gate refusing every name would satisfy the case above and
+    // make the studio unusable.
+    expect(tokenNameIssue(pair, 1, "color.primary-light")).toBeUndefined();
+  });
+});

--- a/packages/builder/src/tokens-studio.test.ts
+++ b/packages/builder/src/tokens-studio.test.ts
@@ -459,6 +459,24 @@ describe("two names that land on one custom property", () => {
     expect(tokenNameIssue(pair, 1, "color-primary.dark")).toBeDefined();
   });
 
+  it("refuses a NEW row claiming an identity another row has frozen", () => {
+    // A renamed token keeps its old name as its identity under a new label, so
+    // that name is taken even though no row READS under it any more. Suppressing
+    // the clash whenever identities match would let the new row claim it, and
+    // the compiler writes the older token and drops this one.
+    const frozen = {
+      tokens: [
+        {
+          id: "color.primary",
+          name: "color.brand",
+          kind: "color",
+          values: { light: "#111111" },
+        },
+      ],
+    } as SiteTokenSet;
+    expect(tokenNameIssue(frozen, 1, "color.primary")).toBeDefined();
+  });
+
   it("accepts a spelling that lands somewhere else", () => {
     // The control. A gate refusing every name would satisfy the case above and
     // make the studio unusable.

--- a/packages/builder/src/tokens-studio.ts
+++ b/packages/builder/src/tokens-studio.ts
@@ -297,11 +297,19 @@ export function tokenNameIssue(
     token.id ?? token.name;
   const claimedIdentity = identityOf(proposed);
   const claimed = tokenCustomProperty(claimedIdentity, "");
+  // Whether this row ALREADY shared its identity with another before the edit.
+  // That is a repair in progress — reporting it leaves the row unfixable
+  // whatever the author types — and it is a property of the row, not of the
+  // name being proposed. Deciding it from the PROPOSED identity instead
+  // suppresses the error whenever an edit newly claims another row's identity,
+  // which is the collision this check exists for.
+  const wasAlreadyTwinned =
+    existing !== undefined &&
+    others.some(token => identityOf(token) === identityOf(existing));
+
   const clash = others.find(token => {
-    // A row sharing this row's identity is the same token twice — a repair the
-    // author is in the middle of rather than a name they may not take. Report
-    // it and that row is unfixable whatever they type.
-    if (identityOf(token) === claimedIdentity) return false;
+    if (wasAlreadyTwinned && identityOf(token) === claimedIdentity)
+      return false;
     return tokenCustomProperty(identityOf(token), "") === claimed;
   });
   return clash === undefined

--- a/packages/builder/src/tokens-studio.ts
+++ b/packages/builder/src/tokens-studio.ts
@@ -39,6 +39,7 @@
 import {
   TOKEN_KINDS,
   emitTokenBlocks,
+  MAX_TOKEN_NAME_LENGTH,
   MAX_TOKEN_NAME_SEGMENTS,
   tokenNamingProblem,
   renameSiteToken,
@@ -256,12 +257,26 @@ export function tokenNameIssue(
   // label is not what the token is written under and the engine accepts it at
   // every gate. Refusing it here would be the editor forbidding what the engine
   // supports, which reads to an author as a rule nobody can find.
-  const problem = tokenNamingProblem({ name: trimmed });
+  // Asked of the token the rename would PRODUCE, not of the label alone. A
+  // rename keeps a working identity pinned, so a long label is fine — but where
+  // the current identity is one the engine cannot write, the rename re-pins to
+  // this label and it becomes the identity, which the emission cap does reach.
+  // Validating the label alone accepts an edit that still leaves the token
+  // dropped from CSS, which is the repair appearing to succeed and not.
+  const existing = tokens?.tokens?.[at];
+  const proposed =
+    existing === undefined
+      ? { name: trimmed }
+      : renameSiteToken(existing, trimmed);
+  const problem = tokenNamingProblem(proposed);
   if (problem?.reason === "grammar") {
     return 'A name is dot-separated words of letters, digits and dashes, like "color.primary".';
   }
   if (problem?.reason === "depth") {
     return `A name holds at most ${MAX_TOKEN_NAME_SEGMENTS} dot-separated parts.`;
+  }
+  if (problem?.reason === "length") {
+    return `A name is at most ${MAX_TOKEN_NAME_LENGTH} characters when it is what the token is written under.`;
   }
   const taken = (tokens?.tokens ?? []).some(
     (token, index) => index !== at && token.name === trimmed

--- a/packages/builder/src/tokens-studio.ts
+++ b/packages/builder/src/tokens-studio.ts
@@ -252,11 +252,6 @@ export function tokenNameIssue(
 ): string | undefined {
   const trimmed = name.trim();
   if (trimmed === "") return "A token needs a name.";
-  // The grammar, and the depth that keeps a name round-trippable — but NOT the
-  // emission cap. Renaming pins the previous name as the token's id, so the new
-  // label is not what the token is written under and the engine accepts it at
-  // every gate. Refusing it here would be the editor forbidding what the engine
-  // supports, which reads to an author as a rule nobody can find.
   // Asked of the token the rename would PRODUCE, not of the label alone. A
   // rename keeps a working identity pinned, so a long label is fine — but where
   // the current identity is one the engine cannot write, the rename re-pins to
@@ -278,10 +273,40 @@ export function tokenNameIssue(
   if (problem?.reason === "length") {
     return `A name is at most ${MAX_TOKEN_NAME_LENGTH} characters when it is what the token is written under.`;
   }
-  const taken = (tokens?.tokens ?? []).some(
-    (token, index) => index !== at && token.name === trimmed
-  );
-  return taken ? `Another token is already called "${trimmed}".` : undefined;
+  // Compared by the custom property each token is WRITTEN under, not by the
+  // name an author reads. The mapping is deliberately not injective — a dot and
+  // a dash both become a dash — so `color.primary-dark` and `color-primary.dark`
+  // are two legal names that land on one property, and the engine drops
+  // whichever it reaches second. A check on raw names accepts that edit and
+  // leaves a token silently unwritten.
+  const others = (tokens?.tokens ?? []).filter((_, index) => index !== at);
+
+  // Two questions, and neither answers the other. This one is what an author
+  // reads: two tokens answering to one name is a table nobody can use, whatever
+  // each is written under.
+  if (others.some(token => token.name === trimmed)) {
+    return `Another token is already called "${trimmed}".`;
+  }
+
+  // And this one is what the engine writes. The name-to-property mapping is
+  // deliberately not injective — a dot and a dash both become a dash — so
+  // `color.primary-dark` and `color-primary.dark` are two legal, visibly
+  // different names landing on one custom property, and the compiler drops
+  // whichever it reaches second. The name check above cannot see that.
+  const identityOf = (token: { name: string; id?: string }) =>
+    token.id ?? token.name;
+  const claimedIdentity = identityOf(proposed);
+  const claimed = tokenCustomProperty(claimedIdentity, "");
+  const clash = others.find(token => {
+    // A row sharing this row's identity is the same token twice — a repair the
+    // author is in the middle of rather than a name they may not take. Report
+    // it and that row is unfixable whatever they type.
+    if (identityOf(token) === claimedIdentity) return false;
+    return tokenCustomProperty(identityOf(token), "") === claimed;
+  });
+  return clash === undefined
+    ? undefined
+    : `"${trimmed}" is written under the same custom property as "${clash.name}".`;
 }
 
 /** Replace one token in the set, leaving every other entry untouched. */

--- a/packages/builder/src/tokens-studio.ts
+++ b/packages/builder/src/tokens-studio.ts
@@ -39,7 +39,8 @@
 import {
   TOKEN_KINDS,
   emitTokenBlocks,
-  isTokenName,
+  MAX_TOKEN_NAME_SEGMENTS,
+  tokenNamingProblem,
   renameSiteToken,
   tokenCustomProperty,
   tokenIdentity,
@@ -238,7 +239,7 @@ function collisionFor(
 /**
  * Why this name cannot be used, or `undefined`.
  *
- * The GRAMMAR is the engine's `isTokenName`, which is the same rule a stored
+ * The GRAMMAR is the engine's own rule, which is the same one a stored
  * `$token` reference is held to — so a table cannot hold a name that no
  * reference could spell. Checked before the edit rather than after, because the
  * emitter's answer to a bad name is to drop the token silently.
@@ -250,8 +251,17 @@ export function tokenNameIssue(
 ): string | undefined {
   const trimmed = name.trim();
   if (trimmed === "") return "A token needs a name.";
-  if (!isTokenName(trimmed)) {
+  // The grammar, and the depth that keeps a name round-trippable — but NOT the
+  // emission cap. Renaming pins the previous name as the token's id, so the new
+  // label is not what the token is written under and the engine accepts it at
+  // every gate. Refusing it here would be the editor forbidding what the engine
+  // supports, which reads to an author as a rule nobody can find.
+  const problem = tokenNamingProblem({ name: trimmed });
+  if (problem?.reason === "grammar") {
     return 'A name is dot-separated words of letters, digits and dashes, like "color.primary".';
+  }
+  if (problem?.reason === "depth") {
+    return `A name holds at most ${MAX_TOKEN_NAME_SEGMENTS} dot-separated parts.`;
   }
   const taken = (tokens?.tokens ?? []).some(
     (token, index) => index !== at && token.name === trimmed

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest-engine-parity.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest-engine-parity.test.ts
@@ -26,13 +26,16 @@ import {
   clearBlocks,
   COMPONENT_INSTANCE_TYPE,
   registerBlocks,
+  MAX_BLOCK_TYPE_LENGTH,
   MAX_BLOCK_VERSION,
 } from "@nextlyhq/blocks-engine";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { definePlugin, type PluginDefinition } from "../../plugin-context";
 import {
+  blockManifestJsonSchema,
   buildBlockManifest,
+  MAX_DECLARED_BLOCK_NAME_LENGTH,
   MAX_DECLARED_BLOCK_VERSION,
   PAGE_BUILDER_PLUGIN,
 } from "../block-manifest";
@@ -44,6 +47,130 @@ afterEach(() => {
 describe("the manifest's block-version bound", () => {
   it("is the bound the engine enforces at registration", () => {
     expect(MAX_DECLARED_BLOCK_VERSION).toBe(MAX_BLOCK_VERSION);
+  });
+});
+
+describe("the manifest's block-name bound", () => {
+  it("is the bound the engine enforces at registration", () => {
+    // The value is restated in this package rather than imported, so nothing but
+    // this holds the two equal. Comparing the numbers is the weaker half; the
+    // pair below exercises both sides on one input, which is what catches the
+    // two agreeing on a length while disagreeing on where it applies.
+    expect(MAX_DECLARED_BLOCK_NAME_LENGTH).toBe(MAX_BLOCK_TYPE_LENGTH);
+  });
+
+  const named = (name: string) => ({
+    name,
+    version: 1,
+    description: "A block.",
+    example: { props: {} },
+    render: () => null,
+  });
+
+  const atCap = `acme/${"a".repeat(MAX_DECLARED_BLOCK_NAME_LENGTH - "acme/".length)}`;
+  const overCap = `acme/${"a".repeat(MAX_DECLARED_BLOCK_NAME_LENGTH - "acme/".length + 1)}`;
+
+  it("straddles the cap, so the pair below means what it says", () => {
+    expect(atCap).toHaveLength(MAX_DECLARED_BLOCK_NAME_LENGTH);
+    expect(overCap).toHaveLength(MAX_DECLARED_BLOCK_NAME_LENGTH + 1);
+  });
+
+  it("both accept a name at the cap", () => {
+    // The positive control on BOTH sides. Without it a pair that refused every
+    // name would agree perfectly and satisfy the refusal check below.
+    expect(() =>
+      registerBlocks([named(atCap)] as never, { source: "acme" })
+    ).not.toThrow();
+    clearBlocks();
+    const manifest = buildBlockManifest([
+      consumer(),
+      declaring([named(atCap)]),
+    ]);
+    expect(manifest.blocks[0]?.name).toBe(atCap);
+  });
+
+  it("publishes the cap in the JSON Schema, not only inside this package", () => {
+    // The schema is handed to outside readers, and a bound enforced here but
+    // absent from it leaves the published contract weaker than the one this
+    // package applies: anyone validating a manifest against the artifact we give
+    // them would accept a name we refuse.
+    //
+    // Covered separately from the refusal below because the two are enforced by
+    // different mechanisms on one call — the schema and an imperative gate — so
+    // a single "does it throw" assertion is satisfied by either and cannot see
+    // one of them go.
+    // Read at the PATHS the bound applies to, not anywhere in the document.
+    // Three fields carry a block name, so searching the serialized schema for
+    // the number is satisfied by any one of them still having it — the check
+    // passes with the bound removed from the other two.
+    const schema = blockManifestJsonSchema();
+    const at = (path: readonly string[]): unknown =>
+      path.reduce<unknown>(
+        (node, key) =>
+          node && typeof node === "object"
+            ? (node as Record<string, unknown>)[key]
+            : undefined,
+        schema
+      );
+
+    const carriers = [
+      ["properties", "blocks", "items", "properties", "name"],
+      ["properties", "blocks", "items", "properties", "parent", "items"],
+      [
+        "properties",
+        "blocks",
+        "items",
+        "properties",
+        "slots",
+        "additionalProperties",
+        "properties",
+        "allow",
+        "items",
+      ],
+    ] as const;
+
+    for (const path of carriers) {
+      expect(at(path), path.join(".")).toMatchObject({
+        maxLength: MAX_DECLARED_BLOCK_NAME_LENGTH,
+      });
+    }
+  });
+
+  it("names the cap when it refuses, so the message is actionable", () => {
+    // The declaration gate's own contribution. The schema refuses this name too,
+    // so a throw alone cannot show which ran — and the two produce different
+    // errors, so the DETAIL is the discriminator as well as the half a plugin
+    // author reads.
+    //
+    // Read from `errors[0]`, not from `.message`: a validation error's top-level
+    // message is the generic "Validation failed." for every instance, so an
+    // assertion against it passes for any validation failure whatsoever.
+    let detail: { code?: string; message?: string } | undefined;
+    try {
+      buildBlockManifest([consumer(), declaring([named(overCap)])]);
+    } catch (error) {
+      detail = (
+        error as {
+          publicData?: { errors?: { code?: string; message?: string }[] };
+        }
+      ).publicData?.errors?.[0];
+    }
+    expect(detail?.code).toBe("INVALID_BLOCK_DECLARATION");
+    expect(detail?.message).toContain(String(MAX_DECLARED_BLOCK_NAME_LENGTH));
+    expect(detail?.message).toContain(overCap);
+  });
+
+  it("neither accepts a name past it, so generation cannot run ahead of boot", () => {
+    // The failure that matters: `nextly generate` succeeding for a declaration
+    // `registerBlocks` refuses leaves a manifest describing a plugin that cannot
+    // start, which is the opposite of what the artifact is for.
+    expect(() =>
+      registerBlocks([named(overCap)] as never, { source: "acme" })
+    ).toThrow();
+    clearBlocks();
+    expect(() =>
+      buildBlockManifest([consumer(), declaring([named(overCap)])])
+    ).toThrow();
   });
 });
 

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest-schema.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest-schema.test.ts
@@ -392,11 +392,13 @@ describe("the published JSON Schema", () => {
                   "type": "object",
                 },
                 "name": {
+                  "maxLength": 128,
                   "pattern": "^(?!(?:nextly\\/component-instance)$)[a-z0-9]+(?:-[a-z0-9]+)*\\/[a-z0-9]+(?:-[a-z0-9]+)*$",
                   "type": "string",
                 },
                 "parent": {
                   "items": {
+                    "maxLength": 128,
                     "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*\\/[a-z0-9]+(?:-[a-z0-9]+)*$",
                     "type": "string",
                   },
@@ -416,6 +418,7 @@ describe("the published JSON Schema", () => {
                     "properties": {
                       "allow": {
                         "items": {
+                          "maxLength": 128,
                           "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*\\/(?:[a-z0-9]+(?:-[a-z0-9]+)*|\\*)$",
                           "type": "string",
                         },

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -92,6 +92,21 @@ const ALLOW_ENTRY_RE = new RegExp(
 export const MAX_DECLARED_BLOCK_VERSION = 1001;
 
 /**
+ * The longest block name a declaration may carry.
+ *
+ * The patterns below constrain the alphabet and not the length, so a name of
+ * megabytes of otherwise-valid characters satisfies them, is scanned in full on
+ * every generation, and is written into the manifest and its JSON Schema.
+ *
+ * Restated rather than imported for the reason {@link MAX_DECLARED_BLOCK_VERSION}
+ * is, and held to the engine's value by the same parity test. Without it
+ * `nextly generate` accepts a declaration that `registerBlocks` refuses at boot,
+ * which is the divergence an artifact describing what a plugin declared exists
+ * to prevent.
+ */
+export const MAX_DECLARED_BLOCK_NAME_LENGTH = 128;
+
+/**
  * Names the engine keeps for itself. A document node of this type is a
  * component instance rather than a block, so a block answering to it would
  * shadow the one type the renderer resolves without the registry.
@@ -170,7 +185,10 @@ export const blockManifestEntrySchema = z
      * published JSON Schema states it too, rather than leaving an outside
      * reader to discover it by having a manifest rejected somewhere else.
      */
-    name: z.string().regex(DECLARABLE_BLOCK_NAME_PATTERN),
+    name: z
+      .string()
+      .max(MAX_DECLARED_BLOCK_NAME_LENGTH)
+      .regex(DECLARABLE_BLOCK_NAME_PATTERN),
     /**
      * The block's own schema version, stamped onto every node of its type.
      *
@@ -226,7 +244,14 @@ export const blockManifestEntrySchema = z
         z.string(),
         z
           .object({
-            allow: z.array(z.string().regex(ALLOW_ENTRY_RE)).optional(),
+            allow: z
+              .array(
+                z
+                  .string()
+                  .max(MAX_DECLARED_BLOCK_NAME_LENGTH)
+                  .regex(ALLOW_ENTRY_RE)
+              )
+              .optional(),
           })
           .loose()
       )
@@ -239,7 +264,12 @@ export const blockManifestEntrySchema = z
      * where a block may be placed. A malformed value here does not degrade, it forbids, so the
      * shape is pinned at the boundary rather than trusted from whoever wrote the file.
      */
-    parent: z.array(z.string().regex(BLOCK_NAME_RE)).min(1).optional(),
+    parent: z
+      .array(
+        z.string().max(MAX_DECLARED_BLOCK_NAME_LENGTH).regex(BLOCK_NAME_RE)
+      )
+      .min(1)
+      .optional(),
   })
   .strict();
 
@@ -533,9 +563,12 @@ function declaredBlocks(value: unknown, source: string): DeclaredBlock[] {
         `Plugin "${source}" declared a block at index ${index} with no name.`
       );
     }
-    if (!BLOCK_NAME_PATTERN.test(definition.name)) {
+    if (
+      definition.name.length > MAX_DECLARED_BLOCK_NAME_LENGTH ||
+      !BLOCK_NAME_PATTERN.test(definition.name)
+    ) {
       throw invalidDeclaration(
-        `Plugin "${source}" declared a block named "${definition.name}" at index ${index}; a block name is a namespaced slug like "core/heading".`
+        `Plugin "${source}" declared a block named "${definition.name}" at index ${index}; a block name is a namespaced slug like "core/heading", at most ${MAX_DECLARED_BLOCK_NAME_LENGTH} characters.`
       );
     }
     if (RESERVED_BLOCK_NAMES.includes(definition.name)) {


### PR DESCRIPTION
Recovers the last commit of #1144, which did not land: the merge was computed from the previous head, so `d97f94b39` stayed on the branch. The narrowing it corrects **did** merge, which is why the first item below is a live defect on `main` rather than a refinement.

Confirmed by content rather than by ancestry, since a squash merge makes every ancestry check unsound:

```
merge 8115473dd — control: both paths resolve, search finds other text in them
  round 11  breakpointContexts(breakpoints).map(...)      PRESENT
  round 12  Object.hasOwn(stated, node.type)              ABSENT
  round 12  value.slice(0, MAX_VALUE_LENGTH + 1)          ABSENT
merge has instead:  : stated[node.type];
                    return JSON.stringify(value);
```

## An inherited block base becomes an emitted rule

`compilePageCss` emits a block type's defaults only when `Object.hasOwn(bases, type)` succeeds, and the comment beneath that check says why the boundary sits there: a node type reaches a SELECTOR, and the compiler reads persisted data whether or not anything validated it.

Narrowing a stated `blockBases` record to the types a page draws copied whatever the lookup answered. A record reached through `Object.create`, or one whose prototype had been polluted, had its inherited entry made an OWN property of the narrowed record — and the compiler then emitted a rule it had deliberately declined to emit.

Deriving a view means inheriting responsibility for every property of the thing it was derived from. The un-narrowed path could not cross this boundary, because it handed the compiler the caller's own object and let `hasOwn` do its job.

## A rejected style value is read no further than the compiler reads it

`css-value.ts:1172` refuses a value past `MAX_VALUE_LENGTH` before parsing and emits no declaration, so two of them compile identically. The stamp carried both in full, which invalidated a byte-identical stored sheet over a suffix nothing reads and put an arbitrarily large allocation into every cache check.

Bounded one character past the limit — what separates a value AT it, emitted and preserved whole, from one over it — and written as a slice rather than a branch, so the ordinary case pays nothing. `MAX_VALUE_LENGTH` is exported and joins the set `document.test.ts` pins.

## One test corrected rather than adapted

`notices a change DEEP inside an oversized envelope` used a 9000-character value, chosen to exceed a 4096-character truncation it was guarding. 9000 is past what the engine reads, so both variants emitted nothing and the sentence in its own comment — "while the compiler emits different CSS for them" — was never true. It now sits under the limit, with a companion asserting the other side: two values the compiler refuses stamp alike.

## Verification

Both fixes break-verified against this base, not only against the one they were written on:

```
emits nothing for a base reachable only through the prototype   FAILED on the bare lookup
CONTROL: emits it when the record owns the entry                passed
holds still for two values the compiler refuses as too long     FAILED on the raw string
```

1335 blocks-engine · 761 blocks-react · 178 plugin-page-builder · 1379 builder. Gates read individually: build, check-types, lint, root eslint, comment convention, and `fallow audit` with every `*_introduced` at 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent validation and published limits for block names, page scopes, style values, token names, prefixes, and related CSS-emitted strings.
  - Added clearer diagnostics for invalid or oversized token names, IDs, prefixes, font formats, and block declarations.
  - Added a public reference of supported CSS string length limits.

- **Bug Fixes**
  - Prevented inherited style definitions and invalid scopes from appearing in generated page styles.
  - Improved token import, export, renaming, and identity handling for long or deeply nested names.
  - Ensured generated manifests and runtime registration enforce matching block-name rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->