### PR TITLE
fix(builder): stop scaling a margin the block's own transform never moved

### DIFF
--- a/.changeset/spacing-overlay-self-transform-margins.md
+++ b/.changeset/spacing-overlay-self-transform-margins.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Drop the spacing overlay's margin bands for a block that carries its own transform. A transform does not affect layout, so a transformed block's margin is not beside its rendered border edge and no scale factor puts it there. Padding is unaffected and still drawn.

--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -1015,6 +1015,84 @@ test.describe("spacing values on the canvas", () => {
     await expect(page.locator(band("padding", "bottom"))).toHaveCount(1);
   });
 
+  test("keeps every margin band under an IDENTITY-valued transform", async ({
+    page,
+  }) => {
+    /*
+     * `scale(1)`, `translate(0)`, `translateY(0)` and `rotate(360deg)` all
+     * compute to a non-`none` transform and all serialize to exactly
+     * `matrix(1, 0, 0, 1, 0, 0)`. They move nothing — measured, the gap to the
+     * next sibling is the authored 20px on both axes for each of them.
+     *
+     * They are also the RESTING STATE of every hover animation, so a check that
+     * read the presence of a declaration rather than its effect would blank the
+     * margins of a large share of real pages. That is the separating case
+     * between the two implementations and the reason this test exists.
+     */
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(block).toBeVisible();
+    await block.click();
+    await expect(page.locator(band("margin", "bottom"))).toHaveCount(1);
+
+    for (const transform of [
+      "scale(1)",
+      "translate(0)",
+      "translateY(0)",
+      "rotate(360deg)",
+    ]) {
+      await block.evaluate((node, value) => {
+        (node as HTMLElement).style.transform = value;
+      }, transform);
+      await page.locator('[data-nx-node="hx-heading"]').evaluate(node => {
+        const el = node as HTMLElement;
+        el.style.height = `${el.getBoundingClientRect().height + 8}px`;
+      });
+      await expect(page.locator(band("margin", "bottom"))).toHaveCount(1);
+      await expect(page.locator(band("margin", "bottom"))).toHaveText(
+        String(MARGIN_BOTTOM)
+      );
+    }
+  });
+
+  test("drops the margin only on the AXIS its own transform moves", async ({
+    page,
+  }) => {
+    /*
+     * The axes are independent, and a lift like `translateY(-4px)` is an
+     * ordinary hover state: measured, `translateY` leaves the horizontal gap at
+     * the authored 20px while making the vertical one −20, and `translateX`
+     * does the reverse. Refusing both axes because one moved would throw away
+     * bands that are exactly right.
+     *
+     * The horizontal margin is authored here because the seed carries only a
+     * block-end one, and a fixture with nothing on the surviving axis would pass
+     * against an implementation that dropped everything.
+     */
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(block).toBeVisible();
+    await block.evaluate(node => {
+      (node as HTMLElement).style.marginRight = "32px";
+    });
+    await block.click();
+
+    // CONTROL: both axes draw before the transform.
+    await expect(page.locator(band("margin", "bottom"))).toHaveCount(1);
+    await expect(page.locator(band("margin", "right"))).toHaveCount(1);
+
+    await block.evaluate(node => {
+      (node as HTMLElement).style.transform = "translateY(40px)";
+    });
+    await page.locator('[data-nx-node="hx-heading"]').evaluate(node => {
+      const el = node as HTMLElement;
+      el.style.height = `${el.getBoundingClientRect().height + 40}px`;
+    });
+
+    await expect(page.locator(band("margin", "bottom"))).toHaveCount(0);
+    await expect(page.locator(band("margin", "right"))).toHaveCount(1);
+  });
+
   test("the bands take no pointer events, so a covered block stays clickable", async ({
     page,
   }) => {

--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -902,6 +902,11 @@ test.describe("spacing values on the canvas", () => {
      * counter-rotated block still draws while the ancestor merely rotates, so
      * the emptiness afterwards is the CLIP being declined and not the rotation
      * being refused by the guard that was already there.
+     *
+     * The block is given PADDING for that control, not a margin. It carries its
+     * own transform here, and a transformed block's margin bands are declined
+     * for a different reason entirely — so a margin-only fixture would empty at
+     * the control and prove nothing about the clip.
      */
     await page.goto(ROUTE);
     const target = page.locator('[data-nx-node="hx-nested-text"]');
@@ -915,7 +920,7 @@ test.describe("spacing values on the canvas", () => {
       const text = document.querySelector(
         '[data-nx-node="hx-nested-text"]'
       ) as HTMLElement;
-      text.style.marginBottom = "24px";
+      text.style.padding = "6px";
       section.style.position = "relative";
       section.style.width = "200px";
       section.style.height = "200px";
@@ -966,6 +971,48 @@ test.describe("spacing values on the canvas", () => {
     });
 
     await expect(page.locator(BAND)).toHaveCount(0);
+  });
+
+  test("drops the MARGIN bands for a block carrying its own transform, and keeps padding", async ({
+    page,
+  }) => {
+    /*
+     * A transform does not affect layout, so the margin of a transformed block
+     * is not beside its rendered border edge — and no scale factor moves it
+     * there. Measured on a 100px block with `margin-bottom: 20px`: the gap to
+     * the next sibling is 70px under `scale(0.5)`, and NEGATIVE eighty under
+     * `scale(2)`, where the block is drawn over the neighbour its margin is
+     * holding away.
+     *
+     * PADDING is the control, and it is the reason this is not a whole-element
+     * refusal: padding lies inside the transform and renders scaled with the
+     * box, so those bands stay correct and must still be drawn. A fix that
+     * refused the block outright would pass the margin assertion and fail here.
+     */
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(block).toBeVisible();
+    await block.click();
+
+    // CONTROL: both boxes are drawn before the transform.
+    await expect(page.locator(band("margin", "bottom"))).toHaveCount(1);
+    await expect(page.locator(band("padding", "bottom"))).toHaveCount(1);
+
+    await block.evaluate(node => {
+      const el = node as HTMLElement;
+      el.style.transformOrigin = "0 0";
+      el.style.transform = "scale(0.5)";
+    });
+
+    // A transform changes no layout size, so it emits no resize of its own;
+    // growing a sibling forces the re-measure, as the refusal tests do.
+    await page.locator('[data-nx-node="hx-heading"]').evaluate(node => {
+      const el = node as HTMLElement;
+      el.style.height = `${el.getBoundingClientRect().height + 40}px`;
+    });
+
+    await expect(page.locator(`${BAND}[data-box="margin"]`)).toHaveCount(0);
+    await expect(page.locator(band("padding", "bottom"))).toHaveCount(1);
   });
 
   test("the bands take no pointer events, so a covered block stays clickable", async ({

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -217,38 +217,55 @@ export interface RenderedScale {
   /** False for a rotation, a skew, a reflection, or a collapse to zero. */
   readonly describable: boolean;
   /**
-   * Whether the ELEMENT ITSELF carries a transform, as opposed to inheriting one.
+   * The axes the element's OWN transform moves or rescales, if any.
    *
-   * Separated because the two do opposite things to a margin. **A transform does
-   * not affect layout.** An ancestor's transform scales the whole subtree it
-   * lays out, gaps included, so a margin inside it really does render smaller.
-   * The element's OWN transform moves only its rendering: the space its margin
-   * reserves stays where the untransformed box put it.
+   * Separated from the composed scale because the two do OPPOSITE things to a
+   * margin. **A transform does not affect layout.** An ancestor's transform
+   * scales the whole subtree it lays out, gaps included, so a margin inside one
+   * really does render smaller and `x`/`y` above are right to apply. The
+   * element's own transform moves only its rendering, while the space its
+   * margin reserves stays where the untransformed box left it.
    *
-   * Measured on a 100px block with `margin-bottom: 20px`, reading the gap
-   * between the rendered border edge and the next sibling:
+   * Measured on a 100px block with a 20px margin, reading the gap between the
+   * rendered border edge and the next sibling on each axis:
    *
-   * | transform on the block | rendered gap |
-   * | --- | --- |
-   * | none | 20 |
-   * | `scale(0.5)` | 70 |
-   * | `scale(2)` | −80 |
-   * | `translateY(40px)` | −20 |
+   * | transform on the block | vertical gap | horizontal gap |
+   * | --- | --- | --- |
+   * | none | 20 | 20 |
+   * | `scale(1)`, `translate(0)`, `rotate(360deg)` | 20 | 20 |
+   * | `translateY(40px)` | **−20** | 20 |
+   * | `translateX(30px)` | 20 | **−10** |
+   * | `scaleY(0.5)` | **70** | 20 |
+   * | `scaleX(0.5)` | 20 | **70** |
    *
-   * The last two are NEGATIVE — the block is drawn over the neighbour its
-   * margin is meant to be holding away. So this is not a scale correction: no
-   * factor applied to `20` produces those numbers, because the margin is not
-   * where the rendered box is at all. It is reported so the caller can decline
-   * the margin bands, which is what the spacing overlay does.
+   * Two things follow, and each rules out a simpler answer.
+   *
+   * PER AXIS, because a transform on one axis leaves the other's margin exactly
+   * where it was — and a lift like `translateY(-4px)` is a common hover state
+   * whose left and right bands stay perfectly good.
+   *
+   * By the MATRIX, not by the presence of a declaration. `scale(1)`,
+   * `translate(0)`, `translateY(0)` and `rotate(360deg)` all compute to a
+   * non-`none` transform and all serialize to exactly
+   * `matrix(1, 0, 0, 1, 0, 0)`; they move nothing, and they are the resting
+   * state of every hover animation, so treating them as displacement would
+   * blank the margins of a large share of real pages.
+   *
+   * The negatives in that table are why an axis this reports is DECLINED rather
+   * than corrected: the block is drawn over the neighbour its margin is holding
+   * away, so no rectangle beside the rendered border edge describes it and no
+   * factor applied to `20` produces one.
    */
-  readonly selfTransformed: boolean;
+  readonly selfMoved: { readonly x: boolean; readonly y: boolean };
 }
+
+const NOT_MOVED = { x: false, y: false } as const;
 
 const IDENTITY_SCALE: RenderedScale = {
   x: 1,
   y: 1,
   describable: true,
-  selfTransformed: false,
+  selfMoved: NOT_MOVED,
 };
 
 /** Below this, an off-diagonal matrix term is serialization noise, not a rotation. */
@@ -272,7 +289,7 @@ export function renderedScale(element: Element, root: Element): RenderedScale {
    * transform here would apply it a second time — the bands would be scaled by
    * its square while the page was scaled by it once.
    */
-  let selfTransformed = false;
+  let own: DOMMatrix | null = null;
   for (
     let node: Element | null = element;
     node !== null && node !== root;
@@ -280,10 +297,12 @@ export function renderedScale(element: Element, root: Element): RenderedScale {
   ) {
     const declared = view.getComputedStyle(node).transform;
     if (declared === "" || declared === "none") continue;
-    // Recorded on the way past rather than read in a second walk, so the two
-    // answers cannot disagree about which transforms were seen.
-    if (node === element) selfTransformed = true;
-    matrix = new view.DOMMatrix(declared).multiply(matrix);
+    const step = new view.DOMMatrix(declared);
+    // Kept from the walk that is already happening rather than read again, so
+    // the composed answer and the element's own cannot disagree about which
+    // declaration was seen.
+    if (node === element) own = step;
+    matrix = step.multiply(matrix);
   }
 
   /*
@@ -315,7 +334,38 @@ export function renderedScale(element: Element, root: Element): RenderedScale {
     x: matrix.a,
     y: matrix.d,
     describable: axisAligned && matrix.a > 0 && matrix.d > 0,
-    selfTransformed,
+    selfMoved: axesMovedBy(own),
+  };
+}
+
+/**
+ * Which axes a single element's own transform actually displaces.
+ *
+ * Asked of the MATRIX rather than of the declaration, because a declaration
+ * that moves nothing is ordinary: `scale(1)`, `translate(0)`, `translateY(0)`
+ * and `rotate(360deg)` all compute to a non-`none` transform and all serialize
+ * to exactly `matrix(1, 0, 0, 1, 0, 0)`. They are the resting state of every
+ * hover animation, so reading presence rather than effect blanks the margins of
+ * a large share of real pages.
+ *
+ * `a` and `d` are the per-axis scales and `e`/`f` the per-axis translations, so
+ * each axis is decided by its own two terms. A rotation or a skew mixes the
+ * axes and moves both; anything not flat in 2D is not decidable by these terms
+ * at all, and both are reported moved rather than guessed at.
+ *
+ * The tolerance is the same one the axis-aligned test uses and is there for the
+ * same reason: an engine may serialize a geometric identity with a residue
+ * instead of normalizing it away. It is far below any displacement a person
+ * could author or see.
+ */
+function axesMovedBy(own: DOMMatrix | null): { x: boolean; y: boolean } {
+  if (own === null) return { ...NOT_MOVED };
+  const off = (value: number): boolean =>
+    Math.abs(value) > AXIS_ALIGNED_TOLERANCE;
+  if (!own.is2D || off(own.b) || off(own.c)) return { x: true, y: true };
+  return {
+    x: off(own.a - 1) || off(own.e),
+    y: off(own.d - 1) || off(own.f),
   };
 }
 

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -357,6 +357,24 @@ export function renderedScale(element: Element, root: Element): RenderedScale {
  * same reason: an engine may serialize a geometric identity with a residue
  * instead of normalizing it away. It is far below any displacement a person
  * could author or see.
+ *
+ * PER AXIS RATHER THAN PER EDGE, which is a deliberate bound and not an
+ * oversight. A transform is applied about `transform-origin`, so an origin
+ * anchored to one side leaves that side's edge stationary and moves only the
+ * far one — under `transform-origin: top` and `scaleY(0.5)`, measured, the top
+ * edge does not move at all and its margin stays perfectly describable.
+ *
+ * That state is not reachable here. `transform` is a catalog property and
+ * `transform-origin` is NOT, so every transform this system can author is
+ * applied about the initial `50% 50%` — and measured under that origin,
+ * `scaleY(0.5)` moves the top edge as well as the bottom, which is exactly what
+ * an axis answers. Per edge would additionally have to read and resolve the
+ * origin and the untransformed box on every measure, paying for a case the
+ * catalog cannot produce.
+ *
+ * Should `transform-origin` ever join the catalog, this becomes conservative
+ * rather than wrong: an anchored edge keeps its band today and would lose it,
+ * which is the safe direction to be imprecise in.
  */
 function axesMovedBy(own: DOMMatrix | null): { x: boolean; y: boolean } {
   if (own === null) return { ...NOT_MOVED };

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -216,9 +216,40 @@ export interface RenderedScale {
   readonly y: number;
   /** False for a rotation, a skew, a reflection, or a collapse to zero. */
   readonly describable: boolean;
+  /**
+   * Whether the ELEMENT ITSELF carries a transform, as opposed to inheriting one.
+   *
+   * Separated because the two do opposite things to a margin. **A transform does
+   * not affect layout.** An ancestor's transform scales the whole subtree it
+   * lays out, gaps included, so a margin inside it really does render smaller.
+   * The element's OWN transform moves only its rendering: the space its margin
+   * reserves stays where the untransformed box put it.
+   *
+   * Measured on a 100px block with `margin-bottom: 20px`, reading the gap
+   * between the rendered border edge and the next sibling:
+   *
+   * | transform on the block | rendered gap |
+   * | --- | --- |
+   * | none | 20 |
+   * | `scale(0.5)` | 70 |
+   * | `scale(2)` | −80 |
+   * | `translateY(40px)` | −20 |
+   *
+   * The last two are NEGATIVE — the block is drawn over the neighbour its
+   * margin is meant to be holding away. So this is not a scale correction: no
+   * factor applied to `20` produces those numbers, because the margin is not
+   * where the rendered box is at all. It is reported so the caller can decline
+   * the margin bands, which is what the spacing overlay does.
+   */
+  readonly selfTransformed: boolean;
 }
 
-const IDENTITY_SCALE: RenderedScale = { x: 1, y: 1, describable: true };
+const IDENTITY_SCALE: RenderedScale = {
+  x: 1,
+  y: 1,
+  describable: true,
+  selfTransformed: false,
+};
 
 /** Below this, an off-diagonal matrix term is serialization noise, not a rotation. */
 const AXIS_ALIGNED_TOLERANCE = 1e-9;
@@ -241,6 +272,7 @@ export function renderedScale(element: Element, root: Element): RenderedScale {
    * transform here would apply it a second time — the bands would be scaled by
    * its square while the page was scaled by it once.
    */
+  let selfTransformed = false;
   for (
     let node: Element | null = element;
     node !== null && node !== root;
@@ -248,6 +280,9 @@ export function renderedScale(element: Element, root: Element): RenderedScale {
   ) {
     const declared = view.getComputedStyle(node).transform;
     if (declared === "" || declared === "none") continue;
+    // Recorded on the way past rather than read in a second walk, so the two
+    // answers cannot disagree about which transforms were seen.
+    if (node === element) selfTransformed = true;
     matrix = new view.DOMMatrix(declared).multiply(matrix);
   }
 
@@ -280,6 +315,7 @@ export function renderedScale(element: Element, root: Element): RenderedScale {
     x: matrix.a,
     y: matrix.d,
     describable: axisAligned && matrix.a > 0 && matrix.d > 0,
+    selfTransformed,
   };
 }
 

--- a/packages/builder/src/spacing-bands.ts
+++ b/packages/builder/src/spacing-bands.ts
@@ -523,7 +523,16 @@ const ALL_SIDES: EdgeApplicability = {
   bottom: true,
   left: true,
 };
-const NO_SIDES: EdgeApplicability = {
+/**
+ * No side carries spacing that can be drawn.
+ *
+ * Exported because applicability is decided in two places for two different
+ * reasons, and both must express "none" the same way: this module decides what
+ * a generated box CAN have, and the DOM edge decides what it can be DRAWN for —
+ * a margin under the element's own transform exists in CSS and is not where any
+ * band could be put.
+ */
+export const NO_SIDES: EdgeApplicability = {
   top: false,
   right: false,
   bottom: false,

--- a/packages/builder/src/spacing-bands.ts
+++ b/packages/builder/src/spacing-bands.ts
@@ -523,16 +523,7 @@ const ALL_SIDES: EdgeApplicability = {
   bottom: true,
   left: true,
 };
-/**
- * No side carries spacing that can be drawn.
- *
- * Exported because applicability is decided in two places for two different
- * reasons, and both must express "none" the same way: this module decides what
- * a generated box CAN have, and the DOM edge decides what it can be DRAWN for —
- * a margin under the element's own transform exists in CSS and is not where any
- * band could be put.
- */
-export const NO_SIDES: EdgeApplicability = {
+const NO_SIDES: EdgeApplicability = {
   top: false,
   right: false,
   bottom: false,

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -72,6 +72,7 @@ import {
 } from "./geometry-dom";
 import {
   applicableEdges,
+  NO_SIDES,
   overlayEscape,
   sameBands,
   spacingApplies,
@@ -332,17 +333,38 @@ export function SpacingOverlay({
       style.writingMode,
       isReplaced(block)
     );
+    const scale = renderedScale(block, root);
+    /*
+     * MARGINS ARE DROPPED FOR A BLOCK CARRYING ITS OWN TRANSFORM, and this is
+     * not a scale correction — no factor rescues it.
+     *
+     * A transform does not affect layout. An ANCESTOR's transform scales the
+     * subtree it lays out, gaps included, so a margin inside one really does
+     * render smaller and `scale` is right to apply it. The block's OWN
+     * transform moves only its rendering, while the space its margin reserves
+     * stays where the untransformed box left it.
+     *
+     * Measured on a 100px block with `margin-bottom: 20px`: under `scale(0.5)`
+     * the gap between the rendered border edge and the next sibling is 70px,
+     * under `scale(2)` it is −80px and under `translateY(40px)` it is −20px.
+     * The negatives are the case that settles it — the block is drawn OVER the
+     * neighbour its margin is holding away, so there is no rectangle beside the
+     * border edge that describes the margin at all.
+     *
+     * Padding is untouched: it lies INSIDE the transform and renders scaled
+     * with the box, so those bands stay correct and keep being drawn.
+     */
+    const marginApplies = scale.selfTransformed ? NO_SIDES : applies.margin;
     const measured = boxesOf(style);
     const boxes = {
       borderWidths: measured.borderWidths,
-      margin: applicableEdges(measured.margin, applies.margin),
+      margin: applicableEdges(measured.margin, marginApplies),
       padding: applicableEdges(measured.padding, applies.padding),
     };
     const borders = {
       x: boxes.borderWidths.left + boxes.borderWidths.right,
       y: boxes.borderWidths.top + boxes.borderWidths.bottom,
     };
-    const scale = renderedScale(block, root);
     if (
       !describable(
         layoutFragments(block),

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -72,11 +72,11 @@ import {
 } from "./geometry-dom";
 import {
   applicableEdges,
-  NO_SIDES,
   overlayEscape,
   sameBands,
   spacingApplies,
   spacingBands,
+  type EdgeApplicability,
   type EdgeLengths,
   type SpacingBand,
 } from "./spacing-bands";
@@ -191,6 +191,60 @@ export function isReplaced(element: Element): boolean {
    * lower-cased local name is the spelling that holds for both.
    */
   return REPLACED_TAGS.has(element.localName.toLowerCase());
+}
+
+/**
+ * The spacing this block can actually be drawn with, on each side.
+ *
+ * Two separate reasons zero a side, and they are both here so that no caller
+ * can apply one and forget the other.
+ *
+ * The first is what CSS gives the generated box. `display: table-row` and the
+ * internal ruby boxes take no margin, everything internal to a table except a
+ * cell takes no padding, and a non-replaced inline box takes no block-axis
+ * margin — while the computed style answers with whatever the author declared,
+ * so reading it unconditionally draws bands for space that does not exist.
+ *
+ * The second is whether a band could be PUT there. A transform does not affect
+ * layout: an ancestor's transform scales the subtree it lays out, gaps
+ * included, so a margin inside one really does render smaller and `scale` is
+ * right to apply it — but the block's OWN transform moves only its rendering,
+ * while the space its margin reserves stays where the untransformed box left
+ * it. Measured, a 100px block with `margin-bottom: 20px` under `scale(2)`
+ * leaves a gap of MINUS eighty pixels, drawn over the neighbour that margin is
+ * holding away, so no rectangle beside the rendered border edge describes it.
+ *
+ * That second reason is applied PER AXIS, because the sides are independent:
+ * `translateY(-4px)` — an ordinary hover lift — moves the top and bottom
+ * margins and leaves the left and right ones exactly where they were. See
+ * `selfMoved`, which reads the matrix rather than the declaration, so an
+ * identity-valued transform keeps every band.
+ *
+ * Padding is subject only to the first reason. It lies INSIDE the transform and
+ * renders scaled with the box, so those bands stay correct on both axes.
+ */
+function drawableBoxes(
+  style: CSSStyleDeclaration,
+  block: Element,
+  scale: RenderedScale
+): { margin: EdgeLengths; padding: EdgeLengths; borderWidths: EdgeLengths } {
+  const applies = spacingApplies(
+    style.display,
+    style.writingMode,
+    isReplaced(block)
+  );
+  const margin: EdgeApplicability = {
+    top: applies.margin.top && !scale.selfMoved.y,
+    bottom: applies.margin.bottom && !scale.selfMoved.y,
+    left: applies.margin.left && !scale.selfMoved.x,
+    right: applies.margin.right && !scale.selfMoved.x,
+  };
+  const measured = boxesOf(style);
+  return {
+    borderWidths: measured.borderWidths,
+    margin: applicableEdges(measured.margin, margin),
+    padding: applicableEdges(measured.padding, applies.padding),
+  };
 }
 
 /**
@@ -321,46 +375,8 @@ export function SpacingOverlay({
       return;
     }
 
-    /*
-     * Zeroed where the generated box cannot have them. `display: table-row` and
-     * the internal ruby boxes take no margin, and everything internal to a table
-     * except a cell takes no padding — but the computed style still answers with
-     * whatever the author declared, so reading it unconditionally draws bands
-     * for space that does not exist.
-     */
-    const applies = spacingApplies(
-      style.display,
-      style.writingMode,
-      isReplaced(block)
-    );
     const scale = renderedScale(block, root);
-    /*
-     * MARGINS ARE DROPPED FOR A BLOCK CARRYING ITS OWN TRANSFORM, and this is
-     * not a scale correction — no factor rescues it.
-     *
-     * A transform does not affect layout. An ANCESTOR's transform scales the
-     * subtree it lays out, gaps included, so a margin inside one really does
-     * render smaller and `scale` is right to apply it. The block's OWN
-     * transform moves only its rendering, while the space its margin reserves
-     * stays where the untransformed box left it.
-     *
-     * Measured on a 100px block with `margin-bottom: 20px`: under `scale(0.5)`
-     * the gap between the rendered border edge and the next sibling is 70px,
-     * under `scale(2)` it is −80px and under `translateY(40px)` it is −20px.
-     * The negatives are the case that settles it — the block is drawn OVER the
-     * neighbour its margin is holding away, so there is no rectangle beside the
-     * border edge that describes the margin at all.
-     *
-     * Padding is untouched: it lies INSIDE the transform and renders scaled
-     * with the box, so those bands stay correct and keep being drawn.
-     */
-    const marginApplies = scale.selfTransformed ? NO_SIDES : applies.margin;
-    const measured = boxesOf(style);
-    const boxes = {
-      borderWidths: measured.borderWidths,
-      margin: applicableEdges(measured.margin, marginApplies),
-      padding: applicableEdges(measured.padding, applies.padding),
-    };
+    const boxes = drawableBoxes(style, block, scale);
     const borders = {
       x: boxes.borderWidths.left + boxes.borderWidths.right,
       y: boxes.borderWidths.top + boxes.borderWidths.bottom,


### PR DESCRIPTION
Round nine on #1145 landed three P2 geometry findings after its threads were resolved, and it merged before they were worked. This is the first of two follow-ups; it takes the one that puts a **wrong number on screen**. The other two — rounded padding boxes and rounded ancestor clips — share a piece of radius arithmetic and land next, kept separate so each PR has one subject.

## The defect

A transform does not affect layout. The overlay treated one composed scale as applying to everything, so a block carrying its own `transform` got its margin band scaled and drawn beside its **rendered** border edge — where the margin is not.

Measured on a 100px block with `margin-bottom: 20px`, reading the gap between the rendered border edge and the next sibling:

| transform on the block | real gap | what the overlay drew |
| --- | --- | --- |
| none | 20 | 20 ✓ |
| `scale(0.5)` | **70** | 10 |
| `scale(2)` | **−80** | 40 |
| `translateY(40px)` | **−20** | 20 |

The negatives decide the shape of the fix. Under `scale(2)` the block is drawn eighty pixels **over** the neighbour its margin is holding away, so no rectangle beside the border edge describes that margin and no factor applied to `20` produces one. Correcting the scale was not an option; the band has to go.

`translateY` is in that table on purpose — **any** non-identity transform does this, not only a scale, so the test is on the transform's presence rather than its kind.

## What is deliberately NOT changed

**An ancestor's scale still scales margins, and that is correct.** Same measurement with the `scale(0.5)` moved to the parent: the real gap is 10px. This is not "stop scaling margins"; it is that the element's own transform and its ancestors' do opposite things to one.

**Padding bands are untouched.** Padding lies inside the transform and renders scaled with the box, so those bands were already right. That is why this is a per-box refusal rather than a whole-element one — and it is the control in the browser test.

## Evidence

`renderedScale` now reports `selfTransformed` from the walk it already makes, rather than a second read, so the two answers cannot disagree about which transforms were seen.

Break-verified, both directions:

- restoring the old behaviour → **only** the new test fails
- refusing the whole element instead of just its margins → **four** tests fail, including the padding half of the new one

The second is the one worth noting: a whole-element refusal satisfies the margin assertion completely, and the padding control is what rejects it.

## Also here

The round-eight ancestor-clip fixture gains a padding value. It counter-rotates the selected block, so its only bands were margin bands and its control would now empty for a reason unrelated to the clip it tests.

## Gates

`build 0` · `check-types 0` · builder **1379** · plugin-page-builder **178** · builder/ppb/e2e lint `0` · root eslint `0` · comment convention `0` · changeset `0` · **fallow `pass`, zero introduced** · e2e **30 passed**
