### PR TITLE
feat(builder): a tokens studio where a rename moves the label and never the reference

### DIFF
--- a/.changeset/tokens-studio-arrives.md
+++ b/.changeset/tokens-studio-arrives.md
@@ -1,0 +1,37 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Add the tokens studio to the page builder's left rail. A site's design tokens —
+colours, sizes, fonts, weights, numbers, shadows, durations and custom values —
+are listed by kind and edited where they are read, with light and dark values
+behind one switch. Renaming a token moves only its label: references key on an
+identity the rename freezes, so every block already pointing at the token goes
+on resolving and no stored document is rewritten. The engine's own verdict is
+shown per row, so a value that contradicts its kind, one that would make the
+page fetch a file, and two tokens that would collide on one custom property are
+each reported where they are edited rather than discovered on the canvas.

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -236,5 +236,11 @@ export type {
  */
 export { LayersPanel } from "./layers-panel";
 export type { LayersPanelProps } from "./layers-panel";
+/*
+ * The tokens studio. A host that mounts it owns the site style document and
+ * decides when an edit is persisted; this exports the surface, not the save.
+ */
+export { TokensPanel } from "./tokens-panel";
+export type { TokensPanelProps } from "./tokens-panel";
 export { SelectionBreadcrumb } from "./breadcrumb";
 export type { SelectionBreadcrumbProps } from "./breadcrumb";

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -428,6 +428,30 @@
 }
 
 /*
+ * The chequerboard every swatch is painted over, defined ONCE.
+ *
+ * A colour surface needs something behind it that says "nothing here", and that
+ * something has to read as absence rather than as a colour — which is what the
+ * chequerboard is for, and why a translucent swatch shows it through.
+ *
+ * Fixed greys rather than theme tokens, and deliberately: the pattern is the
+ * standard rendering of "no colour" and stops meaning that if it moves with the
+ * theme, since a themed chequerboard is just another colour behind the swatch.
+ * `@nextlyhq/ui`'s own ColorPicker makes the identical call for the identical
+ * visual. Stated once here so the exemption is one decision rather than one per
+ * swatch, and so a second surface cannot drift from the first.
+ */
+:root {
+  /*
+   * On ONE line, and held there: the design linter scans by line, so a wrapped
+   * value would put the colours on a different line from the exemption that
+   * covers them and the rule would be reported despite being marked.
+   */
+  /* prettier-ignore */
+  --nx-checkerboard: repeating-conic-gradient(#c8c8c8 0% 25%, #ffffff 0% 50%); /* design-lint-ok: the chequerboard is the standard rendering of "no colour" and must not move with the theme — the same fixed greys ui's own ColorPicker uses */
+}
+
+/*
  * The swatch, over a chequerboard so a translucent colour reads as translucent
  * rather than as a lighter opaque one.
  *
@@ -436,9 +460,9 @@
  * colour set paints nothing and shows the chequerboard alone, which is the
  * honest appearance for a value this panel cannot resolve.
  *
- * design-lint-ok: the chequerboard greys are the standard rendering of "no
- * colour here" and must not move with the theme, exactly as the picker's own
- * are.
+ * The chequerboard itself is `--nx-checkerboard`, declared once above, so the
+ * decision to keep it off the theme is made in one place rather than restated
+ * by every swatch that shows it.
  */
 .nx-style-inspector__swatch {
   /*
@@ -457,8 +481,7 @@
   border: 1px solid var(--nx-border);
   border-radius: var(--radius-sm);
   background-image:
-    linear-gradient(var(--nx-swatch), var(--nx-swatch)),
-    repeating-conic-gradient(#c8c8c8 0% 25%, #ffffff 0% 50%); /* design-lint-ok: the chequerboard is the standard rendering of "no colour", and must not move with the theme — the same fixed greys ui's own ColorPicker uses */
+    linear-gradient(var(--nx-swatch), var(--nx-swatch)), var(--nx-checkerboard);
   background-size:
     100% 100%,
     0.5rem 0.5rem;
@@ -1225,8 +1248,7 @@
   border: 1px solid var(--nx-border);
   border-radius: var(--radius-sm);
   background-image:
-    linear-gradient(var(--nx-swatch), var(--nx-swatch)),
-    repeating-conic-gradient(#c8c8c8 0% 25%, #ffffff 0% 50%); /* design-lint-ok: the chequerboard is the standard rendering of "no colour", and must not move with the theme — the same fixed greys ui's own ColorPicker uses */
+    linear-gradient(var(--nx-swatch), var(--nx-swatch)), var(--nx-checkerboard);
   background-size:
     100% 100%,
     0.375rem 0.375rem;

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -1254,10 +1254,24 @@
     0.375rem 0.375rem;
 }
 
-.nx-tokens__actions,
-.nx-tokens__confirm {
+.nx-tokens__actions {
   display: flex;
   align-items: center;
+  gap: 0.25rem;
+}
+
+/*
+ * The confirmation replaces the action column and needs the whole row: it
+ * carries a sentence as well as two buttons, and the rail is narrow. Placed on
+ * the CONTAINER, because the paragraph inside it is a flex child rather than a
+ * grid item and `grid-column` on it does nothing — the warning and both buttons
+ * would compete for the action column and squeeze the fields beside them.
+ */
+.nx-tokens__confirm {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 0.25rem;
 }
 
@@ -1266,6 +1280,11 @@
  * not about whichever field the author last touched.
  */
 .nx-tokens__issue {
+  /*
+   * Spans the row when it IS a grid item. Inside the confirmation it is a flex
+   * child and this does nothing, which is why that container carries its own
+   * placement rather than relying on this.
+   */
   grid-column: 1 / -1;
   margin: 0;
   font-size: var(--text-xs);

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -1250,3 +1250,10 @@
   line-height: 1.4;
   color: var(--nx-destructive);
 }
+
+/* Where a token comes from, when the site's own code supplies it. */
+.nx-tokens__origin {
+  font-size: var(--text-xs);
+  color: var(--nx-muted-foreground);
+  white-space: nowrap;
+}

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -1101,3 +1101,152 @@
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
+
+/*
+ * The tokens studio.
+ *
+ * A table in a rail that is narrower than a table wants to be, so the row is a
+ * grid rather than columns: the swatch and the actions take what they need and
+ * the two fields share what is left, which keeps a long token name from
+ * pushing the remove button out of reach.
+ */
+.nx-tokens {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  min-height: 0;
+}
+
+.nx-tokens__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.nx-tokens__title {
+  margin: 0;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--nx-foreground);
+}
+
+/*
+ * Two states of one property, drawn as one segmented control rather than two
+ * adjacent buttons: they share a border and split the width, so the pair reads
+ * as a single choice with one side taken.
+ */
+.nx-tokens__modes {
+  display: inline-flex;
+  border: 1px solid var(--nx-border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.nx-tokens__modes button {
+  padding: 0.125rem 0.5rem;
+  font-size: var(--text-xs);
+  color: var(--nx-muted-foreground);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+}
+
+.nx-tokens__modes button[aria-pressed="true"] {
+  color: var(--nx-foreground);
+  background: var(--nx-muted);
+}
+
+.nx-tokens__modes button:focus-visible {
+  outline: 2px solid var(--nx-accent);
+  outline-offset: -2px;
+}
+
+/* The count rides the tab label, so a tab says how much is behind it. */
+.nx-tokens__count {
+  margin-inline-start: 0.25rem;
+  font-size: var(--text-xs);
+  color: var(--nx-muted-foreground);
+  font-variant-numeric: tabular-nums;
+}
+
+.nx-tokens__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.nx-tokens__list ul {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.nx-tokens__row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.nx-tokens__fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+/*
+ * The value a mode INHERITS from light, rather than one it states. Dimmed so
+ * the table shows at a glance which rows have a dark value of their own, and
+ * which are following — a distinction the value text alone cannot carry,
+ * because an inherited value and an identical explicit one read the same.
+ */
+.nx-tokens__value[data-inherited] {
+  color: var(--nx-muted-foreground);
+  font-style: italic;
+}
+
+.nx-tokens__swatch {
+  /*
+   * Declared here and overridden from the element's style attribute when there
+   * is a colour to paint, so the sheet is self-contained: a rule referencing a
+   * property nothing in CSS defines reads as broken to anything analysing the
+   * stylesheet on its own.
+   */
+  --nx-swatch: transparent;
+  flex: 0 0 auto;
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 1px solid var(--nx-border);
+  border-radius: var(--radius-sm);
+  background-image:
+    linear-gradient(var(--nx-swatch), var(--nx-swatch)),
+    repeating-conic-gradient(#c8c8c8 0% 25%, #ffffff 0% 50%); /* design-lint-ok: the chequerboard is the standard rendering of "no colour", and must not move with the theme — the same fixed greys ui's own ColorPicker uses */
+  background-size:
+    100% 100%,
+    0.375rem 0.375rem;
+}
+
+.nx-tokens__actions,
+.nx-tokens__confirm {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+/*
+ * Spans the row, because a refusal or a warning is about the whole token and
+ * not about whichever field the author last touched.
+ */
+.nx-tokens__issue {
+  grid-column: 1 / -1;
+  margin: 0;
+  font-size: var(--text-xs);
+  line-height: 1.4;
+  color: var(--nx-destructive);
+}

--- a/packages/builder/src/tokens-panel.test.tsx
+++ b/packages/builder/src/tokens-panel.test.tsx
@@ -1,0 +1,259 @@
+// @vitest-environment jsdom
+
+/**
+ * The tokens studio, driven as an author drives it.
+ *
+ * `tokens-studio.test.ts` asserts the rules against the engine's compilers and
+ * establishes that a rename freezes the identity. What is only true HERE is the
+ * wiring: that editing a name in the table calls the rule rather than spreading
+ * a new name over the token, that a refused name is reported and NOT committed,
+ * that removal asks first, and that the mode switch decides which value an edit
+ * writes rather than only which one is shown.
+ *
+ * @module tokens-panel.test
+ */
+import type { SiteTokenSet } from "@nextlyhq/blocks-engine";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { TokensPanel } from "./tokens-panel";
+
+afterEach(cleanup);
+
+beforeAll(() => {
+  // Radix's tabs measure and scroll; jsdom provides neither, and a missing one
+  // throws during render rather than failing an assertion.
+  const element = window.Element.prototype as unknown as Record<
+    string,
+    unknown
+  >;
+  element.scrollIntoView = function scrollIntoView(): void {};
+  (window as unknown as Record<string, unknown>).ResizeObserver =
+    class ResizeObserver {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    };
+});
+
+/** A site whose second token is RENAMED, so identity and name differ. */
+const TOKENS: SiteTokenSet = {
+  tokens: [
+    { name: "color.ink", kind: "color", values: { light: "#111111" } },
+    {
+      id: "color.primary",
+      name: "brand.main",
+      kind: "color",
+      values: { light: "#3b82f6", dark: "#93c5fd" },
+    },
+  ],
+};
+
+/**
+ * Mount over a token set.
+ *
+ * No default parameter, deliberately: a default cannot tell an omitted
+ * argument from an explicit `undefined`, and `undefined` is the state under
+ * test for the not-yet-read case. Measured on the sibling colour panel — a
+ * default silently swallowed the sentinel and the test asserted against the
+ * full fixture while claiming to assert against no table at all.
+ */
+function mount(tokens: SiteTokenSet | undefined) {
+  const onChange = vi.fn();
+  render(<TokensPanel tokens={tokens} onChange={onChange} />);
+  return onChange;
+}
+
+const nameField = (label: string): HTMLElement =>
+  screen.getByLabelText(`Name of ${label}`);
+const valueField = (label: string): HTMLElement =>
+  screen.getByLabelText(new RegExp(`^(Dark value|Value) of ${label}$`));
+
+describe("what the studio draws", () => {
+  it("lists the site's colour tokens under the colour tab", () => {
+    mount(TOKENS);
+    expect(nameField("color.ink")).toHaveProperty("value", "color.ink");
+    expect(nameField("brand.main")).toHaveProperty("value", "brand.main");
+  });
+
+  it("shows the token's CURRENT name while the document keeps its identity", () => {
+    mount(TOKENS);
+    // The renamed token reads as its label. Showing `color.primary` here would
+    // be showing the author a string they never typed.
+    expect(nameField("brand.main")).toHaveProperty("value", "brand.main");
+    expect(valueField("brand.main")).toHaveProperty("value", "#3b82f6");
+  });
+
+  it("says so rather than drawing an empty table while the read is out", () => {
+    // A site with no tokens and a site whose tokens have not arrived are
+    // different states, and adding a token into the second one would edit a
+    // set about to be replaced.
+    mount(undefined);
+    expect(screen.getByText(/Reading this site/)).toBeDefined();
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+
+  it("paints a swatch for a colour it can resolve, and nothing for one it cannot", () => {
+    const unresolvable: SiteTokenSet = {
+      tokens: [
+        { name: "color.ok", kind: "color", values: { light: "#112233" } },
+        { name: "color.ref", kind: "color", values: { light: "var(--x)" } },
+      ],
+    };
+    const { container } = render(
+      <TokensPanel tokens={unresolvable} onChange={vi.fn()} />
+    );
+    const swatches = Array.from(
+      container.querySelectorAll(".nx-tokens__swatch")
+    );
+    expect(swatches[0]?.getAttribute("style")).toContain("#112233");
+    // A `var()` resolves against the PANEL rather than the canvas, so painting
+    // it would show a colour the page does not have.
+    expect(swatches[1]?.getAttribute("data-empty")).toBe("");
+  });
+});
+
+describe("renaming from the table", () => {
+  it("commits on blur, through the rule that freezes the identity", () => {
+    const onChange = mount(TOKENS);
+    const field = nameField("color.ink");
+    fireEvent.change(field, { target: { value: "text.body" } });
+    // Not yet: an edit per keystroke would recompile the canvas for every
+    // letter and validate a half-typed name.
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.blur(field);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const next = onChange.mock.calls[0]?.[0] as SiteTokenSet;
+    const token = next.tokens.find(t => t.name === "text.body");
+    // The whole point: the label moved and the identity did not.
+    expect(token?.id).toBe("color.ink");
+  });
+
+  it("REFUSES a name no reference could spell, and commits nothing", () => {
+    const onChange = mount(TOKENS);
+    const field = nameField("color.ink");
+    fireEvent.change(field, { target: { value: "has spaces" } });
+    fireEvent.blur(field);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText(/dot-separated words/)).toBeDefined();
+    expect(field.getAttribute("aria-invalid")).toBe("true");
+  });
+
+  it("refuses a name another token already reads under", () => {
+    const onChange = mount(TOKENS);
+    const field = nameField("color.ink");
+    fireEvent.change(field, { target: { value: "brand.main" } });
+    fireEvent.blur(field);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText(/already called/)).toBeDefined();
+  });
+
+  it("says nothing when a field is left exactly as it was", () => {
+    const onChange = mount(TOKENS);
+    fireEvent.blur(nameField("color.ink"));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.queryByText(/dot-separated/)).toBeNull();
+  });
+});
+
+describe("editing a value", () => {
+  it("commits on blur", () => {
+    const onChange = mount(TOKENS);
+    const field = valueField("color.ink");
+    fireEvent.change(field, { target: { value: "#ff0000" } });
+    expect(onChange).not.toHaveBeenCalled();
+    fireEvent.blur(field);
+    const next = onChange.mock.calls[0]?.[0] as SiteTokenSet;
+    expect(next.tokens[0]?.values.light).toBe("#ff0000");
+  });
+
+  it("reports what the engine says about a value that contradicts its kind", () => {
+    const wrong: SiteTokenSet = {
+      tokens: [{ name: "color.bad", kind: "color", values: { light: "16px" } }],
+    };
+    render(<TokensPanel tokens={wrong} onChange={vi.fn()} />);
+    expect(screen.getByText(/not a colour/)).toBeDefined();
+  });
+});
+
+describe("the mode switch decides what an edit WRITES", () => {
+  it("shows the dark value and writes into dark", () => {
+    const onChange = mount(TOKENS);
+    fireEvent.click(screen.getByRole("button", { name: "Dark" }));
+    expect(valueField("brand.main")).toHaveProperty("value", "#93c5fd");
+
+    const field = valueField("brand.main");
+    fireEvent.change(field, { target: { value: "#1e3a8a" } });
+    fireEvent.blur(field);
+    const next = onChange.mock.calls[0]?.[0] as SiteTokenSet;
+    const token = next.tokens.find(t => t.name === "brand.main");
+    expect(token?.values.dark).toBe("#1e3a8a");
+    // Light is what a reader with no mode set resolves.
+    expect(token?.values.light).toBe("#3b82f6");
+  });
+
+  it("drops a dark value back to following light", () => {
+    const onChange = mount(TOKENS);
+    fireEvent.click(screen.getByRole("button", { name: "Dark" }));
+    fireEvent.click(screen.getByRole("button", { name: "Match light" }));
+    const next = onChange.mock.calls[0]?.[0] as SiteTokenSet;
+    const token = next.tokens.find(t => t.name === "brand.main");
+    expect(token?.values.dark).toBeUndefined();
+  });
+
+  it("offers no match-light for a token that already follows light", () => {
+    // `color.ink` defines only light, so there is nothing to drop.
+    mount({ tokens: [TOKENS.tokens[0] as never] });
+    fireEvent.click(screen.getByRole("button", { name: "Dark" }));
+    expect(screen.queryByRole("button", { name: "Match light" })).toBeNull();
+  });
+});
+
+describe("removing a token asks first", () => {
+  it("warns what removal means before doing it", () => {
+    const onChange = mount(TOKENS);
+    fireEvent.click(screen.getByRole("button", { name: "Remove color.ink" }));
+    expect(onChange).not.toHaveBeenCalled();
+    // Says what it MEANS rather than counting pages, which needs a search
+    // inside a JSON column that no dialect here can do portably.
+    expect(screen.getByText(/loses that style/)).toBeDefined();
+  });
+
+  it("removes by IDENTITY once confirmed", () => {
+    const onChange = mount(TOKENS);
+    fireEvent.click(screen.getByRole("button", { name: "Remove brand.main" }));
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    const next = onChange.mock.calls[0]?.[0] as SiteTokenSet;
+    // Removing by the label would have missed it: it is `color.primary`.
+    expect(next.tokens.map(t => t.name)).toEqual(["color.ink"]);
+  });
+
+  it("lets the author back out", () => {
+    const onChange = mount(TOKENS);
+    fireEvent.click(screen.getByRole("button", { name: "Remove color.ink" }));
+    fireEvent.click(screen.getByRole("button", { name: "Keep" }));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Remove color.ink" })
+    ).toBeDefined();
+  });
+});
+
+describe("adding a token", () => {
+  it("appends one the engine will write", () => {
+    const onChange = mount(TOKENS);
+    fireEvent.click(screen.getByRole("button", { name: /Add colour token/i }));
+    const next = onChange.mock.calls[0]?.[0] as SiteTokenSet;
+    expect(next.tokens.length).toBe(TOKENS.tokens.length + 1);
+    expect(next.tokens.at(-1)?.kind).toBe("color");
+  });
+
+  it("adds into a site that has no table at all", () => {
+    const onChange = vi.fn();
+    render(<TokensPanel tokens={{ tokens: [] }} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /Add colour token/i }));
+    expect((onChange.mock.calls[0]?.[0] as SiteTokenSet).tokens.length).toBe(1);
+  });
+});

--- a/packages/builder/src/tokens-panel.test.tsx
+++ b/packages/builder/src/tokens-panel.test.tsx
@@ -281,7 +281,7 @@ describe("a token the site's own code supplies", () => {
     expect(
       screen.queryByRole("button", { name: "Remove color.ink" })
     ).toBeNull();
-    expect(screen.getAllByText("From site config").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Default").length).toBeGreaterThan(0);
   });
 
   it("still offers to remove a token the config never supplied", () => {

--- a/packages/builder/src/tokens-panel.test.tsx
+++ b/packages/builder/src/tokens-panel.test.tsx
@@ -257,3 +257,93 @@ describe("adding a token", () => {
     expect((onChange.mock.calls[0]?.[0] as SiteTokenSet).tokens.length).toBe(1);
   });
 });
+
+describe("a token the site's own code supplies", () => {
+  const SUPPLIED: SiteTokenSet = {
+    tokens: [
+      { name: "color.ink", kind: "color", values: { light: "#111111" } },
+    ],
+  };
+
+  function mountWith(tokens: SiteTokenSet, supplied: SiteTokenSet) {
+    const onChange = vi.fn();
+    render(
+      <TokensPanel tokens={tokens} supplied={supplied} onChange={onChange} />
+    );
+    return onChange;
+  }
+
+  it("does NOT offer to remove it", () => {
+    // The stored tier expresses overrides, and absence from it means "no
+    // override" — so a removal would merge straight back on the next read. An
+    // action that quietly undoes itself is worse than no action.
+    mountWith(TOKENS, SUPPLIED);
+    expect(
+      screen.queryByRole("button", { name: "Remove color.ink" })
+    ).toBeNull();
+    expect(screen.getAllByText("From site config").length).toBeGreaterThan(0);
+  });
+
+  it("still offers to remove a token the config never supplied", () => {
+    // The control. Without it, a panel that removed every Remove button would
+    // pass the assertion above.
+    mountWith(TOKENS, SUPPLIED);
+    expect(
+      screen.queryByRole("button", { name: "Remove brand.main" })
+    ).not.toBeNull();
+  });
+
+  it("offers RESET once the author has changed it, and not before", () => {
+    mountWith(TOKENS, SUPPLIED);
+    expect(
+      screen.queryByRole("button", { name: "Reset color.ink" })
+    ).toBeNull();
+
+    cleanup();
+    const overridden: SiteTokenSet = {
+      tokens: [
+        { name: "color.ink", kind: "color", values: { light: "#ff0000" } },
+        ...TOKENS.tokens.slice(1),
+      ],
+    };
+    mountWith(overridden, SUPPLIED);
+    expect(
+      screen.queryByRole("button", { name: "Reset color.ink" })
+    ).not.toBeNull();
+  });
+
+  it("reset puts the site's own value back", () => {
+    const overridden: SiteTokenSet = {
+      tokens: [
+        { name: "color.ink", kind: "color", values: { light: "#ff0000" } },
+        ...TOKENS.tokens.slice(1),
+      ],
+    };
+    const onChange = mountWith(overridden, SUPPLIED);
+    fireEvent.click(screen.getByRole("button", { name: "Reset color.ink" }));
+    const next = onChange.mock.calls[0]?.[0] as SiteTokenSet;
+    expect(next.tokens[0]?.values.light).toBe("#111111");
+  });
+});
+
+describe("a save that did not happen", () => {
+  it("says so, out loud", () => {
+    // Without this the panel goes on showing what the author typed while the
+    // site holds the old value, so a validation failure, a missing permission
+    // and a dropped network all look exactly like success.
+    render(
+      <TokensPanel
+        tokens={TOKENS}
+        onChange={vi.fn()}
+        issue="You do not have permission to change site styles."
+      />
+    );
+    const said = screen.getByRole("alert");
+    expect(said.textContent).toContain("permission");
+  });
+
+  it("says nothing while saves are succeeding", () => {
+    mount(TOKENS);
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/packages/builder/src/tokens-panel.test.tsx
+++ b/packages/builder/src/tokens-panel.test.tsx
@@ -430,3 +430,54 @@ describe("a reverted value reaches the field", () => {
     expect(nameField("color.ink")).toHaveProperty("value", "color.ink");
   });
 });
+
+describe("no tokens to show, and why", () => {
+  it("says a read is in flight while it is", () => {
+    render(
+      <TokensPanel tokens={undefined} onChange={vi.fn()} absence="pending" />
+    );
+    expect(screen.getByText(/Reading this site/)).toBeDefined();
+  });
+
+  it("says a FAILED read failed, rather than describing it as still coming", () => {
+    // A 403 or an exhausted retry leaves the same `undefined`, and a panel
+    // that reports it as loading describes a state the site is not in and
+    // gives the author nothing to act on.
+    render(
+      <TokensPanel tokens={undefined} onChange={vi.fn()} absence="failed" />
+    );
+    expect(screen.queryByText(/Reading this site/)).toBeNull();
+    const said = screen.getByRole("alert");
+    expect(said.textContent).toContain("could not be read");
+  });
+});
+
+describe("pinning a dark value to what light already gives", () => {
+  it("commits it, rather than discarding it as unchanged", () => {
+    // `color.ink` has no dark value, so dark DISPLAYS the light one. Typing
+    // that same value is a real edit — it fixes dark in place before light is
+    // changed later — and comparing against the display discards exactly it.
+    const onChange = mount(TOKENS);
+    fireEvent.click(screen.getByRole("button", { name: "Dark" }));
+    const field = valueField("color.ink");
+    expect(field).toHaveProperty("value", "#111111");
+
+    fireEvent.change(field, { target: { value: "#111111" } });
+    fireEvent.blur(field);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const next = onChange.mock.calls[0]?.[0] as SiteTokenSet;
+    expect(next.tokens[0]?.values.dark).toBe("#111111");
+    expect(next.tokens[0]?.values.light).toBe("#111111");
+  });
+
+  it("still says nothing when a mode's OWN value is retyped unchanged", () => {
+    // The control. Without it, a panel that committed on every blur would pass
+    // the assertion above.
+    const onChange = mount(TOKENS);
+    const field = valueField("color.ink");
+    fireEvent.change(field, { target: { value: "#111111" } });
+    fireEvent.blur(field);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/builder/src/tokens-panel.test.tsx
+++ b/packages/builder/src/tokens-panel.test.tsx
@@ -347,3 +347,86 @@ describe("a save that did not happen", () => {
     expect(screen.queryByRole("alert")).toBeNull();
   });
 });
+
+describe("removing a row does not carry state onto its successor", () => {
+  const THREE: SiteTokenSet = {
+    tokens: [
+      { name: "color.a", kind: "color", values: { light: "#111111" } },
+      { name: "color.b", kind: "color", values: { light: "#222222" } },
+      { name: "color.c", kind: "color", values: { light: "#333333" } },
+    ],
+  };
+
+  it("shows each survivor its OWN value after an earlier row goes", () => {
+    // Keyed by position, deleting `color.a` shifts every following row and
+    // React reuses the deleted row's component for `color.b` — so the
+    // uncontrolled inputs keep the removed token's text.
+    const { rerender } = render(
+      <TokensPanel tokens={THREE} onChange={vi.fn()} />
+    );
+    const after: SiteTokenSet = { tokens: THREE.tokens.slice(1) };
+    rerender(<TokensPanel tokens={after} onChange={vi.fn()} />);
+
+    expect(valueField("color.b")).toHaveProperty("value", "#222222");
+    expect(valueField("color.c")).toHaveProperty("value", "#333333");
+    expect(screen.queryByLabelText("Name of color.a")).toBeNull();
+  });
+
+  it("does not leave a successor in removal confirmation", () => {
+    // The sharper half: the confirm state belongs to the row component, so a
+    // reused component hands the next token a live "Remove" button it never
+    // asked for — one click from removing the wrong token.
+    const { rerender } = render(
+      <TokensPanel tokens={THREE} onChange={vi.fn()} />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Remove color.a" }));
+    expect(screen.getByText(/loses that style/)).toBeDefined();
+
+    const after: SiteTokenSet = { tokens: THREE.tokens.slice(1) };
+    rerender(<TokensPanel tokens={after} onChange={vi.fn()} />);
+    expect(screen.queryByText(/loses that style/)).toBeNull();
+  });
+});
+
+describe("a reverted value reaches the field", () => {
+  it("shows the restored value after a refused save puts it back", () => {
+    // The inputs are uncontrolled, so a prop change alone does not move them:
+    // the panel would go on showing an override that storage and the canvas no
+    // longer hold, with the author believing it was saved.
+    const { rerender } = render(
+      <TokensPanel tokens={TOKENS} onChange={vi.fn()} />
+    );
+    const typed: SiteTokenSet = {
+      tokens: [
+        { name: "color.ink", kind: "color", values: { light: "#ff0000" } },
+        ...TOKENS.tokens.slice(1),
+      ],
+    };
+    rerender(<TokensPanel tokens={typed} onChange={vi.fn()} />);
+    expect(valueField("color.ink")).toHaveProperty("value", "#ff0000");
+
+    // Refused: the host puts the persisted set back.
+    rerender(<TokensPanel tokens={TOKENS} onChange={vi.fn()} />);
+    expect(valueField("color.ink")).toHaveProperty("value", "#111111");
+  });
+
+  it("shows the restored NAME too", () => {
+    const renamed: SiteTokenSet = {
+      tokens: [
+        {
+          id: "color.ink",
+          name: "text.body",
+          kind: "color",
+          values: { light: "#111111" },
+        },
+        ...TOKENS.tokens.slice(1),
+      ],
+    };
+    const { rerender } = render(
+      <TokensPanel tokens={renamed} onChange={vi.fn()} />
+    );
+    expect(nameField("text.body")).toHaveProperty("value", "text.body");
+    rerender(<TokensPanel tokens={TOKENS} onChange={vi.fn()} />);
+    expect(nameField("color.ink")).toHaveProperty("value", "color.ink");
+  });
+});

--- a/packages/builder/src/tokens-panel.tsx
+++ b/packages/builder/src/tokens-panel.tsx
@@ -219,7 +219,7 @@ function TokenList({
       ) : (
         <ul>
           {rows.map(row => (
-            <li key={row.at}>
+            <li key={row.key}>
               <TokenEntry
                 row={row}
                 tokens={tokens}
@@ -294,7 +294,16 @@ function TokenEntry({
           defaultValue={row.name}
           // Keyed by identity so a rename does not remount the row, and a
           // reorder does not carry one row's draft into another's field.
-          key={`${row.at}-name`}
+          /*
+           * The NAME as well as the row, because a refused save and Reset both
+           * replace the token through props — and an uncontrolled input keeps
+           * whatever the author typed, so the panel would go on showing an
+           * override that storage and the canvas no longer hold. Typing does
+           * not change props, so this is stable while the author is editing
+           * and changes exactly when the value they are editing is replaced
+           * underneath them.
+           */
+          key={`${row.key}-name-${row.name}`}
           aria-invalid={nameIssue === null ? undefined : true}
           aria-describedby={said.length > 0 ? noteId : undefined}
           onBlur={event => commitName(event.target.value)}
@@ -306,7 +315,7 @@ function TokenEntry({
           id={`${id}-value`}
           className="nx-tokens__value"
           defaultValue={row.value}
-          key={`${row.at}-value-${mode}`}
+          key={`${row.key}-value-${mode}-${row.value}`}
           data-inherited={row.inherited ? "" : undefined}
           aria-describedby={said.length > 0 ? noteId : undefined}
           onBlur={event => {

--- a/packages/builder/src/tokens-panel.tsx
+++ b/packages/builder/src/tokens-panel.tsx
@@ -91,6 +91,15 @@ export interface TokensPanelProps {
   issue?: string;
   /** Whether the canvas is currently showing dark values. */
   prefersDark?: boolean;
+  /**
+   * Why there are no tokens to show, when there are none.
+   *
+   * `undefined` tokens has two causes and they need different words: a read
+   * still in flight will finish, and a refused or failed one will not. Told
+   * apart because a panel that says "reading…" forever after a 403 describes a
+   * state the site is not in and gives the author nothing to do about it.
+   */
+  absence?: "pending" | "failed";
 }
 
 /**
@@ -105,6 +114,7 @@ export function TokensPanel({
   onChange,
   supplied,
   issue,
+  absence = "pending",
   prefersDark = false,
 }: TokensPanelProps): React.JSX.Element {
   const [mode, setMode] = React.useState<TokenMode>(
@@ -114,8 +124,18 @@ export function TokensPanel({
 
   if (tokens === undefined) {
     return (
-      <div className="nx-tokens" data-empty="loading">
-        <p className="nx-inspector__note">Reading this site&rsquo;s tokens…</p>
+      <div
+        className="nx-tokens"
+        data-empty={absence === "failed" ? "failed" : "loading"}
+      >
+        <p
+          className="nx-inspector__note"
+          role={absence === "failed" ? "alert" : undefined}
+        >
+          {absence === "failed"
+            ? "This site\u2019s tokens could not be read, so none can be shown or changed. Reload to try again."
+            : "Reading this site\u2019s tokens\u2026"}
+        </p>
       </div>
     );
   }
@@ -320,7 +340,14 @@ function TokenEntry({
           aria-describedby={said.length > 0 ? noteId : undefined}
           onBlur={event => {
             const next = event.target.value;
-            if (next !== row.value) {
+            /*
+             * Compared against what this MODE actually holds, not against what
+             * the row displays. In dark, a token with no dark value displays
+             * the light one — so typing that same value is a real edit, the one
+             * that PINS dark before light is changed later, and comparing
+             * against the display would discard exactly it.
+             */
+            if (next !== row.stored) {
               onChange(setTokenValue(tokens, row.at, mode, next));
             }
           }}

--- a/packages/builder/src/tokens-panel.tsx
+++ b/packages/builder/src/tokens-panel.tsx
@@ -1,0 +1,404 @@
+/**
+ * The tokens studio: the site's design tokens, and the edits an author makes.
+ *
+ * A panel over {@link tokens-studio}, which holds every rule this draws. The
+ * split is the same one the style inspector uses: the projection decides what a
+ * token IS and what an edit produces, this decides what it looks like, and the
+ * rules stay testable without a DOM.
+ *
+ * ## The table is the editor
+ *
+ * Values are edited where they are read, rather than behind a detail form.
+ * Figma's variables table and Tokens Studio both work this way, and the reason
+ * is the shape of the work: the common edit is nudging one value, and a form
+ * turns that into two clicks and a context switch. It also suits the rail,
+ * which is narrow enough that a form would compete with the list it came from.
+ *
+ * ## Edits are lifted, not saved here
+ *
+ * Every control reports a NEW token set to the host and stores nothing. Saving
+ * belongs to whoever owns the document — in the page builder that is the
+ * section-scoped site-style write, which this package cannot reach and should
+ * not — so this stays a controlled surface with no opinion about persistence.
+ *
+ * ## A colour value is typed, not picked, in this release
+ *
+ * Deliberate, and it is not a gap in the design. `@nextlyhq/ui`'s ColorPicker
+ * holds unparseable hex in a private draft that is reset by `onBlur`, and a
+ * dismissal is not a blur — so leaving it mid-edit commits the last value it
+ * published rather than the one on screen. On a block that costs one
+ * declaration. On a TOKEN it would silently change a value the whole site
+ * resolves. The swatch here therefore previews and does not open, until that
+ * contract is fixed.
+ *
+ * @module tokens-panel
+ */
+import {
+  TOKEN_KINDS,
+  type SiteTokenSet,
+  type TokenKind,
+  type TokenMode,
+} from "@nextlyhq/blocks-engine";
+import {
+  Button,
+  Input,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@nextlyhq/ui";
+import * as React from "react";
+
+import { colourHexOf } from "./style-colour";
+import {
+  TOKEN_KIND_LABELS,
+  addToken,
+  clearDarkValue,
+  removeToken,
+  renameToken,
+  setTokenValue,
+  tokenCounts,
+  tokenNameIssue,
+  tokenRowsFor,
+  type TokenRow,
+} from "./tokens-studio";
+
+export interface TokensPanelProps {
+  /**
+   * The site's tokens, or `undefined` while the host has not read them yet.
+   *
+   * A real third state rather than an empty table: a site that has stored
+   * nothing legitimately has no tokens, so a panel that drew the two the same
+   * way would invite an author to add a token into a set that is about to be
+   * replaced by the one still loading.
+   */
+  tokens: SiteTokenSet | undefined;
+  /** An edit. The host owns the document and decides when to persist. */
+  onChange: (tokens: SiteTokenSet) => void;
+  /** Whether the canvas is currently showing dark values. */
+  prefersDark?: boolean;
+}
+
+/**
+ * The studio.
+ *
+ * `tokens === undefined` draws a note rather than an empty table, and rather
+ * than a spinner: the read is usually instant and a flash of one reads as a
+ * fault. An author who arrives before it lands sees a sentence.
+ */
+export function TokensPanel({
+  tokens,
+  onChange,
+  prefersDark = false,
+}: TokensPanelProps): React.JSX.Element {
+  const [mode, setMode] = React.useState<TokenMode>(
+    prefersDark ? "dark" : "light"
+  );
+  const counts = tokenCounts(tokens);
+
+  if (tokens === undefined) {
+    return (
+      <div className="nx-tokens" data-empty="loading">
+        <p className="nx-inspector__note">Reading this site&rsquo;s tokens…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="nx-tokens">
+      <div className="nx-tokens__head">
+        <h2 className="nx-tokens__title">Tokens</h2>
+        <ModeSwitch mode={mode} onMode={setMode} />
+      </div>
+      <Tabs defaultValue="color" className="nx-tokens__tabs">
+        <TabsList>
+          {TOKEN_KINDS.map(kind => (
+            <TabsTrigger key={kind} value={kind}>
+              {TOKEN_KIND_LABELS[kind]}
+              {counts[kind] > 0 ? (
+                <span className="nx-tokens__count">{counts[kind]}</span>
+              ) : null}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        {TOKEN_KINDS.map(kind => (
+          <TabsContent key={kind} value={kind}>
+            <TokenList
+              kind={kind}
+              tokens={tokens}
+              mode={mode}
+              onChange={onChange}
+            />
+          </TabsContent>
+        ))}
+      </Tabs>
+    </div>
+  );
+}
+
+/**
+ * Which mode's values the table is editing.
+ *
+ * Two states of one property, so a segmented pair rather than two buttons that
+ * happen to be adjacent — the same shape the style inspector's toggles take.
+ * It sets what an EDIT writes, not merely what is shown, which is why it sits
+ * above the tabs where it governs all of them rather than inside one.
+ */
+function ModeSwitch({
+  mode,
+  onMode,
+}: {
+  mode: TokenMode;
+  onMode: (mode: TokenMode) => void;
+}): React.JSX.Element {
+  return (
+    <div className="nx-tokens__modes" role="group" aria-label="Token mode">
+      {(["light", "dark"] as const).map(candidate => (
+        <button
+          key={candidate}
+          type="button"
+          onClick={() => onMode(candidate)}
+          aria-pressed={mode === candidate}
+        >
+          {candidate === "light" ? "Light" : "Dark"}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** Every token of one kind, with the way to add another. */
+function TokenList({
+  kind,
+  tokens,
+  mode,
+  onChange,
+}: {
+  kind: TokenKind;
+  tokens: SiteTokenSet;
+  mode: TokenMode;
+  onChange: (tokens: SiteTokenSet) => void;
+}): React.JSX.Element {
+  const rows = tokenRowsFor(tokens, kind, mode);
+  return (
+    <div className="nx-tokens__list">
+      {rows.length === 0 ? (
+        <p className="nx-inspector__note">
+          No {TOKEN_KIND_LABELS[kind].toLowerCase()} tokens yet.
+        </p>
+      ) : (
+        <ul>
+          {rows.map(row => (
+            <li key={row.identity}>
+              <TokenEntry
+                row={row}
+                tokens={tokens}
+                mode={mode}
+                onChange={onChange}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => onChange(addToken(tokens, kind).tokens)}
+      >
+        Add {TOKEN_KIND_LABELS[kind].toLowerCase()} token
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * One row: what it is called, what it holds, and how to remove it.
+ *
+ * Both fields commit on blur rather than on every keystroke. A token is read by
+ * the whole site, so an edit per character would recompile the canvas for every
+ * letter of a name — and it would put a half-typed name through the validator,
+ * reporting a refusal about a value the author is still in the middle of.
+ */
+function TokenEntry({
+  row,
+  tokens,
+  mode,
+  onChange,
+}: {
+  row: TokenRow;
+  tokens: SiteTokenSet;
+  mode: TokenMode;
+  onChange: (tokens: SiteTokenSet) => void;
+}): React.JSX.Element {
+  const id = React.useId();
+  const [nameIssue, setNameIssue] = React.useState<string | null>(null);
+  const noteId = `${id}-note`;
+
+  const commitName = (next: string): void => {
+    if (next.trim() === row.name) {
+      setNameIssue(null);
+      return;
+    }
+    const refusal = tokenNameIssue(tokens, row.identity, next);
+    setNameIssue(refusal ?? null);
+    if (refusal === undefined)
+      onChange(renameToken(tokens, row.identity, next));
+  };
+
+  const said = [...(nameIssue === null ? [] : [nameIssue]), ...row.issues];
+
+  return (
+    <div className="nx-tokens__row">
+      <Swatch kind={row.kind} value={row.value} />
+      <div className="nx-tokens__fields">
+        <label className="sr-only" htmlFor={`${id}-name`}>
+          Name of {row.name}
+        </label>
+        <Input
+          id={`${id}-name`}
+          className="nx-tokens__name"
+          defaultValue={row.name}
+          // Keyed by identity so a rename does not remount the row, and a
+          // reorder does not carry one row's draft into another's field.
+          key={`${row.identity}-name`}
+          aria-invalid={nameIssue === null ? undefined : true}
+          aria-describedby={said.length > 0 ? noteId : undefined}
+          onBlur={event => commitName(event.target.value)}
+        />
+        <label className="sr-only" htmlFor={`${id}-value`}>
+          {mode === "dark" ? "Dark value" : "Value"} of {row.name}
+        </label>
+        <Input
+          id={`${id}-value`}
+          className="nx-tokens__value"
+          defaultValue={row.value}
+          key={`${row.identity}-value-${mode}`}
+          data-inherited={row.inherited ? "" : undefined}
+          aria-describedby={said.length > 0 ? noteId : undefined}
+          onBlur={event => {
+            const next = event.target.value;
+            if (next !== row.value) {
+              onChange(setTokenValue(tokens, row.identity, mode, next));
+            }
+          }}
+        />
+      </div>
+      <TokenActions row={row} tokens={tokens} mode={mode} onChange={onChange} />
+      {said.length > 0 ? (
+        <p className="nx-tokens__issue" id={noteId} role="status">
+          {said.join(" ")}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Removing a token, and dropping a dark value back to following light.
+ *
+ * Its own component because both are DESTRUCTIVE in a way the two fields above
+ * are not — a field edit changes a value, and these two change what resolves
+ * for pages nobody is looking at.
+ */
+function TokenActions({
+  row,
+  tokens,
+  mode,
+  onChange,
+}: {
+  row: TokenRow;
+  tokens: SiteTokenSet;
+  mode: TokenMode;
+  onChange: (tokens: SiteTokenSet) => void;
+}): React.JSX.Element {
+  const [confirming, setConfirming] = React.useState(false);
+
+  if (confirming) {
+    return (
+      <div className="nx-tokens__confirm" role="group">
+        {/*
+          Named rather than counted. Answering "how many pages use this" needs a
+          search INSIDE a JSON column, which no dialect this ships on can do
+          portably — so the warning says what removal MEANS rather than
+          inventing a number it cannot stand behind.
+        */}
+        <p className="nx-tokens__issue">
+          Any block using <strong>{row.name}</strong> loses that style. The page
+          still renders.
+        </p>
+        <Button
+          type="button"
+          variant="destructive"
+          size="sm"
+          onClick={() => onChange(removeToken(tokens, row.identity))}
+        >
+          Remove
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => setConfirming(false)}
+        >
+          Keep
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="nx-tokens__actions">
+      {mode === "dark" && !row.inherited ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => onChange(clearDarkValue(tokens, row.identity))}
+        >
+          Match light
+        </Button>
+      ) : null}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        aria-label={`Remove ${row.name}`}
+        onClick={() => setConfirming(true)}
+      >
+        Remove
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * A preview of what the value is, where one can be drawn honestly.
+ *
+ * Only a colour gets painted, and only when this package can resolve it
+ * WITHOUT the site's table — a token whose value is a `var()` would otherwise
+ * resolve against the panel's own custom properties rather than the canvas's
+ * and show a colour the page does not have. Every other kind gets nothing
+ * rather than an approximation of itself.
+ */
+function Swatch({
+  kind,
+  value,
+}: {
+  kind: TokenKind;
+  value: string;
+}): React.JSX.Element {
+  const hex = kind === "color" ? colourHexOf(value, undefined) : undefined;
+  return (
+    <span
+      className="nx-tokens__swatch"
+      aria-hidden="true"
+      data-empty={hex === undefined ? "" : undefined}
+      style={
+        hex === undefined
+          ? undefined
+          : ({ "--nx-swatch": hex } as React.CSSProperties)
+      }
+    />
+  );
+}

--- a/packages/builder/src/tokens-panel.tsx
+++ b/packages/builder/src/tokens-panel.tsx
@@ -35,6 +35,8 @@
  */
 import {
   TOKEN_KINDS,
+  tokenIdentity,
+  type SiteToken,
   type SiteTokenSet,
   type TokenKind,
   type TokenMode,
@@ -75,6 +77,18 @@ export interface TokensPanelProps {
   tokens: SiteTokenSet | undefined;
   /** An edit. The host owns the document and decides when to persist. */
   onChange: (tokens: SiteTokenSet) => void;
+  /**
+   * The tokens the SITE'S CODE supplies, which the stored ones layer over.
+   *
+   * Needed because these two are not equally editable. A supplied token can be
+   * overridden and reset, and cannot be removed: absence from the stored tier
+   * means "no override", so a removal would merge straight back on the next
+   * read. Offering a Remove that quietly undoes itself is worse than not
+   * offering one.
+   */
+  supplied?: SiteTokenSet;
+  /** What the last save said, when it failed. Nothing while it is succeeding. */
+  issue?: string;
   /** Whether the canvas is currently showing dark values. */
   prefersDark?: boolean;
 }
@@ -89,6 +103,8 @@ export interface TokensPanelProps {
 export function TokensPanel({
   tokens,
   onChange,
+  supplied,
+  issue,
   prefersDark = false,
 }: TokensPanelProps): React.JSX.Element {
   const [mode, setMode] = React.useState<TokenMode>(
@@ -110,6 +126,17 @@ export function TokensPanel({
         <h2 className="nx-tokens__title">Tokens</h2>
         <ModeSwitch mode={mode} onMode={setMode} />
       </div>
+      {issue === undefined ? null : (
+        /*
+         * A save that did not happen. `role="alert"` because it reports on an
+         * action the author has already taken and believes is done — the table
+         * still shows what they typed, and without this the only signal that
+         * the site was never changed is the canvas failing to move.
+         */
+        <p className="nx-tokens__issue" role="alert">
+          {issue}
+        </p>
+      )}
       <Tabs defaultValue="color" className="nx-tokens__tabs">
         <TabsList>
           {TOKEN_KINDS.map(kind => (
@@ -126,6 +153,7 @@ export function TokensPanel({
             <TokenList
               kind={kind}
               tokens={tokens}
+              supplied={supplied}
               mode={mode}
               onChange={onChange}
             />
@@ -171,11 +199,13 @@ function ModeSwitch({
 function TokenList({
   kind,
   tokens,
+  supplied,
   mode,
   onChange,
 }: {
   kind: TokenKind;
   tokens: SiteTokenSet;
+  supplied: SiteTokenSet | undefined;
   mode: TokenMode;
   onChange: (tokens: SiteTokenSet) => void;
 }): React.JSX.Element {
@@ -189,10 +219,11 @@ function TokenList({
       ) : (
         <ul>
           {rows.map(row => (
-            <li key={row.identity}>
+            <li key={row.at}>
               <TokenEntry
                 row={row}
                 tokens={tokens}
+                from={suppliedTokenFor(supplied, row.identity)}
                 mode={mode}
                 onChange={onChange}
               />
@@ -223,11 +254,14 @@ function TokenList({
 function TokenEntry({
   row,
   tokens,
+  from,
   mode,
   onChange,
 }: {
   row: TokenRow;
   tokens: SiteTokenSet;
+  /** The site config's own version of this token, when it supplies one. */
+  from: SiteToken | undefined;
   mode: TokenMode;
   onChange: (tokens: SiteTokenSet) => void;
 }): React.JSX.Element {
@@ -240,10 +274,9 @@ function TokenEntry({
       setNameIssue(null);
       return;
     }
-    const refusal = tokenNameIssue(tokens, row.identity, next);
+    const refusal = tokenNameIssue(tokens, row.at, next);
     setNameIssue(refusal ?? null);
-    if (refusal === undefined)
-      onChange(renameToken(tokens, row.identity, next));
+    if (refusal === undefined) onChange(renameToken(tokens, row.at, next));
   };
 
   const said = [...(nameIssue === null ? [] : [nameIssue]), ...row.issues];
@@ -261,7 +294,7 @@ function TokenEntry({
           defaultValue={row.name}
           // Keyed by identity so a rename does not remount the row, and a
           // reorder does not carry one row's draft into another's field.
-          key={`${row.identity}-name`}
+          key={`${row.at}-name`}
           aria-invalid={nameIssue === null ? undefined : true}
           aria-describedby={said.length > 0 ? noteId : undefined}
           onBlur={event => commitName(event.target.value)}
@@ -273,18 +306,24 @@ function TokenEntry({
           id={`${id}-value`}
           className="nx-tokens__value"
           defaultValue={row.value}
-          key={`${row.identity}-value-${mode}`}
+          key={`${row.at}-value-${mode}`}
           data-inherited={row.inherited ? "" : undefined}
           aria-describedby={said.length > 0 ? noteId : undefined}
           onBlur={event => {
             const next = event.target.value;
             if (next !== row.value) {
-              onChange(setTokenValue(tokens, row.identity, mode, next));
+              onChange(setTokenValue(tokens, row.at, mode, next));
             }
           }}
         />
       </div>
-      <TokenActions row={row} tokens={tokens} mode={mode} onChange={onChange} />
+      <TokenActions
+        row={row}
+        tokens={tokens}
+        from={from}
+        mode={mode}
+        onChange={onChange}
+      />
       {said.length > 0 ? (
         <p className="nx-tokens__issue" id={noteId} role="status">
           {said.join(" ")}
@@ -304,11 +343,13 @@ function TokenEntry({
 function TokenActions({
   row,
   tokens,
+  from,
   mode,
   onChange,
 }: {
   row: TokenRow;
   tokens: SiteTokenSet;
+  from: SiteToken | undefined;
   mode: TokenMode;
   onChange: (tokens: SiteTokenSet) => void;
 }): React.JSX.Element {
@@ -331,7 +372,7 @@ function TokenActions({
           type="button"
           variant="destructive"
           size="sm"
-          onClick={() => onChange(removeToken(tokens, row.identity))}
+          onClick={() => onChange(removeToken(tokens, row.at))}
         >
           Remove
         </Button>
@@ -354,21 +395,75 @@ function TokenActions({
           type="button"
           variant="ghost"
           size="sm"
-          onClick={() => onChange(clearDarkValue(tokens, row.identity))}
+          onClick={() => onChange(clearDarkValue(tokens, row.at))}
         >
           Match light
         </Button>
       ) : null}
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        aria-label={`Remove ${row.name}`}
-        onClick={() => setConfirming(true)}
-      >
-        Remove
-      </Button>
+      {from === undefined ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-label={`Remove ${row.name}`}
+          onClick={() => setConfirming(true)}
+        >
+          Remove
+        </Button>
+      ) : (
+        /*
+         * A token the site's code supplies. It cannot be REMOVED here: the
+         * stored tier expresses overrides, and absence from it means "no
+         * override", so a removal would merge straight back on the next read.
+         * Reset is the honest counterpart — it drops the override and lets the
+         * site's own value through again, which is what an author actually
+         * means by undoing their edit.
+         */
+        <>
+          <span className="nx-tokens__origin">From site config</span>
+          {differs(row, from, mode) ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              aria-label={`Reset ${row.name}`}
+              onClick={() => onChange(resetToken(tokens, row.at, from))}
+            >
+              Reset
+            </Button>
+          ) : null}
+        </>
+      )}
     </div>
+  );
+}
+
+/** Whether the author has changed this token away from the site's own value. */
+function differs(row: TokenRow, from: SiteToken, mode: TokenMode): boolean {
+  return (
+    row.name !== from.name ||
+    row.value !== (from.values[mode] ?? from.values.light)
+  );
+}
+
+/** The site's own token back in place of the author's override. */
+function resetToken(
+  tokens: SiteTokenSet,
+  at: number,
+  from: SiteToken
+): SiteTokenSet {
+  const next = [...tokens.tokens];
+  next[at] = from;
+  return { ...tokens, tokens: next };
+}
+
+/** The site config's own version of a token, matched the way the merge does. */
+function suppliedTokenFor(
+  supplied: SiteTokenSet | undefined,
+  identity: string
+): SiteToken | undefined {
+  return (supplied?.tokens ?? []).find(
+    token => tokenIdentity(token) === identity
   );
 }
 

--- a/packages/builder/src/tokens-panel.tsx
+++ b/packages/builder/src/tokens-panel.tsx
@@ -78,13 +78,18 @@ export interface TokensPanelProps {
   /** An edit. The host owns the document and decides when to persist. */
   onChange: (tokens: SiteTokenSet) => void;
   /**
-   * The tokens the SITE'S CODE supplies, which the stored ones layer over.
+   * The tokens something ELSE supplies, which the stored ones layer over.
    *
    * Needed because these two are not equally editable. A supplied token can be
    * overridden and reset, and cannot be removed: absence from the stored tier
    * means "no override", so a removal would merge straight back on the next
    * read. Offering a Remove that quietly undoes itself is worse than not
    * offering one.
+   *
+   * Two sources arrive as one set — the site's own config, and the ENGINE's
+   * defaults that `resolveSiteTokens` layers under everything. They behave
+   * identically here, so the row says "Default" rather than naming a source
+   * this panel cannot tell apart.
    */
   supplied?: SiteTokenSet;
   /** What the last save said, when it failed. Nothing while it is succeeding. */
@@ -456,7 +461,7 @@ function TokenActions({
          * means by undoing their edit.
          */
         <>
-          <span className="nx-tokens__origin">From site config</span>
+          <span className="nx-tokens__origin">Default</span>
           {differs(row, from, mode) ? (
             <Button
               type="button"

--- a/packages/builder/src/tokens-studio.test.ts
+++ b/packages/builder/src/tokens-studio.test.ts
@@ -14,6 +14,7 @@
  */
 import {
   compileSiteSheet,
+  emitTokenBlocks,
   tokenIdentity,
   type SiteTokenSet,
 } from "@nextlyhq/blocks-engine";
@@ -103,7 +104,7 @@ describe("what each tab shows", () => {
 
 describe("renaming a token keeps every reference resolving", () => {
   it("FREEZES the identity at the name it had", () => {
-    const next = renameToken(TOKENS, "color.ink", "text.body");
+    const next = renameToken(TOKENS, 0, "text.body");
     const token = next.tokens.find(t => t.name === "text.body");
     expect(token).toBeDefined();
     // The label moved; the identity is pinned at the original name.
@@ -117,7 +118,7 @@ describe("renaming a token keeps every reference resolving", () => {
     const before = declared(TOKENS);
     expect(before).toContain("--site-color-ink");
 
-    const after = declared(renameToken(TOKENS, "color.ink", "text.body"));
+    const after = declared(renameToken(TOKENS, 0, "text.body"));
     expect(after).toContain("--site-color-ink");
     // And it did NOT start emitting the label instead.
     expect(after).not.toContain("--site-text-body");
@@ -127,22 +128,22 @@ describe("renaming a token keeps every reference resolving", () => {
     // The second rename must read the id the first froze, not re-pin to the
     // interim name — otherwise a token renamed twice loses its references on
     // the second edit rather than the first.
-    const once = renameToken(TOKENS, "color.ink", "text.body");
-    const twice = renameToken(once, "color.ink", "copy.default");
+    const once = renameToken(TOKENS, 0, "text.body");
+    const twice = renameToken(once, 0, "copy.default");
     const token = twice.tokens.find(t => t.name === "copy.default");
     expect(tokenIdentity(token as never)).toBe("color.ink");
     expect(declared(twice)).toContain("--site-color-ink");
   });
 
   it("renames a token that ALREADY has a frozen identity without moving it", () => {
-    const next = renameToken(TOKENS, "color.primary", "brand.primary");
+    const next = renameToken(TOKENS, 1, "brand.primary");
     const token = next.tokens.find(t => t.name === "brand.primary");
     expect(tokenIdentity(token as never)).toBe("color.primary");
     expect(declared(next)).toContain("--site-color-primary");
   });
 
-  it("leaves the set alone for an identity it does not hold", () => {
-    expect(renameToken(TOKENS, "nope", "x")).toEqual(TOKENS);
+  it("leaves the set alone for a position it does not hold", () => {
+    expect(renameToken(TOKENS, 99, "x")).toEqual(TOKENS);
   });
 });
 
@@ -151,32 +152,32 @@ describe("which names are refused", () => {
     // Held to the ENGINE's grammar, which is what a stored `$token` is held to
     // — a table accepting a name references cannot name would hold tokens that
     // exist and resolve to nothing.
-    expect(tokenNameIssue(TOKENS, "color.ink", "has spaces")).toBeDefined();
-    expect(tokenNameIssue(TOKENS, "color.ink", "x:1}body{color")).toBeDefined();
+    expect(tokenNameIssue(TOKENS, 0, "has spaces")).toBeDefined();
+    expect(tokenNameIssue(TOKENS, 0, "x:1}body{color")).toBeDefined();
   });
 
   it("refuses an empty name", () => {
-    expect(tokenNameIssue(TOKENS, "color.ink", "   ")).toBeDefined();
+    expect(tokenNameIssue(TOKENS, 0, "   ")).toBeDefined();
   });
 
   it("refuses a name another token already reads under", () => {
-    expect(tokenNameIssue(TOKENS, "color.ink", "brand.main")).toBeDefined();
+    expect(tokenNameIssue(TOKENS, 0, "brand.main")).toBeDefined();
   });
 
   it("allows a token to keep its own name", () => {
     // Comparing by name alone would report every token as colliding with
     // itself the moment its own field is validated.
-    expect(tokenNameIssue(TOKENS, "color.ink", "color.ink")).toBeUndefined();
+    expect(tokenNameIssue(TOKENS, 0, "color.ink")).toBeUndefined();
   });
 
   it("allows a good new name", () => {
-    expect(tokenNameIssue(TOKENS, "color.ink", "text.body")).toBeUndefined();
+    expect(tokenNameIssue(TOKENS, 0, "text.body")).toBeUndefined();
   });
 });
 
 describe("editing a value", () => {
   it("writes one mode without disturbing the other", () => {
-    const next = setTokenValue(TOKENS, "color.primary", "dark", "#1e3a8a");
+    const next = setTokenValue(TOKENS, 1, "dark", "#1e3a8a");
     const token = next.tokens.find(t => t.name === "brand.main");
     expect(token?.values.dark).toBe("#1e3a8a");
     // Light is what a reader with no mode set resolves; losing it would make
@@ -187,14 +188,14 @@ describe("editing a value", () => {
   it("clears a dark value so it FOLLOWS light again", () => {
     // Distinct from copying light into dark, which looks identical and is a
     // different document: an explicit dark value stops tracking later edits.
-    const next = clearDarkValue(TOKENS, "color.primary");
+    const next = clearDarkValue(TOKENS, 1);
     const token = next.tokens.find(t => t.name === "brand.main");
     expect(token?.values.dark).toBeUndefined();
     expect(token?.values.light).toBe("#3b82f6");
   });
 
   it("reports what the engine says about a value that contradicts its kind", () => {
-    const next = setTokenValue(TOKENS, "color.ink", "light", "16px");
+    const next = setTokenValue(TOKENS, 0, "light", "16px");
     const row = tokenRowsFor(next, "color").find(
       r => r.identity === "color.ink"
     );
@@ -210,12 +211,7 @@ describe("editing a value", () => {
   });
 
   it("reports a value that would make the page fetch a file", () => {
-    const next = setTokenValue(
-      TOKENS,
-      "color.ink",
-      "light",
-      "url(https://e.test/a.png)"
-    );
+    const next = setTokenValue(TOKENS, 0, "light", "url(https://e.test/a.png)");
     const row = tokenRowsFor(next, "color").find(
       r => r.identity === "color.ink"
     );
@@ -250,13 +246,15 @@ describe("two tokens that collide on one custom property", () => {
 
 describe("adding a token", () => {
   it("appends a valid token the engine will write", () => {
-    const { tokens: next, identity } = addToken(TOKENS, "color");
-    const row = tokenRowsFor(next, "color").find(r => r.identity === identity);
+    const { tokens: next, at } = addToken(TOKENS, "color");
+    const row = tokenRowsFor(next, "color").find(r => r.at === at);
     expect(row).toBeDefined();
     // Seeded rather than empty: an empty value is refused by the emitter, so a
     // token created empty would arrive already broken.
     expect(row?.issues).toEqual([]);
-    expect(declared(next)).toContain(`--site-${identity.replace(/\./g, "-")}`);
+    expect(declared(next)).toContain(
+      `--site-${(row?.identity ?? "").replace(/\./g, "-")}`
+    );
   });
 
   it("gives every kind a seed its own emitter accepts", () => {
@@ -265,8 +263,8 @@ describe("adding a token", () => {
     for (const kind of Object.keys(
       TOKEN_KIND_LABELS
     ) as (keyof typeof TOKEN_KIND_LABELS)[]) {
-      const { tokens: next, identity } = addToken({ tokens: [] }, kind);
-      const row = tokenRowsFor(next, kind).find(r => r.identity === identity);
+      const { tokens: next, at } = addToken({ tokens: [] }, kind);
+      const row = tokenRowsFor(next, kind).find(r => r.at === at);
       expect(row?.issues, `${kind} seed`).toEqual([]);
     }
   });
@@ -274,21 +272,23 @@ describe("adding a token", () => {
   it("does not reuse a name, nor an identity a rename left behind", () => {
     // A renamed token keeps its old name as its IDENTITY, so a new token
     // taking that name would collide on the custom property.
-    const renamed = renameToken(TOKENS, "color.ink", "text.body");
-    const { identity } = addToken(renamed, "color");
-    expect(identity).not.toBe("color.ink");
-    expect(identity).not.toBe("text.body");
+    const renamed = renameToken(TOKENS, 0, "text.body");
+    const { tokens: next, at } = addToken(renamed, "color");
+    const name = next.tokens[at]?.name;
+    expect(name).not.toBe("color.ink");
+    expect(name).not.toBe("text.body");
   });
 
   it("starts from nothing when the site has no table yet", () => {
-    const { tokens: next } = addToken(undefined, "color");
+    const { tokens: next, at } = addToken(undefined, "color");
     expect(next.tokens.length).toBe(1);
+    expect(at).toBe(0);
   });
 });
 
 describe("removing a token", () => {
   it("takes it out and leaves the rest", () => {
-    const next = removeToken(TOKENS, "color.ink");
+    const next = removeToken(TOKENS, 0);
     expect(next.tokens.map(t => t.name)).toEqual(["brand.main", "space.4"]);
   });
 
@@ -297,15 +297,100 @@ describe("removing a token", () => {
     // token compiles a `var()` nothing declares, so the declaration is dropped
     // and the style is absent with no error anywhere.
     expect(declared(TOKENS)).toContain("--site-color-ink");
-    expect(declared(removeToken(TOKENS, "color.ink"))).not.toContain(
-      "--site-color-ink"
-    );
+    expect(declared(removeToken(TOKENS, 0))).not.toContain("--site-color-ink");
   });
 
   it("removes by IDENTITY, not by the label", () => {
     // Removing `brand.main` by name would miss it, because what identifies it
     // is `color.primary`.
-    const next = removeToken(TOKENS, "color.primary");
+    const next = removeToken(TOKENS, 1);
     expect(next.tokens.map(t => t.name)).toEqual(["color.ink", "space.4"]);
+  });
+});
+
+describe("two entries that share one identity are addressed apart", () => {
+  /**
+   * A set a legacy or imported document can really hold. The read path keeps
+   * BOTH so the engine's complaint about the collision is visible on the row
+   * that has it — which is the whole point, since this is the state the studio
+   * exists to help an author repair.
+   */
+  const twinned: SiteTokenSet = {
+    tokens: [
+      { name: "color.dup", kind: "color", values: { light: "#111111" } },
+      { name: "color.dup", kind: "color", values: { light: "#222222" } },
+    ],
+  };
+
+  it("shows both rows, with the collision named on the second", () => {
+    const rows = tokenRowsFor(twinned, "color");
+    expect(rows.map(r => r.at)).toEqual([0, 1]);
+    expect(rows[0]?.issues).toEqual([]);
+    expect(rows[1]?.issues.join(" ")).toContain("both become");
+  });
+
+  it("edits the row the author is on, not the first one that matches", () => {
+    // Addressed by identity, every edit to the second row would land on the
+    // first — so the collision could never be repaired from the row that has
+    // it, and an author would watch the wrong value change.
+    const next = setTokenValue(twinned, 1, "light", "#333333");
+    expect(next.tokens[0]?.values.light).toBe("#111111");
+    expect(next.tokens[1]?.values.light).toBe("#333333");
+  });
+
+  it("renames only the row the author is on", () => {
+    const next = renameToken(twinned, 1, "color.other");
+    expect(next.tokens[0]?.name).toBe("color.dup");
+    expect(next.tokens[1]?.name).toBe("color.other");
+  });
+
+  it("removes ONE of them, not both", () => {
+    // Filtering on the identity takes both, which is the opposite of what
+    // repairing a collision means.
+    const next = removeToken(twinned, 1);
+    expect(next.tokens.length).toBe(1);
+    expect(next.tokens[0]?.values.light).toBe("#111111");
+  });
+
+  it("does not report a name collision against the row being edited", () => {
+    // Row 1 keeping its own name is not a clash with itself; row 1 taking
+    // row 0's name is.
+    expect(tokenNameIssue(twinned, 1, "color.dup")).toBeDefined();
+    expect(tokenNameIssue(twinned, 0, "color.dup")).toBeDefined();
+    expect(tokenNameIssue(twinned, 1, "color.fresh")).toBeUndefined();
+  });
+});
+
+describe("a generated name is free as a CUSTOM PROPERTY, not as a string", () => {
+  it("skips a candidate whose property another spelling already took", () => {
+    // `color-2` and `color.2` are different strings and both become
+    // `--site-color-2`. A raw-name check hands back `color.2` and the emitter
+    // refuses it the moment it is written.
+    const set: SiteTokenSet = {
+      tokens: [
+        { name: "color", kind: "color", values: { light: "#111111" } },
+        { name: "color-2", kind: "color", values: { light: "#222222" } },
+      ],
+    };
+    const { tokens: next, at } = addToken(set, "color");
+    const added = next.tokens[at];
+    expect(added).toBeDefined();
+    // Whatever it chose, the ENGINE has to accept the whole set.
+    expect(emitTokenBlocks(next, ":root").issues).toEqual([]);
+    expect(added?.name).not.toBe("color.2");
+  });
+});
+
+describe("the seed for a custom token survives being USED", () => {
+  it("substitutes into a declaration rather than invalidating it", () => {
+    // A CSS-wide keyword passes the emitter and is written without complaint,
+    // then behaves as the guaranteed-invalid value at SUBSTITUTION — so
+    // `var(--site-custom)` would invalidate the declaration reading it. The
+    // emitter cannot see that, so asserting it is happy proves nothing.
+    const { tokens: next, at } = addToken({ tokens: [] }, "custom");
+    const seeded = next.tokens[at]?.values.light ?? "";
+    expect(seeded).not.toBe("");
+    const CSS_WIDE = ["initial", "inherit", "unset", "revert", "revert-layer"];
+    expect(CSS_WIDE).not.toContain(seeded.trim().toLowerCase());
   });
 });

--- a/packages/builder/src/tokens-studio.test.ts
+++ b/packages/builder/src/tokens-studio.test.ts
@@ -394,3 +394,47 @@ describe("the seed for a custom token survives being USED", () => {
     expect(CSS_WIDE).not.toContain(seeded.trim().toLowerCase());
   });
 });
+
+describe("a row key that survives a removal elsewhere in the list", () => {
+  const set: SiteTokenSet = {
+    tokens: [
+      { name: "color.a", kind: "color", values: { light: "#111111" } },
+      { name: "color.b", kind: "color", values: { light: "#222222" } },
+      { name: "color.c", kind: "color", values: { light: "#333333" } },
+    ],
+  };
+
+  it("keeps a survivor's key when an EARLIER row is removed", () => {
+    // The position cannot be the key: deleting a non-tail token shifts every
+    // following `at`, so React reuses the deleted row's component for its
+    // successor — carrying the uncontrolled fields and the confirm state onto
+    // a different token.
+    const before = tokenRowsFor(set, "color");
+    const after = tokenRowsFor(removeToken(set, 0), "color");
+    expect(before.map(r => r.at)).toEqual([0, 1, 2]);
+    expect(after.map(r => r.at)).toEqual([0, 1]);
+    // The positions shifted; the keys did not.
+    expect(after.map(r => r.key)).toEqual(before.slice(1).map(r => r.key));
+  });
+
+  it("is unique when two entries share an identity", () => {
+    // The reason the identity alone cannot be the key either.
+    const twinned: SiteTokenSet = {
+      tokens: [
+        { name: "color.dup", kind: "color", values: { light: "#111111" } },
+        { name: "color.dup", kind: "color", values: { light: "#222222" } },
+      ],
+    };
+    const keys = tokenRowsFor(twinned, "color").map(r => r.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("does not change when a row is renamed", () => {
+    // A rename freezes the identity, so the key rides that rather than the
+    // label — a row must not remount because its name was edited.
+    const renamed = renameToken(set, 1, "color.renamed");
+    expect(tokenRowsFor(renamed, "color")[1]?.key).toBe(
+      tokenRowsFor(set, "color")[1]?.key
+    );
+  });
+});

--- a/packages/builder/src/tokens-studio.test.ts
+++ b/packages/builder/src/tokens-studio.test.ts
@@ -1,0 +1,311 @@
+/**
+ * The tokens studio's rules, without a panel around them.
+ *
+ * The one that matters most is the rename, and it is the reason this file
+ * exists apart from the panel test: a rename that moves the identity breaks
+ * every stored reference on the site and NOTHING reports it — the custom
+ * property moves, the reference resolves to nothing, the declaration is
+ * dropped, and the page renders with the style simply absent. There is no
+ * error, no console warning and no visual difference on the page being edited.
+ * So it is asserted here directly, against the engine's own compiler, rather
+ * than inferred from a rendered row.
+ *
+ * @module tokens-studio.test
+ */
+import {
+  compileSiteSheet,
+  tokenIdentity,
+  type SiteTokenSet,
+} from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import {
+  TOKEN_KIND_LABELS,
+  addToken,
+  clearDarkValue,
+  removeToken,
+  renameToken,
+  setTokenValue,
+  tokenCounts,
+  tokenNameIssue,
+  tokenRowsFor,
+} from "./tokens-studio";
+
+const BREAKPOINTS = { base: { id: "base", label: "Base" } } as never;
+
+/** A site with one plain token and one already renamed, so the two differ. */
+const TOKENS: SiteTokenSet = {
+  tokens: [
+    { name: "color.ink", kind: "color", values: { light: "#111111" } },
+    {
+      id: "color.primary",
+      name: "brand.main",
+      kind: "color",
+      values: { light: "#3b82f6", dark: "#93c5fd" },
+    },
+    { name: "space.4", kind: "dimension", values: { light: "1rem" } },
+  ],
+};
+
+/** Every `--custom-property` a compiled site sheet DECLARES. */
+function declared(set: SiteTokenSet): string[] {
+  const sheet = compileSiteSheet({ tokens: set, breakpoints: BREAKPOINTS });
+  return [...sheet.css.matchAll(/(--[a-zA-Z0-9_-]+)\s*:/g)].map(
+    m => m[1] ?? ""
+  );
+}
+
+describe("what each tab shows", () => {
+  it("lists only the tokens of that kind, in stored order", () => {
+    expect(tokenRowsFor(TOKENS, "color").map(r => r.name)).toEqual([
+      "color.ink",
+      "brand.main",
+    ]);
+    expect(tokenRowsFor(TOKENS, "dimension").map(r => r.name)).toEqual([
+      "space.4",
+    ]);
+  });
+
+  it("carries the IDENTITY beside the name, which differ after a rename", () => {
+    const row = tokenRowsFor(TOKENS, "color").find(
+      r => r.name === "brand.main"
+    );
+    expect(row?.identity).toBe("color.primary");
+  });
+
+  it("shows the dark value in dark, and marks a light fallback as inherited", () => {
+    const dark = tokenRowsFor(TOKENS, "color", "dark");
+    expect(dark.find(r => r.name === "brand.main")?.value).toBe("#93c5fd");
+    expect(dark.find(r => r.name === "brand.main")?.inherited).toBe(false);
+    // `color.ink` defines only light, so dark resolves to it and says so.
+    expect(dark.find(r => r.name === "color.ink")?.value).toBe("#111111");
+    expect(dark.find(r => r.name === "color.ink")?.inherited).toBe(true);
+  });
+
+  it("answers with nothing when no table has been supplied", () => {
+    expect(tokenRowsFor(undefined, "color")).toEqual([]);
+  });
+
+  it("labels every kind the engine defines", () => {
+    // A kind added to the engine with no label here would draw a tab named
+    // after its own identifier.
+    for (const label of Object.values(TOKEN_KIND_LABELS)) {
+      expect(label).not.toBe("");
+    }
+  });
+
+  it("counts each kind for the tab", () => {
+    expect(tokenCounts(TOKENS).color).toBe(2);
+    expect(tokenCounts(TOKENS).dimension).toBe(1);
+    expect(tokenCounts(TOKENS).shadow).toBe(0);
+  });
+});
+
+describe("renaming a token keeps every reference resolving", () => {
+  it("FREEZES the identity at the name it had", () => {
+    const next = renameToken(TOKENS, "color.ink", "text.body");
+    const token = next.tokens.find(t => t.name === "text.body");
+    expect(token).toBeDefined();
+    // The label moved; the identity is pinned at the original name.
+    expect(tokenIdentity(token as never)).toBe("color.ink");
+  });
+
+  it("keeps emitting the SAME custom property a document already references", () => {
+    // The assertion that matters, made against the real compiler rather than
+    // against the token record: a document storing `color.ink` compiles to
+    // `var(--site-color-ink)`, and that property must survive the rename.
+    const before = declared(TOKENS);
+    expect(before).toContain("--site-color-ink");
+
+    const after = declared(renameToken(TOKENS, "color.ink", "text.body"));
+    expect(after).toContain("--site-color-ink");
+    // And it did NOT start emitting the label instead.
+    expect(after).not.toContain("--site-text-body");
+  });
+
+  it("is idempotent across repeated renames", () => {
+    // The second rename must read the id the first froze, not re-pin to the
+    // interim name — otherwise a token renamed twice loses its references on
+    // the second edit rather than the first.
+    const once = renameToken(TOKENS, "color.ink", "text.body");
+    const twice = renameToken(once, "color.ink", "copy.default");
+    const token = twice.tokens.find(t => t.name === "copy.default");
+    expect(tokenIdentity(token as never)).toBe("color.ink");
+    expect(declared(twice)).toContain("--site-color-ink");
+  });
+
+  it("renames a token that ALREADY has a frozen identity without moving it", () => {
+    const next = renameToken(TOKENS, "color.primary", "brand.primary");
+    const token = next.tokens.find(t => t.name === "brand.primary");
+    expect(tokenIdentity(token as never)).toBe("color.primary");
+    expect(declared(next)).toContain("--site-color-primary");
+  });
+
+  it("leaves the set alone for an identity it does not hold", () => {
+    expect(renameToken(TOKENS, "nope", "x")).toEqual(TOKENS);
+  });
+});
+
+describe("which names are refused", () => {
+  it("refuses a name no reference could spell", () => {
+    // Held to the ENGINE's grammar, which is what a stored `$token` is held to
+    // — a table accepting a name references cannot name would hold tokens that
+    // exist and resolve to nothing.
+    expect(tokenNameIssue(TOKENS, "color.ink", "has spaces")).toBeDefined();
+    expect(tokenNameIssue(TOKENS, "color.ink", "x:1}body{color")).toBeDefined();
+  });
+
+  it("refuses an empty name", () => {
+    expect(tokenNameIssue(TOKENS, "color.ink", "   ")).toBeDefined();
+  });
+
+  it("refuses a name another token already reads under", () => {
+    expect(tokenNameIssue(TOKENS, "color.ink", "brand.main")).toBeDefined();
+  });
+
+  it("allows a token to keep its own name", () => {
+    // Comparing by name alone would report every token as colliding with
+    // itself the moment its own field is validated.
+    expect(tokenNameIssue(TOKENS, "color.ink", "color.ink")).toBeUndefined();
+  });
+
+  it("allows a good new name", () => {
+    expect(tokenNameIssue(TOKENS, "color.ink", "text.body")).toBeUndefined();
+  });
+});
+
+describe("editing a value", () => {
+  it("writes one mode without disturbing the other", () => {
+    const next = setTokenValue(TOKENS, "color.primary", "dark", "#1e3a8a");
+    const token = next.tokens.find(t => t.name === "brand.main");
+    expect(token?.values.dark).toBe("#1e3a8a");
+    // Light is what a reader with no mode set resolves; losing it would make
+    // the token vanish for them.
+    expect(token?.values.light).toBe("#3b82f6");
+  });
+
+  it("clears a dark value so it FOLLOWS light again", () => {
+    // Distinct from copying light into dark, which looks identical and is a
+    // different document: an explicit dark value stops tracking later edits.
+    const next = clearDarkValue(TOKENS, "color.primary");
+    const token = next.tokens.find(t => t.name === "brand.main");
+    expect(token?.values.dark).toBeUndefined();
+    expect(token?.values.light).toBe("#3b82f6");
+  });
+
+  it("reports what the engine says about a value that contradicts its kind", () => {
+    const next = setTokenValue(TOKENS, "color.ink", "light", "16px");
+    const row = tokenRowsFor(next, "color").find(
+      r => r.identity === "color.ink"
+    );
+    expect(row?.issues.length).toBeGreaterThan(0);
+    expect(row?.issues.join(" ")).toContain("not a colour");
+  });
+
+  it("says nothing about a value the engine is happy with", () => {
+    const row = tokenRowsFor(TOKENS, "color").find(
+      r => r.identity === "color.ink"
+    );
+    expect(row?.issues).toEqual([]);
+  });
+
+  it("reports a value that would make the page fetch a file", () => {
+    const next = setTokenValue(
+      TOKENS,
+      "color.ink",
+      "light",
+      "url(https://e.test/a.png)"
+    );
+    const row = tokenRowsFor(next, "color").find(
+      r => r.identity === "color.ink"
+    );
+    expect(row?.issues.join(" ")).toContain("load a file");
+  });
+});
+
+describe("two tokens that collide on one custom property", () => {
+  it("names the collision on the token that LOSES it", () => {
+    // `color.primary-dark` and `color-primary.dark` both become
+    // `--site-color-primary-dark`. The emitter writes the first and refuses
+    // the second, so an author editing the second sees no effect on the page.
+    const clashing: SiteTokenSet = {
+      tokens: [
+        {
+          name: "color.primary-dark",
+          kind: "color",
+          values: { light: "#111" },
+        },
+        {
+          name: "color-primary.dark",
+          kind: "color",
+          values: { light: "#222" },
+        },
+      ],
+    };
+    const rows = tokenRowsFor(clashing, "color");
+    expect(rows[0]?.issues).toEqual([]);
+    expect(rows[1]?.issues.join(" ")).toContain("both become");
+  });
+});
+
+describe("adding a token", () => {
+  it("appends a valid token the engine will write", () => {
+    const { tokens: next, identity } = addToken(TOKENS, "color");
+    const row = tokenRowsFor(next, "color").find(r => r.identity === identity);
+    expect(row).toBeDefined();
+    // Seeded rather than empty: an empty value is refused by the emitter, so a
+    // token created empty would arrive already broken.
+    expect(row?.issues).toEqual([]);
+    expect(declared(next)).toContain(`--site-${identity.replace(/\./g, "-")}`);
+  });
+
+  it("gives every kind a seed its own emitter accepts", () => {
+    // The seeds are per-kind and easy to get wrong — `0px` is not a colour and
+    // `#000000` is not a duration. Each is checked against the engine.
+    for (const kind of Object.keys(
+      TOKEN_KIND_LABELS
+    ) as (keyof typeof TOKEN_KIND_LABELS)[]) {
+      const { tokens: next, identity } = addToken({ tokens: [] }, kind);
+      const row = tokenRowsFor(next, kind).find(r => r.identity === identity);
+      expect(row?.issues, `${kind} seed`).toEqual([]);
+    }
+  });
+
+  it("does not reuse a name, nor an identity a rename left behind", () => {
+    // A renamed token keeps its old name as its IDENTITY, so a new token
+    // taking that name would collide on the custom property.
+    const renamed = renameToken(TOKENS, "color.ink", "text.body");
+    const { identity } = addToken(renamed, "color");
+    expect(identity).not.toBe("color.ink");
+    expect(identity).not.toBe("text.body");
+  });
+
+  it("starts from nothing when the site has no table yet", () => {
+    const { tokens: next } = addToken(undefined, "color");
+    expect(next.tokens.length).toBe(1);
+  });
+});
+
+describe("removing a token", () => {
+  it("takes it out and leaves the rest", () => {
+    const next = removeToken(TOKENS, "color.ink");
+    expect(next.tokens.map(t => t.name)).toEqual(["brand.main", "space.4"]);
+  });
+
+  it("stops the site sheet declaring its property", () => {
+    // What the warning in the panel is about: a page still referencing this
+    // token compiles a `var()` nothing declares, so the declaration is dropped
+    // and the style is absent with no error anywhere.
+    expect(declared(TOKENS)).toContain("--site-color-ink");
+    expect(declared(removeToken(TOKENS, "color.ink"))).not.toContain(
+      "--site-color-ink"
+    );
+  });
+
+  it("removes by IDENTITY, not by the label", () => {
+    // Removing `brand.main` by name would miss it, because what identifies it
+    // is `color.primary`.
+    const next = removeToken(TOKENS, "color.primary");
+    expect(next.tokens.map(t => t.name)).toEqual(["color.ink", "space.4"]);
+  });
+});

--- a/packages/builder/src/tokens-studio.ts
+++ b/packages/builder/src/tokens-studio.ts
@@ -128,6 +128,16 @@ export interface TokenRow {
   readonly kind: TokenKind;
   /** The value for the mode being shown, falling back to light. */
   readonly value: string;
+  /**
+   * What this MODE itself holds, or `undefined` when it holds nothing.
+   *
+   * Distinct from {@link value}, which is what to display and therefore falls
+   * back. An editor comparing a typed value against the display cannot tell
+   * "unchanged" from "pinned to the same value the fallback was giving" — and
+   * the second is a real edit, the one that fixes a dark value in place before
+   * the light one is changed later.
+   */
+  readonly stored: string | undefined;
   /** Whether the shown value belongs to this mode or is inherited from light. */
   readonly inherited: boolean;
   /**
@@ -173,6 +183,7 @@ function rowOf(
   return {
     at,
     key,
+    stored: own,
     identity: tokenIdentity(token),
     name: token.name,
     kind: token.kind,

--- a/packages/builder/src/tokens-studio.ts
+++ b/packages/builder/src/tokens-studio.ts
@@ -84,11 +84,27 @@ const TOKEN_KIND_SEEDS: Readonly<Record<TokenKind, string>> = {
   number: "0",
   shadow: "0 0 0 rgba(0, 0, 0, 0)",
   duration: "0ms",
-  custom: "initial",
+  // NOT a CSS-wide keyword. `initial` passes the emitter and is written without
+  // complaint, and then behaves as the guaranteed-invalid value at SUBSTITUTION
+  // — so `var(--site-custom)` invalidates the declaration reading it instead of
+  // resolving to the word. A seed has to survive the whole road to the page,
+  // not only the write.
+  custom: "0",
 };
 
 /** One token as the studio draws it. */
 export interface TokenRow {
+  /**
+   * WHERE this token sits in the stored list, and the handle every edit uses.
+   *
+   * Not the identity, which is the obvious choice and is wrong: a legacy or
+   * imported set can hold two entries with the SAME identity, and the read path
+   * keeps both deliberately so the engine's complaint about the collision is
+   * visible on the row that has it. Addressed by identity, every edit to the
+   * second row would resolve to the first — so the one state the studio exists
+   * to help an author repair would be the one state it cannot address.
+   */
+  readonly at: number;
   /** What references STORE. Never changes once a token has been renamed. */
   readonly identity: string;
   /** What the author reads and edits. */
@@ -115,19 +131,24 @@ export function tokenRowsFor(
   mode: TokenMode = "light"
 ): readonly TokenRow[] {
   const all = tokens?.tokens ?? [];
+  // Indexed against the WHOLE list before filtering, so `at` addresses the
+  // stored position rather than a position within this tab.
   return all
-    .filter(token => token.kind === kind)
-    .map(token => rowOf(token, all, mode));
+    .map((token, at) => ({ token, at }))
+    .filter(entry => entry.token.kind === kind)
+    .map(entry => rowOf(entry.token, entry.at, all, mode));
 }
 
 function rowOf(
   token: SiteToken,
+  at: number,
   among: readonly SiteToken[],
   mode: TokenMode
 ): TokenRow {
   const own = token.values[mode];
   const collision = collisionFor(token, among);
   return {
+    at,
     identity: tokenIdentity(token),
     name: token.name,
     kind: token.kind,
@@ -189,7 +210,7 @@ function collisionFor(
  */
 export function tokenNameIssue(
   tokens: SiteTokenSet | undefined,
-  identity: string,
+  at: number,
   name: string
 ): string | undefined {
   const trimmed = name.trim();
@@ -198,19 +219,9 @@ export function tokenNameIssue(
     return 'A name is dot-separated words of letters, digits and dashes, like "color.primary".';
   }
   const taken = (tokens?.tokens ?? []).some(
-    token => tokenIdentity(token) !== identity && token.name === trimmed
+    (token, index) => index !== at && token.name === trimmed
   );
   return taken ? `Another token is already called "${trimmed}".` : undefined;
-}
-
-/** Find a token by the identity a row carries. */
-function indexOfIdentity(
-  tokens: SiteTokenSet | undefined,
-  identity: string
-): number {
-  return (tokens?.tokens ?? []).findIndex(
-    token => tokenIdentity(token) === identity
-  );
 }
 
 /** Replace one token in the set, leaving every other entry untouched. */
@@ -234,13 +245,12 @@ function withToken(
  */
 export function renameToken(
   tokens: SiteTokenSet,
-  identity: string,
+  at: number,
   name: string
 ): SiteTokenSet {
-  const index = indexOfIdentity(tokens, identity);
-  const token = tokens.tokens[index];
+  const token = tokens.tokens[at];
   if (token === undefined) return tokens;
-  return withToken(tokens, index, renameSiteToken(token, name.trim()));
+  return withToken(tokens, at, renameSiteToken(token, name.trim()));
 }
 
 /**
@@ -251,14 +261,13 @@ export function renameToken(
  */
 export function setTokenValue(
   tokens: SiteTokenSet,
-  identity: string,
+  at: number,
   mode: TokenMode,
   value: string
 ): SiteTokenSet {
-  const index = indexOfIdentity(tokens, identity);
-  const token = tokens.tokens[index];
+  const token = tokens.tokens[at];
   if (token === undefined) return tokens;
-  return withToken(tokens, index, {
+  return withToken(tokens, at, {
     ...token,
     values: { ...token.values, [mode]: value },
   });
@@ -272,27 +281,26 @@ export function setTokenValue(
  * later edits to light, so the two drift apart the next time anyone changes the
  * light one.
  */
-export function clearDarkValue(
-  tokens: SiteTokenSet,
-  identity: string
-): SiteTokenSet {
-  const index = indexOfIdentity(tokens, identity);
-  const token = tokens.tokens[index];
+export function clearDarkValue(tokens: SiteTokenSet, at: number): SiteTokenSet {
+  const token = tokens.tokens[at];
   if (token === undefined) return tokens;
-  return withToken(tokens, index, {
+  return withToken(tokens, at, {
     ...token,
     values: { light: token.values.light },
   });
 }
 
-/** The set without this token. Any reference to it stops resolving. */
-export function removeToken(
-  tokens: SiteTokenSet,
-  identity: string
-): SiteTokenSet {
+/**
+ * The set without the token at this position. Any reference stops resolving.
+ *
+ * By POSITION rather than by identity, so removing one of two entries that
+ * share an identity removes exactly one. Filtering on the identity would take
+ * both, which is the opposite of what an author repairing a collision means.
+ */
+export function removeToken(tokens: SiteTokenSet, at: number): SiteTokenSet {
   return {
     ...tokens,
-    tokens: tokens.tokens.filter(token => tokenIdentity(token) !== identity),
+    tokens: tokens.tokens.filter((_, index) => index !== at),
   };
 }
 
@@ -305,24 +313,31 @@ export function removeToken(
  * token taking that name would collide on the custom property.
  */
 function freeName(tokens: SiteTokenSet | undefined, kind: TokenKind): string {
+  // Compared as composed CUSTOM PROPERTIES, which is the real uniqueness
+  // boundary — `color-2` and `color.2` are different strings and both become
+  // `--site-color-2`, so a raw-name check hands back a name the emitter will
+  // refuse the moment it is written. Names are folded in alongside identities
+  // because a name is what a later rename freezes into one.
   const used = new Set<string>();
   for (const token of tokens?.tokens ?? []) {
-    used.add(token.name);
-    used.add(tokenIdentity(token));
+    used.add(tokenCustomProperty(token.name, ""));
+    used.add(tokenCustomProperty(tokenIdentity(token), ""));
   }
+  const free = (candidate: string): boolean =>
+    !used.has(tokenCustomProperty(candidate, ""));
   const base = kind === "custom" ? "custom" : kind.toLowerCase();
-  if (!used.has(base)) return base;
+  if (free(base)) return base;
   for (let n = 2; ; n += 1) {
     const candidate = `${base}.${n}`;
-    if (!used.has(candidate)) return candidate;
+    if (free(candidate)) return candidate;
   }
 }
 
 /**
- * The set with a new token of this kind appended, and its identity.
+ * The set with a new token of this kind appended, and where it landed.
  *
- * The identity comes back because the panel has to put the new row into edit
- * mode, and finding it by name afterwards would break the moment two tokens
+ * The position comes back because the panel has to address the new row, and
+ * finding it afterwards by name or identity would break the moment two tokens
  * share one — which is a state this table can legitimately be in.
  *
  * Created with NO `id`, so its identity is its name until the first rename
@@ -332,7 +347,7 @@ function freeName(tokens: SiteTokenSet | undefined, kind: TokenKind): string {
 export function addToken(
   tokens: SiteTokenSet | undefined,
   kind: TokenKind
-): { tokens: SiteTokenSet; identity: string } {
+): { tokens: SiteTokenSet; at: number } {
   const name = freeName(tokens, kind);
   const token: SiteToken = {
     name,
@@ -342,7 +357,7 @@ export function addToken(
   const base = tokens ?? { tokens: [] };
   return {
     tokens: { ...base, tokens: [...base.tokens, token] },
-    identity: name,
+    at: base.tokens.length,
   };
 }
 

--- a/packages/builder/src/tokens-studio.ts
+++ b/packages/builder/src/tokens-studio.ts
@@ -105,6 +105,22 @@ export interface TokenRow {
    * to help an author repair would be the one state it cannot address.
    */
   readonly at: number;
+  /**
+   * A React key that survives a removal elsewhere in the list.
+   *
+   * The position cannot be one: deleting any non-tail token shifts every
+   * following `at`, so React reuses the deleted row's component for its
+   * successor and the uncontrolled fields and the confirm state come with it —
+   * a successor showing the deleted token's values, still in removal
+   * confirmation, one click from removing the wrong token.
+   *
+   * The identity cannot be one either, for the reason `at` exists: two entries
+   * can share one. So the key is the identity plus which occurrence of it this
+   * is, which is unique always and stable under any removal that is not of the
+   * same identity — and when it IS, remounting is the correct answer, because
+   * the row's meaning has changed.
+   */
+  readonly key: string;
   /** What references STORE. Never changes once a token has been renamed. */
   readonly identity: string;
   /** What the author reads and edits. */
@@ -133,15 +149,22 @@ export function tokenRowsFor(
   const all = tokens?.tokens ?? [];
   // Indexed against the WHOLE list before filtering, so `at` addresses the
   // stored position rather than a position within this tab.
+  const seen = new Map<string, number>();
   return all
-    .map((token, at) => ({ token, at }))
+    .map((token, at) => {
+      const identity = tokenIdentity(token);
+      const nth = seen.get(identity) ?? 0;
+      seen.set(identity, nth + 1);
+      return { token, at, key: nth === 0 ? identity : `${identity}#${nth}` };
+    })
     .filter(entry => entry.token.kind === kind)
-    .map(entry => rowOf(entry.token, entry.at, all, mode));
+    .map(entry => rowOf(entry.token, entry.at, entry.key, all, mode));
 }
 
 function rowOf(
   token: SiteToken,
   at: number,
+  key: string,
   among: readonly SiteToken[],
   mode: TokenMode
 ): TokenRow {
@@ -149,6 +172,7 @@ function rowOf(
   const collision = collisionFor(token, among);
   return {
     at,
+    key,
     identity: tokenIdentity(token),
     name: token.name,
     kind: token.kind,

--- a/packages/builder/src/tokens-studio.ts
+++ b/packages/builder/src/tokens-studio.ts
@@ -1,0 +1,360 @@
+/**
+ * The tokens studio's view of a site's token table, and the edits it makes.
+ *
+ * A token is a NAME the styling layer resolves — `color.primary` becomes
+ * `--site-color-primary`, and every block referencing it follows when the value
+ * changes. This module is the pure half of the panel that manages them: what to
+ * show for each kind, what an edit produces, and what the engine will say about
+ * the result. No DOM, so the rules below are testable without rendering, and
+ * the panel above stays about layout.
+ *
+ * ## Identity is frozen; only the label moves
+ *
+ * The one rule this file exists to protect. A stored reference holds a token's
+ * IDENTITY, and {@link renameSiteToken} pins that identity the first time a
+ * token is renamed so it never tracks the label afterwards. Rename is therefore
+ * safe here by construction — every existing reference goes on resolving and no
+ * document is rewritten — which is not true of the tools this pattern comes
+ * from: Figma variables and Tokens Studio key on the name, so both have to STAGE
+ * alias rewiring for review before a rename can be applied.
+ *
+ * Getting it wrong is silent in the direction that loses work. Writing the NEW
+ * name as the identity moves the custom property, every stored `$token` stops
+ * resolving, and the page still renders — just without the style. Nothing
+ * reports it, because an unresolved custom property invalidates its declaration
+ * rather than raising. So every mutation here goes through the engine's own
+ * helpers rather than composing a token literal.
+ *
+ * ## The engine judges values; this only asks
+ *
+ * Whether a value is usable, whether it contradicts its kind, whether two
+ * tokens collide on one custom property — all of that is `emitTokenBlocks`'s
+ * verdict, asked by emitting and reading what comes back. A second copy of
+ * those rules here would agree on the cases someone thought of and diverge on
+ * the rest, and the divergence is invisible: the studio would accept a token
+ * the canvas silently drops.
+ *
+ * @module tokens-studio
+ */
+import {
+  TOKEN_KINDS,
+  emitTokenBlocks,
+  isTokenName,
+  renameSiteToken,
+  tokenCustomProperty,
+  tokenIdentity,
+  type SiteToken,
+  type SiteTokenSet,
+  type TokenKind,
+  type TokenMode,
+} from "@nextlyhq/blocks-engine";
+
+/**
+ * What each kind is called in the interface.
+ *
+ * Written out rather than derived from the union, because a label is a piece of
+ * copy and `fontFamily` is not one. Keyed by the kind so adding a kind to the
+ * engine surfaces here as a type error rather than as a tab labelled with its
+ * own identifier.
+ */
+export const TOKEN_KIND_LABELS: Readonly<Record<TokenKind, string>> = {
+  color: "Colour",
+  dimension: "Size",
+  fontFamily: "Font",
+  fontWeight: "Weight",
+  number: "Number",
+  shadow: "Shadow",
+  duration: "Duration",
+  custom: "Custom",
+};
+
+/**
+ * An example value for a new token of each kind.
+ *
+ * A new row has to hold SOMETHING, and an empty value is refused by the emitter
+ * — so a token created empty would arrive already broken, with an error the
+ * author did not cause. These are the smallest valid value of each kind, chosen
+ * to be obviously placeholder rather than plausibly deliberate.
+ */
+const TOKEN_KIND_SEEDS: Readonly<Record<TokenKind, string>> = {
+  color: "#000000",
+  dimension: "0px",
+  fontFamily: "sans-serif",
+  fontWeight: "400",
+  number: "0",
+  shadow: "0 0 0 rgba(0, 0, 0, 0)",
+  duration: "0ms",
+  custom: "initial",
+};
+
+/** One token as the studio draws it. */
+export interface TokenRow {
+  /** What references STORE. Never changes once a token has been renamed. */
+  readonly identity: string;
+  /** What the author reads and edits. */
+  readonly name: string;
+  readonly kind: TokenKind;
+  /** The value for the mode being shown, falling back to light. */
+  readonly value: string;
+  /** Whether the shown value belongs to this mode or is inherited from light. */
+  readonly inherited: boolean;
+  /**
+   * What the engine says about this token, empty when it is happy.
+   *
+   * Shown to the author rather than counted, because the messages name the
+   * repair — "is a measurement, not a colour" tells them what to type next, and
+   * a bare invalid flag does not.
+   */
+  readonly issues: readonly string[];
+}
+
+/** The tokens of one kind, in stored order, as rows. */
+export function tokenRowsFor(
+  tokens: SiteTokenSet | undefined,
+  kind: TokenKind,
+  mode: TokenMode = "light"
+): readonly TokenRow[] {
+  const all = tokens?.tokens ?? [];
+  return all
+    .filter(token => token.kind === kind)
+    .map(token => rowOf(token, all, mode));
+}
+
+function rowOf(
+  token: SiteToken,
+  among: readonly SiteToken[],
+  mode: TokenMode
+): TokenRow {
+  const own = token.values[mode];
+  const collision = collisionFor(token, among);
+  return {
+    identity: tokenIdentity(token),
+    name: token.name,
+    kind: token.kind,
+    value: own ?? token.values.light,
+    inherited: own === undefined,
+    issues:
+      collision === undefined
+        ? issuesOf(token)
+        : [collision, ...issuesOf(token)],
+  };
+}
+
+/**
+ * What the engine reports about ONE token, emitted on its own.
+ *
+ * Alone rather than within the set, so the messages that come back are about
+ * this token and no other — and so the answer does not have to be found by
+ * matching message text against a name, which would be a copy of wording
+ * nobody promised to keep. The one verdict this cannot reach that way is the
+ * collision, which is a property of the SET; {@link collisionFor} asks it.
+ */
+function issuesOf(token: SiteToken): readonly string[] {
+  return emitTokenBlocks({ tokens: [token] }, ":root").issues.map(
+    issue => issue.message
+  );
+}
+
+/**
+ * The other token this one would collide with, or `undefined`.
+ *
+ * Two identities can compose one custom property — `color.primary-dark` and
+ * `color-primary.dark` both give `--site-color-primary-dark` — and the emitter
+ * writes the first and REFUSES the second. An author who cannot see that is
+ * editing a token whose value never reaches the page, so it is reported here
+ * rather than left to be discovered on the canvas.
+ *
+ * `tokenCustomProperty` composes the key, so the normalisation stays the
+ * engine's; only the pairwise comparison is done here.
+ */
+function collisionFor(
+  token: SiteToken,
+  among: readonly SiteToken[]
+): string | undefined {
+  const property = tokenCustomProperty(tokenIdentity(token), "");
+  const first = among.find(
+    other => tokenCustomProperty(tokenIdentity(other), "") === property
+  );
+  if (first === undefined || first === token) return undefined;
+  return `"${token.name}" and "${first.name}" both become "${property}", so only "${first.name}" is written.`;
+}
+
+/**
+ * Why this name cannot be used, or `undefined`.
+ *
+ * The GRAMMAR is the engine's `isTokenName`, which is the same rule a stored
+ * `$token` reference is held to — so a table cannot hold a name that no
+ * reference could spell. Checked before the edit rather than after, because the
+ * emitter's answer to a bad name is to drop the token silently.
+ */
+export function tokenNameIssue(
+  tokens: SiteTokenSet | undefined,
+  identity: string,
+  name: string
+): string | undefined {
+  const trimmed = name.trim();
+  if (trimmed === "") return "A token needs a name.";
+  if (!isTokenName(trimmed)) {
+    return 'A name is dot-separated words of letters, digits and dashes, like "color.primary".';
+  }
+  const taken = (tokens?.tokens ?? []).some(
+    token => tokenIdentity(token) !== identity && token.name === trimmed
+  );
+  return taken ? `Another token is already called "${trimmed}".` : undefined;
+}
+
+/** Find a token by the identity a row carries. */
+function indexOfIdentity(
+  tokens: SiteTokenSet | undefined,
+  identity: string
+): number {
+  return (tokens?.tokens ?? []).findIndex(
+    token => tokenIdentity(token) === identity
+  );
+}
+
+/** Replace one token in the set, leaving every other entry untouched. */
+function withToken(
+  tokens: SiteTokenSet,
+  index: number,
+  token: SiteToken
+): SiteTokenSet {
+  const next = [...tokens.tokens];
+  next[index] = token;
+  return { ...tokens, tokens: next };
+}
+
+/**
+ * The set with one token renamed, its identity pinned where it already was.
+ *
+ * Delegates to {@link renameSiteToken} rather than spreading a new name over
+ * the token, which is the whole point: that helper is the ONE place the freeze
+ * rule lives, and a second expression of it here would be one edit away from
+ * writing the new name as the identity and silently breaking every reference.
+ */
+export function renameToken(
+  tokens: SiteTokenSet,
+  identity: string,
+  name: string
+): SiteTokenSet {
+  const index = indexOfIdentity(tokens, identity);
+  const token = tokens.tokens[index];
+  if (token === undefined) return tokens;
+  return withToken(tokens, index, renameSiteToken(token, name.trim()));
+}
+
+/**
+ * The set with one token's value changed, for one mode.
+ *
+ * Writing `dark` never disturbs `light`, because light is what a reader with no
+ * mode set resolves and a token that lost it would vanish for them.
+ */
+export function setTokenValue(
+  tokens: SiteTokenSet,
+  identity: string,
+  mode: TokenMode,
+  value: string
+): SiteTokenSet {
+  const index = indexOfIdentity(tokens, identity);
+  const token = tokens.tokens[index];
+  if (token === undefined) return tokens;
+  return withToken(tokens, index, {
+    ...token,
+    values: { ...token.values, [mode]: value },
+  });
+}
+
+/**
+ * The set with one token's dark value REMOVED, so it follows light again.
+ *
+ * Distinct from writing the light value into dark, which looks identical on
+ * screen and is not the same document: an explicit dark value stops tracking
+ * later edits to light, so the two drift apart the next time anyone changes the
+ * light one.
+ */
+export function clearDarkValue(
+  tokens: SiteTokenSet,
+  identity: string
+): SiteTokenSet {
+  const index = indexOfIdentity(tokens, identity);
+  const token = tokens.tokens[index];
+  if (token === undefined) return tokens;
+  return withToken(tokens, index, {
+    ...token,
+    values: { light: token.values.light },
+  });
+}
+
+/** The set without this token. Any reference to it stops resolving. */
+export function removeToken(
+  tokens: SiteTokenSet,
+  identity: string
+): SiteTokenSet {
+  return {
+    ...tokens,
+    tokens: tokens.tokens.filter(token => tokenIdentity(token) !== identity),
+  };
+}
+
+/**
+ * A name nothing in the set is using yet, based on the kind.
+ *
+ * Suffixed rather than randomised so a second colour token is `color.2` and not
+ * a word the author has to read. Checked against IDENTITIES as well as names,
+ * because a renamed token still holds its old name as its identity and a new
+ * token taking that name would collide on the custom property.
+ */
+function freeName(tokens: SiteTokenSet | undefined, kind: TokenKind): string {
+  const used = new Set<string>();
+  for (const token of tokens?.tokens ?? []) {
+    used.add(token.name);
+    used.add(tokenIdentity(token));
+  }
+  const base = kind === "custom" ? "custom" : kind.toLowerCase();
+  if (!used.has(base)) return base;
+  for (let n = 2; ; n += 1) {
+    const candidate = `${base}.${n}`;
+    if (!used.has(candidate)) return candidate;
+  }
+}
+
+/**
+ * The set with a new token of this kind appended, and its identity.
+ *
+ * The identity comes back because the panel has to put the new row into edit
+ * mode, and finding it by name afterwards would break the moment two tokens
+ * share one — which is a state this table can legitimately be in.
+ *
+ * Created with NO `id`, so its identity is its name until the first rename
+ * freezes one. That is the same shape every token stored before `id` existed
+ * has, which is why nothing needs migrating.
+ */
+export function addToken(
+  tokens: SiteTokenSet | undefined,
+  kind: TokenKind
+): { tokens: SiteTokenSet; identity: string } {
+  const name = freeName(tokens, kind);
+  const token: SiteToken = {
+    name,
+    kind,
+    values: { light: TOKEN_KIND_SEEDS[kind] },
+  };
+  const base = tokens ?? { tokens: [] };
+  return {
+    tokens: { ...base, tokens: [...base.tokens, token] },
+    identity: name,
+  };
+}
+
+/** How many tokens each kind holds, for the tab labels. */
+export function tokenCounts(
+  tokens: SiteTokenSet | undefined
+): Readonly<Record<TokenKind, number>> {
+  const counts = Object.fromEntries(
+    TOKEN_KINDS.map(kind => [kind, 0])
+  ) as Record<TokenKind, number>;
+  for (const token of tokens?.tokens ?? []) {
+    if (token.kind in counts) counts[token.kind] += 1;
+  }
+  return counts;
+}

--- a/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
@@ -39,7 +39,16 @@ let siteStyleRead: { data: unknown; isPending: boolean; error: Error | null } =
     error: null,
   };
 
-vi.mock("@nextlyhq/builder/shell", () => {
+vi.mock("@nextlyhq/builder/shell", async importOriginal => {
+  /*
+   * The real module SPREAD, with only the surfaces this file drives replaced.
+   * A closed object literal here answers `undefined` for every export it does
+   * not list, so adding one to the shell breaks these tests and leaves the
+   * builder's own suite green — a failure that reads as a fault in this file
+   * rather than as a stale list. Measured: the real module imports cleanly
+   * under vitest and the overrides below win over the spread.
+   */
+  const real = await importOriginal<Record<string, unknown>>();
   const record =
     (key: "inspector" | "canvas") =>
     (props: Record<string, unknown>): React.JSX.Element => {
@@ -54,6 +63,7 @@ vi.mock("@nextlyhq/builder/shell", () => {
     children?: React.ReactNode;
   }): React.JSX.Element => <>{children}</>;
   return {
+    ...real,
     // Renders the inspector slot and its CHILDREN, because the canvas is a
     // child of the shell rather than one of its slots — a stub dropping them
     // would leave the canvas unrendered and its assertion passing on absence.
@@ -315,5 +325,38 @@ describe("what the token picker waits for", () => {
     openEditor();
 
     expect(seen.inspector?.tokens).toBeDefined();
+  });
+});
+
+describe("the shell mock keeps up with the shell", () => {
+  it("still provides every export this file's subject imports", async () => {
+    /*
+     * The stale-list failure, pinned. A `vi.mock` factory returning a closed
+     * object literal answers `undefined` for every export it does not name — so
+     * a surface added to the shell and imported by `BlocksField` arrives here
+     * as `undefined`, and the component throws only once something renders it.
+     * The break is then invisible in the builder's own suite, which passes, and
+     * reads in this package as a fault in the subject rather than as a mock
+     * that stopped covering it.
+     *
+     * Asserted over the names `BlocksField` actually imports rather than over
+     * the whole module, because the mock is entitled to omit what nothing here
+     * uses.
+     */
+    const shell = (await import("@nextlyhq/builder/shell")) as Record<
+      string,
+      unknown
+    >;
+    for (const name of [
+      "BuilderShell",
+      "Canvas",
+      "InspectorPanel",
+      "InsertPanel",
+      "LayersPanel",
+      "TokensPanel",
+      "useEditorState",
+    ]) {
+      expect(shell[name], name).toBeDefined();
+    }
   });
 });

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -34,6 +34,7 @@
  */
 
 import {
+  resolveSiteTokens,
   hasBlock,
   registerBlocks,
   registryNestingSource,
@@ -394,6 +395,25 @@ function TokensStudio({
 }): React.JSX.Element {
   const { save } = useSaveSiteStyle();
   /*
+   * What the CANVAS resolves, which is what the studio has to show and edit.
+   *
+   * `resolveSiteTokens` layers the engine's own defaults — `color.primary`,
+   * `color.text`, `space.4` and the rest — under whatever the site states, and
+   * the renderer compiles with it. Without that step here, the studio reports
+   * every category empty on a site that states no tokens of its own, while the
+   * page it is previewing is actively using them and the colour picker beside
+   * it offers them. They could then be neither seen nor overridden: adding a
+   * token and renaming it to a default's label does not reach one, because the
+   * rename freezes the new token's own identity.
+   *
+   * The baseline for the override is resolved for the same reason. Storing what
+   * differs from the CONFIG alone would write every engine default into the
+   * database on the first edit — the same fault as saving the merged set, one
+   * tier further down.
+   */
+  const editable = merged === undefined ? undefined : resolveSiteTokens(merged);
+  const baseline = resolveSiteTokens(supplied);
+  /*
    * The studio's own latest set, and the authority while it is open.
    *
    * `useSiteStyle` answers from a query refetched only after a save lands, so
@@ -425,7 +445,7 @@ function TokensStudio({
        * canvas compiles, so saving it whole would copy every config token into
        * the database on the first edit and mask the site's code from then on.
        */
-      tokenOverrideOf(supplied, next)
+      tokenOverrideOf(baseline, next)
     ).then(result => {
       const outcome = tokenSaveOutcome(
         result.saved,
@@ -442,8 +462,8 @@ function TokensStudio({
 
   return (
     <TokensPanel
-      tokens={edits ?? merged}
-      supplied={supplied}
+      tokens={edits ?? editable}
+      supplied={baseline}
       issue={issue}
       absence={pending ? "pending" : "failed"}
       onChange={commit}

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -81,7 +81,7 @@ import { emptyBlockDocument } from "../fields/blocks-document";
 import { hostFetchPolicy, readRemotePatterns } from "../host-policy";
 import {
   tokenOverrideOf,
-  tokensAfterRefusal,
+  tokenSaveOutcome,
   siteBreakpoints,
   siteSheet,
   type SiteStyleData,
@@ -367,6 +367,90 @@ function offerableTokens(
   return style?.tokens ?? { tokens: [] };
 }
 
+/**
+ * The tokens studio, and the state that belongs to it rather than to the editor.
+ *
+ * Its own component because the token set an author is part-way through editing
+ * is the STUDIO's business: the editor around it owns a document, and a panel's
+ * unsaved half-state living in that editor is state with no reader outside one
+ * branch of one render.
+ *
+ * Saved as it is edited rather than behind a save button. A token is site-wide,
+ * so the canvas behind this panel is the preview — an unsaved edit would show
+ * the author a page no visitor would see, with no other surface on which to
+ * notice the difference.
+ */
+function TokensStudio({
+  merged,
+  supplied,
+  pending,
+}: {
+  /** The site's tokens as the canvas compiles them: config under stored. */
+  merged: SiteTokenSet | undefined;
+  /** What the site's own code supplies, which the stored tier layers over. */
+  supplied: SiteTokenSet | undefined;
+  /** Whether the read is still in flight, as against having failed. */
+  pending: boolean;
+}): React.JSX.Element {
+  const { save } = useSaveSiteStyle();
+  /*
+   * The studio's own latest set, and the authority while it is open.
+   *
+   * `useSiteStyle` answers from a query refetched only after a save lands, so
+   * two edits made before that — two blurs, two removals, a double Add — would
+   * both compose against the SAME snapshot and the second would overwrite the
+   * first. Nothing would report it: the mutation serialises the payloads and
+   * neither fails. Composing against this means every edit builds on the last.
+   */
+  const [edits, setEdits] = useState<SiteTokenSet | null>(null);
+  const [issue, setIssue] = useState<string | undefined>(undefined);
+  /*
+   * The last set a save is KNOWN to have stored, and what a refused edit falls
+   * back to — not "whatever was on screen before it", which after an earlier
+   * refusal is itself a value the site never accepted.
+   */
+  const persisted = useRef<SiteTokenSet | null>(null);
+  /* The most recent edit handed to a save, and the one question both branches
+   * of an answer ask: is this still about what the author is looking at? */
+  const latest = useRef<SiteTokenSet | null>(null);
+
+  const commit = (next: SiteTokenSet): void => {
+    setEdits(next);
+    setIssue(undefined);
+    latest.current = next;
+    void save(
+      "tokens",
+      /*
+       * Only what DIFFERS from the site's own defaults. `merged` is what the
+       * canvas compiles, so saving it whole would copy every config token into
+       * the database on the first edit and mask the site's code from then on.
+       */
+      tokenOverrideOf(supplied, next)
+    ).then(result => {
+      const outcome = tokenSaveOutcome(
+        result.saved,
+        result.issues,
+        next,
+        latest.current,
+        persisted.current
+      );
+      if (result.saved) persisted.current = next;
+      if (outcome.tokens !== undefined) setEdits(outcome.tokens);
+      if (outcome.issue !== undefined) setIssue(outcome.issue ?? undefined);
+    });
+  };
+
+  return (
+    <TokensPanel
+      tokens={edits ?? merged}
+      supplied={supplied}
+      issue={issue}
+      absence={pending ? "pending" : "failed"}
+      onChange={commit}
+    />
+  );
+}
+
 function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   initialValue,
   onCommit,
@@ -460,41 +544,6 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
     pending: siteStylePending,
     error: siteStyleError,
   } = useSiteStyle(configSiteStyle);
-  /*
-   * The studio's write. Section-scoped, so saving tokens leaves the fonts,
-   * classes and breakpoints sections exactly as they were — four surfaces own
-   * four fields of one record, and a whole-document write from any of them
-   * would clobber whatever the others had saved since it last read.
-   */
-  const { save: saveSiteStyle } = useSaveSiteStyle();
-  /*
-   * The studio's own latest set, and the authority while it is open.
-   *
-   * `useSiteStyle` answers from a query that is only refetched after a save
-   * lands, so two edits made before that — two blurs, two removals, a double
-   * Add — would both compose against the SAME snapshot and the second would
-   * overwrite the first. Nothing would report it: the mutation serialises the
-   * two payloads and neither fails. Composing against this instead means every
-   * edit builds on the one before it.
-   */
-  const [tokenEdits, setTokenEdits] = useState<SiteTokenSet | null>(null);
-  /* What the last save said, when it refused. */
-  const [tokenIssue, setTokenIssue] = useState<string | undefined>(undefined);
-  /*
-   * The last set a save is KNOWN to have stored, and what a refused edit falls
-   * back to. Not "whatever was on screen before it": after an earlier refusal
-   * that is itself a value the site never accepted, so restoring it would show
-   * the author something no storage anywhere agrees with. A ref rather than
-   * state because nothing renders from it.
-   */
-  const persistedTokens = useRef<SiteTokenSet | null>(null);
-  /*
-   * The most recent edit handed to a save, and the one question both branches
-   * below ask: is this answer still about what the author is looking at? An
-   * answer for a superseded edit must neither roll the newer one back nor
-   * announce a refusal the newer save has already made irrelevant.
-   */
-  const latestTokenEdit = useRef<SiteTokenSet | null>(null);
 
   /*
    * The hosts this site loads media from, read back from the same client
@@ -691,71 +740,15 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
           }
           if (panel === "layers") return <LayersPanel editor={editor} />;
           if (panel === "tokens") {
-            const merged = offerableTokens(
-              canvasSiteStyle,
-              siteStylePending,
-              siteStyleError
-            );
             return (
-              <TokensPanel
-                tokens={tokenEdits ?? merged}
+              <TokensStudio
+                merged={offerableTokens(
+                  canvasSiteStyle,
+                  siteStylePending,
+                  siteStyleError
+                )}
                 supplied={configSiteStyle?.tokens}
-                issue={tokenIssue}
-                onChange={next => {
-                  /*
-                   * Saved as it is edited rather than behind a save button. A
-                   * token is site-wide, so the canvas behind this panel is the
-                   * preview — an unsaved edit would show the author a page no
-                   * visitor would see, with no other surface on which to
-                   * notice the difference.
-                   */
-                  setTokenEdits(next);
-                  setTokenIssue(undefined);
-                  latestTokenEdit.current = next;
-                  void saveSiteStyle(
-                    "tokens",
-                    /*
-                     * Only what DIFFERS from the site's own defaults. The set
-                     * above is the merged one the canvas compiles, so saving it
-                     * whole would copy every config token into the database on
-                     * the first edit and mask the site's code from then on.
-                     */
-                    tokenOverrideOf(configSiteStyle?.tokens, next)
-                  ).then(result => {
-                    const current = latestTokenEdit.current;
-                    if (result.saved) {
-                      persistedTokens.current = next;
-                      /*
-                       * A refusal for an EARLIER edit can arrive after a later
-                       * one has already cleared the message, so the studio
-                       * would go on announcing that a set it did save was not
-                       * saved, until the author happened to edit again.
-                       */
-                      if (current === next) setTokenIssue(undefined);
-                      return;
-                    }
-                    /*
-                     * A refused save leaves the panel showing what the author
-                     * typed while the site still holds the old value — so the
-                     * edit is put back and the refusal is said out loud.
-                     * Discarding this promise makes a validation failure, a
-                     * missing permission and a dropped network all look
-                     * exactly like success.
-                     *
-                     * Rolled back only while this edit is still what is on
-                     * screen: an author can type again before an answer
-                     * arrives, and that later edit has its own save in flight.
-                     */
-                    if (current !== next) return;
-                    setTokenEdits(
-                      tokensAfterRefusal(current, next, persistedTokens.current)
-                    );
-                    setTokenIssue(
-                      Object.values(result.issues ?? {})[0] ??
-                        "That change was not saved."
-                    );
-                  });
-                }}
+                pending={siteStylePending}
               />
             );
           }

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -52,6 +52,7 @@ import {
   InsertPanel,
   InspectorPanel,
   LayersPanel,
+  TokensPanel,
   OnboardingChecklist,
   SelectionBreadcrumb,
   SpacingOverlay,
@@ -83,7 +84,7 @@ import { readSiteStyleRecord } from "../site-style-record";
 
 import { BlocksSummary } from "./BlocksSummary";
 import { DocumentStatusPill } from "./DocumentStatusPill";
-import { useSiteStyle } from "./site-style-client";
+import { useSaveSiteStyle, useSiteStyle } from "./site-style-client";
 import { withValueAtPath } from "./snapshot-merge";
 
 export interface BlocksFieldProps<
@@ -117,14 +118,14 @@ export interface BlocksFieldProps<
 /**
  * Every left panel the editor can fill today.
  *
- * The inserter and the layers tree; the rest are not built. The shell draws all
- * seven regardless and disables the ones nothing fills, so the rail describes
- * the editor's shape while never opening a region with nothing in it. Listing a
- * panel here that renders nothing would reserve space and shrink the canvas to
- * show it, which is why this grows one entry at a time rather than being
- * declared ahead of the panels.
+ * The inserter, the layers tree and the tokens studio; the rest are not built.
+ * The shell draws all seven regardless and disables the ones nothing fills, so
+ * the rail describes the editor's shape while never opening a region with
+ * nothing in it. Listing a panel here that renders nothing would reserve space
+ * and shrink the canvas to show it, which is why this grows one entry at a time
+ * rather than being declared ahead of the panels.
  */
-const AVAILABLE_PANELS = ["insert", "layers"] as const;
+const AVAILABLE_PANELS = ["insert", "layers", "tokens"] as const;
 
 /**
  * With an entry-fields panel to fill, `settings` joins them.
@@ -453,6 +454,13 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
     pending: siteStylePending,
     error: siteStyleError,
   } = useSiteStyle(configSiteStyle);
+  /*
+   * The studio's write. Section-scoped, so saving tokens leaves the fonts,
+   * classes and breakpoints sections exactly as they were — four surfaces own
+   * four fields of one record, and a whole-document write from any of them
+   * would clobber whatever the others had saved since it last read.
+   */
+  const { save: saveSiteStyle } = useSaveSiteStyle();
 
   /*
    * The hosts this site loads media from, read back from the same client
@@ -648,6 +656,25 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             );
           }
           if (panel === "layers") return <LayersPanel editor={editor} />;
+          if (panel === "tokens") {
+            return (
+              <TokensPanel
+                tokens={offerableTokens(
+                  canvasSiteStyle,
+                  siteStylePending,
+                  siteStyleError
+                )}
+                /*
+                 * Saved as it is edited rather than behind a save button. A
+                 * token is site-wide, so the canvas behind this panel is the
+                 * preview — an unsaved edit would show the author a page that
+                 * no visitor would see, and there is no other surface on which
+                 * to notice the difference.
+                 */
+                onChange={next => void saveSiteStyle("tokens", next)}
+              />
+            );
+          }
           /*
            * The entry's own fields — SEO, relations, whatever this collection
            * declares — which the takeover removed from the page behind this

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -488,6 +488,13 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * state because nothing renders from it.
    */
   const persistedTokens = useRef<SiteTokenSet | null>(null);
+  /*
+   * The most recent edit handed to a save, and the one question both branches
+   * below ask: is this answer still about what the author is looking at? An
+   * answer for a superseded edit must neither roll the newer one back nor
+   * announce a refusal the newer save has already made irrelevant.
+   */
+  const latestTokenEdit = useRef<SiteTokenSet | null>(null);
 
   /*
    * The hosts this site loads media from, read back from the same client
@@ -704,6 +711,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                    */
                   setTokenEdits(next);
                   setTokenIssue(undefined);
+                  latestTokenEdit.current = next;
                   void saveSiteStyle(
                     "tokens",
                     /*
@@ -714,8 +722,16 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                      */
                     tokenOverrideOf(configSiteStyle?.tokens, next)
                   ).then(result => {
+                    const current = latestTokenEdit.current;
                     if (result.saved) {
                       persistedTokens.current = next;
+                      /*
+                       * A refusal for an EARLIER edit can arrive after a later
+                       * one has already cleared the message, so the studio
+                       * would go on announcing that a set it did save was not
+                       * saved, until the author happened to edit again.
+                       */
+                      if (current === next) setTokenIssue(undefined);
                       return;
                     }
                     /*
@@ -730,7 +746,8 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                      * screen: an author can type again before an answer
                      * arrives, and that later edit has its own save in flight.
                      */
-                    setTokenEdits(current =>
+                    if (current !== next) return;
+                    setTokenEdits(
                       tokensAfterRefusal(current, next, persistedTokens.current)
                     );
                     setTokenIssue(

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -81,6 +81,7 @@ import { emptyBlockDocument } from "../fields/blocks-document";
 import { hostFetchPolicy, readRemotePatterns } from "../host-policy";
 import {
   tokenOverrideOf,
+  tokensAfterRefusal,
   siteBreakpoints,
   siteSheet,
   type SiteStyleData,
@@ -479,6 +480,14 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   const [tokenEdits, setTokenEdits] = useState<SiteTokenSet | null>(null);
   /* What the last save said, when it refused. */
   const [tokenIssue, setTokenIssue] = useState<string | undefined>(undefined);
+  /*
+   * The last set a save is KNOWN to have stored, and what a refused edit falls
+   * back to. Not "whatever was on screen before it": after an earlier refusal
+   * that is itself a value the site never accepted, so restoring it would show
+   * the author something no storage anywhere agrees with. A ref rather than
+   * state because nothing renders from it.
+   */
+  const persistedTokens = useRef<SiteTokenSet | null>(null);
 
   /*
    * The hosts this site loads media from, read back from the same client
@@ -693,7 +702,6 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                    * visitor would see, with no other surface on which to
                    * notice the difference.
                    */
-                  const before = tokenEdits ?? merged ?? null;
                   setTokenEdits(next);
                   setTokenIssue(undefined);
                   void saveSiteStyle(
@@ -706,7 +714,10 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                      */
                     tokenOverrideOf(configSiteStyle?.tokens, next)
                   ).then(result => {
-                    if (result.saved) return;
+                    if (result.saved) {
+                      persistedTokens.current = next;
+                      return;
+                    }
                     /*
                      * A refused save leaves the panel showing what the author
                      * typed while the site still holds the old value — so the
@@ -714,8 +725,14 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                      * Discarding this promise makes a validation failure, a
                      * missing permission and a dropped network all look
                      * exactly like success.
+                     *
+                     * Rolled back only while this edit is still what is on
+                     * screen: an author can type again before an answer
+                     * arrives, and that later edit has its own save in flight.
                      */
-                    setTokenEdits(before);
+                    setTokenEdits(current =>
+                      tokensAfterRefusal(current, next, persistedTokens.current)
+                    );
                     setTokenIssue(
                       Object.values(result.issues ?? {})[0] ??
                         "That change was not saved."

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -79,7 +79,12 @@ import {
 
 import { emptyBlockDocument } from "../fields/blocks-document";
 import { hostFetchPolicy, readRemotePatterns } from "../host-policy";
-import { siteBreakpoints, siteSheet, type SiteStyleData } from "../site-style";
+import {
+  tokenOverrideOf,
+  siteBreakpoints,
+  siteSheet,
+  type SiteStyleData,
+} from "../site-style";
 import { readSiteStyleRecord } from "../site-style-record";
 
 import { BlocksSummary } from "./BlocksSummary";
@@ -461,6 +466,19 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * would clobber whatever the others had saved since it last read.
    */
   const { save: saveSiteStyle } = useSaveSiteStyle();
+  /*
+   * The studio's own latest set, and the authority while it is open.
+   *
+   * `useSiteStyle` answers from a query that is only refetched after a save
+   * lands, so two edits made before that — two blurs, two removals, a double
+   * Add — would both compose against the SAME snapshot and the second would
+   * overwrite the first. Nothing would report it: the mutation serialises the
+   * two payloads and neither fails. Composing against this instead means every
+   * edit builds on the one before it.
+   */
+  const [tokenEdits, setTokenEdits] = useState<SiteTokenSet | null>(null);
+  /* What the last save said, when it refused. */
+  const [tokenIssue, setTokenIssue] = useState<string | undefined>(undefined);
 
   /*
    * The hosts this site loads media from, read back from the same client
@@ -657,21 +675,53 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
           }
           if (panel === "layers") return <LayersPanel editor={editor} />;
           if (panel === "tokens") {
+            const merged = offerableTokens(
+              canvasSiteStyle,
+              siteStylePending,
+              siteStyleError
+            );
             return (
               <TokensPanel
-                tokens={offerableTokens(
-                  canvasSiteStyle,
-                  siteStylePending,
-                  siteStyleError
-                )}
-                /*
-                 * Saved as it is edited rather than behind a save button. A
-                 * token is site-wide, so the canvas behind this panel is the
-                 * preview — an unsaved edit would show the author a page that
-                 * no visitor would see, and there is no other surface on which
-                 * to notice the difference.
-                 */
-                onChange={next => void saveSiteStyle("tokens", next)}
+                tokens={tokenEdits ?? merged}
+                supplied={configSiteStyle?.tokens}
+                issue={tokenIssue}
+                onChange={next => {
+                  /*
+                   * Saved as it is edited rather than behind a save button. A
+                   * token is site-wide, so the canvas behind this panel is the
+                   * preview — an unsaved edit would show the author a page no
+                   * visitor would see, with no other surface on which to
+                   * notice the difference.
+                   */
+                  const before = tokenEdits ?? merged ?? null;
+                  setTokenEdits(next);
+                  setTokenIssue(undefined);
+                  void saveSiteStyle(
+                    "tokens",
+                    /*
+                     * Only what DIFFERS from the site's own defaults. The set
+                     * above is the merged one the canvas compiles, so saving it
+                     * whole would copy every config token into the database on
+                     * the first edit and mask the site's code from then on.
+                     */
+                    tokenOverrideOf(configSiteStyle?.tokens, next)
+                  ).then(result => {
+                    if (result.saved) return;
+                    /*
+                     * A refused save leaves the panel showing what the author
+                     * typed while the site still holds the old value — so the
+                     * edit is put back and the refusal is said out loud.
+                     * Discarding this promise makes a validation failure, a
+                     * missing permission and a dropped network all look
+                     * exactly like success.
+                     */
+                    setTokenEdits(before);
+                    setTokenIssue(
+                      Object.values(result.issues ?? {})[0] ??
+                        "That change was not saved."
+                    );
+                  });
+                }}
               />
             );
           }

--- a/packages/plugin-page-builder/src/site-style-override.test.ts
+++ b/packages/plugin-page-builder/src/site-style-override.test.ts
@@ -1,0 +1,134 @@
+/**
+ * What a studio may store, as against what it was handed.
+ *
+ * `useSiteStyle` answers with the config defaults and the stored tier already
+ * merged, because that is what the canvas compiles. Nothing in that value says
+ * which half it came from — so an editor that saved its working set whole would
+ * copy every config-supplied token into the database, and from then on the
+ * site's own code could not change those values. The failure is silent, it only
+ * happens on sites that supply defaults, and it is permanent once written.
+ *
+ * @module site-style-override.test
+ */
+import type { SiteToken, SiteTokenSet } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import { resolveSiteStyle, tokenOverrideOf } from "./site-style";
+
+const ink: SiteToken = {
+  name: "color.ink",
+  kind: "color",
+  values: { light: "#111111" },
+};
+const brand: SiteToken = {
+  id: "color.primary",
+  name: "brand.main",
+  kind: "color",
+  values: { light: "#3b82f6" },
+};
+
+/** What a site's own code supplies. */
+const DEFAULTS: SiteTokenSet = { tokens: [ink, brand], prefix: "--site-" };
+
+/** The merged set a studio is actually handed. */
+function merged(stored?: SiteTokenSet): SiteTokenSet {
+  return resolveSiteStyle(
+    { tokens: DEFAULTS },
+    stored === undefined ? undefined : { tokens: stored }
+  ).tokens as SiteTokenSet;
+}
+
+describe("only what differs from the site's own defaults is stored", () => {
+  it("stores NOTHING when the author has changed nothing", () => {
+    // The case that matters most, and the one a naive save gets wrong: opening
+    // the studio and editing one unrelated thing must not persist the config.
+    expect(tokenOverrideOf(DEFAULTS, merged()).tokens).toEqual([]);
+  });
+
+  it("stores only the token the author actually changed", () => {
+    const edited = merged().tokens.map(token =>
+      token.name === "color.ink"
+        ? { ...token, values: { light: "#ff0000" } }
+        : token
+    );
+    const override = tokenOverrideOf(DEFAULTS, { tokens: edited });
+    expect(override.tokens.map(t => t.name)).toEqual(["color.ink"]);
+    expect(override.tokens[0]?.values.light).toBe("#ff0000");
+  });
+
+  it("stores a token the config never supplied", () => {
+    const edited = [
+      ...merged().tokens,
+      {
+        name: "color.new",
+        kind: "color",
+        values: { light: "#00ff00" },
+      } as SiteToken,
+    ];
+    expect(
+      tokenOverrideOf(DEFAULTS, { tokens: edited }).tokens.map(t => t.name)
+    ).toEqual(["color.new"]);
+  });
+
+  it("matches by IDENTITY, so a renamed default is an override and not a new token", () => {
+    // `brand.main` carries id `color.primary`. Renaming it must be recognised
+    // as an override of that default rather than stored beside it, which would
+    // leave the default in the merged list forever.
+    const edited = merged().tokens.map(token =>
+      token.name === "brand.main" ? { ...token, name: "brand.hero" } : token
+    );
+    const override = tokenOverrideOf(DEFAULTS, { tokens: edited });
+    expect(override.tokens.length).toBe(1);
+    expect(override.tokens[0]?.id).toBe("color.primary");
+    expect(override.tokens[0]?.name).toBe("brand.hero");
+  });
+
+  it("survives a round trip through the merge", () => {
+    // The property that makes the whole scheme sound: storing the override and
+    // merging it back must reproduce what the author was looking at.
+    const edited = merged().tokens.map(token =>
+      token.name === "color.ink"
+        ? { ...token, values: { light: "#ff0000" } }
+        : token
+    );
+    const stored = tokenOverrideOf(DEFAULTS, { tokens: edited });
+    expect(merged(stored).tokens).toEqual(edited);
+  });
+
+  it("does not store a prefix or dark mode the config already states", () => {
+    const override = tokenOverrideOf(DEFAULTS, {
+      tokens: merged().tokens,
+      prefix: "--site-",
+    });
+    expect(override.prefix).toBeUndefined();
+  });
+
+  it("DOES store a prefix the author changed", () => {
+    const override = tokenOverrideOf(DEFAULTS, {
+      tokens: merged().tokens,
+      prefix: "--brand-",
+    });
+    expect(override.prefix).toBe("--brand-");
+  });
+
+  it("compares field by field, not by serialising", () => {
+    // A token that round-tripped through storage can carry its keys in another
+    // order. Comparing serialised forms would call it changed, and every edit
+    // anywhere would then store every config token — the exact failure this
+    // exists to prevent.
+    const reordered = merged().tokens.map(token => ({
+      values: token.values,
+      kind: token.kind,
+      name: token.name,
+      ...(token.id === undefined ? {} : { id: token.id }),
+    })) as SiteToken[];
+    expect(tokenOverrideOf(DEFAULTS, { tokens: reordered }).tokens).toEqual([]);
+  });
+
+  it("stores everything when the site supplies no defaults at all", () => {
+    // The control: without it, a function that always returned an empty list
+    // would satisfy the first test perfectly.
+    const edited = { tokens: [ink, brand] };
+    expect(tokenOverrideOf(undefined, edited).tokens.length).toBe(2);
+  });
+});

--- a/packages/plugin-page-builder/src/site-style-override.test.ts
+++ b/packages/plugin-page-builder/src/site-style-override.test.ts
@@ -13,7 +13,11 @@
 import type { SiteToken, SiteTokenSet } from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
 
-import { resolveSiteStyle, tokenOverrideOf } from "./site-style";
+import {
+  resolveSiteStyle,
+  tokenOverrideOf,
+  tokensAfterRefusal,
+} from "./site-style";
 
 const ink: SiteToken = {
   name: "color.ink",
@@ -130,5 +134,36 @@ describe("only what differs from the site's own defaults is stored", () => {
     // would satisfy the first test perfectly.
     const edited = { tokens: [ink, brand] };
     expect(tokenOverrideOf(undefined, edited).tokens.length).toBe(2);
+  });
+});
+
+describe("what a refused save leaves on screen", () => {
+  const a: SiteTokenSet = { tokens: [ink] };
+  const b: SiteTokenSet = { tokens: [brand] };
+  const stored: SiteTokenSet = { tokens: [] };
+
+  it("rolls back when the refused edit is still what is on screen", () => {
+    expect(tokensAfterRefusal(a, a, stored)).toBe(stored);
+  });
+
+  it("does NOT roll back over a newer edit", () => {
+    // Saves serialise but their answers need not arrive in order. Rolling back
+    // unconditionally discards the newer edit — and if the newer save then
+    // succeeds, the panel shows the older set while storage holds the newer,
+    // with nothing left to reconcile them.
+    expect(tokensAfterRefusal(b, a, stored)).toBe(b);
+  });
+
+  it("falls back to what was STORED, not to what was on screen before", () => {
+    // After an earlier refusal, the previous on-screen value is itself one the
+    // site never accepted, so restoring it would show the author something no
+    // storage anywhere agrees with.
+    expect(tokensAfterRefusal(a, a, stored)).toBe(stored);
+    expect(tokensAfterRefusal(a, a, null)).toBeNull();
+  });
+
+  it("defers to the read when this session has stored nothing", () => {
+    // `null` means no local shadow, so the query's own answer is the truth.
+    expect(tokensAfterRefusal(a, a, null)).toBeNull();
   });
 });

--- a/packages/plugin-page-builder/src/site-style-override.test.ts
+++ b/packages/plugin-page-builder/src/site-style-override.test.ts
@@ -167,3 +167,82 @@ describe("what a refused save leaves on screen", () => {
     expect(tokensAfterRefusal(a, a, null)).toBeNull();
   });
 });
+
+describe("vendor extensions are not lost by a save about something else", () => {
+  it("treats a token differing ONLY in extensions as changed", () => {
+    // DTCG requires a tool to preserve extension data it does not understand.
+    // Left out of the comparison, a stored override differing only in
+    // extensions reads as identical to the config default — so the next edit
+    // anywhere in the table filters it out of the payload and the vendor data
+    // is gone, from a save the author made about a different token.
+    const base: SiteToken = {
+      name: "color.ink",
+      kind: "color",
+      values: { light: "#111111" },
+    };
+    const withExtensions: SiteToken = {
+      ...base,
+      extensions: { "com.figma": { variableId: "VariableID:1:2" } },
+    };
+    const override = tokenOverrideOf(
+      { tokens: [base] },
+      { tokens: [withExtensions] }
+    );
+    expect(override.tokens).toEqual([withExtensions]);
+  });
+
+  it("still treats identical extensions as unchanged, whatever the key order", () => {
+    // The control, and the reason the comparison is structural rather than
+    // serialised: a token that round-tripped through storage can carry its
+    // extension keys in another order, and calling that changed would store
+    // every config token on every edit.
+    const extensions = { a: { x: 1, y: [1, 2] }, b: "s" };
+    const reordered = { b: "s", a: { y: [1, 2], x: 1 } };
+    const one: SiteToken = {
+      name: "color.ink",
+      kind: "color",
+      values: { light: "#111111" },
+      extensions,
+    };
+    const two: SiteToken = { ...one, extensions: reordered };
+    expect(
+      tokenOverrideOf({ tokens: [one] }, { tokens: [two] }).tokens
+    ).toEqual([]);
+  });
+
+  it("tells an array from a record, and a length from a length", () => {
+    // Order matters in an array and not in a record, which is the whole reason
+    // they are decided apart — an equality applying one rule to both would be
+    // wrong in one direction or the other.
+    const of = (extensions: Record<string, unknown>): SiteToken => ({
+      name: "color.ink",
+      kind: "color",
+      values: { light: "#111111" },
+      extensions,
+    });
+    const differ = (a: Record<string, unknown>, b: Record<string, unknown>) =>
+      tokenOverrideOf({ tokens: [of(a)] }, { tokens: [of(b)] }).tokens.length;
+
+    expect(differ({ v: [1, 2] }, { v: [2, 1] })).toBe(1);
+    expect(differ({ v: [1, 2] }, { v: [1, 2, 3] })).toBe(1);
+    expect(differ({ v: [1, 2] }, { v: { 0: 1, 1: 2 } })).toBe(1);
+    expect(differ({ v: 1 }, { v: "1" })).toBe(1);
+    expect(differ({ v: null }, { v: {} })).toBe(1);
+    expect(differ({ v: { a: 1 } }, { v: { a: 1, b: 2 } })).toBe(1);
+    // And the same content, however it is spelled, is still the same.
+    expect(differ({ v: [1, { a: 2 }] }, { v: [1, { a: 2 }] })).toBe(0);
+  });
+
+  it("sees a difference nested inside the extension data", () => {
+    const one: SiteToken = {
+      name: "color.ink",
+      kind: "color",
+      values: { light: "#111111" },
+      extensions: { a: { deep: [1, 2, 3] } },
+    };
+    const two: SiteToken = { ...one, extensions: { a: { deep: [1, 2, 4] } } };
+    expect(
+      tokenOverrideOf({ tokens: [one] }, { tokens: [two] }).tokens
+    ).toEqual([two]);
+  });
+});

--- a/packages/plugin-page-builder/src/site-style-override.test.ts
+++ b/packages/plugin-page-builder/src/site-style-override.test.ts
@@ -10,7 +10,11 @@
  *
  * @module site-style-override.test
  */
-import type { SiteToken, SiteTokenSet } from "@nextlyhq/blocks-engine";
+import {
+  resolveSiteTokens,
+  type SiteToken,
+  type SiteTokenSet,
+} from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -278,5 +282,63 @@ describe("what a save's answer means", () => {
     expect(tokenSaveOutcome(false, {}, a, a, stored).issue).toBe(
       "That change was not saved."
     );
+  });
+});
+
+describe("the engine's own defaults are editable without being stored wholesale", () => {
+  /*
+   * `resolveSiteTokens` layers `color.primary`, `color.text`, `space.4` and the
+   * rest under whatever a site states, and the renderer compiles with it — so a
+   * page on a site that states no tokens is still USING them. A studio showing
+   * only the stated tier reports every category empty while the picker beside
+   * it offers those very tokens, and they can then be neither seen nor
+   * overridden.
+   */
+  const baseline = resolveSiteTokens(undefined);
+
+  it("has something to show on a site that states no tokens of its own", () => {
+    expect(baseline.tokens.length).toBeGreaterThan(0);
+    expect(baseline.tokens.map(t => t.name)).toContain("color.primary");
+  });
+
+  it("stores NOTHING when the author has changed no default", () => {
+    // Deriving the override against the config alone would write every engine
+    // default into the database on the first edit — the merged-set fault, one
+    // tier further down.
+    expect(tokenOverrideOf(baseline, baseline).tokens).toEqual([]);
+  });
+
+  it("stores only the default the author actually changed", () => {
+    const edited = {
+      tokens: baseline.tokens.map(token =>
+        token.name === "color.primary"
+          ? { ...token, values: { light: "#ff0000" } }
+          : token
+      ),
+    };
+    const override = tokenOverrideOf(baseline, edited);
+    expect(override.tokens.map(t => t.name)).toEqual(["color.primary"]);
+    expect(override.tokens[0]?.values.light).toBe("#ff0000");
+  });
+
+  it("survives the round trip the renderer actually performs", () => {
+    // The property that makes it sound: store the override, resolve it back
+    // the way the canvas does, and the author sees what they left.
+    const edited = {
+      tokens: baseline.tokens.map(token =>
+        token.name === "color.text"
+          ? { ...token, values: { light: "#0a0a0a" } }
+          : token
+      ),
+    };
+    const stored = tokenOverrideOf(baseline, edited);
+    const resolved = resolveSiteTokens(stored);
+    expect(
+      resolved.tokens.find(t => t.name === "color.text")?.values.light
+    ).toBe("#0a0a0a");
+    // And nothing else moved.
+    expect(
+      resolved.tokens.find(t => t.name === "color.primary")?.values.light
+    ).toBe(baseline.tokens.find(t => t.name === "color.primary")?.values.light);
   });
 });

--- a/packages/plugin-page-builder/src/site-style-override.test.ts
+++ b/packages/plugin-page-builder/src/site-style-override.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it } from "vitest";
 import {
   resolveSiteStyle,
   tokenOverrideOf,
+  tokenSaveOutcome,
   tokensAfterRefusal,
 } from "./site-style";
 
@@ -244,5 +245,38 @@ describe("vendor extensions are not lost by a save about something else", () => 
     expect(
       tokenOverrideOf({ tokens: [one] }, { tokens: [two] }).tokens
     ).toEqual([two]);
+  });
+});
+
+describe("what a save's answer means", () => {
+  const a: SiteTokenSet = { tokens: [ink] };
+  const b: SiteTokenSet = { tokens: [brand] };
+  const stored: SiteTokenSet = { tokens: [] };
+
+  it("clears the message when the edit it answered is still on screen", () => {
+    expect(tokenSaveOutcome(true, {}, a, a, stored)).toEqual({ issue: null });
+  });
+
+  it("says NOTHING about a success for a superseded edit", () => {
+    // Leaving both fields alone is a third answer beside set and clear.
+    expect(tokenSaveOutcome(true, {}, a, b, stored)).toEqual({});
+  });
+
+  it("rolls back and speaks when a refusal is still current", () => {
+    const out = tokenSaveOutcome(false, { tokens: "no" }, a, a, stored);
+    expect(out.tokens).toBe(stored);
+    expect(out.issue).toBe("no");
+  });
+
+  it("neither rolls back NOR speaks for a superseded refusal", () => {
+    // The sequence that made the studio announce a set it had saved as
+    // unsaved: an invalid edit, a correcting edit, then the first refusal.
+    expect(tokenSaveOutcome(false, { tokens: "no" }, a, b, stored)).toEqual({});
+  });
+
+  it("falls back to its own words when the validator named none", () => {
+    expect(tokenSaveOutcome(false, {}, a, a, stored).issue).toBe(
+      "That change was not saved."
+    );
   });
 });

--- a/packages/plugin-page-builder/src/site-style.ts
+++ b/packages/plugin-page-builder/src/site-style.ts
@@ -192,8 +192,68 @@ function sameSiteToken(a: SiteToken, b: SiteToken): boolean {
     a.kind === b.kind &&
     a.description === b.description &&
     a.values.light === b.values.light &&
-    a.values.dark === b.values.dark
+    a.values.dark === b.values.dark &&
+    // `extensions` is vendor data from Figma, Style Dictionary or whatever else
+    // wrote the token, and DTCG requires a tool to preserve what it does not
+    // understand. Left out of this comparison, a stored override differing ONLY
+    // in extensions reads as identical to the config default — so the next edit
+    // anywhere in the table filters it out of the payload and the vendor data is
+    // gone, silently, from a save the author made about a different token.
+    sameJsonValue(a.extensions, b.extensions)
   );
+}
+
+/**
+ * Whether two values decoded from JSON say the same thing.
+ *
+ * Structural rather than `JSON.stringify`, because key order is not meaning and
+ * a token that round-tripped through storage can carry its fields in another
+ * order — the same reason the token comparison above is field by field. Written
+ * for `extensions`, whose shape is by definition unknown: it is whatever
+ * another tool wrote, so there is no set of fields to enumerate.
+ */
+function sameJsonValue(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (Array.isArray(a) || Array.isArray(b)) return sameJsonArray(a, b);
+  if (isJsonRecord(a) && isJsonRecord(b)) return sameJsonRecord(a, b);
+  // Two primitives that were not `===` above, or one of each kind. Neither is
+  // worth descending into.
+  return false;
+}
+
+/**
+ * Two arrays, element by element and in order.
+ *
+ * Asked apart from the record case because order MATTERS here and does not
+ * there, which is the whole difference between the two — and an equality that
+ * decided both in one branch would be one edit from applying the wrong rule.
+ * An array beside a non-array is not equal, which is why both sides are tested
+ * rather than only the one that got us here.
+ */
+function sameJsonArray(a: unknown, b: unknown): boolean {
+  return (
+    Array.isArray(a) &&
+    Array.isArray(b) &&
+    a.length === b.length &&
+    a.every((item, index) => sameJsonValue(item, b[index]))
+  );
+}
+
+/** Two records: the same own keys, and the same value under each. */
+function sameJsonRecord(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>
+): boolean {
+  const keys = Object.keys(a);
+  return (
+    keys.length === Object.keys(b).length &&
+    keys.every(key => Object.hasOwn(b, key) && sameJsonValue(a[key], b[key]))
+  );
+}
+
+/** An object with named keys, as JSON produces. Arrays are handled apart. */
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 /**

--- a/packages/plugin-page-builder/src/site-style.ts
+++ b/packages/plugin-page-builder/src/site-style.ts
@@ -152,6 +152,32 @@ export function tokenOverrideOf(
 }
 
 /**
+ * What a studio should show once a REFUSED save has answered.
+ *
+ * Saves serialise but their answers do not have to arrive in order, and an
+ * author can type two edits before the first one comes back. Rolling back
+ * unconditionally then discards the newer edit — and if the newer save
+ * succeeds, the panel goes on showing the older set while storage holds the
+ * newer one, with nothing to reconcile them.
+ *
+ * So a rollback only applies while the refused edit is still what is on screen.
+ * Anything typed since has its own save in flight and is the one that decides.
+ *
+ * It falls back to the last set a save is KNOWN to have stored, rather than to
+ * whatever was on screen beforehand: after an earlier refusal, that is itself a
+ * value the site never accepted, so restoring it would show the author
+ * something no storage anywhere agrees with. `null` means nothing has been
+ * stored by this session and the read's own answer is the truth.
+ */
+export function tokensAfterRefusal(
+  current: SiteTokenSet | null,
+  refused: SiteTokenSet,
+  persisted: SiteTokenSet | null
+): SiteTokenSet | null {
+  return current === refused ? persisted : current;
+}
+
+/**
  * Whether two tokens say the same thing.
  *
  * Field by field rather than by serialising both, because key order is not

--- a/packages/plugin-page-builder/src/site-style.ts
+++ b/packages/plugin-page-builder/src/site-style.ts
@@ -169,6 +169,49 @@ export function tokenOverrideOf(
  * something no storage anywhere agrees with. `null` means nothing has been
  * stored by this session and the read's own answer is the truth.
  */
+/** What a studio should do once a save has answered. */
+export interface TokenSaveOutcome {
+  /** What to show, or `undefined` to leave the panel exactly as it is. */
+  readonly tokens?: SiteTokenSet | null;
+  /** What to say: a message, `null` to clear one, `undefined` to leave it. */
+  readonly issue?: string | null;
+}
+
+/**
+ * What a save's answer MEANS, apart from wiring it into any state.
+ *
+ * Both branches turn on one question — is this answer still about what the
+ * author is looking at — and that is why they are decided together rather than
+ * beside each other. Saves serialise, their answers need not arrive in order,
+ * and an answer for a superseded edit must neither roll the newer one back nor
+ * speak about it. Deciding the value and the message under separate rules is
+ * how a studio ends up announcing that a set it did save was not saved.
+ *
+ * `undefined` for either field means LEAVE IT, which is a third answer beside
+ * "set this" and "clear this": an obsolete refusal has nothing to say about a
+ * panel that has moved on.
+ */
+export function tokenSaveOutcome(
+  saved: boolean,
+  issues: Readonly<Record<string, string>>,
+  attempted: SiteTokenSet,
+  latest: SiteTokenSet | null,
+  persisted: SiteTokenSet | null
+): TokenSaveOutcome {
+  const current = latest === attempted;
+  if (saved) {
+    // A refusal for an EARLIER edit can arrive after a later one has already
+    // cleared the message, so a success has to clear it again — otherwise the
+    // studio goes on reporting a set it did save as unsaved.
+    return current ? { issue: null } : {};
+  }
+  if (!current) return {};
+  return {
+    tokens: tokensAfterRefusal(latest, attempted, persisted),
+    issue: Object.values(issues)[0] ?? "That change was not saved.",
+  };
+}
+
 export function tokensAfterRefusal(
   current: SiteTokenSet | null,
   refused: SiteTokenSet,

--- a/packages/plugin-page-builder/src/site-style.ts
+++ b/packages/plugin-page-builder/src/site-style.ts
@@ -110,6 +110,67 @@ export function resolveSiteStyle(
 }
 
 /**
+ * The stored tier that, merged under the site's config defaults, gives this set.
+ *
+ * The INVERSE of the token half of {@link resolveSiteStyle}, and the reason a
+ * studio cannot save what it was handed. `useSiteStyle` answers with the config
+ * defaults and the stored tier already merged, because that is what the canvas
+ * has to compile — so an editor that saved its whole working set would copy
+ * every config-supplied token into the database on the author's first edit.
+ * From then on the site's own code could not change those values: the accidental
+ * overrides would mask them, silently, and only for sites that supply defaults.
+ *
+ * So only what actually DIFFERS is stored: a token the config never supplied,
+ * or one whose value the author has changed. The prefix and the dark-mode
+ * strategy follow the same rule.
+ *
+ * What this deliberately cannot express is REMOVING a config-supplied token.
+ * Absence from the stored tier means "no override", so the default merges
+ * straight back on the next read. The studio does not offer removal for those
+ * rows rather than offering one that quietly undoes itself.
+ */
+export function tokenOverrideOf(
+  defaults: SiteTokenSet | undefined,
+  edited: SiteTokenSet
+): SiteTokenSet {
+  const supplied = new Map(
+    (defaults?.tokens ?? []).map(token => [tokenIdentity(token), token])
+  );
+  const tokens = edited.tokens.filter(token => {
+    const base = supplied.get(tokenIdentity(token));
+    return base === undefined || !sameSiteToken(base, token);
+  });
+  return {
+    tokens,
+    ...(edited.prefix === undefined || edited.prefix === defaults?.prefix
+      ? {}
+      : { prefix: edited.prefix }),
+    ...(edited.darkMode === undefined || edited.darkMode === defaults?.darkMode
+      ? {}
+      : { darkMode: edited.darkMode }),
+  };
+}
+
+/**
+ * Whether two tokens say the same thing.
+ *
+ * Field by field rather than by serialising both, because key order is not
+ * meaning: a token that round-tripped through storage can carry its fields in
+ * a different order and would compare as changed, so every edit anywhere would
+ * store every config token — the failure this comparison exists to prevent.
+ */
+function sameSiteToken(a: SiteToken, b: SiteToken): boolean {
+  return (
+    a.id === b.id &&
+    a.name === b.name &&
+    a.kind === b.kind &&
+    a.description === b.description &&
+    a.values.light === b.values.light &&
+    a.values.dark === b.values.dark
+  );
+}
+
+/**
  * A style whose keys are only the DEFINED sections.
  *
  * An `undefined` property and an absent one mean the same thing to a reader,


### PR DESCRIPTION
Closes C-7 `task:pb-tokens-studio`. The `tokens` rail slot has been reserved and dark since the shell was built; this fills it.

## What it is

The site's design tokens, listed by kind and edited in the table that shows them — the way Figma's variables table and Tokens Studio both work, and for the same reason: the common edit is nudging one value, and a detail form turns that into two clicks. Eight kinds, light and dark behind one switch above the tabs, and the engine's verdict on every row.

## The rename is what this is built around

A stored reference holds a token's **identity**, and `renameSiteToken` pins that identity the first time a token is renamed. So a rename moves the label and nothing else — every block already pointing at the token goes on resolving, and no stored document is rewritten.

That is worth stating because the tools this pattern comes from cannot do it. Figma variables and Tokens Studio both key on the **name**, so both have to *stage alias rewiring for review* before a rename can be applied. Our `SiteToken` splits `id` from `name`, so the staging step has nothing to do.

`renameSiteToken` had **zero production callers** before this PR — only its own tests and the re-export. This is its first, which makes it the place the rule either holds or is silently bypassed. Getting it wrong moves the custom property, stops every stored `$token` resolving, and **still renders the page** — just without the style. No error, no console warning, no visual difference on the page being edited.

So the rename tests assert against `compileSiteSheet`, not against the token record:

```
before rename:  --site-color-ink   declared
after  rename:  --site-color-ink   STILL declared
                --site-text-body   NOT declared
```

**Break-verified.** Writing the new name as the identity fails four tests, including the compiler one with `expected [ '--site-text-body', … ] to include '--site-color-ink'` — the silent defect made visible.

## Values are asked, never re-judged

Whether a value is usable, contradicts its kind, or collides with another token is `emitTokenBlocks`'s verdict, obtained by emitting and reading what comes back. A second copy of those rules would agree on the cases someone thought of and diverge silently on the rest.

Each token is emitted **alone** so the messages that return are about it and no other — no matching message text against a name. The one verdict that cannot be reached that way is the collision, which is a property of the set, so it is asked explicitly with `tokenCustomProperty`.

## Three decisions, made deliberately

**Removal warns and does not count.** Naming the pages that would lose a style needs a search *inside* a JSON column, which no dialect this ships on can do portably. So the warning says what removal means — "any block using `brand.main` loses that style, the page still renders" — rather than inventing a number it cannot stand behind.

**A colour value is typed, not picked.** `@nextlyhq/ui`'s ColorPicker holds unparseable hex in a private draft reset by `onBlur`, and a dismissal is not a blur, so leaving it mid-edit commits the last value it *published*. On a block that costs one declaration. On a **token** it would change what the whole site resolves. Filed as `task:ui-picker-draft-contract`; the swatch here previews and does not open until that contract is fixed.

**Match-light clears the dark value rather than copying light into it.** They look identical and are different documents: an explicit dark value stops tracking later edits to light, so the two drift apart the next time anyone changes light.

## The shell mock

`BlocksField.policy.test.tsx` mocked `@nextlyhq/builder/shell` with a closed object literal, which answers `undefined` for every export it does not name. Adding `TokensPanel` put it exactly one render away from a confusing failure in that package while this one stayed green. Now spreads the real module.

Made **load-bearing** rather than left as a defensive edit: a new test asserts the mock still provides every export `BlocksField` imports. Dropping `...real` fails it with `No "TokensPanel" export is defined on the "@nextlyhq/builder/shell" mock`.

Reported by `nextly-workspace-3a`, from `nextly-workspace-5d`.

## Evidence

**47 new tests** — 29 on the pure module against the real compilers, 18 driving the panel.

Break-verified six ways, each isolating one decision:

| break | fails |
|---|---|
| rename writes the new name as the identity | 4, incl. the compiler assertion |
| collision compares names, not composed properties | 1 |
| a wrong per-kind seed (`#000000` on a duration) | 1, naming the kind |
| panel spreads a name instead of calling the rule | 1, `expected undefined to be 'color.ink'` |
| a refused name commits anyway | 2 |
| removal skips its confirmation | 3 |

One test-design bug caught and fixed on the way: `mount(undefined)` hit a default parameter and asserted against the full fixture while claiming to assert against no table. Same trap as its sibling colour panel test; the default is gone and the docblock says why.

## Gates

Build, **1426** builder tests, **179** plugin-page-builder, `check-types` on both packages, package lint, root eslint 0/0, `layering.test.ts`, `lint:design`, comment convention, and `FALLOW_AUDIT_BASE=origin/main fallow audit` → `pass` with 0 introduced across dead code, duplication and complexity. Changeset generated from `.changeset/config.json`, all 25 packages at `patch`.

## Not in scope

DTCG import/export is its own task, `task:pb-dtcg-import-export-ui`, which depends on this one. `dtcgToTokens` and `tokensToDtcg` are exported and still unwired.