### PR TITLE
fix(admin): colour code from the design tokens, in both themes

### DIFF
--- a/.changeset/code-colours-come-from-the-theme.md
+++ b/.changeset/code-colours-come-from-the-theme.md
@@ -1,0 +1,37 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Colour code in the admin from the theme's own palette instead of CodeMirror's
+bundled one. API Playground responses, generated snippets, request bodies, code
+fields and email templates all read `--nx-code-*`, so they follow a retheme,
+match the rich-text editor's code blocks, and come under the contrast audit
+that already covers those tokens. One style now serves both modes, because the
+tokens are redeclared under `.dark` — light and dark no longer drift apart.
+
+Code also renders in the admin's own mono face rather than a hardcoded stack,
+and a bracket under the caret keeps its highlight instead of losing its colour.

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -116,6 +116,7 @@
     "@lexical/selection": "^0.47.0",
     "@lexical/table": "^0.47.0",
     "@lexical/utils": "^0.47.0",
+    "@lezer/highlight": "^1.2.3",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/packages/admin/src/components/features/entries/APIPlayground/APIPlayground.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/APIPlayground.tsx
@@ -43,7 +43,6 @@ import {
 
 import { RotateCcw } from "@admin/components/icons";
 import { UI } from "@admin/constants/ui";
-import { useTheme } from "@admin/context/providers/ThemeProvider";
 import { cn } from "@admin/lib/utils";
 
 import { generateCode } from "./generate-code";
@@ -272,8 +271,6 @@ export function APIPlayground({
 
   // Copy state
   const [copied, setCopied] = useState(false);
-
-  const { resolvedTheme } = useTheme();
 
   /** The in-flight request, so a re-send or Escape can call it off. */
   const abortRef = useRef<AbortController | null>(null);
@@ -779,7 +776,6 @@ export function APIPlayground({
                           value={requestBody}
                           onChange={setRequestBody}
                           language="json"
-                          theme={resolvedTheme === "dark" ? "dark" : "light"}
                           disabled={false}
                           readOnly={false}
                           minHeight={320}

--- a/packages/admin/src/components/features/entries/APIPlayground/CodeBlock.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/CodeBlock.tsx
@@ -22,7 +22,10 @@ import { EditorView } from "@codemirror/view";
 import CodeMirror from "@uiw/react-codemirror";
 import { useEffect, useMemo, useState } from "react";
 
-import { useTheme } from "@admin/context/providers/ThemeProvider";
+import {
+  nextlyEditorChrome,
+  nextlyHighlighting,
+} from "@admin/lib/code-highlight";
 
 export type CodeBlockLanguage = "json" | "typescript" | "javascript" | "shell";
 
@@ -53,10 +56,6 @@ export function CodeBlock({
   language,
   showGutter = false,
 }: CodeBlockProps) {
-  // resolvedTheme, not theme: the default is "system", which never equals
-  // "dark" and would leave the editor light inside a dark admin.
-  const { resolvedTheme } = useTheme();
-
   // CodeMirror reaches for browser globals, so it renders after mount.
   const [isMounted, setIsMounted] = useState(false);
   useEffect(() => {
@@ -64,39 +63,24 @@ export function CodeBlock({
   }, []);
 
   const extensions = useMemo(
-    () => [languageExtension(language), EditorView.lineWrapping],
-    [language]
-  );
-
-  const editorTheme = useMemo(
-    () =>
+    () => [
+      languageExtension(language),
+      EditorView.lineWrapping,
+      nextlyHighlighting,
+      nextlyEditorChrome({
+        showGutter,
+        padding: showGutter ? "16px 12px" : "16px 24px",
+      }),
+      // Nothing here is editable, so the affordances that say otherwise are
+      // switched off rather than merely unused.
       EditorView.theme({
-        "&": {
-          fontSize: "12px",
-          backgroundColor: "transparent !important",
-        },
-        ".cm-scroller": {
-          // `--font-mono` is the theme's mono stack, so the editor renders in
-          // the same face as every other mono surface in the admin. The
-          // fallback only covers a host that has not loaded the theme.
-          fontFamily: "var(--font-mono, ui-monospace, monospace)",
-          padding: showGutter ? "16px 12px" : "16px 24px",
-        },
-        ".cm-gutters": {
-          borderRight:
-            "1px solid color-mix(in srgb, var(--nx-border) 50%, transparent)",
-          backgroundColor:
-            "color-mix(in srgb, var(--nx-muted) 30%, transparent)",
-          color:
-            "color-mix(in srgb, var(--nx-muted-foreground) 50%, transparent)",
-          padding: "0 4px",
-        },
         ".cm-activeLine, .cm-activeLineGutter": {
           backgroundColor: "transparent",
         },
         ".cm-cursor": { display: "none" },
       }),
-    [showGutter]
+    ],
+    [language, showGutter]
   );
 
   if (!isMounted) {
@@ -110,8 +94,11 @@ export function CodeBlock({
   return (
     <CodeMirror
       value={value}
-      extensions={[...extensions, editorTheme]}
-      theme={resolvedTheme === "dark" ? "dark" : "light"}
+      extensions={extensions}
+      // "none" rather than a resolved light/dark: the colours come from
+      // `--nx-code-*`, which the theme redeclares under `.dark`, so CSS settles
+      // the mode and a bundled palette here would only fight it.
+      theme="none"
       editable={false}
       readOnly
       basicSetup={{

--- a/packages/admin/src/components/features/entries/APIPlayground/CodeBlock.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/CodeBlock.tsx
@@ -22,6 +22,7 @@ import { EditorView } from "@codemirror/view";
 import CodeMirror from "@uiw/react-codemirror";
 import { useEffect, useMemo, useState } from "react";
 
+import { useTheme } from "@admin/context/providers/ThemeProvider";
 import {
   nextlyEditorChrome,
   nextlyHighlighting,
@@ -56,6 +57,11 @@ export function CodeBlock({
   language,
   showGutter = false,
 }: CodeBlockProps) {
+  // Not a colour: every colour here is a token. This is the boolean the
+  // CodeMirror packages read to choose between their OWN light and dark rules,
+  // which nothing sets under `theme="none"`.
+  const { resolvedTheme } = useTheme();
+
   // CodeMirror reaches for browser globals, so it renders after mount.
   const [isMounted, setIsMounted] = useState(false);
   useEffect(() => {
@@ -69,6 +75,7 @@ export function CodeBlock({
       nextlyHighlighting,
       nextlyEditorChrome({
         showGutter,
+        dark: resolvedTheme === "dark",
         padding: showGutter ? "16px 12px" : "16px 24px",
       }),
       // Nothing here is editable, so the affordances that say otherwise are
@@ -80,7 +87,7 @@ export function CodeBlock({
         ".cm-cursor": { display: "none" },
       }),
     ],
-    [language, showGutter]
+    [language, showGutter, resolvedTheme]
   );
 
   if (!isMounted) {
@@ -95,9 +102,11 @@ export function CodeBlock({
     <CodeMirror
       value={value}
       extensions={extensions}
-      // "none" rather than a resolved light/dark: the colours come from
+      // "none" rather than a resolved light/dark: the COLOURS come from
       // `--nx-code-*`, which the theme redeclares under `.dark`, so CSS settles
-      // the mode and a bundled palette here would only fight it.
+      // the mode and a bundled palette here would only fight it. The mode is
+      // still passed to the chrome, but as a flag the CodeMirror packages read
+      // to pick their own light/dark rules -- not as a colour decision.
       theme="none"
       editable={false}
       readOnly

--- a/packages/admin/src/components/features/entries/fields/special/rich-text-kit.ts
+++ b/packages/admin/src/components/features/entries/fields/special/rich-text-kit.ts
@@ -26,6 +26,8 @@ import { HeadingNode, QuoteNode } from "@lexical/rich-text";
 import { TableCellNode, TableNode, TableRowNode } from "@lexical/table";
 import type { Klass, LexicalNode } from "lexical";
 
+import { codeClass } from "@admin/lib/code-palette";
+
 import { ButtonGroupNode } from "./ButtonGroupNode";
 import { ButtonLinkNode } from "./ButtonLinkNode";
 import {
@@ -89,41 +91,41 @@ const editorTheme = {
   // Links
   link: "text-primary underline hover-unified cursor-pointer",
 
-  // Code blocks. The tokenizer names what each token is; these classes decide
-  // how it looks, so the palette lives in the design tokens and both modes are
-  // settled by CSS rather than stored with the content.
+  // Code blocks. The tokenizer names what each token is; the construct table
+  // decides what that is worth, so a colour is never chosen here and cannot
+  // disagree with the CodeMirror surfaces that read the same table.
   code: "block bg-code-bg text-code-fg p-4 rounded-md font-mono text-sm mb-2 overflow-x-auto",
   codeHighlight: {
-    atrule: "text-code-keyword",
-    attr: "text-code-function",
-    boolean: "text-code-number",
-    builtin: "text-code-function",
-    cdata: "text-code-comment",
-    char: "text-code-string",
-    class: "text-code-variable",
-    "class-name": "text-code-variable",
-    comment: "text-code-comment italic",
-    constant: "text-code-number",
-    deleted: "text-code-deleted",
-    doctype: "text-code-comment",
-    entity: "text-code-tag",
-    function: "text-code-function",
-    important: "text-code-tag font-bold",
-    inserted: "text-code-inserted",
-    keyword: "text-code-keyword",
-    namespace: "text-code-comment",
-    number: "text-code-number",
-    operator: "text-code-operator",
-    prolog: "text-code-comment",
-    property: "text-code-function",
-    punctuation: "text-code-punctuation",
-    regex: "text-code-string",
-    selector: "text-code-tag",
-    string: "text-code-string",
-    symbol: "text-code-number",
-    tag: "text-code-tag",
-    url: "text-code-function underline",
-    variable: "text-code-variable",
+    atrule: codeClass("keyword"),
+    attr: codeClass("function"),
+    boolean: codeClass("number"),
+    builtin: codeClass("function"),
+    cdata: codeClass("comment"),
+    char: codeClass("string"),
+    class: codeClass("variable"),
+    "class-name": codeClass("variable"),
+    comment: `${codeClass("comment")} italic`,
+    constant: codeClass("number"),
+    deleted: codeClass("deleted"),
+    doctype: codeClass("comment"),
+    entity: codeClass("tag"),
+    function: codeClass("function"),
+    important: `${codeClass("tag")} font-bold`,
+    inserted: codeClass("inserted"),
+    keyword: codeClass("keyword"),
+    namespace: codeClass("comment"),
+    number: codeClass("number"),
+    operator: codeClass("operator"),
+    prolog: codeClass("comment"),
+    property: codeClass("function"),
+    punctuation: codeClass("punctuation"),
+    regex: codeClass("string"),
+    selector: codeClass("tag"),
+    string: codeClass("string"),
+    symbol: codeClass("number"),
+    tag: codeClass("tag"),
+    url: `${codeClass("function")} underline`,
+    variable: codeClass("variable"),
   },
 
   // Tables

--- a/packages/admin/src/components/features/entries/fields/text/CodeInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/text/CodeInput.tsx
@@ -19,7 +19,6 @@ import {
   type Path,
 } from "react-hook-form";
 
-import { useTheme } from "@admin/context/providers/ThemeProvider";
 import { cn } from "@admin/lib/utils";
 
 // Lazy load CodeMirror and its dependencies to avoid SSR issues with Prism
@@ -158,10 +157,6 @@ export function CodeInput<TFieldValues extends FieldValues = FieldValues>({
   readOnly = false,
   className,
 }: CodeInputProps<TFieldValues>) {
-  // resolvedTheme, not theme: the default is "system", which never equals
-  // "dark" and would leave the editor on its light palette inside a dark admin.
-  const { resolvedTheme } = useTheme();
-
   // SSR guard - only render CodeMirror on the client
   const [isMounted, setIsMounted] = useState(false);
 
@@ -221,7 +216,6 @@ export function CodeInput<TFieldValues extends FieldValues = FieldValues>({
             value={value ?? ""}
             onChange={handleChange}
             language={language}
-            theme={resolvedTheme === "dark" ? "dark" : "light"}
             disabled={disabled}
             readOnly={readOnly}
             minHeight={minHeight}

--- a/packages/admin/src/components/features/entries/fields/text/CodeMirrorEditor.tsx
+++ b/packages/admin/src/components/features/entries/fields/text/CodeMirrorEditor.tsx
@@ -25,6 +25,11 @@ import CodeMirror, { type ReactCodeMirrorProps } from "@uiw/react-codemirror";
 import type { CodeLanguage } from "nextly/config";
 import { useMemo } from "react";
 
+import {
+  nextlyEditorChrome,
+  nextlyHighlighting,
+} from "@admin/lib/code-highlight";
+
 /** Extension type extracted from ReactCodeMirror props (avoids direct @codemirror/state dependency) */
 type Extension = NonNullable<ReactCodeMirrorProps["extensions"]>[number];
 
@@ -36,7 +41,6 @@ export interface CodeMirrorEditorProps {
   value: string;
   onChange: (value: string) => void;
   language: CodeLanguage | "plaintext";
-  theme: "dark" | "light";
   disabled: boolean;
   readOnly: boolean;
   minHeight: number;
@@ -273,7 +277,6 @@ export function CodeMirrorEditor({
   value,
   onChange,
   language,
-  theme,
   disabled,
   readOnly,
   minHeight,
@@ -282,58 +285,38 @@ export function CodeMirrorEditor({
   placeholder,
   onCreateEditor,
 }: CodeMirrorEditorProps) {
-  // Get language extensions with linters
-  const extensions = useMemo(() => getLanguageExtensions(language), [language]);
-
-  // Editor theme configuration
-  const editorTheme = useMemo(() => {
-    return EditorView.theme({
-      "&": {
-        fontSize: `${editorOptions.fontSize ?? 14}px`,
-        fontFamily:
-          editorOptions.fontFamily ??
-          "'Fira Code', 'Cascadia Code', 'JetBrains Mono', monospace",
-      },
-      ".cm-scroller": {
-        fontFamily:
-          editorOptions.fontFamily ??
-          "'Fira Code', 'Cascadia Code', 'JetBrains Mono', monospace",
-      },
-      ".cm-gutters": {
-        borderRight: "1px solid var(--nx-border)",
-        backgroundColor: "var(--nx-muted)",
-      },
-      ".cm-activeLineGutter": {
-        backgroundColor: "var(--nx-accent)",
-      },
-      ".cm-activeLine": {
-        backgroundColor:
-          "color-mix(in srgb, var(--nx-accent) 10%, transparent)",
-      },
-      ".cm-selectionMatch": {
-        backgroundColor:
-          "color-mix(in srgb, var(--nx-primary) 20%, transparent)",
-      },
-      ".cm-searchMatch": {
-        backgroundColor:
-          "color-mix(in srgb, var(--nx-warning) 30%, transparent)",
-      },
-      ".cm-searchMatch.cm-searchMatch-selected": {
-        backgroundColor:
-          "color-mix(in srgb, var(--nx-warning) 50%, transparent)",
-      },
-    });
-  }, [editorOptions.fontSize, editorOptions.fontFamily]);
+  const extensions = useMemo(
+    () => [
+      ...getLanguageExtensions(language),
+      nextlyHighlighting,
+      nextlyEditorChrome({ fontSize: editorOptions.fontSize ?? 14 }),
+      // A caller may still pin a face — a code field whose content is meant to
+      // be read in a particular one. Absent that, the shared chrome's
+      // `--font-mono` stands, so the editor matches every other mono surface.
+      ...(editorOptions.fontFamily
+        ? [
+            EditorView.theme({
+              "&": { fontFamily: editorOptions.fontFamily },
+              ".cm-scroller": { fontFamily: editorOptions.fontFamily },
+            }),
+          ]
+        : []),
+    ],
+    [language, editorOptions.fontSize, editorOptions.fontFamily]
+  );
 
   return (
     <CodeMirror
       value={value}
       onChange={onChange}
-      extensions={[...extensions, editorTheme]}
+      extensions={extensions}
       height={maxHeight ? undefined : `${minHeight}px`}
       minHeight={`${minHeight}px`}
       maxHeight={maxHeight ? `${maxHeight}px` : undefined}
-      theme={theme}
+      // "none" rather than a resolved light/dark: the colours come from
+      // `--nx-code-*`, which the theme redeclares under `.dark`, so CSS settles
+      // the mode and a bundled palette here would only fight it.
+      theme="none"
       editable={!disabled && !readOnly}
       readOnly={disabled || readOnly}
       basicSetup={{

--- a/packages/admin/src/components/features/entries/fields/text/CodeMirrorEditor.tsx
+++ b/packages/admin/src/components/features/entries/fields/text/CodeMirrorEditor.tsx
@@ -25,6 +25,7 @@ import CodeMirror, { type ReactCodeMirrorProps } from "@uiw/react-codemirror";
 import type { CodeLanguage } from "nextly/config";
 import { useMemo } from "react";
 
+import { useTheme } from "@admin/context/providers/ThemeProvider";
 import {
   nextlyEditorChrome,
   nextlyHighlighting,
@@ -285,11 +286,17 @@ export function CodeMirrorEditor({
   placeholder,
   onCreateEditor,
 }: CodeMirrorEditorProps) {
+  // Not a colour: see `EditorChromeOptions.dark`.
+  const { resolvedTheme } = useTheme();
+
   const extensions = useMemo(
     () => [
       ...getLanguageExtensions(language),
       nextlyHighlighting,
-      nextlyEditorChrome({ fontSize: editorOptions.fontSize ?? 14 }),
+      nextlyEditorChrome({
+        fontSize: editorOptions.fontSize ?? 14,
+        dark: resolvedTheme === "dark",
+      }),
       // A caller may still pin a face — a code field whose content is meant to
       // be read in a particular one. Absent that, the shared chrome's
       // `--font-mono` stands, so the editor matches every other mono surface.
@@ -302,7 +309,7 @@ export function CodeMirrorEditor({
           ]
         : []),
     ],
-    [language, editorOptions.fontSize, editorOptions.fontFamily]
+    [language, editorOptions.fontSize, editorOptions.fontFamily, resolvedTheme]
   );
 
   return (
@@ -313,9 +320,11 @@ export function CodeMirrorEditor({
       height={maxHeight ? undefined : `${minHeight}px`}
       minHeight={`${minHeight}px`}
       maxHeight={maxHeight ? `${maxHeight}px` : undefined}
-      // "none" rather than a resolved light/dark: the colours come from
+      // "none" rather than a resolved light/dark: the COLOURS come from
       // `--nx-code-*`, which the theme redeclares under `.dark`, so CSS settles
-      // the mode and a bundled palette here would only fight it.
+      // the mode and a bundled palette here would only fight it. The mode is
+      // still passed to the chrome, but as a flag the CodeMirror packages read
+      // to pick their own light/dark rules -- not as a colour decision.
       theme="none"
       editable={!disabled && !readOnly}
       readOnly={disabled || readOnly}

--- a/packages/admin/src/components/features/settings/EmailTemplateForm.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm.tsx
@@ -67,7 +67,6 @@ import {
 } from "@admin/components/ui/form";
 import { Link } from "@admin/components/ui/link";
 import { ROUTES } from "@admin/constants/routes";
-import { useTheme } from "@admin/context/providers/ThemeProvider";
 import { useEmailProviders } from "@admin/hooks/queries/useEmailProviders";
 import {
   useEmailTemplates,
@@ -1345,7 +1344,6 @@ export function EmailTemplateForm({
   const slugTouchedRef = useRef(false);
   const editorWrapRef = useRef<HTMLDivElement>(null);
   const htmlEditorViewRef = useRef<EditorView | null>(null);
-  const { resolvedTheme } = useTheme();
 
   const [railTab, setRailTab] = useState<RailTab>("variables");
   const [railOpen, setRailOpen] = useState(true);
@@ -1832,7 +1830,6 @@ export function EmailTemplateForm({
                           htmlEditorViewRef.current = view;
                         }}
                         language="html"
-                        theme={resolvedTheme === "dark" ? "dark" : "light"}
                         disabled={isPending}
                         readOnly={false}
                         minHeight={380}

--- a/packages/admin/src/lib/__tests__/code-highlight.test.ts
+++ b/packages/admin/src/lib/__tests__/code-highlight.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The code palette is data, and the defect it guards against is a literal
+ * colour where the theme already names one. A hex renders the same in light and
+ * dark, and it never enters the contrast audit in
+ * `packages/ui/src/styles/contrast` -- which is the state this module exists to
+ * end.
+ *
+ * The theme file is parsed rather than mirrored here. A hand-kept list of token
+ * names is a second implementation of the palette, and it would agree with the
+ * theme on the day it was written and drift silently afterwards.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { CODE_TAG_SPECS } from "../code-highlight";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const THEME = resolve(here, "../../../../ui/src/styles/theme.css");
+
+/**
+ * Every `--nx-code-*` token the theme declares.
+ *
+ * Read from `:root` and `.dark` alike: a token is declared twice by design, and
+ * a Set collapses the pair to the one name both halves define.
+ */
+function declaredCodeTokens(): Set<string> {
+  const css = readFileSync(THEME, "utf8");
+  const found = new Set<string>();
+  for (const match of css.matchAll(/^\s*(--nx-code-[a-z-]+)\s*:/gm)) {
+    found.add(match[1]);
+  }
+  return found;
+}
+
+/** Every token the tag specs actually read. */
+function consumedTokens(): Set<string> {
+  const found = new Set<string>();
+  for (const spec of CODE_TAG_SPECS) {
+    const match = /var\((--nx-[a-z-]+)\)/.exec(spec.color);
+    if (match) found.add(match[1]);
+  }
+  return found;
+}
+
+describe("code-highlight", () => {
+  it("reads the theme file it is measured against", () => {
+    // The three assertions below are all satisfied by an empty palette, so each
+    // would pass against a path that no longer resolves. This is the positive
+    // control that says the file was found and parsed.
+    expect(declaredCodeTokens().size).toBeGreaterThan(0);
+  });
+
+  it("names a colour only through a token, never a literal", () => {
+    const literals = CODE_TAG_SPECS.filter(
+      spec => !/^var\(--nx-[a-z-]+\)$/.test(spec.color)
+    );
+    expect(literals.map(spec => spec.color)).toEqual([]);
+  });
+
+  it("reads only tokens the theme declares", () => {
+    const declared = declaredCodeTokens();
+    const stranded = [...consumedTokens()].filter(
+      token => token.startsWith("--nx-code-") && !declared.has(token)
+    );
+    expect(stranded).toEqual([]);
+  });
+
+  it("leaves no declared code token unreachable", () => {
+    // A token nobody reads is a palette entry that cannot reach the screen.
+    // `--nx-code-bg` and `--nx-code-fg` are chrome rather than tag colours, so
+    // `nextlyEditorChrome` consumes them instead of a tag spec.
+    const chrome = new Set(["--nx-code-bg", "--nx-code-fg"]);
+    const consumed = consumedTokens();
+    const unreachable = [...declaredCodeTokens()].filter(
+      token => !chrome.has(token) && !consumed.has(token)
+    );
+    expect(unreachable).toEqual([]);
+  });
+
+  it("gives every spec at least one tag", () => {
+    const empty = CODE_TAG_SPECS.filter(
+      spec => (Array.isArray(spec.tag) ? spec.tag.length : 1) === 0
+    );
+    expect(empty).toEqual([]);
+  });
+});

--- a/packages/admin/src/lib/__tests__/code-highlight.test.ts
+++ b/packages/admin/src/lib/__tests__/code-highlight.test.ts
@@ -23,6 +23,7 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { tags } from "@lezer/highlight";
 import { describe, expect, it } from "vitest";
 
 import { CODE_TAG_SPECS } from "../code-highlight";
@@ -157,5 +158,61 @@ describe("code-palette", () => {
       spec => (Array.isArray(spec.tag) ? spec.tag.length : 1) === 0
     );
     expect(empty).toEqual([]);
+  });
+});
+
+/**
+ * Tags this palette deliberately does not style, each with the reason.
+ *
+ * The list exists so that leaving a tag out is a DECISION rather than an
+ * oversight. `nextlyHighlighting` is registered without a fallback, so an
+ * unlisted tag is not merely undecorated -- it is claimed and then rendered as
+ * plain foreground, which looks correct in JSON and wrong in Markdown and CSS.
+ * Every omission found so far was found by someone opening the right file.
+ */
+const DELIBERATELY_UNSTYLED: Record<string, string> = {
+  // Prose in a Markdown document. Colouring body text would tint the document
+  // rather than highlight anything in it.
+  content: "ordinary prose, not a construct",
+  // The whole editor is already monospaced, so the tag has nothing to add.
+  monospace: "every editor surface is already mono",
+  // Diff state with no token of its own; `deleted` and `inserted` carry the
+  // two cases this admin actually renders.
+  changed: "no token; deleted and inserted cover the rendered cases",
+  // Styled in `nextlyHighlightStyle` directly rather than through the palette:
+  // a parse error is a fault, and reads from the admin's error token.
+  invalid: "styled outside the palette, from --nx-destructive",
+};
+
+describe("tag coverage", () => {
+  it("styles every standard tag, or says why not", () => {
+    const covered = new Set(
+      CODE_TAG_SPECS.flatMap(spec =>
+        Array.isArray(spec.tag) ? spec.tag : [spec.tag]
+      )
+    );
+    const unaccounted = Object.entries(tags)
+      .filter(([, tag]) => typeof tag !== "function")
+      .filter(
+        ([name, tag]) =>
+          !covered.has(tag as never) && !(name in DELIBERATELY_UNSTYLED)
+      )
+      .map(([name]) => name);
+    expect(unaccounted).toEqual([]);
+  });
+
+  it("keeps the unstyled list honest", () => {
+    // An entry that IS styled should not also claim to be deliberately skipped:
+    // the reason would be false and the next reader would trust it.
+    const covered = new Set(
+      CODE_TAG_SPECS.flatMap(spec =>
+        Array.isArray(spec.tag) ? spec.tag : [spec.tag]
+      )
+    );
+    const contradictory = Object.keys(DELIBERATELY_UNSTYLED).filter(name => {
+      const tag = (tags as Record<string, unknown>)[name];
+      return tag !== undefined && covered.has(tag as never);
+    });
+    expect(contradictory).toEqual([]);
   });
 });

--- a/packages/admin/src/lib/__tests__/code-highlight.test.ts
+++ b/packages/admin/src/lib/__tests__/code-highlight.test.ts
@@ -1,41 +1,68 @@
 /**
- * The code palette is data, and the defect it guards against is a literal
- * colour where the theme already names one. A hex renders the same in light and
- * dark, and it never enters the contrast audit in
- * `packages/ui/src/styles/contrast` -- which is the state this module exists to
- * end.
+ * The code palette is data, and two defects it guards against both render as a
+ * plausible colour rather than as an error.
+ *
+ * A literal colour is the first: it looks right in whichever mode it was picked
+ * for, renders identically in the other, and never enters the contrast audit in
+ * `packages/ui/src/styles/contrast`.
+ *
+ * A token declared in only ONE mode is the second, and it is the quieter one.
+ * The surviving declaration keeps the editor rendering, so nothing looks broken
+ * -- the other mode simply inherits a colour chosen against the wrong
+ * background. Both blocks are therefore parsed separately and each is required
+ * to carry every token the palette reads; collapsing them into one set is how
+ * the half-declared case passes.
  *
  * The theme file is parsed rather than mirrored here. A hand-kept list of token
- * names is a second implementation of the palette, and it would agree with the
- * theme on the day it was written and drift silently afterwards.
+ * names would be a second implementation of the palette, agreeing with it on
+ * the day it was written and drifting silently afterwards.
  */
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import type { Tag } from "@lezer/highlight";
+import { tags as t } from "@lezer/highlight";
 import { describe, expect, it } from "vitest";
 
 import { CODE_TAG_SPECS } from "../code-highlight";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const THEME = resolve(here, "../../../../ui/src/styles/theme.css");
+const RICH_TEXT_KIT = resolve(
+  here,
+  "../../components/features/entries/fields/special/rich-text-kit.ts"
+);
 
 /**
- * Every `--nx-code-*` token the theme declares.
- *
- * Read from `:root` and `.dark` alike: a token is declared twice by design, and
- * a Set collapses the pair to the one name both halves define.
+ * The body of a top-level block, matched by counting braces rather than by
+ * reaching for the next `}`. A nested rule inside the block would end the
+ * naive match early and silently shorten the set being checked.
  */
-function declaredCodeTokens(): Set<string> {
-  const css = readFileSync(THEME, "utf8");
+function blockBody(css: string, selector: string): string {
+  const start = css.indexOf(`${selector} {`);
+  if (start === -1) return "";
+  let depth = 0;
+  for (let i = css.indexOf("{", start); i < css.length; i++) {
+    if (css[i] === "{") depth++;
+    else if (css[i] === "}" && --depth === 0) {
+      return css.slice(start, i);
+    }
+  }
+  return "";
+}
+
+/** The `--nx-code-*` tokens one block declares. */
+function codeTokensIn(selector: string): Set<string> {
+  const body = blockBody(readFileSync(THEME, "utf8"), selector);
   const found = new Set<string>();
-  for (const match of css.matchAll(/^\s*(--nx-code-[a-z-]+)\s*:/gm)) {
+  for (const match of body.matchAll(/^\s*(--nx-code-[a-z-]+)\s*:/gm)) {
     found.add(match[1]);
   }
   return found;
 }
 
-/** Every token the tag specs actually read. */
+/** Every token the tag specs read. */
 function consumedTokens(): Set<string> {
   const found = new Set<string>();
   for (const spec of CODE_TAG_SPECS) {
@@ -45,12 +72,57 @@ function consumedTokens(): Set<string> {
   return found;
 }
 
+/** The token this palette gives one lezer tag, by identity. */
+function tokenForTag(tag: Tag): string | undefined {
+  const spec = CODE_TAG_SPECS.find(s =>
+    (Array.isArray(s.tag) ? s.tag : [s.tag]).includes(tag)
+  );
+  return spec ? /var\((--nx-[a-z-]+)\)/.exec(spec.color)?.[1] : undefined;
+}
+
+/** The token rich-text-kit gives one Prism token name. */
+function tokenForPrism(name: string): string | undefined {
+  const kit = readFileSync(RICH_TEXT_KIT, "utf8");
+  const match = new RegExp(
+    `^\\s*"?${name}"?:\\s*"text-code-([a-z-]+)`,
+    "m"
+  ).exec(kit);
+  return match ? `--nx-code-${match[1]}` : undefined;
+}
+
+/**
+ * Constructs both engines name, and must therefore colour alike.
+ *
+ * Only the ones that genuinely correspond: Prism's `property` and lezer's
+ * `propertyName` are the same thing, while Prism has no counterpart for
+ * `t.separator` and pairing them would be inventing agreement rather than
+ * checking it.
+ */
+const SHARED_CONSTRUCTS: [string, Tag][] = [
+  ["comment", t.comment],
+  ["keyword", t.keyword],
+  ["string", t.string],
+  ["number", t.number],
+  ["boolean", t.bool],
+  ["operator", t.operator],
+  ["punctuation", t.punctuation],
+  ["regex", t.regexp],
+  ["tag", t.tagName],
+  ["class-name", t.className],
+  ["namespace", t.namespace],
+  ["variable", t.variableName],
+  ["property", t.propertyName],
+  ["deleted", t.deleted],
+  ["inserted", t.inserted],
+];
+
 describe("code-highlight", () => {
-  it("reads the theme file it is measured against", () => {
-    // The three assertions below are all satisfied by an empty palette, so each
-    // would pass against a path that no longer resolves. This is the positive
-    // control that says the file was found and parsed.
-    expect(declaredCodeTokens().size).toBeGreaterThan(0);
+  it("reads the theme blocks it is measured against", () => {
+    // Every assertion below is satisfied by an empty palette, so each would
+    // pass against a selector that no longer matches. This is the control that
+    // says both blocks were found and parsed.
+    expect(codeTokensIn(":root").size).toBeGreaterThan(0);
+    expect(codeTokensIn(".dark").size).toBeGreaterThan(0);
   });
 
   it("names a colour only through a token, never a literal", () => {
@@ -60,8 +132,8 @@ describe("code-highlight", () => {
     expect(literals.map(spec => spec.color)).toEqual([]);
   });
 
-  it("reads only tokens the theme declares", () => {
-    const declared = declaredCodeTokens();
+  it.each([":root", ".dark"])("declares every token it reads in %s", sel => {
+    const declared = codeTokensIn(sel);
     const stranded = [...consumedTokens()].filter(
       token => token.startsWith("--nx-code-") && !declared.has(token)
     );
@@ -74,7 +146,7 @@ describe("code-highlight", () => {
     // `nextlyEditorChrome` consumes them instead of a tag spec.
     const chrome = new Set(["--nx-code-bg", "--nx-code-fg"]);
     const consumed = consumedTokens();
-    const unreachable = [...declaredCodeTokens()].filter(
+    const unreachable = [...codeTokensIn(":root")].filter(
       token => !chrome.has(token) && !consumed.has(token)
     );
     expect(unreachable).toEqual([]);
@@ -85,5 +157,30 @@ describe("code-highlight", () => {
       spec => (Array.isArray(spec.tag) ? spec.tag.length : 1) === 0
     );
     expect(empty).toEqual([]);
+  });
+
+  it("reads the rich-text mapping it is compared against", () => {
+    // Same control as above, for the other file: a renamed export or a moved
+    // path would make every pairing below resolve to undefined on both sides
+    // and agree perfectly.
+    const resolved = SHARED_CONSTRUCTS.filter(
+      ([prism]) => tokenForPrism(prism) !== undefined
+    );
+    expect(resolved.length).toBe(SHARED_CONSTRUCTS.length);
+  });
+
+  it("colours a shared construct the same as the rich-text editor does", () => {
+    // Derived rather than restated: this reads both mappings and compares them,
+    // so it cannot itself drift from either. Two engines colouring a class name
+    // differently is invisible in review -- each looks right beside its own
+    // editor.
+    const disagreements = SHARED_CONSTRUCTS.filter(
+      ([prism, tag]) => tokenForTag(tag) !== tokenForPrism(prism)
+    ).map(([prism, tag]) => ({
+      construct: prism,
+      codeMirror: tokenForTag(tag),
+      richText: tokenForPrism(prism),
+    }));
+    expect(disagreements).toEqual([]);
   });
 });

--- a/packages/admin/src/lib/__tests__/code-highlight.test.ts
+++ b/packages/admin/src/lib/__tests__/code-highlight.test.ts
@@ -129,10 +129,27 @@ describe("code-palette", () => {
   });
 
   it("names only constructs the table defines", () => {
+    // A spec may legitimately carry no construct -- markup weight and
+    // decoration modify whatever they sit in rather than recolouring it.
     const unknown = CODE_TAG_SPECS.filter(
-      spec => !(spec.construct in CODE_CONSTRUCTS)
+      spec =>
+        spec.construct !== undefined && !(spec.construct in CODE_CONSTRUCTS)
     ).map(spec => spec.construct);
     expect(unknown).toEqual([]);
+  });
+
+  it("gives every spec something to do", () => {
+    // A spec with neither a construct nor a decoration silences its tags
+    // outright, because this highlighter runs without a fallback: the tag is
+    // claimed and then styled with nothing.
+    const inert = CODE_TAG_SPECS.filter(
+      spec =>
+        spec.construct === undefined &&
+        spec.fontStyle === undefined &&
+        spec.fontWeight === undefined &&
+        spec.textDecoration === undefined
+    );
+    expect(inert).toEqual([]);
   });
 
   it("gives every spec at least one tag", () => {

--- a/packages/admin/src/lib/__tests__/code-highlight.test.ts
+++ b/packages/admin/src/lib/__tests__/code-highlight.test.ts
@@ -1,19 +1,21 @@
 /**
- * The code palette is data, and two defects it guards against both render as a
- * plausible colour rather than as an error.
+ * The construct table is the palette, and the defects it can still carry all
+ * render as a plausible colour rather than as an error.
  *
- * A literal colour is the first: it looks right in whichever mode it was picked
- * for, renders identically in the other, and never enters the contrast audit in
- * `packages/ui/src/styles/contrast`.
+ * A token declared in only ONE theme block is the quietest of them. The
+ * surviving declaration keeps the editor rendering, so nothing looks broken --
+ * the other mode simply inherits a colour chosen against the wrong background.
+ * Both blocks are parsed separately for that reason; collapsing them into one
+ * set is exactly how the half-declared case passes.
  *
- * A token declared in only ONE mode is the second, and it is the quieter one.
- * The surviving declaration keeps the editor rendering, so nothing looks broken
- * -- the other mode simply inherits a colour chosen against the wrong
- * background. Both blocks are therefore parsed separately and each is required
- * to carry every token the palette reads; collapsing them into one set is how
- * the half-declared case passes.
+ * What is NOT tested here any more is agreement between the two highlighting
+ * engines. It used to be, by reading both mappings and comparing them, and that
+ * test is gone because `code-palette.ts` made the question unaskable: Prism and
+ * lezer now read the same table, so there are no longer two answers to compare.
+ * The guard that replaces it is narrower and harder to slip past -- that
+ * nothing bypasses the table.
  *
- * The theme file is parsed rather than mirrored here. A hand-kept list of token
+ * The theme file is parsed rather than mirrored. A hand-kept list of token
  * names would be a second implementation of the palette, agreeing with it on
  * the day it was written and drifting silently afterwards.
  */
@@ -21,11 +23,10 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import type { Tag } from "@lezer/highlight";
-import { tags as t } from "@lezer/highlight";
 import { describe, expect, it } from "vitest";
 
 import { CODE_TAG_SPECS } from "../code-highlight";
+import { CODE_CONSTRUCTS } from "../code-palette";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const THEME = resolve(here, "../../../../ui/src/styles/theme.css");
@@ -36,8 +37,8 @@ const RICH_TEXT_KIT = resolve(
 
 /**
  * The body of a top-level block, matched by counting braces rather than by
- * reaching for the next `}`. A nested rule inside the block would end the
- * naive match early and silently shorten the set being checked.
+ * reaching for the next `}`. A nested rule inside the block would end the naive
+ * match early and silently shorten the set being checked.
  */
 function blockBody(css: string, selector: string): string {
   const start = css.indexOf(`${selector} {`);
@@ -45,9 +46,7 @@ function blockBody(css: string, selector: string): string {
   let depth = 0;
   for (let i = css.indexOf("{", start); i < css.length; i++) {
     if (css[i] === "{") depth++;
-    else if (css[i] === "}" && --depth === 0) {
-      return css.slice(start, i);
-    }
+    else if (css[i] === "}" && --depth === 0) return css.slice(start, i);
   }
   return "";
 }
@@ -62,61 +61,12 @@ function codeTokensIn(selector: string): Set<string> {
   return found;
 }
 
-/** Every token the tag specs read. */
+/** Every token the palette can put on screen. */
 function consumedTokens(): Set<string> {
-  const found = new Set<string>();
-  for (const spec of CODE_TAG_SPECS) {
-    const match = /var\((--nx-[a-z-]+)\)/.exec(spec.color);
-    if (match) found.add(match[1]);
-  }
-  return found;
+  return new Set(Object.values(CODE_CONSTRUCTS).map(entry => entry.token));
 }
 
-/** The token this palette gives one lezer tag, by identity. */
-function tokenForTag(tag: Tag): string | undefined {
-  const spec = CODE_TAG_SPECS.find(s =>
-    (Array.isArray(s.tag) ? s.tag : [s.tag]).includes(tag)
-  );
-  return spec ? /var\((--nx-[a-z-]+)\)/.exec(spec.color)?.[1] : undefined;
-}
-
-/** The token rich-text-kit gives one Prism token name. */
-function tokenForPrism(name: string): string | undefined {
-  const kit = readFileSync(RICH_TEXT_KIT, "utf8");
-  const match = new RegExp(
-    `^\\s*"?${name}"?:\\s*"text-code-([a-z-]+)`,
-    "m"
-  ).exec(kit);
-  return match ? `--nx-code-${match[1]}` : undefined;
-}
-
-/**
- * Constructs both engines name, and must therefore colour alike.
- *
- * Only the ones that genuinely correspond: Prism's `property` and lezer's
- * `propertyName` are the same thing, while Prism has no counterpart for
- * `t.separator` and pairing them would be inventing agreement rather than
- * checking it.
- */
-const SHARED_CONSTRUCTS: [string, Tag][] = [
-  ["comment", t.comment],
-  ["keyword", t.keyword],
-  ["string", t.string],
-  ["number", t.number],
-  ["boolean", t.bool],
-  ["operator", t.operator],
-  ["punctuation", t.punctuation],
-  ["regex", t.regexp],
-  ["tag", t.tagName],
-  ["class-name", t.className],
-  ["namespace", t.namespace],
-  ["variable", t.variableName],
-  ["property", t.propertyName],
-  ["deleted", t.deleted],
-  ["inserted", t.inserted],
-];
-
-describe("code-highlight", () => {
+describe("code-palette", () => {
   it("reads the theme blocks it is measured against", () => {
     // Every assertion below is satisfied by an empty palette, so each would
     // pass against a selector that no longer matches. This is the control that
@@ -125,11 +75,19 @@ describe("code-highlight", () => {
     expect(codeTokensIn(".dark").size).toBeGreaterThan(0);
   });
 
-  it("names a colour only through a token, never a literal", () => {
-    const literals = CODE_TAG_SPECS.filter(
-      spec => !/^var\(--nx-[a-z-]+\)$/.test(spec.color)
-    );
-    expect(literals.map(spec => spec.color)).toEqual([]);
+  it("spells each construct the same in both namespaces", () => {
+    // `--nx-code-string` and `text-code-string` are one name in two
+    // vocabularies. Editing either alone gives a construct whose CSS colour and
+    // whose utility class point at different tokens, and every other assertion
+    // here would still pass.
+    const mismatched = Object.entries(CODE_CONSTRUCTS)
+      .filter(
+        ([, entry]) =>
+          entry.token.replace("--nx-code-", "") !==
+          entry.className.replace("text-code-", "")
+      )
+      .map(([name]) => name);
+    expect(mismatched).toEqual([]);
   });
 
   it.each([":root", ".dark"])("declares every token it reads in %s", sel => {
@@ -142,8 +100,8 @@ describe("code-highlight", () => {
 
   it("leaves no declared code token unreachable", () => {
     // A token nobody reads is a palette entry that cannot reach the screen.
-    // `--nx-code-bg` and `--nx-code-fg` are chrome rather than tag colours, so
-    // `nextlyEditorChrome` consumes them instead of a tag spec.
+    // `--nx-code-bg` and `--nx-code-fg` are chrome rather than construct
+    // colours, so `nextlyEditorChrome` consumes them instead of the table.
     const chrome = new Set(["--nx-code-bg", "--nx-code-fg"]);
     const consumed = consumedTokens();
     const unreachable = [...codeTokensIn(":root")].filter(
@@ -152,35 +110,35 @@ describe("code-highlight", () => {
     expect(unreachable).toEqual([]);
   });
 
+  it("routes the rich-text palette through the table", () => {
+    // The guard that replaces the old cross-engine comparison. Deriving both
+    // engines from one table only holds while both actually read it, and a
+    // literal `text-code-*` written back into the Lexical theme would restore
+    // the divergence silently -- it renders correctly on the day it is written.
+    const kit = readFileSync(RICH_TEXT_KIT, "utf8");
+    const literals = [...kit.matchAll(/"(text-code-[a-z-]+)/g)].map(m => m[1]);
+    // `text-code-fg` is the code BLOCK's own foreground, not a construct, so it
+    // is not in the table and is expected to appear literally.
+    expect(literals.filter(cls => cls !== "text-code-fg")).toEqual([]);
+  });
+
+  it("reads the rich-text file it is checking", () => {
+    // Same control as the theme one: a moved path makes the assertion above
+    // pass against an empty string, certifying a file it never opened.
+    expect(readFileSync(RICH_TEXT_KIT, "utf8")).toContain("codeHighlight");
+  });
+
+  it("names only constructs the table defines", () => {
+    const unknown = CODE_TAG_SPECS.filter(
+      spec => !(spec.construct in CODE_CONSTRUCTS)
+    ).map(spec => spec.construct);
+    expect(unknown).toEqual([]);
+  });
+
   it("gives every spec at least one tag", () => {
     const empty = CODE_TAG_SPECS.filter(
       spec => (Array.isArray(spec.tag) ? spec.tag.length : 1) === 0
     );
     expect(empty).toEqual([]);
-  });
-
-  it("reads the rich-text mapping it is compared against", () => {
-    // Same control as above, for the other file: a renamed export or a moved
-    // path would make every pairing below resolve to undefined on both sides
-    // and agree perfectly.
-    const resolved = SHARED_CONSTRUCTS.filter(
-      ([prism]) => tokenForPrism(prism) !== undefined
-    );
-    expect(resolved.length).toBe(SHARED_CONSTRUCTS.length);
-  });
-
-  it("colours a shared construct the same as the rich-text editor does", () => {
-    // Derived rather than restated: this reads both mappings and compares them,
-    // so it cannot itself drift from either. Two engines colouring a class name
-    // differently is invisible in review -- each looks right beside its own
-    // editor.
-    const disagreements = SHARED_CONSTRUCTS.filter(
-      ([prism, tag]) => tokenForTag(tag) !== tokenForPrism(prism)
-    ).map(([prism, tag]) => ({
-      construct: prism,
-      codeMirror: tokenForTag(tag),
-      richText: tokenForPrism(prism),
-    }));
-    expect(disagreements).toEqual([]);
   });
 });

--- a/packages/admin/src/lib/code-highlight.ts
+++ b/packages/admin/src/lib/code-highlight.ts
@@ -57,7 +57,19 @@ export const CODE_TAG_SPECS: readonly {
     // `boolean` and `constant` are number-coloured in rich-text-kit, and JSON's
     // `null` is the same kind of literal, so it travels with them rather than
     // with the keywords it parses beside.
-    tag: [t.bool, t.null, t.atom, t.number, t.integer, t.float],
+    // `color` and `unit` are CSS values -- `@lezer/css` tags `#fff` and `2rem`
+    // that way -- and read as the numbers they sit among rather than as names.
+    tag: [
+      t.bool,
+      t.null,
+      t.atom,
+      t.number,
+      t.integer,
+      t.float,
+      t.literal,
+      t.color,
+      t.unit,
+    ],
     construct: "number",
   },
   {
@@ -135,7 +147,41 @@ export const CODE_TAG_SPECS: readonly {
   // makes it not literal -- so it takes the escaping colour, not the string's.
   { tag: [t.escape], construct: "operator" },
   { tag: [t.labelName], construct: "variable" },
-  { tag: [t.meta, t.processingInstruction], construct: "comment" },
+  {
+    tag: [t.meta, t.processingInstruction, t.documentMeta],
+    construct: "comment",
+  },
+  { tag: [t.name, t.self, t.modifier], construct: "variable" },
+  { tag: [t.macroName, t.annotation], construct: "function" },
+  { tag: [t.definitionKeyword], construct: "keyword" },
+  { tag: [t.docString, t.attributeValue], construct: "string" },
+  {
+    tag: [
+      t.derefOperator,
+      t.bitwiseOperator,
+      t.updateOperator,
+      t.typeOperator,
+      t.controlOperator,
+    ],
+    construct: "operator",
+  },
+  // Markdown gives each heading level its own tag, so styling `heading` alone
+  // leaves every actual heading unstyled -- the generic tag is what a grammar
+  // falls back to, not what it usually emits.
+  {
+    tag: [
+      t.heading1,
+      t.heading2,
+      t.heading3,
+      t.heading4,
+      t.heading5,
+      t.heading6,
+    ],
+    construct: "keyword",
+    fontWeight: "600",
+  },
+  { tag: [t.contentSeparator, t.list], construct: "punctuation" },
+  { tag: [t.quote], construct: "comment", fontStyle: "italic" },
 ];
 
 /**

--- a/packages/admin/src/lib/code-highlight.ts
+++ b/packages/admin/src/lib/code-highlight.ts
@@ -34,8 +34,15 @@ import { codeColor } from "./code-palette";
  */
 export const CODE_TAG_SPECS: readonly {
   tag: Tag | Tag[];
-  construct: CodeConstruct;
+  /**
+   * Omitted where the tag is about WEIGHT rather than colour. Markdown's strong
+   * and emphasis carry no colour of their own -- they modify whatever they sit
+   * in -- and giving them one would repaint prose that was never coloured.
+   */
+  construct?: CodeConstruct;
   fontStyle?: string;
+  fontWeight?: string;
+  textDecoration?: string;
 }[] = [
   {
     tag: [t.comment, t.lineComment, t.blockComment, t.docComment],
@@ -114,6 +121,21 @@ export const CODE_TAG_SPECS: readonly {
   },
   { tag: [t.deleted], construct: "deleted" },
   { tag: [t.inserted], construct: "inserted" },
+  // Markup, which is what a Markdown code field is made of. These matter
+  // because this highlighter is registered WITHOUT `fallback`, so it is the
+  // only one in effect: a tag nobody lists here renders as plain text rather
+  // than falling through to CodeMirror's defaults. Before that change One Dark
+  // styled them, so leaving them out is a regression rather than a gap.
+  { tag: [t.heading], construct: "keyword", fontWeight: "600" },
+  { tag: [t.strong], fontWeight: "600" },
+  { tag: [t.emphasis], fontStyle: "italic" },
+  { tag: [t.strikethrough], textDecoration: "line-through" },
+  { tag: [t.link, t.url], construct: "function", textDecoration: "underline" },
+  // An escape is part of the string it interrupts, and reads as the thing that
+  // makes it not literal -- so it takes the escaping colour, not the string's.
+  { tag: [t.escape], construct: "operator" },
+  { tag: [t.labelName], construct: "variable" },
+  { tag: [t.meta, t.processingInstruction], construct: "comment" },
 ];
 
 /**
@@ -126,8 +148,14 @@ export const CODE_TAG_SPECS: readonly {
 export const nextlyHighlightStyle = HighlightStyle.define([
   ...CODE_TAG_SPECS.map(spec => ({
     tag: spec.tag,
-    color: codeColor(spec.construct),
+    ...(spec.construct === undefined
+      ? {}
+      : { color: codeColor(spec.construct) }),
     ...(spec.fontStyle === undefined ? {} : { fontStyle: spec.fontStyle }),
+    ...(spec.fontWeight === undefined ? {} : { fontWeight: spec.fontWeight }),
+    ...(spec.textDecoration === undefined
+      ? {}
+      : { textDecoration: spec.textDecoration }),
   })),
   // A parse error is a fault rather than a construct, so it reads from the
   // admin's error token instead of the code palette.
@@ -157,6 +185,22 @@ export interface EditorChromeOptions {
   padding?: string;
   /** Whether a gutter is shown, which changes only the inset the text needs. */
   showGutter?: boolean;
+  /**
+   * Whether the admin is currently dark.
+   *
+   * This is NOT a colour decision -- every colour below is a token, and tokens
+   * settle the mode themselves. It sets `EditorView.darkTheme`, the boolean the
+   * CodeMirror packages read to pick between their own `&light` and `&dark`
+   * rules. Nothing sets it when `theme="none"` is used, so all of them stay on
+   * their light rules inside a dark admin: 41 selectors across view, lint,
+   * autocomplete and search.
+   *
+   * Overriding them one at a time is patching by example across a surface this
+   * package does not own, and one that grows with every extension added.
+   * Setting the flag closes the class outright, and the token rules below still
+   * win wherever this admin wants its own colour rather than CodeMirror's grey.
+   */
+  dark?: boolean;
 }
 
 /**
@@ -172,149 +216,181 @@ export function nextlyEditorChrome({
   fontSize = 12,
   padding,
   showGutter = false,
+  dark = false,
 }: EditorChromeOptions = {}) {
-  return EditorView.theme({
-    "&": {
-      fontSize: `${fontSize}px`,
-      backgroundColor: "transparent",
-      color: "var(--nx-code-fg)",
-    },
-    ".cm-scroller": {
-      // The theme's mono stack, so code renders in the same face as every other
-      // mono surface in the admin. The fallback covers a host that has not
-      // loaded the theme.
-      fontFamily: "var(--font-mono, ui-monospace, monospace)",
-      ...(padding === undefined ? {} : { padding }),
-    },
-    ".cm-content": {
-      caretColor: "var(--nx-foreground)",
-    },
-    ".cm-gutters": {
-      borderRight:
-        "1px solid color-mix(in srgb, var(--nx-border) 50%, transparent)",
-      backgroundColor: "color-mix(in srgb, var(--nx-muted) 30%, transparent)",
-      color: "color-mix(in srgb, var(--nx-muted-foreground) 50%, transparent)",
-      padding: showGutter ? "0 4px" : "0",
-    },
-    ".cm-activeLine": {
-      backgroundColor: "color-mix(in srgb, var(--nx-accent) 10%, transparent)",
-    },
-    ".cm-activeLineGutter": {
-      backgroundColor: "var(--nx-accent)",
-    },
-    ".cm-selectionMatch": {
-      backgroundColor: "color-mix(in srgb, var(--nx-primary) 20%, transparent)",
-    },
-    // Selection is the one decoration `theme="none"` leaves actively wrong
-    // rather than merely unstyled. The base theme picks between its `&light`
-    // and `&dark` rules from `EditorView.darkTheme`, which only a bundled theme
-    // sets -- so without one it stays light, and its pale fill lands under the
-    // light-on-dark token colours in a dark admin.
-    //
-    // Answered with a token instead of by setting the facet: one rule then
-    // serves both modes, which is the same reason there is one highlight style
-    // rather than two.
-    "::selection": {
-      backgroundColor: "color-mix(in srgb, var(--nx-primary) 30%, transparent)",
-    },
-    ".cm-selectionBackground": {
-      backgroundColor: "color-mix(in srgb, var(--nx-primary) 25%, transparent)",
-    },
-    // The base theme raises its own specificity for the focused case, so this
-    // has to match that shape to win rather than relying on precedence alone.
-    "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground":
-      {
-        backgroundColor:
-          "color-mix(in srgb, var(--nx-primary) 35%, transparent)",
+  return [
+    EditorView.darkTheme.of(dark),
+    EditorView.theme({
+      "&": {
+        fontSize: `${fontSize}px`,
+        backgroundColor: "transparent",
+        color: "var(--nx-code-fg)",
       },
-    // Bracket matching replaces the token span rather than decorating it, so
-    // the bracket under the caret arrives with no highlight class of its own.
-    // Without a colour here it falls back to the editor's foreground and reads
-    // as a different character from its own twin two lines down. Unscoped, so
-    // it still holds while the editor is not focused.
-    ".cm-matchingBracket": { color: codeColor("punctuation") },
-    ".cm-nonmatchingBracket": { color: "var(--nx-destructive)" },
-    // The fills are scoped exactly as `bracketMatching`'s own base theme scopes
-    // them. It ships a hardcoded teal under `&.cm-focused`, and a bare
-    // `.cm-matchingBracket` here loses to it on specificity however much
-    // precedence this theme has over a base one.
-    "&.cm-focused .cm-matchingBracket": {
-      backgroundColor: "color-mix(in srgb, var(--nx-primary) 22%, transparent)",
-      outline:
-        "1px solid color-mix(in srgb, var(--nx-primary) 45%, transparent)",
-    },
-    "&.cm-focused .cm-nonmatchingBracket": {
-      backgroundColor:
-        "color-mix(in srgb, var(--nx-destructive) 18%, transparent)",
-    },
-    ".cm-searchMatch": {
-      backgroundColor: "color-mix(in srgb, var(--nx-warning) 30%, transparent)",
-    },
-    ".cm-searchMatch.cm-searchMatch-selected": {
-      backgroundColor: "color-mix(in srgb, var(--nx-warning) 50%, transparent)",
-    },
-    "&.cm-focused .cm-cursor": {
-      borderLeftColor: "var(--nx-foreground)",
-    },
-    // The base theme keys thirteen surfaces off `EditorView.darkTheme`, which
-    // only a bundled theme sets -- so under `theme="none"` every one of them
-    // stays on its light rule. Selection is the one people notice; the search
-    // panel, the autocomplete popup and lint tooltips are the rest, and
-    // `basicSetup` turns all three on.
-    //
-    // Enumerated rather than answered by setting the facet, because setting it
-    // needs the resolved mode and would put back the branch this module exists
-    // to remove. The list is closed rather than a guess: it is every `&light` /
-    // `&dark` selector the base theme declares.
-    ".cm-panels": {
-      backgroundColor: "var(--nx-popover)",
-      color: "var(--nx-popover-foreground)",
-    },
-    ".cm-panels-top": { borderBottom: "1px solid var(--nx-border)" },
-    ".cm-panels-bottom": { borderTop: "1px solid var(--nx-border)" },
-    ".cm-textfield": {
-      backgroundColor: "var(--nx-background)",
-      color: "var(--nx-foreground)",
-      border: "1px solid var(--nx-input)",
-      borderRadius: "var(--radius-sm)",
-    },
-    ".cm-button": {
-      backgroundColor: "var(--nx-secondary)",
-      color: "var(--nx-secondary-foreground)",
-      backgroundImage: "none",
-      border: "1px solid var(--nx-border)",
-      borderRadius: "var(--radius-sm)",
-    },
-    ".cm-tooltip": {
-      backgroundColor: "var(--nx-popover)",
-      color: "var(--nx-popover-foreground)",
-      border: "1px solid var(--nx-border)",
-      borderRadius: "var(--radius-md)",
-    },
-    ".cm-tooltip .cm-tooltip-arrow:before": {
-      borderTopColor: "var(--nx-border)",
-      borderBottomColor: "var(--nx-border)",
-    },
-    ".cm-tooltip .cm-tooltip-arrow:after": {
-      borderTopColor: "var(--nx-popover)",
-      borderBottomColor: "var(--nx-popover)",
-    },
-    ".cm-tooltip-section:not(:first-child)": {
-      borderTop: "1px solid var(--nx-border)",
-    },
-    ".cm-tooltip-autocomplete > ul > li[aria-selected]": {
-      backgroundColor: "var(--nx-accent)",
-      color: "var(--nx-accent-foreground)",
-    },
-    ".cm-specialChar": { color: "var(--nx-destructive)" },
-    "&.cm-focused": {
-      // A ring rather than the base theme's hardcoded dotted outline, which is
-      // off-token. It cannot be dropped: the wrappers these editors sit in draw
-      // a static border and none of them carries a `focus-within` treatment, so
-      // removing this leaves a keyboard user nothing but the caret to say which
-      // control they are in.
-      outline: "2px solid var(--nx-ring)",
-      outlineOffset: "-2px",
-    },
-  });
+      ".cm-scroller": {
+        // The theme's mono stack, so code renders in the same face as every other
+        // mono surface in the admin. The fallback covers a host that has not
+        // loaded the theme.
+        fontFamily: "var(--font-mono, ui-monospace, monospace)",
+        ...(padding === undefined ? {} : { padding }),
+      },
+      ".cm-content": {
+        caretColor: "var(--nx-foreground)",
+      },
+      ".cm-gutters": {
+        borderRight:
+          "1px solid color-mix(in srgb, var(--nx-border) 50%, transparent)",
+        backgroundColor: "color-mix(in srgb, var(--nx-muted) 30%, transparent)",
+        color:
+          "color-mix(in srgb, var(--nx-muted-foreground) 50%, transparent)",
+        padding: showGutter ? "0 4px" : "0",
+      },
+      ".cm-activeLine": {
+        backgroundColor:
+          "color-mix(in srgb, var(--nx-accent) 10%, transparent)",
+      },
+      ".cm-activeLineGutter": {
+        backgroundColor: "var(--nx-accent)",
+      },
+      ".cm-selectionMatch": {
+        backgroundColor:
+          "color-mix(in srgb, var(--nx-primary) 20%, transparent)",
+      },
+      // Selection is the one decoration `theme="none"` leaves actively wrong
+      // rather than merely unstyled. The base theme picks between its `&light`
+      // and `&dark` rules from `EditorView.darkTheme`, which only a bundled theme
+      // sets -- so without one it stays light, and its pale fill lands under the
+      // light-on-dark token colours in a dark admin.
+      //
+      // Answered with a token instead of by setting the facet: one rule then
+      // serves both modes, which is the same reason there is one highlight style
+      // rather than two.
+      "::selection": {
+        backgroundColor:
+          "color-mix(in srgb, var(--nx-primary) 30%, transparent)",
+      },
+      ".cm-selectionBackground": {
+        backgroundColor:
+          "color-mix(in srgb, var(--nx-primary) 25%, transparent)",
+      },
+      // The base theme raises its own specificity for the focused case, so this
+      // has to match that shape to win rather than relying on precedence alone.
+      "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground":
+        {
+          backgroundColor:
+            "color-mix(in srgb, var(--nx-primary) 35%, transparent)",
+        },
+      // Bracket matching replaces the token span rather than decorating it, so
+      // the bracket under the caret arrives with no highlight class of its own.
+      // Without a colour here it falls back to the editor's foreground and reads
+      // as a different character from its own twin two lines down. Unscoped, so
+      // it still holds while the editor is not focused.
+      ".cm-matchingBracket": { color: codeColor("punctuation") },
+      ".cm-nonmatchingBracket": { color: "var(--nx-destructive)" },
+      // The fills are scoped exactly as `bracketMatching`'s own base theme scopes
+      // them. It ships a hardcoded teal under `&.cm-focused`, and a bare
+      // `.cm-matchingBracket` here loses to it on specificity however much
+      // precedence this theme has over a base one.
+      "&.cm-focused .cm-matchingBracket": {
+        backgroundColor:
+          "color-mix(in srgb, var(--nx-primary) 22%, transparent)",
+        outline:
+          "1px solid color-mix(in srgb, var(--nx-primary) 45%, transparent)",
+      },
+      "&.cm-focused .cm-nonmatchingBracket": {
+        backgroundColor:
+          "color-mix(in srgb, var(--nx-destructive) 18%, transparent)",
+      },
+      ".cm-searchMatch": {
+        backgroundColor:
+          "color-mix(in srgb, var(--nx-warning) 30%, transparent)",
+      },
+      ".cm-searchMatch.cm-searchMatch-selected": {
+        backgroundColor:
+          "color-mix(in srgb, var(--nx-warning) 50%, transparent)",
+      },
+      "&.cm-focused .cm-cursor": {
+        borderLeftColor: "var(--nx-foreground)",
+      },
+      // The base theme keys thirteen surfaces off `EditorView.darkTheme`, which
+      // only a bundled theme sets -- so under `theme="none"` every one of them
+      // stays on its light rule. Selection is the one people notice; the search
+      // panel, the autocomplete popup and lint tooltips are the rest, and
+      // `basicSetup` turns all three on.
+      //
+      // Enumerated rather than answered by setting the facet, because setting it
+      // needs the resolved mode and would put back the branch this module exists
+      // to remove. The list is closed rather than a guess: it is every `&light` /
+      // `&dark` selector the base theme declares.
+      ".cm-panels": {
+        backgroundColor: "var(--nx-popover)",
+        color: "var(--nx-popover-foreground)",
+      },
+      ".cm-panels-top": { borderBottom: "1px solid var(--nx-border)" },
+      ".cm-panels-bottom": { borderTop: "1px solid var(--nx-border)" },
+      ".cm-textfield": {
+        backgroundColor: "var(--nx-background)",
+        color: "var(--nx-foreground)",
+        border: "1px solid var(--nx-input)",
+        borderRadius: "var(--radius-sm)",
+      },
+      ".cm-button": {
+        backgroundColor: "var(--nx-secondary)",
+        color: "var(--nx-secondary-foreground)",
+        backgroundImage: "none",
+        border: "1px solid var(--nx-border)",
+        borderRadius: "var(--radius-sm)",
+      },
+      ".cm-tooltip": {
+        backgroundColor: "var(--nx-popover)",
+        color: "var(--nx-popover-foreground)",
+        border: "1px solid var(--nx-border)",
+        borderRadius: "var(--radius-md)",
+      },
+      ".cm-tooltip .cm-tooltip-arrow:before": {
+        borderTopColor: "var(--nx-border)",
+        borderBottomColor: "var(--nx-border)",
+      },
+      ".cm-tooltip .cm-tooltip-arrow:after": {
+        borderTopColor: "var(--nx-popover)",
+        borderBottomColor: "var(--nx-popover)",
+      },
+      ".cm-tooltip-section:not(:first-child)": {
+        borderTop: "1px solid var(--nx-border)",
+      },
+      ".cm-tooltip-autocomplete > ul > li[aria-selected]": {
+        backgroundColor: "var(--nx-accent)",
+        color: "var(--nx-accent-foreground)",
+      },
+      ".cm-specialChar": { color: "var(--nx-destructive)" },
+      "&.cm-focused": {
+        // A ring rather than the base theme's hardcoded dotted outline, which is
+        // off-token. It cannot be dropped: the wrappers these editors sit in draw
+        // a static border and none of them carries a `focus-within` treatment, so
+        // removing this leaves a keyboard user nothing but the caret to say which
+        // control they are in.
+        outline: "2px solid var(--nx-ring)",
+        outlineOffset: "-2px",
+      },
+      // `@codemirror/language` carries 19 hardcoded colours and NOT ONE
+      // light/dark pair, so the flag above cannot reach these: the fold
+      // placeholder is pale in every mode. Same for the drop cursor, which the
+      // view package draws in the foreground colour and which therefore
+      // disappears against a dark background.
+      ".cm-foldPlaceholder": {
+        backgroundColor: "var(--nx-muted)",
+        color: "var(--nx-muted-foreground)",
+        border: "1px solid var(--nx-border)",
+        borderRadius: "var(--radius-sm)",
+        padding: "0 4px",
+      },
+      ".cm-dropCursor": { borderLeftColor: "var(--nx-primary)" },
+      // The lint panel marks its selected row with a fill rather than a colour,
+      // and an unfocused list keeps that fill -- so the row has to carry a
+      // foreground that works on it.
+      ".cm-panel.cm-panel-lint ul [aria-selected]": {
+        backgroundColor: "var(--nx-accent)",
+        color: "var(--nx-accent-foreground)",
+      },
+    }),
+  ];
 }

--- a/packages/admin/src/lib/code-highlight.ts
+++ b/packages/admin/src/lib/code-highlight.ts
@@ -1,0 +1,215 @@
+/**
+ * How code looks, everywhere in the admin.
+ *
+ * One style rather than a light one and a dark one: `--nx-code-*` are
+ * redeclared under `.dark` in `packages/ui/src/styles/theme.css`, so a colour
+ * written as `var(--nx-code-string)` resolves at the element it paints and CSS
+ * settles the mode. The alternative -- two highlight styles chosen by the
+ * resolved theme -- keeps two palettes in step by hand, and renders light
+ * inside a dark admin for the frame before the theme is known.
+ *
+ * The tag-to-token mapping is the vocabulary `rich-text-kit.ts` already uses
+ * for Lexical, so the two engines colour the same construct alike: a property
+ * name is a `function` colour in both, a boolean a `number` in both. Two
+ * mappings that agree today would drift, and the drift would be silent because
+ * each looks right beside its own editor.
+ *
+ * @module lib/code-highlight
+ */
+
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { EditorView } from "@codemirror/view";
+import type { Tag } from "@lezer/highlight";
+import { tags as t } from "@lezer/highlight";
+
+/**
+ * The palette, as data.
+ *
+ * Exported so a test can assert that no entry names a literal colour and that
+ * no declared token is left unreachable. Both are failures a rendered editor
+ * shows only to someone who already knows what the right colour was.
+ */
+export const CODE_TAG_SPECS: readonly {
+  tag: Tag | Tag[];
+  color: string;
+  fontStyle?: string;
+}[] = [
+  {
+    tag: [t.comment, t.lineComment, t.blockComment, t.docComment],
+    color: "var(--nx-code-comment)",
+    fontStyle: "italic",
+  },
+  {
+    tag: [t.keyword, t.controlKeyword, t.moduleKeyword, t.operatorKeyword],
+    color: "var(--nx-code-keyword)",
+  },
+  {
+    // `boolean` and `constant` are number-coloured in rich-text-kit, and JSON's
+    // `null` is the same kind of literal, so it travels with them rather than
+    // with the keywords it parses beside.
+    tag: [t.bool, t.null, t.atom, t.number, t.integer, t.float],
+    color: "var(--nx-code-number)",
+  },
+  {
+    tag: [t.string, t.special(t.string), t.regexp, t.character],
+    color: "var(--nx-code-string)",
+  },
+  {
+    tag: [
+      t.propertyName,
+      t.attributeName,
+      t.function(t.variableName),
+      t.function(t.propertyName),
+    ],
+    color: "var(--nx-code-function)",
+  },
+  {
+    tag: [
+      t.operator,
+      t.compareOperator,
+      t.arithmeticOperator,
+      t.logicOperator,
+      t.definitionOperator,
+    ],
+    color: "var(--nx-code-operator)",
+  },
+  {
+    tag: [
+      t.punctuation,
+      t.separator,
+      t.bracket,
+      t.brace,
+      t.paren,
+      t.squareBracket,
+    ],
+    color: "var(--nx-code-punctuation)",
+  },
+  {
+    tag: [
+      t.variableName,
+      t.definition(t.variableName),
+      t.local(t.variableName),
+    ],
+    color: "var(--nx-code-variable)",
+  },
+  {
+    tag: [t.tagName, t.angleBracket, t.typeName, t.className, t.namespace],
+    color: "var(--nx-code-tag)",
+  },
+  { tag: [t.deleted], color: "var(--nx-code-deleted)" },
+  { tag: [t.inserted], color: "var(--nx-code-inserted)" },
+  // Not a code colour: a parse error is a fault, and the admin already has one
+  // token for that meaning.
+  { tag: [t.invalid], color: "var(--nx-destructive)" },
+];
+
+/** The tag palette, as a CodeMirror highlighter. */
+export const nextlyHighlightStyle = HighlightStyle.define([...CODE_TAG_SPECS]);
+
+/**
+ * Registered WITHOUT `fallback`, which is what makes it win.
+ *
+ * `basicSetup` installs CodeMirror's `defaultHighlightStyle` as a fallback, and
+ * a fallback applies only when no other highlighter is registered. So this one
+ * takes precedence wherever both are present, and nothing has to switch
+ * `basicSetup` off to get it.
+ */
+export const nextlyHighlighting = syntaxHighlighting(nextlyHighlightStyle);
+
+export interface EditorChromeOptions {
+  /** Editor font size in px. Defaults to 12, the admin's code size. */
+  fontSize?: number;
+  /**
+   * Scroller padding.
+   *
+   * Omitted rather than defaulted when absent: a field editor sits inside a
+   * bordered control that supplies its own inset, and forcing padding here
+   * would double it.
+   */
+  padding?: string;
+  /** Whether a gutter is shown, which changes only the inset the text needs. */
+  showGutter?: boolean;
+}
+
+/**
+ * Everything about an editor that is not a token colour: surface, gutter,
+ * selection, cursor, font.
+ *
+ * Split from the highlighter because a read-only viewer and an editable field
+ * want the same colours and different chrome. The background stays transparent
+ * so the surrounding card decides the surface -- an editor that paints its own
+ * would have to be told about every card it is dropped into.
+ */
+export function nextlyEditorChrome({
+  fontSize = 12,
+  padding,
+  showGutter = false,
+}: EditorChromeOptions = {}) {
+  return EditorView.theme({
+    "&": {
+      fontSize: `${fontSize}px`,
+      backgroundColor: "transparent",
+      color: "var(--nx-code-fg)",
+    },
+    ".cm-scroller": {
+      // The theme's mono stack, so code renders in the same face as every other
+      // mono surface in the admin. The fallback covers a host that has not
+      // loaded the theme.
+      fontFamily: "var(--font-mono, ui-monospace, monospace)",
+      ...(padding === undefined ? {} : { padding }),
+    },
+    ".cm-content": {
+      caretColor: "var(--nx-foreground)",
+    },
+    ".cm-gutters": {
+      borderRight:
+        "1px solid color-mix(in srgb, var(--nx-border) 50%, transparent)",
+      backgroundColor: "color-mix(in srgb, var(--nx-muted) 30%, transparent)",
+      color: "color-mix(in srgb, var(--nx-muted-foreground) 50%, transparent)",
+      padding: showGutter ? "0 4px" : "0",
+    },
+    ".cm-activeLine": {
+      backgroundColor: "color-mix(in srgb, var(--nx-accent) 10%, transparent)",
+    },
+    ".cm-activeLineGutter": {
+      backgroundColor: "var(--nx-accent)",
+    },
+    ".cm-selectionMatch": {
+      backgroundColor: "color-mix(in srgb, var(--nx-primary) 20%, transparent)",
+    },
+    // Bracket matching replaces the token span rather than decorating it, so
+    // the bracket under the caret arrives with no highlight class of its own.
+    // Without a colour here it falls back to the editor's foreground and reads
+    // as a different character from its own twin two lines down. Unscoped, so
+    // it still holds while the editor is not focused.
+    ".cm-matchingBracket": { color: "var(--nx-code-punctuation)" },
+    ".cm-nonmatchingBracket": { color: "var(--nx-destructive)" },
+    // The fills are scoped exactly as `bracketMatching`'s own base theme scopes
+    // them. It ships a hardcoded teal under `&.cm-focused`, and a bare
+    // `.cm-matchingBracket` here loses to it on specificity however much
+    // precedence this theme has over a base one.
+    "&.cm-focused .cm-matchingBracket": {
+      backgroundColor: "color-mix(in srgb, var(--nx-primary) 22%, transparent)",
+      outline:
+        "1px solid color-mix(in srgb, var(--nx-primary) 45%, transparent)",
+    },
+    "&.cm-focused .cm-nonmatchingBracket": {
+      backgroundColor:
+        "color-mix(in srgb, var(--nx-destructive) 18%, transparent)",
+    },
+    ".cm-searchMatch": {
+      backgroundColor: "color-mix(in srgb, var(--nx-warning) 30%, transparent)",
+    },
+    ".cm-searchMatch.cm-searchMatch-selected": {
+      backgroundColor: "color-mix(in srgb, var(--nx-warning) 50%, transparent)",
+    },
+    "&.cm-focused .cm-cursor": {
+      borderLeftColor: "var(--nx-foreground)",
+    },
+    "&.cm-focused": {
+      // The bordered control around the editor already draws focus; a second
+      // outline inside it reads as two focused things.
+      outline: "none",
+    },
+  });
+}

--- a/packages/admin/src/lib/code-highlight.ts
+++ b/packages/admin/src/lib/code-highlight.ts
@@ -22,6 +22,9 @@ import { EditorView } from "@codemirror/view";
 import type { Tag } from "@lezer/highlight";
 import { tags as t } from "@lezer/highlight";
 
+import type { CodeConstruct } from "./code-palette";
+import { codeColor } from "./code-palette";
+
 /**
  * The palette, as data.
  *
@@ -31,28 +34,28 @@ import { tags as t } from "@lezer/highlight";
  */
 export const CODE_TAG_SPECS: readonly {
   tag: Tag | Tag[];
-  color: string;
+  construct: CodeConstruct;
   fontStyle?: string;
 }[] = [
   {
     tag: [t.comment, t.lineComment, t.blockComment, t.docComment],
-    color: "var(--nx-code-comment)",
+    construct: "comment",
     fontStyle: "italic",
   },
   {
     tag: [t.keyword, t.controlKeyword, t.moduleKeyword, t.operatorKeyword],
-    color: "var(--nx-code-keyword)",
+    construct: "keyword",
   },
   {
     // `boolean` and `constant` are number-coloured in rich-text-kit, and JSON's
     // `null` is the same kind of literal, so it travels with them rather than
     // with the keywords it parses beside.
     tag: [t.bool, t.null, t.atom, t.number, t.integer, t.float],
-    color: "var(--nx-code-number)",
+    construct: "number",
   },
   {
     tag: [t.string, t.special(t.string), t.regexp, t.character],
-    color: "var(--nx-code-string)",
+    construct: "string",
   },
   {
     tag: [
@@ -61,7 +64,7 @@ export const CODE_TAG_SPECS: readonly {
       t.function(t.variableName),
       t.function(t.propertyName),
     ],
-    color: "var(--nx-code-function)",
+    construct: "function",
   },
   {
     tag: [
@@ -71,7 +74,7 @@ export const CODE_TAG_SPECS: readonly {
       t.logicOperator,
       t.definitionOperator,
     ],
-    color: "var(--nx-code-operator)",
+    construct: "operator",
   },
   {
     tag: [
@@ -82,7 +85,7 @@ export const CODE_TAG_SPECS: readonly {
       t.paren,
       t.squareBracket,
     ],
-    color: "var(--nx-code-punctuation)",
+    construct: "punctuation",
   },
   {
     // `className` and `typeName` ride with the variables because rich-text-kit
@@ -95,29 +98,41 @@ export const CODE_TAG_SPECS: readonly {
       t.className,
       t.typeName,
     ],
-    color: "var(--nx-code-variable)",
+    construct: "variable",
   },
   {
     // Comment-coloured, as rich-text-kit colours `namespace`: it qualifies the
     // name beside it rather than being the name, so it reads quieter.
     tag: [t.namespace],
-    color: "var(--nx-code-comment)",
+    construct: "comment",
   },
   {
     // Markup only -- an element name and the brackets around it, which is what
     // Prism's `tag` means too.
     tag: [t.tagName, t.angleBracket],
-    color: "var(--nx-code-tag)",
+    construct: "tag",
   },
-  { tag: [t.deleted], color: "var(--nx-code-deleted)" },
-  { tag: [t.inserted], color: "var(--nx-code-inserted)" },
-  // Not a code colour: a parse error is a fault, and the admin already has one
-  // token for that meaning.
-  { tag: [t.invalid], color: "var(--nx-destructive)" },
+  { tag: [t.deleted], construct: "deleted" },
+  { tag: [t.inserted], construct: "inserted" },
 ];
 
-/** The tag palette, as a CodeMirror highlighter. */
-export const nextlyHighlightStyle = HighlightStyle.define([...CODE_TAG_SPECS]);
+/**
+ * The tag palette, as a CodeMirror highlighter.
+ *
+ * Colours are resolved from the shared construct table at build time, so this
+ * file records which lezer tags mean which construct and nothing about what a
+ * construct is worth.
+ */
+export const nextlyHighlightStyle = HighlightStyle.define([
+  ...CODE_TAG_SPECS.map(spec => ({
+    tag: spec.tag,
+    color: codeColor(spec.construct),
+    ...(spec.fontStyle === undefined ? {} : { fontStyle: spec.fontStyle }),
+  })),
+  // A parse error is a fault rather than a construct, so it reads from the
+  // admin's error token instead of the code palette.
+  { tag: t.invalid, color: "var(--nx-destructive)" },
+]);
 
 /**
  * Registered WITHOUT `fallback`, which is what makes it win.
@@ -217,7 +232,7 @@ export function nextlyEditorChrome({
     // Without a colour here it falls back to the editor's foreground and reads
     // as a different character from its own twin two lines down. Unscoped, so
     // it still holds while the editor is not focused.
-    ".cm-matchingBracket": { color: "var(--nx-code-punctuation)" },
+    ".cm-matchingBracket": { color: codeColor("punctuation") },
     ".cm-nonmatchingBracket": { color: "var(--nx-destructive)" },
     // The fills are scoped exactly as `bracketMatching`'s own base theme scopes
     // them. It ships a hardcoded teal under `&.cm-focused`, and a bare
@@ -241,6 +256,57 @@ export function nextlyEditorChrome({
     "&.cm-focused .cm-cursor": {
       borderLeftColor: "var(--nx-foreground)",
     },
+    // The base theme keys thirteen surfaces off `EditorView.darkTheme`, which
+    // only a bundled theme sets -- so under `theme="none"` every one of them
+    // stays on its light rule. Selection is the one people notice; the search
+    // panel, the autocomplete popup and lint tooltips are the rest, and
+    // `basicSetup` turns all three on.
+    //
+    // Enumerated rather than answered by setting the facet, because setting it
+    // needs the resolved mode and would put back the branch this module exists
+    // to remove. The list is closed rather than a guess: it is every `&light` /
+    // `&dark` selector the base theme declares.
+    ".cm-panels": {
+      backgroundColor: "var(--nx-popover)",
+      color: "var(--nx-popover-foreground)",
+    },
+    ".cm-panels-top": { borderBottom: "1px solid var(--nx-border)" },
+    ".cm-panels-bottom": { borderTop: "1px solid var(--nx-border)" },
+    ".cm-textfield": {
+      backgroundColor: "var(--nx-background)",
+      color: "var(--nx-foreground)",
+      border: "1px solid var(--nx-input)",
+      borderRadius: "var(--radius-sm)",
+    },
+    ".cm-button": {
+      backgroundColor: "var(--nx-secondary)",
+      color: "var(--nx-secondary-foreground)",
+      backgroundImage: "none",
+      border: "1px solid var(--nx-border)",
+      borderRadius: "var(--radius-sm)",
+    },
+    ".cm-tooltip": {
+      backgroundColor: "var(--nx-popover)",
+      color: "var(--nx-popover-foreground)",
+      border: "1px solid var(--nx-border)",
+      borderRadius: "var(--radius-md)",
+    },
+    ".cm-tooltip .cm-tooltip-arrow:before": {
+      borderTopColor: "var(--nx-border)",
+      borderBottomColor: "var(--nx-border)",
+    },
+    ".cm-tooltip .cm-tooltip-arrow:after": {
+      borderTopColor: "var(--nx-popover)",
+      borderBottomColor: "var(--nx-popover)",
+    },
+    ".cm-tooltip-section:not(:first-child)": {
+      borderTop: "1px solid var(--nx-border)",
+    },
+    ".cm-tooltip-autocomplete > ul > li[aria-selected]": {
+      backgroundColor: "var(--nx-accent)",
+      color: "var(--nx-accent-foreground)",
+    },
+    ".cm-specialChar": { color: "var(--nx-destructive)" },
     "&.cm-focused": {
       // A ring rather than the base theme's hardcoded dotted outline, which is
       // off-token. It cannot be dropped: the wrappers these editors sit in draw

--- a/packages/admin/src/lib/code-highlight.ts
+++ b/packages/admin/src/lib/code-highlight.ts
@@ -85,15 +85,28 @@ export const CODE_TAG_SPECS: readonly {
     color: "var(--nx-code-punctuation)",
   },
   {
+    // `className` and `typeName` ride with the variables because rich-text-kit
+    // colours Prism's `class` and `class-name` that way, and a type name is the
+    // construct that engine already has an opinion about.
     tag: [
       t.variableName,
       t.definition(t.variableName),
       t.local(t.variableName),
+      t.className,
+      t.typeName,
     ],
     color: "var(--nx-code-variable)",
   },
   {
-    tag: [t.tagName, t.angleBracket, t.typeName, t.className, t.namespace],
+    // Comment-coloured, as rich-text-kit colours `namespace`: it qualifies the
+    // name beside it rather than being the name, so it reads quieter.
+    tag: [t.namespace],
+    color: "var(--nx-code-comment)",
+  },
+  {
+    // Markup only -- an element name and the brackets around it, which is what
+    // Prism's `tag` means too.
+    tag: [t.tagName, t.angleBracket],
     color: "var(--nx-code-tag)",
   },
   { tag: [t.deleted], color: "var(--nx-code-deleted)" },
@@ -177,6 +190,28 @@ export function nextlyEditorChrome({
     ".cm-selectionMatch": {
       backgroundColor: "color-mix(in srgb, var(--nx-primary) 20%, transparent)",
     },
+    // Selection is the one decoration `theme="none"` leaves actively wrong
+    // rather than merely unstyled. The base theme picks between its `&light`
+    // and `&dark` rules from `EditorView.darkTheme`, which only a bundled theme
+    // sets -- so without one it stays light, and its pale fill lands under the
+    // light-on-dark token colours in a dark admin.
+    //
+    // Answered with a token instead of by setting the facet: one rule then
+    // serves both modes, which is the same reason there is one highlight style
+    // rather than two.
+    "::selection": {
+      backgroundColor: "color-mix(in srgb, var(--nx-primary) 30%, transparent)",
+    },
+    ".cm-selectionBackground": {
+      backgroundColor: "color-mix(in srgb, var(--nx-primary) 25%, transparent)",
+    },
+    // The base theme raises its own specificity for the focused case, so this
+    // has to match that shape to win rather than relying on precedence alone.
+    "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground":
+      {
+        backgroundColor:
+          "color-mix(in srgb, var(--nx-primary) 35%, transparent)",
+      },
     // Bracket matching replaces the token span rather than decorating it, so
     // the bracket under the caret arrives with no highlight class of its own.
     // Without a colour here it falls back to the editor's foreground and reads
@@ -207,9 +242,13 @@ export function nextlyEditorChrome({
       borderLeftColor: "var(--nx-foreground)",
     },
     "&.cm-focused": {
-      // The bordered control around the editor already draws focus; a second
-      // outline inside it reads as two focused things.
-      outline: "none",
+      // A ring rather than the base theme's hardcoded dotted outline, which is
+      // off-token. It cannot be dropped: the wrappers these editors sit in draw
+      // a static border and none of them carries a `focus-within` treatment, so
+      // removing this leaves a keyboard user nothing but the caret to say which
+      // control they are in.
+      outline: "2px solid var(--nx-ring)",
+      outlineOffset: "-2px",
     },
   });
 }

--- a/packages/admin/src/lib/code-palette.ts
+++ b/packages/admin/src/lib/code-palette.ts
@@ -1,0 +1,57 @@
+/**
+ * What a syntax palette can colour, and what each of those is worth.
+ *
+ * Two engines highlight code in this admin -- Lexical/Prism in the rich-text
+ * field, CodeMirror/lezer everywhere else -- and they name their tokens
+ * differently. Left to themselves each grows its own opinion of what a class
+ * name or a namespace is worth, and the disagreement is invisible in review
+ * because each looks right beside its own editor.
+ *
+ * So the decision lives here once, keyed by the CONSTRUCT rather than by either
+ * tokenizer's vocabulary, and both engines derive from it. Neither can drift
+ * from the other, because there is nothing to drift from.
+ *
+ * **The class strings are written out in full on purpose.** Tailwind discovers
+ * utilities by scanning source text, so a class assembled at runtime --
+ * `text-code-${construct}` -- is invisible to it and gets purged, leaving
+ * rich-text code blocks unstyled with nothing at build time to say so. Every
+ * class here is a literal for that reason; do not compose them.
+ *
+ * @module lib/code-palette
+ */
+
+/**
+ * Each construct's theme token and its matching utility class.
+ *
+ * The two spellings are the same name in two namespaces -- `--nx-code-string`
+ * is what CSS calls it, `text-code-string` is what Tailwind calls it -- and a
+ * test holds them to that, so neither can be edited alone.
+ */
+export const CODE_CONSTRUCTS = {
+  comment: { token: "--nx-code-comment", className: "text-code-comment" },
+  keyword: { token: "--nx-code-keyword", className: "text-code-keyword" },
+  string: { token: "--nx-code-string", className: "text-code-string" },
+  number: { token: "--nx-code-number", className: "text-code-number" },
+  function: { token: "--nx-code-function", className: "text-code-function" },
+  operator: { token: "--nx-code-operator", className: "text-code-operator" },
+  punctuation: {
+    token: "--nx-code-punctuation",
+    className: "text-code-punctuation",
+  },
+  variable: { token: "--nx-code-variable", className: "text-code-variable" },
+  tag: { token: "--nx-code-tag", className: "text-code-tag" },
+  deleted: { token: "--nx-code-deleted", className: "text-code-deleted" },
+  inserted: { token: "--nx-code-inserted", className: "text-code-inserted" },
+} as const;
+
+export type CodeConstruct = keyof typeof CODE_CONSTRUCTS;
+
+/** The construct's colour, for an engine that styles with CSS values. */
+export function codeColor(construct: CodeConstruct): string {
+  return `var(${CODE_CONSTRUCTS[construct].token})`;
+}
+
+/** The construct's colour, for an engine that styles with class names. */
+export function codeClass(construct: CodeConstruct): string {
+  return CODE_CONSTRUCTS[construct].className;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -570,6 +570,9 @@ importers:
       '@lexical/utils':
         specifier: ^0.47.0
         version: 0.47.0(typescript@5.9.3)
+      '@lezer/highlight':
+        specifier: 1.2.3
+        version: 1.2.3
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)


### PR DESCRIPTION
## Summary

Code in the admin was coloured by CodeMirror's bundled themes rather than by the design system. Measured on the live page before this change, the response viewer rendered One Dark's palette exactly — `rgb(224,108,117)`, `rgb(152,195,121)`, `rgb(198,120,221)` — while `theme.css` already declared thirteen `--nx-code-*` tokens for light and dark that `styles/contrast/pairings.ts` already had under the contrast suite. Nothing was reading them.

Switching the bundled theme off turned out to remove more than colours, and most of this PR is the consequences of that. **Each section below is a defect this change caused, not optional extra work.**

### 1 · One palette, read by both engines

`code-palette.ts` holds the construct-to-colour decision once. The CodeMirror specs name a construct and read its colour; the Lexical theme names a construct and reads its class. Previously each engine carried its own opinion and they disagreed on class names and namespaces.

This is the one part outside the API Playground, and it is here because `AGENTS.md` says to derive a narrower view rather than compute it alongside. A test that *compared* the two was the wrong shape — comparison is what you write when unifying is impossible, and it was not.

The utility-class strings are literal on purpose: Tailwind scans source text, so `` `text-code-${construct}` `` would be purged and rich-text code blocks would silently lose colour. Verified against the built stylesheet — all eleven survive.

### 2 · Light chrome inside a dark admin

`theme="none"` leaves `EditorView.darkTheme` unset, so every CodeMirror package stays on its `&light` rules. Measured across the installed packages:

| package | hardcoded colours | behind a light/dark pair |
| --- | --- | --- |
| view | 40 | 29 |
| language | 19 | **0** |
| lint | 16 | 2 |
| autocomplete | 7 | 6 |
| search | 5 | 4 |

The flag now carries the resolved mode, which settles all 41 at once. It is not a colour decision — every colour is still a token. `@codemirror/language` is the case it cannot reach (19 colours, no light/dark pair at all), so its fold placeholder, the drop cursor and the lint row take tokens explicitly.

### 3 · Tags rendering as plain text

A highlighter registered without `fallback` claims **every** tag, so any tag the palette does not name renders as plain foreground. Invisible in JSON; wrong in Markdown and CSS. A coverage test over `@lezer/highlight`'s full vocabulary found **30** uncovered — including `heading1`–`heading6`, so every real Markdown heading was flat while the generic `t.heading` looked covered.

Four tags stay unstyled and say why. Coverage is asked of the **built highlighter** via `style()`, not of the spec array, so a tag counts as covered when CodeMirror will actually colour it.

### 4 · Smaller repairs

Selection background, focus ring, bracket matching, and a hardcoded `'Fira Code'` stack the admin does not ship.

## Test plan

Every guard was break-verified — an untested instrument is not evidence:

| break | expected | result |
| --- | --- | --- |
| token → `#98c379` literal | literal-colour guard | fires |
| token name typo | stranded-token guard | fires |
| theme path → nonexistent | positive control | fires |
| delete `--nx-code-string` from `.dark` only | per-mode guard | fires on `.dark` only |
| delete `--nx-code-fg` from `.dark` only | per-mode guard | fires |
| literal class back into Lexical theme | bypass guard | fires |
| desync a construct's two spellings | naming guard | fires |
| remove `t.color` | coverage guard | fires, names `color` |
| delete the `t.invalid` rule | coverage + dedicated | both fire |

Verified in-browser, both themes, computed styles compared against `getComputedStyle(document.documentElement)`:

- Response viewer — 69 spans, every one matching its token, `oneDarkSurvivors: []`
- Request body and response on one screen — the pair that had to agree, and does
- Email template HTML editor — `tagName`, `attributeName`, `string`, `operator` on-token; scroller font `Geist Mono Variable`
- Search panel in dark — `.cm-panels` = `--nx-popover` exactly; base theme's `#f5f5f5` gone
- Selection in dark — `--nx-primary` at 35%; `#d7d4f0` gone
- Focus ring — `lab(100 0 0) solid 2px` = `--nx-ring`
- Dark facet — light gives `ͼ2`, dark gives `ͼ3`; exactly one class differs

Gates, from the worktree root after `pnpm --filter @nextlyhq/admin... build`: build, `check-types`, `lint` (`--max-warnings 0`), `lint:design`, `check:comments` all pass. `fallow audit` → `pass`, `dead_code_introduced: 0`, `duplication_introduced: 0`.

## Pre-existing failures (not introduced here)

`pnpm --filter @nextlyhq/admin test` reports **15 failures across 4 files**. Measured on a clean tree by stashing this work: the identical 15 in the identical 4 files.

- `dashboard/StatsCard.test.tsx` (2)
- `schema-builder/builder-settings-modal/__tests__/SlugInput.test.tsx` (4)
- `schema-builder/builder-settings-modal/__tests__/BasicsTab.test.tsx` (1)
- `schema-builder/field-editor-sheet/__tests__/DefaultValueField.test.tsx` (8)

None touch code highlighting. With this change: 2604 passed, same 15 failed.

## Not verified in the browser

`CodeInput` — the playground schema declares no `code` field, so no route renders it. It is a pass-through to `CodeMirrorEditor` with no theme handling of its own, but I am naming it rather than letting the other surfaces stand in for it.

## Changeset

Added: yes — patch, all published packages (they version in lockstep).

## Note for the R-13 / R-15 lanes

`EmailTemplateForm.tsx` loses one JSX prop and its now-unused `useTheme` import. No layout or structural change.
