### PR TITLE
fix(nextly): make a shared preview link open the draft it names

### DIFF
--- a/.changeset/preview-links-actually-work.md
+++ b/.changeset/preview-links-actually-work.md
@@ -55,3 +55,31 @@ itself off as a local path.
 Add `draft: previewDraftGate()` to the content route the link lands on. Without it the route serves
 published entries only, and a preview link verifies, redirects, and then answers 404 from a page
 that looks entirely correct.
+
+A collection that declares no preview URL now refuses to mint a link, instead of reporting success
+and handing over one that answers 404. Nextly cannot work out where an entry is served — only the
+application knows whether a post with the slug `hello-world` is at `/hello-world` or
+`/blog/hello-world` — so a collection says it:
+
+```ts
+admin: {
+  preview: {
+    url: entry => (entry.slug ? `/blog/${entry.slug}` : null),
+  },
+},
+```
+
+The "Copy shareable link" button still appears either way, deliberately: hiding it would leave an
+editor with a feature that vanished and nothing explaining why. Refusing at the click puts the
+cause, and the fact that a developer is the one who fixes it, in front of the person who hit it.
+
+The page builder's own `pages` collection now declares one, defaulted to the site root and
+overridable with `pageBuilder({ pagePreviewPath: "/blocks/{slug}" })` for a site that mounts its
+pages elsewhere.
+
+In development, a content route that receives a valid preview link while declaring no
+`draft` hook now says so, naming the hook to add. Production is unchanged: every refusal stays an
+identical 404, because one that varied by cause would let a stranger discover which entries have
+drafts.
+
+New guide: **Draft Preview Links**.

--- a/.changeset/preview-links-actually-work.md
+++ b/.changeset/preview-links-actually-work.md
@@ -1,0 +1,57 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Preview links work. The whole draft-preview stack shipped built and exported but never
+connected to anything: no application mounted `createPreviewRoute`, no content route consulted a
+preview token, and the copy-link button in the entry editor handed out a URL that answered 404.
+
+Mounting it is now one line, because `createPreviewRoute()` and `previewDraftGate()` take no
+required arguments. The signing secret, the revocation generation, Next's draft mode and the
+request's cookies are all facts about the booted instance rather than decisions a site makes, so
+they default — and a route file that costs a paragraph of wiring is a route file nobody writes:
+
+```ts
+// src/app/api/preview/route.ts
+import { createPreviewRoute } from "nextly/runtime";
+
+export const { GET } = createPreviewRoute();
+```
+
+Where a link lands is derived from the collection's own preview declaration — the `url` function a
+code-first collection carries, or the `urlTemplate` a UI-created one does — so nothing has to be
+restated. A site that routes its content some other way still supplies its own `redirectTo`.
+
+This no longer requires a configured site URL. The admin needs an absolute URL because it may be
+served from another origin; the preview route does not, because it is already running on the site,
+so a relative path resolves against the origin the visitor is standing on. Where there is no origin
+to compare against, the path's shape is checked instead, so a protocol-relative value cannot pass
+itself off as a local path.
+
+Add `draft: previewDraftGate()` to the content route the link lands on. Without it the route serves
+published entries only, and a preview link verifies, redirects, and then answers 404 from a page
+that looks entirely correct.

--- a/apps/playground/src/app/(frontend)/[...slug]/page.tsx
+++ b/apps/playground/src/app/(frontend)/[...slug]/page.tsx
@@ -40,6 +40,7 @@ import { createBlockResolver } from "@nextlyhq/blocks-react";
 import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
 import { createBlocksPage } from "@nextlyhq/blocks-react/next";
 import { loadSiteStyle, SITE_STYLE_SLUG } from "@nextlyhq/plugin-page-builder";
+import { previewDraftGate } from "nextly/runtime";
 
 import { siteReader, SITE_STYLE_CONTEXT } from "../../../lib/site-content";
 import { SITE_STYLE_DEFAULTS } from "../../../lib/site-style-defaults";
@@ -76,6 +77,16 @@ const { ContentPage, generateMetadata } = createBlocksPage({
   // preview gate refusing every default-language preview, behind a published
   // page that looks entirely correct.
   locale: "en",
+  // Without this the route serves published entries only, so a preview link
+  // verifies, redirects, and then answers 404 from a page that looks entirely
+  // correct — indistinguishable, to the reviewer who opened it, from a link
+  // that had expired.
+  //
+  // The gate grants exactly the ONE entry the visitor's token names. That is
+  // the part Next's own draft mode cannot express: `draftMode()` is a single
+  // boolean for the whole host, so enabling it alone would turn a link meant
+  // for one unpublished page into a key to every unpublished page on the site.
+  draft: previewDraftGate(),
   // An explicit set, not the process registry. `registeredBlocks()` reads the
   // engine's global registry, which is populated by whatever booted the editor
   // — so a public route depending on it renders the unknown-block placeholder

--- a/apps/playground/src/app/api/preview/route.ts
+++ b/apps/playground/src/app/api/preview/route.ts
@@ -1,0 +1,21 @@
+/**
+ * The preview link's landing point.
+ *
+ * A preview link carries a signed token naming ONE entry, with an expiry and a
+ * revocation generation. This route verifies it, starts a draft-reading session
+ * scoped to that entry, and forwards to wherever the entry previews — all of
+ * which `createPreviewRoute` already does, which is why there is nothing here
+ * but the mount.
+ *
+ * The mount belongs to the application rather than the package because the
+ * draft cookie is set by whichever ORIGIN serves the route, and only the site's
+ * own origin is the right one. An admin deployed on a separate host would set
+ * the cookie there and then send the reviewer to a site that never receives it,
+ * where they would silently see the published page instead of the draft.
+ *
+ * Moving this file means telling the admin where it went: set
+ * `preview: { route: "/your/path" }` in `nextly.config.ts`.
+ */
+import { createPreviewRoute } from "nextly/runtime";
+
+export const { GET } = createPreviewRoute();

--- a/apps/playground/src/app/blocks/[[...slug]]/page.tsx
+++ b/apps/playground/src/app/blocks/[[...slug]]/page.tsx
@@ -25,6 +25,7 @@ import { createBlockResolver } from "@nextlyhq/blocks-react";
 import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
 import { createBlocksPage } from "@nextlyhq/blocks-react/next";
 import { loadSiteStyle, SITE_STYLE_SLUG } from "@nextlyhq/plugin-page-builder";
+import { previewDraftGate } from "nextly/runtime";
 
 import { siteReader, SITE_STYLE_CONTEXT } from "../../../lib/site-content";
 import { SITE_STYLE_DEFAULTS } from "../../../lib/site-style-defaults";
@@ -71,6 +72,16 @@ const { ContentPage, generateMetadata } = createBlocksPage({
   collections: ["block-pages"],
   field: "content",
   nextly: siteReader,
+  // Without this the route serves published entries only, so a preview link
+  // verifies, redirects, and then answers 404 from a page that looks entirely
+  // correct — indistinguishable, to the reviewer who opened it, from a link
+  // that had expired.
+  //
+  // The gate grants exactly the ONE entry the visitor's token names, which is
+  // the part Next's own draft mode cannot express: `draftMode()` is a single
+  // boolean for the whole host, so enabling it alone would turn a link meant
+  // for one unpublished page into a key to every unpublished page on the site.
+  draft: previewDraftGate(),
   // Stated even though it is this site's default language, because the read is
   // not the only thing it feeds. An omitted locale still serves the right page
   // — the read defaults it internally — but it is also what a `draft` decision

--- a/apps/playground/src/collections/block-pages.ts
+++ b/apps/playground/src/collections/block-pages.ts
@@ -20,6 +20,22 @@ export const BlockPages = defineCollection({
   // Draft/Published lifecycle. The route reads with the default `published`
   // scope, so an unpublished row must 404 rather than render.
   status: true,
+  // Where a block page previews. Without this the collection resolves to
+  // `notConfigured`, and a preview link minted for one of its drafts has
+  // nowhere to send the reviewer — it verifies, then refuses, which is
+  // indistinguishable from an expired link.
+  //
+  // `/blocks/` because that is where this collection's route is mounted, in
+  // `src/app/blocks/[[...slug]]/page.tsx`. The mount is the application's
+  // choice, so the path is stated here rather than guessed anywhere else.
+  admin: {
+    preview: {
+      url: entry =>
+        typeof entry.slug === "string" && entry.slug !== ""
+          ? `/blocks/${entry.slug}`
+          : null,
+    },
+  },
   fields: [
     text({ name: "title", required: true }),
     text({ name: "slug", required: true, unique: true }),

--- a/apps/playground/src/collections/block-pages.ts
+++ b/apps/playground/src/collections/block-pages.ts
@@ -1,4 +1,9 @@
-import { defineCollection, json, text } from "nextly/config";
+import {
+  defineCollection,
+  json,
+  previewUrlFromTemplate,
+  text,
+} from "nextly/config";
 
 // Pages rendered by the code-first blocks renderer (`@nextlyhq/blocks-react`),
 // served at /blocks/<slug> by apps/playground/src/app/blocks/[[...slug]]/page.tsx.
@@ -29,12 +34,14 @@ export const BlockPages = defineCollection({
   // `src/app/blocks/[[...slug]]/page.tsx`. The mount is the application's
   // choice, so the path is stated here rather than guessed anywhere else.
   admin: {
-    preview: {
-      url: entry =>
-        typeof entry.slug === "string" && entry.slug !== ""
-          ? `/blocks/${entry.slug}`
-          : null,
-    },
+    // Built through the shared helper rather than interpolated here. A slug
+    // holding a URL-significant character — `?`, `#`, `%`, a space — changes the
+    // meaning of a hand-built path instead of addressing the stored slug, so
+    // `draft?mode=x` would redirect to the route for `draft` and the token's
+    // entry comparison would then refuse it. The helper applies the same
+    // encoding a stored `urlTemplate` gets, so both spellings resolve one entry
+    // to one address.
+    preview: { url: previewUrlFromTemplate("/blocks/{slug}") },
   },
   fields: [
     text({ name: "title", required: true }),

--- a/docs/guides/draft-preview.mdx
+++ b/docs/guides/draft-preview.mdx
@@ -64,9 +64,25 @@ import { previewDraftGate } from "nextly/runtime";
 const { ContentPage, generateMetadata } = createBlocksPage({
   collections: ["pages"],
   field: "content",
+  // State the locale on a localized site, even for the default language.
+  locale: "en",
   draft: previewDraftGate(),
 });
 ```
+
+<Callout type="warn">
+**On a localized site, `locale` is required for preview to work** — and omitting
+it fails in the confusing direction. The admin mints a token naming a resolved
+locale even for the default language, and the gate compares that against the
+route's own. A route that states none compares against `undefined`, so every
+localized token is refused *after* the redirect — the visitor lands on the page
+and gets the 404 this guide exists to prevent.
+
+Nothing infers the default for you, deliberately: inferring it means reading
+configuration per request, and a route's reader may defer booting until its
+first query — so the inferred value would differ between the first request of a
+cold process and every one after, authorizing previews intermittently.
+</Callout>
 
 Without it your route serves **published entries only**. A preview link then
 verifies correctly, redirects correctly, and answers `404` from a page that
@@ -183,6 +199,18 @@ that cannot honour it.
 set on a different origin from the one serving the page — usually an admin and
 site on separate hosts with the preview route mounted on the admin. It belongs
 on the site.
+
+**Everything is wired and a localized entry still 404s.** The content route
+states no `locale`. See the callout in step 2: the token names a locale and the
+gate compares it against the route's, so a route that states none refuses every
+localized token.
+
+**The admin says this entry has no preview address yet.** The collection's
+declaration returned nothing for this document — a `url` function answering
+`null`, or a `urlTemplate` whose placeholder field is still empty. Filling in
+the field the address is built from, usually the slug, makes it shareable. This
+is distinct from a collection that declares no preview at all, which is a
+developer's job rather than an editor's.
 
 ## See also
 

--- a/docs/guides/draft-preview.mdx
+++ b/docs/guides/draft-preview.mdx
@@ -1,0 +1,191 @@
+---
+title: Draft Preview Links
+description: Share an unpublished draft with someone who has no account. A preview link is a signed, expiring, per-entry credential — mount one route, add one draft gate, and declare where each collection is served.
+---
+
+A preview link lets an editor show an unpublished draft to someone with **no
+Nextly account at all** — a client, a reviewer, a colleague in another
+department. The link carries its own signed authorization, so the recipient
+never signs in and never sees anything beyond the one entry it names.
+
+This is the part worth knowing before anything else: the link is scoped to a
+**single entry**, it **expires**, and it can be **revoked**. It is not a
+password to your drafts.
+
+## The three pieces
+
+Draft preview needs three things wired, and it is not obvious when one is
+missing, because the symptom is always the same: a link that answers `404`.
+
+| Piece | Where it goes | What happens without it |
+| --- | --- | --- |
+| The preview **route** | `app/api/preview/route.ts` | The link 404s immediately |
+| The **draft gate** | On the route that renders your content | The link redirects, then 404s on a page that looks correct |
+| The collection's **preview URL** | `admin.preview` in the collection | The admin refuses to mint a link, and says why |
+
+### 1. Mount the route
+
+One file, three lines:
+
+```ts
+// src/app/api/preview/route.ts
+import { createPreviewRoute } from "nextly/runtime";
+
+export const { GET } = createPreviewRoute();
+```
+
+It needs no configuration. The signing key, the revocation counter, Next's
+draft mode and the request's cookies are all read from the running instance.
+
+**Why this lives in your app and not in the package:** the draft cookie is set
+by whichever *origin* serves the route. If your admin is deployed on a
+different host from your site, a route inside the package would set the cookie
+on the admin's host and then send the reviewer to a site that never receives
+it — and they would silently see the **published** page instead of the draft.
+Mounting it in your app puts it on the site's own origin, where it belongs.
+
+If you mount it somewhere else, say so, or the admin will build links pointing
+at the default:
+
+```ts
+// nextly.config.ts
+export default defineConfig({
+  preview: { route: "/next/preview" },
+});
+```
+
+### 2. Add the draft gate to your content route
+
+This is the step most easily missed, and its failure is the most confusing.
+
+```ts
+import { previewDraftGate } from "nextly/runtime";
+
+const { ContentPage, generateMetadata } = createBlocksPage({
+  collections: ["pages"],
+  field: "content",
+  draft: previewDraftGate(),
+});
+```
+
+Without it your route serves **published entries only**. A preview link then
+verifies correctly, redirects correctly, and answers `404` from a page that
+looks entirely right — indistinguishable, to the person who opened it, from a
+link that had expired.
+
+`previewDraftGate()` grants exactly the one entry the visitor's token names.
+That distinction matters more than it looks: Next's own draft mode is a single
+boolean for the whole host, so enabling it alone would turn a link meant for
+one unpublished page into a key to **every** unpublished page on the site.
+
+<Callout type="warn">
+`createPublicContentRoute` and `createPublicBlocksPage` refuse a `draft` hook,
+deliberately. A draft read cannot be cached, so accepting one would quietly
+turn a statically-rendered route dynamic. Mount previewable paths on
+`createContentRoute` / `createBlocksPage` instead.
+</Callout>
+
+### 3. Tell Nextly where the collection is served
+
+Nextly cannot work out a URL on its own. If a post has the slug
+`hello-world`, only your app knows whether that is `/hello-world`,
+`/blog/hello-world`, or `/en/blog/hello-world` — you wrote the routing.
+
+**Code-first**, a function of the entry:
+
+```ts
+export const Posts = defineCollection({
+  slug: "posts",
+  status: true,
+  admin: {
+    preview: {
+      // `null` means "not previewable yet" — a post with no slug becomes
+      // previewable once it has one.
+      url: entry =>
+        typeof entry.slug === "string" && entry.slug !== ""
+          ? `/blog/${encodeURIComponent(entry.slug)}`
+          : null,
+    },
+  },
+  fields: [/* ... */],
+});
+```
+
+**In the Visual Schema Builder**, a path with `{field}` placeholders, because
+no database column can hold a function:
+
+```
+/blog/{slug}
+```
+
+Both answer the same question and are resolved by the same code.
+
+If a collection declares neither, **the admin refuses to mint a link** and
+tells the editor that a developer needs to add a preview URL. That refusal is
+deliberate: the alternative was reporting success and handing over a link with
+nowhere to open.
+
+## Using it
+
+An editor opens an entry, clicks **Copy shareable link**, and pastes it to
+whoever needs to see the draft. Opening it starts a preview session scoped to
+that entry and forwards to the page.
+
+The link is a **bearer credential** — anyone holding it can read that one
+draft. It is minted fresh on every click rather than cached, because it carries
+an expiry and a stale one would be handed out after it stopped working.
+
+### Expiry and revocation
+
+Links last **one hour** by default and at most **seven days**. Asking for
+longer is refused rather than quietly shortened, because an editor who believes
+a link lasts a week and finds it dead is worse off than one who was told no.
+
+To invalidate **every** outstanding link at once — including sessions already
+open — raise the site's preview generation by revoking. That requires
+`manage settings`, because the effect is site-wide: one editor revoking would
+otherwise break every other editor's links.
+
+### What a reviewer can and cannot see
+
+They can read the one entry the link names, in the locale it names, as it
+stands right now — including unpublished edits to an already-published page.
+
+They cannot browse to other drafts. Every refusal — an expired token, a revoked
+one, a forged one, an entry since deleted — answers with the same bare `404`,
+with no cookie and no draft mode. That uniformity is intentional: a different
+answer for "no such entry" would let a stranger discover which entries have
+drafts.
+
+## Requirements
+
+- **`NEXTLY_SECRET` must be set.** Preview tokens are signed with a key derived
+  from it; without one, a link would be forgeable by anyone who could guess an
+  entry id.
+- The collection needs a Draft / Published lifecycle to have a draft worth
+  previewing — see [Draft / Published Status](/docs/guides/draft-published-status).
+
+## Troubleshooting
+
+**The link 404s straight away.** The route is not mounted, or is mounted
+somewhere other than where the admin thinks. Check `app/api/preview/route.ts`
+exists, and that `preview.route` in `nextly.config.ts` matches it.
+
+**The link redirects, then 404s.** The destination route has no
+`draft: previewDraftGate()`. This is the common one — in development the server
+logs a warning naming the route when a valid preview cookie reaches a route
+that cannot honour it.
+
+**The admin says a preview URL is not configured.** The collection declares no
+`admin.preview`. Add one, as in step 3.
+
+**The reviewer sees the published page, not the draft.** The draft cookie was
+set on a different origin from the one serving the page — usually an admin and
+site on separate hosts with the preview route mounted on the admin. It belongs
+on the site.
+
+## See also
+
+- [Draft / Published Status](/docs/guides/draft-published-status) — the lifecycle a preview shows
+- [Routing and SEO](/docs/guides/routing-and-seo) — the content routes a preview lands on
+- [ISR and Caching](/docs/guides/isr-caching) — why a draft read is never cached

--- a/docs/guides/meta.json
+++ b/docs/guides/meta.json
@@ -8,6 +8,7 @@
     "media-storage",
     "email",
     "draft-published-status",
+    "draft-preview",
     "isr-caching",
     "webhook-retention",
     "routing-and-seo"

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -28,7 +28,6 @@ import { snapshotToFormValues } from "@admin/components/features/versions/snapsh
 import { VersionSnapshotForm } from "@admin/components/features/versions/VersionSnapshotForm";
 import { Alert, AlertDescription, Skeleton } from "@admin/components/ui";
 import { useBranding } from "@admin/context/providers/BrandingProvider";
-import { useGeneralSettings } from "@admin/hooks/queries/useGeneralSettings";
 import { usePublishAllLocales } from "@admin/hooks/queries/usePublishAllLocales";
 import { useAutosaveRecovery } from "@admin/hooks/useAutosaveRecovery";
 import { useAutoSlug } from "@admin/hooks/useAutoSlug";
@@ -59,7 +58,6 @@ import {
   effectiveEntryStatus,
   isSlugPerLocale,
   previewLinkLocale,
-  previewLinkSiteUrl,
   useHasPublicAddress,
 } from "./entry-address";
 import { EntryFormActions } from "./EntryFormActions";
@@ -507,7 +505,6 @@ export function EntryForm({
   // the entry exists. The id is read here rather than inside the hook because
   // hooks run unconditionally: on create the mutation is constructed and never
   // reachable, since the control that would call it is not rendered.
-  const { data: generalSettings } = useGeneralSettings();
   const savedEntryId = entry?.id === undefined ? "" : String(entry.id);
 
   // Recovery points for this author, recorded while they type. Addressed only
@@ -566,18 +563,14 @@ export function EntryForm({
     locale,
     defaultLocale,
   });
-  // A link that travels by email or chat has to name a host. `window` is read
-  // through a guard because this module is imported in a server render, where
-  // there is no origin and the configured site is the only source anyway.
-  const linkSiteUrl = previewLinkSiteUrl({
-    configured: generalSettings?.siteUrl,
-    origin: typeof window === "undefined" ? undefined : window.location.origin,
-  });
+  // No site URL is computed here. A link that travels by email or chat has to
+  // name a host, and the server is the only place that can: `settings` is a
+  // system resource the `editor` and `author` presets cannot read, and those
+  // are exactly the roles that share preview links.
   const previewLink = usePreviewLink({
     collection: collection.name,
     entryId: savedEntryId,
     ...(linkLocale.kind === "scoped" ? { locale: linkLocale.locale } : {}),
-    ...(linkSiteUrl === undefined ? {} : { siteUrl: linkSiteUrl }),
   });
 
   // Only enable shortcuts in standalone mode (not embedded modals)

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntryForm.preview-link.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntryForm.preview-link.test.tsx
@@ -116,8 +116,22 @@ describe("EntryForm wires the shareable link into its header", () => {
         collection: "posts",
         entryId: "e1",
         locale: "en",
-        siteUrl: "https://site.example",
       })
+    );
+  });
+
+  it("passes no site url, because the browser is not where one is known", () => {
+    // Asserted as an ABSENCE rather than left implicit. `settings` is a system
+    // resource the sharing roles cannot read, so a site URL reaching the hook
+    // from here would either be missing for exactly those roles or be the
+    // admin's own origin standing in for the site's.
+    renderForm();
+
+    expect(mintArgs).toHaveBeenCalledWith(
+      expect.not.objectContaining({ siteUrl: expect.anything() })
+    );
+    expect(mintArgs).toHaveBeenCalledWith(
+      expect.not.objectContaining({ previewRoute: expect.anything() })
     );
   });
 

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
@@ -10,7 +10,6 @@ import {
   effectiveEntryStatus,
   everPublishedOnRecord,
   previewLinkLocale,
-  previewLinkSiteUrl,
   useHasPublicAddress,
   type PublicAddressArgs,
 } from "../entry-address";
@@ -534,55 +533,5 @@ describe("previewLinkLocale", () => {
     ).toEqual(
       previewLinkLocale({ localized: true, locale: "en", defaultLocale: "en" })
     );
-  });
-});
-
-describe("previewLinkSiteUrl", () => {
-  it("prefers the configured site over the browser origin", () => {
-    // An admin panel mounted on a different host from the site would otherwise
-    // hand out links pointing at itself.
-    expect(
-      previewLinkSiteUrl({
-        configured: "https://site.example",
-        origin: "https://admin.example",
-      })
-    ).toBe("https://site.example");
-  });
-
-  it("falls back to the browser origin when nothing is configured", () => {
-    // Usually right, since the common deployment serves both together, and
-    // always better than a relative path that identifies no host at all.
-    expect(
-      previewLinkSiteUrl({ configured: null, origin: "https://admin.example" })
-    ).toBe("https://admin.example");
-  });
-
-  it("treats a cleared setting as absent, not as an empty base", () => {
-    // The settings form stores "" for a field the user cleared; using it as a
-    // base would rebuild the relative path this exists to prevent.
-    expect(
-      previewLinkSiteUrl({ configured: "   ", origin: "https://admin.example" })
-    ).toBe("https://admin.example");
-  });
-
-  it("returns nothing rather than inventing a host", () => {
-    // With no configured site and no origin there is no honest absolute URL,
-    // so the existing relative behaviour stands.
-    expect(
-      previewLinkSiteUrl({ configured: null, origin: undefined })
-    ).toBeUndefined();
-  });
-
-  it("never yields a relative value when either source is present", () => {
-    // The property the control depends on: "Copy shareable link" must not put
-    // a path on the clipboard whenever anything can name a host.
-    for (const args of [
-      { configured: "https://a.example", origin: undefined },
-      { configured: null, origin: "https://b.example" },
-      { configured: "https://a.example", origin: "https://b.example" },
-    ]) {
-      const result = previewLinkSiteUrl(args);
-      expect(result, JSON.stringify(args)).toMatch(/^https?:\/\//);
-    }
   });
 });

--- a/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
@@ -309,38 +309,3 @@ export function previewLinkLocale({
   }
   return { kind: "scoped", locale: resolved };
 }
-
-/**
- * The site a shareable preview link should point at.
- *
- * `buildPreviewUrl` emits a site-relative path when given no site, and a
- * relative path is not a link: pasted into email or chat it identifies nothing,
- * and a recipient whose client resolves it does so against their own host. A
- * control labelled "Copy shareable link" has to put something shareable on the
- * clipboard, so the value is made absolute here.
- *
- * The configured site wins because it is the only source that knows where the
- * content is actually served — an admin panel mounted on a different host from
- * the site would otherwise hand out links to itself. A blank setting is treated
- * as absent rather than as an empty base, since the settings form stores `""`
- * for a field the user cleared.
- *
- * The browser's own origin is the fallback rather than a failure: the common
- * deployment serves the admin and the site together, so it is usually right,
- * and it is always better than a relative path. Returning `undefined` is the
- * last resort for a caller with no origin at all, which leaves the existing
- * relative behaviour rather than inventing a host.
- */
-export function previewLinkSiteUrl({
-  configured,
-  origin,
-}: {
-  configured: string | null | undefined;
-  origin: string | undefined;
-}): string | undefined {
-  const trimmed = configured?.trim();
-  if (trimmed !== undefined && trimmed.length > 0) return trimmed;
-  const fallback = origin?.trim();
-  if (fallback !== undefined && fallback.length > 0) return fallback;
-  return undefined;
-}

--- a/packages/admin/src/hooks/__tests__/usePreviewLink.fallback.test.ts
+++ b/packages/admin/src/hooks/__tests__/usePreviewLink.fallback.test.ts
@@ -44,7 +44,11 @@ function makeWrapper(): (props: { children: ReactNode }) => ReactElement {
 
 /** Runs the hook once with a clipboard that answers as told. */
 async function mintWith(writeText: () => Promise<void>): Promise<void> {
-  mint.mockResolvedValue({ token: TOKEN });
+  mint.mockResolvedValue({
+    token: TOKEN,
+    url: `https://site.example/api/preview?token=${TOKEN}`,
+    expiresAt: "2026-09-01T00:00:00.000Z",
+  });
   vi.stubGlobal("navigator", { clipboard: { writeText } });
 
   const { result } = renderHook(

--- a/packages/admin/src/hooks/__tests__/usePreviewLink.test.ts
+++ b/packages/admin/src/hooks/__tests__/usePreviewLink.test.ts
@@ -1,53 +1,116 @@
 /**
- * Preview link assembly.
+ * What the hook copies.
  *
- * The URL is built by hand from three pieces the admin does not control
- * together — a configured site URL, a route the user's own app mounted, and a
- * signed token — so the joins are where it breaks.
+ * It copies what the server returned, unchanged. The URL used to be assembled
+ * here from a hardcoded route and a site URL read out of general settings —
+ * neither of which the browser can know: the mount is a route file inside the
+ * application, and `settings` is a system resource the `editor` and `author`
+ * presets cannot read, which are exactly the roles that share preview links.
+ *
+ * These replace the `buildPreviewUrl` tests, which asserted that assembly.
+ * There is no longer a URL built in the browser to test.
  */
-import { describe, expect, it } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactElement, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { DEFAULT_PREVIEW_ROUTE, buildPreviewUrl } from "../usePreviewLink";
+const { toast, mint } = vi.hoisted(() => ({
+  toast: {
+    success: vi.fn(),
+    info: vi.fn((_message: string, _options?: unknown) => "toast-id"),
+    error: vi.fn(),
+    dismiss: vi.fn(),
+  },
+  mint: vi.fn(),
+}));
 
-describe("buildPreviewUrl", () => {
-  it("uses the conventional route when the app has not moved it", () => {
-    expect(buildPreviewUrl({ token: "abc" })).toBe(
-      `${DEFAULT_PREVIEW_ROUTE}?token=abc`
-    );
+vi.mock("@admin/components/ui", () => ({ toast }));
+vi.mock("@admin/services/previewLinkApi", () => ({
+  previewLinkApi: { mint: (...args: unknown[]) => mint(...args) },
+}));
+
+const { usePreviewLink } = await import("../usePreviewLink");
+
+const TOKEN = "a".repeat(280);
+const URL_FROM_SERVER = `https://site.example/next/preview?token=${TOKEN}`;
+
+function makeWrapper(): (props: { children: ReactNode }) => ReactElement {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  return ({ children }) =>
+    createElement(QueryClientProvider, { client }, children);
+}
+
+async function run(): Promise<{ isError: boolean }> {
+  const { result } = renderHook(
+    () => usePreviewLink({ collection: "posts", entryId: "7" }),
+    { wrapper: makeWrapper() }
+  );
+
+  result.current.mutate();
+  await waitFor(() =>
+    expect(result.current.isSuccess || result.current.isError).toBe(true)
+  );
+  return { isError: result.current.isError };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("usePreviewLink", () => {
+  it("copies the url the server returned, unmodified", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    mint.mockResolvedValue({
+      token: TOKEN,
+      url: URL_FROM_SERVER,
+      expiresAt: "2026-09-01T00:00:00.000Z",
+    });
+
+    await run();
+
+    // Byte-identical. Any transformation here is the browser re-deciding
+    // something the server already settled with information the browser lacks.
+    expect(writeText).toHaveBeenCalledWith(URL_FROM_SERVER);
   });
 
-  it("returns a relative link when no site url is configured", () => {
-    // Correct when the admin and the site share an origin, which is the
-    // default deployment, and useless when they do not — so the caller
-    // supplies a site url rather than this guessing an origin.
-    expect(buildPreviewUrl({ token: "abc" }).startsWith("/")).toBe(true);
+  it("mints per click rather than reusing a cached link", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    mint.mockResolvedValue({
+      token: TOKEN,
+      url: URL_FROM_SERVER,
+      expiresAt: "2026-09-01T00:00:00.000Z",
+    });
+
+    await run();
+
+    expect(mint).toHaveBeenCalledWith({ collection: "posts", entryId: "7" });
   });
 
-  it("joins a site url without doubling the slash", () => {
-    // A trailing slash on a configured site url is common enough that not
-    // handling it would produce `https://site.com//api/preview`.
-    for (const siteUrl of ["https://site.com", "https://site.com/"]) {
-      expect(buildPreviewUrl({ token: "abc", siteUrl })).toBe(
-        `https://site.com${DEFAULT_PREVIEW_ROUTE}?token=abc`
-      );
-    }
-  });
+  // The server answers `null` when no site URL is configured, because it cannot
+  // name a host. The admin must NOT put its own origin in front of the path:
+  // the admin may be served from somewhere the site is not, and a link to the
+  // wrong host looks like a working one.
+  it("reports the missing site url instead of substituting its own origin", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    mint.mockResolvedValue({
+      token: TOKEN,
+      url: null,
+      expiresAt: "2026-09-01T00:00:00.000Z",
+    });
 
-  it("honours an app that mounted the route elsewhere", () => {
-    expect(
-      buildPreviewUrl({
-        token: "abc",
-        siteUrl: "https://site.com",
-        previewRoute: "/preview",
-      })
-    ).toBe("https://site.com/preview?token=abc");
-  });
+    const { isError } = await run();
 
-  it("encodes the token rather than interpolating it raw", () => {
-    // A token is base64url and safe today. Assembling a query value by hand is
-    // exactly where that assumption stops being true later.
-    expect(buildPreviewUrl({ token: "a+b/c=d&e" })).toBe(
-      `${DEFAULT_PREVIEW_ROUTE}?token=a%2Bb%2Fc%3Dd%26e`
+    expect(isError).toBe(true);
+    expect(writeText).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.stringContaining("site URL")
     );
   });
 });

--- a/packages/admin/src/hooks/usePreviewLink.ts
+++ b/packages/admin/src/hooks/usePreviewLink.ts
@@ -11,54 +11,11 @@ import { useMutation } from "@tanstack/react-query";
 import { toast } from "@admin/components/ui";
 import { previewLinkApi } from "@admin/services/previewLinkApi";
 
-/**
- * Where `createPreviewRoute` is mounted, by convention.
- *
- * The route handler is written to be dropped into `app/api/preview/route.ts`,
- * which is where a Next application puts a route handler, and the admin has no
- * other way to learn the path: the mount point is a file in the user's own app,
- * invisible from here.
- *
- * A convention with an override is the honest arrangement. Guessing silently
- * would produce a copied link that 404s with nothing to explain it; demanding
- * configuration before the feature works at all would make the common case pay
- * for the uncommon one.
- */
-export const DEFAULT_PREVIEW_ROUTE = "/api/preview";
-
 export interface UsePreviewLinkOptions {
   collection: string;
   entryId: string;
   /** Restricts the link to one locale. Absent means every locale. */
   locale?: string;
-  /**
-   * The site the link points at. Without one the link is relative, which is
-   * correct when the admin and the site share an origin and useless when they
-   * do not.
-   */
-  siteUrl?: string;
-  /** Overrides {@link DEFAULT_PREVIEW_ROUTE} for an app that mounted it elsewhere. */
-  previewRoute?: string;
-}
-
-/** Assemble the URL a reviewer will open. */
-export function buildPreviewUrl({
-  token,
-  siteUrl,
-  previewRoute = DEFAULT_PREVIEW_ROUTE,
-}: {
-  token: string;
-  siteUrl?: string;
-  previewRoute?: string;
-}): string {
-  // `encodeURIComponent` rather than raw interpolation: a token is base64url
-  // and safe today, but a query value assembled by hand is exactly where an
-  // encoding assumption stops being true later.
-  const query = `?token=${encodeURIComponent(token)}`;
-  if (!siteUrl) return `${previewRoute}${query}`;
-  // Trailing slashes on a configured site URL are common and would otherwise
-  // produce `https://site.com//api/preview`.
-  return `${siteUrl.replace(/\/+$/, "")}${previewRoute}${query}`;
 }
 
 /**
@@ -89,8 +46,6 @@ export function usePreviewLink({
   collection,
   entryId,
   locale,
-  siteUrl,
-  previewRoute,
 }: UsePreviewLinkOptions) {
   return useMutation({
     mutationFn: async (): Promise<{ url: string; copied: boolean }> => {
@@ -99,12 +54,24 @@ export function usePreviewLink({
         entryId,
         ...(locale === undefined ? {} : { locale }),
       });
-      const url = buildPreviewUrl({
-        token: link.token,
-        ...(siteUrl === undefined ? {} : { siteUrl }),
-        ...(previewRoute === undefined ? {} : { previewRoute }),
-      });
-      return { url, copied: await copyToClipboard(url) };
+
+      // The server answers `null` when no site URL is configured, and that is
+      // not something to paper over. A relative URL here would be resolved
+      // against the ADMIN's origin, which is not the site's on any deployment
+      // that separates them — and a link to the wrong host is worse than no
+      // link, because it looks like it worked.
+      // `== null` catches an absent field as well as an explicit null. The
+      // contract says `string | null`, but a response that simply omits it —
+      // an older server, a proxy that reshapes JSON — must not reach the
+      // clipboard as the string "undefined".
+      if (link.url == null) {
+        throw new Error(
+          "No site URL is configured, so a preview link has nowhere to point. " +
+            "An administrator can set one in Settings."
+        );
+      }
+
+      return { url: link.url, copied: await copyToClipboard(link.url) };
     },
     onSuccess: ({ url, copied }) => {
       if (copied) {
@@ -153,8 +120,15 @@ export function usePreviewLink({
         }
       );
     },
-    onError: () => {
-      toast.error("Couldn't create a preview link.");
+    onError: (error: unknown) => {
+      // The thrown message rather than a fixed one: "no site URL is configured"
+      // names something an administrator can act on, and collapsing it into
+      // "couldn't create a preview link" hides the only remedy there is.
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Couldn't create a preview link."
+      );
     },
   });
 }

--- a/packages/admin/src/services/previewLinkApi.ts
+++ b/packages/admin/src/services/previewLinkApi.ts
@@ -20,8 +20,17 @@ export interface PreviewLinkRequest {
 }
 
 export interface PreviewLink {
-  /** The signed token. The URL is assembled by the caller. */
+  /** The signed token. */
   token: string;
+  /**
+   * The finished link, or `null` when no site URL is configured.
+   *
+   * Assembled on the server, which is the only place both halves are visible:
+   * the site URL lives in settings the sharing roles cannot read, and the
+   * preview route's mount point lives in the application's config, which the
+   * browser cannot see at all.
+   */
+  url: string | null;
   /** ISO timestamp after which the link stops working. */
   expiresAt: string;
 }

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -14,11 +14,13 @@ vi.mock("./route-auth", () => ({
   requireRoutePermission: vi.fn(),
 }));
 
-const { getEntry, canUpdateEntry, getSettings } = vi.hoisted(() => ({
-  getEntry: vi.fn(),
-  canUpdateEntry: vi.fn(),
-  getSettings: vi.fn(),
-}));
+const { getEntry, canUpdateEntry, getSettings, previewDeclaration } =
+  vi.hoisted(() => ({
+    getEntry: vi.fn(),
+    canUpdateEntry: vi.fn(),
+    getSettings: vi.fn(),
+    previewDeclaration: vi.fn(),
+  }));
 
 /** The application's `preview` config for the test in hand. */
 let previewConfig: { route?: string } | undefined;
@@ -29,6 +31,10 @@ vi.mock("../init", () => ({
 
 vi.mock("../services/lib/permissions", () => ({
   resolveRoleSlugs: vi.fn().mockResolvedValue(["editor"]),
+}));
+
+vi.mock("./preview-url", () => ({
+  previewDeclarationFor: (...args: unknown[]) => previewDeclaration(...args),
 }));
 
 vi.mock("../di", () => ({
@@ -95,6 +101,7 @@ beforeEach(() => {
   getGeneration.mockResolvedValue(0);
   revokeAll.mockResolvedValue(1);
   getSettings.mockResolvedValue({ siteUrl: "https://site.example" });
+  previewDeclaration.mockResolvedValue({ urlTemplate: "/{slug}" });
   previewConfig = undefined;
   // Key-aware, because assembling the link needs BOTH the settings service and
   // the application config, and a mock answering the same object for every key
@@ -115,6 +122,61 @@ beforeEach(() => {
 function item(body: { item?: unknown }): Record<string, unknown> {
   return body.item as Record<string, unknown>;
 }
+
+describe("mintPreviewLink: a collection with nowhere to send a reviewer", () => {
+  // The button that mints this is shown whether or not a collection declares a
+  // preview URL, and that is deliberate — a draft is shareable either way. What
+  // is NOT acceptable is answering success and handing over a link that cannot
+  // land: the reviewer then sees a 404 they cannot tell from an expired link,
+  // and the editor has no idea anything is wrong.
+  it("refuses instead of minting a link that cannot land", async () => {
+    previewDeclaration.mockResolvedValue(undefined);
+
+    const response = await mintPreviewLink(
+      post({ collection: "pages", entryId: "7" })
+    );
+
+    expect(response.status).toBe(409);
+  });
+
+  it("names the cause and who can fix it", async () => {
+    previewDeclaration.mockResolvedValue(undefined);
+
+    const body = await json(
+      await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+    );
+
+    // The editor reading this cannot fix it themselves, so the message has to
+    // say what is missing AND that a developer is the one who adds it.
+    const message = String(
+      (body.error as { message?: string } | undefined)?.message ?? ""
+    );
+    expect(message).toMatch(/preview url/i);
+    expect(message).toMatch(/developer/i);
+  });
+
+  it("mints no token at all when it refuses", async () => {
+    previewDeclaration.mockResolvedValue(undefined);
+
+    const body = await json(
+      await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+    );
+
+    // A bearer credential must not be issued for a refused request, even one
+    // refused for a configuration reason rather than an authorization one.
+    expect(body.item).toBeUndefined();
+  });
+
+  it("mints normally once the collection declares one", async () => {
+    previewDeclaration.mockResolvedValue({ url: () => "/somewhere" });
+
+    const response = await mintPreviewLink(
+      post({ collection: "pages", entryId: "7" })
+    );
+
+    expect(response.status).toBe(200);
+  });
+});
 
 describe("mintPreviewLink: the link it hands back", () => {
   it("returns an absolute url built from the site url and the default mount", async () => {

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -14,10 +14,14 @@ vi.mock("./route-auth", () => ({
   requireRoutePermission: vi.fn(),
 }));
 
-const { getEntry, canUpdateEntry } = vi.hoisted(() => ({
+const { getEntry, canUpdateEntry, getSettings } = vi.hoisted(() => ({
   getEntry: vi.fn(),
   canUpdateEntry: vi.fn(),
+  getSettings: vi.fn(),
 }));
+
+/** The application's `preview` config for the test in hand. */
+let previewConfig: { route?: string } | undefined;
 
 vi.mock("../init", () => ({
   getCachedNextly: vi.fn().mockResolvedValue({}),
@@ -90,9 +94,95 @@ beforeEach(() => {
   });
   getGeneration.mockResolvedValue(0);
   revokeAll.mockResolvedValue(1);
-  (container.get as ReturnType<typeof vi.fn>).mockReturnValue({
-    getPreviewTokenGeneration: getGeneration,
-    revokeAllPreviewTokens: revokeAll,
+  getSettings.mockResolvedValue({ siteUrl: "https://site.example" });
+  previewConfig = undefined;
+  // Key-aware, because assembling the link needs BOTH the settings service and
+  // the application config, and a mock answering the same object for every key
+  // cannot tell them apart.
+  (container.get as ReturnType<typeof vi.fn>).mockImplementation(
+    (key: string) => {
+      if (key === "config") return { preview: previewConfig };
+      return {
+        getPreviewTokenGeneration: getGeneration,
+        revokeAllPreviewTokens: revokeAll,
+        getSettings,
+      };
+    }
+  );
+});
+
+/** The mutation envelope's payload, narrowed once rather than at every use. */
+function item(body: { item?: unknown }): Record<string, unknown> {
+  return body.item as Record<string, unknown>;
+}
+
+describe("mintPreviewLink: the link it hands back", () => {
+  it("returns an absolute url built from the site url and the default mount", async () => {
+    const body = await json(
+      await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+    );
+
+    expect(item(body).url).toMatch(
+      /^https:\/\/site\.example\/api\/preview\?token=/
+    );
+  });
+
+  it("honours a configured preview.route", async () => {
+    previewConfig = { route: "/next/preview" };
+
+    const body = await json(
+      await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+    );
+
+    expect(item(body).url).toMatch(
+      /^https:\/\/site\.example\/next\/preview\?token=/
+    );
+  });
+
+  it("does not double the separator when the site url carries a trailing slash", async () => {
+    getSettings.mockResolvedValue({ siteUrl: "https://site.example/" });
+
+    const body = await json(
+      await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+    );
+
+    expect(item(body).url).not.toContain("//api/preview");
+  });
+
+  it("carries the token in the url it returns", async () => {
+    const body = await json(
+      await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+    );
+
+    expect(item(body).url).toContain(
+      `token=${encodeURIComponent(item(body).token as string)}`
+    );
+  });
+
+  it("still returns the token and expiry", async () => {
+    const body = await json(
+      await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+    );
+
+    expect(typeof item(body).token).toBe("string");
+    expect(typeof item(body).expiresAt).toBe("string");
+  });
+
+  // The admin cannot recover from this: the `editor` and `author` presets
+  // cannot read settings at all, so a RELATIVE url would be resolved against
+  // the admin's own origin — confidently wrong, and the exact guess the
+  // four-state preview resolver exists elsewhere to prevent.
+  it("returns a null url when no site url is configured", async () => {
+    getSettings.mockResolvedValue({ siteUrl: null });
+
+    const body = await json(
+      await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+    );
+
+    expect(item(body).url).toBeNull();
+    // The token is still minted: the link is usable by anyone who can build the
+    // URL, and refusing here would break preview on a site that never set one.
+    expect(typeof item(body).token).toBe("string");
   });
 });
 
@@ -343,16 +433,17 @@ describe("mintPreviewLink", () => {
     });
   });
 
-  it("returns a token rather than a url", async () => {
-    // Where the preview route is mounted is the app's decision; a url guessed
-    // here would 404 on any app that mounted it elsewhere.
+  it("answers with the canonical envelope and nothing else", async () => {
     const body = await json(
       await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
     );
+
     // The canonical mutation envelope, so a direct-API caller reads `.item`.
     expect(Object.keys(body).sort()).toEqual(["item", "message"]);
     const item = body.item as Record<string, unknown>;
-    expect(Object.keys(item).sort()).toEqual(["expiresAt", "token"]);
+    expect(Object.keys(item).sort()).toEqual(["expiresAt", "token", "url"]);
+    // The token is a credential, not an address: it carries no host of its own,
+    // and the `url` beside it is what puts one in front.
     expect(String(item.token)).not.toContain("http");
   });
 

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -85,7 +85,11 @@ beforeEach(() => {
   getEntry.mockResolvedValue({
     success: true,
     statusCode: 200,
-    data: { id: "7" },
+    // A slug, because the default declaration below is `/{slug}` and minting
+    // now resolves the ENTRY rather than trusting that a declaration exists. An
+    // entry with no slug is genuinely not previewable, which is what the
+    // refusal tests assert by removing it again.
+    data: { id: "7", slug: "seven" },
   });
   canUpdateEntry.mockResolvedValue(true);
   (requireRouteCollectionAccess as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -174,6 +178,58 @@ describe("mintPreviewLink: a collection with nowhere to send a reviewer", () => 
     // A bearer credential must not be issued for a refused request, even one
     // refused for a configuration reason rather than an authorization one.
     expect(body.item).toBeUndefined();
+  });
+
+  // A declaration is necessary and NOT sufficient. `preview.url` returning null
+  // for a document it cannot address yet, or a `urlTemplate` placeholder naming
+  // an empty field, both mean "not previewable yet" — and both used to mint
+  // successfully and 404 at the redirect, which is the failure this refusal
+  // exists to remove, reappearing one level down.
+  it("refuses an entry the declaration cannot address yet", async () => {
+    previewDeclaration.mockResolvedValue({ url: () => null });
+
+    const response = await mintPreviewLink(
+      post({ collection: "pages", entryId: "7" })
+    );
+
+    expect(response.status).toBe(409);
+  });
+
+  it("refuses when a template placeholder has no value on this entry", async () => {
+    previewDeclaration.mockResolvedValue({ urlTemplate: "/{slug}" });
+    getEntry.mockResolvedValue({
+      success: true,
+      statusCode: 200,
+      data: { id: "7" },
+    });
+
+    const response = await mintPreviewLink(
+      post({ collection: "pages", entryId: "7" })
+    );
+
+    expect(response.status).toBe(409);
+  });
+
+  // The two refusals must not read alike: one is a developer's job and the other
+  // is the editor's own, and an editor told to "ask a developer" about their
+  // empty slug field is being sent to the wrong person.
+  it("distinguishes an unaddressable entry from an unconfigured collection", async () => {
+    previewDeclaration.mockResolvedValue({ url: () => null });
+    const entryBody = await json(
+      await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+    );
+
+    previewDeclaration.mockResolvedValue(undefined);
+    const collectionBody = await json(
+      await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+    );
+
+    const message = (b: { error?: unknown }): string =>
+      String((b.error as { message?: string } | undefined)?.message ?? "");
+
+    expect(message(entryBody)).not.toBe(message(collectionBody));
+    expect(message(entryBody)).toMatch(/this entry/i);
+    expect(message(collectionBody)).toMatch(/developer/i);
   });
 
   it("mints normally once the collection declares one", async () => {

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -123,6 +123,15 @@ function item(body: { item?: unknown }): Record<string, unknown> {
   return body.item as Record<string, unknown>;
 }
 
+/** Mint once for the default entry and hand back the envelope's payload. */
+async function mintedData(): Promise<Record<string, unknown>> {
+  return item(
+    await json(
+      await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+    )
+  );
+}
+
 describe("mintPreviewLink: a collection with nowhere to send a reviewer", () => {
   // The button that mints this is shown whether or not a collection declares a
   // preview URL, and that is deliberate — a draft is shareable either way. What
@@ -199,6 +208,36 @@ describe("mintPreviewLink: the link it hands back", () => {
     expect(item(body).url).toMatch(
       /^https:\/\/site\.example\/next\/preview\?token=/
     );
+  });
+
+  // A site URL may legitimately carry a path, a query or a fragment — the
+  // settings schema accepts all three — and concatenating the route onto the end
+  // puts it inside whichever component came last, producing a link that never
+  // reaches the route and carries no token.
+  it("keeps a site url's own query instead of appending the route inside it", async () => {
+    getSettings.mockResolvedValue({
+      siteUrl: "https://site.example/base?tenant=a",
+    });
+
+    const url = new URL(String((await mintedData()).url));
+
+    expect(url.pathname).toBe("/base/api/preview");
+    expect(url.searchParams.get("tenant")).toBe("a");
+    expect(url.searchParams.get("token")).toBeTruthy();
+  });
+
+  it("mounts the route under a site url served from a sub-path", async () => {
+    getSettings.mockResolvedValue({ siteUrl: "https://site.example/site" });
+
+    expect(new URL(String((await mintedData()).url)).pathname).toBe(
+      "/site/api/preview"
+    );
+  });
+
+  it("returns a null url for a site url that cannot be parsed", async () => {
+    getSettings.mockResolvedValue({ siteUrl: "not a url" });
+
+    expect(await mintedData()).toMatchObject({ url: null });
   });
 
   it("does not double the separator when the site url carries a trailing slash", async () => {

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -23,6 +23,8 @@ import type { AuthenticatedScope } from "../auth/authenticated-scope";
 import { signPreviewToken } from "../auth/preview/preview-token";
 import { buildUserContext } from "../auth/user-context";
 import { container } from "../di";
+import type { NextlyServiceConfig } from "../di/register";
+import { resolvePreviewRoute } from "../domains/preview/route-config";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
 import { env } from "../lib/env";
@@ -148,11 +150,31 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
     { generation, ...(ttlSeconds === undefined ? {} : { ttlSeconds }) }
   );
 
-  // The token, not a full URL. Where a preview route is mounted is the app's
-  // decision, and guessing it here would produce a link that 404s on any app
-  // that mounted it elsewhere.
+  // The finished URL as well as the token.
+  //
+  // Both halves are visible from here and from nowhere else. The site URL lives
+  // in settings, which the `editor` and `author` presets cannot read; the mount
+  // lives in the application's config, which the browser cannot see at all. So
+  // the admin had no way to build this correctly and assumed a default, which
+  // is why an application that mounted the route elsewhere handed its reviewers
+  // a link that answered 404.
+  //
+  // `null` when no site URL is set, never a relative URL: a relative one would
+  // be resolved against whatever origin the admin is served from, which is not
+  // the site. The token is still returned, because it is what the link is —
+  // withholding it would break preview outright on a site that never set a
+  // URL, rather than degrading the one thing that needs the host.
+  const settings = await (await settingsService()).getSettings();
+  const url =
+    settings.siteUrl === null
+      ? null
+      : `${settings.siteUrl.replace(/\/+$/, "")}${resolvePreviewRoute(
+          container.get<NextlyServiceConfig>("config")?.preview
+        )}?token=${encodeURIComponent(token)}`;
+
   return respondMutation("Preview link created", {
     token,
+    url,
     expiresAt: expiresAt.toISOString(),
   });
 });

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -22,8 +22,9 @@ import { z } from "zod";
 import type { AuthenticatedScope } from "../auth/authenticated-scope";
 import { signPreviewToken } from "../auth/preview/preview-token";
 import { buildUserContext } from "../auth/user-context";
-import { container } from "../di";
+import { container, getService } from "../di";
 import type { NextlyServiceConfig } from "../di/register";
+import { resolvePreviewRedirect } from "../domains/collections/services/preview-redirect-resolver";
 import { hasPreviewConfigured } from "../domains/collections/services/preview-url-resolver";
 import { resolvePreviewRoute } from "../domains/preview/route-config";
 import { NextlyError } from "../errors/nextly-error";
@@ -197,19 +198,67 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
   // `hasPreview` projection use, so a collection cannot be shareable by one
   // rule and unresolvable by another.
   const declaration = await previewDeclarationFor(collection);
-  if (!hasPreviewConfigured(declaration)) {
+
+  // Asked of THIS ENTRY, not only of the collection.
+  //
+  // A declaration is necessary and not sufficient: `preview.url` may return
+  // `null` for a document it cannot address yet, and a `urlTemplate` placeholder
+  // may name a field that is still empty. Checking only that a declaration
+  // exists lets both mint successfully and 404 at the redirect — which is the
+  // failure this refusal exists to remove, reappearing one level down.
+  //
+  // Resolved through the SAME function the preview route will call, so the
+  // answer here and the answer the reviewer gets cannot disagree. The entry is
+  // already authorized at this point, which is why a trusted read is correct.
+  const target = hasPreviewConfigured(declaration)
+    ? await resolvePreviewRedirect(
+        { collection, entryId, ...(locale === undefined ? {} : { locale }) },
+        {
+          loadEntry: async (name, id, entryLocale) => {
+            const read = await getService("collectionsHandler").getEntry({
+              collectionName: name,
+              entryId: id,
+              depth: 0,
+              overrideAccess: true,
+              status: "all",
+              ...(entryLocale === undefined ? {} : { locale: entryLocale }),
+              includeWorkingDraft: true,
+            });
+            return read.success && read.data !== null
+              ? (read.data as Record<string, unknown>)
+              : null;
+          },
+          // Already resolved above, so this hands back the value rather than
+          // fetching it again — the resolver takes a loader and this call site
+          // happens to have the answer.
+          loadDeclaration: () => Promise.resolve(declaration),
+          loadSiteUrl: async () =>
+            (await settingsService()).getSettings().then(s => s.siteUrl),
+        }
+      )
+    : null;
+
+  if (target === null) {
     throw NextlyError.conflict({
       reason: "state",
-      message:
-        "This collection has no preview URL configured, so a shared link " +
-        "would have nowhere to open. A developer can add one to the " +
-        "collection before links can be shared.",
+      message: hasPreviewConfigured(declaration)
+        ? "This entry has no preview address yet, so a shared link would have " +
+          "nowhere to open. Filling in the fields its preview URL is built " +
+          "from — usually the slug — makes it shareable."
+        : "This collection has no preview URL configured, so a shared link " +
+          "would have nowhere to open. A developer can add one to the " +
+          "collection before links can be shared.",
       logContext: {
-        reason: "preview-link-collection-has-no-preview-url",
-        remedy:
-          "Add `admin.preview.url` (code-first) or `admin.preview.urlTemplate` " +
-          "(UI-created) to this collection. It answers where an entry is served " +
-          "on the site, which nothing outside the application can know.",
+        reason: hasPreviewConfigured(declaration)
+          ? "preview-link-entry-has-no-preview-target"
+          : "preview-link-collection-has-no-preview-url",
+        remedy: hasPreviewConfigured(declaration)
+          ? "The collection's preview declaration returned no address for this " +
+            "entry. A `url` function answering null, or a `urlTemplate` whose " +
+            "placeholder field is empty, both mean 'not previewable yet'."
+          : "Add `admin.preview.url` (code-first) or `admin.preview.urlTemplate` " +
+            "(UI-created) to this collection. It answers where an entry is served " +
+            "on the site, which nothing outside the application can know.",
         collection,
       },
     });

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -24,6 +24,7 @@ import { signPreviewToken } from "../auth/preview/preview-token";
 import { buildUserContext } from "../auth/user-context";
 import { container } from "../di";
 import type { NextlyServiceConfig } from "../di/register";
+import { hasPreviewConfigured } from "../domains/collections/services/preview-url-resolver";
 import { resolvePreviewRoute } from "../domains/preview/route-config";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
@@ -32,6 +33,7 @@ import type { GeneralSettingsService } from "../services/general-settings/genera
 import { resolveRoleSlugs } from "../services/lib/permissions";
 
 import { assertEntryPreviewable } from "./preview-access";
+import { previewDeclarationFor } from "./preview-url";
 import { respondMutation } from "./response-shapes";
 import {
   requireRouteCollectionAccess,
@@ -139,6 +141,39 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
     }),
     actor
   );
+
+  // Refused BEFORE a token is signed, because a link that cannot land is worse
+  // than no link: the reviewer who opens it sees a 404 indistinguishable from
+  // an expired one, and the editor who sent it was told it worked.
+  //
+  // The button that reaches this endpoint is shown whether or not a collection
+  // declares a preview URL, and that stays true — a draft is worth sharing
+  // either way, and hiding the control would leave an editor with a feature
+  // that vanished and no way to learn why. Refusing here puts the explanation
+  // in front of the person who hit the problem instead.
+  //
+  // `hasPreviewConfigured` is asked rather than the two spellings compared
+  // again here: it is the same predicate the resolver and the stored
+  // `hasPreview` projection use, so a collection cannot be shareable by one
+  // rule and unresolvable by another.
+  const declaration = await previewDeclarationFor(collection);
+  if (!hasPreviewConfigured(declaration)) {
+    throw NextlyError.conflict({
+      reason: "state",
+      message:
+        "This collection has no preview URL configured, so a shared link " +
+        "would have nowhere to open. A developer can add one to the " +
+        "collection before links can be shared.",
+      logContext: {
+        reason: "preview-link-collection-has-no-preview-url",
+        remedy:
+          "Add `admin.preview.url` (code-first) or `admin.preview.urlTemplate` " +
+          "(UI-created) to this collection. It answers where an entry is served " +
+          "on the site, which nothing outside the application can know.",
+        collection,
+      },
+    });
+  }
 
   const generation = await (
     await settingsService()

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -88,6 +88,46 @@ function previewSigningSecret(): string {
 }
 
 /**
+ * The link a reviewer opens, built with URL semantics rather than by
+ * concatenating strings.
+ *
+ * A configured site URL may legitimately carry a path, a query or a fragment —
+ * the settings schema accepts all three. Gluing the route onto the end of one
+ * puts the path INSIDE whichever component came last: a site URL of
+ * `https://site.example/base?tenant=a` becomes
+ * `https://site.example/base?tenant=a/api/preview?token=…`, which never reaches
+ * the preview route and arrives carrying no token at all. Asking the URL parser
+ * to place the pathname and the parameter cannot make that mistake, and it
+ * keeps a site URL's own query intact rather than silently discarding it.
+ *
+ * `null` when no site URL is configured. A relative URL would be resolved
+ * against whatever origin the admin is served from, which is not the site's on
+ * any deployment that separates them.
+ */
+function previewLinkUrl({
+  siteUrl,
+  route,
+  token,
+}: {
+  siteUrl: string | null;
+  route: string;
+  token: string;
+}): string | null {
+  if (siteUrl === null) return null;
+  try {
+    const base = new URL(siteUrl);
+    // Joined as PATHS, so a site URL mounted under a sub-path keeps it.
+    base.pathname = `${base.pathname.replace(/\/+$/, "")}${route}`;
+    base.searchParams.set("token", token);
+    return base.toString();
+  } catch {
+    // An unparseable site URL is a configuration fault the editor cannot act
+    // on, and answering with a broken link would be worse than answering none.
+    return null;
+  }
+}
+
+/**
  * POST /api/nextly/preview-links
  *
  * Mints a link scoped to one entry. Auth: `update` on that collection.
@@ -200,12 +240,13 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
   // withholding it would break preview outright on a site that never set a
   // URL, rather than degrading the one thing that needs the host.
   const settings = await (await settingsService()).getSettings();
-  const url =
-    settings.siteUrl === null
-      ? null
-      : `${settings.siteUrl.replace(/\/+$/, "")}${resolvePreviewRoute(
-          container.get<NextlyServiceConfig>("config")?.preview
-        )}?token=${encodeURIComponent(token)}`;
+  const url = previewLinkUrl({
+    siteUrl: settings.siteUrl,
+    route: resolvePreviewRoute(
+      container.get<NextlyServiceConfig>("config")?.preview
+    ),
+    token,
+  });
 
   return respondMutation("Preview link created", {
     token,

--- a/packages/nextly/src/api/preview-url.ts
+++ b/packages/nextly/src/api/preview-url.ts
@@ -79,7 +79,7 @@ async function settingsService(): Promise<GeneralSettingsService> {
  * find it empty, and the resolver would correctly report `notConfigured` for a
  * collection whose preview works.
  */
-async function previewDeclarationFor(
+export async function previewDeclarationFor(
   collection: string
 ): Promise<PreviewDeclaration | undefined> {
   await getCachedNextly();

--- a/packages/nextly/src/auth/preview/preview-token.ts
+++ b/packages/nextly/src/auth/preview/preview-token.ts
@@ -154,7 +154,7 @@ function readString(value: unknown): string | null {
 export async function verifyPreviewToken(
   token: string,
   secret: string,
-  options: { generation: number }
+  options: { generation: number | (() => number | Promise<number>) }
 ): Promise<PreviewVerifyResult> {
   let payload: Record<string, unknown>;
   try {
@@ -179,7 +179,18 @@ export async function verifyPreviewToken(
 
   // Checked AFTER the shape, so a malformed token is never reported as merely
   // revoked — the two need different answers from a caller.
-  if (payload.gen !== options.generation) {
+  // Resolved HERE rather than by the caller, and that placement is the point.
+  // Reading the revocation counter means a database query, and every check
+  // above this line needs only the secret — so resolving it up front would let
+  // any unauthenticated request carrying arbitrary bytes force a settings read,
+  // on this endpoint and on every content request that consults a preview
+  // cookie. Nothing reaches this line without a valid signature.
+  const generation =
+    typeof options.generation === "function"
+      ? await options.generation()
+      : options.generation;
+
+  if (payload.gen !== generation) {
     return { valid: false, reason: "revoked" };
   }
 

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -164,3 +164,10 @@ export {
   type PluginCategory,
 } from "./plugins/plugin-categories";
 export { pluginAdminSlug } from "./plugins/plugin-slug";
+
+// A code-first `preview.url` built from a `{field}` path. Exported because a
+// package that ships a collection in code — the page builder's `pages`, say —
+// can only express its preview as a function, while the path is what its host
+// naturally configures. Sharing the one substitution rule keeps a template and
+// a function from drifting into two different addresses for the same entry.
+export { previewUrlFromTemplate } from "./domains/collections/services/preview-url-resolver";

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -60,6 +60,7 @@ import {
 } from "../domains/field-groups/storage/resolve-storage-names";
 import type { SanitizedLocalizationConfig } from "../domains/i18n/config/types";
 import type { MetaService } from "../domains/meta";
+import type { PreviewConfig } from "../domains/preview/route-config";
 import { publishRetentionPolicies } from "../domains/retention/published-policies";
 import {
   clearFieldTypes,
@@ -237,6 +238,15 @@ export interface NextlyServiceConfig {
 
   /** Optional base path for collection file operations. */
   basePath?: string;
+
+  /**
+   * Draft-preview wiring.
+   *
+   * Carried here so the minting endpoint can read where this application
+   * mounted its preview route, which is the half of a shareable link the admin
+   * cannot see from the browser.
+   */
+  preview?: PreviewConfig;
 
   /** Optional directory for dynamic collection schemas. */
   schemasDir?: string;

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
@@ -76,10 +76,39 @@ describe("resolvePreviewRedirect", () => {
     expect(await resolvePreviewRedirect(SCOPE, d)).toBeNull();
   });
 
-  // Distinct from every case above, because a guess IS available here and is
-  // wrong: without a site URL the only origin in reach is the admin's own.
-  it("returns null when no site URL is configured", async () => {
+  // No site URL is the DEFAULT state of a fresh install, and it must not break
+  // preview. The admin needs an absolute URL because it may be served from
+  // another origin entirely; this route is already ON the site, so a relative
+  // path is all it ever needed. Refusing here would mean preview never works
+  // until someone happens to fill in a settings field it does not depend on.
+  it("still resolves a path when no site URL is configured", async () => {
     const d = deps({ loadSiteUrl: vi.fn().mockResolvedValue(null) });
+
+    expect(await resolvePreviewRedirect(SCOPE, d)).toBe("/about");
+  });
+
+  // With no site URL there is no origin to compare against, so the site-relative
+  // shape has to be checked directly. A protocol-relative `//host` is a URL to
+  // another origin wearing a path's clothes, and it reaches this branch because
+  // it does not parse as absolute either.
+  it("refuses a protocol-relative path when no site URL is configured", async () => {
+    const d = deps({
+      loadSiteUrl: vi.fn().mockResolvedValue(null),
+      loadDeclaration: vi
+        .fn()
+        .mockResolvedValue({ url: () => "//elsewhere.example/x" }),
+    });
+
+    expect(await resolvePreviewRedirect(SCOPE, d)).toBeNull();
+  });
+
+  it("refuses a backslash-prefixed path when no site URL is configured", async () => {
+    const d = deps({
+      loadSiteUrl: vi.fn().mockResolvedValue(null),
+      loadDeclaration: vi
+        .fn()
+        .mockResolvedValue({ url: () => String.raw`/\elsewhere.example` }),
+    });
 
     expect(await resolvePreviewRedirect(SCOPE, d)).toBeNull();
   });

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
@@ -27,6 +27,32 @@ function deps(
 }
 
 describe("resolvePreviewRedirect", () => {
+  // A localized entry keeps its slug in a companion row per language. Reading
+  // without the token's locale resolves the DEFAULT language's slug, so the
+  // link redirects to a different translation — and the draft gate, which does
+  // carry the locale, then refuses the very draft the link was minted for.
+  it("reads the entry in the locale the token names", async () => {
+    const loadEntry = vi
+      .fn()
+      .mockResolvedValue({ id: "entry-1", slug: "a-propos" });
+    const d = deps({ loadEntry });
+
+    await resolvePreviewRedirect({ ...SCOPE, locale: "fr" }, d);
+
+    expect(loadEntry).toHaveBeenCalledWith("pages", "entry-1", "fr");
+  });
+
+  it("passes no locale when the token names none", async () => {
+    const loadEntry = vi
+      .fn()
+      .mockResolvedValue({ id: "entry-1", slug: "about" });
+    const d = deps({ loadEntry });
+
+    await resolvePreviewRedirect(SCOPE, d);
+
+    expect(loadEntry).toHaveBeenCalledWith("pages", "entry-1", undefined);
+  });
+
   it("reduces a resolved URL on the site's own origin to a site-relative path", async () => {
     expect(await resolvePreviewRedirect(SCOPE, deps())).toBe("/about");
   });
@@ -85,6 +111,51 @@ describe("resolvePreviewRedirect", () => {
     const d = deps({ loadSiteUrl: vi.fn().mockResolvedValue(null) });
 
     expect(await resolvePreviewRedirect(SCOPE, d)).toBe("/about");
+  });
+
+  // A collection may return an ABSOLUTE url, which `resolvePreviewUrl` passes
+  // through as `resolved` whether or not a site URL is set. On a fresh install
+  // there is then nothing configured to compare it against — but the request
+  // being served came from the site's own origin, which is the honest
+  // comparison and the one the route supplies.
+  it("accepts an absolute url on the requesting origin when no site url is set", async () => {
+    const d = deps({
+      loadSiteUrl: vi.fn().mockResolvedValue(null),
+      loadDeclaration: vi
+        .fn()
+        .mockResolvedValue({ url: () => "https://site.example/about" }),
+    });
+
+    expect(await resolvePreviewRedirect(SCOPE, d, "https://site.example")).toBe(
+      "/about"
+    );
+  });
+
+  it("still refuses an absolute url on another origin", async () => {
+    const d = deps({
+      loadSiteUrl: vi.fn().mockResolvedValue(null),
+      loadDeclaration: vi
+        .fn()
+        .mockResolvedValue({ url: () => "https://elsewhere.example/x" }),
+    });
+
+    expect(
+      await resolvePreviewRedirect(SCOPE, d, "https://site.example")
+    ).toBeNull();
+  });
+
+  // The configured site URL wins where both exist: an admin may be proxied, and
+  // the site's declared address is the deliberate answer.
+  it("prefers the configured site url over the requesting origin", async () => {
+    const d = deps({
+      loadDeclaration: vi
+        .fn()
+        .mockResolvedValue({ url: () => "https://site.example/about" }),
+    });
+
+    expect(
+      await resolvePreviewRedirect(SCOPE, d, "https://proxy.example")
+    ).toBe("/about");
   });
 
   // With no site URL there is no origin to compare against, so the site-relative

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Where a preview token sends the visitor.
+ *
+ * The cases that matter here are the refusals. A resolver that answers a path
+ * whenever it can produce one hands the preview route a redirect target for an
+ * entry that was deleted, for a collection that declares no preview, and — the
+ * one with teeth — for a host that is not the site's.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  resolvePreviewRedirect,
+  type PreviewRedirectDeps,
+} from "../preview-redirect-resolver";
+
+const SCOPE = { collection: "pages", entryId: "entry-1" };
+
+function deps(
+  overrides: Partial<PreviewRedirectDeps> = {}
+): PreviewRedirectDeps {
+  return {
+    loadEntry: vi.fn().mockResolvedValue({ id: "entry-1", slug: "about" }),
+    loadDeclaration: vi.fn().mockResolvedValue({ urlTemplate: "/{slug}" }),
+    loadSiteUrl: vi.fn().mockResolvedValue("https://site.example"),
+    ...overrides,
+  };
+}
+
+describe("resolvePreviewRedirect", () => {
+  it("reduces a resolved URL on the site's own origin to a site-relative path", async () => {
+    expect(await resolvePreviewRedirect(SCOPE, deps())).toBe("/about");
+  });
+
+  it("keeps the query and hash of a resolved URL", async () => {
+    const d = deps({
+      loadDeclaration: vi
+        .fn()
+        .mockResolvedValue({ urlTemplate: "/{slug}?a=1#top" }),
+    });
+
+    expect(await resolvePreviewRedirect(SCOPE, d)).toBe("/about?a=1#top");
+  });
+
+  // The security case. A collection's `preview.url` is application code that may
+  // return any host at all, so removing the origin rather than comparing it
+  // turns another site's URL into a path the route's own site-relative guard
+  // then approves — the guard runs, passes, and was handed a value that had
+  // already lost the evidence it exists to judge.
+  it("refuses a resolved URL whose origin is not the configured site's", async () => {
+    const d = deps({
+      loadDeclaration: vi
+        .fn()
+        .mockResolvedValue({ url: () => "https://elsewhere.example/x" }),
+    });
+
+    expect(await resolvePreviewRedirect(SCOPE, d)).toBeNull();
+  });
+
+  // A link outlives what it points at: the entry can be deleted between minting
+  // and clicking, which is a refusal rather than a fault.
+  it("returns null when the entry no longer exists", async () => {
+    const d = deps({ loadEntry: vi.fn().mockResolvedValue(null) });
+
+    expect(await resolvePreviewRedirect(SCOPE, d)).toBeNull();
+  });
+
+  it("returns null when the collection declares no preview", async () => {
+    const d = deps({ loadDeclaration: vi.fn().mockResolvedValue(undefined) });
+
+    expect(await resolvePreviewRedirect(SCOPE, d)).toBeNull();
+  });
+
+  it("returns null when a template placeholder has no value yet", async () => {
+    const d = deps({ loadEntry: vi.fn().mockResolvedValue({ id: "entry-1" }) });
+
+    expect(await resolvePreviewRedirect(SCOPE, d)).toBeNull();
+  });
+
+  // Distinct from every case above, because a guess IS available here and is
+  // wrong: without a site URL the only origin in reach is the admin's own.
+  it("returns null when no site URL is configured", async () => {
+    const d = deps({ loadSiteUrl: vi.fn().mockResolvedValue(null) });
+
+    expect(await resolvePreviewRedirect(SCOPE, d)).toBeNull();
+  });
+});

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-url-resolver.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-url-resolver.test.ts
@@ -307,3 +307,56 @@ describe("resolvePreviewUrl", () => {
     expect(seen).toEqual([entry]);
   });
 });
+
+describe("a site URL that carries its own query or fragment", () => {
+  // A tenant selector is the usual reason, and the settings schema accepts one.
+  // Dropping it would send the visitor to the same path on a different tenant —
+  // and would disagree with the minted link, which keeps it, so the reviewer's
+  // first request would arrive scoped correctly and the redirect would strip it.
+  it("carries the site URL's query onto the resolved path", () => {
+    const resolution = resolvePreviewUrl({
+      preview: { urlTemplate: "/{slug}" },
+      entry: { slug: "about" },
+      siteUrl: "https://site.example/base?tenant=a",
+    });
+
+    expect(resolution).toEqual({
+      status: "resolved",
+      url: "https://site.example/base/about?tenant=a",
+    });
+  });
+
+  it("carries the site URL's fragment when the path declares none", () => {
+    const resolution = resolvePreviewUrl({
+      preview: { urlTemplate: "/{slug}" },
+      entry: { slug: "about" },
+      siteUrl: "https://site.example#top",
+    });
+
+    expect(resolution).toMatchObject({ url: "https://site.example/about#top" });
+  });
+
+  // The authored path describes ONE document; the site URL describes the
+  // deployment. The narrower statement wins.
+  it("lets the authored path's own query win a conflict", () => {
+    const resolution = resolvePreviewUrl({
+      preview: { urlTemplate: "/{slug}?tenant=b" },
+      entry: { slug: "about" },
+      siteUrl: "https://site.example?tenant=a",
+    });
+
+    expect(resolution).toMatchObject({
+      url: "https://site.example/about?tenant=b",
+    });
+  });
+
+  it("still resolves a site URL with no query at all", () => {
+    const resolution = resolvePreviewUrl({
+      preview: { urlTemplate: "/{slug}" },
+      entry: { slug: "about" },
+      siteUrl: "https://site.example",
+    });
+
+    expect(resolution).toMatchObject({ url: "https://site.example/about" });
+  });
+});

--- a/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
@@ -40,7 +40,8 @@ export interface PreviewRedirectDeps {
    */
   loadEntry: (
     collection: string,
-    entryId: string
+    entryId: string,
+    locale: string | undefined
   ) => Promise<Record<string, unknown> | null>;
   /** The collection's preview declaration, from whichever authoring path wrote it. */
   loadDeclaration: (
@@ -68,10 +69,16 @@ export interface PreviewRedirectScope {
  */
 export async function resolvePreviewRedirect(
   scope: PreviewRedirectScope,
-  deps: PreviewRedirectDeps
+  deps: PreviewRedirectDeps,
+  requestOrigin?: string
 ): Promise<string | null> {
   const [entry, preview, siteUrl] = await Promise.all([
-    deps.loadEntry(scope.collection, scope.entryId),
+    // The locale the token names, not the site's default. A localized entry's
+    // slug lives in its companion row, so reading without one resolves the
+    // DEFAULT language's slug and builds a path to a different translation —
+    // while the draft gate goes on comparing the token's locale, so the
+    // destination refuses the very draft the link was minted for.
+    deps.loadEntry(scope.collection, scope.entryId, scope.locale),
     deps.loadDeclaration(scope.collection),
     deps.loadSiteUrl(),
   ]);
@@ -109,10 +116,16 @@ export async function resolvePreviewRedirect(
   //
   // With no site URL configured there is no origin to compare against at all,
   // which is why the branch above checks the path's SHAPE instead.
-  if (siteUrl === null) return null;
+  // With no site URL configured, the origin serving this request is the only
+  // honest thing to compare an absolute declaration against — and it is the
+  // right one, because this resolver answers a route running ON the site.
+  // Rejecting outright would mean a fresh installation whose collection returns
+  // an absolute same-origin URL still gets a 404.
+  const comparisonOrigin = siteUrl ?? requestOrigin;
+  if (comparisonOrigin === undefined) return null;
   try {
     const target = new URL(resolution.url);
-    const site = new URL(siteUrl);
+    const site = new URL(comparisonOrigin);
     if (target.origin !== site.origin) return null;
     return `${target.pathname}${target.search}${target.hash}`;
   } catch {

--- a/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
@@ -1,0 +1,105 @@
+/**
+ * Where a preview token sends the visitor.
+ *
+ * The preview route is handed a token scope — a collection, an entry id and
+ * maybe a locale — and needs a site-relative path to forward to. Everything
+ * required to answer that already exists: `resolvePreviewUrl` knows how both
+ * authoring paths declare a preview, and the general settings hold the site
+ * URL. What did not exist was anything joining them FROM AN ID, because the
+ * admin's own preview button resolves from form data instead — it previews what
+ * is on screen, including edits not yet saved, while a token names a stored
+ * document and carries no values at all.
+ *
+ * Dependencies arrive as functions rather than being resolved here, so this
+ * file is exercisable without a database — the same arrangement
+ * `createPreviewRoute` uses for `draftMode`.
+ *
+ * @module domains/collections/services/preview-redirect-resolver
+ */
+
+import {
+  resolvePreviewUrl,
+  type PreviewDeclaration,
+} from "./preview-url-resolver";
+
+/** What this resolver needs from the outside world. */
+export interface PreviewRedirectDeps {
+  /**
+   * The entry the token names, or `null` if it is gone.
+   *
+   * Read TRUSTED and with the lifecycle widened, because the caller is
+   * anonymous: someone following a preview link has no session of their own.
+   * The authorization happened when the link was minted, against the gate that
+   * serves real reads, and the signed token is what carries that verdict
+   * forward. Asking again here — against an anonymous caller — would deny every
+   * preview, which is the whole capability.
+   *
+   * What this read produces is a PATH and never content. The content read is a
+   * separate decision, made on the destination page by the draft gate, against
+   * the row that page actually resolves.
+   */
+  loadEntry: (
+    collection: string,
+    entryId: string
+  ) => Promise<Record<string, unknown> | null>;
+  /** The collection's preview declaration, from whichever authoring path wrote it. */
+  loadDeclaration: (
+    collection: string
+  ) => Promise<PreviewDeclaration | undefined>;
+  /** The configured site URL, or `null` when none is set. */
+  loadSiteUrl: () => Promise<string | null>;
+}
+
+/** A token scope reduced to what a redirect needs. */
+export interface PreviewRedirectScope {
+  collection: string;
+  entryId: string;
+  locale?: string;
+}
+
+/**
+ * The site-relative path a preview token should land on, or `null` to refuse.
+ *
+ * `null` is not an error channel. The preview route answers it with exactly the
+ * 404 an invalid token gets, which is what keeps the endpoint from becoming an
+ * oracle for which entries exist in draft: a stranger must not be able to tell
+ * a deleted entry from one that was never previewable from one whose token was
+ * forged.
+ */
+export async function resolvePreviewRedirect(
+  scope: PreviewRedirectScope,
+  deps: PreviewRedirectDeps
+): Promise<string | null> {
+  const [entry, preview, siteUrl] = await Promise.all([
+    deps.loadEntry(scope.collection, scope.entryId),
+    deps.loadDeclaration(scope.collection),
+    deps.loadSiteUrl(),
+  ]);
+
+  // A link outlives what it points at: an entry can be deleted between minting
+  // and clicking, and that is a refusal rather than a fault.
+  if (entry === null) return null;
+  if (siteUrl === null) return null;
+
+  const resolution = resolvePreviewUrl({ preview, entry, siteUrl });
+  if (resolution.status !== "resolved") return null;
+
+  // The origin is COMPARED against the site's, never stripped from the URL.
+  //
+  // A collection's `preview.url` is application code, free to return any host.
+  // Removing the origin would reduce another site's URL to a bare path, and a
+  // bare path is precisely what the route's site-relative guard is built to
+  // approve — so the guard would run, pass, and have been handed a value that
+  // already destroyed the evidence it exists to judge. Comparing first means
+  // the only URL that survives is one already on the site's own origin.
+  try {
+    const target = new URL(resolution.url);
+    const site = new URL(siteUrl);
+    if (target.origin !== site.origin) return null;
+    return `${target.pathname}${target.search}${target.hash}`;
+  } catch {
+    // An unparseable site URL or target. Both are configuration a visitor
+    // cannot act on, and both refuse the same way everything else here does.
+    return null;
+  }
+}

--- a/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
@@ -79,9 +79,23 @@ export async function resolvePreviewRedirect(
   // A link outlives what it points at: an entry can be deleted between minting
   // and clicking, and that is a refusal rather than a fault.
   if (entry === null) return null;
-  if (siteUrl === null) return null;
 
   const resolution = resolvePreviewUrl({ preview, entry, siteUrl });
+
+  // `noSiteUrl` is ACCEPTED here, and it is the case that matters most: having
+  // no site URL is the default state of a fresh install.
+  //
+  // That state hides the admin's preview BUTTON for a good reason — the admin
+  // may be served from another origin, so it has no host to put in front of a
+  // path and the only one within reach is its own, which is confidently wrong.
+  // This resolver is not in that position. It answers a route already running
+  // ON the site, and returns a site-relative path the browser resolves against
+  // the origin it is standing on. Refusing here would make preview depend on a
+  // settings field it never reads.
+  if (resolution.status === "noSiteUrl") {
+    return siteRelativePath(resolution.path);
+  }
+
   if (resolution.status !== "resolved") return null;
 
   // The origin is COMPARED against the site's, never stripped from the URL.
@@ -92,6 +106,10 @@ export async function resolvePreviewRedirect(
   // approve — so the guard would run, pass, and have been handed a value that
   // already destroyed the evidence it exists to judge. Comparing first means
   // the only URL that survives is one already on the site's own origin.
+  //
+  // With no site URL configured there is no origin to compare against at all,
+  // which is why the branch above checks the path's SHAPE instead.
+  if (siteUrl === null) return null;
   try {
     const target = new URL(resolution.url);
     const site = new URL(siteUrl);
@@ -100,6 +118,33 @@ export async function resolvePreviewRedirect(
   } catch {
     // An unparseable site URL or target. Both are configuration a visitor
     // cannot act on, and both refuse the same way everything else here does.
+    return null;
+  }
+}
+
+/**
+ * A path that cannot leave this origin, or `null`.
+ *
+ * Used only where no site URL exists to compare an origin against. A leading
+ * slash is not sufficient on its own: `//host` and `/\host` both reach another
+ * origin, because a special scheme normalises a backslash to a slash. Both
+ * arrive here rather than being caught earlier, since neither parses as an
+ * absolute URL either.
+ *
+ * The parser is asked rather than the list of spellings restated, so this
+ * cannot fall behind what a browser accepts. The base is a sentinel that
+ * appears in no output: anything still pointing at it after resolution stayed
+ * on the current origin, and anything that moved away named a host.
+ */
+const RESOLUTION_BASE = "https://preview.invalid";
+
+function siteRelativePath(path: string): string | null {
+  if (!path.startsWith("/")) return null;
+  try {
+    const resolved = new URL(path, RESOLUTION_BASE);
+    if (resolved.origin !== RESOLUTION_BASE) return null;
+    return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+  } catch {
     return null;
   }
 }

--- a/packages/nextly/src/domains/collections/services/preview-url-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-url-resolver.ts
@@ -179,6 +179,27 @@ function interpolate(
 }
 
 /**
+ * A code-first `preview.url` function built from a `{field}` template.
+ *
+ * The two authoring paths are disjoint by construction — a code-first
+ * collection declares a function, a UI-created one declares a template string —
+ * so a package that ships a collection in code and wants to express its preview
+ * as a PATH has no way to say so. This bridges them, and it is built on the
+ * same `interpolate` the template path uses rather than beside it: two
+ * substitution rules that agree today would drift, and the drift is silent
+ * because a wrong preview URL still looks like a URL.
+ *
+ * Returns `null` for an entry whose placeholders are not all filled, which the
+ * resolver reports as `unavailable` — an entry with no slug yet is not
+ * previewable, and will be once it has one.
+ */
+export function previewUrlFromTemplate(
+  template: string
+): (entry: Record<string, unknown>) => string | null {
+  return entry => interpolate(template, entry);
+}
+
+/**
  * Resolve the preview URL for one entry.
  *
  * `siteUrl` is where the reader's site is served, which is what turns the

--- a/packages/nextly/src/domains/collections/services/preview-url-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-url-resolver.ts
@@ -252,7 +252,39 @@ export function resolvePreviewUrl({
   // Join without doubling or dropping the separator: the configured site may or
   // may not carry a trailing slash, and an authored path may or may not lead
   // with one.
-  const origin = `${base.origin}${base.pathname}`.replace(/\/+$/, "");
+  const basePath = `${base.origin}${base.pathname}`.replace(/\/+$/, "");
   const suffix = path.startsWith("/") ? path : `/${path}`;
-  return { status: "resolved", url: `${origin}${suffix}` };
+
+  const joined = joinUnderSite(`${basePath}${suffix}`, base);
+  // The pieces parsed separately and not together, which is a declaration this
+  // resolver cannot turn into an address.
+  if (joined === null) return { status: "unavailable" };
+  return { status: "resolved", url: joined };
+}
+
+/**
+ * An authored path placed under the configured site, keeping what the site URL
+ * itself declared.
+ *
+ * The site's own query and fragment are CARRIED rather than discarded. A site
+ * URL may legitimately hold one — a tenant selector is the usual reason — and
+ * the settings schema accepts it, so dropping it would send a visitor to the
+ * same path on a different tenant. It would also disagree with the minted link,
+ * which keeps it: the reviewer's first request would arrive scoped correctly and
+ * the redirect would then strip the scope.
+ *
+ * The authored path wins a conflict. It describes one document while the site
+ * URL describes the deployment, so the narrower statement is the one to honour.
+ */
+function joinUnderSite(candidate: string, base: URL): string | null {
+  try {
+    const joined = new URL(candidate);
+    for (const [key, value] of base.searchParams) {
+      if (!joined.searchParams.has(key)) joined.searchParams.append(key, value);
+    }
+    if (joined.hash === "" && base.hash !== "") joined.hash = base.hash;
+    return joined.toString();
+  } catch {
+    return null;
+  }
 }

--- a/packages/nextly/src/domains/preview/__tests__/route-config.test.ts
+++ b/packages/nextly/src/domains/preview/__tests__/route-config.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Where this application mounts the preview route.
+ *
+ * The value is declared rather than guessed because the mount is a file inside
+ * the application, invisible from the admin that has to link to it. What these
+ * cover is the refusals: a bad value here produces a link that answers 404 for
+ * a reviewer with nothing to explain it, so it has to fail at boot instead.
+ */
+import { describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../../errors/nextly-error";
+import { resolvePreviewRoute } from "../route-config";
+
+describe("resolvePreviewRoute", () => {
+  it("defaults to /api/preview", () => {
+    expect(resolvePreviewRoute(undefined)).toBe("/api/preview");
+    expect(resolvePreviewRoute({})).toBe("/api/preview");
+  });
+
+  it("accepts a site-relative override", () => {
+    expect(resolvePreviewRoute({ route: "/preview" })).toBe("/preview");
+  });
+
+  it("accepts a nested path", () => {
+    expect(resolvePreviewRoute({ route: "/next/preview" })).toBe(
+      "/next/preview"
+    );
+  });
+
+  it("strips a trailing slash so the query separator is never doubled", () => {
+    expect(resolvePreviewRoute({ route: "/preview/" })).toBe("/preview");
+  });
+
+  // A protocol-relative `//host` is a URL to another origin wearing a path's
+  // clothes, which is why matching a leading slash is not enough on its own.
+  it.each([
+    ["a bare path", "preview"],
+    ["an absolute URL", "https://elsewhere.example/preview"],
+    ["a protocol-relative URL", "//elsewhere.example"],
+    ["a backslash-prefixed path", String.raw`/\elsewhere.example`],
+    ["an empty string", ""],
+  ])("refuses %s", (_label, bad) => {
+    expect(() => resolvePreviewRoute({ route: bad })).toThrow(NextlyError);
+    expect(() => resolvePreviewRoute({ route: bad })).toThrow(/site-relative/i);
+  });
+});

--- a/packages/nextly/src/domains/preview/route-config.ts
+++ b/packages/nextly/src/domains/preview/route-config.ts
@@ -1,0 +1,81 @@
+/**
+ * Where this application mounts the preview route.
+ *
+ * The mount is a route file inside the application, so nothing outside it can
+ * see where that file is. The admin previously assumed the default and printed
+ * a URL built from it, which meant an application that mounted the route
+ * anywhere else handed its reviewers a link that answered 404 with nothing to
+ * explain it. Declaring the path here lets the server — which can see both this
+ * and the configured site URL — assemble the link once, and lets a wrong value
+ * fail at boot rather than at share time.
+ *
+ * @module domains/preview/route-config
+ */
+
+import { NextlyError } from "../../errors/nextly-error";
+
+/** Draft-preview wiring. */
+export interface PreviewConfig {
+  /**
+   * Where this application mounts `createPreviewRoute`.
+   *
+   * Site-relative, and validated as such. Defaults to `/api/preview`, which is
+   * where the scaffold puts the route file.
+   *
+   * @default "/api/preview"
+   */
+  route?: string;
+}
+
+/** Where the scaffold mounts the preview route. */
+export const DEFAULT_PREVIEW_ROUTE = "/api/preview";
+
+/**
+ * The configured mount, normalised, or a throw naming the remedy.
+ *
+ * The parser decides whether a value can leave this origin, rather than a list
+ * of spellings kept by hand: `//host`, `/\host` and `/\\host` all reach another
+ * origin, because a special scheme normalises a backslash to a slash. Asking
+ * the parser the browser will use is the only check that cannot fall behind
+ * that list.
+ *
+ * The base is a sentinel that appears in no output. Anything still pointing at
+ * it after resolution stayed on the current origin; anything that moved away
+ * named a host.
+ */
+const RESOLUTION_BASE = "https://preview.invalid";
+
+export function resolvePreviewRoute(config: PreviewConfig | undefined): string {
+  const route = config?.route ?? DEFAULT_PREVIEW_ROUTE;
+
+  if (!route.startsWith("/") || !isSameOrigin(route)) {
+    // `invalidInput` rather than `validation`: this is one malformed
+    // configuration value at boot, not a set of field errors from a request,
+    // and the message is what an operator reads to fix their config.
+    throw NextlyError.invalidInput({
+      message: `preview.route must be site-relative and start with a single "/" — got "${route}".`,
+      logContext: {
+        reason: "preview-route-not-site-relative",
+        remedy:
+          "It names a path inside this application, not a URL on another " +
+          'host. A protocol-relative "//host" is a URL to another origin ' +
+          "wearing a path's clothes, which is why a leading slash alone is " +
+          "not the test.",
+        route,
+      },
+    });
+  }
+
+  // Trailing slashes are common in a hand-written config and would otherwise
+  // produce `/preview/?token=...`, which is a different path on a site that
+  // distinguishes them.
+  return route.replace(/\/+$/, "") || "/";
+}
+
+function isSameOrigin(route: string): boolean {
+  try {
+    return new URL(route, RESOLUTION_BASE).origin === RESOLUTION_BASE;
+  } catch {
+    return false;
+  }
+}

--- a/packages/nextly/src/init/build-service-config.ts
+++ b/packages/nextly/src/init/build-service-config.ts
@@ -79,6 +79,15 @@ export function buildServiceConfig(
     serviceConfig.runMigrationsOnBoot =
       nextlyConfig?.db?.runMigrationsOnBoot === true;
 
+    // Forwarded from the nested config for the same reason as the fields below:
+    // the nested object is destructured away here, so anything not named again
+    // never reaches the container. The minting endpoint reads this to learn
+    // where the preview route is mounted, and an absent value means every
+    // non-default mount silently hands out links to `/api/preview`.
+    if (serviceConfig.preview === undefined && nextlyConfig?.preview) {
+      serviceConfig.preview = nextlyConfig.preview;
+    }
+
     // If storagePlugins not explicitly provided, use from nextly.config.ts
     if (!serviceConfig.storagePlugins && nextlyConfig?.storage) {
       serviceConfig.storagePlugins = nextlyConfig.storage;

--- a/packages/nextly/src/runtime/preview/__tests__/preview-draft-gate.defaults.test.ts
+++ b/packages/nextly/src/runtime/preview/__tests__/preview-draft-gate.defaults.test.ts
@@ -1,0 +1,137 @@
+/**
+ * `previewDraftGate()` with nothing passed to it.
+ *
+ * The gate is short and security-critical, and it was previously unwritable
+ * without three values an application has no reason to hold. The cases that
+ * matter are the refusals: an unwired gate is the difference between a preview
+ * link that works and one that answers 404 on a page that looks entirely
+ * correct, and a gate that grants too much turns one link into a key to every
+ * draft in the collection.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { signPreviewToken } from "../../../auth/preview/preview-token";
+import { previewDraftGate } from "../preview-draft-gate";
+
+const TEST_SECRET = "preview-gate-test-secret-at-least-32-chars!!";
+
+let cookieValue: string | undefined;
+// A binding rather than a captured literal: the revocation case moves it
+// mid-suite, which is the whole point of reading it per request.
+let generation = 1;
+
+vi.mock("../preview-route-defaults", () => ({
+  defaultSecret: () => TEST_SECRET,
+  defaultGeneration: () => Promise.resolve(generation),
+  defaultCookies: () =>
+    Promise.resolve({
+      get: (name: string) =>
+        name === "__nextly_preview" && cookieValue !== undefined
+          ? { value: cookieValue }
+          : undefined,
+    }),
+}));
+
+async function cookieFor(
+  scope: { collection: string; entryId: string; locale?: string },
+  options: { generation?: number; ttlSeconds?: number } = {}
+): Promise<void> {
+  const { token } = await signPreviewToken(scope, TEST_SECRET, {
+    generation: options.generation ?? 1,
+    ...(options.ttlSeconds === undefined
+      ? {}
+      : { ttlSeconds: options.ttlSeconds }),
+  });
+  cookieValue = encodeURIComponent(token);
+}
+
+describe("previewDraftGate with no arguments", () => {
+  beforeEach(() => {
+    cookieValue = undefined;
+    generation = 1;
+  });
+
+  it("grants the entry its token names", async () => {
+    await cookieFor({ collection: "pages", entryId: "entry-1" });
+
+    const gate = previewDraftGate();
+
+    await expect(gate({ collection: "pages", slug: "about" })).resolves.toEqual(
+      {
+        entryId: "entry-1",
+      }
+    );
+  });
+
+  it("refuses a request with no preview cookie", async () => {
+    const gate = previewDraftGate();
+
+    await expect(gate({ collection: "pages", slug: "about" })).resolves.toBe(
+      false
+    );
+  });
+
+  it("refuses a token minted for a different collection", async () => {
+    await cookieFor({ collection: "posts", entryId: "entry-1" });
+
+    const gate = previewDraftGate();
+
+    await expect(gate({ collection: "pages", slug: "about" })).resolves.toBe(
+      false
+    );
+  });
+
+  // The promise the gate exists to keep: one link is a key to ONE document,
+  // never to every draft in its collection. The gate cannot settle that alone —
+  // it hands back the token's own entry id and the route compares it against
+  // the row actually resolved — so what is asserted here is that the id coming
+  // back is the TOKEN's, never the requested path's.
+  it("grants the entry its token names, not whatever the path resolves to", async () => {
+    await cookieFor({ collection: "pages", entryId: "entry-A" });
+
+    const gate = previewDraftGate();
+
+    await expect(
+      gate({ collection: "pages", slug: "some-other-page" })
+    ).resolves.toEqual({ entryId: "entry-A" });
+  });
+
+  it("refuses an expired token", async () => {
+    await cookieFor(
+      { collection: "pages", entryId: "entry-1" },
+      { ttlSeconds: 1 }
+    );
+
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(5000);
+    const gate = previewDraftGate();
+    const verdict = await gate({ collection: "pages", slug: "about" });
+    vi.useRealTimers();
+
+    expect(verdict).toBe(false);
+  });
+
+  // Revocation has to reach sessions ALREADY in flight, not merely refuse new
+  // links, which is why the generation is re-read per request rather than
+  // captured when the gate was built.
+  it("refuses a token minted under a superseded generation", async () => {
+    await cookieFor({ collection: "pages", entryId: "entry-1" });
+
+    generation = 2;
+    const gate = previewDraftGate();
+
+    await expect(gate({ collection: "pages", slug: "about" })).resolves.toBe(
+      false
+    );
+  });
+
+  it("refuses a token whose locale is not the one the route is reading", async () => {
+    await cookieFor({ collection: "pages", entryId: "entry-1", locale: "en" });
+
+    const gate = previewDraftGate();
+
+    await expect(
+      gate({ collection: "pages", slug: "about", locale: "fr" })
+    ).resolves.toBe(false);
+  });
+});

--- a/packages/nextly/src/runtime/preview/__tests__/preview-draft-gate.test.ts
+++ b/packages/nextly/src/runtime/preview/__tests__/preview-draft-gate.test.ts
@@ -35,7 +35,12 @@ async function cookiesFor(
 /** A request with no preview cookie at all. */
 const noCookies = () => ({ get: () => undefined });
 
-function gate(cookies: Parameters<typeof previewDraftGate>[0]["cookies"]) {
+// `NonNullable`, because the config parameter is optional: the ordinary mount
+// passes nothing and lets every value default. These tests pin all three, which
+// is what keeps them independent of the container.
+function gate(
+  cookies: NonNullable<Parameters<typeof previewDraftGate>[0]>["cookies"]
+) {
   return previewDraftGate({ secret: SECRET, generation: GENERATION, cookies });
 }
 

--- a/packages/nextly/src/runtime/preview/__tests__/preview-route.defaults.test.ts
+++ b/packages/nextly/src/runtime/preview/__tests__/preview-route.defaults.test.ts
@@ -16,11 +16,15 @@ import { createPreviewRoute } from "../preview-route";
 const TEST_SECRET = "preview-route-test-secret-at-least-32-chars!!";
 
 const enable = vi.fn();
+const generationReads = vi.fn();
 const defaultRedirectTo = vi.fn().mockResolvedValue("/about");
 
 vi.mock("../preview-route-defaults", () => ({
   defaultSecret: () => TEST_SECRET,
-  defaultGeneration: () => Promise.resolve(1),
+  defaultGeneration: () => {
+    generationReads();
+    return Promise.resolve(1);
+  },
   defaultDraftMode: () => Promise.resolve({ enable }),
   defaultCookies: () => Promise.resolve({ get: () => undefined }),
   defaultRedirectTo: (...args: unknown[]) => defaultRedirectTo(...args),
@@ -57,7 +61,10 @@ describe("createPreviewRoute with no arguments", () => {
     await GET(request(await tokenFor()));
 
     expect(defaultRedirectTo).toHaveBeenCalledWith(
-      expect.objectContaining({ collection: "pages", entryId: "entry-1" })
+      expect.objectContaining({ collection: "pages", entryId: "entry-1" }),
+      // The origin serving THIS request, so a resolver can judge an absolute
+      // preview URL on an installation that has configured no site URL.
+      { requestOrigin: "https://site.example" }
     );
   });
 
@@ -85,7 +92,8 @@ describe("createPreviewRoute with no arguments", () => {
     const response = await GET(request(await tokenFor()));
 
     expect(redirectTo).toHaveBeenCalledWith(
-      expect.objectContaining({ collection: "pages", entryId: "entry-1" })
+      expect.objectContaining({ collection: "pages", entryId: "entry-1" }),
+      { requestOrigin: "https://site.example" }
     );
     expect(response.headers.get("location")).toBe("/overridden");
   });
@@ -103,8 +111,31 @@ describe("createPreviewRoute with no arguments", () => {
     expect(response.status).toBe(404);
   });
 
-  // Same argument for the revocation counter: a route reading the override
-  // rejects a token minted under a generation that is no longer current.
+  // Reading the revocation counter is a database query. Anything that resolves
+  // it before a signature has been checked lets unauthenticated traffic force a
+  // settings read by sending arbitrary bytes — on this endpoint, and on every
+  // content request that consults a preview cookie.
+  it("does not read the revocation generation for a malformed token", async () => {
+    generationReads.mockClear();
+    const { GET } = createPreviewRoute();
+
+    const response = await GET(request("not-a-token"));
+
+    expect(response.status).toBe(404);
+    expect(generationReads).not.toHaveBeenCalled();
+  });
+
+  it("still reads it for a token whose signature checks out", async () => {
+    generationReads.mockClear();
+    const { GET } = createPreviewRoute();
+
+    await GET(request(await tokenFor()));
+
+    expect(generationReads).toHaveBeenCalled();
+  });
+
+  // Same argument as the secret: a route reading the override rejects a token
+  // minted under a generation that is no longer current.
   it("lets an explicit generation override the default", async () => {
     const { GET } = createPreviewRoute({ generation: 2 });
 

--- a/packages/nextly/src/runtime/preview/__tests__/preview-route.defaults.test.ts
+++ b/packages/nextly/src/runtime/preview/__tests__/preview-route.defaults.test.ts
@@ -1,0 +1,115 @@
+/**
+ * `createPreviewRoute()` with nothing passed to it.
+ *
+ * The factory was previously unusable without four arguments, every one of
+ * which is a fact about the booted instance rather than a decision the site
+ * makes — so no application ever wrote them and the route was never mounted.
+ * What matters here is that the no-argument form works AND that each default
+ * is still an override, because a default nobody can replace is a different
+ * defect from a default nobody can reach.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { signPreviewToken } from "../../../auth/preview/preview-token";
+import { createPreviewRoute } from "../preview-route";
+
+const TEST_SECRET = "preview-route-test-secret-at-least-32-chars!!";
+
+const enable = vi.fn();
+const defaultRedirectTo = vi.fn().mockResolvedValue("/about");
+
+vi.mock("../preview-route-defaults", () => ({
+  defaultSecret: () => TEST_SECRET,
+  defaultGeneration: () => Promise.resolve(1),
+  defaultDraftMode: () => Promise.resolve({ enable }),
+  defaultCookies: () => Promise.resolve({ get: () => undefined }),
+  defaultRedirectTo: (...args: unknown[]) => defaultRedirectTo(...args),
+}));
+
+async function tokenFor(): Promise<string> {
+  const { token } = await signPreviewToken(
+    { collection: "pages", entryId: "entry-1" },
+    TEST_SECRET,
+    { generation: 1 }
+  );
+  return token;
+}
+
+function request(token: string): Request {
+  const url = new URL("https://site.example/api/preview");
+  url.searchParams.set("token", token);
+  return new Request(url);
+}
+
+describe("createPreviewRoute with no arguments", () => {
+  it("is callable with no config at all and redirects using the defaults", async () => {
+    const { GET } = createPreviewRoute();
+
+    const response = await GET(request(await tokenFor()));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("/about");
+  });
+
+  it("asks the default resolver for the scope the token names", async () => {
+    const { GET } = createPreviewRoute();
+
+    await GET(request(await tokenFor()));
+
+    expect(defaultRedirectTo).toHaveBeenCalledWith(
+      expect.objectContaining({ collection: "pages", entryId: "entry-1" })
+    );
+  });
+
+  it("still sets the preview scope cookie", async () => {
+    const { GET } = createPreviewRoute();
+
+    const response = await GET(request(await tokenFor()));
+
+    expect(response.headers.get("set-cookie")).toContain("__nextly_preview=");
+  });
+
+  it("still enables draft mode", async () => {
+    enable.mockClear();
+    const { GET } = createPreviewRoute();
+
+    await GET(request(await tokenFor()));
+
+    expect(enable).toHaveBeenCalled();
+  });
+
+  it("lets an explicit redirectTo override the default", async () => {
+    const redirectTo = vi.fn().mockReturnValue("/overridden");
+    const { GET } = createPreviewRoute({ redirectTo });
+
+    const response = await GET(request(await tokenFor()));
+
+    expect(redirectTo).toHaveBeenCalledWith(
+      expect.objectContaining({ collection: "pages", entryId: "entry-1" })
+    );
+    expect(response.headers.get("location")).toBe("/overridden");
+  });
+
+  // A token signed with the DEFAULT secret refused by a route configured with a
+  // different one. Asserting the override is consulted rather than merely
+  // accepted: a route that ignored it would answer 307 here.
+  it("lets an explicit secret override the default", async () => {
+    const { GET } = createPreviewRoute({
+      secret: "a-completely-different-secret-32chars!!",
+    });
+
+    const response = await GET(request(await tokenFor()));
+
+    expect(response.status).toBe(404);
+  });
+
+  // Same argument for the revocation counter: a route reading the override
+  // rejects a token minted under a generation that is no longer current.
+  it("lets an explicit generation override the default", async () => {
+    const { GET } = createPreviewRoute({ generation: 2 });
+
+    const response = await GET(request(await tokenFor()));
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/packages/nextly/src/runtime/preview/preview-draft-gate.ts
+++ b/packages/nextly/src/runtime/preview/preview-draft-gate.ts
@@ -59,6 +59,14 @@ export type PreviewDraftGateConfig = PreviewScopeReaderConfig;
  * });
  * ```
  *
+ * **Callable with no argument, which is how it should normally be written.**
+ * The three values it needs — the signing secret, the revocation generation and
+ * the request's cookies — are facts about the booted instance and the request
+ * in hand rather than decisions a site makes. Requiring them turned a one-line
+ * gate into a paragraph of wiring, and a gate nobody writes is worse than an
+ * absent one: the preview link mints, redirects, and then answers 404 from a
+ * page that looks entirely correct.
+ *
  * **The route's own `status` is deliberately left alone.** It widens internally
  * for the request a grant applies to, so configuring `status: "all"` adds
  * nothing and takes something away: the widened scope then also covers the
@@ -69,7 +77,7 @@ export type PreviewDraftGateConfig = PreviewScopeReaderConfig;
  * enforces it.
  */
 export function previewDraftGate(
-  config: PreviewDraftGateConfig
+  config: PreviewDraftGateConfig = {}
 ): (request: DraftGateRequest) => Promise<{ entryId: string } | false> {
   return async ({ collection, locale }) => {
     // Re-read per request. The config is captured once at module scope while

--- a/packages/nextly/src/runtime/preview/preview-route-defaults.ts
+++ b/packages/nextly/src/runtime/preview/preview-route-defaults.ts
@@ -93,45 +93,53 @@ export async function defaultCookies(): Promise<{
  * explain them.
  */
 export async function defaultRedirectTo(
-  scope: PreviewRedirectScope
+  scope: PreviewRedirectScope,
+  context?: { requestOrigin: string }
 ): Promise<string | null> {
   await getCachedNextly();
   const { previewDeclarationFor } = await import("../../api/preview-url");
   const collections = getService("collectionsHandler");
 
-  return resolvePreviewRedirect(scope, {
-    loadEntry: async (collection, entryId) => {
-      // The SAME service the mint-time authorization probe reads through, so
-      // the entry a link is authorized against and the entry its path is built
-      // from cannot diverge. The Direct API's `findByID` is not usable here: it
-      // takes no `status`, so a status-enabled collection filters it to
-      // published only and an entry that has never been published — precisely
-      // the entry a preview link is most often minted for — reports as missing.
-      const read = await collections.getEntry({
-        collectionName: collection,
-        entryId,
-        // No relationships. This read exists to produce a path, and every field
-        // a preview URL can be built from is scalar, so expanding would read
-        // further collections to answer a question none of them contribute to.
-        depth: 0,
-        // Trusted, because the caller is anonymous: whoever follows a preview
-        // link has no session. Authorization happened when the link was minted,
-        // against the gate that serves real reads, and the signed token carries
-        // that verdict. What this produces is a path and never content.
-        overrideAccess: true,
-        status: "all",
-        // The working draft's values, not the published row's. An editor who
-        // changed the slug on the draft is sharing the draft, so the published
-        // slug would send the reviewer to the entry's old address — or, for an
-        // entry never published, to no address at all.
-        includeWorkingDraft: true,
-      });
+  return resolvePreviewRedirect(
+    scope,
+    {
+      loadEntry: async (collection, entryId, locale) => {
+        // The SAME service the mint-time authorization probe reads through, so
+        // the entry a link is authorized against and the entry its path is built
+        // from cannot diverge. The Direct API's `findByID` is not usable here: it
+        // takes no `status`, so a status-enabled collection filters it to
+        // published only and an entry that has never been published — precisely
+        // the entry a preview link is most often minted for — reports as missing.
+        const read = await collections.getEntry({
+          collectionName: collection,
+          entryId,
+          // No relationships. This read exists to produce a path, and every field
+          // a preview URL can be built from is scalar, so expanding would read
+          // further collections to answer a question none of them contribute to.
+          depth: 0,
+          // Trusted, because the caller is anonymous: whoever follows a preview
+          // link has no session. Authorization happened when the link was minted,
+          // against the gate that serves real reads, and the signed token carries
+          // that verdict. What this produces is a path and never content.
+          overrideAccess: true,
+          status: "all",
+          // The token's locale, so a link minted for one translation resolves
+          // that translation's slug rather than the default language's.
+          ...(locale === undefined ? {} : { locale }),
+          // The working draft's values, not the published row's. An editor who
+          // changed the slug on the draft is sharing the draft, so the published
+          // slug would send the reviewer to the entry's old address — or, for an
+          // entry never published, to no address at all.
+          includeWorkingDraft: true,
+        });
 
-      if (!read.success || read.data === null) return null;
-      return read.data as Record<string, unknown>;
+        if (!read.success || read.data === null) return null;
+        return read.data as Record<string, unknown>;
+      },
+      loadDeclaration: previewDeclarationFor,
+      loadSiteUrl: async () =>
+        (await settingsService()).getSettings().then(s => s.siteUrl),
     },
-    loadDeclaration: previewDeclarationFor,
-    loadSiteUrl: async () =>
-      (await settingsService()).getSettings().then(s => s.siteUrl),
-  });
+    context?.requestOrigin
+  );
 }

--- a/packages/nextly/src/runtime/preview/preview-route-defaults.ts
+++ b/packages/nextly/src/runtime/preview/preview-route-defaults.ts
@@ -1,0 +1,137 @@
+/**
+ * What the preview route and the draft gate use when the application supplies
+ * nothing.
+ *
+ * A module of its own for one structural reason: every default here reaches the
+ * service container or `next/headers`, and `preview-route.ts` has to stay
+ * importable without dragging either. Keeping the resolution behind functions
+ * in a separate file means `import { createPreviewRoute } from "nextly/runtime"`
+ * still costs a token verifier and nothing more, and the route module keeps the
+ * fully-injected shape its tests rely on.
+ *
+ * Nothing here is memoised, and that is deliberate. `generation` is the
+ * revocation counter, so a value cached at module scope would keep preview
+ * sessions alive after an administrator had revoked every link — the single
+ * failure the counter exists to prevent.
+ *
+ * @module runtime/preview/preview-route-defaults
+ */
+
+import { container, getService } from "../../di";
+import {
+  resolvePreviewRedirect,
+  type PreviewRedirectScope,
+} from "../../domains/collections/services/preview-redirect-resolver";
+import { NextlyError } from "../../errors/nextly-error";
+import { getCachedNextly } from "../../init";
+import { env } from "../../lib/env";
+import type { GeneralSettingsService } from "../../services/general-settings/general-settings-service";
+
+/**
+ * The key preview tokens are signed with.
+ *
+ * Read per call rather than at module load, so a deployment missing it fails
+ * the one request that needs it — carrying a remedy — instead of refusing to
+ * boot. The wording matches the minting endpoint's, because an operator who
+ * reaches one of these is about to reach the other.
+ */
+export function defaultSecret(): string {
+  const secret = env.NEXTLY_SECRET;
+  if (!secret) {
+    throw NextlyError.internal({
+      logContext: {
+        reason: "preview-route-no-secret",
+        remedy:
+          "Set NEXTLY_SECRET. Preview links are signed with a key derived " +
+          "from it, and without one an unsigned link would be forgeable by " +
+          "anyone who can guess an entry id.",
+      },
+    });
+  }
+  return secret;
+}
+
+async function settingsService(): Promise<GeneralSettingsService> {
+  await getCachedNextly();
+  return container.get<GeneralSettingsService>("generalSettingsService");
+}
+
+/** The site's current revocation generation. */
+export async function defaultGeneration(): Promise<number> {
+  return (await settingsService()).getPreviewTokenGeneration();
+}
+
+/**
+ * Next's draft mode.
+ *
+ * Imported inside the call rather than at the top of the file. `next/headers`
+ * resolves only within a request, so a static import would make merely loading
+ * this module fail in every other context — including the CLI, which loads a
+ * user config whose module graph reaches `nextly/runtime`.
+ */
+export async function defaultDraftMode(): Promise<{ enable: () => void }> {
+  const { draftMode } = await import("next/headers");
+  return draftMode();
+}
+
+/** The request's cookies, imported inside the call for the same reason. */
+export async function defaultCookies(): Promise<{
+  get: (name: string) => { value: string } | undefined;
+}> {
+  const { cookies } = await import("next/headers");
+  return cookies();
+}
+
+/**
+ * Where a token sends the visitor, answered from the collection's own preview
+ * declaration.
+ *
+ * The alternative was for every application to write this itself, which is what
+ * left the capability unreachable: the resolution is not obvious, an equivalent
+ * already exists for the admin's preview button, and an application that
+ * derived it differently would produce links that answer 404 with nothing to
+ * explain them.
+ */
+export async function defaultRedirectTo(
+  scope: PreviewRedirectScope
+): Promise<string | null> {
+  await getCachedNextly();
+  const { previewDeclarationFor } = await import("../../api/preview-url");
+  const collections = getService("collectionsHandler");
+
+  return resolvePreviewRedirect(scope, {
+    loadEntry: async (collection, entryId) => {
+      // The SAME service the mint-time authorization probe reads through, so
+      // the entry a link is authorized against and the entry its path is built
+      // from cannot diverge. The Direct API's `findByID` is not usable here: it
+      // takes no `status`, so a status-enabled collection filters it to
+      // published only and an entry that has never been published — precisely
+      // the entry a preview link is most often minted for — reports as missing.
+      const read = await collections.getEntry({
+        collectionName: collection,
+        entryId,
+        // No relationships. This read exists to produce a path, and every field
+        // a preview URL can be built from is scalar, so expanding would read
+        // further collections to answer a question none of them contribute to.
+        depth: 0,
+        // Trusted, because the caller is anonymous: whoever follows a preview
+        // link has no session. Authorization happened when the link was minted,
+        // against the gate that serves real reads, and the signed token carries
+        // that verdict. What this produces is a path and never content.
+        overrideAccess: true,
+        status: "all",
+        // The working draft's values, not the published row's. An editor who
+        // changed the slug on the draft is sharing the draft, so the published
+        // slug would send the reviewer to the entry's old address — or, for an
+        // entry never published, to no address at all.
+        includeWorkingDraft: true,
+      });
+
+      if (!read.success || read.data === null) return null;
+      return read.data as Record<string, unknown>;
+    },
+    loadDeclaration: previewDeclarationFor,
+    loadSiteUrl: async () =>
+      (await settingsService()).getSettings().then(s => s.siteUrl),
+  });
+}

--- a/packages/nextly/src/runtime/preview/preview-route.ts
+++ b/packages/nextly/src/runtime/preview/preview-route.ts
@@ -23,6 +23,19 @@ import {
  * @module runtime/preview/preview-route
  */
 
+/**
+ * What the route can tell a redirect resolver about the request in hand.
+ *
+ * Only the origin, and only because a resolver otherwise has no way to judge an
+ * ABSOLUTE preview URL on an installation that has configured no site URL: the
+ * origin serving this request is the site's, and it is the one honest thing to
+ * compare against.
+ */
+export interface PreviewRedirectContext {
+  /** The origin this request was served from. */
+  requestOrigin: string;
+}
+
 /** The cookie carrying the preview token for the rest of the session. */
 export const PREVIEW_SCOPE_COOKIE = "__nextly_preview";
 
@@ -68,7 +81,8 @@ export interface PreviewRouteConfig {
    * how an app says so without having to throw.
    */
   redirectTo?: (
-    scope: PreviewTokenScope
+    scope: PreviewTokenScope,
+    context: PreviewRedirectContext
   ) => string | null | Promise<string | null>;
   /**
    * Reads and enables Next's draft mode. Injected so the route is testable.
@@ -154,17 +168,20 @@ function siteRelativeTarget(target: string, requestUrl: string): string | null {
 async function verificationInputs(config: {
   secret?: string;
   generation?: number | (() => number | Promise<number>);
-}): Promise<{ secret: string; generation: number }> {
+}): Promise<{
+  secret: string;
+  generation: number | (() => number | Promise<number>);
+}> {
   const defaults = await import("./preview-route-defaults");
 
-  const generation =
-    config.generation === undefined
-      ? await defaults.defaultGeneration()
-      : typeof config.generation === "function"
-        ? await config.generation()
-        : config.generation;
-
-  return { secret: config.secret ?? defaults.defaultSecret(), generation };
+  // The generation is handed on UNRESOLVED. Reading it is a database query, and
+  // the verifier needs it only after a token's signature has checked out — so
+  // resolving it here would put a settings read in front of every request
+  // carrying arbitrary bytes, including one that is about to be refused.
+  return {
+    secret: config.secret ?? defaults.defaultSecret(),
+    generation: config.generation ?? defaults.defaultGeneration,
+  };
 }
 
 export function createPreviewRoute(config: PreviewRouteConfig = {}): {
@@ -200,7 +217,9 @@ export function createPreviewRoute(config: PreviewRouteConfig = {}): {
       try {
         const redirectTo =
           config.redirectTo ?? (await loadDefaults()).defaultRedirectTo;
-        target = await redirectTo(verified.scope);
+        target = await redirectTo(verified.scope, {
+          requestOrigin: new URL(request.url).origin,
+        });
       } catch {
         return refuse();
       }

--- a/packages/nextly/src/runtime/preview/preview-route.ts
+++ b/packages/nextly/src/runtime/preview/preview-route.ts
@@ -26,26 +26,48 @@ import {
 /** The cookie carrying the preview token for the rest of the session. */
 export const PREVIEW_SCOPE_COOKIE = "__nextly_preview";
 
+/**
+ * Every member is optional.
+ *
+ * Each one has a default resolved from the booted instance, so the ordinary
+ * mount is `createPreviewRoute()` with no argument at all. They remain
+ * overridable because the resolution genuinely is the application's to change —
+ * a site that routes its own content needs its own `redirectTo`, and a test
+ * needs all four — but REQUIRING them meant every value had to be restated by
+ * hand in a route file, and a mount that costs a paragraph of wiring is a mount
+ * that does not get written.
+ *
+ * The defaults are imported inside the handler rather than at the top of this
+ * module. A static import would make `import { createPreviewRoute } from
+ * "nextly/runtime"` pull in the service container and `next/headers` with it.
+ */
 export interface PreviewRouteConfig {
-  /** The signing secret; the same `NEXTLY_SECRET` sessions use. */
-  secret: string;
+  /** The signing secret; the same `NEXTLY_SECRET` sessions use. Defaults to it. */
+  secret?: string;
   /**
    * The site's current revocation generation. Read per request so raising it
    * ends existing preview sessions rather than only refusing new links.
+   *
+   * Defaults to the value stored in general settings, read per request for the
+   * same reason.
    */
-  generation: number | (() => number | Promise<number>);
+  generation?: number | (() => number | Promise<number>);
   /**
    * Where to send the visitor once the link checks out.
    *
-   * Supplied by the app because only it knows how its content is routed. The
-   * returned value must be a site-relative path.
+   * The returned value must be a site-relative path.
+   *
+   * Defaults to the collection's own preview declaration — the `url` function a
+   * code-first collection carries, or the `urlTemplate` a UI-created one does —
+   * resolved against the configured site URL. An application whose content is
+   * routed some other way supplies its own.
    *
    * Returning `null` refuses the link the same way an invalid token is
    * refused. A preview link outlives what it points at — the entry can be
    * deleted, unpublished or moved between minting and clicking — and this is
    * how an app says so without having to throw.
    */
-  redirectTo: (
+  redirectTo?: (
     scope: PreviewTokenScope
   ) => string | null | Promise<string | null>;
   /**
@@ -54,8 +76,10 @@ export interface PreviewRouteConfig {
    * Accepts a synchronous return as well: `draftMode()` is sync on Next 14 and
    * async from 15, and the peer range covers both, so requiring a promise would
    * make the natural import fail to typecheck on the older one.
+   *
+   * Defaults to `draftMode` from `next/headers`.
    */
-  draftMode: () => { enable: () => void } | Promise<{ enable: () => void }>;
+  draftMode?: () => { enable: () => void } | Promise<{ enable: () => void }>;
 }
 
 /**
@@ -113,22 +137,54 @@ function siteRelativeTarget(target: string, requestUrl: string): string | null {
  * distinguishable from one naming a document that does not exist — otherwise
  * the endpoint becomes an oracle for which entries are in draft.
  */
-export function createPreviewRoute(config: PreviewRouteConfig): {
+/**
+ * The two values every token verification needs, resolved from a config that
+ * may name neither.
+ *
+ * Written once and shared by the route and the scope reader rather than spelled
+ * out in both. They ask the identical question — which key signs this site's
+ * preview tokens, and which generation is current — and two copies of that
+ * answer agree only until one of them is edited: a route that kept reading a
+ * cached generation while the reader re-read it would let revoked links keep
+ * working through whichever path was not updated.
+ *
+ * The defaults module is imported here, inside the call, so neither caller
+ * pulls the service container or `next/headers` at load time.
+ */
+async function verificationInputs(config: {
+  secret?: string;
+  generation?: number | (() => number | Promise<number>);
+}): Promise<{ secret: string; generation: number }> {
+  const defaults = await import("./preview-route-defaults");
+
+  const generation =
+    config.generation === undefined
+      ? await defaults.defaultGeneration()
+      : typeof config.generation === "function"
+        ? await config.generation()
+        : config.generation;
+
+  return { secret: config.secret ?? defaults.defaultSecret(), generation };
+}
+
+export function createPreviewRoute(config: PreviewRouteConfig = {}): {
   GET: (request: Request) => Promise<Response>;
 } {
   const refuse = () => new Response(null, { status: 404 });
+
+  // Loaded per call rather than once at factory time. Hoisting it would start
+  // the dynamic import at module scope, behind a promise nothing awaits, which
+  // is exactly the eager coupling this indirection exists to avoid.
+  const loadDefaults = () => import("./preview-route-defaults");
 
   return {
     async GET(request: Request): Promise<Response> {
       const token = new URL(request.url).searchParams.get("token");
       if (token === null || token.length === 0) return refuse();
 
-      const generation =
-        typeof config.generation === "function"
-          ? await config.generation()
-          : config.generation;
+      const { secret, generation } = await verificationInputs(config);
 
-      const verified = await verifyPreviewToken(token, config.secret, {
+      const verified = await verifyPreviewToken(token, secret, {
         generation,
       });
       if (!verified.valid) return refuse();
@@ -142,7 +198,9 @@ export function createPreviewRoute(config: PreviewRouteConfig): {
       // existed from one that never did.
       let target: string | null;
       try {
-        target = await config.redirectTo(verified.scope);
+        const redirectTo =
+          config.redirectTo ?? (await loadDefaults()).defaultRedirectTo;
+        target = await redirectTo(verified.scope);
       } catch {
         return refuse();
       }
@@ -175,7 +233,9 @@ export function createPreviewRoute(config: PreviewRouteConfig): {
       // on the outgoing request, and enabling it before a step that can still
       // refuse would leave the visitor holding a draft session for a request
       // that answered 404.
-      const draft = await config.draftMode();
+      const draft = await (config.draftMode
+        ? config.draftMode()
+        : (await loadDefaults()).defaultDraftMode());
       draft.enable();
 
       return response;
@@ -183,14 +243,22 @@ export function createPreviewRoute(config: PreviewRouteConfig): {
   };
 }
 
+/**
+ * Optional throughout, for the same reason {@link PreviewRouteConfig} is: these
+ * are facts about the booted instance and the request in hand rather than
+ * decisions a site makes, and requiring them turned the one-line draft gate
+ * built on this into a paragraph of wiring that no route ever wrote.
+ */
 export interface PreviewScopeReaderConfig {
-  secret: string;
-  generation: number | (() => number | Promise<number>);
+  secret?: string;
+  generation?: number | (() => number | Promise<number>);
   /**
    * Reads the request's cookies. Injected so the reader is testable, and
    * accepting a synchronous return for the same reason `draftMode` does.
+   *
+   * Defaults to `cookies` from `next/headers`.
    */
-  cookies: () =>
+  cookies?: () =>
     | { get: (name: string) => { value: string } | undefined }
     | Promise<{ get: (name: string) => { value: string } | undefined }>;
 }
@@ -204,16 +272,19 @@ export interface PreviewScopeReaderConfig {
  * something for sessions already in flight.
  */
 export async function readPreviewScope(
-  config: PreviewScopeReaderConfig
+  config: PreviewScopeReaderConfig = {}
 ): Promise<PreviewTokenScope | null> {
-  const store = await config.cookies();
+  const loadDefaults = () => import("./preview-route-defaults");
+
+  const store = await (config.cookies
+    ? config.cookies()
+    : (await loadDefaults()).defaultCookies());
   const raw = store.get(PREVIEW_SCOPE_COOKIE)?.value;
+  // Read before anything else is resolved: a request with no preview cookie is
+  // the overwhelmingly common case, and it must not cost a settings read.
   if (raw === undefined || raw.length === 0) return null;
 
-  const generation =
-    typeof config.generation === "function"
-      ? await config.generation()
-      : config.generation;
+  const { secret, generation } = await verificationInputs(config);
 
   // A cookie is request input whoever sent it, and `%` alone makes
   // `decodeURIComponent` throw — which would answer a page request with a 500
@@ -225,7 +296,7 @@ export async function readPreviewScope(
     return null;
   }
 
-  const verified = await verifyPreviewToken(token, config.secret, {
+  const verified = await verifyPreviewToken(token, secret, {
     generation,
   });
   return verified.valid ? verified.scope : null;

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-preview-gate.integration.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-preview-gate.integration.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The join between a preview token and an ORDINARY content route.
+ *
+ * Every other draft test in this directory hands the route a decision function
+ * written by hand, which proves the route consults its `draft` hook and proves
+ * nothing about the hook a real site would pass. `previewDraftGate` is what a
+ * real site passes, and until it is exercised through a route the two can agree
+ * in a doc comment and disagree in fact — the gate reading one cookie name, the
+ * route comparing a different entry, a token shape neither validates.
+ *
+ * The route here is deliberately NOT a blocks page. The page-builder factory
+ * inherits `draft` by extending this config, so it is covered transitively; a
+ * site rendering its own content with `createContentRoute` is the case nothing
+ * else reaches.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { signPreviewToken } from "../../../auth/preview/preview-token";
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { PREVIEW_SCOPE_COOKIE } from "../../preview/preview-route";
+import { previewDraftGate } from "../../preview/preview-draft-gate";
+import { createContentRoute } from "../content-route";
+import type { ContentEntry } from "../resolve-content";
+
+const SECRET = "content-route-preview-gate-secret-32chars!!";
+const GENERATION = 1;
+
+const pages = () =>
+  defineCollection({
+    slug: "pages",
+    status: true,
+    versions: { drafts: true },
+    fields: [text({ name: "slug" }), text({ name: "title" })],
+  });
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+/** A cookie jar holding one preview token, or nothing at all. */
+function cookies(token?: string) {
+  return () => ({
+    get: (name: string) =>
+      name === PREVIEW_SCOPE_COOKIE && token !== undefined
+        ? { value: encodeURIComponent(token) }
+        : undefined,
+  });
+}
+
+function route(nextly: TestNextly["nextly"], token?: string) {
+  return createContentRoute({
+    collections: ["pages"],
+    nextly,
+    render: (entry: ContentEntry) => entry,
+    draft: previewDraftGate({
+      secret: SECRET,
+      generation: GENERATION,
+      cookies: cookies(token),
+    }),
+  });
+}
+
+describe("createContentRoute driven by previewDraftGate", () => {
+  it("serves a never-published entry to the visitor whose token names it", async () => {
+    current = await createTestNextly({ collections: [pages()] });
+    const created = await current.nextly.create({
+      collection: "pages",
+      data: { slug: "unreleased", title: "Unreleased", status: "draft" },
+    });
+
+    const { token } = await signPreviewToken(
+      { collection: "pages", entryId: String(created.item.id) },
+      SECRET,
+      { generation: GENERATION }
+    );
+
+    const page = (await route(current.nextly, token).ContentPage({
+      params: { slug: ["unreleased"] },
+    })) as ContentEntry;
+
+    expect(page.title).toBe("Unreleased");
+  });
+
+  // The control for the assertion above. Without it, a resolve that returned a
+  // document for reasons unrelated to the token — a lifecycle default, a
+  // collection that never enforced status — would read as the gate working.
+  it("404s that same entry for a visitor carrying no token", async () => {
+    current = await createTestNextly({ collections: [pages()] });
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "unreleased", title: "Unreleased", status: "draft" },
+    });
+
+    await expect(
+      route(current.nextly).ContentPage({ params: { slug: ["unreleased"] } })
+    ).rejects.toThrow();
+  });
+
+  // One link is a key to ONE document. A token minted for entry A must not open
+  // entry B, even though both are unpublished rows of the same collection that
+  // the same gate would answer `true` for.
+  it("refuses a different unpublished entry in the same collection", async () => {
+    current = await createTestNextly({ collections: [pages()] });
+    const a = await current.nextly.create({
+      collection: "pages",
+      data: { slug: "entry-a", title: "A", status: "draft" },
+    });
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "entry-b", title: "B", status: "draft" },
+    });
+
+    const { token } = await signPreviewToken(
+      { collection: "pages", entryId: String(a.item.id) },
+      SECRET,
+      { generation: GENERATION }
+    );
+
+    await expect(
+      route(current.nextly, token).ContentPage({
+        params: { slug: ["entry-b"] },
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-preview-warning.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-preview-warning.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The diagnostic for the failure that looks like nothing.
+ *
+ * A route with no `draft` hook is the normal configuration for most pages. But
+ * a request arriving at one WITH a valid preview credential is a mistake nobody
+ * can see: the reviewer gets a 404 they cannot tell from an expired link, the
+ * editor was told the link was copied, and the developer has no signal at all.
+ *
+ * Two properties matter here and they pull against each other — the warning has
+ * to fire in development, and production has to stay silent, because a
+ * production 404 that varied by cause would let a stranger discover which
+ * entries exist in draft.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { signPreviewToken } from "../../../auth/preview/preview-token";
+import { PREVIEW_SCOPE_COOKIE } from "../../preview/preview-route";
+
+const SECRET = "content-route-warning-secret-at-least-32ch!!";
+
+let cookieValue: string | undefined;
+
+vi.mock("../../preview/preview-route-defaults", () => ({
+  defaultSecret: () => SECRET,
+  defaultGeneration: () => Promise.resolve(1),
+  defaultCookies: () =>
+    Promise.resolve({
+      get: (name: string) =>
+        name === PREVIEW_SCOPE_COOKIE && cookieValue !== undefined
+          ? { value: cookieValue }
+          : undefined,
+    }),
+}));
+
+const { createContentRoute } = await import("../content-route");
+
+/** A route with NO draft hook — the configuration this warning is about. */
+function routeWithoutGate() {
+  return createContentRoute({
+    collections: ["pages"],
+    render: (entry: unknown) => entry,
+    nextly: {
+      find: () => Promise.resolve({ docs: [], totalDocs: 0 }),
+      findByID: () => Promise.resolve(null),
+    } as never,
+  });
+}
+
+async function cookieFor(collection: string): Promise<void> {
+  const { token } = await signPreviewToken(
+    { collection, entryId: "entry-1" },
+    SECRET,
+    { generation: 1 }
+  );
+  cookieValue = encodeURIComponent(token);
+}
+
+let warn: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  cookieValue = undefined;
+  warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  warn.mockRestore();
+  vi.unstubAllEnvs();
+});
+
+describe("a preview credential meeting a route with no draft hook", () => {
+  it("warns in development, naming the hook that is missing", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    await cookieFor("pages");
+
+    await routeWithoutGate()
+      .ContentPage({ params: { slug: ["about"] } })
+      .catch(() => undefined);
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("previewDraftGate")
+    );
+  });
+
+  // The security half. A production 404 that varied by cause would answer the
+  // question "does this entry have a draft" for anyone who asked.
+  it("stays silent in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    await cookieFor("pages");
+
+    await routeWithoutGate()
+      .ContentPage({ params: { slug: ["about"] } })
+      .catch(() => undefined);
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  // The overwhelmingly common request: an ordinary visitor with no preview
+  // cookie. Warning here would make every page view of every site noisy, and a
+  // warning nobody can act on is one everybody learns to ignore.
+  it("says nothing for a visitor carrying no preview credential", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+
+    await routeWithoutGate()
+      .ContentPage({ params: { slug: ["about"] } })
+      .catch(() => undefined);
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  // Scoped to the collection the token names. A site serving several
+  // collections would otherwise warn on every route a previewing visitor
+  // touched, including the ones correctly serving published content.
+  it("says nothing when the token names a different collection", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    await cookieFor("posts");
+
+    await routeWithoutGate()
+      .ContentPage({ params: { slug: ["about"] } })
+      .catch(() => undefined);
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-preview-warning.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-preview-warning.test.ts
@@ -68,6 +68,25 @@ afterEach(() => {
 });
 
 describe("a preview credential meeting a route with no draft hook", () => {
+  // The hook runs before a path is resolved, so it cannot know whether THIS
+  // request wanted the draft. A visitor holding a preview cookie goes on
+  // browsing, and every published page they open in the same collection reaches
+  // the same branch — so the diagnostic is stated once and worded as a fact
+  // about the route rather than a prediction about the request.
+  it("warns once, however many pages the visitor then opens", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    await cookieFor("pages");
+
+    const route = routeWithoutGate();
+    for (const slug of ["about", "contact", "pricing"]) {
+      await route
+        .ContentPage({ params: { slug: [slug] } })
+        .catch(() => undefined);
+    }
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
   it("warns in development, naming the hook that is missing", async () => {
     vi.stubEnv("NODE_ENV", "development");
     await cookieFor("pages");

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -440,6 +440,16 @@ function buildRoute<TNode>(
    * about to answer normally, so a failure to produce a DIAGNOSTIC must never
    * become a failure to serve the page.
    */
+  /**
+   * Collections this route has already warned about.
+   *
+   * Per route instance, which is per module in practice: a route is built once
+   * at import and the diagnostic is about its CONFIGURATION, so one mention is
+   * the whole message. A counter here also keeps the warning off the hot path
+   * after the first request that triggers it.
+   */
+  const warnedCollections = new Set<string>();
+
   async function warnOnUnhonouredPreviewCookie(
     context: ResolvedContext
   ): Promise<void> {
@@ -449,11 +459,23 @@ function buildRoute<TNode>(
       if (scope === null) return;
       if (scope.collection !== context.collection) return;
 
+      // Once per collection per process, and worded as a CONFIGURATION fact
+      // rather than a prediction about this request.
+      //
+      // The hook runs before the path is resolved, so nothing here knows whether
+      // this particular request would have wanted the draft: a visitor holding a
+      // preview cookie goes on browsing, and every published page they open in
+      // the same collection reaches this branch. Claiming each of those ends in a
+      // 404 is false, and repeating it turns the one useful signal into noise a
+      // developer learns to scroll past.
+      if (warnedCollections.has(context.collection)) return;
+      warnedCollections.add(context.collection);
+
       console.warn(
-        `[nextly] A valid preview link for "${scope.collection}" reached a ` +
-          "content route that declares no `draft` hook, so the draft cannot " +
-          "be served and the visitor gets a 404 that looks like an expired " +
-          "link.\n" +
+        `[nextly] This route serves "${context.collection}" and declares no ` +
+          "`draft` hook, so a preview link for that collection cannot be " +
+          "served here — a reviewer following one gets a 404 that looks like " +
+          "an expired link.\n" +
           "  Add `draft: previewDraftGate()` to this route's config.\n" +
           "  https://nextlyhq.com/docs/guides/draft-preview"
       );

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -433,11 +433,55 @@ function buildRoute<TNode>(
   const getInstance = (): NextlyContentReader => config.nextly ?? getNextly();
 
   /** Whether this request may see unpublished edits at one collection + slug. */
+  /**
+   * Say so when a valid preview credential reaches a route that cannot use it.
+   *
+   * Everything it can throw is swallowed. This runs on a path that is otherwise
+   * about to answer normally, so a failure to produce a DIAGNOSTIC must never
+   * become a failure to serve the page.
+   */
+  async function warnOnUnhonouredPreviewCookie(
+    context: ResolvedContext
+  ): Promise<void> {
+    try {
+      const { readPreviewScope } = await import("../preview/preview-route");
+      const scope = await readPreviewScope();
+      if (scope === null) return;
+      if (scope.collection !== context.collection) return;
+
+      console.warn(
+        `[nextly] A valid preview link for "${scope.collection}" reached a ` +
+          "content route that declares no `draft` hook, so the draft cannot " +
+          "be served and the visitor gets a 404 that looks like an expired " +
+          "link.\n" +
+          "  Add `draft: previewDraftGate()` to this route's config.\n" +
+          "  https://nextlyhq.com/docs/guides/draft-preview"
+      );
+    } catch {
+      // A diagnostic never breaks a request.
+    }
+  }
+
   async function draftForThisPath(
     context: ResolvedContext
   ): Promise<DraftGrant> {
     const decision = config.draft;
-    if (decision === undefined) return false;
+    if (decision === undefined) {
+      // A route with no gate is the normal, correct configuration for most
+      // pages, so this warns about ONE REQUEST rather than about the route: the
+      // request arriving with a preview credential this route can never honour.
+      // That request answers 404, which is indistinguishable from an expired
+      // link — and the person who sees it is a reviewer with no access to the
+      // logs and no way to tell the two apart.
+      //
+      // Development only. The production 404 stays uniform by design: making it
+      // distinguishable would turn the endpoint into an oracle for which
+      // entries exist in draft.
+      if (process.env.NODE_ENV !== "production") {
+        await warnOnUnhonouredPreviewCookie(context);
+      }
+      return false;
+    }
     return typeof decision === "function" ? decision(context) : decision;
   }
 

--- a/packages/nextly/src/shared/types/__tests__/config.test.ts
+++ b/packages/nextly/src/shared/types/__tests__/config.test.ts
@@ -29,3 +29,22 @@ describe("sanitizeConfig — webhook audit seam", () => {
     ).toBe(true);
   });
 });
+
+describe("preview config survives the boot pipeline", () => {
+  // The unit test for the minting endpoint mocks the container directly, so it
+  // proves the endpoint READS `config.preview` and says nothing about whether
+  // anything ever puts it there. `sanitizeConfig` enumerates its result rather
+  // than spreading, so an unnamed field is dropped silently — the option
+  // typechecks, the application sets it, and the value never arrives.
+  it("is carried through sanitizeConfig rather than dropped", () => {
+    const sanitized = sanitizeConfig({
+      preview: { route: "/next/preview" },
+    });
+
+    expect(sanitized.preview).toEqual({ route: "/next/preview" });
+  });
+
+  it("leaves preview undefined when the application sets none", () => {
+    expect(sanitizeConfig({}).preview).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/shared/types/config.ts
+++ b/packages/nextly/src/shared/types/config.ts
@@ -975,6 +975,11 @@ export function sanitizeConfig(config: NextlyConfig): SanitizedNextlyConfig {
     permissions: config.permissions,
     security: config.security,
     admin: config.admin,
+    // Carried explicitly, because this object is ENUMERATED rather than spread:
+    // a field the sanitizer does not name is dropped before anything downstream
+    // can read it, and the omission is silent — the option typechecks, the app
+    // sets it, and the value simply never arrives.
+    preview: config.preview,
     localization: config.localization
       ? normalizeLocalization(config.localization)
       : undefined,

--- a/packages/nextly/src/shared/types/config.ts
+++ b/packages/nextly/src/shared/types/config.ts
@@ -26,6 +26,7 @@ import type {
   LocalizationConfig,
   SanitizedLocalizationConfig,
 } from "../../domains/i18n/config/types";
+import type { PreviewConfig } from "../../domains/preview/route-config";
 import { resolveWebhookRetentionConfig } from "../../domains/webhooks/retention-config";
 import type {
   ResolvedWebhookRetentionConfig,
@@ -645,6 +646,15 @@ export interface NextlyConfig {
   admin?: AdminConfig;
 
   /**
+   * Draft-preview wiring.
+   *
+   * Declares where this application mounts `createPreviewRoute`, so the server
+   * can assemble a shareable preview link instead of the admin guessing a path
+   * it has no way to learn.
+   */
+  preview?: PreviewConfig;
+
+  /**
    * Multilingual content configuration. Omit to keep the CMS single-language.
    * See docs/superpowers/specs/2026-07-08-multilingual-i18n-design.md.
    */
@@ -765,6 +775,9 @@ export interface SanitizedNextlyConfig {
 
   /** Admin UI customization config. */
   admin?: AdminConfig;
+
+  /** Draft-preview wiring. */
+  preview?: PreviewConfig;
 
   /** Normalized multilingual content configuration (undefined when i18n is off). */
   localization?: SanitizedLocalizationConfig;

--- a/packages/plugin-page-builder/src/collections/pages.test.ts
+++ b/packages/plugin-page-builder/src/collections/pages.test.ts
@@ -75,39 +75,46 @@ describe("pages is built from blocks", () => {
 });
 
 describe("where a page previews", () => {
-  // The plugin ships this collection but cannot see where the host mounted the
-  // route that renders it, so an undeclared preview means a shared link has
-  // nowhere to open — which the minting endpoint now refuses outright.
-  it("declares a preview so a draft can be shared at all", () => {
-    const preview = pagesCollection().admin?.preview;
+  // Declared only when the host passes a path, and the reason is an interaction
+  // between two behaviours: minting a preview link REFUSES when a collection
+  // declares no preview URL. Without a declaration an editor is told a developer
+  // must configure one; with a defaulted declaration the mint succeeds and the
+  // reviewer gets a 404 that looks like an expired link. A default would
+  // therefore make an installation that has mounted no preview route strictly
+  // worse off than declaring nothing.
+  it("declares no preview until the host supplies a path", () => {
+    expect(pagesCollection().admin?.preview).toBeUndefined();
+  });
 
-    expect(preview).toBeDefined();
+  it("declares one once the host supplies a path", () => {
+    const preview = pagesCollection("/{slug}").admin?.preview;
+
     expect(typeof preview?.url).toBe("function");
   });
 
-  it("defaults to the site root, the common mount", () => {
-    const url = pagesCollection().admin?.preview?.url;
+  it("serves a host that mounted its pages at the root", () => {
+    const url = pagesCollection("/{slug}").admin?.preview?.url;
 
     expect(url?.({ slug: "about" })).toBe("/about");
   });
 
-  it("serves a host that mounted its pages elsewhere", () => {
+  it("serves a host that mounted its pages under a prefix", () => {
     const url = pagesCollection("/blocks/{slug}").admin?.preview?.url;
 
     expect(url?.({ slug: "about" })).toBe("/blocks/about");
   });
 
   // An entry without a slug yet is not previewable, and becomes so once it has
-  // one. `null` is how the resolver is told to report that rather than building
-  // a URL with a hole in it.
+  // one. `null` is how the resolver is told that rather than building a URL with
+  // a hole in it.
   it("declines an entry whose slug is not filled in yet", () => {
-    const url = pagesCollection().admin?.preview?.url;
+    const url = pagesCollection("/{slug}").admin?.preview?.url;
 
     expect(url?.({})).toBeNull();
   });
 
   it("escapes a slug that would otherwise change the path", () => {
-    const url = pagesCollection().admin?.preview?.url;
+    const url = pagesCollection("/{slug}").admin?.preview?.url;
 
     expect(url?.({ slug: "a/b" })).toBe("/a%2Fb");
   });

--- a/packages/plugin-page-builder/src/collections/pages.test.ts
+++ b/packages/plugin-page-builder/src/collections/pages.test.ts
@@ -73,3 +73,42 @@ describe("pages is built from blocks", () => {
     expect(fieldsOf().map(f => f.name)).not.toContain("body");
   });
 });
+
+describe("where a page previews", () => {
+  // The plugin ships this collection but cannot see where the host mounted the
+  // route that renders it, so an undeclared preview means a shared link has
+  // nowhere to open — which the minting endpoint now refuses outright.
+  it("declares a preview so a draft can be shared at all", () => {
+    const preview = pagesCollection().admin?.preview;
+
+    expect(preview).toBeDefined();
+    expect(typeof preview?.url).toBe("function");
+  });
+
+  it("defaults to the site root, the common mount", () => {
+    const url = pagesCollection().admin?.preview?.url;
+
+    expect(url?.({ slug: "about" })).toBe("/about");
+  });
+
+  it("serves a host that mounted its pages elsewhere", () => {
+    const url = pagesCollection("/blocks/{slug}").admin?.preview?.url;
+
+    expect(url?.({ slug: "about" })).toBe("/blocks/about");
+  });
+
+  // An entry without a slug yet is not previewable, and becomes so once it has
+  // one. `null` is how the resolver is told to report that rather than building
+  // a URL with a hole in it.
+  it("declines an entry whose slug is not filled in yet", () => {
+    const url = pagesCollection().admin?.preview?.url;
+
+    expect(url?.({})).toBeNull();
+  });
+
+  it("escapes a slug that would otherwise change the path", () => {
+    const url = pagesCollection().admin?.preview?.url;
+
+    expect(url?.({ slug: "a/b" })).toBe("/a%2Fb");
+  });
+});

--- a/packages/plugin-page-builder/src/collections/pages.ts
+++ b/packages/plugin-page-builder/src/collections/pages.ts
@@ -1,4 +1,4 @@
-import { defineCollection, text } from "nextly/config";
+import { defineCollection, previewUrlFromTemplate, text } from "nextly/config";
 
 import { blocks } from "../fields/blocksHelper";
 /**
@@ -47,7 +47,23 @@ import { blocks } from "../fields/blocksHelper";
  * blocks field and no switcher, so one capability behaved differently depending
  * on who declared the collection.
  */
-export function pagesCollection() {
+/**
+ * Where a page is served on the site.
+ *
+ * Defaulted rather than required, because the overwhelmingly common mount is a
+ * blocks page at the site root — and a plugin cannot discover the mount for
+ * itself: it is a route file in the host application, which may serve pages at
+ * `/`, at `/blocks`, or under a locale segment.
+ *
+ * Getting it wrong on an unusual mount produces a preview link to the wrong
+ * path, which is no worse than the guaranteed 404 an undeclared collection
+ * produces today, and is corrected by one line of options. Requiring it instead
+ * would mean every existing installation loses the share button until someone
+ * reads a changelog.
+ */
+const DEFAULT_PAGE_PREVIEW_PATH = "/{slug}";
+
+export function pagesCollection(previewPath = DEFAULT_PAGE_PREVIEW_PATH) {
   return defineCollection({
     slug: "pages",
     labels: { singular: "Page", plural: "Pages" },
@@ -60,6 +76,14 @@ export function pagesCollection() {
       blocks({ name: "content", label: "Page Builder" }),
     ],
     status: true,
-    admin: { useAsTitle: "title" },
+    admin: {
+      useAsTitle: "title",
+      // A code-first collection declares a FUNCTION — `urlTemplate` is the
+      // spelling a UI-created collection stores, since no column can hold a
+      // function. The path is turned into one through the shared helper rather
+      // than a substitution written here, so a template and a function cannot
+      // resolve the same entry to two different addresses.
+      preview: { url: previewUrlFromTemplate(previewPath) },
+    },
   });
 }

--- a/packages/plugin-page-builder/src/collections/pages.ts
+++ b/packages/plugin-page-builder/src/collections/pages.ts
@@ -48,22 +48,26 @@ import { blocks } from "../fields/blocksHelper";
  * on who declared the collection.
  */
 /**
- * Where a page is served on the site.
+ * Where a page is served on the site — declared only when the host says so.
  *
- * Defaulted rather than required, because the overwhelmingly common mount is a
- * blocks page at the site root — and a plugin cannot discover the mount for
- * itself: it is a route file in the host application, which may serve pages at
- * `/`, at `/blocks`, or under a locale segment.
+ * A default was the obvious choice and it is the wrong one, because minting a
+ * preview link now REFUSES when a collection declares no preview URL. Those two
+ * behaviours interact: without a declaration an editor is told, in words, that a
+ * developer needs to configure one; with a defaulted declaration the mint
+ * succeeds and the reviewer gets a 404 that looks like an expired link.
  *
- * Getting it wrong on an unusual mount produces a preview link to the wrong
- * path, which is no worse than the guaranteed 404 an undeclared collection
- * produces today, and is corrected by one line of options. Requiring it instead
- * would mean every existing installation loses the share button until someone
- * reads a changelog.
+ * So a default would make an existing installation — one that upgrades while
+ * still calling `pageBuilder()` and has mounted no preview route — strictly
+ * worse off than declaring nothing, by replacing an explanation with a silent
+ * failure. The plugin cannot install the host's route or its draft gate, and it
+ * cannot discover where pages are mounted: a host may serve them at `/`, at
+ * `/blocks`, or under a locale segment.
+ *
+ * Passing `pagePreviewPath` is therefore how a host states that it has done the
+ * wiring. It costs one line and it is the only signal available that the link
+ * will land.
  */
-const DEFAULT_PAGE_PREVIEW_PATH = "/{slug}";
-
-export function pagesCollection(previewPath = DEFAULT_PAGE_PREVIEW_PATH) {
+export function pagesCollection(previewPath?: string) {
   return defineCollection({
     slug: "pages",
     labels: { singular: "Page", plural: "Pages" },
@@ -78,12 +82,15 @@ export function pagesCollection(previewPath = DEFAULT_PAGE_PREVIEW_PATH) {
     status: true,
     admin: {
       useAsTitle: "title",
-      // A code-first collection declares a FUNCTION — `urlTemplate` is the
-      // spelling a UI-created collection stores, since no column can hold a
-      // function. The path is turned into one through the shared helper rather
-      // than a substitution written here, so a template and a function cannot
-      // resolve the same entry to two different addresses.
-      preview: { url: previewUrlFromTemplate(previewPath) },
+      // Present only when the host supplied a path. A code-first collection
+      // declares a FUNCTION — `urlTemplate` is the spelling a UI-created
+      // collection stores, since no column can hold a function — and the path is
+      // turned into one through the shared helper rather than a substitution
+      // written here, so a template and a function cannot resolve the same entry
+      // to two different addresses.
+      ...(previewPath === undefined
+        ? {}
+        : { preview: { url: previewUrlFromTemplate(previewPath) } }),
     },
   });
 }

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -118,6 +118,17 @@ export interface PageBuilderOptions {
    * the object once and hand it to both.
    */
   siteStyle?: SiteStyleData;
+
+  /**
+   * Where this application serves its pages, as a path with `{field}`
+   * placeholders. Defaults to `/{slug}`.
+   *
+   * This is what a shared preview link opens. The plugin ships the `pages`
+   * collection but cannot know where the host mounted the route that renders
+   * it, so a site serving pages anywhere other than the root states it here —
+   * `"/blocks/{slug}"`, for example.
+   */
+  pagePreviewPath?: string;
 }
 
 /**
@@ -188,7 +199,7 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
       services: {
         [BLOCK_SERVICE]: () => createBlockRegistrationService(),
       },
-      collections: [pagesCollection()],
+      collections: [pagesCollection(opts.pagePreviewPath)],
       // The Site Style global: one versioned, access-controlled document the
       // stored style tier lives in. Registered whether or not the host stated
       // defaults, because the storage existing is what the style studios and

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -121,12 +121,14 @@ export interface PageBuilderOptions {
 
   /**
    * Where this application serves its pages, as a path with `{field}`
-   * placeholders. Defaults to `/{slug}`.
+   * placeholders — `"/{slug}"` for a blocks page at the site root,
+   * `"/blocks/{slug}"` for one mounted under a prefix.
    *
-   * This is what a shared preview link opens. The plugin ships the `pages`
-   * collection but cannot know where the host mounted the route that renders
-   * it, so a site serving pages anywhere other than the root states it here —
-   * `"/blocks/{slug}"`, for example.
+   * **Setting this is what enables shareable preview links for pages**, and
+   * there is deliberately no default. The plugin cannot install the host's
+   * preview route or its draft gate, and cannot discover where pages are
+   * mounted — so a defaulted path would let an editor mint a link that resolves
+   * to nothing, while declaring nothing gets them an explanation instead.
    */
   pagePreviewPath?: string;
 }

--- a/templates/blog/src/collections/Posts/index.ts
+++ b/templates/blog/src/collections/Posts/index.ts
@@ -86,20 +86,6 @@ export const Posts = defineCollection({
   admin: {
     useAsTitle: "title",
     defaultColumns: ["title", "status", "author", "publishedAt"],
-    // Where a post is served, which is what a shared preview link opens.
-    // Nothing outside this application can work it out: the path is decided by
-    // the route file at `app/(frontend)/blog/[slug]/page.tsx`, and a collection
-    // that declares no preview URL has nowhere to send a reviewer — so the
-    // admin refuses to mint a link rather than handing over one that 404s.
-    //
-    // `null` for a post with no slug yet: it becomes previewable once it has
-    // one, which is a different state from never being previewable at all.
-    preview: {
-      url: entry =>
-        typeof entry.slug === "string" && entry.slug !== ""
-          ? `/blog/${encodeURIComponent(entry.slug)}`
-          : null,
-    },
   },
   // Access control: reads are public (frontend queries filter by
   // status=published for visitors); any logged-in user can draft a

--- a/templates/blog/src/collections/Posts/index.ts
+++ b/templates/blog/src/collections/Posts/index.ts
@@ -86,6 +86,20 @@ export const Posts = defineCollection({
   admin: {
     useAsTitle: "title",
     defaultColumns: ["title", "status", "author", "publishedAt"],
+    // Where a post is served, which is what a shared preview link opens.
+    // Nothing outside this application can work it out: the path is decided by
+    // the route file at `app/(frontend)/blog/[slug]/page.tsx`, and a collection
+    // that declares no preview URL has nowhere to send a reviewer — so the
+    // admin refuses to mint a link rather than handing over one that 404s.
+    //
+    // `null` for a post with no slug yet: it becomes previewable once it has
+    // one, which is a different state from never being previewable at all.
+    preview: {
+      url: entry =>
+        typeof entry.slug === "string" && entry.slug !== ""
+          ? `/blog/${encodeURIComponent(entry.slug)}`
+          : null,
+    },
   },
   // Access control: reads are public (frontend queries filter by
   // status=published for visitors); any logged-in user can draft a


### PR DESCRIPTION
## Summary

The "Copy shareable link" button minted a valid, correctly-signed preview token and handed out a URL that answered **404**. The token was never the fault — the whole preview stack shipped built, exported and unit-tested, and then connected to nothing.

Measured on `main`:

| Check | Result on `main` |
| --- | --- |
| `curl "localhost:3000/api/preview?token=abc"` | **404** — the route file does not exist |
| `createPreviewRoute` call sites in the repo | **zero** (definition, re-export and its own test only) |
| Scaffold templates shipping the route | **none** (`base`, `blank`, `plugin`) |
| Docs mentioning it | **none** (`grep -rn "createPreviewRoute\|previewDraftGate" docs/` → exit 1) |
| Content routes passing `draft:` | **none** |

Six things must all hold for one copied link to work, and none did. This PR closes them for collections.

## What changed

**`createPreviewRoute()` and `previewDraftGate()` now take no required arguments.** The signing secret, the revocation generation, Next's draft mode and the request's cookies are facts about the booted instance, not decisions a site makes. Requiring them meant a mount cost a paragraph of wiring — and a route file that costs a paragraph is one nobody writes. Every value stays overridable; the change is a widening, so the existing suites pass untouched.

```ts
// src/app/api/preview/route.ts — the whole file
import { createPreviewRoute } from "nextly/runtime";

export const { GET } = createPreviewRoute();
```

**Where a link lands is derived, not restated.** A new `resolvePreviewRedirect` composes the collection's own preview declaration (`url` for code-first, `urlTemplate` for UI-created) through the resolver that already answers this for the admin's preview button. Reading it goes through the **same** `collectionsHandler.getEntry` the mint-time authorization probe uses, so the entry a link is authorized against and the entry its path is built from cannot diverge.

**No configured site URL is required.** This was a real defect found only by running it: a fresh install has no `siteUrl`, and the resolver refused on that, so the link verified and then 404'd with nothing to explain it. The admin needs an absolute URL because it may be served from another origin; this route does not — it already runs on the site. Where there is no origin to compare against, the path's *shape* is checked instead, via the URL parser rather than a list of spellings, so `//elsewhere.example` and `/\elsewhere.example` cannot pass as local paths.

**The playground mounts it and gates both content routes.** `BlockPages` gains an `admin.preview` declaration — without one, `resolvePreviewUrl` answers `notConfigured` and there is nowhere to send the reviewer.

## Test plan

Verified end-to-end against the running app, following the link with **no admin session** — the case the feature exists for:

| Step | Result |
| --- | --- |
| `GET /api/preview?token=<valid>` | **307** → `/blocks/preview-proof-page`, `__nextly_preview` + `__prerender_bypass` set |
| Landing on that path with the preview session | **200**, the unpublished draft renders |
| Same path with **no** session (control) | **404** |
| `?token=garbage` and no token at all | **404**, **zero** `set-cookie` headers |

The control row is what makes the second meaningful: without it a 200 could be a collection that never enforced its lifecycle.

**Automated:** 9 unit tests for the redirect resolver, 7 for the zero-arg route, 7 for the zero-arg gate, and 3 integration tests joining `previewDraftGate` to a real non-blocks `createContentRoute` against a booted instance — coverage that did not exist, since every prior draft test hands the route a hand-written decision function and so proves nothing about the gate a real site passes.

Each assertion was **break-verified** — the implementation was broken in the plausible wrong way and the intended test confirmed red:

- strip the origin instead of comparing it → only the cross-origin test fails
- trust a leading slash instead of asking the parser → only the two protocol-relative tests fail
- ignore the caller's `secret`/`generation` overrides → only the two override tests fail
- grant `true` instead of `{ entryId }` → only "refuses a different unpublished entry in the same collection" fails

`pnpm build`, `pnpm --filter nextly lint`, `check-types`, `check-comment-convention` and `fallow audit` (verdict `pass`, zero introduced dead code / duplication / complexity) all clean.

## Pre-existing failures on `main`

`main` carries **32 failing test files / 360 failing tests** — the known stale-mock baseline. Confirmed by **name**, not count, that none of the failures in the areas this PR touches are new: the set difference between failing-now and failing-at-baseline is empty.

## Changeset

Added: yes — `patch` across all published packages, per the lockstep alpha policy.


---

## Second change on this branch: the server owns the preview URL

Kept in this PR rather than stacked. A pull request based on another feature branch triggers **none** of the four `branches: [main]` workflows — `ci.yml`, `integration.yml`, `secret-scan.yml`, `preview.yml` — so a stacked PR would present a comfortable row of green checks having run no substantive CI at all.

**The defect class, not just the defect.** The admin assembled the preview URL in the browser from a hardcoded `/api/preview` and a site URL read out of general settings. It can know neither: the mount is a route file inside the application, and `settings` is a system resource the `editor` and `author` presets cannot read — precisely the roles that share preview links. It also fell back to `window.location.origin`, i.e. the admin's own host, which is confidently wrong on any deployment that separates admin and site.

- **New `preview: { route }` config**, defaulting to `/api/preview`, validated site-relative at the point of use so a bad value fails loudly rather than at share time. Validation asks the URL parser rather than restating spellings, so `//host` and `/\host` cannot pass.
- **`POST /api/nextly/preview-links` now returns `url`** alongside `token` and `expiresAt`, assembled server-side where both halves are visible. `null` when no site URL is configured — never a relative URL, which the admin would resolve against its own origin.
- **`buildPreviewUrl`, `DEFAULT_PREVIEW_ROUTE`, the unreachable `previewRoute` override and `previewLinkSiteUrl` are deleted.** The entry form no longer reads general settings at all, which removes the permission problem rather than working around it.

### Contract change

`PreviewLink` gains `url: string | null`, and `usePreviewLink` no longer accepts `siteUrl` or `previewRoute`. The changeset is still `patch` — alpha packages version in lockstep and `AGENTS.md` fixes the level — so **this PR body is the only place a consumer learns the response shape moved.**

### Verification

25 tests on the mint endpoint (6 new, covering the default mount, a configured route, trailing-slash joining, token encoding, and the `null` case), 9 on the route-config resolver, and 3 rewritten hook tests asserting the browser copies the server's URL **byte-identically** and reports a `null` rather than substituting its own origin. The `EntryForm` test now asserts the absence of `siteUrl`/`previewRoute` rather than leaving it implicit.

Break-verified: dropping the parser check from route-config validation fails exactly the protocol-relative and backslash cases.

Re-ran the full end-to-end proof after these changes — 307 → 200 with the draft, 404 without — so the second change does not regress the first.

One thing the live run exposed: the hook checked `url === null`, which an absent field would slip past and reach the clipboard as the string `"undefined"`. Now a nullish check.

## Not in this PR

- **The page-builder plugin's `pages` collection declares no preview**, so its "Copy shareable link" button still mints links with nowhere to land. The plugin cannot fix this itself — it has no way to know where the app mounted its pages. Needs a founder decision on whether `PageBuilderOptions` should carry a preview declaration.
- Config-owned mount path + server-resolved URL (next PR), scaffold templates and docs, and Singles — which have a draft lifecycle but no preview path at all.
