### PR TITLE
fix(builder): keep the band beside an edge a transform leaves put

### DIFF
--- a/.changeset/spacing-overlay-stationary-edges.md
+++ b/.changeset/spacing-overlay-stationary-edges.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Keep a spacing overlay margin band beside an edge the block's own transform leaves where layout put it. A translate composed with a scale pins one edge and moves the other, so suppressing a whole axis hid a band that was still correct.

--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -1093,6 +1093,67 @@ test.describe("spacing values on the canvas", () => {
     await expect(page.locator(band("margin", "right"))).toHaveCount(1);
   });
 
+  test("keeps the band beside an edge its transform leaves STATIONARY", async ({
+    page,
+  }) => {
+    /*
+     * A transform is applied about `transform-origin`, so a translate composed
+     * with a scale can pin one edge and move only the other. Measured on a 100px
+     * block: `translateY(-25px) scaleY(0.5)` computes to
+     * `matrix(1, 0, 0, 0.5, 0, -25)` and renders its top edge at exactly the
+     * position layout gave it, while plain `scaleY(0.5)` moves that edge by 25.
+     * The shift below is derived from the block's measured height for that
+     * reason — the pinning is a relationship between the two, not a number.
+     *
+     * Reachable with `transform` ALONE, which is a catalog property —
+     * `transform-origin` is not, and an earlier version of this rule concluded
+     * from that fact that a pinned edge could not arise. It can; composing two
+     * functions is enough.
+     *
+     * So the top band must survive while the bottom one goes, and an answer per
+     * axis fails this while satisfying every other transform test in the file.
+     */
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(block).toBeVisible();
+    await block.evaluate(node => {
+      (node as HTMLElement).style.marginTop = "28px";
+    });
+    await block.click();
+
+    // CONTROL: both vertical bands draw before the transform.
+    await expect(page.locator(band("margin", "top"))).toHaveCount(1);
+    await expect(page.locator(band("margin", "bottom"))).toHaveCount(1);
+
+    const pinned = await block.evaluate(node => {
+      const el = node as HTMLElement;
+      const before = el.getBoundingClientRect();
+      /*
+       * The shift is DERIVED from the block's own height rather than written as
+       * a constant. With the initial origin at the box's centre, halving the
+       * height draws the top edge down by a quarter of it, so the translate that
+       * cancels that is a function of the height — a literal would pin the edge
+       * only for a block that happened to be the size the literal was written
+       * for, and the seed's is not.
+       */
+      const shift = (before.height / 2) * (1 - 0.5);
+      el.style.transform = `translateY(${String(-shift)}px) scaleY(0.5)`;
+      return Math.abs(el.getBoundingClientRect().top - before.top) < 0.5;
+    });
+    // The fixture's separating property, asserted rather than assumed: layout
+    // that drifted so the top edge DID move would leave this test passing on the
+    // axis rule it exists to reject.
+    expect(pinned).toBe(true);
+
+    await page.locator('[data-nx-node="hx-heading"]').evaluate(node => {
+      const el = node as HTMLElement;
+      el.style.height = `${el.getBoundingClientRect().height + 40}px`;
+    });
+
+    await expect(page.locator(band("margin", "top"))).toHaveCount(1);
+    await expect(page.locator(band("margin", "bottom"))).toHaveCount(0);
+  });
+
   test("the bands take no pointer events, so a covered block stays clickable", async ({
     page,
   }) => {

--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -1154,6 +1154,103 @@ test.describe("spacing values on the canvas", () => {
     await expect(page.locator(band("margin", "bottom"))).toHaveCount(0);
   });
 
+  test("drops the band when a STRONG own scale moves the edge", async ({
+    page,
+  }) => {
+    /*
+     * The case that separates converting the displacement by the ancestors from
+     * converting it by the composed scale. The displacement is already in the
+     * parent's coordinates — the element's own transform is what produced it —
+     * so multiplying by that transform again counts it twice.
+     *
+     * Measured on a 100px block under `scaleY(0.01)`: each vertical edge moves
+     * 49.5 rendered pixels, while the composed conversion answers 0.495, which
+     * is under the half-pixel threshold and would call a plainly moved edge
+     * stationary. The pinned-edge test above cannot catch this — its
+     * displacement is exactly zero, so both multipliers agree there.
+     */
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(block).toBeVisible();
+    await block.evaluate(node => {
+      const el = node as HTMLElement;
+      el.style.marginTop = "28px";
+    });
+    await block.click();
+    await expect(page.locator(band("margin", "top"))).toHaveCount(1);
+
+    /*
+     * The scale is chosen rather than picked, and it is what makes this test
+     * separate at all. The wrong conversion answers `displacement * scale`, so
+     * the two implementations only disagree while that product is under the
+     * half-pixel threshold — and the displacement is about half the block's
+     * height, which the seed's own padding puts at 120. A tenth of a percent
+     * clears it with room; a hundredth of the box, tried first, did not, and
+     * both implementations dropped the bands for the same reason.
+     */
+    const OWN_SCALE = 0.001;
+    const moved = await block.evaluate((node, value) => {
+      const el = node as HTMLElement;
+      const before = el.getBoundingClientRect().top;
+      el.style.transform = `scaleY(${String(value)})`;
+      return Math.abs(el.getBoundingClientRect().top - before);
+    }, OWN_SCALE);
+    // The separating property, asserted BOTH ways: the edge really moves far,
+    // and the wrong conversion of that same displacement lands under the
+    // threshold — so the two implementations must disagree here.
+    expect(moved).toBeGreaterThan(5);
+    expect(moved * OWN_SCALE).toBeLessThan(0.5);
+
+    await page.locator('[data-nx-node="hx-heading"]').evaluate(node => {
+      const el = node as HTMLElement;
+      el.style.height = `${el.getBoundingClientRect().height + 40}px`;
+    });
+
+    await expect(page.locator(`${BAND}[data-box="margin"]`)).toHaveCount(0);
+  });
+
+  test("draws a retained margin band at its FULL height, not the scaled one", async ({
+    page,
+  }) => {
+    /*
+     * A transform does not scale the space a margin reserves. With the top edge
+     * pinned the band survives, and it has to cover the real gap: measured, a
+     * block with `margin-top: 28px` under a pinning transform leaves 28 rendered
+     * pixels above it, while the composed scale would draw 14 and name half the
+     * space it points at.
+     *
+     * The pinned-edge test asserts the band EXISTS and stops there, so it stays
+     * green against the halved geometry. This one reads the rectangle.
+     */
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(block).toBeVisible();
+    await block.evaluate(node => {
+      (node as HTMLElement).style.marginTop = "28px";
+    });
+    await block.click();
+
+    const before = await page.locator(band("margin", "top")).boundingBox();
+    if (before === null) throw new Error("the margin band has no box");
+    expect(Math.abs(before.height - 28)).toBeLessThan(TOLERANCE);
+
+    await block.evaluate(node => {
+      const el = node as HTMLElement;
+      const shift = (el.getBoundingClientRect().height / 2) * (1 - 0.5);
+      el.style.transform = `translateY(${String(-shift)}px) scaleY(0.5)`;
+    });
+    await page.locator('[data-nx-node="hx-heading"]').evaluate(node => {
+      const el = node as HTMLElement;
+      el.style.height = `${el.getBoundingClientRect().height + 40}px`;
+    });
+
+    const after = await page.locator(band("margin", "top")).boundingBox();
+    if (after === null) throw new Error("the margin band was dropped");
+    expect(Math.abs(after.height - 28)).toBeLessThan(TOLERANCE);
+    // And the number still reads what the author typed.
+    await expect(page.locator(band("margin", "top"))).toHaveText("28");
+  });
+
   test("the bands take no pointer events, so a covered block stays clickable", async ({
     page,
   }) => {

--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -1055,19 +1055,20 @@ test.describe("spacing values on the canvas", () => {
     }
   });
 
-  test("drops the margin only on the AXIS its own transform moves", async ({
+  test("drops EVERY band when a plain translate moves the whole box", async ({
     page,
   }) => {
     /*
-     * The axes are independent, and a lift like `translateY(-4px)` is an
-     * ordinary hover state: measured, `translateY` leaves the horizontal gap at
-     * the authored 20px while making the vertical one −20, and `translateX`
-     * does the reverse. Refusing both axes because one moved would throw away
-     * bands that are exactly right.
+     * An earlier version of this test asserted the opposite for the horizontal
+     * side — that `translateY` left the right margin drawable, on the grounds
+     * that the gap it names is still 32px wide. That was wrong, and the reason
+     * is worth keeping: an edge is a SEGMENT, and the right edge's endpoints are
+     * both displaced vertically by a `translateY`. Its band therefore has the
+     * correct WIDTH forty pixels away from the space it names, which is the
+     * failure this module treats as worse than drawing nothing.
      *
-     * The horizontal margin is authored here because the seed carries only a
-     * block-end one, and a fixture with nothing on the surviving axis would pass
-     * against an implementation that dropped everything.
+     * A pinned edge is a different case and still keeps its band — the test
+     * below covers it. What a plain translate cannot do is pin anything.
      */
     await page.goto(ROUTE);
     const block = page.locator(`[data-nx-node="${PADDED}"]`);
@@ -1077,7 +1078,8 @@ test.describe("spacing values on the canvas", () => {
     });
     await block.click();
 
-    // CONTROL: both axes draw before the transform.
+    // CONTROL: both axes draw before the transform, so the emptiness afterwards
+    // is the rule firing rather than a fixture that authored nothing.
     await expect(page.locator(band("margin", "bottom"))).toHaveCount(1);
     await expect(page.locator(band("margin", "right"))).toHaveCount(1);
 
@@ -1089,8 +1091,11 @@ test.describe("spacing values on the canvas", () => {
       el.style.height = `${el.getBoundingClientRect().height + 40}px`;
     });
 
-    await expect(page.locator(band("margin", "bottom"))).toHaveCount(0);
-    await expect(page.locator(band("margin", "right"))).toHaveCount(1);
+    await expect(page.locator(`${BAND}[data-box="margin"]`)).toHaveCount(0);
+    // PADDING is the control on the other side: it lies inside the transform and
+    // travels with the box, so it stays correct and must still be drawn. Without
+    // this, a whole-element refusal would satisfy the assertion above.
+    await expect(page.locator(band("padding", "bottom"))).toHaveCount(1);
   });
 
   test("keeps the band beside an edge its transform leaves STATIONARY", async ({
@@ -1249,6 +1254,139 @@ test.describe("spacing values on the canvas", () => {
     expect(Math.abs(after.height - 28)).toBeLessThan(TOLERANCE);
     // And the number still reads what the author typed.
     await expect(page.locator(band("margin", "top"))).toHaveText("28");
+  });
+
+  test("drops a band whose edge is pinned on its own axis but slid ALONG itself", async ({
+    page,
+  }) => {
+    /*
+     * An edge is a SEGMENT, so its own coordinate is only half the question.
+     * Measured, `translate(30px, -25px) scaleY(0.5)` leaves the top edge's Y
+     * exactly where layout put it and slides the whole edge thirty pixels
+     * sideways — a band anchored to it then names pixels the margin never
+     * occupied, at exactly the right height.
+     *
+     * The pinned-edge test above varies only Y, so it passes whether or not the
+     * perpendicular extent is considered. This is the case that separates them.
+     */
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(block).toBeVisible();
+    await block.evaluate(node => {
+      (node as HTMLElement).style.marginTop = "28px";
+    });
+    await block.click();
+    await expect(page.locator(band("margin", "top"))).toHaveCount(1);
+
+    const shifted = await block.evaluate(node => {
+      const el = node as HTMLElement;
+      const before = el.getBoundingClientRect();
+      // Derived so the vertical pin holds for this block's height, exactly as
+      // the pinned-edge test does; the sideways slide is what this one adds.
+      const lift = (before.height / 2) * (1 - 0.5);
+      el.style.transform = `translate(30px, ${String(-lift)}px) scaleY(0.5)`;
+      const after = el.getBoundingClientRect();
+      return {
+        topStillPinned: Math.abs(after.top - before.top) < 0.5,
+        movedSideways: Math.abs(after.left - before.left),
+      };
+    });
+    // Both halves of the separating property, asserted rather than assumed.
+    expect(shifted.topStillPinned).toBe(true);
+    expect(shifted.movedSideways).toBeGreaterThan(5);
+
+    await page.locator('[data-nx-node="hx-heading"]').evaluate(node => {
+      const el = node as HTMLElement;
+      el.style.height = `${el.getBoundingClientRect().height + 40}px`;
+    });
+
+    await expect(page.locator(band("margin", "top"))).toHaveCount(0);
+  });
+
+  test("declines margins under an ancestor reflection the block cancels", async ({
+    page,
+  }) => {
+    /*
+     * A reflection cancelled by the element's own composes to a POSITIVE matrix,
+     * so the describability guard — which reads the composed matrix — passes.
+     * Measured: a parent at `scaleX(-1)` holding a child at
+     * `translateX(-width) scaleX(-1)` composes to `a = 1` while the ancestor's
+     * own `a` is still −1.
+     *
+     * That negative factor is what a margin would be scaled by, turning a
+     * positive margin into a negative extent — drawn INWARD over the content and
+     * still labelled as ordinary positive spacing. The mirrored space is real; a
+     * rectangle claiming to be it is not.
+     */
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="hx-nested-text"]`);
+    await expect(block).toBeVisible();
+    await block.evaluate(node => {
+      (node as HTMLElement).style.marginLeft = "24px";
+    });
+    await block.click();
+
+    // CONTROL: the band draws before either reflection exists.
+    await expect(page.locator(band("margin", "left"))).toHaveCount(1);
+
+    /*
+     * Both transforms go on together, because neither alone reaches the state.
+     * The element's reflection ALONE composes to a negative matrix and the
+     * describability guard refuses the whole overlay; the ancestor's alone does
+     * the same. Only the pair composes to a positive matrix that passes.
+     *
+     * The element's shift is `-2 * originX`, which pins the endpoint at local
+     * `v = 0`: a transform about `o` maps `v` to `o + a(v - o) + e`, so with
+     * `a = -1` that endpoint moves by `2o + e`, and `e = -2o` makes it zero.
+     * That endpoint is what the per-edge rule consults for the LEFT side, so the
+     * left margin survives the endpoint rule and the ancestor's sign becomes the
+     * only thing left to refuse it.
+     *
+     * Note the reflection SWAPS which edge is which on screen — the image of
+     * `v = 0` is the rendered box's right side — so an on-screen check of
+     * `rect.left` would be measuring the wrong endpoint. The separation is
+     * established by the break instead: removing the ancestor guard puts this
+     * band back.
+     */
+    const cancelled = await page.evaluate(() => {
+      const section = document.querySelector(
+        '[data-nx-node="hx-section"]'
+      ) as HTMLElement;
+      const text = document.querySelector(
+        '[data-nx-node="hx-nested-text"]'
+      ) as HTMLElement;
+      const originX = Number.parseFloat(
+        getComputedStyle(text).transformOrigin.split(" ")[0] ?? "0"
+      );
+      section.style.transform = "scaleX(-1)";
+      text.style.transform = `translateX(${String(-2 * originX)}px) scaleX(-1)`;
+      const compose = (el: Element | null): DOMMatrix => {
+        let m = new DOMMatrix();
+        for (let n = el; n !== null; n = n.parentElement) {
+          const t = getComputedStyle(n).transform;
+          if (t !== "" && t !== "none") m = new DOMMatrix(t).multiply(m);
+        }
+        return m;
+      };
+      return {
+        ancestorNegative: compose(section).a < 0,
+        composedPositive:
+          compose(document.querySelector('[data-nx-node="hx-nested-text"]')).a >
+          0,
+      };
+    });
+    // The separating property: the describability guard upstream sees a POSITIVE
+    // composition and lets this through, so an ancestor-side check is the only
+    // thing that can refuse it.
+    expect(cancelled.ancestorNegative).toBe(true);
+    expect(cancelled.composedPositive).toBe(true);
+
+    await page.locator('[data-nx-node="hx-heading"]').evaluate(node => {
+      const el = node as HTMLElement;
+      el.style.height = `${el.getBoundingClientRect().height + 40}px`;
+    });
+
+    await expect(page.locator(`${BAND}[data-box="margin"]`)).toHaveCount(0);
   });
 
   test("the bands take no pointer events, so a covered block stays clickable", async ({

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -217,55 +217,66 @@ export interface RenderedScale {
   /** False for a rotation, a skew, a reflection, or a collapse to zero. */
   readonly describable: boolean;
   /**
-   * The axes the element's OWN transform moves or rescales, if any.
+   * The physical edges the element's OWN transform draws away from their layout
+   * position.
    *
    * Separated from the composed scale because the two do OPPOSITE things to a
    * margin. **A transform does not affect layout.** An ancestor's transform
    * scales the whole subtree it lays out, gaps included, so a margin inside one
    * really does render smaller and `x`/`y` above are right to apply. The
-   * element's own transform moves only its rendering, while the space its
-   * margin reserves stays where the untransformed box left it.
+   * element's own transform moves only its rendering, while the space its margin
+   * reserves stays where the untransformed box left it — measured, a 100px block
+   * with `margin-bottom: 20px` under `scale(2)` leaves a gap of MINUS eighty
+   * pixels, drawn over the neighbour the margin is holding away.
    *
-   * Measured on a 100px block with a 20px margin, reading the gap between the
-   * rendered border edge and the next sibling on each axis:
+   * PER EDGE, and the question asked is the direct one: does this edge RENDER
+   * where it LAYS OUT. Coarser answers were tried and each was a different wrong
+   * one. Reading whether a transform is DECLARED blanks the margins of every
+   * resting hover state, since `scale(1)`, `translate(0)` and `rotate(360deg)`
+   * all compute to a non-`none` matrix that moves nothing. Reading it per AXIS
+   * blanks a valid band whenever one edge is pinned: measured,
+   * `translateY(-25px) scaleY(0.5)` on a 100px block computes to
+   * `matrix(1, 0, 0, 0.5, 0, -25)` and renders its top edge exactly where the
+   * layout put it while moving the bottom one, and `transform` is a catalog
+   * property so an author reaches that with no `transform-origin` at all.
    *
-   * | transform on the block | vertical gap | horizontal gap |
-   * | --- | --- | --- |
-   * | none | 20 | 20 |
-   * | `scale(1)`, `translate(0)`, `rotate(360deg)` | 20 | 20 |
-   * | `translateY(40px)` | **−20** | 20 |
-   * | `translateX(30px)` | 20 | **−10** |
-   * | `scaleY(0.5)` | **70** | 20 |
-   * | `scaleX(0.5)` | 20 | **70** |
-   *
-   * Two things follow, and each rules out a simpler answer.
-   *
-   * PER AXIS, because a transform on one axis leaves the other's margin exactly
-   * where it was — and a lift like `translateY(-4px)` is a common hover state
-   * whose left and right bands stay perfectly good.
-   *
-   * By the MATRIX, not by the presence of a declaration. `scale(1)`,
-   * `translate(0)`, `translateY(0)` and `rotate(360deg)` all compute to a
-   * non-`none` transform and all serialize to exactly
-   * `matrix(1, 0, 0, 1, 0, 0)`; they move nothing, and they are the resting
-   * state of every hover animation, so treating them as displacement would
-   * blank the margins of a large share of real pages.
-   *
-   * The negatives in that table are why an axis this reports is DECLINED rather
-   * than corrected: the block is drawn over the neighbour its margin is holding
-   * away, so no rectangle beside the rendered border edge describes it and no
-   * factor applied to `20` produces one.
+   * There is no finer grain below an edge, which is the point of asking the
+   * question this way rather than refining a proxy again.
    */
-  readonly selfMoved: { readonly x: boolean; readonly y: boolean };
+  readonly selfMoved: MovedEdges;
 }
 
-const NOT_MOVED = { x: false, y: false } as const;
+/** Which physical edges are drawn away from where they were laid out. */
+export interface MovedEdges {
+  readonly top: boolean;
+  readonly right: boolean;
+  readonly bottom: boolean;
+  readonly left: boolean;
+}
+
+const NO_EDGE_MOVED: MovedEdges = {
+  top: false,
+  right: false,
+  bottom: false,
+  left: false,
+};
+
+/**
+ * How far an edge may be drawn from its layout position and still count as put.
+ *
+ * Half a rendered pixel: below that the band and the space it names are the same
+ * pixels on screen, and refusing the band would cost an author information to
+ * avoid an error nobody can see. Deliberately NOT the axis-aligned tolerance,
+ * which guards serialization noise in a matrix term; this one is about what is
+ * visible, and the two would drift apart if they shared a constant.
+ */
+const EDGE_STILL_PX = 0.5;
 
 const IDENTITY_SCALE: RenderedScale = {
   x: 1,
   y: 1,
   describable: true,
-  selfMoved: NOT_MOVED,
+  selfMoved: NO_EDGE_MOVED,
 };
 
 /** Below this, an off-diagonal matrix term is serialization noise, not a rotation. */
@@ -330,11 +341,25 @@ export function renderedScale(element: Element, root: Element): RenderedScale {
     matrix.is2D &&
     Math.abs(matrix.b) < AXIS_ALIGNED_TOLERANCE &&
     Math.abs(matrix.c) < AXIS_ALIGNED_TOLERANCE;
+  const describable = axisAligned && matrix.a > 0 && matrix.d > 0;
+  const scale = { x: matrix.a, y: matrix.d };
   return {
-    x: matrix.a,
-    y: matrix.d,
-    describable: axisAligned && matrix.a > 0 && matrix.d > 0,
-    selfMoved: axesMovedBy(own),
+    ...scale,
+    describable,
+    /*
+     * Only asked where the composed scale is usable, because deriving the
+     * untransformed box divides by it: a collapsed or mirrored composition has
+     * no box to measure against, and the caller refuses such an element
+     * outright, so every edge is reported moved rather than divided for.
+     */
+    selfMoved: describable
+      ? edgesMovedBy(
+          own,
+          transformOriginOf(view.getComputedStyle(element)),
+          untransformedBox(element, scale),
+          scale
+        )
+      : { top: true, right: true, bottom: true, left: true },
   };
 }
 
@@ -376,15 +401,78 @@ export function renderedScale(element: Element, root: Element): RenderedScale {
  * rather than wrong: an anchored edge keeps its band today and would lose it,
  * which is the safe direction to be imprecise in.
  */
-function axesMovedBy(own: DOMMatrix | null): { x: boolean; y: boolean } {
-  if (own === null) return { ...NOT_MOVED };
-  const off = (value: number): boolean =>
-    Math.abs(value) > AXIS_ALIGNED_TOLERANCE;
-  if (!own.is2D || off(own.b) || off(own.c)) return { x: true, y: true };
+function edgesMovedBy(
+  own: DOMMatrix | null,
+  origin: { x: number; y: number },
+  box: { width: number; height: number },
+  scale: { x: number; y: number }
+): MovedEdges {
+  if (own === null) return { ...NO_EDGE_MOVED };
+  const skewed =
+    !own.is2D ||
+    Math.abs(own.b) > AXIS_ALIGNED_TOLERANCE ||
+    Math.abs(own.c) > AXIS_ALIGNED_TOLERANCE;
+  if (skewed) return { top: true, right: true, bottom: true, left: true };
+
+  /*
+   * How far one edge is drawn from where it was laid out.
+   *
+   * A transform about an origin maps a local coordinate `v` to
+   * `o + factor * (v - o) + shift`, so an edge at `v` is displaced by
+   * `(o - v) * (1 - factor) + shift`. The near edge sits at `v = 0` and the far
+   * one at `v = size`, which is the whole of the arithmetic.
+   *
+   * Compared in RENDERED pixels rather than local ones, because the tolerance is
+   * about what an author can see: a tenth of a local pixel under a tenfold
+   * ancestor scale is a visible pixel on screen, and the same displacement
+   * inside a shrunken ancestor is not.
+   */
+  const moved = (
+    o: number,
+    v: number,
+    factor: number,
+    shift: number,
+    axisScale: number
+  ): boolean =>
+    Math.abs(((o - v) * (1 - factor) + shift) * axisScale) > EDGE_STILL_PX;
+
   return {
-    x: off(own.a - 1) || off(own.e),
-    y: off(own.d - 1) || off(own.f),
+    top: moved(origin.y, 0, own.d, own.f, scale.y),
+    bottom: moved(origin.y, box.height, own.d, own.f, scale.y),
+    left: moved(origin.x, 0, own.a, own.e, scale.x),
+    right: moved(origin.x, box.width, own.a, own.e, scale.x),
   };
+}
+
+/**
+ * The element's own border box before its own transform, in local pixels.
+ *
+ * Derived from the rendered rectangle and the COMPOSED scale rather than read
+ * from `offsetWidth`, which is integer-rounded: half a pixel of rounding is
+ * multiplied by `1 - factor` in the arithmetic above, and under a large scale
+ * that is enough to report a stationary edge as displaced.
+ *
+ * The composed scale is used because the rendered rectangle has been through
+ * every transform between the element and the root, not only its own.
+ */
+function untransformedBox(
+  element: Element,
+  scale: { x: number; y: number }
+): { width: number; height: number } {
+  const rect = element.getBoundingClientRect();
+  return { width: rect.width / scale.x, height: rect.height / scale.y };
+}
+
+/** The resolved `transform-origin`, in local pixels from the border box's corner. */
+function transformOriginOf(style: CSSStyleDeclaration): {
+  x: number;
+  y: number;
+} {
+  // Two or three components, space separated, already resolved to pixels by the
+  // time computed style reports them — a keyword or a percentage never survives
+  // to here. The third is the Z origin, which an axis-aligned box ignores.
+  const parts = style.transformOrigin.split(" ");
+  return { x: edgeWidth(parts[0] ?? ""), y: edgeWidth(parts[1] ?? "") };
 }
 
 /**

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -391,6 +391,56 @@ export function renderedScale(element: Element, root: Element): RenderedScale {
 }
 
 /**
+ * How far each of the box's four extremes is drawn from where it was laid out.
+ *
+ * A transform about an origin maps a local coordinate `v` to
+ * `o + factor * (v - o) + shift`, so an extreme at `v` is displaced by
+ * `(o - v) * (1 - factor) + shift`. The near extreme sits at `v = 0` and the far
+ * one at `v = size`, which is the whole of the arithmetic.
+ *
+ * Compared in RENDERED pixels rather than local ones, because the tolerance is
+ * about what an author can see: a tenth of a local pixel under a tenfold
+ * ancestor scale is a visible pixel on screen, and the same displacement inside
+ * a shrunken ancestor is not.
+ *
+ * Converted by the ANCESTOR scale, never the composed one. The displacement is
+ * already expressed in the parent's coordinates — the element's own transform is
+ * what produced it — so multiplying by that transform again counts it twice and
+ * understates the movement by exactly the factor doing the moving. Measured, a
+ * 100px block under `scaleY(0.01)` displaces each vertical extreme by 49.5
+ * rendered pixels while the composed conversion answers 0.495, which is under
+ * the threshold and would call a plainly moved extreme stationary.
+ *
+ * These are EXTREMES of the box rather than named sides, and the distinction is
+ * load-bearing under a reflection: the image of `v = 0` is then the rendered
+ * box's far side, so `leftX` names the displacement of the near extreme and not
+ * of whatever ends up on the left. Callers that could meet a reflection refuse
+ * it before reading these.
+ */
+function endpointsMovedBy(
+  own: DOMMatrix,
+  origin: { x: number; y: number },
+  box: { width: number; height: number },
+  ancestor: { x: number; y: number }
+): { topY: boolean; bottomY: boolean; leftX: boolean; rightX: boolean } {
+  const moved = (
+    o: number,
+    v: number,
+    factor: number,
+    shift: number,
+    axisScale: number
+  ): boolean =>
+    Math.abs(((o - v) * (1 - factor) + shift) * axisScale) > EDGE_STILL_PX;
+
+  return {
+    topY: moved(origin.y, 0, own.d, own.f, ancestor.y),
+    bottomY: moved(origin.y, box.height, own.d, own.f, ancestor.y),
+    leftX: moved(origin.x, 0, own.a, own.e, ancestor.x),
+    rightX: moved(origin.x, box.width, own.a, own.e, ancestor.x),
+  };
+}
+
+/**
  * Which physical edges a single element's own transform draws away from layout.
  *
  * Asked of the MATRIX rather than of the declaration, because a declaration that
@@ -427,14 +477,34 @@ function edgesMovedBy(
   own: DOMMatrix | null,
   origin: { x: number; y: number },
   box: { width: number; height: number },
-  scale: { x: number; y: number }
+  ancestor: { x: number; y: number }
 ): MovedEdges {
+  const EVERY_EDGE: MovedEdges = {
+    top: true,
+    right: true,
+    bottom: true,
+    left: true,
+  };
   if (own === null) return { ...NO_EDGE_MOVED };
+  /*
+   * A non-positive ancestor scale carries no margin that can be drawn, and it
+   * reaches here past the caller's own guard: that guard reads the COMPOSED
+   * matrix, and an ancestor reflection CANCELLED by the element's own reflection
+   * composes to a positive matrix. Measured, a parent at `scaleX(-1)` holding a
+   * child at `translateX(-200px) scaleX(-1)` composes to `a = 1` and passes
+   * describability while the ancestor's own `a` is still −1.
+   *
+   * Left unchecked that negative factor becomes the margin's scale, turning a
+   * positive margin into a negative extent — which the band code draws INWARD
+   * over the content while still labelling it as ordinary positive spacing. The
+   * mirrored space is real; a rectangle claiming to be it is not.
+   */
+  if (!(ancestor.x > 0) || !(ancestor.y > 0)) return EVERY_EDGE;
   const skewed =
     !own.is2D ||
     Math.abs(own.b) > AXIS_ALIGNED_TOLERANCE ||
     Math.abs(own.c) > AXIS_ALIGNED_TOLERANCE;
-  if (skewed) return { top: true, right: true, bottom: true, left: true };
+  if (skewed) return EVERY_EDGE;
 
   /*
    * How far one edge is drawn from where it was laid out.
@@ -458,20 +528,43 @@ function edgesMovedBy(
    * 0.495, which is under the threshold and would call a plainly moved edge
    * stationary.
    */
-  const moved = (
-    o: number,
-    v: number,
-    factor: number,
-    shift: number,
-    axisScale: number
-  ): boolean =>
-    Math.abs(((o - v) * (1 - factor) + shift) * axisScale) > EDGE_STILL_PX;
+  const { topY, bottomY, leftX, rightX } = endpointsMovedBy(
+    own,
+    origin,
+    box,
+    ancestor
+  );
 
+  return edgesFromEndpoints({ topY, bottomY, leftX, rightX });
+}
+
+/**
+ * Which edges are undrawable, given which of the box's extremes moved.
+ *
+ * An edge is a SEGMENT, so BOTH of its endpoints have to land where layout put
+ * them. Its own coordinate is only half the question: measured,
+ * `translate(30px, -25px) scaleY(0.5)` leaves the top edge's Y exactly where
+ * layout had it and slides the whole edge thirty pixels sideways, so a band
+ * anchored to it names pixels the margin never occupied, at exactly the right
+ * height.
+ *
+ * The top and bottom edges therefore need the horizontal extent still, and the
+ * left and right edges need the vertical extent still — which is why the four
+ * answers are not independent even though the four displacements are.
+ */
+function edgesFromEndpoints(moved: {
+  topY: boolean;
+  bottomY: boolean;
+  leftX: boolean;
+  rightX: boolean;
+}): MovedEdges {
+  const acrossStill = !moved.leftX && !moved.rightX;
+  const downStill = !moved.topY && !moved.bottomY;
   return {
-    top: moved(origin.y, 0, own.d, own.f, scale.y),
-    bottom: moved(origin.y, box.height, own.d, own.f, scale.y),
-    left: moved(origin.x, 0, own.a, own.e, scale.x),
-    right: moved(origin.x, box.width, own.a, own.e, scale.x),
+    top: moved.topY || !acrossStill,
+    bottom: moved.bottomY || !acrossStill,
+    left: moved.leftX || !downStill,
+    right: moved.rightX || !downStill,
   };
 }
 

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -244,6 +244,20 @@ export interface RenderedScale {
    * question this way rather than refining a proxy again.
    */
   readonly selfMoved: MovedEdges;
+  /**
+   * The composition ABOVE the element, excluding its own transform.
+   *
+   * Margins are measured with this and padding with the composed scale, because
+   * the two live in different spaces. Padding is inside the element's own
+   * transform and renders scaled with it; a margin is laid out in the PARENT's
+   * coordinates, and the element's own transform never touches the space it
+   * reserves.
+   *
+   * Measured: a 100px block with `margin-top: 28px` and a transform pinning its
+   * top edge leaves a real gap of 28 rendered pixels above it, not 14 — so a
+   * band drawn at the composed scale is half the size of the space it names.
+   */
+  readonly ancestor: { readonly x: number; readonly y: number };
 }
 
 /** Which physical edges are drawn away from where they were laid out. */
@@ -275,6 +289,7 @@ const EDGE_STILL_PX = 0.5;
 const IDENTITY_SCALE: RenderedScale = {
   x: 1,
   y: 1,
+  ancestor: { x: 1, y: 1 },
   describable: true,
   selfMoved: NO_EDGE_MOVED,
 };
@@ -301,6 +316,15 @@ export function renderedScale(element: Element, root: Element): RenderedScale {
    * its square while the page was scaled by it once.
    */
   let own: DOMMatrix | null = null;
+  /*
+   * The composition ABOVE the element, accumulated in the same walk.
+   *
+   * Margins need it and padding does not, because they live in different
+   * spaces: padding is inside the element's own transform and renders scaled
+   * with it, while a margin is laid out in the PARENT's coordinates and the
+   * element's own transform never touches it.
+   */
+  let ancestors = new view.DOMMatrix();
   for (
     let node: Element | null = element;
     node !== null && node !== root;
@@ -313,6 +337,7 @@ export function renderedScale(element: Element, root: Element): RenderedScale {
     // the composed answer and the element's own cannot disagree about which
     // declaration was seen.
     if (node === element) own = step;
+    else ancestors = step.multiply(ancestors);
     matrix = step.multiply(matrix);
   }
 
@@ -343,8 +368,10 @@ export function renderedScale(element: Element, root: Element): RenderedScale {
     Math.abs(matrix.c) < AXIS_ALIGNED_TOLERANCE;
   const describable = axisAligned && matrix.a > 0 && matrix.d > 0;
   const scale = { x: matrix.a, y: matrix.d };
+  const ancestor = { x: ancestors.a, y: ancestors.d };
   return {
     ...scale,
+    ancestor,
     describable,
     /*
      * Only asked where the composed scale is usable, because deriving the
@@ -357,49 +384,44 @@ export function renderedScale(element: Element, root: Element): RenderedScale {
           own,
           transformOriginOf(view.getComputedStyle(element)),
           untransformedBox(element, scale),
-          scale
+          ancestor
         )
       : { top: true, right: true, bottom: true, left: true },
   };
 }
 
 /**
- * Which axes a single element's own transform actually displaces.
+ * Which physical edges a single element's own transform draws away from layout.
  *
- * Asked of the MATRIX rather than of the declaration, because a declaration
- * that moves nothing is ordinary: `scale(1)`, `translate(0)`, `translateY(0)`
- * and `rotate(360deg)` all compute to a non-`none` transform and all serialize
- * to exactly `matrix(1, 0, 0, 1, 0, 0)`. They are the resting state of every
- * hover animation, so reading presence rather than effect blanks the margins of
- * a large share of real pages.
+ * Asked of the MATRIX rather than of the declaration, because a declaration that
+ * moves nothing is ordinary: `scale(1)`, `translate(0)`, `translateY(0)` and
+ * `rotate(360deg)` all compute to a non-`none` transform and all serialize to
+ * exactly `matrix(1, 0, 0, 1, 0, 0)`. They are the resting state of every hover
+ * animation, so reading presence rather than effect blanks the margins of a
+ * large share of real pages.
  *
- * `a` and `d` are the per-axis scales and `e`/`f` the per-axis translations, so
- * each axis is decided by its own two terms. A rotation or a skew mixes the
- * axes and moves both; anything not flat in 2D is not decidable by these terms
- * at all, and both are reported moved rather than guessed at.
+ * Asked PER EDGE rather than per axis, because a transform is applied about
+ * `transform-origin` and a translate composed with a scale pins one edge while
+ * moving the other. Measured, `translateY(-25px) scaleY(0.5)` on a 100px block
+ * renders its top edge exactly where layout put it and moves only the bottom —
+ * and that needs `transform` alone, which IS a catalog property.
  *
- * The tolerance is the same one the axis-aligned test uses and is there for the
- * same reason: an engine may serialize a geometric identity with a residue
- * instead of normalizing it away. It is far below any displacement a person
- * could author or see.
+ * An earlier version answered per axis and argued the pinned case could not
+ * arise, on the grounds that `transform-origin` is not authorable here. That
+ * trace was right and the conclusion drawn from it was too wide: proving one
+ * MECHANISM unreachable is not proving the STATE unreachable, and composing two
+ * functions of one property reaches it. The note is kept because the shape of
+ * the error is worth more than the correction — the question to ask of an
+ * unreachability argument is what ELSE produces the state.
  *
- * PER AXIS RATHER THAN PER EDGE, which is a deliberate bound and not an
- * oversight. A transform is applied about `transform-origin`, so an origin
- * anchored to one side leaves that side's edge stationary and moves only the
- * far one — under `transform-origin: top` and `scaleY(0.5)`, measured, the top
- * edge does not move at all and its margin stays perfectly describable.
+ * `a` and `d` are the per-axis scales and `e`/`f` the per-axis translations,
+ * which is why each edge is decided by the two terms of its own axis. A rotation
+ * or a skew mixes the axes and moves every edge; anything not flat in 2D is not
+ * decidable by these terms at all, and all four are reported moved rather than
+ * guessed at.
  *
- * That state is not reachable here. `transform` is a catalog property and
- * `transform-origin` is NOT, so every transform this system can author is
- * applied about the initial `50% 50%` — and measured under that origin,
- * `scaleY(0.5)` moves the top edge as well as the bottom, which is exactly what
- * an axis answers. Per edge would additionally have to read and resolve the
- * origin and the untransformed box on every measure, paying for a case the
- * catalog cannot produce.
- *
- * Should `transform-origin` ever join the catalog, this becomes conservative
- * rather than wrong: an anchored edge keeps its band today and would lose it,
- * which is the safe direction to be imprecise in.
+ * There is no grain below an edge, which is the point of asking whether an edge
+ * RENDERS WHERE IT LAYS OUT rather than refining a proxy for a fourth time.
  */
 function edgesMovedBy(
   own: DOMMatrix | null,
@@ -426,6 +448,15 @@ function edgesMovedBy(
    * about what an author can see: a tenth of a local pixel under a tenfold
    * ancestor scale is a visible pixel on screen, and the same displacement
    * inside a shrunken ancestor is not.
+   *
+   * Converted by the ANCESTOR scale, never the composed one. The displacement
+   * above is already expressed in the parent's coordinates — the element's own
+   * transform is what produced it — so multiplying by that transform again
+   * counts it twice and understates the movement by exactly the factor doing
+   * the moving. Measured, a 100px block under `scaleY(0.01)` displaces each
+   * vertical edge by 49.5 rendered pixels while the composed conversion answers
+   * 0.495, which is under the threshold and would call a plainly moved edge
+   * stationary.
    */
   const moved = (
     o: number,

--- a/packages/builder/src/spacing-bands.test.ts
+++ b/packages/builder/src/spacing-bands.test.ts
@@ -30,6 +30,9 @@ function bandsFor(over: Partial<SpacingGeometry>): readonly SpacingBand[] {
     margin: NONE,
     padding: NONE,
     scale: { x: 1, y: 1 },
+    // Equal to `scale` unless a case says otherwise, which is what an element
+    // carrying no transform of its own reports.
+    marginScale: over.scale ?? { x: 1, y: 1 },
     ...over,
   });
 }
@@ -293,6 +296,54 @@ describe("where a margin band lands", () => {
       width: 20,
       height: 150,
     });
+  });
+});
+
+describe("which scale each box is drawn at", () => {
+  it("scales a MARGIN by the ancestors alone, not by the element's own transform", () => {
+    /*
+     * The separating case, and it needs the two scales to DIFFER — with one
+     * scale for both boxes every assertion here passes on either implementation.
+     *
+     * A transform does not scale the space a margin reserves. Measured, a 100px
+     * block with `margin-top: 28px` under a transform pinning its top edge
+     * leaves a real gap of 28 rendered pixels while the composed scale would
+     * draw the band 14 high, naming the space beside it wrongly by half.
+     */
+    const bands = bandsFor({
+      margin: { ...NONE, top: 28 },
+      scale: { x: 1, y: 0.5 },
+      marginScale: { x: 1, y: 1 },
+    });
+
+    expect(band(bands, "margin", "top")?.rect.height).toBe(28);
+  });
+
+  it("scales PADDING by the composed scale, which includes the element's own", () => {
+    // The mirror, and the reason this is not simply "stop scaling". Padding
+    // lies INSIDE the transform and renders scaled with the box, so the same
+    // fixture must halve the padding while leaving the margin whole.
+    const bands = bandsFor({
+      padding: { ...NONE, top: 28 },
+      scale: { x: 1, y: 0.5 },
+      marginScale: { x: 1, y: 1 },
+    });
+
+    expect(band(bands, "padding", "top")?.rect.height).toBe(14);
+  });
+
+  it("labels both with the AUTHORED value, whichever scale drew them", () => {
+    // The number is what the author typed, and neither scale is allowed to
+    // reach it — a band reading `14` names a value in no document.
+    const bands = bandsFor({
+      margin: { ...NONE, top: 28 },
+      padding: { ...NONE, top: 28 },
+      scale: { x: 1, y: 0.5 },
+      marginScale: { x: 1, y: 1 },
+    });
+
+    expect(band(bands, "margin", "top")?.label).toBe("28");
+    expect(band(bands, "padding", "top")?.label).toBe("28");
   });
 });
 

--- a/packages/builder/src/spacing-bands.ts
+++ b/packages/builder/src/spacing-bands.ts
@@ -93,6 +93,21 @@ export interface SpacingGeometry {
   readonly padding: EdgeLengths;
   /** The scale `border` was measured at. See the module docblock. */
   readonly scale: Scale;
+  /**
+   * The scale a MARGIN renders at, which is not always the one above.
+   *
+   * Padding and border widths lie inside the element's own transform and render
+   * scaled with it, so `scale` is right for them. A margin does not: it is laid
+   * out in the PARENT's coordinates, and the element's own transform moves only
+   * its own rendering. Measured — a 100px block with `margin-top: 28px` under a
+   * transform that pins its top edge leaves a real gap of 28 rendered pixels,
+   * while the composed scale would draw the band 14 high and name the space
+   * beside it wrongly by half.
+   *
+   * Equal to {@link scale} for the ordinary element that carries no transform of
+   * its own, which is why this is easy to miss.
+   */
+  readonly marginScale: Scale;
 }
 
 const SIDES: readonly SpacingSide[] = ["top", "right", "bottom", "left"];
@@ -140,14 +155,20 @@ export function spacingBands(
    * right only while the transform is uniform, and `scale(2, 0.5)` is a single
    * legal value that makes it wrong on one axis.
    */
-  const scaled = (edges: EdgeLengths): EdgeLengths => ({
-    top: edges.top * scale.y,
-    right: edges.right * scale.x,
-    bottom: edges.bottom * scale.y,
-    left: edges.left * scale.x,
-  });
+  const scaledBy =
+    (by: Scale) =>
+    (edges: EdgeLengths): EdgeLengths => ({
+      top: edges.top * by.y,
+      right: edges.right * by.x,
+      bottom: edges.bottom * by.y,
+      left: edges.left * by.x,
+    });
+  const scaled = scaledBy(scale);
 
-  const margin = scaled(geometry.margin);
+  // Margins take the ancestors' scale alone. See `marginScale`: the element's
+  // own transform renders its box smaller without touching the space its margin
+  // reserves, so the two boxes genuinely scale differently.
+  const margin = scaledBy(geometry.marginScale)(geometry.margin);
   const padding = scaled(geometry.padding);
   const bands: SpacingBand[] = [];
 

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -413,6 +413,9 @@ export function SpacingOverlay({
         // Composed from the real transform between the block and the root, so
         // a scaled ancestor counts and no rounded layout value is involved.
         scale: { x: scale.x, y: scale.y },
+        // Margins take the ancestors' scale ALONE — a transform does not scale
+        // the space a margin reserves, only the box it is drawn beside.
+        marginScale: { x: scale.ancestor.x, y: scale.ancestor.y },
       }),
       layerBox
     );

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -214,11 +214,12 @@ export function isReplaced(element: Element): boolean {
  * leaves a gap of MINUS eighty pixels, drawn over the neighbour that margin is
  * holding away, so no rectangle beside the rendered border edge describes it.
  *
- * That second reason is applied PER AXIS, because the sides are independent:
- * `translateY(-4px)` — an ordinary hover lift — moves the top and bottom
- * margins and leaves the left and right ones exactly where they were. See
- * `selfMoved`, which reads the matrix rather than the declaration, so an
- * identity-valued transform keeps every band.
+ * That second reason is applied PER EDGE, because the sides are independent and
+ * so are the two ends of one axis: `translateY(-4px)` — an ordinary hover lift —
+ * moves the top and bottom margins and leaves left and right where they were,
+ * while `translateY(-25px) scaleY(0.5)` pins the TOP edge and moves only the
+ * bottom. See `selfMoved`, which asks whether each edge renders where it lays
+ * out rather than inspecting the declaration.
  *
  * Padding is subject only to the first reason. It lies INSIDE the transform and
  * renders scaled with the box, so those bands stay correct on both axes.
@@ -234,10 +235,10 @@ function drawableBoxes(
     isReplaced(block)
   );
   const margin: EdgeApplicability = {
-    top: applies.margin.top && !scale.selfMoved.y,
-    bottom: applies.margin.bottom && !scale.selfMoved.y,
-    left: applies.margin.left && !scale.selfMoved.x,
-    right: applies.margin.right && !scale.selfMoved.x,
+    top: applies.margin.top && !scale.selfMoved.top,
+    bottom: applies.margin.bottom && !scale.selfMoved.bottom,
+    left: applies.margin.left && !scale.selfMoved.left,
+    right: applies.margin.right && !scale.selfMoved.right,
   };
   const measured = boxesOf(style);
   return {


### PR DESCRIPTION
Greptile raised this as a **P1** on #1148 after it merged, and it defeats an argument I made in that PR's review. Fixing it here, along with the reasoning error behind it.

## The defect

A transform is applied about `transform-origin`, so a **translate composed with a scale pins one edge and moves only the other**. Suppressing the whole axis hid a band that was still correct.

Measured on a 100px block:

| transform | top edge | bottom edge |
| --- | --- | --- |
| `scaleY(0.5)` | moves 70 → 95 | moves |
| `translateY(-25px) scaleY(0.5)` | **stays at 70** | moves |

The second computes to `matrix(1, 0, 0, 0.5, 0, -25)` — and it needs **only `transform`**, which is a catalog property.

## The reasoning error, stated plainly

An earlier round asked for exactly this and cited `transform-origin: top`. I traced it: `transform-origin` is **not** a catalog property, no named class or custom CSS reaches it, and under the only origin the catalog can produce both edges move. I recorded that as a bound and argued the thread rather than building.

**The trace was right. The conclusion was too wide.** I proved one *mechanism* unreachable and concluded the *state* was unreachable, without asking what else produces a stationary edge. Composing two functions of one property does.

## Why this formulation, and not a fourth proxy

This is the fourth round on one property — declared → identity → per-axis → per-edge — and each earlier answer was a different wrong one:

- **declared** blanks every resting hover state: `scale(1)`, `translate(0)` and `rotate(360deg)` all compute to a non-`none` matrix that moves nothing
- **per axis** blanks a pinned edge, which is this finding

So the question asked is now the direct one — **does this edge render where it lays out** — rather than a proxy refined once more. There is no grain below an edge, which is the point.

The arithmetic is just the definition of a transform about an origin: `v ↦ o + factor·(v − o) + shift`, so an edge is displaced by `(o − v)(1 − factor) + shift`, near edge at `v = 0`, far edge at `v = size`.

## Two details that would be silently wrong

**The comparison is in rendered pixels.** The tolerance is about what an author can see, and a tenth of a local pixel under a tenfold ancestor scale is a visible one.

**The untransformed box is derived from the rendered rect and the composed scale**, not read from `offsetWidth` — that is integer-rounded, and half a pixel multiplied by `1 − factor` reports a stationary edge as displaced under a large scale.

`EDGE_STILL_PX` is deliberately separate from the axis-aligned tolerance: that guards serialization noise in a matrix term, this is about visibility, and sharing a constant would let them drift into each other.

## Evidence

Break-verified: collapsing back to per-axis fails **only** the new test, and every earlier transform test still passes — so this is a strict refinement rather than a replacement.

The browser fixture **derives its translate from the block's measured height**, because a literal pins the edge only for a block of that exact size and the seed's is not. Written the obvious way it failed its own pinning assertion — which is the assertion that stops it passing on the axis rule it exists to reject.

## Gates

`build 0` · `check-types 0` · builder **1465** · plugin-page-builder **205** · builder/e2e lint `0` · root eslint `0` · comment convention `0` · changeset `0` · **fallow `pass`, zero introduced** · e2e **33 passed**

## Still open from #1145, not in this PR

Two P2s about rounded geometry — padding boxes and ancestor clips are both modelled as rectangles while `border-radius` is a catalog style. They share a piece of radius arithmetic and land next, kept separate so each PR has one subject.
