### PR TITLE
test(admin): restore the code-palette guards lost from #1151

### DIFF
--- a/packages/admin/src/lib/__tests__/code-highlight.test.ts
+++ b/packages/admin/src/lib/__tests__/code-highlight.test.ts
@@ -23,10 +23,11 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { tags } from "@lezer/highlight";
+import type { Tag } from "@lezer/highlight";
+import { tags, tags as t } from "@lezer/highlight";
 import { describe, expect, it } from "vitest";
 
-import { CODE_TAG_SPECS } from "../code-highlight";
+import { CODE_TAG_SPECS, nextlyHighlightStyle } from "../code-highlight";
 import { CODE_CONSTRUCTS } from "../code-palette";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -62,9 +63,22 @@ function codeTokensIn(selector: string): Set<string> {
   return found;
 }
 
-/** Every token the palette can put on screen. */
+/**
+ * The chrome's own tokens.
+ *
+ * Consumed by `nextlyEditorChrome` rather than by the construct table, which is
+ * why they are named here rather than derived. They still have to be declared
+ * in BOTH blocks: losing `--nx-code-fg` from `.dark` leaves code inheriting a
+ * foreground picked for a white page.
+ */
+const CHROME_TOKENS = ["--nx-code-bg", "--nx-code-fg"];
+
+/** Every token that can reach the screen, from the table or from the chrome. */
 function consumedTokens(): Set<string> {
-  return new Set(Object.values(CODE_CONSTRUCTS).map(entry => entry.token));
+  return new Set([
+    ...Object.values(CODE_CONSTRUCTS).map(entry => entry.token),
+    ...CHROME_TOKENS,
+  ]);
 }
 
 describe("code-palette", () => {
@@ -103,10 +117,9 @@ describe("code-palette", () => {
     // A token nobody reads is a palette entry that cannot reach the screen.
     // `--nx-code-bg` and `--nx-code-fg` are chrome rather than construct
     // colours, so `nextlyEditorChrome` consumes them instead of the table.
-    const chrome = new Set(["--nx-code-bg", "--nx-code-fg"]);
     const consumed = consumedTokens();
     const unreachable = [...codeTokensIn(":root")].filter(
-      token => !chrome.has(token) && !consumed.has(token)
+      token => !consumed.has(token)
     );
     expect(unreachable).toEqual([]);
   });
@@ -179,40 +192,44 @@ const DELIBERATELY_UNSTYLED: Record<string, string> = {
   // Diff state with no token of its own; `deleted` and `inserted` carry the
   // two cases this admin actually renders.
   changed: "no token; deleted and inserted cover the rendered cases",
-  // Styled in `nextlyHighlightStyle` directly rather than through the palette:
-  // a parse error is a fault, and reads from the admin's error token.
-  invalid: "styled outside the palette, from --nx-destructive",
 };
 
 describe("tag coverage", () => {
   it("styles every standard tag, or says why not", () => {
-    const covered = new Set(
-      CODE_TAG_SPECS.flatMap(spec =>
-        Array.isArray(spec.tag) ? spec.tag : [spec.tag]
-      )
-    );
+    // Asked of the BUILT highlighter rather than of `CODE_TAG_SPECS`, because
+    // the specs are the input and the highlighter is what CodeMirror consults.
+    // The two can disagree -- `t.invalid` is styled by an entry that never
+    // appears in the table -- and reading the input would call that tag
+    // unstyled while the editor colours it correctly.
     const unaccounted = Object.entries(tags)
       .filter(([, tag]) => typeof tag !== "function")
       .filter(
         ([name, tag]) =>
-          !covered.has(tag as never) && !(name in DELIBERATELY_UNSTYLED)
+          nextlyHighlightStyle.style([tag as Tag]) === null &&
+          !(name in DELIBERATELY_UNSTYLED)
       )
       .map(([name]) => name);
     expect(unaccounted).toEqual([]);
   });
 
   it("keeps the unstyled list honest", () => {
-    // An entry that IS styled should not also claim to be deliberately skipped:
-    // the reason would be false and the next reader would trust it.
-    const covered = new Set(
-      CODE_TAG_SPECS.flatMap(spec =>
-        Array.isArray(spec.tag) ? spec.tag : [spec.tag]
-      )
-    );
+    // An entry that IS styled must not also claim to be deliberately skipped:
+    // the reason would be false, and the next reader would trust it.
     const contradictory = Object.keys(DELIBERATELY_UNSTYLED).filter(name => {
       const tag = (tags as Record<string, unknown>)[name];
-      return tag !== undefined && covered.has(tag as never);
+      return (
+        tag !== undefined && nextlyHighlightStyle.style([tag as Tag]) !== null
+      );
     });
     expect(contradictory).toEqual([]);
+  });
+
+  it("styles a parse error from the admin's error token", () => {
+    // `t.invalid` is styled by an entry outside the construct table, so nothing
+    // in the table's own checks reaches it. Without this, deleting that entry
+    // leaves every other assertion green.
+    expect(nextlyHighlightStyle.style([t.invalid])).not.toBeNull();
+    const rule = nextlyHighlightStyle.module?.getRules() ?? "";
+    expect(rule).toContain("--nx-destructive");
   });
 });


### PR DESCRIPTION
## Summary

Restores the last commit of #1151, which did not reach `main`.

#1151's merge was computed at 19:17:43 UTC; this commit was pushed at ~19:20, so GitHub's snapshot of the branch predated it. Nothing went wrong in the change itself — it is a timing race between a push and a merge.

**Nothing user-facing was lost.** The stranded commit touched one file and it was a test file. Every behaviour fix from #1151 is on `main`, verified individually by content against the squash commit `8fa89e1689`: the dark facet wiring, `heading1`–`heading6`, the CSS colour literal, the fold placeholder, the drop cursor, the shared palette module, and the rich-text theme deriving from it.

What was lost is guard strength. Two gaps CodeRabbit found on #1151 are currently open on `main`:

1. **The per-mode token check excluded the chrome tokens.** `--nx-code-bg` and `--nx-code-fg` are consumed by `nextlyEditorChrome` but were filtered out of the assertion that requires a token in BOTH theme blocks. Deleting `--nx-code-fg` from `.dark` leaves code inheriting a foreground chosen for a white page, and the suite stays green.

2. **Tag coverage was read from the spec array rather than the built highlighter.** `t.invalid` is styled by an entry that never appears in `CODE_TAG_SPECS`, so it had to be excused as "deliberately unstyled" — an excuse nothing verified. Deleting the rule it pointed at breaks nothing visible.

The fix for the second is the more interesting one: coverage is now asked of `nextlyHighlightStyle.style()`, so a tag counts as covered when CodeMirror will actually colour it, wherever the rule was declared. That removes the exemption rather than testing around it.

## Test plan

Both gaps break-verified **against the current `main`**, so the failures below are the state this PR repairs rather than a hypothetical:

| break | before this PR | with this PR |
| --- | --- | --- |
| delete `--nx-code-fg` from `.dark` only | passes | fails — `declares every token it reads in .dark` |
| delete the `t.invalid` rule | passes | fails **twice** — coverage check and the dedicated assertion |

`build`, `check-types`, `lint` (`--max-warnings 0`), `check:comments` all pass. `fallow audit` → `pass`, zero introduced. `code-highlight` suite: 13 passed.

## Changeset

Skipped — test-only. `AGENTS.md`: "Test-only, CI-only, or docs-only PRs get NO changeset."

## Pre-existing failures

Unchanged from #1151: 15 failures across 4 files (`StatsCard`, `SlugInput`, `BasicsTab`, `DefaultValueField`), none related to code highlighting.
