### PR TITLE
docs(admin): name the right consumer for each chrome token

### DIFF
--- a/packages/admin/src/lib/__tests__/code-highlight.test.ts
+++ b/packages/admin/src/lib/__tests__/code-highlight.test.ts
@@ -64,12 +64,15 @@ function codeTokensIn(selector: string): Set<string> {
 }
 
 /**
- * The chrome's own tokens.
+ * Tokens outside the construct table, named here because nothing derives them.
  *
- * Consumed by `nextlyEditorChrome` rather than by the construct table, which is
- * why they are named here rather than derived. They still have to be declared
- * in BOTH blocks: losing `--nx-code-fg` from `.dark` leaves code inheriting a
- * foreground picked for a white page.
+ * They have different consumers, which matters to anyone updating this list:
+ * `--nx-code-fg` is the editor's own foreground, set by `nextlyEditorChrome`,
+ * while `--nx-code-bg` is the rich-text code BLOCK's surface, reached through
+ * the `bg-code-bg` utility in `rich-text-kit.ts` and by no editor at all.
+ *
+ * Both still have to be declared in BOTH blocks: losing `--nx-code-fg` from
+ * `.dark` leaves code inheriting a foreground picked for a white page.
  */
 const CHROME_TOKENS = ["--nx-code-bg", "--nx-code-fg"];
 


### PR DESCRIPTION
## Summary

Follow-up to a review note on #1155. The `CHROME_TOKENS` comment attributed both tokens to `nextlyEditorChrome`; only one is its.

Verified on `main`: `code-highlight.ts` contains **zero** occurrences of `--nx-code-bg`, and `bg-code-bg` has exactly one consumer — `rich-text-kit.ts:97`, the rich-text code block's surface.

The list is deliberately hand-maintained, since nothing derives it. A comment sending the next maintainer to the wrong file is the specific way that goes wrong, which is why this is worth its own change rather than being left.

## Test plan

Comment-only; no code touched. `code-highlight` suite 13 passed, `check:comments` passes, `fallow audit` pass.

## Changeset

Skipped — comment-only, no published behaviour changes.