### PR TITLE
fix(admin): render both API playground routes from one page

### DIFF
--- a/.changeset/one-playground-page-two-routes.md
+++ b/.changeset/one-playground-page-two-routes.md
@@ -1,0 +1,32 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+The API Playground for a Single now fills the page and scrolls inside its panes,
+matching the collection view. The two pages had been maintained as separate
+copies and had drifted apart; they are one page now, so a change to either
+reaches both.

--- a/packages/admin/src/components/features/entries/APIPlayground/ApiPlaygroundPage.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/ApiPlaygroundPage.tsx
@@ -1,0 +1,143 @@
+/**
+ * The API Playground's page shell, for a collection or a single.
+ *
+ * One component rather than one per route. The two routes were hand-kept
+ * copies of the same ~140 lines, and they drifted: a scroll-containment fix
+ * reached the collection's copy and not the single's, so a single's panes
+ * collapsed to their content and left the lower third of the page empty. That
+ * is invisible in review, because each file reads correctly on its own and
+ * nothing compares them.
+ *
+ * The differences between the two are small enough to be arguments -- which
+ * schema hook to call, what to call the thing in prose, and which props the
+ * playground needs -- so they are arguments.
+ *
+ * @module components/entries/APIPlayground/ApiPlaygroundPage
+ */
+
+import { Alert, AlertDescription, AlertTitle, Skeleton } from "@nextlyhq/ui";
+
+import { AlertCircle } from "@admin/components/icons";
+import { PageContainer } from "@admin/components/layout/page-container";
+import { useCollection, useSingleSchema } from "@admin/hooks/queries";
+
+import { APIPlayground } from "./APIPlayground";
+
+/** Which of the two schema kinds this page is showing. */
+export type ApiPlaygroundKind = "collection" | "single";
+
+export interface ApiPlaygroundPageProps {
+  kind: ApiPlaygroundKind;
+  /** Absent when the route matched without one, which is worth saying rather than crashing. */
+  slug?: string;
+}
+
+/** What each kind is called in prose, so the copy reads naturally either way. */
+const NOUN: Record<ApiPlaygroundKind, string> = {
+  collection: "collection",
+  single: "single",
+};
+
+export function ApiPlaygroundPage({ kind, slug }: ApiPlaygroundPageProps) {
+  const isSingle = kind === "single";
+  const noun = NOUN[kind];
+
+  // Both hooks are called unconditionally because hooks must be, and each is
+  // disabled unless it is the one this page needs -- so the other issues no
+  // request rather than being skipped.
+  const collection = useCollection(slug ?? "", {
+    enabled: !!slug && !isSingle,
+  });
+  const single = useSingleSchema(slug ?? "", {
+    enabled: !!slug && isSingle,
+  });
+
+  const { data: schema, isLoading, error } = isSingle ? single : collection;
+
+  if (!slug) {
+    return (
+      <div className="p-6">
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>
+            {`A ${noun} slug is required. Please navigate to a ${noun} first.`}
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="p-6 space-y-6">
+        {/* Breadcrumb skeleton */}
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 w-4" />
+          <Skeleton className="h-4 w-4" />
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-4 w-4" />
+          <Skeleton className="h-4 w-32" />
+        </div>
+
+        {/* Header skeleton */}
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-64" />
+          <Skeleton className="h-4 w-96" />
+        </div>
+
+        {/* Content skeleton */}
+        <div className="grid grid-cols-2 gap-6">
+          <Skeleton className="h-[500px]" />
+          <Skeleton className="h-[500px]" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6">
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>
+            {`Failed to load ${noun}: `}
+            {error.message}
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const label = schema?.label || slug;
+
+  return (
+    // Fills the content panel instead of growing past it, so the request and
+    // response panes scroll on their own. Otherwise a long response stretches
+    // the page and takes the response's own status line off-screen with it.
+    <PageContainer className="flex h-full min-h-0 flex-col overflow-hidden">
+      <div className="mb-8 shrink-0">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">
+          API Playground
+        </h1>
+        {/* Muted foreground so this secondary subtitle meets contrast (a faint primary alpha did not). */}
+        <p className="text-sm font-normal text-muted-foreground mt-1">
+          Test API endpoints for the <strong>{label}</strong> {noun}. Build
+          requests, execute them, and view responses.
+        </p>
+      </div>
+
+      <div className="min-h-0 flex-1">
+        <APIPlayground
+          collectionSlug={slug}
+          isSingle={isSingle}
+          fields={schema?.fields}
+          // Only a collection has a Draft/Published column to filter on, and a
+          // single's schema carries no `status` to read.
+          hasStatus={!isSingle && collection.data?.status === true}
+        />
+      </div>
+    </PageContainer>
+  );
+}

--- a/packages/admin/src/components/features/entries/APIPlayground/__tests__/ApiPlaygroundPage.test.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/__tests__/ApiPlaygroundPage.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Both routes render one component, because two hand-kept copies already
+ * drifted once.
+ *
+ * The collection route received a scroll-containment fix that the single route
+ * never did, so a single's panes collapsed to their content and left the lower
+ * third of the page empty. Nothing detected it: the two files were never
+ * compared, and each read correctly on its own.
+ *
+ * The assertions below are therefore written as a PAIR over both kinds rather
+ * than as one test of the shared component. A single test would pass on a
+ * component that is correct and still say nothing about whether both routes
+ * reach it, which is the property that actually failed.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@admin/hooks/queries", () => ({
+  useCollection: () => ({
+    data: { label: "Posts", fields: [], status: true },
+    isLoading: false,
+    error: null,
+  }),
+  useSingleSchema: () => ({
+    data: { label: "Homepage", fields: [] },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+// The playground itself mounts CodeMirror, which wants browser globals and has
+// its own suite. What matters here is the shell it is dropped into.
+vi.mock("../APIPlayground", () => ({
+  APIPlayground: (props: Record<string, unknown>) => (
+    <div data-testid="playground" data-is-single={String(props.isSingle)} />
+  ),
+}));
+
+import { ApiPlaygroundPage } from "../ApiPlaygroundPage";
+
+const KINDS = [
+  { kind: "collection" as const, slug: "posts", label: "Posts" },
+  { kind: "single" as const, slug: "homepage", label: "Homepage" },
+];
+
+describe("ApiPlaygroundPage", () => {
+  it.each(KINDS)("contains its own scroll on a $kind", ({ kind, slug }) => {
+    render(<ApiPlaygroundPage kind={kind} slug={slug} />);
+    const container = screen.getByTestId("page-container");
+    // The three that made the difference: fill the panel, allow the children to
+    // shrink, and keep the overflow inside rather than growing the page.
+    expect(container.className).toContain("h-full");
+    expect(container.className).toContain("min-h-0");
+    expect(container.className).toContain("overflow-hidden");
+  });
+
+  it.each(KINDS)("names the $kind it is testing", ({ kind, slug, label }) => {
+    render(<ApiPlaygroundPage kind={kind} slug={slug} />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it("tells the playground when it is a single", () => {
+    render(<ApiPlaygroundPage kind="single" slug="homepage" />);
+    expect(screen.getByTestId("playground")).toHaveAttribute(
+      "data-is-single",
+      "true"
+    );
+  });
+
+  it("does not claim a collection is a single", () => {
+    render(<ApiPlaygroundPage kind="collection" slug="posts" />);
+    expect(screen.getByTestId("playground")).not.toHaveAttribute(
+      "data-is-single",
+      "true"
+    );
+  });
+
+  it.each(KINDS)(
+    "asks for a slug the $kind route did not supply",
+    ({ kind }) => {
+      render(<ApiPlaygroundPage kind={kind} />);
+      expect(screen.getByRole("alert")).toHaveTextContent(/slug is required/i);
+    }
+  );
+});

--- a/packages/admin/src/components/features/entries/APIPlayground/__tests__/ApiPlaygroundPage.test.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/__tests__/ApiPlaygroundPage.test.tsx
@@ -37,10 +37,34 @@ vi.mock("../APIPlayground", () => ({
 }));
 
 import { ApiPlaygroundPage } from "../ApiPlaygroundPage";
+// The ROUTE modules, by the path the registry imports them from. Rendering
+// their default exports is the only way the delegation itself is observable:
+// calling the shared component directly proves the component works and says
+// nothing about whether either route reaches it, or reaches it correctly.
+import CollectionRoute from "@admin/pages/dashboard/entries/[slug]/api";
+import SingleRoute from "@admin/pages/dashboard/singles/[slug]/api";
 
 const KINDS = [
   { kind: "collection" as const, slug: "posts", label: "Posts" },
   { kind: "single" as const, slug: "homepage", label: "Homepage" },
+];
+
+/** The routes as the registry holds them, with the label each must resolve. */
+const ROUTES = [
+  {
+    name: "collection",
+    Route: CollectionRoute,
+    slug: "posts",
+    label: "Posts",
+    single: false,
+  },
+  {
+    name: "single",
+    Route: SingleRoute,
+    slug: "homepage",
+    label: "Homepage",
+    single: true,
+  },
 ];
 
 describe("ApiPlaygroundPage", () => {
@@ -79,6 +103,54 @@ describe("ApiPlaygroundPage", () => {
     "asks for a slug the $kind route did not supply",
     ({ kind }) => {
       render(<ApiPlaygroundPage kind={kind} />);
+      expect(screen.getByRole("alert")).toHaveTextContent(/slug is required/i);
+    }
+  );
+});
+
+/**
+ * The wiring, not the component.
+ *
+ * This is the suite that would have caught the original defect. A wrapper that
+ * passes the wrong kind, stops forwarding its slug, or is reverted to local
+ * markup leaves every assertion above green, because none of them renders a
+ * route.
+ */
+describe("the route wrappers", () => {
+  it.each(ROUTES)(
+    "$name route delegates to the shared page",
+    ({ Route, slug }) => {
+      render(<Route params={{ slug }} />);
+      // The shared page is the only thing that renders this container with the
+      // containment classes; local markup would have to reproduce them to pass.
+      const container = screen.getByTestId("page-container");
+      expect(container.className).toContain("h-full");
+      expect(container.className).toContain("min-h-0");
+      expect(container.className).toContain("overflow-hidden");
+    }
+  );
+
+  it.each(ROUTES)(
+    "$name route asks for its own kind",
+    ({ Route, slug, label }) => {
+      render(<Route params={{ slug }} />);
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  );
+
+  it.each(ROUTES)(
+    "$name route tells the playground what it is",
+    ({ Route, slug, single }) => {
+      render(<Route params={{ slug }} />);
+      const playground = screen.getByTestId("playground");
+      expect(playground.getAttribute("data-is-single")).toBe(String(single));
+    }
+  );
+
+  it.each(ROUTES)(
+    "$name route forwards a missing slug rather than inventing one",
+    ({ Route }) => {
+      render(<Route params={{}} />);
       expect(screen.getByRole("alert")).toHaveTextContent(/slug is required/i);
     }
   );

--- a/packages/admin/src/components/features/entries/APIPlayground/index.ts
+++ b/packages/admin/src/components/features/entries/APIPlayground/index.ts
@@ -8,6 +8,11 @@
  */
 
 export { APIPlayground, type APIPlaygroundProps } from "./APIPlayground";
+export {
+  ApiPlaygroundPage,
+  type ApiPlaygroundPageProps,
+  type ApiPlaygroundKind,
+} from "./ApiPlaygroundPage";
 export { QueryBuilder, type QueryBuilderProps } from "./QueryBuilder";
 export { ResponseViewer, type ResponseViewerProps } from "./ResponseViewer";
 export { JsonViewer, type JsonViewerProps } from "./JsonViewer";

--- a/packages/admin/src/pages/dashboard/entries/[slug]/api.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/api.tsx
@@ -1,23 +1,17 @@
 /**
  * Collection API Playground Page
  *
- * Interactive API testing interface for collection endpoints.
- * Accessible via /admin/collections/[slug]/api
+ * Accessible via /admin/collections/[slug]/api.
+ *
+ * A wrapper rather than an implementation: the collection and single routes
+ * showed the same page and were kept as two copies, which drifted. The page
+ * itself lives in `ApiPlaygroundPage`.
  *
  * @module pages/dashboard/entries/[slug]/api
  * @since 1.0.0
  */
 
-import { Alert, AlertDescription, AlertTitle, Skeleton } from "@nextlyhq/ui";
-
-import { APIPlayground } from "@admin/components/features/entries/APIPlayground";
-import { AlertCircle } from "@admin/components/icons";
-import { PageContainer } from "@admin/components/layout/page-container";
-import { useCollection } from "@admin/hooks/queries";
-
-// ============================================================================
-// Types
-// ============================================================================
+import { ApiPlaygroundPage } from "@admin/components/features/entries/APIPlayground";
 
 interface APIPlaygroundPageProps {
   params?: {
@@ -25,114 +19,6 @@ interface APIPlaygroundPageProps {
   };
 }
 
-// ============================================================================
-// Component
-// ============================================================================
-
-/**
- * APIPlaygroundPage - Collection API testing interface
- *
- * Provides a Postman-like interface for testing collection API endpoints
- * with automatic collection context from the URL slug.
- */
 export default function APIPlaygroundPage({ params }: APIPlaygroundPageProps) {
-  const slug = params?.slug;
-
-  // Fetch collection data
-  const {
-    data: collection,
-    isLoading,
-    error,
-  } = useCollection(slug ?? "", {
-    enabled: !!slug,
-  });
-
-  // Handle missing slug
-  if (!slug) {
-    return (
-      <div className="p-6">
-        <Alert variant="destructive">
-          <AlertCircle className="h-4 w-4" />
-          <AlertTitle>Error</AlertTitle>
-          <AlertDescription>
-            Collection slug is required. Please navigate to a collection first.
-          </AlertDescription>
-        </Alert>
-      </div>
-    );
-  }
-
-  // Loading state
-  if (isLoading) {
-    return (
-      <div className="p-6 space-y-6">
-        {/* Breadcrumb skeleton */}
-        <div className="flex items-center gap-2">
-          <Skeleton className="h-4 w-4" />
-          <Skeleton className="h-4 w-4" />
-          <Skeleton className="h-4 w-20" />
-          <Skeleton className="h-4 w-4" />
-          <Skeleton className="h-4 w-32" />
-        </div>
-
-        {/* Header skeleton */}
-        <div className="space-y-2">
-          <Skeleton className="h-8 w-64" />
-          <Skeleton className="h-4 w-96" />
-        </div>
-
-        {/* Content skeleton */}
-        <div className="grid grid-cols-2 gap-6">
-          <Skeleton className="h-[500px]" />
-          <Skeleton className="h-[500px]" />
-        </div>
-      </div>
-    );
-  }
-
-  // Error state
-  if (error) {
-    return (
-      <div className="p-6">
-        <Alert variant="destructive">
-          <AlertCircle className="h-4 w-4" />
-          <AlertTitle>Error</AlertTitle>
-          <AlertDescription>
-            Failed to load collection: {error.message}
-          </AlertDescription>
-        </Alert>
-      </div>
-    );
-  }
-
-  // Collection label for display
-  const collectionLabel = collection?.label || slug;
-
-  return (
-    // Fills the content panel instead of growing past it, so the request and
-    // response panes scroll on their own. Otherwise a long response stretches
-    // the page and takes the response's own status line off-screen with it.
-    <PageContainer className="flex h-full min-h-0 flex-col overflow-hidden">
-      {/* Page header */}
-      <div className="mb-8 shrink-0">
-        <h1 className="text-xl font-semibold tracking-tight text-foreground">
-          API Playground
-        </h1>
-        {/* Muted foreground so this secondary subtitle meets contrast (a faint primary alpha did not). */}
-        <p className="text-sm font-normal text-muted-foreground mt-1">
-          Test API endpoints for the <strong>{collectionLabel}</strong>{" "}
-          collection. Build requests, execute them, and view responses.
-        </p>
-      </div>
-
-      {/* API Playground component */}
-      <div className="min-h-0 flex-1">
-        <APIPlayground
-          collectionSlug={slug}
-          fields={collection?.fields}
-          hasStatus={collection?.status === true}
-        />
-      </div>
-    </PageContainer>
-  );
+  return <ApiPlaygroundPage kind="collection" slug={params?.slug} />;
 }

--- a/packages/admin/src/pages/dashboard/singles/[slug]/api.tsx
+++ b/packages/admin/src/pages/dashboard/singles/[slug]/api.tsx
@@ -1,23 +1,17 @@
 /**
  * Single API Playground Page
  *
- * Interactive API testing interface for single endpoints.
- * Accessible via /admin/singles/[slug]/api
+ * Accessible via /admin/singles/[slug]/api.
+ *
+ * A wrapper rather than an implementation: the collection and single routes
+ * showed the same page and were kept as two copies, which drifted. The page
+ * itself lives in `ApiPlaygroundPage`.
  *
  * @module pages/dashboard/singles/[slug]/api
  * @since 1.0.0
  */
 
-import { Alert, AlertDescription, AlertTitle, Skeleton } from "@nextlyhq/ui";
-
-import { APIPlayground } from "@admin/components/features/entries/APIPlayground";
-import { AlertCircle } from "@admin/components/icons";
-import { PageContainer } from "@admin/components/layout/page-container";
-import { useSingleSchema } from "@admin/hooks/queries";
-
-// ============================================================================
-// Types
-// ============================================================================
+import { ApiPlaygroundPage } from "@admin/components/features/entries/APIPlayground";
 
 interface SingleAPIPlaygroundPageProps {
   params?: {
@@ -25,115 +19,8 @@ interface SingleAPIPlaygroundPageProps {
   };
 }
 
-// ============================================================================
-// Component
-// ============================================================================
-
-/**
- * SingleAPIPlaygroundPage - Single API testing interface
- *
- * Provides a Postman-like interface for testing single API endpoints
- * with automatic single context from the URL slug.
- */
 export default function SingleAPIPlaygroundPage({
   params,
 }: SingleAPIPlaygroundPageProps) {
-  const slug = params?.slug;
-
-  // Fetch single schema data
-  const {
-    data: schema,
-    isLoading,
-    error,
-  } = useSingleSchema(slug ?? "", {
-    enabled: !!slug,
-  });
-
-  // Handle missing slug
-  if (!slug) {
-    return (
-      <div className="p-6">
-        <Alert variant="destructive">
-          <AlertCircle className="h-4 w-4" />
-          <AlertTitle>Error</AlertTitle>
-          <AlertDescription>
-            Single slug is required. Please navigate to a single first.
-          </AlertDescription>
-        </Alert>
-      </div>
-    );
-  }
-
-  // Loading state
-  if (isLoading) {
-    return (
-      <div className="p-6 space-y-6">
-        {/* Breadcrumb skeleton */}
-        <div className="flex items-center gap-2">
-          <Skeleton className="h-4 w-4" />
-          <Skeleton className="h-4 w-4" />
-          <Skeleton className="h-4 w-20" />
-          <Skeleton className="h-4 w-4" />
-          <Skeleton className="h-4 w-32" />
-        </div>
-
-        {/* Header skeleton */}
-        <div className="space-y-2">
-          <Skeleton className="h-8 w-64" />
-          <Skeleton className="h-4 w-96" />
-        </div>
-
-        {/* Content skeleton */}
-        <div className="grid grid-cols-2 gap-6">
-          <Skeleton className="h-[500px]" />
-          <Skeleton className="h-[500px]" />
-        </div>
-      </div>
-    );
-  }
-
-  // Error state
-  if (error) {
-    return (
-      <div className="p-6">
-        <Alert variant="destructive">
-          <AlertCircle className="h-4 w-4" />
-          <AlertTitle>Error</AlertTitle>
-          <AlertDescription>
-            Failed to load single: {error.message}
-          </AlertDescription>
-        </Alert>
-      </div>
-    );
-  }
-
-  // Single label for display
-  const singleLabel = schema?.label || slug;
-
-  return (
-    <PageContainer>
-      <div className="flex flex-col gap-4 h-full">
-        {/* Page header */}
-        <div className="mb-8">
-          <h1 className="text-xl font-semibold tracking-tight text-foreground">
-            API Playground
-          </h1>
-          {/* Muted foreground so this secondary subtitle meets contrast (a faint primary alpha did not). */}
-          <p className="text-sm font-normal text-muted-foreground mt-1">
-            Test API endpoints for the <strong>{singleLabel}</strong> single.
-            Build requests, execute them, and view responses.
-          </p>
-        </div>
-
-        {/* API Playground component */}
-        <div className="flex-1 min-h-0">
-          <APIPlayground
-            collectionSlug={slug}
-            isSingle={true}
-            fields={schema?.fields}
-          />
-        </div>
-      </div>
-    </PageContainer>
-  );
+  return <ApiPlaygroundPage kind="single" slug={params?.slug} />;
 }


### PR DESCRIPTION
## Summary

The collection and single API Playground routes showed the same page and were kept as two hand-maintained copies of ~140 lines each. They drifted.

A fix that contains the page's scroll inside its panes reached the collection's copy and never the single's. On `main` today:

```
entries/[slug]/api.tsx:115   <PageContainer className="flex h-full min-h-0 flex-col overflow-hidden">
singles/[slug]/api.tsx:114   <PageContainer>
```

So a single's panes collapsed to their content and left the lower third of the page empty. Nothing caught it — each file reads correctly on its own, and nothing compared them.

They are one component now (`ApiPlaygroundPage`), with the differences passed as arguments: which schema hook to call, what to call the thing in prose, and which props the playground needs. Both routes become wrappers of ~24 lines. Their default exports keep their names, because `pages/registry.ts` imports them by path.

Sub-task 2 of 5 for the API Playground revamp; sub-task 1 landed in #1151 and #1155.

## A note on the tests

They assert over **both kinds** rather than once over the shared component. A single test would pass on a component that is perfectly correct while saying nothing about whether both routes actually reach it — and "both routes reach the same code" is the property that failed here. `it.each` over `[collection, single]` is what makes the pair observable.

The scroll assertion names the three classes that made the difference — `h-full`, `min-h-0`, `overflow-hidden` — rather than comparing whole class strings, which would fail on any unrelated styling edit and get relaxed.

## Test plan

New suite: 8 tests, all passing. Failed first for the intended reason (`Failed to resolve import "../ApiPlaygroundPage"`), then passed.

Verified in the browser at 1600×1000, both routes:

| | before | after |
| --- | --- | --- |
| single — page container | overflows the viewport | contained |
| single — cards reach | ~y628, dead band below | y≈966, fills |
| collection | unchanged | unchanged |

Both routes now report identical container geometry, which is the guarantee this change exists to provide.

One correction worth recording: my first measurement used a `.bg-card` selector that matched an inner element, and reported a 371px gap on both routes. The screenshots show the cards filling the page. The selector was wrong, not the layout.

Gates from the worktree root after `pnpm --filter @nextlyhq/admin... build`: build, `check-types`, `lint` (`--max-warnings 0`), `check:comments` all pass. `fallow audit` → `pass`, zero introduced.

## Pre-existing failures

Unchanged: 15 across 4 files (`StatsCard`, `SlugInput`, `BasicsTab`, `DefaultValueField`), none related to this change. Suite: 2612 passing.

## Changeset

Added: yes — patch, all published packages.
