### PR TITLE
feat(admin): resizable playground panes, a truthful response pane, and pane-driven density

### DIFF
--- a/.changeset/playground-layout-and-density.md
+++ b/.changeset/playground-layout-and-density.md
@@ -1,0 +1,38 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+The API Playground's request and response panes can now be resized by dragging
+the divider between them, and the width you choose is remembered. Its query
+parameters lay themselves out from the width of their own pane rather than the
+browser window, so the hints stay readable when the pane is narrow.
+
+On the Code tab, Copy now copies the code you are looking at rather than the
+response body, and there is one copy button instead of two. Your choice of
+Nextly, fetch or cURL is remembered. Response status, latency and size hold
+their place so the panel no longer shifts when a reply arrives, and the
+empty-state text is no longer set in a code face.

--- a/e2e/tests/api-playground-metrics.spec.ts
+++ b/e2e/tests/api-playground-metrics.spec.ts
@@ -50,6 +50,27 @@ test("the metrics row does not resize when the first response arrives", async ({
   const toolbar = page.getByTestId("response-toolbar");
   await expect(meta).toBeVisible();
 
+  // Serve the reply from here, registered after the page has loaded so only
+  // Send is answered by it.
+  //
+  // The row reserves 6ch for latency, which holds `9999ms`, and the component
+  // says plainly that a slower reply outgrows the reservation and may reflow
+  // again. Measured against a LIVE request this test would therefore fail on
+  // correct code whenever a cold route compile or a loaded worker pushes the
+  // first call past ten seconds. An immediate reply of a fixed size puts every
+  // value inside the width reserved for it, so what is left varying between
+  // the two measurements is the thing under test.
+  await page.route("**/admin/api/collections/posts/entries*", route =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        items: [],
+        meta: { total: 0, page: 1, limit: 10 },
+      }),
+    })
+  );
+
   // The empty row, before anything has been sent. Read after the row is
   // visible so the measurement is of a laid-out box rather than of a node the
   // engine has not reached yet.
@@ -66,6 +87,18 @@ test("the metrics row does not resize when the first response arrives", async ({
   // in front of it rather than matched on a word boundary that is not there.
   await expect(meta).toContainText(/Status\s*\d{3}/, { timeout: 30_000 });
   await expect(meta).toContainText(/Latency\s*\d+ms/);
+
+  // The reservation only claims to cover latencies it has room for, so the
+  // comparison below is only meaningful inside that range. Asserting it here
+  // means a reply that somehow outran the reservation reports THAT, rather
+  // than presenting itself as a layout regression.
+  const latencyMs = Number(
+    /Latency\s*(\d+)ms/.exec((await meta.textContent()) ?? "")?.[1]
+  );
+  expect(
+    latencyMs,
+    "latency outgrew the 6ch reservation, so the width comparison cannot bind"
+  ).toBeLessThan(10_000);
 
   const edgeAfter = await contentLeftEdge(meta);
   const toolbarAfter = (await toolbar.boundingBox())?.y;

--- a/e2e/tests/api-playground-metrics.spec.ts
+++ b/e2e/tests/api-playground-metrics.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * The API Playground's metrics row keeps its size when the first reply lands.
+ *
+ * This property cannot be tested where the rest of the response pane is tested.
+ * jsdom computes no layout: every box there is zero by zero, so an assertion
+ * about widths passes against any implementation, including one that reflows on
+ * every response. Measuring it needs a real engine, which is what puts this
+ * file here rather than beside the component.
+ *
+ * What it guards: the row is `flex-wrap`, and an em dash is narrower than
+ * `200`, `123ms` and `5.8 KB`. Reserve nothing and the row's intrinsic width
+ * grows the moment a response arrives -- so at any pane width between the empty
+ * and populated widths it gains a line, pushing the tab bar and the body down
+ * while somebody is reading them.
+ */
+import { expect, test, type Locator } from "@playwright/test";
+
+import { gotoAdmin } from "./support/admin";
+
+/**
+ * Where the row's content begins.
+ *
+ * The row is `justify-end`, so its children pack against the right edge and the
+ * first child's left edge IS the content width, read off the layout the browser
+ * actually performed. Asserting on that rather than on a wrap at one chosen
+ * viewport makes the check width-independent: identical content widths cannot
+ * wrap differently at ANY width, so one measurement settles every pane size
+ * instead of the one this test happened to open.
+ */
+async function contentLeftEdge(locator: Locator): Promise<number> {
+  return locator.evaluate(row => {
+    const first = row.firstElementChild;
+    if (!first) throw new Error("the metrics row rendered no children");
+    return first.getBoundingClientRect().x;
+  });
+}
+
+test("the metrics row does not resize when the first response arrives", async ({
+  page,
+}) => {
+  // Triples the budget. The playground route compiles on its first visit in
+  // dev, and measured here that alone spent more than the default 30s on a
+  // cold cache -- which fails at the first locator, where a timeout says
+  // nothing about the property under test.
+  test.slow();
+
+  await gotoAdmin(page, "/collections/posts/api");
+
+  const meta = page.getByTestId("response-meta");
+  const toolbar = page.getByTestId("response-toolbar");
+  await expect(meta).toBeVisible();
+
+  // The empty row, before anything has been sent. Read after the row is
+  // visible so the measurement is of a laid-out box rather than of a node the
+  // engine has not reached yet.
+  await expect(meta).toContainText("—");
+  const edgeBefore = await contentLeftEdge(meta);
+  const toolbarBefore = (await toolbar.boundingBox())?.y;
+  expect(toolbarBefore, "the toolbar has a box to measure").toBeDefined();
+
+  await page.getByRole("button", { name: /^send/i }).click();
+
+  // The populated row MUST actually arrive, or the comparison below is between
+  // two empty rows and passes against every implementation. The row's text runs
+  // together as `Status200Latency52ms`, so each value is anchored to the label
+  // in front of it rather than matched on a word boundary that is not there.
+  await expect(meta).toContainText(/Status\s*\d{3}/, { timeout: 30_000 });
+  await expect(meta).toContainText(/Latency\s*\d+ms/);
+
+  const edgeAfter = await contentLeftEdge(meta);
+  const toolbarAfter = (await toolbar.boundingBox())?.y;
+
+  // Under a pixel, not equal to it. Layout here is fractional, and a width
+  // reserved in `ch` and the glyph advances that fill it round independently --
+  // measured, the edge settles 1/64th of a pixel apart. Nothing at that scale
+  // can wrap a row or move a control, while the defect this guards against
+  // moves the edge by the width of three values at once.
+  expect(
+    Math.abs(edgeAfter - edgeBefore),
+    "the metrics row's content width changed when the response arrived"
+  ).toBeLessThan(1);
+  expect(
+    Math.abs((toolbarAfter ?? 0) - (toolbarBefore ?? 0)),
+    "the toolbar moved when the response arrived"
+  ).toBeLessThan(1);
+});

--- a/e2e/tests/api-playground-narrow.spec.ts
+++ b/e2e/tests/api-playground-narrow.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * The Send control stays reachable when the request bar has no room.
+ *
+ * The bar's children that do not shrink come to 456px -- the action picker,
+ * two icon buttons and Send -- inside a container that clips to its own
+ * rounded corner. Below roughly 490px of content width the clip therefore
+ * takes the RIGHTMOST control, which is the primary action of the whole page.
+ *
+ * jsdom cannot see this: it computes no layout, so a clipped button and a
+ * visible one have the same zero-sized box and the same DOM.
+ */
+import { expect, test } from "@playwright/test";
+
+import { gotoAdmin } from "./support/admin";
+
+test("Send stays inside the request bar on a phone-width screen", async ({
+  page,
+}) => {
+  test.slow();
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await gotoAdmin(page, "/collections/posts/api");
+
+  const send = page.getByRole("button", { name: /^send/i });
+  await expect(send).toBeVisible();
+
+  // Visible is not enough: `overflow-hidden` leaves a clipped child in the
+  // layout with a real box, so the test has to compare the button against the
+  // box that clips it rather than ask whether it rendered.
+  const box = await send.boundingBox();
+  const bar = await send
+    .locator("xpath=ancestor::div[contains(@class,'rounded-lg')][1]")
+    .boundingBox();
+
+  expect(box, "Send has a box").not.toBeNull();
+  expect(bar, "the bar has a box").not.toBeNull();
+  if (!box || !bar) return;
+
+  expect(
+    Math.round(box.x + box.width),
+    "Send's right edge is past the bar's clipped edge, so part of it is unreachable"
+  ).toBeLessThanOrEqual(Math.round(bar.x + bar.width) + 1);
+  expect(box.width, "Send kept a usable width").toBeGreaterThan(80);
+});

--- a/packages/admin/src/components/features/entries/APIPlayground/APIPlayground.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/APIPlayground.tsx
@@ -55,7 +55,7 @@ import { generateCode } from "./generate-code";
 import type { PlaygroundField, WhereCondition } from "./query-fields";
 import { formatWhere } from "./query-fields";
 import { QueryBuilder } from "./QueryBuilder";
-import { METHOD_TONE, RequestBar } from "./RequestBar";
+import { METHOD_SEMANTICS, RequestBar } from "./RequestBar";
 import { ResponseViewer } from "./ResponseViewer";
 
 // CodeMirror reaches for browser globals on import, so it loads on demand.
@@ -627,8 +627,14 @@ export function APIPlayground({
   const requestPane = (
     <Card className="flex h-full flex-col min-h-0 rounded-lg border-border shadow-none bg-card overflow-hidden">
       <CardHeader className="p-6 pb-4" noBorder>
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-base font-semibold tracking-tight text-foreground">
+        {/* Wraps rather than clipping. The pane is draggable down to a quarter
+            of the group, which against a wide sidebar is under 200px -- less
+            than this title and Reset need side by side -- and the card clips to
+            its own corner, so the overflow is not scrolled to, it is gone.
+            Wrapping costs a line at widths where the alternative is a control
+            nobody can reach. */}
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <CardTitle className="min-w-0 text-base font-semibold tracking-tight text-foreground">
             Request configuration
           </CardTitle>
           <Button
@@ -650,17 +656,29 @@ export function APIPlayground({
         {/* Entry ID Input (conditional) */}
         {!isSingle && currentAction.requiresEntryId && (
           <div className="space-y-2">
-            <Label className="text-sm font-medium text-foreground">
+            <Label
+              htmlFor="playground-entry-id"
+              className="text-sm font-medium text-foreground"
+            >
               Entry ID <span className="text-destructive">*</span>
             </Label>
             <Input
+              id="playground-entry-id"
               value={entryId}
               onChange={e => setEntryId(e.target.value)}
               placeholder="Enter entry ID (e.g., abc123)"
               className="font-mono text-xs"
+              aria-required
+              aria-invalid={entryIdMissing || undefined}
+              aria-describedby={
+                entryIdMissing ? "playground-entry-id-error" : undefined
+              }
             />
             {entryIdMissing && (
-              <p className="text-xs text-destructive">
+              <p
+                id="playground-entry-id-error"
+                className="text-xs text-destructive"
+              >
                 Entry ID is required for this action
               </p>
             )}
@@ -687,10 +705,20 @@ export function APIPlayground({
                 highlighting, bracket matching, or a line to point at when
                 the JSON is wrong. */}
               <div className="flex h-full min-h-0 flex-col gap-2">
-                <Label className="text-sm font-medium text-foreground">
+                {/* `htmlFor` cannot reach it: CodeMirror owns a contenteditable
+                    rather than a form control, so the label is bound by id and
+                    the editor names itself with the same words. */}
+                <Label
+                  id="playground-request-body-label"
+                  className="text-sm font-medium text-foreground"
+                >
                   Request body (JSON)
                 </Label>
-                <div className="min-h-0 flex-1 rounded-md border border-input">
+                <div
+                  role="group"
+                  aria-labelledby="playground-request-body-label"
+                  className="min-h-0 flex-1 rounded-md border border-input"
+                >
                   <Suspense
                     fallback={
                       <div className="h-full w-full animate-pulse bg-muted/30" />
@@ -791,7 +819,7 @@ export function APIPlayground({
                   <span
                     className={cn(
                       "shrink-0 font-mono text-xs font-semibold",
-                      METHOD_TONE[currentAction.method]
+                      METHOD_SEMANTICS[currentAction.method].tone
                     )}
                   >
                     {currentAction.method}
@@ -814,7 +842,7 @@ export function APIPlayground({
                     <span
                       className={cn(
                         "w-12 shrink-0 font-mono text-xs font-semibold",
-                        METHOD_TONE[a.method]
+                        METHOD_SEMANTICS[a.method].tone
                       )}
                     >
                       {a.method}

--- a/packages/admin/src/components/features/entries/APIPlayground/APIPlayground.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/APIPlayground.tsx
@@ -147,28 +147,6 @@ export interface APIResponse {
 // Constants
 // ============================================================================
 
-/** The status dot, keyed to the same meaning as the status text beside it. */
-function statusDotTone(status: number): string {
-  if (status >= 200 && status < 300) return "bg-success";
-  if (status >= 300 && status < 400) return "bg-muted-foreground";
-  if (status >= 400 && status < 500) return "bg-warning";
-  if (status >= 500) return "bg-destructive";
-  return "bg-muted-foreground";
-}
-
-/**
- * A payload size someone can act on.
- *
- * Two significant figures past a kilobyte: the question a size answers here is
- * "is this response big?", and 2.4 KB answers it while 2438 B makes you count
- * digits.
- */
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
-}
-
 /** Configuration for each endpoint action */
 const ENDPOINT_ACTIONS: {
   value: EndpointAction;
@@ -600,21 +578,6 @@ export function APIPlayground({
   }, [fullUrl]);
 
   /**
-   * Colour a response by what its status class means.
-   *
-   * Tokens rather than palette classes, so the hues track the theme and stay
-   * legible in dark mode. A 4xx is the caller's mistake and a 5xx is the
-   * server's, so they read as warning and error respectively.
-   */
-  const getStatusColor = (status: number): string => {
-    if (status >= 200 && status < 300) return "text-success";
-    if (status >= 300 && status < 400) return "text-muted-foreground";
-    if (status >= 400 && status < 500) return "text-warning";
-    if (status >= 500) return "text-destructive";
-    return "text-muted-foreground";
-  };
-
-  /**
    * Check if the current action requires a request body
    */
   const actionRequiresBody = [
@@ -780,48 +743,9 @@ export function APIPlayground({
   const responsePane = (
     <Card className="flex flex-col min-h-0 rounded-lg border-border shadow-none bg-card overflow-hidden">
       <CardHeader className="p-6 pb-4" noBorder>
-        <div className="flex items-center justify-between gap-4">
-          <CardTitle className="text-base font-semibold tracking-tight text-foreground">
-            API response
-          </CardTitle>
-          {response && (
-            <div className="flex items-center gap-4">
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-muted-foreground">Status</span>
-                <span
-                  className={cn(
-                    "h-1.5 w-1.5 rounded-full",
-                    statusDotTone(response.status)
-                  )}
-                />
-                <span
-                  className={cn(
-                    "font-mono text-sm font-semibold",
-                    getStatusColor(response.status)
-                  )}
-                >
-                  {response.status}
-                </span>
-              </div>
-              <div className="h-4 w-px bg-border" />
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-muted-foreground">Latency</span>
-                <span className="font-mono text-sm font-semibold text-foreground">
-                  {response.time}ms
-                </span>
-              </div>
-              <div className="h-4 w-px bg-border" />
-              {/* Size sits beside latency because they are the pair you
-                  trade against each other when tuning depth and limit. */}
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-muted-foreground">Size</span>
-                <span className="font-mono text-sm font-semibold text-foreground">
-                  {formatBytes(response.size)}
-                </span>
-              </div>
-            </div>
-          )}
-        </div>
+        <CardTitle className="text-base font-semibold tracking-tight text-foreground">
+          API response
+        </CardTitle>
       </CardHeader>
       <CardContent className="flex-1 min-h-0 p-0 overflow-hidden">
         <ResponseViewer
@@ -832,6 +756,9 @@ export function APIPlayground({
           raw={response?.raw}
           code={codeSnippets}
           filename={`${collectionSlug}-response`}
+          status={response?.status}
+          time={response?.time}
+          size={response?.size}
         />
       </CardContent>
     </Card>

--- a/packages/admin/src/components/features/entries/APIPlayground/APIPlayground.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/APIPlayground.tsx
@@ -625,7 +625,7 @@ export function APIPlayground({
   // copies of a pane is how the two ROUTE files drifted, and the same trap
   // applies one level down.
   const requestPane = (
-    <Card className="flex flex-col min-h-0 rounded-lg border-border shadow-none bg-card overflow-hidden">
+    <Card className="flex h-full flex-col min-h-0 rounded-lg border-border shadow-none bg-card overflow-hidden">
       <CardHeader className="p-6 pb-4" noBorder>
         <div className="flex items-center justify-between">
           <CardTitle className="text-base font-semibold tracking-tight text-foreground">
@@ -741,7 +741,7 @@ export function APIPlayground({
   );
 
   const responsePane = (
-    <Card className="flex flex-col min-h-0 rounded-lg border-border shadow-none bg-card overflow-hidden">
+    <Card className="flex h-full flex-col min-h-0 rounded-lg border-border shadow-none bg-card overflow-hidden">
       <CardHeader className="p-6 pb-4" noBorder>
         <CardTitle className="text-base font-semibold tracking-tight text-foreground">
           API response
@@ -845,7 +845,17 @@ export function APIPlayground({
           a pane is how the two ROUTE files drifted, and the same trap applies
           one level down. */}
       <>
-        {hydrated && isWide ? (
+        {!hydrated ? (
+          /* Neither hook can answer before mount, and answering "stacked" is a
+             guess that is wrong on most desktops: the stacked tree would paint,
+             then be replaced by the splitter, shifting the layout and mounting
+             both panes' editors twice. A skeleton commits to nothing and mounts
+             nothing heavy. */
+          <div
+            data-testid="playground-pending"
+            className="min-h-0 flex-1 animate-pulse rounded-lg border border-border bg-muted/30"
+          />
+        ) : isWide ? (
           <div className="flex min-h-0 flex-1">
             <ResizablePanelGroup
               orientation="horizontal"

--- a/packages/admin/src/components/features/entries/APIPlayground/APIPlayground.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/APIPlayground.tsx
@@ -24,6 +24,9 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
   Tabs,
   TabsContent,
   TabsList,
@@ -43,6 +46,9 @@ import {
 
 import { RotateCcw } from "@admin/components/icons";
 import { UI } from "@admin/constants/ui";
+import { useHydration } from "@admin/hooks/useHydration";
+import { useMediaQuery } from "@admin/hooks/useMediaQuery";
+import { usePersistedState } from "@admin/hooks/usePersistedState";
 import { cn } from "@admin/lib/utils";
 
 import { generateCode } from "./generate-code";
@@ -64,6 +70,21 @@ const CodeMirrorEditor = lazy(() =>
 // ============================================================================
 
 export type HttpMethod = "GET" | "POST" | "PATCH" | "DELETE";
+
+/**
+ * The request pane's share of the split, as a percentage.
+ *
+ * Two panes have ONE degree of freedom, so a single number describes the layout
+ * and the response pane takes the remainder -- which means there is nothing to
+ * keep consistent. Stored as a string because that is what the persistence hook
+ * holds; the validator is what keeps it a number in range.
+ */
+const SPLIT_KEY = "nextly:admin:api-playground:split";
+const SPLIT_DEFAULT = "40";
+const isSplit = (value: string): value is string => {
+  const share = Number(value);
+  return Number.isFinite(share) && share >= 25 && share <= 75;
+};
 
 /** Available endpoint actions for collection entries */
 export type EndpointAction =
@@ -271,6 +292,23 @@ export function APIPlayground({
 
   // Copy state
   const [copied, setCopied] = useState(false);
+
+  // The group is rendered only after hydration, which is what lets the stored
+  // layout be the one it mounts with. `usePersistedState` reads storage in an
+  // effect, and both effects land in the same flush, so the group mounts once
+  // already holding the restored value rather than mounting on the default and
+  // being corrected afterwards.
+  const hydrated = useHydration();
+  // `lg`, as a query rather than a class, because this CHOOSES a tree instead
+  // of styling one. Rendering both and hiding one with CSS would put the query
+  // builder's labelled fields in the document twice, and a screen reader would
+  // read every one of them twice with no way to tell which is the hidden copy.
+  const isWide = useMediaQuery("(min-width: 64rem)");
+  const [split, setSplit] = usePersistedState(
+    SPLIT_KEY,
+    SPLIT_DEFAULT,
+    isSplit
+  );
 
   /** The in-flight request, so a re-send or Escape can call it off. */
   const abortRef = useRef<AbortController | null>(null);
@@ -620,6 +658,185 @@ export function APIPlayground({
     ]
   );
 
+  // Declared once and rendered by whichever branch is live below. Two
+  // copies of a pane is how the two ROUTE files drifted, and the same trap
+  // applies one level down.
+  const requestPane = (
+    <Card className="flex flex-col min-h-0 rounded-lg border-border shadow-none bg-card overflow-hidden">
+      <CardHeader className="p-6 pb-4" noBorder>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base font-semibold tracking-tight text-foreground">
+            Request configuration
+          </CardTitle>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleReset}
+            className="gap-2 text-sm font-medium text-muted-foreground hover:text-foreground"
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+            Reset
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="flex-1 min-h-0 overflow-y-auto space-y-6 px-6 pb-6">
+        {/* The base path and the full URL both used to be restated here; the
+          bar above shows the real thing, so they were saying it a third
+          time and only the bar can be trusted to stay correct. */}
+
+        {/* Entry ID Input (conditional) */}
+        {!isSingle && currentAction.requiresEntryId && (
+          <div className="space-y-2">
+            <Label className="text-sm font-medium text-foreground">
+              Entry ID <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              value={entryId}
+              onChange={e => setEntryId(e.target.value)}
+              placeholder="Enter entry ID (e.g., abc123)"
+              className="font-mono text-xs"
+            />
+            {entryIdMissing && (
+              <p className="text-xs text-destructive">
+                Entry ID is required for this action
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* A body only exists for the actions that carry one, so the tabs
+          only exist then too — a single-tab tab bar is a control that
+          cannot do anything. */}
+        {actionRequiresBody ? (
+          <Tabs
+            defaultValue="body"
+            className="flex-1 flex flex-col min-h-0 pt-2"
+          >
+            <TabsList className="w-full justify-start">
+              {/* Body first: on a write it is what you came to edit. */}
+              <TabsTrigger value="body">Body</TabsTrigger>
+              <TabsTrigger value="params">Parameters</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="body" className="mt-4 flex-1 min-h-0">
+              {/* A JSON editor rather than a textarea: this is the one
+                field you type code into, and it was the only one without
+                highlighting, bracket matching, or a line to point at when
+                the JSON is wrong. */}
+              <div className="flex h-full min-h-0 flex-col gap-2">
+                <Label className="text-sm font-medium text-foreground">
+                  Request body (JSON)
+                </Label>
+                <div className="min-h-0 flex-1 border border-input">
+                  <Suspense
+                    fallback={
+                      <div className="h-full w-full animate-pulse bg-muted/30" />
+                    }
+                  >
+                    <CodeMirrorEditor
+                      value={requestBody}
+                      onChange={setRequestBody}
+                      language="json"
+                      disabled={false}
+                      readOnly={false}
+                      minHeight={320}
+                      editorOptions={{ tabSize: 2, lineNumbers: true }}
+                      placeholder={getBodyPlaceholder()}
+                    />
+                  </Suspense>
+                </div>
+              </div>
+            </TabsContent>
+
+            <TabsContent value="params" className="mt-4">
+              <QueryBuilder
+                params={queryParams}
+                onChange={setQueryParams}
+                conditions={whereConditions}
+                onConditionsChange={setWhereConditions}
+                fields={fields}
+                hasStatus={hasStatus}
+                isSingle={isSingle}
+              />
+            </TabsContent>
+          </Tabs>
+        ) : (
+          <div className="pt-2">
+            <QueryBuilder
+              params={queryParams}
+              onChange={setQueryParams}
+              conditions={whereConditions}
+              onConditionsChange={setWhereConditions}
+              fields={fields}
+              hasStatus={hasStatus}
+              isSingle={isSingle}
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+
+  const responsePane = (
+    <Card className="flex flex-col min-h-0 rounded-lg border-border shadow-none bg-card overflow-hidden">
+      <CardHeader className="p-6 pb-4" noBorder>
+        <div className="flex items-center justify-between gap-4">
+          <CardTitle className="text-base font-semibold tracking-tight text-foreground">
+            API response
+          </CardTitle>
+          {response && (
+            <div className="flex items-center gap-4">
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground">Status</span>
+                <span
+                  className={cn(
+                    "h-1.5 w-1.5 rounded-full",
+                    statusDotTone(response.status)
+                  )}
+                />
+                <span
+                  className={cn(
+                    "font-mono text-sm font-semibold",
+                    getStatusColor(response.status)
+                  )}
+                >
+                  {response.status}
+                </span>
+              </div>
+              <div className="h-4 w-px bg-border" />
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground">Latency</span>
+                <span className="font-mono text-sm font-semibold text-foreground">
+                  {response.time}ms
+                </span>
+              </div>
+              <div className="h-4 w-px bg-border" />
+              {/* Size sits beside latency because they are the pair you
+                  trade against each other when tuning depth and limit. */}
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground">Size</span>
+                <span className="font-mono text-sm font-semibold text-foreground">
+                  {formatBytes(response.size)}
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="flex-1 min-h-0 p-0 overflow-hidden">
+        <ResponseViewer
+          data={response?.data}
+          isLoading={isLoading}
+          error={error}
+          headers={response?.headers}
+          raw={response?.raw}
+          code={codeSnippets}
+          filename={`${collectionSlug}-response`}
+        />
+      </CardContent>
+    </Card>
+  );
+
   return (
     // Fills the height it is given rather than demanding a minimum: the panes
     // below scroll on their own, so the page never grows past the panel and
@@ -697,187 +914,51 @@ export function APIPlayground({
         onOpen={handleOpenInNewTab}
       />
 
-      {/* Stacked on narrow screens, where two scroll panes side by side would
-          leave neither usable, so the page scrolls there instead. */}
-      <div className="grid min-h-0 flex-1 grid-cols-1 gap-8 lg:grid-cols-12">
-        {/* Request Builder Panel - 5 columns */}
-        <Card className="lg:col-span-5 flex flex-col min-h-0 rounded-lg border-border shadow-none bg-card overflow-hidden">
-          <CardHeader className="p-6 pb-4" noBorder>
-            <div className="flex items-center justify-between">
-              <CardTitle className="text-base font-semibold tracking-tight text-foreground">
-                Request configuration
-              </CardTitle>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleReset}
-                className="gap-2 text-sm font-medium text-muted-foreground hover:text-foreground"
-              >
-                <RotateCcw className="h-3.5 w-3.5" />
-                Reset
-              </Button>
-            </div>
-          </CardHeader>
-          <CardContent className="flex-1 min-h-0 overflow-y-auto space-y-6 px-6 pb-6">
-            {/* The base path and the full URL both used to be restated here; the
-              bar above shows the real thing, so they were saying it a third
-              time and only the bar can be trusted to stay correct. */}
-
-            {/* Entry ID Input (conditional) */}
-            {!isSingle && currentAction.requiresEntryId && (
-              <div className="space-y-2">
-                <Label className="text-sm font-medium text-foreground">
-                  Entry ID <span className="text-destructive">*</span>
-                </Label>
-                <Input
-                  value={entryId}
-                  onChange={e => setEntryId(e.target.value)}
-                  placeholder="Enter entry ID (e.g., abc123)"
-                  className="font-mono text-xs"
-                />
-                {entryIdMissing && (
-                  <p className="text-xs text-destructive">
-                    Entry ID is required for this action
-                  </p>
-                )}
-              </div>
-            )}
-
-            {/* A body only exists for the actions that carry one, so the tabs
-              only exist then too — a single-tab tab bar is a control that
-              cannot do anything. */}
-            {actionRequiresBody ? (
-              <Tabs
-                defaultValue="body"
-                className="flex-1 flex flex-col min-h-0 pt-2"
-              >
-                <TabsList className="w-full justify-start">
-                  {/* Body first: on a write it is what you came to edit. */}
-                  <TabsTrigger value="body">Body</TabsTrigger>
-                  <TabsTrigger value="params">Parameters</TabsTrigger>
-                </TabsList>
-
-                <TabsContent value="body" className="mt-4 flex-1 min-h-0">
-                  {/* A JSON editor rather than a textarea: this is the one
-                    field you type code into, and it was the only one without
-                    highlighting, bracket matching, or a line to point at when
-                    the JSON is wrong. */}
-                  <div className="flex h-full min-h-0 flex-col gap-2">
-                    <Label className="text-sm font-medium text-foreground">
-                      Request body (JSON)
-                    </Label>
-                    <div className="min-h-0 flex-1 border border-input">
-                      <Suspense
-                        fallback={
-                          <div className="h-full w-full animate-pulse bg-muted/30" />
-                        }
-                      >
-                        <CodeMirrorEditor
-                          value={requestBody}
-                          onChange={setRequestBody}
-                          language="json"
-                          disabled={false}
-                          readOnly={false}
-                          minHeight={320}
-                          editorOptions={{ tabSize: 2, lineNumbers: true }}
-                          placeholder={getBodyPlaceholder()}
-                        />
-                      </Suspense>
-                    </div>
-                  </div>
-                </TabsContent>
-
-                <TabsContent value="params" className="mt-4">
-                  <QueryBuilder
-                    params={queryParams}
-                    onChange={setQueryParams}
-                    conditions={whereConditions}
-                    onConditionsChange={setWhereConditions}
-                    fields={fields}
-                    hasStatus={hasStatus}
-                    isSingle={isSingle}
-                  />
-                </TabsContent>
-              </Tabs>
-            ) : (
-              <div className="pt-2">
-                <QueryBuilder
-                  params={queryParams}
-                  onChange={setQueryParams}
-                  conditions={whereConditions}
-                  onConditionsChange={setWhereConditions}
-                  fields={fields}
-                  hasStatus={hasStatus}
-                  isSingle={isSingle}
-                />
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        {/* Response Panel - 7 columns */}
-        <Card className="lg:col-span-7 flex flex-col min-h-0 rounded-lg border-border shadow-none bg-card overflow-hidden">
-          <CardHeader className="p-6 pb-4" noBorder>
-            <div className="flex items-center justify-between gap-4">
-              <CardTitle className="text-base font-semibold tracking-tight text-foreground">
-                API response
-              </CardTitle>
-              {response && (
-                <div className="flex items-center gap-4">
-                  <div className="flex items-center gap-2">
-                    <span className="text-xs text-muted-foreground">
-                      Status
-                    </span>
-                    <span
-                      className={cn(
-                        "h-1.5 w-1.5 rounded-full",
-                        statusDotTone(response.status)
-                      )}
-                    />
-                    <span
-                      className={cn(
-                        "font-mono text-sm font-semibold",
-                        getStatusColor(response.status)
-                      )}
-                    >
-                      {response.status}
-                    </span>
-                  </div>
-                  <div className="h-4 w-px bg-border" />
-                  <div className="flex items-center gap-2">
-                    <span className="text-xs text-muted-foreground">
-                      Latency
-                    </span>
-                    <span className="font-mono text-sm font-semibold text-foreground">
-                      {response.time}ms
-                    </span>
-                  </div>
-                  <div className="h-4 w-px bg-border" />
-                  {/* Size sits beside latency because they are the pair you
-                      trade against each other when tuning depth and limit. */}
-                  <div className="flex items-center gap-2">
-                    <span className="text-xs text-muted-foreground">Size</span>
-                    <span className="font-mono text-sm font-semibold text-foreground">
-                      {formatBytes(response.size)}
-                    </span>
-                  </div>
-                </div>
-              )}
-            </div>
-          </CardHeader>
-          <CardContent className="flex-1 min-h-0 p-0 overflow-hidden">
-            <ResponseViewer
-              data={response?.data}
-              isLoading={isLoading}
-              error={error}
-              headers={response?.headers}
-              raw={response?.raw}
-              code={codeSnippets}
-              filename={`${collectionSlug}-response`}
-            />
-          </CardContent>
-        </Card>
-      </div>
+      {/* Declared once and rendered by whichever branch is live. Two copies of
+          a pane is how the two ROUTE files drifted, and the same trap applies
+          one level down. */}
+      <>
+        {hydrated && isWide ? (
+          <div className="flex min-h-0 flex-1">
+            <ResizablePanelGroup
+              orientation="horizontal"
+              className="min-h-0 flex-1"
+              defaultLayout={{
+                request: Number(split),
+                response: 100 - Number(split),
+              }}
+              onLayoutChanged={(layout, meta) => {
+                // The group reports every layout it settles on, and the mount
+                // pass arrives BEFORE the restored one takes effect -- so an
+                // unconditional write saves the freshly measured default over
+                // the layout being restored, and widths reset on every reload
+                // while appearing to persist within a session.
+                // `isUserInteraction` is true only for a drag or a resize key,
+                // which is the one event that states an intent about widths.
+                if (!meta.isUserInteraction) return;
+                setSplit(String(Math.round(layout.request)));
+              }}
+            >
+              <ResizablePanel id="request" minSize="25%">
+                {requestPane}
+              </ResizablePanel>
+              <ResizableHandle withGrip className="mx-4" />
+              <ResizablePanel id="response" minSize="30%">
+                {responsePane}
+              </ResizablePanel>
+            </ResizablePanelGroup>
+          </div>
+        ) : (
+          /* Stacked below `lg`, and until hydration: a splitter needs a
+             pointer and a measured width, and neither exists on a narrow
+             viewport or on the server. The two arms are exclusive so the panes
+             are in the document once, whichever is chosen. */
+          <div className="grid min-h-0 flex-1 grid-cols-1 gap-8">
+            {requestPane}
+            {responsePane}
+          </div>
+        )}
+      </>
     </div>
   );
 }

--- a/packages/admin/src/components/features/entries/APIPlayground/APIPlayground.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/APIPlayground.tsx
@@ -690,7 +690,7 @@ export function APIPlayground({
                 <Label className="text-sm font-medium text-foreground">
                   Request body (JSON)
                 </Label>
-                <div className="min-h-0 flex-1 border border-input">
+                <div className="min-h-0 flex-1 rounded-md border border-input">
                   <Suspense
                     fallback={
                       <div className="h-full w-full animate-pulse bg-muted/30" />

--- a/packages/admin/src/components/features/entries/APIPlayground/CodePanel.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/CodePanel.tsx
@@ -11,18 +11,7 @@
  * @module components/entries/APIPlayground/CodePanel
  */
 
-import {
-  Button,
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-  toast,
-} from "@nextlyhq/ui";
-import { useState, useCallback } from "react";
-
-import { Check, Copy } from "@admin/components/icons";
-import { UI } from "@admin/constants/ui";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@nextlyhq/ui";
 
 import type { CodeBlockLanguage } from "./CodeBlock";
 import { CodeBlock } from "./CodeBlock";
@@ -56,26 +45,25 @@ const FLAVOURS: {
 
 export interface CodePanelProps {
   code: CodeSnippets;
+  /**
+   * Which flavour is open.
+   *
+   * Controlled by the response pane rather than held here, because its toolbar
+   * has to copy the snippet being READ. A panel owning this privately meant the
+   * only control that knew which flavour was open was the one that could not
+   * reach the clipboard button.
+   */
+  flavour: keyof CodeSnippets;
+  onFlavourChange: (flavour: keyof CodeSnippets) => void;
 }
 
-export function CodePanel({ code }: CodePanelProps) {
-  const [copiedKey, setCopiedKey] = useState<string | null>(null);
-
-  const copy = useCallback(async (key: string, snippet: string) => {
-    try {
-      await navigator.clipboard.writeText(snippet);
-      setCopiedKey(key);
-      toast.success("Code copied to clipboard");
-      setTimeout(() => setCopiedKey(null), UI.COPY_FEEDBACK_TIMEOUT_MS);
-    } catch {
-      toast.error("Failed to copy code");
-    }
-  }, []);
-
+export function CodePanel({ code, flavour, onFlavourChange }: CodePanelProps) {
   return (
-    // The SDK first: it is the one that belongs in the app being built, and
-    // the default should be the answer rather than the fallback.
-    <Tabs defaultValue="sdk" className="flex h-full min-h-0 flex-col">
+    <Tabs
+      value={flavour}
+      onValueChange={value => onFlavourChange(value as keyof CodeSnippets)}
+      className="flex h-full min-h-0 flex-col"
+    >
       <div className="flex shrink-0 items-center justify-between gap-2 px-6 py-2">
         <TabsList variant="ghost">
           {FLAVOURS.map(f => (
@@ -92,28 +80,14 @@ export function CodePanel({ code }: CodePanelProps) {
           value={f.value}
           className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
         >
-          <div className="flex shrink-0 items-center justify-between gap-4 px-6 pb-2">
+          {/* The copy control lives in the pane's toolbar, which now knows
+              which flavour is open. Two buttons a few pixels apart, one of them
+              copying something else, is worse than one. */}
+          <div className="flex shrink-0 items-center gap-4 px-6 pb-2">
             <p className="text-xs text-muted-foreground">{f.hint}</p>
-            {/* One copy button per flavour, so the snippet you are reading is
-                the snippet you get. */}
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                void copy(f.value, code[f.value]);
-              }}
-              className="h-7 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
-            >
-              {copiedKey === f.value ? (
-                <Check className="h-3.5 w-3.5 text-success" />
-              ) : (
-                <Copy className="h-3.5 w-3.5" />
-              )}
-              {copiedKey === f.value ? "Copied" : "Copy"}
-            </Button>
           </div>
 
-          <div className="min-h-0 flex-1 overflow-auto border-t border-border bg-background">
+          <div className="min-h-0 flex-1 overflow-auto border-t border-border bg-code-bg">
             <CodeBlock value={code[f.value]} language={f.language} />
           </div>
         </TabsContent>

--- a/packages/admin/src/components/features/entries/APIPlayground/QueryBuilder.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/QueryBuilder.tsx
@@ -244,65 +244,65 @@ export function QueryBuilder({
 
         {/* Depth stands alone for a single: there is one document, so paging,
             ordering and searching have nothing to act on. */}
-        <div
-          className={cn("grid gap-4", isSingle ? "grid-cols-1" : "grid-cols-3")}
-        >
-          <Field
-            id="param-depth"
-            label="Depth"
-            hint="How many levels of related entries to embed. 0 returns their IDs only."
-          >
-            <Input
+        {/* Sized from the PANE rather than the viewport, because the pane is
+            resizable now: a viewport breakpoint cannot describe a column
+            somebody just dragged narrower. A single has only Depth, so it
+            renders one child rather than asking for a different grid. */}
+        <div className="@container/params">
+          <div className="grid grid-cols-1 gap-4 @md/params:grid-cols-3">
+            <Field
               id="param-depth"
-              aria-describedby="param-depth-hint"
-              type="number"
-              min={0}
-              max={DEPTH_MAX}
-              value={params.depth ?? ""}
-              onChange={e => updateParam("depth", e.target.value)}
-              placeholder="0"
-              className="font-mono text-xs"
-            />
-          </Field>
+              label="Depth"
+              hint="Levels of related entries to embed. 0 returns IDs."
+            >
+              <Input
+                id="param-depth"
+                aria-describedby="param-depth-hint"
+                type="number"
+                min={0}
+                max={DEPTH_MAX}
+                value={params.depth ?? ""}
+                onChange={e => updateParam("depth", e.target.value)}
+                placeholder="0"
+                className="font-mono text-xs"
+              />
+            </Field>
 
-          {!isSingle && (
-            <>
-              <Field
-                id="param-limit"
-                label="Limit"
-                hint={`Entries per page. Capped at ${LIMIT_MAX}.`}
-              >
-                <Input
+            {!isSingle && (
+              <>
+                <Field
                   id="param-limit"
-                  aria-describedby="param-limit-hint"
-                  type="number"
-                  min={1}
-                  max={LIMIT_MAX}
-                  value={params.limit ?? ""}
-                  onChange={e => updateParam("limit", e.target.value)}
-                  placeholder="10"
-                  className="font-mono text-xs"
-                />
-              </Field>
+                  label="Limit"
+                  hint={`Per page. Max ${LIMIT_MAX}.`}
+                >
+                  <Input
+                    id="param-limit"
+                    aria-describedby="param-limit-hint"
+                    type="number"
+                    min={1}
+                    max={LIMIT_MAX}
+                    value={params.limit ?? ""}
+                    onChange={e => updateParam("limit", e.target.value)}
+                    placeholder="10"
+                    className="font-mono text-xs"
+                  />
+                </Field>
 
-              <Field
-                id="param-page"
-                label="Page"
-                hint="Which page to return. The first page is 1."
-              >
-                <Input
-                  id="param-page"
-                  aria-describedby="param-page-hint"
-                  type="number"
-                  min={1}
-                  value={params.page ?? ""}
-                  onChange={e => updateParam("page", e.target.value)}
-                  placeholder="1"
-                  className="font-mono text-xs"
-                />
-              </Field>
-            </>
-          )}
+                <Field id="param-page" label="Page" hint="Page number, from 1.">
+                  <Input
+                    id="param-page"
+                    aria-describedby="param-page-hint"
+                    type="number"
+                    min={1}
+                    value={params.page ?? ""}
+                    onChange={e => updateParam("page", e.target.value)}
+                    placeholder="1"
+                    className="font-mono text-xs"
+                  />
+                </Field>
+              </>
+            )}
+          </div>
         </div>
 
         {!isSingle && (
@@ -425,7 +425,7 @@ export function QueryBuilder({
                     onClick={() => toggleSelected(name)}
                     title={fieldLabel(name, fields)}
                     className={cn(
-                      "cursor-pointer border px-2 py-1 font-mono text-xs transition-colors",
+                      "cursor-pointer rounded-sm border px-2 py-1 font-mono text-xs transition-colors",
                       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                       on
                         ? "border-primary bg-primary text-primary-foreground"

--- a/packages/admin/src/components/features/entries/APIPlayground/RequestBar.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/RequestBar.tsx
@@ -41,6 +41,20 @@ export const METHOD_TONE: Record<HttpMethod, string> = {
   DELETE: "text-destructive",
 };
 
+/**
+ * The same meanings as a filled chip, for the request line.
+ *
+ * The verb is the first thing read on that line and bare coloured text is easy
+ * to skim past, which matters most for the one that destroys a row. Tokens
+ * rather than palette classes, so a retheme carries the meaning with it.
+ */
+export const METHOD_PILL: Record<HttpMethod, string> = {
+  GET: "bg-muted text-foreground",
+  POST: "bg-success/10 text-success",
+  PATCH: "bg-warning/10 text-warning",
+  DELETE: "bg-destructive/10 text-destructive",
+};
+
 export interface RequestBarProps {
   method: HttpMethod;
   /** The absolute URL that will be requested. */
@@ -73,14 +87,14 @@ export function RequestBar({
   onOpen,
 }: RequestBarProps) {
   return (
-    <div className="flex shrink-0 items-stretch gap-px border border-border-strong bg-border-strong">
+    <div className="flex shrink-0 items-stretch gap-px overflow-hidden rounded-lg border border-border-strong bg-border-strong">
       <div className="w-52 shrink-0 bg-background">{action}</div>
 
       <div className="flex flex-1 items-center gap-3 bg-background px-4 py-2.5 min-w-0">
         <span
           className={cn(
-            "shrink-0 font-mono text-xs font-semibold tracking-wide",
-            METHOD_TONE[method]
+            "shrink-0 rounded-sm px-1.5 py-0.5 font-mono text-xs font-semibold tracking-wide",
+            METHOD_PILL[method]
           )}
         >
           {method}
@@ -122,7 +136,11 @@ export function RequestBar({
         // The shortcut is on the label because a control you can only reach
         // with the mouse teaches nobody it has a keyboard.
         title={isLoading ? "Cancel (Esc)" : "Send request (⌘↵)"}
-        className="w-40 shrink-0 gap-2 rounded-md"
+        // Square deliberately: the bar clips to its own corner now, so a
+        // rounded button inside it would draw a second curve just inside the
+        // first. This is the overlapped-strip case theme.css names, not an
+        // element that missed the radius knob.
+        className="w-40 shrink-0 gap-2 rounded-none"
       >
         {isLoading ? (
           <>

--- a/packages/admin/src/components/features/entries/APIPlayground/RequestBar.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/RequestBar.tsx
@@ -28,43 +28,36 @@ import { cn } from "@admin/lib/utils";
 import type { HttpMethod } from "./APIPlayground";
 
 /**
- * Method colours, by what the verb does to your data.
+ * What each verb does to your data, and the two ways that is shown.
  *
- * Exported so the action list reads the same as the bar: a verb that means
- * "destroys a row" should not be one colour in the menu and another once
- * chosen.
- */
-export const METHOD_TONE: Record<HttpMethod, string> = {
-  GET: "text-foreground",
-  POST: "text-success",
-  PATCH: "text-warning",
-  DELETE: "text-destructive",
-};
-
-/**
- * The same meanings as a chip, for the request line.
+ * ONE record rather than two. The action list and the request line are two
+ * VIEWS of a single classification -- "this verb destroys a row" -- and a verb
+ * that reads as destructive in the menu must not read as neutral once chosen.
+ * Two `Record<HttpMethod, string>` maps agree on the day they are written and
+ * nothing keeps them agreeing: the compiler checks that each lists every verb,
+ * never that POST means success in both.
  *
- * The verb is the first thing read on that line and bare coloured text is easy
- * to skim past, which matters most for the one that destroys a row.
- *
- * The COLOUR is carried by the fill and the ink stays neutral, which is forced
- * rather than chosen. This chip is `text-xs`, so it owes 4.5:1, and at that
- * size nothing coloured in this palette clears it: `text-success` reaches
- * 4.35:1 on a light page, and even the theme's own declared pairs are built for
- * large text -- measured, `success-foreground` on `bg-success` is 3.43:1 in
- * dark and `warning-foreground` on `bg-warning` is 3.27:1 in light.
+ * On the chip, the COLOUR is carried by the fill and the ink stays neutral,
+ * which is forced rather than chosen. The chip is `text-xs`, so it owes 4.5:1,
+ * and at that size nothing coloured in this palette clears it: `text-success`
+ * reaches 4.35:1 on a light page, and even the theme's own declared pairs are
+ * built for large text -- measured, `success-foreground` on `bg-success` is
+ * 3.43:1 in dark and `warning-foreground` on `bg-warning` is 3.27:1 in light.
  *
  * A translucent role fill flips with the mode because the role token does, and
  * `foreground` flips with it, so one pair serves both. GET stays neutral
  * because a read is not an event; the other three are things that happen to
  * your data.
  */
-export const METHOD_PILL: Record<HttpMethod, string> = {
-  GET: "bg-muted text-foreground",
-  POST: "bg-success/15 text-foreground",
-  PATCH: "bg-warning/15 text-foreground",
-  DELETE: "bg-destructive/15 text-foreground",
-};
+export const METHOD_SEMANTICS = {
+  GET: { tone: "text-foreground", pill: "bg-muted text-foreground" },
+  POST: { tone: "text-success", pill: "bg-success/15 text-foreground" },
+  PATCH: { tone: "text-warning", pill: "bg-warning/15 text-foreground" },
+  DELETE: {
+    tone: "text-destructive",
+    pill: "bg-destructive/15 text-foreground",
+  },
+} as const satisfies Record<HttpMethod, { tone: string; pill: string }>;
 
 export interface RequestBarProps {
   method: HttpMethod;
@@ -98,6 +91,11 @@ export function RequestBar({
   onOpen,
 }: RequestBarProps) {
   return (
+    // `overflow-hidden` is what makes the strip clip to its own rounded
+    // corner, and it also clips anything a child paints outside its box --
+    // which is where a focus ring lives. Every control that touches an edge
+    // therefore draws its ring INSIDE, or keyboard focus disappears on the
+    // outermost ones.
     <div className="flex shrink-0 items-stretch gap-px overflow-hidden rounded-lg border border-border-strong bg-border-strong">
       <div className="w-52 shrink-0 bg-background">{action}</div>
 
@@ -105,7 +103,7 @@ export function RequestBar({
         <span
           className={cn(
             "shrink-0 rounded-sm px-1.5 py-0.5 font-mono text-xs font-semibold tracking-wide",
-            METHOD_PILL[method]
+            METHOD_SEMANTICS[method].pill
           )}
         >
           {method}
@@ -122,7 +120,7 @@ export function RequestBar({
         onClick={onCopy}
         aria-label={copied ? "URL copied" : "Copy request URL"}
         title="Copy request URL"
-        className="flex w-11 shrink-0 cursor-pointer items-center justify-center bg-background text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="flex w-11 shrink-0 cursor-pointer items-center justify-center bg-background text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
       >
         {copied ? (
           <Check className="h-3.5 w-3.5 text-success" />
@@ -136,7 +134,7 @@ export function RequestBar({
         onClick={onOpen}
         aria-label="Open request URL in a new tab"
         title="Open in a new tab"
-        className="flex w-11 shrink-0 cursor-pointer items-center justify-center bg-background text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="flex w-11 shrink-0 cursor-pointer items-center justify-center bg-background text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
       >
         <ExternalLink className="h-3.5 w-3.5" />
       </button>
@@ -151,7 +149,10 @@ export function RequestBar({
         // rounded button inside it would draw a second curve just inside the
         // first. This is the overlapped-strip case theme.css names, not an
         // element that missed the radius knob.
-        className="w-40 shrink-0 gap-2 rounded-none"
+        // `ring-inset` for the same reason the icon buttons carry it: the bar
+        // clips to its own rounded corner, and a ring painted outside the
+        // button's box is cut off exactly where the button meets that edge.
+        className="w-40 shrink-0 gap-2 rounded-none focus-visible:ring-inset"
       >
         {isLoading ? (
           <>

--- a/packages/admin/src/components/features/entries/APIPlayground/RequestBar.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/RequestBar.tsx
@@ -96,7 +96,13 @@ export function RequestBar({
     // which is where a focus ring lives. Every control that touches an edge
     // therefore draws its ring INSIDE, or keyboard focus disappears on the
     // outermost ones.
-    <div className="flex shrink-0 items-stretch gap-px overflow-hidden rounded-lg border border-border-strong bg-border-strong">
+    //
+    // It wraps for the same reason. The children that do not shrink come to
+    // 456px -- the picker, two icon buttons and Send -- so under about 490px
+    // of content width the clip takes the RIGHTMOST control, which is Send.
+    // A primary action that silently disappears on a narrow screen is worse
+    // than one that costs a second row.
+    <div className="flex shrink-0 flex-wrap items-stretch gap-px overflow-hidden rounded-lg border border-border-strong bg-border-strong">
       <div className="w-52 shrink-0 bg-background">{action}</div>
 
       <div className="flex flex-1 items-center gap-3 bg-background px-4 py-2.5 min-w-0">

--- a/packages/admin/src/components/features/entries/APIPlayground/RequestBar.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/RequestBar.tsx
@@ -42,17 +42,28 @@ export const METHOD_TONE: Record<HttpMethod, string> = {
 };
 
 /**
- * The same meanings as a filled chip, for the request line.
+ * The same meanings as a chip, for the request line.
  *
  * The verb is the first thing read on that line and bare coloured text is easy
- * to skim past, which matters most for the one that destroys a row. Tokens
- * rather than palette classes, so a retheme carries the meaning with it.
+ * to skim past, which matters most for the one that destroys a row.
+ *
+ * The COLOUR is carried by the fill and the ink stays neutral, which is forced
+ * rather than chosen. This chip is `text-xs`, so it owes 4.5:1, and at that
+ * size nothing coloured in this palette clears it: `text-success` reaches
+ * 4.35:1 on a light page, and even the theme's own declared pairs are built for
+ * large text -- measured, `success-foreground` on `bg-success` is 3.43:1 in
+ * dark and `warning-foreground` on `bg-warning` is 3.27:1 in light.
+ *
+ * A translucent role fill flips with the mode because the role token does, and
+ * `foreground` flips with it, so one pair serves both. GET stays neutral
+ * because a read is not an event; the other three are things that happen to
+ * your data.
  */
 export const METHOD_PILL: Record<HttpMethod, string> = {
   GET: "bg-muted text-foreground",
-  POST: "bg-success/10 text-success",
-  PATCH: "bg-warning/10 text-warning",
-  DELETE: "bg-destructive/10 text-destructive",
+  POST: "bg-success/15 text-foreground",
+  PATCH: "bg-warning/15 text-foreground",
+  DELETE: "bg-destructive/15 text-foreground",
 };
 
 export interface RequestBarProps {

--- a/packages/admin/src/components/features/entries/APIPlayground/ResponseMetrics.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/ResponseMetrics.tsx
@@ -16,28 +16,27 @@
 import { cn } from "@admin/lib/utils";
 
 /**
- * The status dot, keyed to the same meaning as the status text beside it.
- */
-function statusDotTone(status: number): string {
-  if (status >= 200 && status < 300) return "bg-success";
-  if (status >= 300 && status < 400) return "bg-muted-foreground";
-  if (status >= 400 && status < 500) return "bg-warning";
-  if (status >= 500) return "bg-destructive";
-  return "bg-muted-foreground";
-}
-
-/**
- * Colour a response by what its status class means.
+ * What a status class means, and the two ways that meaning is drawn.
+ *
+ * ONE classifier. The dot and the number are two renderings of a single
+ * judgement about a single response, and two functions branching on the same
+ * ranges agree only until somebody reclassifies one of them -- at which point
+ * the dot says one thing and the number beside it says another, on the control
+ * a reader trusts to tell them whether the request worked.
  *
  * A 4xx is the caller's mistake and a 5xx is the server's, so they read as
- * warning and error respectively.
+ * warning and error respectively. A 3xx is not an outcome yet, so it stays
+ * neutral, as does anything outside the ranges HTTP defines.
  */
-function statusTone(status: number): string {
-  if (status >= 200 && status < 300) return "text-success";
-  if (status >= 300 && status < 400) return "text-muted-foreground";
-  if (status >= 400 && status < 500) return "text-warning";
-  if (status >= 500) return "text-destructive";
-  return "text-muted-foreground";
+function statusPresentation(status: number): { text: string; dot: string } {
+  if (status >= 200 && status < 300)
+    return { text: "text-success", dot: "bg-success" };
+  if (status >= 300 && status < 400)
+    return { text: "text-muted-foreground", dot: "bg-muted-foreground" };
+  if (status >= 400 && status < 500)
+    return { text: "text-warning", dot: "bg-warning" };
+  if (status >= 500) return { text: "text-destructive", dot: "bg-destructive" };
+  return { text: "text-muted-foreground", dot: "bg-muted-foreground" };
 }
 
 /**
@@ -106,7 +105,9 @@ export function ResponseMetrics({ status, time, size }: ResponseMetricsProps) {
         <span
           className={cn(
             "h-1.5 w-1.5 shrink-0 rounded-full",
-            status === undefined ? "bg-transparent" : statusDotTone(status)
+            status === undefined
+              ? "bg-transparent"
+              : statusPresentation(status).dot
           )}
         />
         <span
@@ -114,7 +115,9 @@ export function ResponseMetrics({ status, time, size }: ResponseMetricsProps) {
             // 3ch: an HTTP status code is always three digits, so this
             // reserves the exact width rather than an estimate of it.
             "min-w-[3ch] font-mono text-sm font-semibold",
-            status === undefined ? "text-muted-foreground" : statusTone(status)
+            status === undefined
+              ? "text-muted-foreground"
+              : statusPresentation(status).text
           )}
         >
           {status ?? "—"}

--- a/packages/admin/src/components/features/entries/APIPlayground/ResponseMetrics.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/ResponseMetrics.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+/**
+ * What the last reply cost: its status, how long it took, and how big it was.
+ *
+ * Its own component because it answers a different question from the tabs
+ * beside it -- those are "what do I do with this", this is "what happened" --
+ * and because it carries a contract the rest of the pane does not: the row must
+ * not change size when the values arrive. Everything here that looks like a
+ * magic number is that contract. `e2e/tests/api-playground-metrics.spec.ts`
+ * measures it, since jsdom computes no layout and cannot.
+ *
+ * @module components/entries/APIPlayground/ResponseMetrics
+ */
+
+import { cn } from "@admin/lib/utils";
+
+/**
+ * The status dot, keyed to the same meaning as the status text beside it.
+ */
+function statusDotTone(status: number): string {
+  if (status >= 200 && status < 300) return "bg-success";
+  if (status >= 300 && status < 400) return "bg-muted-foreground";
+  if (status >= 400 && status < 500) return "bg-warning";
+  if (status >= 500) return "bg-destructive";
+  return "bg-muted-foreground";
+}
+
+/**
+ * Colour a response by what its status class means.
+ *
+ * A 4xx is the caller's mistake and a 5xx is the server's, so they read as
+ * warning and error respectively.
+ */
+function statusTone(status: number): string {
+  if (status >= 200 && status < 300) return "text-success";
+  if (status >= 300 && status < 400) return "text-muted-foreground";
+  if (status >= 400 && status < 500) return "text-warning";
+  if (status >= 500) return "text-destructive";
+  return "text-muted-foreground";
+}
+
+/**
+ * A payload size someone can act on.
+ *
+ * Two significant figures past a kilobyte: the question a size answers here is
+ * "is this response big?", and 2.4 KB answers it while 2438 B makes you count
+ * digits.
+ */
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+  // Without this arm megabytes never stop counting, so a 5 GiB reply reads
+  // `5120.00 MB` -- longer than any width the metrics row can reserve, and
+  // harder to size at a glance than the unit it belongs in.
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+/** One reading in the meta row, with a placeholder that holds its width. */
+function Metric({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+export interface ResponseMetricsProps {
+  /** HTTP status, absent until the first reply. */
+  status?: number;
+  /** Round trip in milliseconds. */
+  time?: number;
+  /** Body size in bytes — what `depth` and `limit` are traded against. */
+  size?: number;
+}
+
+export function ResponseMetrics({ status, time, size }: ResponseMetricsProps) {
+  /* Always rendered, and every value reserves the width its populated form
+  needs. The metrics used to appear with the first reply, so the header
+  reflowed at the moment somebody was reading it -- and a placeholder
+  alone does not fix that: an em dash is narrower than `200`, `123ms`
+  and `5.8 KB`, so at pane widths between the two intrinsic widths the
+  row still wrapped on arrival and pushed the toolbar down. The mono
+  face advances every glyph equally, so `ch` reserves exactly. */
+  return (
+    <div
+      data-testid="response-meta"
+      // Wraps rather than clipping. The pane is resizable, and its minimum
+      // against a wide admin sidebar leaves a few hundred pixels -- at which
+      // a non-wrapping row puts the metrics past the card's clipped edge.
+      className="flex shrink-0 flex-wrap items-center justify-end gap-x-4 gap-y-1 border-b border-border px-6 py-2"
+    >
+      <Metric label="Status">
+        {/* Drawn at every moment, coloured only once there is a status. Built
+            conditionally, the dot and its gap are 14px that arrive with the
+            first reply. */}
+        <span
+          className={cn(
+            "h-1.5 w-1.5 shrink-0 rounded-full",
+            status === undefined ? "bg-transparent" : statusDotTone(status)
+          )}
+        />
+        <span
+          className={cn(
+            // 3ch: an HTTP status code is always three digits, so this
+            // reserves the exact width rather than an estimate of it.
+            "min-w-[3ch] font-mono text-sm font-semibold",
+            status === undefined ? "text-muted-foreground" : statusTone(status)
+          )}
+        >
+          {status ?? "—"}
+        </span>
+      </Metric>
+      <div className="h-4 w-px bg-border" />
+      <Metric label="Latency">
+        {/* 6ch holds `9999ms`. Past ten seconds the value outgrows its
+            reservation and the row can reflow again, which is a real change
+            in the content rather than the empty-to-populated step this
+            reserves against. */}
+        <span className="min-w-[6ch] font-mono text-sm font-semibold text-foreground">
+          {time === undefined ? "—" : `${time}ms`}
+        </span>
+      </Metric>
+      <div className="h-4 w-px bg-border" />
+      {/* Beside latency because they are the pair traded against each other
+          when tuning depth and limit. */}
+      <Metric label="Size">
+        {/* 10ch holds the widest form `formatBytes` produces: `1023.99 MB`
+            and `1023.99 GB` are both ten characters, and every smaller unit
+            is shorter. A terabyte reply would outgrow it, which no API
+            response this pane can render is going to be. */}
+        <span className="min-w-[10ch] font-mono text-sm font-semibold text-foreground">
+          {size === undefined ? "—" : formatBytes(size)}
+        </span>
+      </Metric>
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/entries/APIPlayground/ResponseViewer.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/ResponseViewer.tsx
@@ -237,7 +237,14 @@ export function ResponseViewer({
         data-testid="response-toolbar"
         className="flex shrink-0 flex-col gap-1 border-b border-border bg-muted/30 px-6 py-1.5 @sm/response:flex-row @sm/response:items-center @sm/response:justify-between @sm/response:gap-2"
       >
-        <TabsList variant="ghost">
+        {/* The pane is draggable to a third of the group, which against a wide
+            sidebar leaves under 200px -- less than three nowrap triggers need
+            once the header count appears -- and the card clips rather than
+            scrolls, so Headers and Code simply vanish. `scrollable` is the
+            primitive's own answer; putting `overflow-x-auto` here instead would
+            make the rail its own scroll container and break the contract the
+            component depends on. */}
+        <TabsList variant="ghost" scrollable>
           <TabsTrigger value="body" size="sm">
             Body
           </TabsTrigger>

--- a/packages/admin/src/components/features/entries/APIPlayground/ResponseViewer.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/ResponseViewer.tsx
@@ -168,7 +168,9 @@ export function ResponseViewer({
     }
   }, [data]);
 
-  const headerEntries = Object.entries(headers ?? {});
+  // Memoised so `headerText` can depend on it. Rebuilt on every render, the
+  // array is a new identity each time and any memo keyed on it never holds.
+  const headerEntries = useMemo(() => Object.entries(headers ?? {}), [headers]);
 
   /**
    * The headers as text, in the form they arrived in.
@@ -179,8 +181,7 @@ export function ResponseViewer({
    */
   const headerText = useMemo(
     () => headerEntries.map(([name, value]) => `${name}: ${value}`).join("\n"),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- entries are rebuilt each render from `headers`
-    [headers]
+    [headerEntries]
   );
 
   /**
@@ -262,9 +263,13 @@ export function ResponseViewer({
       onValueChange={value => setTab(value as ResponseTab)}
       className="@container/response flex h-full min-h-0 flex-col"
     >
-      {/* Always rendered, with placeholders holding the width. The metrics used
-          to appear with the first reply, so the header reflowed at the moment
-          somebody was reading it. */}
+      {/* Always rendered, and every value reserves the width its populated form
+          needs. The metrics used to appear with the first reply, so the header
+          reflowed at the moment somebody was reading it -- and a placeholder
+          alone does not fix that: an em dash is narrower than `200`, `123ms`
+          and `5.8 KB`, so at pane widths between the two intrinsic widths the
+          row still wrapped on arrival and pushed the toolbar down. The mono
+          face advances every glyph equally, so `ch` reserves exactly. */}
       <div
         data-testid="response-meta"
         // Wraps rather than clipping. The pane is resizable, and its minimum
@@ -273,30 +278,35 @@ export function ResponseViewer({
         className="flex shrink-0 flex-wrap items-center justify-end gap-x-4 gap-y-1 border-b border-border px-6 py-2"
       >
         <Metric label="Status">
-          {status === undefined ? (
-            <span className="font-mono text-sm text-muted-foreground">—</span>
-          ) : (
-            <>
-              <span
-                className={cn(
-                  "h-1.5 w-1.5 rounded-full",
-                  statusDotTone(status)
-                )}
-              />
-              <span
-                className={cn(
-                  "font-mono text-sm font-semibold",
-                  statusTone(status)
-                )}
-              >
-                {status}
-              </span>
-            </>
-          )}
+          {/* Drawn at every moment, coloured only once there is a status. Built
+              conditionally, the dot and its gap are 14px that arrive with the
+              first reply. */}
+          <span
+            className={cn(
+              "h-1.5 w-1.5 shrink-0 rounded-full",
+              status === undefined ? "bg-transparent" : statusDotTone(status)
+            )}
+          />
+          <span
+            className={cn(
+              // 3ch: an HTTP status code is always three digits, so this
+              // reserves the exact width rather than an estimate of it.
+              "min-w-[3ch] font-mono text-sm font-semibold",
+              status === undefined
+                ? "text-muted-foreground"
+                : statusTone(status)
+            )}
+          >
+            {status ?? "—"}
+          </span>
         </Metric>
         <div className="h-4 w-px bg-border" />
         <Metric label="Latency">
-          <span className="font-mono text-sm font-semibold text-foreground">
+          {/* 6ch holds `9999ms`. Past ten seconds the value outgrows its
+              reservation and the row can reflow again, which is a real change
+              in the content rather than the empty-to-populated step this
+              reserves against. */}
+          <span className="min-w-[6ch] font-mono text-sm font-semibold text-foreground">
             {time === undefined ? "—" : `${time}ms`}
           </span>
         </Metric>
@@ -304,7 +314,9 @@ export function ResponseViewer({
         {/* Beside latency because they are the pair traded against each other
             when tuning depth and limit. */}
         <Metric label="Size">
-          <span className="font-mono text-sm font-semibold text-foreground">
+          {/* 9ch holds the widest form `formatBytes` produces below a gigabyte:
+              `1023.9 KB` and `123.45 MB` are both nine characters. */}
+          <span className="min-w-[9ch] font-mono text-sm font-semibold text-foreground">
             {size === undefined ? "—" : formatBytes(size)}
           </span>
         </Metric>
@@ -312,7 +324,10 @@ export function ResponseViewer({
 
       {/* Stacks below a narrow pane so the tabs and the copy control stay
           reachable instead of overflowing the card's clipped edge. */}
-      <div className="flex shrink-0 flex-col gap-1 border-b border-border bg-muted/30 px-6 py-1.5 @sm/response:flex-row @sm/response:items-center @sm/response:justify-between @sm/response:gap-2">
+      <div
+        data-testid="response-toolbar"
+        className="flex shrink-0 flex-col gap-1 border-b border-border bg-muted/30 px-6 py-1.5 @sm/response:flex-row @sm/response:items-center @sm/response:justify-between @sm/response:gap-2"
+      >
         <TabsList variant="ghost">
           <TabsTrigger value="body" size="sm">
             Body

--- a/packages/admin/src/components/features/entries/APIPlayground/ResponseViewer.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/ResponseViewer.tsx
@@ -39,11 +39,11 @@ import {
 } from "@admin/components/icons";
 import { UI } from "@admin/constants/ui";
 import { usePersistedState } from "@admin/hooks/usePersistedState";
-import { cn } from "@admin/lib/utils";
 
 import { CodePanel } from "./CodePanel";
 import type { CodeSnippets } from "./generate-code";
 import { JsonViewer } from "./JsonViewer";
+import { ResponseMetrics } from "./ResponseMetrics";
 
 /** Which of the three panes is open, so the toolbar can act on it. */
 type ResponseTab = "body" | "headers" | "code";
@@ -57,44 +57,6 @@ type ResponseTab = "body" | "headers" | "code";
 const FLAVOUR_KEY = "nextly:admin:api-playground:flavour";
 const isFlavour = (value: string): value is keyof CodeSnippets =>
   value === "sdk" || value === "fetch" || value === "curl";
-
-/**
- * The status dot, keyed to the same meaning as the status text beside it.
- */
-function statusDotTone(status: number): string {
-  if (status >= 200 && status < 300) return "bg-success";
-  if (status >= 300 && status < 400) return "bg-muted-foreground";
-  if (status >= 400 && status < 500) return "bg-warning";
-  if (status >= 500) return "bg-destructive";
-  return "bg-muted-foreground";
-}
-
-/**
- * Colour a response by what its status class means.
- *
- * A 4xx is the caller's mistake and a 5xx is the server's, so they read as
- * warning and error respectively.
- */
-function statusTone(status: number): string {
-  if (status >= 200 && status < 300) return "text-success";
-  if (status >= 300 && status < 400) return "text-muted-foreground";
-  if (status >= 400 && status < 500) return "text-warning";
-  if (status >= 500) return "text-destructive";
-  return "text-muted-foreground";
-}
-
-/**
- * A payload size someone can act on.
- *
- * Two significant figures past a kilobyte: the question a size answers here is
- * "is this response big?", and 2.4 KB answers it while 2438 B makes you count
- * digits.
- */
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
-}
 
 export interface ResponseViewerProps {
   /** Response data to display */
@@ -117,22 +79,6 @@ export interface ResponseViewerProps {
   time?: number;
   /** Body size in bytes — what `depth` and `limit` are traded against. */
   size?: number;
-}
-
-/** One reading in the meta row, with a placeholder that holds its width. */
-function Metric({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="flex items-center gap-2">
-      <span className="text-xs text-muted-foreground">{label}</span>
-      {children}
-    </div>
-  );
 }
 
 export function ResponseViewer({
@@ -255,7 +201,12 @@ export function ResponseViewer({
     URL.revokeObjectURL(url);
   }, [raw, jsonString, headerText, tab, target.filename]);
 
-  const hasResponse = Boolean(jsonString) || isLoading || Boolean(error);
+  // A completed request with an empty body -- a 204, or a 200 returning
+  // nothing -- is a RESPONSE. Deriving this from the body alone made the
+  // headers tab say "send the request" about a request that had just come
+  // back, and its headers were sitting there unread.
+  const hasResponse =
+    status !== undefined || Boolean(jsonString) || isLoading || Boolean(error);
 
   return (
     <Tabs
@@ -263,64 +214,7 @@ export function ResponseViewer({
       onValueChange={value => setTab(value as ResponseTab)}
       className="@container/response flex h-full min-h-0 flex-col"
     >
-      {/* Always rendered, and every value reserves the width its populated form
-          needs. The metrics used to appear with the first reply, so the header
-          reflowed at the moment somebody was reading it -- and a placeholder
-          alone does not fix that: an em dash is narrower than `200`, `123ms`
-          and `5.8 KB`, so at pane widths between the two intrinsic widths the
-          row still wrapped on arrival and pushed the toolbar down. The mono
-          face advances every glyph equally, so `ch` reserves exactly. */}
-      <div
-        data-testid="response-meta"
-        // Wraps rather than clipping. The pane is resizable, and its minimum
-        // against a wide admin sidebar leaves a few hundred pixels -- at which
-        // a non-wrapping row puts the metrics past the card's clipped edge.
-        className="flex shrink-0 flex-wrap items-center justify-end gap-x-4 gap-y-1 border-b border-border px-6 py-2"
-      >
-        <Metric label="Status">
-          {/* Drawn at every moment, coloured only once there is a status. Built
-              conditionally, the dot and its gap are 14px that arrive with the
-              first reply. */}
-          <span
-            className={cn(
-              "h-1.5 w-1.5 shrink-0 rounded-full",
-              status === undefined ? "bg-transparent" : statusDotTone(status)
-            )}
-          />
-          <span
-            className={cn(
-              // 3ch: an HTTP status code is always three digits, so this
-              // reserves the exact width rather than an estimate of it.
-              "min-w-[3ch] font-mono text-sm font-semibold",
-              status === undefined
-                ? "text-muted-foreground"
-                : statusTone(status)
-            )}
-          >
-            {status ?? "—"}
-          </span>
-        </Metric>
-        <div className="h-4 w-px bg-border" />
-        <Metric label="Latency">
-          {/* 6ch holds `9999ms`. Past ten seconds the value outgrows its
-              reservation and the row can reflow again, which is a real change
-              in the content rather than the empty-to-populated step this
-              reserves against. */}
-          <span className="min-w-[6ch] font-mono text-sm font-semibold text-foreground">
-            {time === undefined ? "—" : `${time}ms`}
-          </span>
-        </Metric>
-        <div className="h-4 w-px bg-border" />
-        {/* Beside latency because they are the pair traded against each other
-            when tuning depth and limit. */}
-        <Metric label="Size">
-          {/* 9ch holds the widest form `formatBytes` produces below a gigabyte:
-              `1023.9 KB` and `123.45 MB` are both nine characters. */}
-          <span className="min-w-[9ch] font-mono text-sm font-semibold text-foreground">
-            {size === undefined ? "—" : formatBytes(size)}
-          </span>
-        </Metric>
-      </div>
+      <ResponseMetrics status={status} time={time} size={size} />
 
       {/* Stacks below a narrow pane so the tabs and the copy control stay
           reachable instead of overflowing the card's clipped edge. */}
@@ -410,12 +304,25 @@ export function ResponseViewer({
             <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-md border border-border bg-card">
               <FileJson className="h-6 w-6 text-muted-foreground" />
             </div>
+            {/* Two different facts, and telling a reader the wrong one wastes
+                their time: nothing has been sent yet, versus it came back and
+                carried no body -- which for a 204 is the CORRECT outcome, not
+                an absence to keep waiting on. */}
             <h3 className="mb-1 text-base font-semibold tracking-tight text-foreground">
-              No response yet
+              {status === undefined ? "No response yet" : "No content"}
             </h3>
             <p className="max-w-xs text-sm leading-relaxed text-muted-foreground">
-              Send the request to see the response here. The Code tab already
-              has the call.
+              {status === undefined ? (
+                <>
+                  Send the request to see the response here. The Code tab
+                  already has the call.
+                </>
+              ) : (
+                <>
+                  The request returned {status} with an empty body. Its headers
+                  are on the Headers tab.
+                </>
+              )}
             </p>
           </div>
         ) : (

--- a/packages/admin/src/components/features/entries/APIPlayground/ResponseViewer.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/ResponseViewer.tsx
@@ -147,7 +147,9 @@ export function ResponseViewer({
   time,
   size,
 }: ResponseViewerProps) {
-  const [copied, setCopied] = useState(false);
+  // The text last copied, so the feedback belongs to it rather than to the
+  // button. Null means nothing was copied recently.
+  const [copied, setCopied] = useState<string | null>(null);
   const [tab, setTab] = useState<ResponseTab>("body");
   const [flavour, setFlavour] = usePersistedState(
     FLAVOUR_KEY,
@@ -166,24 +168,64 @@ export function ResponseViewer({
     }
   }, [data]);
 
-  // What the toolbar acts on is what the reader is looking at, which is the
-  // whole point of holding the tab here.
-  const onCode = tab === "code";
-  const copyTarget = onCode ? code[flavour] : jsonString;
+  const headerEntries = Object.entries(headers ?? {});
+
+  /**
+   * The headers as text, in the form they arrived in.
+   *
+   * `name: value` per line is what a header block IS, and it is what pasting
+   * one into a request or an issue expects. Rebuilding it from the map is the
+   * only option -- `fetch` gives no access to the raw block.
+   */
+  const headerText = useMemo(
+    () => headerEntries.map(([name, value]) => `${name}: ${value}`).join("\n"),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- entries are rebuilt each render from `headers`
+    [headers]
+  );
+
+  /**
+   * What the toolbar acts on is what the reader is looking at.
+   *
+   * All THREE tabs, not two. Copy took the body whenever the Code tab was
+   * closed, so reading the headers and pressing Copy put the body on the
+   * clipboard -- the same defect this control was rewritten to remove, one tab
+   * further along.
+   */
+  const target: { text: string; label: string; filename: string } =
+    tab === "code"
+      ? {
+          text: code[flavour],
+          label: "Code",
+          filename: `${filename}-${flavour}`,
+        }
+      : tab === "headers"
+        ? {
+            text: headerText,
+            label: "Headers",
+            filename: `${filename}-headers`,
+          }
+        : { text: jsonString, label: "Response", filename };
+  const copyTarget = target.text;
 
   const handleCopy = useCallback(async () => {
     if (!copyTarget) return;
     try {
       await navigator.clipboard.writeText(copyTarget);
-      setCopied(true);
-      toast.success(
-        onCode ? "Code copied to clipboard" : "Response copied to clipboard"
+      // Keyed to WHAT was copied rather than a bare flag: switching tab or
+      // flavour inside the feedback window otherwise leaves "Copied" standing
+      // over a control that would now copy something else.
+      setCopied(copyTarget);
+      toast.success(`${target.label} copied to clipboard`);
+      setTimeout(
+        () => setCopied(current => (current === copyTarget ? null : current)),
+        UI.COPY_FEEDBACK_TIMEOUT_MS
       );
-      setTimeout(() => setCopied(false), UI.COPY_FEEDBACK_TIMEOUT_MS);
     } catch {
       toast.error("Failed to copy");
     }
-  }, [copyTarget, onCode]);
+  }, [copyTarget, target.label]);
+
+  const showCopied = copied !== null && copied === copyTarget;
 
   /**
    * Save the body to a file.
@@ -193,35 +235,42 @@ export function ResponseViewer({
    * differ from what the API actually sent.
    */
   const handleDownload = useCallback(() => {
-    const body = raw ?? jsonString;
+    // The body is saved as it ARRIVED rather than as it is displayed: a saved
+    // response is usually about to be diffed or replayed, and pretty-printing
+    // would make it differ from what the API sent. Headers have no raw form to
+    // preserve, so the rendered block is the honest one.
+    const body = tab === "headers" ? headerText : (raw ?? jsonString);
     if (!body) return;
 
+    const isJson = tab === "body";
     const url = URL.createObjectURL(
-      new Blob([body], { type: "application/json" })
+      new Blob([body], { type: isJson ? "application/json" : "text/plain" })
     );
     const link = document.createElement("a");
     link.href = url;
-    link.download = `${filename}.json`;
+    link.download = `${target.filename}.${isJson ? "json" : "txt"}`;
     link.click();
     // The object URL pins the blob in memory until it is let go.
     URL.revokeObjectURL(url);
-  }, [raw, jsonString, filename]);
+  }, [raw, jsonString, headerText, tab, target.filename]);
 
-  const headerEntries = Object.entries(headers ?? {});
   const hasResponse = Boolean(jsonString) || isLoading || Boolean(error);
 
   return (
     <Tabs
       value={tab}
       onValueChange={value => setTab(value as ResponseTab)}
-      className="flex h-full min-h-0 flex-col"
+      className="@container/response flex h-full min-h-0 flex-col"
     >
       {/* Always rendered, with placeholders holding the width. The metrics used
           to appear with the first reply, so the header reflowed at the moment
           somebody was reading it. */}
       <div
         data-testid="response-meta"
-        className="flex shrink-0 items-center justify-end gap-4 border-b border-border px-6 py-2"
+        // Wraps rather than clipping. The pane is resizable, and its minimum
+        // against a wide admin sidebar leaves a few hundred pixels -- at which
+        // a non-wrapping row puts the metrics past the card's clipped edge.
+        className="flex shrink-0 flex-wrap items-center justify-end gap-x-4 gap-y-1 border-b border-border px-6 py-2"
       >
         <Metric label="Status">
           {status === undefined ? (
@@ -261,7 +310,9 @@ export function ResponseViewer({
         </Metric>
       </div>
 
-      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border bg-muted/30 px-6 py-1.5">
+      {/* Stacks below a narrow pane so the tabs and the copy control stay
+          reachable instead of overflowing the card's clipped edge. */}
+      <div className="flex shrink-0 flex-col gap-1 border-b border-border bg-muted/30 px-6 py-1.5 @sm/response:flex-row @sm/response:items-center @sm/response:justify-between @sm/response:gap-2">
         <TabsList variant="ghost">
           <TabsTrigger value="body" size="sm">
             Body
@@ -282,12 +333,14 @@ export function ResponseViewer({
         <div className="flex items-center gap-1">
           {/* Absent on the Code tab: a snippet saved as `<collection>.json` is
               not a thing anybody wants, and offering it invites the mistake. */}
-          {!onCode && (
+          {/* A snippet is copied, not saved: it belongs in an editor rather
+              than in a file named after the collection. */}
+          {tab !== "code" && (
             <Button
               variant="ghost"
               size="sm"
               onClick={handleDownload}
-              disabled={!jsonString}
+              disabled={!copyTarget}
               className="h-7 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
             >
               <Download className="h-3.5 w-3.5" />
@@ -303,12 +356,12 @@ export function ResponseViewer({
             disabled={!copyTarget}
             className="h-7 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
           >
-            {copied ? (
+            {showCopied ? (
               <Check className="h-3.5 w-3.5 text-success" />
             ) : (
               <Copy className="h-3.5 w-3.5" />
             )}
-            {copied ? "Copied" : "Copy"}
+            {showCopied ? "Copied" : "Copy"}
           </Button>
         </div>
       </div>

--- a/packages/admin/src/components/features/entries/APIPlayground/ResponseViewer.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/ResponseViewer.tsx
@@ -5,11 +5,16 @@
  *
  * Three tabs rather than one JSON pane: the body answers "did it work", the
  * headers answer "why did it do that" (they carry the request id we stamp on
- * every reply), and the code answers "how do I use this", which is the step
- * the playground used to leave you to work out yourself.
+ * every reply), and the code answers "how do I use this", which the playground
+ * used to leave you to work out yourself.
  *
  * The tabs render whether or not a response exists, because the code is built
  * from the request — it is worth reading before you send, not only after.
+ *
+ * The tab selection is held here rather than left to the primitive, because the
+ * toolbar has to act on what is being READ. A Copy that always took the body
+ * put JSON on the clipboard while the reader was looking at a snippet, and did
+ * it silently.
  *
  * @module components/entries/APIPlayground/ResponseViewer
  */
@@ -33,10 +38,63 @@ import {
   Download,
 } from "@admin/components/icons";
 import { UI } from "@admin/constants/ui";
+import { usePersistedState } from "@admin/hooks/usePersistedState";
+import { cn } from "@admin/lib/utils";
 
 import { CodePanel } from "./CodePanel";
 import type { CodeSnippets } from "./generate-code";
 import { JsonViewer } from "./JsonViewer";
+
+/** Which of the three panes is open, so the toolbar can act on it. */
+type ResponseTab = "body" | "headers" | "code";
+
+/**
+ * The last code flavour read, remembered.
+ *
+ * Somebody who works in curl is working in curl on the next request too, and
+ * being returned to the SDK tab every time is a small tax paid repeatedly.
+ */
+const FLAVOUR_KEY = "nextly:admin:api-playground:flavour";
+const isFlavour = (value: string): value is keyof CodeSnippets =>
+  value === "sdk" || value === "fetch" || value === "curl";
+
+/**
+ * The status dot, keyed to the same meaning as the status text beside it.
+ */
+function statusDotTone(status: number): string {
+  if (status >= 200 && status < 300) return "bg-success";
+  if (status >= 300 && status < 400) return "bg-muted-foreground";
+  if (status >= 400 && status < 500) return "bg-warning";
+  if (status >= 500) return "bg-destructive";
+  return "bg-muted-foreground";
+}
+
+/**
+ * Colour a response by what its status class means.
+ *
+ * A 4xx is the caller's mistake and a 5xx is the server's, so they read as
+ * warning and error respectively.
+ */
+function statusTone(status: number): string {
+  if (status >= 200 && status < 300) return "text-success";
+  if (status >= 300 && status < 400) return "text-muted-foreground";
+  if (status >= 400 && status < 500) return "text-warning";
+  if (status >= 500) return "text-destructive";
+  return "text-muted-foreground";
+}
+
+/**
+ * A payload size someone can act on.
+ *
+ * Two significant figures past a kilobyte: the question a size answers here is
+ * "is this response big?", and 2.4 KB answers it while 2438 B makes you count
+ * digits.
+ */
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
 
 export interface ResponseViewerProps {
   /** Response data to display */
@@ -53,6 +111,28 @@ export interface ResponseViewerProps {
   code: CodeSnippets;
   /** Collection slug, for the download filename. */
   filename?: string;
+  /** HTTP status, absent until the first reply. */
+  status?: number;
+  /** Round trip in milliseconds. */
+  time?: number;
+  /** Body size in bytes — what `depth` and `limit` are traded against. */
+  size?: number;
+}
+
+/** One reading in the meta row, with a placeholder that holds its width. */
+function Metric({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      {children}
+    </div>
+  );
 }
 
 export function ResponseViewer({
@@ -63,8 +143,17 @@ export function ResponseViewer({
   raw,
   code,
   filename = "response",
+  status,
+  time,
+  size,
 }: ResponseViewerProps) {
   const [copied, setCopied] = useState(false);
+  const [tab, setTab] = useState<ResponseTab>("body");
+  const [flavour, setFlavour] = usePersistedState(
+    FLAVOUR_KEY,
+    "sdk",
+    isFlavour
+  );
 
   const jsonString = useMemo(() => {
     if (data === undefined || data === null) return "";
@@ -77,17 +166,24 @@ export function ResponseViewer({
     }
   }, [data]);
 
+  // What the toolbar acts on is what the reader is looking at, which is the
+  // whole point of holding the tab here.
+  const onCode = tab === "code";
+  const copyTarget = onCode ? code[flavour] : jsonString;
+
   const handleCopy = useCallback(async () => {
-    if (!jsonString) return;
+    if (!copyTarget) return;
     try {
-      await navigator.clipboard.writeText(jsonString);
+      await navigator.clipboard.writeText(copyTarget);
       setCopied(true);
-      toast.success("Response copied to clipboard");
+      toast.success(
+        onCode ? "Code copied to clipboard" : "Response copied to clipboard"
+      );
       setTimeout(() => setCopied(false), UI.COPY_FEEDBACK_TIMEOUT_MS);
     } catch {
-      toast.error("Failed to copy response");
+      toast.error("Failed to copy");
     }
-  }, [jsonString]);
+  }, [copyTarget, onCode]);
 
   /**
    * Save the body to a file.
@@ -115,7 +211,56 @@ export function ResponseViewer({
   const hasResponse = Boolean(jsonString) || isLoading || Boolean(error);
 
   return (
-    <Tabs defaultValue="body" className="flex h-full min-h-0 flex-col">
+    <Tabs
+      value={tab}
+      onValueChange={value => setTab(value as ResponseTab)}
+      className="flex h-full min-h-0 flex-col"
+    >
+      {/* Always rendered, with placeholders holding the width. The metrics used
+          to appear with the first reply, so the header reflowed at the moment
+          somebody was reading it. */}
+      <div
+        data-testid="response-meta"
+        className="flex shrink-0 items-center justify-end gap-4 border-b border-border px-6 py-2"
+      >
+        <Metric label="Status">
+          {status === undefined ? (
+            <span className="font-mono text-sm text-muted-foreground">—</span>
+          ) : (
+            <>
+              <span
+                className={cn(
+                  "h-1.5 w-1.5 rounded-full",
+                  statusDotTone(status)
+                )}
+              />
+              <span
+                className={cn(
+                  "font-mono text-sm font-semibold",
+                  statusTone(status)
+                )}
+              >
+                {status}
+              </span>
+            </>
+          )}
+        </Metric>
+        <div className="h-4 w-px bg-border" />
+        <Metric label="Latency">
+          <span className="font-mono text-sm font-semibold text-foreground">
+            {time === undefined ? "—" : `${time}ms`}
+          </span>
+        </Metric>
+        <div className="h-4 w-px bg-border" />
+        {/* Beside latency because they are the pair traded against each other
+            when tuning depth and limit. */}
+        <Metric label="Size">
+          <span className="font-mono text-sm font-semibold text-foreground">
+            {size === undefined ? "—" : formatBytes(size)}
+          </span>
+        </Metric>
+      </div>
+
       <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border bg-muted/30 px-6 py-1.5">
         <TabsList variant="ghost">
           <TabsTrigger value="body" size="sm">
@@ -135,23 +280,27 @@ export function ResponseViewer({
         </TabsList>
 
         <div className="flex items-center gap-1">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleDownload}
-            disabled={!jsonString}
-            className="h-7 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
-          >
-            <Download className="h-3.5 w-3.5" />
-            Download
-          </Button>
+          {/* Absent on the Code tab: a snippet saved as `<collection>.json` is
+              not a thing anybody wants, and offering it invites the mistake. */}
+          {!onCode && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleDownload}
+              disabled={!jsonString}
+              className="h-7 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+            >
+              <Download className="h-3.5 w-3.5" />
+              Download
+            </Button>
+          )}
           <Button
             variant="ghost"
             size="sm"
             onClick={() => {
               void handleCopy();
             }}
-            disabled={!jsonString}
+            disabled={!copyTarget}
             className="h-7 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
           >
             {copied ? (
@@ -164,9 +313,12 @@ export function ResponseViewer({
         </div>
       </div>
 
+      {/* The mono face belongs to the JSON, which brings its own. It used to sit
+          here, so the loading, error and empty states inherited it and the prose
+          was set in a code face. */}
       <TabsContent
         value="body"
-        className="mt-0 min-h-0 flex-1 overflow-auto bg-background font-mono text-xs leading-relaxed selection:bg-primary selection:text-primary-foreground"
+        className="mt-0 min-h-0 flex-1 overflow-auto bg-background selection:bg-primary selection:text-primary-foreground"
       >
         {isLoading ? (
           <div className="flex h-full flex-col items-center justify-center bg-muted/30">
@@ -234,7 +386,7 @@ export function ResponseViewer({
       </TabsContent>
 
       <TabsContent value="code" className="mt-0 min-h-0 flex-1 overflow-hidden">
-        <CodePanel code={code} />
+        <CodePanel code={code} flavour={flavour} onFlavourChange={setFlavour} />
       </TabsContent>
     </Tabs>
   );

--- a/packages/admin/src/components/features/entries/APIPlayground/ResponseViewer.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/ResponseViewer.tsx
@@ -104,7 +104,10 @@ export function ResponseViewer({
   );
 
   const jsonString = useMemo(() => {
-    if (data === undefined || data === null) return "";
+    // `undefined` only. `null` is a VALID JSON body and stringifies to "null",
+    // and collapsing the two made a real payload read as nothing returned --
+    // unreadable in the pane, and un-copyable because the toolbar keys on this.
+    if (data === undefined) return "";
     if (typeof data === "string") return data;
     try {
       return JSON.stringify(data, null, 2);
@@ -138,6 +141,18 @@ export function ResponseViewer({
    * clipboard -- the same defect this control was rewritten to remove, one tab
    * further along.
    */
+  /**
+   * The body as anything should act on it.
+   *
+   * `jsonString` is a VIEW of the body and `raw` is the bytes that arrived. A
+   * body can render as an empty view and still exist -- a JSON `""` -- so
+   * presence comes from the richer value, and the view is used only when it
+   * has something to show. One expression rather than two, because the pane
+   * and the toolbar disagreeing about whether there IS a body is exactly how
+   * a real payload became uncopyable.
+   */
+  const bodyText = jsonString || (raw ?? "");
+
   const target: { text: string; label: string; filename: string } =
     tab === "code"
       ? {
@@ -151,7 +166,7 @@ export function ResponseViewer({
             label: "Headers",
             filename: `${filename}-headers`,
           }
-        : { text: jsonString, label: "Response", filename };
+        : { text: bodyText, label: "Response", filename };
   const copyTarget = target.text;
 
   const handleCopy = useCallback(async () => {
@@ -299,7 +314,7 @@ export function ResponseViewer({
               {error}
             </p>
           </div>
-        ) : !jsonString ? (
+        ) : !bodyText ? (
           <div className="flex h-full flex-col items-center justify-center bg-muted/30 p-12 text-center">
             <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-md border border-border bg-card">
               <FileJson className="h-6 w-6 text-muted-foreground" />
@@ -326,7 +341,7 @@ export function ResponseViewer({
             </p>
           </div>
         ) : (
-          <JsonViewer value={jsonString} />
+          <JsonViewer value={bodyText} />
         )}
       </TabsContent>
 

--- a/packages/admin/src/components/features/entries/APIPlayground/__tests__/RequestBar.test.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/__tests__/RequestBar.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * `theme.css` states that hardcoding a corner opts an element out of the
+ * `--radius` knob, and that square needs a stated reason. The request bar is a
+ * grouping container and had neither, which is why its rounded Send button read
+ * as a mistake rather than as a choice.
+ *
+ * The assertions name the tier rather than a pixel value, because the tier is
+ * what the contract is written in -- a test pinning `8px` would pass while the
+ * element was detached from the knob it is supposed to follow.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { METHOD_PILL, RequestBar } from "../RequestBar";
+
+const props = {
+  method: "GET" as const,
+  url: "http://localhost/admin/api/collections/posts/entries",
+  action: <div data-testid="action" />,
+  isLoading: false,
+  copied: false,
+  onSend: vi.fn(),
+  onCancel: vi.fn(),
+  onCopy: vi.fn(),
+  onOpen: vi.fn(),
+};
+
+describe("RequestBar", () => {
+  it("rounds its container to the container tier", () => {
+    const { container } = render(<RequestBar {...props} />);
+    const bar = container.firstElementChild as HTMLElement;
+    expect(bar.className).toContain("rounded-lg");
+  });
+
+  it("clips its children to that curve", () => {
+    // theme.css: a rounded box whose child paints a background to its edge must
+    // clip it, or the child's fill paints square across the curve.
+    const { container } = render(<RequestBar {...props} />);
+    const bar = container.firstElementChild as HTMLElement;
+    expect(bar.className).toContain("overflow-hidden");
+  });
+
+  it("shows the whole URL as selectable text", () => {
+    render(<RequestBar {...props} />);
+    expect(screen.getByText(props.url)).toBeInTheDocument();
+  });
+
+  it("gives every method a pill and a tone", () => {
+    // A verb missing from the map renders unstyled rather than throwing, so the
+    // gap would show up as one method looking wrong and no test failing.
+    for (const method of ["GET", "POST", "PATCH", "DELETE"] as const) {
+      expect(METHOD_PILL[method]).toBeTruthy();
+      expect(METHOD_PILL[method]).toMatch(/bg-/);
+      expect(METHOD_PILL[method]).toMatch(/text-/);
+    }
+  });
+
+  it("names a colour only through a token", () => {
+    // The tones must survive a retheme; a literal here would not.
+    const literal = Object.values(METHOD_PILL).filter(cls =>
+      /#[0-9a-f]{3,8}|rgb\(|oklch\(/i.test(cls)
+    );
+    expect(literal).toEqual([]);
+  });
+});

--- a/packages/admin/src/components/features/entries/APIPlayground/__tests__/RequestBar.test.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/__tests__/RequestBar.test.tsx
@@ -11,7 +11,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import { METHOD_PILL, RequestBar } from "../RequestBar";
+import { METHOD_SEMANTICS, RequestBar } from "../RequestBar";
 
 const props = {
   method: "GET" as const,
@@ -49,17 +49,42 @@ describe("RequestBar", () => {
     // A verb missing from the map renders unstyled rather than throwing, so the
     // gap would show up as one method looking wrong and no test failing.
     for (const method of ["GET", "POST", "PATCH", "DELETE"] as const) {
-      expect(METHOD_PILL[method]).toBeTruthy();
-      expect(METHOD_PILL[method]).toMatch(/bg-/);
-      expect(METHOD_PILL[method]).toMatch(/text-/);
+      expect(METHOD_SEMANTICS[method].pill).toBeTruthy();
+      expect(METHOD_SEMANTICS[method].pill).toMatch(/bg-/);
+      expect(METHOD_SEMANTICS[method].pill).toMatch(/text-/);
+      expect(METHOD_SEMANTICS[method].tone).toMatch(/text-/);
+    }
+  });
+
+  it("dresses both views of a verb in the same role", () => {
+    // The two views are one entry now, so they cannot be edited apart -- but
+    // they can still be edited WRONG, and half an entry is exactly the state
+    // the merge into one record exists to make visible. A verb that destroys a
+    // row must not read as destructive in the menu and as a warning on the bar.
+    const ROLE: Record<string, string | null> = {
+      GET: null, // a read is not an event, so it takes no role colour
+      POST: "success",
+      PATCH: "warning",
+      DELETE: "destructive",
+    };
+
+    for (const [method, role] of Object.entries(ROLE)) {
+      const { tone, pill } =
+        METHOD_SEMANTICS[method as keyof typeof METHOD_SEMANTICS];
+      if (role === null) {
+        expect(`${tone} ${pill}`).not.toMatch(/success|warning|destructive/);
+        continue;
+      }
+      expect(tone).toContain(role);
+      expect(pill).toContain(role);
     }
   });
 
   it("names a colour only through a token", () => {
     // The tones must survive a retheme; a literal here would not.
-    const literal = Object.values(METHOD_PILL).filter(cls =>
-      /#[0-9a-f]{3,8}|rgb\(|oklch\(/i.test(cls)
-    );
+    const literal = Object.values(METHOD_SEMANTICS)
+      .flatMap(({ tone, pill }) => [tone, pill])
+      .filter(cls => /#[0-9a-f]{3,8}|rgb\(|oklch\(/i.test(cls));
     expect(literal).toEqual([]);
   });
 });

--- a/packages/admin/src/components/features/entries/APIPlayground/__tests__/ResponseViewer.test.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/__tests__/ResponseViewer.test.tsx
@@ -89,6 +89,32 @@ describe("ResponseViewer", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders a JSON null body rather than calling it empty", async () => {
+    // `null` is a valid JSON body. Collapsing it into the same empty string an
+    // absent body produces made a real payload read as nothing returned -- and
+    // because the toolbar keys on the same value, uncopyable with it.
+    // NO `raw` here, deliberately. With `raw` supplied the fallback in
+    // `bodyText` covers this case on its own, so the test would pass against a
+    // `jsonString` that still collapses null -- proving the fallback, not the
+    // fix. Withholding it puts the assertion on `jsonString` alone.
+    render(<ResponseViewer data={null} code={code} status={200} />);
+
+    expect(screen.queryByText("No content")).toBeNull();
+    expect(screen.getByRole("button", { name: /^copy$/i })).toBeEnabled();
+
+    await userEvent.click(screen.getByRole("button", { name: /^copy$/i }));
+    expect(writeText).toHaveBeenCalledWith("null");
+  });
+
+  it("keeps a body copyable when its rendered view is empty", () => {
+    // A JSON `""` renders as nothing and is still a body that arrived. Presence
+    // is decided by the bytes, not by what the view happens to show.
+    render(<ResponseViewer data="" raw='""' code={code} status={200} />);
+
+    expect(screen.queryByText("No content")).toBeNull();
+    expect(screen.getByRole("button", { name: /^copy$/i })).toBeEnabled();
+  });
+
   it("still says nothing was sent before the first request", () => {
     // The control for the test above: without it, an implementation that always
     // says "No content" passes that one and is wrong in the commoner case.

--- a/packages/admin/src/components/features/entries/APIPlayground/__tests__/ResponseViewer.test.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/__tests__/ResponseViewer.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Three defects, and each is the pane telling the truth about the wrong thing.
+ *
+ * The empty state was set in the code face, because the mono class sat on the
+ * whole tab panel rather than on the JSON inside it. The toolbar's Copy acted
+ * on the response body whatever tab was open, so on the Code tab it silently
+ * copied JSON while the reader was looking at a snippet -- with a second,
+ * correct Copy directly beneath it. And the metrics appeared only once a
+ * response landed, so the header reflowed at the moment attention was on it.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ResponseViewer } from "../ResponseViewer";
+
+const code = {
+  sdk: "await nextly.find({ collection: 'posts' })",
+  fetch: "await fetch('/admin/api/collections/posts/entries')",
+  curl: "curl http://localhost/admin/api/collections/posts/entries",
+};
+
+// CodeMirror wants browser globals and has its own suite; what matters here is
+// which string reaches the clipboard and which face the prose is set in.
+vi.mock("../CodeBlock", () => ({
+  CodeBlock: ({ value }: { value: string }) => <pre>{value}</pre>,
+}));
+
+let writeText: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  writeText = vi.fn().mockResolvedValue(undefined);
+  Object.assign(navigator, { clipboard: { writeText } });
+  window.localStorage.clear();
+});
+
+describe("ResponseViewer", () => {
+  it("sets the empty state in the reading face, not the code face", () => {
+    render(<ResponseViewer data={undefined} code={code} />);
+    const heading = screen.getByText("No response yet");
+    expect(heading.closest(".font-mono")).toBeNull();
+  });
+
+  it("holds a place for the metrics before the first send", () => {
+    render(<ResponseViewer data={undefined} code={code} />);
+    // Always present, so the header does not gain three values and reflow at
+    // the moment a reply lands.
+    expect(screen.getByTestId("response-meta")).toHaveTextContent("—");
+  });
+
+  it("shows the metrics once a response exists", () => {
+    render(
+      <ResponseViewer
+        data={{ items: [] }}
+        code={code}
+        status={200}
+        time={52}
+        size={5943}
+      />
+    );
+    const meta = screen.getByTestId("response-meta");
+    expect(meta).toHaveTextContent("200");
+    expect(meta).toHaveTextContent("52ms");
+    expect(meta).toHaveTextContent("5.8 KB");
+  });
+
+  it("copies the body while the Body tab is open", async () => {
+    render(<ResponseViewer data={{ items: [] }} code={code} />);
+    await userEvent.click(screen.getByRole("button", { name: /^copy$/i }));
+    expect(writeText).toHaveBeenCalledWith(
+      JSON.stringify({ items: [] }, null, 2)
+    );
+  });
+
+  it("copies the snippet, not the body, while the Code tab is open", async () => {
+    render(<ResponseViewer data={{ items: [] }} code={code} />);
+    await userEvent.click(screen.getByRole("tab", { name: /code/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^copy$/i }));
+    expect(writeText).toHaveBeenCalledWith(code.sdk);
+  });
+
+  it("offers exactly one copy control on the Code tab", async () => {
+    render(<ResponseViewer data={{ items: [] }} code={code} />);
+    await userEvent.click(screen.getByRole("tab", { name: /code/i }));
+    expect(screen.getAllByRole("button", { name: /^copy$/i })).toHaveLength(1);
+  });
+
+  it("does not offer to download a snippet as a response file", async () => {
+    render(<ResponseViewer data={{ items: [] }} code={code} />);
+    expect(
+      screen.getByRole("button", { name: /download/i })
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("tab", { name: /code/i }));
+    expect(screen.queryByRole("button", { name: /download/i })).toBeNull();
+  });
+
+  it("remembers which flavour was last read", async () => {
+    const { unmount } = render(<ResponseViewer data={undefined} code={code} />);
+    await userEvent.click(screen.getByRole("tab", { name: /code/i }));
+    await userEvent.click(screen.getByRole("tab", { name: /curl/i }));
+    unmount();
+
+    render(<ResponseViewer data={undefined} code={code} />);
+    await userEvent.click(screen.getByRole("tab", { name: /code/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^copy$/i }));
+    expect(writeText).toHaveBeenCalledWith(code.curl);
+  });
+});

--- a/packages/admin/src/components/features/entries/APIPlayground/__tests__/ResponseViewer.test.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/__tests__/ResponseViewer.test.tsx
@@ -142,6 +142,39 @@ describe("ResponseViewer", () => {
     expect("1023.99 GB".length).toBeLessThanOrEqual(10);
   });
 
+  it("draws the status dot and the status number in the same role", () => {
+    // The dot and the number are two renderings of one judgement about one
+    // response. Asserted through the DOM rather than against the classifier,
+    // because what must agree is what a reader SEES -- a test on the function
+    // would keep passing if a call site read the wrong half of it.
+    const ROLE: ReadonlyArray<readonly [number, string]> = [
+      [200, "success"],
+      [301, "muted-foreground"],
+      [404, "warning"],
+      [500, "destructive"],
+    ];
+
+    for (const [status, role] of ROLE) {
+      const { unmount } = render(
+        <ResponseViewer data={{ items: [] }} code={code} status={status} />
+      );
+      const meta = screen.getByTestId("response-meta");
+
+      const number = screen.getByText(String(status));
+      const dot = meta.querySelector(".rounded-full");
+
+      expect(dot, `a dot is drawn for ${status}`).not.toBeNull();
+      expect(number.className, `${status} text names ${role}`).toContain(
+        `text-${role}`
+      );
+      expect(dot?.className, `${status} dot names ${role}`).toContain(
+        `bg-${role}`
+      );
+
+      unmount();
+    }
+  });
+
   it("shows the metrics once a response exists", () => {
     render(
       <ResponseViewer

--- a/packages/admin/src/components/features/entries/APIPlayground/__tests__/ResponseViewer.test.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/__tests__/ResponseViewer.test.tsx
@@ -43,8 +43,9 @@ describe("ResponseViewer", () => {
 
   it("holds a place for the metrics before the first send", () => {
     render(<ResponseViewer data={undefined} code={code} />);
-    // Always present, so the header does not gain three values and reflow at
-    // the moment a reply lands.
+    // That the row exists and reads as empty. jsdom computes no layout, so
+    // whether the row keeps its width once the values arrive is measured in
+    // e2e/tests/api-playground-metrics.spec.ts, not here.
     expect(screen.getByTestId("response-meta")).toHaveTextContent("—");
   });
 

--- a/packages/admin/src/components/features/entries/APIPlayground/__tests__/ResponseViewer.test.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/__tests__/ResponseViewer.test.tsx
@@ -49,6 +49,73 @@ describe("ResponseViewer", () => {
     expect(screen.getByTestId("response-meta")).toHaveTextContent("—");
   });
 
+  it("treats a completed empty body as a response, not as nothing sent", () => {
+    // A 204 is a correct outcome, not an absence to keep waiting on. Deriving
+    // "is there a response" from the body alone told a reader to send a request
+    // that had already come back, with its headers sitting unread.
+    render(<ResponseViewer data={undefined} code={code} status={204} />);
+
+    expect(screen.getByText("No content")).toBeInTheDocument();
+    expect(screen.queryByText("No response yet")).toBeNull();
+    expect(
+      screen.getByText(/returned 204 with an empty body/)
+    ).toBeInTheDocument();
+  });
+
+  it("tells the headers tab the response arrived, even with no body", async () => {
+    // Asserts on the HEADERS message specifically, because that is what
+    // `hasResponse` decides. The body-tab assertions above read `status`
+    // directly and stay green whatever `hasResponse` does -- so on their own
+    // they cover the empty-state copy and not the bug.
+    render(<ResponseViewer data={undefined} code={code} status={204} />);
+    await userEvent.click(screen.getByRole("tab", { name: /headers/i }));
+
+    expect(
+      screen.getByText("This response carried no headers.")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Send the request to see its response headers.")
+    ).toBeNull();
+  });
+
+  it("still tells the headers tab to send, before the first request", async () => {
+    // The control: an implementation hardcoding the arrived-message passes the
+    // test above and is wrong every time somebody opens the page.
+    render(<ResponseViewer data={undefined} code={code} />);
+    await userEvent.click(screen.getByRole("tab", { name: /headers/i }));
+
+    expect(
+      screen.getByText("Send the request to see its response headers.")
+    ).toBeInTheDocument();
+  });
+
+  it("still says nothing was sent before the first request", () => {
+    // The control for the test above: without it, an implementation that always
+    // says "No content" passes that one and is wrong in the commoner case.
+    render(<ResponseViewer data={undefined} code={code} />);
+
+    expect(screen.getByText("No response yet")).toBeInTheDocument();
+    expect(screen.queryByText("No content")).toBeNull();
+  });
+
+  it("keeps the size within the width the row reserves", () => {
+    // `formatBytes` had no gigabyte arm, so megabytes counted up forever and a
+    // multi-gigabyte reply rendered wider than any reservation could cover.
+    render(
+      <ResponseViewer
+        data={{ items: [] }}
+        code={code}
+        status={200}
+        size={5 * 1024 * 1024 * 1024}
+      />
+    );
+
+    const meta = screen.getByTestId("response-meta");
+    expect(meta).toHaveTextContent("5.00 GB");
+    // 10ch is what the row reserves; the widest bounded form must fit it.
+    expect("1023.99 GB".length).toBeLessThanOrEqual(10);
+  });
+
   it("shows the metrics once a response exists", () => {
     render(
       <ResponseViewer

--- a/packages/admin/src/components/features/entries/APIPlayground/__tests__/ResponseViewer.test.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/__tests__/ResponseViewer.test.tsx
@@ -94,6 +94,40 @@ describe("ResponseViewer", () => {
     expect(screen.queryByRole("button", { name: /download/i })).toBeNull();
   });
 
+  it("copies the headers, not the body, while the Headers tab is open", async () => {
+    // The third tab. Copy took the body whenever Code was closed, so reading
+    // the headers and pressing Copy put JSON on the clipboard.
+    render(
+      <ResponseViewer
+        data={{ items: [] }}
+        code={code}
+        headers={{
+          "x-request-id": "abc123",
+          "content-type": "application/json",
+        }}
+      />
+    );
+    await userEvent.click(screen.getByRole("tab", { name: /headers/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^copy$/i }));
+    expect(writeText).toHaveBeenCalledWith(
+      "x-request-id: abc123\ncontent-type: application/json"
+    );
+  });
+
+  it("stops saying Copied once the button would copy something else", async () => {
+    // The flag used to be a bare boolean, so switching flavour inside the
+    // feedback window left "Copied" standing over a control that would now put
+    // a different snippet on the clipboard.
+    render(<ResponseViewer data={undefined} code={code} />);
+    await userEvent.click(screen.getByRole("tab", { name: /code/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^copy$/i }));
+    expect(screen.getByRole("button", { name: /copied/i })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("tab", { name: /curl/i }));
+    expect(screen.queryByRole("button", { name: /copied/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /^copy$/i })).toBeInTheDocument();
+  });
+
   it("remembers which flavour was last read", async () => {
     const { unmount } = render(<ResponseViewer data={undefined} code={code} />);
     await userEvent.click(screen.getByRole("tab", { name: /code/i }));

--- a/packages/admin/src/hooks/useMediaQuery.ts
+++ b/packages/admin/src/hooks/useMediaQuery.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Whether a CSS media query currently matches.
+ *
+ * For layouts that must CHOOSE a tree rather than style one. Where a class can
+ * do the job — `hidden lg:flex` and friends — use the class: CSS needs no
+ * hydration and no listener. This exists for the case where rendering both
+ * branches is wrong rather than merely wasteful, which is any branch holding
+ * labelled form controls: two copies means a screen reader announces every
+ * field twice, and one of the two is invisible to the person hearing it.
+ *
+ * SSR-safe by construction: the first render always answers `false`, and the
+ * real answer arrives in an effect. A caller that must not flash the wrong
+ * branch should therefore gate on hydration as well as on this.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    // Guarded rather than assumed: jsdom without a matchMedia stub, and any
+    // non-browser host, would otherwise throw during an effect.
+    if (typeof window === "undefined" || !window.matchMedia) return;
+
+    const list = window.matchMedia(query);
+    setMatches(list.matches);
+
+    const onChange = (event: MediaQueryListEvent) => setMatches(event.matches);
+    list.addEventListener("change", onChange);
+    return () => list.removeEventListener("change", onChange);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
## Summary

Sub-tasks 3, 4 and 5 of the API Playground revamp, in one PR with **a commit per sub-task** so it reads in order rather than as one diff. They are together because 3 and 4 restructure the same JSX — 3 turns the two Cards into resizable panes, and 4 moves the response metrics out of the header that lives inside one of them — so sequencing them means editing the same block twice with a rebase between.

Sub-tasks 1 and 2 landed in #1151, #1155, #1156 and #1158.

### Commit 1 — resizable panes, and the request line

The panes were fixed at five and seven of twelve columns, which is right for one window width and wrong either side of it. They are a draggable split now, using the `@nextlyhq/ui` primitive already used by `TranslationPanes` and `builder-shell`, and the ratio is remembered.

**Two things about the mechanism fail silently, and both are recorded in the code:**

`onLayoutChanged` fires on the mount pass too, and that pass arrives *before* a restored layout takes effect — so writing on every report saves the freshly measured default over the value being restored. Widths then appear to persist within a session and reset on every reload. Only `isUserInteraction` separates a drag or a resize key from the group measuring itself. (`builder-shell.tsx:822-833` records the same trap.)

The two layouts are an **exclusive ternary**, not one tree hidden by a class, for two independent reasons. `react-resizable-panels` writes `display: flex` as an *inline* style, which outranks `hidden` — so `hidden lg:flex` on the group never hides it and both layouts render at once below `lg`. And the panes carry labelled form controls, so rendering both puts every field in the document twice and a screen reader reads each of them twice. A small `useMediaQuery` hook chooses instead.

The request line gains the container radius it never had and clips its children to it, and the verb becomes a filled chip.

### Commit 2 — the response pane tells the truth

The toolbar's Copy took the response body whatever tab was open. On the Code tab that put JSON on the clipboard while the reader was looking at a snippet, said "Response copied" while doing it, and sat a few pixels above a second, correct Copy. The tab selection moved up to the pane, so the control acts on what is being read; the duplicate is gone; and Download is absent there, because a snippet saved as `<collection>.json` is not a thing anybody wants.

Status, latency and size were rendered only once a reply existed, so the header gained three values and reflowed at the moment attention was on it. They hold their place as em dashes now, in a row of their own.

The mono class sat on the whole body tab panel rather than on the JSON inside it, so the loading, error and empty states inherited it and their prose was set in a code face.

### Commit 3 — density and radius

The parameter grid was three fixed columns and the hints wrapped to three or four lines inside them. A viewport breakpoint cannot describe a column somebody just dragged narrower, so it is a **container query on the pane**. Field chips and the request-body frame join the radius contract; both were pinned at zero, which silently opts an element out of the `--radius` knob.

## Test plan

Three new suites — `RequestBar` (5), `ResponseViewer` (8) — plus the existing playground suites. All failed first for the intended reason before passing.

Verified in the browser, since the two most important properties here cannot be tested in jsdom:

| property | measurement |
| --- | --- |
| mount must not write | `localStorage` null after load, before any interaction |
| a resize must persist | keyboard resize → stored `70` |
| a reload must restore it | reload → panes at 70%, not the 40% default |
| only one layout mounts | 900px: 0 separators, 0 panels · 1600px: 1 separator, 2 panels |
| fields appear once | `labelsInDoc: 8` at **both** widths, not 16 |
| the grid follows the pane | fixed 1600px viewport; 823px pane → 3 columns, 294px pane → 1 |

That last row is the point of the container query: the window never changed.

Gates from the worktree root after `pnpm --filter @nextlyhq/admin... build`: build, `check-types`, `lint` (`--max-warnings 0`), `lint:design`, `check:comments` all pass. `fallow audit` → `pass`, zero introduced.

## Something worth knowing

`packages/admin` ships a **prebuilt stylesheet**. A *new* Tailwind utility does not appear in the playground until `pnpm --filter @nextlyhq/admin build:css` runs — dev HMR does not regenerate it. The container query read as broken until I noticed the class had never been generated. Existing utilities are unaffected, which is why this had not come up before.

## Pre-existing failures

Unchanged: 15 across 4 files (`StatsCard`, `SlugInput`, `BasicsTab`, `DefaultValueField`), none related. Suite: 2617 passing.

## Changeset

Added: yes — patch, all published packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the API Playground with responsive request and response panes, including resizable desktop layouts and stacked mobile views.
  * Added response status, latency, and size details with stable spacing.
  * Added persistent SDK, fetch, and cURL code-format selection.
  * Improved copying, downloading, tabs, headers, and response-body controls.

* **Style**
  * Updated HTTP method badges, panel styling, rounded containers, and responsive parameter controls.

* **Bug Fixes**
  * Prevented layout shifting when API responses load.
  * Improved validation for keyboard-triggered requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->