### PR TITLE
fix(ui): declare the shell measure token in the theme

### DIFF
--- a/.changeset/declare-shell-measure-token.md
+++ b/.changeset/declare-shell-measure-token.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Declare `--nx-shell-measure` in the theme.
+
+The page shell read the token but nothing declared it, so it resolved to a
+`var()` fallback written at its one call site — meaning a theme retuning the
+form measure moved every surface around the page content and left the content
+column where it was. Declaring it restores that reach and lets the grid template
+read the token directly.

--- a/packages/ui/src/styles/__tests__/page-shell-grid.test.ts
+++ b/packages/ui/src/styles/__tests__/page-shell-grid.test.ts
@@ -69,12 +69,24 @@ describe("page shell stylesheet", () => {
 
   it("reads the measure through the custom property the component sets", () => {
     // `PageShell` writes `--nx-shell-measure` inline per `width`. If the
-    // template stopped reading it, every width would render at the fallback and
-    // the prop would silently do nothing — which the component test cannot
-    // detect, because the property would still be set correctly.
-    expect(flat).toContain(
-      "minmax(0, var(--nx-shell-measure, var(--nx-measure-form)))"
-    );
+    // template stopped reading it, every width would render at the declared
+    // default and the prop would silently do nothing — which the component test
+    // cannot detect, because the property would still be set correctly.
+    expect(flat).toContain("minmax(0, var(--nx-shell-measure))");
+  });
+
+  it("declares the measure token rather than leaning on a var() fallback", () => {
+    // A token read but never declared cannot be retuned by a theme: it resolves
+    // to whatever fallback the one call site happened to write, so a palette
+    // change moves every surface around it and leaves this one where it was.
+    // `admin-token-reachability` enforces that across the admin, and this keeps
+    // the pairing visible from the stylesheet's own suite.
+    expect(flat).toContain("--nx-shell-measure: var(--nx-measure-form);");
+
+    // The fallback form is what an undeclared token forces. Rejecting it here
+    // means a revert to that shape fails, rather than passing on the assertion
+    // above alone.
+    expect(flat).not.toContain("var(--nx-shell-measure, ");
   });
 
   it("puts ordinary children in the content column and Bleed in the full one", () => {

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -913,6 +913,14 @@
   --nx-measure-form: 56rem;
   --nx-measure-wide: 72rem;
 
+  /* The measure the content column is bounded to, declared here so a theme can
+   * retune it centrally and so the token resolves to a real value rather than
+   * to a `var()` fallback. `PageShell` overrides it INLINE per its `width`
+   * prop, which is what makes the three widths one grid template instead of
+   * three near-identical ones; this declaration is the value that applies when
+   * the grid is used without that component. */
+  --nx-shell-measure: var(--nx-measure-form);
+
   /* Focus ring colors */
   --nx-focus-ring: var(--nx-primary);
   --nx-focus-ring-offset: oklch(1 0 0);
@@ -1163,7 +1171,7 @@
      * container and there is no free space for it to distribute. */
     grid-template-columns:
       [full-start] minmax(var(--nx-gutter), 1fr)
-      [content-start] minmax(0, var(--nx-shell-measure, var(--nx-measure-form)))
+      [content-start] minmax(0, var(--nx-shell-measure))
       [content-end] minmax(var(--nx-gutter), 1fr)
       [full-end];
     align-content: start;


### PR DESCRIPTION
## Summary

**`main` is red on `admin-token-reachability`, and this fixes it.** The failure
came in with #1150, which I authored.

`packages/ui/src/styles/theme.css` read `--nx-shell-measure` in the page-shell
grid template, and nothing declared it. `admin-token-reachability` exists to
catch exactly that, and its message states the consequence precisely: an
undeclared token *"keeps its current value, or resolves to its fallback, while
every surface around it moves"*. So a theme retuning `--nx-measure-form` would
have moved the gutters and left the content column where it was.

Two changes:

- `--nx-shell-measure: var(--nx-measure-form)` is declared in the theme, beside
  the layout tokens it sits among. `PageShell` still overrides it inline per
  `width` — that is what keeps the three widths one grid template instead of
  three near-identical ones — and this declaration is what applies when the grid
  is used without the component.
- The template's `var(--nx-shell-measure, var(--nx-measure-form))` fallback is
  gone. With the token declared it was a second answer to the same question
  living inside the template.

## Why #1150's CI did not catch this — answered, and it is not caching

I first guessed turbo input scoping. **That is wrong**, and the real cause is
plainer: `ci.yml`'s `Test` step runs `pnpm turbo test` against an **explicit
allowlist of seventeen packages**, and `@nextlyhq/admin` is not one of them.

The exclusion is deliberate and the step's own comment explains it — `nextly` and
`@nextlyhq/admin` carry a large pre-existing failing baseline, so they are held
out until repaired (`task:test-baseline-repair`). So `admin-token-reachability`
is not a check that got cached or skipped; it is a check CI never runs at all,
and no other workflow picks it up (`integration.yml`'s filters name the adapters,
`nextly` and `plugin-page-builder`).

Two consequences worth recording:

- **This is a known gap doing exactly what it was set up to do, not a new
  defect.** Nothing about CI needs fixing here; the guard exists and is correct,
  and it caught this the moment it was run locally.
- **`packages/admin` guards cannot gate a merge today.** Every remaining PR in
  this series touches admin, so I will run its suites locally and report the
  numbers in each PR body rather than leaning on the green check.

One stale line worth a follow-up, noted rather than changed here: the same
comment says *"ui / storage-s3 / storage-uploadthing have no test files yet"*.
`@nextlyhq/ui` now has 47 test files and 1120 tests, and is gated — the listing
worked as intended and the comment did not keep up.

## Test plan

- `pnpm --filter @nextlyhq/admin test --run admin-token-reachability` → **7 passed**
  (fails on `main` without this change)
- `pnpm --filter @nextlyhq/ui test --run` → **1120 passed, 47 files**
- `pnpm build` → 19/19 · `pnpm --filter @nextlyhq/ui... lint` → exit 0
- `fallow audit --gate-marker agent` → `pass`

### Break-verification

Reverting to the undeclared-token-plus-fallback shape fails three tests, one of
them the guard that caught this on `main`:

| break | fails |
| --- | --- |
| remove the declaration, restore the fallback | `reads the measure through the custom property the component sets` |
| " | `declares the measure token rather than leaning on a var() fallback` |
| " | `admin-token-reachability › declares every token the admin renders with` |

`page-shell-grid.test.ts` also now rejects the `var(--nx-shell-measure, …)`
spelling by name, so a revert fails there rather than passing on the positive
assertion alone.

## Changeset

Changeset added: yes (patch, all 25 lockstep packages, derived from
`.changeset/config.json` rather than copied from another changeset).

## Pre-existing failures

`packages/admin` carries a large pre-existing failing baseline — 16 failures
across 29 files on `main` at `a691def61`, tracked as `task:test-baseline-repair`.
`admin-token-reachability` was NOT part of that baseline; it is the one this PR
fixes. None of the others touch this diff.
