### PR TITLE
fix(builder): cut the spacing bands to a rounded block's curve

### DIFF
--- a/.changeset/bands-follow-the-curve.md
+++ b/.changeset/bands-follow-the-curve.md
@@ -1,0 +1,41 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+An author who rounded a block's corners saw the spacing overlay paint colour into the
+transparent corners beside it, outside the shape the block actually renders as. The padding
+bands were full-width strips cut from the padding box's RECTANGLE, while a rounded padding box
+curves away from that rectangle — and a band is read as a measurement, so one covering ground
+the block does not occupy states a measurement that is false. The bands are now cut to the
+curve, and the value chip still overflows its band so a number in a four-pixel gap stays
+readable.
+
+The same curve is now respected on the way in. A block inside a rounded container that clips
+its overflow can sit within all four of that container's straight edges and still have a corner
+removed by the curve; the overlay accepted it and drew bands across the part that is not
+rendered. It now tests the corner itself rather than declining every rounded container, so the
+ordinary rounded card keeps its overlay.

--- a/.changeset/bands-follow-the-curve.md
+++ b/.changeset/bands-follow-the-curve.md
@@ -39,3 +39,10 @@ its overflow can sit within all four of that container's straight edges and stil
 removed by the curve; the overlay accepted it and drew bands across the part that is not
 rendered. It now tests the corner itself rather than declining every rounded container, so the
 ordinary rounded card keeps its overlay.
+
+Two further cases the curve reaches. A block rounded to match the container it fills is not cut
+at all, while its bounding rectangle's corners sit outside every one of that container's arcs, so
+the overlay used to vanish on the ordinary nested rounded card; the block's own curve is now part
+of the comparison. And an overlay already on screen now notices a radius change on its own —
+nothing else about a band moves when only the corner does, so it previously kept painting the
+curve the block used to have until something else happened to move it.

--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -1804,4 +1804,60 @@ test.describe("rounded geometry", () => {
 
     await expect(page.locator(BAND)).toHaveCount(0);
   });
+  test("keeps drawing under an ancestor whose overflow CANNOT clip", async ({
+    page,
+  }) => {
+    /*
+     * A computed `overflow` is not an overflow that clips. The property does not
+     * apply to every generated box, and the computed value says nothing about
+     * that — so an author who writes `overflow: hidden` where it has no effect
+     * would otherwise lose the whole overlay to a clip that does not exist.
+     *
+     * `display: contents` is the sharpest of the nine measured cases, because it
+     * fails twice over: the element generates NO BOX, so nothing clips AND
+     * `getBoundingClientRect` answers 0x0 — and a descendant compared against a
+     * zero-sized rectangle is outside it on every edge.
+     */
+    await page.goto(ROUTE);
+    const target = page.locator('[data-nx-node="hx-nested-text"]');
+    await expect(target).toBeVisible();
+
+    await page.evaluate(() => {
+      (
+        document.querySelector('[data-nx-node="hx-nested-text"]') as HTMLElement
+      ).style.marginBottom = "24px";
+      const section = document.querySelector(
+        '[data-nx-node="hx-section"]'
+      ) as HTMLElement;
+      section.style.overflow = "hidden";
+      section.style.borderRadius = "60px";
+      section.style.display = "contents";
+    });
+    await target.click();
+
+    const ancestor = await page.evaluate(() => {
+      const section = document.querySelector(
+        '[data-nx-node="hx-section"]'
+      ) as HTMLElement;
+      const style = getComputedStyle(section);
+      const box = section.getBoundingClientRect();
+      return {
+        display: style.display,
+        overflow: style.overflowX,
+        area: box.width * box.height,
+      };
+    });
+
+    /*
+     * The separating properties. The computed overflow really does say `hidden`,
+     * so a reader that trusted it would act — and the box really is empty, so
+     * acting would refuse every descendant on the rectangle alone, before the
+     * curve was ever consulted.
+     */
+    expect(ancestor.display).toBe("contents");
+    expect(ancestor.overflow).toBe("hidden");
+    expect(ancestor.area).toBe(0);
+
+    await expect(page.locator(BAND)).not.toHaveCount(0);
+  });
 });

--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -1425,3 +1425,235 @@ test.describe("spacing values on the canvas", () => {
     await expect(page.locator(band("padding", "bottom"))).toHaveCount(0);
   });
 });
+
+/**
+ * A rounded block is not the rectangle its bands are cut from.
+ *
+ * `borderRadius` is a catalog property, so an author reaches every case here
+ * from the inspector. Two separate things go wrong on a curve, and only a
+ * browser can settle either: whether the paint lands where the block is, and
+ * whether a rounded container's clip removes a corner the rectangle comparison
+ * calls contained.
+ */
+test.describe("rounded geometry", () => {
+  /**
+   * One pixel out of a screenshot, in CSS pixels.
+   *
+   * Hit-testing cannot stand in for this. `elementFromPoint` reports a child
+   * sitting in the cut-away corner of an `overflow: hidden` ancestor as hit —
+   * measured in Chromium — so it answers about the box tree while the question
+   * here is about what was painted.
+   */
+  async function pixels(
+    page: import("@playwright/test").Page,
+    points: readonly (readonly [number, number])[]
+  ): Promise<string[]> {
+    const shot = (await page.screenshot()).toString("base64");
+    const ratio = await page.evaluate(() => window.devicePixelRatio);
+    return page.evaluate(
+      async ({ b64, at, r }) => {
+        const img = new Image();
+        img.src = `data:image/png;base64,${b64}`;
+        await img.decode();
+        const canvas = document.createElement("canvas");
+        canvas.width = img.width;
+        canvas.height = img.height;
+        const ctx = canvas.getContext("2d");
+        if (ctx === null) throw new Error("no 2d context");
+        ctx.drawImage(img, 0, 0);
+        return at.map(([x, y]) => {
+          const d = ctx.getImageData(
+            Math.round(x * r),
+            Math.round(y * r),
+            1,
+            1
+          ).data;
+          return `${String(d[0])},${String(d[1])},${String(d[2])}`;
+        });
+      },
+      { b64: shot, at: points, r: ratio }
+    );
+  }
+
+  test("paints nothing in the corner a rounded block curves away from", async ({
+    page,
+  }) => {
+    /*
+     * The padding box of a rounded block has curved corners while its bands are
+     * full-width strips, so the strip covers ground the block does not occupy —
+     * and a band is read as a MEASUREMENT, so one painted over the page beside
+     * the block states a measurement that is false.
+     *
+     * Asserted as pixels rather than as a `clip-path` attribute because the
+     * attribute is the mechanism and this is the property: a clip applied to the
+     * wrong element, in the wrong coordinate space, or to a band that then paints
+     * its chip over the gap would all satisfy an attribute check.
+     */
+    await page.goto(ROUTE);
+    const block = page.locator(`[data-nx-node="${PADDED}"]`);
+    await expect(block).toBeVisible();
+    await block.scrollIntoViewIfNeeded();
+
+    const where = await block.evaluate(node => {
+      const el = node as HTMLElement;
+      const box = el.getBoundingClientRect();
+      /*
+       * Small enough that CSS's overlap reduction leaves it alone, so the corner
+       * measured below is the one declared rather than a shrunk one.
+       */
+      const radius = Math.min(80, box.width / 2, box.height / 2);
+      el.style.borderRadius = `${String(radius)}px`;
+      /*
+       * Six pixels into the bottom-left corner: inside the band's rectangle on
+       * both axes, and outside the arc, since (74/80)² + (74/80)² is 1.71.
+       *
+       * It is also some twenty-four pixels clear of the rendered edge along the
+       * diagonal, so a selection outline drawn on that edge cannot reach it and
+       * be mistaken for a band.
+       */
+      const inset = 6;
+      return {
+        radius,
+        corner: [box.left + inset, box.bottom - inset] as [number, number],
+        middle: [box.left + box.width / 2, box.bottom - inset] as [
+          number,
+          number,
+        ],
+      };
+    });
+
+    // The corner really is outside the curve, stated here so the assertion below
+    // cannot be satisfied by a fixture that drifted into a gentler radius.
+    const depth = where.radius - 6;
+    expect((depth / where.radius) ** 2 * 2).toBeGreaterThan(1);
+
+    const before = await pixels(page, [where.corner, where.middle]);
+
+    await block.click();
+    await expect(page.locator(band("padding", "bottom"))).toHaveCount(1);
+
+    const after = await pixels(page, [where.corner, where.middle]);
+
+    /*
+     * The separating half FIRST: the band really did paint, at the same distance
+     * from the bottom edge, in the middle of the same strip. Without this the
+     * corner assertion is satisfied by an overlay that drew nothing at all.
+     */
+    expect(after[1]).not.toBe(before[1]);
+
+    // And the corner is untouched. Selecting a block must not colour the page
+    // beside it.
+    expect(after[0]).toBe(before[0]);
+  });
+
+  test("draws nothing for a block cut by a rounded ancestor's CORNER", async ({
+    page,
+  }) => {
+    /*
+     * A container with `border-radius` and `overflow: hidden` clips on the
+     * curve. A child inside all four padding edges can still lose a corner, and
+     * a rectangular comparison accepts it.
+     *
+     * The control is the point of the test as much as the refusal is: the
+     * rounded card is the ordinary layout, so an implementation that declined
+     * every rounded clipping ancestor would blank the overlay for most blocks on
+     * a real page and would pass a test that only checked the refusal.
+     */
+    await page.goto(ROUTE);
+    const target = page.locator('[data-nx-node="hx-nested-text"]');
+    await expect(target).toBeVisible();
+
+    await page.evaluate(() => {
+      (
+        document.querySelector('[data-nx-node="hx-nested-text"]') as HTMLElement
+      ).style.marginBottom = "24px";
+      const section = document.querySelector(
+        '[data-nx-node="hx-section"]'
+      ) as HTMLElement;
+      section.style.overflow = "hidden";
+      section.style.borderRadius = "100px";
+      // Holds the child clear of all four arcs without moving it out of the
+      // container, which is what makes the first phase a control and not a
+      // second copy of the refusal.
+      section.style.padding = "40px";
+    });
+    await target.click();
+
+    /** How far the child reaches past a corner's arc centre, per axis. */
+    const reach = () =>
+      page.evaluate(() => {
+        const section = document.querySelector(
+          '[data-nx-node="hx-section"]'
+        ) as HTMLElement;
+        const child = document.querySelector(
+          '[data-nx-node="hx-nested-text"]'
+        ) as HTMLElement;
+        const outer = section.getBoundingClientRect();
+        const box = child.getBoundingClientRect();
+        const radius = Number.parseFloat(
+          getComputedStyle(section).borderTopLeftRadius
+        );
+        const dx = outer.left + radius - box.left;
+        const dy = outer.top + radius - box.top;
+        return (dx / radius) ** 2 + (dy / radius) ** 2;
+      });
+
+    // CONTROL: inside the arc, and the bands are drawn.
+    expect(await reach()).toBeLessThan(1);
+    await expect(page.locator(BAND)).not.toHaveCount(0);
+
+    await page.evaluate(() => {
+      (
+        document.querySelector('[data-nx-node="hx-section"]') as HTMLElement
+      ).style.padding = "0px";
+    });
+
+    // The same block, now genuinely through the curve — and still inside all
+    // four straight edges, which is the case the rectangle comparison misses.
+    expect(await reach()).toBeGreaterThan(1);
+    await expect(page.locator(BAND)).toHaveCount(0);
+  });
+
+  test("keeps drawing at the corner of an ancestor that clips ONE axis", async ({
+    page,
+  }) => {
+    /*
+     * `overflow: clip visible` is the one mixed pair that survives computation,
+     * and it leaves the clip region unbounded on the visible axis — a corner
+     * needs two bounds to exist at all.
+     *
+     * Measured in Chromium: a child at the corner of a 60px-radius box under
+     * `overflow: clip visible` is painted in full, while the same child under
+     * `overflow: hidden` is cut away. Applying the arc on one axis would refuse
+     * a block nothing removes.
+     */
+    await page.goto(ROUTE);
+    const target = page.locator('[data-nx-node="hx-nested-text"]');
+    await expect(target).toBeVisible();
+
+    await page.evaluate(() => {
+      (
+        document.querySelector('[data-nx-node="hx-nested-text"]') as HTMLElement
+      ).style.marginBottom = "24px";
+      const section = document.querySelector(
+        '[data-nx-node="hx-section"]'
+      ) as HTMLElement;
+      section.style.overflow = "clip visible";
+      section.style.borderRadius = "100px";
+      section.style.padding = "0px";
+    });
+    await target.click();
+
+    const axes = await page.evaluate(() => {
+      const style = getComputedStyle(
+        document.querySelector('[data-nx-node="hx-section"]') as HTMLElement
+      );
+      return [style.overflowX, style.overflowY];
+    });
+    // The separating property: only ONE axis clips. Were both clipping, the
+    // refusal would be correct and this test would pin the opposite of its name.
+    expect(axes).toEqual(["clip", "visible"]);
+
+    await expect(page.locator(BAND)).not.toHaveCount(0);
+  });
+});

--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -1656,4 +1656,152 @@ test.describe("rounded geometry", () => {
 
     await expect(page.locator(BAND)).not.toHaveCount(0);
   });
+  test("keeps drawing for a rounded block FLUSH inside a rounded container", async ({
+    page,
+  }) => {
+    /*
+     * The nested rounded card, and the case a rectangular comparison gets wrong
+     * in the opposite direction from the corner test above.
+     *
+     * A block whose curve matches the container it fills is not cut anywhere —
+     * but its BOUNDING RECTANGLE's corners lie outside every one of that
+     * container's arcs, so a check that reads only the rectangle refuses it and
+     * takes the whole overlay with it.
+     *
+     * The two boxes are given the same SIZE as well as the same radius, and that
+     * is not tidiness. CSS reduces the radii to fit the box, so the same
+     * declaration on two differently-sized boxes produces two different curves:
+     * on the seeded 1280x48 section a declared 60px is drawn at 24, while the
+     * 1280x24 child inside it is drawn at 12 — and that child really is cut.
+     */
+    await page.goto(ROUTE);
+    const target = page.locator('[data-nx-node="hx-nested-text"]');
+    await expect(target).toBeVisible();
+
+    await page.evaluate(() => {
+      const section = document.querySelector(
+        '[data-nx-node="hx-section"]'
+      ) as HTMLElement;
+      section.style.overflow = "hidden";
+      section.style.borderRadius = "60px";
+      section.style.padding = "0px";
+      section.style.height = "200px";
+      const child = document.querySelector(
+        '[data-nx-node="hx-nested-text"]'
+      ) as HTMLElement;
+      child.style.marginBottom = "24px";
+      // Matched to the container it fills, which is how the pattern is authored.
+      child.style.borderRadius = "60px";
+      child.style.height = "200px";
+    });
+    await target.click();
+
+    const geometry = await page.evaluate(() => {
+      const section = document.querySelector(
+        '[data-nx-node="hx-section"]'
+      ) as HTMLElement;
+      const child = document.querySelector(
+        '[data-nx-node="hx-nested-text"]'
+      ) as HTMLElement;
+      const outer = section.getBoundingClientRect();
+      const box = child.getBoundingClientRect();
+      const radius = Number.parseFloat(
+        getComputedStyle(section).borderTopLeftRadius
+      );
+      const dx = outer.left + radius - box.left;
+      const dy = outer.top + radius - box.top;
+      return {
+        cornerReach: (dx / radius) ** 2 + (dy / radius) ** 2,
+        sameBox:
+          Math.abs(box.left - outer.left) < 1.5 &&
+          Math.abs(box.top - outer.top) < 1.5 &&
+          Math.abs(box.right - outer.right) < 1.5 &&
+          Math.abs(box.bottom - outer.bottom) < 1.5,
+        sameRadius:
+          getComputedStyle(section).borderTopLeftRadius ===
+          getComputedStyle(child).borderTopLeftRadius,
+      };
+    });
+
+    /*
+     * The separating properties, asserted so this cannot pass for a reason other
+     * than the one it names. The two boxes coincide and carry the same
+     * declaration — so CSS reduces both by the same factor and the two curves
+     * are the same curve — while the block's RECTANGULAR corner is outside the
+     * container's arc, which is precisely what the earlier implementation
+     * refused on.
+     */
+    expect(geometry.sameBox).toBe(true);
+    expect(geometry.sameRadius).toBe(true);
+    expect(geometry.cornerReach).toBeGreaterThan(1);
+
+    await expect(page.locator(BAND)).not.toHaveCount(0);
+  });
+  test("draws nothing under an ancestor whose curve cannot be read", async ({
+    page,
+  }) => {
+    /*
+     * A radius the computed value does not resolve is a clip of UNKNOWN shape,
+     * and the block is refused rather than treated as sitting inside a square
+     * one — the same answer this package gives for every other geometry it
+     * cannot describe.
+     *
+     * Reachable, and measured: a percentage inside a math function still depends
+     * on the box, so `border-radius: calc(10% + 5px)` stays exactly that in the
+     * computed value where `calc(10px + 5px)` resolves to `15px`. The catalog
+     * accepts a `calc()` length, so an author reaches this from the inspector.
+     *
+     * The control comes first, with the resolvable form of the same declaration:
+     * a block clear of the corners keeps its bands, so the emptiness afterwards
+     * is the value being unreadable and not the shape being wrong.
+     */
+    await page.goto(ROUTE);
+    const target = page.locator('[data-nx-node="hx-nested-text"]');
+    await expect(target).toBeVisible();
+
+    await page.evaluate(() => {
+      (
+        document.querySelector('[data-nx-node="hx-nested-text"]') as HTMLElement
+      ).style.marginBottom = "24px";
+      const section = document.querySelector(
+        '[data-nx-node="hx-section"]'
+      ) as HTMLElement;
+      section.style.overflow = "hidden";
+      section.style.padding = "40px";
+      section.style.borderRadius = "calc(10px + 5px)";
+    });
+    await target.click();
+
+    const resolved = await page.evaluate(
+      () =>
+        getComputedStyle(
+          document.querySelector('[data-nx-node="hx-section"]') as HTMLElement
+        ).borderTopLeftRadius
+    );
+    // The control's radius really did resolve, so the bands below are drawn
+    // under a curve this can read.
+    expect(resolved).toBe("15px");
+    await expect(page.locator(BAND)).not.toHaveCount(0);
+
+    await page.evaluate(() => {
+      (
+        document.querySelector('[data-nx-node="hx-section"]') as HTMLElement
+      ).style.borderRadius = "calc(10% + 5px)";
+    });
+
+    const unresolved = await page.evaluate(
+      () =>
+        getComputedStyle(
+          document.querySelector('[data-nx-node="hx-section"]') as HTMLElement
+        ).borderTopLeftRadius
+    );
+    /*
+     * The separating property: the browser really did leave this unresolved. A
+     * version of Chromium that resolved it would make the refusal below wrong
+     * rather than merely untested, and this says so loudly instead.
+     */
+    expect(unresolved).toBe("calc(10% + 5px)");
+
+    await expect(page.locator(BAND)).toHaveCount(0);
+  });
 });

--- a/packages/builder/src/border-radii.test.ts
+++ b/packages/builder/src/border-radii.test.ts
@@ -519,6 +519,136 @@ describe("a ROUNDED shape inside a rounded one", () => {
   });
 });
 
+describe("the sampling allowance at extreme radii", () => {
+  it("still accepts two identical flush shapes at a huge rendered radius", () => {
+    /*
+     * A fixed sample count runs out of precision on a large shape: at
+     * sixty-four steps the chord falls further from the arc than the whole
+     * half-pixel allowance somewhere above a 6,600px rendered half-axis, the
+     * allowance goes NEGATIVE, and two identical flush rounded rectangles start
+     * failing containment — so the overlay vanishes on a block nothing removes.
+     *
+     * Reachable on a large box, and more easily under an ancestor `scale`, since
+     * these radii are in RENDERED pixels.
+     */
+    const huge = 40_000;
+    const clip = { top: 0, right: 100_000, bottom: 100_000, left: 0 };
+    const radii: CornerRadii = {
+      topLeft: { x: huge, y: huge },
+      topRight: { x: huge, y: huge },
+      bottomRight: { x: huge, y: huge },
+      bottomLeft: { x: huge, y: huge },
+    };
+    expect(roundedInsideRounded(clip, radii, clip, radii, 0.5)).toBe(true);
+  });
+
+  it("still refuses a shape that genuinely leaves the curve at that scale", () => {
+    /*
+     * The other half. Adapting the sample count must not turn into accepting
+     * everything large — a square-cornered block pushed into a huge arc is still
+     * cut, and reads as cut.
+     */
+    const huge = 40_000;
+    const clip = { top: 0, right: 100_000, bottom: 100_000, left: 0 };
+    const radii: CornerRadii = {
+      topLeft: { x: huge, y: huge },
+      topRight: { x: huge, y: huge },
+      bottomRight: { x: huge, y: huge },
+      bottomLeft: { x: huge, y: huge },
+    };
+    expect(roundedInsideRounded(clip, SQUARE_CORNERS, clip, radii, 0.5)).toBe(
+      false
+    );
+  });
+
+  it("spends the chord error out of the allowance, not on top of it", () => {
+    /*
+     * The reason the error is SUBTRACTED rather than merely bounded. Without it
+     * the guarantee slips: the caller asks to tolerate half a pixel, sampling
+     * can miss a violation by up to the chord error on top of that, and the two
+     * add up to more overhang than anyone allowed.
+     *
+     * At a 300,000px half-axis the sample count is capped, so the chord error is
+     * a substantial 0.353px and the effective allowance is 0.147px. A shape
+     * pushed out by 0.3px therefore sits BETWEEN the two: inside the raw slack,
+     * outside the allowance the error leaves. It has to be refused.
+     */
+    const huge = 300_000;
+    const clip = { top: 0, right: 1_000_000, bottom: 1_000_000, left: 0 };
+    const radii: CornerRadii = {
+      topLeft: { x: huge, y: huge },
+      topRight: { x: huge, y: huge },
+      bottomRight: { x: huge, y: huge },
+      bottomLeft: { x: huge, y: huge },
+    };
+    const pushedOut = (by: number) => ({ ...clip, top: -by, left: -by });
+
+    expect(roundedInsideRounded(pushedOut(0.3), radii, clip, radii, 0.5)).toBe(
+      false
+    );
+
+    /*
+     * The separating half: a displacement comfortably inside the remaining
+     * allowance is still accepted, so the refusal above is the error being spent
+     * and not a blanket refusal of large shapes.
+     */
+    expect(roundedInsideRounded(pushedOut(0.05), radii, clip, radii, 0.5)).toBe(
+      true
+    );
+  });
+
+  it("degrades toward refusing past the cap, without refusing everything", () => {
+    /*
+     * Past the sample cap the chords are further from the arcs than the whole
+     * allowance and it goes negative, which TIGHTENS every depth rather than
+     * loosening it. Both halves are asserted, because the useful behaviour is
+     * the pair:
+     *
+     * - a shape sitting ON the curve is refused, since nothing here can certify
+     *   it and answering "inside" would accept a shape the container cuts;
+     * - a shape comfortably INSIDE is still accepted, which a blanket refusal at
+     *   this point would have thrown away for no gain.
+     *
+     * It takes a rendered half-axis over 400,000px, which no layout produces on
+     * its own; `transform` is a catalog property, so an ancestor `scale` is the
+     * route that reaches it.
+     */
+    const absurd = 1_000_000;
+    const clip = { top: 0, right: 4_000_000, bottom: 4_000_000, left: 0 };
+    const radii: CornerRadii = {
+      topLeft: { x: absurd, y: absurd },
+      topRight: { x: absurd, y: absurd },
+      bottomRight: { x: absurd, y: absurd },
+      bottomLeft: { x: absurd, y: absurd },
+    };
+    expect(roundedInsideRounded(clip, radii, clip, radii, 0.5)).toBe(false);
+
+    const wellInside = {
+      top: 100_000,
+      right: 3_900_000,
+      bottom: 3_900_000,
+      left: 100_000,
+    };
+    expect(roundedInsideRounded(wellInside, radii, clip, radii, 0.5)).toBe(
+      true
+    );
+  });
+
+  it("keeps a small corner cheap", () => {
+    // The count is derived, so a four-pixel corner is not paid for at the rate a
+    // four-thousand-pixel one needs. Asserted through behaviour rather than by
+    // reaching for the private count: a tiny flush shape is still accepted.
+    const clip = { top: 0, right: 40, bottom: 20, left: 0 };
+    const tiny: CornerRadii = {
+      topLeft: { x: 4, y: 4 },
+      topRight: { x: 4, y: 4 },
+      bottomRight: { x: 4, y: 4 },
+      bottomLeft: { x: 4, y: 4 },
+    };
+    expect(roundedInsideRounded(clip, tiny, clip, tiny, 0.5)).toBe(true);
+  });
+});
+
 describe("stating the shape as a clip", () => {
   it("states the shape in the clipped element's own coordinates", () => {
     const band = { x: 10, y: 20, width: 100, height: 40 };

--- a/packages/builder/src/border-radii.test.ts
+++ b/packages/builder/src/border-radii.test.ts
@@ -1,15 +1,16 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  boundsInsideRounded,
   clipPathOf,
   insetCornerRadii,
   isSquare,
-  roundedInsetOf,
+  roundedInsideRounded,
+  roundedShapeIn,
   scaleCornerRadii,
   SQUARE_CORNERS,
   usedCornerRadii,
   type CornerRadii,
+  type CornerRadius,
   type DeclaredRadii,
 } from "./border-radii";
 
@@ -35,40 +36,87 @@ function declare(all: string | Partial<DeclaredRadii>): DeclaredRadii {
     : { ...none, ...all };
 }
 
+/**
+ * The resolved radii, or a failure naming the input.
+ *
+ * `usedCornerRadii` answers `undefined` for a value it cannot resolve, and a
+ * test that let that through would compare `undefined` to `undefined` and pass
+ * while resolving nothing.
+ */
+function used(declared: DeclaredRadii, box = BOX): CornerRadii {
+  const radii = usedCornerRadii(declared, box);
+  if (radii === undefined) {
+    throw new Error(`unresolved: ${JSON.stringify(declared)}`);
+  }
+  return radii;
+}
+
 describe("resolving the computed value", () => {
   it("takes a length as the same number on both axes", () => {
-    expect(usedCornerRadii(declare("8px"), BOX).topLeft).toEqual({
+    expect(used(declare("8px")).topLeft).toEqual({
       x: 8,
       y: 8,
     });
   });
 
   it("resolves a percentage per AXIS, against different lengths", () => {
-    const radii = usedCornerRadii(declare({ topLeft: "50%" }), BOX);
+    const radii = used(declare({ topLeft: "50%" }));
     // 50% of a 200-wide, 100-tall box is 100 across and 50 down. One number for
     // both would be right only on a square box, which is why BOX is not one.
     expect(radii.topLeft).toEqual({ x: 100, y: 50 });
   });
 
   it("reads the two-value form an elliptical corner serializes as", () => {
-    const radii = usedCornerRadii(declare({ topLeft: "10px 30px" }), BOX);
+    const radii = used(declare({ topLeft: "10px 30px" }));
     expect(radii.topLeft).toEqual({ x: 10, y: 30 });
   });
 
   it("mixes a length and a percentage within one corner", () => {
-    const radii = usedCornerRadii(declare({ topLeft: "10px 20%" }), BOX);
+    const radii = used(declare({ topLeft: "10px 20%" }));
     expect(radii.topLeft).toEqual({ x: 10, y: 20 });
   });
 
-  it("answers zero for a value it cannot parse", () => {
-    // A `NaN` here would poison every comparison downstream into silently
-    // answering false, which reads as "nothing is clipped" rather than as an error.
-    const radii = usedCornerRadii(declare({ topLeft: "" }), BOX);
-    expect(radii.topLeft).toEqual({ x: 0, y: 0 });
+  it("reads an EMPTY value as square rather than as unknown", () => {
+    /*
+     * The one unreadable case that is not unknown. A computed style never
+     * reports a supported longhand as blank, so a blank one means the engine has
+     * no such property — and an engine without `border-radius` draws a square
+     * corner, which is what zero says.
+     *
+     * Refusing it instead would blank the overlay in every renderer that does
+     * not implement the property, jsdom included.
+     */
+    expect(used(declare({ topLeft: "" })).topLeft).toEqual({ x: 0, y: 0 });
+  });
+
+  it("answers UNDEFINED for a percentage inside a math function", () => {
+    /*
+     * Reachable, and measured: a percentage inside `calc()` still depends on the
+     * box, so the computed longhand stays `"calc(10% + 5px)"` where
+     * `calc(10px + 5px)` resolves to `"15px"`. The catalog accepts a `calc()`
+     * length, so an author reaches this from the inspector.
+     */
+    expect(
+      usedCornerRadii(declare({ topLeft: "calc(10% + 5px)" }), BOX)
+    ).toBeUndefined();
+    // The control: a math function the browser DID resolve arrives as a plain
+    // length and must not be refused with it.
+    expect(used(declare({ topLeft: "15px" })).topLeft).toEqual({
+      x: 15,
+      y: 15,
+    });
+  });
+
+  it("refuses the whole box when any ONE corner is unresolvable", () => {
+    // The shape is refused, not the corner: three known corners and one unknown
+    // is still a shape that cannot be drawn.
+    expect(
+      usedCornerRadii(declare({ bottomLeft: "min(10px, 5%)" }), BOX)
+    ).toBeUndefined();
   });
 
   it("leaves radii that already fit alone", () => {
-    const radii = usedCornerRadii(declare("20px"), BOX);
+    const radii = used(declare("20px"));
     expect(radii.topRight).toEqual({ x: 20, y: 20 });
   });
 });
@@ -80,7 +128,7 @@ describe("the overlap reduction CSS applies and the computed value does not", ()
      * its corners at 50, not at the 200 the computed value reports. The tightest
      * side is the 100-tall one, whose two radii sum to 400, so f = 0.25.
      */
-    const radii = usedCornerRadii(declare("200px"), BOX);
+    const radii = used(declare("200px"));
     expect(radii.topLeft).toEqual({ x: 50, y: 50 });
     expect(radii.bottomRight).toEqual({ x: 50, y: 50 });
   });
@@ -95,14 +143,13 @@ describe("the overlap reduction CSS applies and the computed value does not", ()
      * leave this at 200, since nothing about the top-left corner alone is too
      * big for a 200-wide box.
      */
-    const radii = usedCornerRadii(declare({ topLeft: "200px" }), BOX);
+    const radii = used(declare({ topLeft: "200px" }));
     expect(radii.topLeft).toEqual({ x: 100, y: 100 });
   });
 
   it("carries the factor to corners that were not themselves too big", () => {
-    const radii = usedCornerRadii(
-      declare({ topLeft: "150px", topRight: "150px", bottomLeft: "10px" }),
-      BOX
+    const radii = used(
+      declare({ topLeft: "150px", topRight: "150px", bottomLeft: "10px" })
     );
     /*
      * Four sides constrain, and the tightest wins: top gives 200/300, right
@@ -137,7 +184,7 @@ describe("the overlap reduction CSS applies and the computed value does not", ()
      * a side is constrained by the half-axes running ALONG it, so a corner that
      * is wide and shallow loads the horizontal sides and spares the vertical.
      */
-    const radii = usedCornerRadii(declare(declared), BOX);
+    const radii = used(declare(declared));
     const corner = Object.keys(declared)[0] as keyof CornerRadii;
     const declaredMajor = 150;
     expect([side, radii[corner].x + radii[corner].y]).toEqual([
@@ -151,18 +198,18 @@ describe("the overlap reduction CSS applies and the computed value does not", ()
 
   it("does not divide by a side with no curve on it", () => {
     // Every side sums to zero here, and `L / 0` would reduce the box by Infinity.
-    expect(usedCornerRadii(declare("0px"), BOX)).toEqual(SQUARE_CORNERS);
+    expect(used(declare("0px"))).toEqual(SQUARE_CORNERS);
   });
 
   it("squares every corner on a box with no width", () => {
-    const radii = usedCornerRadii(declare("20px"), { width: 0, height: 100 });
+    const radii = used(declare("20px"), { width: 0, height: 100 });
     expect(radii.topLeft).toEqual({ x: 0, y: 0 });
   });
 });
 
 describe("the padding box's curve", () => {
   it("takes each border width off the half-axis running alongside it", () => {
-    const outer = usedCornerRadii(declare("40px"), BOX);
+    const outer = used(declare("40px"));
     const inner = insetCornerRadii(outer, {
       top: 4,
       right: 8,
@@ -176,7 +223,7 @@ describe("the padding box's curve", () => {
   });
 
   it("squares a corner whose border is thicker than its curve", () => {
-    const inner = insetCornerRadii(usedCornerRadii(declare("6px"), BOX), {
+    const inner = insetCornerRadii(used(declare("6px")), {
       top: 10,
       right: 10,
       bottom: 10,
@@ -199,14 +246,14 @@ describe("the padding box's curve", () => {
      * giving 80. The engine draws 90, so this asserts BOTH the number and that
      * it is not the other one.
      */
-    const outer = usedCornerRadii(declare({ topLeft: "100px" }), BOX);
+    const outer = used(declare({ topLeft: "100px" }));
     expect(outer.topLeft).toEqual({ x: 100, y: 100 });
 
     const border = { top: 10, right: 10, bottom: 10, left: 10 };
     const inner = insetCornerRadii(outer, border);
     expect(inner.topLeft).toEqual({ x: 90, y: 90 });
 
-    const otherOrder = usedCornerRadii(declare({ topLeft: "90px" }), {
+    const otherOrder = used(declare({ topLeft: "90px" }), {
       width: BOX.width - 20,
       height: BOX.height - 20,
     });
@@ -217,7 +264,7 @@ describe("the padding box's curve", () => {
 
 describe("moving radii into rendered pixels", () => {
   it("scales each half-axis by its own axis", () => {
-    const scaled = scaleCornerRadii(usedCornerRadii(declare("10px"), BOX), {
+    const scaled = scaleCornerRadii(used(declare("10px")), {
       x: 2,
       y: 0.5,
     });
@@ -266,14 +313,18 @@ const CURVED: CornerRadii = {
 describe("whether a rectangle fits inside a rounded one", () => {
   it("accepts a box clear of every corner", () => {
     const box = { top: 160, right: 400, bottom: 240, left: 300 };
-    expect(boundsInsideRounded(box, CLIP, CURVED, 0.5)).toBe(true);
+    expect(roundedInsideRounded(box, SQUARE_CORNERS, CLIP, CURVED, 0.5)).toBe(
+      true
+    );
   });
 
   it("rejects a box that pokes through the arc", () => {
     // Top-left arc centre is (260, 140). The box corner at (210, 110) sits
     // (50, 30) inside it: (50/60)^2 + (30/40)^2 = 1.26, which is outside.
     const box = { top: 110, right: 400, bottom: 240, left: 210 };
-    expect(boundsInsideRounded(box, CLIP, CURVED, 0.5)).toBe(false);
+    expect(roundedInsideRounded(box, SQUARE_CORNERS, CLIP, CURVED, 0.5)).toBe(
+      false
+    );
   });
 
   it("accepts a box INSIDE the corner's square but inside its arc too", () => {
@@ -295,7 +346,9 @@ describe("whether a rectangle fits inside a rounded one", () => {
       (dx / CURVED.topLeft.x) ** 2 + (dy / CURVED.topLeft.y) ** 2
     ).toBeLessThan(1);
 
-    expect(boundsInsideRounded(box, CLIP, CURVED, 0.5)).toBe(true);
+    expect(roundedInsideRounded(box, SQUARE_CORNERS, CLIP, CURVED, 0.5)).toBe(
+      true
+    );
   });
 
   it("tests each corner independently", () => {
@@ -312,16 +365,18 @@ describe("whether a rectangle fits inside a rounded one", () => {
     };
     expect(inset).toBe(6);
     for (const [name, box] of Object.entries(corners)) {
-      expect([name, boundsInsideRounded(box, CLIP, CURVED, 0.5)]).toEqual([
+      expect([
         name,
-        false,
-      ]);
+        roundedInsideRounded(box, SQUARE_CORNERS, CLIP, CURVED, 0.5),
+      ]).toEqual([name, false]);
     }
   });
 
   it("accepts everything when the corners are square", () => {
     const flush = { top: 100, right: 500, bottom: 300, left: 200 };
-    expect(boundsInsideRounded(flush, CLIP, SQUARE_CORNERS, 0.5)).toBe(true);
+    expect(
+      roundedInsideRounded(flush, SQUARE_CORNERS, CLIP, SQUARE_CORNERS, 0.5)
+    ).toBe(true);
   });
 
   it("forgives an overhang past the ARC no bigger than the slack", () => {
@@ -338,31 +393,175 @@ describe("whether a rectangle fits inside a rounded one", () => {
      * than the half-pixel allowance.
      */
     const grazing = { top: 111.416, right: 400, bottom: 240, left: 217.274 };
-    expect(boundsInsideRounded(grazing, CLIP, CURVED, 0.5)).toBe(true);
+    expect(
+      roundedInsideRounded(grazing, SQUARE_CORNERS, CLIP, CURVED, 0.5)
+    ).toBe(true);
     // The separating half: with no allowance the same box IS outside the curve,
     // so the acceptance above is the slack's doing and not the box's.
-    expect(boundsInsideRounded(grazing, CLIP, CURVED, 0)).toBe(false);
+    expect(roundedInsideRounded(grazing, SQUARE_CORNERS, CLIP, CURVED, 0)).toBe(
+      false
+    );
+  });
+});
+
+describe("a ROUNDED shape inside a rounded one", () => {
+  it("accepts a block flush inside an equally rounded container", () => {
+    /*
+     * The nested rounded card, and the case a rectangle comparison gets wrong.
+     * The block fills the clip exactly and is not cut anywhere — while its
+     * bounding rectangle's corners sit outside every one of the container's
+     * arcs, which is what a test reading only the rectangle would refuse.
+     */
+    const flush = { top: 100, right: 500, bottom: 300, left: 200 };
+    expect(roundedInsideRounded(flush, CURVED, CLIP, CURVED, 0.5)).toBe(true);
+
+    // The separating half: the SAME box with square corners IS refused, so the
+    // acceptance above is the block's own curve and not a widened allowance.
+    expect(roundedInsideRounded(flush, SQUARE_CORNERS, CLIP, CURVED, 0.5)).toBe(
+      false
+    );
+  });
+
+  it("accepts a block rounded MORE than the container it sits in", () => {
+    const flush = { top: 100, right: 500, bottom: 300, left: 200 };
+    const rounder: CornerRadii = {
+      topLeft: { x: 90, y: 60 },
+      topRight: { x: 90, y: 60 },
+      bottomRight: { x: 90, y: 60 },
+      bottomLeft: { x: 90, y: 60 },
+    };
+    expect(roundedInsideRounded(flush, rounder, CLIP, CURVED, 0.5)).toBe(true);
+  });
+
+  it("still refuses a rounded block whose curve leaves the container's", () => {
+    /*
+     * A block rounded too gently for the corner it is pushed into. Without this
+     * the fix for the flush case would be "accept anything with a radius", which
+     * reopens the defect the corner test exists for.
+     */
+    const pushed = { top: 110, right: 400, bottom: 240, left: 210 };
+    const gentle: CornerRadii = {
+      topLeft: { x: 4, y: 4 },
+      topRight: { x: 4, y: 4 },
+      bottomRight: { x: 4, y: 4 },
+      bottomLeft: { x: 4, y: 4 },
+    };
+    expect(roundedInsideRounded(pushed, gentle, CLIP, CURVED, 0.5)).toBe(false);
+  });
+
+  it.each<[string, CornerRadius]>([
+    ["40px / 0", { x: 40, y: 0 }],
+    ["0 / 40px", { x: 0, y: 40 }],
+  ])("reads a corner declared %s as the box corner", (_label, topLeft) => {
+    /*
+     * `border-radius: 40px / 0` draws a right angle: an ellipse with a zero
+     * half-axis has no interior, so the block's extreme point there is its box
+     * CORNER rather than a point along a curve.
+     *
+     * BOTH orientations, because they fail differently and only one of them
+     * fails at all. Zeroing just the axis that is zero leaves `0 / 40px`
+     * sampling a point forty pixels DOWN from the corner and missing the
+     * incursion entirely, while `40px / 0` still happens to sweep through the
+     * corner and gives the right answer for the wrong reason.
+     */
+    const pushed = { top: 110, right: 400, bottom: 240, left: 210 };
+    const degenerate: CornerRadii = { ...SQUARE_CORNERS, topLeft };
+    expect(roundedInsideRounded(pushed, degenerate, CLIP, CURVED, 0.5)).toBe(
+      false
+    );
+    // And it agrees with the square reading, which is what the browser draws.
+    expect(
+      roundedInsideRounded(pushed, SQUARE_CORNERS, CLIP, CURVED, 0.5)
+    ).toBe(false);
+  });
+
+  it("samples the arc rather than only its two ends", () => {
+    /*
+     * A block whose corner arc is INSIDE the container's curve at both of its
+     * endpoints and outside it in between. Testing only the ends — the cheap
+     * thing to write, and the thing that looks sufficient — accepts a block the
+     * container visibly cuts.
+     *
+     * The fixture was found by searching the parameter space rather than
+     * reasoned out, because the case needs a wide shallow container arc against
+     * a wide shallow block arc and does not turn up by picking round numbers.
+     * Both halves are asserted below, so it cannot drift into a fixture where an
+     * endpoint is already outside and the test passes for the wrong reason.
+     */
+    const wide: CornerRadii = {
+      ...SQUARE_CORNERS,
+      topLeft: { x: 130, y: 24 },
+    };
+    const own: CornerRadii = { ...SQUARE_CORNERS, topLeft: { x: 60, y: 8 } };
+    const box = { top: 102, right: 400, bottom: 240, left: 230 };
+
+    /** How far past the container's top-left arc a point on the block's is. */
+    const reach = (angle: number): number => {
+      const cx = box.left + own.topLeft.x;
+      const cy = box.top + own.topLeft.y;
+      const px = cx - own.topLeft.x * Math.cos(angle);
+      const py = cy - own.topLeft.y * Math.sin(angle);
+      const dx = CLIP.left + wide.topLeft.x - px;
+      const dy = CLIP.top + wide.topLeft.y - py;
+      if (dx <= 0 || dy <= 0) return 0;
+      return (dx / wide.topLeft.x) ** 2 + (dy / wide.topLeft.y) ** 2;
+    };
+
+    // Both ENDS of the block's arc are inside the container's curve.
+    expect(reach(0)).toBeLessThan(1);
+    expect(reach(Math.PI / 2)).toBeLessThan(1);
+    // Somewhere in between, it is not.
+    expect(
+      Math.max(...[0.2, 0.3, 0.4, 0.5].map(f => reach(f * Math.PI)))
+    ).toBeGreaterThan(1);
+
+    expect(roundedInsideRounded(box, own, CLIP, wide, 0.5)).toBe(false);
   });
 });
 
 describe("stating the shape as a clip", () => {
-  it("measures each inset from the band to the shape", () => {
+  it("states the shape in the clipped element's own coordinates", () => {
     const band = { x: 10, y: 20, width: 100, height: 40 };
     const shape = { x: 20, y: 25, width: 70, height: 20 };
-    expect(roundedInsetOf(band, shape, SQUARE_CORNERS)).toEqual({
-      top: 5,
-      left: 10,
-      right: 20,
-      bottom: 15,
+    // A `clip-path` resolves against the element carrying it, so the shape is
+    // offset by the difference between the two origins and keeps its own size.
+    expect(roundedShapeIn(band, shape, SQUARE_CORNERS)).toEqual({
+      x: 10,
+      y: 5,
+      width: 70,
+      height: 20,
       radii: SQUARE_CORNERS,
     });
   });
 
-  it("writes the horizontal radii before the vertical ones", () => {
+  it("writes a PATH rather than an inset, so nothing renormalises it", () => {
     /*
-     * The two lists are easy to transpose and impossible to notice once
-     * transposed, because they differ only on an elliptical corner — so the
-     * fixture makes every corner elliptical and every corner distinct.
+     * `inset(... round ...)` resolves its radii the way `border-radius` does,
+     * which includes the overlap reduction against the inset rectangle —
+     * measured, a 180x80 element under `inset(0 round 90px)` is cut at 80. A
+     * padding-box curve that legitimately exceeds its own box would be silently
+     * shrunk, and that case is reachable: an outer corner of 100 less a 10px
+     * border leaves 90 on a padding box 80 tall, and the engine draws the 90.
+     */
+    const value = clipPathOf({
+      x: 0,
+      y: 0,
+      width: 180,
+      height: 80,
+      radii: { ...SQUARE_CORNERS, topLeft: { x: 90, y: 90 } },
+    });
+    expect(value.startsWith("path(")).toBe(true);
+    expect(value).not.toContain("inset(");
+    // The radius survives at its full size rather than being clamped to the box.
+    expect(value).toContain("A 90 90");
+  });
+
+  it("writes each corner's own radii, in path order", () => {
+    /*
+     * Every corner elliptical and every corner distinct, because a transposed
+     * pair of half-axes is invisible on a circular corner and the arcs are
+     * written in the order the outline is walked rather than the order the
+     * shorthand lists them.
      */
     const radii: CornerRadii = {
       topLeft: { x: 1, y: 5 },
@@ -370,19 +569,23 @@ describe("stating the shape as a clip", () => {
       bottomRight: { x: 3, y: 7 },
       bottomLeft: { x: 4, y: 8 },
     };
-    expect(clipPathOf({ top: 0, right: 0, bottom: 0, left: 0, radii })).toBe(
-      "inset(0px 0px 0px 0px round 1px 2px 3px 4px / 5px 6px 7px 8px)"
+    expect(clipPathOf({ x: 0, y: 0, width: 100, height: 50, radii })).toBe(
+      'path("M 1 0 L 98 0 A 2 6 0 0 1 100 6 L 100 43 A 3 7 0 0 1 97 50 ' +
+        'L 4 50 A 4 8 0 0 1 0 42 L 0 5 A 1 5 0 0 1 1 0 Z")'
     );
   });
 
-  it("writes the edges in the order CSS reads them", () => {
+  it("offsets the whole outline by the shape's origin", () => {
+    // A band is rarely at the clipped element's own origin, and a path written
+    // as if it were lands the curve in the wrong corner.
     const value = clipPathOf({
-      top: 1,
-      right: 2,
-      bottom: 3,
-      left: 4,
+      x: 7,
+      y: 11,
+      width: 20,
+      height: 30,
       radii: SQUARE_CORNERS,
     });
-    expect(value.startsWith("inset(1px 2px 3px 4px round")).toBe(true);
+    expect(value).toContain("M 7 11");
+    expect(value).toContain("27 41");
   });
 });

--- a/packages/builder/src/border-radii.test.ts
+++ b/packages/builder/src/border-radii.test.ts
@@ -1,0 +1,388 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  boundsInsideRounded,
+  clipPathOf,
+  insetCornerRadii,
+  isSquare,
+  roundedInsetOf,
+  scaleCornerRadii,
+  SQUARE_CORNERS,
+  usedCornerRadii,
+  type CornerRadii,
+  type DeclaredRadii,
+} from "./border-radii";
+
+/**
+ * A box that is neither square nor at the origin, so no assertion here can pass
+ * by coincidence: an implementation that swapped the axes, resolved both
+ * percentages against one length or dropped the origin would land on the same
+ * numbers for a 100×100 box at `0,0`.
+ */
+const BOX = { width: 200, height: 100 };
+
+function declare(all: string): DeclaredRadii;
+function declare(all: Partial<DeclaredRadii>): DeclaredRadii;
+function declare(all: string | Partial<DeclaredRadii>): DeclaredRadii {
+  const none = {
+    topLeft: "0px",
+    topRight: "0px",
+    bottomRight: "0px",
+    bottomLeft: "0px",
+  };
+  return typeof all === "string"
+    ? { topLeft: all, topRight: all, bottomRight: all, bottomLeft: all }
+    : { ...none, ...all };
+}
+
+describe("resolving the computed value", () => {
+  it("takes a length as the same number on both axes", () => {
+    expect(usedCornerRadii(declare("8px"), BOX).topLeft).toEqual({
+      x: 8,
+      y: 8,
+    });
+  });
+
+  it("resolves a percentage per AXIS, against different lengths", () => {
+    const radii = usedCornerRadii(declare({ topLeft: "50%" }), BOX);
+    // 50% of a 200-wide, 100-tall box is 100 across and 50 down. One number for
+    // both would be right only on a square box, which is why BOX is not one.
+    expect(radii.topLeft).toEqual({ x: 100, y: 50 });
+  });
+
+  it("reads the two-value form an elliptical corner serializes as", () => {
+    const radii = usedCornerRadii(declare({ topLeft: "10px 30px" }), BOX);
+    expect(radii.topLeft).toEqual({ x: 10, y: 30 });
+  });
+
+  it("mixes a length and a percentage within one corner", () => {
+    const radii = usedCornerRadii(declare({ topLeft: "10px 20%" }), BOX);
+    expect(radii.topLeft).toEqual({ x: 10, y: 20 });
+  });
+
+  it("answers zero for a value it cannot parse", () => {
+    // A `NaN` here would poison every comparison downstream into silently
+    // answering false, which reads as "nothing is clipped" rather than as an error.
+    const radii = usedCornerRadii(declare({ topLeft: "" }), BOX);
+    expect(radii.topLeft).toEqual({ x: 0, y: 0 });
+  });
+
+  it("leaves radii that already fit alone", () => {
+    const radii = usedCornerRadii(declare("20px"), BOX);
+    expect(radii.topRight).toEqual({ x: 20, y: 20 });
+  });
+});
+
+describe("the overlap reduction CSS applies and the computed value does not", () => {
+  it("shrinks every radius by the tightest side's factor", () => {
+    /*
+     * Measured in Chromium: a 200×100 box with `border-radius: 200px` renders
+     * its corners at 50, not at the 200 the computed value reports. The tightest
+     * side is the 100-tall one, whose two radii sum to 400, so f = 0.25.
+     */
+    const radii = usedCornerRadii(declare("200px"), BOX);
+    expect(radii.topLeft).toEqual({ x: 50, y: 50 });
+    expect(radii.bottomRight).toEqual({ x: 50, y: 50 });
+  });
+
+  it("applies ONE factor across all four corners, not one per corner", () => {
+    /*
+     * The separating case, and it is measured: with only the top-left corner
+     * declared, the box's HEIGHT still constrains it — the left side's radii sum
+     * to 200 against a length of 100, so f = 0.5 and the corner draws at 100.
+     *
+     * An implementation that clamped each corner to the sides it touches would
+     * leave this at 200, since nothing about the top-left corner alone is too
+     * big for a 200-wide box.
+     */
+    const radii = usedCornerRadii(declare({ topLeft: "200px" }), BOX);
+    expect(radii.topLeft).toEqual({ x: 100, y: 100 });
+  });
+
+  it("carries the factor to corners that were not themselves too big", () => {
+    const radii = usedCornerRadii(
+      declare({ topLeft: "150px", topRight: "150px", bottomLeft: "10px" }),
+      BOX
+    );
+    /*
+     * Four sides constrain, and the tightest wins: top gives 200/300, right
+     * 100/150, bottom 200/10, and LEFT 100/(10 + 150) = 0.625, which is the one.
+     *
+     * The 10px corner is not too big for anything and is reduced anyway, which
+     * is what one shared factor means — and it is the corner that makes the
+     * left side tight in the first place.
+     */
+    expect(radii.bottomLeft.x).toBeCloseTo(10 * 0.625, 6);
+    expect(radii.topLeft.x).toBeCloseTo(150 * 0.625, 6);
+  });
+
+  it.each([
+    ["top", { topLeft: "150px 10px", topRight: "150px 10px" }, 200 / 300],
+    ["right", { topRight: "10px 150px", bottomRight: "10px 150px" }, 100 / 300],
+    [
+      "bottom",
+      { bottomLeft: "150px 10px", bottomRight: "150px 10px" },
+      200 / 300,
+    ],
+    ["left", { topLeft: "10px 150px", bottomLeft: "10px 150px" }, 100 / 300],
+  ])("lets the %s side alone be the binding one", (side, declared, factor) => {
+    /*
+     * One case per side, each built so that ONLY that side is tight — the other
+     * three come out at ten or twenty times over. A factor that skipped any
+     * single side would leave its case unreduced, which no fixture with a
+     * symmetric box can show: dropping the right side changes nothing while the
+     * left side happens to bind with the same numbers.
+     *
+     * Elliptical corners are what make one side tight without its neighbours:
+     * a side is constrained by the half-axes running ALONG it, so a corner that
+     * is wide and shallow loads the horizontal sides and spares the vertical.
+     */
+    const radii = usedCornerRadii(declare(declared), BOX);
+    const corner = Object.keys(declared)[0] as keyof CornerRadii;
+    const declaredMajor = 150;
+    expect([side, radii[corner].x + radii[corner].y]).toEqual([
+      side,
+      expect.closeTo((declaredMajor + 10) * factor, 6),
+    ]);
+    // And the factor really is below one, so the assertion above is not
+    // satisfied by an implementation that reduced nothing.
+    expect(factor).toBeLessThan(1);
+  });
+
+  it("does not divide by a side with no curve on it", () => {
+    // Every side sums to zero here, and `L / 0` would reduce the box by Infinity.
+    expect(usedCornerRadii(declare("0px"), BOX)).toEqual(SQUARE_CORNERS);
+  });
+
+  it("squares every corner on a box with no width", () => {
+    const radii = usedCornerRadii(declare("20px"), { width: 0, height: 100 });
+    expect(radii.topLeft).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe("the padding box's curve", () => {
+  it("takes each border width off the half-axis running alongside it", () => {
+    const outer = usedCornerRadii(declare("40px"), BOX);
+    const inner = insetCornerRadii(outer, {
+      top: 4,
+      right: 8,
+      bottom: 12,
+      left: 16,
+    });
+    // Horizontal half-axes lose the left or right border, vertical ones the top
+    // or bottom. Using one width for both is right only on a uniform border.
+    expect(inner.topLeft).toEqual({ x: 40 - 16, y: 40 - 4 });
+    expect(inner.bottomRight).toEqual({ x: 40 - 8, y: 40 - 12 });
+  });
+
+  it("squares a corner whose border is thicker than its curve", () => {
+    const inner = insetCornerRadii(usedCornerRadii(declare("6px"), BOX), {
+      top: 10,
+      right: 10,
+      bottom: 10,
+      left: 10,
+    });
+    // Floored rather than inverted: a negative radius would draw a corner
+    // bulging outward, which is not a shape CSS has.
+    expect(inner.topLeft).toEqual({ x: 0, y: 0 });
+  });
+
+  it("reduces BEFORE insetting, which is not the same answer", () => {
+    /*
+     * The order is load-bearing and this is the case that separates the two,
+     * measured in Chromium: a 200×100 box with `border-top-left-radius: 100px`
+     * and a 10px border draws its inner curve at 90.
+     *
+     * Reducing first finds f = 1 — the corner already fits — and insets 100 to
+     * 90. Insetting first gives 90 and then reduces it against the 180×80
+     * padding box, where the left side's radii sum to 90 over a length of 80,
+     * giving 80. The engine draws 90, so this asserts BOTH the number and that
+     * it is not the other one.
+     */
+    const outer = usedCornerRadii(declare({ topLeft: "100px" }), BOX);
+    expect(outer.topLeft).toEqual({ x: 100, y: 100 });
+
+    const border = { top: 10, right: 10, bottom: 10, left: 10 };
+    const inner = insetCornerRadii(outer, border);
+    expect(inner.topLeft).toEqual({ x: 90, y: 90 });
+
+    const otherOrder = usedCornerRadii(declare({ topLeft: "90px" }), {
+      width: BOX.width - 20,
+      height: BOX.height - 20,
+    });
+    expect(otherOrder.topLeft.y).toBeCloseTo(80, 6);
+    expect(inner.topLeft.y).not.toBeCloseTo(otherOrder.topLeft.y, 6);
+  });
+});
+
+describe("moving radii into rendered pixels", () => {
+  it("scales each half-axis by its own axis", () => {
+    const scaled = scaleCornerRadii(usedCornerRadii(declare("10px"), BOX), {
+      x: 2,
+      y: 0.5,
+    });
+    // `scale(2, 0.5)` is one legal value, and a single factor would be right on
+    // one axis and wrong on the other.
+    expect(scaled.topLeft).toEqual({ x: 20, y: 5 });
+  });
+});
+
+describe("whether a box has any curve at all", () => {
+  it("calls a box with no radius square", () => {
+    expect(isSquare(SQUARE_CORNERS)).toBe(true);
+  });
+
+  it("calls a corner with a zero half-axis square", () => {
+    // `border-radius: 40px / 0` draws a right angle: an ellipse with a zero
+    // half-axis has no interior. Reading only `x` would call this curved and
+    // send every consumer on to divide by `y`.
+    const radii: CornerRadii = {
+      ...SQUARE_CORNERS,
+      topLeft: { x: 40, y: 0 },
+    };
+    expect(isSquare(radii)).toBe(true);
+  });
+
+  it("calls one genuinely curved corner enough", () => {
+    const radii: CornerRadii = {
+      ...SQUARE_CORNERS,
+      bottomLeft: { x: 1, y: 1 },
+    };
+    expect(isSquare(radii)).toBe(false);
+  });
+});
+
+/** A clip rectangle away from the origin, for the same reason `BOX` is not square. */
+const CLIP = { top: 100, right: 500, bottom: 300, left: 200 };
+
+/** Every corner curved, and the two axes different so a transposition shows. */
+const CURVED: CornerRadii = {
+  topLeft: { x: 60, y: 40 },
+  topRight: { x: 60, y: 40 },
+  bottomRight: { x: 60, y: 40 },
+  bottomLeft: { x: 60, y: 40 },
+};
+
+describe("whether a rectangle fits inside a rounded one", () => {
+  it("accepts a box clear of every corner", () => {
+    const box = { top: 160, right: 400, bottom: 240, left: 300 };
+    expect(boundsInsideRounded(box, CLIP, CURVED, 0.5)).toBe(true);
+  });
+
+  it("rejects a box that pokes through the arc", () => {
+    // Top-left arc centre is (260, 140). The box corner at (210, 110) sits
+    // (50, 30) inside it: (50/60)^2 + (30/40)^2 = 1.26, which is outside.
+    const box = { top: 110, right: 400, bottom: 240, left: 210 };
+    expect(boundsInsideRounded(box, CLIP, CURVED, 0.5)).toBe(false);
+  });
+
+  it("accepts a box INSIDE the corner's square but inside its arc too", () => {
+    /*
+     * The separating case. This box reaches into the top-left corner's quarter
+     * on both axes, so an implementation that refused anything entering that
+     * quarter would reject it — and it is nonetheless entirely within the curve.
+     *
+     * Both halves are asserted, so a change that widens the refusal fails here
+     * rather than passing quietly.
+     */
+    const box = { top: 125, right: 400, bottom: 240, left: 220 };
+    expect(box.left).toBeLessThan(CLIP.left + CURVED.topLeft.x);
+    expect(box.top).toBeLessThan(CLIP.top + CURVED.topLeft.y);
+
+    const dx = CLIP.left + CURVED.topLeft.x - box.left;
+    const dy = CLIP.top + CURVED.topLeft.y - box.top;
+    expect(
+      (dx / CURVED.topLeft.x) ** 2 + (dy / CURVED.topLeft.y) ** 2
+    ).toBeLessThan(1);
+
+    expect(boundsInsideRounded(box, CLIP, CURVED, 0.5)).toBe(true);
+  });
+
+  it("tests each corner independently", () => {
+    /*
+     * One case per corner, each poking through only that one. A copy-paste slip
+     * that measured the same corner four times passes any single-corner test.
+     */
+    const inset = 6;
+    const corners = {
+      topLeft: { top: 106, right: 400, bottom: 240, left: 206 },
+      topRight: { top: 106, right: 494, bottom: 240, left: 300 },
+      bottomRight: { top: 160, right: 494, bottom: 294, left: 300 },
+      bottomLeft: { top: 160, right: 400, bottom: 294, left: 206 },
+    };
+    expect(inset).toBe(6);
+    for (const [name, box] of Object.entries(corners)) {
+      expect([name, boundsInsideRounded(box, CLIP, CURVED, 0.5)]).toEqual([
+        name,
+        false,
+      ]);
+    }
+  });
+
+  it("accepts everything when the corners are square", () => {
+    const flush = { top: 100, right: 500, bottom: 300, left: 200 };
+    expect(boundsInsideRounded(flush, CLIP, SQUARE_CORNERS, 0.5)).toBe(true);
+  });
+
+  it("forgives an overhang past the ARC no bigger than the slack", () => {
+    /*
+     * Two fractional measurements disagreeing by a third of a pixel is rounding,
+     * not a block being cut.
+     *
+     * The corners must be CURVED for this to reach the slack at all: on a square
+     * corner the arc test returns before it is consulted, so a fixture built on
+     * `SQUARE_CORNERS` passes whether the slack is applied or not.
+     *
+     * The box starts on the top-left arc — 45° along it, at (217.574, 111.716) —
+     * and is pushed 0.3px deeper on both axes, which is past the curve by less
+     * than the half-pixel allowance.
+     */
+    const grazing = { top: 111.416, right: 400, bottom: 240, left: 217.274 };
+    expect(boundsInsideRounded(grazing, CLIP, CURVED, 0.5)).toBe(true);
+    // The separating half: with no allowance the same box IS outside the curve,
+    // so the acceptance above is the slack's doing and not the box's.
+    expect(boundsInsideRounded(grazing, CLIP, CURVED, 0)).toBe(false);
+  });
+});
+
+describe("stating the shape as a clip", () => {
+  it("measures each inset from the band to the shape", () => {
+    const band = { x: 10, y: 20, width: 100, height: 40 };
+    const shape = { x: 20, y: 25, width: 70, height: 20 };
+    expect(roundedInsetOf(band, shape, SQUARE_CORNERS)).toEqual({
+      top: 5,
+      left: 10,
+      right: 20,
+      bottom: 15,
+      radii: SQUARE_CORNERS,
+    });
+  });
+
+  it("writes the horizontal radii before the vertical ones", () => {
+    /*
+     * The two lists are easy to transpose and impossible to notice once
+     * transposed, because they differ only on an elliptical corner — so the
+     * fixture makes every corner elliptical and every corner distinct.
+     */
+    const radii: CornerRadii = {
+      topLeft: { x: 1, y: 5 },
+      topRight: { x: 2, y: 6 },
+      bottomRight: { x: 3, y: 7 },
+      bottomLeft: { x: 4, y: 8 },
+    };
+    expect(clipPathOf({ top: 0, right: 0, bottom: 0, left: 0, radii })).toBe(
+      "inset(0px 0px 0px 0px round 1px 2px 3px 4px / 5px 6px 7px 8px)"
+    );
+  });
+
+  it("writes the edges in the order CSS reads them", () => {
+    const value = clipPathOf({
+      top: 1,
+      right: 2,
+      bottom: 3,
+      left: 4,
+      radii: SQUARE_CORNERS,
+    });
+    expect(value.startsWith("inset(1px 2px 3px 4px round")).toBe(true);
+  });
+});

--- a/packages/builder/src/border-radii.ts
+++ b/packages/builder/src/border-radii.ts
@@ -1,0 +1,390 @@
+/**
+ * The used corner radii of a CSS box, as arithmetic over plain numbers.
+ *
+ * A rounded box is not the rectangle `getBoundingClientRect` reports for it, and
+ * two things in this package care. The spacing overlay paints bands inside the
+ * padding box, which on a rounded block curves away from the rectangle those
+ * bands are cut from; and an ancestor that clips its overflow clips on that same
+ * curve, so a child sitting inside all four of its padding edges can still be
+ * visibly cut at a corner.
+ *
+ * Both need the USED radii, and reaching them from the computed value is three
+ * steps that do not commute:
+ *
+ * 1. **Resolve.** A percentage stays a percentage in the computed value —
+ *    `border-radius: 50%` computes as `"50%"` — and resolves against the border
+ *    box, horizontally against its width and vertically against its height. A
+ *    corner serializes as TWO values when it is elliptical (`"10px 30px"`) and
+ *    one when it is not, and both forms occur.
+ * 2. **Reduce.** CSS Backgrounds §5.5 shrinks every radius by a single factor
+ *    when any side's two radii would overlap: `f = min(Lᵢ / Sᵢ)` over the four
+ *    sides, where `Lᵢ` is the side's length and `Sᵢ` the sum of the two radii
+ *    meeting it, applied to all eight radii when it comes out below one. The
+ *    engine does not do this in the computed value — `border-radius: 200px` on a
+ *    200×100 box still computes as `200px` while it renders as 50 — so a reader
+ *    that trusts the computed value describes a corner four times the size of
+ *    the one on screen. ONE factor for the whole box, not one per corner:
+ *    measured, a 200×100 box with only `border-top-left-radius: 200px` draws
+ *    that corner at 100, which is the box's own height constraining it through
+ *    the shared factor.
+ * 3. **Inset.** The padding box's radius is the border box's less that corner's
+ *    two border widths, floored at zero — and NOT reduced a second time, even
+ *    when the result no longer fits the padding box. Measured on a 200×100 box
+ *    with `border-top-left-radius: 100px` and a 10px border: the inner curve is
+ *    90, while the padding box is only 80 tall, and the engine draws the 90.
+ *
+ * Reducing after insetting gives different numbers than insetting after
+ * reducing, and the order above is the one CSS specifies — the same box
+ * separates them, since insetting first and then reducing against the 180×80
+ * padding box would give 80 where the engine draws 90.
+ *
+ * Kept away from the DOM for the reason `spacing-bands.ts` gives about itself:
+ * jsdom lays nothing out and reports every element as zero-sized, so a rule
+ * written against live elements can only be exercised in a browser, while the
+ * same rule written against numbers can be exercised anywhere.
+ *
+ * @module border-radii
+ */
+
+import type { EdgeLengths, Rect, Scale } from "./geometry";
+
+/**
+ * One corner, as its two half-axes.
+ *
+ * Always a pair, never a single number: `border-radius: 10px / 30px` is one
+ * declaration and an elliptical corner is what most `border-radius: 50%` boxes
+ * actually have, since a non-square box resolves the two percentages against
+ * different lengths.
+ */
+export interface CornerRadius {
+  /** The half-axis along the box's width. */
+  readonly x: number;
+  /** The half-axis along the box's height. */
+  readonly y: number;
+}
+
+/** The four corners, in the order the `border-radius` shorthand writes them. */
+export interface CornerRadii {
+  readonly topLeft: CornerRadius;
+  readonly topRight: CornerRadius;
+  readonly bottomRight: CornerRadius;
+  readonly bottomLeft: CornerRadius;
+}
+
+/**
+ * The four computed `border-*-radius` values, exactly as a computed style
+ * reports them.
+ *
+ * Strings rather than numbers because that is the whole of what the DOM offers,
+ * and resolving them needs the box they were declared on — which the reader has
+ * and the parser would otherwise have to be told twice.
+ */
+export interface DeclaredRadii {
+  readonly topLeft: string;
+  readonly topRight: string;
+  readonly bottomRight: string;
+  readonly bottomLeft: string;
+}
+
+/** A corner with no curve at all. */
+const SQUARE: CornerRadius = { x: 0, y: 0 };
+
+/** The radii of a box with no `border-radius`, which is nearly every box. */
+export const SQUARE_CORNERS: CornerRadii = {
+  topLeft: SQUARE,
+  topRight: SQUARE,
+  bottomRight: SQUARE,
+  bottomLeft: SQUARE,
+};
+
+/** The four corners by name, in the order the shorthand writes them. */
+const CORNERS = [
+  "topLeft",
+  "topRight",
+  "bottomRight",
+  "bottomLeft",
+] as const satisfies readonly (keyof CornerRadii)[];
+
+/**
+ * Whether every corner is square, so no consumer needs to clip anything.
+ *
+ * A corner is square when EITHER half-axis is zero, not only when both are.
+ * `border-radius: 40px / 0` is a legal declaration and draws a right angle: an
+ * ellipse with a zero half-axis has no interior, so the corner it cuts away is
+ * empty. Reading only one axis calls that corner curved and sends every consumer
+ * on to divide by the other.
+ */
+export function isSquare(radii: CornerRadii): boolean {
+  return CORNERS.every(corner => radii[corner].x <= 0 || radii[corner].y <= 0);
+}
+
+/** The size of the box a radius is resolved against. */
+interface BoxSize {
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
+ * One computed `<length-percentage>` against the length it is a fraction of.
+ *
+ * Anything unparseable answers zero rather than propagating a `NaN`, which would
+ * poison every comparison downstream into silently answering false.
+ */
+function lengthAgainst(token: string, basis: number): number {
+  const parsed = Number.parseFloat(token);
+  if (!Number.isFinite(parsed)) return 0;
+  const length = token.endsWith("%") ? (parsed / 100) * basis : parsed;
+  // A negative radius is invalid CSS and never computes, but the floor costs
+  // nothing and keeps a hand-built input from producing an inverted corner.
+  return Math.max(0, length);
+}
+
+/**
+ * One corner's computed value, which is one token or two.
+ *
+ * With a single token the SAME token resolves twice, once against each axis —
+ * so `50%` is half the width horizontally and half the height vertically, and
+ * only a length comes out equal on both.
+ */
+function parseCorner(value: string, box: BoxSize): CornerRadius {
+  const tokens = value.trim().split(/\s+/);
+  const horizontal = tokens[0] ?? "0";
+  const vertical = tokens[1] ?? horizontal;
+  return {
+    x: lengthAgainst(horizontal, box.width),
+    y: lengthAgainst(vertical, box.height),
+  };
+}
+
+/**
+ * The factor CSS Backgrounds §5.5 shrinks every radius by when two meeting on
+ * one side would together be longer than it.
+ *
+ * One factor for the whole box rather than one per side, which is what keeps the
+ * corners consistent with each other: reducing only the offending side would
+ * leave the two ends of an adjacent side scaled differently and the curve would
+ * no longer meet the edge.
+ *
+ * A side with no curve on it contributes nothing — `Lᵢ / 0` is infinite, and a
+ * box whose radii are all zero would otherwise reduce by `Infinity`.
+ */
+function reductionFactor(radii: CornerRadii, box: BoxSize): number {
+  const sides = [
+    { length: box.width, sum: radii.topLeft.x + radii.topRight.x },
+    { length: box.height, sum: radii.topRight.y + radii.bottomRight.y },
+    { length: box.width, sum: radii.bottomRight.x + radii.bottomLeft.x },
+    { length: box.height, sum: radii.bottomLeft.y + radii.topLeft.y },
+  ];
+  let factor = 1;
+  for (const { length, sum } of sides) {
+    if (sum > 0) factor = Math.min(factor, length / sum);
+  }
+  return factor;
+}
+
+/** Every radius multiplied by one factor, per axis. */
+function mapCorners(
+  radii: CornerRadii,
+  by: (corner: CornerRadius) => CornerRadius
+): CornerRadii {
+  return {
+    topLeft: by(radii.topLeft),
+    topRight: by(radii.topRight),
+    bottomRight: by(radii.bottomRight),
+    bottomLeft: by(radii.bottomLeft),
+  };
+}
+
+/**
+ * The border box's used radii: resolved against it, then reduced to fit it.
+ *
+ * `box` is the BORDER box, in the same units the declarations are in — unscaled
+ * CSS pixels. Handing it a post-transform rectangle resolves every percentage
+ * against the rendered size, which is right only while the scale is one.
+ */
+export function usedCornerRadii(
+  declared: DeclaredRadii,
+  box: BoxSize
+): CornerRadii {
+  const resolved: CornerRadii = {
+    topLeft: parseCorner(declared.topLeft, box),
+    topRight: parseCorner(declared.topRight, box),
+    bottomRight: parseCorner(declared.bottomRight, box),
+    bottomLeft: parseCorner(declared.bottomLeft, box),
+  };
+  const factor = reductionFactor(resolved, box);
+  if (factor >= 1) return resolved;
+  return mapCorners(resolved, corner => ({
+    x: corner.x * factor,
+    y: corner.y * factor,
+  }));
+}
+
+/**
+ * The padding box's radii, given the border box's.
+ *
+ * Each half-axis loses the border width it runs alongside — the horizontal one
+ * the left or right border, the vertical one the top or bottom — and a border
+ * thicker than the curve squares the corner off rather than inverting it.
+ */
+export function insetCornerRadii(
+  radii: CornerRadii,
+  borders: EdgeLengths
+): CornerRadii {
+  const shrink = (value: number, by: number): number => Math.max(0, value - by);
+  return {
+    topLeft: {
+      x: shrink(radii.topLeft.x, borders.left),
+      y: shrink(radii.topLeft.y, borders.top),
+    },
+    topRight: {
+      x: shrink(radii.topRight.x, borders.right),
+      y: shrink(radii.topRight.y, borders.top),
+    },
+    bottomRight: {
+      x: shrink(radii.bottomRight.x, borders.right),
+      y: shrink(radii.bottomRight.y, borders.bottom),
+    },
+    bottomLeft: {
+      x: shrink(radii.bottomLeft.x, borders.left),
+      y: shrink(radii.bottomLeft.y, borders.bottom),
+    },
+  };
+}
+
+/**
+ * Radii moved from layout pixels into the rendered pixels a transform draws
+ * them at.
+ *
+ * Per-axis for the reason every other scale here is: `scale(2, 0.5)` is a single
+ * legal value, and one factor would be right on one axis and wrong on the other.
+ */
+export function scaleCornerRadii(
+  radii: CornerRadii,
+  scale: Scale
+): CornerRadii {
+  return mapCorners(radii, corner => ({
+    x: corner.x * scale.x,
+    y: corner.y * scale.y,
+  }));
+}
+
+/** A rectangle given by its four edge COORDINATES rather than an origin and a size. */
+export interface EdgeBounds {
+  readonly top: number;
+  readonly right: number;
+  readonly bottom: number;
+  readonly left: number;
+}
+
+/**
+ * Whether a point reaching `dx` past a corner's horizontal centre and `dy` past
+ * its vertical one is still inside that corner's arc.
+ *
+ * The two depths are measured from the arc's CENTRE — the point one radius in
+ * along each axis — because that is where the ellipse is centred. A depth at or
+ * below zero means the box never reaches into the corner's quarter at all on
+ * that axis, which is the common case and the one that must not be mistaken for
+ * a violation.
+ */
+function insideArc(dx: number, dy: number, radius: CornerRadius): boolean {
+  if (radius.x <= 0 || radius.y <= 0) return true;
+  if (dx <= 0 || dy <= 0) return true;
+  const nx = dx / radius.x;
+  const ny = dy / radius.y;
+  return nx * nx + ny * ny <= 1;
+}
+
+/**
+ * Whether a rectangle lies inside a ROUNDED one.
+ *
+ * The caller is expected to have compared the two rectangles first: this asks
+ * only the question the rectangular comparison cannot, which is whether a box
+ * inside all four straight edges still pokes through one of the four arcs.
+ *
+ * `slack` is subtracted from each depth rather than from the rectangles, so it
+ * means the same thing here as it does there — how far a box may overhang before
+ * the overhang is real rather than a rounding artefact of two fractional
+ * measurements.
+ */
+export function boundsInsideRounded(
+  box: EdgeBounds,
+  clip: EdgeBounds,
+  radii: CornerRadii,
+  slack: number
+): boolean {
+  const left = (radius: number): number =>
+    clip.left + radius - box.left - slack;
+  const right = (radius: number): number =>
+    box.right - (clip.right - radius) - slack;
+  const top = (radius: number): number => clip.top + radius - box.top - slack;
+  const bottom = (radius: number): number =>
+    box.bottom - (clip.bottom - radius) - slack;
+
+  return (
+    insideArc(left(radii.topLeft.x), top(radii.topLeft.y), radii.topLeft) &&
+    insideArc(right(radii.topRight.x), top(radii.topRight.y), radii.topRight) &&
+    insideArc(
+      right(radii.bottomRight.x),
+      bottom(radii.bottomRight.y),
+      radii.bottomRight
+    ) &&
+    insideArc(
+      left(radii.bottomLeft.x),
+      bottom(radii.bottomLeft.y),
+      radii.bottomLeft
+    )
+  );
+}
+
+/**
+ * A rounded rectangle expressed as insets from the rectangle it clips.
+ *
+ * The shape a band must be cut to is the block's rounded box, which is a
+ * different rectangle from the band — so it cannot be stated in the band's own
+ * terms without saying how far each of its edges is from the shape's. That is
+ * exactly the form `clip-path: inset()` takes, and stating it here rather than
+ * building the CSS keeps the arithmetic testable without a browser.
+ */
+export interface RoundedInset {
+  readonly top: number;
+  readonly right: number;
+  readonly bottom: number;
+  readonly left: number;
+  readonly radii: CornerRadii;
+}
+
+/** Where `shape` sits inside `clipped`, as one inset per edge. */
+export function roundedInsetOf(
+  clipped: Rect,
+  shape: Rect,
+  radii: CornerRadii
+): RoundedInset {
+  return {
+    top: shape.y - clipped.y,
+    left: shape.x - clipped.x,
+    right: clipped.x + clipped.width - (shape.x + shape.width),
+    bottom: clipped.y + clipped.height - (shape.y + shape.height),
+    radii,
+  };
+}
+
+/**
+ * A rounded inset as the `clip-path` value that cuts a band's fill to it.
+ *
+ * Built here rather than at the call site so the shape and its CSS spelling stay
+ * in one module: the two radius lists are written horizontal-then-vertical
+ * across a solidus, an order that is easy to transpose and impossible to notice
+ * once transposed, since it is wrong only on an elliptical corner.
+ */
+export function clipPathOf(inset: RoundedInset): string {
+  const px = (value: number): string =>
+    `${String(Math.round(value * 100) / 100)}px`;
+  const corners = CORNERS.map(corner => inset.radii[corner]);
+  const horizontal = corners.map(corner => px(corner.x)).join(" ");
+  const vertical = corners.map(corner => px(corner.y)).join(" ");
+  const edges = [inset.top, inset.right, inset.bottom, inset.left]
+    .map(px)
+    .join(" ");
+  return `inset(${edges} round ${horizontal} / ${vertical})`;
+}

--- a/packages/builder/src/border-radii.ts
+++ b/packages/builder/src/border-radii.ts
@@ -321,16 +321,54 @@ function insideArc(dx: number, dy: number, radius: CornerRadius): boolean {
 }
 
 /**
- * How finely each corner arc is sampled when the INNER shape is itself rounded.
+ * The most samples one corner arc is ever cut into.
  *
- * A rounded child's extreme point in a corner is not its box corner — it is a
- * point on its own arc — so the two curves have to be compared along their
- * length rather than at one point. Sixty-four steps over a quarter turn leaves
- * the sampled chord within `r * (1 - cos(pi / 256))` of the true arc, which is
- * 0.08px on a 1000px radius. See `samplingBound`, which takes that off the
- * caller's allowance so the approximation can only ever refuse too much.
+ * A rounded inner shape's extreme point in a corner is not its box corner — it
+ * is a point on its own arc — so the two curves have to be compared along their
+ * length rather than at one point, and the comparison is only as good as the
+ * chord between samples.
+ *
+ * The count is DERIVED from the radius rather than fixed, because a fixed one is
+ * wrong at both ends: it wastes several dozen evaluations on a four-pixel corner
+ * and runs out of precision on a large one. A fixed sixty-four exceeds a
+ * half-pixel allowance somewhere above a 6,600px rendered half-axis — reachable
+ * on a large box, and more easily under an ancestor `scale`, where the allowance
+ * would go NEGATIVE and refuse two identical flush rectangles.
+ *
+ * The cap bounds the cost. At this many samples the chord stays within a quarter
+ * pixel of the arc out to a radius of some 210,000px, which no layout reaches;
+ * past it, `roundedInsideRounded` refuses rather than answering to a precision it
+ * cannot deliver.
  */
-const ARC_SAMPLES = 64;
+const MAX_ARC_SAMPLES = 512;
+
+/** The fewest, for a corner so small the chord is already the arc. */
+const MIN_ARC_SAMPLES = 4;
+
+/**
+ * How far a sampled chord can fall short of the arc it stands in for.
+ *
+ * The worst case sits half a step along, at `r * (1 - cos(theta / 2))` for a step
+ * of `theta`. Taken off the caller's allowance rather than ignored, so the
+ * approximation spends the slack instead of exceeding it.
+ */
+function chordError(radius: number, samples: number): number {
+  return radius * (1 - Math.cos(Math.PI / (4 * samples)));
+}
+
+/**
+ * The fewest samples that keep {@link chordError} within `target`.
+ *
+ * Inverting the expression above: a step of `2 * acos(1 - target / radius)`
+ * lands exactly on the target, and a quarter turn needs that many of them.
+ */
+function arcSamplesFor(radius: number, target: number): number {
+  if (!(radius > 0) || !(target > 0)) return MIN_ARC_SAMPLES;
+  const step = 2 * Math.acos(Math.max(-1, 1 - target / radius));
+  if (!(step > 0)) return MAX_ARC_SAMPLES;
+  const needed = Math.ceil(Math.PI / 2 / step);
+  return Math.min(MAX_ARC_SAMPLES, Math.max(MIN_ARC_SAMPLES, needed));
+}
 
 /** Which side of the box each corner sits on: -1 is left or top, 1 right or bottom. */
 const CORNER_SIGNS = {
@@ -340,13 +378,13 @@ const CORNER_SIGNS = {
   bottomLeft: { x: -1, y: 1 },
 } as const satisfies Record<keyof CornerRadii, { x: -1 | 1; y: -1 | 1 }>;
 
-/** How far the sampled chords can fall short of the arcs they stand in for. */
-function samplingBound(radii: CornerRadii): number {
+/** The largest half-axis anywhere on a shape, which is what bounds the error. */
+function largestRadius(radii: CornerRadii): number {
   let largest = 0;
   for (const corner of CORNERS) {
     largest = Math.max(largest, radii[corner].x, radii[corner].y);
   }
-  return largest * (1 - Math.cos(Math.PI / (4 * ARC_SAMPLES)));
+  return largest;
 }
 
 /**
@@ -364,7 +402,8 @@ function cornerInside(
   boxRadius: CornerRadius,
   clip: EdgeBounds,
   clipRadius: CornerRadius,
-  slack: number
+  slack: number,
+  samples: number
 ): boolean {
   // A square outer corner cuts nothing the straight-edge comparison has not
   // already answered.
@@ -373,7 +412,7 @@ function cornerInside(
   const sign = CORNER_SIGNS[corner];
   const centre = arcCentre(sign, box, own);
   const against = arcCentre(sign, clip, clipRadius);
-  const steps = own.x > 0 ? ARC_SAMPLES : 1;
+  const steps = own.x > 0 ? samples : 1;
   for (let step = 0; step < steps; step += 1) {
     const angle = (step / Math.max(1, steps - 1)) * (Math.PI / 2);
     const px = centre.x + sign.x * own.x * Math.cos(angle);
@@ -428,7 +467,23 @@ export function roundedInsideRounded(
   clipRadii: CornerRadii,
   slack: number
 ): boolean {
-  const allowance = slack - samplingBound(boxRadii);
+  const largest = largestRadius(boxRadii);
+  /*
+   * Half the allowance is spent on the approximation and half kept for the
+   * fractional measurements the slack exists for, so neither can consume the
+   * other.
+   */
+  const samples = arcSamplesFor(largest, slack / 2);
+  /*
+   * Past the cap the chords are further from the arcs than the whole allowance
+   * and this goes NEGATIVE, which is deliberate rather than a case to guard.
+   * A negative allowance makes every depth larger, so the comparison tightens
+   * instead of loosening: a shape sitting on the curve is refused while one
+   * comfortably inside is still accepted, which is exactly the right way to
+   * degrade. An explicit refusal here would throw away the second answer as
+   * well, and the arithmetic already delivers the first.
+   */
+  const allowance = slack - chordError(largest, samples);
   return CORNERS.every(corner =>
     cornerInside(
       corner,
@@ -436,7 +491,8 @@ export function roundedInsideRounded(
       boxRadii[corner],
       clip,
       clipRadii[corner],
-      allowance
+      allowance,
+      samples
     )
   );
 }

--- a/packages/builder/src/border-radii.ts
+++ b/packages/builder/src/border-radii.ts
@@ -127,12 +127,27 @@ interface BoxSize {
 /**
  * One computed `<length-percentage>` against the length it is a fraction of.
  *
- * Anything unparseable answers zero rather than propagating a `NaN`, which would
- * poison every comparison downstream into silently answering false.
+ * Answers UNDEFINED rather than zero for anything it cannot read, and the
+ * difference is the whole point: zero means a square corner, and a value this
+ * cannot resolve is a corner of UNKNOWN shape. Reading the second as the first
+ * is what makes a rounded block draw square bands.
+ *
+ * It is reachable. A percentage inside a math function stays unresolved in the
+ * computed value because it still depends on the box — measured, `border-radius:
+ * calc(10% + 5px)` computes as `"calc(10% + 5px)"` while `calc(10px + 5px)`
+ * computes as `"15px"` — and the catalog accepts a `calc()` length.
+ *
+ * An EMPTY value is the one unreadable case that is not unknown. A computed
+ * style never reports a supported longhand as blank, so a blank one means the
+ * engine has no such property — and an engine with no `border-radius` draws a
+ * square corner, which is exactly what zero says. Treating it as unknown instead
+ * would refuse every block in any renderer that does not implement the
+ * property, jsdom included.
  */
-function lengthAgainst(token: string, basis: number): number {
+function lengthAgainst(token: string, basis: number): number | undefined {
+  if (token === "") return 0;
   const parsed = Number.parseFloat(token);
-  if (!Number.isFinite(parsed)) return 0;
+  if (!Number.isFinite(parsed)) return undefined;
   const length = token.endsWith("%") ? (parsed / 100) * basis : parsed;
   // A negative radius is invalid CSS and never computes, but the floor costs
   // nothing and keeps a hand-built input from producing an inverted corner.
@@ -146,14 +161,14 @@ function lengthAgainst(token: string, basis: number): number {
  * so `50%` is half the width horizontally and half the height vertically, and
  * only a length comes out equal on both.
  */
-function parseCorner(value: string, box: BoxSize): CornerRadius {
+function parseCorner(value: string, box: BoxSize): CornerRadius | undefined {
   const tokens = value.trim().split(/\s+/);
   const horizontal = tokens[0] ?? "0";
   const vertical = tokens[1] ?? horizontal;
-  return {
-    x: lengthAgainst(horizontal, box.width),
-    y: lengthAgainst(vertical, box.height),
-  };
+  const x = lengthAgainst(horizontal, box.width);
+  const y = lengthAgainst(vertical, box.height);
+  if (x === undefined || y === undefined) return undefined;
+  return { x, y };
 }
 
 /**
@@ -201,17 +216,27 @@ function mapCorners(
  * `box` is the BORDER box, in the same units the declarations are in — unscaled
  * CSS pixels. Handing it a post-transform rectangle resolves every percentage
  * against the rendered size, which is right only while the scale is one.
+ *
+ * UNDEFINED when any corner cannot be resolved, which callers are expected to
+ * treat as a shape they cannot describe rather than as a square one.
  */
 export function usedCornerRadii(
   declared: DeclaredRadii,
   box: BoxSize
-): CornerRadii {
-  const resolved: CornerRadii = {
-    topLeft: parseCorner(declared.topLeft, box),
-    topRight: parseCorner(declared.topRight, box),
-    bottomRight: parseCorner(declared.bottomRight, box),
-    bottomLeft: parseCorner(declared.bottomLeft, box),
-  };
+): CornerRadii | undefined {
+  const topLeft = parseCorner(declared.topLeft, box);
+  const topRight = parseCorner(declared.topRight, box);
+  const bottomRight = parseCorner(declared.bottomRight, box);
+  const bottomLeft = parseCorner(declared.bottomLeft, box);
+  if (
+    topLeft === undefined ||
+    topRight === undefined ||
+    bottomRight === undefined ||
+    bottomLeft === undefined
+  ) {
+    return undefined;
+  }
+  const resolved: CornerRadii = { topLeft, topRight, bottomRight, bottomLeft };
   const factor = reductionFactor(resolved, box);
   if (factor >= 1) return resolved;
   return mapCorners(resolved, corner => ({
@@ -296,95 +321,196 @@ function insideArc(dx: number, dy: number, radius: CornerRadius): boolean {
 }
 
 /**
- * Whether a rectangle lies inside a ROUNDED one.
+ * How finely each corner arc is sampled when the INNER shape is itself rounded.
  *
- * The caller is expected to have compared the two rectangles first: this asks
- * only the question the rectangular comparison cannot, which is whether a box
- * inside all four straight edges still pokes through one of the four arcs.
- *
- * `slack` is subtracted from each depth rather than from the rectangles, so it
- * means the same thing here as it does there — how far a box may overhang before
- * the overhang is real rather than a rounding artefact of two fractional
- * measurements.
+ * A rounded child's extreme point in a corner is not its box corner — it is a
+ * point on its own arc — so the two curves have to be compared along their
+ * length rather than at one point. Sixty-four steps over a quarter turn leaves
+ * the sampled chord within `r * (1 - cos(pi / 256))` of the true arc, which is
+ * 0.08px on a 1000px radius. See `samplingBound`, which takes that off the
+ * caller's allowance so the approximation can only ever refuse too much.
  */
-export function boundsInsideRounded(
+const ARC_SAMPLES = 64;
+
+/** Which side of the box each corner sits on: -1 is left or top, 1 right or bottom. */
+const CORNER_SIGNS = {
+  topLeft: { x: -1, y: -1 },
+  topRight: { x: 1, y: -1 },
+  bottomRight: { x: 1, y: 1 },
+  bottomLeft: { x: -1, y: 1 },
+} as const satisfies Record<keyof CornerRadii, { x: -1 | 1; y: -1 | 1 }>;
+
+/** How far the sampled chords can fall short of the arcs they stand in for. */
+function samplingBound(radii: CornerRadii): number {
+  let largest = 0;
+  for (const corner of CORNERS) {
+    largest = Math.max(largest, radii[corner].x, radii[corner].y);
+  }
+  return largest * (1 - Math.cos(Math.PI / (4 * ARC_SAMPLES)));
+}
+
+/**
+ * Whether one corner of the inner shape stays inside the matching corner of the
+ * outer one.
+ *
+ * A corner with a zero half-axis is square on BOTH axes — an ellipse with no
+ * interior cuts nothing — so its radii are zeroed together before sampling
+ * rather than one at a time, which would otherwise put the sampled point a
+ * radius away from the box corner it should be at.
+ */
+function cornerInside(
+  corner: keyof CornerRadii,
   box: EdgeBounds,
+  boxRadius: CornerRadius,
   clip: EdgeBounds,
-  radii: CornerRadii,
+  clipRadius: CornerRadius,
   slack: number
 ): boolean {
-  const left = (radius: number): number =>
-    clip.left + radius - box.left - slack;
-  const right = (radius: number): number =>
-    box.right - (clip.right - radius) - slack;
-  const top = (radius: number): number => clip.top + radius - box.top - slack;
-  const bottom = (radius: number): number =>
-    box.bottom - (clip.bottom - radius) - slack;
+  // A square outer corner cuts nothing the straight-edge comparison has not
+  // already answered.
+  if (clipRadius.x <= 0 || clipRadius.y <= 0) return true;
+  const own = boxRadius.x > 0 && boxRadius.y > 0 ? boxRadius : SQUARE;
+  const sign = CORNER_SIGNS[corner];
+  const centre = arcCentre(sign, box, own);
+  const against = arcCentre(sign, clip, clipRadius);
+  const steps = own.x > 0 ? ARC_SAMPLES : 1;
+  for (let step = 0; step < steps; step += 1) {
+    const angle = (step / Math.max(1, steps - 1)) * (Math.PI / 2);
+    const px = centre.x + sign.x * own.x * Math.cos(angle);
+    const py = centre.y + sign.y * own.y * Math.sin(angle);
+    const dx = sign.x * (px - against.x) - slack;
+    const dy = sign.y * (py - against.y) - slack;
+    if (!insideArc(dx, dy, clipRadius)) return false;
+  }
+  return true;
+}
 
-  return (
-    insideArc(left(radii.topLeft.x), top(radii.topLeft.y), radii.topLeft) &&
-    insideArc(right(radii.topRight.x), top(radii.topRight.y), radii.topRight) &&
-    insideArc(
-      right(radii.bottomRight.x),
-      bottom(radii.bottomRight.y),
-      radii.bottomRight
-    ) &&
-    insideArc(
-      left(radii.bottomLeft.x),
-      bottom(radii.bottomLeft.y),
-      radii.bottomLeft
+/**
+ * Where a corner's arc is centred: one radius in along each axis from it.
+ *
+ * The same arithmetic for the inner shape and the outer one, which is the point
+ * — the two are compared in the same frame, and a sign written out twice is a
+ * sign that can be written differently twice.
+ */
+function arcCentre(
+  sign: { readonly x: -1 | 1; readonly y: -1 | 1 },
+  bounds: EdgeBounds,
+  radius: CornerRadius
+): { readonly x: number; readonly y: number } {
+  return {
+    x: sign.x < 0 ? bounds.left + radius.x : bounds.right - radius.x,
+    y: sign.y < 0 ? bounds.top + radius.y : bounds.bottom - radius.y,
+  };
+}
+
+/**
+ * Whether one rounded rectangle lies inside another.
+ *
+ * The caller is expected to have compared the two rectangles first: this asks
+ * only the question the rectangular comparison cannot, which is whether a shape
+ * inside all four straight edges still pokes through one of the four arcs.
+ *
+ * The INNER shape's own curve is part of the question, not a detail. A rounded
+ * block flush inside an equally rounded clipping container is not cut at all,
+ * while its bounding rectangle's corners lie outside every one of that
+ * container's arcs — so a test that reads only the rectangle refuses the
+ * ordinary nested rounded card and takes the whole overlay with it.
+ *
+ * `slack` means the same thing here as it does for the straight edges: how far a
+ * shape may overhang before the overhang is real rather than a rounding artefact
+ * of two fractional measurements. The sampling bound comes off it, so the
+ * approximation spends the allowance rather than exceeding it.
+ */
+export function roundedInsideRounded(
+  box: EdgeBounds,
+  boxRadii: CornerRadii,
+  clip: EdgeBounds,
+  clipRadii: CornerRadii,
+  slack: number
+): boolean {
+  const allowance = slack - samplingBound(boxRadii);
+  return CORNERS.every(corner =>
+    cornerInside(
+      corner,
+      box,
+      boxRadii[corner],
+      clip,
+      clipRadii[corner],
+      allowance
     )
   );
 }
 
 /**
- * A rounded rectangle expressed as insets from the rectangle it clips.
+ * A rounded rectangle in the coordinate space of the element it clips.
  *
  * The shape a band must be cut to is the block's rounded box, which is a
- * different rectangle from the band — so it cannot be stated in the band's own
- * terms without saying how far each of its edges is from the shape's. That is
- * exactly the form `clip-path: inset()` takes, and stating it here rather than
- * building the CSS keeps the arithmetic testable without a browser.
+ * different rectangle from the band — so it is stated relative to the band's own
+ * origin, which is what a `clip-path` is resolved against.
  */
-export interface RoundedInset {
-  readonly top: number;
-  readonly right: number;
-  readonly bottom: number;
-  readonly left: number;
+export interface RoundedShape {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
   readonly radii: CornerRadii;
 }
 
-/** Where `shape` sits inside `clipped`, as one inset per edge. */
-export function roundedInsetOf(
+/** Where `shape` sits inside `clipped`, in `clipped`'s own coordinates. */
+export function roundedShapeIn(
   clipped: Rect,
   shape: Rect,
   radii: CornerRadii
-): RoundedInset {
+): RoundedShape {
   return {
-    top: shape.y - clipped.y,
-    left: shape.x - clipped.x,
-    right: clipped.x + clipped.width - (shape.x + shape.width),
-    bottom: clipped.y + clipped.height - (shape.y + shape.height),
+    x: shape.x - clipped.x,
+    y: shape.y - clipped.y,
+    width: shape.width,
+    height: shape.height,
     radii,
   };
 }
 
 /**
- * A rounded inset as the `clip-path` value that cuts a band's fill to it.
+ * The shape as the `clip-path` value that cuts a band's fill to it.
  *
- * Built here rather than at the call site so the shape and its CSS spelling stay
- * in one module: the two radius lists are written horizontal-then-vertical
- * across a solidus, an order that is easy to transpose and impossible to notice
- * once transposed, since it is wrong only on an elliptical corner.
+ * A PATH rather than `inset(... round ...)`, and that is not a style choice.
+ * `inset()` resolves its radii the way `border-radius` does, which includes the
+ * overlap reduction against the inset rectangle — so a padding-box curve that
+ * legitimately exceeds its own box is silently shrunk by the browser and the
+ * clip stops following the element's real edge.
+ *
+ * That case is exactly the one this module documents: an outer corner of 100
+ * less a 10px border leaves an inner curve of 90 on a padding box only 80 tall,
+ * and the engine draws the 90. Measured — a 180x80 element under
+ * `inset(0 round 90px)` is cut at 80, so the two disagree wherever a border is
+ * thick enough to matter. A path states the arcs outright and is not
+ * renormalised.
+ *
+ * An arc with a zero radius is drawn as a straight line by the SVG path
+ * grammar, so a square corner needs no special case and every shape is written
+ * the same way.
  */
-export function clipPathOf(inset: RoundedInset): string {
-  const px = (value: number): string =>
-    `${String(Math.round(value * 100) / 100)}px`;
-  const corners = CORNERS.map(corner => inset.radii[corner]);
-  const horizontal = corners.map(corner => px(corner.x)).join(" ");
-  const vertical = corners.map(corner => px(corner.y)).join(" ");
-  const edges = [inset.top, inset.right, inset.bottom, inset.left]
-    .map(px)
-    .join(" ");
-  return `inset(${edges} round ${horizontal} / ${vertical})`;
+export function clipPathOf(shape: RoundedShape): string {
+  const n = (value: number): string => String(Math.round(value * 100) / 100);
+  const { radii } = shape;
+  const left = shape.x;
+  const top = shape.y;
+  const right = shape.x + shape.width;
+  const bottom = shape.y + shape.height;
+  const arc = (radius: CornerRadius, x: number, y: number): string =>
+    `A ${n(radius.x)} ${n(radius.y)} 0 0 1 ${n(x)} ${n(y)}`;
+  const steps = [
+    `M ${n(left + radii.topLeft.x)} ${n(top)}`,
+    `L ${n(right - radii.topRight.x)} ${n(top)}`,
+    arc(radii.topRight, right, top + radii.topRight.y),
+    `L ${n(right)} ${n(bottom - radii.bottomRight.y)}`,
+    arc(radii.bottomRight, right - radii.bottomRight.x, bottom),
+    `L ${n(left + radii.bottomLeft.x)} ${n(bottom)}`,
+    arc(radii.bottomLeft, left, bottom - radii.bottomLeft.y),
+    `L ${n(left)} ${n(top + radii.topLeft.y)}`,
+    arc(radii.topLeft, left + radii.topLeft.x, top),
+    "Z",
+  ];
+  return `path("${steps.join(" ")}")`;
 }

--- a/packages/builder/src/geometry-dom.test.ts
+++ b/packages/builder/src/geometry-dom.test.ts
@@ -23,6 +23,7 @@ import {
   frameInsetOf,
   canvasRootFrom,
   hasScrollbarGutter,
+  overflowApplies,
 } from "./geometry-dom";
 
 /**
@@ -309,4 +310,66 @@ describe("hasScrollbarGutter", () => {
 
     frame.remove();
   });
+});
+
+describe("whether overflow clips at all", () => {
+  /*
+   * MEASURED in Chromium across the catalog's display set, by giving each value
+   * `overflow: hidden` and a child pulled outside it with a negative margin,
+   * then reading the pixels.
+   *
+   * The negative margin matters: an OVERSIZED child makes a table box grow to
+   * fit, so "not clipped" would really mean "never overflowed" — which read as
+   * six false entries on the first pass.
+   */
+  it.each([
+    "inline",
+    "inline list-item",
+    "table-row",
+    "table-row-group",
+    "table-header-group",
+    "table-footer-group",
+    "ruby",
+    "ruby-text",
+    "contents",
+  ])("says a %s box takes no clip", display => {
+    expect(overflowApplies(display)).toBe(false);
+  });
+
+  it.each([
+    "block",
+    "inline-block",
+    "flow-root",
+    "list-item",
+    "flow-root list-item",
+    "flex",
+    "inline-flex",
+    "grid",
+    "inline-grid",
+    "table",
+    "inline-table",
+    "table-cell",
+    "table-column",
+    "table-column-group",
+    "table-caption",
+  ])("says a %s box does clip", display => {
+    /*
+     * The control half, and it carries the surprises: `table` and `table-cell`
+     * clip normally while the row boxes between them do not, so a rule written
+     * as "anything table-ish" would be wrong in both directions.
+     */
+    expect(overflowApplies(display)).toBe(true);
+  });
+
+  it.each(["ruby-base", "ruby-base-container", "ruby-text-container"])(
+    "does not carry an entry for %s, which never arrives",
+    display => {
+      /*
+       * All three compute to plain `block` in Chromium, so the computed value
+       * this is asked about is never the declared one. An entry for them would
+       * describe a value no element reports.
+       */
+      expect(overflowApplies(display)).toBe(true);
+    }
+  );
 });

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -20,6 +20,14 @@
  * @module geometry-dom
  */
 
+import type { EdgeBounds } from "./border-radii";
+import {
+  boundsInsideRounded,
+  insetCornerRadii,
+  isSquare,
+  scaleCornerRadii,
+  usedCornerRadii,
+} from "./border-radii";
 import type { FrameInset, Point, Rect } from "./geometry";
 
 /**
@@ -704,83 +712,198 @@ export function clippedByAncestor(element: Element, root: Element): boolean {
     node !== null && node !== root;
     node = node.parentElement
   ) {
-    const style = view.getComputedStyle(node);
-    /*
-     * PER AXIS, because the two can differ and the catalog ships the shorthand
-     * that makes them differ: `overflow` takes two values, so `clip visible` is
-     * a declaration an author can store. Measured in Chromium it is also the
-     * ONLY mixed pair that survives computation — pairing `visible` with
-     * `hidden`, `auto` or `scroll` resolves the `visible` side to `auto`, while
-     * `clip visible` stays exactly as written.
-     *
-     * Asking whether EITHER axis clips and then comparing all four edges
-     * refuses a block that overflows only the axis still rendering it, and a
-     * refusal costs every band on the block.
-     */
-    const clipsX = style.overflowX !== "visible";
-    const clipsY = style.overflowY !== "visible";
-    if (!clipsX && !clipsY) continue;
-    /*
-     * Overflow clips at the PADDING edge, and `getBoundingClientRect` reports the
-     * BORDER box. On a container with a border the two differ by its width, so a
-     * child pulled into the border by a negative margin or a transform is
-     * visibly cut while a border-box comparison reports it contained — measured,
-     * a 20px border puts the border box at 217 and the clip edge at 237.
-     */
-    const outer = node.getBoundingClientRect();
-    /*
-     * Scaled, because the two readings are in different units: `outer` is
-     * post-transform and a computed border width is unscaled CSS pixels. Under
-     * `scale(2)` a 20px border renders 40px thick, so insetting by 20 puts the
-     * clip edge half way through the border and accepts a child the container
-     * visibly cuts — measured, the real padding edge sat at 40 while this
-     * arithmetic answered 20 and a child at exactly 20 was let through.
-     */
-    const scale = renderedScale(node, root);
-    /*
-     * A clipping ancestor that is not axis-aligned is DECLINED rather than
-     * measured, because neither reading survives its transform: `a` and `d` are
-     * not scale factors once a rotation is present, and `getBoundingClientRect`
-     * answers with an axis-aligned BOUNDING box whose edges are not the clip
-     * edges at all. The real clip is a slanted rectangle sitting inside that
-     * box, so a child cut by it still reads as contained.
-     *
-     * It cannot be left to the caller's own describability check, which is what
-     * an earlier version of this assumed: a descendant carrying the INVERSE
-     * transform composes back to an axis-aligned matrix, so the block passes
-     * that check while this ancestor fails it. Measured — a block under
-     * `rotate(-30deg)` inside an ancestor under `rotate(30deg)` composes to
-     * `a=0.999999, b=0, c=0, d=0.999999` and is called describable, while its
-     * ancestor's own matrix carries `b=0.5, c=-0.5`; the block sat inside the
-     * ancestor's bounding box with a quarter of it beyond the clip.
-     *
-     * Refusing is deliberately broader than the defect: a block WHOLLY INSIDE a
-     * rotated clipping ancestor is not cut and loses its bands anyway. Deciding
-     * that needs the clip as an oriented rectangle, and drawing nothing is the
-     * same answer this module already gives for every other shape it cannot
-     * describe.
-     */
-    if (!scale.describable) return true;
-    const clip = {
-      top: outer.top + edgeWidth(style.borderTopWidth) * scale.y,
-      left: outer.left + edgeWidth(style.borderLeftWidth) * scale.x,
-      bottom: outer.bottom - edgeWidth(style.borderBottomWidth) * scale.y,
-      right: outer.right - edgeWidth(style.borderRightWidth) * scale.x,
-    };
-    // Half a pixel, because both rectangles are fractional and a block laid out
-    // flush against its container's edge is not clipped by rounding.
-    const slack = 0.5;
-    const cutVertically =
-      clipsY &&
-      (box.top < clip.top - slack || box.bottom > clip.bottom + slack);
-    const cutHorizontally =
-      clipsX &&
-      (box.left < clip.left - slack || box.right > clip.right + slack);
-    if (cutVertically || cutHorizontally) {
-      return true;
-    }
+    if (cutByAncestor(node, box, view, root)) return true;
   }
   return false;
+}
+
+/**
+ * Whether ONE ancestor cuts the block.
+ *
+ * Separated from the walk above so that each answers a single question: which
+ * elements to ask, and what the answer is for one of them. The decision needs
+ * four readings of that element and three independent reasons to refuse, and
+ * inlining it into the loop puts all of that inside a `for` whose own job is
+ * one line long.
+ */
+function cutByAncestor(
+  node: Element,
+  box: DOMRect,
+  view: Window,
+  root: Element
+): boolean {
+  const style = view.getComputedStyle(node);
+  /*
+   * PER AXIS, because the two can differ and the catalog ships the shorthand
+   * that makes them differ: `overflow` takes two values, so `clip visible` is
+   * a declaration an author can store. Measured in Chromium it is also the
+   * ONLY mixed pair that survives computation — pairing `visible` with
+   * `hidden`, `auto` or `scroll` resolves the `visible` side to `auto`, while
+   * `clip visible` stays exactly as written.
+   *
+   * Asking whether EITHER axis clips and then comparing all four edges
+   * refuses a block that overflows only the axis still rendering it, and a
+   * refusal costs every band on the block.
+   */
+  const clipsX = style.overflowX !== "visible";
+  const clipsY = style.overflowY !== "visible";
+  if (!clipsX && !clipsY) return false;
+  /*
+   * Overflow clips at the PADDING edge, and `getBoundingClientRect` reports the
+   * BORDER box. On a container with a border the two differ by its width, so a
+   * child pulled into the border by a negative margin or a transform is
+   * visibly cut while a border-box comparison reports it contained — measured,
+   * a 20px border puts the border box at 217 and the clip edge at 237.
+   */
+  const outer = node.getBoundingClientRect();
+  /*
+   * Scaled, because the two readings are in different units: `outer` is
+   * post-transform and a computed border width is unscaled CSS pixels. Under
+   * `scale(2)` a 20px border renders 40px thick, so insetting by 20 puts the
+   * clip edge half way through the border and accepts a child the container
+   * visibly cuts — measured, the real padding edge sat at 40 while this
+   * arithmetic answered 20 and a child at exactly 20 was let through.
+   */
+  const scale = renderedScale(node, root);
+  /*
+   * A clipping ancestor that is not axis-aligned is DECLINED rather than
+   * measured, because neither reading survives its transform: `a` and `d` are
+   * not scale factors once a rotation is present, and `getBoundingClientRect`
+   * answers with an axis-aligned BOUNDING box whose edges are not the clip
+   * edges at all. The real clip is a slanted rectangle sitting inside that
+   * box, so a child cut by it still reads as contained.
+   *
+   * It cannot be left to the caller's own describability check, which is what
+   * an earlier version of this assumed: a descendant carrying the INVERSE
+   * transform composes back to an axis-aligned matrix, so the block passes
+   * that check while this ancestor fails it. Measured — a block under
+   * `rotate(-30deg)` inside an ancestor under `rotate(30deg)` composes to
+   * `a=0.999999, b=0, c=0, d=0.999999` and is called describable, while its
+   * ancestor's own matrix carries `b=0.5, c=-0.5`; the block sat inside the
+   * ancestor's bounding box with a quarter of it beyond the clip.
+   *
+   * Refusing is deliberately broader than the defect: a block WHOLLY INSIDE a
+   * rotated clipping ancestor is not cut and loses its bands anyway. Deciding
+   * that needs the clip as an oriented rectangle, and drawing nothing is the
+   * same answer this module already gives for every other shape it cannot
+   * describe.
+   */
+  if (!scale.describable) return true;
+  const clip = clipEdges(outer, style, scale);
+  if (cutByEdges(box, clip, clipsX, clipsY)) return true;
+  return cutByCorner(box, clip, style, scale, clipsX && clipsY, CLIP_SLACK_PX);
+}
+
+/**
+ * How far a block may sit outside a clip edge before the overhang is real.
+ *
+ * Half a pixel, because both rectangles are fractional and a block laid out
+ * flush against its container's edge is not clipped by rounding.
+ */
+const CLIP_SLACK_PX = 0.5;
+
+/** The ancestor's PADDING edge, which is where overflow actually clips. */
+function clipEdges(
+  outer: DOMRect,
+  style: CSSStyleDeclaration,
+  scale: RenderedScale
+): EdgeBounds {
+  return {
+    top: outer.top + edgeWidth(style.borderTopWidth) * scale.y,
+    left: outer.left + edgeWidth(style.borderLeftWidth) * scale.x,
+    bottom: outer.bottom - edgeWidth(style.borderBottomWidth) * scale.y,
+    right: outer.right - edgeWidth(style.borderRightWidth) * scale.x,
+  };
+}
+
+/**
+ * Whether the block falls outside the clip RECTANGLE, on an axis that clips.
+ *
+ * Each axis is asked only where it clips: a block overflowing the axis that is
+ * still `visible` has its overflow rendered, and refusing it costs every band.
+ */
+function cutByEdges(
+  box: DOMRect,
+  clip: EdgeBounds,
+  clipsX: boolean,
+  clipsY: boolean
+): boolean {
+  const cutVertically =
+    clipsY &&
+    (box.top < clip.top - CLIP_SLACK_PX ||
+      box.bottom > clip.bottom + CLIP_SLACK_PX);
+  const cutHorizontally =
+    clipsX &&
+    (box.left < clip.left - CLIP_SLACK_PX ||
+      box.right > clip.right + CLIP_SLACK_PX);
+  return cutVertically || cutHorizontally;
+}
+
+/**
+ * Whether a rounded clipping ancestor cuts the block at one of its CORNERS.
+ *
+ * A container with `border-radius` and `overflow: hidden` clips on the curve,
+ * not on the rectangle: a child inside all four padding edges can still have a
+ * corner visibly removed, and the comparison above accepts it. That container is
+ * the ordinary card, so declining every rounded ancestor outright would blank
+ * the overlay for most blocks on a real page — the exact test is what keeps the
+ * refusal to the blocks that are genuinely cut.
+ *
+ * Asked only when BOTH axes clip, which is measured rather than assumed. With
+ * `overflow: clip visible` the clip region is unbounded on the visible axis, and
+ * a corner needs two bounds to exist — probed in Chromium, a child at the corner
+ * of a 60px-radius box under `overflow: clip visible` is painted in full, while
+ * the same child under `overflow: hidden` is cut away. Applying the arc there
+ * would refuse a block nothing removes.
+ *
+ * The radii come off the PADDING box, because that is where overflow clips and
+ * `border-radius` states the border box's curve.
+ */
+function cutByCorner(
+  box: DOMRect,
+  clip: EdgeBounds,
+  style: CSSStyleDeclaration,
+  scale: RenderedScale,
+  bothAxesClip: boolean,
+  slack: number
+): boolean {
+  if (!bothAxesClip) return false;
+  const outer = usedCornerRadii(
+    {
+      topLeft: style.borderTopLeftRadius,
+      topRight: style.borderTopRightRadius,
+      bottomRight: style.borderBottomRightRadius,
+      bottomLeft: style.borderBottomLeftRadius,
+    },
+    /*
+     * The ancestor's LAYOUT size, so a percentage resolves against what the
+     * author declared it against. `clip` is post-transform and inset to the
+     * padding edge, so it is divided back out by the scale and re-widened by the
+     * borders that were taken off it.
+     */
+    {
+      width: (clip.right - clip.left) / scale.x + borderSpan(style, "x"),
+      height: (clip.bottom - clip.top) / scale.y + borderSpan(style, "y"),
+    }
+  );
+  const inner = scaleCornerRadii(
+    insetCornerRadii(outer, {
+      top: edgeWidth(style.borderTopWidth),
+      right: edgeWidth(style.borderRightWidth),
+      bottom: edgeWidth(style.borderBottomWidth),
+      left: edgeWidth(style.borderLeftWidth),
+    }),
+    scale
+  );
+  if (isSquare(inner)) return false;
+  return !boundsInsideRounded(box, clip, inner, slack);
+}
+
+/** The two border widths an axis loses, in unscaled CSS pixels. */
+function borderSpan(style: CSSStyleDeclaration, axis: "x" | "y"): number {
+  return axis === "x"
+    ? edgeWidth(style.borderLeftWidth) + edgeWidth(style.borderRightWidth)
+    : edgeWidth(style.borderTopWidth) + edgeWidth(style.borderBottomWidth);
 }
 
 /**

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -696,6 +696,48 @@ export function hasScrollbarGutter(
  * that clipping applies to the bands and the page alike, so it produces no
  * mismatch; only a clip between the block and the root does.
  */
+/**
+ * Computed `display` values whose generated box `overflow` does not clip.
+ *
+ * MEASURED across the catalog's display set in Chromium rather than read off a
+ * spec table, by giving each value `overflow: hidden` and a child pulled outside
+ * it, then reading the pixels. The list is wider than the inline box people
+ * reach for first, and two of the entries are not guessable:
+ *
+ * - The internal TABLE boxes take no clip — a row, a row group, a header group
+ *   and a footer group all paint a child straight through the edge — while
+ *   `table`, `inline-table` and `table-cell` all clip normally.
+ * - `contents` generates no box at all, so nothing clips AND
+ *   `getBoundingClientRect` answers 0x0 on it. A caller that skipped this entry
+ *   would compare a descendant against a zero-sized rectangle and conclude every
+ *   block is outside it.
+ *
+ * `ruby-base`, `ruby-base-container` and `ruby-text-container` are deliberately
+ * ABSENT: all three compute to plain `block` in Chromium, so they clip and an
+ * entry for them would describe a value that never arrives.
+ *
+ * The measurement had to force overflow with a NEGATIVE MARGIN rather than an
+ * oversized child, because table boxes size to their content: a wide child makes
+ * them grow to fit, and "not clipped" then means "never overflowed" — which read
+ * as six false entries on the first pass.
+ */
+const OVERFLOW_NEVER_CLIPS: ReadonlySet<string> = new Set([
+  "inline",
+  "inline list-item",
+  "table-row",
+  "table-row-group",
+  "table-header-group",
+  "table-footer-group",
+  "ruby",
+  "ruby-text",
+  "contents",
+]);
+
+/** Whether `overflow` establishes a clip on a box with this computed display. */
+export function overflowApplies(display: string): boolean {
+  return !OVERFLOW_NEVER_CLIPS.has(display);
+}
+
 /** A computed border width in pixels, or zero when the browser reports no number. */
 function edgeWidth(value: string): number {
   const parsed = Number.parseFloat(value);
@@ -753,6 +795,14 @@ function cutByAncestor(
   const clipsX = style.overflowX !== "visible";
   const clipsY = style.overflowY !== "visible";
   if (!clipsX && !clipsY) return false;
+  /*
+   * A computed `overflow` is not the same as an overflow that CLIPS. The
+   * property does not apply to every generated box, and the computed value says
+   * nothing about that — so an author who writes `overflow: hidden` on an inline
+   * span gets the declaration in the computed style and no clip on the page.
+   * Reading the first as the second cuts a descendant nothing removes.
+   */
+  if (!overflowApplies(style.display)) return false;
   /*
    * Overflow clips at the PADDING edge, and `getBoundingClientRect` reports the
    * BORDER box. On a container with a border the two differ by its width, so a

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -20,11 +20,11 @@
  * @module geometry-dom
  */
 
-import type { EdgeBounds } from "./border-radii";
+import type { CornerRadii, EdgeBounds } from "./border-radii";
 import {
-  boundsInsideRounded,
   insetCornerRadii,
   isSquare,
+  roundedInsideRounded,
   scaleCornerRadii,
   usedCornerRadii,
 } from "./border-radii";
@@ -702,7 +702,11 @@ function edgeWidth(value: string): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-export function clippedByAncestor(element: Element, root: Element): boolean {
+export function clippedByAncestor(
+  element: Element,
+  root: Element,
+  radii: CornerRadii
+): boolean {
   const view = element.ownerDocument.defaultView;
   if (view === null) return false;
   const box = element.getBoundingClientRect();
@@ -712,7 +716,7 @@ export function clippedByAncestor(element: Element, root: Element): boolean {
     node !== null && node !== root;
     node = node.parentElement
   ) {
-    if (cutByAncestor(node, box, view, root)) return true;
+    if (cutByAncestor(node, box, radii, view, root)) return true;
   }
   return false;
 }
@@ -729,6 +733,7 @@ export function clippedByAncestor(element: Element, root: Element): boolean {
 function cutByAncestor(
   node: Element,
   box: DOMRect,
+  radii: CornerRadii,
   view: Window,
   root: Element
 ): boolean {
@@ -791,7 +796,15 @@ function cutByAncestor(
   if (!scale.describable) return true;
   const clip = clipEdges(outer, style, scale);
   if (cutByEdges(box, clip, clipsX, clipsY)) return true;
-  return cutByCorner(box, clip, style, scale, clipsX && clipsY, CLIP_SLACK_PX);
+  return cutByCorner(
+    box,
+    radii,
+    clip,
+    style,
+    scale,
+    clipsX && clipsY,
+    CLIP_SLACK_PX
+  );
 }
 
 /**
@@ -861,6 +874,7 @@ function cutByEdges(
  */
 function cutByCorner(
   box: DOMRect,
+  radii: CornerRadii,
   clip: EdgeBounds,
   style: CSSStyleDeclaration,
   scale: RenderedScale,
@@ -886,6 +900,12 @@ function cutByCorner(
       height: (clip.bottom - clip.top) / scale.y + borderSpan(style, "y"),
     }
   );
+  /*
+   * A radius this cannot resolve is a clip of UNKNOWN shape, and the block is
+   * refused rather than treated as sitting inside a square one — the same answer
+   * this module gives for every other geometry it cannot describe.
+   */
+  if (outer === undefined) return true;
   const inner = scaleCornerRadii(
     insetCornerRadii(outer, {
       top: edgeWidth(style.borderTopWidth),
@@ -896,7 +916,14 @@ function cutByCorner(
     scale
   );
   if (isSquare(inner)) return false;
-  return !boundsInsideRounded(box, clip, inner, slack);
+  /*
+   * The block's OWN curve is part of the comparison. A rounded block flush
+   * inside an equally rounded container is not cut at all, while its bounding
+   * rectangle's corners lie outside every one of that container's arcs — so
+   * reading only the rectangle refuses the ordinary nested rounded card and
+   * takes the whole overlay with it.
+   */
+  return !roundedInsideRounded(box, radii, clip, inner, slack);
 }
 
 /** The two border widths an axis loses, in unscaled CSS pixels. */

--- a/packages/builder/src/geometry.ts
+++ b/packages/builder/src/geometry.ts
@@ -50,6 +50,25 @@ export interface Rect {
   readonly height: number;
 }
 
+/** Four physical edge lengths, in unscaled CSS pixels. */
+export interface EdgeLengths {
+  readonly top: number;
+  readonly right: number;
+  readonly bottom: number;
+  readonly left: number;
+}
+
+/**
+ * How much bigger a measured rectangle is than the layout it came from.
+ *
+ * Per-axis because a transform scales the two independently. `{ x: 1, y: 1 }`
+ * for an untransformed element, which is the ordinary case.
+ */
+export interface Scale {
+  readonly x: number;
+  readonly y: number;
+}
+
 /**
  * How the canvas frame sits inside the host page.
  *

--- a/packages/builder/src/spacing-bands.test.ts
+++ b/packages/builder/src/spacing-bands.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { SQUARE_CORNERS } from "./border-radii";
 import type { Rect } from "./geometry";
 import {
   overlayEscape,
@@ -33,6 +34,9 @@ function bandsFor(over: Partial<SpacingGeometry>): readonly SpacingBand[] {
     // Equal to `scale` unless a case says otherwise, which is what an element
     // carrying no transform of its own reports.
     marginScale: over.scale ?? { x: 1, y: 1 },
+    // Square unless a case says otherwise, which is what a block with no
+    // `border-radius` reports and what nearly every block on a page is.
+    radii: SQUARE_CORNERS,
     ...over,
   });
 }

--- a/packages/builder/src/spacing-bands.test.ts
+++ b/packages/builder/src/spacing-bands.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import type { RoundedShape } from "./border-radii";
 import { SQUARE_CORNERS } from "./border-radii";
 import type { Rect } from "./geometry";
 import {
@@ -576,6 +577,77 @@ describe("comparing two band lists", () => {
      * exactly the case it exists to report.
      */
     expect(sameBands([one()], [one(over)])).toBe(false);
+  });
+
+  /** A clip whose every field can be varied one at a time. */
+  const clipOf = (over: Partial<RoundedShape> = {}): RoundedShape => ({
+    x: 0,
+    y: 0,
+    width: 10,
+    height: 20,
+    radii: {
+      topLeft: { x: 1, y: 2 },
+      topRight: { x: 3, y: 4 },
+      bottomRight: { x: 5, y: 6 },
+      bottomLeft: { x: 7, y: 8 },
+    },
+    ...over,
+  });
+
+  it.each<[string, RoundedShape | undefined]>([
+    ["a clip appearing", clipOf()],
+    ["the clip's origin", clipOf({ x: 9 })],
+    ["the clip's size", clipOf({ width: 99 })],
+    [
+      "one corner's horizontal radius",
+      clipOf({
+        radii: {
+          topLeft: { x: 99, y: 2 },
+          topRight: { x: 3, y: 4 },
+          bottomRight: { x: 5, y: 6 },
+          bottomLeft: { x: 7, y: 8 },
+        },
+      }),
+    ],
+    [
+      "one corner's vertical radius",
+      clipOf({
+        radii: {
+          topLeft: { x: 1, y: 2 },
+          topRight: { x: 3, y: 4 },
+          bottomRight: { x: 5, y: 6 },
+          bottomLeft: { x: 7, y: 99 },
+        },
+      }),
+    ],
+  ])("notices %s, which nothing else reports", (_label, clip) => {
+    /*
+     * NOTHING else here changes when only the radius does. An author dragging
+     * `border-radius` moves no band rectangle, no label and no sign — so a
+     * comparison over those fields alone reports the bands equal, the caller
+     * keeps the array it already had, and the fill stays cut to the curve the
+     * block used to have.
+     *
+     * The control comes with it: the two bands are otherwise identical, so a
+     * `false` here can only be the clip.
+     */
+    expect(sameBands([one()], [one()])).toBe(true);
+    expect(sameBands([one()], [one({ clip })])).toBe(false);
+  });
+
+  it("notices a clip being REMOVED, not only added", () => {
+    // Rounding a block and then squaring it again are the same author gesture
+    // in two directions, and an implementation that only compared where both
+    // clips exist would freeze on the way back.
+    expect(sameBands([one({ clip: clipOf() })], [one()])).toBe(false);
+  });
+
+  it("says two bands with the SAME clip are the same", () => {
+    // The other half: a comparison that always reported a difference would
+    // rebuild the overlay on every measure and defeat the check entirely.
+    expect(
+      sameBands([one({ clip: clipOf() })], [one({ clip: clipOf() })])
+    ).toBe(true);
   });
 });
 

--- a/packages/builder/src/spacing-bands.ts
+++ b/packages/builder/src/spacing-bands.ts
@@ -32,11 +32,11 @@
  * @module spacing-bands
  */
 
-import type { CornerRadii, RoundedInset } from "./border-radii";
+import type { CornerRadii, RoundedShape } from "./border-radii";
 import {
   insetCornerRadii,
   isSquare,
-  roundedInsetOf,
+  roundedShapeIn,
   scaleCornerRadii,
 } from "./border-radii";
 import type { EdgeLengths, Rect, Scale } from "./geometry";
@@ -85,10 +85,10 @@ export interface SpacingBand {
    * where the margin box is a plain rectangle whatever the corners do, so
    * nothing there is drawn over ground the block does not occupy.
    *
-   * Present as INSETS rather than a rectangle because the shape is a different
-   * rectangle from the band, and the band is what carries the clip.
+   * Stated in the BAND's own coordinates, because that is what a `clip-path` on
+   * the band is resolved against.
    */
-  readonly clip?: RoundedInset;
+  readonly clip?: RoundedShape;
 }
 
 /** Everything the placement needs, and nothing that has to be read from a DOM. */
@@ -262,9 +262,9 @@ function clipWithin(
   band: Rect,
   shape: Rect,
   radii: CornerRadii
-): RoundedInset | undefined {
+): RoundedShape | undefined {
   if (isSquare(radii)) return undefined;
-  return roundedInsetOf(band, shape, radii);
+  return roundedShapeIn(band, shape, radii);
 }
 
 /** A rectangle reduced on each side, never past zero in either dimension. */
@@ -503,19 +503,73 @@ export function sameBands(
   if (left.length !== right.length) return false;
   return left.every((one, index) => {
     const other = right[index];
-    return (
-      other !== undefined &&
-      one.box === other.box &&
-      one.side === other.side &&
-      one.label === other.label &&
-      one.negative === other.negative &&
-      one.rect.x === other.rect.x &&
-      one.rect.y === other.rect.y &&
-      one.rect.width === other.rect.width &&
-      one.rect.height === other.rect.height
-    );
+    return other !== undefined && sameBand(one, other);
   });
 }
+
+/**
+ * Whether two bands describe the same thing.
+ *
+ * Every field, not a subset. A band that MOVED without resizing, a label that
+ * changed while the geometry held, and a curve that changed while both held are
+ * all real changes an author has to see, and a comparison skipping any of them
+ * freezes the overlay in exactly the case it exists to report.
+ */
+function sameBand(one: SpacingBand, other: SpacingBand): boolean {
+  return (
+    one.box === other.box &&
+    one.side === other.side &&
+    one.label === other.label &&
+    one.negative === other.negative &&
+    sameRect(one.rect, other.rect) &&
+    sameClip(one.clip, other.clip)
+  );
+}
+
+/** Whether two rectangles are the same rectangle. */
+function sameRect(one: Rect, other: Rect): boolean {
+  return (
+    one.x === other.x &&
+    one.y === other.y &&
+    one.width === other.width &&
+    one.height === other.height
+  );
+}
+
+/**
+ * Whether two bands are cut to the same shape.
+ *
+ * Compared because NOTHING else here changes when only the radius does. An
+ * author dragging `border-radius` moves no band rectangle, no label and no
+ * sign, so a comparison over those fields alone reports the bands equal, the
+ * caller keeps the array it already had, and the fill stays cut to the curve the
+ * block used to have — which is the case this clip exists for.
+ */
+function sameClip(
+  left: RoundedShape | undefined,
+  right: RoundedShape | undefined
+): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  return (
+    left.x === right.x &&
+    left.y === right.y &&
+    left.width === right.width &&
+    left.height === right.height &&
+    CLIP_CORNERS.every(
+      corner =>
+        left.radii[corner].x === right.radii[corner].x &&
+        left.radii[corner].y === right.radii[corner].y
+    )
+  );
+}
+
+/** The four corners, named so the comparison above cannot silently skip one. */
+const CLIP_CORNERS = [
+  "topLeft",
+  "topRight",
+  "bottomRight",
+  "bottomLeft",
+] as const satisfies readonly (keyof CornerRadii)[];
 
 /**
  * Boxes that CSS gives no margin, whatever the computed style reports.

--- a/packages/builder/src/spacing-bands.ts
+++ b/packages/builder/src/spacing-bands.ts
@@ -32,7 +32,21 @@
  * @module spacing-bands
  */
 
-import type { Rect } from "./geometry";
+import type { CornerRadii, RoundedInset } from "./border-radii";
+import {
+  insetCornerRadii,
+  isSquare,
+  roundedInsetOf,
+  scaleCornerRadii,
+} from "./border-radii";
+import type { EdgeLengths, Rect, Scale } from "./geometry";
+
+/*
+ * Re-exported rather than moved outright because both are the vocabulary this
+ * module's callers already speak, while `border-radii.ts` needs them too and a
+ * type imported FROM here would make the two modules import each other.
+ */
+export type { EdgeLengths, Scale } from "./geometry";
 
 /** The four physical sides, in the order a CSS shorthand writes them. */
 export type SpacingSide = "top" | "right" | "bottom" | "left";
@@ -44,14 +58,6 @@ export type SpacingSide = "top" | "right" | "bottom" | "left";
  * padding box cannot be located without it.
  */
 export type SpacingBox = "margin" | "padding";
-
-/** Four physical edge lengths, in unscaled CSS pixels. */
-export interface EdgeLengths {
-  readonly top: number;
-  readonly right: number;
-  readonly bottom: number;
-  readonly left: number;
-}
 
 /** One band to draw, with the text that goes on it. */
 export interface SpacingBand {
@@ -70,17 +76,19 @@ export interface SpacingBand {
    * it differently so it cannot be mistaken for padding.
    */
   readonly negative: boolean;
-}
-
-/**
- * How much bigger the measured rectangle is than the layout it came from.
- *
- * Per-axis because a transform scales the two independently. `{ x: 1, y: 1 }`
- * for an untransformed element, which is the ordinary case.
- */
-export interface Scale {
-  readonly x: number;
-  readonly y: number;
+  /**
+   * The rounded box this band's FILL has to be cut to, when one is smaller than
+   * the band.
+   *
+   * Absent on the ordinary square block, and absent on every band that lies
+   * wholly outside the block: a positive margin sits beyond the border edge,
+   * where the margin box is a plain rectangle whatever the corners do, so
+   * nothing there is drawn over ground the block does not occupy.
+   *
+   * Present as INSETS rather than a rectangle because the shape is a different
+   * rectangle from the band, and the band is what carries the clip.
+   */
+  readonly clip?: RoundedInset;
 }
 
 /** Everything the placement needs, and nothing that has to be read from a DOM. */
@@ -108,6 +116,15 @@ export interface SpacingGeometry {
    * its own, which is why this is easy to miss.
    */
   readonly marginScale: Scale;
+  /**
+   * The border box's USED corner radii, unscaled, already resolved and reduced.
+   *
+   * Resolved by the caller because a percentage resolves against the border
+   * box's own size in LAYOUT pixels, and `border` has already been through the
+   * transform by the time it arrives here. See `border-radii.ts` for why the
+   * computed value is not the used one.
+   */
+  readonly radii: CornerRadii;
 }
 
 const SIDES: readonly SpacingSide[] = ["top", "right", "bottom", "left"];
@@ -173,17 +190,37 @@ export function spacingBands(
   const bands: SpacingBand[] = [];
 
   const inward = inwardExtents(margin, border);
+  /*
+   * Two rounded shapes, because the two kinds of band sit in different boxes. A
+   * negative margin is drawn INSIDE the border edge, so it is the border box's
+   * own curve that decides where it may paint; padding is drawn inside the
+   * border, where the curve is that much tighter.
+   *
+   * Both are scaled AFTER the border widths come off, which is the order the
+   * lengths are in: a radius and a border width are both unscaled CSS pixels
+   * until the transform is applied to their difference.
+   */
+  const outerRadii = scaleCornerRadii(geometry.radii, scale);
+  const innerRadii = scaleCornerRadii(
+    insetCornerRadii(geometry.radii, geometry.borderWidths),
+    scale
+  );
 
   for (const side of SIDES) {
     const value = geometry.margin[side];
     const label = labelFor(value);
     if (!reports(label)) continue;
+    const rect = marginRect(border, side, margin, inward);
+    const negative = value < 0;
     bands.push({
       box: "margin",
       side,
-      rect: marginRect(border, side, margin, inward),
+      rect,
       label,
-      negative: value < 0,
+      negative,
+      // Only the negative one, which is the only margin band laid inside the
+      // border edge and so the only one a corner can cut.
+      clip: negative ? clipWithin(rect, border, outerRadii) : undefined,
     });
   }
 
@@ -199,16 +236,35 @@ export function spacingBands(
     const value = geometry.padding[side];
     const label = labelFor(value);
     if (!reports(label)) continue;
+    const rect = paddingRect(inner, side, padding);
     bands.push({
       box: "padding",
       side,
-      rect: paddingRect(inner, side, padding),
+      rect,
       label,
       negative: false,
+      clip: clipWithin(rect, inner, innerRadii),
     });
   }
 
   return bands;
+}
+
+/**
+ * The clip a band's fill needs, or nothing when the box it sits in has square
+ * corners.
+ *
+ * Nothing is the answer for nearly every block, and it is worth distinguishing:
+ * a `clip-path` that happens to cut nothing still puts the fill on its own
+ * compositing path, and an absent clip lets the ordinary case stay ordinary.
+ */
+function clipWithin(
+  band: Rect,
+  shape: Rect,
+  radii: CornerRadii
+): RoundedInset | undefined {
+  if (isSquare(radii)) return undefined;
+  return roundedInsetOf(band, shape, radii);
 }
 
 /** A rectangle reduced on each side, never past zero in either dimension. */

--- a/packages/builder/src/spacing-overlay.test.tsx
+++ b/packages/builder/src/spacing-overlay.test.tsx
@@ -104,6 +104,13 @@ function styleOf(values: Record<string, string>): CSSStyleDeclaration {
     borderRightWidth: "0px",
     borderBottomWidth: "0px",
     borderLeftWidth: "0px",
+    // Square unless a case says otherwise. A real `CSSStyleDeclaration` always
+    // carries these, so leaving them out here is a property of the fake and not
+    // of anything the overlay could meet.
+    borderTopLeftRadius: "0px",
+    borderTopRightRadius: "0px",
+    borderBottomRightRadius: "0px",
+    borderBottomLeftRadius: "0px",
   };
   return { ...zeroed, ...values } as unknown as CSSStyleDeclaration;
 }

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -61,6 +61,7 @@ import * as React from "react";
 
 import {
   clipPathOf,
+  scaleCornerRadii,
   SQUARE_CORNERS,
   usedCornerRadii,
   type CornerRadii,
@@ -168,12 +169,16 @@ function boxesOf(style: CSSStyleDeclaration): {
  * A scale that is zero on either axis leaves nothing to resolve against and no
  * band to draw; `describable` refuses that block anyway, and answering square
  * here keeps this from dividing by it on the way to that refusal.
+ *
+ * UNDEFINED when a corner cannot be resolved at all — a percentage inside a
+ * `calc()` stays unresolved in the computed value — which the caller treats as a
+ * shape it cannot describe rather than as a square one.
  */
 function radiiOf(
   style: CSSStyleDeclaration,
   border: Rect,
   scale: Scale
-): CornerRadii {
+): CornerRadii | undefined {
   if (!(scale.x > 0) || !(scale.y > 0)) return SQUARE_CORNERS;
   return usedCornerRadii(
     {
@@ -448,12 +453,35 @@ export function SpacingOverlay({
       x: boxes.borderWidths.left + boxes.borderWidths.right,
       y: boxes.borderWidths.top + boxes.borderWidths.bottom,
     };
+    /*
+     * Through `canvasContentRect` rather than a rectangle read here: this
+     * package reads a rectangle in one place, so chrome measured one way cannot
+     * disagree with chrome measured another at a scroll offset.
+     */
+    const border = canvasContentRect(block, root);
+    const scaledBy: Scale = { x: scale.x, y: scale.y };
+    const radii = radiiOf(style, border, scaledBy);
+    /*
+     * A block whose own radii cannot be resolved is a shape this cannot
+     * describe, and drawing nothing is the answer it already gives for every
+     * other one. Deciding it here rather than inside `describable` keeps that
+     * predicate over the four values it is handed.
+     */
     if (
+      radii === undefined ||
       !describable(
         layoutFragments(block),
         style.position,
         hasScrollbarGutter(block, borders),
-        clippedByAncestor(block, root),
+        /*
+         * The block's own curve goes in with it: a rounded block flush inside an
+         * equally rounded clipping container is not cut, while its bounding
+         * rectangle's corners are outside every one of that container's arcs.
+         *
+         * Scaled, because the clip walk compares rendered rectangles while the
+         * radii are resolved in layout pixels.
+         */
+        clippedByAncestor(block, root, scaleCornerRadii(radii, scaledBy)),
         scale
       )
     ) {
@@ -467,13 +495,6 @@ export function SpacingOverlay({
      * asking for it separately would be a second answer to one question.
      */
     const layerBox = canvasContentRect(root, root);
-    /*
-     * Through `canvasContentRect` rather than a rectangle read here: this
-     * package reads a rectangle in one place, so chrome measured one way cannot
-     * disagree with chrome measured another at a scroll offset.
-     */
-    const border = canvasContentRect(block, root);
-    const scaledBy: Scale = { x: scale.x, y: scale.y };
     apply(
       spacingBands({
         border,
@@ -489,7 +510,7 @@ export function SpacingOverlay({
         // Resolved against the LAYOUT box, which is why the scale goes in with
         // it: a rounded block's bands have to be cut to the curve, and the curve
         // is stated in the units the author declared it in.
-        radii: radiiOf(style, border, scaledBy),
+        radii,
       }),
       layerBox
     );

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -59,8 +59,15 @@
 
 import * as React from "react";
 
+import {
+  clipPathOf,
+  SQUARE_CORNERS,
+  usedCornerRadii,
+  type CornerRadii,
+} from "./border-radii";
 import { CANVAS_ROOT_CLASS, nodeElement, nodeElements } from "./canvas";
 import type { EditorState } from "./editor-state";
+import type { Rect, Scale } from "./geometry";
 import {
   canvasContentRect,
   canvasRootFrom,
@@ -142,6 +149,65 @@ function boxesOf(style: CSSStyleDeclaration): {
       left: lengthOf(style.borderLeftWidth),
     },
   };
+}
+
+/**
+ * The block's USED border-box corner radii, in LAYOUT pixels.
+ *
+ * A percentage radius resolves against the border box's own size, and the size
+ * that governs is the one the element was LAID OUT at rather than the one it is
+ * drawn at — `border-radius: 50%` on a block under `scale(2)` is half its layout
+ * width, which then renders doubled like everything else inside the transform.
+ *
+ * That layout size is the measured rectangle divided back out by the scale it
+ * was measured at, rather than a second reading from the element. `offsetWidth`
+ * would answer the same question in whole pixels only, and `getComputedStyle`
+ * reports whichever box `box-sizing` selects — so both are a second answer to a
+ * question `renderedScale` has already answered exactly.
+ *
+ * A scale that is zero on either axis leaves nothing to resolve against and no
+ * band to draw; `describable` refuses that block anyway, and answering square
+ * here keeps this from dividing by it on the way to that refusal.
+ */
+function radiiOf(
+  style: CSSStyleDeclaration,
+  border: Rect,
+  scale: Scale
+): CornerRadii {
+  if (!(scale.x > 0) || !(scale.y > 0)) return SQUARE_CORNERS;
+  return usedCornerRadii(
+    {
+      topLeft: style.borderTopLeftRadius,
+      topRight: style.borderTopRightRadius,
+      bottomRight: style.borderBottomRightRadius,
+      bottomLeft: style.borderBottomLeftRadius,
+    },
+    { width: border.width / scale.x, height: border.height / scale.y }
+  );
+}
+
+/**
+ * The band's box, plus the clip its FILL takes when the block is rounded.
+ *
+ * The clip travels as a custom property rather than as this element's own
+ * `clip-path` because the band carries the value chip, and the chip
+ * deliberately overflows the band it names — the case where a number is hardest
+ * to guess is the case where the space is too small to hold it. Clipping the
+ * element would take the number with it, so the stylesheet applies the property
+ * to the fill alone.
+ */
+function bandStyle(band: SpacingBand): React.CSSProperties {
+  const box: React.CSSProperties = {
+    left: band.rect.x,
+    top: band.rect.y,
+    width: band.rect.width,
+    height: band.rect.height,
+  };
+  if (band.clip === undefined) return box;
+  return {
+    ...box,
+    "--nx-spacing-clip": clipPathOf(band.clip),
+  } as React.CSSProperties;
 }
 
 /**
@@ -401,21 +467,29 @@ export function SpacingOverlay({
      * asking for it separately would be a second answer to one question.
      */
     const layerBox = canvasContentRect(root, root);
+    /*
+     * Through `canvasContentRect` rather than a rectangle read here: this
+     * package reads a rectangle in one place, so chrome measured one way cannot
+     * disagree with chrome measured another at a scroll offset.
+     */
+    const border = canvasContentRect(block, root);
+    const scaledBy: Scale = { x: scale.x, y: scale.y };
     apply(
       spacingBands({
-        // Through `canvasContentRect` rather than a rectangle read here: this
-        // package reads a rectangle in one place, so chrome measured one way
-        // cannot disagree with chrome measured another at a scroll offset.
-        border: canvasContentRect(block, root),
+        border,
         borderWidths: boxes.borderWidths,
         margin: boxes.margin,
         padding: boxes.padding,
         // Composed from the real transform between the block and the root, so
         // a scaled ancestor counts and no rounded layout value is involved.
-        scale: { x: scale.x, y: scale.y },
+        scale: scaledBy,
         // Margins take the ancestors' scale ALONE — a transform does not scale
         // the space a margin reserves, only the box it is drawn beside.
         marginScale: { x: scale.ancestor.x, y: scale.ancestor.y },
+        // Resolved against the LAYOUT box, which is why the scale goes in with
+        // it: a rounded block's bands have to be cut to the curve, and the curve
+        // is stated in the units the author declared it in.
+        radii: radiiOf(style, border, scaledBy),
       }),
       layerBox
     );
@@ -578,12 +652,7 @@ export function SpacingOverlay({
           data-box={band.box}
           data-side={band.side}
           data-negative={band.negative ? "" : undefined}
-          style={{
-            left: band.rect.x,
-            top: band.rect.y,
-            width: band.rect.width,
-            height: band.rect.height,
-          }}
+          style={bandStyle(band)}
         >
           <span className="nx-spacing-overlay__value">{band.label}</span>
         </div>

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -1075,11 +1075,32 @@
   justify-content: center;
 }
 
-.nx-spacing-overlay__band[data-box="margin"] {
+/*
+ * The fill is a pseudo-element rather than the band's own background, because on
+ * a rounded block it has to be CLIPPED and the value chip must not be.
+ *
+ * A block with `border-radius` curves away from the rectangle its bands are cut
+ * from, so a full-width strip paints colour into the transparent corner OUTSIDE
+ * the rendered border — a band is read as a measurement, and one covering ground
+ * the block does not occupy states a measurement that is false. The component
+ * supplies the curve as `--nx-spacing-clip`; a square block sets nothing and the
+ * fallback leaves the fill uncut.
+ *
+ * Clipping the band itself would take the chip with it, and the chip
+ * deliberately overflows the band it names.
+ */
+.nx-spacing-overlay__band::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  clip-path: var(--nx-spacing-clip, none);
+}
+
+.nx-spacing-overlay__band[data-box="margin"]::before {
   background-color: color-mix(in srgb, var(--nx-chart-4) 22%, transparent);
 }
 
-.nx-spacing-overlay__band[data-box="padding"] {
+.nx-spacing-overlay__band[data-box="padding"]::before {
   background-color: color-mix(in srgb, var(--nx-chart-3) 22%, transparent);
 }
 
@@ -1091,7 +1112,7 @@
  * ordinary space and says the opposite of what is happening; a hatch reads as
  * the element being pulled over its neighbour, which it is.
  */
-.nx-spacing-overlay__band[data-box="margin"][data-negative] {
+.nx-spacing-overlay__band[data-box="margin"][data-negative]::before {
   background-color: transparent;
   background-image: repeating-linear-gradient(
     45deg,
@@ -1113,6 +1134,12 @@
  * centred on the band it names.
  */
 .nx-spacing-overlay__value {
+  /*
+   * Positioned so it paints ABOVE the fill. The fill is an absolutely positioned
+   * pseudo-element, which takes the positioned-descendants layer and would
+   * otherwise be painted over this in-flow text whatever the source order says.
+   */
+  position: relative;
   padding: 0 3px;
   border-radius: 2px;
   background-color: var(--nx-background);


### PR DESCRIPTION
Closes the two rounded-geometry findings left open on the merged #1145
(`PRRT_kwDOSYwUJs6bga9o`, `PRRT_kwDOSYwUJs6bga9q`).

#1154 merged while this was being built, so the base is now `main` and the
branch was rebased onto it — the three commits #1154 landed as a squash are
gone from this branch and only the rounded-geometry commit remains.

## The defect, both directions

A block with `border-radius` curves away from the rectangle its bands are cut
from, and the overlay treated both sides of that as rectangles.

**Outward.** The padding bands are full-width strips taken from the padding
box's rectangle, so a heavily rounded block got colour painted into the
transparent corners outside its rendered border. A band is read as a
MEASUREMENT, so one covering ground the block does not occupy states a
measurement that is false.

**Inward.** A container with `border-radius` and `overflow: hidden` clips on the
curve, so a child inside all four of its padding edges can still lose a corner.
The rectangular comparison accepted it and the bands painted across the part
that is not rendered.

## What was measured rather than assumed

Reaching the USED radii from the computed value is three steps that do not
commute. Each was probed in Chromium:

| Question | Measured |
| --- | --- |
| Do percentages resolve in the computed value? | No — `border-radius: 50%` computes as `"50%"` |
| Is the overlap reduction applied to the computed value? | No — `200px` on a 200×100 box still computes as `200px`, and renders at **50** |
| Is the reduction one factor or one per corner? | **One factor.** `border-top-left-radius: 200px` alone on a 200×100 box draws that corner at 100 — the box's height constraining it through the shared factor |
| Is the padding-box curve reduced a second time when it no longer fits? | **No.** A 200×100 box with a 100px corner and a 10px border draws an inner curve of 90 inside a padding box only 80 tall |
| Does `overflow: clip visible` round its corner? | **No.** The corner is painted in full, where `overflow: hidden` cuts it away |

The last one is why the corner test is asked only when BOTH axes clip: a corner
needs two bounds to exist, and applying the arc on one axis would refuse a block
nothing removes.

Reducing after insetting gives different numbers, so the order is pinned by a
test asserting both the value and that it is not the other one.

## Two decisions worth disagreeing with

**The corner is tested exactly rather than declining every rounded clipping
ancestor.** `border-radius` with `overflow: hidden` is the ordinary card, so a
blanket refusal would blank the overlay for most blocks on a real page. The e2e
test's CONTROL phase is what pins this — a blanket decline fails there, not at
the refusal.

**The fill moved to a pseudo-element.** The band carries the value chip and the
chip deliberately overflows the band it names, so `clip-path` on the band itself
would take the number with it.

## Evidence

Certified by PIXELS, not by attributes. `elementFromPoint` reports a child in
the cut-away corner of an `overflow: hidden` ancestor as hit — measured — so
hit-testing answers about the box tree while the question is what was painted.

Selecting a rounded block must not change a pixel outside it, and the same test
asserts the band DID paint in the middle of the strip, so it cannot pass against
an overlay that drew nothing. With the clip removed that corner pixel reads
`204,235,215` instead of white.

Every new test was break-verified. Two came back GREEN and both were real gaps,
now closed:

- dropping one side from the reduction changed nothing, because every fixture
  let the opposite side bind with the same numbers — there is now one case per
  side, each built so only that side is tight;
- the slack fixture used square corners, so the arc test returned before the
  slack was ever consulted — it now uses a curved corner and asserts the same
  box IS refused with no allowance.

## Gates

Re-run in full after the rebase onto `main`: `pnpm build` 0 · `check-types` 0 ·
builder **1574** · plugin-page-builder 214 · blocks-react 764 · four lints 0 ·
comment convention 0 · changeset 0 ·
`fallow audit` **pass, zero introduced** · e2e **40 passed**.

Two warn-tier styling notes, neither gating. `css-selector-complexity` at the
negative-margin hatch is mine: `[data-negative]` already implies a margin band,
so dropping `[data-box="margin"]` would satisfy the linter, but it would make the
CSS depend on a component invariant instead of saying which band it targets —
left explicit deliberately, and happy to be overruled. The `unused-layer` note is
at line 1 of a file whose first modified line is 1078.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spacing overlays now respect rounded corners when displaying margin and padding bands.
  * Rounded clipping preserves value chips and supports elliptical radii, borders, scaling, and nested clipping scenarios.
  * Added accurate handling for blocks partially clipped by rounded ancestor corners.

* **Bug Fixes**
  * Prevented spacing-band fills from painting outside rounded block boundaries.
  * Improved clipping behavior for axis-specific overflow and rounded ancestor edges.

* **Tests**
  * Added comprehensive unit and end-to-end coverage for rounded geometry and overlay rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->