### PR TITLE
feat(builder): an Advanced tab for a block's id and its own HTML attributes

### DIFF
--- a/.changeset/block-html-surface.md
+++ b/.changeset/block-html-surface.md
@@ -1,0 +1,40 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Adds an Advanced tab to the page builder's inspector, where a block's `id` and
+its own HTML attributes can be set. Both were already modelled and already
+applied to the rendered element; until now nothing in the editor could write
+them, so an anchor to link to or a `data-` attribute an analytics script reads
+had to be added outside the builder.
+
+A row that the page would not render is refused where the author can still see
+why, rather than saved and dropped later: an attribute the renderer does not
+allow, a second row setting a name another row already sets, and an `id` that
+the CSS id field beside it would win over. The rule is the renderer's own and is
+asked rather than copied, so the editor cannot come to accept a name the page
+then discards.

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -91,8 +91,14 @@ const ALLOWED_ATTRIBUTE_NAMES = new Set(["id", "title", "lang", "dir"]);
  * author data and accessibility semantics, neither can name a destination or
  * execute anything, and closing them would defeat the feature the field exists
  * for. `role` is the ARIA sibling of `aria-*` and belongs with them.
+ *
+ * EXPORTED so an editor offering this field can ask it rather than restate it.
+ * The list above already says the render-safe set lives here and only here; a
+ * second copy in an editor would drift, and it would drift silently in the
+ * worse direction — the editor accepting a name this loop then skips, so the
+ * author sets an attribute, sees it saved, and never sees it on the page.
  */
-function isAllowedAttribute(name: string): boolean {
+export function isAllowedAttribute(name: string): boolean {
   const lower = name.toLowerCase();
   if (lower === "role") return true;
   if (lower.startsWith("data-") || lower.startsWith("aria-")) return true;

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -164,6 +164,16 @@ export const NODE_ID_ATTRIBUTE = "data-nx-node";
 export const PROP_ATTRIBUTE = "data-nx-prop";
 
 /**
+ * The prefix every marker the editor puts on a rendered element shares.
+ *
+ * A NAMESPACE rather than a list, because a list is a thing to keep in sync
+ * and this one already fell behind once: three markers exist and only the
+ * node id was protected here. Anything a future overlay needs is covered by
+ * construction.
+ */
+export const EDITOR_NAMESPACE = "data-nx-";
+
+/**
  * Builds the `markProp` a block spreads onto the element carrying a value.
  *
  * Returns nothing at all outside an editor, and nothing for a prop the block
@@ -225,6 +235,17 @@ function withNodeAttributes(
       // document can hold anything; a non-string would be handed to React as a
       // prop value it never expected.
       if (typeof value !== "string") continue;
+      /*
+       * The editor's own namespace is not the document's to write, and only
+       * while this render is FOR the editor: on a published page these are
+       * ordinary author data and none of this system's business.
+       *
+       * Filtered HERE rather than trusted to the panel that offers the field.
+       * A document can arrive from an import or a script, and the marker it
+       * would overwrite decides which block a click selects and which
+       * property inline editing commits into.
+       */
+      if (nodeAttribute && key.startsWith(EDITOR_NAMESPACE)) continue;
       extra[key] = value;
     }
   }

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -85,6 +85,32 @@ function slotNodes(node: BlockNode, name: string): BlockNode[] {
 const ALLOWED_ATTRIBUTE_NAMES = new Set(["id", "title", "lang", "dir"]);
 
 /**
+ * A name HTML can carry, which is the XML `Name` production.
+ *
+ * Mirrors React's own attribute-name validation rather than a narrower rule of
+ * this project's own: refusing a name React WOULD render is a false alarm on
+ * correct input, and this predicate is what an editor asks before telling an
+ * author their attribute is unusable. The unicode ranges are that production's,
+ * so a non-ASCII `data-` name is accepted exactly where the DOM accepts it.
+ */
+/** The first character of an XML `Name`. */
+const NAME_START =
+  "[:A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD]";
+
+/**
+ * Every LATER character, combining ranges first.
+ *
+ * Order matters only to a reader: with a base character immediately before a
+ * combining range, the two read as one combined character rather than as two
+ * alternatives, and a linter says so. Leading with the combining ranges keeps
+ * the set identical and the intent unambiguous.
+ */
+const NAME_CHAR =
+  "[\\u0300-\\u036F\\u203F-\\u2040\\u00B7\\-.0-9:A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD]";
+
+const ATTRIBUTE_NAME = new RegExp(`^${NAME_START}${NAME_CHAR}*$`, "u");
+
+/**
  * Whether an author-supplied attribute may reach the DOM.
  *
  * `data-*` and `aria-*` are open by prefix: both are namespaces defined to carry
@@ -99,6 +125,11 @@ const ALLOWED_ATTRIBUTE_NAMES = new Set(["id", "title", "lang", "dir"]);
  * author sets an attribute, sees it saved, and never sees it on the page.
  */
 export function isAllowedAttribute(name: string): boolean {
+  // SYNTAX first, because the open prefixes below admit anything after them.
+  // `data-x foo` and `data-x"` start with `data-` and are not attribute names:
+  // React refuses them and renders nothing, so a check that stopped at the
+  // prefix let a value be stored that could never appear on a page.
+  if (!ATTRIBUTE_NAME.test(name)) return false;
   const lower = name.toLowerCase();
   if (lower === "role") return true;
   if (lower.startsWith("data-") || lower.startsWith("aria-")) return true;

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -182,9 +182,6 @@ function withNodeAttributes(
   if (typeof output.type !== "string") return output;
 
   const extra: Record<string, string> = {};
-  // Written before the author's own attributes so it cannot be overwritten by
-  // one: the editor's address for a node is not a value the document may set.
-  if (nodeAttribute) extra[NODE_ID_ATTRIBUTE] = node.id;
   if (attributes) {
     for (const [name, value] of Object.entries(attributes)) {
       if (!isAllowedAttribute(name)) continue;
@@ -203,6 +200,18 @@ function withNodeAttributes(
   // The modelled field wins over an attribute of the same name: `cssId` is what
   // the editor writes, and the attribute bag is the escape hatch beside it.
   if (cssId !== undefined) extra.id = cssId;
+  /*
+   * LAST, so it cannot be overwritten. This was written first, with a comment
+   * saying that made it safe — the opposite of what the code did: the author's
+   * loop ran afterwards and assigning the same key simply replaced it. A
+   * document could therefore hand every block the same address, or one block
+   * another's, and the editor's hit-testing reads exactly this value to decide
+   * which block was clicked.
+   *
+   * It is the editor's address for a node, not a value the document may set, so
+   * the position enforces that rather than a note asking the loop above to.
+   */
+  if (nodeAttribute) extra[NODE_ID_ATTRIBUTE] = node.id;
 
   return Object.keys(extra).length > 0 ? cloneElement(output, extra) : output;
 }

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -272,6 +272,9 @@ describe("the root entry", () => {
       "BlockBoundary",
       "BlockList",
       "BlockPlaceholder",
+      // The editor marker namespace, public so an editor refuses a name the
+      // renderer would drop rather than keeping a list beside it.
+      "EDITOR_NAMESPACE",
       "NODE_ID_ATTRIBUTE",
       "PROP_ATTRIBUTE",
       "PageRenderer",

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -292,6 +292,7 @@ describe("the root entry", () => {
       "preparePageForRead",
       "pruneHiddenNodes",
       "registeredBlocks",
+      "rendersOwnMarkup",
       "resolvePageStyles",
       "styleTextForInjection",
     ]);

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -281,6 +281,9 @@ describe("the root entry", () => {
       "defineBlock",
       "emptyDataProvider",
       "fetchPolicyLabel",
+      // The render-safe attribute rule. Public because the editor offering that
+      // field asks it rather than keeping a copy that would drift.
+      "isAllowedAttribute",
       "migrationSourceFor",
       "prepareDocumentForRead",
       "preparePageForRead",

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -59,7 +59,11 @@ export { BlockBoundary, BlockList } from "./block-boundary";
 // `NODE_ID_ATTRIBUTE` is published deliberately: an editor hit-testing on the
 // attribute must not hard-code its spelling, or the renderer and the editor hold
 // two copies of one string and the editor breaks silently when it moves.
-export { NODE_ID_ATTRIBUTE, PROP_ATTRIBUTE } from "./block-boundary";
+export {
+  EDITOR_NAMESPACE,
+  NODE_ID_ATTRIBUTE,
+  PROP_ATTRIBUTE,
+} from "./block-boundary";
 // The render-safe attribute rule, public so an editor asks it instead of
 // keeping a second copy that would accept names the renderer drops.
 export { isAllowedAttribute } from "./block-boundary";

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -60,6 +60,9 @@ export { BlockBoundary, BlockList } from "./block-boundary";
 // attribute must not hard-code its spelling, or the renderer and the editor hold
 // two copies of one string and the editor breaks silently when it moves.
 export { NODE_ID_ATTRIBUTE, PROP_ATTRIBUTE } from "./block-boundary";
+// The render-safe attribute rule, public so an editor asks it instead of
+// keeping a second copy that would accept names the renderer drops.
+export { isAllowedAttribute } from "./block-boundary";
 export type { BlockBoundaryProps, BlockListProps } from "./block-boundary";
 
 /**

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -126,7 +126,7 @@ export type { PageStyles, ResolveStyleOptions } from "./styles";
  * from the evidence, which is why it exists rather than a documented instruction to pass a flag.
  */
 export { pruneHiddenNodes } from "./visibility";
-export { prepareDocumentForRead } from "./prepare-document";
+export { prepareDocumentForRead, rendersOwnMarkup } from "./prepare-document";
 export type { PrepareDocumentArgs } from "./prepare-document";
 export { preparePageForRead } from "./read-page";
 export type { PreparedPage, ReadPageArgs } from "./read-page";

--- a/packages/blocks-react/src/inline-props.test.tsx
+++ b/packages/blocks-react/src/inline-props.test.tsx
@@ -14,7 +14,7 @@ import type { ReactElement } from "react";
 import { describe, expect, it } from "vitest";
 
 import { coreBlocks } from "./blocks";
-import { PROP_ATTRIBUTE } from "./block-boundary";
+import { NODE_ID_ATTRIBUTE, PROP_ATTRIBUTE } from "./block-boundary";
 import { PageRenderer } from "./page-renderer";
 import { createBlockResolver } from "./resolver";
 
@@ -177,5 +177,66 @@ describe("the declaration and the marking must agree", () => {
         `${blockName} declares "${propName}" inline but never marks an element for it`
       ).toContain(`${PROP_ATTRIBUTE}="${propName}"`);
     }
+  });
+});
+
+describe("a document cannot forge the editor's own markers", () => {
+  const forged = (attributes: Record<string, string>): BlockDocument =>
+    ({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/heading",
+          version: 1,
+          props: { text: "Hello" },
+          attributes,
+        },
+      ],
+    }) as unknown as BlockDocument;
+
+  it("drops an authored marker while rendering FOR the editor", async () => {
+    /*
+     * All three markers share the editor's namespace and all three matter: the
+     * node id decides which block a click selects, the prop marker decides
+     * which property inline editing commits into, and the canvas treats a
+     * chrome ancestor as its own UI and ignores clicks inside it. A document can
+     * arrive from an import or a script, so the panel that offers this field is
+     * not the only way one is written.
+     */
+    const markup = await html(
+      forged({
+        [NODE_ID_ATTRIBUTE]: "somewhere-else",
+        [PROP_ATTRIBUTE]: "another-prop",
+        "data-nx-chrome": "true",
+      }),
+      true
+    );
+
+    expect(markup).toContain(`${NODE_ID_ATTRIBUTE}="n1"`);
+    expect(markup).not.toContain("somewhere-else");
+    expect(markup).not.toContain("another-prop");
+    expect(markup).not.toContain("data-nx-chrome");
+  });
+
+  it("keeps an ordinary author attribute beside them", async () => {
+    // The control: the namespace is reserved, `data-` is not.
+    const markup = await html(
+      forged({ "data-analytics": "hero", [PROP_ATTRIBUTE]: "another-prop" }),
+      true
+    );
+    expect(markup).toContain('data-analytics="hero"');
+    expect(markup).not.toContain("another-prop");
+  });
+
+  it("leaves them alone on a PUBLISHED page", async () => {
+    /*
+     * Off the editor there is no marker to protect and no hit-testing to
+     * confuse: these are ordinary author data, and dropping them would be this
+     * system taking a namespace it is not using.
+     */
+    const markup = await html(forged({ "data-nx-chrome": "true" }), false);
+    expect(markup).toContain('data-nx-chrome="true"');
   });
 });

--- a/packages/builder/src/advanced-panel.tsx
+++ b/packages/builder/src/advanced-panel.tsx
@@ -26,6 +26,7 @@
  * @module advanced-panel
  */
 import { registeredBlocks } from "@nextlyhq/blocks-react";
+import type { BlockResolver } from "@nextlyhq/blocks-react";
 import { Button, Input, Label } from "@nextlyhq/ui";
 import * as React from "react";
 
@@ -59,6 +60,20 @@ export interface AdvancedPanelProps {
    * This is how it is told.
    */
   readonly active: boolean;
+  /**
+   * The definitions the CANVAS is rendering against.
+   *
+   * Which ids are taken depends on which nodes render, and that turns on the
+   * block set. `Canvas` forwards a `render.blocks` resolver to `PageRenderer`,
+   * so a host that supplies one and a panel that reached for the global
+   * registry would be answering about two different pages: a node the canvas
+   * renders would look like a placeholder here and free its id, and a node it
+   * does not would reserve one.
+   *
+   * Optional, and defaulted to the same registry `PageRenderer` defaults to, so
+   * the ordinary host states nothing and the two still agree.
+   */
+  readonly blocks?: BlockResolver;
 }
 
 export function AdvancedPanel({
@@ -67,6 +82,7 @@ export function AdvancedPanel({
   attributes,
   editor,
   active,
+  blocks,
 }: AdvancedPanelProps): React.JSX.Element {
   const [draft, setDraft] = React.useState<Draft>(() => ({
     id: cssId,
@@ -135,8 +151,9 @@ export function AdvancedPanel({
   }, [cssId, attributes]);
 
   const taken = React.useMemo(
-    () => domIdsTaken(editor.document.nodes, nodeId, registeredBlocks()),
-    [editor.document, nodeId]
+    () =>
+      domIdsTaken(editor.document.nodes, nodeId, blocks ?? registeredBlocks()),
+    [editor.document, nodeId, blocks]
   );
 
   /*

--- a/packages/builder/src/advanced-panel.tsx
+++ b/packages/builder/src/advanced-panel.tsx
@@ -1,0 +1,289 @@
+/**
+ * The block's HTML surface: its `id`, and the attributes an author may add.
+ *
+ * ## Why these two sit together, and away from Content and Style
+ *
+ * Neither is a block PROPERTY — those are the block's own schema and live on
+ * the Content tab — and neither is a style. They are the escape hatch: the way
+ * an author reaches the rendered element itself, for an anchor to link to, a
+ * `data-` attribute an analytics script reads, or an `aria-` attribute the
+ * block's own markup does not offer. Every editor that has this puts it behind
+ * its own heading for the same reason, and the surface this replaces did too.
+ *
+ * ## The rules are the RENDERER's, and are asked rather than repeated
+ *
+ * `custom-attributes.ts` holds that reasoning. What matters here is that this
+ * panel shows a row as refused for exactly the reasons the page would drop it,
+ * so an author is never told something saved and then finds it missing.
+ *
+ * ## Warnings wait for the author to stop typing
+ *
+ * A refusal shown mid-keystroke says `data-` is not allowed while the author is
+ * two characters into typing `data-x`. `useDeferredValue` lets the character
+ * land first, which is the same reason the editor this replaces deferred its
+ * own validation.
+ *
+ * @module advanced-panel
+ */
+import { Button, Input, Label } from "@nextlyhq/ui";
+import * as React from "react";
+
+import {
+  isBlankRow,
+  problemMessage,
+  rowProblem,
+  rowsOf,
+  storedAttributes,
+  type AttributeRow,
+} from "./custom-attributes";
+import type { EditorState } from "./editor-state";
+
+export interface AdvancedPanelProps {
+  readonly nodeId: string;
+  readonly cssId: string;
+  readonly attributes: Readonly<Record<string, string>> | undefined;
+  readonly editor: EditorState;
+}
+
+/**
+ * The panel, holding the author's rows while they are being edited.
+ *
+ * Rows are LOCAL state rather than derived per render, because a half-typed row
+ * has no home in the document: a name with no value yet, or a name that is not
+ * allowed, is not something to store. The document is written on commit, and
+ * the stored value is what comes back if the panel is remounted.
+ */
+export function AdvancedPanel({
+  nodeId,
+  cssId,
+  attributes,
+  editor,
+}: AdvancedPanelProps): React.JSX.Element {
+  const [idDraft, setIdDraft] = React.useState(cssId);
+  const [rows, setRows] = React.useState<AttributeRow[]>(() =>
+    rowsOf(attributes)
+  );
+
+  // The stored values win whenever they change underneath the panel — an undo,
+  // or an edit applied from somewhere else. Without this the fields would go on
+  // showing what the document no longer holds.
+  React.useEffect(() => {
+    setIdDraft(cssId);
+  }, [cssId]);
+  React.useEffect(() => {
+    setRows(rowsOf(attributes));
+  }, [attributes]);
+
+  /*
+   * Judged against the SETTLED text, so a refusal does not appear while a name
+   * is still being typed. The rows themselves stay live — the input must show
+   * every keystroke — and only the verdict lags.
+   */
+  const settled = React.useDeferredValue(rows);
+  const settledId = React.useDeferredValue(idDraft);
+
+  const commitId = (): void => {
+    if (idDraft.trim() === cssId) return;
+    editor.apply({
+      kind: "update",
+      id: nodeId,
+      // Removed rather than stored empty: a node that never had an id and one
+      // whose id was cleared are the same node, and an empty string would
+      // render as `id=""`.
+      patch: { cssId: idDraft.trim() === "" ? undefined : idDraft.trim() },
+    });
+  };
+
+  const commitRows = (next: readonly AttributeRow[]): void => {
+    editor.apply({
+      kind: "update",
+      id: nodeId,
+      patch: { attributes: storedAttributes(next, idDraft) },
+    });
+  };
+
+  const change = (index: number, part: Partial<AttributeRow>): void => {
+    setRows(current =>
+      current.map((row, at) => (at === index ? { ...row, ...part } : row))
+    );
+  };
+
+  const remove = (index: number): void => {
+    const next = rows.filter((_row, at) => at !== index);
+    setRows(next);
+    // Immediately, with no blur to wait for: removal is a decision rather than
+    // a value being typed, and there is nothing to coalesce.
+    commitRows(next);
+  };
+
+  return (
+    <div className="nx-inspector__fields">
+      <div className="nx-inspector__field">
+        <Label htmlFor="nx-block-css-id">CSS id</Label>
+        <Input
+          id="nx-block-css-id"
+          value={idDraft}
+          placeholder="none"
+          onChange={event => setIdDraft(event.target.value)}
+          // Committed on blur and on Enter, matching every other text field
+          // here: an op per keystroke would make one undo remove one letter.
+          onBlur={commitId}
+          onKeyDown={event => {
+            if (event.key !== "Enter") return;
+            event.preventDefault();
+            commitId();
+          }}
+        />
+        <p className="nx-inspector__hint">
+          Becomes this block&rsquo;s <code>id</code>, so a link can point at it.
+          It must be different from every other block&rsquo;s.
+        </p>
+      </div>
+
+      <fieldset className="nx-attributes">
+        <legend className="nx-attributes__legend">Attributes</legend>
+        {rows.length === 0 ? (
+          <p className="nx-inspector__note">No attributes on this block.</p>
+        ) : (
+          <>
+            {/*
+              Column headings, shown ONCE. Repeating "Name" and "Value" against
+              every row is noise to look at, and worse to listen to: each
+              repetition is another control announced with a word that already
+              means the block's own name field above the tabs.
+
+              `aria-hidden` because they label nothing — every input carries its
+              own accessible name, which is unique per row and still contains
+              the word written here.
+            */}
+            <div className="nx-attributes__head" aria-hidden="true">
+              <span>Name</span>
+              <span>Value</span>
+            </div>
+            <ul className="nx-attributes__rows">
+              {rows.map((row, index) => (
+                <AttributeRowFields
+                  // Keyed by POSITION, not by name: a name is what the author is
+                  // editing, so keying on it would remount the input on every
+                  // keystroke and lose the caret.
+                  key={`${nodeId}:${String(index)}`}
+                  row={row}
+                  index={index}
+                  problem={problemOf(settled, index, settledId, rows)}
+                  onChange={change}
+                  onCommit={() => commitRows(rows)}
+                  onRemove={() => remove(index)}
+                />
+              ))}
+            </ul>
+          </>
+        )}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => setRows([...rows, { name: "", value: "" }])}
+        >
+          Add attribute
+        </Button>
+      </fieldset>
+    </div>
+  );
+}
+
+/**
+ * The verdict for one row, read from the settled text but keyed to the live one.
+ *
+ * `useDeferredValue` can hand back a row list one keystroke behind the one being
+ * rendered, and a verdict read at an index that no longer holds the same row
+ * would be attached to the wrong input. So the row is compared before the
+ * verdict is used, and a stale pair simply says nothing yet.
+ */
+function problemOf(
+  settled: readonly AttributeRow[],
+  index: number,
+  settledId: string,
+  live: readonly AttributeRow[]
+): string | undefined {
+  const behind = settled[index];
+  const now = live[index];
+  if (behind === undefined || now === undefined) return undefined;
+  if (behind.name !== now.name) return undefined;
+  const problem = rowProblem(settled, index, settledId);
+  return problem === undefined ? undefined : problemMessage(problem);
+}
+
+function AttributeRowFields({
+  row,
+  index,
+  problem,
+  onChange,
+  onCommit,
+  onRemove,
+}: {
+  row: AttributeRow;
+  index: number;
+  problem: string | undefined;
+  onChange: (index: number, part: Partial<AttributeRow>) => void;
+  onCommit: () => void;
+  onRemove: () => void;
+}): React.JSX.Element {
+  const nameId = `nx-attr-name-${String(index)}`;
+  const valueId = `nx-attr-value-${String(index)}`;
+  const problemId = `nx-attr-problem-${String(index)}`;
+  /*
+   * The visible labels are short because they sit inline beside the fields, and
+   * short labels REPEAT: "Name" is also the block's own name field a few
+   * hundred pixels above, and every row here would announce "Name" again. A
+   * screen reader reading the page in order would hear one word for several
+   * different things.
+   *
+   * So the accessible name is made unique per row while still CONTAINING the
+   * visible word, which is what lets someone say "name" to a voice control and
+   * have it match what they can see.
+   */
+  const position = String(index + 1);
+  return (
+    <li className="nx-attributes__row">
+      <div className="nx-attributes__pair">
+        <Input
+          id={nameId}
+          value={row.name}
+          placeholder="data-example"
+          aria-label={`Name of attribute ${position}`}
+          // Named so a screen reader reaches the reason with the field, rather
+          // than leaving it as text that happens to sit nearby.
+          aria-describedby={problem === undefined ? undefined : problemId}
+          aria-invalid={problem === undefined ? undefined : true}
+          onChange={event => onChange(index, { name: event.target.value })}
+          onBlur={onCommit}
+        />
+        <Input
+          id={valueId}
+          value={row.value}
+          aria-label={`Value of attribute ${position}`}
+          onChange={event => onChange(index, { value: event.target.value })}
+          onBlur={onCommit}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          // Named per row, because six identical "Remove" buttons give a screen
+          // reader six identical announcements and no way to tell them apart.
+          aria-label={
+            isBlankRow(row) ? "Remove empty attribute" : `Remove ${row.name}`
+          }
+          onClick={onRemove}
+        >
+          Remove
+        </Button>
+      </div>
+      {problem === undefined ? null : (
+        <p className="nx-attributes__problem" id={problemId} role="alert">
+          {problem}
+        </p>
+      )}
+    </li>
+  );
+}

--- a/packages/builder/src/advanced-panel.tsx
+++ b/packages/builder/src/advanced-panel.tsx
@@ -137,7 +137,19 @@ export function AdvancedPanel({
     const keptId = id !== "" && taken.has(id) ? cssId : id;
     const wanted = {
       cssId: keptId,
-      attributes: storedAttributes(next.rows, keptId, attributes ?? {}),
+      /*
+       * The shadowed `id` is dropped only when the author has just SET the
+       * field, never merely because it holds something. A node imported with
+       * both a `cssId` and a legacy `id` would otherwise lose the second the
+       * moment anyone opened this tab — and lose it again on a change that was
+       * REFUSED, since a refusal keeps the id the node already had and that is
+       * still non-empty. Nothing the author did not ask for gets deleted.
+       */
+      attributes: storedAttributes(
+        next.rows,
+        keptId === cssId ? "" : keptId,
+        attributes ?? {}
+      ),
     };
     const update = htmlUpdate(wanted, { cssId, attributes });
     if (update === undefined) return;

--- a/packages/builder/src/advanced-panel.tsx
+++ b/packages/builder/src/advanced-panel.tsx
@@ -30,7 +30,9 @@ import * as React from "react";
 
 import {
   domIdsTaken,
+  holdsTheWrite,
   htmlUpdate,
+  type HtmlFields,
   isBlankRow,
   problemMessage,
   rowProblem,
@@ -77,10 +79,27 @@ export function AdvancedPanel({
     rows: rowsOf(attributes),
   });
 
-  // The stored values win whenever they change underneath the panel — an undo,
-  // or an edit applied from somewhere else. Without this the fields would go on
-  // showing what the document no longer holds.
+  /*
+   * What this panel last WROTE, so it can tell its own echo from a real change.
+   *
+   * The stored values must win when they change underneath the panel — an undo,
+   * or an edit from somewhere else — or the fields go on showing what the
+   * document no longer holds. But a write of our own comes back through the
+   * same props, and resetting on that throws away whatever the author has typed
+   * since: a row renamed to a refused name lost its text AND the explanation
+   * beside it, in the same moment the valid attribute it replaced was deleted.
+   */
+  const lastWritten = React.useRef<HtmlFields | null>(null);
   React.useEffect(() => {
+    const written = lastWritten.current;
+    // Asked through the same function that decides whether a write is needed,
+    // so "unchanged" means one thing here and there rather than two.
+    if (
+      written !== null &&
+      htmlUpdate(written, { cssId, attributes }) === undefined
+    ) {
+      return;
+    }
     const stored = { id: cssId, rows: rowsOf(attributes) };
     setDraft(stored);
     setSettled(stored);
@@ -107,11 +126,30 @@ export function AdvancedPanel({
     // what the author typed, with the reason beside it, and the document keeps
     // what it had.
     const keptId = id !== "" && taken.has(id) ? cssId : id;
-    const update = htmlUpdate(
-      { cssId: keptId, attributes: storedAttributes(next.rows, keptId, taken) },
-      { cssId, attributes }
-    );
+    /*
+     * A row the page would drop is not a request to DELETE what is stored.
+     * Renaming `data-x` to `onclick` means the author has typed something
+     * wrong, not that they want `data-x` gone — and writing the reduced set
+     * would remove it while the row showing the mistake was replaced by the
+     * empty stored value, so both the attribute and its explanation vanished.
+     *
+     * So the attributes are left exactly as they are until every row can land.
+     * The id still commits: it is a separate field and holding it hostage to an
+     * unrelated typo would be its own surprise.
+     */
+    const refused = next.rows.some((_row, index) => {
+      const problem = rowProblem(next.rows, index, keptId, taken);
+      return problem !== undefined && holdsTheWrite(problem);
+    });
+    const wanted = {
+      cssId: keptId,
+      attributes: refused
+        ? attributes
+        : storedAttributes(next.rows, keptId, taken),
+    };
+    const update = htmlUpdate(wanted, { cssId, attributes });
     if (update === undefined) return;
+    lastWritten.current = wanted;
     editor.apply({
       kind: "update",
       id: nodeId,

--- a/packages/builder/src/advanced-panel.tsx
+++ b/packages/builder/src/advanced-panel.tsx
@@ -38,6 +38,7 @@ import {
   rowProblem,
   rowsOf,
   storedAttributes,
+  withoutShadowedId,
   type AttributeRow,
 } from "./custom-attributes";
 import type { EditorState } from "./editor-state";
@@ -143,9 +144,16 @@ export function AdvancedPanel({
     });
     const wanted = {
       cssId: keptId,
-      attributes: refused
-        ? attributes
-        : storedAttributes(next.rows, keptId, taken),
+      /*
+       * The shadowing is applied to WHICHEVER set is written. Holding the rows
+       * because one is a mistake must not also hold back dropping an id the
+       * new CSS id shadows — those are two different reasons and only one of
+       * them is the author's to fix.
+       */
+      attributes: withoutShadowedId(
+        refused ? attributes : storedAttributes(next.rows, keptId, taken),
+        keptId
+      ),
     };
     const update = htmlUpdate(wanted, { cssId, attributes });
     if (update === undefined) return;

--- a/packages/builder/src/advanced-panel.tsx
+++ b/packages/builder/src/advanced-panel.tsx
@@ -25,6 +25,7 @@
  *
  * @module advanced-panel
  */
+import { registeredBlocks } from "@nextlyhq/blocks-react";
 import { Button, Input, Label } from "@nextlyhq/ui";
 import * as React from "react";
 
@@ -36,6 +37,7 @@ import {
   problemMessage,
   rebasedRows,
   rowProblem,
+  requestedId,
   rowsOf,
   sameDraft,
   wantedFields,
@@ -133,7 +135,7 @@ export function AdvancedPanel({
   }, [cssId, attributes]);
 
   const taken = React.useMemo(
-    () => domIdsTaken(editor.document.nodes, nodeId),
+    () => domIdsTaken(editor.document.nodes, nodeId, registeredBlocks()),
     [editor.document, nodeId]
   );
 
@@ -163,6 +165,9 @@ export function AdvancedPanel({
       return;
     }
     const stored = { cssId, attributes };
+    // Read BEFORE `loaded` moves below, or it compares the draft against the
+    // value this very write is about to record and always agrees.
+    const asked = requestedId(next, loaded.current);
     const wanted = wantedFields(next, loaded.current, stored, taken);
     const update = htmlUpdate(wanted, stored);
     // Edited, but to something the document already holds — a value typed back
@@ -212,10 +217,19 @@ export function AdvancedPanel({
      */
     const landed = wanted.cssId;
     loaded.current = { id: landed, rows: rebasedRows(next.rows, wanted) };
+    /*
+     * The FIELD only follows when the author's own id is the one that landed.
+     *
+     * A refused id — one another block already holds — is kept out of the write
+     * while staying in the field with its reason beside it, so `wanted.cssId`
+     * is the value the node already had rather than anything the author typed.
+     * Rebasing the field onto that replaced the text they were fixing, and took
+     * the collision message with it, because an unrelated attribute saved.
+     */
     setDraft(current => ({
       // Unless the author has typed since, in which case theirs is newer than
       // anything this write knows about.
-      id: current.id === next.id ? landed : current.id,
+      id: current.id === next.id && landed === asked ? landed : current.id,
       rows: rebasedRows(current.rows, wanted),
     }));
   };

--- a/packages/builder/src/advanced-panel.tsx
+++ b/packages/builder/src/advanced-panel.tsx
@@ -37,13 +37,14 @@ import {
   isBlankRow,
   problemMessage,
   rebasedRows,
-  rowProblem,
   requestedId,
   rowsOf,
+  rowProblems,
   sameDraft,
   wantedFields,
   type AttributeRow,
   type Draft,
+  type RowProblem,
 } from "./custom-attributes";
 import type { EditorState } from "./editor-state";
 
@@ -321,6 +322,13 @@ export function AdvancedPanel({
   };
 
   const idProblem = idProblemOf(settled.id, cssId, taken);
+  /*
+   * Analysed ONCE for the settled set, not once per row. Every verdict depends
+   * on the whole set — who keeps a contested key, which keys refused rows are
+   * holding — so asking row by row recomputed all of it for each row, and an
+   * imported bag of a few hundred attributes stopped rendering.
+   */
+  const problems = React.useMemo(() => rowProblems(settled.rows), [settled]);
 
   return (
     <div className="nx-inspector__fields">
@@ -394,7 +402,7 @@ export function AdvancedPanel({
                   key={`${nodeId}:${String(index)}`}
                   row={row}
                   index={index}
-                  problem={problemOf(settled, index, draft)}
+                  problem={problemOf(settled, problems, index, draft)}
                   onChange={change}
                   onCommit={() => settle(latest.current)}
                   onRemove={() => remove(index)}
@@ -442,6 +450,7 @@ function idProblemOf(
  */
 function problemOf(
   settled: Draft,
+  problems: readonly (RowProblem | undefined)[],
   index: number,
   live: Draft
 ): string | undefined {
@@ -456,7 +465,7 @@ function problemOf(
    * an id belongs in the field above, and that field carries its own collision
    * message on the one input whose value it is about.
    */
-  const problem = rowProblem(settled.rows, index);
+  const problem = problems[index];
   return problem === undefined ? undefined : problemMessage(problem);
 }
 

--- a/packages/builder/src/advanced-panel.tsx
+++ b/packages/builder/src/advanced-panel.tsx
@@ -30,7 +30,6 @@ import * as React from "react";
 
 import {
   domIdsTaken,
-  holdsTheWrite,
   htmlUpdate,
   type HtmlFields,
   isBlankRow,
@@ -38,7 +37,6 @@ import {
   rowProblem,
   rowsOf,
   storedAttributes,
-  withoutShadowedId,
   type AttributeRow,
 } from "./custom-attributes";
 import type { EditorState } from "./editor-state";
@@ -99,6 +97,14 @@ export function AdvancedPanel({
       written !== null &&
       htmlUpdate(written, { cssId, attributes }) === undefined
     ) {
+      /*
+       * CONSUMED, not merely matched. Left in place, the marker goes on
+       * describing a state the document may return to — undo then redo lands
+       * back on it, this branch returns again, and the panel keeps showing the
+       * undone value while a later blur writes from that stale draft and erases
+       * the redone edit. One echo, one write.
+       */
+      lastWritten.current = null;
       return;
     }
     const stored = { id: cssId, rows: rowsOf(attributes) };
@@ -127,33 +133,9 @@ export function AdvancedPanel({
     // what the author typed, with the reason beside it, and the document keeps
     // what it had.
     const keptId = id !== "" && taken.has(id) ? cssId : id;
-    /*
-     * A row the page would drop is not a request to DELETE what is stored.
-     * Renaming `data-x` to `onclick` means the author has typed something
-     * wrong, not that they want `data-x` gone — and writing the reduced set
-     * would remove it while the row showing the mistake was replaced by the
-     * empty stored value, so both the attribute and its explanation vanished.
-     *
-     * So the attributes are left exactly as they are until every row can land.
-     * The id still commits: it is a separate field and holding it hostage to an
-     * unrelated typo would be its own surprise.
-     */
-    const refused = next.rows.some((_row, index) => {
-      const problem = rowProblem(next.rows, index, keptId, taken);
-      return problem !== undefined && holdsTheWrite(problem);
-    });
     const wanted = {
       cssId: keptId,
-      /*
-       * The shadowing is applied to WHICHEVER set is written. Holding the rows
-       * because one is a mistake must not also hold back dropping an id the
-       * new CSS id shadows — those are two different reasons and only one of
-       * them is the author's to fix.
-       */
-      attributes: withoutShadowedId(
-        refused ? attributes : storedAttributes(next.rows, keptId, taken),
-        keptId
-      ),
+      attributes: storedAttributes(next.rows, keptId, attributes ?? {}),
     };
     const update = htmlUpdate(wanted, { cssId, attributes });
     if (update === undefined) return;
@@ -276,7 +258,7 @@ export function AdvancedPanel({
                   key={`${nodeId}:${String(index)}`}
                   row={row}
                   index={index}
-                  problem={problemOf(settled, index, draft, taken)}
+                  problem={problemOf(settled, index, draft)}
                   onChange={change}
                   onCommit={() => settle(latest.current)}
                   onRemove={() => remove(index)}
@@ -325,14 +307,20 @@ function idProblemOf(
 function problemOf(
   settled: Draft,
   index: number,
-  live: Draft,
-  taken: ReadonlySet<string>
+  live: Draft
 ): string | undefined {
   const behind = settled.rows[index];
   const now = live.rows[index];
   if (behind === undefined || now === undefined) return undefined;
   if (behind.name !== now.name) return undefined;
-  const problem = rowProblem(settled.rows, index, settled.id.trim(), taken);
+  /*
+   * Every row problem is about the NAME, which is why the reason below is wired
+   * to that input alone. A colliding id used to be the exception — a good name
+   * with a value another block held — and it no longer reaches a row at all:
+   * an id belongs in the field above, and that field carries its own collision
+   * message on the one input whose value it is about.
+   */
+  const problem = rowProblem(settled.rows, index);
   return problem === undefined ? undefined : problemMessage(problem);
 }
 
@@ -371,7 +359,8 @@ function AttributeRowFields({
           placeholder="data-example"
           aria-label={`Name of attribute ${position}`}
           // Named so a screen reader reaches the reason with the field, rather
-          // than leaving it as text that happens to sit nearby.
+          // than leaving it as text that happens to sit nearby — and only when
+          // the NAME is the thing that is wrong.
           aria-describedby={problem === undefined ? undefined : problemId}
           aria-invalid={problem === undefined ? undefined : true}
           onChange={event => onChange(index, { name: event.target.value })}

--- a/packages/builder/src/advanced-panel.tsx
+++ b/packages/builder/src/advanced-panel.tsx
@@ -7,21 +7,21 @@
  * the Content tab — and neither is a style. They are the escape hatch: the way
  * an author reaches the rendered element itself, for an anchor to link to, a
  * `data-` attribute an analytics script reads, or an `aria-` attribute the
- * block's own markup does not offer. Every editor that has this puts it behind
- * its own heading for the same reason, and the surface this replaces did too.
+ * block's own markup does not offer.
  *
- * ## The rules are the RENDERER's, and are asked rather than repeated
+ * ## ONE writer for both fields
  *
- * `custom-attributes.ts` holds that reasoning. What matters here is that this
- * panel shows a row as refused for exactly the reasons the page would drop it,
- * so an author is never told something saved and then finds it missing.
+ * They are written by a single function, because they decide each other. A
+ * `cssId` beats an `id` in the attribute bag, so setting one changes whether
+ * the other lands — and two commit paths, one per field, disagreed about that:
+ * committing rows dropped the shadowed `id` and committing the id did not, so
+ * clearing the id later brought a stale one back to life.
  *
- * ## Warnings wait for the author to stop typing
+ * ## Removal is `unset`, never `undefined`
  *
- * A refusal shown mid-keystroke says `data-` is not allowed while the author is
- * two characters into typing `data-x`. `useDeferredValue` lets the character
- * land first, which is the same reason the editor this replaces deferred its
- * own validation.
+ * `applyOp` refuses `undefined` as a patch value and says why: the key
+ * disappears when the op is stored, so a replayed edit would silently do
+ * nothing. Clearing a field is `unset`, which survives being written down.
  *
  * @module advanced-panel
  */
@@ -29,6 +29,8 @@ import { Button, Input, Label } from "@nextlyhq/ui";
 import * as React from "react";
 
 import {
+  domIdsTaken,
+  htmlUpdate,
   isBlankRow,
   problemMessage,
   rowProblem,
@@ -45,76 +47,121 @@ export interface AdvancedPanelProps {
   readonly editor: EditorState;
 }
 
-/**
- * The panel, holding the author's rows while they are being edited.
- *
- * Rows are LOCAL state rather than derived per render, because a half-typed row
- * has no home in the document: a name with no value yet, or a name that is not
- * allowed, is not something to store. The document is written on commit, and
- * the stored value is what comes back if the panel is remounted.
- */
+/** The draft an author is editing, before any of it is written down. */
+interface Draft {
+  readonly id: string;
+  readonly rows: readonly AttributeRow[];
+}
+
 export function AdvancedPanel({
   nodeId,
   cssId,
   attributes,
   editor,
 }: AdvancedPanelProps): React.JSX.Element {
-  const [idDraft, setIdDraft] = React.useState(cssId);
-  const [rows, setRows] = React.useState<AttributeRow[]>(() =>
-    rowsOf(attributes)
-  );
+  const [draft, setDraft] = React.useState<Draft>(() => ({
+    id: cssId,
+    rows: rowsOf(attributes),
+  }));
+  /*
+   * What the author has FINISHED typing, and the only thing verdicts are read
+   * from. Judging every keystroke tells someone two characters into `data-x`
+   * that `da` is not allowed, and `useDeferredValue` does not prevent that —
+   * it schedules a background render immediately and catches up whenever
+   * React has capacity, so intermediate values are judged and shown exactly as
+   * they would be without it. Settling on blur is the behaviour the panel
+   * actually wanted, and it says what it does.
+   */
+  const [settled, setSettled] = React.useState<Draft>({
+    id: cssId,
+    rows: rowsOf(attributes),
+  });
 
   // The stored values win whenever they change underneath the panel — an undo,
   // or an edit applied from somewhere else. Without this the fields would go on
   // showing what the document no longer holds.
   React.useEffect(() => {
-    setIdDraft(cssId);
-  }, [cssId]);
-  React.useEffect(() => {
-    setRows(rowsOf(attributes));
-  }, [attributes]);
+    const stored = { id: cssId, rows: rowsOf(attributes) };
+    setDraft(stored);
+    setSettled(stored);
+  }, [cssId, attributes]);
+
+  const taken = React.useMemo(
+    () => domIdsTaken(editor.document.nodes, nodeId),
+    [editor.document, nodeId]
+  );
 
   /*
-   * Judged against the SETTLED text, so a refusal does not appear while a name
-   * is still being typed. The rows themselves stay live — the input must show
-   * every keystroke — and only the verdict lags.
+   * Read at write time rather than closed over. The panel commits from an
+   * unmount cleanup — see below — which runs after the render that removed it,
+   * so a closure captured earlier would write a draft the author has since
+   * changed.
    */
-  const settled = React.useDeferredValue(rows);
-  const settledId = React.useDeferredValue(idDraft);
+  const latest = React.useRef<Draft>(draft);
+  latest.current = draft;
+  const write = React.useRef<(next: Draft) => void>(() => {});
 
-  const commitId = (): void => {
-    if (idDraft.trim() === cssId) return;
+  write.current = (next: Draft): void => {
+    const id = next.id.trim();
+    // An id another block holds is not written at all: the field keeps showing
+    // what the author typed, with the reason beside it, and the document keeps
+    // what it had.
+    const keptId = id !== "" && taken.has(id) ? cssId : id;
+    const update = htmlUpdate(
+      { cssId: keptId, attributes: storedAttributes(next.rows, keptId, taken) },
+      { cssId, attributes }
+    );
+    if (update === undefined) return;
     editor.apply({
       kind: "update",
       id: nodeId,
-      // Removed rather than stored empty: a node that never had an id and one
-      // whose id was cleared are the same node, and an empty string would
-      // render as `id=""`.
-      patch: { cssId: idDraft.trim() === "" ? undefined : idDraft.trim() },
-    });
+      patch: update.patch,
+      ...(update.unset.length > 0 ? { unset: update.unset } : {}),
+    } as Parameters<EditorState["apply"]>[0]);
   };
 
-  const commitRows = (next: readonly AttributeRow[]): void => {
-    editor.apply({
-      kind: "update",
-      id: nodeId,
-      patch: { attributes: storedAttributes(next, idDraft) },
-    });
+  /*
+   * Committed when the panel GOES AWAY, not only on blur.
+   *
+   * The inspector's tabs activate on `mousedown` and unmount the inactive tab's
+   * content, so an author who types an attribute and clicks Style has this
+   * panel removed before the browser delivers the blur — and the draft was
+   * lost with it, silently. Selecting another block does the same through the
+   * key on this element.
+   */
+  React.useEffect(
+    () => () => {
+      write.current(latest.current);
+    },
+    []
+  );
+
+  const settle = (next: Draft): void => {
+    setSettled(next);
+    write.current(next);
   };
 
   const change = (index: number, part: Partial<AttributeRow>): void => {
-    setRows(current =>
-      current.map((row, at) => (at === index ? { ...row, ...part } : row))
-    );
+    setDraft(current => ({
+      ...current,
+      rows: current.rows.map((row, at) =>
+        at === index ? { ...row, ...part } : row
+      ),
+    }));
   };
 
   const remove = (index: number): void => {
-    const next = rows.filter((_row, at) => at !== index);
-    setRows(next);
-    // Immediately, with no blur to wait for: removal is a decision rather than
-    // a value being typed, and there is nothing to coalesce.
-    commitRows(next);
+    const next: Draft = {
+      ...draft,
+      rows: draft.rows.filter((_row, at) => at !== index),
+    };
+    setDraft(next);
+    // Immediately: removal is a decision rather than a value being typed, and
+    // there is nothing to coalesce.
+    settle(next);
   };
+
+  const idProblem = idProblemOf(settled.id, cssId, taken);
 
   return (
     <div className="nx-inspector__fields">
@@ -122,27 +169,41 @@ export function AdvancedPanel({
         <Label htmlFor="nx-block-css-id">CSS id</Label>
         <Input
           id="nx-block-css-id"
-          value={idDraft}
+          value={draft.id}
           placeholder="none"
-          onChange={event => setIdDraft(event.target.value)}
-          // Committed on blur and on Enter, matching every other text field
-          // here: an op per keystroke would make one undo remove one letter.
-          onBlur={commitId}
+          aria-describedby={
+            idProblem === undefined ? undefined : "nx-css-id-problem"
+          }
+          aria-invalid={idProblem === undefined ? undefined : true}
+          onChange={event =>
+            setDraft(current => ({ ...current, id: event.target.value }))
+          }
+          onBlur={() => settle(latest.current)}
           onKeyDown={event => {
             if (event.key !== "Enter") return;
             event.preventDefault();
-            commitId();
+            settle(latest.current);
           }}
         />
-        <p className="nx-inspector__hint">
-          Becomes this block&rsquo;s <code>id</code>, so a link can point at it.
-          It must be different from every other block&rsquo;s.
-        </p>
+        {idProblem === undefined ? (
+          <p className="nx-inspector__hint">
+            Becomes this block&rsquo;s <code>id</code>, so a link can point at
+            it. It must be different from every other block&rsquo;s.
+          </p>
+        ) : (
+          <p
+            className="nx-attributes__problem"
+            id="nx-css-id-problem"
+            role="alert"
+          >
+            {idProblem}
+          </p>
+        )}
       </div>
 
       <fieldset className="nx-attributes">
         <legend className="nx-attributes__legend">Attributes</legend>
-        {rows.length === 0 ? (
+        {draft.rows.length === 0 ? (
           <p className="nx-inspector__note">No attributes on this block.</p>
         ) : (
           <>
@@ -161,7 +222,7 @@ export function AdvancedPanel({
               <span>Value</span>
             </div>
             <ul className="nx-attributes__rows">
-              {rows.map((row, index) => (
+              {draft.rows.map((row, index) => (
                 <AttributeRowFields
                   // Keyed by POSITION, not by name: a name is what the author is
                   // editing, so keying on it would remount the input on every
@@ -169,9 +230,9 @@ export function AdvancedPanel({
                   key={`${nodeId}:${String(index)}`}
                   row={row}
                   index={index}
-                  problem={problemOf(settled, index, settledId, rows)}
+                  problem={problemOf(settled, index, draft, taken)}
                   onChange={change}
-                  onCommit={() => commitRows(rows)}
+                  onCommit={() => settle(latest.current)}
                   onRemove={() => remove(index)}
                 />
               ))}
@@ -182,7 +243,12 @@ export function AdvancedPanel({
           type="button"
           variant="ghost"
           size="sm"
-          onClick={() => setRows([...rows, { name: "", value: "" }])}
+          onClick={() =>
+            setDraft(current => ({
+              ...current,
+              rows: [...current.rows, { name: "", value: "" }],
+            }))
+          }
         >
           Add attribute
         </Button>
@@ -191,25 +257,36 @@ export function AdvancedPanel({
   );
 }
 
+/** Why the CSS id will not be written, or `undefined`. */
+function idProblemOf(
+  id: string,
+  stored: string,
+  taken: ReadonlySet<string>
+): string | undefined {
+  const trimmed = id.trim();
+  if (trimmed === "" || trimmed === stored) return undefined;
+  return taken.has(trimmed)
+    ? "Another block on this page already uses that id. Two elements with one id give a link, a label and a style rule two possible targets."
+    : undefined;
+}
+
 /**
- * The verdict for one row, read from the settled text but keyed to the live one.
+ * The verdict for one row, read from the settled draft but keyed to the live one.
  *
- * `useDeferredValue` can hand back a row list one keystroke behind the one being
- * rendered, and a verdict read at an index that no longer holds the same row
- * would be attached to the wrong input. So the row is compared before the
- * verdict is used, and a stale pair simply says nothing yet.
+ * A row the author is still typing has no verdict yet, so a settled list that
+ * no longer matches the live one at this position simply says nothing.
  */
 function problemOf(
-  settled: readonly AttributeRow[],
+  settled: Draft,
   index: number,
-  settledId: string,
-  live: readonly AttributeRow[]
+  live: Draft,
+  taken: ReadonlySet<string>
 ): string | undefined {
-  const behind = settled[index];
-  const now = live[index];
+  const behind = settled.rows[index];
+  const now = live.rows[index];
   if (behind === undefined || now === undefined) return undefined;
   if (behind.name !== now.name) return undefined;
-  const problem = rowProblem(settled, index, settledId);
+  const problem = rowProblem(settled.rows, index, settled.id.trim(), taken);
   return problem === undefined ? undefined : problemMessage(problem);
 }
 
@@ -232,13 +309,9 @@ function AttributeRowFields({
   const valueId = `nx-attr-value-${String(index)}`;
   const problemId = `nx-attr-problem-${String(index)}`;
   /*
-   * The visible labels are short because they sit inline beside the fields, and
-   * short labels REPEAT: "Name" is also the block's own name field a few
-   * hundred pixels above, and every row here would announce "Name" again. A
-   * screen reader reading the page in order would hear one word for several
-   * different things.
-   *
-   * So the accessible name is made unique per row while still CONTAINING the
+   * The visible headings are short because they sit over the columns, and short
+   * words REPEAT: "Name" is also the block's own name field above the tabs. So
+   * the accessible name is made unique per row while still CONTAINING the
    * visible word, which is what lets someone say "name" to a voice control and
    * have it match what they can see.
    */

--- a/packages/builder/src/advanced-panel.tsx
+++ b/packages/builder/src/advanced-panel.tsx
@@ -194,11 +194,23 @@ export function AdvancedPanel({
     }
     setRefusal(undefined);
     lastWritten.current = wanted;
-    // In step with the document again, so the next commit finds nothing to do
-    // rather than writing this same edit a second time.
-    loaded.current = { id: next.id, rows: rebasedRows(next.rows, wanted) };
+    /*
+     * REBASED onto what landed — the id as well as the rows, because the id is
+     * normalized on the way out and the rows are not.
+     *
+     * Recording the raw draft here left the two disagreeing: the document held
+     * `hero` while the draft still held `" hero "`, so the next commit saw an id
+     * unchanged from what was loaded, declined to trim it a second time, and
+     * patched the spaces back — breaking every fragment link to the block. The
+     * rows were already rebased for the same reason; the id was the site this
+     * rule had not reached.
+     */
+    const landed = wanted.cssId;
+    loaded.current = { id: landed, rows: rebasedRows(next.rows, wanted) };
     setDraft(current => ({
-      ...current,
+      // Unless the author has typed since, in which case theirs is newer than
+      // anything this write knows about.
+      id: current.id === next.id ? landed : current.id,
       rows: rebasedRows(current.rows, wanted),
     }));
   };

--- a/packages/builder/src/advanced-panel.tsx
+++ b/packages/builder/src/advanced-panel.tsx
@@ -29,6 +29,7 @@ import { Button, Input, Label } from "@nextlyhq/ui";
 import * as React from "react";
 
 import {
+  attributeKey,
   domIdsTaken,
   htmlUpdate,
   type HtmlFields,
@@ -89,6 +90,7 @@ export function AdvancedPanel({
    * beside it, in the same moment the valid attribute it replaced was deleted.
    */
   const lastWritten = React.useRef<HtmlFields | null>(null);
+  const [refusal, setRefusal] = React.useState<string | undefined>(undefined);
   React.useEffect(() => {
     const written = lastWritten.current;
     // Asked through the same function that decides whether a write is needed,
@@ -139,13 +141,46 @@ export function AdvancedPanel({
     };
     const update = htmlUpdate(wanted, { cssId, attributes });
     if (update === undefined) return;
-    lastWritten.current = wanted;
-    editor.apply({
+    const applied = editor.apply({
       kind: "update",
       id: nodeId,
       patch: update.patch,
       ...(update.unset.length > 0 ? { unset: update.unset } : {}),
     } as Parameters<EditorState["apply"]>[0]);
+    /*
+     * REFUSED ops leave the document alone — a value that pushes it past its
+     * byte limit is the reachable one — and `apply` says so by answering
+     * `null`. Marking the attempt as written before knowing would tell the
+     * effect below that the props it sees are this panel's own echo, so it
+     * would stop re-reading the document and the field would go on showing a
+     * value nothing stored.
+     */
+    if (applied === null) {
+      setRefusal(
+        "That change could not be saved — the page is at its size limit. Shorten the value and try again."
+      );
+      return;
+    }
+    setRefusal(undefined);
+    lastWritten.current = wanted;
+    /*
+     * REBASED onto what was stored. A row keeps the name it was loaded with so
+     * a later mistake can fall back to it — but once the rename has landed,
+     * that old name is no longer in the document, and falling back to it finds
+     * nothing and unsets the value the rename had just saved.
+     *
+     * Only the origins move; the names and values the author is looking at stay
+     * exactly as they are, so nothing shifts under a cursor.
+     */
+    setDraft(current => ({
+      ...current,
+      rows: current.rows.map(row =>
+        wanted.attributes !== undefined &&
+        wanted.attributes[attributeKey(row.name)] === row.value
+          ? { ...row, origin: attributeKey(row.name) }
+          : row
+      ),
+    }));
   };
 
   /*
@@ -193,6 +228,11 @@ export function AdvancedPanel({
 
   return (
     <div className="nx-inspector__fields">
+      {refusal === undefined ? null : (
+        <p className="nx-attributes__problem" role="alert">
+          {refusal}
+        </p>
+      )}
       <div className="nx-inspector__field">
         <Label htmlFor="nx-block-css-id">CSS id</Label>
         <Input
@@ -339,6 +379,17 @@ function AttributeRowFields({
   onCommit: () => void;
   onRemove: () => void;
 }): React.JSX.Element {
+  /*
+   * Enter COMMITS here; it must not reach the form above. The builder mounts
+   * inside the entry's `<form>`, and a single-line input with nothing
+   * stopping the key implicitly submits it — so typing an attribute and
+   * pressing Enter would save the whole entry.
+   */
+  const onEnter = (event: React.KeyboardEvent): void => {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    onCommit();
+  };
   const nameId = `nx-attr-name-${String(index)}`;
   const valueId = `nx-attr-value-${String(index)}`;
   const problemId = `nx-attr-problem-${String(index)}`;
@@ -365,6 +416,7 @@ function AttributeRowFields({
           aria-invalid={problem === undefined ? undefined : true}
           onChange={event => onChange(index, { name: event.target.value })}
           onBlur={onCommit}
+          onKeyDown={onEnter}
         />
         <Input
           id={valueId}
@@ -372,6 +424,7 @@ function AttributeRowFields({
           aria-label={`Value of attribute ${position}`}
           onChange={event => onChange(index, { value: event.target.value })}
           onBlur={onCommit}
+          onKeyDown={onEnter}
         />
         <Button
           type="button"

--- a/packages/builder/src/advanced-panel.tsx
+++ b/packages/builder/src/advanced-panel.tsx
@@ -29,16 +29,18 @@ import { Button, Input, Label } from "@nextlyhq/ui";
 import * as React from "react";
 
 import {
-  attributeKey,
   domIdsTaken,
   htmlUpdate,
   type HtmlFields,
   isBlankRow,
   problemMessage,
+  rebasedRows,
   rowProblem,
   rowsOf,
-  storedAttributes,
+  sameDraft,
+  wantedFields,
   type AttributeRow,
+  type Draft,
 } from "./custom-attributes";
 import type { EditorState } from "./editor-state";
 
@@ -47,12 +49,14 @@ export interface AdvancedPanelProps {
   readonly cssId: string;
   readonly attributes: Readonly<Record<string, string>> | undefined;
   readonly editor: EditorState;
-}
-
-/** The draft an author is editing, before any of it is written down. */
-interface Draft {
-  readonly id: string;
-  readonly rows: readonly AttributeRow[];
+  /**
+   * Whether this is the tab currently on screen.
+   *
+   * The panel stays MOUNTED behind the other tabs — see the commit effect below
+   * — so it no longer learns that the author looked away by being destroyed.
+   * This is how it is told.
+   */
+  readonly active: boolean;
 }
 
 export function AdvancedPanel({
@@ -60,6 +64,7 @@ export function AdvancedPanel({
   cssId,
   attributes,
   editor,
+  active,
 }: AdvancedPanelProps): React.JSX.Element {
   const [draft, setDraft] = React.useState<Draft>(() => ({
     id: cssId,
@@ -90,6 +95,18 @@ export function AdvancedPanel({
    * beside it, in the same moment the valid attribute it replaced was deleted.
    */
   const lastWritten = React.useRef<HtmlFields | null>(null);
+  /*
+   * The draft as last SYNCHRONIZED with the document — what the fields held
+   * when they were filled from it, or when a write of ours landed.
+   *
+   * A commit asks this before it asks anything else, because "the normalized
+   * draft differs from what is stored" is not the same question as "the author
+   * changed something", and answering the first one for the second wrote an
+   * edit nobody made: a stored `" hero "` trims and a stored `DATA-X`
+   * lowercases, so opening Advanced and switching tabs rewrote the document,
+   * added an undo entry, and moved the anchor a link pointed at.
+   */
+  const loaded = React.useRef<Draft>(draft);
   const [refusal, setRefusal] = React.useState<string | undefined>(undefined);
   React.useEffect(() => {
     const written = lastWritten.current;
@@ -112,6 +129,7 @@ export function AdvancedPanel({
     const stored = { id: cssId, rows: rowsOf(attributes) };
     setDraft(stored);
     setSettled(stored);
+    loaded.current = stored;
   }, [cssId, attributes]);
 
   const taken = React.useMemo(
@@ -130,29 +148,30 @@ export function AdvancedPanel({
   const write = React.useRef<(next: Draft) => void>(() => {});
 
   write.current = (next: Draft): void => {
-    const id = next.id.trim();
-    // An id another block holds is not written at all: the field keeps showing
-    // what the author typed, with the reason beside it, and the document keeps
-    // what it had.
-    const keptId = id !== "" && taken.has(id) ? cssId : id;
-    const wanted = {
-      cssId: keptId,
-      /*
-       * The shadowed `id` is dropped only when the author has just SET the
-       * field, never merely because it holds something. A node imported with
-       * both a `cssId` and a legacy `id` would otherwise lose the second the
-       * moment anyone opened this tab — and lose it again on a change that was
-       * REFUSED, since a refusal keeps the id the node already had and that is
-       * still non-empty. Nothing the author did not ask for gets deleted.
-       */
-      attributes: storedAttributes(
-        next.rows,
-        keptId === cssId ? "" : keptId,
-        attributes ?? {}
-      ),
-    };
-    const update = htmlUpdate(wanted, { cssId, attributes });
-    if (update === undefined) return;
+    /*
+     * NOTHING is written unless the author edited something. Every other test
+     * this could have used compares a NORMALIZED draft against the document,
+     * and normalization is exactly what an untouched panel does to a value it
+     * did not choose — so a panel that had only been looked at wrote a change,
+     * added an undo entry, and moved the anchor a link pointed at.
+     *
+     * The refusal goes with it: a message about a save that failed is about a
+     * pending change, and there is no longer one to fail.
+     */
+    if (sameDraft(next, loaded.current)) {
+      setRefusal(undefined);
+      return;
+    }
+    const stored = { cssId, attributes };
+    const wanted = wantedFields(next, loaded.current, stored, taken);
+    const update = htmlUpdate(wanted, stored);
+    // Edited, but to something the document already holds — a value typed back
+    // to what it was, or a row whose refusal leaves the stored bag as it was.
+    // Nothing to save, so nothing left to report about saving.
+    if (update === undefined) {
+      setRefusal(undefined);
+      return;
+    }
     const applied = editor.apply({
       kind: "update",
       id: nodeId,
@@ -163,7 +182,7 @@ export function AdvancedPanel({
      * REFUSED ops leave the document alone — a value that pushes it past its
      * byte limit is the reachable one — and `apply` says so by answering
      * `null`. Marking the attempt as written before knowing would tell the
-     * effect below that the props it sees are this panel's own echo, so it
+     * effect above that the props it sees are this panel's own echo, so it
      * would stop re-reading the document and the field would go on showing a
      * value nothing stored.
      */
@@ -175,34 +194,56 @@ export function AdvancedPanel({
     }
     setRefusal(undefined);
     lastWritten.current = wanted;
-    /*
-     * REBASED onto what was stored. A row keeps the name it was loaded with so
-     * a later mistake can fall back to it — but once the rename has landed,
-     * that old name is no longer in the document, and falling back to it finds
-     * nothing and unsets the value the rename had just saved.
-     *
-     * Only the origins move; the names and values the author is looking at stay
-     * exactly as they are, so nothing shifts under a cursor.
-     */
+    // In step with the document again, so the next commit finds nothing to do
+    // rather than writing this same edit a second time.
+    loaded.current = { id: next.id, rows: rebasedRows(next.rows, wanted) };
     setDraft(current => ({
       ...current,
-      rows: current.rows.map(row =>
-        wanted.attributes !== undefined &&
-        wanted.attributes[attributeKey(row.name)] === row.value
-          ? { ...row, origin: attributeKey(row.name) }
-          : row
-      ),
+      rows: rebasedRows(current.rows, wanted),
     }));
   };
 
+  const settle = (next: Draft): void => {
+    setSettled(next);
+    write.current(next);
+  };
+
   /*
-   * Committed when the panel GOES AWAY, not only on blur.
+   * Read at commit time rather than closed over, for the same reason `latest`
+   * is: both effects below run after a render the author has already moved on
+   * from.
+   */
+  const settleLatest = React.useRef<() => void>(() => {});
+  settleLatest.current = (): void => {
+    settle(latest.current);
+  };
+
+  /*
+   * Committed when the author LOOKS AWAY, and again if the panel goes away.
    *
-   * The inspector's tabs activate on `mousedown` and unmount the inactive tab's
-   * content, so an author who types an attribute and clicks Style has this
-   * panel removed before the browser delivers the blur — and the draft was
-   * lost with it, silently. Selecting another block does the same through the
-   * key on this element.
+   * The inspector's tabs activate on `mousedown`, so an author who types an
+   * attribute and clicks Style leaves before the browser delivers the blur.
+   * This tab's content is force-mounted for that reason — destroying it took
+   * the draft with it, and took the explanation beside a refused row with it
+   * too: renaming `data-x` to `onclick` and clicking Style correctly declined
+   * to store the name, then discarded the row that said so, so returning to
+   * Advanced showed `data-x` again and the author never learned why.
+   *
+   * Settled rather than merely written, because the verdicts an author needs to
+   * come back to are read from the settled draft.
+   */
+  const shown = React.useRef(active);
+  React.useEffect(() => {
+    if (shown.current === active) return;
+    shown.current = active;
+    if (active) return;
+    settleLatest.current();
+  }, [active]);
+
+  /*
+   * Selecting another block still DESTROYS this panel, through the key on it,
+   * and so does closing the inspector. Neither passes through the effect above,
+   * so the draft is committed here as well.
    */
   React.useEffect(
     () => () => {
@@ -210,11 +251,6 @@ export function AdvancedPanel({
     },
     []
   );
-
-  const settle = (next: Draft): void => {
-    setSettled(next);
-    write.current(next);
-  };
 
   const change = (index: number, part: Partial<AttributeRow>): void => {
     setDraft(current => ({

--- a/packages/builder/src/advanced-panel.tsx
+++ b/packages/builder/src/advanced-panel.tsx
@@ -179,16 +179,21 @@ export function AdvancedPanel({
       ...(update.unset.length > 0 ? { unset: update.unset } : {}),
     } as Parameters<EditorState["apply"]>[0]);
     /*
-     * REFUSED ops leave the document alone — a value that pushes it past its
-     * byte limit is the reachable one — and `apply` says so by answering
+     * REFUSED ops leave the document alone, and `apply` says so by answering
      * `null`. Marking the attempt as written before knowing would tell the
      * effect above that the props it sees are this panel's own echo, so it
      * would stop re-reading the document and the field would go on showing a
      * value nothing stored.
+     *
+     * The message names no single cause, because `apply` reports none: it
+     * answers `null` for ANY refused op — a value past the document's byte
+     * limit, but equally an update to a node a concurrent edit or an undo has
+     * removed. Both are reachable from this panel, and telling an author their
+     * page is full when their block has gone sends them to fix the wrong thing.
      */
     if (applied === null) {
       setRefusal(
-        "That change could not be saved — the page is at its size limit. Shorten the value and try again."
+        "That change could not be saved. A very long value can push the page past its size limit; otherwise the block may have changed since you opened this tab."
       );
       return;
     }

--- a/packages/builder/src/custom-attributes.test.ts
+++ b/packages/builder/src/custom-attributes.test.ts
@@ -779,3 +779,46 @@ describe("a refused rename beside a rename onto its origin", () => {
     });
   });
 });
+
+describe("a DUPLICATE-refused row holding an origin too", () => {
+  const stored = { "data-a": "1", "data-b": "2", "data-c": "3" };
+
+  it("counts what a duplicate-refused row preserves, not only a malformed one", () => {
+    /*
+     * The first origin-reservation fix counted only rows refused on their own
+     * terms. A row refused as a DUPLICATE preserves its origin just the same:
+     * rename `data-a` onto `data-b` (duplicate, so it keeps `data-a`) and
+     * `data-c` onto `data-a`, and the second was accepted and overwrote the
+     * preserved value — `data-c` gone.
+     */
+    const rows = [
+      { name: "data-b", value: "1", origin: "data-a" },
+      { name: "data-b", value: "2", origin: "data-b" },
+      { name: "data-a", value: "3", origin: "data-c" },
+    ];
+    expect(rowProblem(rows, 2)).toEqual({ kind: "duplicate" });
+    expect(storedAttributes(rows, "", stored)).toEqual(stored);
+  });
+
+  it("settles a CHAIN of refusals rather than one link of it", () => {
+    /*
+     * A row refused because of a held origin holds its OWN origin in turn, so
+     * the set has to be settled rather than swept once.
+     *
+     * Ordered so the chain runs BACKWARD through the rows, which is the only
+     * arrangement that can tell one sweep from a fixed point: a chain running
+     * forward resolves inside a single pass, because the set grows as that pass
+     * walks. Here the last row frees nothing until it is reached, and only then
+     * does the first row become refused — and only then the second.
+     */
+    const rows = [
+      { name: "data-b", value: "1", origin: "data-a" },
+      { name: "data-a", value: "3", origin: "data-c" },
+      { name: "onclick", value: "2", origin: "data-b" },
+    ];
+    expect(rowProblem(rows, 2)).toEqual({ kind: "not-allowed" });
+    expect(rowProblem(rows, 0)).toEqual({ kind: "duplicate" });
+    expect(rowProblem(rows, 1)).toEqual({ kind: "duplicate" });
+    expect(storedAttributes(rows, "", stored)).toEqual(stored);
+  });
+});

--- a/packages/builder/src/custom-attributes.test.ts
+++ b/packages/builder/src/custom-attributes.test.ts
@@ -1,0 +1,155 @@
+/**
+ * What the attributes editor accepts, and what it refuses to accept silently.
+ *
+ * The security decision is NOT here: `blocks-react` owns the render-safe set
+ * and is tested there. What is only true here is that the editor asks that same
+ * question rather than keeping a second copy — so these tests drive the real
+ * predicate through the real export, and a divergence between the two shows up
+ * as a failure rather than as an attribute that saves and never renders.
+ *
+ * @module custom-attributes.test
+ */
+import { isAllowedAttribute } from "@nextlyhq/blocks-react";
+import { describe, expect, it } from "vitest";
+
+import {
+  attributeKey,
+  problemMessage,
+  rowProblem,
+  rowsOf,
+  storedAttributes,
+  type AttributeRow,
+} from "./custom-attributes";
+
+const row = (name: string, value = "x"): AttributeRow => ({ name, value });
+
+describe("the editor asks the renderer, and does not restate it", () => {
+  it("accepts exactly what the renderer accepts", () => {
+    /*
+     * Driven through the RENDERER's own predicate rather than a list written
+     * here. A list would pass on the day it was written and drift afterwards,
+     * which is the failure this arrangement exists to prevent — and it would
+     * drift silently, because the editor is where an author is told and the
+     * renderer is where the value is dropped.
+     */
+    for (const name of [
+      "data-analytics",
+      "aria-label",
+      "role",
+      "title",
+      "lang",
+      "dir",
+      "id",
+      "onclick",
+      "href",
+      "src",
+      "style",
+      "class",
+      "srcdoc",
+    ]) {
+      const refused = rowProblem([row(name)], 0, "") !== undefined;
+      expect(refused, name).toBe(!isAllowedAttribute(name));
+    }
+  });
+
+  it("has something to test", () => {
+    // The control on the loop above: if the predicate accepted everything, or
+    // refused everything, that assertion would hold vacuously.
+    expect(isAllowedAttribute("data-x")).toBe(true);
+    expect(isAllowedAttribute("onclick")).toBe(false);
+  });
+});
+
+describe("two rows that are one attribute", () => {
+  it("treats names differing only in capitals as the same", () => {
+    // HTML attribute names are ASCII case-insensitive and the renderer
+    // lowercases before writing, so these are one attribute on the page.
+    expect(attributeKey("Data-X")).toBe(attributeKey("data-x"));
+    const rows = [row("data-x", "first"), row("Data-X", "second")];
+    expect(rowProblem(rows, 0, "")).toBeUndefined();
+    expect(rowProblem(rows, 1, "")).toEqual({
+      kind: "duplicate",
+    });
+  });
+
+  it("reports the LOSING row, not both", () => {
+    // Reporting both would leave an author with two errors and no indication
+    // which value survives; the first is the one the renderer keeps.
+    const rows = [row("data-x"), row("data-x")];
+    const reported = rows.filter(
+      (_each, index) => rowProblem(rows, index, "") !== undefined
+    );
+    expect(reported).toHaveLength(1);
+  });
+});
+
+describe("an id the CSS id field already owns", () => {
+  it("says the row will not be used", () => {
+    /*
+     * The renderer resolves this in favour of `cssId` and says so: the modelled
+     * field wins over an attribute of the same name. That is the right
+     * precedence and it is invisible from the editor — without this an author
+     * types an id, sees it saved, and the page carries a different one.
+     */
+    const rows = [row("id", "from-the-bag")];
+    expect(rowProblem(rows, 0, "from-the-field")).toEqual({
+      kind: "overridden-by-css-id",
+    });
+  });
+
+  it("allows the row when no CSS id is set", () => {
+    // The control. `id` is on the renderer's allowlist, so the bag is a valid
+    // way to set one when the dedicated field is empty.
+    const rows = [row("id", "from-the-bag")];
+    expect(rowProblem(rows, 0, "")).toBeUndefined();
+    expect(rowProblem(rows, 0, "   ")).toBeUndefined();
+  });
+});
+
+describe("what gets stored", () => {
+  it("drops rows that would not reach the page", () => {
+    // Storing a value the page never uses is the silent half of the problem
+    // this surface exists to make loud.
+    const rows = [row("data-keep", "yes"), row("onclick", "no"), row("")];
+    expect(storedAttributes(rows, "")).toEqual({ "data-keep": "yes" });
+  });
+
+  it("stores NOTHING rather than an empty bag", () => {
+    // So removing the last attribute leaves the node as it was before any were
+    // added, rather than carrying an empty record forever.
+    expect(storedAttributes([row("")], "")).toBeUndefined();
+    expect(storedAttributes([], "")).toBeUndefined();
+  });
+
+  it("lowercases the stored name, as the renderer will", () => {
+    expect(storedAttributes([row("Data-X", "v")], "")).toEqual({
+      "data-x": "v",
+    });
+  });
+
+  it("round-trips what it stored", () => {
+    // The property an author actually feels: what they typed comes back.
+    const rows = [row("data-b", "two"), row("data-a", "one")];
+    const stored = storedAttributes(rows, "");
+    expect(rowsOf(stored)).toEqual([
+      { name: "data-a", value: "one" },
+      { name: "data-b", value: "two" },
+    ]);
+  });
+});
+
+describe("what the author is told", () => {
+  it("names the open prefixes rather than only refusing", () => {
+    // A refusal that does not say what IS allowed leaves an author guessing at
+    // an allowlist they cannot see.
+    const said = problemMessage({ kind: "not-allowed" });
+    expect(said).toContain("data-");
+    expect(said).toContain("aria-");
+  });
+
+  it("tells the author how to resolve an overridden id", () => {
+    expect(problemMessage({ kind: "overridden-by-css-id" })).toContain(
+      "CSS id"
+    );
+  });
+});

--- a/packages/builder/src/custom-attributes.test.ts
+++ b/packages/builder/src/custom-attributes.test.ts
@@ -9,7 +9,10 @@
  *
  * @module custom-attributes.test
  */
-import { isAllowedAttribute } from "@nextlyhq/blocks-react";
+import {
+  createBlockResolver,
+  isAllowedAttribute,
+} from "@nextlyhq/blocks-react";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -202,6 +205,13 @@ describe("names the editor needs for itself", () => {
   });
 });
 
+/*
+ * Every fixture node in this file is `acme/x` at version 1 and renders its own
+ * markup, so the id scan reaches all of them. The placeholder cases below say
+ * so by naming a node this resolver does NOT know.
+ */
+const renders = createBlockResolver([{ name: "acme/x", version: 1 } as never]);
+
 describe("which ids a document already holds", () => {
   const node = (over: Record<string, unknown>): never =>
     ({ id: "n", type: "acme/x", version: 1, props: {}, ...over }) as never;
@@ -214,7 +224,8 @@ describe("which ids a document already holds", () => {
         node({ id: "b", cssId: "from-field" }),
         node({ id: "c", attributes: { id: "from-bag" } }),
       ],
-      "a"
+      "a",
+      renders
     );
     expect([...taken].sort()).toEqual(["from-bag", "from-field"]);
   });
@@ -228,7 +239,8 @@ describe("which ids a document already holds", () => {
           slots: { main: [node({ id: "d", cssId: "nested" })] },
         }),
       ],
-      "a"
+      "a",
+      renders
     );
     // Its own id is not a collision with itself.
     expect(taken.has("mine")).toBe(false);
@@ -300,7 +312,8 @@ describe("an id spelled with capitals in the bag", () => {
      */
     const taken = domIdsTaken(
       [node({ id: "b", attributes: { ID: "hero" } })],
-      "a"
+      "a",
+      renders
     );
     expect(taken.has("hero")).toBe(true);
   });
@@ -310,7 +323,8 @@ describe("an id spelled with capitals in the bag", () => {
     // earlier one. This editor never writes two spellings; an import can.
     const taken = domIdsTaken(
       [node({ id: "b", attributes: { ID: "first", id: "second" } })],
-      "a"
+      "a",
+      renders
     );
     expect(taken.has("second")).toBe(true);
     expect(taken.has("first")).toBe(false);
@@ -387,7 +401,8 @@ describe("the id a node actually renders", () => {
      */
     const taken = domIdsTaken(
       [node({ id: "b", cssId: "", attributes: { id: "hero" } })],
-      "a"
+      "a",
+      renders
     );
     expect(taken.has("hero")).toBe(false);
     // And the empty one takes nothing: it is not an id, it only stops the bag.
@@ -398,7 +413,8 @@ describe("the id a node actually renders", () => {
     // The control: the rule is about PRESENCE, not about emptiness in general.
     const taken = domIdsTaken(
       [node({ id: "b", attributes: { id: "hero" } })],
-      "a"
+      "a",
+      renders
     );
     expect(taken.has("hero")).toBe(true);
   });
@@ -418,7 +434,8 @@ describe("the id a node actually renders", () => {
           node({ id: "c", slots: { main: [null, "nope"] } }),
           node({ id: "d", cssId: "kept" }),
         ],
-        "a"
+        "a",
+        renders
       )
     ).not.toThrow();
     // And a real nested node beside the rubbish is still read, so the guard
@@ -430,7 +447,8 @@ describe("the id a node actually renders", () => {
           slots: { main: [null, node({ id: "e", cssId: "nested" })] },
         }),
       ],
-      "a"
+      "a",
+      renders
     );
     expect(taken.has("nested")).toBe(true);
   });
@@ -448,7 +466,8 @@ describe("the id a node actually renders", () => {
           node({ id: "c", attributes: ["nope"] }),
           node({ id: "d", cssId: "kept" }),
         ],
-        "a"
+        "a",
+        renders
       )
     ).not.toThrow();
     // And the good node beside them is still read, so the guard skips rather
@@ -456,7 +475,8 @@ describe("the id a node actually renders", () => {
     expect(
       domIdsTaken(
         [node({ id: "b", attributes: null }), node({ id: "d", cssId: "kept" })],
-        "a"
+        "a",
+        renders
       ).has("kept")
     ).toBe(true);
   });
@@ -523,7 +543,8 @@ describe("the id a bag renders when it holds an empty spelling last", () => {
      */
     const taken = domIdsTaken(
       [node({ id: "b", attributes: { id: "hero", ID: "" } })],
-      "a"
+      "a",
+      renders
     );
     expect(taken.has("hero")).toBe(false);
   });
@@ -532,7 +553,8 @@ describe("the id a bag renders when it holds an empty spelling last", () => {
     // The control: last-wins, not empty-wins.
     const taken = domIdsTaken(
       [node({ id: "b", attributes: { ID: "", id: "hero" } })],
-      "a"
+      "a",
+      renders
     );
     expect(taken.has("hero")).toBe(true);
   });
@@ -568,5 +590,80 @@ describe("an empty bag and no bag", () => {
         { cssId: "", attributes: {} }
       )
     ).toEqual({ patch: { attributes: { a: "1" } }, unset: [] });
+  });
+});
+
+describe("ids on a node the page replaces with a placeholder", () => {
+  const node = (over: Record<string, unknown>): never =>
+    ({ id: "n", type: "acme/x", version: 1, props: {}, ...over }) as never;
+
+  it("reserves nothing for a node whose block is unknown", () => {
+    /*
+     * The renderer emits no modelled id for a placeholder — asserted in
+     * `page-renderer.test.tsx`, "does not reserve a dom id for a node that
+     * renders a placeholder". Counting one here refuses a healthy block an
+     * anchor the rendered page would contain exactly once.
+     */
+    const taken = domIdsTaken(
+      [node({ id: "b", type: "acme/missing", cssId: "hero" })],
+      "a",
+      renders
+    );
+    expect([...taken]).toEqual([]);
+  });
+
+  it("reserves nothing for a node whose migration failed", () => {
+    const taken = domIdsTaken(
+      [node({ id: "b", cssId: "hero", migrationFailed: true })],
+      "a",
+      renders
+    );
+    expect([...taken]).toEqual([]);
+  });
+
+  it("reserves nothing for a node ahead of its definition", () => {
+    // The third of the predicate's three conditions, which a hand-written copy
+    // of "unknown or migration-failed" would have missed.
+    const taken = domIdsTaken(
+      [node({ id: "b", version: 2, cssId: "hero" })],
+      "a",
+      renders
+    );
+    expect([...taken]).toEqual([]);
+  });
+
+  it("reserves nothing INSIDE one either", () => {
+    /*
+     * The second site. `pruneNodes` drops the whole subtree, so a healthy child
+     * of a placeholder never reaches the page and its id is as free as the
+     * parent's. Skipping the node while still descending would have fixed one
+     * of the two.
+     */
+    const taken = domIdsTaken(
+      [
+        node({
+          id: "b",
+          type: "acme/missing",
+          cssId: "outer",
+          slots: { children: [node({ id: "c", cssId: "inner" })] },
+        }),
+      ],
+      "a",
+      renders
+    );
+    expect([...taken]).toEqual([]);
+  });
+
+  it("still reserves ids on the healthy nodes beside it", () => {
+    // The control: the skip must not swallow the scan it sits in.
+    const taken = domIdsTaken(
+      [
+        node({ id: "b", type: "acme/missing", cssId: "gone" }),
+        node({ id: "c", cssId: "kept" }),
+      ],
+      "a",
+      renders
+    );
+    expect([...taken]).toEqual(["kept"]);
   });
 });

--- a/packages/builder/src/custom-attributes.test.ts
+++ b/packages/builder/src/custom-attributes.test.ts
@@ -667,3 +667,55 @@ describe("ids on a node the page replaces with a placeholder", () => {
     expect([...taken]).toEqual(["kept"]);
   });
 });
+
+describe("ids on a node the page gates behind a condition", () => {
+  const node = (over: Record<string, unknown>): never =>
+    ({ id: "n", type: "acme/x", version: 1, props: {}, ...over }) as never;
+  const gated = { conditions: [[{ field: "tier", op: "eq", value: "pro" }]] };
+
+  it("reserves nothing for a gated node", () => {
+    /*
+     * `pruneHiddenNodes` removes it before the render and before the style
+     * compile, and the gate fails closed because no evaluator exists — so the
+     * id is on no page. Refusing it blocks the pattern the feature is for:
+     * two variants of one section sharing an anchor, one of them served.
+     */
+    const taken = domIdsTaken(
+      [node({ id: "b", cssId: "hero", visibility: gated })],
+      "a",
+      renders
+    );
+    expect([...taken]).toEqual([]);
+  });
+
+  it("reserves nothing INSIDE one either", () => {
+    // The second site: the subtree goes with the node it hung from.
+    const taken = domIdsTaken(
+      [
+        node({
+          id: "b",
+          cssId: "outer",
+          visibility: gated,
+          slots: { children: [node({ id: "c", cssId: "inner" })] },
+        }),
+      ],
+      "a",
+      renders
+    );
+    expect([...taken]).toEqual([]);
+  });
+
+  it("still reserves an id on a node whose gate is EMPTY", () => {
+    /*
+     * The control, and the boundary the engine draws: an empty condition list
+     * is not a restriction, so the node is served and its id is taken. Reading
+     * "has a visibility envelope" as gated would free an id that renders.
+     */
+    const taken = domIdsTaken(
+      [node({ id: "b", cssId: "hero", visibility: { conditions: [] } })],
+      "a",
+      renders
+    );
+    expect([...taken]).toEqual(["hero"]);
+  });
+});

--- a/packages/builder/src/custom-attributes.test.ts
+++ b/packages/builder/src/custom-attributes.test.ts
@@ -183,11 +183,22 @@ describe("names the editor needs for itself", () => {
     }
   });
 
+  it("reserves the whole namespace, not just the markers that exist", () => {
+    /*
+     * A prefix rather than a list. The list version fell behind once already
+     * — three markers existed and two were reserved — and a marker a future
+     * overlay needs is covered here without anyone remembering to add it.
+     */
+    expect(rowProblem([row("data-nx-anything")], 0)).toEqual({
+      kind: "reserved",
+    });
+  });
+
   it("still allows an ordinary data attribute", () => {
     // The control that stops the reservation swallowing the namespace it sits
-    // in: `data-` is the feature, and only these two names are taken.
-    expect(rowProblem([row("data-nx-something-else")], 0)).toBeUndefined();
+    // in: `data-` is the feature and only `data-nx-` is spoken for.
     expect(rowProblem([row("data-analytics")], 0)).toBeUndefined();
+    expect(rowProblem([row("data-nxt")], 0)).toBeUndefined();
   });
 });
 
@@ -360,5 +371,81 @@ describe("a row that cannot land keeps what it replaced", () => {
     expect(
       storedAttributes([{ name: "onclick", value: "1" }], "", stored)
     ).toBeUndefined();
+  });
+});
+
+describe("the id a node actually renders", () => {
+  const node = (over: Record<string, unknown>): never =>
+    ({ id: "n", type: "acme/x", version: 1, props: {}, ...over }) as never;
+
+  it("treats an EMPTY modelled id as present, as the renderer does", () => {
+    /*
+     * The renderer writes `extra.id = cssId` whenever `cssId !== undefined`, so
+     * an empty one still overwrites the bag and the element renders `id=""`.
+     * Reading it as absent recorded the bag's value and refused another block an
+     * id that never appears on the page.
+     */
+    const taken = domIdsTaken(
+      [node({ id: "b", cssId: "", attributes: { id: "hero" } })],
+      "a"
+    );
+    expect(taken.has("hero")).toBe(false);
+    // And the empty one takes nothing: it is not an id, it only stops the bag.
+    expect(taken.has("")).toBe(false);
+  });
+
+  it("still takes the bag id when there is no modelled field at all", () => {
+    // The control: the rule is about PRESENCE, not about emptiness in general.
+    const taken = domIdsTaken(
+      [node({ id: "b", attributes: { id: "hero" } })],
+      "a"
+    );
+    expect(taken.has("hero")).toBe(true);
+  });
+
+  it("survives a malformed bag on another node", () => {
+    /*
+     * This walks every OTHER node, and a stored document holds whatever the
+     * database returned. `Object.entries(null)` throws, and one bad node
+     * elsewhere took the whole tab down before it rendered.
+     */
+    expect(() =>
+      domIdsTaken(
+        [
+          node({ id: "b", attributes: null }),
+          node({ id: "c", attributes: ["nope"] }),
+          node({ id: "d", cssId: "kept" }),
+        ],
+        "a"
+      )
+    ).not.toThrow();
+    // And the good node beside them is still read, so the guard skips rather
+    // than abandoning the walk.
+    expect(
+      domIdsTaken(
+        [node({ id: "b", attributes: null }), node({ id: "d", cssId: "kept" })],
+        "a"
+      ).has("kept")
+    ).toBe(true);
+  });
+});
+
+describe("a bag holding two spellings of id", () => {
+  it("drops EVERY variant once the field above is set", () => {
+    /*
+     * The duplicate check runs before the id rule, so the first variant draws
+     * `use-css-id-field` and every later one draws `duplicate`. Keying the drop
+     * on one kind preserved the second — and clearing the CSS id later made a
+     * supposedly removed value render again.
+     */
+    const bag = { ID: "first", id: "second" };
+    expect(storedAttributes(rowsOf(bag), "new", bag)).toBeUndefined();
+  });
+
+  it("keeps both when no CSS id is set, rather than deleting silently", () => {
+    // The control: with nothing in the field above, the author has not asked
+    // for anything to go, so nothing does.
+    const bag = { ID: "first", id: "second" };
+    expect(storedAttributes(rowsOf(bag), "", bag)).toEqual(bag);
   });
 });

--- a/packages/builder/src/custom-attributes.test.ts
+++ b/packages/builder/src/custom-attributes.test.ts
@@ -403,6 +403,38 @@ describe("the id a node actually renders", () => {
     expect(taken.has("hero")).toBe(true);
   });
 
+  it("survives a malformed SLOTS map, and a null inside one", () => {
+    /*
+     * Two more shapes a stored document can hold, and neither is the attribute
+     * bag: `Object.values(null)` throws on a null `slots`, and a null sitting
+     * inside a slot array reaches the walk itself, which reads `.id` off it.
+     * Guarding only the first — the obvious one — leaves the second, so the
+     * check lives at the single point every node passes through.
+     */
+    expect(() =>
+      domIdsTaken(
+        [
+          node({ id: "b", slots: null }),
+          node({ id: "c", slots: { main: [null, "nope"] } }),
+          node({ id: "d", cssId: "kept" }),
+        ],
+        "a"
+      )
+    ).not.toThrow();
+    // And a real nested node beside the rubbish is still read, so the guard
+    // skips rather than abandoning the walk.
+    const taken = domIdsTaken(
+      [
+        node({
+          id: "b",
+          slots: { main: [null, node({ id: "e", cssId: "nested" })] },
+        }),
+      ],
+      "a"
+    );
+    expect(taken.has("nested")).toBe(true);
+  });
+
   it("survives a malformed bag on another node", () => {
     /*
      * This walks every OTHER node, and a stored document holds whatever the

--- a/packages/builder/src/custom-attributes.test.ts
+++ b/packages/builder/src/custom-attributes.test.ts
@@ -15,7 +15,6 @@ import { describe, expect, it } from "vitest";
 import {
   attributeKey,
   domIdsTaken,
-  holdsTheWrite,
   htmlUpdate,
   problemMessage,
   rowProblem,
@@ -42,7 +41,6 @@ describe("the editor asks the renderer, and does not restate it", () => {
       "title",
       "lang",
       "dir",
-      "id",
       "onclick",
       "href",
       "src",
@@ -50,9 +48,20 @@ describe("the editor asks the renderer, and does not restate it", () => {
       "class",
       "srcdoc",
     ]) {
-      const refused = rowProblem([row(name)], 0, "") !== undefined;
+      const refused = rowProblem([row(name)], 0) !== undefined;
       expect(refused, name).toBe(!isAllowedAttribute(name));
     }
+  });
+
+  it("refuses `id` even though the renderer allows it", () => {
+    // A deliberate editor narrowing, like the canvas markers: there is a
+    // field for an id above, and offering two routes to one identifier is
+    // the "two spellings of one question" problem wearing a UI. Asserted
+    // here so its absence from the loop above reads as a decision.
+    expect(isAllowedAttribute("id")).toBe(true);
+    expect(rowProblem([row("id")], 0)).toEqual({
+      kind: "use-css-id-field",
+    });
   });
 
   it("has something to test", () => {
@@ -69,8 +78,8 @@ describe("two rows that are one attribute", () => {
     // lowercases before writing, so these are one attribute on the page.
     expect(attributeKey("Data-X")).toBe(attributeKey("data-x"));
     const rows = [row("data-x", "first"), row("Data-X", "second")];
-    expect(rowProblem(rows, 0, "")).toBeUndefined();
-    expect(rowProblem(rows, 1, "")).toEqual({
+    expect(rowProblem(rows, 0)).toBeUndefined();
+    expect(rowProblem(rows, 1)).toEqual({
       kind: "duplicate",
     });
   });
@@ -80,14 +89,14 @@ describe("two rows that are one attribute", () => {
     // which value survives; the first is the one the renderer keeps.
     const rows = [row("data-x"), row("data-x")];
     const reported = rows.filter(
-      (_each, index) => rowProblem(rows, index, "") !== undefined
+      (_each, index) => rowProblem(rows, index) !== undefined
     );
     expect(reported).toHaveLength(1);
   });
 });
 
-describe("an id the CSS id field already owns", () => {
-  it("says the row will not be used", () => {
+describe("an id in the bag, with a field for it above", () => {
+  it("always points the author at the field", () => {
     /*
      * The renderer resolves this in favour of `cssId` and says so: the modelled
      * field wins over an attribute of the same name. That is the right
@@ -95,17 +104,17 @@ describe("an id the CSS id field already owns", () => {
      * types an id, sees it saved, and the page carries a different one.
      */
     const rows = [row("id", "from-the-bag")];
-    expect(rowProblem(rows, 0, "from-the-field")).toEqual({
-      kind: "overridden-by-css-id",
+    expect(rowProblem(rows, 0)).toEqual({
+      kind: "use-css-id-field",
     });
+    // And with no CSS id set either: one route to an identifier, not two.
+    expect(rowProblem(rows, 0)).toEqual({ kind: "use-css-id-field" });
   });
 
-  it("allows the row when no CSS id is set", () => {
-    // The control. `id` is on the renderer's allowlist, so the bag is a valid
-    // way to set one when the dedicated field is empty.
-    const rows = [row("id", "from-the-bag")];
-    expect(rowProblem(rows, 0, "")).toBeUndefined();
-    expect(rowProblem(rows, 0, "   ")).toBeUndefined();
+  it("still allows every OTHER name", () => {
+    // The control: the rule is about `id` alone, not about the bag.
+    expect(rowProblem([row("data-x")], 0)).toBeUndefined();
+    expect(rowProblem([row("title")], 0)).toBeUndefined();
   });
 });
 
@@ -135,8 +144,8 @@ describe("what gets stored", () => {
     const rows = [row("data-b", "two"), row("data-a", "one")];
     const stored = storedAttributes(rows, "");
     expect(rowsOf(stored)).toEqual([
-      { name: "data-a", value: "one" },
-      { name: "data-b", value: "two" },
+      { name: "data-a", value: "one", origin: "data-a" },
+      { name: "data-b", value: "two", origin: "data-b" },
     ]);
   });
 });
@@ -150,10 +159,8 @@ describe("what the author is told", () => {
     expect(said).toContain("aria-");
   });
 
-  it("tells the author how to resolve an overridden id", () => {
-    expect(problemMessage({ kind: "overridden-by-css-id" })).toContain(
-      "CSS id"
-    );
+  it("tells the author where an id belongs", () => {
+    expect(problemMessage({ kind: "use-css-id-field" })).toContain("CSS id");
   });
 });
 
@@ -170,7 +177,7 @@ describe("names the editor needs for itself", () => {
       // The control: the renderer DOES allow it, so this refusal is the
       // editor's own narrowing rather than the shared rule showing through.
       expect(isAllowedAttribute(name), name).toBe(true);
-      expect(rowProblem([row(name)], 0, ""), name).toEqual({
+      expect(rowProblem([row(name)], 0), name).toEqual({
         kind: "reserved",
       });
     }
@@ -179,27 +186,8 @@ describe("names the editor needs for itself", () => {
   it("still allows an ordinary data attribute", () => {
     // The control that stops the reservation swallowing the namespace it sits
     // in: `data-` is the feature, and only these two names are taken.
-    expect(rowProblem([row("data-nx-something-else")], 0, "")).toBeUndefined();
-    expect(rowProblem([row("data-analytics")], 0, "")).toBeUndefined();
-  });
-});
-
-describe("an id another block already uses", () => {
-  it("refuses it, and says why two would be a problem", () => {
-    const taken = new Set(["hero"]);
-    expect(rowProblem([row("id", "hero")], 0, "", taken)).toEqual({
-      kind: "duplicate-dom-id",
-    });
-    expect(problemMessage({ kind: "duplicate-dom-id" })).toContain(
-      "two possible targets"
-    );
-  });
-
-  it("allows an id nobody else holds", () => {
-    // The control: the check must be about THIS value, not about ids in general.
-    expect(
-      rowProblem([row("id", "unique")], 0, "", new Set(["hero"]))
-    ).toBeUndefined();
+    expect(rowProblem([row("data-nx-something-else")], 0)).toBeUndefined();
+    expect(rowProblem([row("data-analytics")], 0)).toBeUndefined();
   });
 });
 
@@ -318,23 +306,59 @@ describe("an id spelled with capitals in the bag", () => {
   });
 });
 
-describe("which problems hold the write", () => {
-  it("holds for a mistake, and not for a shadowed id", () => {
+describe("a name inside an open prefix that HTML cannot carry", () => {
+  it("refuses it, because the page would carry nothing", () => {
     /*
-     * Renaming `data-x` to `onclick` is a typo, and writing the reduced set
-     * would delete `data-x` — which renaming does not ask for. A row the CSS id
-     * shadows is not a mistake: the value could never reach the page, and
-     * holding the write for it would stop an author setting a CSS id at all
-     * while such a row existed.
+     * `data-x foo` starts with `data-` and is not an attribute name. React
+     * refuses it and renders nothing, so a check stopping at the prefix let a
+     * value be stored that could never appear — the saved-but-absent failure
+     * this whole surface exists to prevent.
      */
-    for (const kind of [
-      "not-allowed",
-      "reserved",
-      "duplicate",
-      "duplicate-dom-id",
-    ] as const) {
-      expect(holdsTheWrite({ kind }), kind).toBe(true);
+    for (const name of ["data-x foo", 'data-x"', "data-x=y", "aria-a<b"]) {
+      expect(isAllowedAttribute(name), name).toBe(false);
+      expect(rowProblem([row(name)], 0), name).toEqual({
+        kind: "not-allowed",
+      });
     }
-    expect(holdsTheWrite({ kind: "overridden-by-css-id" })).toBe(false);
+  });
+
+  it("still accepts names the DOM does carry, including non-ASCII", () => {
+    // The control, and the reason the rule mirrors React's own production
+    // rather than a narrower one: refusing a name that WOULD render is a false
+    // alarm on correct input.
+    for (const name of ["data-x", "aria-label", "data-æøå", "data-x1"]) {
+      expect(isAllowedAttribute(name), name).toBe(true);
+    }
+  });
+});
+
+describe("a row that cannot land keeps what it replaced", () => {
+  const stored = { "data-x": "1", "data-y": "2" };
+
+  it("does not delete the attribute behind a mistyped rename", () => {
+    // Renaming means the author typed something wrong, not that they want the
+    // old attribute gone.
+    const rows = [
+      { name: "onclick", value: "1", origin: "data-x" },
+      { name: "data-y", value: "2", origin: "data-y" },
+    ];
+    expect(storedAttributes(rows, "", stored)).toEqual(stored);
+  });
+
+  it("still removes a DIFFERENT row while one is mistyped", () => {
+    /*
+     * The interaction that an earlier design got wrong: holding the whole write
+     * for a mistyped row meant clicking Remove on an unrelated row did nothing,
+     * and the attribute came back when the panel was reopened.
+     */
+    const rows = [{ name: "onclick", value: "1", origin: "data-x" }];
+    expect(storedAttributes(rows, "", stored)).toEqual({ "data-x": "1" });
+  });
+
+  it("writes nothing for a mistyped row the author ADDED", () => {
+    // Nothing to keep: it never had a stored value behind it.
+    expect(
+      storedAttributes([{ name: "onclick", value: "1" }], "", stored)
+    ).toBeUndefined();
   });
 });

--- a/packages/builder/src/custom-attributes.test.ts
+++ b/packages/builder/src/custom-attributes.test.ts
@@ -481,3 +481,92 @@ describe("a bag holding two spellings of id", () => {
     expect(storedAttributes(rowsOf(bag), "", bag)).toEqual(bag);
   });
 });
+
+describe("renaming a row onto a name another row already holds", () => {
+  const stored = { "data-a": "one", "data-b": "two" };
+
+  it("blames the EDITED row, not the untouched one", () => {
+    /*
+     * First-wins alone got this backwards: the edited row sat earlier, looked
+     * fine, and the untouched row was marked the duplicate — so on rebuild the
+     * untouched row's old value overwrote the edit and `data-a` disappeared.
+     */
+    const rows = [
+      { name: "data-b", value: "edited", origin: "data-a" },
+      { name: "data-b", value: "two", origin: "data-b" },
+    ];
+    expect(rowProblem(rows, 0)).toEqual({ kind: "duplicate" });
+    expect(rowProblem(rows, 1)).toBeUndefined();
+    // And nothing is lost: the edited row falls back to what it replaced.
+    expect(storedAttributes(rows, "", stored)).toEqual(stored);
+  });
+
+  it("still uses first-wins between two rows the DOCUMENT supplied", () => {
+    // Neither is the author's doing, so there is no one to blame and the
+    // earlier spelling is kept — which is what the renderer does too.
+    const bag = { ID: "first", id: "second" };
+    const rows = rowsOf(bag);
+    expect(rowProblem(rows, 0)).toEqual({ kind: "use-css-id-field" });
+    expect(rowProblem(rows, 1)).toEqual({ kind: "duplicate" });
+  });
+});
+
+describe("the id a bag renders when it holds an empty spelling last", () => {
+  const node = (over: Record<string, unknown>): never =>
+    ({ id: "n", type: "acme/x", version: 1, props: {}, ...over }) as never;
+
+  it("takes the LAST variant even when it is empty", () => {
+    /*
+     * The renderer assigns each lowercased key in turn, so a trailing `ID: ""`
+     * leaves the element with `id=""`. Skipping the empty one kept `hero` and
+     * refused another block an id that does not render.
+     */
+    const taken = domIdsTaken(
+      [node({ id: "b", attributes: { id: "hero", ID: "" } })],
+      "a"
+    );
+    expect(taken.has("hero")).toBe(false);
+  });
+
+  it("still takes it when the last variant holds something", () => {
+    // The control: last-wins, not empty-wins.
+    const taken = domIdsTaken(
+      [node({ id: "b", attributes: { ID: "", id: "hero" } })],
+      "a"
+    );
+    expect(taken.has("hero")).toBe(true);
+  });
+});
+
+describe("an empty bag and no bag", () => {
+  it("are the same to `htmlUpdate`, so viewing writes nothing", () => {
+    /*
+     * The renderer asks `Object.keys(attributes).length > 0`, so `{}` behaves
+     * as absent. Treating them as different rewrote a node stored with `{}` the
+     * moment anyone opened the tab, putting an edit in the undo history for
+     * having looked at a panel.
+     */
+    expect(
+      htmlUpdate(
+        { cssId: "", attributes: undefined },
+        { cssId: "", attributes: {} }
+      )
+    ).toBeUndefined();
+    expect(
+      htmlUpdate(
+        { cssId: "", attributes: {} },
+        { cssId: "", attributes: undefined }
+      )
+    ).toBeUndefined();
+  });
+
+  it("still notices a bag that actually gained something", () => {
+    // The control: the equality must not swallow a real change.
+    expect(
+      htmlUpdate(
+        { cssId: "", attributes: { a: "1" } },
+        { cssId: "", attributes: {} }
+      )
+    ).toEqual({ patch: { attributes: { a: "1" } }, unset: [] });
+  });
+});

--- a/packages/builder/src/custom-attributes.test.ts
+++ b/packages/builder/src/custom-attributes.test.ts
@@ -14,6 +14,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   attributeKey,
+  domIdsTaken,
+  htmlUpdate,
   problemMessage,
   rowProblem,
   rowsOf,
@@ -151,5 +153,136 @@ describe("what the author is told", () => {
     expect(problemMessage({ kind: "overridden-by-css-id" })).toContain(
       "CSS id"
     );
+  });
+});
+
+describe("names the editor needs for itself", () => {
+  it("refuses the canvas markers, which the RENDERER has no reason to refuse", () => {
+    /*
+     * Both are `data-` attributes, so the render-safe rule admits them — rightly,
+     * because on a published page they are ordinary author data. They are not
+     * ordinary in the editor: the canvas reads one to decide which block was
+     * clicked and treats the other as its own chrome, so a block carrying
+     * either sends a click to the wrong block or swallows it.
+     */
+    for (const name of ["data-nx-node", "data-nx-chrome"]) {
+      // The control: the renderer DOES allow it, so this refusal is the
+      // editor's own narrowing rather than the shared rule showing through.
+      expect(isAllowedAttribute(name), name).toBe(true);
+      expect(rowProblem([row(name)], 0, ""), name).toEqual({
+        kind: "reserved",
+      });
+    }
+  });
+
+  it("still allows an ordinary data attribute", () => {
+    // The control that stops the reservation swallowing the namespace it sits
+    // in: `data-` is the feature, and only these two names are taken.
+    expect(rowProblem([row("data-nx-something-else")], 0, "")).toBeUndefined();
+    expect(rowProblem([row("data-analytics")], 0, "")).toBeUndefined();
+  });
+});
+
+describe("an id another block already uses", () => {
+  it("refuses it, and says why two would be a problem", () => {
+    const taken = new Set(["hero"]);
+    expect(rowProblem([row("id", "hero")], 0, "", taken)).toEqual({
+      kind: "duplicate-dom-id",
+    });
+    expect(problemMessage({ kind: "duplicate-dom-id" })).toContain(
+      "two possible targets"
+    );
+  });
+
+  it("allows an id nobody else holds", () => {
+    // The control: the check must be about THIS value, not about ids in general.
+    expect(
+      rowProblem([row("id", "unique")], 0, "", new Set(["hero"]))
+    ).toBeUndefined();
+  });
+});
+
+describe("which ids a document already holds", () => {
+  const node = (over: Record<string, unknown>): never =>
+    ({ id: "n", type: "acme/x", version: 1, props: {}, ...over }) as never;
+
+  it("reads BOTH the modelled field and the attribute bag", () => {
+    // They become the same page-wide identifier, so a check reading one of them
+    // would let the other collide silently.
+    const taken = domIdsTaken(
+      [
+        node({ id: "b", cssId: "from-field" }),
+        node({ id: "c", attributes: { id: "from-bag" } }),
+      ],
+      "a"
+    );
+    expect([...taken].sort()).toEqual(["from-bag", "from-field"]);
+  });
+
+  it("skips the node being edited, and descends into slots", () => {
+    const taken = domIdsTaken(
+      [
+        node({ id: "a", cssId: "mine" }),
+        node({
+          id: "b",
+          slots: { main: [node({ id: "d", cssId: "nested" })] },
+        }),
+      ],
+      "a"
+    );
+    // Its own id is not a collision with itself.
+    expect(taken.has("mine")).toBe(false);
+    // And a block inside a slot is still on the page.
+    expect(taken.has("nested")).toBe(true);
+  });
+});
+
+describe("the op that stores the two fields", () => {
+  const fields = (
+    cssId: string,
+    attributes?: Record<string, string>
+  ): { cssId: string; attributes: Record<string, string> | undefined } => ({
+    cssId,
+    attributes,
+  });
+
+  it("says nothing when nothing changed", () => {
+    // An op that rewrites a value to itself is an undo entry that undoes
+    // nothing, and an author pressing undo gets a step that does nothing.
+    expect(
+      htmlUpdate(fields("hero", { a: "1" }), fields("hero", { a: "1" }))
+    ).toBeUndefined();
+    expect(htmlUpdate(fields(""), fields(""))).toBeUndefined();
+  });
+
+  it("UNSETS rather than patching undefined", () => {
+    /*
+     * `applyOp` refuses `undefined` as a patch value and says why: the key
+     * disappears when the op is stored, so a replayed edit would do nothing.
+     */
+    expect(htmlUpdate(fields(""), fields("hero"))).toEqual({
+      patch: {},
+      unset: ["cssId"],
+    });
+    expect(htmlUpdate(fields("hero"), fields("hero", { a: "1" }))).toEqual({
+      patch: {},
+      unset: ["attributes"],
+    });
+  });
+
+  it("does not unset a field the node never had", () => {
+    // Setting an id on a block with no attributes must not carry an instruction
+    // to remove attributes it does not have.
+    expect(htmlUpdate(fields("hero"), fields(""))).toEqual({
+      patch: { cssId: "hero" },
+      unset: [],
+    });
+  });
+
+  it("writes both when both changed", () => {
+    expect(htmlUpdate(fields("hero", { a: "1" }), fields("old"))).toEqual({
+      patch: { cssId: "hero", attributes: { a: "1" } },
+      unset: [],
+    });
   });
 });

--- a/packages/builder/src/custom-attributes.test.ts
+++ b/packages/builder/src/custom-attributes.test.ts
@@ -719,3 +719,63 @@ describe("ids on a node the page gates behind a condition", () => {
     expect([...taken]).toEqual(["hero"]);
   });
 });
+
+describe("a refused rename beside a rename onto its origin", () => {
+  const stored = { "data-a": "1", "data-b": "2" };
+
+  it("does not let the accepted row overwrite what the refused one keeps", () => {
+    /*
+     * `{ "data-a": "1", "data-b": "2" }` with the first row renamed to
+     * `onclick` (refused, so it keeps `data-a`) and the second renamed onto
+     * `data-a`. The duplicate check saw only ONE live `data-a` and accepted the
+     * second row, which then overwrote the value the first was preserving —
+     * `{ "data-a": "2" }`, with `data-b` gone and the refused row's promise to
+     * keep what it replaced quietly broken.
+     */
+    const rows = [
+      { name: "onclick", value: "1", origin: "data-a" },
+      { name: "data-a", value: "2", origin: "data-b" },
+    ];
+    expect(storedAttributes(rows, "", stored)).toEqual(stored);
+  });
+
+  it("says WHY the accepted row will not land", () => {
+    // The author has to be told, or the row simply looks fine and does nothing.
+    const rows = [
+      { name: "onclick", value: "1", origin: "data-a" },
+      { name: "data-a", value: "2", origin: "data-b" },
+    ];
+    expect(rowProblem(rows, 1)).toEqual({ kind: "duplicate" });
+  });
+
+  it("still accepts a rename onto a name nothing is holding", () => {
+    // The control: the reservation must not swallow ordinary renames.
+    const rows = [
+      { name: "onclick", value: "1", origin: "data-a" },
+      { name: "data-c", value: "2", origin: "data-b" },
+    ];
+    expect(rowProblem(rows, 1)).toBeUndefined();
+    expect(storedAttributes(rows, "", stored)).toEqual({
+      "data-a": "1",
+      "data-c": "2",
+    });
+  });
+
+  it("still accepts a rename onto a name another row is VACATING", () => {
+    /*
+     * The second control, and the one that says only REFUSED rows hold their
+     * origins. Both rows here land, so `data-a` is genuinely freed by the first
+     * and genuinely taken by the second; treating every row's origin as held
+     * would refuse an ordinary pair of renames and look exactly like the fix.
+     */
+    const rows = [
+      { name: "data-c", value: "1", origin: "data-a" },
+      { name: "data-a", value: "2", origin: "data-b" },
+    ];
+    expect(rowProblem(rows, 1)).toBeUndefined();
+    expect(storedAttributes(rows, "", stored)).toEqual({
+      "data-c": "1",
+      "data-a": "2",
+    });
+  });
+});

--- a/packages/builder/src/custom-attributes.test.ts
+++ b/packages/builder/src/custom-attributes.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from "vitest";
 import {
   attributeKey,
   domIdsTaken,
+  holdsTheWrite,
   htmlUpdate,
   problemMessage,
   rowProblem,
@@ -165,7 +166,7 @@ describe("names the editor needs for itself", () => {
      * clicked and treats the other as its own chrome, so a block carrying
      * either sends a click to the wrong block or swallows it.
      */
-    for (const name of ["data-nx-node", "data-nx-chrome"]) {
+    for (const name of ["data-nx-node", "data-nx-prop", "data-nx-chrome"]) {
       // The control: the renderer DOES allow it, so this refusal is the
       // editor's own narrowing rather than the shared rule showing through.
       expect(isAllowedAttribute(name), name).toBe(true);
@@ -284,5 +285,56 @@ describe("the op that stores the two fields", () => {
       patch: { cssId: "hero", attributes: { a: "1" } },
       unset: [],
     });
+  });
+});
+
+describe("an id spelled with capitals in the bag", () => {
+  const node = (over: Record<string, unknown>): never =>
+    ({ id: "n", type: "acme/x", version: 1, props: {}, ...over }) as never;
+
+  it("counts as taken, because the renderer lowercases it", () => {
+    /*
+     * A stored `{ ID: "hero" }` renders as `id="hero"` — HTML attribute names
+     * are ASCII case-insensitive and the renderer lowercases every key before
+     * writing. A scan reading only the exact key `id` misses it, and another
+     * block is then allowed to take the same id.
+     */
+    const taken = domIdsTaken(
+      [node({ id: "b", attributes: { ID: "hero" } })],
+      "a"
+    );
+    expect(taken.has("hero")).toBe(true);
+  });
+
+  it("takes the LAST spelling, as the renderer's own loop does", () => {
+    // It assigns each lowercased key in turn, so a later one replaces an
+    // earlier one. This editor never writes two spellings; an import can.
+    const taken = domIdsTaken(
+      [node({ id: "b", attributes: { ID: "first", id: "second" } })],
+      "a"
+    );
+    expect(taken.has("second")).toBe(true);
+    expect(taken.has("first")).toBe(false);
+  });
+});
+
+describe("which problems hold the write", () => {
+  it("holds for a mistake, and not for a shadowed id", () => {
+    /*
+     * Renaming `data-x` to `onclick` is a typo, and writing the reduced set
+     * would delete `data-x` — which renaming does not ask for. A row the CSS id
+     * shadows is not a mistake: the value could never reach the page, and
+     * holding the write for it would stop an author setting a CSS id at all
+     * while such a row existed.
+     */
+    for (const kind of [
+      "not-allowed",
+      "reserved",
+      "duplicate",
+      "duplicate-dom-id",
+    ] as const) {
+      expect(holdsTheWrite({ kind }), kind).toBe(true);
+    }
+    expect(holdsTheWrite({ kind: "overridden-by-css-id" })).toBe(false);
   });
 });

--- a/packages/builder/src/custom-attributes.test.ts
+++ b/packages/builder/src/custom-attributes.test.ts
@@ -22,6 +22,7 @@ import {
   problemMessage,
   rowProblem,
   rowsOf,
+  rowProblems,
   storedAttributes,
   type AttributeRow,
 } from "./custom-attributes";
@@ -820,5 +821,87 @@ describe("a DUPLICATE-refused row holding an origin too", () => {
     expect(rowProblem(rows, 0)).toEqual({ kind: "duplicate" });
     expect(rowProblem(rows, 1)).toEqual({ kind: "duplicate" });
     expect(storedAttributes(rows, "", stored)).toEqual(stored);
+  });
+});
+
+describe("a held origin spelled with capitals", () => {
+  it("is matched case-insensitively, as every other key here is", () => {
+    /*
+     * `{ "DATA-A": "1", "data-b": "2" }` loaded, the first row renamed to the
+     * refused `onclick` and the second onto `data-a`. The held set carried the
+     * raw `DATA-A` while the check asked for the normalized `data-a`, so the
+     * second rename was accepted and both spellings were stored — and the
+     * renderer, which lowercases and lets the last one win, would have changed
+     * the rendered value while `data-b` disappeared.
+     */
+    const stored = { "DATA-A": "1", "data-b": "2" };
+    const rows = [
+      { name: "onclick", value: "1", origin: "DATA-A" },
+      { name: "data-a", value: "2", origin: "data-b" },
+    ];
+    expect(rowProblem(rows, 1)).toEqual({ kind: "duplicate" });
+    expect(storedAttributes(rows, "", stored)).toEqual(stored);
+  });
+});
+
+describe("a bag with a great many rows in it", () => {
+  it("is judged without the work growing faster than the bag", () => {
+    /*
+     * A COMPLEXITY guard rather than a timing assertion: every row's verdict
+     * rebuilt the held set, which walked every row, each of which rescanned
+     * every row for its key. An imported bag of a few hundred permitted
+     * `data-*` entries froze the panel outright, so this fails by not finishing
+     * rather than by being slow.
+     */
+    const size = 600;
+    /*
+     * A backward chain of refusals, which is what actually costs: the last row
+     * is refused on its own terms and holds its origin, refusing the row before
+     * it, and so on. Every link needs another pass over the set, so this is the
+     * shape where recomputing the analysis per row multiplies.
+     *
+     * A field of ordinary VALID rows would not have caught it — the fixed point
+     * exits after one pass when nothing is refused, and the first version of
+     * this test passed against the unfixed code for exactly that reason.
+     */
+    const rows = [
+      ...Array.from({ length: size - 1 }, (_each, at) => ({
+        name: `data-${String(at + 1)}`,
+        value: String(at),
+        origin: `data-${String(at)}`,
+      })),
+      { name: "onclick", value: "x", origin: `data-${String(size - 1)}` },
+    ];
+    const stored = Object.fromEntries(rows.map(row => [row.origin, row.value]));
+
+    // Every row refused, so the document is left exactly as it was.
+    expect(storedAttributes(rows, "", stored)).toEqual(stored);
+    expect(rowProblems(rows).filter(each => each === undefined)).toHaveLength(
+      0
+    );
+  });
+});
+
+describe("which of two rows keeps a key spelled with capitals", () => {
+  it("keeps the DOCUMENT's row even when it is not the first one", () => {
+    /*
+     * The rule is that a row which came from the document and still carries its
+     * own name keeps the key, and only first-wins between two document rows.
+     * That comparison has to normalize: a bag spelled `DATA-A` supplies a row
+     * whose origin is `DATA-A` while the key everything else speaks is
+     * `data-a`, so an unnormalized check does not recognise it as the
+     * document's row at all — and first-wins then blames it for the new row
+     * the author typed above it.
+     */
+    const rows = [
+      { name: "data-a", value: "new" },
+      { name: "DATA-A", value: "stored", origin: "DATA-A" },
+    ];
+    expect(rowProblem(rows, 1)).toBeUndefined();
+    expect(rowProblem(rows, 0)).toEqual({ kind: "duplicate" });
+    // And the stored value is what survives, not the row typed over it.
+    expect(storedAttributes(rows, "", { "DATA-A": "stored" })).toEqual({
+      "data-a": "stored",
+    });
   });
 });

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -17,7 +17,7 @@
  *
  * @module custom-attributes
  */
-import type { BlockNode } from "@nextlyhq/blocks-engine";
+import { isConditionGated, type BlockNode } from "@nextlyhq/blocks-engine";
 import {
   EDITOR_NAMESPACE,
   isAllowedAttribute,
@@ -297,6 +297,25 @@ export function domIdsTaken(
      * copy of that list is a copy to keep in step.
      */
     if (!rendersOwnMarkup(held, resolver)) return;
+    /*
+     * A CONDITION-GATED node reserves nothing either, and neither does anything
+     * inside it — `pruneHiddenNodes` drops the subtree before either the render
+     * or the style compile sees it. The gate fails closed because the engine
+     * defines no evaluator yet, so such a node is currently absent from every
+     * page, and the pattern this most affects is the one the feature is for:
+     * personalised variants of a section, each carrying the same anchor,
+     * exactly one of them served.
+     *
+     * Asked of the engine's own predicate, which the renderer and the style
+     * compiler already share. They once derived it separately and disagreed in
+     * both directions; a third copy here would be a third way to disagree.
+     *
+     * What this cannot decide is the day an evaluator arrives and two gated
+     * nodes both match. Nothing here or in `validateDomIds` would catch that,
+     * and it belongs to the evaluator rather than to a scan that has no
+     * conditions to read.
+     */
+    if (isConditionGated(held)) return;
     if (held.id !== exceptNodeId) {
       const rendered = renderedIdOf(held);
       if (rendered !== undefined) taken.add(rendered);

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -97,17 +97,31 @@ export function rowProblem(
    * matching the renderer's own iteration over the stored record — so position
    * is what the caller passes.
    */
-  const first = rows.findIndex(
-    other => !isBlankRow(other) && attributeKey(other.name) === key
-  );
-  if (first !== -1 && first !== index) return { kind: "duplicate" };
   /*
-   * ONE way to set an id, and it is the field above. The renderer accepts an
-   * `id` here — a document from elsewhere may carry one — but offering an
-   * author two routes to one identifier is the "two spellings of one question"
-   * problem wearing a UI, and the two do not even agree: the modelled field
-   * wins, so a value typed here would sit in the document doing nothing.
+   * Among rows sharing a key, exactly one is kept and the rest are duplicates.
+   * The one kept is a row that came from the DOCUMENT and still carries its
+   * own name — never a row the author has just renamed onto it.
+   *
+   * First-wins alone got this backwards in one direction: renaming the first
+   * row onto a name a later row already held left the edited row looking fine
+   * and blamed the untouched one, so on rebuild the untouched row's old value
+   * overwrote the edit and the name renamed FROM disappeared. Between two rows
+   * that both came from the document — two spellings of one name in an
+   * imported bag — first-wins is still the answer.
    */
+  const sharing = rows
+    .map((other, at) => ({ other, at }))
+    .filter(
+      ({ other }) => !isBlankRow(other) && attributeKey(other.name) === key
+    );
+  if (sharing.length > 1) {
+    const settled = sharing.filter(
+      ({ other }) =>
+        other.origin !== undefined && attributeKey(other.origin) === key
+    );
+    const keeps = (settled.length > 0 ? settled : sharing)[0]?.at;
+    if (keeps !== index) return { kind: "duplicate" };
+  }
   if (key === "id") return { kind: "use-css-id-field" };
   return undefined;
 }
@@ -283,7 +297,13 @@ function renderedIdIn(
   let found: string | undefined;
   for (const [name, value] of Object.entries(attributes)) {
     if (name.toLowerCase() !== "id") continue;
-    if (typeof value === "string" && value !== "") found = value;
+    /*
+     * The last variant wins whatever it holds, empty included: the renderer
+     * assigns each lowercased key in turn, so a trailing `ID: ""` leaves the
+     * element with `id=""`. Skipping it here kept an earlier value and
+     * refused another block an id that does not render.
+     */
+    if (typeof value === "string") found = value;
   }
   return found;
 }
@@ -348,8 +368,18 @@ function sameRecord(
   left: Readonly<Record<string, string>> | undefined,
   right: Readonly<Record<string, string>> | undefined
 ): boolean {
-  if (left === undefined || right === undefined) return left === right;
-  const names = Object.keys(left);
-  if (names.length !== Object.keys(right).length) return false;
-  return names.every(name => left[name] === right[name]);
+  /*
+   * An EMPTY bag and no bag are the same thing to a reader — the renderer
+   * asks `Object.keys(attributes).length > 0` — so they must compare equal
+   * here too. Treating them as different meant a node stored with `{}` was
+   * rewritten the moment anyone looked at the tab, putting an edit in the
+   * undo history for having opened a panel.
+   */
+  const held = (bag: Readonly<Record<string, string>> | undefined) =>
+    bag === undefined || Object.keys(bag).length === 0 ? undefined : bag;
+  const [a, b] = [held(left), held(right)];
+  if (a === undefined || b === undefined) return a === b;
+  const names = Object.keys(a);
+  if (names.length !== Object.keys(b).length) return false;
+  return names.every(name => a[name] === b[name]);
 }

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -219,8 +219,18 @@ export function domIdsTaken(
   exceptNodeId: string
 ): Set<string> {
   const taken = new Set<string>();
-  const visit = (node: BlockNode): void => {
-    if (node.id !== exceptNodeId) {
+  /*
+   * Every node passes through HERE, which is why the shape is checked here
+   * and not at the two places that call it. A stored document holds what the
+   * database returned: a `null` inside a slot array reaches this, and reading
+   * `.id` off it throws before the tab renders. Guarding the callers instead
+   * would be two guards to keep in step, and the walk gained its second
+   * caller in the same commit that guarded the first.
+   */
+  const visit = (node: unknown): void => {
+    if (typeof node !== "object" || node === null) return;
+    const held = node as BlockNode;
+    if (held.id !== exceptNodeId) {
       /*
        * ONE id per node, because the renderer emits one: the modelled field
        * wins over the bag. Adding both refused another block the bag's value
@@ -234,12 +244,12 @@ export function domIdsTaken(
        * recorded the bag's value and refused another block an id that never
        * renders.
        */
-      const modelled = typeof node.cssId === "string" ? node.cssId : undefined;
-      const rendered = modelled ?? renderedIdIn(node.attributes);
+      const modelled = typeof held.cssId === "string" ? held.cssId : undefined;
+      const rendered = modelled ?? renderedIdIn(held.attributes);
       // An empty id is not an id, so it takes nothing — it only stops the bag.
       if (rendered !== undefined && rendered !== "") taken.add(rendered);
     }
-    for (const child of childNodesOf(node)) visit(child);
+    for (const child of childNodesOf(held)) visit(child);
   };
   for (const node of nodes) visit(node);
   return taken;
@@ -279,9 +289,11 @@ function renderedIdIn(
 }
 
 /** Every node nested inside one, across all of its slots. */
-function childNodesOf(node: BlockNode): BlockNode[] {
+function childNodesOf(node: BlockNode): unknown[] {
   const slots = node.slots;
-  if (slots === undefined) return [];
+  // `Object.values(null)` throws, and a stored `slots` can be anything —
+  // the same shape check the attribute bag beside it already gets.
+  if (typeof slots !== "object" || slots === null) return [];
   return Object.values(slots).flatMap(held =>
     Array.isArray(held) ? held : []
   );

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -38,6 +38,40 @@ export interface AttributeRow {
   readonly origin?: string;
 }
 
+/** The id and rows an author is editing, before any of it is written down. */
+export interface Draft {
+  readonly id: string;
+  readonly rows: readonly AttributeRow[];
+}
+
+/**
+ * Whether two drafts hold the same TEXT — what the author typed, character for
+ * character.
+ *
+ * Deliberately not `htmlUpdate`, which compares a NORMALIZED draft against the
+ * document and therefore reports a difference nobody made: a stored `" hero "`
+ * trims and a stored `DATA-X` lowercases, so a panel that had only been looked
+ * at wrote a change, added an undo entry, and moved the rendered anchor. The
+ * question a commit has to ask first is whether the author edited anything, and
+ * that is this one.
+ *
+ * `origin` is not compared: it records where a row came from so a mistake can
+ * fall back to it, and it moves when a write lands rather than when an author
+ * types.
+ */
+export function sameDraft(left: Draft, right: Draft): boolean {
+  if (left.id !== right.id) return false;
+  if (left.rows.length !== right.rows.length) return false;
+  return left.rows.every((row, at) => {
+    const other = right.rows[at];
+    return (
+      other !== undefined &&
+      row.name === other.name &&
+      row.value === other.value
+    );
+  });
+}
+
 /** Why a row will not reach the page, or `undefined` when it will. */
 export type RowProblem =
   | { readonly kind: "not-allowed" }
@@ -323,6 +357,74 @@ function childNodesOf(node: BlockNode): unknown[] {
 export interface HtmlFields {
   readonly cssId: string;
   readonly attributes: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * What a draft wants the node to hold — the whole question of what to STORE.
+ *
+ * Separate from getting the document there, which is the caller's job and a
+ * different kind of problem: this one is about attribute rules and knows
+ * nothing about ops, refusals or undo.
+ *
+ * The id is trimmed only when the author TYPED it. Normalizing a value nobody
+ * touched is a change nobody asked for, and the two normalizations here are not
+ * alike: the renderer lowercases an attribute name itself, so storing `DATA-X`
+ * as `data-x` renders the same byte for byte — but it does not trim `cssId`, so
+ * tidying a stored `" hero "` silently moves the anchor every link to this
+ * block points at. What the renderer already does is safe to store; what it
+ * does not do is the author's to decide.
+ *
+ * An id another block holds is not written at all: the field keeps showing what
+ * the author typed, with the reason beside it, and the document keeps what it
+ * had.
+ */
+export function wantedFields(
+  draft: Draft,
+  loaded: Draft,
+  stored: HtmlFields,
+  taken: ReadonlySet<string>
+): HtmlFields {
+  const id = draft.id === loaded.id ? draft.id : draft.id.trim();
+  const keptId = id !== "" && taken.has(id) ? stored.cssId : id;
+  return {
+    cssId: keptId,
+    /*
+     * The shadowed `id` is dropped only when the author has just SET the field,
+     * never merely because it holds something. A node imported with both a
+     * `cssId` and a legacy `id` would otherwise lose the second the moment
+     * anyone opened this tab — and lose it again on a change that was REFUSED,
+     * since a refusal keeps the id the node already had and that is still
+     * non-empty. Nothing the author did not ask for gets deleted.
+     */
+    attributes: storedAttributes(
+      draft.rows,
+      keptId === stored.cssId ? "" : keptId,
+      stored.attributes ?? {}
+    ),
+  };
+}
+
+/**
+ * The rows again, each pointed at the name it is now STORED under.
+ *
+ * A row keeps the name it was loaded with so a later mistake can fall back to
+ * it — but once a rename has landed, that old name is no longer in the document,
+ * and falling back to it finds nothing and unsets the value the rename had just
+ * saved.
+ *
+ * Only the origins move. The names and values the author is looking at stay
+ * exactly as they are, so nothing shifts under a cursor.
+ */
+export function rebasedRows(
+  rows: readonly AttributeRow[],
+  wanted: HtmlFields
+): AttributeRow[] {
+  const written = wanted.attributes;
+  return rows.map(row =>
+    written !== undefined && written[attributeKey(row.name)] === row.value
+      ? { ...row, origin: attributeKey(row.name) }
+      : row
+  );
 }
 
 /**

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -18,7 +18,12 @@
  * @module custom-attributes
  */
 import type { BlockNode } from "@nextlyhq/blocks-engine";
-import { EDITOR_NAMESPACE, isAllowedAttribute } from "@nextlyhq/blocks-react";
+import {
+  EDITOR_NAMESPACE,
+  isAllowedAttribute,
+  rendersOwnMarkup,
+  type BlockResolver,
+} from "@nextlyhq/blocks-react";
 
 /** One row of the attributes editor, as the author is typing it. */
 export interface AttributeRow {
@@ -264,7 +269,8 @@ export function storedAttributes(
  */
 export function domIdsTaken(
   nodes: readonly BlockNode[],
-  exceptNodeId: string
+  exceptNodeId: string,
+  resolver: BlockResolver
 ): Set<string> {
   const taken = new Set<string>();
   /*
@@ -278,29 +284,48 @@ export function domIdsTaken(
   const visit = (node: unknown): void => {
     if (typeof node !== "object" || node === null) return;
     const held = node as BlockNode;
+    /*
+     * A node the page replaces with a PLACEHOLDER reserves nothing, and neither
+     * does anything inside it: the renderer prunes the whole subtree, so none
+     * of those ids reach the page. Counting them refuses a healthy block an id
+     * the rendered page would contain exactly once — trading a real anchor for
+     * one nothing was going to use.
+     *
+     * Asked of the renderer's own predicate rather than restated. Whether a
+     * node renders its own markup turns on three things — a failed migration,
+     * an unknown type, and a version ahead of the definition — and a second
+     * copy of that list is a copy to keep in step.
+     */
+    if (!rendersOwnMarkup(held, resolver)) return;
     if (held.id !== exceptNodeId) {
-      /*
-       * ONE id per node, because the renderer emits one: the modelled field
-       * wins over the bag. Adding both refused another block the bag's value
-       * even though that id never reaches the page.
-       */
-      /*
-       * PRESENT whenever it is a string, the empty one included, because that
-       * is the renderer's test: it writes `extra.id = cssId` on
-       * `cssId !== undefined`, so an empty modelled field still overwrites
-       * the bag and the element renders `id=""`. Reading it as absent here
-       * recorded the bag's value and refused another block an id that never
-       * renders.
-       */
-      const modelled = typeof held.cssId === "string" ? held.cssId : undefined;
-      const rendered = modelled ?? renderedIdIn(held.attributes);
-      // An empty id is not an id, so it takes nothing — it only stops the bag.
-      if (rendered !== undefined && rendered !== "") taken.add(rendered);
+      const rendered = renderedIdOf(held);
+      if (rendered !== undefined) taken.add(rendered);
     }
     for (const child of childNodesOf(held)) visit(child);
   };
   for (const node of nodes) visit(node);
   return taken;
+}
+
+/**
+ * The one id a node puts on the page, or `undefined` when it puts none.
+ *
+ * ONE per node, because the renderer emits one: the modelled field wins over
+ * the bag. Adding both refused another block the bag's value even though that
+ * id never reaches the page.
+ *
+ * The modelled field counts as PRESENT whenever it is a string, the empty one
+ * included, because that is the renderer's test: it writes `extra.id = cssId`
+ * on `cssId !== undefined`, so an empty modelled field still overwrites the bag
+ * and the element renders `id=""`. Reading it as absent here recorded the bag's
+ * value and refused another block an id that never renders.
+ *
+ * An empty id is not an id, so it takes nothing — it only stops the bag.
+ */
+function renderedIdOf(node: BlockNode): string | undefined {
+  const modelled = typeof node.cssId === "string" ? node.cssId : undefined;
+  const rendered = modelled ?? renderedIdIn(node.attributes);
+  return rendered === "" ? undefined : rendered;
 }
 
 /**
@@ -360,19 +385,31 @@ export interface HtmlFields {
 }
 
 /**
+ * The id the author is ASKING for, normalized the way it would be stored.
+ *
+ * Its own function because two questions need the same answer and must not
+ * answer it twice: what to write, and — once the write lands — whether what the
+ * author asked for is what the node now holds. A collision makes those differ,
+ * and the panel has to tell them apart to know whose text belongs in the field.
+ *
+ * Trimmed only when the author TYPED it. Normalizing a value nobody touched is a
+ * change nobody asked for, and the two normalizations are not alike: the
+ * renderer lowercases an attribute name itself, so storing `DATA-X` as `data-x`
+ * renders the same byte for byte — but it does not trim `cssId`, so tidying a
+ * stored `" hero "` silently moves the anchor every link to this block points
+ * at. What the renderer already does is safe to store; what it does not do is
+ * the author's to decide.
+ */
+export function requestedId(draft: Draft, loaded: Draft): string {
+  return draft.id === loaded.id ? draft.id : draft.id.trim();
+}
+
+/**
  * What a draft wants the node to hold — the whole question of what to STORE.
  *
  * Separate from getting the document there, which is the caller's job and a
  * different kind of problem: this one is about attribute rules and knows
  * nothing about ops, refusals or undo.
- *
- * The id is trimmed only when the author TYPED it. Normalizing a value nobody
- * touched is a change nobody asked for, and the two normalizations here are not
- * alike: the renderer lowercases an attribute name itself, so storing `DATA-X`
- * as `data-x` renders the same byte for byte — but it does not trim `cssId`, so
- * tidying a stored `" hero "` silently moves the anchor every link to this
- * block points at. What the renderer already does is safe to store; what it
- * does not do is the author's to decide.
  *
  * An id another block holds is not written at all: the field keeps showing what
  * the author typed, with the reason beside it, and the document keeps what it
@@ -384,7 +421,7 @@ export function wantedFields(
   stored: HtmlFields,
   taken: ReadonlySet<string>
 ): HtmlFields {
-  const id = draft.id === loaded.id ? draft.id : draft.id.trim();
+  const id = requestedId(draft, loaded);
   const keptId = id !== "" && taken.has(id) ? stored.cssId : id;
   return {
     cssId: keptId,

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -115,7 +115,28 @@ export function rowProblem(
   rows: readonly AttributeRow[],
   index: number
 ): RowProblem | undefined {
-  return problemGiven(rows, index, heldOrigins(rows));
+  return rowProblems(rows)[index];
+}
+
+/**
+ * Every row's verdict, worked out ONCE for the whole set.
+ *
+ * The verdicts are not independent — who keeps a contested key, and which keys
+ * refused rows are holding, are both facts about the set — so asking row by row
+ * recomputed both for every row. With the held set settled to a fixed point on
+ * top of that, a large imported bag froze the panel: a few hundred permitted
+ * `data-*` entries is an ordinary import and was enough.
+ *
+ * So the set is analysed once and each row reads its answer out. `rowProblem`
+ * stays for the single-row callers, and says by its own shape that asking it in
+ * a loop is asking for the analysis again each time.
+ */
+export function rowProblems(
+  rows: readonly AttributeRow[]
+): (RowProblem | undefined)[] {
+  const keepers = keepersOf(rows);
+  const held = heldOrigins(rows, keepers);
+  return rows.map((_row, index) => problemGiven(rows, index, keepers, held));
 }
 
 /**
@@ -128,6 +149,7 @@ export function rowProblem(
 function problemGiven(
   rows: readonly AttributeRow[],
   index: number,
+  keepers: ReadonlyMap<string, number>,
   held: ReadonlySet<string>
 ): RowProblem | undefined {
   const row = rows[index];
@@ -135,7 +157,7 @@ function problemGiven(
   const alone = soloProblem(row);
   if (alone !== undefined) return alone;
   const key = attributeKey(row.name);
-  const keeps = keeperOf(rows, key);
+  const keeps = keepers.get(key);
   if (keeps !== undefined && keeps !== index) return { kind: "duplicate" };
   // Asked BEFORE the held keys, so a row the field above owns is told that
   // rather than being called a duplicate of whatever is holding the name.
@@ -178,21 +200,27 @@ function problemGiven(
  * document — two spellings of one name in an imported bag — first-wins is still
  * the answer.
  */
-function keeperOf(
-  rows: readonly AttributeRow[],
-  key: string
-): number | undefined {
-  const sharing = rows
-    .map((other, at) => ({ other, at }))
-    .filter(
-      ({ other }) => !isBlankRow(other) && attributeKey(other.name) === key
-    );
-  if (sharing.length <= 1) return undefined;
-  const settled = sharing.filter(
-    ({ other }) =>
-      other.origin !== undefined && attributeKey(other.origin) === key
-  );
-  return (settled.length > 0 ? settled : sharing)[0]?.at;
+function keepersOf(rows: readonly AttributeRow[]): Map<string, number> {
+  const sharing = new Map<string, number[]>();
+  rows.forEach((row, at) => {
+    if (isBlankRow(row)) return;
+    const key = attributeKey(row.name);
+    const holders = sharing.get(key);
+    if (holders === undefined) sharing.set(key, [at]);
+    else holders.push(at);
+  });
+  const keepers = new Map<string, number>();
+  for (const [key, holders] of sharing) {
+    // One holder is nobody displaced, which is the ordinary row.
+    if (holders.length <= 1) continue;
+    const settled = holders.filter(at => {
+      const origin = rows[at]?.origin;
+      return origin !== undefined && attributeKey(origin) === key;
+    });
+    const keeps = (settled.length > 0 ? settled : holders)[0];
+    if (keeps !== undefined) keepers.set(key, keeps);
+  }
+  return keepers;
 }
 
 /**
@@ -230,15 +258,27 @@ function soloProblem(row: AttributeRow): RowProblem | undefined {
  * turns a refused row back into an accepted one — so the loop is monotone and
  * cannot run longer than there are rows to refuse.
  */
-function heldOrigins(rows: readonly AttributeRow[]): Set<string> {
+function heldOrigins(
+  rows: readonly AttributeRow[],
+  keepers: ReadonlyMap<string, number>
+): Set<string> {
   const held = new Set<string>();
   for (let pass = 0; pass < rows.length; pass += 1) {
     let grew = false;
     rows.forEach((row, index) => {
       const origin = row.origin;
-      if (origin === undefined || held.has(origin)) return;
-      if (problemGiven(rows, index, held) === undefined) return;
-      held.add(origin);
+      if (origin === undefined) return;
+      /*
+       * NORMALIZED, because the membership test asks with a normalized key.
+       * A stored `DATA-A` went in raw and was never matched, so a row renamed
+       * onto `data-a` was accepted and both spellings were stored — and the
+       * renderer lowercases and lets the last one win, so the rendered value
+       * changed while another attribute disappeared.
+       */
+      const key = attributeKey(origin);
+      if (held.has(key)) return;
+      if (problemGiven(rows, index, keepers, held) === undefined) return;
+      held.add(key);
       grew = true;
     });
     if (!grew) break;
@@ -290,6 +330,7 @@ export function storedAttributes(
   stored: Readonly<Record<string, string>> = {}
 ): Record<string, string> | undefined {
   const kept: Record<string, string> = {};
+  const problems = rowProblems(rows);
   rows.forEach((row, index) => {
     /*
      * Blankness is asked SEPARATELY from correctness, because they are
@@ -299,7 +340,7 @@ export function storedAttributes(
      * answer for both stored an attribute under the empty name.
      */
     if (isBlankRow(row)) return;
-    const problem = rowProblem(rows, index);
+    const problem = problems[index];
     if (problem === undefined) {
       kept[attributeKey(row.name)] = row.value;
       return;

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -117,16 +117,9 @@ export function rowProblem(
 ): RowProblem | undefined {
   const row = rows[index];
   if (row === undefined || isBlankRow(row)) return undefined;
+  const alone = soloProblem(row);
+  if (alone !== undefined) return alone;
   const key = attributeKey(row.name);
-  if (!isAllowedAttribute(key)) return { kind: "not-allowed" };
-  /*
-   * The editor's own NAMESPACE, asked as a prefix rather than as a list of
-   * the markers that exist today. The renderer drops these while it is
-   * rendering for the editor, so accepting one here would store a name that
-   * never appears — and a list is a thing to keep in sync, which this one
-   * already fell behind on once.
-   */
-  if (key.startsWith(EDITOR_NAMESPACE)) return { kind: "reserved" };
   /*
    * Located by INDEX, never by object identity. A row is a plain value the UI
    * rebuilds on every keystroke, so two rows holding the same name and value
@@ -161,8 +154,60 @@ export function rowProblem(
     const keeps = (settled.length > 0 ? settled : sharing)[0]?.at;
     if (keeps !== index) return { kind: "duplicate" };
   }
+  /*
+   * The keys refused rows are HOLDING count as taken too.
+   *
+   * A refused row keeps what it replaced, so its origin is still in the stored
+   * record even though no row on screen carries that name. Judging collisions
+   * on the live names alone therefore accepted a second row renamed onto it —
+   * and the write, which places the preserved value first, was then overwritten
+   * by that row. `{ "data-a": "1", "data-b": "2" }` with one row refused onto
+   * `onclick` and the other renamed to `data-a` stored `{ "data-a": "2" }`:
+   * `data-b` gone, and the promise the refused row makes quietly broken.
+   *
+   * Reported rather than resolved in the write, because the author is the only
+   * one who can say which of the two they meant. Both rows keep their origins
+   * until they do, so the document is left exactly as it was.
+   */
+  if (heldByRefusedRows(rows).has(key)) return { kind: "duplicate" };
   if (key === "id") return { kind: "use-css-id-field" };
   return undefined;
+}
+
+/**
+ * What is wrong with a row judged ALONE, before any sibling is looked at.
+ *
+ * Separated because the answer is needed while deciding what the siblings even
+ * occupy, and asking the whole question there would be asking it of itself.
+ */
+function soloProblem(row: AttributeRow): RowProblem | undefined {
+  const key = attributeKey(row.name);
+  if (!isAllowedAttribute(key)) return { kind: "not-allowed" };
+  /*
+   * The editor's own NAMESPACE, asked as a prefix rather than as a list of
+   * the markers that exist today. The renderer drops these while it is
+   * rendering for the editor, so accepting one here would store a name that
+   * never appears — and a list is a thing to keep in sync, which this one
+   * already fell behind on once.
+   */
+  if (key.startsWith(EDITOR_NAMESPACE)) return { kind: "reserved" };
+  return undefined;
+}
+
+/**
+ * The stored keys that rows refused on their own terms will hold on to.
+ *
+ * Read from `soloProblem` rather than `rowProblem`, which would ask this
+ * function while this function was answering it.
+ */
+function heldByRefusedRows(rows: readonly AttributeRow[]): Set<string> {
+  const held = new Set<string>();
+  for (const row of rows) {
+    if (isBlankRow(row)) continue;
+    if (soloProblem(row) === undefined) continue;
+    if (row.origin !== undefined) held.add(row.origin);
+  }
+  return held;
 }
 
 /** What to tell the author about a row that will not land. */

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -17,7 +17,10 @@
  *
  * @module custom-attributes
  */
-import { isAllowedAttribute } from "@nextlyhq/blocks-react";
+import type { BlockNode } from "@nextlyhq/blocks-engine";
+import { NODE_ID_ATTRIBUTE, isAllowedAttribute } from "@nextlyhq/blocks-react";
+
+import { CHROME_ATTRIBUTE } from "./canvas";
 
 /** One row of the attributes editor, as the author is typing it. */
 export interface AttributeRow {
@@ -25,11 +28,28 @@ export interface AttributeRow {
   readonly value: string;
 }
 
+/**
+ * Names the EDITOR needs, which the renderer has no reason to refuse.
+ *
+ * Both are `data-` attributes, so the render-safe rule admits them — correctly,
+ * because on a published page they are ordinary author data. They are not
+ * ordinary HERE: the canvas reads one to decide which block was clicked and
+ * treats the other as its own chrome, so a block carrying either can send a
+ * click to the wrong block or swallow it. That is an editing surface the
+ * renderer cannot see, which is why this narrowing lives here and not there.
+ *
+ * Taken from the two modules that define them rather than written out, so
+ * renaming either moves this with it.
+ */
+const RESERVED_FOR_THE_EDITOR = new Set([NODE_ID_ATTRIBUTE, CHROME_ATTRIBUTE]);
+
 /** Why a row will not reach the page, or `undefined` when it will. */
 export type RowProblem =
   | { readonly kind: "not-allowed" }
+  | { readonly kind: "reserved" }
   | { readonly kind: "duplicate" }
-  | { readonly kind: "overridden-by-css-id" };
+  | { readonly kind: "overridden-by-css-id" }
+  | { readonly kind: "duplicate-dom-id" };
 
 /**
  * HTML attribute names are ASCII case-insensitive; React props are not.
@@ -61,12 +81,14 @@ export function isBlankRow(row: AttributeRow): boolean {
 export function rowProblem(
   rows: readonly AttributeRow[],
   index: number,
-  cssId: string
+  cssId: string,
+  takenIds: ReadonlySet<string> = new Set()
 ): RowProblem | undefined {
   const row = rows[index];
   if (row === undefined || isBlankRow(row)) return undefined;
   const key = attributeKey(row.name);
   if (!isAllowedAttribute(key)) return { kind: "not-allowed" };
+  if (RESERVED_FOR_THE_EDITOR.has(key)) return { kind: "reserved" };
   /*
    * Located by INDEX, never by object identity. A row is a plain value the UI
    * rebuilds on every keystroke, so two rows holding the same name and value
@@ -83,6 +105,11 @@ export function rowProblem(
   if (key === "id" && cssId.trim() !== "") {
     return { kind: "overridden-by-css-id" };
   }
+  // An `id` set through the bag is the same page-wide identifier as one set in
+  // the field beside it, so it collides with other blocks the same way.
+  if (key === "id" && takenIds.has(row.value.trim())) {
+    return { kind: "duplicate-dom-id" };
+  }
   return undefined;
 }
 
@@ -91,10 +118,14 @@ export function problemMessage(problem: RowProblem): string {
   switch (problem.kind) {
     case "not-allowed":
       return "This site does not put that attribute on a page. Names starting with “data-” or “aria-” are open, along with role, title, lang and dir.";
+    case "reserved":
+      return "The editor uses that name to find blocks on the canvas, so setting it here would make clicking this block select the wrong one. Pick another name.";
     case "duplicate":
       return "Another row already sets this attribute, and only the first is used. Attribute names ignore capitals, so “Data-X” and “data-x” are one name.";
     case "overridden-by-css-id":
       return "The CSS id above sets this element’s id, and it wins over this row, so this value would not be used. Clear the CSS id, or set the id there instead.";
+    case "duplicate-dom-id":
+      return "Another block on this page already uses that id. Two elements with one id give a link, a label and a style rule two possible targets.";
   }
 }
 
@@ -124,7 +155,8 @@ export function rowsOf(
  */
 export function storedAttributes(
   rows: readonly AttributeRow[],
-  cssId: string
+  cssId: string,
+  takenIds: ReadonlySet<string> = new Set()
 ): Record<string, string> | undefined {
   const kept: Record<string, string> = {};
   rows.forEach((row, index) => {
@@ -136,8 +168,114 @@ export function storedAttributes(
      * answer for both stored an attribute under the empty name.
      */
     if (isBlankRow(row)) return;
-    if (rowProblem(rows, index, cssId) !== undefined) return;
+    if (rowProblem(rows, index, cssId, takenIds) !== undefined) return;
     kept[attributeKey(row.name)] = row.value;
   });
   return Object.keys(kept).length === 0 ? undefined : kept;
+}
+
+/**
+ * Every DOM id the document already uses, other than one node's own.
+ *
+ * A rendered id must be unique across the page: two elements answering to one
+ * `id` give a fragment link, a `<label for>` and a CSS selector two possible
+ * targets, and which one wins is the document order rather than anything the
+ * author chose.
+ *
+ * The engine already detects this — `validateDomIds` reports `duplicate-dom-id`
+ * — but only as a WARNING in forgiving mode, and the field's own validation
+ * discards warnings, so a duplicate saves and publishes with nothing said. This
+ * is the editor refusing it while the author still has the keyboard, which is
+ * the only moment they can act on it.
+ *
+ * Both sources are read, because both become the same attribute: the modelled
+ * `cssId` and the `id` an author can put in the attribute bag.
+ */
+export function domIdsTaken(
+  nodes: readonly BlockNode[],
+  exceptNodeId: string
+): Set<string> {
+  const taken = new Set<string>();
+  const visit = (node: BlockNode): void => {
+    if (node.id !== exceptNodeId) {
+      if (typeof node.cssId === "string" && node.cssId !== "") {
+        taken.add(node.cssId);
+      }
+      const own = node.attributes;
+      if (
+        own !== undefined &&
+        typeof own["id"] === "string" &&
+        own["id"] !== ""
+      ) {
+        taken.add(own["id"]);
+      }
+    }
+    for (const child of childNodesOf(node)) visit(child);
+  };
+  for (const node of nodes) visit(node);
+  return taken;
+}
+
+/** Every node nested inside one, across all of its slots. */
+function childNodesOf(node: BlockNode): BlockNode[] {
+  const slots = node.slots;
+  if (slots === undefined) return [];
+  return Object.values(slots).flatMap(held =>
+    Array.isArray(held) ? held : []
+  );
+}
+
+/** What a node should hold, and what it holds now. */
+export interface HtmlFields {
+  readonly cssId: string;
+  readonly attributes: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * The smallest update that makes a node hold `wanted`, or nothing to do.
+ *
+ * Its own question, and a pure one: deciding what an author's draft SHOULD
+ * become is about attribute rules, and saying so as an op is about the patch
+ * contract. Both live away from the component, which then only has to hand over
+ * two values and apply what comes back.
+ *
+ * Removal is spelled `unset`, never `undefined` as a patch value: `applyOp`
+ * refuses that and says why — the key disappears when the op is stored, so a
+ * replayed edit would silently do nothing.
+ *
+ * Only what CHANGED is named. An op that unsets a field the node never had, or
+ * rewrites one to the value it already holds, is an undo entry that undoes
+ * nothing — and an author pressing undo for their last edit gets a step that
+ * does nothing instead.
+ */
+export function htmlUpdate(
+  wanted: HtmlFields,
+  stored: HtmlFields
+): { patch: Record<string, unknown>; unset: string[] } | undefined {
+  const sameId = wanted.cssId === stored.cssId;
+  const sameAttributes = sameRecord(wanted.attributes, stored.attributes);
+  if (sameId && sameAttributes) return undefined;
+
+  const patch: Record<string, unknown> = {};
+  const unset: string[] = [];
+  if (!sameId) {
+    if (wanted.cssId === "") unset.push("cssId");
+    else patch["cssId"] = wanted.cssId;
+  }
+  if (!sameAttributes) {
+    if (wanted.attributes === undefined) unset.push("attributes");
+    else patch["attributes"] = wanted.attributes;
+  }
+  return { patch, unset };
+}
+
+/** Whether two attribute records hold the same names and values. */
+function sameRecord(
+  left: Readonly<Record<string, string>> | undefined,
+  right: Readonly<Record<string, string>> | undefined
+): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  const names = Object.keys(left);
+  if (names.length !== Object.keys(right).length) return false;
+  return names.every(name => left[name] === right[name]);
 }

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -18,13 +18,7 @@
  * @module custom-attributes
  */
 import type { BlockNode } from "@nextlyhq/blocks-engine";
-import {
-  NODE_ID_ATTRIBUTE,
-  PROP_ATTRIBUTE,
-  isAllowedAttribute,
-} from "@nextlyhq/blocks-react";
-
-import { CHROME_ATTRIBUTE } from "./canvas";
+import { EDITOR_NAMESPACE, isAllowedAttribute } from "@nextlyhq/blocks-react";
 
 /** One row of the attributes editor, as the author is typing it. */
 export interface AttributeRow {
@@ -43,32 +37,6 @@ export interface AttributeRow {
    */
   readonly origin?: string;
 }
-
-/**
- * Names the EDITOR needs, which the renderer has no reason to refuse.
- *
- * Both are `data-` attributes, so the render-safe rule admits them — correctly,
- * because on a published page they are ordinary author data. They are not
- * ordinary HERE: the canvas reads one to decide which block was clicked and
- * treats the other as its own chrome, so a block carrying either can send a
- * click to the wrong block or swallow it. That is an editing surface the
- * renderer cannot see, which is why this narrowing lives here and not there.
- *
- * ALL THREE, which is the point: the first version of this reserved two and
- * missed `data-nx-prop`, the marker inline editing reads to decide which
- * property a click makes editable. On a block with more than one inline
- * property, an author's value matching another property makes the whole root
- * editable and commits its text into the wrong property; a value matching none
- * disables inline editing on that root entirely.
- *
- * Taken from the modules that define them rather than written out, so renaming
- * any of them moves this with it.
- */
-const RESERVED_FOR_THE_EDITOR = new Set([
-  NODE_ID_ATTRIBUTE,
-  PROP_ATTRIBUTE,
-  CHROME_ATTRIBUTE,
-]);
 
 /** Why a row will not reach the page, or `undefined` when it will. */
 export type RowProblem =
@@ -112,7 +80,14 @@ export function rowProblem(
   if (row === undefined || isBlankRow(row)) return undefined;
   const key = attributeKey(row.name);
   if (!isAllowedAttribute(key)) return { kind: "not-allowed" };
-  if (RESERVED_FOR_THE_EDITOR.has(key)) return { kind: "reserved" };
+  /*
+   * The editor's own NAMESPACE, asked as a prefix rather than as a list of
+   * the markers that exist today. The renderer drops these while it is
+   * rendering for the editor, so accepting one here would store a name that
+   * never appears — and a list is a thing to keep in sync, which this one
+   * already fell behind on once.
+   */
+  if (key.startsWith(EDITOR_NAMESPACE)) return { kind: "reserved" };
   /*
    * Located by INDEX, never by object identity. A row is a plain value the UI
    * rebuilds on every keystroke, so two rows holding the same name and value
@@ -206,7 +181,14 @@ export function storedAttributes(
      * the renderer fall back to it the moment that field is cleared, which is
      * the value coming back from the dead.
      */
-    if (problem.kind === "use-css-id-field" && cssId.trim() !== "") return;
+    /*
+     * ANY row that would render as `id`, whichever problem it happened to
+     * draw. A bag holding two spellings gives the first `use-css-id-field`
+     * and every later one `duplicate` — the duplicate check runs earlier —
+     * so keying this on one kind preserved the second, and clearing the CSS
+     * id later made a supposedly removed value render again.
+     */
+    if (cssId.trim() !== "" && attributeKey(row.name) === "id") return;
     const origin = row.origin;
     if (origin === undefined) return;
     const had = stored[origin];
@@ -244,12 +226,18 @@ export function domIdsTaken(
        * wins over the bag. Adding both refused another block the bag's value
        * even though that id never reaches the page.
        */
-      const modelled =
-        typeof node.cssId === "string" && node.cssId !== ""
-          ? node.cssId
-          : undefined;
+      /*
+       * PRESENT whenever it is a string, the empty one included, because that
+       * is the renderer's test: it writes `extra.id = cssId` on
+       * `cssId !== undefined`, so an empty modelled field still overwrites
+       * the bag and the element renders `id=""`. Reading it as absent here
+       * recorded the bag's value and refused another block an id that never
+       * renders.
+       */
+      const modelled = typeof node.cssId === "string" ? node.cssId : undefined;
       const rendered = modelled ?? renderedIdIn(node.attributes);
-      if (rendered !== undefined) taken.add(rendered);
+      // An empty id is not an id, so it takes nothing — it only stops the bag.
+      if (rendered !== undefined && rendered !== "") taken.add(rendered);
     }
     for (const child of childNodesOf(node)) visit(child);
   };
@@ -273,7 +261,15 @@ export function domIdsTaken(
 function renderedIdIn(
   attributes: Readonly<Record<string, string>> | undefined
 ): string | undefined {
-  if (attributes === undefined) return undefined;
+  /*
+   * Shape-checked, because this walks OTHER nodes and a stored document can
+   * hold whatever the database returned. `Object.entries(null)` throws, and
+   * one malformed node elsewhere would take down the whole tab before it
+   * rendered. The reader and the renderer both treat a malformed bag as
+   * absent; this agrees with them.
+   */
+  if (typeof attributes !== "object" || attributes === null) return undefined;
+  if (Array.isArray(attributes)) return undefined;
   let found: string | undefined;
   for (const [name, value] of Object.entries(attributes)) {
     if (name.toLowerCase() !== "id") continue;

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -30,6 +30,18 @@ import { CHROME_ATTRIBUTE } from "./canvas";
 export interface AttributeRow {
   readonly name: string;
   readonly value: string;
+  /**
+   * The name this row was LOADED with, when it came from the document.
+   *
+   * Kept so a row that cannot land does not delete what it replaced. Renaming
+   * `data-x` to `onclick` means the author typed something wrong, not that they
+   * want `data-x` gone — and without an origin the only way to avoid deleting
+   * it was to hold the whole write, which then blocked removing an unrelated
+   * row beside it.
+   *
+   * Absent on a row the author added, which has nothing to fall back to.
+   */
+  readonly origin?: string;
 }
 
 /**
@@ -63,8 +75,7 @@ export type RowProblem =
   | { readonly kind: "not-allowed" }
   | { readonly kind: "reserved" }
   | { readonly kind: "duplicate" }
-  | { readonly kind: "overridden-by-css-id" }
-  | { readonly kind: "duplicate-dom-id" };
+  | { readonly kind: "use-css-id-field" };
 
 /**
  * HTML attribute names are ASCII case-insensitive; React props are not.
@@ -95,9 +106,7 @@ export function isBlankRow(row: AttributeRow): boolean {
  */
 export function rowProblem(
   rows: readonly AttributeRow[],
-  index: number,
-  cssId: string,
-  takenIds: ReadonlySet<string> = new Set()
+  index: number
 ): RowProblem | undefined {
   const row = rows[index];
   if (row === undefined || isBlankRow(row)) return undefined;
@@ -117,33 +126,15 @@ export function rowProblem(
     other => !isBlankRow(other) && attributeKey(other.name) === key
   );
   if (first !== -1 && first !== index) return { kind: "duplicate" };
-  if (key === "id" && cssId.trim() !== "") {
-    return { kind: "overridden-by-css-id" };
-  }
-  // An `id` set through the bag is the same page-wide identifier as one set in
-  // the field beside it, so it collides with other blocks the same way.
-  if (key === "id" && takenIds.has(row.value.trim())) {
-    return { kind: "duplicate-dom-id" };
-  }
+  /*
+   * ONE way to set an id, and it is the field above. The renderer accepts an
+   * `id` here — a document from elsewhere may carry one — but offering an
+   * author two routes to one identifier is the "two spellings of one question"
+   * problem wearing a UI, and the two do not even agree: the modelled field
+   * wins, so a value typed here would sit in the document doing nothing.
+   */
+  if (key === "id") return { kind: "use-css-id-field" };
   return undefined;
-}
-
-/**
- * Whether a problem is the author's to FIX before anything is stored.
- *
- * Most are: a name the page would drop, a name the editor needs, a second row
- * setting a name another row sets, an id another block holds. Each means the
- * author has typed something wrong, and writing the reduced set would delete
- * whatever the row used to hold — renaming `data-x` to `onclick` would remove
- * `data-x`, which is not what renaming asks for.
- *
- * One is not: a row the CSS id field shadows is not a mistake, it is a
- * consequence of the field beside it, and dropping it is exactly right — the
- * value could never reach the page anyway, and holding the whole write for it
- * would mean an author could not set a CSS id while such a row existed.
- */
-export function holdsTheWrite(problem: RowProblem): boolean {
-  return problem.kind !== "overridden-by-css-id";
 }
 
 /** What to tell the author about a row that will not land. */
@@ -155,10 +146,8 @@ export function problemMessage(problem: RowProblem): string {
       return "The editor uses that name to find blocks on the canvas, so setting it here would make clicking this block select the wrong one. Pick another name.";
     case "duplicate":
       return "Another row already sets this attribute, and only the first is used. Attribute names ignore capitals, so “Data-X” and “data-x” are one name.";
-    case "overridden-by-css-id":
-      return "The CSS id above sets this element’s id, and it wins over this row, so this value would not be used. Clear the CSS id, or set the id there instead.";
-    case "duplicate-dom-id":
-      return "Another block on this page already uses that id. Two elements with one id give a link, a label and a style rule two possible targets.";
+    case "use-css-id-field":
+      return "Set this block’s id in the CSS id field above. An id written here is not used while that field has a value, and it is the field the rest of the editor reads.";
   }
 }
 
@@ -173,7 +162,7 @@ export function rowsOf(
   attributes: Readonly<Record<string, string>> | undefined
 ): AttributeRow[] {
   return Object.entries(attributes ?? {})
-    .map(([name, value]) => ({ name, value }))
+    .map(([name, value]) => ({ name, value, origin: name }))
     .sort((left, right) => left.name.localeCompare(right.name));
 }
 
@@ -189,7 +178,7 @@ export function rowsOf(
 export function storedAttributes(
   rows: readonly AttributeRow[],
   cssId: string,
-  takenIds: ReadonlySet<string> = new Set()
+  stored: Readonly<Record<string, string>> = {}
 ): Record<string, string> | undefined {
   const kept: Record<string, string> = {};
   rows.forEach((row, index) => {
@@ -201,8 +190,27 @@ export function storedAttributes(
      * answer for both stored an attribute under the empty name.
      */
     if (isBlankRow(row)) return;
-    if (rowProblem(rows, index, cssId, takenIds) !== undefined) return;
-    kept[attributeKey(row.name)] = row.value;
+    const problem = rowProblem(rows, index);
+    if (problem === undefined) {
+      kept[attributeKey(row.name)] = row.value;
+      return;
+    }
+    /*
+     * A row that cannot land KEEPS what it replaced, rather than deleting it.
+     * The author has typed something wrong, and the row is on screen with the
+     * reason — removing the attribute underneath it as well would take away
+     * work they never asked to lose. A row they ADDED has no origin, so there
+     * is nothing to keep and nothing is written.
+     *
+     * The one exception is an id the field above now owns: keeping it would let
+     * the renderer fall back to it the moment that field is cleared, which is
+     * the value coming back from the dead.
+     */
+    if (problem.kind === "use-css-id-field" && cssId.trim() !== "") return;
+    const origin = row.origin;
+    if (origin === undefined) return;
+    const had = stored[origin];
+    if (had !== undefined) kept[origin] = had;
   });
   return Object.keys(kept).length === 0 ? undefined : kept;
 }
@@ -231,11 +239,17 @@ export function domIdsTaken(
   const taken = new Set<string>();
   const visit = (node: BlockNode): void => {
     if (node.id !== exceptNodeId) {
-      if (typeof node.cssId === "string" && node.cssId !== "") {
-        taken.add(node.cssId);
-      }
-      const fromBag = renderedIdIn(node.attributes);
-      if (fromBag !== undefined) taken.add(fromBag);
+      /*
+       * ONE id per node, because the renderer emits one: the modelled field
+       * wins over the bag. Adding both refused another block the bag's value
+       * even though that id never reaches the page.
+       */
+      const modelled =
+        typeof node.cssId === "string" && node.cssId !== ""
+          ? node.cssId
+          : undefined;
+      const rendered = modelled ?? renderedIdIn(node.attributes);
+      if (rendered !== undefined) taken.add(rendered);
     }
     for (const child of childNodesOf(node)) visit(child);
   };
@@ -275,35 +289,6 @@ function childNodesOf(node: BlockNode): BlockNode[] {
   return Object.values(slots).flatMap(held =>
     Array.isArray(held) ? held : []
   );
-}
-
-/**
- * The same bag without an `id` the CSS id field would shadow.
- *
- * Applied to whatever set is about to be stored, because the shadowing is a
- * consequence of the ID rather than of the rows. Reducing the rows already
- * drops it — `rowProblem` reports the row and `storedAttributes` skips it — but
- * the rows are NOT always what gets written: when one of them is a mistake the
- * stored bag is kept instead, and that bag still holds the old id. Without this
- * the two fixes cancelled: setting a CSS id beside a mistyped row left the
- * shadowed id in place, and clearing the CSS id later brought it back.
- *
- * Case-insensitive, for the reason the collision scan is: the renderer
- * lowercases every key, so `ID` and `id` are one attribute on the page.
- */
-export function withoutShadowedId(
-  attributes: Readonly<Record<string, string>> | undefined,
-  cssId: string
-): Record<string, string> | undefined {
-  if (attributes === undefined || cssId.trim() === "") {
-    return attributes === undefined ? undefined : { ...attributes };
-  }
-  const kept: Record<string, string> = {};
-  for (const [name, value] of Object.entries(attributes)) {
-    if (name.toLowerCase() === "id") continue;
-    kept[name] = value;
-  }
-  return Object.keys(kept).length === 0 ? undefined : kept;
 }
 
 /** What a node should hold, and what it holds now. */

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -18,7 +18,11 @@
  * @module custom-attributes
  */
 import type { BlockNode } from "@nextlyhq/blocks-engine";
-import { NODE_ID_ATTRIBUTE, isAllowedAttribute } from "@nextlyhq/blocks-react";
+import {
+  NODE_ID_ATTRIBUTE,
+  PROP_ATTRIBUTE,
+  isAllowedAttribute,
+} from "@nextlyhq/blocks-react";
 
 import { CHROME_ATTRIBUTE } from "./canvas";
 
@@ -38,10 +42,21 @@ export interface AttributeRow {
  * click to the wrong block or swallow it. That is an editing surface the
  * renderer cannot see, which is why this narrowing lives here and not there.
  *
- * Taken from the two modules that define them rather than written out, so
- * renaming either moves this with it.
+ * ALL THREE, which is the point: the first version of this reserved two and
+ * missed `data-nx-prop`, the marker inline editing reads to decide which
+ * property a click makes editable. On a block with more than one inline
+ * property, an author's value matching another property makes the whole root
+ * editable and commits its text into the wrong property; a value matching none
+ * disables inline editing on that root entirely.
+ *
+ * Taken from the modules that define them rather than written out, so renaming
+ * any of them moves this with it.
  */
-const RESERVED_FOR_THE_EDITOR = new Set([NODE_ID_ATTRIBUTE, CHROME_ATTRIBUTE]);
+const RESERVED_FOR_THE_EDITOR = new Set([
+  NODE_ID_ATTRIBUTE,
+  PROP_ATTRIBUTE,
+  CHROME_ATTRIBUTE,
+]);
 
 /** Why a row will not reach the page, or `undefined` when it will. */
 export type RowProblem =
@@ -111,6 +126,24 @@ export function rowProblem(
     return { kind: "duplicate-dom-id" };
   }
   return undefined;
+}
+
+/**
+ * Whether a problem is the author's to FIX before anything is stored.
+ *
+ * Most are: a name the page would drop, a name the editor needs, a second row
+ * setting a name another row sets, an id another block holds. Each means the
+ * author has typed something wrong, and writing the reduced set would delete
+ * whatever the row used to hold — renaming `data-x` to `onclick` would remove
+ * `data-x`, which is not what renaming asks for.
+ *
+ * One is not: a row the CSS id field shadows is not a mistake, it is a
+ * consequence of the field beside it, and dropping it is exactly right — the
+ * value could never reach the page anyway, and holding the whole write for it
+ * would mean an author could not set a CSS id while such a row existed.
+ */
+export function holdsTheWrite(problem: RowProblem): boolean {
+  return problem.kind !== "overridden-by-css-id";
 }
 
 /** What to tell the author about a row that will not land. */
@@ -201,19 +234,38 @@ export function domIdsTaken(
       if (typeof node.cssId === "string" && node.cssId !== "") {
         taken.add(node.cssId);
       }
-      const own = node.attributes;
-      if (
-        own !== undefined &&
-        typeof own["id"] === "string" &&
-        own["id"] !== ""
-      ) {
-        taken.add(own["id"]);
-      }
+      const fromBag = renderedIdIn(node.attributes);
+      if (fromBag !== undefined) taken.add(fromBag);
     }
     for (const child of childNodesOf(node)) visit(child);
   };
   for (const node of nodes) visit(node);
   return taken;
+}
+
+/**
+ * The `id` the renderer would emit from an attribute bag, if any.
+ *
+ * Read case-INSENSITIVELY, because that is how the renderer reads it: HTML
+ * attribute names are ASCII case-insensitive and it lowercases every key before
+ * writing, so a stored `{ ID: "hero" }` renders as `id="hero"`. A scan looking
+ * only at the exact key `id` misses it, and another block is then allowed to
+ * take the same id — producing the collision this exists to prevent.
+ *
+ * The LAST variant wins, matching the renderer's own loop: it assigns each
+ * lowercased key in turn, so a later one replaces an earlier one. This editor
+ * never writes two spellings, but an import or a script can.
+ */
+function renderedIdIn(
+  attributes: Readonly<Record<string, string>> | undefined
+): string | undefined {
+  if (attributes === undefined) return undefined;
+  let found: string | undefined;
+  for (const [name, value] of Object.entries(attributes)) {
+    if (name.toLowerCase() !== "id") continue;
+    if (typeof value === "string" && value !== "") found = value;
+  }
+  return found;
 }
 
 /** Every node nested inside one, across all of its slots. */

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -115,63 +115,84 @@ export function rowProblem(
   rows: readonly AttributeRow[],
   index: number
 ): RowProblem | undefined {
+  return problemGiven(rows, index, heldOrigins(rows));
+}
+
+/**
+ * One row's verdict, given the set of keys refused rows are already holding.
+ *
+ * Takes `held` as DATA rather than computing it, because computing it has to
+ * ask this question of every row — and a version that reached for the answer
+ * itself would be asking itself.
+ */
+function problemGiven(
+  rows: readonly AttributeRow[],
+  index: number,
+  held: ReadonlySet<string>
+): RowProblem | undefined {
   const row = rows[index];
   if (row === undefined || isBlankRow(row)) return undefined;
   const alone = soloProblem(row);
   if (alone !== undefined) return alone;
   const key = attributeKey(row.name);
-  /*
-   * Located by INDEX, never by object identity. A row is a plain value the UI
-   * rebuilds on every keystroke, so two rows holding the same name and value
-   * are indistinguishable by `===`, and a caller passing an equal-but-separate
-   * object had every row reported as a duplicate of itself. Position is what
-   * actually decides this — the FIRST row holding a key is the one that lands,
-   * matching the renderer's own iteration over the stored record — so position
-   * is what the caller passes.
-   */
-  /*
-   * Among rows sharing a key, exactly one is kept and the rest are duplicates.
-   * The one kept is a row that came from the DOCUMENT and still carries its
-   * own name — never a row the author has just renamed onto it.
-   *
-   * First-wins alone got this backwards in one direction: renaming the first
-   * row onto a name a later row already held left the edited row looking fine
-   * and blamed the untouched one, so on rebuild the untouched row's old value
-   * overwrote the edit and the name renamed FROM disappeared. Between two rows
-   * that both came from the document — two spellings of one name in an
-   * imported bag — first-wins is still the answer.
-   */
-  const sharing = rows
-    .map((other, at) => ({ other, at }))
-    .filter(
-      ({ other }) => !isBlankRow(other) && attributeKey(other.name) === key
-    );
-  if (sharing.length > 1) {
-    const settled = sharing.filter(
-      ({ other }) =>
-        other.origin !== undefined && attributeKey(other.origin) === key
-    );
-    const keeps = (settled.length > 0 ? settled : sharing)[0]?.at;
-    if (keeps !== index) return { kind: "duplicate" };
-  }
+  const keeps = keeperOf(rows, key);
+  if (keeps !== undefined && keeps !== index) return { kind: "duplicate" };
+  // Asked BEFORE the held keys, so a row the field above owns is told that
+  // rather than being called a duplicate of whatever is holding the name.
+  if (key === "id") return { kind: "use-css-id-field" };
   /*
    * The keys refused rows are HOLDING count as taken too.
    *
    * A refused row keeps what it replaced, so its origin is still in the stored
    * record even though no row on screen carries that name. Judging collisions
-   * on the live names alone therefore accepted a second row renamed onto it —
-   * and the write, which places the preserved value first, was then overwritten
-   * by that row. `{ "data-a": "1", "data-b": "2" }` with one row refused onto
-   * `onclick` and the other renamed to `data-a` stored `{ "data-a": "2" }`:
-   * `data-b` gone, and the promise the refused row makes quietly broken.
+   * on the live names alone accepted a second row renamed onto it — and the
+   * write, which places the preserved value first, was then overwritten by that
+   * row, deleting an attribute nobody asked to lose.
    *
    * Reported rather than resolved in the write, because the author is the only
    * one who can say which of the two they meant. Both rows keep their origins
    * until they do, so the document is left exactly as it was.
    */
-  if (heldByRefusedRows(rows).has(key)) return { kind: "duplicate" };
-  if (key === "id") return { kind: "use-css-id-field" };
+  if (held.has(key)) return { kind: "duplicate" };
   return undefined;
+}
+
+/**
+ * Among the rows spelling one key, the index of the row that KEEPS it.
+ *
+ * `undefined` when nobody is displaced, which is the ordinary row.
+ *
+ * Located by INDEX, never by object identity. A row is a plain value the UI
+ * rebuilds on every keystroke, so two rows holding the same name and value are
+ * indistinguishable by `===`, and a caller passing an equal-but-separate object
+ * had every row reported as a duplicate of itself. Position is what actually
+ * decides this — the FIRST row holding a key is the one that lands, matching
+ * the renderer's own iteration over the stored record.
+ *
+ * The one kept is a row that came from the DOCUMENT and still carries its own
+ * name — never a row the author has just renamed onto it. First-wins alone got
+ * this backwards in one direction: renaming the first row onto a name a later
+ * row already held left the edited row looking fine and blamed the untouched
+ * one, so on rebuild the untouched row's old value overwrote the edit and the
+ * name renamed FROM disappeared. Between two rows that both came from the
+ * document — two spellings of one name in an imported bag — first-wins is still
+ * the answer.
+ */
+function keeperOf(
+  rows: readonly AttributeRow[],
+  key: string
+): number | undefined {
+  const sharing = rows
+    .map((other, at) => ({ other, at }))
+    .filter(
+      ({ other }) => !isBlankRow(other) && attributeKey(other.name) === key
+    );
+  if (sharing.length <= 1) return undefined;
+  const settled = sharing.filter(
+    ({ other }) =>
+      other.origin !== undefined && attributeKey(other.origin) === key
+  );
+  return (settled.length > 0 ? settled : sharing)[0]?.at;
 }
 
 /**
@@ -195,17 +216,32 @@ function soloProblem(row: AttributeRow): RowProblem | undefined {
 }
 
 /**
- * The stored keys that rows refused on their own terms will hold on to.
+ * Every stored key a refused row will hold on to, settled.
  *
- * Read from `soloProblem` rather than `rowProblem`, which would ask this
- * function while this function was answering it.
+ * EVERY refused row, not only the malformed ones. `storedAttributes` preserves
+ * the origin of any row that cannot land, and counting one kind of refusal but
+ * not the other left the same hole one layer along: a row refused as a
+ * DUPLICATE also keeps its origin, and a third row renamed onto that origin was
+ * accepted and overwrote it.
+ *
+ * Settled to a FIXED POINT, because holding a key refuses another row, and that
+ * row then holds an origin of its own. One pass closes one link of the chain
+ * and leaves the next open. Each pass can only ADD — a larger `held` never
+ * turns a refused row back into an accepted one — so the loop is monotone and
+ * cannot run longer than there are rows to refuse.
  */
-function heldByRefusedRows(rows: readonly AttributeRow[]): Set<string> {
+function heldOrigins(rows: readonly AttributeRow[]): Set<string> {
   const held = new Set<string>();
-  for (const row of rows) {
-    if (isBlankRow(row)) continue;
-    if (soloProblem(row) === undefined) continue;
-    if (row.origin !== undefined) held.add(row.origin);
+  for (let pass = 0; pass < rows.length; pass += 1) {
+    let grew = false;
+    rows.forEach((row, index) => {
+      const origin = row.origin;
+      if (origin === undefined || held.has(origin)) return;
+      if (problemGiven(rows, index, held) === undefined) return;
+      held.add(origin);
+      grew = true;
+    });
+    if (!grew) break;
   }
   return held;
 }

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -277,6 +277,35 @@ function childNodesOf(node: BlockNode): BlockNode[] {
   );
 }
 
+/**
+ * The same bag without an `id` the CSS id field would shadow.
+ *
+ * Applied to whatever set is about to be stored, because the shadowing is a
+ * consequence of the ID rather than of the rows. Reducing the rows already
+ * drops it — `rowProblem` reports the row and `storedAttributes` skips it — but
+ * the rows are NOT always what gets written: when one of them is a mistake the
+ * stored bag is kept instead, and that bag still holds the old id. Without this
+ * the two fixes cancelled: setting a CSS id beside a mistyped row left the
+ * shadowed id in place, and clearing the CSS id later brought it back.
+ *
+ * Case-insensitive, for the reason the collision scan is: the renderer
+ * lowercases every key, so `ID` and `id` are one attribute on the page.
+ */
+export function withoutShadowedId(
+  attributes: Readonly<Record<string, string>> | undefined,
+  cssId: string
+): Record<string, string> | undefined {
+  if (attributes === undefined || cssId.trim() === "") {
+    return attributes === undefined ? undefined : { ...attributes };
+  }
+  const kept: Record<string, string> = {};
+  for (const [name, value] of Object.entries(attributes)) {
+    if (name.toLowerCase() === "id") continue;
+    kept[name] = value;
+  }
+  return Object.keys(kept).length === 0 ? undefined : kept;
+}
+
 /** What a node should hold, and what it holds now. */
 export interface HtmlFields {
   readonly cssId: string;

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -1,0 +1,143 @@
+/**
+ * What an author may put on a block's root element, and why a row will not land.
+ *
+ * The engine models two fields beside a node's props: `cssId`, which becomes the
+ * element's `id`, and `attributes`, a bag of author-supplied HTML attributes.
+ * `blocks-react` already decides which of those reach the DOM and already
+ * applies them — this module is the EDITOR's half, and it owns exactly one
+ * question: what to tell an author before they save.
+ *
+ * ## Every rule here is ASKED, never restated
+ *
+ * The render-safe set lives in the renderer and says so in its own docblock, so
+ * `isAllowedAttribute` is imported rather than copied. A second copy would
+ * drift, and it drifts in the worse direction: an editor accepting a name the
+ * renderer skips lets an author set an attribute, watch it save, and never see
+ * it on the page. Nothing here decides what is safe — it decides what to SAY.
+ *
+ * @module custom-attributes
+ */
+import { isAllowedAttribute } from "@nextlyhq/blocks-react";
+
+/** One row of the attributes editor, as the author is typing it. */
+export interface AttributeRow {
+  readonly name: string;
+  readonly value: string;
+}
+
+/** Why a row will not reach the page, or `undefined` when it will. */
+export type RowProblem =
+  | { readonly kind: "not-allowed" }
+  | { readonly kind: "duplicate" }
+  | { readonly kind: "overridden-by-css-id" };
+
+/**
+ * HTML attribute names are ASCII case-insensitive; React props are not.
+ *
+ * The renderer lowercases before writing for exactly that reason — `ID` and
+ * `id` would otherwise both survive and land as two id attributes on one
+ * element. So two rows differing only in case are ONE attribute here too, and
+ * the editor has to say so rather than let an author believe they set two.
+ */
+export function attributeKey(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+/** Whether a row has been started at all. A blank row is not an error. */
+export function isBlankRow(row: AttributeRow): boolean {
+  return row.name.trim() === "";
+}
+
+/**
+ * What is wrong with one row, judged against its siblings and the node's id.
+ *
+ * `cssId` is checked because the renderer resolves the collision in its favour
+ * and says so: "the modelled field wins over an attribute of the same name".
+ * That is not a defect to fix here — a dedicated field beating an escape hatch
+ * is the right precedence — but it is invisible from the editor, so an author
+ * typing `id` beside a filled CSS id is writing a value that will never be
+ * used. Naming it is the whole point of the surface.
+ */
+export function rowProblem(
+  rows: readonly AttributeRow[],
+  index: number,
+  cssId: string
+): RowProblem | undefined {
+  const row = rows[index];
+  if (row === undefined || isBlankRow(row)) return undefined;
+  const key = attributeKey(row.name);
+  if (!isAllowedAttribute(key)) return { kind: "not-allowed" };
+  /*
+   * Located by INDEX, never by object identity. A row is a plain value the UI
+   * rebuilds on every keystroke, so two rows holding the same name and value
+   * are indistinguishable by `===`, and a caller passing an equal-but-separate
+   * object had every row reported as a duplicate of itself. Position is what
+   * actually decides this — the FIRST row holding a key is the one that lands,
+   * matching the renderer's own iteration over the stored record — so position
+   * is what the caller passes.
+   */
+  const first = rows.findIndex(
+    other => !isBlankRow(other) && attributeKey(other.name) === key
+  );
+  if (first !== -1 && first !== index) return { kind: "duplicate" };
+  if (key === "id" && cssId.trim() !== "") {
+    return { kind: "overridden-by-css-id" };
+  }
+  return undefined;
+}
+
+/** What to tell the author about a row that will not land. */
+export function problemMessage(problem: RowProblem): string {
+  switch (problem.kind) {
+    case "not-allowed":
+      return "This site does not put that attribute on a page. Names starting with “data-” or “aria-” are open, along with role, title, lang and dir.";
+    case "duplicate":
+      return "Another row already sets this attribute, and only the first is used. Attribute names ignore capitals, so “Data-X” and “data-x” are one name.";
+    case "overridden-by-css-id":
+      return "The CSS id above sets this element’s id, and it wins over this row, so this value would not be used. Clear the CSS id, or set the id there instead.";
+  }
+}
+
+/**
+ * The rows an author edits, from what the node stores.
+ *
+ * Sorted by name so the list does not reorder itself as an author types — a
+ * record's key order is its insertion order, and rewriting the record on every
+ * keystroke would make rows jump.
+ */
+export function rowsOf(
+  attributes: Readonly<Record<string, string>> | undefined
+): AttributeRow[] {
+  return Object.entries(attributes ?? {})
+    .map(([name, value]) => ({ name, value }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+/**
+ * What to store for a set of rows, or `undefined` to store nothing at all.
+ *
+ * Blank rows are dropped rather than saved as empty keys, and a row that cannot
+ * land is dropped too: storing a value the page will never use is the silent
+ * half of the problem this surface exists to make loud. `undefined` rather than
+ * `{}` for an empty result, so removing the last attribute leaves the node as
+ * it was before any were added rather than carrying an empty bag forever.
+ */
+export function storedAttributes(
+  rows: readonly AttributeRow[],
+  cssId: string
+): Record<string, string> | undefined {
+  const kept: Record<string, string> = {};
+  rows.forEach((row, index) => {
+    /*
+     * Blankness is asked SEPARATELY from correctness, because they are
+     * different questions and `rowProblem` answers only the second. A row an
+     * author has not started typing is not an error to show them — that is why
+     * it has no problem — and it is not something to store either. Reading one
+     * answer for both stored an attribute under the empty name.
+     */
+    if (isBlankRow(row)) return;
+    if (rowProblem(rows, index, cssId) !== undefined) return;
+    kept[attributeKey(row.name)] = row.value;
+  });
+  return Object.keys(kept).length === 0 ? undefined : kept;
+}

--- a/packages/builder/src/editor-state.test.ts
+++ b/packages/builder/src/editor-state.test.ts
@@ -359,3 +359,89 @@ describe("applying several ops as one action", () => {
     expect(ids(result.current.document)).toEqual(["a", "c"]);
   });
 });
+
+describe("an op applied from a closure the document has moved past", () => {
+  /*
+   * A panel that commits from an unmount cleanup calls the `apply` it captured
+   * on its LAST render — the removed component never renders again, so its
+   * closure predates the edit that removed it. Folding onto that render's
+   * document made the op SUCCEED against a tree the node was still in, and the
+   * commit wrote the whole stale document back: the deleted node returned and
+   * every change since was lost.
+   */
+  it("refuses an update to a node a later edit removed", () => {
+    const { result } = renderHook(() =>
+      useEditorState({ initialDocument: doc([node("a"), node("b")]) })
+    );
+
+    // Captured BEFORE the removal, exactly as an unmount cleanup holds it.
+    const stale = result.current.apply;
+
+    act(() => {
+      result.current.apply({ kind: "remove", id: "a" });
+    });
+    expect(result.current.document.nodes.map(each => each.id)).toEqual(["b"]);
+
+    let answered: unknown = "not called";
+    act(() => {
+      answered = stale({
+        kind: "update",
+        id: "a",
+        patch: { cssId: "hero" },
+      });
+    });
+
+    // Refused, because the node is gone from the document as it stands now.
+    expect(answered).toBeNull();
+    // And the removal still holds — the stale write did not resurrect it.
+    expect(result.current.document.nodes.map(each => each.id)).toEqual(["b"]);
+  });
+
+  it("still applies a stale op to a node that is STILL there", () => {
+    // The control: refusing every stale call would break the commit-on-unmount
+    // path this exists to protect, which is the ordinary case.
+    const { result } = renderHook(() =>
+      useEditorState({ initialDocument: doc([node("a"), node("b")]) })
+    );
+    const stale = result.current.apply;
+
+    act(() => {
+      result.current.apply({ kind: "remove", id: "b" });
+    });
+    act(() => {
+      stale({ kind: "update", id: "a", patch: { cssId: "hero" } });
+    });
+
+    const nodes = result.current.document.nodes;
+    expect(nodes.map(each => each.id)).toEqual(["a"]);
+    expect((nodes[0] as BlockNode).cssId).toBe("hero");
+  });
+});
+
+describe("two ops applied in one tick", () => {
+  it("keeps both, rather than folding the second onto the first's input", () => {
+    /*
+     * `setDocument` does not take effect until the next render, so a second op
+     * applied before that render must not read the document the first one
+     * replaced — it would be folded onto a tree without the first edit and
+     * write it back, silently discarding it.
+     *
+     * `applyAll` exists for a deliberate group; this is the accidental pair,
+     * two handlers on one gesture, and it must not lose an edit either.
+     */
+    const { result } = renderHook(() =>
+      useEditorState({ initialDocument: doc([node("a"), node("b")]) })
+    );
+
+    act(() => {
+      result.current.apply({ kind: "update", id: "a", patch: { cssId: "x" } });
+      result.current.apply({ kind: "update", id: "b", patch: { cssId: "y" } });
+    });
+
+    const byId = new Map(
+      result.current.document.nodes.map(each => [each.id, each])
+    );
+    expect(byId.get("a")?.cssId).toBe("x");
+    expect(byId.get("b")?.cssId).toBe("y");
+  });
+});

--- a/packages/builder/src/editor-state.ts
+++ b/packages/builder/src/editor-state.ts
@@ -113,6 +113,33 @@ export function useEditorState({
   const [document, setDocument] = useState<BlockDocument>(initialDocument);
   const [selection, setSelection] = useState<BlockSelection>(EMPTY_SELECTION);
 
+  /**
+   * The document as it stands NOW, for everything a LATER event reaches.
+   *
+   * Every callback below closes over the render it was made in. Most callers
+   * take theirs from the current render and the distinction never shows, but
+   * two paths do not, and both read this ref rather than the state.
+   *
+   * `select`, because a gesture is handled by whatever handler the last render
+   * bound and the selection rules need the document that is current when the
+   * click lands. Closing over it resolves a range against a stale tree, which
+   * is a wrong selection rather than a missing one.
+   *
+   * `run`, because a panel that commits from an unmount cleanup necessarily
+   * holds an older callback: the component going away does not render again, so
+   * its closure predates the very edit that removed it. Folding onto that older
+   * document did not merely apply a stale edit — it SUCCEEDED where it should
+   * have been refused, the node still being present in that copy, and then
+   * wrote the whole document back. Deleting a block with an unsaved panel open
+   * restored the block and discarded everything since. Read through the ref the
+   * same call is refused, which is what callers are already written to handle.
+   *
+   * The hazard was named here for `select` alone and left on the op path, which
+   * is the more expensive of the two.
+   */
+  const latestDocument = useRef(document);
+  latestDocument.current = document;
+
   const undoStack = useRef<BuilderOp[][]>([]);
   const redoStack = useRef<BuilderOp[][]>([]);
   // Mirrors the stack lengths so the flags below are STATE and re-render when
@@ -160,9 +187,9 @@ export function useEditorState({
       // Nothing to do, and nothing to record. An empty group must NOT push an
       // entry: that would be an undo that appears to do nothing, which reads as
       // the history being broken.
-      if (ops.length === 0) return document;
+      if (ops.length === 0) return latestDocument.current;
 
-      let working = document;
+      let working = latestDocument.current;
       const inverses: BuilderOp[] = [];
       for (const op of ops) {
         let applied;
@@ -204,6 +231,10 @@ export function useEditorState({
         undo: undoStack.current.length,
         redo: redoStack.current.length,
       });
+      // Ahead of `setDocument`, which does not take effect until the next
+      // render: two ops applied in one tick must see each other, or the second
+      // is folded onto the document the first already replaced.
+      latestDocument.current = applied.document;
       setDocument(applied.document);
 
       // A selection pointing at a node this edit removed would leave every
@@ -215,7 +246,11 @@ export function useEditorState({
 
       return applied.document;
     },
-    [document, limits]
+    // NOT `document`: it is read through the ref above, so depending on it here
+    // would rebuild these callbacks every edit for a value none of them close
+    // over. Stable identity is also the point — a stale `run` is now the same
+    // `run`, folding onto the tree as it stands.
+    [limits]
   );
 
   const apply = useCallback((op: BuilderOp) => run([op], "new"), [run]);
@@ -242,18 +277,6 @@ export function useEditorState({
     setDepths(d => ({ ...d, redo: redoStack.current.length }));
     run(group, "undo");
   }, [run]);
-
-  /*
-   * The document is read from a REF rather than closed over.
-   *
-   * A gesture is handled by whatever handler the last render bound, and the
-   * selection rules need the document that is current when the click lands —
-   * not the one that was current when the handler was made. Closing over it
-   * would resolve a range against a stale tree, which is a wrong selection
-   * rather than a missing one.
-   */
-  const latestDocument = useRef(document);
-  latestDocument.current = document;
 
   const select = useCallback(
     (id: string | null, mode: SelectionMode = "replace") =>

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -1299,3 +1299,59 @@ describe("the Advanced tab stays mounted without staying on screen", () => {
     expect(screen.queryByLabelText("CSS id")).not.toBeNull();
   });
 });
+
+describe("a refused id while an unrelated attribute saves", () => {
+  it("keeps the author's id and its reason on screen", () => {
+    /*
+     * A colliding id is held out of the write while staying in the field, so
+     * `wanted.cssId` is the value the node ALREADY had. Rebasing the field onto
+     * what landed therefore replaced the text the author was fixing with the
+     * old id, and took the collision message with it — because an unrelated
+     * attribute happened to save.
+     */
+    register();
+    const editor = editorFor({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "a",
+          type: "acme/heading",
+          version: 1,
+          props: {},
+          attributes: { "data-x": "1" },
+        },
+        { id: "b", type: "acme/heading", version: 1, props: {}, cssId: "hero" },
+      ],
+    } as unknown as BlockDocument);
+    render(<InspectorPanel editor={editor} />);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: "hero" } });
+    fireEvent.blur(field);
+    // The control: refused, and both the text and the reason are present to be
+    // lost by what follows.
+    expect(editor.apply).not.toHaveBeenCalled();
+    expect((field as HTMLInputElement).value).toBe("hero");
+
+    const value = screen.getByLabelText("Value of attribute 1");
+    fireEvent.change(value, { target: { value: "2" } });
+    fireEvent.blur(value);
+
+    // The attribute saved, and ONLY the attribute.
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: { attributes: { "data-x": "2" } },
+    });
+    expect((screen.getByLabelText("CSS id") as HTMLInputElement).value).toBe(
+      "hero"
+    );
+    expect(
+      screen
+        .queryAllByRole("alert")
+        .some(each => each.textContent?.includes("already uses that id"))
+    ).toBe(true);
+  });
+});

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -1172,3 +1172,57 @@ describe("a refusal that no longer describes anything", () => {
     );
   });
 });
+
+describe("an id the editor tidied on the way in", () => {
+  it("does not put the whitespace back on the next unrelated edit", () => {
+    /*
+     * Trimming only what the author typed needs the draft to be rebased onto
+     * what LANDED, or the two disagree: the document holds `hero`, the draft
+     * still holds `" hero "`, and the next commit sees an id unchanged from
+     * what was loaded, skips the trim, and patches the spaces back — breaking
+     * every fragment link to the block. The rows were rebased and the id was
+     * not, which is the whole defect.
+     */
+    const editor = mount({ attributes: { "data-x": "1" } });
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: " hero " } });
+    fireEvent.blur(field);
+    // The control: it was stored trimmed, so there is a tidied value to lose.
+    expect(editor.apply).toHaveBeenLastCalledWith({
+      kind: "update",
+      id: "a",
+      patch: { cssId: "hero" },
+    });
+    // And the field shows what was actually saved, not what was typed.
+    expect((field as HTMLInputElement).value).toBe("hero");
+
+    const value = screen.getByLabelText("Value of attribute 1");
+    fireEvent.change(value, { target: { value: "2" } });
+    fireEvent.blur(value);
+
+    /*
+     * Replayed through the REAL store, both ops in order, because what matters
+     * is the document they leave rather than the shape of either one. The spy
+     * editor never updates what it hands back, so the second op is computed
+     * against the first op's props — which is exactly the situation that let
+     * the untrimmed id return.
+     */
+    let node = {
+      id: "a",
+      type: "acme/heading",
+      version: 1,
+      props: {},
+      attributes: { "data-x": "1" },
+    } as unknown as BlockNode;
+    for (const call of editor.apply.mock.calls) {
+      node = applyOp(
+        { formatVersion: 1, kind: "page", nodes: [node] } as BlockDocument,
+        call[0] as never
+      ).document.nodes[0] as BlockNode;
+    }
+    expect(node.cssId).toBe("hero");
+    expect(node.attributes).toEqual({ "data-x": "2" });
+  });
+});

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -300,3 +300,142 @@ describe("InspectorPanel with several blocks selected", () => {
     ]);
   });
 });
+
+/**
+ * The Advanced tab: the block's `id` and the attributes an author may add.
+ *
+ * `custom-attributes.ts` decides which rows may land and asserts that without a
+ * DOM. What is only true HERE is the wiring — that a refusal is shown against
+ * the field it belongs to, that an edit reaches `editor.apply`, and that what
+ * the page would drop is never stored.
+ */
+describe("InspectorPanel advanced fields", () => {
+  const openAdvanced = () => {
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+  };
+
+  it("shows the block's stored id and attributes", () => {
+    mount({ cssId: "hero", attributes: { "data-x": "1" } });
+    openAdvanced();
+
+    expect((screen.getByLabelText("CSS id") as HTMLInputElement).value).toBe(
+      "hero"
+    );
+    expect(
+      (screen.getByLabelText("Name of attribute 1") as HTMLInputElement).value
+    ).toBe("data-x");
+  });
+
+  it("commits an id through the editor, so undo covers it", () => {
+    const editor = mount({});
+    openAdvanced();
+
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: "hero" } });
+    // Nothing yet: an op per keystroke would make one undo remove one letter.
+    expect(editor.apply).not.toHaveBeenCalled();
+    fireEvent.blur(field);
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: { cssId: "hero" },
+    });
+  });
+
+  it("REMOVES an id rather than storing an empty one", () => {
+    // A node that never had an id and one whose id was cleared are the same
+    // node; an empty string would render as `id=""`.
+    const editor = mount({ cssId: "hero" });
+    openAdvanced();
+
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: "  " } });
+    fireEvent.blur(field);
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: { cssId: undefined },
+    });
+  });
+
+  it("says why a refused attribute will not reach the page, and stores nothing", () => {
+    /*
+     * The whole point of the surface. Without it an author types `onclick`,
+     * watches it save, and finds the page without it — the renderer drops the
+     * name and nothing anywhere says so.
+     */
+    const editor = mount({ attributes: { "data-x": "1" } });
+    openAdvanced();
+
+    const name = screen.getByLabelText("Name of attribute 1");
+    fireEvent.change(name, { target: { value: "onclick" } });
+    fireEvent.blur(name);
+
+    const said = screen.getByRole("alert");
+    expect(said.textContent).toContain("does not put that attribute");
+    // Named to the field, so a screen reader reaches the reason with it.
+    expect(name.getAttribute("aria-describedby")).toBe(said.id);
+    expect(name.getAttribute("aria-invalid")).toBe("true");
+    // And the value the page would drop is not written to the document.
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: { attributes: undefined },
+    });
+  });
+
+  it("says an id attribute loses to the CSS id field", () => {
+    /*
+     * The renderer resolves this in favour of `cssId` and says so. That is the
+     * right precedence and it is invisible from here: without this the author
+     * sets an id, sees it saved, and the page carries the other one.
+     */
+    mount({ cssId: "from-the-field", attributes: { id: "from-the-bag" } });
+    openAdvanced();
+
+    expect(screen.getByRole("alert").textContent).toContain("CSS id");
+  });
+
+  it("says nothing about an attribute that WILL reach the page", () => {
+    // The control: a refusal shown on a valid row would make the surface noise,
+    // and every assertion above would still pass.
+    mount({ cssId: "hero", attributes: { "data-x": "1" } });
+    openAdvanced();
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("gives every row a distinct name, and does not collide with the block's", () => {
+    /*
+     * The visible labels are short because they sit inline, and short labels
+     * repeat: "Name" is also the block's own name field above the tabs. Two
+     * rows plus that one would announce the same word three times for three
+     * different things, and a voice-control user saying "name" would have no
+     * way to pick.
+     */
+    mount({ attributes: { "data-a": "1", "data-b": "2" } });
+    openAdvanced();
+
+    expect(
+      (screen.getByLabelText("Name of attribute 1") as HTMLInputElement).value
+    ).toBe("data-a");
+    expect(
+      (screen.getByLabelText("Name of attribute 2") as HTMLInputElement).value
+    ).toBe("data-b");
+    // The block's own field is still reachable by its own label, which is what
+    // an ambiguous name would break — `getByLabelText` throws on two matches.
+    expect(screen.getByLabelText("Name")).toHaveProperty("id", "nx-block-name");
+    // Each Remove is named too, for the same reason.
+    expect(screen.getByRole("button", { name: "Remove data-a" })).toBeDefined();
+  });
+
+  it("keeps the identity fields above the tabs", () => {
+    // The Advanced tab must not have moved the block's own name into it: the
+    // name answers "which of six headings is this" under every tab.
+    mount({ name: "Hero title" });
+    openAdvanced();
+    expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe(
+      "Hero title"
+    );
+  });
+});

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -16,7 +16,13 @@
  *
  * @module inspector-panel.test
  */
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  createEvent,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import * as React from "react";
 
@@ -792,5 +798,65 @@ describe("undo then redo, with the panel open", () => {
     expect((screen.getByLabelText("CSS id") as HTMLInputElement).value).toBe(
       "two"
     );
+  });
+});
+
+describe("the Advanced tab inside the entry's form", () => {
+  it("does not let Enter submit the form", () => {
+    /*
+     * The builder mounts inside the entry's `<form>`, and a single-line input
+     * with nothing stopping the key implicitly submits it — so typing an
+     * attribute and pressing Enter would save the whole entry. The CSS id field
+     * already prevented it; the two row inputs did not.
+     */
+    const editor = mount({ attributes: { "data-x": "1" } });
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    for (const label of [
+      "CSS id",
+      "Name of attribute 1",
+      "Value of attribute 1",
+    ]) {
+      const event = createEvent.keyDown(screen.getByLabelText(label), {
+        key: "Enter",
+      });
+      fireEvent(screen.getByLabelText(label), event);
+      expect(event.defaultPrevented, label).toBe(true);
+    }
+    // And Enter still COMMITS, rather than merely being swallowed.
+    expect(editor.apply).not.toHaveBeenCalled();
+  });
+
+  it("reports a refused save instead of showing a value nothing stored", () => {
+    /*
+     * `apply` answers `null` when the op is refused — a value past the
+     * document's byte limit is the reachable case — and the document is left
+     * alone. Ignoring that told the panel its own write had landed, so it
+     * stopped re-reading the document and went on showing the unsaved value.
+     */
+    register();
+    const editor = editorFor(documentOf({}));
+    editor.apply.mockReturnValue(null);
+    render(<InspectorPanel editor={editor} />);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: "hero" } });
+    fireEvent.blur(field);
+
+    expect(screen.getByRole("alert").textContent).toContain("size limit");
+  });
+
+  it("says nothing when the save DID land", () => {
+    // The control: a refusal shown on every successful edit would be worse
+    // than the silence it replaced.
+    const editor = mount({});
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: "hero" } });
+    fireEvent.blur(field);
+
+    expect(editor.apply).toHaveBeenCalled();
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 });

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -860,3 +860,76 @@ describe("the Advanced tab inside the entry's form", () => {
     expect(screen.queryByRole("alert")).toBeNull();
   });
 });
+
+describe("a node carrying both a css id and a legacy id attribute", () => {
+  const both = { cssId: "kept", attributes: { id: "legacy", "data-x": "1" } };
+
+  it("does not delete the legacy id just by being looked at", () => {
+    /*
+     * An imported node can hold both. The renderer ignores the bag one while
+     * the field has a value, so it is dead data — but deleting it because
+     * someone opened a tab is not the author asking for it to go, and if they
+     * later clear the field it is what would render.
+     */
+    const editor = mount(both);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Style" }));
+
+    expect(editor.apply).not.toHaveBeenCalled();
+  });
+
+  it("does not delete it when the requested id was REFUSED", () => {
+    /*
+     * A refusal keeps the id the node already had, which is still non-empty —
+     * so a rule keyed on "the field holds something" fired and wrote an
+     * attributes-only update, deleting data on a change that did not happen.
+     */
+    register();
+    const editor = editorFor({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "a", type: "acme/heading", version: 1, props: {}, ...both },
+        {
+          id: "b",
+          type: "acme/heading",
+          version: 1,
+          props: {},
+          cssId: "taken",
+        },
+      ],
+    } as unknown as BlockDocument);
+    render(<InspectorPanel editor={editor} />);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: "taken" } });
+    fireEvent.blur(field);
+
+    // Two alerts are correct here — the field's collision, and the id row
+    // pointing at the field — so this names the one under test.
+    const said = screen
+      .getAllByRole("alert")
+      .map(each => each.textContent ?? "")
+      .join(" ");
+    expect(said).toContain("already uses that id");
+    expect(editor.apply).not.toHaveBeenCalled();
+  });
+
+  it("DOES drop it when the author actually sets a new id", () => {
+    // The control, and the behaviour an earlier finding asked for: once the
+    // author sets the field, the bag value can never render again, so keeping
+    // it would let a later clear bring a dead id back to life.
+    const editor = mount(both);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: "fresh" } });
+    fireEvent.blur(field);
+
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: { cssId: "fresh", attributes: { "data-x": "1" } },
+    });
+  });
+});

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -384,13 +384,16 @@ describe("InspectorPanel advanced fields", () => {
     // Named to the field, so a screen reader reaches the reason with it.
     expect(name.getAttribute("aria-describedby")).toBe(said.id);
     expect(name.getAttribute("aria-invalid")).toBe("true");
-    // And the value the page would drop is not written to the document.
-    expect(editor.apply).toHaveBeenCalledWith({
-      kind: "update",
-      id: "a",
-      patch: {},
-      unset: ["attributes"],
-    });
+    /*
+     * And NOTHING is written. Renaming `data-x` to `onclick` means the author
+     * typed something wrong, not that they want `data-x` removed — writing the
+     * reduced set would delete it, and the row showing the mistake would be
+     * replaced by the now-empty stored value, so the attribute and the reason
+     * for the refusal would disappear together.
+     */
+    expect(editor.apply).not.toHaveBeenCalled();
+    // The row and its explanation are still on screen for the author to fix.
+    expect((name as HTMLInputElement).value).toBe("onclick");
   });
 
   it("says an id attribute loses to the CSS id field", () => {
@@ -588,5 +591,77 @@ describe("the Advanced tab keeps what the author typed", () => {
       patch: { cssId: "new" },
       unset: ["attributes"],
     });
+  });
+});
+
+describe("a refused row survives its own commit", () => {
+  it("keeps the draft and the stored attribute when a rename is refused", () => {
+    /*
+     * The failure this closes needs the panel to RE-RENDER after a write, which
+     * a spy-only editor never does. Here the parent is re-rendered with the
+     * stored attributes unchanged, which is what a real store does when nothing
+     * was written — and the refused row, its explanation, and the attribute it
+     * replaced must all still be there.
+     */
+    const editor = mount({ attributes: { "data-x": "1" } });
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    const name = screen.getByLabelText("Name of attribute 1");
+    fireEvent.change(name, { target: { value: "onclick" } });
+    fireEvent.blur(name);
+
+    // Nothing written, so `data-x` is still the stored value.
+    expect(editor.apply).not.toHaveBeenCalled();
+    // The draft the author is fixing is still on screen, with its reason.
+    expect((name as HTMLInputElement).value).toBe("onclick");
+    expect(screen.getByRole("alert").textContent).toContain(
+      "does not put that attribute"
+    );
+  });
+
+  it("still commits a CSS id while a row is refused", () => {
+    // The id is a separate field, and holding it hostage to an unrelated typo
+    // in the rows below would be its own surprise.
+    const editor = mount({ attributes: { "data-x": "1" } });
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    const name = screen.getByLabelText("Name of attribute 1");
+    fireEvent.change(name, { target: { value: "onclick" } });
+    fireEvent.blur(name);
+
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: "hero" } });
+    fireEvent.blur(field);
+
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: { cssId: "hero" },
+    });
+  });
+
+  it("refuses an id another block already holds, and writes nothing", () => {
+    // The engine reports this only as a warning and the field's validation
+    // discards warnings, so without refusing here it saves and publishes.
+    register();
+    const editor = editorFor({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "a", type: "acme/heading", version: 1, props: {} },
+        { id: "b", type: "acme/heading", version: 1, props: {}, cssId: "hero" },
+      ],
+    } as unknown as BlockDocument);
+    render(<InspectorPanel editor={editor} />);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: "hero" } });
+    fireEvent.blur(field);
+
+    expect(editor.apply).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert").textContent).toContain(
+      "already uses that id"
+    );
   });
 });

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -823,8 +823,24 @@ describe("the Advanced tab inside the entry's form", () => {
       fireEvent(screen.getByLabelText(label), event);
       expect(event.defaultPrevented, label).toBe(true);
     }
-    // And Enter still COMMITS, rather than merely being swallowed.
+    // Nothing was written, because nothing was edited — swallowing the key
+    // must not be mistaken for the commit being asserted below.
     expect(editor.apply).not.toHaveBeenCalled();
+
+    // And Enter COMMITS, rather than merely being swallowed. Asserted on an
+    // edit, because the check above passes on a panel that ignores the key
+    // entirely and would have read as proof of a commit it never made.
+    fireEvent.change(screen.getByLabelText("Value of attribute 1"), {
+      target: { value: "2" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Value of attribute 1"), {
+      key: "Enter",
+    });
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: { attributes: { "data-x": "2" } },
+    });
   });
 
   it("reports a refused save instead of showing a value nothing stored", () => {
@@ -844,7 +860,9 @@ describe("the Advanced tab inside the entry's form", () => {
     fireEvent.change(field, { target: { value: "hero" } });
     fireEvent.blur(field);
 
-    expect(screen.getByRole("alert").textContent).toContain("size limit");
+    expect(screen.getByRole("alert").textContent).toContain(
+      "could not be saved"
+    );
   });
 
   it("says nothing when the save DID land", () => {
@@ -1127,14 +1145,16 @@ describe("a refusal that no longer describes anything", () => {
     fireEvent.change(field, { target: { value: "enormous" } });
     fireEvent.blur(field);
     // The control on both tests below: the alert was there to be cleared.
-    expect(screen.getByRole("alert").textContent).toContain("size limit");
+    expect(screen.getByRole("alert").textContent).toContain(
+      "could not be saved"
+    );
     return field;
   };
 
   const sizeAlert = () =>
     screen
       .queryAllByRole("alert")
-      .find(each => each.textContent?.includes("size limit"));
+      .find(each => each.textContent?.includes("could not be saved"));
 
   it("clears when the field is put back to what it was", () => {
     // The first route: the draft matches what was loaded, so the commit stops
@@ -1224,5 +1244,58 @@ describe("an id the editor tidied on the way in", () => {
     }
     expect(node.cssId).toBe("hero");
     expect(node.attributes).toEqual({ "data-x": "2" });
+  });
+});
+
+describe("the Advanced tab stays mounted without staying on screen", () => {
+  /*
+   * Keeping the draft alive across a tab switch means keeping the panel
+   * mounted, and Radix ties presence to visibility: `TabsContent` renders
+   * `hidden={!present}` with `present` = `forceMount || isSelected`, so asking
+   * it to stay mounted also told it it was on screen. The Advanced fields
+   * appeared under Content and under Style.
+   *
+   * Retention and invisibility are therefore two claims, and the draft tests
+   * above only make the first. This makes the second.
+   */
+  const panelOf = (element: HTMLElement): HTMLElement => {
+    const panel = element.closest('[role="tabpanel"]');
+    if (panel === null) throw new Error("no tabpanel above the CSS id field");
+    return panel as HTMLElement;
+  };
+
+  it("is hidden under the other tabs, and shown under its own", () => {
+    mount({});
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+    // The control: it really is on screen when chosen, so `hidden` below is
+    // a state it moved INTO rather than one it never left.
+    expect(panelOf(screen.getByLabelText("CSS id")).hidden).toBe(false);
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Style" }));
+    expect(panelOf(screen.getByLabelText("CSS id")).hidden).toBe(true);
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Content" }));
+    expect(panelOf(screen.getByLabelText("CSS id")).hidden).toBe(true);
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+    expect(panelOf(screen.getByLabelText("CSS id")).hidden).toBe(false);
+  });
+
+  it("is out of the accessibility tree while hidden", () => {
+    /*
+     * `hidden` is the claim that matters to someone who cannot see the panel:
+     * a mounted-but-offscreen tab that a screen reader still announces is the
+     * same defect wearing different clothes. Asked by ROLE, which resolves
+     * against the accessibility tree rather than the DOM.
+     */
+    mount({});
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+    expect(screen.queryByRole("textbox", { name: "CSS id" })).not.toBeNull();
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Style" }));
+    expect(screen.queryByRole("textbox", { name: "CSS id" })).toBeNull();
+    // Still MOUNTED, which is the whole point of hiding it rather than
+    // removing it — the draft has to survive.
+    expect(screen.queryByLabelText("CSS id")).not.toBeNull();
   });
 });

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -26,6 +26,7 @@ import {
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import * as React from "react";
 
+import { createBlockResolver } from "@nextlyhq/blocks-react";
 import {
   clearBlocks,
   hasBlock,
@@ -1353,5 +1354,76 @@ describe("a refused id while an unrelated attribute saves", () => {
         .queryAllByRole("alert")
         .some(each => each.textContent?.includes("already uses that id"))
     ).toBe(true);
+  });
+});
+
+describe("the block set the collision check answers about", () => {
+  it("uses the resolver the canvas renders with, not the global registry", () => {
+    /*
+     * `Canvas` forwards `render.blocks` to `PageRenderer`, so a host can render
+     * against definitions the global registry has never seen. A panel that
+     * reached for the registry would call such a node a placeholder, free its
+     * id, and let another block take an id the page already renders.
+     *
+     * `acme/host` is deliberately NOT registered: only the resolver passed in
+     * knows it, so the id it holds can only be reserved by way of that
+     * resolver.
+     */
+    register();
+    const editor = editorFor({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "a", type: "acme/heading", version: 1, props: {} },
+        { id: "b", type: "acme/host", version: 1, props: {}, cssId: "hero" },
+      ],
+    } as unknown as BlockDocument);
+    render(
+      <InspectorPanel
+        editor={editor}
+        blocks={createBlockResolver([
+          { name: "acme/host", version: 1 } as never,
+        ])}
+      />
+    );
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: "hero" } });
+    fireEvent.blur(field);
+
+    expect(editor.apply).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert").textContent).toContain(
+      "already uses that id"
+    );
+  });
+
+  it("falls back to the global registry when the host states none", () => {
+    // The control, and the ordinary case: `PageRenderer` defaults the same way,
+    // so a host that says nothing still has the two sides agreeing.
+    register();
+    const editor = editorFor({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "a", type: "acme/heading", version: 1, props: {} },
+        {
+          id: "b",
+          type: "acme/heading",
+          version: 1,
+          props: {},
+          cssId: "hero",
+        },
+      ],
+    } as unknown as BlockDocument);
+    render(<InspectorPanel editor={editor} />);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    fireEvent.change(screen.getByLabelText("CSS id"), {
+      target: { value: "hero" },
+    });
+    fireEvent.blur(screen.getByLabelText("CSS id"));
+
+    expect(editor.apply).not.toHaveBeenCalled();
   });
 });

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -665,3 +665,34 @@ describe("a refused row survives its own commit", () => {
     );
   });
 });
+
+describe("a shadowed id and a mistyped row at the same time", () => {
+  it("still drops the shadowed id while holding the mistyped row", () => {
+    /*
+     * The two rules interacting. Holding the write because a row is a mistake
+     * must not also hold back dropping an id the new CSS id shadows: those are
+     * different reasons and only one is the author's to fix. Without this,
+     * clearing the CSS id later brought the old bag id back to life.
+     */
+    const editor = mount({ attributes: { id: "old", "data-x": "1" } });
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    // Row 2 is `data-x` — rename it to something the page would drop.
+    const second = screen.getByLabelText("Name of attribute 2");
+    fireEvent.change(second, { target: { value: "onclick" } });
+    fireEvent.blur(second);
+    expect(editor.apply).not.toHaveBeenCalled();
+
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: "new" } });
+    fireEvent.blur(field);
+
+    // The id commits, and the shadowed bag id goes with it — `data-x` is kept
+    // because the author is still fixing that row.
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: { cssId: "new", attributes: { "data-x": "1" } },
+    });
+  });
+});

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -677,10 +677,15 @@ describe("a shadowed id and a mistyped row at the same time", () => {
     const editor = mount({ attributes: { id: "old", "data-x": "1" } });
     fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
 
-    // Row 2 is `data-x` — rename it to something the page would drop.
-    const second = screen.getByLabelText("Name of attribute 2");
-    fireEvent.change(second, { target: { value: "onclick" } });
-    fireEvent.blur(second);
+    /*
+     * Rows are shown in NAME order, so `data-x` is the first and `id` the
+     * second — an earlier version of this test edited the row it did not mean
+     * and passed for the wrong reason.
+     */
+    const first = screen.getByLabelText("Name of attribute 1");
+    expect((first as HTMLInputElement).value).toBe("data-x");
+    fireEvent.change(first, { target: { value: "onclick" } });
+    fireEvent.blur(first);
     expect(editor.apply).not.toHaveBeenCalled();
 
     const field = screen.getByLabelText("CSS id");
@@ -694,5 +699,98 @@ describe("a shadowed id and a mistyped row at the same time", () => {
       id: "a",
       patch: { cssId: "new", attributes: { "data-x": "1" } },
     });
+  });
+});
+
+describe("the panel's own write does not fight the document", () => {
+  it("removes one row while another is mistyped", () => {
+    /*
+     * Holding the whole write for a mistyped row used to mean this Remove did
+     * nothing: the row vanished locally, no op removed it, and leaving the tab
+     * brought it back. Origin tracking lets the mistyped row keep what it
+     * replaced without freezing everything beside it.
+     */
+    const editor = mount({ attributes: { "data-a": "1", "data-b": "2" } });
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    const first = screen.getByLabelText("Name of attribute 1");
+    expect((first as HTMLInputElement).value).toBe("data-a");
+    fireEvent.change(first, { target: { value: "onclick" } });
+    fireEvent.blur(first);
+    expect(editor.apply).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove data-b" }));
+
+    // `data-b` is gone and `data-a` survives its own bad rename.
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: { attributes: { "data-a": "1" } },
+    });
+  });
+
+  it("points an id row at the field above rather than storing it", () => {
+    // One route to an identifier. The renderer accepts an `id` here, so a
+    // document from elsewhere can carry one — it is shown, explained, and not
+    // rewritten under a new value.
+    mount({ attributes: { id: "from-a-file" } });
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    expect(screen.getByRole("alert").textContent).toContain("CSS id field");
+  });
+});
+
+describe("undo then redo, with the panel open", () => {
+  it("follows the document back to the redone value", () => {
+    /*
+     * The panel skips re-reading the document when the incoming props are its
+     * own write echoing back, or a local draft would be wiped by every save.
+     * The marker for that has to be CONSUMED once matched: left in place it
+     * goes on describing a state the document can return to, and a redo lands
+     * exactly there — so the panel keeps showing the undone value while a later
+     * blur writes from that stale draft and erases the redone edit.
+     */
+    register();
+    const withId = (cssId?: string): BlockDocument =>
+      ({
+        formatVersion: 1,
+        kind: "page",
+        nodes: [
+          {
+            id: "a",
+            type: "acme/heading",
+            version: 1,
+            props: {},
+            ...(cssId === undefined ? {} : { cssId }),
+          },
+        ],
+      }) as unknown as BlockDocument;
+
+    const editor = editorFor(withId("one"));
+    const { rerender } = render(<InspectorPanel editor={editor} />);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: "two" } });
+    fireEvent.blur(field);
+    expect(editor.apply).toHaveBeenCalled();
+
+    // The write echoes back through the document.
+    rerender(<InspectorPanel editor={editorFor(withId("two"))} />);
+    expect((screen.getByLabelText("CSS id") as HTMLInputElement).value).toBe(
+      "two"
+    );
+
+    // Undo.
+    rerender(<InspectorPanel editor={editorFor(withId("one"))} />);
+    expect((screen.getByLabelText("CSS id") as HTMLInputElement).value).toBe(
+      "one"
+    );
+
+    // Redo — the field must follow, not sit on the undone value.
+    rerender(<InspectorPanel editor={editorFor(withId("two"))} />);
+    expect((screen.getByLabelText("CSS id") as HTMLInputElement).value).toBe(
+      "two"
+    );
   });
 });

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -29,6 +29,7 @@ import {
 } from "@nextlyhq/blocks-engine";
 
 import { InspectorPanel } from "./inspector-panel";
+import { applyOp } from "./ops";
 import type { EditorState } from "./editor-state";
 
 afterEach(() => {
@@ -351,10 +352,17 @@ describe("InspectorPanel advanced fields", () => {
     const field = screen.getByLabelText("CSS id");
     fireEvent.change(field, { target: { value: "  " } });
     fireEvent.blur(field);
+    /*
+     * `unset`, never `undefined`. `applyOp` refuses an undefined patch value —
+     * the key disappears when the op is stored, so a replayed edit would do
+     * nothing — and the op below is checked against the REAL store in the
+     * control beneath this describe, not only against a spy.
+     */
     expect(editor.apply).toHaveBeenCalledWith({
       kind: "update",
       id: "a",
-      patch: { cssId: undefined },
+      patch: {},
+      unset: ["cssId"],
     });
   });
 
@@ -380,7 +388,8 @@ describe("InspectorPanel advanced fields", () => {
     expect(editor.apply).toHaveBeenCalledWith({
       kind: "update",
       id: "a",
-      patch: { attributes: undefined },
+      patch: {},
+      unset: ["attributes"],
     });
   });
 
@@ -437,5 +446,147 @@ describe("InspectorPanel advanced fields", () => {
     expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe(
       "Hero title"
     );
+  });
+});
+
+/**
+ * The ops the Advanced tab emits, applied for REAL.
+ *
+ * The tests above drive a spy, which records an op and never judges it — so an
+ * op the store would refuse looks identical there to one it accepts. That is
+ * how `{ cssId: undefined }` passed review here: the panel appeared to clear an
+ * id, `applyOp` threw on the undefined value, and the document kept the old one
+ * while the field showed it gone.
+ *
+ * So these hand the recorded op to the real `applyOp` and assert what the
+ * DOCUMENT holds afterwards. A shape the store rejects fails here.
+ */
+describe("the Advanced tab's ops, through the real store", () => {
+  const nodeWith = (node: Partial<BlockNode>): BlockNode =>
+    ({
+      id: "a",
+      type: "acme/heading",
+      version: 1,
+      props: {},
+      ...node,
+    }) as BlockNode;
+
+  const applyRecorded = (
+    editor: { apply: ReturnType<typeof vi.fn> },
+    before: BlockNode
+  ): BlockNode => {
+    const op = editor.apply.mock.calls.at(-1)?.[0] as never;
+    const applied = applyOp(
+      {
+        formatVersion: 1,
+        kind: "page",
+        nodes: [before],
+      } as unknown as BlockDocument,
+      op
+    );
+    return applied.document.nodes[0] as BlockNode;
+  };
+
+  it("actually REMOVES a cleared css id", () => {
+    const before = nodeWith({ cssId: "hero" });
+    const editor = mount({ cssId: "hero" });
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: "" } });
+    fireEvent.blur(field);
+
+    // The control: the op was recorded at all, so an empty call list cannot
+    // satisfy the assertion below.
+    expect(editor.apply).toHaveBeenCalled();
+    expect(applyRecorded(editor, before).cssId).toBeUndefined();
+  });
+
+  it("actually REMOVES the last attribute", () => {
+    const before = nodeWith({ attributes: { "data-x": "1" } });
+    const editor = mount({ attributes: { "data-x": "1" } });
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove data-x" }));
+
+    expect(editor.apply).toHaveBeenCalled();
+    expect(applyRecorded(editor, before).attributes).toBeUndefined();
+  });
+
+  it("actually WRITES an id the author typed", () => {
+    // The positive control on the pair above: the same route that removes must
+    // be shown to store, or "undefined afterwards" would pass on a store that
+    // never writes anything.
+    const before = nodeWith({});
+    const editor = mount({});
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: "hero" } });
+    fireEvent.blur(field);
+
+    expect(applyRecorded(editor, before).cssId).toBe("hero");
+  });
+});
+
+/**
+ * The two ways a draft used to be lost, and the shadowed id it left behind.
+ */
+describe("the Advanced tab keeps what the author typed", () => {
+  const openAdvanced = () => {
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+  };
+
+  it("commits a draft when the tab is switched away", () => {
+    /*
+     * The tabs activate on `mousedown` and unmount the inactive tab's content,
+     * so the panel is removed before the browser delivers `blur` — and the
+     * draft went with it, silently. Typing an id and clicking Style must not
+     * throw the id away.
+     */
+    const editor = mount({});
+    openAdvanced();
+    fireEvent.change(screen.getByLabelText("CSS id"), {
+      target: { value: "hero" },
+    });
+    // No blur: the tab is clicked with the field still focused, which is what
+    // an author does.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Style" }));
+
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: { cssId: "hero" },
+    });
+  });
+
+  it("does not commit when nothing was typed", () => {
+    // The control: an unmount that always wrote would put an empty edit in the
+    // undo history every time an author looked at this tab.
+    const editor = mount({ cssId: "hero" });
+    openAdvanced();
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Style" }));
+
+    expect(editor.apply).not.toHaveBeenCalled();
+  });
+
+  it("drops an id attribute the CSS id now shadows", () => {
+    /*
+     * Setting a CSS id used to patch only `cssId`, leaving the shadowed
+     * attribute stored — so clearing the CSS id later brought a stale id back
+     * to life on a block the author thought had none.
+     */
+    const editor = mount({ attributes: { id: "old" } });
+    openAdvanced();
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: "new" } });
+    fireEvent.blur(field);
+
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: { cssId: "new" },
+      unset: ["attributes"],
+    });
   });
 });

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -933,3 +933,242 @@ describe("a node carrying both a css id and a legacy id attribute", () => {
     });
   });
 });
+
+describe("an attribute bag the document should not have held", () => {
+  /*
+   * A stored bag can hold anything an import or a script put there. The
+   * renderer skips a non-string value and emits every attribute beside it, so
+   * a panel that refused the WHOLE bag on one bad entry showed no rows for a
+   * block that was visibly carrying attributes.
+   */
+  // Cast at the definition, because the whole point of this fixture is a node
+  // holding what its own type forbids — which is what a stored document does
+  // when an import or a script wrote it.
+  const mixed = {
+    attributes: { "data-keep": "yes", "data-bad": 5 },
+  } as unknown as Partial<BlockNode>;
+
+  it("offers the entries it CAN edit rather than none of them", () => {
+    mount(mixed);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    expect(
+      (screen.getByLabelText("Name of attribute 1") as HTMLInputElement).value
+    ).toBe("data-keep");
+    // And only that one: the unreadable entry is not offered as a row, because
+    // there is no value for the author to see or type over.
+    expect(screen.queryByLabelText("Name of attribute 2")).toBeNull();
+  });
+
+  it("does not delete the valid attribute when another is added", () => {
+    /*
+     * The data loss this closes: with no rows shown, the first attribute the
+     * author added was written from an empty view, and `data-keep` went with
+     * it. Driven through the real store, because what matters is the document
+     * the op leaves behind rather than the op's shape.
+     */
+    const before = {
+      id: "a",
+      type: "acme/heading",
+      version: 1,
+      props: {},
+      ...mixed,
+    } as unknown as BlockNode;
+    const editor = mount(mixed);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Add attribute" }));
+    fireEvent.change(screen.getByLabelText("Name of attribute 2"), {
+      target: { value: "data-new" },
+    });
+    fireEvent.blur(screen.getByLabelText("Name of attribute 2"));
+
+    expect(editor.apply).toHaveBeenCalled();
+    const op = editor.apply.mock.calls.at(-1)?.[0] as never;
+    const after = applyOp(
+      { formatVersion: 1, kind: "page", nodes: [before] } as BlockDocument,
+      op
+    ).document.nodes[0] as BlockNode;
+    expect(after.attributes).toEqual({ "data-keep": "yes", "data-new": "" });
+  });
+
+  it("leaves the bag alone entirely while only the id is edited", () => {
+    /*
+     * The unreadable entry cannot survive an edit to the attributes — `update`
+     * refuses a bag holding a non-string, so no op could carry it — but an edit
+     * to a different field must not take it. `htmlUpdate` names only what
+     * changed, and this is the assertion that keeps it that way.
+     */
+    const editor = mount({ ...mixed, cssId: "old" });
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: "new" } });
+    fireEvent.blur(field);
+
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: { cssId: "new" },
+    });
+  });
+});
+
+describe("a panel that was only LOOKED at", () => {
+  /*
+   * Stored values the editor would spell differently: `cssId` is trimmed on the
+   * way out and an attribute name is lowercased. Committing whenever the
+   * normalized draft differed from the document therefore wrote a change the
+   * author never made — an undo entry for opening a tab, and a moved anchor.
+   */
+  const noncanonical = {
+    cssId: " hero ",
+    attributes: { "DATA-X": "1" },
+  };
+
+  it("writes nothing when the tab is switched away", () => {
+    const editor = mount(noncanonical);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Style" }));
+
+    expect(editor.apply).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing when a field is merely focused and left", () => {
+    // The same cause through the other door: blur commits too, so a click into
+    // the id field and out of it was enough to rewrite the value.
+    const editor = mount(noncanonical);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+    fireEvent.blur(screen.getByLabelText("CSS id"));
+    fireEvent.blur(screen.getByLabelText("Name of attribute 1"));
+
+    expect(editor.apply).not.toHaveBeenCalled();
+  });
+
+  it("still normalizes once the author DOES edit", () => {
+    /*
+     * The control. Holding the write back until an edit must not mean the
+     * editor stops normalizing what it writes — an author who changes the value
+     * beside `DATA-X` gets the lowercased name stored, which is what the page
+     * renders.
+     */
+    const editor = mount(noncanonical);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+    const value = screen.getByLabelText("Value of attribute 1");
+    fireEvent.change(value, { target: { value: "2" } });
+    fireEvent.blur(value);
+
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: { attributes: { "data-x": "2" } },
+    });
+  });
+});
+
+describe("a refused row when the author leaves the tab", () => {
+  it("keeps the draft and its reason to come back to", () => {
+    /*
+     * The tabs activate on `mousedown`, before blur. The commit correctly
+     * declined to store `onclick` — but the panel was destroyed with it, so
+     * returning to Advanced showed `data-x` again and nothing had said why the
+     * rename did not take. The tab's content is force-mounted for this.
+     */
+    const editor = mount({ attributes: { "data-x": "1" } });
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+    const name = screen.getByLabelText("Name of attribute 1");
+    fireEvent.change(name, { target: { value: "onclick" } });
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Style" }));
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    // The document kept what it had: the rename was refused, not applied.
+    expect(editor.apply).not.toHaveBeenCalled();
+    expect(
+      (screen.getByLabelText("Name of attribute 1") as HTMLInputElement).value
+    ).toBe("onclick");
+    expect(screen.getByRole("alert").textContent).toContain(
+      "does not put that attribute"
+    );
+  });
+
+  it("keeps a VALID draft too, and commits it", () => {
+    // The other half: leaving the tab still saves work that can be saved.
+    const editor = mount({});
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+    fireEvent.change(screen.getByLabelText("CSS id"), {
+      target: { value: "hero" },
+    });
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Style" }));
+
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: { cssId: "hero" },
+    });
+  });
+});
+
+describe("a refusal that no longer describes anything", () => {
+  /*
+   * `apply` answers `null` for a value past the document's byte limit, and the
+   * panel says so. The message is about a PENDING change, so it has to go when
+   * there is no longer one to fail — and a commit reaches that conclusion by
+   * two different routes, which is why both are driven here.
+   */
+  const refusedFirst = (node: Partial<BlockNode>) => {
+    register();
+    const editor = editorFor(documentOf(node));
+    editor.apply.mockReturnValue(null);
+    render(<InspectorPanel editor={editor} />);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    const field = screen.getByLabelText("CSS id");
+    fireEvent.change(field, { target: { value: "enormous" } });
+    fireEvent.blur(field);
+    // The control on both tests below: the alert was there to be cleared.
+    expect(screen.getByRole("alert").textContent).toContain("size limit");
+    return field;
+  };
+
+  const sizeAlert = () =>
+    screen
+      .queryAllByRole("alert")
+      .find(each => each.textContent?.includes("size limit"));
+
+  it("clears when the field is put back to what it was", () => {
+    // The first route: the draft matches what was loaded, so the commit stops
+    // before it has anything to compare against the document.
+    const field = refusedFirst({ cssId: "hero" });
+
+    fireEvent.change(field, { target: { value: "hero" } });
+    fireEvent.blur(field);
+
+    expect(sizeAlert()).toBeUndefined();
+  });
+
+  it("clears when the draft still differs but stores the same thing", () => {
+    /*
+     * The second route, and the one the first cannot reach: the author reverts
+     * the oversized id AND renames a row to a name that will not be stored. The
+     * draft is not what was loaded, so the commit runs — and finds the document
+     * already holds what the draft would store, which is the early return that
+     * used to leave this alert standing.
+     */
+    const field = refusedFirst({
+      cssId: "hero",
+      attributes: { "data-x": "1" },
+    });
+
+    fireEvent.change(field, { target: { value: "hero" } });
+    const name = screen.getByLabelText("Name of attribute 1");
+    fireEvent.change(name, { target: { value: "onclick" } });
+    fireEvent.blur(name);
+
+    expect(sizeAlert()).toBeUndefined();
+    // And the row's OWN reason is what the author is left looking at.
+    expect(screen.getByRole("alert").textContent).toContain(
+      "does not put that attribute"
+    );
+  });
+});

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -265,10 +265,17 @@ export function InspectorPanel({
           FORCE-MOUNTED, alone among the three. The other two hold controls that
           write on the spot; this one holds a draft, and unmounting it threw
           away both what the author had typed and the reason a refused row was
-          not saved. Radix keeps it hidden while another tab is chosen, so it is
-          out of the accessibility tree exactly as before.
+          not saved.
+
+          HIDDEN here rather than left to Radix, which ties the two together:
+          `TabsContent` renders `hidden={!present}` where `present` is
+          `forceMount || isSelected`, so asking it to stay mounted also tells it
+          it is on screen — and the Advanced fields appeared under Content and
+          Style as well. Keeping the mount and stating the visibility separately
+          is what was actually wanted, and `hidden` takes it out of the
+          accessibility tree exactly as an unmounted panel was.
         */}
-        <TabsContent value="advanced" forceMount>
+        <TabsContent value="advanced" forceMount hidden={tab !== "advanced"}>
           <AdvancedPanel
             // Keyed by node, so a half-typed attribute does not travel to the
             // next block the way an uncommitted name would. The panel holds

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -29,6 +29,7 @@ import {
   type SiteTokenSet,
   type StyleState,
 } from "@nextlyhq/blocks-engine";
+import type { BlockResolver } from "@nextlyhq/blocks-react";
 import {
   Checkbox,
   Input,
@@ -85,6 +86,15 @@ export interface InspectorPanelProps {
   /** The breakpoint the Style tab edits. The unconditional one by default. */
   breakpoint?: BreakpointId;
   /**
+   * The definitions the CANVAS renders against, forwarded to the Advanced tab.
+   *
+   * A host that gives `Canvas` a `render.blocks` resolver must give the same one
+   * here, or the id-collision check answers about a different page than the one
+   * on screen. Omitted, both sides fall back to the global registry, which is
+   * what `PageRenderer` itself defaults to.
+   */
+  blocks?: BlockResolver;
+  /**
    * The site's design tokens, forwarded to the Style tab's colour controls.
    *
    * Carried rather than defaulted, as `policy` is: omitting it means the
@@ -121,6 +131,7 @@ export function InspectorPanel({
   styleState,
   breakpoint,
   tokens,
+  blocks,
 }: InspectorPanelProps): React.JSX.Element {
   // Recomputed each render rather than memoised: an inspection is only valid
   // against the document it was read from, and an edit anywhere changes both
@@ -287,6 +298,7 @@ export function InspectorPanel({
             attributes={inspection.html.attributes}
             editor={editor}
             active={tab === "advanced"}
+            blocks={blocks}
           />
         </TabsContent>
       </Tabs>

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -46,6 +46,7 @@ import {
 } from "@nextlyhq/ui";
 import * as React from "react";
 
+import { AdvancedPanel } from "./advanced-panel";
 import type { EditorState } from "./editor-state";
 import {
   fieldLabel,
@@ -104,6 +105,14 @@ export interface InspectorPanelProps {
 const INSPECTOR_TABS = [
   { value: "content", label: "Content" },
   { value: "style", label: "Style" },
+  /*
+   * Last, and named for what it is rather than for what it holds. An author
+   * reaching for a `data-` attribute or an anchor id is leaving the modelled
+   * surface behind, and putting that beside Content would invite it as an
+   * ordinary next step. Every editor with this surface separates it the same
+   * way, and the one this replaces did too.
+   */
+  { value: "advanced", label: "Advanced" },
 ] as const;
 
 export function InspectorPanel({
@@ -241,6 +250,20 @@ export function InspectorPanel({
             state={styleState}
             breakpoint={breakpoint}
             tokens={tokens}
+          />
+        </TabsContent>
+
+        <TabsContent value="advanced">
+          <AdvancedPanel
+            // Keyed by node, so a half-typed attribute does not travel to the
+            // next block the way an uncommitted name would. The panel holds
+            // rows locally; without this an author would select another block
+            // and find this one's unsaved row waiting there.
+            key={`${inspection.nodeId}:advanced`}
+            nodeId={inspection.nodeId}
+            cssId={inspection.html.cssId}
+            attributes={inspection.html.attributes}
+            editor={editor}
           />
         </TabsContent>
       </Tabs>

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -127,6 +127,10 @@ export function InspectorPanel({
   // the document and the values shown.
   const inspection = inspectSelection(editor.document, editor.selectedId);
 
+  // Declared before the early returns below, because a hook has to run on every
+  // render of this component and "no selection" is one of them.
+  const [tab, setTab] = React.useState<string>("content");
+
   const commit = React.useCallback(
     (name: string, value: unknown) => {
       const id = editor.selectedId;
@@ -207,12 +211,16 @@ export function InspectorPanel({
       />
 
       {/*
-        Uncontrolled, so the chosen tab survives a change of selection — an
-        author styling one block after another means to stay on Style. React
-        keeps that state because this element's position does not change; a
-        `key` on the node id here would reset it on every click.
+        Held HERE, so the chosen tab survives a change of selection — an author
+        styling one block after another means to stay on Style. This element's
+        position does not change, so the state lives across every selection; a
+        `key` on the node id would reset it on every click.
+
+        Controlled rather than left to Radix because the Advanced tab has to be
+        told when it stops being the one on screen: it is force-mounted, so its
+        own removal no longer tells it.
       */}
-      <Tabs defaultValue="content" className="nx-inspector__tabs">
+      <Tabs value={tab} onValueChange={setTab} className="nx-inspector__tabs">
         <TabsList>
           {INSPECTOR_TABS.map(tab => (
             <TabsTrigger key={tab.value} value={tab.value}>
@@ -253,7 +261,14 @@ export function InspectorPanel({
           />
         </TabsContent>
 
-        <TabsContent value="advanced">
+        {/*
+          FORCE-MOUNTED, alone among the three. The other two hold controls that
+          write on the spot; this one holds a draft, and unmounting it threw
+          away both what the author had typed and the reason a refused row was
+          not saved. Radix keeps it hidden while another tab is chosen, so it is
+          out of the accessibility tree exactly as before.
+        */}
+        <TabsContent value="advanced" forceMount>
           <AdvancedPanel
             // Keyed by node, so a half-typed attribute does not travel to the
             // next block the way an uncommitted name would. The panel holds
@@ -264,6 +279,7 @@ export function InspectorPanel({
             cssId={inspection.html.cssId}
             attributes={inspection.html.attributes}
             editor={editor}
+            active={tab === "advanced"}
           />
         </TabsContent>
       </Tabs>

--- a/packages/builder/src/inspector.ts
+++ b/packages/builder/src/inspector.ts
@@ -275,7 +275,7 @@ export function inspectSelection(
      */
     html: {
       cssId: typeof node.cssId === "string" ? node.cssId : "",
-      attributes: isStringRecord(node.attributes) ? node.attributes : undefined,
+      attributes: editableAttributes(node.attributes),
     },
     // The same name the palette offered and the layers panel shows. Reading
     // `editor.label ?? node.type` here instead was a second rule that agreed
@@ -287,20 +287,59 @@ export function inspectSelection(
 }
 
 /**
- * Whether a stored value is the string map the attribute field is typed as.
+ * The entries of a stored attribute bag the editor can actually put in a row.
  *
- * Checked value by value rather than by shape alone: `typeof x === "object"`
- * admits an array and `null`, and a record of numbers passes any check that
- * stops at the container.
+ * Narrowed ENTRY BY ENTRY, not bag by bag. The renderer skips a single
+ * non-string value and emits every other attribute beside it, so an
+ * all-or-nothing check disagreed with the page: a bag holding
+ * `{ "data-keep": "yes", "data-bad": 5 }` rendered `data-keep` while the panel
+ * showed no rows at all — and the first attribute the author added was written
+ * from that empty view, deleting `data-keep` without saying so.
+ *
+ * The unrepresentable entries cannot be carried through an edit: `update`
+ * refuses an `attributes` bag holding a non-string, so an op preserving one
+ * would never apply. They therefore survive exactly as long as the author
+ * leaves the attributes alone — `htmlUpdate` names only the field that changed,
+ * so editing the CSS id does not rewrite the bag — and are dropped by the first
+ * edit to the attributes themselves, which is the only form that edit can take.
  */
-function isStringRecord(
+function editableAttributes(
   value: unknown
-): value is Readonly<Record<string, string>> {
+): Readonly<Record<string, string>> | undefined {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return false;
+    return undefined;
   }
-  return Object.values(value).every(each => typeof each === "string");
+  const cached = editableBags.get(value);
+  if (cached !== undefined) return cached;
+  const kept: Record<string, string> = {};
+  let dropped = false;
+  for (const [name, each] of Object.entries(value)) {
+    if (typeof each === "string") kept[name] = each;
+    else dropped = true;
+  }
+  // `undefined` rather than `{}` for a bag with nothing readable in it, so it
+  // compares equal to no bag at all wherever the two are asked apart.
+  if (Object.keys(kept).length === 0) return undefined;
+  // Nothing was dropped, so the stored object IS the readable one — handed back
+  // as itself rather than as a copy, which is both the common case and the one
+  // that needs no help staying identical between renders.
+  if (!dropped) return value as Readonly<Record<string, string>>;
+  editableBags.set(value, kept);
+  return kept;
 }
+
+/**
+ * Filtered bags, keyed by the stored object they were read from.
+ *
+ * An inspection is rebuilt on EVERY render, and the attributes panel resets its
+ * draft whenever the stored bag it is given changes. A copy made fresh each
+ * time is a new object each time, so the panel would see the document change on
+ * every render — resetting the draft under the author's cursor, and re-running
+ * the effect that reset it. A node's `attributes` object is itself replaced
+ * only by an op, so keying on it hands back one reference for as long as the
+ * document holds one bag.
+ */
+const editableBags = new WeakMap<object, Readonly<Record<string, string>>>();
 
 /**
  * The patch that sets one prop.

--- a/packages/builder/src/inspector.ts
+++ b/packages/builder/src/inspector.ts
@@ -80,12 +80,35 @@ export interface BlockIdentity {
   readonly locked: boolean;
 }
 
+/**
+ * The block's HTML surface: what it renders AS, rather than what it holds.
+ *
+ * Read here with everything else the inspector shows, so one function reads the
+ * document and the panels read the function. A panel reaching back for the node
+ * itself would be a second reader of the same selection, free to disagree with
+ * this one about which node is selected.
+ */
+export interface BlockHtml {
+  /** The element's `id`, empty when the author has not set one. */
+  readonly cssId: string;
+  /**
+   * The author's own attributes, absent when there are none.
+   *
+   * Absent rather than empty, because the node itself distinguishes them: a
+   * block that never had attributes and one whose last was removed both store
+   * nothing, and an empty record here would invite writing one back.
+   */
+  readonly attributes: Readonly<Record<string, string>> | undefined;
+}
+
 /** The selected block, as something to edit. */
 export interface BlockInspection {
   readonly nodeId: string;
   readonly blockName: string;
   /** What the block IS, beside what it holds. */
   readonly identity: BlockIdentity;
+  /** What the block renders as, beside what it holds. */
+  readonly html: BlockHtml;
   /** What to title the panel: the block's label, or its name. */
   readonly label: string;
   /**
@@ -244,6 +267,16 @@ export function inspectSelection(
     nodeId: node.id,
     blockName: node.type,
     identity: { name: node.name ?? "", locked: node.locked === true },
+    /*
+     * Narrowed HERE rather than trusted. A stored document can hold anything
+     * the database returned — the engine's validator reports these but does not
+     * rewrite them — so a `cssId` that is not a string, or an `attributes`
+     * that is an array or null, must not reach a control typed for neither.
+     */
+    html: {
+      cssId: typeof node.cssId === "string" ? node.cssId : "",
+      attributes: isStringRecord(node.attributes) ? node.attributes : undefined,
+    },
     // The same name the palette offered and the layers panel shows. Reading
     // `editor.label ?? node.type` here instead was a second rule that agreed
     // only for blocks which declare a label: an unlabelled third-party block
@@ -251,6 +284,22 @@ export function inspectSelection(
     label: blockLabel(node.type),
     props,
   };
+}
+
+/**
+ * Whether a stored value is the string map the attribute field is typed as.
+ *
+ * Checked value by value rather than by shape alone: `typeof x === "object"`
+ * admits an array and `null`, and a record of numbers passes any check that
+ * stops at the container.
+ */
+function isStringRecord(
+  value: unknown
+): value is Readonly<Record<string, string>> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  return Object.values(value).every(each => typeof each === "string");
 }
 
 /**

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -1383,3 +1383,87 @@
   flex-direction: column;
   gap: 0.25rem;
 }
+
+/*
+ * The Advanced tab's attribute rows.
+ *
+ * A LIST, because that is what it is: an author adds and removes rows, and a
+ * screen reader announcing "list, 3 items" is the only thing that tells them
+ * how many they have without tabbing through. The markers are removed and the
+ * semantics are not.
+ */
+.nx-attributes {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  min-inline-size: 0;
+}
+
+.nx-attributes__legend {
+  padding: 0;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--nx-foreground);
+}
+
+.nx-attributes__rows {
+  list-style: none;
+  margin: 0 0 0.5rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+/*
+ * Name, value and Remove on one line where there is room, wrapping rather than
+ * shrinking the inputs below what a `data-` attribute needs to be readable in.
+ */
+.nx-attributes__pair {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.nx-attributes__pair > input {
+  flex: 1 1 8rem;
+  min-inline-size: 0;
+}
+
+/*
+ * Column headings for the rows below, shown once. Laid out on the same flex
+ * basis as the inputs so the words sit over the fields they name.
+ */
+.nx-attributes__head {
+  display: flex;
+  gap: 0.25rem;
+  margin-block-end: 0.25rem;
+  font-size: var(--text-xs);
+  color: var(--nx-muted-foreground);
+}
+
+.nx-attributes__head > span {
+  flex: 1 1 8rem;
+  min-inline-size: 0;
+}
+
+/*
+ * The reason a row will not reach the page. Coloured with the theme's own
+ * destructive token so it reads as a refusal in both light and dark, and given
+ * the row's full width so a sentence is not squeezed beside three controls.
+ */
+.nx-attributes__problem {
+  flex: 1 1 100%;
+  margin: 0.25rem 0 0;
+  font-size: var(--text-xs);
+  line-height: 1.4;
+  color: var(--nx-destructive);
+}
+
+.nx-inspector__hint {
+  margin: 0.25rem 0 0;
+  font-size: var(--text-xs);
+  line-height: 1.4;
+  color: var(--nx-muted-foreground);
+}


### PR DESCRIPTION
C-15. An **Advanced** tab in the inspector, where a block's `id` and its own HTML attributes can be set.

## Why this is UI and not a security feature

Both fields were already modelled and `block-boundary` already applies them to the rendered element, behind an allowlist it owns. Nothing in the editor could write either, so an anchor to link to or a `data-` attribute an analytics script reads had to be added outside the builder. This PR adds the writer, and moves no security decision.

The tag picker stays excluded, as the task says: there is no engine field for a node's HTML tag, so offering one would store a value nothing reads.

## The rules are the renderer's, and are asked rather than copied

`isAllowedAttribute` is now exported from `blocks-react`. Its own docblock already said the render-safe list lives there and only there — so the editor imports it. A second copy would drift, and it drifts the worse way: an editor accepting a name the renderer skips lets an author set an attribute, watch it save, and never see it on the page.

That is asserted rather than asserted-about. One test drives the editor and the renderer through the same predicate over the same names, so a divergence fails here. Break-verified by giving the editor its own copy that differs by a single entry — the test fails and names `class`.

## Three refusals, shown where the author still has the keyboard

- a name the renderer would drop
- a second row setting a name an earlier row already sets — case-insensitively, because HTML attribute names are and the renderer lowercases before writing
- an `id` that the CSS id field beside it wins over

The third is invisible from the editor. The renderer resolves it in favour of the modelled field, which is the right precedence — but without saying so, an author sets an id, sees it saved, and the page carries a different one.

A row that cannot land is not stored either. Storing a value the page will never use is the silent half of the problem this surface exists to make loud.

## Two things found by writing the tests

- `rowProblem` compared rows by object identity, so it only worked if the caller passed an element of the same array. Position is what actually decides the answer, so it takes an index now.
- The block's own name field is labelled "Name", and so was every attribute row's — a screen reader hears one word for several different things, and `getByLabelText` throws on it. Column headings are shown once instead, and each input carries its own accessible name that still contains the visible word.

## Deliberately not here

Duplicate `id`s across blocks. The engine already detects them (`validateDomIds`) and the builder does not surface document validation in the inspector at all today. Wiring that is a decision about where validation appears in the editor generally, not one to make inside an attributes panel.

## Gates

Build; 1563 builder tests, 764 blocks-react, 214 plugin-page-builder; check-types and lint on both changed packages; root eslint 0/0; design lint; comment convention; fallow `pass` (0 introduced); 0 leaked shell escapes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Advanced inspector tab for editing CSS IDs and custom HTML attributes.
  * Added accessible validation messages, attribute removal controls, and collision checks.
  * Preserved drafts across inspector tab changes and committed edits on blur, Enter, removal, or panel exit.

* **Bug Fixes**
  * Prevented editor-only attributes from being published or overwritten.
  * Improved duplicate and reserved-attribute handling, including refused edits.
  * Prevented stale edits from overwriting current content and ensured multiple same-time updates are preserved.
  * Avoided unnecessary saves and clearly reported failed updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->