### PR TITLE
fix(ui): scroll a tab rail without making the rail the scroller

### DIFF
--- a/.changeset/scrollable-tab-rail.md
+++ b/.changeset/scrollable-tab-rail.md
@@ -1,0 +1,37 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Scroll a tab strip without making the strip itself the scroller.
+
+A tab list that carried its own `overflow-x-auto` became a scroll container on
+BOTH axes, because CSS computes `visible` to `auto` when the other axis is not
+visible. The trigger's underline is drawn by a 2px pull-up onto the list's rail,
+so that pull-up was then reported as vertical overflow and the strip grew a
+stray vertical scrollbar it had no use for. `TabsList` now takes a `scrollable`
+prop that puts the scroll container in a wrapper, leaving the rail intact and
+letting it span the full scroll width.

--- a/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
+++ b/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
@@ -445,9 +445,13 @@ function FormBuilderViewInner({
           {/* Layout only. The underline, the active and hover colours, the
               focus ring and the disabled state all come from the shared
               primitive; restating them here is how two copies of one
-              appearance start drifting. `gap-0` and the scroll behaviour
-              are genuinely local: this strip can overflow its container. */}
-          <TabsList className="bg-transparent justify-start gap-0 max-w-full overflow-x-auto">
+              appearance start drifting.
+
+              The strip can overflow its container, so it asks for scrolling
+              through `scrollable` rather than by putting `overflow-x-auto` on
+              the list: that spelling makes the LIST the scroll container, which
+              costs the rail its indicator. */}
+          <TabsList scrollable className="bg-transparent justify-start gap-0">
             {mainTabs.map(tab => (
               <TabsTrigger
                 key={tab.value}

--- a/packages/ui/src/components/tabs-scrollable.test.tsx
+++ b/packages/ui/src/components/tabs-scrollable.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+/**
+ * A tab strip too wide for its container has to scroll sideways, and the list
+ * itself must NOT be what scrolls.
+ *
+ * Two independent reasons, and the second is why the obvious remedy is also
+ * wrong:
+ *
+ *  - Per the CSS overflow rules `visible` computes to `auto` when the other
+ *    axis is neither `visible` nor `clip`, so `overflow-x` alone always makes
+ *    the element a VERTICAL scroll container too.
+ *  - `TabsTrigger` carries `-mb-0.5` so its 2px underline lands ON the list's
+ *    rail rather than below it, and `tabs-rail.test.tsx` pins that pair
+ *    together. The pull-up puts content past the content-box edge, which the
+ *    new scroll container reports as vertical overflow — so adding
+ *    `overflow-y-hidden` would clip the 2px the underline is made of, silencing
+ *    a scrollbar by deleting the feature that test exists to protect.
+ *
+ * Moving the scroll container to a WRAPPER keeps the rail intact, and
+ * `w-max min-w-full` makes that rail span the full scroll width rather than
+ * stopping where the triggers do.
+ *
+ * jsdom computes no scroll geometry, so these assert the STRUCTURE that
+ * produces the behaviour. The geometry itself was measured in a browser.
+ */
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Tabs, TabsList, TabsTrigger } from "./tabs";
+
+function renderList(scrollable: boolean) {
+  const { container } = render(
+    <Tabs defaultValue="one">
+      <TabsList scrollable={scrollable}>
+        <TabsTrigger value="one">One</TabsTrigger>
+        <TabsTrigger value="two">Two</TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
+  return {
+    list: container.querySelector<HTMLElement>("[data-slot='tabs-list']"),
+    scroller: container.querySelector<HTMLElement>(
+      "[data-slot='tabs-list-scroller']"
+    ),
+  };
+}
+
+describe("scrollable TabsList", () => {
+  it("puts the scroll container OUTSIDE the rail", () => {
+    const { list, scroller } = renderList(true);
+
+    expect(scroller).not.toBeNull();
+    expect(scroller?.className).toContain("overflow-x-auto");
+    expect(list?.parentElement).toBe(scroller);
+  });
+
+  it("leaves the list itself with no overflow of its own", () => {
+    const { list } = renderList(true);
+
+    // The list carrying `overflow-x` is the defect: it becomes a scroll
+    // container on BOTH axes, and the trigger's pull-up is then reported as
+    // vertical overflow.
+    expect(list?.className).not.toContain("overflow-x");
+    expect(list?.className).not.toContain("overflow-y");
+  });
+
+  it("never clips the axis the trigger's pull-up lives on", () => {
+    const { list, scroller } = renderList(true);
+
+    // `overflow-y-hidden` is the tempting fix and it removes the underline.
+    expect(list?.className).not.toContain("overflow-y-hidden");
+    expect(scroller?.className).not.toContain("overflow-y-hidden");
+  });
+
+  it("makes the rail span the full scroll width", () => {
+    const { list } = renderList(true);
+
+    // Without `min-w-full` the rail stops where the triggers do, leaving the
+    // underline short of the content beside it; without `w-max` it cannot grow
+    // past the container and there is nothing to scroll.
+    expect(list?.className).toContain("w-max");
+    expect(list?.className).toContain("min-w-full");
+  });
+
+  it("keeps the rail and the pull-up that tabs-rail.test.tsx pairs", () => {
+    const { list } = renderList(true);
+
+    // The scrollable variant must not cost the strip its rail. Asserted here as
+    // well as in that file because this is the variant most likely to drop it.
+    expect(list?.className).toContain("border-b");
+  });
+
+  it("adds no wrapper when not scrollable, so the default DOM is unchanged", () => {
+    const { list, scroller } = renderList(false);
+
+    expect(scroller).toBeNull();
+    expect(list?.className).not.toContain("w-max");
+    expect(list?.className).not.toContain("min-w-full");
+  });
+
+  it("defaults to not scrollable", () => {
+    const { container } = render(
+      <Tabs defaultValue="one">
+        <TabsList>
+          <TabsTrigger value="one">One</TabsTrigger>
+        </TabsList>
+      </Tabs>
+    );
+
+    expect(
+      container.querySelector("[data-slot='tabs-list-scroller']")
+    ).toBeNull();
+  });
+});

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -105,8 +105,13 @@ const Tabs = Root;
  * settles the height rather than leaving two answers in the tree.
  *
  * Only APPEARANCE is promoted. Layout a caller chooses -- `w-full`,
- * `justify-start`, margins, `overflow-x-auto` -- stays on `className`, because
- * a variant names a decision this component owns and layout is the caller's.
+ * `justify-start`, margins -- stays on `className`, because a variant names a
+ * decision this component owns and layout is the caller's.
+ *
+ * Horizontal SCROLLING is the exception, and it moved to the `scrollable` prop
+ * for a reason rather than as tidying: a caller putting `overflow-x-auto` on the
+ * list makes the list itself the scroll container, which breaks the rail
+ * contract this file's other half depends on. See that prop.
  *
  * The arms are a named declaration rather than an object literal inside `cva`,
  * because `cva` does not expose its configuration on the function it returns —
@@ -155,15 +160,53 @@ const tabsListVariants = cva(
  */
 const TabsList = forwardRef<
   TabsListRef,
-  TabsListBaseProps & VariantProps<typeof tabsListVariants>
->(({ className, variant, ...props }, ref) => (
-  <List
-    ref={ref}
-    data-slot="tabs-list"
-    className={cn(tabsListVariants({ variant }), className)}
-    {...props}
-  />
-));
+  TabsListBaseProps &
+    VariantProps<typeof tabsListVariants> & {
+      /**
+       * Let a strip too wide for its container scroll sideways.
+       *
+       * The scroll container is a WRAPPER, never the list, and that is why this
+       * prop exists rather than callers reaching for `overflow-x-auto`
+       * themselves. Two things go wrong when the list is the scroller, and the
+       * second is why the obvious remedy is also wrong:
+       *
+       *  - Per the CSS overflow rules, `visible` computes to `auto` when the
+       *    other axis is neither `visible` nor `clip`, so `overflow-x` alone
+       *    always makes the element a VERTICAL scroll container too.
+       *  - `TabsTrigger` carries `-mb-0.5` so its 2px underline lands ON this
+       *    list's rail rather than below it. That pull-up puts content past the
+       *    content-box edge, which the new scroll container reports as vertical
+       *    overflow — so `overflow-y-hidden` would clip the 2px the underline is
+       *    made of, silencing a scrollbar by deleting the indicator.
+       *
+       * With the wrapper scrolling instead, the list keeps its rail and
+       * `w-max min-w-full` makes that rail span the full scroll width rather
+       * than stopping where the triggers do.
+       */
+      scrollable?: boolean;
+    }
+>(({ className, variant, scrollable = false, ...props }, ref) => {
+  const list = (
+    <List
+      ref={ref}
+      data-slot="tabs-list"
+      className={cn(
+        tabsListVariants({ variant }),
+        scrollable && "w-max min-w-full",
+        className
+      )}
+      {...props}
+    />
+  );
+
+  if (!scrollable) return list;
+
+  return (
+    <div data-slot="tabs-list-scroller" className="w-full overflow-x-auto">
+      {list}
+    </div>
+  );
+});
 TabsList.displayName = List.displayName;
 
 /**


### PR DESCRIPTION
## Summary

Fixes the reported "weird vertical scrolling in the tabs row" on
`/admin/collections/forms/create`.

The strip carried its own `overflow-x-auto`. Per the CSS overflow rules,
`visible` computes to `auto` when the other axis is neither `visible` nor
`clip` — so `overflow-x` alone makes an element a scroll container on **both**
axes. `TabsTrigger` draws its underline as a 2px pull-up onto the list's rail
(`-mb-0.5`), and that pull-up puts content past the content box, which the new
scroll container reports as vertical overflow.

Measured on that page before the change: **1px of vertical scroll range and zero
horizontal**. A scrollbar for an overflow that did not exist — the strip did not
need to scroll sideways at that width at all.

**`overflow-y-hidden` is the tempting fix and it is wrong.** It clips the 2px the
underline is made of, so it silences the scrollbar by deleting the active tab's
indicator — the exact pair `tabs-rail.test.tsx` exists to hold together.

So the scroll container moves to a **wrapper**. `TabsList` gains a `scrollable`
prop; the list keeps its rail, and `w-max min-w-full` makes that rail span the
full scroll width instead of stopping where the triggers do.

## Why a prop rather than leaving it to the caller

The variant doc previously listed `overflow-x-auto` among the layout choices a
caller makes on `className`. That is what produced this defect: the spelling
looks like ordinary layout and silently breaks a contract the component owns.
The doc now says so and points at the prop.

## Test plan

- `pnpm --filter @nextlyhq/ui test --run` → **1127 passed, 48 files** (includes
  `tabs-rail.test.tsx`, still green — the rail contract is intact)
- `pnpm --filter @nextlyhq/plugin-form-builder test --run` → **89 passed**
- `pnpm build` → 19/19 · `lint` → 0 · `check:comments` → 0 · `fallow` → `pass`

### Measured in a browser

Three structures side by side in a 420px container:

| structure | list `overflow-x` / `overflow-y` | rail width |
| --- | --- | --- |
| A — shipped: list carries `overflow-x-auto` | `auto` / **`auto`** | 327px |
| B — `overflow-y-hidden` "fix" | `auto` / `hidden` | 327px |
| C — this PR: wrapper scrolls | **`visible` / `visible`** | **420px** |

A confirms the computed-value rule with nothing setting `overflow-y`. C leaves
the list not a scroll container at all, so a spurious scrollbar is not merely
hidden but impossible, and the rail reaches the full width.

Verified against a standalone harness rather than the running admin: another
session on this machine is running a `pkill -f "next dev"` loop that repeatedly
killed the playground mid-measurement. The harness isolates exactly the CSS under
test, and the 1px figure above is from the real page earlier in this work.

### Break-verification

Each break fails at runtime — confirmed the file still compiles, since a test
that stops compiling proves nothing:

| break | fails |
| --- | --- |
| put `overflow-x-auto` back on the list | `leaves the list itself with no overflow of its own` |
| add `overflow-y-hidden` to the wrapper | `never clips the axis the trigger's pull-up lives on` |
| drop `min-w-full` | `makes the rail span the full scroll width` |
| return the list with no wrapper | `puts the scroll container OUTSIDE the rail` (+1) |

## Changeset

Changeset added: yes (patch, all 25 lockstep packages).

## Pre-existing failures

None encountered. Both packages this touches (`@nextlyhq/ui`,
`@nextlyhq/plugin-form-builder`) are in `ci.yml`'s `Test` allowlist, so this
change is fully merge-gated — unlike the `packages/admin` half of #1161.
