### PR TITLE
feat(nextly): preview links for singles

### DIFF
--- a/.changeset/preview-links-for-singles.md
+++ b/.changeset/preview-links-for-singles.md
@@ -1,0 +1,67 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Singles can be previewed. A Single is draftable — it carries the same Draft / Published lifecycle a
+collection does — and was structurally unable to produce a shareable link: the preview token could
+only name a collection and an entry id, and a Single has neither.
+
+A preview token now names either an entry or a single. Every token already minted keeps verifying,
+byte-identically: the entry variant's discriminator is optional and an entry token is still signed
+without it. An unrecognised kind is refused rather than defaulted.
+
+Declare where a Single is served, as you would for a collection:
+
+```ts
+export const Homepage = defineSingle({
+  slug: "homepage",
+  status: true,
+  admin: { preview: { url: () => "/" } },
+});
+```
+
+Then gate the route that renders it — `createSingleRoute` for a hand-rendered Single, or
+`createSinglePage` for one built in the page builder, which accepts the hook now:
+
+```ts
+const { SinglePage, generateMetadata } = createSinglePage({
+  slug: "homepage",
+  field: "layout",
+  draft: previewSingleDraftGate(),
+});
+```
+
+`previewSingleDraftGate()` answers yes or no rather than handing back an id, because a Single has
+exactly one document: the gate's subject and the token's subject are the same thing, so there is no
+second row to check the answer against. A granted draft read is trusted and uncached — trusted
+because the working-draft overlay is gated on edit capability while the route resolves anonymously,
+and an enforced read would return published values while reporting success; uncached because a
+draft is per-visitor, and one cached draft is served to everyone who asks next.
+`createPublicSingleRoute` refuses the hook outright for that reason.
+
+The Single editor offers "Copy shareable link" on the same terms as the entry editor, including the
+refusal that names what a developer must add when no preview URL is declared.

--- a/.changeset/preview-links-for-singles.md
+++ b/.changeset/preview-links-for-singles.md
@@ -64,4 +64,32 @@ draft is per-visitor, and one cached draft is served to everyone who asks next.
 `createPublicSingleRoute` refuses the hook outright for that reason.
 
 The Single editor offers "Copy shareable link" on the same terms as the entry editor, including the
-refusal that names what a developer must add when no preview URL is declared.
+refusal that names what a developer must add when no preview URL is declared. On a localized Single
+the link is scoped to the language being edited — including the DEFAULT language, where the editor
+represents the active locale as "none". An absent locale claim is not "the default language": it
+authorizes every locale, so a link minted that way would open translations that have never been
+published.
+
+Minting evaluates the Single's own stored access rules, not just the coarse per-slug permission.
+Owner-only, role-based and custom rules are decided against the loaded document and can deny a
+caller who holds the permission — and a link is a bearer credential for the draft, so authorizing it
+on the permission alone handed out a view the real update path refuses. That evaluation is now one
+function shared with version history, which gates the same kind of disclosure for the same reason.
+
+**`createSingleRoute` and `createSinglePage` gain `trustedCollections`, and it defaults to nothing.**
+A draft grant names ONE document and says nothing about what that document points at, so the
+trusted read it triggers no longer spreads to everything the Single populates — a target reached
+through a relationship is read the way an anonymous visitor would read it unless you name it:
+
+```ts
+createSinglePage({
+  slug: "landing-page",
+  field: "hero",
+  trustedCollections: ["posts"],
+  draft: previewSingleDraftGate(),
+});
+```
+
+This is the same option, with the same meaning, that `createContentRoute` already carries. It only
+ever narrows, and it applies to `createPublicSingleRoute` too — a public Single page that populates
+relationships and needs them read as trusted must now name those collections.

--- a/.changeset/preview-links-for-singles.md
+++ b/.changeset/preview-links-for-singles.md
@@ -70,6 +70,15 @@ represents the active locale as "none". An absent locale claim is not "the defau
 authorizes every locale, so a link minted that way would open translations that have never been
 published.
 
+Minting authorizes the view the token hands out, rather than the coarser one that is easier to ask
+for. Three things it now checks that it did not: the caller's **read** grant — the mint route gates
+on `update`, so nothing had established that whoever asks may read the document at all; the Single's
+own **stored access rules**, evaluated against the loaded document; and the **translation the token
+names**, since a custom rule can allow the default language and deny the one being shared.
+
+A localized Single with no locale named is refused outright. An absent locale claim covers every
+translation, so honouring the request would hand out the grant the refusal exists to withhold.
+
 Minting evaluates the Single's own stored access rules, not just the coarse per-slug permission.
 Owner-only, role-based and custom rules are decided against the loaded document and can deny a
 caller who holds the permission — and a link is a bearer credential for the draft, so authorizing it
@@ -92,4 +101,10 @@ createSinglePage({
 
 This is the same option, with the same meaning, that `createContentRoute` already carries. It only
 ever narrows, and it applies to `createPublicSingleRoute` too — a public Single page that populates
-relationships and needs them read as trusted must now name those collections.
+relationships and needs them read as trusted must now name those collections. The bound is part of
+the cached read's key, so two routes mounting one Single with different bounds no longer share a
+cache entry: without that, the more-trusted route warms the cache and the other is served its
+populated restricted rows having never run its own bound.
+
+`SinglePreviewConfig` is exported from `nextly/config`, so a typed preview declaration can be
+defined or shared the way `CollectionPreviewConfig` already allows.

--- a/apps/playground/src/app/(frontend)/landing/page.tsx
+++ b/apps/playground/src/app/(frontend)/landing/page.tsx
@@ -1,0 +1,56 @@
+/**
+ * The Landing Page single, rendered as a blocks page.
+ *
+ * A Single rather than a collection entry, for the same reason the home page is
+ * one: there is exactly one landing page and its address is fixed, so nothing
+ * about it is looked up by slug.
+ *
+ * What it adds beside `(frontend)/page.tsx` is a publish lifecycle, which is
+ * what makes it the route where draft preview is demonstrable — the home page
+ * has no Draft/Published split, so it has no pending state to show a reviewer.
+ *
+ * @module app/(frontend)/landing/page
+ */
+import { createBlockResolver } from "@nextlyhq/blocks-react";
+import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
+import { createSinglePage } from "@nextlyhq/blocks-react/next";
+import { previewSingleDraftGate } from "nextly/runtime";
+
+import { siteReader, SITE_STYLE_CONTEXT } from "../../../lib/site-content";
+
+const { SinglePage, generateMetadata } = createSinglePage({
+  slug: "landing-page",
+  // The `blocks()` field on this single. Named rather than guessed: a wrong name
+  // renders a blank page instead of raising, which is the least debuggable
+  // outcome available.
+  field: "hero",
+  nextly: siteReader,
+  // Stated even though it is this site's default language, because nothing
+  // infers the default on your behalf — inferring it means reading
+  // configuration at request time, and a reader may defer booting until its
+  // first query. It is also what a preview token's locale is compared against.
+  locale: "en",
+  // Without this the route serves the PUBLISHED document only, so a preview
+  // link verifies, redirects, and then shows the live page — the reviewer sees
+  // no sign that what they are looking at is not the draft they were sent.
+  //
+  // The gate answers yes or no rather than handing back an id: a Single has
+  // exactly one document, so its slug is its identity and there is no second
+  // row for the route to check the answer against.
+  draft: previewSingleDraftGate(),
+  // An explicit set rather than the process registry, which is populated by
+  // whatever booted the editor — so a public route depending on it draws the
+  // unknown-block placeholder whenever a visitor arrives before an admin does.
+  blocks: createBlockResolver(coreBlocks),
+  styleContext: SITE_STYLE_CONTEXT,
+  metadata: (document, _context, derived) => ({
+    title: derived.title ?? (document.title as string | undefined),
+    description: derived.description,
+    ...(derived.image
+      ? { openGraph: { images: [{ url: derived.image }] } }
+      : {}),
+  }),
+});
+
+export { generateMetadata };
+export default SinglePage;

--- a/apps/playground/src/singles/landing-page.ts
+++ b/apps/playground/src/singles/landing-page.ts
@@ -1,6 +1,11 @@
 /**
  * Landing Page single — a second blocks-backed single, demonstrating the field
  * across multiple singles alongside the Homepage.
+ *
+ * The one that carries a publish lifecycle, which is what makes it the single
+ * where draft preview can be exercised: a Single with no Draft/Published split
+ * has no unpublished state to show anyone, so the admin offers no shareable
+ * link for one. The Homepage deliberately has none, and covers the other half.
  */
 import { blocks } from "@nextlyhq/plugin-page-builder";
 import { defineSingle, text } from "nextly/config";
@@ -8,6 +13,12 @@ import { defineSingle, text } from "nextly/config";
 export const LandingPage = defineSingle({
   slug: "landing-page",
   label: { singular: "Landing Page" },
+  // The Draft / Published lifecycle. Without it there is no pending state to
+  // preview and nothing for a shareable link to show.
+  status: true,
+  // Where this Single is served — the one thing Nextly cannot work out, because
+  // only the app knows that `app/landing/page.tsx` renders it.
+  admin: { preview: { url: () => "/landing" } },
   fields: [
     text({ name: "title" }),
     blocks({

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -30,8 +30,6 @@ import { z } from "zod";
 
 import { singleSourceFetcher } from "@admin/components/features/entries/entry-locale-source";
 import { AutosaveRecoveryBanner } from "@admin/components/features/entries/EntryForm/AutosaveRecoveryBanner";
-import { previewLinkLocale } from "@admin/components/features/entries/EntryForm/entry-address";
-import type { PreviewLinkLocale } from "@admin/components/features/entries/EntryForm/entry-address";
 import { EntryFormContent } from "@admin/components/features/entries/EntryForm/EntryFormContent";
 import {
   EntryFormContextProvider,
@@ -72,10 +70,6 @@ import {
 import { useEntryFormShortcuts } from "@admin/hooks/useKeyboardShortcuts";
 import { useLocalization } from "@admin/hooks/useLocalization";
 import {
-  usePreviewLink,
-  type UsePreviewLinkOptions,
-} from "@admin/hooks/usePreviewLink";
-import {
   computeMainFields,
   takeoverControllerNames,
   takeoverTypesFromBranding,
@@ -85,6 +79,7 @@ import { getDefaultValues } from "@admin/lib/form/default-values";
 import { cn } from "@admin/lib/utils";
 
 import { relaxIdentityRequired } from "./identity-fields";
+import { useSinglePreviewLink } from "./useSinglePreviewLink";
 
 // ============================================================================
 // Types
@@ -241,31 +236,6 @@ export interface SingleFormProps {
  * }
  * ```
  */
-/**
- * What a Single's preview link is minted against.
- *
- * A Single is addressed by slug and has exactly one document, so there is no id
- * to wait for — unlike an entry, whose link cannot be minted until it has been
- * saved once.
- *
- * The locale comes from `previewLinkLocale`, the same resolver the entry editor
- * uses, rather than from the active locale directly. That distinction is the
- * whole point: on a localized Single opened in its DEFAULT language the active
- * locale reads as `undefined`, and an absent claim is not "the default
- * language" — `previewTokenCovers` treats it as covering EVERY locale, so the
- * recipient could open every other unpublished translation with it. Absent is
- * the correct grant only when the Single is not localized at all, which is the
- * case that resolver answers `unscoped` for.
- */
-function singlePreviewTarget(
-  slug: string,
-  linkLocale: PreviewLinkLocale
-): UsePreviewLinkOptions {
-  return {
-    single: slug,
-    ...(linkLocale.kind === "scoped" ? { locale: linkLocale.locale } : {}),
-  };
-}
 
 export function SingleForm({
   schema,
@@ -478,23 +448,17 @@ export function SingleForm({
     enabled: localizationEnabled,
   } = useLocalization();
 
-  // Resolved through the shared rule rather than read off the active locale: on
-  // a localized Single in its default language that value is `undefined`, and a
-  // token minted with no locale claim grants every translation. `unresolved`
-  // withholds the control below rather than minting one of those.
-  const linkLocale = previewLinkLocale({
+  // One decision rather than three: which language the link is for, whether it
+  // can be offered at all, and the mint itself. No site URL is computed here —
+  // a link that travels by email or chat has to name a host, and the server is
+  // the only place that can.
+  const previewLink = useSinglePreviewLink({
+    slug: schema.slug,
     localized: schema.localized === true,
+    hasStatus,
     locale,
     defaultLocale,
   });
-
-  // No site URL is computed here. A link that travels by email or chat has to
-  // name a host, and the server is the only place that can: `settings` is a
-  // system resource the `editor` and `author` presets cannot read, and those
-  // are exactly the roles that share preview links.
-  const previewLink = usePreviewLink(
-    singlePreviewTarget(schema.slug, linkLocale)
-  );
 
   // The per-locale translation-status map, read once and shared by the header
   // adapter and the language panel: two reads of the same document key would
@@ -687,11 +651,9 @@ export function SingleForm({
                    that lifecycle; whether a link can actually be minted is the
                    server's call, and it refuses with a message naming what is
                    missing rather than handing out one that 404s. */
-                        isLinkAvailable={
-                          hasStatus && linkLocale.kind !== "unresolved"
-                        }
-                        onCopyLink={() => previewLink.mutate()}
-                        isCopyingLink={previewLink.isPending}
+                        isLinkAvailable={previewLink.isAvailable}
+                        onCopyLink={previewLink.copy}
+                        isCopyingLink={previewLink.isCopying}
                         toolbarSlot={
                           <EntryFormToolbarSlots
                             context="single"

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -30,6 +30,8 @@ import { z } from "zod";
 
 import { singleSourceFetcher } from "@admin/components/features/entries/entry-locale-source";
 import { AutosaveRecoveryBanner } from "@admin/components/features/entries/EntryForm/AutosaveRecoveryBanner";
+import { previewLinkLocale } from "@admin/components/features/entries/EntryForm/entry-address";
+import type { PreviewLinkLocale } from "@admin/components/features/entries/EntryForm/entry-address";
 import { EntryFormContent } from "@admin/components/features/entries/EntryForm/EntryFormContent";
 import {
   EntryFormContextProvider,
@@ -244,17 +246,25 @@ export interface SingleFormProps {
  *
  * A Single is addressed by slug and has exactly one document, so there is no id
  * to wait for — unlike an entry, whose link cannot be minted until it has been
- * saved once. The locale is forwarded so a link minted while editing one
- * translation opens that translation, and it is spread rather than assigned
- * because an explicit `undefined` is not the same as an absent key here: absent
- * means "every locale", which is the correct grant for a Single that is not
- * localized.
+ * saved once.
+ *
+ * The locale comes from `previewLinkLocale`, the same resolver the entry editor
+ * uses, rather than from the active locale directly. That distinction is the
+ * whole point: on a localized Single opened in its DEFAULT language the active
+ * locale reads as `undefined`, and an absent claim is not "the default
+ * language" — `previewTokenCovers` treats it as covering EVERY locale, so the
+ * recipient could open every other unpublished translation with it. Absent is
+ * the correct grant only when the Single is not localized at all, which is the
+ * case that resolver answers `unscoped` for.
  */
 function singlePreviewTarget(
   slug: string,
-  locale: string | undefined
+  linkLocale: PreviewLinkLocale
 ): UsePreviewLinkOptions {
-  return { single: slug, ...(locale === undefined ? {} : { locale }) };
+  return {
+    single: slug,
+    ...(linkLocale.kind === "scoped" ? { locale: linkLocale.locale } : {}),
+  };
 }
 
 export function SingleForm({
@@ -434,8 +444,6 @@ export function SingleForm({
   // EntryMetaStrip / DocumentPanel surface the status pill.
   const hasStatus = schema.status === true;
 
-  const previewLink = usePreviewLink(singlePreviewTarget(schema.slug, locale));
-
   // Auto-fill slug from title — same form-level pattern as EntryForm. The
   // title input lives in EntrySystemHeader (not TextInput) so the slug
   // generator must be mounted at the form level to see its keystrokes.
@@ -469,6 +477,24 @@ export function SingleForm({
     defaultLocale,
     enabled: localizationEnabled,
   } = useLocalization();
+
+  // Resolved through the shared rule rather than read off the active locale: on
+  // a localized Single in its default language that value is `undefined`, and a
+  // token minted with no locale claim grants every translation. `unresolved`
+  // withholds the control below rather than minting one of those.
+  const linkLocale = previewLinkLocale({
+    localized: schema.localized === true,
+    locale,
+    defaultLocale,
+  });
+
+  // No site URL is computed here. A link that travels by email or chat has to
+  // name a host, and the server is the only place that can: `settings` is a
+  // system resource the `editor` and `author` presets cannot read, and those
+  // are exactly the roles that share preview links.
+  const previewLink = usePreviewLink(
+    singlePreviewTarget(schema.slug, linkLocale)
+  );
 
   // The per-locale translation-status map, read once and shared by the header
   // adapter and the language panel: two reads of the same document key would
@@ -661,7 +687,9 @@ export function SingleForm({
                    that lifecycle; whether a link can actually be minted is the
                    server's call, and it refuses with a message naming what is
                    missing rather than handing out one that 404s. */
-                        isLinkAvailable={hasStatus}
+                        isLinkAvailable={
+                          hasStatus && linkLocale.kind !== "unresolved"
+                        }
                         onCopyLink={() => previewLink.mutate()}
                         isCopyingLink={previewLink.isPending}
                         toolbarSlot={

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -70,6 +70,10 @@ import {
 import { useEntryFormShortcuts } from "@admin/hooks/useKeyboardShortcuts";
 import { useLocalization } from "@admin/hooks/useLocalization";
 import {
+  usePreviewLink,
+  type UsePreviewLinkOptions,
+} from "@admin/hooks/usePreviewLink";
+import {
   computeMainFields,
   takeoverControllerNames,
   takeoverTypesFromBranding,
@@ -235,6 +239,24 @@ export interface SingleFormProps {
  * }
  * ```
  */
+/**
+ * What a Single's preview link is minted against.
+ *
+ * A Single is addressed by slug and has exactly one document, so there is no id
+ * to wait for — unlike an entry, whose link cannot be minted until it has been
+ * saved once. The locale is forwarded so a link minted while editing one
+ * translation opens that translation, and it is spread rather than assigned
+ * because an explicit `undefined` is not the same as an absent key here: absent
+ * means "every locale", which is the correct grant for a Single that is not
+ * localized.
+ */
+function singlePreviewTarget(
+  slug: string,
+  locale: string | undefined
+): UsePreviewLinkOptions {
+  return { single: slug, ...(locale === undefined ? {} : { locale }) };
+}
+
 export function SingleForm({
   schema,
   document,
@@ -411,6 +433,8 @@ export function SingleForm({
   // When true, EntrySystemHeader shows Save Draft / Update split, and
   // EntryMetaStrip / DocumentPanel surface the status pill.
   const hasStatus = schema.status === true;
+
+  const previewLink = usePreviewLink(singlePreviewTarget(schema.slug, locale));
 
   // Auto-fill slug from title — same form-level pattern as EntryForm. The
   // title input lives in EntrySystemHeader (not TextInput) so the slug
@@ -632,6 +656,14 @@ export function SingleForm({
                         locale={locale}
                         onLocaleChange={onLocaleChange}
                         localized={schema.localized === true}
+                        /* A Single has a draft lifecycle, so it has drafts worth
+                   sharing. The control is offered whenever the Single carries
+                   that lifecycle; whether a link can actually be minted is the
+                   server's call, and it refuses with a message naming what is
+                   missing rather than handing out one that 404s. */
+                        isLinkAvailable={hasStatus}
+                        onCopyLink={() => previewLink.mutate()}
+                        isCopyingLink={previewLink.isPending}
                         toolbarSlot={
                           <EntryFormToolbarSlots
                             context="single"

--- a/packages/admin/src/components/features/singles/__tests__/SingleForm.preview-link.test.tsx
+++ b/packages/admin/src/components/features/singles/__tests__/SingleForm.preview-link.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * The join between `SingleForm` and its header for the shareable link.
+ *
+ * The halves are covered elsewhere — `entry-address.test.tsx` pins the locale
+ * outcomes and `EntrySystemHeader.preview.test.tsx` pins what the header
+ * renders given props — and neither sees the conjunction that consumes them.
+ * The collection form has the same seam and the same tests, for the reason
+ * recorded there: removing the `unresolved` guard leaves every test around the
+ * helper green, because a helper is unchanged when its caller stops consulting
+ * it.
+ *
+ * The Single case is the sharper one. A Single is addressed by slug, so there
+ * is no unsaved state to withhold the control for, and the locale is the ONLY
+ * thing that can make a link wrong: on a localized Single opened in its default
+ * language the editor's active locale is `undefined`, and a token minted with
+ * no locale claim covers every translation — including the unpublished ones.
+ *
+ * So these assert the PROPS the header actually receives and the ARGS the mint
+ * hook is actually called with, rather than reconstructing either decision
+ * here: a hand-copied condition keeps passing after someone edits the line it
+ * exists to watch.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { render } from "@admin/__tests__/utils";
+
+const { headerProps, mintArgs, localization } = vi.hoisted(() => ({
+  headerProps: vi.fn(),
+  mintArgs: vi.fn(),
+  localization: { current: { defaultLocale: "en" } },
+}));
+
+vi.mock(
+  "@admin/components/features/entries/EntryForm/EntrySystemHeader",
+  () => ({
+    EntrySystemHeader: (props: Record<string, unknown>) => {
+      headerProps(props);
+      return null;
+    },
+  })
+);
+
+vi.mock("@admin/hooks/useLocalization", () => ({
+  useLocalization: () => ({
+    enabled: true,
+    locales: [],
+    defaultLocale: localization.current.defaultLocale,
+    fallback: true,
+    getLocale: () => undefined,
+  }),
+}));
+
+vi.mock("@admin/hooks/usePreviewLink", () => ({
+  usePreviewLink: (args: unknown) => {
+    mintArgs(args);
+    return { mutate: vi.fn(), isPending: false };
+  },
+}));
+
+import { SingleForm } from "../SingleForm";
+
+/**
+ * A localized Single with a publish lifecycle — the combination that makes a
+ * preview link both available and locale-sensitive.
+ */
+const schema = {
+  slug: "landing-page",
+  label: { singular: "Landing Page" },
+  localized: true,
+  status: true,
+  fields: [{ name: "title", type: "text", label: "Title" }],
+} as never;
+
+const document = { id: "s1", title: "Hello" } as never;
+
+function renderForm(props: Record<string, unknown> = {}) {
+  return render(
+    <SingleForm
+      schema={schema}
+      document={document}
+      onSubmit={vi.fn()}
+      {...props}
+    />
+  );
+}
+
+/** The most recent props the header was rendered with. */
+function lastHeaderProps(): Record<string, unknown> {
+  const calls = headerProps.mock.calls;
+  expect(calls.length, "the header was never rendered").toBeGreaterThan(0);
+  return calls[calls.length - 1]?.[0] as Record<string, unknown>;
+}
+
+describe("SingleForm wires the shareable link into its header", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localization.current = { defaultLocale: "en" };
+  });
+
+  it("offers the link once the language resolves", () => {
+    renderForm();
+
+    expect(lastHeaderProps().isLinkAvailable).toBe(true);
+  });
+
+  // The defect this covers. The editor represents the default language as
+  // `undefined`, and an absent locale claim is not "the default language" —
+  // it authorizes EVERY locale, so the recipient could open translations that
+  // have never been published.
+  it("mints against the resolved language, never the editor's sentinel", () => {
+    renderForm();
+
+    expect(mintArgs).toHaveBeenCalledWith(
+      expect.objectContaining({ single: "landing-page", locale: "en" })
+    );
+  });
+
+  it("withholds the link while the default locale is still blank", () => {
+    // `useLocalization` reports `""` until the config loads. Minting then is a
+    // 400, and dropping the claim to avoid that is a token covering every
+    // translation — so the control is not offered at all.
+    localization.current = { defaultLocale: "" };
+    renderForm();
+
+    expect(lastHeaderProps().isLinkAvailable).toBe(false);
+  });
+
+  it("scopes to the language being edited, not the default one", () => {
+    renderForm({ locale: "fr" });
+
+    expect(mintArgs).toHaveBeenCalledWith(
+      expect.objectContaining({ single: "landing-page", locale: "fr" })
+    );
+  });
+
+  // The negative control for the claim above: absent IS correct here, and a
+  // rule that always scoped would refuse a link for every unlocalized Single.
+  it("sends no locale claim for a Single that is not localized", () => {
+    render(
+      <SingleForm
+        schema={{ ...(schema as object), localized: false } as never}
+        document={document}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(mintArgs).toHaveBeenCalledWith(
+      expect.not.objectContaining({ locale: expect.anything() })
+    );
+  });
+});

--- a/packages/admin/src/components/features/singles/useSinglePreviewLink.ts
+++ b/packages/admin/src/components/features/singles/useSinglePreviewLink.ts
@@ -1,0 +1,73 @@
+"use client";
+
+/**
+ * The shareable-link wiring for a Single, as one decision rather than three
+ * scattered through the form.
+ *
+ * It exists because the parts are only correct together. The locale has to be
+ * RESOLVED before it can be minted against — on a localized Single opened in
+ * its default language the editor's active locale is absent, and an absent
+ * locale claim is not "the default language": it authorizes every locale, so a
+ * link minted that way opens translations that have never been published. And
+ * where it cannot be resolved the control has to be withheld, because minting
+ * without a claim is that same grant and minting an empty one is refused by the
+ * route.
+ *
+ * @module components/features/singles/useSinglePreviewLink
+ */
+
+import { previewLinkLocale } from "@admin/components/features/entries/EntryForm/entry-address";
+import { usePreviewLink } from "@admin/hooks/usePreviewLink";
+import type { UsePreviewLinkOptions } from "@admin/hooks/usePreviewLink";
+
+export interface SinglePreviewLinkInput {
+  /** The Single's slug, which is its identity — there is no id to wait for. */
+  slug: string;
+  /** Whether the Single carries translations. */
+  localized: boolean;
+  /** Whether the Single carries a Draft / Published lifecycle. */
+  hasStatus: boolean;
+  /** The language being edited; absent means the default one. */
+  locale: string | undefined;
+  /** The site's default language, once localization config has loaded. */
+  defaultLocale: string | undefined;
+}
+
+export interface SinglePreviewLink {
+  /** Whether to offer the control at all. */
+  isAvailable: boolean;
+  /** Mint and copy. */
+  copy: () => void;
+  /** Whether a mint is in flight. */
+  isCopying: boolean;
+}
+
+export function useSinglePreviewLink({
+  slug,
+  localized,
+  hasStatus,
+  locale,
+  defaultLocale,
+}: SinglePreviewLinkInput): SinglePreviewLink {
+  // The same resolver the entry editor uses, rather than a second rule written
+  // here: two answers to "which language is this link for" drift, and the drift
+  // is silent because both look correct.
+  const linkLocale = previewLinkLocale({ localized, locale, defaultLocale });
+
+  const target: UsePreviewLinkOptions = {
+    single: slug,
+    ...(linkLocale.kind === "scoped" ? { locale: linkLocale.locale } : {}),
+  };
+
+  const link = usePreviewLink(target);
+
+  return {
+    // A Single with no publish lifecycle has no pending state to show anyone,
+    // so there is nothing to share and the control is not offered.
+    isAvailable: hasStatus && linkLocale.kind !== "unresolved",
+    copy: () => {
+      link.mutate();
+    },
+    isCopying: link.isPending,
+  };
+}

--- a/packages/admin/src/hooks/__tests__/usePreviewLink.test.ts
+++ b/packages/admin/src/hooks/__tests__/usePreviewLink.test.ts
@@ -122,3 +122,48 @@ describe("usePreviewLink", () => {
     );
   });
 });
+
+describe("usePreviewLink for a Single", () => {
+  // A Single is addressed by slug and has exactly one document, so there is no
+  // id to wait for — unlike an entry, whose link cannot be minted until it has
+  // been saved once.
+  it("mints against the Single's slug", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    mint.mockResolvedValue({
+      token: TOKEN,
+      url: URL_FROM_SERVER,
+      expiresAt: "2026-09-01T00:00:00.000Z",
+    });
+
+    const { result } = renderHook(
+      () => usePreviewLink({ single: "homepage" }),
+      { wrapper: makeWrapper() }
+    );
+    result.current.mutate();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Passed through as the union it arrived as, rather than destructured and
+    // rebuilt — which would be a second place deciding what a request carries.
+    expect(mint).toHaveBeenCalledWith({ single: "homepage" });
+  });
+
+  it("forwards the locale so a link opens the translation being edited", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    mint.mockResolvedValue({
+      token: TOKEN,
+      url: URL_FROM_SERVER,
+      expiresAt: "2026-09-01T00:00:00.000Z",
+    });
+
+    const { result } = renderHook(
+      () => usePreviewLink({ single: "homepage", locale: "fr" }),
+      { wrapper: makeWrapper() }
+    );
+    result.current.mutate();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mint).toHaveBeenCalledWith({ single: "homepage", locale: "fr" });
+  });
+});

--- a/packages/admin/src/hooks/usePreviewLink.ts
+++ b/packages/admin/src/hooks/usePreviewLink.ts
@@ -9,14 +9,18 @@
 import { useMutation } from "@tanstack/react-query";
 
 import { toast } from "@admin/components/ui";
-import { previewLinkApi } from "@admin/services/previewLinkApi";
+import {
+  previewLinkApi,
+  type PreviewLinkRequest,
+} from "@admin/services/previewLinkApi";
 
-export interface UsePreviewLinkOptions {
-  collection: string;
-  entryId: string;
-  /** Restricts the link to one locale. Absent means every locale. */
-  locale?: string;
-}
+/**
+ * What to mint a link for: one collection entry, or one Single.
+ *
+ * The union is the endpoint's own, restated here so the two cannot drift into
+ * accepting different shapes.
+ */
+export type UsePreviewLinkOptions = PreviewLinkRequest;
 
 /**
  * Copy text to the clipboard, reporting whether it worked.
@@ -42,18 +46,13 @@ async function copyToClipboard(text: string): Promise<boolean> {
  * carries an expiry, so a value cached in the page would be handed out after it
  * had stopped working.
  */
-export function usePreviewLink({
-  collection,
-  entryId,
-  locale,
-}: UsePreviewLinkOptions) {
+export function usePreviewLink(target: UsePreviewLinkOptions) {
   return useMutation({
     mutationFn: async (): Promise<{ url: string; copied: boolean }> => {
-      const link = await previewLinkApi.mint({
-        collection,
-        entryId,
-        ...(locale === undefined ? {} : { locale }),
-      });
+      // Passed through as the union it arrived as. Destructuring and rebuilding
+      // it here would be a second place that decides which fields a mint
+      // request carries, and the two would drift the moment one gains a field.
+      const link = await previewLinkApi.mint(target);
 
       // The server answers `null` only when it can find the site's address
       // NOWHERE — neither the Site URL setting nor the application's own

--- a/packages/admin/src/services/previewLinkApi.ts
+++ b/packages/admin/src/services/previewLinkApi.ts
@@ -12,12 +12,28 @@
 
 import { protectedApi } from "@admin/lib/api/protectedApi";
 
-export interface PreviewLinkRequest {
-  collection: string;
-  entryId: string;
-  /** Restricts the link to one locale. Absent means every locale. */
-  locale?: string;
-}
+/**
+ * What a mint request names: ONE collection entry, or ONE Single.
+ *
+ * A union rather than three optional fields, mirroring the endpoint's own
+ * schema — so a caller cannot express "both", which names two different
+ * documents, or "neither".
+ */
+export type PreviewLinkRequest =
+  | {
+      collection: string;
+      entryId: string;
+      single?: never;
+      /** Restricts the link to one locale. Absent means every locale. */
+      locale?: string;
+    }
+  | {
+      single: string;
+      collection?: never;
+      entryId?: never;
+      /** Restricts the link to one locale. Absent means every locale. */
+      locale?: string;
+    };
 
 export interface PreviewLink {
   /** The signed token. */

--- a/packages/blocks-react/src/next.single-draft.test.ts
+++ b/packages/blocks-react/src/next.single-draft.test.ts
@@ -1,0 +1,101 @@
+/**
+ * A Single rendered as a blocks page can honour a preview token.
+ *
+ * The composition is what these cover, not the gate: `createSinglePage` builds a
+ * `SingleRouteConfig` from a blocks config, and a `draft` hook that is dropped
+ * on the way through leaves a route that verifies a preview link, redirects to
+ * it, and then serves the PUBLISHED document from a page that looks entirely
+ * correct — the failure the whole draft-preview path exists to remove, and the
+ * one that is invisible from either end.
+ *
+ * Asserted through the arguments the reader receives, because that is where a
+ * dropped hook becomes observable: the read either asks for the working draft
+ * or it does not.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { createPublicSinglePage, createSinglePage } from "./next";
+import { coreBlocks } from "./blocks";
+import { createBlockResolver } from "./resolver";
+
+/** A reader recording how the route asked for the Single. */
+function singleReader() {
+  const calls: Record<string, unknown>[] = [];
+  const reader = {
+    findSingle: vi.fn(async (args: Record<string, unknown>) => {
+      calls.push(args);
+      return { title: "Home", content: null };
+    }),
+    find: vi.fn(async () => ({ docs: [], totalDocs: 0 })),
+    findByID: vi.fn(async () => null),
+  };
+  return { reader, calls };
+}
+
+function pageWith(draft: boolean | (() => boolean) | undefined) {
+  const { reader, calls } = singleReader();
+  const route = createSinglePage({
+    slug: "homepage",
+    field: "content",
+    blocks: createBlockResolver(coreBlocks),
+    nextly: reader as never,
+    // Present because `generateMetadata` short-circuits without one, returning
+    // `{}` before it resolves anything — the reader would never be asked, and
+    // every assertion below would be measuring a route that never ran.
+    metadata: () => ({ title: "Home" }),
+    ...(draft === undefined ? {} : { draft }),
+  });
+  return { route, calls };
+}
+
+describe("a Single blocks page and its draft hook", () => {
+  // The positive control. Without it the negative below cannot distinguish
+  // "the hook was threaded and answered no" from "the hook never arrived".
+  it("asks for the working draft when the hook grants it", async () => {
+    const { route, calls } = pageWith(true);
+
+    await route.generateMetadata();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].draft).toBe(true);
+    expect(calls[0].status).toBe("all");
+    // Trusted follows from the grant, not from the posture: the overlay is
+    // gated on edit capability while this route resolves anonymously, so an
+    // enforced draft read would return published values and report success.
+    expect(calls[0].overrideAccess).toBe(true);
+  });
+
+  it("does not when the hook refuses", async () => {
+    const { route, calls } = pageWith(() => false);
+
+    await route.generateMetadata();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].draft).toBeUndefined();
+    expect(calls[0].overrideAccess).toBe(false);
+  });
+
+  it("does not when no hook is declared, which is most routes", async () => {
+    const { route, calls } = pageWith(undefined);
+
+    await route.generateMetadata();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].draft).toBeUndefined();
+  });
+
+  // The refusal lives in `createPublicSingleRoute`; this asserts the hook
+  // reaches it rather than being dropped on the way, which would leave the
+  // public factory silently accepting a draft it cannot serve.
+  it("refuses the hook on the public factory, which is cached", () => {
+    expect(() =>
+      createPublicSinglePage({
+        slug: "homepage",
+        field: "content",
+        blocks: createBlockResolver(coreBlocks),
+        nextly: singleReader().reader as never,
+        draft: true,
+      })
+    ).toThrow(/cannot serve drafts/i);
+  });
+});

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -1209,9 +1209,13 @@ function blocksRouteConfig(
  *
  * The blocks options are the page route's, minus everything that only means
  * something when a path is being RESOLVED. A Single is not looked up by slug, so
- * `collections`, `slugField` and `staticParamsLimit` have nothing to act on;
- * `status` and `draft` are the collection lifecycle's, which a Single route does
- * not scope.
+ * `collections`, `slugField` and `staticParamsLimit` have nothing to act on, and
+ * `status` is the collection lifecycle's, which a Single route does not scope.
+ *
+ * `draft` is omitted from the page route's set and RE-DECLARED below, because
+ * the two hooks answer differently shaped questions: a collection's returns the
+ * entry id the route must then compare against the row a path resolved to, and a
+ * Single has no path and no id to compare.
  */
 export interface BlocksSinglePageConfig
   extends Omit<
@@ -1226,6 +1230,26 @@ export interface BlocksSinglePageConfig
   > {
   /** Which Single to serve, by its slug. */
   slug: string;
+
+  /**
+   * Whether this request may read the Single's pending working draft.
+   *
+   * Without it the route serves the published document only, so a preview link
+   * verifies, redirects, and then answers 404 from a page that looks entirely
+   * correct — indistinguishable, to the reviewer who opened it, from a link that
+   * had expired.
+   *
+   * @example
+   * ```ts
+   * import { previewSingleDraftGate } from "nextly/runtime";
+   *
+   * createSinglePage({ slug: "homepage", draft: previewSingleDraftGate() });
+   * ```
+   *
+   * `createPublicSinglePage` refuses it, because a draft read is per-visitor and
+   * uncacheable while that factory exists to be cached and pre-rendered.
+   */
+  draft?: SingleRouteConfig<ReactElement>["draft"];
   /*
    * No `user`, deliberately, and for the same reason the page route has none:
    * these helpers read anonymously or trusted, and offering an identity here
@@ -1261,7 +1285,11 @@ function blocksSingleConfig(
   config: BlocksSinglePageConfig,
   isPublic: boolean
 ): SingleRouteConfig<ReactElement> {
-  const { slug, tags, revalidate, ...blocksOptions } = config;
+  // `draft` is pulled out rather than left in the rest, because what follows
+  // hands `blocksOptions` to the PAGE route's config builder, whose `draft` hook
+  // has the collection shape — resolving an entry id this route has nothing to
+  // compare against.
+  const { slug, tags, revalidate, draft, ...blocksOptions } = config;
 
   const routeConfig = blocksRouteConfig(
     { ...blocksOptions, collections: [slug] },
@@ -1280,6 +1308,10 @@ function blocksSingleConfig(
     ...(config.depth === undefined ? {} : { depth: config.depth }),
     ...(config.nextly === undefined ? {} : { nextly: config.nextly }),
     ...(revalidate === undefined ? {} : { revalidate }),
+    // Passed straight to the Single route, which is where the refusal lives:
+    // `createPublicSingleRoute` rejects a draft hook at construction, so
+    // `createPublicSinglePage` inherits that rather than restating it.
+    ...(draft === undefined ? {} : { draft }),
     // The media tag comes from the page route's own tag set, which is computed
     // for a collection this route does not have. Taking it from there rather
     // than recomputing keeps one answer to "what does a blocks page depend on".

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -1250,6 +1250,17 @@ export interface BlocksSinglePageConfig
    * uncacheable while that factory exists to be cached and pre-rendered.
    */
   draft?: SingleRouteConfig<ReactElement>["draft"];
+
+  /**
+   * The collections this route's trust extends to when it populates
+   * relationships. Defaults to nothing — see
+   * `SingleRouteConfig.trustedCollections`, which this forwards to verbatim.
+   *
+   * It matters most alongside `draft`: the grant names one document and says
+   * nothing about what that document points at, so without a bound a previewed
+   * Single hands its reader every related record it touches.
+   */
+  trustedCollections?: SingleRouteConfig<ReactElement>["trustedCollections"];
   /*
    * No `user`, deliberately, and for the same reason the page route has none:
    * these helpers read anonymously or trusted, and offering an identity here
@@ -1281,15 +1292,51 @@ export interface BlocksSinglePageConfig
  * whose error names where a missing field was looked for, and the SEO
  * derivation, which uses it as the page's own identity.
  */
+/**
+ * The options a Single route takes verbatim from a blocks config.
+ *
+ * Split out because they are pure passthrough — every one is "state it only if
+ * the caller did" — while the function below assembles the parts that are
+ * DERIVED from the page route. Keeping the two apart means adding a passthrough
+ * costs a line here rather than another branch in the assembly.
+ *
+ * Spread rather than assigned: an explicit `undefined` is not the same as an
+ * absent key, because the route's own defaults are what an absent key selects.
+ */
+function singlePassthrough(
+  config: BlocksSinglePageConfig
+): Partial<SingleRouteConfig<ReactElement>> {
+  const { locale, depth, nextly, revalidate, draft, trustedCollections } =
+    config;
+  return {
+    ...(locale === undefined ? {} : { locale }),
+    ...(depth === undefined ? {} : { depth }),
+    ...(nextly === undefined ? {} : { nextly }),
+    ...(revalidate === undefined ? {} : { revalidate }),
+    // Passed straight to the Single route, which is where the refusal lives:
+    // `createPublicSingleRoute` rejects a draft hook at construction, so
+    // `createPublicSinglePage` inherits that rather than restating it.
+    ...(draft === undefined ? {} : { draft }),
+    ...(trustedCollections === undefined ? {} : { trustedCollections }),
+  };
+}
+
 function blocksSingleConfig(
   config: BlocksSinglePageConfig,
   isPublic: boolean
 ): SingleRouteConfig<ReactElement> {
-  // `draft` is pulled out rather than left in the rest, because what follows
-  // hands `blocksOptions` to the PAGE route's config builder, whose `draft` hook
-  // has the collection shape — resolving an entry id this route has nothing to
-  // compare against.
-  const { slug, tags, revalidate, draft, ...blocksOptions } = config;
+  // `draft` and `trustedCollections` are pulled out rather than left in the
+  // rest, because what follows hands `blocksOptions` to the PAGE route's config
+  // builder, whose `draft` hook has the collection shape — resolving an entry id
+  // this route has nothing to compare against.
+  const {
+    slug,
+    tags,
+    revalidate: _revalidate,
+    draft: _draft,
+    trustedCollections: _trustedCollections,
+    ...blocksOptions
+  } = config;
 
   const routeConfig = blocksRouteConfig(
     { ...blocksOptions, collections: [slug] },
@@ -1304,14 +1351,7 @@ function blocksSingleConfig(
 
   return {
     slug,
-    ...(config.locale === undefined ? {} : { locale: config.locale }),
-    ...(config.depth === undefined ? {} : { depth: config.depth }),
-    ...(config.nextly === undefined ? {} : { nextly: config.nextly }),
-    ...(revalidate === undefined ? {} : { revalidate }),
-    // Passed straight to the Single route, which is where the refusal lives:
-    // `createPublicSingleRoute` rejects a draft hook at construction, so
-    // `createPublicSinglePage` inherits that rather than restating it.
-    ...(draft === undefined ? {} : { draft }),
+    ...singlePassthrough(config),
     // The media tag comes from the page route's own tag set, which is computed
     // for a collection this route does not have. Taking it from there rather
     // than recomputing keeps one answer to "what does a blocks page depend on".

--- a/packages/nextly/src/api/preview-access.ts
+++ b/packages/nextly/src/api/preview-access.ts
@@ -169,12 +169,31 @@ export async function assertEntryPreviewable(
  */
 export async function assertSinglePreviewable(
   single: string,
+  locale: string | undefined,
   user: UserContext,
   actor?: AuthenticatedScope
 ): Promise<void> {
-  const subject = { user, ...(actor === undefined ? {} : { actor }) };
+  const identity = {
+    user,
+    ...(actor === undefined ? {} : { actor }),
+    // The TRANSLATION the token will name, so the rules are evaluated against
+    // the document the bearer actually receives. A localized Single is a
+    // different document per language, and an owner-only or custom rule can
+    // answer differently for each — authorizing the default translation and
+    // then signing another is authorizing something else.
+    ...(locale === undefined ? {} : { locale }),
+  };
 
-  if (!(await singleDocumentReadable(single, subject))) {
+  if (
+    !(await singleDocumentReadable(single, {
+      ...identity,
+      // FALSE, and this is the whole point. The mint route gated `update`, so
+      // nothing has checked this caller's READ permission — and skipping it as
+      // redundant would hand a bearer token for the draft to someone holding
+      // `update` with no read grant at all.
+      routeAuthorized: false,
+    }))
+  ) {
     throw NextlyError.forbidden({
       logContext: { reason: "preview-link-single-not-visible", single },
     });
@@ -183,7 +202,14 @@ export async function assertSinglePreviewable(
   // The token's view is the DRAFT, and the draft overlay surfaces a pending
   // working draft only to a caller trusted to EDIT the document. Reading the
   // published one proves nothing about that.
-  if (!(await singleDocumentEditable(single, subject))) {
+  if (
+    !(await singleDocumentEditable(single, {
+      ...identity,
+      // TRUE here: the mint route ran exactly this gate, so the coarse update
+      // check is the redundant one this flag exists to skip.
+      routeAuthorized: true,
+    }))
+  ) {
     throw NextlyError.forbidden({
       logContext: { reason: "preview-link-single-not-editable", single },
     });

--- a/packages/nextly/src/api/preview-access.ts
+++ b/packages/nextly/src/api/preview-access.ts
@@ -25,6 +25,10 @@
 
 import type { AuthenticatedScope } from "../auth/authenticated-scope";
 import { getService } from "../di";
+import {
+  singleDocumentEditable,
+  singleDocumentReadable,
+} from "../domains/singles/services/single-document-access";
 import type { UserContext } from "../domains/singles/types";
 import { errorFromServiceEnvelope } from "../errors/from-service-envelope";
 import { NextlyError } from "../errors/nextly-error";
@@ -144,6 +148,44 @@ export async function assertEntryPreviewable(
         collection,
         entryId,
       },
+    });
+  }
+}
+
+/**
+ * Confirm the caller may be handed a preview link for this Single.
+ *
+ * The Single counterpart of {@link assertEntryPreviewable}, asking the same two
+ * questions for the same reason. It is NOT redundant with the route's own gate:
+ * that gate is per-slug RBAC, and a Single's stored rules — owner-only, role
+ * based, custom — are evaluated against the loaded document and can deny a
+ * caller who holds the coarse permission. Stopping at the permission would mint
+ * a bearer credential for a draft the real update path refuses to show them.
+ *
+ * One answer for every refusal, deliberately: a caller who is refused a link
+ * learns only that they are refused.
+ *
+ * @throws {NextlyError} `forbidden` when no link may be minted.
+ */
+export async function assertSinglePreviewable(
+  single: string,
+  user: UserContext,
+  actor?: AuthenticatedScope
+): Promise<void> {
+  const subject = { user, ...(actor === undefined ? {} : { actor }) };
+
+  if (!(await singleDocumentReadable(single, subject))) {
+    throw NextlyError.forbidden({
+      logContext: { reason: "preview-link-single-not-visible", single },
+    });
+  }
+
+  // The token's view is the DRAFT, and the draft overlay surfaces a pending
+  // working draft only to a caller trusted to EDIT the document. Reading the
+  // published one proves nothing about that.
+  if (!(await singleDocumentEditable(single, subject))) {
+    throw NextlyError.forbidden({
+      logContext: { reason: "preview-link-single-not-editable", single },
     });
   }
 }

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -47,6 +47,14 @@ vi.mock("./preview-url", () => ({
   previewDeclarationFor: (...args: unknown[]) => previewDeclaration(...args),
   singlePreviewDeclarationFor: (...args: unknown[]) =>
     singleDeclaration(...args),
+  // Delegates to the same `findSingle` double the mint used to reach directly,
+  // so what these tests drive is unchanged: the read moved behind a shared
+  // loader, and the loader is the one the preview ROUTE reads through too.
+  loadSingleForPreview: async (slug: string, locale: string | undefined) =>
+    (await findSingle({
+      slug,
+      ...(locale === undefined ? {} : { locale }),
+    })) ?? null,
 }));
 
 vi.mock("../di", () => ({

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -21,6 +21,8 @@ const {
   previewDeclaration,
   singleDeclaration,
   findSingle,
+  singleReadable,
+  singleEditable,
 } = vi.hoisted(() => ({
   getEntry: vi.fn(),
   canUpdateEntry: vi.fn(),
@@ -28,6 +30,8 @@ const {
   previewDeclaration: vi.fn(),
   singleDeclaration: vi.fn(),
   findSingle: vi.fn(),
+  singleReadable: vi.fn(),
+  singleEditable: vi.fn(),
 }));
 
 /** The application's `preview` config for the test in hand. */
@@ -55,6 +59,13 @@ vi.mock("./preview-url", () => ({
       slug,
       ...(locale === undefined ? {} : { locale }),
     })) ?? null,
+}));
+
+// The gate itself is exercised where it lives; what these cover is that the
+// mint ASKS it, and that a refusal stops short of signing anything.
+vi.mock("../domains/singles/services/single-document-access", () => ({
+  singleDocumentReadable: (...args: unknown[]) => singleReadable(...args),
+  singleDocumentEditable: (...args: unknown[]) => singleEditable(...args),
 }));
 
 vi.mock("../di", () => ({
@@ -160,6 +171,58 @@ describe("mintPreviewLink for a Single", () => {
   beforeEach(() => {
     singleDeclaration.mockResolvedValue({ url: () => "/" });
     findSingle.mockResolvedValue({ id: "homepage" });
+    singleReadable.mockResolvedValue(true);
+    singleEditable.mockResolvedValue(true);
+  });
+
+  /**
+   * The route gate answers a COARSE question — may this caller update this slug
+   * — while a Single's stored rules are evaluated against the loaded document
+   * and can deny a caller who holds that permission. A link minted on the
+   * permission alone is a bearer credential for a draft the real update path
+   * refuses to show them.
+   */
+  describe("the Single's own stored rules", () => {
+    it("refuses when the caller cannot see the document", async () => {
+      singleReadable.mockResolvedValue(false);
+
+      const response = await mintPreviewLink(post({ single: "homepage" }));
+
+      expect(response.status).toBe(403);
+    });
+
+    // Reading proves nothing about this. Where a Single allows broad reads and
+    // restricts updates, a caller reads the published document and would
+    // otherwise be handed the author's unpublished edits.
+    it("refuses when the caller cannot edit the document", async () => {
+      singleEditable.mockResolvedValue(false);
+
+      const response = await mintPreviewLink(post({ single: "homepage" }));
+
+      expect(response.status).toBe(403);
+    });
+
+    // The property that matters: a refusal must stop short of SIGNING. A token
+    // that exists is a working credential whatever the response says.
+    it("signs nothing when it refuses", async () => {
+      singleEditable.mockResolvedValue(false);
+
+      const body = await json(
+        await mintPreviewLink(post({ single: "homepage" }))
+      );
+
+      expect(JSON.stringify(body)).not.toContain("eyJ");
+    });
+
+    // Asked BEFORE the trusted read that builds the redirect, so a refused
+    // caller never reaches a document they may not see.
+    it("asks before loading the document", async () => {
+      singleReadable.mockResolvedValue(false);
+
+      await mintPreviewLink(post({ single: "homepage" }));
+
+      expect(findSingle).not.toHaveBeenCalled();
+    });
   });
 
   it("mints a link scoped to the Single", async () => {

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -45,6 +45,14 @@ let previewConfig: { route?: string } | undefined;
  */
 const localizedSingles = new Set<string>();
 
+/**
+ * Which singles carry a Draft / Published lifecycle, for the test in hand.
+ *
+ * A single without one has no pending version to preview, so minting is refused
+ * — which every other Single test would otherwise trip over.
+ */
+const statusSingles = new Set<string>();
+
 vi.mock("../init", () => ({
   // Carries findSingle, because the Single mint path reads the document through
   // the Direct API rather than the collections handler.
@@ -84,7 +92,10 @@ vi.mock("../di", () => ({
     // The registry fallback the localized probe reaches when the authored
     // config has nothing to say about this slug.
     getSingleBySlug: (slug: string) =>
-      Promise.resolve({ localized: localizedSingles.has(slug) }),
+      Promise.resolve({
+        localized: localizedSingles.has(slug),
+        status: statusSingles.has(slug),
+      }),
   })),
 }));
 
@@ -128,6 +139,7 @@ beforeEach(() => {
   // Nothing is localized unless a test says so, which keeps the unscoped grant
   // correct for the singles that genuinely have one document.
   localizedSingles.clear();
+  statusSingles.clear();
   // The default: the caller can see the entry they named AND may edit it, so
   // the draft the token hands out is one they could already open. Tests about
   // the entry gate override whichever half they are about.
@@ -191,6 +203,7 @@ describe("mintPreviewLink for a Single", () => {
     findSingle.mockResolvedValue({ id: "homepage" });
     singleReadable.mockResolvedValue(true);
     singleEditable.mockResolvedValue(true);
+    statusSingles.add("homepage");
   });
 
   /**
@@ -285,6 +298,57 @@ describe("mintPreviewLink for a Single", () => {
         "homepage",
         expect.objectContaining({ locale: "fr" })
       );
+    });
+  });
+
+  /**
+   * A Single with no Draft / Published lifecycle has no pending version, so a
+   * link would hand its recipient the CURRENT private document through a route
+   * that reads it trusted. The admin already withholds the control; this is the
+   * same rule for a caller reaching the endpoint directly.
+   */
+  describe("a single with no draft lifecycle", () => {
+    it("refuses to mint at all", async () => {
+      statusSingles.delete("homepage");
+
+      const response = await mintPreviewLink(post({ single: "homepage" }));
+
+      expect(response.status).toBe(409);
+    });
+
+    it("signs nothing when it refuses", async () => {
+      statusSingles.delete("homepage");
+
+      const body = await json(
+        await mintPreviewLink(post({ single: "homepage" }))
+      );
+
+      expect(JSON.stringify(body)).not.toContain("eyJ");
+    });
+
+    // Refused before the trusted read that builds the redirect, so nothing
+    // loads a document the caller is not going to be given.
+    it("refuses before loading the document", async () => {
+      statusSingles.delete("homepage");
+
+      await mintPreviewLink(post({ single: "homepage" }));
+
+      expect(findSingle).not.toHaveBeenCalled();
+    });
+  });
+
+  // The registry and the authored config can disagree — a metadata sync that
+  // fails deliberately keeps the previous registry row — and the read path
+  // consumes the registry. Believing the config alone reports a localized
+  // Single as unlocalized and signs an all-locales token.
+  describe("when the authored config and the registry disagree", () => {
+    it("treats a Single the registry calls localized as localized", async () => {
+      localizedSingles.add("homepage");
+      previewConfig = undefined;
+
+      const response = await mintPreviewLink(post({ single: "homepage" }));
+
+      expect(response.status).toBe(400);
     });
   });
 

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -37,6 +37,14 @@ const {
 /** The application's `preview` config for the test in hand. */
 let previewConfig: { route?: string } | undefined;
 
+/**
+ * Which singles the config reports as localized, for the test in hand.
+ *
+ * A set rather than a flag because the endpoint asks per slug, and a single
+ * boolean would answer for a single it was never asked about.
+ */
+const localizedSingles = new Set<string>();
+
 vi.mock("../init", () => ({
   // Carries findSingle, because the Single mint path reads the document through
   // the Direct API rather than the collections handler.
@@ -70,7 +78,14 @@ vi.mock("../domains/singles/services/single-document-access", () => ({
 
 vi.mock("../di", () => ({
   container: { get: vi.fn(), has: vi.fn().mockReturnValue(false) },
-  getService: vi.fn(() => ({ getEntry, canUpdateEntry })),
+  getService: vi.fn(() => ({
+    getEntry,
+    canUpdateEntry,
+    // The registry fallback the localized probe reaches when the authored
+    // config has nothing to say about this slug.
+    getSingleBySlug: (slug: string) =>
+      Promise.resolve({ localized: localizedSingles.has(slug) }),
+  })),
 }));
 
 vi.mock("../lib/env", () => ({
@@ -110,6 +125,9 @@ async function json(response: Response): Promise<Record<string, unknown>> {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Nothing is localized unless a test says so, which keeps the unscoped grant
+  // correct for the singles that genuinely have one document.
+  localizedSingles.clear();
   // The default: the caller can see the entry they named AND may edit it, so
   // the draft the token hands out is one they could already open. Tests about
   // the entry gate override whichever half they are about.
@@ -222,6 +240,96 @@ describe("mintPreviewLink for a Single", () => {
       await mintPreviewLink(post({ single: "homepage" }));
 
       expect(findSingle).not.toHaveBeenCalled();
+    });
+
+    /**
+     * `routeAuthorized` tells the checker that the coarse RBAC gate for THIS
+     * operation already ran, so it is skipped as redundant. The mint route gated
+     * `update` and nothing else — so claiming it for the READ probe would skip a
+     * permission check that never happened, and a caller holding `update` with
+     * no read grant would be handed a bearer token for the draft.
+     */
+    it("does not claim a read gate the mint route never ran", async () => {
+      await mintPreviewLink(post({ single: "homepage" }));
+
+      expect(singleReadable).toHaveBeenCalledWith(
+        "homepage",
+        expect.objectContaining({ routeAuthorized: false })
+      );
+    });
+
+    // The other half, and the reason this is a per-call-site decision rather
+    // than one polarity for both: the update gate DID run, so re-running it
+    // would reject a scoped API key by resolving its creator's roles instead.
+    it("does claim the update gate it did run", async () => {
+      await mintPreviewLink(post({ single: "homepage" }));
+
+      expect(singleEditable).toHaveBeenCalledWith(
+        "homepage",
+        expect.objectContaining({ routeAuthorized: true })
+      );
+    });
+
+    // The token names one translation; the probe must judge that one. A custom
+    // read rule can allow the default document and deny the requested locale,
+    // and authorizing the default while signing the other authorizes nothing
+    // about what the bearer receives.
+    it("authorizes the translation the token will name", async () => {
+      await mintPreviewLink(post({ single: "homepage", locale: "fr" }));
+
+      expect(singleReadable).toHaveBeenCalledWith(
+        "homepage",
+        expect.objectContaining({ locale: "fr" })
+      );
+      expect(singleEditable).toHaveBeenCalledWith(
+        "homepage",
+        expect.objectContaining({ locale: "fr" })
+      );
+    });
+  });
+
+  /**
+   * An absent locale claim covers EVERY translation. On a localized Single that
+   * is a grant over drafts nobody authorized, so the endpoint refuses rather
+   * than widening the probe to match — honouring the request would hand out the
+   * very grant the refusal exists to withhold.
+   */
+  describe("a localized single with no locale named", () => {
+    it("refuses rather than minting a token covering every translation", async () => {
+      localizedSingles.add("homepage");
+
+      const response = await mintPreviewLink(post({ single: "homepage" }));
+
+      expect(response.status).toBe(400);
+    });
+
+    it("signs nothing when it refuses", async () => {
+      localizedSingles.add("homepage");
+
+      const body = await json(
+        await mintPreviewLink(post({ single: "homepage" }))
+      );
+
+      expect(JSON.stringify(body)).not.toContain("eyJ");
+    });
+
+    it("mints once a translation is named", async () => {
+      localizedSingles.add("homepage");
+
+      const response = await mintPreviewLink(
+        post({ single: "homepage", locale: "fr" })
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    // The negative control. An unlocalized Single has exactly one document, so
+    // an absent claim is the CORRECT grant there — a rule that always demanded
+    // a locale would refuse every link for every non-localized Single.
+    it("still mints unscoped for a single that is not localized", async () => {
+      const response = await mintPreviewLink(post({ single: "homepage" }));
+
+      expect(response.status).toBe(200);
     });
   });
 

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -14,19 +14,29 @@ vi.mock("./route-auth", () => ({
   requireRoutePermission: vi.fn(),
 }));
 
-const { getEntry, canUpdateEntry, getSettings, previewDeclaration } =
-  vi.hoisted(() => ({
-    getEntry: vi.fn(),
-    canUpdateEntry: vi.fn(),
-    getSettings: vi.fn(),
-    previewDeclaration: vi.fn(),
-  }));
+const {
+  getEntry,
+  canUpdateEntry,
+  getSettings,
+  previewDeclaration,
+  singleDeclaration,
+  findSingle,
+} = vi.hoisted(() => ({
+  getEntry: vi.fn(),
+  canUpdateEntry: vi.fn(),
+  getSettings: vi.fn(),
+  previewDeclaration: vi.fn(),
+  singleDeclaration: vi.fn(),
+  findSingle: vi.fn(),
+}));
 
 /** The application's `preview` config for the test in hand. */
 let previewConfig: { route?: string } | undefined;
 
 vi.mock("../init", () => ({
-  getCachedNextly: vi.fn().mockResolvedValue({}),
+  // Carries findSingle, because the Single mint path reads the document through
+  // the Direct API rather than the collections handler.
+  getCachedNextly: () => Promise.resolve({ findSingle }),
 }));
 
 vi.mock("../services/lib/permissions", () => ({
@@ -35,6 +45,8 @@ vi.mock("../services/lib/permissions", () => ({
 
 vi.mock("./preview-url", () => ({
   previewDeclarationFor: (...args: unknown[]) => previewDeclaration(...args),
+  singlePreviewDeclarationFor: (...args: unknown[]) =>
+    singleDeclaration(...args),
 }));
 
 vi.mock("../di", () => ({
@@ -135,6 +147,81 @@ async function mintedData(): Promise<Record<string, unknown>> {
     )
   );
 }
+
+describe("mintPreviewLink for a Single", () => {
+  beforeEach(() => {
+    singleDeclaration.mockResolvedValue({ url: () => "/" });
+    findSingle.mockResolvedValue({ id: "homepage" });
+  });
+
+  it("mints a link scoped to the Single", async () => {
+    const response = await mintPreviewLink(post({ single: "homepage" }));
+
+    expect(response.status).toBe(200);
+  });
+
+  it("signs a token that names the Single rather than a collection entry", async () => {
+    const body = await json(
+      await mintPreviewLink(post({ single: "homepage" }))
+    );
+    const verified = await verifyPreviewToken(
+      String(item(body).token),
+      SECRET,
+      { generation: 0 }
+    );
+
+    expect(verified.valid && verified.scope).toEqual({
+      kind: "single",
+      single: "homepage",
+    });
+  });
+
+  // The same gate a Single's document update asks for, keyed on its slug — so a
+  // caller who cannot edit the Single cannot mint a credential to read its
+  // draft.
+  it("authorizes update on the Single, not on some collection", async () => {
+    await mintPreviewLink(post({ single: "homepage" }));
+
+    expect(requireRouteCollectionAccess).toHaveBeenCalledWith(
+      expect.anything(),
+      "update",
+      "homepage"
+    );
+  });
+
+  it("refuses a Single that declares no preview url", async () => {
+    singleDeclaration.mockResolvedValue(undefined);
+
+    const response = await mintPreviewLink(post({ single: "homepage" }));
+
+    expect(response.status).toBe(409);
+  });
+
+  it("refuses a Single whose declaration cannot address it yet", async () => {
+    singleDeclaration.mockResolvedValue({ url: () => null });
+
+    const response = await mintPreviewLink(post({ single: "homepage" }));
+
+    expect(response.status).toBe(409);
+  });
+
+  // Naming both is not a narrower request, it is two different documents — and
+  // silently honouring one would mint a credential for a document the caller
+  // may not have meant.
+  it("refuses a request that names both a Single and a collection entry", async () => {
+    const response = await mintPreviewLink(
+      post({ single: "homepage", collection: "pages", entryId: "7" })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("refuses a request that names neither", async () => {
+    const response = await mintPreviewLink(post({}));
+
+    expect(response.status).toBe(400);
+  });
+});
 
 describe("mintPreviewLink: a collection with nowhere to send a reviewer", () => {
   // The button that mints this is shown whether or not a collection declares a

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -37,13 +37,17 @@ import {
 } from "../domains/collections/services/preview-url-resolver";
 import { resolvePreviewRoute } from "../domains/preview/route-config";
 import { resolvePreviewSiteUrl } from "../domains/preview/site-url";
+import type { UserContext } from "../domains/singles/types";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
 import { env } from "../lib/env";
 import type { GeneralSettingsService } from "../services/general-settings/general-settings-service";
 import { resolveRoleSlugs } from "../services/lib/permissions";
 
-import { assertEntryPreviewable } from "./preview-access";
+import {
+  assertEntryPreviewable,
+  assertSinglePreviewable,
+} from "./preview-access";
 import {
   loadSingleForPreview,
   previewDeclarationFor,
@@ -273,17 +277,53 @@ async function respondWithPreviewLink(
 }
 
 /**
+ * Who is asking, resolved the one way both mint paths must resolve it.
+ *
+ * An API key is authorized on the grants stamped on the KEY, never on its
+ * owner's roles. Without that distinction the probe resolves the owner's RBAC —
+ * including a super-admin bypass — so a key holding `update-*` but not `read-*`
+ * would mint a link on the strength of an account that can read, handing out a
+ * bearer credential for a document the key itself may not fetch.
+ *
+ * Shared rather than derived per call site: an entry link and a Single link
+ * confer the same kind of credential, so a difference in who they think is
+ * asking would be a difference in who can obtain one.
+ */
+async function callerFor(
+  auth: Awaited<ReturnType<typeof requireRouteCollectionAccess>>
+): Promise<{
+  user: UserContext;
+  actor: AuthenticatedScope | undefined;
+}> {
+  const roles = await resolveRoleSlugs(auth);
+  return {
+    user: buildUserContext({
+      claims: auth.claims,
+      id: auth.userId,
+      name: auth.userName,
+      email: auth.userEmail,
+      roles,
+    }),
+    actor:
+      auth.authMethod === "api-key"
+        ? { actorType: "apiKey", permissions: auth.permissions }
+        : undefined,
+  };
+}
+
+/**
  * Mint a link scoped to one Single.
  *
- * Authorized with the SAME gate a Single's document update asks for, keyed on
- * its slug — which is what the dispatcher uses for every write to it. So a
- * caller who cannot edit the Single cannot mint a credential to read its draft.
+ * Two gates, because the route's own is one axis short of what the token hands
+ * out. `requireRouteCollectionAccess` answers the coarse RBAC question — may
+ * this caller update this slug — while a Single's STORED rules (owner-only,
+ * role based, custom) are evaluated against the loaded document and can deny a
+ * caller who holds that permission. A link minted on the permission alone is a
+ * bearer credential for a draft the real update path refuses to show them.
  *
- * There is no second, row-level probe as there is for an entry, and there is
- * nothing missing: that probe exists because a collection gate answers about
- * the COLLECTION while the token names one ENTRY, and a row-level rule makes
- * the two diverge. A Single has exactly one document, so the gate's subject and
- * the token's subject are the same thing.
+ * That the token's subject and the gate's subject are the same document does
+ * not close it: the divergence here is between a PERMISSION and a stored RULE,
+ * not between a collection and a row.
  */
 async function mintForSingle(
   req: Request,
@@ -291,8 +331,16 @@ async function mintForSingle(
 ): Promise<Response> {
   const { single, locale, ttlSeconds } = args;
 
-  await requireRouteCollectionAccess(req, "update", single);
+  const auth = await requireRouteCollectionAccess(req, "update", single);
+  // Booted first because the gate below resolves services from the container,
+  // and on a cold process the permission lookup itself needs them registered.
   await getCachedNextly();
+
+  // The Single's STORED rules, against the real document. Runs before anything
+  // is signed and before the trusted read below, so a refused caller reaches
+  // neither.
+  const { user, actor } = await callerFor(auth);
+  await assertSinglePreviewable(single, user, actor);
 
   const declaration = await singlePreviewDeclarationFor(single);
 
@@ -363,35 +411,14 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
   // read. Booted first because that gate resolves services from the container,
   // and on a cold process the permission lookup itself needs them registered.
   await getCachedNextly();
-  const roles = await resolveRoleSlugs(auth);
-
-  // An API key is authorized on the grants stamped on the KEY, never on its
-  // owner's roles. Without this the probe resolves the owner's RBAC — including
-  // a super-admin bypass — so a key holding `update-*` but not `read-*` would
-  // mint a link on the strength of an account that can read, handing out a
-  // bearer credential for a document the key itself may not fetch.
-  const actor: AuthenticatedScope | undefined =
-    auth.authMethod === "api-key"
-      ? { actorType: "apiKey", permissions: auth.permissions }
-      : undefined;
+  const { user, actor } = await callerFor(auth);
   // Authorized through the gate that serves collection reads and writes, so the
   // verdict here is the verdict the bearer's own read will reach. It asks two
   // questions the previous by-id probe could not express: whether the entry is
   // visible at all INCLUDING one never published, and whether this caller may
   // edit it — which is what the draft overlay requires before surfacing the
   // working draft the token hands out.
-  await assertEntryPreviewable(
-    collection,
-    entryId,
-    buildUserContext({
-      claims: auth.claims,
-      id: auth.userId,
-      name: auth.userName,
-      email: auth.userEmail,
-      roles,
-    }),
-    actor
-  );
+  await assertEntryPreviewable(collection, entryId, user, actor);
 
   // Refused BEFORE a token is signed, because a link that cannot land is worse
   // than no link: the reviewer who opens it sees a 404 indistinguishable from

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -318,16 +318,27 @@ async function callerFor(
  * then the registry — because a code-first Single is synced into the registry
  * and the two must not answer differently about the same document.
  */
-async function singleIsLocalized(slug: string): Promise<boolean> {
+async function singleFacts(
+  slug: string
+): Promise<{ localized: boolean; hasStatus: boolean }> {
   const authored = container
     .get<NextlyServiceConfig>("config")
     ?.singles?.find(s => s.slug === slug);
-  if (authored !== undefined) return authored.localized === true;
-
   const stored = await getService("singleRegistryService").getSingleBySlug(
     slug
   );
-  return stored?.localized === true;
+
+  // EITHER source saying yes is taken as yes, rather than the authored config
+  // answering alone. The two can disagree — a per-Single metadata sync that
+  // fails deliberately retains the previous registry row — and the read path
+  // consumes the registry, so a config-first answer reports a Single as
+  // unlocalized while every read still treats it as localized. That direction
+  // is the dangerous one: it accepts an omitted locale and signs a token whose
+  // absent claim covers every translation.
+  return {
+    localized: authored?.localized === true || stored?.localized === true,
+    hasStatus: authored?.status === true || stored?.status === true,
+  };
 }
 
 /**
@@ -361,7 +372,31 @@ async function mintForSingle(
   // the endpoint directly. Refused rather than widened: authorizing every
   // translation to honour the request would hand out the grant this exists to
   // withhold.
-  if (locale === undefined && (await singleIsLocalized(single))) {
+  const facts = await singleFacts(single);
+
+  // A Single with no Draft / Published lifecycle has no pending state to
+  // preview, so a link would hand its recipient the CURRENT private document
+  // rather than a draft — through a route that reads it trusted. The admin
+  // already withholds the control for exactly this; refusing here is the same
+  // rule for a caller that reaches the endpoint directly.
+  if (!facts.hasStatus) {
+    throw NextlyError.conflict({
+      reason: "state",
+      message:
+        "This single has no draft/published lifecycle, so there is no " +
+        "pending version to preview.",
+      logContext: {
+        reason: "preview-link-single-has-no-status",
+        remedy:
+          "Add `status: true` to the single. Without it every save is live, " +
+          "so a preview link would show the published document rather than " +
+          "an unpublished change.",
+        single,
+      },
+    });
+  }
+
+  if (locale === undefined && facts.localized) {
     throw NextlyError.invalidInput({
       message:
         "A localized single needs a locale, so the link grants one " +

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -312,6 +312,25 @@ async function callerFor(
 }
 
 /**
+ * Whether this Single carries translations.
+ *
+ * Read the way its preview declaration is read — the authored config first,
+ * then the registry — because a code-first Single is synced into the registry
+ * and the two must not answer differently about the same document.
+ */
+async function singleIsLocalized(slug: string): Promise<boolean> {
+  const authored = container
+    .get<NextlyServiceConfig>("config")
+    ?.singles?.find(s => s.slug === slug);
+  if (authored !== undefined) return authored.localized === true;
+
+  const stored = await getService("singleRegistryService").getSingleBySlug(
+    slug
+  );
+  return stored?.localized === true;
+}
+
+/**
  * Mint a link scoped to one Single.
  *
  * Two gates, because the route's own is one axis short of what the token hands
@@ -336,11 +355,33 @@ async function mintForSingle(
   // and on a cold process the permission lookup itself needs them registered.
   await getCachedNextly();
 
-  // The Single's STORED rules, against the real document. Runs before anything
-  // is signed and before the trusted read below, so a refused caller reaches
-  // neither.
+  // An unscoped token covers EVERY translation, which on a localized Single is
+  // a grant over drafts nobody authorized — the admin resolves a locale before
+  // it offers the control, and this is the same rule for a caller that reaches
+  // the endpoint directly. Refused rather than widened: authorizing every
+  // translation to honour the request would hand out the grant this exists to
+  // withhold.
+  if (locale === undefined && (await singleIsLocalized(single))) {
+    throw NextlyError.invalidInput({
+      message:
+        "A localized single needs a locale, so the link grants one " +
+        "translation rather than every one of them.",
+      logContext: {
+        reason: "preview-link-single-locale-required",
+        remedy:
+          "Name the translation being shared. A token with no locale claim " +
+          "covers every locale, including translations that have never been " +
+          "published.",
+        single,
+      },
+    });
+  }
+
+  // The Single's STORED rules, against the real document, in the TRANSLATION
+  // the token will name. Runs before anything is signed and before the trusted
+  // read below, so a refused caller reaches neither.
   const { user, actor } = await callerFor(auth);
-  await assertSinglePreviewable(single, user, actor);
+  await assertSinglePreviewable(single, locale, user, actor);
 
   const declaration = await singlePreviewDeclarationFor(single);
 

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -45,6 +45,7 @@ import { resolveRoleSlugs } from "../services/lib/permissions";
 
 import { assertEntryPreviewable } from "./preview-access";
 import {
+  loadSingleForPreview,
   previewDeclarationFor,
   singlePreviewDeclarationFor,
 } from "./preview-url";
@@ -303,18 +304,7 @@ async function mintForSingle(
     ? await resolveSinglePreviewRedirect(
         { single, ...(locale === undefined ? {} : { locale }) },
         {
-          loadSingle: async (slug, singleLocale) => {
-            const nextly = await getCachedNextly();
-            const document = await nextly.findSingle({
-              slug,
-              overrideAccess: true,
-              draft: true,
-              status: "all",
-              depth: 0,
-              ...(singleLocale === undefined ? {} : { locale: singleLocale }),
-            });
-            return document ?? null;
-          },
+          loadSingle: loadSingleForPreview,
           ...sharedRedirectDeps(declaration),
         }
       )

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -20,12 +20,21 @@
 import { z } from "zod";
 
 import type { AuthenticatedScope } from "../auth/authenticated-scope";
-import { signPreviewToken } from "../auth/preview/preview-token";
+import {
+  signPreviewToken,
+  type PreviewTokenScope,
+} from "../auth/preview/preview-token";
 import { buildUserContext } from "../auth/user-context";
 import { container, getService } from "../di";
 import type { NextlyServiceConfig } from "../di/register";
-import { resolvePreviewRedirect } from "../domains/collections/services/preview-redirect-resolver";
-import { hasPreviewConfigured } from "../domains/collections/services/preview-url-resolver";
+import {
+  resolvePreviewRedirect,
+  resolveSinglePreviewRedirect,
+} from "../domains/collections/services/preview-redirect-resolver";
+import {
+  hasPreviewConfigured,
+  type PreviewDeclaration,
+} from "../domains/collections/services/preview-url-resolver";
 import { resolvePreviewRoute } from "../domains/preview/route-config";
 import { resolvePreviewSiteUrl } from "../domains/preview/site-url";
 import { NextlyError } from "../errors/nextly-error";
@@ -35,7 +44,10 @@ import type { GeneralSettingsService } from "../services/general-settings/genera
 import { resolveRoleSlugs } from "../services/lib/permissions";
 
 import { assertEntryPreviewable } from "./preview-access";
-import { previewDeclarationFor } from "./preview-url";
+import {
+  previewDeclarationFor,
+  singlePreviewDeclarationFor,
+} from "./preview-url";
 import { respondMutation } from "./response-shapes";
 import {
   requireRouteCollectionAccess,
@@ -55,12 +67,32 @@ import { nextlyValidationFromZod } from "./zod-to-nextly-error";
  */
 const MAX_TTL_SECONDS = 7 * 24 * 60 * 60;
 
-const mintSchema = z.object({
-  collection: z.string().min(1),
-  entryId: z.string().min(1),
-  locale: z.string().min(1).optional(),
-  ttlSeconds: z.number().int().positive().max(MAX_TTL_SECONDS).optional(),
-});
+/**
+ * What a mint request may name: ONE collection entry, or ONE Single.
+ *
+ * A union rather than three optional fields, so "both" and "neither" are
+ * unrepresentable rather than validated afterwards. Naming both is not a
+ * narrower request — they are different documents — and honouring one silently
+ * would mint a credential for a document the caller may not have meant.
+ *
+ * The entry variant is unchanged, so every existing caller keeps working.
+ */
+const mintSchema = z.union([
+  z.object({
+    collection: z.string().min(1),
+    entryId: z.string().min(1),
+    single: z.undefined().optional(),
+    locale: z.string().min(1).optional(),
+    ttlSeconds: z.number().int().positive().max(MAX_TTL_SECONDS).optional(),
+  }),
+  z.object({
+    single: z.string().min(1),
+    collection: z.undefined().optional(),
+    entryId: z.undefined().optional(),
+    locale: z.string().min(1).optional(),
+    ttlSeconds: z.number().int().positive().max(MAX_TTL_SECONDS).optional(),
+  }),
+]);
 
 async function settingsService(): Promise<GeneralSettingsService> {
   await getCachedNextly();
@@ -131,15 +163,201 @@ function previewLinkUrl({
 }
 
 /**
+ * The two loaders both redirect resolvers need identically.
+ *
+ * The document loaders genuinely differ — one reads an entry by id through the
+ * collections handler, the other reads a Single by slug through the Direct API —
+ * but where the DECLARATION and the site URL come from does not, and writing
+ * that twice is how the two paths start disagreeing about which settings read
+ * they trust.
+ */
+function sharedRedirectDeps(declaration: PreviewDeclaration | undefined): {
+  loadDeclaration: () => Promise<PreviewDeclaration | undefined>;
+  loadSiteUrl: () => Promise<string | null>;
+} {
+  return {
+    // Already resolved by the caller, so this hands the value back rather than
+    // fetching it again.
+    loadDeclaration: () => Promise.resolve(declaration),
+    loadSiteUrl: async () =>
+      resolvePreviewSiteUrl(
+        await (await settingsService()).getSettings().then(s => s.siteUrl)
+      ),
+  };
+}
+
+/**
+ * The one refusal both mint paths make, and the two causes it distinguishes.
+ *
+ * Written once because the DECISION is one decision — "there is nowhere for
+ * this link to open" — while only the noun and the remedy differ. Two copies
+ * would drift in the wording, and the wording is the whole value of it: this is
+ * the message an editor reads instead of finding out from a reviewer that the
+ * link 404s.
+ *
+ * The two causes are kept apart because they name different people. An
+ * unconfigured collection or Single is a developer's job; a document whose
+ * address cannot be built yet is usually one empty field the editor can fill.
+ * Telling an editor to "ask a developer" about their own unfilled slug sends
+ * them to the wrong person.
+ */
+function refuseUnservableLink(args: {
+  subject: "collection" | "single";
+  name: string;
+  declared: boolean;
+}): never {
+  const { subject, name, declared } = args;
+  const noun = subject === "single" ? "single" : "collection";
+
+  throw NextlyError.conflict({
+    reason: "state",
+    message: declared
+      ? `This ${subject === "single" ? "single" : "entry"} has no preview ` +
+        "address yet, so a shared link would have nowhere to open. Filling in " +
+        "the fields its preview URL is built from — usually the slug — makes " +
+        "it shareable."
+      : `This ${noun} has no preview URL configured, so a shared link would ` +
+        "have nowhere to open. A developer can add one before links can be " +
+        "shared.",
+    logContext: {
+      reason: declared
+        ? `preview-link-${subject}-has-no-preview-target`
+        : `preview-link-${subject}-has-no-preview-url`,
+      remedy: declared
+        ? "The preview declaration returned no address for this document. A " +
+          "`url` function answering null, or a `urlTemplate` whose placeholder " +
+          "field is empty, both mean 'not previewable yet'."
+        : "Add `admin.preview.url` (code-first) or `admin.preview.urlTemplate` " +
+          "(UI-created). It answers where the document is served on the site, " +
+          "which nothing outside the application can know.",
+      [noun]: name,
+    },
+  });
+}
+
+/**
+ * Sign a scope and answer with the link, which is identical for both paths.
+ *
+ * The generation is read here rather than by each caller, so a link minted for
+ * a Single and one minted for an entry cannot end up recorded against different
+ * revocation generations — which would make "revoke everything" miss one kind.
+ */
+async function respondWithPreviewLink(
+  scope: PreviewTokenScope,
+  ttlSeconds?: number
+): Promise<Response> {
+  const generation = await (
+    await settingsService()
+  ).getPreviewTokenGeneration();
+
+  const { token, expiresAt } = await signPreviewToken(
+    scope,
+    previewSigningSecret(),
+    { generation, ...(ttlSeconds === undefined ? {} : { ttlSeconds }) }
+  );
+
+  const settings = await (await settingsService()).getSettings();
+
+  return respondMutation("Preview link created", {
+    token,
+    url: previewLinkUrl({
+      siteUrl: resolvePreviewSiteUrl(settings.siteUrl),
+      route: resolvePreviewRoute(
+        container.get<NextlyServiceConfig>("config")?.preview
+      ),
+      token,
+    }),
+    expiresAt: expiresAt.toISOString(),
+  });
+}
+
+/**
+ * Mint a link scoped to one Single.
+ *
+ * Authorized with the SAME gate a Single's document update asks for, keyed on
+ * its slug — which is what the dispatcher uses for every write to it. So a
+ * caller who cannot edit the Single cannot mint a credential to read its draft.
+ *
+ * There is no second, row-level probe as there is for an entry, and there is
+ * nothing missing: that probe exists because a collection gate answers about
+ * the COLLECTION while the token names one ENTRY, and a row-level rule makes
+ * the two diverge. A Single has exactly one document, so the gate's subject and
+ * the token's subject are the same thing.
+ */
+async function mintForSingle(
+  req: Request,
+  args: { single: string; locale?: string; ttlSeconds?: number }
+): Promise<Response> {
+  const { single, locale, ttlSeconds } = args;
+
+  await requireRouteCollectionAccess(req, "update", single);
+  await getCachedNextly();
+
+  const declaration = await singlePreviewDeclarationFor(single);
+
+  // Resolved for THIS Single, not merely checked for a declaration, for the
+  // same reason the entry path does it: a `url` answering null means "not
+  // previewable yet", and minting on the strength of a declaration alone hands
+  // out a link that 404s at the redirect.
+  const target = hasPreviewConfigured(declaration)
+    ? await resolveSinglePreviewRedirect(
+        { single, ...(locale === undefined ? {} : { locale }) },
+        {
+          loadSingle: async (slug, singleLocale) => {
+            const nextly = await getCachedNextly();
+            const document = await nextly.findSingle({
+              slug,
+              overrideAccess: true,
+              draft: true,
+              status: "all",
+              depth: 0,
+              ...(singleLocale === undefined ? {} : { locale: singleLocale }),
+            });
+            return document ?? null;
+          },
+          ...sharedRedirectDeps(declaration),
+        }
+      )
+    : null;
+
+  if (target === null) {
+    refuseUnservableLink({
+      subject: "single",
+      name: single,
+      declared: hasPreviewConfigured(declaration),
+    });
+  }
+
+  return respondWithPreviewLink(
+    { kind: "single", single, ...(locale === undefined ? {} : { locale }) },
+    ttlSeconds
+  );
+}
+
+/**
  * POST /api/nextly/preview-links
  *
- * Mints a link scoped to one entry. Auth: `update` on that collection.
+ * Mints a link scoped to one entry, or to one Single. Auth: `update` on the
+ * collection, or on the Single's own slug.
  */
 export const mintPreviewLink = withErrorHandler(async (req: Request) => {
   const body: unknown = await req.json().catch(() => undefined);
   const parsed = mintSchema.safeParse(body);
   if (!parsed.success) throw nextlyValidationFromZod(parsed.error);
-  const { collection, entryId, locale, ttlSeconds } = parsed.data;
+  const { locale, ttlSeconds } = parsed.data;
+
+  // A Single takes its own path from here. It shares the refusal and the link
+  // assembly and nothing else: it is addressed by slug with no id, so there is
+  // no entry to authorize by row and no by-id read to make.
+  if (parsed.data.single !== undefined) {
+    return mintForSingle(req, {
+      single: parsed.data.single,
+      ...(locale === undefined ? {} : { locale }),
+      ...(ttlSeconds === undefined ? {} : { ttlSeconds }),
+    });
+  }
+
+  const { collection, entryId } = parsed.data;
 
   // The gate is per COLLECTION, so a caller who may edit posts cannot mint a
   // link into a collection they have no access to by naming it here.
@@ -233,80 +451,23 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
           // Already resolved above, so this hands back the value rather than
           // fetching it again — the resolver takes a loader and this call site
           // happens to have the answer.
-          loadDeclaration: () => Promise.resolve(declaration),
-          loadSiteUrl: async () =>
-            resolvePreviewSiteUrl(
-              await (await settingsService()).getSettings().then(s => s.siteUrl)
-            ),
+          ...sharedRedirectDeps(declaration),
         }
       )
     : null;
 
   if (target === null) {
-    throw NextlyError.conflict({
-      reason: "state",
-      message: hasPreviewConfigured(declaration)
-        ? "This entry has no preview address yet, so a shared link would have " +
-          "nowhere to open. Filling in the fields its preview URL is built " +
-          "from — usually the slug — makes it shareable."
-        : "This collection has no preview URL configured, so a shared link " +
-          "would have nowhere to open. A developer can add one to the " +
-          "collection before links can be shared.",
-      logContext: {
-        reason: hasPreviewConfigured(declaration)
-          ? "preview-link-entry-has-no-preview-target"
-          : "preview-link-collection-has-no-preview-url",
-        remedy: hasPreviewConfigured(declaration)
-          ? "The collection's preview declaration returned no address for this " +
-            "entry. A `url` function answering null, or a `urlTemplate` whose " +
-            "placeholder field is empty, both mean 'not previewable yet'."
-          : "Add `admin.preview.url` (code-first) or `admin.preview.urlTemplate` " +
-            "(UI-created) to this collection. It answers where an entry is served " +
-            "on the site, which nothing outside the application can know.",
-        collection,
-      },
+    refuseUnservableLink({
+      subject: "collection",
+      name: collection,
+      declared: hasPreviewConfigured(declaration),
     });
   }
 
-  const generation = await (
-    await settingsService()
-  ).getPreviewTokenGeneration();
-
-  const { token, expiresAt } = await signPreviewToken(
+  return respondWithPreviewLink(
     { collection, entryId, ...(locale === undefined ? {} : { locale }) },
-    previewSigningSecret(),
-    { generation, ...(ttlSeconds === undefined ? {} : { ttlSeconds }) }
+    ttlSeconds
   );
-
-  // The finished URL as well as the token.
-  //
-  // Both halves are visible from here and from nowhere else. The site URL lives
-  // in settings, which the `editor` and `author` presets cannot read; the mount
-  // lives in the application's config, which the browser cannot see at all. So
-  // the admin had no way to build this correctly and assumed a default, which
-  // is why an application that mounted the route elsewhere handed its reviewers
-  // a link that answered 404.
-  //
-  // `null` when no site URL is set, never a relative URL: a relative one would
-  // be resolved against whatever origin the admin is served from, which is not
-  // the site. The token is still returned, because it is what the link is —
-  // withholding it would break preview outright on a site that never set a
-  // URL, rather than degrading the one thing that needs the host.
-  const settings = await (await settingsService()).getSettings();
-  const siteUrl = resolvePreviewSiteUrl(settings.siteUrl);
-  const url = previewLinkUrl({
-    siteUrl,
-    route: resolvePreviewRoute(
-      container.get<NextlyServiceConfig>("config")?.preview
-    ),
-    token,
-  });
-
-  return respondMutation("Preview link created", {
-    token,
-    url,
-    expiresAt: expiresAt.toISOString(),
-  });
 });
 
 /**

--- a/packages/nextly/src/api/preview-url.ts
+++ b/packages/nextly/src/api/preview-url.ts
@@ -34,6 +34,7 @@ import {
   type PreviewDeclaration,
 } from "../domains/collections/services/preview-url-resolver";
 import { resolvePreviewSiteUrl } from "../domains/preview/site-url";
+import type { SingleRegistryService } from "../domains/singles/services/single-registry-service";
 import { getCachedNextly } from "../init";
 import type { GeneralSettingsService } from "../services/general-settings/general-settings-service";
 
@@ -93,6 +94,34 @@ export async function previewDeclarationFor(
     "collectionRegistryService"
   );
   const stored = await registry.getCollectionBySlug(collection);
+  return stored?.admin?.preview;
+}
+
+/**
+ * Read the preview declaration for a Single.
+ *
+ * The mirror of {@link previewDeclarationFor}, and separate for the same reason
+ * the resolvers are: a Single is addressed by slug with no id, so the lookup
+ * differs even though what is done with the answer does not.
+ *
+ * The AUTHORED config is consulted first, and the order is load-bearing for the
+ * identical reason: a code-first Single is synced into the registry, but the
+ * `url` function cannot survive that trip, so reading the registry first would
+ * find a declaration for exactly those Singles and find it empty.
+ */
+export async function singlePreviewDeclarationFor(
+  slug: string
+): Promise<PreviewDeclaration | undefined> {
+  await getCachedNextly();
+
+  const config = container.get<NextlyServiceConfig>("config");
+  const authored = config?.singles?.find(s => s.slug === slug);
+  if (authored?.admin?.preview) return authored.admin.preview;
+
+  const registry = container.get<SingleRegistryService>(
+    "singleRegistryService"
+  );
+  const stored = await registry.getSingleBySlug(slug);
   return stored?.admin?.preview;
 }
 

--- a/packages/nextly/src/api/preview-url.ts
+++ b/packages/nextly/src/api/preview-url.ts
@@ -126,6 +126,43 @@ export async function singlePreviewDeclarationFor(
 }
 
 /**
+ * A Single's document, read the way a preview redirect needs it.
+ *
+ * Shared by the minting endpoint and the preview route's own default, because
+ * they are asking one question — where does this Single's DRAFT live — and two
+ * implementations of it would drift into minting a link at one address and
+ * landing it at another.
+ *
+ * Trusted, because both callers are already past their own authorization: the
+ * mint has checked `update` on the Single, and whoever follows a link carries a
+ * signed token that recorded that verdict. What this produces is a path, never
+ * content.
+ *
+ * The working draft's values rather than the published row's, and every status,
+ * because an editor sharing a draft is sharing what the draft says — and a
+ * Single that has never been published is exactly the one a preview link is most
+ * often minted for.
+ */
+export async function loadSingleForPreview(
+  slug: string,
+  locale: string | undefined
+): Promise<Record<string, unknown> | null> {
+  const nextly = await getCachedNextly();
+  const document = await nextly.findSingle({
+    slug,
+    overrideAccess: true,
+    draft: true,
+    status: "all",
+    // No relationships: every field a preview URL can be built from is scalar,
+    // so expanding would read further collections to answer a question none of
+    // them contribute to.
+    depth: 0,
+    ...(locale === undefined ? {} : { locale }),
+  });
+  return document ?? null;
+}
+
+/**
  * POST /api/nextly/preview-url
  *
  * Answers with one of the resolver's states, so a caller can tell "this

--- a/packages/nextly/src/api/versions-access.ts
+++ b/packages/nextly/src/api/versions-access.ts
@@ -223,6 +223,9 @@ async function canUpdateLiveSingle(
   // is this gate's own.
   return singleDocumentEditable(slug, {
     user,
+    // A version-label edit is a route-authorized `update`, so the coarse gate
+    // for the operation being probed here has already run.
+    routeAuthorized: true,
     ...(authenticatedScope === undefined ? {} : { actor: authenticatedScope }),
   });
 }
@@ -298,6 +301,10 @@ async function canReadLiveSingle(
   // Shared with draft preview for the reason the update gate above gives.
   return singleDocumentReadable(slug, {
     user,
+    // The version route gates on `read` before reaching here, so the coarse
+    // read check has run and re-running it would reject a scoped API key by
+    // resolving its creator's roles.
+    routeAuthorized: true,
     ...(authenticatedScope === undefined ? {} : { actor: authenticatedScope }),
   });
 }

--- a/packages/nextly/src/api/versions-access.ts
+++ b/packages/nextly/src/api/versions-access.ts
@@ -20,7 +20,10 @@ import type { FieldConfig } from "../collections/fields/types";
 import { getService } from "../di";
 import { container } from "../di/container";
 import type { FieldGroupDataService } from "../domains/field-groups/services/field-group-data-service";
-import { checkSingleAccess } from "../domains/singles";
+import {
+  singleDocumentEditable,
+  singleDocumentReadable,
+} from "../domains/singles/services/single-document-access";
 import type { UserContext } from "../domains/singles/types";
 import { computeVersionDiff } from "../domains/versions/diff";
 import type { VersionDiff } from "../domains/versions/diff";
@@ -36,7 +39,6 @@ import type {
   ResolvedVersionsConfig,
   VersionScopeKind,
 } from "../schemas/versions/types";
-import { AccessControlService } from "../services/access/access-control-service";
 import { resolveRoleSlugs } from "../services/lib/permissions";
 import { applyFieldReadAccess } from "../shared/lib/field-level-registry";
 import { stripPasswordFieldValues } from "../shared/lib/password-fields";
@@ -213,40 +215,16 @@ async function canUpdateLiveSingle(
   user: UserContext,
   authenticatedScope?: AuthenticatedScope
 ): Promise<boolean> {
-  const registry = getService("singleRegistryService");
-  const record = await registry.getSingleBySlug(slug);
-  if (!record?.tableName) return false;
-
   const liveId = await resolveSingleDocumentId(slug);
   if (liveId === null || liveId !== entryId) return false;
 
-  const adapter = getService("adapter");
-  // Loaded because an owner-only rule compares against the stored row, and
-  // `checkSingleAccess` refuses outright when such a rule has no document.
-  const document = await adapter.selectOne<Record<string, unknown>>(
-    record.tableName,
-    {}
-  );
-  if (!document) return false;
-
-  const denied = await checkSingleAccess({
-    slug,
-    operation: "update",
+  // The access evaluation itself is shared with draft preview, which authorizes
+  // the same disclosure for the same reason. Only the identity comparison above
+  // is this gate's own.
+  return singleDocumentEditable(slug, {
     user,
-    overrideAccess: false,
-    routeAuthorized: true,
-    rbacAccessControlService: getService("rbacAccessControlService"),
-    // Stateless evaluator for the Single's stored rules; it holds no
-    // per-request state, so constructing one here matches the write path.
-    accessControlService: new AccessControlService(),
-    accessRules: record.accessRules,
-    document,
-    // A scoped API key is judged on its own update grant, so a super-admin-owned
-    // key does not skip stored owner/role rules on a version-label edit.
-    authenticatedScope,
-    logger: getService("logger"),
+    ...(authenticatedScope === undefined ? {} : { actor: authenticatedScope }),
   });
-  return denied === null;
 }
 
 /**
@@ -317,17 +295,11 @@ async function canReadLiveSingle(
   const liveId = await resolveSingleDocumentId(slug);
   if (liveId === null || liveId !== entryId) return false;
 
-  const singles = getService("singleEntryService");
-  const result = await singles.get(slug, {
+  // Shared with draft preview for the reason the update gate above gives.
+  return singleDocumentReadable(slug, {
     user,
-    overrideAccess: false,
-    routeAuthorized: true,
-    // A scoped API key is judged on its OWN read grant, mirroring the collection
-    // read gate above.
-    authenticatedScope,
-    status: "all",
+    ...(authenticatedScope === undefined ? {} : { actor: authenticatedScope }),
   });
-  return interpretReadResult(result.success, result.statusCode);
 }
 
 /**

--- a/packages/nextly/src/auth/preview/__tests__/preview-token.test.ts
+++ b/packages/nextly/src/auth/preview/__tests__/preview-token.test.ts
@@ -238,3 +238,103 @@ describe("preview tokens", () => {
     });
   });
 });
+
+describe("a token that names a Single", () => {
+  // A Single has a draft lifecycle but no entry id — it is addressed by slug
+  // and there is exactly one of it. Squeezing that into `{collection, entryId}`
+  // would mean inventing an id that names nothing, and `previewTokenCovers`
+  // comparing two made-up values.
+  it("round-trips a single scope", async () => {
+    const { token } = await signPreviewToken(
+      { kind: "single", single: "homepage" },
+      TEST_SECRET,
+      { generation: GENERATION }
+    );
+
+    const verified = await verifyPreviewToken(token, TEST_SECRET, {
+      generation: GENERATION,
+    });
+
+    expect(verified.valid && verified.scope).toEqual({
+      kind: "single",
+      single: "homepage",
+    });
+  });
+
+  it("round-trips a single scope restricted to one locale", async () => {
+    const { token } = await signPreviewToken(
+      { kind: "single", single: "homepage", locale: "fr" },
+      TEST_SECRET,
+      { generation: GENERATION }
+    );
+
+    const verified = await verifyPreviewToken(token, TEST_SECRET, {
+      generation: GENERATION,
+    });
+
+    expect(verified.valid && verified.scope).toEqual({
+      kind: "single",
+      single: "homepage",
+      locale: "fr",
+    });
+  });
+
+  it("does not cover a different single", () => {
+    expect(
+      previewTokenCovers(
+        { kind: "single", single: "homepage" },
+        { kind: "single", single: "footer" }
+      )
+    ).toBe(false);
+  });
+
+  // The two kinds must not satisfy each other. A single named `pages` and a
+  // collection named `pages` are different documents, and a comparison that
+  // ignored the kind would let one link open the other.
+  it("does not cover a collection entry, nor the reverse", () => {
+    expect(
+      previewTokenCovers(
+        { kind: "single", single: "pages" },
+        { collection: "pages", entryId: "pages" }
+      )
+    ).toBe(false);
+    expect(
+      previewTokenCovers(
+        { collection: "pages", entryId: "pages" },
+        { kind: "single", single: "pages" }
+      )
+    ).toBe(false);
+  });
+
+  it("refuses an empty single slug at the mint, as it does an empty locale", async () => {
+    await expect(
+      signPreviewToken({ kind: "single", single: "" }, TEST_SECRET, {
+        generation: GENERATION,
+      })
+    ).rejects.toThrow();
+  });
+});
+
+describe("tokens minted before the scope gained a kind", () => {
+  // The load-bearing compatibility case. Every outstanding link was signed
+  // without a `kind` claim, and an editor who shared one last week must not
+  // find it dead because the type grew a discriminant.
+  it("still verifies as an entry scope", async () => {
+    // Signed through the same signer, which omits `kind` for an entry scope —
+    // so this is byte-identical to what the previous version produced.
+    const { token } = await signPreviewToken(
+      { collection: "pages", entryId: "7" },
+      TEST_SECRET,
+      { generation: GENERATION }
+    );
+
+    const verified = await verifyPreviewToken(token, TEST_SECRET, {
+      generation: GENERATION,
+    });
+
+    expect(verified.valid && verified.scope).toEqual({
+      collection: "pages",
+      entryId: "7",
+    });
+  });
+});

--- a/packages/nextly/src/auth/preview/preview-token.ts
+++ b/packages/nextly/src/auth/preview/preview-token.ts
@@ -46,13 +46,55 @@ const PREVIEW_KEY_BYTES = 32;
 export const DEFAULT_PREVIEW_TTL_SECONDS = 60 * 60;
 
 /** The single document a preview token authorizes, and nothing else. */
-export interface PreviewTokenScope {
+/** One entry of a collection. */
+export interface PreviewEntryScope {
+  /**
+   * Optional, and that is what keeps every already-minted link working.
+   *
+   * Tokens signed before this type gained a discriminant carry no `kind` claim
+   * at all, so requiring one would kill every outstanding link the moment this
+   * shipped — an editor who shared a draft last week would find it dead with no
+   * explanation. An absent kind reads as an entry, which is what those tokens
+   * are.
+   */
+  kind?: "entry";
   /** Collection slug the entry belongs to. */
   collection: string;
   /** The entry's id. Ids, not slugs: a slug can be edited on the draft itself. */
   entryId: string;
   /** Locale to preview, when the entry is localized. */
   locale?: string;
+}
+
+/**
+ * One Single.
+ *
+ * Addressed by slug and not by id, because there is exactly one of it and its
+ * identity IS the slug. Reusing the entry shape would mean inventing an id that
+ * names nothing and having `previewTokenCovers` compare two made-up values.
+ */
+export interface PreviewSingleScope {
+  kind: "single";
+  /** The Single's slug. */
+  single: string;
+  /** Locale to preview, when the Single is localized. */
+  locale?: string;
+}
+
+/**
+ * The ONE document a preview token authorizes.
+ *
+ * A union rather than a widened entry shape, so a comparison cannot accidentally
+ * satisfy one kind with the other: a Single named `pages` and a collection named
+ * `pages` are different documents.
+ */
+export type PreviewTokenScope = PreviewEntryScope | PreviewSingleScope;
+
+/** Whether a scope names a Single rather than a collection entry. */
+export function isSingleScope(
+  scope: PreviewTokenScope
+): scope is PreviewSingleScope {
+  return scope.kind === "single";
 }
 
 export interface SignPreviewTokenOptions {
@@ -104,6 +146,21 @@ export async function signPreviewToken(
   // covers every locale — so an empty string would quietly widen a
   // locale-specific link into an all-locales grant. Refusing at the mint is
   // where the caller can still be told.
+  // Refused for the same reason an empty locale is: verification reads an
+  // unusable claim as ABSENT, and an absent single slug would leave a token
+  // that names no document at all.
+  if (isSingleScope(scope) && scope.single.length === 0) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "single",
+          code: "INVALID_FORMAT",
+          message: "A preview token's single slug must be a non-empty string.",
+        },
+      ],
+    });
+  }
+
   if (scope.locale !== undefined && scope.locale.length === 0) {
     throw NextlyError.validation({
       errors: [
@@ -121,9 +178,15 @@ export async function signPreviewToken(
   const issuedAt = Math.floor(Date.now() / 1000);
   const expiresAt = issuedAt + ttlSeconds;
 
+  // An entry scope is signed WITHOUT a `kind` claim, byte-identical to what
+  // this signer produced before Singles existed. That keeps the common token
+  // unchanged rather than migrating every outstanding link.
+  const claims = isSingleScope(scope)
+    ? { kind: "single" as const, sng: scope.single }
+    : { col: scope.collection, eid: scope.entryId };
+
   const token = await new SignJWT({
-    col: scope.collection,
-    eid: scope.entryId,
+    ...claims,
     ...(scope.locale === undefined ? {} : { loc: scope.locale }),
     gen: options.generation,
   })
@@ -131,7 +194,11 @@ export async function signPreviewToken(
     .setAudience(PREVIEW_AUDIENCE)
     // `sub` names the document rather than a user: nobody is authenticated by
     // this token, and reading it as a user id is the mistake worth preventing.
-    .setSubject(`${scope.collection}:${scope.entryId}`)
+    .setSubject(
+      isSingleScope(scope)
+        ? `single:${scope.single}`
+        : `${scope.collection}:${scope.entryId}`
+    )
     .setJti(randomBytes(16).toString("hex"))
     .setIssuedAt(issuedAt)
     .setExpirationTime(expiresAt)
@@ -143,6 +210,39 @@ export async function signPreviewToken(
 /** Whether a decoded claim value is a usable, non-empty string. */
 function readString(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/**
+ * The document a verified payload names, or `null` when it names none.
+ *
+ * Split out of the verifier so the two questions stay separate: that function
+ * answers "is this token real", and this one answers "what does it point at".
+ * The locale is deliberately NOT read here — it qualifies whichever document
+ * this returns, and folding it in would make one function answer both.
+ *
+ * An absent `kind` is an ENTRY, which is what every token minted before Singles
+ * existed carries. A kind that is present but unrecognised is refused rather
+ * than defaulted: one this version cannot judge is not one to guess at, and
+ * treating it as an entry would read `col`/`eid` claims never meant to be an
+ * entry's. A token missing what its kind requires names no document at all, so
+ * it is malformed rather than a grant over everything.
+ */
+function decodeScope(
+  payload: Record<string, unknown>
+): PreviewTokenScope | null {
+  const kind = payload.kind;
+
+  if (kind === "single") {
+    const single = readString(payload.sng);
+    return single === null ? null : { kind: "single", single };
+  }
+
+  if (kind !== undefined) return null;
+
+  const collection = readString(payload.col);
+  const entryId = readString(payload.eid);
+  if (collection === null || entryId === null) return null;
+  return { collection, entryId };
 }
 
 /**
@@ -169,13 +269,8 @@ export async function verifyPreviewToken(
     return { valid: false, reason: "invalid" };
   }
 
-  const collection = readString(payload.col);
-  const entryId = readString(payload.eid);
-  // A token missing either half names no document, so there is nothing it could
-  // authorize. Treated as malformed rather than as a grant over everything.
-  if (collection === null || entryId === null) {
-    return { valid: false, reason: "invalid" };
-  }
+  const scope = decodeScope(payload);
+  if (scope === null) return { valid: false, reason: "invalid" };
 
   // Checked AFTER the shape, so a malformed token is never reported as merely
   // revoked — the two need different answers from a caller.
@@ -210,11 +305,7 @@ export async function verifyPreviewToken(
 
   return {
     valid: true,
-    scope: {
-      collection,
-      entryId,
-      ...(locale === null ? {} : { locale }),
-    },
+    scope: locale === null ? scope : { ...scope, locale },
     expiresAt,
   };
 }
@@ -235,8 +326,20 @@ export function previewTokenCovers(
   scope: PreviewTokenScope,
   requested: PreviewTokenScope
 ): boolean {
-  if (scope.collection !== requested.collection) return false;
-  if (scope.entryId !== requested.entryId) return false;
+  // The KIND first, so one kind can never satisfy the other: a Single named
+  // `pages` and a collection named `pages` are different documents, and a
+  // comparison that only looked at names would let one link open the other.
+  if (isSingleScope(scope) !== isSingleScope(requested)) return false;
+
+  if (isSingleScope(scope) && isSingleScope(requested)) {
+    if (scope.single !== requested.single) return false;
+  } else if (!isSingleScope(scope) && !isSingleScope(requested)) {
+    if (scope.collection !== requested.collection) return false;
+    if (scope.entryId !== requested.entryId) return false;
+  }
+
+  // An absent locale covers every locale, deliberately: a link minted without
+  // one is a link to the document rather than to one translation of it.
   if (scope.locale === undefined) return true;
   return scope.locale === requested.locale;
 }

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -36,6 +36,7 @@ export {
   type SingleAdminOptions,
   type SingleAccessControl,
   type SingleHooks,
+  type SinglePreviewConfig,
 } from "./singles/config/define-single";
 
 // Hook types for collection hooks

--- a/packages/nextly/src/direct-api/namespaces/singles.ts
+++ b/packages/nextly/src/direct-api/namespaces/singles.ts
@@ -43,6 +43,11 @@ export async function findSingle<TSlug extends SingleSlug>(
     // field falls back to the default language, and a rule keyed on it sees
     // `undefined` when it is dropped here.
     fallbackLocale: config.fallbackLocale,
+    // Forwarded to the same service option `findByID` uses for its own `draft`
+    // flag, so one idea keeps one spelling across the two read paths. The
+    // service applies the trust gate; nothing is decided here.
+    includeWorkingDraft: args.draft,
+    ...(args.status === undefined ? {} : { status: args.status }),
     ...accessOptions(config),
     context: config.context,
   });

--- a/packages/nextly/src/direct-api/types/singles.ts
+++ b/packages/nextly/src/direct-api/types/singles.ts
@@ -26,6 +26,30 @@ export interface FindSingleArgs<TSlug extends SingleSlug = SingleSlug>
   slug: TSlug;
 
   /**
+   * Return the pending working draft in place of the live document when one
+   * exists (draft/published split). Mirrors `draft` on `findByID`, and forwards
+   * to the same service option, so a Single and a collection entry are read the
+   * same way rather than through two spellings of one idea.
+   *
+   * Gated by trust in the service: a caller who cannot edit the document still
+   * gets the published values, so this never exposes a draft to a read-only
+   * caller.
+   *
+   * @default false
+   */
+  draft?: boolean;
+
+  /**
+   * Which lifecycle states this read may return, for a Single carrying the
+   * `status` column.
+   *
+   * `"all"` is what reaches a Single that has never been published — the state a
+   * preview link is most often shared from — which the default published-only
+   * filter reports as missing.
+   */
+  status?: "published" | "draft" | "all";
+
+  /**
    * Specific fields to include/exclude.
    */
   select?: Record<string, boolean>;

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
@@ -10,7 +10,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   resolvePreviewRedirect,
+  resolveSinglePreviewRedirect,
   type PreviewRedirectDeps,
+  type SinglePreviewRedirectDeps,
 } from "../preview-redirect-resolver";
 
 const SCOPE = { collection: "pages", entryId: "entry-1" };
@@ -182,5 +184,92 @@ describe("resolvePreviewRedirect", () => {
     });
 
     expect(await resolvePreviewRedirect(SCOPE, d)).toBeNull();
+  });
+});
+
+describe("resolveSinglePreviewRedirect", () => {
+  function singleDeps(
+    overrides: Partial<SinglePreviewRedirectDeps> = {}
+  ): SinglePreviewRedirectDeps {
+    return {
+      loadSingle: vi.fn().mockResolvedValue({ path: "welcome" }),
+      loadDeclaration: vi.fn().mockResolvedValue({ url: () => "/" }),
+      loadSiteUrl: vi.fn().mockResolvedValue("https://site.example"),
+      ...overrides,
+    };
+  }
+
+  it("answers the path the declaration names", async () => {
+    expect(
+      await resolveSinglePreviewRedirect({ single: "homepage" }, singleDeps())
+    ).toBe("/");
+  });
+
+  it("reads the Single in the locale the token names", async () => {
+    const loadSingle = vi.fn().mockResolvedValue({ path: "accueil" });
+
+    await resolveSinglePreviewRedirect(
+      { single: "homepage", locale: "fr" },
+      singleDeps({ loadSingle })
+    );
+
+    expect(loadSingle).toHaveBeenCalledWith("homepage", "fr");
+  });
+
+  it("can derive the path from the Single's own document", async () => {
+    const d = singleDeps({
+      loadDeclaration: vi.fn().mockResolvedValue({
+        url: (doc: Record<string, unknown>) => `/${String(doc.path)}`,
+      }),
+    });
+
+    expect(await resolveSinglePreviewRedirect({ single: "landing" }, d)).toBe(
+      "/welcome"
+    );
+  });
+
+  it("returns null when the Single declares no preview", async () => {
+    const d = singleDeps({
+      loadDeclaration: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(
+      await resolveSinglePreviewRedirect({ single: "homepage" }, d)
+    ).toBeNull();
+  });
+
+  // A Single is not deleted the way an entry is, but it can be dropped from the
+  // configuration — and a link minted before that points at nothing.
+  it("returns null when the Single can no longer be read", async () => {
+    const d = singleDeps({ loadSingle: vi.fn().mockResolvedValue(null) });
+
+    expect(
+      await resolveSinglePreviewRedirect({ single: "homepage" }, d)
+    ).toBeNull();
+  });
+
+  // The same refusal the entry path makes, reached through the SAME reduction
+  // rather than a second origin comparison written beside it.
+  it("refuses an absolute url on another origin", async () => {
+    const d = singleDeps({
+      loadDeclaration: vi
+        .fn()
+        .mockResolvedValue({ url: () => "https://elsewhere.example/x" }),
+    });
+
+    expect(
+      await resolveSinglePreviewRedirect({ single: "homepage" }, d)
+    ).toBeNull();
+  });
+
+  it("works with no site url configured, as a fresh install has none", async () => {
+    const d = singleDeps({
+      loadSiteUrl: vi.fn().mockResolvedValue(null),
+      loadDeclaration: vi.fn().mockResolvedValue({ url: () => "/about" }),
+    });
+
+    expect(await resolveSinglePreviewRedirect({ single: "homepage" }, d)).toBe(
+      "/about"
+    );
   });
 });

--- a/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
@@ -87,7 +87,30 @@ export async function resolvePreviewRedirect(
   // and clicking, and that is a refusal rather than a fault.
   if (entry === null) return null;
 
-  const resolution = resolvePreviewUrl({ preview, entry, siteUrl });
+  return reduceToSitePath({ preview, document: entry, siteUrl, requestOrigin });
+}
+
+/**
+ * A preview declaration and a document reduced to a site-relative path.
+ *
+ * Shared by the entry path above and the Single path beside it rather than
+ * written twice. Both ask the identical question — given a declaration and the
+ * document it describes, what path on this site does it name — and two copies
+ * of an origin comparison agree only until one is edited, at which point the
+ * one that drifted still returns a plausible-looking path.
+ */
+export function reduceToSitePath({
+  preview,
+  document,
+  siteUrl,
+  requestOrigin,
+}: {
+  preview: PreviewDeclaration | undefined;
+  document: Record<string, unknown>;
+  siteUrl: string | null;
+  requestOrigin?: string;
+}): string | null {
+  const resolution = resolvePreviewUrl({ preview, entry: document, siteUrl });
 
   // `noSiteUrl` is ACCEPTED here, and it is the case that matters most: having
   // no site URL is the default state of a fresh install.
@@ -105,22 +128,19 @@ export async function resolvePreviewRedirect(
 
   if (resolution.status !== "resolved") return null;
 
-  // The origin is COMPARED against the site's, never stripped from the URL.
+  // The origin is COMPARED, never stripped from the URL.
   //
-  // A collection's `preview.url` is application code, free to return any host.
+  // A declaration's `url` is application code, free to return any host.
   // Removing the origin would reduce another site's URL to a bare path, and a
   // bare path is precisely what the route's site-relative guard is built to
   // approve — so the guard would run, pass, and have been handed a value that
-  // already destroyed the evidence it exists to judge. Comparing first means
-  // the only URL that survives is one already on the site's own origin.
+  // already destroyed the evidence it exists to judge.
   //
-  // With no site URL configured there is no origin to compare against at all,
-  // which is why the branch above checks the path's SHAPE instead.
   // With no site URL configured, the origin serving this request is the only
-  // honest thing to compare an absolute declaration against — and it is the
-  // right one, because this resolver answers a route running ON the site.
-  // Rejecting outright would mean a fresh installation whose collection returns
-  // an absolute same-origin URL still gets a 404.
+  // honest thing to compare against — and it is the right one, because this
+  // answers a route running ON the site. Rejecting outright would mean a fresh
+  // installation whose declaration returns an absolute same-origin URL still
+  // gets a 404.
   const comparisonOrigin = siteUrl ?? requestOrigin;
   if (comparisonOrigin === undefined) return null;
   try {
@@ -160,4 +180,56 @@ function siteRelativePath(path: string): string | null {
   } catch {
     return null;
   }
+}
+
+/** What resolving a Single's redirect needs from the outside world. */
+export interface SinglePreviewRedirectDeps {
+  /**
+   * The Single's document in the locale the token names, or `null` if it cannot
+   * be read.
+   *
+   * A Single is addressed by slug, so unlike an entry there is nothing to look
+   * up by id — but the document is still needed, because a declaration may
+   * derive the path from it.
+   */
+  loadSingle: (
+    slug: string,
+    locale: string | undefined
+  ) => Promise<Record<string, unknown> | null>;
+  /** The Single's preview declaration, from whichever authoring path wrote it. */
+  loadDeclaration: (slug: string) => Promise<PreviewDeclaration | undefined>;
+  /** The configured site URL, or `null` when none is set. */
+  loadSiteUrl: () => Promise<string | null>;
+}
+
+/** A Single-scoped token reduced to what a redirect needs. */
+export interface SinglePreviewRedirectScope {
+  single: string;
+  locale?: string;
+}
+
+/**
+ * The site-relative path a Single's preview token should land on, or `null`.
+ *
+ * Deliberately its own function rather than a branch inside the entry resolver:
+ * the two differ in everything they LOAD — one by id from a collection, one by
+ * slug with no id at all — and share only what they do with the result, which
+ * is `reduceToSitePath` and is called by both.
+ */
+export async function resolveSinglePreviewRedirect(
+  scope: SinglePreviewRedirectScope,
+  deps: SinglePreviewRedirectDeps,
+  requestOrigin?: string
+): Promise<string | null> {
+  const [document, preview, siteUrl] = await Promise.all([
+    deps.loadSingle(scope.single, scope.locale),
+    deps.loadDeclaration(scope.single),
+    deps.loadSiteUrl(),
+  ]);
+
+  // A Single is never deleted the way an entry is, but it can be removed from
+  // the configuration, and a link minted before that is a link to nothing.
+  if (document === null) return null;
+
+  return reduceToSitePath({ preview, document, siteUrl, requestOrigin });
 }

--- a/packages/nextly/src/domains/singles/services/__tests__/single-document-access.test.ts
+++ b/packages/nextly/src/domains/singles/services/__tests__/single-document-access.test.ts
@@ -1,0 +1,140 @@
+/**
+ * The probes that decide whether a Single's draft may be handed to a bearer.
+ *
+ * Two gates ask this — version history and draft preview — and both give out a
+ * view the caller cannot otherwise reach, so each must authorize the view it
+ * actually gives rather than a weaker one that is easier to ask for.
+ *
+ * What these cover is the two ways that goes wrong silently: authorizing a
+ * DIFFERENT DOCUMENT from the one handed over, and claiming a permission check
+ * has already run when it has not.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+const { get, getSingleBySlug, selectOne, checkSingleAccess } = vi.hoisted(
+  () => ({
+    get: vi.fn(),
+    getSingleBySlug: vi.fn(),
+    selectOne: vi.fn(),
+    checkSingleAccess: vi.fn(),
+  })
+);
+
+vi.mock("../../../../di", () => ({
+  getService: (name: string) => {
+    if (name === "singleEntryService") return { get };
+    if (name === "singleRegistryService") return { getSingleBySlug };
+    if (name === "adapter") return { selectOne };
+    return {};
+  },
+}));
+vi.mock("../single-query-service", () => ({ checkSingleAccess }));
+vi.mock("../../../../services/access/access-control-service", () => ({
+  AccessControlService: class {},
+}));
+
+const { singleDocumentReadable, singleDocumentEditable } = await import(
+  "../single-document-access"
+);
+
+const USER = { id: "u1", roles: ["editor"] } as never;
+
+describe("authorizing a read of a Single's draft", () => {
+  // The view the token hands out is the WORKING DRAFT. Authorizing the live
+  // document instead leaves a custom rule that allows the published values and
+  // denies the pending ones bypassed: the probe says yes about a document the
+  // bearer never receives, and consumption reads the draft trusted without
+  // re-running that rule.
+  it("authorizes the working draft, not the live document", async () => {
+    get.mockResolvedValue({ success: true, statusCode: 200 });
+
+    await singleDocumentReadable("homepage", {
+      user: USER,
+      routeAuthorized: false,
+    });
+
+    expect(get).toHaveBeenCalledWith(
+      "homepage",
+      expect.objectContaining({ includeWorkingDraft: true, status: "all" })
+    );
+  });
+
+  // `routeAuthorized` skips the coarse RBAC check for the operation being
+  // probed. Whether that is honest depends on which gate the CALLER's route
+  // ran, so it is passed through rather than decided here — a route that gated
+  // `update` has authorized nothing about `read`.
+  it("passes the caller's own claim about its route gate", async () => {
+    get.mockResolvedValue({ success: true, statusCode: 200 });
+
+    await singleDocumentReadable("homepage", {
+      user: USER,
+      routeAuthorized: false,
+    });
+    expect(get).toHaveBeenCalledWith(
+      "homepage",
+      expect.objectContaining({ routeAuthorized: false })
+    );
+
+    get.mockClear();
+    await singleDocumentReadable("homepage", {
+      user: USER,
+      routeAuthorized: true,
+    });
+    expect(get).toHaveBeenCalledWith(
+      "homepage",
+      expect.objectContaining({ routeAuthorized: true })
+    );
+  });
+
+  // A denial and a miss are both answers and are deliberately collapsed;
+  // anything else is the read FAILING, and reporting that as "not allowed"
+  // would turn an outage into a permission decision that looks deliberate.
+  it.each([
+    [403, false],
+    [404, false],
+  ])("treats %i as a refusal", async (statusCode, expected) => {
+    get.mockResolvedValue({ success: false, statusCode });
+
+    await expect(
+      singleDocumentReadable("homepage", { user: USER, routeAuthorized: false })
+    ).resolves.toBe(expected);
+  });
+
+  it("throws rather than denying when the read could not be made", async () => {
+    get.mockResolvedValue({ success: false, statusCode: 500 });
+
+    await expect(
+      singleDocumentReadable("homepage", { user: USER, routeAuthorized: false })
+    ).rejects.toThrow();
+  });
+});
+
+describe("authorizing an edit of a Single", () => {
+  // Reading proves nothing about editing: where a Single allows broad reads and
+  // restricts updates, a caller reads the published document and would
+  // otherwise be handed the author's unpublished edits.
+  it("asks the update question against the stored document", async () => {
+    getSingleBySlug.mockResolvedValue({ tableName: "t", accessRules: {} });
+    selectOne.mockResolvedValue({ id: "s1" });
+    checkSingleAccess.mockResolvedValue(null);
+
+    await expect(
+      singleDocumentEditable("homepage", { user: USER, routeAuthorized: true })
+    ).resolves.toBe(true);
+
+    expect(checkSingleAccess).toHaveBeenCalledWith(
+      expect.objectContaining({ operation: "update", document: { id: "s1" } })
+    );
+  });
+
+  // `checkSingleAccess` refuses outright when an owner-only rule has no
+  // document, so a Single with no row cannot be authorized either way.
+  it("refuses when there is no document to judge", async () => {
+    getSingleBySlug.mockResolvedValue({ tableName: "t", accessRules: {} });
+    selectOne.mockResolvedValue(null);
+
+    await expect(
+      singleDocumentEditable("homepage", { user: USER, routeAuthorized: true })
+    ).resolves.toBe(false);
+  });
+});

--- a/packages/nextly/src/domains/singles/services/single-document-access.ts
+++ b/packages/nextly/src/domains/singles/services/single-document-access.ts
@@ -13,9 +13,17 @@
  * gate that stops at the permission therefore authorizes a disclosure the real
  * operation would refuse.
  *
- * `routeAuthorized: true` throughout: the caller's route already ran the coarse
- * RBAC check, and this flag skips ONLY that. The stored rules still run, which
- * is the part these functions exist for.
+ * **`routeAuthorized` is the CALLER's to state, and it is required.** It tells
+ * `checkSingleAccess` that the route already ran the coarse RBAC gate FOR THIS
+ * OPERATION, so the check is skipped as redundant. Whether that is true depends
+ * on which gate the caller's route ran, not on anything visible here: version
+ * history reaches the read probe behind a `read` gate, while minting a preview
+ * link reaches it behind an `update` gate — and passing `true` there would skip
+ * a `read` permission check that never ran, handing a bearer token for the draft
+ * to a caller holding `update` and no read grant at all.
+ *
+ * Required rather than defaulted for that reason. A default is a polarity this
+ * module cannot know, and the wrong one is silent.
  *
  * @module domains/singles/services/single-document-access
  */
@@ -36,6 +44,23 @@ export interface SingleAccessSubject {
    * admin does not inherit that owner's stored rules.
    */
   actor?: AuthenticatedScope;
+  /**
+   * Whether the caller's route already ran the RBAC gate for the operation
+   * being probed here — read for {@link singleDocumentReadable}, update for
+   * {@link singleDocumentEditable}.
+   *
+   * `true` skips that one check as redundant. State it from what the route
+   * actually gated, never from what is convenient: a route that gated `update`
+   * has authorized nothing about `read`.
+   */
+  routeAuthorized: boolean;
+  /**
+   * Which translation is being authorized. A localized Single is a different
+   * document per language, and an owner-only or custom rule can answer
+   * differently for each — so a probe that reads the default translation
+   * authorizes a document the caller may not be asking about.
+   */
+  locale?: string;
 }
 
 /**
@@ -71,14 +96,15 @@ function readVerdict(result: {
  */
 export async function singleDocumentReadable(
   slug: string,
-  { user, actor }: SingleAccessSubject
+  { user, actor, routeAuthorized, locale }: SingleAccessSubject
 ): Promise<boolean> {
   const singles = getService("singleEntryService");
   const result = await singles.get(slug, {
     user,
     overrideAccess: false,
-    routeAuthorized: true,
+    routeAuthorized,
     ...(actor === undefined ? {} : { authenticatedScope: actor }),
+    ...(locale === undefined ? {} : { locale }),
     status: "all",
   });
   return readVerdict(result);
@@ -98,7 +124,7 @@ export async function singleDocumentReadable(
  */
 export async function singleDocumentEditable(
   slug: string,
-  { user, actor }: SingleAccessSubject
+  { user, actor, routeAuthorized }: SingleAccessSubject
 ): Promise<boolean> {
   const registry = getService("singleRegistryService");
   const record = await registry.getSingleBySlug(slug);
@@ -116,7 +142,7 @@ export async function singleDocumentEditable(
     operation: "update",
     user,
     overrideAccess: false,
-    routeAuthorized: true,
+    routeAuthorized,
     rbacAccessControlService: getService("rbacAccessControlService"),
     // Stateless evaluator for the Single's stored rules; it holds no
     // per-request state, so constructing one here matches the write path.

--- a/packages/nextly/src/domains/singles/services/single-document-access.ts
+++ b/packages/nextly/src/domains/singles/services/single-document-access.ts
@@ -92,7 +92,8 @@ function readVerdict(result: {
  * `status: "all"` is the part a plain read cannot express: a Single with a
  * publish lifecycle otherwise filters to published only, so one that has never
  * been published reports as missing — exactly the document these gates exist
- * for.
+ * for. The working draft is asked for alongside it, so what is authorized here
+ * is the view the caller will actually be handed rather than the live one.
  */
 export async function singleDocumentReadable(
   slug: string,
@@ -106,6 +107,12 @@ export async function singleDocumentReadable(
     ...(actor === undefined ? {} : { authenticatedScope: actor }),
     ...(locale === undefined ? {} : { locale }),
     status: "all",
+    // The DRAFT, because that is the view the token hands out. Authorizing the
+    // live document instead leaves a custom rule that allows the published
+    // values and denies the pending ones bypassed entirely: the probe says yes
+    // about a document the bearer never receives, and consumption reads the
+    // working draft trusted without re-running the rule.
+    includeWorkingDraft: true,
   });
   return readVerdict(result);
 }

--- a/packages/nextly/src/domains/singles/services/single-document-access.ts
+++ b/packages/nextly/src/domains/singles/services/single-document-access.ts
@@ -1,0 +1,130 @@
+/**
+ * Whether a caller may read, or edit, a Single's live document.
+ *
+ * Two gates ask this and they must not answer differently: version history and
+ * draft preview both hand out a view of a document the caller cannot reach
+ * through the ordinary read path, so both have to authorize the view they give
+ * rather than the coarser one that is easier to ask for.
+ *
+ * The route gate they each run first is per-SLUG RBAC, and it is one axis short
+ * of the question. A Single can carry stored access rules — owner-only, role
+ * based, custom — that deny a caller holding the coarse permission, and those
+ * rules are evaluated against the loaded document rather than the request. A
+ * gate that stops at the permission therefore authorizes a disclosure the real
+ * operation would refuse.
+ *
+ * `routeAuthorized: true` throughout: the caller's route already ran the coarse
+ * RBAC check, and this flag skips ONLY that. The stored rules still run, which
+ * is the part these functions exist for.
+ *
+ * @module domains/singles/services/single-document-access
+ */
+
+import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
+import { getService } from "../../../di";
+import { NextlyError } from "../../../errors/nextly-error";
+import { AccessControlService } from "../../../services/access/access-control-service";
+import type { UserContext } from "../types";
+
+import { checkSingleAccess } from "./single-query-service";
+
+/** Who is asking, and on whose behalf. */
+export interface SingleAccessSubject {
+  user: UserContext;
+  /**
+   * A scoped API key is judged on its OWN grant, so a key owned by a super
+   * admin does not inherit that owner's stored rules.
+   */
+  actor?: AuthenticatedScope;
+}
+
+/**
+ * Turn a read outcome into a verdict, keeping "denied" and "could not ask"
+ * apart.
+ *
+ * A 403 and a 404 are both answers and are deliberately collapsed: telling them
+ * apart would report whether a Single exists to a caller who may not see it.
+ * Anything else is the read FAILING rather than refusing, and returning `false`
+ * for it would turn an outage into a permission denial that looks deliberate.
+ */
+function readVerdict(result: {
+  success: boolean;
+  statusCode: number;
+}): boolean {
+  if (result.success) return true;
+  if (result.statusCode === 403 || result.statusCode === 404) return false;
+  throw NextlyError.internal({
+    logContext: {
+      reason: "single-access-probe-failed",
+      statusCode: result.statusCode,
+    },
+  });
+}
+
+/**
+ * Whether the caller may read the Single's live document, unpublished included.
+ *
+ * `status: "all"` is the part a plain read cannot express: a Single with a
+ * publish lifecycle otherwise filters to published only, so one that has never
+ * been published reports as missing — exactly the document these gates exist
+ * for.
+ */
+export async function singleDocumentReadable(
+  slug: string,
+  { user, actor }: SingleAccessSubject
+): Promise<boolean> {
+  const singles = getService("singleEntryService");
+  const result = await singles.get(slug, {
+    user,
+    overrideAccess: false,
+    routeAuthorized: true,
+    ...(actor === undefined ? {} : { authenticatedScope: actor }),
+    status: "all",
+  });
+  return readVerdict(result);
+}
+
+/**
+ * Whether the caller may edit the Single's live document.
+ *
+ * Reading it proves nothing about this: where a Single allows broad reads and
+ * restricts updates, a caller can read the published document and would
+ * otherwise be handed the author's unpublished edits.
+ *
+ * The row is loaded through the adapter rather than taken from a read result,
+ * because an owner-only rule compares against the STORED values and
+ * `checkSingleAccess` refuses outright when such a rule has no document — while
+ * a read result is presentation data an `afterRead` hook may have reshaped.
+ */
+export async function singleDocumentEditable(
+  slug: string,
+  { user, actor }: SingleAccessSubject
+): Promise<boolean> {
+  const registry = getService("singleRegistryService");
+  const record = await registry.getSingleBySlug(slug);
+  if (!record?.tableName) return false;
+
+  const adapter = getService("adapter");
+  const document = await adapter.selectOne<Record<string, unknown>>(
+    record.tableName,
+    {}
+  );
+  if (!document) return false;
+
+  const denied = await checkSingleAccess({
+    slug,
+    operation: "update",
+    user,
+    overrideAccess: false,
+    routeAuthorized: true,
+    rbacAccessControlService: getService("rbacAccessControlService"),
+    // Stateless evaluator for the Single's stored rules; it holds no
+    // per-request state, so constructing one here matches the write path.
+    accessControlService: new AccessControlService(),
+    accessRules: record.accessRules,
+    document,
+    ...(actor === undefined ? {} : { authenticatedScope: actor }),
+    logger: getService("logger"),
+  });
+  return denied === null;
+}

--- a/packages/nextly/src/runtime.ts
+++ b/packages/nextly/src/runtime.ts
@@ -72,6 +72,13 @@ export {
 // short, which is the combination that gets retyped subtly wrong — and its
 // failure grants every draft rather than erroring.
 export { previewDraftGate } from "./runtime/preview/preview-draft-gate";
+
+// The Single counterpart. A sibling rather than a branch: a collection gate
+// returns an entry id so the route can compare it against the row a PATH
+// resolved to, while a Single has no path and no id — its slug is its identity —
+// so its gate settles the question and answers a boolean.
+export { previewSingleDraftGate } from "./runtime/preview/preview-single-draft-gate";
+export type { PreviewSingleDraftGateConfig } from "./runtime/preview/preview-single-draft-gate";
 export type {
   PreviewDraftGateConfig,
   DraftGateRequest,
@@ -107,6 +114,7 @@ export {
   type SingleRoute,
   type SingleRouteConfig,
   type SingleContext,
+  type SingleDraftRequest,
   type SingleDocument,
   type NextlySingleReader,
   type ResolvedContext,

--- a/packages/nextly/src/runtime/preview/__tests__/preview-route.test.ts
+++ b/packages/nextly/src/runtime/preview/__tests__/preview-route.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { signPreviewToken } from "../../../auth/preview/preview-token";
+import {
+  isSingleScope,
+  signPreviewToken,
+} from "../../../auth/preview/preview-token";
 import {
   PREVIEW_SCOPE_COOKIE,
   createPreviewRoute,
@@ -27,7 +30,13 @@ function routeFor(
   const route = createPreviewRoute({
     secret: TEST_SECRET,
     generation: GENERATION,
-    redirectTo: scope => `/${scope.collection}/${scope.entryId}`,
+    // Narrowed rather than asserted: the scope is a union, and this suite's
+    // tokens are all entry-scoped, so the single branch is genuinely
+    // unreachable here and says so instead of being cast away.
+    redirectTo: scope =>
+      isSingleScope(scope)
+        ? `/single/${scope.single}`
+        : `/${scope.collection}/${scope.entryId}`,
     draftMode: draft.draftMode,
     ...overrides,
   });

--- a/packages/nextly/src/runtime/preview/__tests__/preview-single-draft-gate.test.ts
+++ b/packages/nextly/src/runtime/preview/__tests__/preview-single-draft-gate.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The gate that decides whether a request may read a Single's working draft.
+ *
+ * The refusals are what matter. An unwired gate answers 404 on a page that looks
+ * entirely correct; a gate that grants too much turns one shared link into a key
+ * to every unpublished Single on the site.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { signPreviewToken } from "../../../auth/preview/preview-token";
+import { previewSingleDraftGate } from "../preview-single-draft-gate";
+
+const TEST_SECRET = "single-gate-test-secret-at-least-32-chars!!";
+
+let cookieValue: string | undefined;
+let generation = 1;
+
+vi.mock("../preview-route-defaults", () => ({
+  defaultSecret: () => TEST_SECRET,
+  defaultGeneration: () => Promise.resolve(generation),
+  defaultCookies: () =>
+    Promise.resolve({
+      get: (name: string) =>
+        name === "__nextly_preview" && cookieValue !== undefined
+          ? { value: cookieValue }
+          : undefined,
+    }),
+}));
+
+async function cookieFor(
+  scope: Parameters<typeof signPreviewToken>[0],
+  options: { generation?: number; ttlSeconds?: number } = {}
+): Promise<void> {
+  const { token } = await signPreviewToken(scope, TEST_SECRET, {
+    generation: options.generation ?? 1,
+    ...(options.ttlSeconds === undefined
+      ? {}
+      : { ttlSeconds: options.ttlSeconds }),
+  });
+  cookieValue = encodeURIComponent(token);
+}
+
+beforeEach(() => {
+  cookieValue = undefined;
+  generation = 1;
+});
+
+describe("previewSingleDraftGate", () => {
+  it("grants the Single its token names", async () => {
+    await cookieFor({ kind: "single", single: "homepage" });
+
+    await expect(previewSingleDraftGate()({ slug: "homepage" })).resolves.toBe(
+      true
+    );
+  });
+
+  it("refuses a request with no preview cookie", async () => {
+    await expect(previewSingleDraftGate()({ slug: "homepage" })).resolves.toBe(
+      false
+    );
+  });
+
+  // The promise the gate exists to keep: one link opens ONE Single, never every
+  // unpublished Single on the site.
+  it("refuses a different Single", async () => {
+    await cookieFor({ kind: "single", single: "footer" });
+
+    await expect(previewSingleDraftGate()({ slug: "homepage" })).resolves.toBe(
+      false
+    );
+  });
+
+  // A Single named `pages` and a collection named `pages` are different
+  // documents, so the kind is compared and not only the name.
+  it("refuses a collection entry's token, even one naming the same slug", async () => {
+    await cookieFor({ collection: "homepage", entryId: "homepage" });
+
+    await expect(previewSingleDraftGate()({ slug: "homepage" })).resolves.toBe(
+      false
+    );
+  });
+
+  // The POSITIVE half, and the one that separates a correct locale comparison
+  // from a gate that simply refuses every locale. Without it, deleting the
+  // locale entirely still passes the refusal below.
+  it("grants the locale its token names", async () => {
+    await cookieFor({ kind: "single", single: "homepage", locale: "en" });
+
+    await expect(
+      previewSingleDraftGate()({ slug: "homepage", locale: "en" })
+    ).resolves.toBe(true);
+  });
+
+  it("refuses a token whose locale is not the one the route reads", async () => {
+    await cookieFor({ kind: "single", single: "homepage", locale: "en" });
+
+    await expect(
+      previewSingleDraftGate()({ slug: "homepage", locale: "fr" })
+    ).resolves.toBe(false);
+  });
+
+  // A token minted without a locale is a link to the document rather than to
+  // one translation of it.
+  it("grants any locale when the token names none", async () => {
+    await cookieFor({ kind: "single", single: "homepage" });
+
+    await expect(
+      previewSingleDraftGate()({ slug: "homepage", locale: "fr" })
+    ).resolves.toBe(true);
+  });
+
+  it("refuses an expired token", async () => {
+    await cookieFor({ kind: "single", single: "homepage" }, { ttlSeconds: 1 });
+
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(5000);
+    const verdict = await previewSingleDraftGate()({ slug: "homepage" });
+    vi.useRealTimers();
+
+    expect(verdict).toBe(false);
+  });
+
+  // Revocation has to reach sessions already in flight, not merely refuse new
+  // links, which is why the generation is re-read per request.
+  it("refuses a token minted under a superseded generation", async () => {
+    await cookieFor({ kind: "single", single: "homepage" });
+
+    generation = 2;
+
+    await expect(previewSingleDraftGate()({ slug: "homepage" })).resolves.toBe(
+      false
+    );
+  });
+});

--- a/packages/nextly/src/runtime/preview/preview-draft-gate.ts
+++ b/packages/nextly/src/runtime/preview/preview-draft-gate.ts
@@ -16,7 +16,10 @@
  *
  * @module runtime/preview/preview-draft-gate
  */
-import type { PreviewTokenScope } from "../../auth/preview/preview-token";
+import {
+  isSingleScope,
+  type PreviewTokenScope,
+} from "../../auth/preview/preview-token";
 import type { ResolvedContext } from "../routing/content-route";
 
 import { previewGrantsDraft, readPreviewScope } from "./preview-route";
@@ -86,6 +89,12 @@ export function previewDraftGate(
     const scope = await readPreviewScope(config);
 
     if (scope === null) return false;
+
+    // A Single's token cannot grant a collection draft. Both name one document
+    // and only one, but they are different documents — and this gate answers
+    // for a COLLECTION path, so a single-scoped token reaching it is a token
+    // for somewhere else entirely.
+    if (isSingleScope(scope)) return false;
 
     // `previewGrantsDraft` owns the whole authorization question — an absent
     // session AND whether a present one reaches the document — so it is asked

--- a/packages/nextly/src/runtime/preview/preview-route-defaults.ts
+++ b/packages/nextly/src/runtime/preview/preview-route-defaults.ts
@@ -17,6 +17,10 @@
  * @module runtime/preview/preview-route-defaults
  */
 
+import {
+  isSingleScope,
+  type PreviewTokenScope,
+} from "../../auth/preview/preview-token";
 import { container, getService } from "../../di";
 import {
   resolvePreviewRedirect,
@@ -94,9 +98,14 @@ export async function defaultCookies(): Promise<{
  * explain them.
  */
 export async function defaultRedirectTo(
-  scope: PreviewRedirectScope,
+  scope: PreviewTokenScope,
   context?: { requestOrigin: string }
 ): Promise<string | null> {
+  // A Single names no collection and no entry id, so the collection-preview
+  // resolution below cannot answer for one. Refused rather than guessed, which
+  // the route reports as the same 404 every other refusal gets.
+  if (isSingleScope(scope)) return null;
+
   await getCachedNextly();
   const { previewDeclarationFor } = await import("../../api/preview-url");
   const collections = getService("collectionsHandler");

--- a/packages/nextly/src/runtime/preview/preview-route-defaults.ts
+++ b/packages/nextly/src/runtime/preview/preview-route-defaults.ts
@@ -24,6 +24,7 @@ import {
 import { container, getService } from "../../di";
 import {
   resolvePreviewRedirect,
+  resolveSinglePreviewRedirect,
   type PreviewRedirectScope,
 } from "../../domains/collections/services/preview-redirect-resolver";
 import { resolvePreviewSiteUrl } from "../../domains/preview/site-url";
@@ -101,13 +102,39 @@ export async function defaultRedirectTo(
   scope: PreviewTokenScope,
   context?: { requestOrigin: string }
 ): Promise<string | null> {
-  // A Single names no collection and no entry id, so the collection-preview
-  // resolution below cannot answer for one. Refused rather than guessed, which
-  // the route reports as the same 404 every other refusal gets.
-  if (isSingleScope(scope)) return null;
-
   await getCachedNextly();
-  const { previewDeclarationFor } = await import("../../api/preview-url");
+  const {
+    loadSingleForPreview,
+    previewDeclarationFor,
+    singlePreviewDeclarationFor,
+  } = await import("../../api/preview-url");
+
+  // A Single names no collection and no entry id, so the entry resolution below
+  // cannot answer for one. It is a sibling rather than a branch: the two differ
+  // in everything they LOAD — one by id from a collection, one by slug with no
+  // id at all — and share only what they do with the result.
+  //
+  // Answering here rather than leaving it to the application is the whole point
+  // of the default. A route that refused every Single would let the admin mint a
+  // link and then 404 it, which is indistinguishable from an expired one.
+  if (isSingleScope(scope)) {
+    return resolveSinglePreviewRedirect(
+      {
+        single: scope.single,
+        ...(scope.locale === undefined ? {} : { locale: scope.locale }),
+      },
+      {
+        loadSingle: loadSingleForPreview,
+        loadDeclaration: singlePreviewDeclarationFor,
+        loadSiteUrl: async () =>
+          resolvePreviewSiteUrl(
+            await (await settingsService()).getSettings().then(s => s.siteUrl)
+          ),
+      },
+      context?.requestOrigin
+    );
+  }
+
   const collections = getService("collectionsHandler");
 
   return resolvePreviewRedirect(

--- a/packages/nextly/src/runtime/preview/preview-route-defaults.ts
+++ b/packages/nextly/src/runtime/preview/preview-route-defaults.ts
@@ -25,7 +25,6 @@ import { container, getService } from "../../di";
 import {
   resolvePreviewRedirect,
   resolveSinglePreviewRedirect,
-  type PreviewRedirectScope,
 } from "../../domains/collections/services/preview-redirect-resolver";
 import { resolvePreviewSiteUrl } from "../../domains/preview/site-url";
 import { NextlyError } from "../../errors/nextly-error";

--- a/packages/nextly/src/runtime/preview/preview-single-draft-gate.ts
+++ b/packages/nextly/src/runtime/preview/preview-single-draft-gate.ts
@@ -1,0 +1,61 @@
+/**
+ * `previewSingleDraftGate` — wire a preview token to a Single route's `draft`
+ * hook.
+ *
+ * A sibling of `previewDraftGate` rather than a branch inside it, because the
+ * two answer different questions and return different things. A collection gate
+ * hands back an entry id, so the route can compare the grant against the row a
+ * PATH resolved to; a Single has no path to resolve and no id — its slug is its
+ * identity — so the gate settles the whole question and answers a boolean.
+ *
+ * Sharing one function would mean a return type that is sometimes an id and
+ * sometimes a boolean, and a caller that has to know which. Two functions with
+ * one comparison underneath is the honest arrangement: `previewTokenCovers`
+ * remains the single place a scope is judged.
+ *
+ * @module runtime/preview/preview-single-draft-gate
+ */
+import { previewTokenCovers } from "../../auth/preview/preview-token";
+import type { SingleDraftRequest } from "../routing/single-route";
+
+import { readPreviewScope } from "./preview-route";
+import type { PreviewScopeReaderConfig } from "./preview-route";
+
+/** Options for {@link previewSingleDraftGate}. */
+export type PreviewSingleDraftGateConfig = PreviewScopeReaderConfig;
+
+/**
+ * A `draft` hook that grants exactly the Single the request's token covers.
+ *
+ * Callable with no argument, like its collection counterpart: the signing
+ * secret, the revocation generation and the request's cookies are facts about
+ * the booted instance and the request in hand, not decisions a site makes.
+ */
+export function previewSingleDraftGate(
+  config: PreviewSingleDraftGateConfig = {}
+): (request: SingleDraftRequest) => Promise<boolean> {
+  return async ({ slug, locale }) => {
+    // Re-read per request. The configuration is captured once, while whether
+    // this visitor is previewing — and whether their token has since expired or
+    // been revoked — is a fact about the request in hand.
+    const scope = await readPreviewScope(config);
+    if (scope === null) return false;
+
+    // A collection entry's token cannot open a Single — a Single named `pages`
+    // is not the `pages` collection — and that comparison is NOT repeated here.
+    // `previewTokenCovers` compares the kind first, so a guard beside it would
+    // be a second copy of a question it already owns, and the copy is the one
+    // that keeps the old policy when the shared rule moves.
+    //
+    // Asked of the shared comparison rather than rebuilt from its parts. The
+    // locale comes from the ROUTE, so it is the language about to be read: a
+    // token scoped to `en` must not grant the `fr` document, and taking the
+    // locale from this gate's own configuration would make it a second
+    // declaration of a value the route already holds.
+    return previewTokenCovers(scope, {
+      kind: "single",
+      single: slug,
+      ...(locale === undefined ? {} : { locale }),
+    });
+  };
+}

--- a/packages/nextly/src/runtime/routing/__tests__/single-route-cache-key.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/single-route-cache-key.test.ts
@@ -1,0 +1,109 @@
+/**
+ * A cached Single read is keyed by every input that decides what it returns.
+ *
+ * The locale was already in the key for that reason. `trustedCollections` joined
+ * it the moment a trust bound started deciding which RELATED rows come back: two
+ * routes may mount the same Single in the same language with different bounds,
+ * and a key that cannot tell them apart lets the more-trusted one warm the cache
+ * and serve its populated restricted rows to the other — which never runs its
+ * own bound at all.
+ *
+ * Only the PUBLIC factory reaches the cache. An enforced read and a granted
+ * draft read are both per-visitor and marked dynamic, so neither is cached and
+ * neither can leak this way.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+/** Options the route hands the cache, as the real `cachedFind` receives them. */
+interface CacheOptions {
+  keyParts: unknown[];
+  tags?: string[];
+}
+
+const { cachedFind } = vi.hoisted(() => ({
+  cachedFind: vi.fn(
+    async (reader: () => Promise<unknown>, _options: { keyParts: unknown[] }) =>
+      reader()
+  ),
+}));
+
+vi.mock("../../cache/cached-find", () => ({ cachedFind }));
+
+const { createPublicSingleRoute } = await import("../single-route");
+
+const HOME = { title: "Home" };
+
+/** The `keyParts` the route handed the cache for one configuration. */
+async function keyFor(config: Record<string, unknown>): Promise<unknown[]> {
+  cachedFind.mockClear();
+  const reader = {
+    findSingle: async () => HOME,
+  } as unknown as Parameters<typeof createPublicSingleRoute>[0]["nextly"];
+
+  const { generateMetadata } = createPublicSingleRoute({
+    slug: "homepage",
+    nextly: reader,
+    render: () => "rendered",
+    buildMetadata: () => ({ title: "Home" }),
+    ...config,
+  } as Parameters<typeof createPublicSingleRoute>[0]);
+
+  await generateMetadata();
+
+  expect(cachedFind, "the cache was never consulted").toHaveBeenCalled();
+  const [, options] = cachedFind.mock.calls[0] as unknown as [
+    unknown,
+    CacheOptions,
+  ];
+  return options.keyParts;
+}
+
+describe("what a cached Single read is keyed by", () => {
+  // The positive control: without it the comparisons below cannot tell a key
+  // that omits the bound from a route that never reached the cache.
+  it("keys by the single and its locale", async () => {
+    const key = await keyFor({ locale: "en" });
+
+    expect(key).toContain("homepage");
+    expect(key).toContain("en");
+  });
+
+  it("separates two routes whose trust bounds differ", async () => {
+    const narrow = await keyFor({ locale: "en", trustedCollections: [] });
+    const wide = await keyFor({
+      locale: "en",
+      trustedCollections: ["posts"],
+    });
+
+    expect(narrow).not.toEqual(wide);
+  });
+
+  // Stated as its own case because "different keys" is satisfied by a key that
+  // differs for the wrong reason — a counter, a timestamp, an object identity.
+  // The bound has to be IN the key, not merely correlated with it.
+  it("names the trusted collections in the key", async () => {
+    const key = await keyFor({
+      locale: "en",
+      trustedCollections: ["posts", "authors"],
+    });
+
+    expect(key.join("|")).toContain("authors");
+    expect(key.join("|")).toContain("posts");
+  });
+
+  // The negative control. Two routes stating the same trust in a different
+  // order are the same policy, and warming two cache entries for one policy
+  // would be a slow correctness-neutral regression nobody would notice.
+  it("treats the same trust set in a different order as one policy", async () => {
+    const first = await keyFor({
+      locale: "en",
+      trustedCollections: ["posts", "authors"],
+    });
+    const second = await keyFor({
+      locale: "en",
+      trustedCollections: ["authors", "posts"],
+    });
+
+    expect(first).toEqual(second);
+  });
+});

--- a/packages/nextly/src/runtime/routing/__tests__/single-route.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/single-route.test.ts
@@ -209,3 +209,64 @@ describe("createPublicSingleRoute construction", () => {
     ).not.toThrow();
   });
 });
+
+/**
+ * A draft grant authorizes ONE document and says nothing about what that
+ * document points at.
+ *
+ * The read it triggers is trusted, so without a bound the bypass spreads to
+ * every collection the Single populates — and a caller who may preview this
+ * document receives related records they have no permission to read at all.
+ * The bound is the same option, with the same meaning, that a content route
+ * carries.
+ */
+describe("how far a Single route's trust reaches", () => {
+  /** The `trusted` predicate the route handed the reader, if any. */
+  async function boundFrom(
+    config: Record<string, unknown>
+  ): Promise<((collection: string) => boolean) | undefined> {
+    const { reader, calls } = stubReader(HOME);
+    const { generateMetadata } = createSingleRoute({
+      slug: "homepage",
+      nextly: reader,
+      render: () => "rendered",
+      buildMetadata: document => ({ title: String(document.title) }),
+      ...config,
+    });
+
+    await generateMetadata();
+
+    expect(calls).toHaveLength(1);
+    return (calls[0] as { trusted?: (collection: string) => boolean }).trusted;
+  }
+
+  // The positive control. Without it the assertions below cannot tell "bounded
+  // to nothing" from "no bound was passed at all", which are opposite outcomes
+  // reported by the same `false`.
+  it("passes a bound the reader can actually consult", async () => {
+    expect(await boundFrom({ draft: true })).toBeTypeOf("function");
+  });
+
+  it("trusts nothing by default, which is what a draft grant authorizes", async () => {
+    const trusted = await boundFrom({ draft: true });
+
+    expect(trusted?.("posts")).toBe(false);
+  });
+
+  it("trusts exactly what the route named, and nothing beside it", async () => {
+    const trusted = await boundFrom({
+      draft: true,
+      trustedCollections: ["posts"],
+    });
+
+    expect(trusted?.("posts")).toBe(true);
+    expect(trusted?.("authors")).toBe(false);
+  });
+
+  // Passed on an enforced read too. It decides nothing there — the reader
+  // evaluates `overrideAccess && trusted(target)` — and travelling with every
+  // read is what makes it impossible to omit on the one path that matters.
+  it("travels with an ordinary read as well", async () => {
+    expect(await boundFrom({})).toBeTypeOf("function");
+  });
+});

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -455,8 +455,14 @@ function buildRoute<TNode>(
   ): Promise<void> {
     try {
       const { readPreviewScope } = await import("../preview/preview-route");
+      const { isSingleScope } = await import(
+        "../../auth/preview/preview-token"
+      );
       const scope = await readPreviewScope();
       if (scope === null) return;
+      // A Single's token says nothing about this content route, so a visitor
+      // previewing one while browsing the site is not a misconfiguration here.
+      if (isSingleScope(scope)) return;
       if (scope.collection !== context.collection) return;
 
       // Once per collection per process, and worded as a CONFIGURATION fact

--- a/packages/nextly/src/runtime/routing/index.ts
+++ b/packages/nextly/src/runtime/routing/index.ts
@@ -38,6 +38,7 @@ export type {
   SingleRoute,
   SingleRouteConfig,
   SingleContext,
+  SingleDraftRequest,
   SingleDocument,
   NextlySingleReader,
 } from "./single-route";

--- a/packages/nextly/src/runtime/routing/single-route.ts
+++ b/packages/nextly/src/runtime/routing/single-route.ts
@@ -263,6 +263,12 @@ function buildSingleRoute<TNode>(
   // read this route issues.
   const trustedSet = new Set(config.trustedCollections ?? []);
 
+  // SORTED, so two routes stating the same trust in a different order share a
+  // cache entry rather than warming two — the key names the policy, not the
+  // spelling of it. Derived from the Set so it cannot drift from the predicate
+  // above: one is the bound, the other is that bound's identity.
+  const trustedKey = [...trustedSet].sort().join(",");
+
   function readArgs(draft: boolean) {
     return {
       slug: config.slug,
@@ -326,7 +332,15 @@ function buildSingleRoute<TNode>(
       // The locale is part of the key: one Single serves a different document
       // per language, and a key that omitted it would serve whichever language
       // warmed the cache first to everyone.
-      keyParts: ["nextly-single", config.slug, config.locale ?? ""],
+      //
+      // The trust bound is part of it for the same reason, and it became one the
+      // moment that bound started deciding what a read RETURNS. Two routes may
+      // mount the same Single in the same language with different
+      // `trustedCollections` — and without this the more-trusted one warms the
+      // cache and the other is served its populated restricted rows, having
+      // never run its own bound at all. A cache key has to name every input the
+      // cached value depends on, and this is now one of them.
+      keyParts: ["nextly-single", config.slug, config.locale ?? "", trustedKey],
       ...(config.revalidate === undefined
         ? {}
         : { revalidate: config.revalidate }),

--- a/packages/nextly/src/runtime/routing/single-route.ts
+++ b/packages/nextly/src/runtime/routing/single-route.ts
@@ -116,6 +116,41 @@ export interface SingleRouteConfig<TNode> {
   locale?: string;
   /** Relation depth for the read. Defaults to the reader's own default. */
   depth?: number;
+  /**
+   * The collections this route's trust extends to, when it populates
+   * relationships.
+   *
+   * **Defaults to NOTHING**, which is what a draft grant actually authorizes.
+   * The grant names ONE document and says nothing about what that document
+   * points at, so a target reached through a field is read the way an anonymous
+   * visitor would read it: its own access rules apply, and only its published
+   * rows come back.
+   *
+   * Without it a trusted read spreads to everything the Single populates, and a
+   * caller who may preview this document receives related records they have no
+   * permission to read at all.
+   *
+   * ```ts
+   * // The landing page populates a featured post, and those are public.
+   * createSingleRoute({
+   *   slug: "landing-page",
+   *   trustedCollections: ["posts"],
+   *   draft: previewSingleDraftGate(),
+   *   render: ...,
+   * });
+   * ```
+   *
+   * **This only ever narrows.** It is evaluated as
+   * `overrideAccess && trusted(target)`, so naming a collection cannot grant
+   * more than the read already holds, and it decides nothing on an enforced
+   * read. Naming one does NOT admit its drafts: trusting a collection says its
+   * published content may be shown, and nothing here widens a lifecycle.
+   *
+   * The same option, with the same meaning, as
+   * `ContentRouteConfig.trustedCollections` — one question keeps one answer
+   * whether the document came from a collection or is a Single.
+   */
+  trustedCollections?: string[];
   /** Identity to evaluate access rules against. Enforced routes only. */
   user?: UserContext;
 
@@ -224,9 +259,18 @@ function buildSingleRoute<TNode>(
    * worth reading apart: this decides the POSTURE of the request, while `read`
    * below only classifies what came back.
    */
+  // Built once: a `Set` lookup per populated target, and the same bound on every
+  // read this route issues.
+  const trustedSet = new Set(config.trustedCollections ?? []);
+
   function readArgs(draft: boolean) {
     return {
       slug: config.slug,
+      // The bound travels WITH the widening. Passed on every read rather than
+      // only the trusted ones, because it is evaluated as
+      // `overrideAccess && trusted(target)` — inert when the read is enforced,
+      // and impossible to forget on the one path where it matters.
+      trusted: (collection: string): boolean => trustedSet.has(collection),
       // The posture, expressed to the reader. An enforced route asks as the
       // visitor would; a public route has stated that this Single is public.
       //

--- a/packages/nextly/src/runtime/routing/single-route.ts
+++ b/packages/nextly/src/runtime/routing/single-route.ts
@@ -53,6 +53,20 @@ export type SingleDocument = Record<string, unknown>;
  */
 export type NextlySingleReader = Pick<Nextly, "findSingle">;
 
+/**
+ * What a Single route hands its `draft` hook.
+ *
+ * A Single is addressed by slug and there is exactly one of it, so unlike a
+ * collection path there is no id to resolve and nothing to compare afterwards —
+ * the slug IS the identity, and the gate settles the whole question.
+ */
+export interface SingleDraftRequest {
+  /** The Single's slug, as configured. */
+  slug: string;
+  /** The locale this route reads in, verbatim from the configuration. */
+  locale?: string;
+}
+
 /** What `render` and `buildMetadata` are told about the document they got. */
 export interface SingleContext {
   /** The Single's slug, as configured. */
@@ -104,6 +118,39 @@ export interface SingleRouteConfig<TNode> {
   depth?: number;
   /** Identity to evaluate access rules against. Enforced routes only. */
   user?: UserContext;
+
+  /**
+   * Whether this request may read the Single's pending working draft.
+   *
+   * The argument is the point, not a convenience. Next's draft mode is a single
+   * boolean for the whole host, so answering from `draftMode().isEnabled` alone
+   * turns a link scoped to ONE unpublished document into a key to every
+   * unpublished document on the site. A hook is asked per request instead, and
+   * `previewSingleDraftGate()` is the implementation that answers it from the
+   * visitor's own token.
+   *
+   * ```ts
+   * createSingleRoute({
+   *   slug: "homepage",
+   *   render: doc => <Home {...doc} />,
+   *   draft: previewSingleDraftGate(),
+   * });
+   * ```
+   *
+   * **A granted draft read is TRUSTED and UNCACHED**, and both follow from what
+   * a draft is. Trusted, because this route resolves anonymously and the
+   * working-draft overlay is gated on being able to edit the document — an
+   * enforced draft read could only ever return the published values, so the
+   * grant would appear to work and quietly show the wrong thing. Uncached,
+   * because a draft is per-visitor by construction: writing one into the route
+   * cache would serve it to everyone who asked next.
+   *
+   * `draft` belongs to this factory alone. `createPublicSingleRoute` refuses it,
+   * for the same reason its content-route counterpart does.
+   */
+  draft?:
+    | boolean
+    | ((request: SingleDraftRequest) => Promise<boolean> | boolean);
   /**
    * Extra cache tags for a public route, beyond the Single's own.
    *
@@ -159,18 +206,50 @@ function buildSingleRoute<TNode>(
     ...(config.locale === undefined ? {} : { locale: config.locale }),
   };
 
-  async function read(): Promise<SingleDocument | null> {
+  /** Whether this request was granted the working draft. */
+  async function draftForThisRequest(): Promise<boolean> {
+    const decision = config.draft;
+    if (decision === undefined || decision === false) return false;
+    if (decision === true) return true;
+    return decision({
+      slug: config.slug,
+      ...(config.locale === undefined ? {} : { locale: config.locale }),
+    });
+  }
+
+  /**
+   * What this route asks the reader for, given whether a draft was granted.
+   *
+   * Separated from the read itself because the two fail differently and are
+   * worth reading apart: this decides the POSTURE of the request, while `read`
+   * below only classifies what came back.
+   */
+  function readArgs(draft: boolean) {
+    return {
+      slug: config.slug,
+      // The posture, expressed to the reader. An enforced route asks as the
+      // visitor would; a public route has stated that this Single is public.
+      //
+      // A granted draft read is trusted whatever the posture, because the
+      // working-draft overlay is gated on being able to EDIT the document and
+      // this route resolves anonymously. An enforced draft read would return the
+      // published values while reporting success — the grant would look honoured
+      // and show the wrong document.
+      overrideAccess: trusted || draft,
+      // Widened only for a granted draft, so a Single that has never been
+      // published resolves at all. Left alone otherwise: widening it for every
+      // read would serve unpublished content to ordinary visitors.
+      ...(draft ? { draft: true, status: "all" as const } : {}),
+      ...(config.locale === undefined ? {} : { locale: config.locale }),
+      ...(config.depth === undefined ? {} : { depth: config.depth }),
+      ...(config.user === undefined ? {} : { user: config.user }),
+    };
+  }
+
+  async function read(draft: boolean): Promise<SingleDocument | null> {
     const reader = config.nextly ?? getNextly();
     try {
-      const document = await reader.findSingle({
-        slug: config.slug,
-        // The posture, expressed to the reader. An enforced route asks as the
-        // visitor would; a public route has stated that this Single is public.
-        overrideAccess: trusted,
-        ...(config.locale === undefined ? {} : { locale: config.locale }),
-        ...(config.depth === undefined ? {} : { depth: config.depth }),
-        ...(config.user === undefined ? {} : { user: config.user }),
-      });
+      const document = await reader.findSingle(readArgs(draft));
       return document ?? null;
     } catch (error) {
       if (isMissOrDenied(error)) return null;
@@ -179,14 +258,26 @@ function buildSingleRoute<TNode>(
   }
 
   async function resolve(): Promise<SingleDocument | null> {
+    const draft = await draftForThisRequest();
+
+    // A draft is per-visitor by construction, so it must reach neither the data
+    // cache nor the route cache: one cached draft is served to everyone who asks
+    // next, which turns a link scoped to one reviewer into a site-wide leak of
+    // unpublished content. Bypassing the data cache alone does not opt out of
+    // the route cache, which is why this marks the render dynamic as well.
+    if (draft) {
+      markDynamic();
+      return read(true);
+    }
+
     if (!trusted) {
       // An enforced read depends on who is asking, so it must not be frozen
       // into a build-time prerender or held in the route cache. Bypassing the
       // data cache alone does not opt out of the route cache.
       markDynamic();
-      return read();
+      return read(false);
     }
-    return cachedFind(read, {
+    return cachedFind(() => read(false), {
       tags: [...nextlySingleTags(config.slug), ...(config.tags ?? [])],
       // The locale is part of the key: one Single serves a different document
       // per language, and a key that omitted it would serve whichever language
@@ -252,6 +343,23 @@ export function createPublicSingleRoute<TNode>(
   // "what may THIS person see", and a trusted read has already answered "not
   // consulted" — so honouring both is impossible and silently dropping one
   // leaves a route whose config states a restriction it does not apply.
+  // Refused for the reason a draft read cannot be public: it is per-visitor and
+  // uncacheable, while this factory exists to be cached and pre-rendered. A
+  // route that accepted both would either cache one reviewer's draft for
+  // everyone or silently stop being static.
+  if (config.draft !== undefined && config.draft !== false) {
+    throw NextlyError.invalidInput({
+      message:
+        "createPublicSingleRoute() cannot serve drafts. Use " +
+        "createSingleRoute() with `draft` and mount previewable Singles there.",
+      logContext: {
+        reason:
+          "a draft read is per-visitor and uncacheable, which is incompatible " +
+          "with a route whose whole purpose is to be cached and pre-rendered",
+      },
+    });
+  }
+
   if (config.user !== undefined) {
     throw NextlyError.invalidInput({
       message:

--- a/packages/nextly/src/singles/config/__tests__/single-preview-config.test.ts
+++ b/packages/nextly/src/singles/config/__tests__/single-preview-config.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Where a Single is served.
+ *
+ * A Single has a Draft / Published lifecycle, so it has drafts worth sharing —
+ * and until now no way to say where a reviewer should open one. A collection
+ * declares this through `admin.preview`; a Single needs the same, and for the
+ * same reason: nothing outside the application knows whether the homepage
+ * Single is served at `/`, at `/home`, or under a locale segment.
+ *
+ * The declaration is a function of the Single's own document rather than a bare
+ * path, so a Single whose address depends on its content can express that —
+ * matching the collection shape rather than inventing a second one.
+ */
+import { describe, expect, it } from "vitest";
+
+import { text } from "../../../collections/fields/helpers";
+import { defineSingle } from "../define-single";
+
+describe("a Single's preview declaration", () => {
+  it("survives defineSingle", () => {
+    const single = defineSingle({
+      slug: "homepage",
+      fields: [text({ name: "title" })],
+      status: true,
+      admin: { preview: { url: () => "/" } },
+    });
+
+    expect(typeof single.admin?.preview?.url).toBe("function");
+  });
+
+  it("can answer a fixed path, which is the common case", () => {
+    const single = defineSingle({
+      slug: "homepage",
+      fields: [text({ name: "title" })],
+      admin: { preview: { url: () => "/" } },
+    });
+
+    expect(single.admin?.preview?.url({})).toBe("/");
+  });
+
+  it("can derive the path from the Single's own document", () => {
+    const single = defineSingle({
+      slug: "landing",
+      fields: [text({ name: "title" })],
+      admin: {
+        preview: {
+          url: doc => (typeof doc.path === "string" ? `/${doc.path}` : null),
+        },
+      },
+    });
+
+    expect(single.admin?.preview?.url({ path: "welcome" })).toBe("/welcome");
+  });
+
+  // `null` is how a declaration says "not previewable right now", which is a
+  // different state from a Single that declares no preview at all: the first
+  // can become previewable, the second never does.
+  it("can decline for a document that is not previewable yet", () => {
+    const single = defineSingle({
+      slug: "landing",
+      fields: [text({ name: "title" })],
+      admin: {
+        preview: {
+          url: doc => (typeof doc.path === "string" ? `/${doc.path}` : null),
+        },
+      },
+    });
+
+    expect(single.admin?.preview?.url({})).toBeNull();
+  });
+
+  it("is optional, so every existing Single keeps compiling", () => {
+    const single = defineSingle({ slug: "contact-details", fields: [] });
+
+    expect(single.admin?.preview).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/singles/config/define-single.ts
+++ b/packages/nextly/src/singles/config/define-single.ts
@@ -51,6 +51,7 @@ import type {
   SingleLabel,
   SingleAdminOptions,
   SingleHooks,
+  SinglePreviewConfig,
 } from "./types";
 import { assertValidSingleConfig } from "./validate-single";
 
@@ -300,5 +301,11 @@ export function defineSingle(config: SingleConfigInput): SingleConfig {
 // Re-exports for Convenience
 // ============================================================
 
-export type { SingleConfig, SingleLabel, SingleAdminOptions, SingleHooks };
+export type {
+  SingleConfig,
+  SingleLabel,
+  SingleAdminOptions,
+  SingleHooks,
+  SinglePreviewConfig,
+};
 export type { SingleAccessControl };

--- a/packages/nextly/src/singles/config/types.ts
+++ b/packages/nextly/src/singles/config/types.ts
@@ -68,6 +68,42 @@ export interface SingleLabel {
  * };
  * ```
  */
+/**
+ * Where a Single previews.
+ *
+ * Deliberately the same shape as `CollectionPreviewConfig`: both answer the one
+ * question "given this document, what is its address on the site", and the
+ * resolver that answers it for collections is the resolver that should answer
+ * it here. A second shape would mean a second resolution, and two of those
+ * agree only until one is edited.
+ *
+ * The argument is the Single's own document rather than an entry, which is the
+ * only difference that matters — a Single is addressed by slug and has no id.
+ */
+export interface SinglePreviewConfig {
+  /**
+   * Computes the URL from the Single's document, or declines by returning
+   * `null`.
+   *
+   * `null` says "not previewable right now" — a document whose path field is
+   * still empty, say — which is a different state from a Single that declares no
+   * preview at all: the first becomes previewable, the second never does.
+   */
+  url: (document: Record<string, unknown>) => string | null;
+
+  /**
+   * Whether to open the preview in a new browser tab.
+   * @default true
+   */
+  openInNewTab?: boolean;
+
+  /**
+   * Custom label for the preview button.
+   * @default "Preview"
+   */
+  label?: string;
+}
+
 export interface SingleAdminOptions {
   /**
    * Group name for organizing Singles in the sidebar.
@@ -98,6 +134,20 @@ export interface SingleAdminOptions {
 
   /** Custom sidebar group slug. When set, item moves from its default section to this custom group */
   sidebarGroup?: string;
+
+  /**
+   * Where this Single is served on the site.
+   *
+   * A Single with a Draft / Published lifecycle has drafts worth sharing, and a
+   * shared preview link needs somewhere to open. Nothing outside the
+   * application can work that out — whether the homepage Single is at `/`, at
+   * `/home`, or under a locale segment is decided by a route file — so it is
+   * declared here, exactly as a collection declares its own.
+   *
+   * Absent means this Single is not previewable, and the admin says so rather
+   * than handing out a link with nowhere to land.
+   */
+  preview?: SinglePreviewConfig;
 
   /**
    * Description text displayed below the Single title.


### PR DESCRIPTION
Singles are draftable — they carry the same Draft / Published lifecycle a collection does — and were structurally unable to produce a shareable preview link. The token could only name a collection and an entry id, and a Single has neither.

Follows #1152, which closed the same hole for collections. Stacked on nothing: this branch is rebased onto the merged `main`.

## The shape of it

A preview token now names **either** an entry **or** a single, as a discriminated union.

**Backward compatibility is load-bearing, not incidental.** The entry variant's `kind` is *optional*, and an entry token is still signed **without** the claim — byte-identical to before — so every link already in someone's inbox keeps verifying. An *unrecognised* kind is refused rather than defaulted.

Declaring where a Single is served, and gating the route that renders it:

```ts
export const LandingPage = defineSingle({
  slug: "landing-page",
  status: true,
  admin: { preview: { url: () => "/landing" } },
});

const { SinglePage, generateMetadata } = createSinglePage({
  slug: "landing-page",
  field: "hero",
  draft: previewSingleDraftGate(),
});
```

## Design points a reviewer will ask about

**`previewSingleDraftGate` is a sibling, not a branch.** A collection gate returns an entry id so the route can compare it against the row a *path* resolved to. A Single has no path and no id, so its gate settles the question and returns a boolean. `previewTokenCovers` remains the single place a scope is judged.

**A granted draft read is TRUSTED and UNCACHED.** Trusted because the working-draft overlay is gated on edit capability while the route resolves anonymously — an enforced draft read would return published values while reporting success. Uncached because a draft is per-visitor, and one cached draft is served to everyone who asks next. `createPublicSingleRoute` and `createPublicSinglePage` refuse the hook outright.

**No second row-level probe, and nothing is missing.** That probe exists for entries because a collection gate answers about the *collection* while the token names one *entry*. A Single has exactly one document, so gate subject and token subject are the same thing.

## Two defects found by running it, not by testing it

Both were invisible to a green unit suite, and both would have shipped the reported bug back.

**The preview route refused every Single.** `defaultRedirectTo` returned `null` for a Single scope, so `createPreviewRoute()` — the zero-config mount — answered 404 to every link the mint had just handed out. `resolveSinglePreviewRedirect` existed and had exactly one caller, the minting endpoint. The unit tests passed because they exercise the resolver directly and the mint separately; nothing asked what the route does with a Single token.

The read is now one shared function, because two implementations of "where does this Single's draft live" is precisely how a link gets minted at one address and landed at another.

**The page-builder path could not serve a draft.** `createSinglePage` omitted `draft` from its config, on the reasoning that the hook belongs to the collection lifecycle "which a Single route does not scope" — true when written, false once a Single route gained one. Since `createSinglePage` is how a Single built in the page builder is rendered, the common authoring path verified the link, redirected, and showed the **published** document.

## Verified end to end

Against the playground, with the landing page single unpublished:

```
mint    → 200
follow  → 307 → /landing          (404 before the route-default fix)
target WITH the preview session   → 200
target with NO session (control)  → 404
garbage token                     → no Set-Cookie
```

The control is what makes the 200 mean anything. Scope refusal — a token that names a different subject — is covered by `previewSingleDraftGate`'s own tests rather than claimed from this run.

## Evidence

Break-verified: removing the `draft` threading in `blocks-react` turns the positive control and the public-factory refusal red, and leaves the two negative cases green — which is why the positive control is there. Earlier rounds on this branch caught a redundant `kind` guard duplicating `previewTokenCovers`, and a locale test that could not distinguish "compares correctly" from "refuses everything".

One test in this PR was repaired rather than trusted: the first version of the Single-draft suite passed while `generateMetadata` short-circuited before resolving anything, so the reader was never asked and every assertion was measuring a route that never ran.

`fallow audit`: **pass**, 0 introduced across all four categories.
`build`, `check-types`, `lint`, `check:comment-convention`: clean.
`packages/nextly` 360 failing / `packages/admin` 15 failing — both the documented pre-existing baselines, compared by name; no failing file touches this area. `packages/blocks-react`: 768 passing, 0 failing.
