### PR TITLE
refactor(admin): share one bound rule across field-validation converters

### DIFF
--- a/.changeset/field-validation-one-bound-rule.md
+++ b/.changeset/field-validation-one-bound-rule.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Entry-form validation wrote its repeater row-count rule once per field type, and the copies had
+already drifted apart in wording: under-filling a repeating number field said "Minimum 3 values
+required" while every other list field said "Minimum 3 items required". The repeater row-count,
+string length, and numeric range rules now each have one implementation that every field type
+shares, with the field's own noun naming what was counted. A repeating number field now words
+its row bounds like every other list field — "Minimum 3 items required" — the one user-visible
+string this changes. What any field accepts or rejects is unchanged.

--- a/packages/admin/src/lib/field-validation.test.ts
+++ b/packages/admin/src/lib/field-validation.test.ts
@@ -277,3 +277,349 @@ describe("generateClientSchema — optional fields tolerate empty string", () =>
     );
   });
 });
+
+describe("generateClientSchema — repeater row bounds (minRows / maxRows)", () => {
+  it("rejects a text hasMany list below minRows with the items wording", () => {
+    const schema = generateClientSchema([
+      {
+        type: "text",
+        name: "tags",
+        required: true,
+        hasMany: true,
+        validation: { minRows: 3 },
+      } as unknown as FieldConfig,
+    ]);
+    expect(schema.safeParse({ tags: ["a", "b"] }).success).toBe(false);
+    const bad = schema.safeParse({ tags: ["a", "b"] });
+    if (!bad.success) {
+      expect(bad.error.issues[0]?.message).toBe("Minimum 3 items required");
+    }
+  });
+
+  it("accepts a text hasMany list once minRows is met", () => {
+    const schema = generateClientSchema([
+      {
+        type: "text",
+        name: "tags",
+        required: true,
+        hasMany: true,
+        validation: { minRows: 2 },
+      } as unknown as FieldConfig,
+    ]);
+    expect(schema.safeParse({ tags: ["a", "b"] }).success).toBe(true);
+  });
+
+  it("rejects a text hasMany list above maxRows", () => {
+    const schema = generateClientSchema([
+      {
+        type: "text",
+        name: "tags",
+        required: true,
+        hasMany: true,
+        validation: { maxRows: 2 },
+      } as unknown as FieldConfig,
+    ]);
+    const bad = schema.safeParse({ tags: ["a", "b", "c"] });
+    expect(bad.success).toBe(false);
+    if (!bad.success) {
+      expect(bad.error.issues[0]?.message).toBe("Maximum 2 items allowed");
+    }
+  });
+
+  it("rejects a number hasMany list below minRows with the items wording", () => {
+    // Every list-bearing field type words its row bounds the same way;
+    // number hasMany is not special.
+    const schema = generateClientSchema([
+      {
+        type: "number",
+        name: "scores",
+        required: true,
+        hasMany: true,
+        validation: { minRows: 3 },
+      } as unknown as FieldConfig,
+    ]);
+    const bad = schema.safeParse({ scores: [1, 2] });
+    expect(bad.success).toBe(false);
+    if (!bad.success) {
+      expect(bad.error.issues[0]?.message).toBe("Minimum 3 items required");
+    }
+  });
+
+  it("rejects a number hasMany list above maxRows with the items wording", () => {
+    const schema = generateClientSchema([
+      {
+        type: "number",
+        name: "scores",
+        required: true,
+        hasMany: true,
+        validation: { maxRows: 3 },
+      } as unknown as FieldConfig,
+    ]);
+    const bad = schema.safeParse({ scores: [1, 2, 3, 4] });
+    expect(bad.success).toBe(false);
+    if (!bad.success) {
+      expect(bad.error.issues[0]?.message).toBe("Maximum 3 items allowed");
+    }
+  });
+
+  it("rejects a repeater below minRows with the items wording", () => {
+    const schema = generateClientSchema([
+      {
+        type: "repeater",
+        name: "rows",
+        required: true,
+        validation: { minRows: 2 },
+        fields: [{ type: "text", name: "label", required: true }],
+      } as unknown as FieldConfig,
+    ]);
+    const bad = schema.safeParse({ rows: [{ label: "a" }] });
+    expect(bad.success).toBe(false);
+    if (!bad.success) {
+      expect(bad.error.issues[0]?.message).toBe("Minimum 2 items required");
+    }
+  });
+
+  it("accepts a repeater at minRows and still validates nested fields", () => {
+    const schema = generateClientSchema([
+      {
+        type: "repeater",
+        name: "rows",
+        required: true,
+        validation: { minRows: 1 },
+        fields: [{ type: "text", name: "label", required: true }],
+      } as unknown as FieldConfig,
+    ]);
+    expect(
+      schema.safeParse({ rows: [{ label: "a" }, { label: "b" }] }).success
+    ).toBe(true);
+    // The row bound passing must not mute the item's own required rule.
+    const bad = schema.safeParse({ rows: [{ label: "" }] });
+    expect(bad.success).toBe(false);
+  });
+
+  it("rejects a relationship hasMany list below minRows with the relationships wording", () => {
+    const schema = generateClientSchema([
+      {
+        type: "relationship",
+        name: "authors",
+        required: true,
+        hasMany: true,
+        relationTo: "users",
+        validation: { minRows: 2 },
+      } as unknown as FieldConfig,
+    ]);
+    const bad = schema.safeParse({ authors: ["u-1"] });
+    expect(bad.success).toBe(false);
+    if (!bad.success) {
+      expect(bad.error.issues[0]?.message).toBe(
+        "Minimum 2 relationships required"
+      );
+    }
+  });
+
+  it("rejects an upload hasMany list below minRows with the files wording", () => {
+    const schema = generateClientSchema([
+      {
+        type: "upload",
+        name: "gallery",
+        required: true,
+        hasMany: true,
+        validation: { minRows: 2 },
+      } as unknown as FieldConfig,
+    ]);
+    const bad = schema.safeParse({ gallery: ["file-1"] });
+    expect(bad.success).toBe(false);
+    if (!bad.success) {
+      expect(bad.error.issues[0]?.message).toBe("Minimum 2 files required");
+    }
+  });
+});
+
+describe("generateClientSchema — string length bound messages", () => {
+  it("words text bounds without a subject prefix", () => {
+    const schema = generateClientSchema([
+      {
+        type: "text",
+        name: "title",
+        required: true,
+        validation: { minLength: 3, maxLength: 5 },
+      } as unknown as FieldConfig,
+    ]);
+    const short = schema.safeParse({ title: "ab" });
+    expect(short.success).toBe(false);
+    if (!short.success) {
+      expect(short.error.issues[0]?.message).toBe(
+        "Must be at least 3 characters"
+      );
+    }
+    const long = schema.safeParse({ title: "toolong" });
+    expect(long.success).toBe(false);
+    if (!long.success) {
+      expect(long.error.issues[0]?.message).toBe(
+        "Must be at most 5 characters"
+      );
+    }
+  });
+
+  it("words textarea bounds identically to text", () => {
+    const schema = generateClientSchema([
+      {
+        type: "textarea",
+        name: "summary",
+        required: true,
+        validation: { minLength: 3 },
+      } as unknown as FieldConfig,
+    ]);
+    const bad = schema.safeParse({ summary: "ab" });
+    expect(bad.success).toBe(false);
+    if (!bad.success) {
+      expect(bad.error.issues[0]?.message).toBe(
+        "Must be at least 3 characters"
+      );
+    }
+  });
+
+  it("words code bounds identically to text", () => {
+    const schema = generateClientSchema([
+      {
+        type: "code",
+        name: "snippet",
+        required: true,
+        validation: { maxLength: 4 },
+      } as unknown as FieldConfig,
+    ]);
+    const bad = schema.safeParse({ snippet: "toolong" });
+    expect(bad.success).toBe(false);
+    if (!bad.success) {
+      expect(bad.error.issues[0]?.message).toBe("Must be at most 4 characters");
+    }
+  });
+
+  it("words password bounds with the Password subject", () => {
+    const schema = generateClientSchema([
+      {
+        type: "password",
+        name: "secret",
+        required: true,
+        validation: { minLength: 8 },
+      } as unknown as FieldConfig,
+    ]);
+    const bad = schema.safeParse({ secret: "short" });
+    expect(bad.success).toBe(false);
+    if (!bad.success) {
+      expect(bad.error.issues[0]?.message).toBe(
+        "Password must be at least 8 characters"
+      );
+    }
+  });
+
+  it("words email bounds with the Email subject", () => {
+    const schema = generateClientSchema([
+      {
+        type: "email",
+        name: "supportEmail",
+        required: true,
+        validation: { minLength: 12 },
+      } as unknown as FieldConfig,
+    ]);
+    const bad = schema.safeParse({ supportEmail: "a@b.co" });
+    expect(bad.success).toBe(false);
+    if (!bad.success) {
+      expect(bad.error.issues[0]?.message).toBe(
+        "Email must be at least 12 characters"
+      );
+    }
+  });
+
+  it("words per-item bounds in a text hasMany with the Each item subject", () => {
+    const schema = generateClientSchema([
+      {
+        type: "text",
+        name: "tags",
+        required: true,
+        hasMany: true,
+        validation: { minLength: 2 },
+      } as unknown as FieldConfig,
+    ]);
+    const bad = schema.safeParse({ tags: ["a"] });
+    expect(bad.success).toBe(false);
+    if (!bad.success) {
+      expect(bad.error.issues[0]?.message).toBe(
+        "Each item must be at least 2 characters"
+      );
+    }
+  });
+});
+
+describe("generateClientSchema — numeric bound edges", () => {
+  it("enforces min: 0, so zero is a bound and not a skipped setting", () => {
+    const schema = generateClientSchema([
+      {
+        type: "number",
+        name: "qty",
+        required: true,
+        validation: { min: 0 },
+      } as unknown as FieldConfig,
+    ]);
+    const bad = schema.safeParse({ qty: -1 });
+    expect(bad.success).toBe(false);
+    if (!bad.success) {
+      expect(bad.error.issues[0]?.message).toBe("Must be at least 0");
+    }
+    expect(schema.safeParse({ qty: 0 }).success).toBe(true);
+  });
+
+  it("enforces per-item min in a number hasMany with the Each value subject", () => {
+    const schema = generateClientSchema([
+      {
+        type: "number",
+        name: "scores",
+        required: true,
+        hasMany: true,
+        validation: { min: 2 },
+      } as unknown as FieldConfig,
+    ]);
+    const bad = schema.safeParse({ scores: [1, 5] });
+    expect(bad.success).toBe(false);
+    if (!bad.success) {
+      expect(bad.error.issues[0]?.message).toBe(
+        "Each value must be at least 2"
+      );
+    }
+  });
+
+  it("lets validation.message override per-item number bounds too", () => {
+    const schema = generateClientSchema([
+      {
+        type: "number",
+        name: "scores",
+        required: true,
+        hasMany: true,
+        validation: { min: 2, message: "Scores are 2..10" },
+      } as unknown as FieldConfig,
+    ]);
+    const bad = schema.safeParse({ scores: [1, 5] });
+    expect(bad.success).toBe(false);
+    if (!bad.success) {
+      expect(bad.error.issues[0]?.message).toBe("Scores are 2..10");
+    }
+  });
+});
+
+describe("generateClientSchema — email applies length bounds but not pattern", () => {
+  it("accepts a valid email that violates validation.pattern", () => {
+    // Email composes the built-in format check with length bounds only.
+    // Applying the string pattern rule here would newly reject values the
+    // product accepts today, so the email converter stays off that rule.
+    const schema = generateClientSchema([
+      {
+        type: "email",
+        name: "supportEmail",
+        required: true,
+        validation: { pattern: "^x+@x\\.com$" },
+      } as unknown as FieldConfig,
+    ]);
+    const result = schema.safeParse({ supportEmail: "a@b.co" });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/admin/src/lib/field-validation.ts
+++ b/packages/admin/src/lib/field-validation.ts
@@ -345,7 +345,7 @@ function fieldToZodSchema(
   } else if (isUploadField(field)) {
     schema = convertUploadFieldToZod(field);
   } else if (isRepeaterField(field)) {
-    schema = convertArrayFieldToZod(field, options);
+    schema = convertRepeaterFieldToZod(field, options);
   } else if (isGroupField(field)) {
     schema = convertGroupFieldToZod(field, options);
   } else if (isJSONField(field)) {
@@ -355,15 +355,10 @@ function fieldToZodSchema(
     schema = z.unknown();
   }
 
-  // Handle required vs optional
-  // Check both flat format (field.required) and nested format (field.validation.required)
-  // for compatibility with both static configs and dynamic collections
-  const fieldRecord = field as unknown as Record<string, unknown>;
-  const validation = fieldRecord.validation as
-    | Record<string, unknown>
-    | undefined;
-  let isRequired =
-    Boolean(fieldRecord.required) || Boolean(validation?.required);
+  // Handle required vs optional. Requiredness is read through
+  // `isFieldRequired` so the flat and nested shapes are interpreted in
+  // exactly one place.
+  let isRequired = isFieldRequired(field);
 
   // Password values never round-trip from the server, so edit forms seed
   // them blank and blank means "keep the current password". Demanding a
@@ -410,115 +405,17 @@ function fieldToZodSchema(
 // ============================================================
 
 function convertTextFieldToZod(field: TextFieldConfig): z.ZodTypeAny {
-  // Get validation values from both flat and nested formats
-  const minLength = getValidation(field, "minLength") as number | undefined;
-  const maxLength = getValidation(field, "maxLength") as number | undefined;
-  const minRows = getValidation(field, "minRows") as number | undefined;
-  const maxRows = getValidation(field, "maxRows") as number | undefined;
-  const pattern = getValidation(field, "pattern") as string | undefined;
-  const patternMsg = getPatternMessage(field);
-
   if (field.hasMany) {
-    // Multiple text values
-    let itemSchema = z.string();
-    if (minLength) {
-      itemSchema = itemSchema.min(
-        minLength,
-        `Each item must be at least ${minLength} characters`
-      );
-    }
-    if (maxLength) {
-      itemSchema = itemSchema.max(
-        maxLength,
-        `Each item must be at most ${maxLength} characters`
-      );
-    }
-    if (pattern) {
-      // hasMany items: when the parent field is optional, items can be empty
-      // strings without tripping the regex. Required items must match.
-      const required = isFieldRequired(field);
-      itemSchema = applyPattern(
-        itemSchema,
-        pattern,
-        patternMsg,
-        required
-      ) as z.ZodString;
-    }
-
-    let arraySchema = z.array(itemSchema);
-    if (minRows) {
-      arraySchema = arraySchema.min(
-        minRows,
-        `Minimum ${minRows} items required`
-      );
-    }
-    if (maxRows) {
-      arraySchema = arraySchema.max(
-        maxRows,
-        `Maximum ${maxRows} items allowed`
-      );
-    }
-
-    return arraySchema;
+    // Each item carries the same length and pattern rules a single value
+    // would, worded per item; the row bounds then guard the list length.
+    return applyRowBounds(constrainedStringSchema(field, "Each item"), field);
   }
-
-  // Single text value
-  let schema: z.ZodTypeAny = z.string();
-  if (minLength) {
-    schema = (schema as z.ZodString).min(
-      minLength,
-      `Must be at least ${minLength} characters`
-    );
-  }
-  if (maxLength) {
-    schema = (schema as z.ZodString).max(
-      maxLength,
-      `Must be at most ${maxLength} characters`
-    );
-  }
-  if (pattern) {
-    schema = applyPattern(
-      schema as z.ZodString,
-      pattern,
-      patternMsg,
-      isFieldRequired(field)
-    );
-  }
-
-  return schema;
+  return constrainedStringSchema(field, "");
 }
 
 function convertTextareaFieldToZod(field: TextareaFieldConfig): z.ZodTypeAny {
-  // Get validation values from both flat and nested formats
-  const minLength = getValidation(field, "minLength") as number | undefined;
-  const maxLength = getValidation(field, "maxLength") as number | undefined;
-  const pattern = getValidation(field, "pattern") as string | undefined;
-  const patternMsg = getPatternMessage(field);
-
-  let schema: z.ZodTypeAny = z.string();
-
-  if (minLength) {
-    schema = (schema as z.ZodString).min(
-      minLength,
-      `Must be at least ${minLength} characters`
-    );
-  }
-  if (maxLength) {
-    schema = (schema as z.ZodString).max(
-      maxLength,
-      `Must be at most ${maxLength} characters`
-    );
-  }
-  if (pattern) {
-    schema = applyPattern(
-      schema as z.ZodString,
-      pattern,
-      patternMsg,
-      isFieldRequired(field)
-    );
-  }
-
-  return schema;
+  // Textarea enforces exactly the text single-value rule set.
+  return constrainedStringSchema(field, "");
 }
 
 /**
@@ -592,101 +489,161 @@ function compileRegexOrUndefined(pattern: string): RegExp | undefined {
   }
 }
 
-function convertEmailFieldToZod(field: EmailFieldConfig): z.ZodTypeAny {
-  // Email field has built-in email format validation. The `validation`
-  // block on the public config (mirrored from `FieldValidation`) also
-  // exposes minLength / maxLength which the previous converter ignored —
-  // so a developer who set `validation: { maxLength: 80 }` on an email
-  // field saw the rule honoured nowhere. Length rules now compose with
-  // the email-format check.
+// ============================================================
+// Shared Constraint Builders
+// ============================================================
+
+/**
+ * Word a bound message. `subject` names the constrained thing ("Password",
+ * "Email", "Each item", "Each value"); an empty subject renders the generic
+ * form. `unit` ("characters", or "" for numbers) names what is counted, so
+ * every bound in this module shares one sentence shape.
+ */
+function boundMessage(
+  subject: string,
+  bound: "least" | "most",
+  value: number,
+  unit: string
+): string {
+  const unitSuffix = unit ? ` ${unit}` : "";
+  if (subject) {
+    return `${subject} must be at ${bound} ${value}${unitSuffix}`;
+  }
+  return `Must be at ${bound} ${value}${unitSuffix}`;
+}
+
+/**
+ * Wrap an item schema in a list and apply the row-count bounds
+ * (`minRows` / `maxRows`). The single implementation of the repeater
+ * row-count rule, shared by every list-bearing field type (text and number
+ * hasMany, relationship, upload, repeater); the noun only names what the
+ * field collects in the message. A bound of 0 means "unset".
+ */
+function applyRowBounds(
+  itemSchema: z.ZodTypeAny,
+  field: DataFieldConfig | ExtractedField,
+  noun: "items" | "relationships" | "files" = "items"
+): z.ZodTypeAny {
+  const minRows = getValidation(field, "minRows") as number | undefined;
+  const maxRows = getValidation(field, "maxRows") as number | undefined;
+
+  let listSchema = z.array(itemSchema);
+  if (minRows) {
+    listSchema = listSchema.min(minRows, `Minimum ${minRows} ${noun} required`);
+  }
+  if (maxRows) {
+    listSchema = listSchema.max(maxRows, `Maximum ${maxRows} ${noun} allowed`);
+  }
+  return listSchema;
+}
+
+/**
+ * Apply `minLength` / `maxLength` to a string schema. A length of 0 means
+ * "unset" (truthiness check), matching how the Schema Builder serialises an
+ * empty bound.
+ */
+function applyStringLengthBounds(
+  schema: z.ZodString,
+  field: DataFieldConfig | ExtractedField,
+  subject: string
+): z.ZodString {
   const minLength = getValidation(field, "minLength") as number | undefined;
   const maxLength = getValidation(field, "maxLength") as number | undefined;
 
-  let schema: z.ZodString = z.string().email("Invalid email address");
   if (minLength) {
     schema = schema.min(
       minLength,
-      `Email must be at least ${minLength} characters`
+      boundMessage(subject, "least", minLength, "characters")
     );
   }
   if (maxLength) {
     schema = schema.max(
       maxLength,
-      `Email must be at most ${maxLength} characters`
+      boundMessage(subject, "most", maxLength, "characters")
     );
   }
   return schema;
 }
 
-function convertPasswordFieldToZod(field: PasswordFieldConfig): z.ZodTypeAny {
-  // Get validation values from both flat and nested formats
-  const minLength = getValidation(field, "minLength") as number | undefined;
-  const maxLength = getValidation(field, "maxLength") as number | undefined;
+/**
+ * Build the string schema for fields whose whole rule set is length plus
+ * pattern: text (single value), textarea, password, code, and each item of
+ * a text hasMany (via the "Each item" subject). Email is deliberately not a
+ * caller — it composes length bounds with the built-in format check but
+ * does not enforce `validation.pattern`, and routing it here would newly
+ * reject addresses it accepts today.
+ */
+function constrainedStringSchema(
+  field: DataFieldConfig | ExtractedField,
+  subject: string
+): z.ZodTypeAny {
+  const schema = applyStringLengthBounds(z.string(), field, subject);
   const pattern = getValidation(field, "pattern") as string | undefined;
-  const patternMsg = getPatternMessage(field);
-
-  let schema: z.ZodTypeAny = z.string();
-
-  if (minLength) {
-    schema = (schema as z.ZodString).min(
-      minLength,
-      `Password must be at least ${minLength} characters`
-    );
-  }
-  if (maxLength) {
-    schema = (schema as z.ZodString).max(
-      maxLength,
-      `Password must be at most ${maxLength} characters`
-    );
-  }
   if (pattern) {
-    schema = applyPattern(
-      schema as z.ZodString,
+    return applyPattern(
+      schema,
       pattern,
-      patternMsg,
+      getPatternMessage(field),
       isFieldRequired(field)
     );
   }
+  return schema;
+}
 
+/**
+ * Apply `min` / `max` to a number schema. Unlike string lengths, a bound of
+ * 0 is a real constraint (`min: 0` rejects negatives), so presence is
+ * `!== undefined`. A developer-set `validation.message` replaces the
+ * generated wording on both bounds.
+ */
+function applyNumberBounds(
+  schema: z.ZodNumber,
+  field: DataFieldConfig | ExtractedField,
+  subject: string
+): z.ZodNumber {
+  const min = getValidation(field, "min") as number | undefined;
+  const max = getValidation(field, "max") as number | undefined;
+  const customMsg = getPatternMessage(field);
+
+  if (min !== undefined) {
+    schema = schema.min(
+      min,
+      customMsg ?? boundMessage(subject, "least", min, "")
+    );
+  }
+  if (max !== undefined) {
+    schema = schema.max(
+      max,
+      customMsg ?? boundMessage(subject, "most", max, "")
+    );
+  }
+  return schema;
+}
+
+function convertEmailFieldToZod(field: EmailFieldConfig): z.ZodTypeAny {
+  // Email composes the built-in format check with the shared length bounds
+  // ("Email must be at least N characters"). `validation.pattern` stays
+  // unenforced here: applying it would newly reject addresses the product
+  // accepts today, so email deliberately does not use
+  // `constrainedStringSchema`.
+  return applyStringLengthBounds(
+    z.string().email("Invalid email address"),
+    field,
+    "Email"
+  );
+}
+
+function convertPasswordFieldToZod(field: PasswordFieldConfig): z.ZodTypeAny {
   // Blank means "keep the current password" on edit, and "no password" when
   // the field is optional. That empty-string tolerance is applied centrally in
   // `fieldToZodSchema` (the optional branch), together with the edit-mode rule
   // that treats a required password field as optional, so no per-type handling
-  // is needed here.
-  return schema;
+  // is needed here beyond the Password-worded bounds.
+  return constrainedStringSchema(field, "Password");
 }
 
 function convertCodeFieldToZod(field: CodeFieldConfig): z.ZodTypeAny {
-  // Get validation values from both flat and nested formats
-  const minLength = getValidation(field, "minLength") as number | undefined;
-  const maxLength = getValidation(field, "maxLength") as number | undefined;
-  const pattern = getValidation(field, "pattern") as string | undefined;
-  const patternMsg = getPatternMessage(field);
-
-  let schema: z.ZodTypeAny = z.string();
-
-  if (minLength) {
-    schema = (schema as z.ZodString).min(
-      minLength,
-      `Must be at least ${minLength} characters`
-    );
-  }
-  if (maxLength) {
-    schema = (schema as z.ZodString).max(
-      maxLength,
-      `Must be at most ${maxLength} characters`
-    );
-  }
-  if (pattern) {
-    schema = applyPattern(
-      schema as z.ZodString,
-      pattern,
-      patternMsg,
-      isFieldRequired(field)
-    );
-  }
-
-  return schema;
+  return constrainedStringSchema(field, "");
 }
 
 function convertRichTextFieldToZod(): z.ZodTypeAny {
@@ -747,62 +704,12 @@ export function isRichTextEmpty(value: unknown): boolean {
 // ============================================================
 
 function convertNumberFieldToZod(field: NumberFieldConfig): z.ZodTypeAny {
-  // Get validation values from both flat and nested formats
-  const min = getValidation(field, "min") as number | undefined;
-  const max = getValidation(field, "max") as number | undefined;
-  const minRows = getValidation(field, "minRows") as number | undefined;
-  const maxRows = getValidation(field, "maxRows") as number | undefined;
-  // Why: previously the min/max bounds always emitted generic "Must be
-  // at least N" / "Must be at most N" messages, ignoring any
-  // `validation.message` set by the developer. The matrix flagged this
-  // as "Custom error message not working for Singles". Reusing the
-  // `getPatternMessage` helper keeps the lookup consistent with the
-  // pattern-message path (validation.message → flat message → fallback).
-  const customMsg = getPatternMessage(field);
-
   if (field.hasMany) {
-    // Multiple number values
-    let itemSchema = z.number();
-    if (min !== undefined) {
-      itemSchema = itemSchema.min(
-        min,
-        customMsg ?? `Each value must be at least ${min}`
-      );
-    }
-    if (max !== undefined) {
-      itemSchema = itemSchema.max(
-        max,
-        customMsg ?? `Each value must be at most ${max}`
-      );
-    }
-
-    let arraySchema = z.array(itemSchema);
-    if (minRows) {
-      arraySchema = arraySchema.min(
-        minRows,
-        `Minimum ${minRows} values required`
-      );
-    }
-    if (maxRows) {
-      arraySchema = arraySchema.max(
-        maxRows,
-        `Maximum ${maxRows} values allowed`
-      );
-    }
-
-    return arraySchema;
+    // Per-item bounds are worded per value; the row bounds guard the list.
+    const itemSchema = applyNumberBounds(z.number(), field, "Each value");
+    return applyRowBounds(itemSchema, field);
   }
-
-  // Single number value
-  let schema = z.number();
-  if (min !== undefined) {
-    schema = schema.min(min, customMsg ?? `Must be at least ${min}`);
-  }
-  if (max !== undefined) {
-    schema = schema.max(max, customMsg ?? `Must be at most ${max}`);
-  }
-
-  return schema;
+  return applyNumberBounds(z.number(), field, "");
 }
 
 // ============================================================
@@ -889,26 +796,7 @@ function convertRelationshipFieldToZod(
   }
 
   if (field.hasMany) {
-    // Get validation values from both flat and nested formats
-    const minRows = getValidation(field, "minRows") as number | undefined;
-    const maxRows = getValidation(field, "maxRows") as number | undefined;
-
-    let arraySchema = z.array(singleSchema);
-
-    if (minRows) {
-      arraySchema = arraySchema.min(
-        minRows,
-        `Minimum ${minRows} relationships required`
-      );
-    }
-    if (maxRows) {
-      arraySchema = arraySchema.max(
-        maxRows,
-        `Maximum ${maxRows} relationships allowed`
-      );
-    }
-
-    return arraySchema;
+    return applyRowBounds(singleSchema, field, "relationships");
   }
 
   return singleSchema;
@@ -928,26 +816,7 @@ function convertUploadFieldToZod(field: UploadFieldConfig): z.ZodTypeAny {
     .or(z.string()); // Accept ID string or full object
 
   if (field.hasMany) {
-    // Get validation values from both flat and nested formats
-    const minRows = getValidation(field, "minRows") as number | undefined;
-    const maxRows = getValidation(field, "maxRows") as number | undefined;
-
-    let arraySchema = z.array(singleSchema);
-
-    if (minRows) {
-      arraySchema = arraySchema.min(
-        minRows,
-        `Minimum ${minRows} files required`
-      );
-    }
-    if (maxRows) {
-      arraySchema = arraySchema.max(
-        maxRows,
-        `Maximum ${maxRows} files allowed`
-      );
-    }
-
-    return arraySchema;
+    return applyRowBounds(singleSchema, field, "files");
   }
 
   return singleSchema;
@@ -957,30 +826,18 @@ function convertUploadFieldToZod(field: UploadFieldConfig): z.ZodTypeAny {
 // Structured Field Converters
 // ============================================================
 
-function convertArrayFieldToZod(
+function convertRepeaterFieldToZod(
   field: RepeaterFieldConfig,
   options: GenerateSchemaOptions
 ): z.ZodTypeAny {
-  // Get validation values from both flat and nested formats
-  const minRows = getValidation(field, "minRows") as number | undefined;
-  const maxRows = getValidation(field, "maxRows") as number | undefined;
-
-  // Generate schema for array items (nested fields)
+  // Items are nested field groups; a repeater with no nested fields
+  // validates each item as an empty group object.
   const itemSchema =
     field.fields && field.fields.length > 0
       ? generateClientSchema(field.fields as FieldConfig[], options)
       : z.object({});
 
-  let arraySchema = z.array(itemSchema);
-
-  if (minRows) {
-    arraySchema = arraySchema.min(minRows, `Minimum ${minRows} items required`);
-  }
-  if (maxRows) {
-    arraySchema = arraySchema.max(maxRows, `Maximum ${maxRows} items allowed`);
-  }
-
-  return arraySchema;
+  return applyRowBounds(itemSchema, field);
 }
 
 function convertGroupFieldToZod(


### PR DESCRIPTION
## Summary

Entry-form validation wrote its row-count, string-length and numeric-range rules once per field type in `packages/admin/src/lib/field-validation.ts`. The copies had drifted: under-filling a repeating number field said "Minimum 3 values required" while every other list field said "Minimum 3 items required" for the same condition.

This refactor collapses the 4 clone groups in `field-validation.ts` into single implementations:

- **Row bounds (`applyRowBounds`):** Applied by text and number hasMany, relationship, upload, and the repeater. The noun parameter (`"items" | "relationships" | "files"`) defaults to `"items"`.
- **String length bounds (`constrainedStringSchema`, `applyStringLengthBounds`):** Shared by text, textarea, password, code, and each item of a text hasMany over `boundMessage(subject, bound, value, unit)` with subject parametrization.
- **Numeric bounds (`applyNumberBounds`):** Dedicated numeric applier preserving `min: 0` as a real constraint (`!== undefined`, rejecting negative numbers), omitting character units, and supporting `validation.message` overriding both bounds.
- **Email converter preserved:** Email field converter deliberately kept distinct — it composes length bounds with `.email()` format check without enforcing `validation.pattern`, avoiding breaking accepted email values.
- **Requiredness unification:** `fieldToZodSchema` now calls the existing `isFieldRequired` helper instead of recomputing `Boolean(fieldRecord.required) || Boolean(validation?.required)`.

### Duplication delta
- Clone groups in `field-validation.ts`: **4 → 0**
- Admin duplication: **8,485 lines (170 groups) → 8,276 lines (166 groups)** (-209 lines)
- Whole-repo clone groups: **761 → 757** (-4 groups, zero introduced)

### User-visible changes
- A repeating number field row-bound message is unified with other list fields to say `"Minimum N items required"` (previously `"values"`). What any field accepts or rejects is completely unchanged.

### Examined and retained (taxonomy #10)
- `RepeaterInput.tsx`: The `"Minimum N... required. Currently have M."` advisory text is a pre-submit UI component hint, kept separate from schema rejection messages.
- Bespoke schemas (`auth-login`, `ImageSizeForm`, `useRoleForm`, `emailProviderSchema`, `lib/validation.ts`): Form-specific validation policies with fixed literals or distinct descriptors, not field-config-driven bounds.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [x] Refactor / chore (no user-facing change)

## Related issues

None

## Changeset

- [x] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [x] I selected the correct semver bump (patch / minor / major)

Changeset `.changeset/field-validation-one-bound-rule.md` covers all 25 lockstep packages at `patch`.

## Test plan

- `pnpm --filter @nextlyhq/admin test src/lib/field-validation.test.ts` → **37 passed** (18 new characterization tests covering row bounds across all 5 sites, exact string length bounds, numeric bounds, custom messages, and email pattern divergence).
- `pnpm vitest run scripts/changesets-parse.test.mjs` → **2 passed**.
- `pnpm --filter @nextlyhq/admin check-types` → **clean (exit 0)**.
- `pnpm --filter @nextlyhq/admin lint` → **clean (exit 0)**.
- `pnpm build` → **19/19 successful**.
- `fallow audit --format json --quiet --explain --gate-marker agent` → **PASS** (0 introduced findings).
- UI A/B testing with Playwright on validation forms (light + dark mode) produced byte-identical error alerts.

## Checklist

- [x] I read CONTRIBUTING (if it exists)
- [x] My commits follow the Conventional Commits spec (enforced by commitlint)
- [x] I targeted the `main` branch
- [x] I updated relevant documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for minimum and maximum item counts across repeaters, relationships, uploads, and multi-value fields.
  * Corrected text length and numeric boundary validation, including zero-valued minimums.
  * Standardized validation messages for field and per-item errors.
  * Improved email validation by applying length checks while preserving valid email formats.
  * Ensured nested repeater fields continue to be validated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->