### PR TITLE
feat(nextly): fall back to the app url when no site url is configured

### DIFF
--- a/.changeset/preview-links-actually-work.md
+++ b/.changeset/preview-links-actually-work.md
@@ -52,6 +52,15 @@ so a relative path resolves against the origin the visitor is standing on. Where
 to compare against, the path's shape is checked instead, so a protocol-relative value cannot pass
 itself off as a local path.
 
+The absolute URL the admin hands out no longer requires one either. The **Site URL** setting still
+wins where it is set, because it is the only value that can name a site on a different origin from
+the admin — but where it is empty, `NEXT_PUBLIC_APP_URL` answers, which is the same chain media
+URLs and email links already resolve through and is already required in production. That setting
+starts empty on every installation and nothing prompts anyone to fill it in, so "Copy shareable
+link" previously answered "ask an administrator" on every fresh install, including one where the
+admin and the site are plainly the same application. A value that is not http(s) is refused from
+either source rather than copied to a clipboard.
+
 Add `draft: previewDraftGate()` to the content route the link lands on. Without it the route serves
 published entries only, and a preview link verifies, redirects, and then answers 404 from a page
 that looks entirely correct.

--- a/docs/guides/draft-preview.mdx
+++ b/docs/guides/draft-preview.mdx
@@ -216,6 +216,14 @@ that cannot honour it.
 **The admin says a preview URL is not configured.** The collection declares no
 `admin.preview`. Add one, as in step 3.
 
+**The admin says this site has no address configured.** The link has to name a
+host, because it travels by email and chat to someone with no session. Nextly
+takes that host from the **Site URL** setting, and falls back to
+`NEXT_PUBLIC_APP_URL` when it is empty — so this means neither is set, or one of
+them holds something that is not an `http(s)` address. Set either; the setting
+is what you want when the admin and the site are on different origins, since it
+is the only one that can name the site rather than the app the admin runs in.
+
 **The reviewer sees the published page, not the draft.** The draft cookie was
 set on a different origin from the one serving the page — usually an admin and
 site on separate hosts with the preview route mounted on the admin. It belongs

--- a/packages/admin/src/hooks/__tests__/usePreviewLink.test.ts
+++ b/packages/admin/src/hooks/__tests__/usePreviewLink.test.ts
@@ -92,10 +92,11 @@ describe("usePreviewLink", () => {
     expect(mint).toHaveBeenCalledWith({ collection: "posts", entryId: "7" });
   });
 
-  // The server answers `null` when no site URL is configured, because it cannot
-  // name a host. The admin must NOT put its own origin in front of the path:
-  // the admin may be served from somewhere the site is not, and a link to the
-  // wrong host looks like a working one.
+  // The server answers `null` only when the site's address is available nowhere
+  // — neither the stored setting nor the application's own URL — because it
+  // then cannot name a host. The admin must NOT put its own origin in front of
+  // the path: the admin may be served from somewhere the site is not, and a
+  // link to the wrong host looks like a working one.
   it("reports the missing site url instead of substituting its own origin", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal("navigator", { clipboard: { writeText } });
@@ -109,8 +110,15 @@ describe("usePreviewLink", () => {
 
     expect(isError).toBe(true);
     expect(writeText).not.toHaveBeenCalled();
+    // Both remedies, because either one settles it and they belong to different
+    // people: the setting is an administrator's and the variable is a
+    // developer's. Naming only one sends half the readers looking in a place
+    // they cannot act.
     expect(toast.error).toHaveBeenCalledWith(
-      expect.stringContaining("site URL")
+      expect.stringContaining("Site URL")
+    );
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.stringContaining("NEXT_PUBLIC_APP_URL")
     );
   });
 });

--- a/packages/admin/src/hooks/usePreviewLink.ts
+++ b/packages/admin/src/hooks/usePreviewLink.ts
@@ -55,19 +55,25 @@ export function usePreviewLink({
         ...(locale === undefined ? {} : { locale }),
       });
 
-      // The server answers `null` when no site URL is configured, and that is
-      // not something to paper over. A relative URL here would be resolved
-      // against the ADMIN's origin, which is not the site's on any deployment
-      // that separates them — and a link to the wrong host is worse than no
-      // link, because it looks like it worked.
+      // The server answers `null` only when it can find the site's address
+      // NOWHERE — neither the Site URL setting nor the application's own
+      // `NEXT_PUBLIC_APP_URL` — and that is not something to paper over. A
+      // relative URL here would be resolved against the ADMIN's origin, which is
+      // not the site's on any deployment that separates them, and a link to the
+      // wrong host is worse than no link because it looks like it worked.
+      //
+      // Both remedies are named because either one settles it, and they belong
+      // to different people: an administrator can fill in the setting without a
+      // deploy, while the environment variable is a developer's to set.
       // `== null` catches an absent field as well as an explicit null. The
       // contract says `string | null`, but a response that simply omits it —
       // an older server, a proxy that reshapes JSON — must not reach the
       // clipboard as the string "undefined".
       if (link.url == null) {
         throw new Error(
-          "No site URL is configured, so a preview link has nowhere to point. " +
-            "An administrator can set one in Settings."
+          "This site has no address configured, so a preview link has nowhere " +
+            "to point. An administrator can set the Site URL in Settings, or a " +
+            "developer can set NEXT_PUBLIC_APP_URL."
         );
       }
 
@@ -121,9 +127,9 @@ export function usePreviewLink({
       );
     },
     onError: (error: unknown) => {
-      // The thrown message rather than a fixed one: "no site URL is configured"
-      // names something an administrator can act on, and collapsing it into
-      // "couldn't create a preview link" hides the only remedy there is.
+      // The thrown message rather than a fixed one: it names what is missing and
+      // who can supply it, and collapsing it into "couldn't create a preview
+      // link" hides the only remedies there are.
       toast.error(
         error instanceof Error
           ? error.message

--- a/packages/admin/src/services/previewLinkApi.ts
+++ b/packages/admin/src/services/previewLinkApi.ts
@@ -23,7 +23,7 @@ export interface PreviewLink {
   /** The signed token. */
   token: string;
   /**
-   * The finished link, or `null` when no site URL is configured.
+   * The finished link, or `null` when the site's address is configured nowhere.
    *
    * Assembled on the server, which is the only place both halves are visible:
    * the site URL lives in settings the sharing roles cannot read, and the

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -27,6 +27,7 @@ import type { NextlyServiceConfig } from "../di/register";
 import { resolvePreviewRedirect } from "../domains/collections/services/preview-redirect-resolver";
 import { hasPreviewConfigured } from "../domains/collections/services/preview-url-resolver";
 import { resolvePreviewRoute } from "../domains/preview/route-config";
+import { resolvePreviewSiteUrl } from "../domains/preview/site-url";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
 import { env } from "../lib/env";
@@ -101,7 +102,8 @@ function previewSigningSecret(): string {
  * to place the pathname and the parameter cannot make that mistake, and it
  * keeps a site URL's own query intact rather than silently discarding it.
  *
- * `null` when no site URL is configured. A relative URL would be resolved
+ * `null` only when the site's address is available NOWHERE — neither the stored
+ * setting nor the application's own URL. A relative URL would be resolved
  * against whatever origin the admin is served from, which is not the site's on
  * any deployment that separates them.
  */
@@ -233,7 +235,9 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
           // happens to have the answer.
           loadDeclaration: () => Promise.resolve(declaration),
           loadSiteUrl: async () =>
-            (await settingsService()).getSettings().then(s => s.siteUrl),
+            resolvePreviewSiteUrl(
+              await (await settingsService()).getSettings().then(s => s.siteUrl)
+            ),
         }
       )
     : null;
@@ -289,8 +293,9 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
   // withholding it would break preview outright on a site that never set a
   // URL, rather than degrading the one thing that needs the host.
   const settings = await (await settingsService()).getSettings();
+  const siteUrl = resolvePreviewSiteUrl(settings.siteUrl);
   const url = previewLinkUrl({
-    siteUrl: settings.siteUrl,
+    siteUrl,
     route: resolvePreviewRoute(
       container.get<NextlyServiceConfig>("config")?.preview
     ),

--- a/packages/nextly/src/api/preview-url.ts
+++ b/packages/nextly/src/api/preview-url.ts
@@ -33,6 +33,7 @@ import {
   resolvePreviewUrl,
   type PreviewDeclaration,
 } from "../domains/collections/services/preview-url-resolver";
+import { resolvePreviewSiteUrl } from "../domains/preview/site-url";
 import { getCachedNextly } from "../init";
 import type { GeneralSettingsService } from "../services/general-settings/general-settings-service";
 
@@ -121,6 +122,10 @@ export const resolveEntryPreviewUrl = withErrorHandler(async (req: Request) => {
   ]);
 
   return respondData(
-    resolvePreviewUrl({ preview, entry, siteUrl: settings.siteUrl })
+    resolvePreviewUrl({
+      preview,
+      entry,
+      siteUrl: resolvePreviewSiteUrl(settings.siteUrl),
+    })
   );
 });

--- a/packages/nextly/src/domains/collections/services/preview-url-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-url-resolver.ts
@@ -142,7 +142,7 @@ const NAVIGABLE_PROTOCOLS = new Set(["http:", "https:"]);
  * same-origin blank tab — turning a settings write into script execution in the
  * admin for whoever next clicks Preview.
  */
-function asNavigableUrl(value: string): URL | null {
+export function asNavigableUrl(value: string): URL | null {
   let parsed: URL;
   try {
     parsed = new URL(value);

--- a/packages/nextly/src/domains/preview/__tests__/site-url.test.ts
+++ b/packages/nextly/src/domains/preview/__tests__/site-url.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Where a preview link's host comes from.
+ *
+ * The setting is the only value that can name a site on a DIFFERENT origin from
+ * the admin, so it wins. Absent, the application's own URL answers — which is
+ * correct wherever the admin is mounted inside the site's own app, and is the
+ * ordinary case. Before that fallback existed the feature was unreachable on a
+ * new installation: nothing prompts an operator to fill the setting in.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The real module validates the WHOLE environment on import and throws without
+// a database URL, which has nothing to do with what these cover. The stub reads
+// `process.env` on every access rather than snapshotting it, so `stubEnv` below
+// still drives the value under test.
+vi.mock("../../../lib/env", () => ({
+  get env() {
+    return { NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL };
+  },
+}));
+
+const { resolvePreviewSiteUrl } = await import("../site-url");
+
+/** The environment variable under test, set for one case at a time. */
+function withAppUrl(value: string | undefined): void {
+  vi.stubEnv("NEXT_PUBLIC_APP_URL", value ?? "");
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("resolvePreviewSiteUrl", () => {
+  it("prefers the configured setting, which is the only split-deployment answer", () => {
+    withAppUrl("https://admin.example");
+
+    expect(resolvePreviewSiteUrl("https://site.example")).toBe(
+      "https://site.example/"
+    );
+  });
+
+  it("falls back to the application's own url when nothing is configured", () => {
+    withAppUrl("https://site.example");
+
+    expect(resolvePreviewSiteUrl(null)).toBe("https://site.example/");
+  });
+
+  // A stored empty string is what an operator leaves behind by clearing the
+  // field, and it is not a site URL. Treating it as one produces `new URL("")`,
+  // which throws where it is joined rather than here.
+  it("treats a blank setting as unset rather than as an address", () => {
+    withAppUrl("https://site.example");
+
+    expect(resolvePreviewSiteUrl("   ")).toBe("https://site.example/");
+  });
+
+  it("answers null when neither source names anywhere", () => {
+    withAppUrl(undefined);
+
+    expect(resolvePreviewSiteUrl(null)).toBeNull();
+  });
+
+  // The setting's own API refuses these now, but that check is newer than the
+  // column — and the environment schema validates with `z.string().url()`,
+  // which accepts any scheme the WHATWG parser does. A link built from one is
+  // copied to a clipboard and pasted into an address bar.
+  it.each([
+    ["javascript:", "javascript:alert(1)"],
+    ["data:", "data:text/html,<script>alert(1)</script>"],
+    ["file:", "file:///etc/passwd"],
+  ])("refuses a %s setting and falls through to the app url", (_label, bad) => {
+    withAppUrl("https://site.example");
+
+    expect(resolvePreviewSiteUrl(bad)).toBe("https://site.example/");
+  });
+
+  it("refuses an unnavigable app url rather than handing one out", () => {
+    withAppUrl("javascript:alert(1)");
+
+    expect(resolvePreviewSiteUrl(null)).toBeNull();
+  });
+
+  it("refuses a value that is not a url at all", () => {
+    withAppUrl(undefined);
+
+    expect(resolvePreviewSiteUrl("site.example")).toBeNull();
+  });
+});

--- a/packages/nextly/src/domains/preview/site-url.ts
+++ b/packages/nextly/src/domains/preview/site-url.ts
@@ -1,0 +1,58 @@
+/**
+ * The site's absolute address, for a preview link that has to name a host.
+ *
+ * A link travels by email and chat, so it cannot be relative: the recipient has
+ * no admin session and no origin to resolve one against. The address itself is
+ * a fact about the deployment rather than about the entry being shared, which
+ * is why it is resolved once here instead of at each of the four places a link
+ * or a preview URL is assembled.
+ *
+ * **Two sources, in this order, and the order is the whole design.** The stored
+ * Site URL setting wins because it is the only value that can name a site on a
+ * DIFFERENT origin from the admin — the split deployment it exists for. Absent,
+ * the application's own `NEXT_PUBLIC_APP_URL` answers, which is correct for the
+ * ordinary case where the admin is mounted inside the site's own Next.js app,
+ * and is already required in production by the environment schema.
+ *
+ * Refusing when the setting is unset was the previous behaviour and it made the
+ * feature unreachable on a new installation: nothing prompts an operator to
+ * fill that setting in, so "Copy shareable link" answered "ask an
+ * administrator" on every fresh install, including one where the admin and the
+ * site are plainly the same origin. This is the chain media URLs and email
+ * links already resolve through, so the answer is one the codebase already
+ * gives rather than a second opinion about where this site lives.
+ *
+ * @module domains/preview/site-url
+ */
+
+import { env } from "../../lib/env";
+import { asNavigableUrl } from "../collections/services/preview-url-resolver";
+
+/**
+ * The first source that names somewhere a browser may actually navigate.
+ *
+ * Both are checked rather than just the fallback. The setting's own API refuses
+ * a non-http(s) scheme, but that check is newer than the column, so a row
+ * written before it can still hold `javascript:alert(1)` — and the environment
+ * schema validates its value with `z.string().url()`, which accepts any scheme
+ * the WHATWG parser does. A link built from either is copied to a clipboard and
+ * pasted into an address bar.
+ *
+ * `null` when neither answers, which callers report rather than paper over: a
+ * link to nowhere is worse than no link, because it looks like it worked.
+ */
+export function resolvePreviewSiteUrl(
+  configured: string | null
+): string | null {
+  for (const candidate of [configured, env.NEXT_PUBLIC_APP_URL]) {
+    if (candidate === null || candidate === undefined) continue;
+    const trimmed = candidate.trim();
+    if (trimmed === "") continue;
+    // The parsed form, not the input: it normalises the origin, and returning
+    // the raw string would let two spellings of one address reach the two
+    // callers that join a path onto it.
+    const parsed = asNavigableUrl(trimmed);
+    if (parsed !== null) return parsed.toString();
+  }
+  return null;
+}

--- a/packages/nextly/src/runtime/preview/preview-route-defaults.ts
+++ b/packages/nextly/src/runtime/preview/preview-route-defaults.ts
@@ -22,6 +22,7 @@ import {
   resolvePreviewRedirect,
   type PreviewRedirectScope,
 } from "../../domains/collections/services/preview-redirect-resolver";
+import { resolvePreviewSiteUrl } from "../../domains/preview/site-url";
 import { NextlyError } from "../../errors/nextly-error";
 import { getCachedNextly } from "../../init";
 import { env } from "../../lib/env";
@@ -138,7 +139,9 @@ export async function defaultRedirectTo(
       },
       loadDeclaration: previewDeclarationFor,
       loadSiteUrl: async () =>
-        (await settingsService()).getSettings().then(s => s.siteUrl),
+        resolvePreviewSiteUrl(
+          await (await settingsService()).getSettings().then(s => s.siteUrl)
+        ),
     },
     context?.requestOrigin
   );


### PR DESCRIPTION
The **Site URL** setting starts empty on every installation and nothing prompts anyone to fill it in, so "Copy shareable link" answered *"No site URL is configured — ask an administrator"* on every fresh install. Including one where the admin and the site are plainly the same Next.js application, which is the ordinary case.

**This commit was stranded off #1163.** It was pushed after GitHub computed that merge, so it is absent from `ab11bf76b`; `verify-merge.mjs` named it and `git grep` on the merge commit confirmed it by content, with a control against the branch head. This PR lands it on current `main`.

## The decision, and the prior art behind it

Founder-approved after research into how the field solves this:

| | Where the frontend URL lives | Default when unset |
| --- | --- | --- |
| [Payload](https://payloadcms.com/docs/live-preview/overview) | `admin.livePreview.url` in code | **Relative URL allowed** — Payload injects the browser's protocol/domain/port. Absolute only for a different domain. |
| [Sanity](https://www.sanity.io/docs/visual-editing/configuring-the-presentation-tool) | `previewUrl.origin`, usually from an env var | Required *"when the Studio and frontend are separate apps"* |
| [Strapi](https://docs.strapi.io/cms/features/preview) | `CLIENT_URL` env var | Required |
| [Directus](https://directus.com/docs/guides/content/live-preview) | Per-collection Preview URL in the UI | None |

The pattern is consistent: **same-app is the common case and gets a working default; separate-app is the exception that needs configuration.** Nextly was treating the exception as the rule.

The decisive fact is internal, though: `NEXT_PUBLIC_APP_URL` is already **required in production** by Nextly's own env schema, and this codebase already resolves absolute URLs for **media files and email links** through the chain `emailConfig.baseUrl → NEXT_PUBLIC_APP_URL → localhost:3000`. The answer already existed here; preview links just did not use it.

## What changed

The Site URL setting still **wins** where it is set — it is the only value that can name a site on a different origin from the admin, which is what it exists for. Where it is empty, `NEXT_PUBLIC_APP_URL` answers.

One resolver rather than a fallback bolted onto each of the four places a link or preview URL is assembled, because four copies of "where does this site live" is four chances to disagree.

It applies the **navigability check to both sources**, which is a fix in its own right. The setting's own API refuses a non-`http(s)` scheme, but that check is newer than the column — and the env schema validates with `z.string().url()`, which accepts `javascript:alert(1)`. `previewLinkUrl` had no scheme guard at all, so either could previously reach a clipboard. It reuses the existing `asNavigableUrl` predicate rather than adding a second opinion about what is navigable.

The admin's refusal now names both remedies, because they belong to different people: an administrator can set the setting without a deploy; the variable is a developer's.

## Verified by running it

On a fresh playground with `siteUrl` explicitly `null`:

```
mint    → http://localhost:3212/api/preview?token=…   (previously: url: null, refused)
follow  → 307 → /fallback-check
target WITH the preview session   → 200
target with NO session (control)  → 404
```

## Evidence

Break-verified: reversing the precedence turns the split-deployment test red, and dropping the scheme guard turns eight of nine red — including the three that pin `javascript:`, `data:` and `file:`.

`fallow audit`: **pass**, 0 introduced. `build`, `check-types`, `lint`, `check:comment-convention`: clean. `packages/nextly` 360 failing / `packages/admin` 15 failing — both the documented pre-existing baselines, compared by name, no failing file in this area.
