### PR TITLE
feat(ui): let a page declare its own header instead of matching its url

### DIFF
--- a/.changeset/page-header-declares-identity.md
+++ b/.changeset/page-header-declares-identity.md
@@ -1,0 +1,37 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Add `PageHeader`, and let each settings page declare its own identity.
+
+A page's breadcrumb trail, name, summary and actions are now one component
+instead of markup written out at each page. The settings pages previously took
+their title from a chain of sixteen branches matching `window.location.pathname`
+in a file none of them imported, so adding a route meant editing a foreign
+`if`, the header was wrong for any page reachable at more than one path, and a
+plugin could not contribute a settings page at all because it cannot add a
+branch to a chain it does not ship. Each page now passes its own title.

--- a/packages/admin/src/components/features/settings/SettingsLayout.tsx
+++ b/packages/admin/src/components/features/settings/SettingsLayout.tsx
@@ -1,198 +1,79 @@
 "use client";
 
+import { PageHeader } from "@nextlyhq/ui";
 import type React from "react";
-import { useMemo } from "react";
 
 import { Breadcrumbs } from "@admin/components/shared";
 import { ROUTES } from "@admin/constants/routes";
 
 interface SettingsLayoutProps {
-  children: React.ReactNode;
+  /** The page's name, rendered as its `h1`. */
+  title: string;
+  /** A sentence under the title. */
+  description?: React.ReactNode;
+  /**
+   * This page's own crumb, last in the trail. Omitted for the settings root,
+   * whose crumb would repeat the "Settings" link immediately before it.
+   */
+  crumb?: string;
+  /**
+   * The listing a create/edit page belongs under, placed between "Settings"
+   * and this page's own crumb.
+   */
+  parentCrumb?: { label: string; href: string };
   actions?: React.ReactNode;
+  children: React.ReactNode;
 }
 
 /**
- * SettingsLayout Component
+ * The shared chrome for a settings page: its breadcrumb trail and its header.
  *
- * Shared layout wrapper for all Settings pages. Renders the page header
- * and breadcrumbs. Tabs are removed as they are redundant with the inner sidebar.
+ * Each page DECLARES its own identity through props. It previously derived
+ * every title, description and crumb here by matching `window.location.pathname`
+ * against a chain of sixteen branches — so a page's name lived in a file the
+ * page did not import, adding a route meant editing a foreign `if`, and a
+ * plugin could not contribute a settings page at all because it cannot add a
+ * branch to a chain it does not ship. Reading the URL also made the header
+ * wrong for any page reachable at more than one path.
+ *
+ * The registry already made this call for the sidebar: a private route must
+ * declare the rail section it belongs to, so a missing declaration is a compile
+ * error rather than a page that silently highlights the wrong entry. This is
+ * the same decision applied to the page's own name.
+ *
+ * What stays shared is the TRAIL, not the identity. Every settings page hangs
+ * off Dashboard › Settings, so composing that here keeps one implementation of
+ * it; a page supplying its whole breadcrumb array would put sixteen copies of
+ * the same two links in the tree.
  */
-export function SettingsLayout({ children, actions }: SettingsLayoutProps) {
-  const pathname =
-    typeof window !== "undefined" ? window.location.pathname : "";
-
-  // Map of routes to their display labels for breadcrumbs and titles
-  const pageInfo = useMemo(() => {
-    if (pathname === ROUTES.SETTINGS) {
-      return {
-        title: "General Settings",
-        description: "Manage your application and configuration",
-        crumb: "General",
-      };
-    }
-    if (pathname.includes("user-fields")) {
-      return {
-        title: "User Fields",
-        description: "Manage custom fields and attributes for users",
-        crumb: "User Fields",
-      };
-    }
-    if (pathname.includes("email-providers")) {
-      if (pathname.includes("/create")) {
-        return {
-          title: "New Email Provider",
-          description: "Configure a new email delivery provider",
-          crumb: "New Email Provider",
-          parentCrumb: {
-            label: "Email Providers",
-            href: ROUTES.SETTINGS_EMAIL_PROVIDERS,
-          },
-        };
-      }
-      if (pathname.includes("/edit/")) {
-        return {
-          title: "Edit Email Provider",
-          description: "Update the email provider configuration",
-          crumb: "Edit Email Provider",
-          parentCrumb: {
-            label: "Email Providers",
-            href: ROUTES.SETTINGS_EMAIL_PROVIDERS,
-          },
-        };
-      }
-      return {
-        title: "Email Providers",
-        description: "Configure your SMTP and email delivery services",
-        crumb: "Email Providers",
-      };
-    }
-    if (pathname.includes("email-templates")) {
-      if (pathname.includes("/create")) {
-        return {
-          title: "New Email Template",
-          description: "Create a new email template for your application",
-          crumb: "New Email Template",
-          parentCrumb: {
-            label: "Email Templates",
-            href: ROUTES.SETTINGS_EMAIL_TEMPLATES,
-          },
-        };
-      }
-      if (pathname.includes("/edit/")) {
-        return {
-          title: "Edit Email Template",
-          description: "Update the email template content and settings",
-          crumb: "Edit Email Template",
-          parentCrumb: {
-            label: "Email Templates",
-            href: ROUTES.SETTINGS_EMAIL_TEMPLATES,
-          },
-        };
-      }
-      return {
-        title: "Email Templates",
-        description: "Manage and customize system email content",
-        crumb: "Email Templates",
-      };
-    }
-    if (pathname.includes("api-keys")) {
-      return {
-        title: "API Keys",
-        description: "Manage secure access keys for API integrations",
-        crumb: "API Keys",
-      };
-    }
-    if (pathname.includes("webhooks")) {
-      if (pathname.includes("/deliveries")) {
-        return {
-          title: "Deliveries",
-          description:
-            "Delivery attempts for this endpoint, with response status and retries",
-          crumb: "Deliveries",
-          parentCrumb: { label: "Webhooks", href: ROUTES.SETTINGS_WEBHOOKS },
-        };
-      }
-      if (pathname.includes("/create")) {
-        return {
-          title: "New Webhook",
-          description: "Send signed events to an external endpoint",
-          crumb: "New Webhook",
-          parentCrumb: { label: "Webhooks", href: ROUTES.SETTINGS_WEBHOOKS },
-        };
-      }
-      if (pathname.includes("/edit/")) {
-        return {
-          title: "Edit Webhook",
-          description: "Update the endpoint, events, and headers",
-          crumb: "Edit Webhook",
-          parentCrumb: { label: "Webhooks", href: ROUTES.SETTINGS_WEBHOOKS },
-        };
-      }
-      return {
-        title: "Webhooks",
-        description: "Send signed events to your services when content changes",
-        crumb: "Webhooks",
-      };
-    }
-    if (pathname.includes("permissions")) {
-      return {
-        title: "Permissions",
-        description: "Define user roles and access control levels",
-        crumb: "Permissions",
-      };
-    }
-    if (pathname.includes("image-sizes")) {
-      return {
-        title: "Image Sizes",
-        description: "Configure image sizes generated for uploaded images",
-        crumb: "Image Sizes",
-      };
-    }
-    return {
-      title: "General Settings",
-      description: "Manage your application and configuration",
-      crumb: null,
-    };
-  }, [pathname]);
-
+export function SettingsLayout({
+  title,
+  description,
+  crumb,
+  parentCrumb,
+  actions,
+  children,
+}: SettingsLayoutProps) {
   return (
     <div>
-      {/* Breadcrumbs */}
-      <div className="mb-6">
-        <Breadcrumbs
-          items={[
-            { label: "Dashboard", href: ROUTES.DASHBOARD, isDashboard: true },
-            { label: "Settings", href: ROUTES.SETTINGS },
-            ...("parentCrumb" in pageInfo && pageInfo.parentCrumb
-              ? [
-                  {
-                    label: pageInfo.parentCrumb.label,
-                    href: pageInfo.parentCrumb.href,
-                  },
-                ]
-              : []),
-            ...(pageInfo.crumb && pageInfo.crumb !== "General"
-              ? [{ label: pageInfo.crumb }]
-              : []),
-          ]}
-        />
-      </div>
+      <PageHeader
+        title={title}
+        description={description}
+        actions={actions}
+        breadcrumbs={
+          <Breadcrumbs
+            items={[
+              { label: "Dashboard", href: ROUTES.DASHBOARD, isDashboard: true },
+              { label: "Settings", href: ROUTES.SETTINGS },
+              ...(parentCrumb
+                ? [{ label: parentCrumb.label, href: parentCrumb.href }]
+                : []),
+              ...(crumb ? [{ label: crumb }] : []),
+            ]}
+          />
+        }
+      />
 
-      {/* Page Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
-        <div className="space-y-1">
-          <h1 className="text-xl font-semibold tracking-tight">
-            {pageInfo.title}
-          </h1>
-          {/* Muted foreground so this secondary text meets contrast; a faint primary alpha did not. */}
-          <p className="text-sm font-normal text-muted-foreground mt-1">
-            {pageInfo.description}
-          </p>
-        </div>
-        {actions && <div className="flex items-center gap-3">{actions}</div>}
-      </div>
-
-      {/* Content Area */}
       <div className="pt-2">{children}</div>
     </div>
   );

--- a/packages/admin/src/pages/dashboard/settings/api-keys/create.tsx
+++ b/packages/admin/src/pages/dashboard/settings/api-keys/create.tsx
@@ -67,7 +67,11 @@ const CreateApiKeyPage: React.FC = () => {
   return (
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout
+          title="API Keys"
+          description="Manage secure access keys for API integrations"
+          crumb="API Keys"
+        >
           <CreateApiKeyContent />
         </SettingsLayout>
       </PageContainer>

--- a/packages/admin/src/pages/dashboard/settings/api-keys/edit/[id].tsx
+++ b/packages/admin/src/pages/dashboard/settings/api-keys/edit/[id].tsx
@@ -22,6 +22,16 @@ import { validateUUID } from "@admin/lib/validation";
 // Inner content (inside QueryErrorBoundary)
 // ============================================================
 
+/**
+ * This page renders the settings chrome in several branches — loading,
+ * error and the resolved document — and its identity is the same in all of
+ * them. Stated once here so the branches cannot drift apart.
+ */
+const API_KEYS_PAGE = {
+  title: "API Keys",
+  description: "Manage secure access keys for API integrations",
+  crumb: "API Keys",
+} as const;
 const EditApiKeyContent: React.FC<{ id: string }> = ({ id }) => {
   // The API exposes only a list endpoint, so find the key in the cached list.
   const { data, isLoading, isError, error } = useApiKeys();
@@ -108,7 +118,7 @@ export default function EditApiKeyPage() {
   if (!id) {
     return (
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout {...API_KEYS_PAGE}>
           <Alert variant="destructive">
             <AlertDescription>
               Invalid API key ID. Please go back and try again.
@@ -127,7 +137,7 @@ export default function EditApiKeyPage() {
   return (
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout {...API_KEYS_PAGE}>
           <EditApiKeyContent id={id} />
         </SettingsLayout>
       </PageContainer>

--- a/packages/admin/src/pages/dashboard/settings/api-keys/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/api-keys/index.tsx
@@ -101,6 +101,9 @@ const ApiKeysPage: React.FC = () => {
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
       <PageContainer>
         <SettingsLayout
+          title="API Keys"
+          description="Manage secure access keys for API integrations"
+          crumb="API Keys"
           actions={
             <Button
               size="md"

--- a/packages/admin/src/pages/dashboard/settings/email-providers/create.tsx
+++ b/packages/admin/src/pages/dashboard/settings/email-providers/create.tsx
@@ -79,6 +79,13 @@ export default function CreateEmailProviderPage() {
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
       <PageContainer>
         <SettingsLayout
+          title="New Email Provider"
+          description="Configure a new email delivery provider"
+          crumb="New Email Provider"
+          parentCrumb={{
+            label: "Email Providers",
+            href: ROUTES.SETTINGS_EMAIL_PROVIDERS,
+          }}
           actions={
             <>
               {/* Test Connection is only meaningful once a provider has been

--- a/packages/admin/src/pages/dashboard/settings/email-providers/edit/[id].tsx
+++ b/packages/admin/src/pages/dashboard/settings/email-providers/edit/[id].tsx
@@ -206,6 +206,7 @@ export default function EditEmailProviderPage() {
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
       <PageContainer>
         <SettingsLayout
+          {...EMAIL_PROVIDER_PAGE}
           actions={
             <>
               {/* Test Connection — preserves the previous form behaviour

--- a/packages/admin/src/pages/dashboard/settings/email-providers/edit/[id].tsx
+++ b/packages/admin/src/pages/dashboard/settings/email-providers/edit/[id].tsx
@@ -104,7 +104,7 @@ export default function EditEmailProviderPage() {
   if (!providerId) {
     return (
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout {...EMAIL_PROVIDER_PAGE}>
           <Alert variant="destructive">
             <AlertDescription>
               Invalid provider ID. Please go back and try again.
@@ -124,7 +124,7 @@ export default function EditEmailProviderPage() {
   if (isLoading) {
     return (
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout {...EMAIL_PROVIDER_PAGE}>
           <div className="space-y-6">
             <Skeleton className="h-12 w-full rounded-md" />
             <Skeleton className="h-[500px] w-full rounded-lg" />
@@ -138,7 +138,7 @@ export default function EditEmailProviderPage() {
   if (fetchError) {
     return (
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout {...EMAIL_PROVIDER_PAGE}>
           <Alert variant="destructive">
             <AlertDescription className="flex items-center justify-between">
               <span>
@@ -250,3 +250,18 @@ export default function EditEmailProviderPage() {
     </QueryErrorBoundary>
   );
 }
+
+/**
+ * This page renders the settings chrome in several branches — loading,
+ * error and the resolved document — and its identity is the same in all of
+ * them. Stated once here so the branches cannot drift apart.
+ */
+const EMAIL_PROVIDER_PAGE = {
+  title: "Edit Email Provider",
+  description: "Update the email provider configuration",
+  crumb: "Edit Email Provider",
+  parentCrumb: {
+    label: "Email Providers",
+    href: ROUTES.SETTINGS_EMAIL_PROVIDERS,
+  },
+} as const;

--- a/packages/admin/src/pages/dashboard/settings/email-providers/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/email-providers/index.tsx
@@ -810,6 +810,9 @@ const EmailProvidersPage: React.FC = () => {
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
       <PageContainer>
         <SettingsLayout
+          title="Email Providers"
+          description="Configure your SMTP and email delivery services"
+          crumb="Email Providers"
           actions={
             <Link href={ROUTES.SETTINGS_EMAIL_PROVIDERS_CREATE}>
               <Button size="md" className="flex items-center gap-1">

--- a/packages/admin/src/pages/dashboard/settings/email-templates/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/email-templates/index.tsx
@@ -511,6 +511,9 @@ const EmailTemplatesPage: React.FC = () => {
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
       <PageContainer>
         <SettingsLayout
+          title="Email Templates"
+          description="Manage and customize system email content"
+          crumb="Email Templates"
           actions={
             <Button
               onClick={() => navigateTo(ROUTES.SETTINGS_EMAIL_TEMPLATES_CREATE)}

--- a/packages/admin/src/pages/dashboard/settings/image-sizes/create.tsx
+++ b/packages/admin/src/pages/dashboard/settings/image-sizes/create.tsx
@@ -39,7 +39,11 @@ export default function CreateImageSizePage() {
   return (
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout
+          title="Image Sizes"
+          description="Configure image sizes generated for uploaded images"
+          crumb="Image Sizes"
+        >
           <ImageSizeForm
             mode="create"
             isPending={isPending}

--- a/packages/admin/src/pages/dashboard/settings/image-sizes/edit/[id].tsx
+++ b/packages/admin/src/pages/dashboard/settings/image-sizes/edit/[id].tsx
@@ -80,7 +80,7 @@ export default function EditImageSizePage() {
   if (!imageSizeId) {
     return (
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout {...IMAGE_SIZES_PAGE}>
           <Alert variant="destructive">
             <AlertDescription>
               Invalid image size ID. Please go back and try again.
@@ -100,7 +100,7 @@ export default function EditImageSizePage() {
   if (isLoading) {
     return (
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout {...IMAGE_SIZES_PAGE}>
           <div className="space-y-6">
             <div className="flex items-center gap-4">
               <Skeleton className="w-9 rounded-md" />
@@ -120,7 +120,7 @@ export default function EditImageSizePage() {
   if (fetchError) {
     return (
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout {...IMAGE_SIZES_PAGE}>
           <Alert variant="destructive">
             <AlertDescription className="flex items-center justify-between">
               <span>
@@ -155,7 +155,7 @@ export default function EditImageSizePage() {
   if (!imageSize) {
     return (
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout {...IMAGE_SIZES_PAGE}>
           <Alert variant="destructive">
             <AlertDescription>
               Image size not found. It may have been deleted.
@@ -174,7 +174,7 @@ export default function EditImageSizePage() {
   return (
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout {...IMAGE_SIZES_PAGE}>
           <ImageSizeForm
             mode="edit"
             imageSize={imageSize}
@@ -188,3 +188,14 @@ export default function EditImageSizePage() {
     </QueryErrorBoundary>
   );
 }
+
+/**
+ * This page renders the settings chrome in several branches — loading,
+ * error and the resolved document — and its identity is the same in all of
+ * them. Stated once here so the branches cannot drift apart.
+ */
+const IMAGE_SIZES_PAGE = {
+  title: "Image Sizes",
+  description: "Configure image sizes generated for uploaded images",
+  crumb: "Image Sizes",
+} as const;

--- a/packages/admin/src/pages/dashboard/settings/image-sizes/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/image-sizes/index.tsx
@@ -333,6 +333,9 @@ export default function ImageSizesSettingsPage() {
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
       <PageContainer>
         <SettingsLayout
+          title="Image Sizes"
+          description="Configure image sizes generated for uploaded images"
+          crumb="Image Sizes"
           actions={
             <Link href={ROUTES.SETTINGS_IMAGE_SIZES_CREATE}>
               <Button size="md" className="flex items-center gap-1.5">

--- a/packages/admin/src/pages/dashboard/settings/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/index.tsx
@@ -217,7 +217,10 @@ const SettingsGeneralPage: React.FC = () => {
             void form.handleSubmit(onSubmit)(e);
           }}
         >
-          <SettingsLayout>
+          <SettingsLayout
+            title="General Settings"
+            description="Manage your application and configuration"
+          >
             <FormLayout>
               {isLoading ? (
                 <GeneralSettingsSkeleton />

--- a/packages/admin/src/pages/dashboard/settings/permissions/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/permissions/index.tsx
@@ -379,7 +379,11 @@ const SettingsPermissionsPage: React.FC = () => {
   return (
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout
+          title="Permissions"
+          description="Define user roles and access control levels"
+          crumb="Permissions"
+        >
           <PermissionsContent />
         </SettingsLayout>
       </PageContainer>

--- a/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/[deliveryId].tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/[deliveryId].tsx
@@ -30,6 +30,19 @@ import { apiErrorMessage } from "@admin/lib/api/parseApiError";
  * `MAX_ATTEMPT_LOG` cap in the webhook deliver pipeline). Mirrored here so the
  * timeline can say so when the log is full and older attempts are truncated.
  */
+
+/**
+ * This page renders the settings chrome in several branches — loading,
+ * error and the resolved document — and its identity is the same in all of
+ * them. Stated once here so the branches cannot drift apart.
+ */
+const DELIVERIES_PAGE = {
+  title: "Deliveries",
+  description:
+    "Delivery attempts for this endpoint, with response status and retries",
+  crumb: "Deliveries",
+  parentCrumb: { label: "Webhooks", href: ROUTES.SETTINGS_WEBHOOKS },
+} as const;
 const ATTEMPT_LOG_LIMIT = 20;
 
 /** One read-only label/value row in a metadata card. */
@@ -280,7 +293,7 @@ export default function WebhookDeliveryDetailPage() {
   if (!id || !deliveryId) {
     return (
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout {...DELIVERIES_PAGE}>
           <Alert variant="destructive">
             <AlertDescription>
               Invalid delivery reference. Please go back and try again.
@@ -299,7 +312,7 @@ export default function WebhookDeliveryDetailPage() {
   return (
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout {...DELIVERIES_PAGE}>
           <DeliveryDetailContent webhookId={id} deliveryId={deliveryId} />
         </SettingsLayout>
       </PageContainer>

--- a/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/index.tsx
@@ -34,6 +34,19 @@ import type {
 } from "@admin/types/webhooks";
 
 /** A short human summary of a drain pass for the toast. */
+
+/**
+ * This page renders the settings chrome in several branches — loading,
+ * error and the resolved document — and its identity is the same in all of
+ * them. Stated once here so the branches cannot drift apart.
+ */
+const DELIVERIES_PAGE = {
+  title: "Deliveries",
+  description:
+    "Delivery attempts for this endpoint, with response status and retries",
+  crumb: "Deliveries",
+  parentCrumb: { label: "Webhooks", href: ROUTES.SETTINGS_WEBHOOKS },
+} as const;
 function summarizeDrain(result: RunDrainResult): string {
   return `${result.attempted} attempted · ${result.delivered} delivered · ${result.retried} retrying · ${result.failed} failed.`;
 }
@@ -222,7 +235,7 @@ export default function WebhookDeliveriesPage() {
   if (!id) {
     return (
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout {...DELIVERIES_PAGE}>
           <Alert variant="destructive">
             <AlertDescription>
               Invalid endpoint ID. Please go back and try again.
@@ -241,7 +254,7 @@ export default function WebhookDeliveriesPage() {
   return (
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout {...DELIVERIES_PAGE}>
           <DeliveriesContent id={id} />
         </SettingsLayout>
       </PageContainer>

--- a/packages/admin/src/pages/dashboard/settings/webhooks/create.tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/create.tsx
@@ -70,7 +70,12 @@ const CreateWebhookPage: React.FC = () => {
   return (
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout
+          title="New Webhook"
+          description="Send signed events to an external endpoint"
+          crumb="New Webhook"
+          parentCrumb={{ label: "Webhooks", href: ROUTES.SETTINGS_WEBHOOKS }}
+        >
           <CreateWebhookContent />
         </SettingsLayout>
       </PageContainer>

--- a/packages/admin/src/pages/dashboard/settings/webhooks/edit/[id].tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/edit/[id].tsx
@@ -35,6 +35,17 @@ import {
   type WebhookFormValues,
 } from "@admin/lib/webhook-validation";
 
+/**
+ * This page renders the settings chrome in several branches — loading,
+ * error and the resolved document — and its identity is the same in all of
+ * them. Stated once here so the branches cannot drift apart.
+ */
+const WEBHOOK_PAGE = {
+  title: "Edit Webhook",
+  description: "Update the endpoint, events, and headers",
+  crumb: "Edit Webhook",
+  parentCrumb: { label: "Webhooks", href: ROUTES.SETTINGS_WEBHOOKS },
+} as const;
 const EditWebhookContent: React.FC<{ id: string }> = ({ id }) => {
   const { data: webhook, isLoading, isError, error } = useWebhook(id);
   const { mutate: doUpdate, isPending } = useUpdateWebhook();
@@ -286,7 +297,7 @@ export default function EditWebhookPage() {
   if (!id) {
     return (
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout {...WEBHOOK_PAGE}>
           <Alert variant="destructive">
             <AlertDescription>
               Invalid endpoint ID. Please go back and try again.
@@ -305,7 +316,7 @@ export default function EditWebhookPage() {
   return (
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
       <PageContainer>
-        <SettingsLayout>
+        <SettingsLayout {...WEBHOOK_PAGE}>
           <EditWebhookContent id={id} />
         </SettingsLayout>
       </PageContainer>

--- a/packages/admin/src/pages/dashboard/settings/webhooks/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/index.tsx
@@ -178,6 +178,9 @@ const WebhooksPage: React.FC = () => {
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
       <PageContainer>
         <SettingsLayout
+          title="Webhooks"
+          description="Send signed events to your services when content changes"
+          crumb="Webhooks"
           actions={
             canCreate ? (
               <Button

--- a/packages/ui/STABILITY.md
+++ b/packages/ui/STABILITY.md
@@ -86,7 +86,7 @@ Everything else the barrel exports, including: `Accordion`, `Alert`, `AlertDialo
 `Progress`, `ResizablePanelGroup`/`ResizablePanel`/`ResizableHandle`, `Separator`,
 `Skeleton`, `Slider`, `Spinner`, `Table` and its family, `TableSearch`, `TableSkeleton`,
 `TreeView`, the table state components, the layout primitives (`Stack`, `Grid`, `Stat`,
-`PageShell`, `Bleed`),
+`PageShell`, `Bleed`, `PageHeader`),
 `Toaster` and the shortcut manager (`ShortcutProvider`, `ShortcutScope`, `useShortcuts`,
 `useShortcutManager`, `useActiveShortcuts`, `createShortcutManager`, `parseKeys`).
 
@@ -208,6 +208,23 @@ combinator, which is the half that makes the nested case inert. Both forward the
 and any div attributes, which matters more for `Bleed` than for an ordinary box: a
 consumer cannot reach for the usual remedy of wrapping it, since a wrapper is exactly
 what stops it working.
+
+`PageHeader` (with `PageHeaderProps`) is a page's own identity: its breadcrumb trail,
+its `h1`, a one-line description and its actions. Every value arrives as a PROP, and
+that is the contract rather than an implementation choice. The markup it replaces was
+written out by hand on 22 pages, and the settings pages took their title from a
+~130-line chain matching `window.location.pathname` in a file none of them imported —
+so a page's name lived either in 22 copies or in one foreign file, adding a route meant
+editing someone else's `if`, and the header was wrong for any page reachable at more
+than one path. A plugin could not contribute a settings page at all, because it cannot
+add a branch to a chain it does not ship.
+
+This mirrors a decision the route registry already made: a private route must DECLARE
+the rail section it belongs to, so a missing declaration is a compile error rather than
+a page that silently highlights the wrong entry. `PageHeader` applies the same rule to
+the page's own name. `description` is a `ReactNode` rather than a string because a
+description carrying a link or inline code is ordinary here, and a narrower type would
+push those pages back to hand-rolling the header this exists to remove.
 
 `PageShell` deliberately applies no horizontal padding of its own; a `px-*` utility on it
 would be the second declaration this design exists to remove. Its outer grid tracks are

--- a/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
+++ b/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
@@ -165,6 +165,8 @@ exports[`ui public export surface > . surface is unchanged 1`] = `
   "KeySequence (type)",
   "Label (value)",
   "ListResponse (type)",
+  "PageHeader (value)",
+  "PageHeaderProps (type)",
   "PageShell (value)",
   "PageShellProps (type)",
   "PaginationConfig (type)",

--- a/packages/ui/src/components/page-header.test.tsx
+++ b/packages/ui/src/components/page-header.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+/**
+ * A page's own identity, rendered once.
+ *
+ * The markup this replaces was written out by hand on 22 pages, and the
+ * settings pages took their title from a ~130-line if-chain that matched
+ * `window.location.pathname` in a file none of them import. Both are the same
+ * defect from opposite ends: the page knows what it is, and nothing let it say
+ * so. Every value here therefore arrives as a PROP.
+ *
+ * That mirrors a decision the route registry already made. A private route must
+ * declare the rail section it belongs to, because the sidebar reads the
+ * declaration rather than matching the URL — so a route added without one is a
+ * compile error instead of a page that silently highlights the wrong entry.
+ * A title derived from a pathname is the version of that defect nobody caught.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PageHeader } from "./page-header";
+
+describe("PageHeader", () => {
+  it("renders the title as the page's h1", () => {
+    render(<PageHeader title="General Settings" />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "General Settings" })
+    ).toBeTruthy();
+  });
+
+  it("renders description, breadcrumbs and actions when given", () => {
+    render(
+      <PageHeader
+        title="New Webhook"
+        description="Send signed events to an external endpoint"
+        breadcrumbs={<nav aria-label="Breadcrumb">crumbs</nav>}
+        actions={<button type="button">Save</button>}
+      />
+    );
+
+    expect(
+      screen.getByText("Send signed events to an external endpoint")
+    ).toBeTruthy();
+    expect(screen.getByLabelText("Breadcrumb")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save" })).toBeTruthy();
+  });
+
+  it("omits each optional slot rather than rendering it empty", () => {
+    const { container } = render(<PageHeader title="Only a title" />);
+
+    // An empty <p> still occupies a line and still separates the title from
+    // what follows, so "renders nothing visible" is not the same as "is not
+    // there" — and only the second keeps the spacing of a title-only page
+    // identical to a page that never had a description.
+    expect(container.querySelector("nav")).toBeNull();
+    expect(container.querySelectorAll("p")).toHaveLength(0);
+  });
+
+  it("takes a ReactNode description, not only a string", () => {
+    // A description carrying a link or an inline code span is ordinary in this
+    // admin; typing it as `string` would push those pages back to hand-rolling
+    // the whole header, which is what this component exists to end.
+    render(
+      <PageHeader
+        title="Webhooks"
+        description={
+          <>
+            Send signed events. <a href="/docs">Read the docs</a>
+          </>
+        }
+      />
+    );
+
+    expect(screen.getByRole("link", { name: "Read the docs" })).toBeTruthy();
+  });
+
+  it("keeps the description in muted ink", () => {
+    const { container } = render(
+      <PageHeader title="Webhooks" description="Secondary text" />
+    );
+
+    // Recorded rather than assumed: a faint primary alpha was tried here and
+    // failed contrast, so the muted token is the one that passes.
+    expect(container.querySelector("p")?.className).toContain(
+      "text-muted-foreground"
+    );
+  });
+
+  it("accepts a caller's className without losing its own layout", () => {
+    const { container } = render(
+      <PageHeader title="Webhooks" className="mb-0" />
+    );
+    const header = container.querySelector("[data-slot='page-header']");
+
+    expect(header?.classList.contains("mb-0")).toBe(true);
+  });
+});

--- a/packages/ui/src/components/page-header.tsx
+++ b/packages/ui/src/components/page-header.tsx
@@ -1,0 +1,80 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { forwardRef } from "react";
+
+import { cn } from "../lib/utils";
+
+/** @experimental */
+export interface PageHeaderProps
+  extends Omit<HTMLAttributes<HTMLElement>, "title"> {
+  /** The page's name, rendered as its `h1`. */
+  title: string;
+  /**
+   * A sentence under the title. A `ReactNode` rather than a string because a
+   * description carrying a link or an inline code span is ordinary here, and
+   * typing it narrowly would push those pages back to hand-rolling the header.
+   */
+  description?: ReactNode;
+  /** The trail above the title. The page supplies it; this only places it. */
+  breadcrumbs?: ReactNode;
+  /** Page-level actions, trailing the title on one line where there is room. */
+  actions?: ReactNode;
+}
+
+/**
+ * A page's own identity — its trail, its name, its one-line summary and its
+ * actions — rendered once instead of at every page that needs one.
+ *
+ * Every value arrives as a PROP, and that is the point rather than an
+ * implementation detail. The markup this replaces was written out by hand on 22
+ * pages, and the settings pages took their title from a ~130-line chain that
+ * matched `window.location.pathname` in a file none of them import. Both are
+ * the same defect from opposite ends: a page knows what it is, and nothing let
+ * it say so — so the title lived either in 22 copies or in one foreign file
+ * that had to be edited whenever a route was added.
+ *
+ * The route registry already made this decision for the sidebar. A private
+ * route must DECLARE the rail section it belongs to, because the sidebar reads
+ * that declaration rather than matching the URL, which makes a route added
+ * without one a compile error instead of a page that silently highlights the
+ * wrong entry. A title derived from a pathname is the same defect in the half
+ * nobody had covered.
+ *
+ * It also makes a plugin's page indistinguishable from a first-party one: a
+ * plugin cannot add a branch to an if-chain it does not ship, but it can pass a
+ * prop.
+ * @experimental
+ */
+export const PageHeader = forwardRef<HTMLElement, PageHeaderProps>(
+  ({ title, description, breadcrumbs, actions, className, ...props }, ref) => (
+    <header
+      ref={ref}
+      data-slot="page-header"
+      className={cn("mb-8", className)}
+      {...props}
+    >
+      {breadcrumbs ? <div className="mb-6">{breadcrumbs}</div> : null}
+
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+        <div className="space-y-1">
+          <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+          {/* Muted rather than a faint tint of the primary: the latter was tried
+              and did not meet contrast for secondary text. */}
+          {description ? (
+            <p className="mt-1 text-sm font-normal text-muted-foreground">
+              {description}
+            </p>
+          ) : null}
+        </div>
+
+        {/* Each optional slot is omitted rather than rendered empty. An empty
+            <p> still occupies a line and still separates the title from what
+            follows, so a title-only page would not keep the spacing of a page
+            that never had a description. */}
+        {actions ? (
+          <div className="flex items-center gap-3">{actions}</div>
+        ) : null}
+      </div>
+    </header>
+  )
+);
+PageHeader.displayName = "PageHeader";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -581,5 +581,13 @@ export type {
  * measure in order to escape it. No first-party plugin has exercised it yet.
  */
 export { Bleed, PageShell } from "./components/page-shell";
+/**
+ * @experimental A page's own identity — trail, name, summary and actions — fed
+ * entirely by props, so a page declares what it is instead of a foreign file
+ * deriving it from the URL. No first-party plugin has exercised it yet.
+ */
+export { PageHeader } from "./components/page-header";
+/** @experimental */
+export type { PageHeaderProps } from "./components/page-header";
 /** @experimental */
 export type { BleedProps, PageShellProps } from "./components/page-shell";


### PR DESCRIPTION
## Summary

Adds `PageHeader` and deletes the pathname if-chain that named every settings
page from outside.

`SettingsLayout` derived each page's title, description and crumb by matching
`window.location.pathname` against **sixteen branches**. Four consequences, and
only the first is cosmetic:

- A page's name lived in a file the page does not import. 199 lines → 79.
- Adding a settings route meant editing a foreign `if`, and forgetting to
  produced a page headed "General Settings".
- The header was **wrong for any page reachable at more than one path**, because
  a URL is not an identity.
- **A plugin could not contribute a settings page at all.** It cannot add a
  branch to a chain it does not ship.

Each page now passes its own `title` / `description` / `crumb`. This mirrors a
decision the route registry already made for the sidebar: a private route must
DECLARE the rail section it belongs to, so a missing declaration is a compile
error rather than a page that silently highlights the wrong entry. A title
derived from a pathname was the same defect in the half nobody had covered.

**What stays shared is the trail, not the identity.** Every settings page hangs
off Dashboard › Settings, so `SettingsLayout` still composes that — a page
supplying its whole breadcrumb array would put sixteen copies of the same two
links in the tree.

## Duplication, which the if-chain had been hiding

Hoisting the titles out surfaced real repetition: six pages render the chrome in
several branches (loading, error, resolved) and were then restating their
identity in each. Those state it once as a module constant and spread it.

`fallow` reports `warn` with `duplication_introduced: 3`, and the honest reading
is that those three are **pre-existing clones re-attributed to this diff because
it touched their lines**. Verified rather than assumed — the guard branch on
`main`:

```tsx
if (!id) { return (<PageContainer><SettingsLayout>          // main
if (!id) { return (<PageContainer><SettingsLayout {...DELIVERIES_PAGE}>   // here
```

Same structure, only the props differ. The remaining clone is the guard chrome
itself, which is worth extracting but belongs to error handling rather than to
this change.

## Test plan

- `pnpm --filter @nextlyhq/ui test --run` → **1133 passed, 49 files**
- `pnpm build` → 19/19 · ui lint → 0 · admin lint → 0 · `check:comments` → 0

### Verified in a browser

Every migrated route, checking the rendered `h1`, description and trail:

| route | h1 | trail |
| --- | --- | --- |
| `/settings` | General Settings | Dashboard › Settings |
| `/settings/api-keys` | API Keys | Dashboard › Settings › API Keys |
| `/settings/webhooks` | Webhooks | … › Webhooks |
| `/settings/webhooks/create` | New Webhook | … › Webhooks › New Webhook |
| `/settings/image-sizes` | Image Sizes | … › Image Sizes |
| `/settings/email-providers` | Email Providers | … › Email Providers |
| `/settings/email-templates` | Email Templates | … › Email Templates |
| `/settings/permissions` | Permissions | … › Permissions |

Every string is carried over verbatim from the deleted chain, so no user-visible
copy changes in this PR.

### Break-verification

| break | fails |
| --- | --- |
| `h1` downgraded to `h2` | `renders the title as the page's h1` |
| empty description rendered rather than omitted | `omits each optional slot rather than rendering it empty` |
| description ink changed off the muted token | `keeps the description in muted ink` |

## Changeset

Changeset added: yes (patch, all 25 lockstep packages).

## Pre-existing failures

`packages/admin` is not in `ci.yml`'s `Test` allowlist, so its suites are not
merge-gated and I ran them locally. **15 failed / 2614 passed across the same 4
files as `main`'s baseline** — `StatsCard`, `BasicsTab`, `SlugInput`,
`DefaultValueField`. None touches this diff, and the count is unchanged from the
baseline I measured on `main` at `82348299e`.

## Coordination

`permissions/index.tsx` is in this diff. `nextly-workspace-d5` holds R-5
(permissions) and explicitly handed me the header migration for that file rather
than hand-rolling one page's header inside their task; if their audit later calls
for a structural rethink of that page, it sequences after this.
