### PR TITLE
fix(ui): close two holes in the preset boundary guard

### DIFF
--- a/.changeset/preset-boundary-guard-holes.md
+++ b/.changeset/preset-boundary-guard-holes.md
@@ -1,0 +1,42 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Close two holes in the preset/stylesheet boundary check, and fix the v3 config example.
+
+The duplication guard read only the first `@layer components` block and only
+plugins written as a bare function. A cascade layer may be opened more than
+once, and Tailwind's own `plugin()` helper returns `{ handler, config }` rather
+than the function, so a rule restated through either route passed the guard
+while it reported a clean boundary.
+
+The Tailwind v3 config in the README was not valid JavaScript and omitted the
+scan path for the published bundle, so following it produced a syntax error and,
+once corrected, components with their utilities missing.
+
+Also records why three rows in the admin no longer pad themselves: the enclosing
+section supplies the rhythm, and the two paddings are additive.

--- a/packages/admin/src/components/features/api-keys/EditApiKeyForm.tsx
+++ b/packages/admin/src/components/features/api-keys/EditApiKeyForm.tsx
@@ -66,6 +66,13 @@ function formatDate(iso: string | null): string {
  * Left as its own hand-rolled row rather than `FieldShell`: it renders no
  * input, so there is nothing for a computed id or `aria-describedby` to
  * attach to — the label just names a static value.
+ *
+ * It carries no vertical padding of its own, and that absence is deliberate.
+ * The enclosing `FormSection` applies the rhythm to every direct child through
+ * `--nx-field-gap`, so the section's edge inset and the gap between two rows
+ * are one measurement. The two paddings would be additive, so a row that
+ * restored its own would render at double the gap while looking correct in
+ * isolation.
  */
 function ReadOnlyRow({
   label,

--- a/packages/admin/src/components/features/role-management/RoleForm.tsx
+++ b/packages/admin/src/components/features/role-management/RoleForm.tsx
@@ -104,7 +104,14 @@ export function RoleForm({ roleId }: RoleFormProps) {
             aria-labelledby="role-form-title"
             noValidate
           >
-            {/* Top section: Role Details (full width) */}
+            {/* Top section: Role Details (full width).
+
+                Neither this wrapper nor the Permissions one below pads itself
+                vertically. `SettingsSection` applies the rhythm to every direct
+                child through `--nx-field-gap`, and the two paddings are
+                additive, so a wrapper that restored its own would render at
+                double the gap on exactly the sections that already looked
+                correct. */}
             <SettingsSection label="Role Details">
               <div className="flex flex-col gap-6">
                 <RoleBasicInfo

--- a/packages/admin/src/components/features/settings/ImageSizeForm.tsx
+++ b/packages/admin/src/components/features/settings/ImageSizeForm.tsx
@@ -188,7 +188,12 @@ export function ImageSizeForm({
             {/* Width + Height — two controls, one shared label/description, so
                 this stays a hand-rolled row rather than FieldShell: there is no
                 single control for one id/error pair to describe. Each Input
-                keeps its own FieldShell for error display. */}
+                keeps its own FieldShell for error display.
+
+                No vertical padding here, deliberately. The enclosing `SettingsSection` supplies the vertical rhythm to every
+                direct child through `--nx-field-gap`, so this row must not pad
+                itself: the two paddings are additive and a row that carried its
+                own would render at double the gap. */}
             <div className="flex flex-col gap-1.5">
               <span className="text-sm font-medium text-foreground">
                 Dimensions

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -69,7 +69,18 @@ directly (`var(--nx-primary)`) — never wrap them in `hsl()`.
 ```js
 // tailwind.config.js
 const { uiPreset } = require("@nextlyhq/ui/tailwind-preset");
-module.exports = { presets: [uiPreset], content: [...] };
+
+module.exports = {
+  presets: [uiPreset],
+  content: [
+    "./src/**/*.{js,jsx,ts,tsx}",
+    // Required. Tailwind generates a utility only for a class it has SEEN, and
+    // the classes these components write live in the published bundle rather
+    // than in your source. Omit this path and the components render with their
+    // utilities missing — no error, just unstyled markup.
+    "./node_modules/@nextlyhq/ui/dist/**/*.{js,mjs,cjs}",
+  ],
+};
 ```
 
 Import `@nextlyhq/ui/theme.css` alongside it. The preset carries tokens and the utilities

--- a/packages/ui/src/tailwind-preset.test.ts
+++ b/packages/ui/src/tailwind-preset.test.ts
@@ -153,49 +153,92 @@ describe("the Tailwind v3 preset", () => {
  * below covers whichever ones exist rather than whichever ones someone
  * remembered.
  */
+/**
+ * The class selectors of the rules inside ONE brace-delimited block, given the
+ * index of its opening brace. Nested at-rules count: a rule inside a
+ * `@media` inside the layer is still a component rule.
+ */
+function selectorsInBlock(source: string, open: number): string[] {
+  const found: string[] = [];
+  let depth = 0;
+
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+      continue;
+    }
+    if (source[i] !== "{") continue;
+
+    depth++;
+    if (depth < 2) continue;
+
+    // The text between the previous brace and this one is the selector of the
+    // rule being opened. Depth 1 is the block itself; deeper is a rule in it.
+    const head = source.slice(0, i);
+    const from = Math.max(head.lastIndexOf("{"), head.lastIndexOf("}")) + 1;
+    const selector = head.slice(from).trim().replace(/\s+/g, " ");
+    if (selector.startsWith(".")) found.push(selector);
+  }
+
+  return found;
+}
+
 function themeComponentSelectors(css: string): Set<string> {
   const source = css.replace(/\/\*[\s\S]*?\*\//g, "");
   const selectors = new Set<string>();
-  const open = source.indexOf("@layer components");
-  if (open === -1) return selectors;
 
-  let depth = 0;
-  for (let i = source.indexOf("{", open); i < source.length; i++) {
-    if (source[i] === "{") {
-      depth++;
-      if (depth >= 2) {
-        // The text between the previous brace or semicolon and this one is the
-        // selector of the rule being opened. At depth 2 it is a rule inside the
-        // layer; deeper still is an at-rule's body, whose rules count too.
-        const head = source.slice(0, i);
-        const from = Math.max(head.lastIndexOf("{"), head.lastIndexOf("}")) + 1;
-        const selector = head.slice(from).trim().replace(/\s+/g, " ");
-        if (selector.startsWith(".")) selectors.add(selector);
-      }
-    } else if (source[i] === "}") {
-      depth--;
-      if (depth === 0) break;
+  // EVERY component layer, not the first one. A cascade layer may be opened as
+  // many times as its author likes and the declarations accumulate, so a
+  // stylesheet with two `@layer components` blocks is ordinary CSS rather than
+  // a mistake. Reading only the first would leave every selector in the later
+  // ones unguarded while the guard still reported success.
+  for (const layer of source.matchAll(/@layer\s+components\s*\{/g)) {
+    const open = layer.index + layer[0].length - 1;
+    for (const selector of selectorsInBlock(source, open)) {
+      selectors.add(selector);
     }
   }
+
   return selectors;
 }
 
 /**
  * Every selector the preset registers through a plugin's `addComponents`.
  *
- * The preset is read through a widened view because it declares no `plugins`
- * key today, and a property access typed against its literal shape would not
- * compile. Widening rather than asserting keeps this readable on the day a
- * plugin IS added — which is the day the guard below has to work. `theme` is
- * named alongside it only to give the two types a property in common, without
- * which TypeScript rejects the assignment as a weak-type mismatch.
+ * The preset is read through a widened parameter because it declares no
+ * `plugins` key today, and a property access typed against its literal shape
+ * would not compile. Widening rather than asserting keeps this readable on the
+ * day a plugin IS added — which is the day the guard below has to work.
+ * `theme` is named alongside it only to give the two types a property in
+ * common, without which TypeScript rejects the assignment as a weak-type
+ * mismatch.
+ *
+ * Taking the preset as an argument, defaulted to the real one, is what lets a
+ * fixture exercise THIS function rather than a copy of its branch: a test that
+ * restated the plugin-shape handling inline would pass while the shipped guard
+ * remained blind.
  */
-function presetComponentSelectors(): Set<string> {
+function presetComponentSelectors(
+  preset: { theme?: unknown; plugins?: unknown[] } = uiPreset
+): Set<string> {
   const selectors = new Set<string>();
-  const withPlugins: { theme?: unknown; plugins?: unknown[] } = uiPreset;
-  const plugins: unknown[] = withPlugins.plugins ?? [];
+  const plugins: unknown[] = preset.plugins ?? [];
   for (const plugin of plugins) {
-    const run = typeof plugin === "function" ? plugin : undefined;
+    // Tailwind accepts a plugin in two shapes, and the guard has to see both.
+    // A bare function is one; the `plugin()` helper wraps that function in an
+    // object under a `handler` key so it can carry a `config` alongside, and
+    // that object form is what the documented helper produces. Reading only
+    // the callable form would let the helper's output register anything at all
+    // while this file reported a clean boundary.
+    const run =
+      typeof plugin === "function"
+        ? plugin
+        : typeof plugin === "object" &&
+            plugin !== null &&
+            typeof (plugin as { handler?: unknown }).handler === "function"
+          ? (plugin as { handler: (api: unknown) => void }).handler
+          : undefined;
     run?.({
       addComponents: (rules: Record<string, unknown>) => {
         for (const selector of Object.keys(rules)) selectors.add(selector);
@@ -242,6 +285,50 @@ describe("the boundary between the preset and the stylesheet", () => {
       ".nx-nested",
       ".nx-real",
     ]);
+  });
+
+  it("collects rules from a second component layer", () => {
+    // A layer may be opened more than once and the declarations accumulate, so
+    // a parser that stopped at the first block would leave everything after it
+    // unguarded while still reporting a clean boundary.
+    const fixture = `
+      @layer components {
+        .nx-first { color: red; }
+      }
+      @layer utilities {
+        .nx-not-a-component { color: grey; }
+      }
+      @layer components {
+        .nx-second { color: blue; }
+      }
+    `;
+
+    expect([...themeComponentSelectors(fixture)].sort()).toEqual([
+      ".nx-first",
+      ".nx-second",
+    ]);
+  });
+
+  it("sees a rule registered through a plugin object, not only a bare function", () => {
+    // `plugin()` returns `{ handler, config }` rather than the function itself,
+    // and it is the documented way to write one. A guard blind to that shape
+    // reports a clean boundary for the very form a contributor is most likely
+    // to reach for.
+    type Api = { addComponents: (rules: Record<string, unknown>) => void };
+
+    const found = presetComponentSelectors({
+      plugins: [
+        {
+          handler: ({ addComponents }: Api) =>
+            addComponents({ ".nx-from-object": { color: "red" } }),
+          config: {},
+        },
+        ({ addComponents }: Api) =>
+          addComponents({ ".nx-from-function": { color: "blue" } }),
+      ],
+    });
+
+    expect([...found].sort()).toEqual([".nx-from-function", ".nx-from-object"]);
   });
 
   it("registers no rule the stylesheet already declares", () => {


### PR DESCRIPTION
Follow-up to #1161. Seven review findings landed after it merged; six were real and are fixed here, one was a false positive and is answered on the original thread.

## Two holes in the guard #1161 added

The duplication guard was supposed to fail if a component rule declared in `theme.css` were restated in the Tailwind preset. It could be walked past two ways:

- **Only the first `@layer components` block was read.** A cascade layer may be opened as many times as its author likes and the declarations accumulate, so a second block is ordinary CSS. Everything in it was unguarded while the check still reported success.
- **Only bare-function plugins were run.** Tailwind`s own `plugin()` helper returns `{ handler, config }` rather than the function — the shape a contributor is most likely to reach for. A rule registered through it was invisible.

Both fixtures exercise the shipped functions rather than restating their branches. That required one change to make possible: `presetComponentSelectors` now takes the preset as a defaulted parameter, so a fixture preset can be handed to the real reader instead of a copy of its logic. A test that re-implemented the plugin-shape branch inline would have passed while the shipped guard stayed blind.

## The v3 config example was not runnable

`module.exports = { presets: [uiPreset], content: [...] };` — `[...]` is not valid JavaScript, so copying it produced a syntax error. Corrected, it still omitted `./node_modules/@nextlyhq/ui/dist/**`, and without that path Tailwind never sees the classes the components write: the page renders with utilities missing and nothing errors. The example is now real config, and I evaluated it rather than eyeballing it.

## Three rows that no longer pad themselves

`ReadOnlyRow` in `EditApiKeyForm`, the dimensions row in `ImageSizeForm`, and both section wrappers in `RoleForm` had `py-5` removed in #1161 without recording why the absence matters. Each now says it: the enclosing section supplies the rhythm through `--nx-field-gap`, and the two paddings are additive, so a row that restored its own would render at double the gap while looking correct in isolation.

## The one I did not act on

Greptile reported P1 double padding on the general-settings loading skeleton. It is a false positive. `GeneralSettingsSkeleton` is rendered as a **sibling** of `SettingsSection` (`settings/index.tsx:226` vs `:229`), not inside one, and it hand-rolls its own card and rows — so `.nx-form-section-rows` never applies to it and its `py-5` is the only padding it gets. Answered on the thread.

## Verification

- Break-verified both closed holes: restoring each one fails exactly its own fixture at runtime, and only that one. Restored, 8/8 pass.
- `pnpm turbo check-types --continue` — 22/22.

  One note for anyone hitting the same wall: this failed first on `plugin-page-builder` with `MAX_CLASSES_PER_NODE` and `selectNodes` missing from `@nextlyhq/blocks-engine`. The source exports both; the cached `dist` was stale after #1157. `pnpm --filter @nextlyhq/blocks-engine build` clears it. Not a break on `main`.
- `packages/ui` — 1141 passed, 49 files.
- `packages/admin` — 15 failed / 2635 passed, 4 files: the known shared baseline on `main`, unchanged. CI does not run this suite.
- `fallow audit --base origin/main` — pass, zero introduced. The layer-iteration change first pushed `themeComponentSelectors` over the cognitive threshold; the block scan is now its own function, which is both under the limit and easier to read.

Changeset derived from `.changeset/config.json` — 25 packages, patch.

@codex please review