### PR TITLE
fix(nextly): refuse a filter on a field the caller may not read

### DIFF
--- a/.changeset/denied-field-filter.md
+++ b/.changeset/denied-field-filter.md
@@ -1,0 +1,45 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+A field a caller may not read can no longer be used to filter
+
+Field-level read rules redact values from rows that have already been selected,
+so they were powerless against a `where`: the row set itself varied with the
+hidden value. A caller could ask `equals` for each candidate and read the answer
+off which query returned the row -- the value never rendered, and fully
+recoverable.
+
+Demonstrated against a real database before being fixed: with a `codename` field
+denied to the reader, filtering on it returned different rows per term while the
+column was correctly absent from every response.
+
+A filter naming a field that carries a read rule is now refused, and says which
+field. Conservative on purpose -- a read rule is a function of the row, and at
+query time there is no row to judge, so a field that CAN deny is treated as one
+that does. Fields with no read rule are unaffected, as are callers passing
+`overrideAccess`, which have already decided who is asking.

--- a/packages/nextly/src/domains/collections/__tests__/denied-field-filter.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/denied-field-filter.integration.test.ts
@@ -30,6 +30,10 @@ type ReadHandler = {
     success: boolean;
     data: { docs: Record<string, unknown>[] } | null;
   }>;
+  countEntries: (p: Record<string, unknown>) => Promise<{
+    success: boolean;
+    data: unknown;
+  }>;
   createEntry: (
     p: Record<string, unknown>,
     data: Record<string, unknown>
@@ -121,6 +125,25 @@ describe("a denied field and the where clause (integration)", () => {
     // MORE rows than asked for, which is safe and lies to the caller; naming the
     // field discloses only that it is restricted, which its absence from every
     // response already says.
+    expect(refused.success).toBe(false);
+    expect(JSON.stringify(refused)).toContain("FIELD_NOT_FILTERABLE");
+  });
+
+  it("refuses the same filter on a count", async () => {
+    // A count is a CLEANER oracle than a listing, not a lesser one: it answers
+    // 1 or 0 for a guessed value and hands back no row to redact, so a guard
+    // that covered only the listing would leave the shorter path open.
+    current = await boot();
+    const h = current.getService(
+      "collectionsHandler"
+    ) as unknown as ReadHandler;
+
+    const refused = await h.countEntries({
+      collectionName: VAULTS,
+      overrideAccess: false,
+      where: { codename: { equals: "alpha" } },
+    });
+
     expect(refused.success).toBe(false);
     expect(JSON.stringify(refused)).toContain("FIELD_NOT_FILTERABLE");
   });

--- a/packages/nextly/src/domains/collections/__tests__/denied-field-filter.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/denied-field-filter.integration.test.ts
@@ -1,0 +1,163 @@
+/**
+ * A field a caller may not READ must not be a field it can FILTER on.
+ *
+ * Redaction runs on rows that have already been selected, so it can remove a
+ * value from a row and cannot un-select the row. If a `where` on a denied field
+ * still reaches the database, the caller never sees the value and still learns
+ * it: ask for `equals` each candidate and watch which query returns the row.
+ *
+ * Against a real (in-memory SQLite) database, because the claim is about what
+ * SQL the query actually runs. A mocked query builder would only restate the
+ * call the test itself made.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+type ReadHandler = {
+  listEntries: (p: Record<string, unknown>) => Promise<{
+    success: boolean;
+    data: { docs: Record<string, unknown>[] } | null;
+  }>;
+  createEntry: (
+    p: Record<string, unknown>,
+    data: Record<string, unknown>
+  ) => Promise<{
+    success: boolean;
+    data: Record<string, unknown> | null;
+  }>;
+};
+
+const VAULTS = "vaults";
+
+async function boot(): Promise<TestNextly> {
+  const t = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: VAULTS,
+        // The collection is readable; only the one field is not. That is the
+        // shape a field rule exists for -- "you may see these rows, not this
+        // column" -- and the shape this test is about.
+        access: { read: () => true, create: () => true, update: () => true },
+        fields: [
+          text({ name: "title" }),
+          text({ name: "codename", access: { read: () => false } }),
+        ],
+      }),
+    ],
+  });
+
+  const h = t.getService("collectionsHandler") as unknown as ReadHandler;
+  await h.createEntry(
+    { collectionName: VAULTS, overrideAccess: true },
+    { title: "north", codename: "alpha" }
+  );
+  await h.createEntry(
+    { collectionName: VAULTS, overrideAccess: true },
+    { title: "south", codename: "beta" }
+  );
+  return t;
+}
+
+describe("a denied field and the where clause (integration)", () => {
+  it("hides the field from the reader", async () => {
+    // The control. Without it the test below proves nothing: if the field were
+    // readable, filtering on it would be entirely correct behaviour.
+    current = await boot();
+    const h = current.getService(
+      "collectionsHandler"
+    ) as unknown as ReadHandler;
+
+    const listed = await h.listEntries({
+      collectionName: VAULTS,
+      overrideAccess: false,
+    });
+
+    expect(listed.success).toBe(true);
+    expect(listed.data!.docs).toHaveLength(2);
+    for (const doc of listed.data!.docs) {
+      expect(doc.title).toBeDefined();
+      expect(doc.codename).toBeUndefined();
+    }
+  });
+
+  it("refuses a where that names the denied field", async () => {
+    current = await boot();
+    const h = current.getService(
+      "collectionsHandler"
+    ) as unknown as ReadHandler;
+
+    // The fixture control. If the values never reached the column, every query
+    // returns nothing, two empty answers agree, and a broken fixture reads as a
+    // guard that works. Measured: this exact test passed by emptiness before the
+    // create call was corrected.
+    const stored = await h.listEntries({
+      collectionName: VAULTS,
+      overrideAccess: true,
+    });
+    expect(stored.data!.docs.map(d => d.codename).sort()).toEqual([
+      "alpha",
+      "beta",
+    ]);
+
+    const refused = await h.listEntries({
+      collectionName: VAULTS,
+      overrideAccess: false,
+      where: { codename: { equals: "alpha" } },
+    });
+
+    // Refused rather than silently widened. A filter that is dropped returns
+    // MORE rows than asked for, which is safe and lies to the caller; naming the
+    // field discloses only that it is restricted, which its absence from every
+    // response already says.
+    expect(refused.success).toBe(false);
+    expect(JSON.stringify(refused)).toContain("FIELD_NOT_FILTERABLE");
+  });
+
+  it("still filters on a field the caller may read", async () => {
+    // The negative control. A guard that refused every filter would pass the
+    // test above and break the product.
+    current = await boot();
+    const h = current.getService(
+      "collectionsHandler"
+    ) as unknown as ReadHandler;
+
+    const listed = await h.listEntries({
+      collectionName: VAULTS,
+      overrideAccess: false,
+      where: { title: { equals: "north" } },
+    });
+
+    expect(listed.success).toBe(true);
+    expect(listed.data!.docs.map(d => String(d.title))).toEqual(["north"]);
+  });
+
+  it("lets a trusted caller filter on it", async () => {
+    // `overrideAccess` means the caller has already decided who is asking, and
+    // internal reads legitimately filter on fields no end user may see.
+    current = await boot();
+    const h = current.getService(
+      "collectionsHandler"
+    ) as unknown as ReadHandler;
+
+    const listed = await h.listEntries({
+      collectionName: VAULTS,
+      overrideAccess: true,
+      where: { codename: { equals: "alpha" } },
+    });
+
+    expect(listed.success).toBe(true);
+    expect(listed.data!.docs.map(d => String(d.title))).toEqual(["north"]);
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -73,6 +73,7 @@ import {
   type ReadAccessRedactions,
   runFieldHooks,
 } from "../../../shared/lib/field-level-registry";
+import { assertFilterableFields } from "../../../shared/lib/filterable-fields";
 import {
   hasPasswordField,
   stripPasswordFieldValues,
@@ -1060,6 +1061,15 @@ export class CollectionQueryService extends BaseService {
       // i18n M7: pull the reserved `_translated` language filter out FIRST — the geo/component
       // extractors below drop object-valued keys they don't recognize, so it must be removed
       // before them and turned into a companion EXISTS/NOT EXISTS condition.
+      // Before the filter can reach SQL. Redaction runs on rows already chosen,
+      // so it cannot answer a `where` that selected them BY a hidden value.
+      assertFilterableFields(
+        "collection",
+        params.collectionName,
+        listQueryWhere,
+        { overrideAccess: params.overrideAccess }
+      );
+
       const { filter: translationFilter, cleanedWhere: whereAfterTranslation } =
         this.extractTranslationStatusFilter(listQueryWhere);
       if (translationFilter) {

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1977,6 +1977,17 @@ export class CollectionQueryService extends BaseService {
         return accessDenied;
       }
 
+      // A count is a cleaner oracle than a listing, not a lesser one: "how many
+      // rows carry this value" answers 1 or 0 without returning a row at all.
+      assertFilterableFields(
+        "collection",
+        params.collectionName,
+        params.where,
+        {
+          overrideAccess: params.overrideAccess,
+        }
+      );
+
       const schema = await this.fileManager.loadDynamicSchema(
         params.collectionName
       );

--- a/packages/nextly/src/shared/lib/filterable-fields.ts
+++ b/packages/nextly/src/shared/lib/filterable-fields.ts
@@ -1,0 +1,95 @@
+/**
+ * A field a caller may not READ is a field it may not FILTER on.
+ *
+ * Field-level read rules redact values from rows that have ALREADY been
+ * selected. That makes them powerless against a `where`: the row set itself
+ * varies with the hidden value, so a caller can ask `equals` each candidate and
+ * read the answer off which query returns the row. The value is never rendered,
+ * so redaction never sees it leave.
+ *
+ * This closes the input side, where redaction cannot reach.
+ *
+ * @module shared/lib/filterable-fields
+ * @since 1.0.0
+ */
+
+import { NextlyError } from "../../errors/nextly-error";
+
+import { getFieldFunctions } from "./field-level-registry";
+
+type EntityKind = "collection" | "single";
+
+/** Keys that structure a filter rather than naming a field. */
+const STRUCTURAL_KEYS = new Set(["and", "or"]);
+
+/**
+ * Field names a filter refers to, at any nesting depth.
+ *
+ * `and`/`or` carry arrays of nested filters; everything else is a leaf whose
+ * KEY is a field name and whose value is the operator object.
+ */
+function referencedFields(node: unknown, into: Set<string>): void {
+  if (!node || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    for (const child of node) referencedFields(child, into);
+    return;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (STRUCTURAL_KEYS.has(key)) {
+      referencedFields(value, into);
+      continue;
+    }
+    // `a.b` addresses a nested field; the guard below is keyed on the field
+    // that OWNS the rule, so compare on the first segment.
+    into.add(key.split(".")[0]);
+  }
+}
+
+/**
+ * Refuse a filter that names a field carrying a read rule.
+ *
+ * **Conservative by construction, and deliberately so.** A field read rule is a
+ * function of the ROW — it may consult `data` or `id` — and at query time there
+ * is no row to judge, so "may this caller read this field" is not yet
+ * answerable. Rather than guess, this refuses any field that CAN deny. Fields
+ * with no read rule, which is nearly all of them, are untouched.
+ *
+ * That direction is forced rather than chosen: this is a precondition, and a
+ * precondition that cannot decide must fail closed. Guessing "allowed" here
+ * would hand back exactly the disclosure the module exists to stop.
+ *
+ * Refusing NAMES the field. That discloses the field is restricted, which the
+ * caller already learns from its absence in every response, and it is the
+ * difference between an API a developer can work with and one that silently
+ * returns the wrong rows.
+ */
+export function assertFilterableFields(
+  kind: EntityKind,
+  slug: string,
+  where: unknown,
+  opts: { overrideAccess?: boolean } = {}
+): void {
+  // A trusted caller has already decided who is asking.
+  if (opts.overrideAccess) return;
+  if (!where) return;
+
+  const fns = getFieldFunctions(kind, slug);
+  if (!fns) return;
+
+  const referenced = new Set<string>();
+  referencedFields(where, referenced);
+  if (referenced.size === 0) return;
+
+  const denied = [...referenced]
+    .filter(name => fns[name]?.access?.read !== undefined)
+    .sort();
+  if (denied.length === 0) return;
+
+  throw NextlyError.validation({
+    errors: denied.map(field => ({
+      path: `where.${field}`,
+      code: "FIELD_NOT_FILTERABLE",
+      message: `The field "${field}" carries a read rule, so it cannot be used to filter. Filtering on a field you may not read would reveal its contents through the rows returned.`,
+    })),
+  });
+}


### PR DESCRIPTION
## What this fixes

A field a caller may not **read** could still be used to **filter**, and the row set gave the value away.

Field-level read rules redact values from rows that have **already been selected**. That makes them powerless against a `where`: the selection itself varies with the hidden value, so a caller asks `equals` for each candidate and reads the answer off which query returns the row. The value is never rendered, so redaction never sees it leave.

## Demonstrated before it was fixed

`packages/nextly/src/domains/collections/__tests__/denied-field-filter.integration.test.ts`, against a real in-memory SQLite database. With `codename` denied to the reader:

| query | rows returned |
| --- | --- |
| `where: { codename: { equals: "alpha" } }` | `["north"]` |
| `where: { codename: { equals: "beta" } }` | `["south"]` |

while `codename` was correctly **absent from every response**. The redaction was working the whole time and could not help, because it runs after selection and cannot un-select a row.

Two things about that test worth knowing, because both nearly produced a false result:

- Its first version **passed against the unfixed code** — both queries returned zero rows, and two empty answers are equal. A population clause now asserts the query returned rows at all, so the comparison means something.
- The zero rows were **my own broken fixture**: `createEntry(params, data)` takes two arguments and I had merged them, so `codename` was never stored. The test now validates its own fixture before trusting it.

## The fix, and three choices inside it

`assertFilterableFields` refuses a filter naming a field that carries a read rule.

**Refuse rather than silently drop the condition.** A dropped filter returns *more* rows than asked for — safe, and a lie to the caller. Naming the field discloses only that it is restricted, which its absence from every response already says.

**Refuse any field that CAN deny, not one proven to deny.** A read rule is a function of the row — it may consult `data` or `id` — and at query time there is no row, so the question is not yet answerable. This is a precondition, and one that cannot decide fails closed. Fields with no read rule, nearly all of them, are untouched.

**`overrideAccess` still filters on anything.** That caller has already decided who is asking, and internal reads legitimately filter on fields no end user may see.

## Verification

- Break-verified: removing the guard call fails `refuses a where that names the denied field`, at runtime, on the assertion that names it.
- Negative control in the suite: a **readable** field still filters (`title` → `["north"]`), so the guard is not over-broad.
- `overrideAccess` control: a trusted caller still filters on the denied field.
- Full `nextly` integration suite: **1293 passed, 0 failed**.
- `nextly` unit baseline unchanged: `collection-access` + `collection-mutation` measured at **9 failed / 61 passed both with and without** this change.
- `pnpm --filter nextly lint` and `tsc --noEmit` clean. `fallow audit` passes with 0 introduced.

## Scope, stated rather than implied

Wired into **both** collection read verbs that accept a filter: `listEntries` and `countEntries`. Each is break-verified separately.

`countEntries` was missed in the first version of this PR and is the sharper of the two — a count is a CLEANER oracle than a listing, not a lesser one: it answers 1 or 0 for a guessed value and hands back no row to redact at all. A guard on the listing alone would have left the shorter path open.

**Correcting an earlier claim in this description: singles do NOT need this.** I originally wrote that they share the read path. They do not — `single-query-service.ts` builds no where clause and the singles types carry no `where` at all. A single is one document; there is nothing to filter. The guard still lives in `shared/lib` because that is where a cross-entity precondition belongs, not because singles are waiting on it.

Nested field addressing (`group.child`) is keyed on the owning field's first segment. A rule on a nested leaf is not separately consulted — stated as a known limit rather than left to be discovered.

## Related

Found while auditing R-5 (F9 Permissions); recorded as F-5 in `findings/R-5-permissions-audit.md`. It is the third defect found around `overrideAccess` today — see also the row-versus-field trust split another lane is landing, and the unbounded relationship expansion in `plans/2026-08-24-R-5-trust-boundary-design.md`. The pattern is the finding: that flag carries more decisions than a boolean can express.
