### PR TITLE
fix(blocks-engine): terminate the tree primitives on a cyclic document

### DIFF
--- a/.changeset/engine-traversal-cycle-safety.md
+++ b/.changeset/engine-traversal-cycle-safety.md
@@ -38,7 +38,12 @@ different slots is two elements of the document and is still counted, measured
 and rebuilt twice, exactly as before. Behaviour on every acyclic document is
 unchanged.
 
-An immutable rebuild cannot reproduce a cycle — the result would have to
-contain itself — so `updateNode`, `duplicateNode` and `reidSubtree` drop the
-edge that closes it and return a finite forest, rather than failing the
-operation.
+An immutable rebuild cannot reproduce a cycle, since the result would have to
+contain itself. `updateNode` and `reidSubtree` therefore drop the edge that
+closes it and return a finite forest rather than failing the operation.
+
+`duplicateNode` REFUSES instead, returning the forest unchanged, and the
+difference is deliberate. It adds a node rather than transforming one, so the
+original stays in the result — a copy taken from a forest that cannot be
+serialized still cannot be serialized, whatever is done to the clone. Reporting
+success there would hand back a document that cannot be stored.

--- a/.changeset/engine-traversal-cycle-safety.md
+++ b/.changeset/engine-traversal-cycle-safety.md
@@ -1,0 +1,44 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-plugin": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/ui": patch
+---
+
+The engine's tree primitives terminate on a document whose slots form a cycle.
+
+Such a document reaches these functions the same way every other malformed
+shape does: a stored forest is not required to have been validated, and an
+in-process producer can build one directly. `countNodes`, `findNode` asked for
+an absent id, `updateNode`, `duplicateNode` and `reidSubtree` exited with
+`RangeError: Maximum call stack size exceeded`, and `treeDepth` did not throw
+at all — it SPUN, holding a caller open rather than failing, which is the
+version nobody attributes correctly.
+
+Each now carries the ancestors its current position was reached through, so a
+node reached through itself is not descended into again. That is deliberately
+narrower than skipping every node already seen: one node object placed in two
+different slots is two elements of the document and is still counted, measured
+and rebuilt twice, exactly as before. Behaviour on every acyclic document is
+unchanged.
+
+An immutable rebuild cannot reproduce a cycle — the result would have to
+contain itself — so `updateNode`, `duplicateNode` and `reidSubtree` drop the
+edge that closes it and return a finite forest, rather than failing the
+operation.

--- a/packages/blocks-engine/src/forest-walk.ts
+++ b/packages/blocks-engine/src/forest-walk.ts
@@ -1,0 +1,169 @@
+/**
+ * The one iterative walk over a stored node forest.
+ *
+ * Every reader of a document needs the same three things and no two of them
+ * agree on what to DO with an entry, so the traversal is shared and the
+ * decision is not. Writing the walk per caller produced two copies that
+ * differed only in their accumulator, which is the drift this repository has a
+ * rule about — and each copy had to re-learn the same three hazards.
+ *
+ * ## What it guarantees
+ *
+ * - **Iterative.** Depth costs a frame, not a stack level. These run over
+ *   documents nothing validated, so a chain deeper than the machine allows
+ *   would otherwise exit with `RangeError` from inside the very helper a caller
+ *   uses to REFUSE such a document.
+ * - **Cycle-terminating.** A node reached through itself is not descended into
+ *   again. Deliberately narrower than skipping every node already seen: one
+ *   node object placed in two slots is two elements of the document, and
+ *   counting it once reports half a real size and passes a cap the document
+ *   exceeds.
+ * - **Linear.** One mutable ancestor set with `leave` markers, not a copy per
+ *   descent. Copying is correct and quadratic — measured, it took a
+ *   five-thousand-node chain from under a millisecond to 159ms, in helpers
+ *   whose whole purpose is bounding large documents.
+ * - **Width-safe.** A list is held with a cursor rather than expanded into one
+ *   frame per entry, so a very wide root array — the cheapest oversized
+ *   document there is — costs one frame.
+ *
+ * ## What it leaves to the caller
+ *
+ * Whether an entry counts, whether to descend into it, and when to stop. A
+ * counter counts malformed entries because its caps are about real element
+ * counts; a renderer skips them because it has nothing to draw. Folding either
+ * choice in here would make one caller's answer everybody's default.
+ *
+ * @module forest-walk
+ */
+import type { BlockNode } from "./document";
+
+/** One entry the walk reached, with where it sits. */
+export interface ForestEntry {
+  /** Unvalidated: may be `null`, a primitive, or an array. */
+  node: unknown;
+  /** The node whose slot holds this entry, or `undefined` at the top level. */
+  parent: BlockNode | undefined;
+  /** Nesting depth; top-level entries are 1. */
+  depth: number;
+  /**
+   * Whether this entry is its own ancestor — the point at which a cycle closes.
+   *
+   * Reported rather than silently skipped, because the two kinds of caller need
+   * opposite things from it. A READER must tolerate a cycle and answer anyway;
+   * a WRITER must refuse, since a cycle it accepts becomes a forest later
+   * operations cannot traverse at all. The walk is the only place that knows —
+   * detecting one is a property of having traversed — so a caller left to find
+   * out for itself would need a second traversal and a second definition.
+   *
+   * The walk never descends into such an entry regardless of what is returned.
+   */
+  cycle: boolean;
+}
+
+/**
+ * What the walk should do after an entry has been reported.
+ *
+ * `descend` reads the entry's slots next; `skip` leaves them unread; `stop`
+ * abandons the walk with the stack unread, which is what makes a budget bound
+ * the TRAVERSAL rather than only the work done per entry.
+ */
+export type ForestStep = "descend" | "skip" | "stop";
+
+/** A source list being read, or the end of a subtree. */
+type Frame =
+  | {
+      kind: "list";
+      nodes: readonly unknown[];
+      index: number;
+      parent: BlockNode | undefined;
+      depth: number;
+    }
+  | { kind: "leave"; node: unknown };
+
+/**
+ * Take the next unread entry, discarding frames that are finished on the way.
+ *
+ * Leaving a subtree is what removes its node from the ancestor path, so it
+ * happens here: that is a property of the stack unwinding rather than of any
+ * entry being visited.
+ */
+function takeNext(
+  stack: Frame[],
+  onPath: Set<unknown>
+): { node: unknown; parent: BlockNode | undefined; depth: number } | undefined {
+  while (stack.length > 0) {
+    const top = stack[stack.length - 1];
+    if (top === undefined) return undefined;
+    if (top.kind === "leave") {
+      stack.pop();
+      onPath.delete(top.node);
+      continue;
+    }
+    if (top.index >= top.nodes.length) {
+      stack.pop();
+      continue;
+    }
+    const node = top.nodes[top.index];
+    top.index += 1;
+    return { node, parent: top.parent, depth: top.depth };
+  }
+  return undefined;
+}
+
+/** Queue a node's slot children so they are read before the next sibling. */
+function pushSlots(stack: Frame[], block: BlockNode, depth: number): void {
+  const lists = Object.values(block.slots ?? {});
+  // Reversed so the first slot is read first: this is a pre-order walk, and a
+  // caller reading a document in document order would otherwise see it mirrored
+  // slot by slot.
+  for (let i = lists.length - 1; i >= 0; i -= 1) {
+    const children = lists[i];
+    // A slot whose value is not an array is skipped rather than read. Persisted
+    // documents arrive unvalidated and iterating a non-array throws.
+    if (!Array.isArray(children)) continue;
+    stack.push({
+      kind: "list",
+      nodes: children,
+      index: 0,
+      parent: block,
+      depth: depth + 1,
+    });
+  }
+}
+
+/** Whether an entry is a value this walk can descend into. */
+function isDescendable(node: unknown): node is BlockNode {
+  // `Array.isArray` is checked separately because `typeof [] === "object"`.
+  return typeof node === "object" && node !== null && !Array.isArray(node);
+}
+
+/** Visit every entry of the forest, letting `onEntry` decide how to proceed. */
+export function walkForest(
+  nodes: readonly unknown[],
+  onEntry: (entry: ForestEntry) => ForestStep
+): void {
+  if (!Array.isArray(nodes)) return;
+  const onPath = new Set<unknown>();
+  const stack: Frame[] = [
+    { kind: "list", nodes, index: 0, parent: undefined, depth: 1 },
+  ];
+
+  for (;;) {
+    const next = takeNext(stack, onPath);
+    if (next === undefined) return;
+    const { node, parent, depth } = next;
+
+    const cycle = isDescendable(node) && onPath.has(node);
+    const step = onEntry({ node, parent, depth, cycle });
+    if (step === "stop") return;
+    if (step === "skip") continue;
+
+    // Asking to descend into something with no slots is not an error; it simply
+    // has nowhere to go. Checked here so no caller has to.
+    if (!isDescendable(node) || cycle || !node.slots) continue;
+
+    onPath.add(node);
+    stack.push({ kind: "leave", node });
+    pushSlots(stack, node, depth);
+  }
+}

--- a/packages/blocks-engine/src/limits.ts
+++ b/packages/blocks-engine/src/limits.ts
@@ -37,6 +37,31 @@ export const DEFAULT_LIMITS: DocumentLimits = {
   maxBytes: DEFAULT_MAX_DOCUMENT_BYTES,
 };
 
+/**
+ * Queue a node's slot children for the counter, carrying the ancestors below it.
+ *
+ * Enqueued one at a time. `push(...children)` passes each child as a call
+ * ARGUMENT, and V8 caps those near 100k — so a slot wider than that throws a
+ * native RangeError from inside the counter, before any caller can refuse the
+ * document for being too large. The count exists to reject exactly that
+ * document.
+ *
+ * A malformed slot value (a non-array) is skipped: these helpers run over
+ * untrusted documents during validation and must not throw.
+ */
+function enqueueChildren(
+  node: BlockNode,
+  path: ReadonlySet<unknown>,
+  queue: { node: BlockNode; path: ReadonlySet<unknown> }[]
+): void {
+  if (typeof node !== "object" || node === null || !node.slots) return;
+  const below: ReadonlySet<unknown> = new Set(path).add(node);
+  for (const children of Object.values(node.slots)) {
+    if (!Array.isArray(children)) continue;
+    for (const child of children) queue.push({ node: child, path: below });
+  }
+}
+
 /** Total node count across the forest, slots included. */
 export function countNodes(nodes: BlockNode[]): number {
   let count = 0;
@@ -44,23 +69,25 @@ export function countNodes(nodes: BlockNode[]): number {
   // ones (null, a primitive): the node cap must reflect the real element count
   // so an array padded with junk cannot slip past it. Only well-formed objects
   // are descended into.
-  const queue: BlockNode[] = [...nodes];
+  // Each entry carries the ancestors it was reached through, so a slot holding
+  // one of its own ancestors is not descended into again. Without it the queue
+  // gains entries forever on a cyclic document and this exits with a native
+  // RangeError — from inside the counter whose job is to let a caller REFUSE
+  // such a document.
+  //
+  // Ancestors rather than everything seen, because the two differ where it
+  // matters: one node object placed in two slots is two elements of this
+  // document and is counted twice, exactly as it is today. Only a true cycle is
+  // cut, and only where it closes.
+  const queue: { node: BlockNode; path: ReadonlySet<unknown> }[] = nodes.map(
+    node => ({ node, path: new Set() })
+  );
   for (let i = 0; i < queue.length; i++) {
-    const node = queue[i];
+    const node = queue[i]?.node;
+    const path = queue[i]?.path ?? new Set();
     count++;
-    if (typeof node === "object" && node !== null && node.slots) {
-      // Guard against malformed slots (a non-array value): these helpers run
-      // over untrusted documents during validation and must not throw.
-      for (const children of Object.values(node.slots)) {
-        if (!Array.isArray(children)) continue;
-        // Enqueued one at a time. `push(...children)` passes each child as a
-        // call ARGUMENT, and V8 caps those near 100k — so a slot wider than
-        // that throws a native RangeError from inside the counter, before any
-        // caller can refuse the document for being too large. The count exists
-        // to reject exactly that document.
-        for (const child of children) queue.push(child);
-      }
-    }
+    if (path.has(node)) continue;
+    enqueueChildren(node, path, queue);
   }
   return count;
 }
@@ -68,14 +95,24 @@ export function countNodes(nodes: BlockNode[]): number {
 /** Deepest nesting level in the forest; an empty forest is depth 0. */
 export function treeDepth(nodes: BlockNode[]): number {
   let deepest = 0;
-  const stack: Array<{ node: BlockNode; depth: number }> = nodes.map(node => ({
-    node,
-    depth: 1,
-  }));
+  // Carries the ancestors each entry was reached through, for the reason the
+  // node counter does: a slot holding one of its own ancestors otherwise makes
+  // this walk gain entries forever while `depth` climbs without bound, and it
+  // does not crash — it SPINS. A hang holds a request open and presents as
+  // slowness somewhere unrelated, which is the failure nobody attributes here.
+  //
+  // Ancestors rather than everything seen: the deepest path to a node shared
+  // between two branches is still the answer, and only a cycle is cut.
+  const stack: Array<{
+    node: BlockNode;
+    depth: number;
+    path: ReadonlySet<unknown>;
+  }> = nodes.map(node => ({ node, depth: 1, path: new Set() }));
   while (stack.length > 0) {
     const entry = stack.pop();
     if (!entry) continue;
     if (entry.depth > deepest) deepest = entry.depth;
+    if (entry.path.has(entry.node)) continue;
     // A malformed array element (null, or a non-object) has no slots and must
     // not be dereferenced: validation runs this over untrusted documents.
     if (
@@ -87,8 +124,9 @@ export function treeDepth(nodes: BlockNode[]): number {
       // during validation cannot make this throw.
       for (const children of Object.values(entry.node.slots)) {
         if (!Array.isArray(children)) continue;
+        const below: ReadonlySet<unknown> = new Set(entry.path).add(entry.node);
         for (const child of children) {
-          stack.push({ node: child, depth: entry.depth + 1 });
+          stack.push({ node: child, depth: entry.depth + 1, path: below });
         }
       }
     }

--- a/packages/blocks-engine/src/limits.ts
+++ b/packages/blocks-engine/src/limits.ts
@@ -3,6 +3,7 @@
  * lets tooling surface "approaching the limit" before authors hit a wall.
  */
 import type { BlockDocument, BlockNode } from "./document";
+import { walkForest } from "./forest-walk";
 
 /** Maximum nesting depth of nodes (top-level nodes are depth 1). */
 export const MAX_DEPTH = 12;
@@ -37,100 +38,26 @@ export const DEFAULT_LIMITS: DocumentLimits = {
   maxBytes: DEFAULT_MAX_DOCUMENT_BYTES,
 };
 
-/**
- * Queue a node's slot children for the counter, carrying the ancestors below it.
- *
- * Enqueued one at a time. `push(...children)` passes each child as a call
- * ARGUMENT, and V8 caps those near 100k — so a slot wider than that throws a
- * native RangeError from inside the counter, before any caller can refuse the
- * document for being too large. The count exists to reject exactly that
- * document.
- *
- * A malformed slot value (a non-array) is skipped: these helpers run over
- * untrusted documents during validation and must not throw.
- */
-function enqueueChildren(
-  node: BlockNode,
-  path: ReadonlySet<unknown>,
-  queue: { node: BlockNode; path: ReadonlySet<unknown> }[]
-): void {
-  if (typeof node !== "object" || node === null || !node.slots) return;
-  const below: ReadonlySet<unknown> = new Set(path).add(node);
-  for (const children of Object.values(node.slots)) {
-    if (!Array.isArray(children)) continue;
-    for (const child of children) queue.push({ node: child, path: below });
-  }
-}
-
 /** Total node count across the forest, slots included. */
 export function countNodes(nodes: BlockNode[]): number {
   let count = 0;
-  // Index-based walk so every array element is counted, including malformed
-  // ones (null, a primitive): the node cap must reflect the real element count
-  // so an array padded with junk cannot slip past it. Only well-formed objects
-  // are descended into.
-  // Each entry carries the ancestors it was reached through, so a slot holding
-  // one of its own ancestors is not descended into again. Without it the queue
-  // gains entries forever on a cyclic document and this exits with a native
-  // RangeError — from inside the counter whose job is to let a caller REFUSE
-  // such a document.
-  //
-  // Ancestors rather than everything seen, because the two differ where it
-  // matters: one node object placed in two slots is two elements of this
-  // document and is counted twice, exactly as it is today. Only a true cycle is
-  // cut, and only where it closes.
-  const queue: { node: BlockNode; path: ReadonlySet<unknown> }[] = nodes.map(
-    node => ({ node, path: new Set() })
-  );
-  for (let i = 0; i < queue.length; i++) {
-    const node = queue[i]?.node;
-    const path = queue[i]?.path ?? new Set();
-    count++;
-    if (path.has(node)) continue;
-    enqueueChildren(node, path, queue);
-  }
+  // EVERY entry counts, malformed ones included: the cap exists to reject a
+  // document by its real element count, so an array padded with junk must not
+  // slip past it.
+  walkForest(nodes, () => {
+    count += 1;
+    return "descend";
+  });
   return count;
 }
 
 /** Deepest nesting level in the forest; an empty forest is depth 0. */
 export function treeDepth(nodes: BlockNode[]): number {
   let deepest = 0;
-  // Carries the ancestors each entry was reached through, for the reason the
-  // node counter does: a slot holding one of its own ancestors otherwise makes
-  // this walk gain entries forever while `depth` climbs without bound, and it
-  // does not crash — it SPINS. A hang holds a request open and presents as
-  // slowness somewhere unrelated, which is the failure nobody attributes here.
-  //
-  // Ancestors rather than everything seen: the deepest path to a node shared
-  // between two branches is still the answer, and only a cycle is cut.
-  const stack: Array<{
-    node: BlockNode;
-    depth: number;
-    path: ReadonlySet<unknown>;
-  }> = nodes.map(node => ({ node, depth: 1, path: new Set() }));
-  while (stack.length > 0) {
-    const entry = stack.pop();
-    if (!entry) continue;
+  walkForest(nodes, entry => {
     if (entry.depth > deepest) deepest = entry.depth;
-    if (entry.path.has(entry.node)) continue;
-    // A malformed array element (null, or a non-object) has no slots and must
-    // not be dereferenced: validation runs this over untrusted documents.
-    if (
-      typeof entry.node === "object" &&
-      entry.node !== null &&
-      entry.node.slots
-    ) {
-      // Skip malformed (non-array) slot values so untrusted documents passed in
-      // during validation cannot make this throw.
-      for (const children of Object.values(entry.node.slots)) {
-        if (!Array.isArray(children)) continue;
-        const below: ReadonlySet<unknown> = new Set(entry.path).add(entry.node);
-        for (const child of children) {
-          stack.push({ node: child, depth: entry.depth + 1, path: below });
-        }
-      }
-    }
-  }
+    return "descend";
+  });
   return deepest;
 }
 

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -366,8 +366,31 @@ describe("a forest whose slots form a cycle", () => {
     expect(next[1]?.id).not.toBe(parent.id);
   });
 
-  it("re-ids a cyclic subtree without recursing forever", () => {
-    expect(() => reidSubtree(cyclic()[0]!)).not.toThrow();
+  it("re-ids a cyclic subtree into a fresh, SERIALIZABLE one", () => {
+    // "Does not throw" is satisfied by a fallback that returns the original
+    // node untouched — no new ids, still cyclic, still unstorable. So the
+    // assertions are the two things that separate a real rebuild from that:
+    // the ids changed, and the result can actually be written.
+    const source = cyclic()[0]!;
+
+    const copy = reidSubtree(source);
+
+    expect(copy.id).not.toBe(source.id);
+    expect(copy.slots?.main?.[0]?.id).not.toBe(source.slots?.main?.[0]?.id);
+    expect(() => JSON.stringify(copy)).not.toThrow();
+  });
+
+  it("keeps a malformed slots CONTAINER on an unrelated edit", () => {
+    // `slots: null` is not the same as absent. It has no entries to enumerate,
+    // so a rebuild that treated only `undefined` as absent replaced it with
+    // `{}` — stored content rewritten by an edit naming a different node.
+    const holder = makeNode("core/box", 1);
+    holder.slots = null as unknown as Record<string, BlockNode[]>;
+    const other = makeNode("core/text", 1);
+
+    const next = updateNode([holder, other], other.id, { props: { x: 1 } });
+
+    expect(next[0]?.slots).toBeNull();
   });
 
   it("terminates on a cycle LONGER than the call stack, not just a short one", () => {

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -336,6 +336,24 @@ describe("a forest whose slots form a cycle", () => {
     expect(duplicateNode(nodes, nodes[0]!.id)).toBe(nodes);
   });
 
+  it("refuses a duplicate when a SIBLING branch carries the cycle", () => {
+    // The selected node is perfectly fine; the cycle is somewhere else in the
+    // forest. The result is equally unstorable, because `JSON.stringify`
+    // refuses the FOREST rather than the node — so a guard that inspected only
+    // the subtree being copied reported success and handed back something that
+    // cannot be persisted.
+    //
+    // The previous test cannot separate these implementations: it selects the
+    // cyclic node itself, so checking the subtree and checking the forest give
+    // the same answer.
+    const cyclic = makeNode("core/box", 1, {}, { main: [] });
+    cyclic.slots!.main.push(cyclic);
+    const target = makeNode("core/text", 1);
+    const forest = [cyclic, target];
+
+    expect(duplicateNode(forest, target.id)).toBe(forest);
+  });
+
   it("still duplicates an ACYCLIC subtree, so the refusal is not blanket", () => {
     // The control. A `duplicateNode` that refused everything would satisfy the
     // case above while never duplicating anything for anyone.
@@ -421,6 +439,29 @@ describe("a forest whose slots form a cycle", () => {
     const next = updateNode([holder, other], other.id, { props: { x: 1 } });
 
     expect(next[0]?.slots?.constructor).toEqual({ nope: true });
+  });
+
+  it("keeps an own `__proto__` slot, which plain assignment would swallow", () => {
+    // The write-side twin of the `constructor` case. Reading through a `Map`
+    // fixed the lookup; the STORE was still `slots[name] = value`, and that is
+    // not a plain write for `__proto__` — it invokes the legacy prototype
+    // setter, so the stored value becomes the object's prototype and
+    // serialization emits `{}`. The constructor test stays green throughout,
+    // because it exercises the read and not the write.
+    const holder = makeNode("core/box", 1);
+    const slots: Record<string, BlockNode[]> = {};
+    Object.defineProperty(slots, "__proto__", {
+      value: { nope: true } as unknown as BlockNode[],
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+    holder.slots = slots;
+    const other = makeNode("core/text", 1);
+
+    const next = updateNode([holder, other], other.id, { props: { x: 1 } });
+
+    expect(JSON.stringify(next[0]?.slots)).toBe('{"__proto__":{"nope":true}}');
   });
 
   it("passes a malformed ENTRY through rather than mapping it", () => {

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -311,14 +311,89 @@ describe("a forest whose slots form a cycle", () => {
     const next = updateNode(nodes, nodes[0]!.id, { props: { touched: true } });
 
     expect(next[0]?.props).toEqual({ touched: true });
-    // Terminated, and returned a forest that is itself finite to walk.
-    expect(countNodes(next)).toBe(3);
+
+    // The entry that CLOSES the cycle is omitted, not kept as a childless copy.
+    // Keeping it returned `[parent, child, parent]` — the same id twice, which
+    // makes every id lookup ambiguous and fails the validation this repair
+    // exists to satisfy. A node count alone cannot see that; the ids can.
+    const ids: string[] = [];
+    walkNodes(next, node => ids.push(node.id));
+    expect(ids).toEqual([nodes[0]!.id, nodes[0]!.slots!.main![0]!.id]);
+    expect(new Set(ids).size).toBe(ids.length);
   });
 
   it("duplicates and re-ids a cyclic subtree without recursing forever", () => {
     const nodes = cyclic();
     expect(() => duplicateNode(nodes, nodes[0]!.id)).not.toThrow();
     expect(() => reidSubtree(nodes[0]!)).not.toThrow();
+  });
+
+  it("terminates on a cycle LONGER than the call stack, not just a short one", () => {
+    // The two-node fixture above cannot establish this. A recursive walk
+    // notices a cycle only after descending to the repeated ancestor, so its
+    // guard is unreachable for any cycle deeper than the machine allows — a
+    // five-thousand-node chain closing on its root exited with a RangeError
+    // while the check sat unreached. Machine depth was the real bound.
+    //
+    // Sized past the measured limit so the test does not go quiet if a future
+    // engine grants a larger stack.
+    const DEEP = 5_000;
+    let root: BlockNode = makeNode("core/text", 1);
+    const leaf = root;
+    for (let i = 0; i < DEEP; i++) {
+      root = makeNode("core/box", 1, {}, { main: [root] });
+    }
+    leaf.slots = { main: [root] };
+
+    expect(findNode([root], "absent")).toBeUndefined();
+    expect(() => countNodes([root])).not.toThrow();
+    expect(() => treeDepth([root])).not.toThrow();
+    expect(() =>
+      updateNode([root], root.id, { props: { x: 1 } })
+    ).not.toThrow();
+    expect(() => reidSubtree(root)).not.toThrow();
+  });
+
+  it("rebuilds a forest nested deeper than the call stack allows", () => {
+    // The other axis, and the one a cycle guard does nothing for. An immutable
+    // rebuild recursed per level, so a deep ACYCLIC document — no cycle at all
+    // — exhausted the stack on an ordinary edit.
+    let root: BlockNode = makeNode("core/text", 1);
+    for (let i = 0; i < 20_000; i++) {
+      root = makeNode("core/box", 1, {}, { main: [root] });
+    }
+
+    const next = updateNode([root], root.id, { props: { deep: true } });
+
+    expect(next[0]?.props).toEqual({ deep: true });
+    expect(countNodes(next)).toBe(20_001);
+  });
+
+  it("keeps a malformed SLOT VALUE that an unrelated edit never named", () => {
+    // Rebuilding used to throw on these, which lost nothing. Replacing them
+    // with an empty array would be worse than the throw: an edit to a different
+    // field would silently destroy stored content a caller may still need to
+    // read or repair, and nothing would report it.
+    const holder = makeNode("core/box", 1);
+    holder.slots = { broken: { nope: true } as unknown as BlockNode[] };
+    const other = makeNode("core/text", 1);
+
+    const next = updateNode([holder, other], other.id, { props: { x: 1 } });
+
+    expect(next[0]?.slots?.broken).toEqual({ nope: true });
+  });
+
+  it("passes a malformed ENTRY through rather than mapping it", () => {
+    // `fn` is written for nodes and reads `id` off what it is handed, so a
+    // `null` neighbour would throw — failing an edit the caller made to a
+    // different node entirely.
+    const real = makeNode("core/text", 1);
+    const forest = [null, real] as unknown as BlockNode[];
+
+    const next = updateNode(forest, real.id, { props: { x: 1 } });
+
+    expect(next[0]).toBeNull();
+    expect(next[1]?.props).toEqual({ x: 1 });
   });
 
   it("still counts a REPEATED node that is not a cycle twice", () => {

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -322,10 +322,34 @@ describe("a forest whose slots form a cycle", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it("duplicates and re-ids a cyclic subtree without recursing forever", () => {
+  it("REFUSES to duplicate a cyclic subtree rather than adding an unusable clone", () => {
+    // The clone is rebuilt without the edge that closes the cycle, but the
+    // ORIGINAL stays in the forest and stays cyclic — so the result carries a
+    // structure `JSON.stringify` refuses and the page cannot be stored at all.
+    // "Did not throw" cannot see that, which is why the previous version of
+    // this test passed while the returned forest was still unusable.
+    //
+    // Refused rather than repaired: silently rebuilding the source would edit a
+    // node the caller never named, on an operation they asked to be additive.
     const nodes = cyclic();
-    expect(() => duplicateNode(nodes, nodes[0]!.id)).not.toThrow();
-    expect(() => reidSubtree(nodes[0]!)).not.toThrow();
+
+    expect(duplicateNode(nodes, nodes[0]!.id)).toBe(nodes);
+  });
+
+  it("still duplicates an ACYCLIC subtree, so the refusal is not blanket", () => {
+    // The control. A `duplicateNode` that refused everything would satisfy the
+    // case above while never duplicating anything for anyone.
+    const child = makeNode("core/text", 1);
+    const parent = makeNode("core/box", 1, {}, { main: [child] });
+
+    const next = duplicateNode([parent], parent.id);
+
+    expect(next).toHaveLength(2);
+    expect(next[1]?.id).not.toBe(parent.id);
+  });
+
+  it("re-ids a cyclic subtree without recursing forever", () => {
+    expect(() => reidSubtree(cyclic()[0]!)).not.toThrow();
   });
 
   it("terminates on a cycle LONGER than the call stack, not just a short one", () => {
@@ -381,6 +405,22 @@ describe("a forest whose slots form a cycle", () => {
     const next = updateNode([holder, other], other.id, { props: { x: 1 } });
 
     expect(next[0]?.slots?.broken).toEqual({ nope: true });
+  });
+
+  it("keeps a malformed slot whose NAME collides with Object.prototype", () => {
+    // Slot names come from unvalidated stored data. A plain object answers for
+    // keys it never had — `built["constructor"]` resolves
+    // `Object.prototype.constructor` — so a malformed slot deliberately left
+    // out of the rebuilt set came back as a FUNCTION and was then dropped by
+    // serialization. The stored value destroyed by an unrelated edit, which is
+    // the exact loss preserving it was meant to prevent.
+    const holder = makeNode("core/box", 1);
+    holder.slots = { constructor: { nope: true } as unknown as BlockNode[] };
+    const other = makeNode("core/text", 1);
+
+    const next = updateNode([holder, other], other.id, { props: { x: 1 } });
+
+    expect(next[0]?.slots?.constructor).toEqual({ nope: true });
   });
 
   it("passes a malformed ENTRY through rather than mapping it", () => {

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -264,6 +264,79 @@ describe("walkNodes / findNode / locateNode", () => {
   });
 });
 
+describe("a forest whose slots form a cycle", () => {
+  // A cycle reaches these primitives the same way every other malformed shape
+  // does: persisted documents are not required to have been validated, and an
+  // in-process producer can build one directly. None of these crashed on a
+  // document an author could make — they crashed on one the system admits.
+  //
+  // Measured before the fix, on the built package: `treeDepth` did not throw,
+  // it SPUN, which is the failure nobody attributes correctly. The rest exited
+  // with `RangeError: Maximum call stack size exceeded`.
+  function cyclic(): BlockNode[] {
+    const parent = makeNode("core/box", 1);
+    const child = makeNode("core/box", 1, {}, { main: [parent] });
+    parent.slots = { main: [child] };
+    return [parent];
+  }
+
+  it("counts a cyclic forest instead of exhausting its own queue", () => {
+    expect(countNodes(cyclic())).toBe(3);
+  });
+
+  it("measures depth instead of spinning forever", () => {
+    expect(treeDepth(cyclic())).toBe(3);
+  });
+
+  it("returns undefined for an ABSENT id rather than overflowing", () => {
+    // The half that hid this: a lookup for an id that is PRESENT returns before
+    // it can loop, so only a miss fails — and a miss is the ordinary case for
+    // any lookup that can have one.
+    // One forest, not two: `cyclic()` mints fresh ids per call, so an id taken
+    // from a second build is absent from the first by construction and would
+    // pass this whatever `findNode` did.
+    const nodes = cyclic();
+    expect(findNode(nodes, "nope")).toBeUndefined();
+    expect(findNode(nodes, nodes[0]!.id)).toBeDefined();
+  });
+
+  it("rebuilds through updateNode by breaking the back edge", () => {
+    // An immutable rebuild of a cyclic forest is not a thing that exists: the
+    // result would have to contain itself. Dropping the edge that closes the
+    // cycle is the only outcome that terminates, and it is the repair a caller
+    // wants — the operation succeeds on a finite forest.
+    // `updateNode` takes a PATCH, not a mapper — it merges the given fields
+    // onto the node whose id matches.
+    const nodes = cyclic();
+    const next = updateNode(nodes, nodes[0]!.id, { props: { touched: true } });
+
+    expect(next[0]?.props).toEqual({ touched: true });
+    // Terminated, and returned a forest that is itself finite to walk.
+    expect(countNodes(next)).toBe(3);
+  });
+
+  it("duplicates and re-ids a cyclic subtree without recursing forever", () => {
+    const nodes = cyclic();
+    expect(() => duplicateNode(nodes, nodes[0]!.id)).not.toThrow();
+    expect(() => reidSubtree(nodes[0]!)).not.toThrow();
+  });
+
+  it("still counts a REPEATED node that is not a cycle twice", () => {
+    // The boundary. One node object placed in two slots is two elements of this
+    // document and is not a cycle — a guard keyed on everything seen would
+    // report half the real size and pass a cap the document exceeds.
+    const shared = makeNode("core/text", 1);
+    const host = makeNode(
+      "core/box",
+      1,
+      {},
+      { left: [shared], right: [shared] }
+    );
+
+    expect(countNodes([host])).toBe(3);
+  });
+});
+
 describe("insertNode", () => {
   it("inserts at the top level with a clamped index", () => {
     const { nodes } = fixture();

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -328,7 +328,13 @@ function mapForest(
     if (onPath.has(entry)) continue;
 
     const mapped = fn(entry);
-    if (mapped.slots === undefined) {
+    // Anything that is not a slots RECORD is passed through untouched, not just
+    // `undefined`. A stored `slots: null` — or a primitive — has no entries to
+    // enumerate, and sending it on would replace it with `{}`: stored content
+    // rewritten by an edit that named a different node. The recursive rebuild
+    // this replaced kept such a node as it was, and losing that was a
+    // regression rather than a change of policy.
+    if (!isSlotsRecord(mapped.slots)) {
       top.out.push(mapped);
       continue;
     }
@@ -346,6 +352,13 @@ function mapForest(
   }
 
   return rebuilt as BlockNode[];
+}
+
+/** Whether a node's `slots` is a record this rebuild can enumerate. */
+function isSlotsRecord(slots: unknown): slots is Record<string, BlockNode[]> {
+  // `Array.isArray` separately, because `typeof [] === "object"` and an array
+  // of slots is malformed rather than empty.
+  return typeof slots === "object" && slots !== null && !Array.isArray(slots);
 }
 
 /** Put the rebuilt slots back on a node, keeping any slot that was not rebuilt. */

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -358,7 +358,22 @@ function assembleSlots(
     // A slot absent from `built` held something this rebuild could not walk.
     // Keeping the stored value is the point: an unrelated edit must not be the
     // thing that destroys it.
-    slots[name] = built.get(name) ?? original;
+    const value = built.get(name) ?? original;
+    // DEFINED rather than assigned. Slot names come from unvalidated stored
+    // data, and plain assignment is not a plain write for all of them: an own
+    // `__proto__` slot invokes the legacy prototype setter instead of creating
+    // a property, so the stored value becomes the object's prototype and
+    // serialization emits `{}` — the slot silently emptied by an edit that
+    // named a different node.
+    //
+    // This is the write-side twin of reading through a `Map`. Fixing only the
+    // read left the one slot name that defeats the write.
+    Object.defineProperty(slots, name, {
+      value,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
   }
   return { ...mapped, slots };
 }
@@ -534,7 +549,7 @@ function reidOne(node: BlockNode): BlockNode {
 }
 
 /**
- * Whether a subtree contains a node reached through itself.
+ * Whether a forest contains a node reached through itself.
  *
  * Asked of the walk rather than looked for here. `walkNodes` is cycle-TOLERANT
  * by design — a reader counting classes or measuring a document must answer
@@ -542,9 +557,9 @@ function reidOne(node: BlockNode): BlockNode {
  * walk REPORTS is the only account of it. A second traversal written here would
  * be a second definition of the same thing.
  */
-function isCyclic(node: BlockNode): boolean {
+function isCyclic(nodes: BlockNode[]): boolean {
   let cyclic = false;
-  walkNodes([node], () => undefined, {
+  walkNodes(nodes, () => undefined, {
     onCycle: () => {
       cyclic = true;
     },
@@ -565,7 +580,14 @@ export function duplicateNode(nodes: BlockNode[], id: string): BlockNode[] {
   // is what makes that safe to say: silently rebuilding the source would edit a
   // node the caller never named, on an operation they asked to be additive.
   // `insertNode` refuses a cyclic subtree for the same reason.
-  if (isCyclic(found)) return nodes;
+  // The WHOLE forest, not just the subtree being copied. A cycle in a sibling
+  // branch leaves the result equally unstorable — `JSON.stringify` refuses the
+  // forest, not the node — so an operation reporting success while handing back
+  // something that cannot be persisted is the thing worth refusing.
+  //
+  // The forest was already in that state before the call, so this declines to
+  // ADD to a document that cannot be saved rather than claiming to repair one.
+  if (isCyclic(nodes)) return nodes;
   const location = locateNode(nodes, id);
   if (!location) return nodes;
   return insertNode(nodes, reidSubtree(found), {

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -263,14 +263,51 @@ export function findNode(
   nodes: BlockNode[],
   id: string
 ): BlockNode | undefined {
+  return findWithin(nodes, id, new Set());
+}
+
+/**
+ * `findNode`, carrying the ancestors the current forest was reached through.
+ *
+ * The path is what makes a MISS terminate. A hit returns before descending
+ * further, so a lookup for an id that is present has always worked even on a
+ * cyclic document — which is exactly why this went unnoticed: the failure needs
+ * an id that is ABSENT, and asking for one that is not there is the ordinary
+ * case for any lookup that can miss.
+ *
+ * A node reached through itself is not descended into again; the back edge is
+ * simply not followed, so the search still covers everything reachable without
+ * a cycle.
+ */
+function findWithin(
+  nodes: BlockNode[],
+  id: string,
+  path: ReadonlySet<unknown>
+): BlockNode | undefined {
+  if (!Array.isArray(nodes)) return undefined;
   for (const node of nodes) {
+    // Persisted forests reach these primitives unvalidated, so an entry may be
+    // `null` or a primitive and reading `id` off one throws.
+    if (typeof node !== "object" || node === null) continue;
     if (node.id === id) return node;
-    if (node.slots) {
-      for (const children of Object.values(node.slots)) {
-        const hit = findNode(children, id);
-        if (hit) return hit;
-      }
-    }
+    if (path.has(node) || !node.slots) continue;
+    const hit = findBelow(node, id, path);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+/** Search a node's slots, with that node added to the ancestor path. */
+function findBelow(
+  node: BlockNode,
+  id: string,
+  path: ReadonlySet<unknown>
+): BlockNode | undefined {
+  const below: ReadonlySet<unknown> = new Set(path).add(node);
+  for (const children of Object.values(node.slots ?? {})) {
+    if (!Array.isArray(children)) continue;
+    const hit = findWithin(children, id, below);
+    if (hit) return hit;
   }
   return undefined;
 }
@@ -306,14 +343,31 @@ export function locateNode(
 /** Immutably rebuild the forest, applying `fn` to every node (parents before children). */
 function mapForest(
   nodes: BlockNode[],
-  fn: (node: BlockNode) => BlockNode
+  fn: (node: BlockNode) => BlockNode,
+  path: ReadonlySet<unknown> = new Set()
 ): BlockNode[] {
+  if (!Array.isArray(nodes)) return [];
   return nodes.map(node => {
+    // Unvalidated entries reach here, and `fn` is written for nodes.
+    if (typeof node !== "object" || node === null) return node;
     const mapped = fn(node);
     if (!mapped.slots) return mapped;
+    // A node reached through itself CANNOT be rebuilt: the result would have to
+    // contain itself, and the attempt recurses until the stack runs out. The
+    // back edge is dropped instead, so the rebuild returns a finite forest with
+    // the cycle broken rather than failing the caller's operation outright.
+    //
+    // Dropping rather than keeping is the only option that terminates, and it
+    // is the repair a caller would want anyway: an immutable rebuild of a
+    // cyclic forest is not a thing that exists.
+    if (path.has(node)) {
+      const { slots: _cyclic, ...withoutSlots } = mapped;
+      return withoutSlots;
+    }
+    const below: ReadonlySet<unknown> = new Set(path).add(node);
     const slots: Record<string, BlockNode[]> = {};
     for (const [name, children] of Object.entries(mapped.slots)) {
-      slots[name] = mapForest(children, fn);
+      slots[name] = mapForest(children, fn, below);
     }
     return { ...mapped, slots };
   });
@@ -455,6 +509,18 @@ export function moveNode(
 
 /** Deep-clone a subtree, assigning fresh ids to every node (copy/paste, patterns). */
 export function reidSubtree(node: BlockNode): BlockNode {
+  return reidWithin(node, new Set());
+}
+
+/**
+ * `reidSubtree`, carrying the ancestors this node was reached through.
+ *
+ * A node reached through itself has its slots dropped rather than rebuilt. The
+ * re-id'd copy would otherwise have to contain a copy of itself, which is not a
+ * finite structure — the recursion simply runs the stack out. Breaking the back
+ * edge yields a duplicable subtree instead of failing the duplicate.
+ */
+function reidWithin(node: BlockNode, path: ReadonlySet<unknown>): BlockNode {
   // Clone only this node's own fields; descendants are cloned by the recursive
   // calls below, so cloning `slots` here too would deep-copy them twice.
   const { slots, ...own } = node;
@@ -473,10 +539,16 @@ export function reidSubtree(node: BlockNode): BlockNode {
     if (Object.keys(attributes).length > 0) copy.attributes = attributes;
     else delete copy.attributes;
   }
-  if (slots) {
+  if (slots && !path.has(node)) {
+    const below: ReadonlySet<unknown> = new Set(path).add(node);
     const newSlots: Record<string, BlockNode[]> = {};
     for (const [name, children] of Object.entries(slots)) {
-      newSlots[name] = children.map(reidSubtree);
+      if (!Array.isArray(children)) continue;
+      newSlots[name] = children.map(child =>
+        typeof child === "object" && child !== null
+          ? reidWithin(child, below)
+          : child
+      );
     }
     copy.slots = newSlots;
   }

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -242,7 +242,7 @@ type BuildTask =
       kind: "close";
       source: unknown;
       mapped: BlockNode;
-      built: Record<string, BlockNode[]>;
+      built: Map<string, BlockNode[]>;
       out: unknown[];
     };
 
@@ -255,7 +255,7 @@ type BuildTask =
 function queueSlotRebuilds(
   stack: BuildTask[],
   mapped: BlockNode,
-  built: Record<string, BlockNode[]>
+  built: Map<string, BlockNode[]>
 ): void {
   const names = Object.keys(mapped.slots ?? {});
   // Reversed so the first slot is rebuilt first.
@@ -265,7 +265,7 @@ function queueSlotRebuilds(
     const children = mapped.slots?.[name];
     if (!Array.isArray(children)) continue;
     const into: BlockNode[] = [];
-    built[name] = into;
+    built.set(name, into);
     stack.push({ kind: "read", source: children, index: 0, out: into });
   }
 }
@@ -334,7 +334,13 @@ function mapForest(
     }
 
     onPath.add(entry);
-    const built: Record<string, BlockNode[]> = {};
+    // A Map, not a record. Slot NAMES come from unvalidated stored data, and a
+    // plain object answers for keys it never had: `built["constructor"]`
+    // resolves `Object.prototype.constructor`, so a malformed slot deliberately
+    // left out of this set would come back as a function and be dropped by
+    // serialization — the stored value destroyed by an unrelated edit, which is
+    // the exact loss preserving it was meant to prevent.
+    const built = new Map<string, BlockNode[]>();
     stack.push({ kind: "close", source: entry, mapped, built, out: top.out });
     queueSlotRebuilds(stack, mapped, built);
   }
@@ -345,14 +351,14 @@ function mapForest(
 /** Put the rebuilt slots back on a node, keeping any slot that was not rebuilt. */
 function assembleSlots(
   mapped: BlockNode,
-  built: Record<string, BlockNode[]>
+  built: Map<string, BlockNode[]>
 ): BlockNode {
   const slots: Record<string, BlockNode[]> = {};
   for (const [name, original] of Object.entries(mapped.slots ?? {})) {
     // A slot absent from `built` held something this rebuild could not walk.
     // Keeping the stored value is the point: an unrelated edit must not be the
     // thing that destroys it.
-    slots[name] = built[name] ?? original;
+    slots[name] = built.get(name) ?? original;
   }
   return { ...mapped, slots };
 }
@@ -527,10 +533,39 @@ function reidOne(node: BlockNode): BlockNode {
   return copy;
 }
 
+/**
+ * Whether a subtree contains a node reached through itself.
+ *
+ * Asked of the walk rather than looked for here. `walkNodes` is cycle-TOLERANT
+ * by design — a reader counting classes or measuring a document must answer
+ * rather than fail — so a cycle is invisible in what it visits, and what the
+ * walk REPORTS is the only account of it. A second traversal written here would
+ * be a second definition of the same thing.
+ */
+function isCyclic(node: BlockNode): boolean {
+  let cyclic = false;
+  walkNodes([node], () => undefined, {
+    onCycle: () => {
+      cyclic = true;
+    },
+  });
+  return cyclic;
+}
+
 /** Insert a re-id'd copy of a node immediately after the original. */
 export function duplicateNode(nodes: BlockNode[], id: string): BlockNode[] {
   const found = findNode(nodes, id);
   if (!found) return nodes;
+  // A cyclic subtree cannot be duplicated into a usable forest. The clone is
+  // rebuilt without the edge that closes the cycle, but the ORIGINAL is still
+  // in the forest and still cyclic — so the result carries a structure
+  // `JSON.stringify` refuses, and the page cannot be stored at all.
+  //
+  // Refused rather than repaired, and the no-op contract these primitives share
+  // is what makes that safe to say: silently rebuilding the source would edit a
+  // node the caller never named, on an operation they asked to be additive.
+  // `insertNode` refuses a cyclic subtree for the same reason.
+  if (isCyclic(found)) return nodes;
   const location = locateNode(nodes, id);
   if (!location) return nodes;
   return insertNode(nodes, reidSubtree(found), {

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -22,6 +22,7 @@
  *   with a machine-readable path, not silently corrected here.
  */
 import type { BlockNode } from "./document";
+import { walkForest } from "./forest-walk";
 
 /** Stable unique node id. `crypto.randomUUID` exists in Node ≥ 20 and browsers. */
 export function newId(): string {
@@ -47,29 +48,6 @@ export interface TreePosition {
   slot?: string;
   index: number;
 }
-
-/**
- * One step of the walk: a list being read, or the moment a subtree ends.
- *
- * A LIST rather than a node, so a forest is never copied onto the stack to be
- * walked. Seeding one entry per top-level node would read the whole array and
- * allocate against it before any bound applied, which makes a budget powerless
- * against the cheapest oversized document there is: a very wide root array.
- * Holding the array with a cursor spends memory on DEPTH, not on width.
- *
- * The `leave` marker is what makes ancestry observable in an iterative walk. A
- * recursive one knows it has left a subtree because the call returns; a stack
- * has to be told, so each node queues its own marker BEFORE its children and
- * the marker is reached again only after every descendant.
- */
-type Frame =
-  | {
-      kind: "list";
-      nodes: readonly unknown[];
-      index: number;
-      parent: BlockNode | undefined;
-    }
-  | { kind: "leave"; node: unknown };
 
 /** How a caller narrows the walk. */
 export interface WalkOptions {
@@ -115,50 +93,6 @@ function toWalkOptions(
 ): WalkOptions {
   if (third === undefined) return {};
   return "id" in third ? { parent: third } : third;
-}
-
-/** Queue a node's slot children so they are read before the next sibling. */
-function pushChildren(stack: Frame[], node: BlockNode): void {
-  if (!node.slots) return;
-  const slots = Object.values(node.slots);
-  // Reversed, so the first slot ends up on top of the stack and is read first.
-  for (let s = slots.length - 1; s >= 0; s -= 1) {
-    const children = slots[s];
-    // A slot whose value is not an array is skipped rather than read. Persisted
-    // documents reach this walk unvalidated, and iterating a non-array throws.
-    if (!Array.isArray(children)) continue;
-    stack.push({ kind: "list", nodes: children, index: 0, parent: node });
-  }
-}
-
-/**
- * Take the next unread entry, discarding frames that are finished on the way.
- *
- * Leaving a subtree is what removes its node from the ancestor path, so that
- * happens here: it is a property of the stack unwinding rather than of any node
- * being visited.
- */
-function takeNext(
-  stack: Frame[],
-  onPath: Set<unknown>
-): { node: unknown; parent: BlockNode | undefined } | undefined {
-  while (stack.length > 0) {
-    const top = stack[stack.length - 1];
-    if (top === undefined) return undefined;
-    if (top.kind === "leave") {
-      stack.pop();
-      onPath.delete(top.node);
-      continue;
-    }
-    if (top.index >= top.nodes.length) {
-      stack.pop();
-      continue;
-    }
-    const node = top.nodes[top.index];
-    top.index += 1;
-    return { node, parent: top.parent };
-  }
-  return undefined;
 }
 
 /** Whether an entry is a value this walk can treat as a node. */
@@ -214,48 +148,32 @@ export function walkNodes(
   fn: (node: BlockNode, parent: BlockNode | undefined) => void,
   third?: BlockNode | WalkOptions
 ): void {
-  if (!Array.isArray(nodes)) return;
   const options = toWalkOptions(third);
   const limit = options.maxNodes ?? Number.POSITIVE_INFINITY;
   if (limit <= 0) return;
 
-  const onPath = new Set<unknown>();
-  // ONE frame for the whole top level. Reading the roots array through a cursor
-  // is what keeps a budget meaningful against a very wide forest: entries are
-  // taken one at a time and the walk returns the moment the budget is spent, so
-  // a million roots with a budget of ten reads ten of them.
-  const stack: Frame[] = [
-    { kind: "list", nodes, index: 0, parent: options.parent },
-  ];
-
-  // Every entry READ spends the budget, not every entry that turned out to be a
-  // node. Reading is the work being bounded, so a forest beginning with a long
-  // run of nulls or primitives would otherwise be traversed in full while the
-  // budget sat untouched — the callback never fires, and a bound counting
-  // callbacks cannot see it. `selectNodes` bounds the same quantity, for the
-  // same reason, and the two agreeing is what lets a caller reason about one
-  // budget rather than two.
-  //
-  // Checked BEFORE taking the next entry rather than after using it, so
-  // "entries read" is exactly what the number means.
   let read = 0;
-  for (;;) {
-    if (read >= limit) return;
-    const entry = takeNext(stack, onPath);
-    if (entry === undefined) return;
+  walkForest(nodes, entry => {
+    // Every entry READ spends the budget, not every entry that turned out to be
+    // a node. Reading is the work being bounded, so a forest beginning with a
+    // long run of nulls would otherwise be traversed in full while the budget
+    // sat untouched — the callback never fires, and a bound counting callbacks
+    // cannot see it. `selectNodes` bounds the same quantity for the same reason.
     read += 1;
+    if (!isWalkableNode(entry.node)) return read >= limit ? "stop" : "skip";
 
-    if (!isWalkableNode(entry.node)) continue;
-    if (onPath.has(entry.node)) {
+    // The shared walk does not descend into a node already on the path, so an
+    // entry reported twice at the same identity is the cycle closing. Reported
+    // rather than silently skipped: a READER tolerates one, a WRITER has to
+    // refuse, and the walk is the only place that knows.
+    if (entry.cycle) {
       options.onCycle?.(entry.node);
-      continue;
+      return read >= limit ? "stop" : "skip";
     }
 
-    onPath.add(entry.node);
-    fn(entry.node, entry.parent);
-    stack.push({ kind: "leave", node: entry.node });
-    pushChildren(stack, entry.node);
-  }
+    fn(entry.node, entry.parent ?? options.parent);
+    return read >= limit ? "stop" : "descend";
+  });
 }
 
 /** Find a node anywhere in the forest by id. */
@@ -263,53 +181,22 @@ export function findNode(
   nodes: BlockNode[],
   id: string
 ): BlockNode | undefined {
-  return findWithin(nodes, id, new Set());
-}
-
-/**
- * `findNode`, carrying the ancestors the current forest was reached through.
- *
- * The path is what makes a MISS terminate. A hit returns before descending
- * further, so a lookup for an id that is present has always worked even on a
- * cyclic document — which is exactly why this went unnoticed: the failure needs
- * an id that is ABSENT, and asking for one that is not there is the ordinary
- * case for any lookup that can miss.
- *
- * A node reached through itself is not descended into again; the back edge is
- * simply not followed, so the search still covers everything reachable without
- * a cycle.
- */
-function findWithin(
-  nodes: BlockNode[],
-  id: string,
-  path: ReadonlySet<unknown>
-): BlockNode | undefined {
-  if (!Array.isArray(nodes)) return undefined;
-  for (const node of nodes) {
-    // Persisted forests reach these primitives unvalidated, so an entry may be
-    // `null` or a primitive and reading `id` off one throws.
-    if (typeof node !== "object" || node === null) continue;
-    if (node.id === id) return node;
-    if (path.has(node) || !node.slots) continue;
-    const hit = findBelow(node, id, path);
-    if (hit) return hit;
-  }
-  return undefined;
-}
-
-/** Search a node's slots, with that node added to the ancestor path. */
-function findBelow(
-  node: BlockNode,
-  id: string,
-  path: ReadonlySet<unknown>
-): BlockNode | undefined {
-  const below: ReadonlySet<unknown> = new Set(path).add(node);
-  for (const children of Object.values(node.slots ?? {})) {
-    if (!Array.isArray(children)) continue;
-    const hit = findWithin(children, id, below);
-    if (hit) return hit;
-  }
-  return undefined;
+  let found: BlockNode | undefined;
+  walkForest(nodes, entry => {
+    // Persisted forests reach here unvalidated, so an entry may be `null` or a
+    // primitive and reading `id` off one throws.
+    if (!isWalkableNode(entry.node)) return "skip";
+    if (entry.node.id === id) {
+      found = entry.node;
+      // Abandons the walk with the stack unread. A recursive search noticed a
+      // cycle only AFTER descending to the repeated ancestor, so a cycle longer
+      // than the call stack exhausted it before the guard ever ran — machine
+      // depth was the real bound, not the guard.
+      return "stop";
+    }
+    return "descend";
+  });
+  return found;
 }
 
 /** A found node's placement: its parent (undefined at top level), slot, and index. */
@@ -340,37 +227,134 @@ export function locateNode(
   return found;
 }
 
-/** Immutably rebuild the forest, applying `fn` to every node (parents before children). */
+/**
+ * One step of an immutable rebuild: a source list being read, or a node whose
+ * slots are now built and can be assembled.
+ *
+ * `close` sits BELOW its slot frames, so it is reached only after every
+ * descendant has been rebuilt — which is what makes this a post-order walk
+ * without recursion. Depth then costs a frame rather than a stack level, and
+ * these primitives run on documents nothing validated.
+ */
+type BuildTask =
+  | { kind: "read"; source: readonly unknown[]; index: number; out: unknown[] }
+  | {
+      kind: "close";
+      source: unknown;
+      mapped: BlockNode;
+      built: Record<string, BlockNode[]>;
+      out: unknown[];
+    };
+
+/**
+ * Queue each of a node's slots for rebuilding, recording where each result goes.
+ *
+ * A slot whose stored value is not an array is left OUT of `built`, which is how
+ * `assembleSlots` knows to keep it exactly as it was.
+ */
+function queueSlotRebuilds(
+  stack: BuildTask[],
+  mapped: BlockNode,
+  built: Record<string, BlockNode[]>
+): void {
+  const names = Object.keys(mapped.slots ?? {});
+  // Reversed so the first slot is rebuilt first.
+  for (let i = names.length - 1; i >= 0; i -= 1) {
+    const name = names[i];
+    if (name === undefined) continue;
+    const children = mapped.slots?.[name];
+    if (!Array.isArray(children)) continue;
+    const into: BlockNode[] = [];
+    built[name] = into;
+    stack.push({ kind: "read", source: children, index: 0, out: into });
+  }
+}
+
+/**
+ * Immutably rebuild the forest, applying `fn` to every node.
+ *
+ * Three things it must not do, each learned from getting one of them wrong:
+ *
+ * A node reached through itself is DROPPED from its parent's list, not kept as
+ * a childless copy. Keeping it returns a forest carrying that node's id twice —
+ * `parent -> child -> parent` rebuilt as `[parent, child, parent]` — which makes
+ * every id lookup ambiguous and fails the validation the repair was for. The
+ * entry that closes the cycle is the one that cannot exist in a finite tree, so
+ * it is the one that goes.
+ *
+ * A malformed ENTRY is passed through untouched rather than mapped. `fn` is
+ * written for nodes and reads `id` off what it is given, so handing it a `null`
+ * throws — and a caller editing an unrelated field has no business failing over
+ * a neighbour it never named.
+ *
+ * A malformed SLOT VALUE is preserved exactly. Replacing it with an empty array
+ * would let any unrelated edit silently destroy stored content that a caller
+ * may still need to read or repair, which is a worse outcome than the throw it
+ * replaced: the throw was loud and lost nothing.
+ */
 function mapForest(
   nodes: BlockNode[],
-  fn: (node: BlockNode) => BlockNode,
-  path: ReadonlySet<unknown> = new Set()
+  fn: (node: BlockNode) => BlockNode
 ): BlockNode[] {
-  if (!Array.isArray(nodes)) return [];
-  return nodes.map(node => {
-    // Unvalidated entries reach here, and `fn` is written for nodes.
-    if (typeof node !== "object" || node === null) return node;
-    const mapped = fn(node);
-    if (!mapped.slots) return mapped;
-    // A node reached through itself CANNOT be rebuilt: the result would have to
-    // contain itself, and the attempt recurses until the stack runs out. The
-    // back edge is dropped instead, so the rebuild returns a finite forest with
-    // the cycle broken rather than failing the caller's operation outright.
-    //
-    // Dropping rather than keeping is the only option that terminates, and it
-    // is the repair a caller would want anyway: an immutable rebuild of a
-    // cyclic forest is not a thing that exists.
-    if (path.has(node)) {
-      const { slots: _cyclic, ...withoutSlots } = mapped;
-      return withoutSlots;
+  if (!Array.isArray(nodes)) return nodes;
+  const rebuilt: unknown[] = [];
+  const onPath = new Set<unknown>();
+  const stack: BuildTask[] = [
+    { kind: "read", source: nodes, index: 0, out: rebuilt },
+  ];
+
+  while (stack.length > 0) {
+    const top = stack[stack.length - 1];
+    if (top === undefined) break;
+
+    if (top.kind === "close") {
+      stack.pop();
+      onPath.delete(top.source);
+      top.out.push(assembleSlots(top.mapped, top.built));
+      continue;
     }
-    const below: ReadonlySet<unknown> = new Set(path).add(node);
-    const slots: Record<string, BlockNode[]> = {};
-    for (const [name, children] of Object.entries(mapped.slots)) {
-      slots[name] = mapForest(children, fn, below);
+    if (top.index >= top.source.length) {
+      stack.pop();
+      continue;
     }
-    return { ...mapped, slots };
-  });
+    const entry = top.source[top.index];
+    top.index += 1;
+
+    if (!isWalkableNode(entry)) {
+      top.out.push(entry);
+      continue;
+    }
+    // The cycle closes here: this entry is its own ancestor, so it is omitted.
+    if (onPath.has(entry)) continue;
+
+    const mapped = fn(entry);
+    if (mapped.slots === undefined) {
+      top.out.push(mapped);
+      continue;
+    }
+
+    onPath.add(entry);
+    const built: Record<string, BlockNode[]> = {};
+    stack.push({ kind: "close", source: entry, mapped, built, out: top.out });
+    queueSlotRebuilds(stack, mapped, built);
+  }
+
+  return rebuilt as BlockNode[];
+}
+
+/** Put the rebuilt slots back on a node, keeping any slot that was not rebuilt. */
+function assembleSlots(
+  mapped: BlockNode,
+  built: Record<string, BlockNode[]>
+): BlockNode {
+  const slots: Record<string, BlockNode[]> = {};
+  for (const [name, original] of Object.entries(mapped.slots ?? {})) {
+    // A slot absent from `built` held something this rebuild could not walk.
+    // Keeping the stored value is the point: an unrelated edit must not be the
+    // thing that destroys it.
+    slots[name] = built[name] ?? original;
+  }
+  return { ...mapped, slots };
 }
 
 /** Clamp an insertion index into a list's valid range. */
@@ -509,20 +493,18 @@ export function moveNode(
 
 /** Deep-clone a subtree, assigning fresh ids to every node (copy/paste, patterns). */
 export function reidSubtree(node: BlockNode): BlockNode {
-  return reidWithin(node, new Set());
+  // Rebuilt through the shared walk rather than by recursing here. It already
+  // knows how to drop a cycle-closing entry, leave a malformed slot alone and
+  // keep depth off the call stack, and a second traversal written here would be
+  // a second set of answers to the same three questions.
+  const [rebuilt] = mapForest([node], reidOne);
+  return rebuilt ?? node;
 }
 
-/**
- * `reidSubtree`, carrying the ancestors this node was reached through.
- *
- * A node reached through itself has its slots dropped rather than rebuilt. The
- * re-id'd copy would otherwise have to contain a copy of itself, which is not a
- * finite structure — the recursion simply runs the stack out. Breaking the back
- * edge yields a duplicable subtree instead of failing the duplicate.
- */
-function reidWithin(node: BlockNode, path: ReadonlySet<unknown>): BlockNode {
-  // Clone only this node's own fields; descendants are cloned by the recursive
-  // calls below, so cloning `slots` here too would deep-copy them twice.
+/** One node's own fields, freshly identified. Slots are the rebuild's job. */
+function reidOne(node: BlockNode): BlockNode {
+  // Clone only this node's own fields; descendants are cloned as the rebuild
+  // reaches them, so cloning `slots` here too would deep-copy them twice.
   const { slots, ...own } = node;
   const copy: BlockNode = { ...structuredClone(own), id: newId() };
   // A re-id'd node is a distinct element: it must not carry the original's DOM
@@ -539,19 +521,9 @@ function reidWithin(node: BlockNode, path: ReadonlySet<unknown>): BlockNode {
     if (Object.keys(attributes).length > 0) copy.attributes = attributes;
     else delete copy.attributes;
   }
-  if (slots && !path.has(node)) {
-    const below: ReadonlySet<unknown> = new Set(path).add(node);
-    const newSlots: Record<string, BlockNode[]> = {};
-    for (const [name, children] of Object.entries(slots)) {
-      if (!Array.isArray(children)) continue;
-      newSlots[name] = children.map(child =>
-        typeof child === "object" && child !== null
-          ? reidWithin(child, below)
-          : child
-      );
-    }
-    copy.slots = newSlots;
-  }
+  // Handed back so the rebuild knows this node HAS slots to descend into; it
+  // replaces them with the rebuilt lists.
+  if (slots !== undefined) copy.slots = slots;
   return copy;
 }
 


### PR DESCRIPTION
A forest whose slots form a cycle reaches the engine's tree primitives the way every other malformed shape does: a stored document is not required to have been validated, and an in-process producer can build one directly. Six of them did not survive it.

## Measured, against the built package

| function | before | after |
|---|---|---|
| `treeDepth` | **hangs — never returns** | 3 |
| `countNodes` | `RangeError` | 3 |
| `findNode` (id ABSENT) | `RangeError` | `undefined` |
| `updateNode` | `RangeError` | returns |
| `duplicateNode` | `RangeError` | returns |
| `reidSubtree` | `RangeError` | returns |

`treeDepth` is the one worth naming: it does not crash, it spins. A `RangeError` surfaces with a stack that names the function; a hang holds a request open and presents as slowness in whatever is downstream.

`findNode` splitting on whether the id is PRESENT is why this went unnoticed — a hit returns before it can loop, so only a miss fails, and a miss is the ordinary case for any lookup that can have one.

## The fix, and the boundary it keeps

Each function carries the ancestors its current position was reached through, so a node reached through itself is not descended into again.

That is deliberately narrower than skipping every node already seen. **One node object placed in two different slots is two elements of the document**, and is still counted, measured and rebuilt twice — a guard keyed on everything seen would report half a document's real size and pass a cap the document exceeds. Only a true cycle is cut, and only where it closes.

Behaviour on every acyclic document is unchanged, asserted alongside: shared objects counted twice, malformed entries counted, depths and counts identical.

An immutable rebuild cannot reproduce a cycle — the result would have to contain itself — so `updateNode`, `duplicateNode` and `reidSubtree` drop the edge that closes it and return a finite forest rather than failing the caller's operation.

## Not touched, because they were already right

`measureBytes` and `surveyDocument` handle this correctly today. They carry an ancestor set and report `reason: "unwritable"` — the same category a BigInt earns, because `JSON.stringify` refuses both. My first audit reported them as failing; that was my probe calling them without their `limits` argument. The instrument was the defect.

`documentBytes` does still throw on a cycle. It has **zero non-test callers**, and `ops.ts` explains why — it builds the JSON string and then a UTF-8 buffer of it, so `measureBytes` is used instead everywhere the question is actually asked. Whether it should delegate or be removed is a separate question and not folded in here.

## A live caller

Lane `5a` reports that the builder's id-collision scan walks `editor.document.nodes` on every document change while the inspector is mounted. A cyclic document there would hang the **editor**, not a test.

## Verification

- `blocks-engine` 1406, `blocks-react` 771, `builder` 1726, `plugin-page-builder` 297 — all passing
- `check-types`, package lint (`--max-warnings 0`), root `eslint`, comment convention: clean
- `fallow audit`: `pass`, every `*_introduced` at 0 (it caught `countNodes` and `findWithin` at cognitive 18; both split rather than suppressed)
- Break-verified per guard: removing the `countNodes` path guard makes the suite time out — the intended failure — and removing `findNode`'s fails exactly its own test