### PR TITLE
fix(builder): let an author remove a CSS id that is present but empty

### DIFF
--- a/.changeset/empty-css-id-removal.md
+++ b/.changeset/empty-css-id-removal.md
@@ -1,0 +1,41 @@
+---
+
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+
+Lets an author remove a CSS id that is present but empty.
+
+The renderer treats the modelled field as present whenever it is a string, so a
+stored empty id renders `id=""` and hides any `id` set in the attributes beside
+it. The inspector collapsed that state into an absent field, so the box looked
+empty, every attempt to clear it read as no change, and the id could never be
+removed — a state only an import or a script can create, and then not undo.
+
+The three states the document distinguishes now survive being read, and removing
+an empty id is an explicit action that appears only in that state and says
+whether it is about to reveal an id the attributes were holding. Cleaning it up
+on sight, or folding it into an unrelated save, would change the anchor a page
+renders without the author asking.

--- a/packages/builder/src/advanced-panel.tsx
+++ b/packages/builder/src/advanced-panel.tsx
@@ -31,6 +31,7 @@ import { Button, Input, Label } from "@nextlyhq/ui";
 import * as React from "react";
 
 import {
+  attributeKey,
   domIdsTaken,
   htmlUpdate,
   type HtmlFields,
@@ -50,7 +51,15 @@ import type { EditorState } from "./editor-state";
 
 export interface AdvancedPanelProps {
   readonly nodeId: string;
-  readonly cssId: string;
+  /**
+   * The element's `id`, or `undefined` when the node carries no such field.
+   *
+   * The two are different states and the renderer reads them differently: a
+   * stored `""` is PRESENT, renders `id=""`, and shadows any `id` in the bag
+   * below. The panel has to be able to say which one it is looking at, or the
+   * empty-but-present one can never be removed.
+   */
+  readonly cssId: string | undefined;
   readonly attributes: Readonly<Record<string, string>> | undefined;
   readonly editor: EditorState;
   /**
@@ -86,7 +95,7 @@ export function AdvancedPanel({
   blocks,
 }: AdvancedPanelProps): React.JSX.Element {
   const [draft, setDraft] = React.useState<Draft>(() => ({
-    id: cssId,
+    id: cssId ?? "",
     rows: rowsOf(attributes),
   }));
   /*
@@ -99,7 +108,7 @@ export function AdvancedPanel({
    * actually wanted, and it says what it does.
    */
   const [settled, setSettled] = React.useState<Draft>({
-    id: cssId,
+    id: cssId ?? "",
     rows: rowsOf(attributes),
   });
 
@@ -145,7 +154,7 @@ export function AdvancedPanel({
       lastWritten.current = null;
       return;
     }
-    const stored = { id: cssId, rows: rowsOf(attributes) };
+    const stored = { id: cssId ?? "", rows: rowsOf(attributes) };
     setDraft(stored);
     setSettled(stored);
     loaded.current = stored;
@@ -233,7 +242,9 @@ export function AdvancedPanel({
      * rows were already rebased for the same reason; the id was the site this
      * rule had not reached.
      */
-    const landed = wanted.cssId;
+    // The DRAFT is text, so an absent field and an empty one are both the empty
+    // box; the difference lives in `wanted` and is settled before this.
+    const landed = wanted.cssId ?? "";
     loaded.current = { id: landed, rows: rebasedRows(next.rows, wanted) };
     /*
      * The FIELD only follows when the author's own id is the one that landed.
@@ -321,7 +332,7 @@ export function AdvancedPanel({
     settle(next);
   };
 
-  const idProblem = idProblemOf(settled.id, cssId, taken);
+  const idProblem = idProblemOf(settled.id, cssId ?? "", taken);
   /*
    * Analysed ONCE for the settled set, not once per row. Every verdict depends
    * on the whole set — who keeps a contested key, which keys refused rows are
@@ -329,6 +340,32 @@ export function AdvancedPanel({
    * imported bag of a few hundred attributes stopped rendering.
    */
   const problems = React.useMemo(() => rowProblems(settled.rows), [settled]);
+  /*
+   * Whether removing the empty id would reveal one. The bag's `id` is dead
+   * while the modelled field is present, so saying so is the difference
+   * between "this does nothing visible" and "this changes the anchor".
+   */
+  const emptyIdShadows =
+    attributes !== undefined &&
+    Object.keys(attributes).some(name => attributeKey(name) === "id");
+
+  /*
+   * Written directly rather than through the draft, because the draft cannot
+   * hold the distinction: its id is text, and the box is already empty.
+   */
+  const removeEmptyId = (): void => {
+    const update = htmlUpdate(
+      { cssId: undefined, attributes },
+      { cssId, attributes }
+    );
+    if (update === undefined) return;
+    editor.apply({
+      kind: "update",
+      id: nodeId,
+      patch: update.patch,
+      ...(update.unset.length > 0 ? { unset: update.unset } : {}),
+    } as Parameters<EditorState["apply"]>[0]);
+  };
 
   return (
     <div className="nx-inspector__fields">
@@ -369,6 +406,38 @@ export function AdvancedPanel({
             role="alert"
           >
             {idProblem}
+          </p>
+        )}
+        {/*
+          The EMPTY-BUT-PRESENT id, which the box above cannot express.
+
+          A field holding `""` renders `id=""` and shadows any `id` in the bag
+          below, and no amount of typing in an already-empty box says "remove
+          it" — the draft matches what was loaded, so a commit correctly finds
+          nothing to do. This is the gesture that was missing.
+
+          Shown only in that state. Cleaning it up on open would be a write
+          nobody asked for, and folding it into an unrelated save would change
+          the id the page renders as a side effect of editing an attribute:
+          removing the modelled field UNSHADOWS the bag's `id`, so it has to be
+          the author's decision and has to say what it does.
+        */}
+        {cssId !== "" ? null : (
+          <p className="nx-inspector__note" role="status">
+            This block has an empty id set, which renders as{" "}
+            <code>id=&quot;&quot;</code>
+            {emptyIdShadows
+              ? " and hides the id set in the attributes below"
+              : ""}
+            .{" "}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => removeEmptyId()}
+            >
+              Remove the empty id
+            </Button>
           </p>
         )}
       </div>

--- a/packages/builder/src/advanced-panel.tsx
+++ b/packages/builder/src/advanced-panel.tsx
@@ -49,6 +49,18 @@ import {
 } from "./custom-attributes";
 import type { EditorState } from "./editor-state";
 
+/**
+ * What a refused write says, wherever it is refused.
+ *
+ * Names no single cause, because `apply` reports none: it answers `null` for
+ * ANY refused op — a value past the document's byte limit, but equally an
+ * update to a node a concurrent edit or an undo has removed, or a document
+ * carrying duplicate node ids. Telling an author their page is full when their
+ * block has gone sends them to fix the wrong thing.
+ */
+const REFUSED =
+  "That change could not be saved. A very long value can push the page past its size limit; otherwise the block may have changed since you opened this tab.";
+
 export interface AdvancedPanelProps {
   readonly nodeId: string;
   /**
@@ -224,9 +236,7 @@ export function AdvancedPanel({
      * page is full when their block has gone sends them to fix the wrong thing.
      */
     if (applied === null) {
-      setRefusal(
-        "That change could not be saved. A very long value can push the page past its size limit; otherwise the block may have changed since you opened this tab."
-      );
+      setRefusal(REFUSED);
       return;
     }
     setRefusal(undefined);
@@ -359,12 +369,20 @@ export function AdvancedPanel({
       { cssId, attributes }
     );
     if (update === undefined) return;
-    editor.apply({
+    const applied = editor.apply({
       kind: "update",
       id: nodeId,
       patch: update.patch,
       ...(update.unset.length > 0 ? { unset: update.unset } : {}),
     } as Parameters<EditorState["apply"]>[0]);
+    /*
+     * REFUSED ops answer `null`, and this button targets exactly the documents
+     * where that is reachable — an import can carry duplicate node ids, which
+     * pass this panel's own reading and are refused by the store. Discarding
+     * the answer presented a failure as a success, while the writer beside it
+     * reports the same refusal. One panel, one way of saying it.
+     */
+    setRefusal(applied === null ? REFUSED : undefined);
   };
 
   return (

--- a/packages/builder/src/advanced-panel.tsx
+++ b/packages/builder/src/advanced-panel.tsx
@@ -31,8 +31,8 @@ import { Button, Input, Label } from "@nextlyhq/ui";
 import * as React from "react";
 
 import {
-  attributeKey,
   domIdsTaken,
+  renderedIdIn,
   htmlUpdate,
   type HtmlFields,
   isBlankRow,
@@ -188,6 +188,46 @@ export function AdvancedPanel({
   latest.current = draft;
   const write = React.useRef<(next: Draft) => void>(() => {});
 
+  /*
+   * The ONE place an op leaves this panel.
+   *
+   * Both things that write — the field commit below and the empty-id removal
+   * beside the CSS id — have to record the same three facts afterwards, and a
+   * second `editor.apply` that recorded none of them is what let a removal
+   * arrive at the effect above looking like an edit from somewhere else. The
+   * effect then replaced the draft with the stored rows, discarding a refused
+   * name and the explanation beside it. The module's own header names this
+   * shape: two commit paths for one pair of fields, disagreeing about what they
+   * had just written.
+   *
+   * Answers whether the op landed, so a caller can stop.
+   */
+  const store = React.useRef<
+    (wanted: HtmlFields, update: { patch: object; unset: string[] }) => boolean
+  >(() => false);
+  store.current = (wanted, update): boolean => {
+    const applied = editor.apply({
+      kind: "update",
+      id: nodeId,
+      patch: update.patch,
+      ...(update.unset.length > 0 ? { unset: update.unset } : {}),
+    } as Parameters<EditorState["apply"]>[0]);
+    /*
+     * REFUSED ops leave the document alone, and `apply` says so by answering
+     * `null`. Marking the attempt as written before knowing would tell the
+     * effect above that the props it sees are this panel's own echo, so it
+     * would stop re-reading the document and the field would go on showing a
+     * value nothing stored.
+     */
+    if (applied === null) {
+      setRefusal(REFUSED);
+      return false;
+    }
+    setRefusal(undefined);
+    lastWritten.current = wanted;
+    return true;
+  };
+
   write.current = (next: Draft): void => {
     /*
      * NOTHING is written unless the author edited something. Every other test
@@ -216,31 +256,7 @@ export function AdvancedPanel({
       setRefusal(undefined);
       return;
     }
-    const applied = editor.apply({
-      kind: "update",
-      id: nodeId,
-      patch: update.patch,
-      ...(update.unset.length > 0 ? { unset: update.unset } : {}),
-    } as Parameters<EditorState["apply"]>[0]);
-    /*
-     * REFUSED ops leave the document alone, and `apply` says so by answering
-     * `null`. Marking the attempt as written before knowing would tell the
-     * effect above that the props it sees are this panel's own echo, so it
-     * would stop re-reading the document and the field would go on showing a
-     * value nothing stored.
-     *
-     * The message names no single cause, because `apply` reports none: it
-     * answers `null` for ANY refused op — a value past the document's byte
-     * limit, but equally an update to a node a concurrent edit or an undo has
-     * removed. Both are reachable from this panel, and telling an author their
-     * page is full when their block has gone sends them to fix the wrong thing.
-     */
-    if (applied === null) {
-      setRefusal(REFUSED);
-      return;
-    }
-    setRefusal(undefined);
-    lastWritten.current = wanted;
+    if (!store.current(wanted, update)) return;
     /*
      * REBASED onto what landed — the id as well as the rows, because the id is
      * normalized on the way out and the rows are not.
@@ -354,10 +370,14 @@ export function AdvancedPanel({
    * Whether removing the empty id would reveal one. The bag's `id` is dead
    * while the modelled field is present, so saying so is the difference
    * between "this does nothing visible" and "this changes the anchor".
+   *
+   * Asked of the RENDERER's reading rather than of this editor's. The two are
+   * not the same rule: `attributeKey` trims a name on its way to being stored,
+   * so an imported `" id "` normalizes to `id` under it while the renderer,
+   * which matches the stored name, emits no id at all — and the note would then
+   * promise to reveal something that was never there.
    */
-  const emptyIdShadows =
-    attributes !== undefined &&
-    Object.keys(attributes).some(name => attributeKey(name) === "id");
+  const emptyIdShadows = renderedIdIn(attributes) !== undefined;
 
   /*
    * Written directly rather than through the draft, because the draft cannot
@@ -369,20 +389,19 @@ export function AdvancedPanel({
       { cssId, attributes }
     );
     if (update === undefined) return;
-    const applied = editor.apply({
-      kind: "update",
-      id: nodeId,
-      patch: update.patch,
-      ...(update.unset.length > 0 ? { unset: update.unset } : {}),
-    } as Parameters<EditorState["apply"]>[0]);
+    const wanted = { cssId: undefined, attributes };
     /*
-     * REFUSED ops answer `null`, and this button targets exactly the documents
-     * where that is reachable — an import can carry duplicate node ids, which
-     * pass this panel's own reading and are refused by the store. Discarding
-     * the answer presented a failure as a success, while the writer beside it
-     * reports the same refusal. One panel, one way of saying it.
+     * Through the SAME writer as every other op this panel sends, so the echo
+     * is recorded and the effect above does not mistake this panel's own write
+     * for an edit from elsewhere. Written separately once, it discarded a
+     * refused row and its reason every time an empty id was removed.
+     *
+     * `loaded` moves with it: the field is gone, so the draft is in step with
+     * the document at an empty box, and the next commit has nothing to do
+     * rather than proposing this removal a second time.
      */
-    setRefusal(applied === null ? REFUSED : undefined);
+    if (!store.current(wanted, update)) return;
+    loaded.current = { id: "", rows: rebasedRows(latest.current.rows, wanted) };
   };
 
   return (

--- a/packages/builder/src/custom-attributes.test.ts
+++ b/packages/builder/src/custom-attributes.test.ts
@@ -252,9 +252,12 @@ describe("which ids a document already holds", () => {
 
 describe("the op that stores the two fields", () => {
   const fields = (
-    cssId: string,
+    cssId: string | undefined,
     attributes?: Record<string, string>
-  ): { cssId: string; attributes: Record<string, string> | undefined } => ({
+  ): {
+    cssId: string | undefined;
+    attributes: Record<string, string> | undefined;
+  } => ({
     cssId,
     attributes,
   });
@@ -272,8 +275,11 @@ describe("the op that stores the two fields", () => {
     /*
      * `applyOp` refuses `undefined` as a patch value and says why: the key
      * disappears when the op is stored, so a replayed edit would do nothing.
+     *
+     * Removal is `undefined`, not `""`. The two are different requests — see
+     * the test below — and this one asks for the field to be GONE.
      */
-    expect(htmlUpdate(fields(""), fields("hero"))).toEqual({
+    expect(htmlUpdate(fields(undefined), fields("hero"))).toEqual({
       patch: {},
       unset: ["cssId"],
     });
@@ -281,6 +287,26 @@ describe("the op that stores the two fields", () => {
       patch: {},
       unset: ["attributes"],
     });
+  });
+
+  it("keeps an EMPTY id distinct from an absent one", () => {
+    /*
+     * A third state, and the renderer reads it: it writes `extra.id = cssId`
+     * on `cssId !== undefined`, so a stored `""` renders `id=""` and shadows
+     * any `id` in the bag. Asking for one is therefore a patch, not an unset,
+     * and asking to remove one is an unset even though the box looks the same.
+     */
+    expect(htmlUpdate(fields(""), fields("hero"))).toEqual({
+      patch: { cssId: "" },
+      unset: [],
+    });
+    expect(htmlUpdate(fields(undefined), fields(""))).toEqual({
+      patch: {},
+      unset: ["cssId"],
+    });
+    // And neither is a change from itself.
+    expect(htmlUpdate(fields(""), fields(""))).toBeUndefined();
+    expect(htmlUpdate(fields(undefined), fields(undefined))).toBeUndefined();
   });
 
   it("does not unset a field the node never had", () => {

--- a/packages/builder/src/custom-attributes.test.ts
+++ b/packages/builder/src/custom-attributes.test.ts
@@ -931,3 +931,34 @@ describe("which of two rows keeps a key spelled with capitals", () => {
     });
   });
 });
+
+describe("a bag whose id NAME the renderer will not accept", () => {
+  const node = (over: Record<string, unknown>): never =>
+    ({ id: "n", type: "acme/x", version: 1, props: {}, ...over }) as never;
+
+  it("reserves nothing for it", () => {
+    /*
+     * `isAllowedAttribute(" id ")` is false — the renderer checks the STORED
+     * name, syntax and all, before lowercasing it — so no id reaches the page
+     * and another block may use that value. Reading the name through
+     * `attributeKey`, which trims, is the EDITOR's normalization and describes
+     * what this panel would write rather than what the document holds.
+     */
+    const taken = domIdsTaken(
+      [node({ id: "b", attributes: { " id ": "hero" } })],
+      "a",
+      renders
+    );
+    expect([...taken]).toEqual([]);
+  });
+
+  it("still reserves one the renderer WILL accept", () => {
+    // The control: the rejection is about the spelling, not about the bag.
+    const taken = domIdsTaken(
+      [node({ id: "b", attributes: { ID: "hero" } })],
+      "a",
+      renders
+    );
+    expect([...taken]).toEqual(["hero"]);
+  });
+});

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -554,6 +554,11 @@ export function requestedId(draft: Draft, loaded: Draft): string {
   return draft.id === loaded.id ? draft.id : draft.id.trim();
 }
 
+/** Whether the author has left the id field exactly as it was loaded. */
+function untouchedId(draft: Draft, loaded: Draft): boolean {
+  return draft.id === loaded.id;
+}
+
 /**
  * What a draft wants the node to hold — the whole question of what to STORE.
  *
@@ -573,11 +578,24 @@ export function wantedFields(
 ): HtmlFields {
   const id = requestedId(draft, loaded);
   /*
-   * An empty box means the field should be GONE, not present and empty. The
-   * panel has no gesture that asks for `id=""` and the renderer would emit one,
-   * so `undefined` is the only thing an empty draft can honestly mean.
+   * An UNTOUCHED field wants whatever the node already holds, including an
+   * empty-but-present one. Reading an empty box as "remove it" made every other
+   * save carry `unset: ["cssId"]` along with it — bypassing the explicit
+   * removal the panel offers, and silently unshadowing the bag's `id` so the
+   * rendered anchor changed because an attribute was edited.
+   *
+   * Once the author HAS typed, an empty box means the field should be gone
+   * rather than present and empty: the panel has no gesture that asks for
+   * `id=""` while the renderer would emit one, so `undefined` is the only thing
+   * a cleared box can honestly mean.
    */
-  const keptId = id === "" ? undefined : taken.has(id) ? stored.cssId : id;
+  const keptId = untouchedId(draft, loaded)
+    ? stored.cssId
+    : id === ""
+      ? undefined
+      : taken.has(id)
+        ? stored.cssId
+        : id;
   return {
     cssId: keptId,
     /*

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -472,6 +472,13 @@ function renderedIdOf(node: BlockNode): string | undefined {
 /**
  * The `id` the renderer would emit from an attribute bag, if any.
  *
+ * EXPORTED so nothing asks this question a second way. The editor normalizes a
+ * name it is about to write — trimming and lowercasing through `attributeKey` —
+ * and that describes what this panel WOULD store, not what a stored bag holds:
+ * an imported `" id "` normalizes to `id` under that rule while the renderer,
+ * matching the stored name, emits nothing for it. A caller wanting to know what
+ * the page shows has to ask the reading that models the page.
+ *
  * Read case-INSENSITIVELY, because that is how the renderer reads it: HTML
  * attribute names are ASCII case-insensitive and it lowercases every key before
  * writing, so a stored `{ ID: "hero" }` renders as `id="hero"`. A scan looking
@@ -482,7 +489,7 @@ function renderedIdOf(node: BlockNode): string | undefined {
  * lowercased key in turn, so a later one replaces an earlier one. This editor
  * never writes two spellings, but an import or a script can.
  */
-function renderedIdIn(
+export function renderedIdIn(
   attributes: Readonly<Record<string, string>> | undefined
 ): string | undefined {
   /*

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -521,7 +521,16 @@ function childNodesOf(node: BlockNode): unknown[] {
 
 /** What a node should hold, and what it holds now. */
 export interface HtmlFields {
-  readonly cssId: string;
+  /**
+   * The element's `id`, or `undefined` for a node carrying no such field.
+   *
+   * `""` is a THIRD state and a reachable one: the renderer writes
+   * `extra.id = cssId` on `cssId !== undefined`, so a stored empty string
+   * renders `id=""` and shadows any `id` in the bag. This editor never writes
+   * it — clearing the field is `unset` — but an import can, and telling it
+   * apart from an absent field is what makes it removable.
+   */
+  readonly cssId: string | undefined;
   readonly attributes: Readonly<Record<string, string>> | undefined;
 }
 
@@ -563,7 +572,12 @@ export function wantedFields(
   taken: ReadonlySet<string>
 ): HtmlFields {
   const id = requestedId(draft, loaded);
-  const keptId = id !== "" && taken.has(id) ? stored.cssId : id;
+  /*
+   * An empty box means the field should be GONE, not present and empty. The
+   * panel has no gesture that asks for `id=""` and the renderer would emit one,
+   * so `undefined` is the only thing an empty draft can honestly mean.
+   */
+  const keptId = id === "" ? undefined : taken.has(id) ? stored.cssId : id;
   return {
     cssId: keptId,
     /*
@@ -576,7 +590,7 @@ export function wantedFields(
      */
     attributes: storedAttributes(
       draft.rows,
-      keptId === stored.cssId ? "" : keptId,
+      keptId === stored.cssId ? "" : (keptId ?? ""),
       stored.attributes ?? {}
     ),
   };
@@ -633,7 +647,10 @@ export function htmlUpdate(
   const patch: Record<string, unknown> = {};
   const unset: string[] = [];
   if (!sameId) {
-    if (wanted.cssId === "") unset.push("cssId");
+    // REMOVED rather than written empty. `applyOp` refuses `undefined` as a
+    // patch value and says why, and an empty string is a different request —
+    // it would leave the field present and rendering `id=""`.
+    if (wanted.cssId === undefined) unset.push("cssId");
     else patch["cssId"] = wanted.cssId;
   }
   if (!sameAttributes) {

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -1487,3 +1487,65 @@ describe("a node whose CSS id is present but empty", () => {
     expect(screen.queryByRole("status")).toBeNull();
   });
 });
+
+describe("an empty id while an unrelated attribute is edited", () => {
+  it("is NOT removed as a side effect of that edit", () => {
+    /*
+     * The removal has to stay the author's explicit decision. Treating an
+     * untouched empty box as a request to drop the field meant any other save
+     * carried `unset: ["cssId"]` with it — bypassing the button, and silently
+     * unshadowing the bag's `id` so the rendered anchor changed because an
+     * attribute was edited.
+     */
+    const editor = mount({
+      cssId: "",
+      attributes: { id: "from-bag", "data-x": "1" },
+    } as unknown as Partial<BlockNode>);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    /*
+     * Row ONE, not two: `rowsOf` sorts by name, so `data-x` sits above `id`.
+     * Editing by position without checking which row it is has passed for the
+     * wrong reason here before.
+     */
+    const name = screen.getByLabelText("Name of attribute 1");
+    expect((name as HTMLInputElement).value).toBe("data-x");
+    const value = screen.getByLabelText("Value of attribute 1");
+    fireEvent.change(value, { target: { value: "2" } });
+    fireEvent.blur(value);
+
+    expect(editor.apply).toHaveBeenCalled();
+    const op = editor.apply.mock.calls.at(-1)?.[0] as {
+      patch: Record<string, unknown>;
+      unset?: string[];
+    };
+    expect(op.unset ?? []).not.toContain("cssId");
+    // The control: the edit itself DID land, so this is not passing on a write
+    // that never happened.
+    expect(op.patch["attributes"]).toMatchObject({ "data-x": "2" });
+  });
+
+  it("still reports a refused removal instead of doing nothing", () => {
+    /*
+     * `apply` answers `null` for any refused op — a document with duplicate
+     * node ids passes inspection and is refused by the store. The panel's other
+     * writer says so through the refusal line; the button silently did nothing.
+     */
+    register();
+    const editor = editorFor(
+      documentOf({ cssId: "" } as unknown as Partial<BlockNode>)
+    );
+    editor.apply.mockReturnValue(null);
+    render(<InspectorPanel editor={editor} />);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove the empty id" })
+    );
+
+    expect(editor.apply).toHaveBeenCalled();
+    expect(screen.getByRole("alert").textContent).toContain(
+      "could not be saved"
+    );
+  });
+});

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -1427,3 +1427,63 @@ describe("the block set the collision check answers about", () => {
     expect(editor.apply).not.toHaveBeenCalled();
   });
 });
+
+describe("a node whose CSS id is present but empty", () => {
+  /*
+   * The renderer treats the modelled field as PRESENT whenever it is a string:
+   * it writes `extra.id = cssId` on `cssId !== undefined`, so `cssId: ""`
+   * renders `id=""` AND shadows any `id` in the attribute bag. The inspection
+   * collapsed it with an absent field, so the panel showed an empty box, every
+   * clear attempt read as untouched, and no `unset` could ever be emitted.
+   *
+   * Unreachable through the editor, which writes `unset` rather than `""`, so
+   * it arrives by import or by a script — and then cannot be undone.
+   */
+  const shadowed = {
+    cssId: "",
+    attributes: { id: "from-bag" },
+  } as unknown as Partial<BlockNode>;
+
+  it("says the empty id is there and what it is doing", () => {
+    mount(shadowed);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    expect(screen.getByRole("status").textContent).toContain("empty id");
+  });
+
+  it("offers a way to remove it, and removes it", () => {
+    const editor = mount(shadowed);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove the empty id" })
+    );
+
+    expect(editor.apply).toHaveBeenCalledWith({
+      kind: "update",
+      id: "a",
+      patch: {},
+      unset: ["cssId"],
+    });
+  });
+
+  it("says nothing when the field is simply ABSENT", () => {
+    // The control: the ordinary block has no id and no note, or every block
+    // would carry a warning about a state it is not in.
+    mount({ attributes: { id: "from-bag" } });
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Remove the empty id" })
+    ).toBeNull();
+  });
+
+  it("says nothing when the id holds a value", () => {
+    // The other control: a real id is not the empty-but-present state either.
+    mount({ cssId: "hero" });
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -1549,3 +1549,92 @@ describe("an empty id while an unrelated attribute is edited", () => {
     );
   });
 });
+
+describe("what the empty-id note promises", () => {
+  it("does not claim to reveal an id the renderer would not emit", () => {
+    /*
+     * `isAllowedAttribute(" id ")` is false — the renderer checks the STORED
+     * name, spaces and all — so no bag id reaches the page and removing the
+     * empty modelled field reveals nothing. Reading the name through the
+     * editor's own normalization, which trims, promised otherwise.
+     */
+    mount({
+      cssId: "",
+      attributes: { " id ": "never-rendered" },
+    } as unknown as Partial<BlockNode>);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    const note = screen.getByRole("status").textContent ?? "";
+    // The control: the note IS shown, so this is not passing on its absence.
+    expect(note).toContain("empty id");
+    expect(note).not.toContain("hides the id");
+  });
+
+  it("DOES claim it when the renderer would emit one", () => {
+    // The other half: the promise is right when the bag really is shadowed.
+    mount({
+      cssId: "",
+      attributes: { ID: "revealed" },
+    } as unknown as Partial<BlockNode>);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    expect(screen.getByRole("status").textContent).toContain("hides the id");
+  });
+});
+
+describe("removing an empty id while a row is refused", () => {
+  it("keeps the refused row and its reason on screen", () => {
+    /*
+     * The removal wrote through its own `editor.apply` rather than the panel's
+     * one writer, so it recorded no echo: the resulting prop change arrived at
+     * the synchronisation effect looking like an edit from somewhere else, and
+     * the effect replaced the draft with the stored rows — discarding the
+     * refused name the author was fixing, and the explanation beside it.
+     *
+     * The module's own docblock names this shape: two commit paths for the same
+     * pair of fields, disagreeing about what they had just written.
+     */
+    register();
+    const document = documentOf({
+      cssId: "",
+      attributes: { "data-x": "1" },
+    } as unknown as Partial<BlockNode>);
+    const editor = editorFor(document);
+    const { rerender } = render(<InspectorPanel editor={editor} />);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
+
+    const name = screen.getByLabelText("Name of attribute 1");
+    fireEvent.change(name, { target: { value: "onclick" } });
+    fireEvent.blur(name);
+    // The control: the refused draft and its reason are on screen to be lost.
+    expect((name as HTMLInputElement).value).toBe("onclick");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove the empty id" })
+    );
+    /*
+     * Re-rendered with the field GONE, which is what a real store does after
+     * this op. A spy editor never re-renders, and the defect only appears when
+     * the panel sees its own write arrive back through props.
+     */
+    rerender(
+      <InspectorPanel
+        editor={
+          {
+            ...editor,
+            document: documentOf({
+              attributes: { "data-x": "1" },
+            } as unknown as Partial<BlockNode>),
+          } as never
+        }
+      />
+    );
+
+    expect(
+      (screen.getByLabelText("Name of attribute 1") as HTMLInputElement).value
+    ).toBe("onclick");
+    expect(screen.getByRole("alert").textContent).toContain(
+      "does not put that attribute"
+    );
+  });
+});

--- a/packages/builder/src/inspector.ts
+++ b/packages/builder/src/inspector.ts
@@ -89,8 +89,19 @@ export interface BlockIdentity {
  * this one about which node is selected.
  */
 export interface BlockHtml {
-  /** The element's `id`, empty when the author has not set one. */
-  readonly cssId: string;
+  /**
+   * The element's `id`. `undefined` when the node does not carry the field at
+   * all, which is NOT the same as carrying an empty one.
+   *
+   * The renderer treats the field as present whenever it is a string — it
+   * writes `extra.id = cssId` on `cssId !== undefined` — so a stored `""`
+   * renders `id=""` and shadows any `id` in the attribute bag. Collapsing the
+   * two into `""` here left the panel unable to tell them apart, so every
+   * attempt to clear an empty-but-present field read as no change and the
+   * field could never be removed. The distinction the document draws has to
+   * survive the reading of it.
+   */
+  readonly cssId: string | undefined;
   /**
    * The author's own attributes, absent when there are none.
    *
@@ -274,7 +285,7 @@ export function inspectSelection(
      * that is an array or null, must not reach a control typed for neither.
      */
     html: {
-      cssId: typeof node.cssId === "string" ? node.cssId : "",
+      cssId: typeof node.cssId === "string" ? node.cssId : undefined,
       attributes: editableAttributes(node.attributes),
     },
     // The same name the palette offered and the layers panel shows. Reading


### PR DESCRIPTION
Follow-up to the merged #1164, closing thread 3845262564.

## The defect

The renderer treats the modelled `cssId` as PRESENT whenever it is a string — it writes `extra.id = cssId` on `cssId !== undefined` — so a stored `cssId: ""` renders `id=""` **and shadows any `id` in the attribute bag**.

`getBlockInspection` collapsed that into the absent state with `typeof node.cssId === "string" ? node.cssId : ""`. Both arrived as `""`, so:

- the panel showed an empty box with nothing to say,
- `htmlUpdate` compared `"" === ""` and found no change,
- no `unset: ["cssId"]` could ever be emitted, and
- the bag's `id` stayed hidden with no way to reveal it.

Unreachable through this editor, which writes `unset` rather than `""` — so it arrives by import or by a script, and then cannot be undone.

## The fix

`BlockHtml.cssId` and `HtmlFields.cssId` are now `string | undefined`, so the three states the document actually distinguishes survive being read: absent, empty-and-present, and set.

An empty draft means the field should be **gone** rather than present and empty — the only thing an empty box can honestly mean from a panel that has no gesture for the other.

Removal is an explicit affordance, shown only in that state, and it says what it will do — including whether it is about to reveal an `id` the bag was holding.

## Why not clean it up automatically

Both alternatives were rejected for reasons this area has already established:

- **On open** is "merely viewing writes to the document", removed twice during #1164.
- **Folded into an unrelated save** is worse than the `" hero "` trim that was removed for the same reason, because dropping the modelled field UNSHADOWS the bag's `id` — so editing an attribute would silently change the id the page renders.

## Evidence

Four tests, two of them controls asserting the note does **not** appear for an absent id or a set one. Break-verified four ways: restoring the collapse, treating `""` as removal in `htmlUpdate`, showing the affordance unconditionally, and having `wantedFields` write `""` instead of removing — each fails a different assertion.

Gates: builder 1731, blocks-react 771, plugin-page-builder 297, `check-types` and lint on both packages, `lint:design`, comment convention, `fallow` pass with `complexity_introduced: 0`.