### PR TITLE
fix(blocks-react): warn a block author when their block does not render one element

### DIFF
--- a/.changeset/warn-non-single-root.md
+++ b/.changeset/warn-non-single-root.md
@@ -1,0 +1,45 @@
+---
+
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+
+Warns a block author, in development, when their block does not render a single
+element. The block contract states that a block renders one element and never
+wraps it, because the generated class has to go somewhere — so a block returning
+a fragment, a list or a primitive already has styles that never apply, and until
+now nothing said so.
+
+The only existing signal arrived through the placeholder that replaces such a
+block when a document sets an `id` or an attribute on it. That blames the wrong
+person at the wrong moment: a page author sets an anchor, watches the block
+vanish, and has done nothing wrong, while the block author never hears about it.
+The warning fires on the first render instead, whether or not anyone asked for
+anything.
+
+Read from what the boundary actually received rather than predicted from the
+definition, so the warning and the placeholder cannot come to disagree about the
+same output. A block that draws nothing on purpose is exempt, asked through the
+same rule the placeholder already uses.

--- a/.changeset/warn-non-single-root.md
+++ b/.changeset/warn-non-single-root.md
@@ -29,8 +29,15 @@
 Warns a block author, in development, when their block does not render a single
 element. The block contract states that a block renders one element and never
 wraps it, because the generated class has to go somewhere — so a block returning
-a fragment, a list or a primitive already has styles that never apply, and until
-now nothing said so.
+a fragment, a list or a primitive gives that class no root element to sit on,
+and until now nothing said so.
+
+Deliberately NOT "its styles never apply", which is the stronger claim and is
+false for a real shape: a wrapper root that places the supplied class on a child
+renders it into the DOM, and the compiled CSS matches normally. What such a
+block certainly loses is the node's ROOT FIELDS — `cssId` and attributes are
+attached to the block's own root element and have nowhere to go — so the warning
+is right and the diagnosis is the narrower one.
 
 The only existing signal arrived through the placeholder that replaces such a
 block when a document sets an `id` or an attribute on it. That blames the wrong

--- a/.changeset/warn-non-single-root.md
+++ b/.changeset/warn-non-single-root.md
@@ -1,5 +1,4 @@
 ---
-
 "nextly": patch
 "create-nextly-app": patch
 "@nextlyhq/admin": patch
@@ -25,6 +24,7 @@
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/builder": patch
 "@nextlyhq/module-specifiers": patch
+---
 
 Warns a block author, in development, when their block does not render a single
 element. The block contract states that a block renders one element and never

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -489,8 +489,13 @@ function rootShapeOf(output: ReactNode): RootShape {
  * direction is the opposite. A component that renders one host element and
  * forwards `className` is a legitimate shape whose compiled styles DO apply, so
  * warning about it would be false, and a diagnostic that is sometimes false is
- * one people learn to scroll past. Only shapes with nowhere for the class to go
- * at all are named: no element, or a fragment.
+ * one people learn to scroll past. Only shapes with no root element of their
+ * own are named: no element, or a wrapper.
+ *
+ * Naming a shape is not a claim that its styles are lost. A wrapper root can
+ * still forward the class to a child, and the warning above says so — what it
+ * reports is the shape, which is outside the contract whatever the block did
+ * with the class.
  */
 function brokenRootReason(output: ReactNode): string | null {
   switch (rootShapeOf(output)) {
@@ -514,8 +519,14 @@ function brokenRootReason(output: ReactNode): string | null {
  * `BlockRenderArgs.className` states the contract every block is handed: "The
  * generated class the block MUST place on its own root element. Blocks render a
  * single element and never wrap it, so styles target that element." A block
- * returning a Fragment, a list or a primitive has nowhere to put that class, so
- * its compiled styles never apply — it is already broken, and nothing said so.
+ * returning a Fragment, a list or a primitive gives that class no root element
+ * to sit on — it is already outside the contract, and nothing said so.
+ *
+ * NOT "its styles never apply", which is the stronger claim and is false for
+ * one real shape: a wrapper whose child takes the class renders it into the
+ * DOM, and the compiled CSS then matches normally. What that block loses is the
+ * node's ROOT FIELDS, which are attached here and have nowhere to go — so the
+ * warning is right and the diagnosis has to be the narrower one.
  *
  * The only signal today arrives through the placeholder above, which fires when
  * a DOCUMENT asks for `cssId` or an attribute. That blames the wrong party at
@@ -572,8 +583,21 @@ function warnNoHostRoot(
     if (declaresNothing || rendersNothing(output)) return;
     const shape = brokenRootReason(output);
     if (shape === null) return;
+    /*
+     * Says what is CERTAIN and nothing more. The class is handed to the block
+     * rather than attached here, so a wrapper root that forwards it to a child
+     * — `({ className }) => <><div className={className} /></>` — does get its
+     * compiled styles, on a page whose DOM carries the class. Telling that
+     * author their styles do not apply sends them hunting a failure that is not
+     * there, and a diagnostic people find wrong once is one they stop reading.
+     *
+     * What IS certain either way: the shape is outside the contract, the node
+     * has no root element of its own, and its root fields therefore have
+     * nowhere to go. The style consequence is stated as the condition it
+     * actually is.
+     */
     console.warn(
-      `[nextly] Block "${node.type}" ${shape}. Blocks render a single element and never wrap it, so the generated class has nowhere to go and this block's styles do not apply. Setting an id or an attribute on it will replace it with a placeholder.`
+      `[nextly] Block "${node.type}" ${shape}. Blocks render a single element and never wrap it: with no root element of its own, this block's styles apply only where the block itself placed the class, and setting an id or an attribute on the node will replace it with a placeholder.`
     );
   } catch {
     /*

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -540,20 +540,32 @@ function warnNoHostRoot(
   declaresNothing: boolean
 ): void {
   /*
-   * Read at render rather than module scope, so a consumer's bundler can inline
-   * it per build and a test can exercise both modes in one process.
+   * Speaks only where the environment is POSITIVELY identified as one a
+   * developer is watching. Read at render rather than module scope, so a
+   * consumer's bundler can inline it per build and a test can exercise several
+   * environments in one process.
    *
-   * An ABSENT `process` counts as production here, which is the opposite of how
-   * the placeholder reads the same signal — and deliberately so. This renderer
-   * runs anywhere React does, and an Edge or Worker runtime need not define
-   * `process` at all; a placeholder that appears there is a visible box on a
-   * block that is already broken, while this is an undeduplicated line written
-   * on every render of every such block. Unable to tell, a diagnostic says
+   * Everything else stays silent, which is the opposite of how the placeholder
+   * reads the same signal and deliberately so: a placeholder is a visible box
+   * on a block that is already broken, while this is an undeduplicated line on
+   * every render of every affected block. Unable to tell, a diagnostic says
    * nothing.
+   *
+   * Being unable to tell has more than one shape, which is what a check for
+   * `process === undefined` missed. This renderer runs anywhere React does: an
+   * Edge or Worker runtime need not define `process`, a standalone SSR host can
+   * expose a partial shim with no `NODE_ENV`, and a deployment may name its
+   * environment something this does not recognise. Asking which environments
+   * may speak covers all of them at once; asking which must stay quiet is a
+   * list, and a list falls behind toward noise in production.
+   *
+   * The cost is a bare harness that sets no `NODE_ENV` hearing nothing. For an
+   * advisory diagnostic that is the cheaper error: a miss costs the report,
+   * while a false one in production teaches everyone to filter the message.
    */
-  const isProduction =
-    typeof process === "undefined" || process.env?.NODE_ENV === "production";
-  if (isProduction) return;
+  const environment =
+    typeof process === "undefined" ? undefined : process.env?.NODE_ENV;
+  if (environment !== "development" && environment !== "test") return;
   try {
     // Rendering nothing is a DECISION, not a violation — the same exemption the
     // placeholder grants, asked the same way.

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -393,16 +393,81 @@ function nodeRootReason(
   // that legitimately draws nothing from a wrapper root says so through
   // `rendersNothing`, which is computed from props and cannot vary.
   if (declaresNothing || rendersNothing(output)) return null;
+  const shape = noHostRootReason(output);
+  if (shape === null) return null;
   const named = hasCssId ? "`cssId`" : "attributes";
   // A primitive or a list, on the other hand, is real output with no single
   // element to carry the fields, so it loses them anyway — silently, and with
   // the same broken anchors as a wrapper root. The format says a block renders
   // a single element for these to target.
-  if (!isValidElement(output)) {
-    return `a node carrying ${named} whose block returned no element, so there is no DOM root to put them on`;
-  }
+  return `a node carrying ${named} whose block ${shape}, so there is no DOM root to put them on`;
+}
+
+/**
+ * Why this output gives the node no single host element, or `null` when it does.
+ *
+ * The SHAPE question alone, separated from what the document asked for, because
+ * two readers need it and they must not answer it apart: the placeholder above
+ * decides whether root fields can land, and the warning below tells a block
+ * author their block does not conform at all. A second copy would let the two
+ * disagree about the same output.
+ *
+ * Asked of what the boundary RECEIVED, never of what a definition predicts.
+ * A prediction is a second model of a thing this function already knows
+ * first-hand, and the two drift; the artifact is the only witness.
+ */
+function noHostRootReason(output: ReactNode): string | null {
+  if (!isValidElement(output)) return "returned no element";
   if (typeof output.type === "string") return null;
-  return `a node carrying ${named} whose block returned a wrapper rather than an element, so there is no DOM root to put them on`;
+  return "returned a wrapper rather than an element";
+}
+
+/**
+ * Tells a BLOCK AUTHOR, in development, that their block does not conform.
+ *
+ * `BlockRenderArgs.className` states the contract every block is handed: "The
+ * generated class the block MUST place on its own root element. Blocks render a
+ * single element and never wrap it, so styles target that element." A block
+ * returning a Fragment, a list or a primitive has nowhere to put that class, so
+ * its compiled styles never apply — it is already broken, and nothing said so.
+ *
+ * The only signal today arrives through the placeholder above, which fires when
+ * a DOCUMENT asks for `cssId` or an attribute. That blames the wrong party at
+ * the wrong time: a page author sets an anchor and watches the block vanish,
+ * having done nothing wrong, while the block author never hears about it. This
+ * fires on the first render instead, whether or not anyone asked for anything.
+ *
+ * NOT deduplicated by type. A module-scoped set would either couple one test's
+ * warning to another's or need a reset API exported for tests to call, and this
+ * fires only for a block that is already broken — which in development is one
+ * or two instances on screen, not a page full. If that stops being true,
+ * deduplicating is a change with its own reset rather than hidden state added
+ * to this one.
+ *
+ * A warning is not an EXEMPTION, which is why reading the output here is safe
+ * where granting one from it would not be: nothing about the render changes,
+ * so a reading React need not repeat can at worst produce a wrong message.
+ */
+function warnNoHostRoot(
+  output: ReactNode,
+  node: BlockNode,
+  declaresNothing: boolean
+): void {
+  // Read at render rather than module scope, so a consumer's bundler can inline
+  // it per build and a test can exercise both modes in one process. Read
+  // defensively: this renderer runs anywhere React does, and an Edge or Worker
+  // runtime need not define `process` at all.
+  const isProduction =
+    typeof process !== "undefined" && process.env?.NODE_ENV === "production";
+  if (isProduction) return;
+  // Rendering nothing is a DECISION, not a violation — the same exemption the
+  // placeholder grants, asked the same way.
+  if (declaresNothing || rendersNothing(output)) return;
+  const shape = noHostRootReason(output);
+  if (shape === null) return;
+  console.warn(
+    `[nextly] Block "${node.type}" ${shape}. Blocks render a single element and never wrap it, so the generated class has nowhere to go and this block's styles do not apply. Setting an id or an attribute on it will replace it with a placeholder.`
+  );
 }
 
 /**
@@ -458,6 +523,10 @@ function checkedOutput(
     );
   }
 
+  // Warned INDEPENDENTLY of whether the document asked for root fields: the
+  // block is non-conforming either way, and waiting for someone to set an
+  // anchor is what made a page author look responsible for it.
+  if (isBlockRoot) warnNoHostRoot(result.node, node, declaresNothing);
   const rootReason = isBlockRoot
     ? nodeRootReason(result.node, node, declaresNothing)
     : null;

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -612,10 +612,24 @@ function warnNoHostRoot(
    * advisory diagnostic that is the cheaper error: a miss costs the report,
    * while a false one in production teaches everyone to filter the message.
    */
-  const environment =
-    typeof process === "undefined" ? undefined : process.env?.NODE_ENV;
-  if (environment !== "development" && environment !== "test") return;
   try {
+    /*
+     * Read INSIDE the guard, because reading it is itself author-exposed. A
+     * standalone SSR host supplies its own `process`, and `env` can be a
+     * throwing getter or a proxy — so `process.env?.NODE_ENV` raises before a
+     * `try` placed after it ever begins. The synchronous call to
+     * `checkedOutput` sits PAST the try that contains `render`, as the comment
+     * at that call site says, so a raise here does not become a placeholder: it
+     * takes the page. An advisory diagnostic aborting the render is the exact
+     * thing this function promises not to do.
+     *
+     * Failing to read it lands in the catch below and says nothing, which is
+     * the same answer the checks below give any environment that cannot be
+     * positively identified. Unable to tell, a diagnostic stays quiet.
+     */
+    const environment =
+      typeof process === "undefined" ? undefined : process.env?.NODE_ENV;
+    if (environment !== "development" && environment !== "test") return;
     // Rendering nothing is a DECISION, not a violation — the same exemption the
     // placeholder grants, asked the same way.
     if (declaresNothing || rendersNothing(output)) return;
@@ -644,12 +658,9 @@ function warnNoHostRoot(
      *
      * It no longer covers the CLASSIFICATION, which was the exposure it was
      * written for: that is read once by {@link readRootShape}, under its own
-     * floor, and arrives here as a value. What is left is `rendersNothing` over
-     * an array this renderer materialised and the `console` call itself — a
-     * host with a broken console is not much of a case, but neither is it worth
-     * a page.
-     *
-     * UNREACHED in testing, and stated as such rather than implied by a test.
+     * floor, and arrives here as a value. What it covers now is the environment
+     * read above, `rendersNothing` over an array this renderer materialised,
+     * and the `console` call itself.
      */
   }
 }

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -1,11 +1,5 @@
 import { blockTypeClassName, type BlockNode } from "@nextlyhq/blocks-engine";
-import {
-  Fragment,
-  Suspense,
-  cloneElement,
-  isValidElement,
-  type ReactNode,
-} from "react";
+import { Suspense, cloneElement, isValidElement, type ReactNode } from "react";
 
 import type { BlockHostPolicy, PageContext } from "./context";
 import { BlockPlaceholder } from "./placeholder";
@@ -428,7 +422,7 @@ function noHostRootReason(output: ReactNode): string | null {
       return null;
     case "none":
       return "returned no element";
-    case "fragment":
+    case "builtin":
     case "component":
       return "returned a wrapper rather than an element";
   }
@@ -449,15 +443,36 @@ function noHostRootReason(output: ReactNode): string | null {
  * prediction is a second model of something this already knows first-hand, and
  * the two drift; the artifact is the only witness.
  */
-type RootShape = "host" | "component" | "fragment" | "none";
+type RootShape = "host" | "component" | "builtin" | "none";
 
 function rootShapeOf(output: ReactNode): RootShape {
   if (!isValidElement(output)) return "none";
-  if (output.type === Fragment) return "fragment";
-  // A string type is a host element. Anything else React accepts here is a
-  // component, which may or may not render a host element of its own — which
-  // is exactly why the two policies below answer differently about it.
-  return typeof output.type === "string" ? "host" : "component";
+  // A string type is a host element, and the only shape that HAS a root.
+  if (typeof output.type === "string") return "host";
+  /*
+   * A SYMBOL type is one of React's own wrappers — `Fragment`, `Suspense`,
+   * `StrictMode`, `Profiler` — and none of them renders an element of its own,
+   * so the generated class has nowhere to go in any of them.
+   *
+   * Asked as "is it a symbol" rather than as a list of the wrappers that exist
+   * today, for the reason a list is the wrong instrument: React adds these, and
+   * a list falls behind silently in the direction of saying nothing. Nothing
+   * with a symbol type can be a host element, so widening this way adds no
+   * false positive.
+   */
+  if (typeof output.type === "symbol") return "builtin";
+  /*
+   * Everything else is a COMPONENT, and that is deliberately under-reporting.
+   * A function component may render a host element and forward `className`, so
+   * it cannot be called broken. React also spells several non-function
+   * constructs as objects — a context provider has no root, while `memo` and
+   * `forwardRef` wrap something that may well have one — and telling those
+   * apart means reading `$$typeof` against React's internal symbols. This check
+   * errs toward silence there rather than risking a warning on a working
+   * `memo`, because a diagnostic that is sometimes false is one people learn to
+   * scroll past.
+   */
+  return "component";
 }
 
 /**
@@ -488,8 +503,8 @@ function brokenRootReason(output: ReactNode): string | null {
       return null;
     case "none":
       return "returned no element";
-    case "fragment":
-      return "returned a fragment rather than an element";
+    case "builtin":
+      return "returned a wrapper rather than an element";
   }
 }
 

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -1,5 +1,11 @@
 import { blockTypeClassName, type BlockNode } from "@nextlyhq/blocks-engine";
-import { Suspense, cloneElement, isValidElement, type ReactNode } from "react";
+import {
+  Fragment,
+  Suspense,
+  cloneElement,
+  isValidElement,
+  type ReactNode,
+} from "react";
 
 import type { BlockHostPolicy, PageContext } from "./context";
 import { BlockPlaceholder } from "./placeholder";
@@ -423,6 +429,31 @@ function noHostRootReason(output: ReactNode): string | null {
 }
 
 /**
+ * Why this output is DEFINITELY not the single element the contract asks for,
+ * or `null` when it might be.
+ *
+ * Deliberately NARROWER than {@link noHostRootReason}, and the difference is
+ * the point rather than a duplication of it. That one asks whether the renderer
+ * may attach root fields, and answers no for a component root because it cannot
+ * know the component forwards them — conservative in the direction of refusing,
+ * which is right when an anchor is at stake.
+ *
+ * This one asks whether to tell an author their block is broken, where the safe
+ * direction is the opposite. A component that renders one host element and
+ * forwards `className` is a legitimate shape whose compiled styles DO apply, so
+ * warning about it would be false, and a diagnostic that is sometimes false is
+ * one people learn to scroll past. Only shapes with nowhere for the class to go
+ * at all are named: no element, or a fragment.
+ */
+function brokenRootReason(output: ReactNode): string | null {
+  if (!isValidElement(output)) return "returned no element";
+  if (output.type === Fragment) {
+    return "returned a fragment rather than an element";
+  }
+  return null;
+}
+
+/**
  * Tells a BLOCK AUTHOR, in development, that their block does not conform.
  *
  * `BlockRenderArgs.className` states the contract every block is handed: "The
@@ -453,21 +484,47 @@ function warnNoHostRoot(
   node: BlockNode,
   declaresNothing: boolean
 ): void {
-  // Read at render rather than module scope, so a consumer's bundler can inline
-  // it per build and a test can exercise both modes in one process. Read
-  // defensively: this renderer runs anywhere React does, and an Edge or Worker
-  // runtime need not define `process` at all.
+  /*
+   * Read at render rather than module scope, so a consumer's bundler can inline
+   * it per build and a test can exercise both modes in one process.
+   *
+   * An ABSENT `process` counts as production here, which is the opposite of how
+   * the placeholder reads the same signal — and deliberately so. This renderer
+   * runs anywhere React does, and an Edge or Worker runtime need not define
+   * `process` at all; a placeholder that appears there is a visible box on a
+   * block that is already broken, while this is an undeduplicated line written
+   * on every render of every such block. Unable to tell, a diagnostic says
+   * nothing.
+   */
   const isProduction =
-    typeof process !== "undefined" && process.env?.NODE_ENV === "production";
+    typeof process === "undefined" || process.env?.NODE_ENV === "production";
   if (isProduction) return;
-  // Rendering nothing is a DECISION, not a violation — the same exemption the
-  // placeholder grants, asked the same way.
-  if (declaresNothing || rendersNothing(output)) return;
-  const shape = noHostRootReason(output);
-  if (shape === null) return;
-  console.warn(
-    `[nextly] Block "${node.type}" ${shape}. Blocks render a single element and never wrap it, so the generated class has nowhere to go and this block's styles do not apply. Setting an id or an attribute on it will replace it with a placeholder.`
-  );
+  try {
+    // Rendering nothing is a DECISION, not a violation — the same exemption the
+    // placeholder grants, asked the same way.
+    if (declaresNothing || rendersNothing(output)) return;
+    const shape = brokenRootReason(output);
+    if (shape === null) return;
+    console.warn(
+      `[nextly] Block "${node.type}" ${shape}. Blocks render a single element and never wrap it, so the generated class has nowhere to go and this block's styles do not apply. Setting an id or an attribute on it will replace it with a placeholder.`
+    );
+  } catch {
+    /*
+     * A DIAGNOSTIC must never be the thing that fails the page. Reading `.type`
+     * touches author-controlled output, and this call sits past the try block
+     * that contains `render` — the comment at the second `checkedOutput` call
+     * says what happens to a predicate that raises out here.
+     *
+     * UNREACHED in testing, and stated as such rather than implied by a test.
+     * An element whose `type` misbehaves is refused by `normalizeRenderable`
+     * before this runs — a proxy answering differently on a later read comes
+     * back `invalid-output` and returns above — so no case was found that
+     * arrives here. `nodeRootReason` carries the same exposure on the same
+     * value and has no floor of its own; the difference is that it runs only
+     * for a document that set root fields while this runs on every render, so
+     * the cheap guard is kept rather than removed for want of a witness.
+     */
+  }
 }
 
 /**

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -349,7 +349,17 @@ function nodeRootReason(
    * React afterwards, and every accessor, proxy trap and custom iterator in it
    * can answer differently the second time.
    */
-  declaresNothing: boolean
+  declaresNothing: boolean,
+  /**
+   * How the output was classified, read ONCE by the caller.
+   *
+   * Passed in rather than read again here. The warning above asks the same
+   * question of the same value, and a second reading is a second chance for an
+   * author-controlled accessor to answer differently — which for this policy
+   * means throwing on a path with no guard over it, taking the page instead of
+   * producing the placeholder this function exists to produce.
+   */
+  shape: RootShape
 ): string | null {
   const hasCssId = typeof node.cssId === "string";
   const attributes = node.attributes;
@@ -398,14 +408,14 @@ function nodeRootReason(
   // that legitimately draws nothing from a wrapper root says so through
   // `rendersNothing`, which is computed from props and cannot vary.
   if (declaresNothing || rendersNothing(output)) return null;
-  const shape = noHostRootReason(output);
-  if (shape === null) return null;
+  const noRoot = noHostRootReason(shape);
+  if (noRoot === null) return null;
   const named = hasCssId ? "`cssId`" : "attributes";
   // A primitive or a list, on the other hand, is real output with no single
   // element to carry the fields, so it loses them anyway — silently, and with
   // the same broken anchors as a wrapper root. The format says a block renders
   // a single element for these to target.
-  return `a node carrying ${named} whose block ${shape}, so there is no DOM root to put them on`;
+  return `a node carrying ${named} whose block ${noRoot}, so there is no DOM root to put them on`;
 }
 
 /**
@@ -421,8 +431,8 @@ function nodeRootReason(
  * A prediction is a second model of a thing this function already knows
  * first-hand, and the two drift; the artifact is the only witness.
  */
-function noHostRootReason(output: ReactNode): string | null {
-  switch (rootShapeOf(output)) {
+function noHostRootReason(shape: RootShape): string | null {
+  switch (shape) {
     case "host":
       return null;
     case "none":
@@ -476,6 +486,32 @@ function rootShapeOf(output: ReactNode): RootShape {
 }
 
 /**
+ * {@link rootShapeOf} with a floor under it, called ONCE per block root.
+ *
+ * The classification touches `output.type` and the tag on the type object, both
+ * author-controlled, and both readable more than once with different answers: a
+ * getter that counts, a proxy that flips. Reproduced against React 19 with a
+ * context-tagged type whose `$$typeof` accessor throws on its seventh read —
+ * the read the placeholder path made, which had no guard, so the throw left
+ * this package entirely and the stream never settled. Not "the page shows an
+ * error": nothing resolved at all.
+ *
+ * So the reading happens here, once, and both policies are handed the result.
+ * `unreadable` is a real answer rather than an exception, and the caller turns
+ * it into the placeholder every other unusable output already gets — the same
+ * direction `isRenderableElementType` takes for a type React would refuse:
+ * refusing something valid shows up as a placeholder, accepting something
+ * invalid takes the page.
+ */
+function readRootShape(output: ReactNode): RootShape | "unreadable" {
+  try {
+    return rootShapeOf(output);
+  } catch {
+    return "unreadable";
+  }
+}
+
+/**
  * Why this output is DEFINITELY not the single element the contract asks for,
  * or `null` when it might be.
  *
@@ -497,8 +533,8 @@ function rootShapeOf(output: ReactNode): RootShape {
  * reports is the shape, which is outside the contract whatever the block did
  * with the class.
  */
-function brokenRootReason(output: ReactNode): string | null {
-  switch (rootShapeOf(output)) {
+function brokenRootReason(shape: RootShape): string | null {
+  switch (shape) {
     // A COMPONENT is not broken: one that renders a host element and forwards
     // `className` gets its compiled styles applied. The placeholder still
     // refuses to attach root fields to it, not being able to know that — which
@@ -548,7 +584,9 @@ function brokenRootReason(output: ReactNode): string | null {
 function warnNoHostRoot(
   output: ReactNode,
   node: BlockNode,
-  declaresNothing: boolean
+  declaresNothing: boolean,
+  /** How the output was classified, read once by the caller. */
+  shape: RootShape
 ): void {
   /*
    * Speaks only where the environment is POSITIVELY identified as one a
@@ -581,8 +619,8 @@ function warnNoHostRoot(
     // Rendering nothing is a DECISION, not a violation — the same exemption the
     // placeholder grants, asked the same way.
     if (declaresNothing || rendersNothing(output)) return;
-    const shape = brokenRootReason(output);
-    if (shape === null) return;
+    const broken = brokenRootReason(shape);
+    if (broken === null) return;
     /*
      * Says what is CERTAIN and nothing more. The class is handed to the block
      * rather than attached here, so a wrapper root that forwards it to a child
@@ -597,23 +635,21 @@ function warnNoHostRoot(
      * actually is.
      */
     console.warn(
-      `[nextly] Block "${node.type}" ${shape}. Blocks render a single element and never wrap it: with no root element of its own, this block's styles apply only where the block itself placed the class, and setting an id or an attribute on the node will replace it with a placeholder.`
+      `[nextly] Block "${node.type}" ${broken}. Blocks render a single element and never wrap it: with no root element of its own, this block's styles apply only where the block itself placed the class, and setting an id or an attribute on the node will replace it with a placeholder.`
     );
   } catch {
     /*
-     * A DIAGNOSTIC must never be the thing that fails the page. Reading `.type`
-     * touches author-controlled output, and this call sits past the try block
-     * that contains `render` — the comment at the second `checkedOutput` call
-     * says what happens to a predicate that raises out here.
+     * A DIAGNOSTIC must never be the thing that fails the page, and this call
+     * sits past the try block that contains `render`.
+     *
+     * It no longer covers the CLASSIFICATION, which was the exposure it was
+     * written for: that is read once by {@link readRootShape}, under its own
+     * floor, and arrives here as a value. What is left is `rendersNothing` over
+     * an array this renderer materialised and the `console` call itself — a
+     * host with a broken console is not much of a case, but neither is it worth
+     * a page.
      *
      * UNREACHED in testing, and stated as such rather than implied by a test.
-     * An element whose `type` misbehaves is refused by `normalizeRenderable`
-     * before this runs — a proxy answering differently on a later read comes
-     * back `invalid-output` and returns above — so no case was found that
-     * arrives here. `nodeRootReason` carries the same exposure on the same
-     * value and has no floor of its own; the difference is that it runs only
-     * for a document that set root fields while this runs on every render, so
-     * the cheap guard is kept rather than removed for want of a witness.
      */
   }
 }
@@ -674,10 +710,35 @@ function checkedOutput(
   // Warned INDEPENDENTLY of whether the document asked for root fields: the
   // block is non-conforming either way, and waiting for someone to set an
   // anchor is what made a page author look responsible for it.
-  if (isBlockRoot) warnNoHostRoot(result.node, node, declaresNothing);
-  const rootReason = isBlockRoot
-    ? nodeRootReason(result.node, node, declaresNothing)
-    : null;
+  /*
+   * Classified ONCE, and both policies below read that value rather than the
+   * output. They ask the same question of the same author-controlled object,
+   * and asking twice is asking something that can answer differently — which
+   * for the placeholder path meant an accessor throwing where nothing guarded
+   * it. One reading, two policies.
+   */
+  const shape = isBlockRoot ? readRootShape(result.node) : null;
+  if (shape === "unreadable") {
+    /*
+     * Refused rather than passed on. React reads the same accessors after this
+     * returns, so output that cannot be classified here is output whose next
+     * read is React's, past this boundary and past any containment — which is
+     * exactly the failure `normalizeRenderable` exists to prevent.
+     */
+    return (
+      <BlockPlaceholder
+        reason="invalid-output"
+        type={node.type}
+        id={node.id}
+        detail="Expected a React node, received output whose own element type could not be read"
+      />
+    );
+  }
+  if (shape !== null) warnNoHostRoot(result.node, node, declaresNothing, shape);
+  const rootReason =
+    shape !== null
+      ? nodeRootReason(result.node, node, declaresNothing, shape)
+      : null;
   if (rootReason !== null) {
     return (
       <BlockPlaceholder

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -423,9 +423,41 @@ function nodeRootReason(
  * first-hand, and the two drift; the artifact is the only witness.
  */
 function noHostRootReason(output: ReactNode): string | null {
-  if (!isValidElement(output)) return "returned no element";
-  if (typeof output.type === "string") return null;
-  return "returned a wrapper rather than an element";
+  switch (rootShapeOf(output)) {
+    case "host":
+      return null;
+    case "none":
+      return "returned no element";
+    case "fragment":
+    case "component":
+      return "returned a wrapper rather than an element";
+  }
+}
+
+/**
+ * What KIND of root a block's output gives the node.
+ *
+ * The classification itself, held ONCE, because two policies read it and must
+ * not classify apart. The placeholder above decides whether root fields can
+ * land; the warning below decides whether to tell an author their block is
+ * broken. Those are different questions with opposite safe directions — each
+ * says which, beside itself — but they are the same READING, and a second copy
+ * of the reading is where recognising another wrapper kind updates one answer
+ * and leaves the other behind.
+ *
+ * Asked of what the boundary RECEIVED, never of what a definition predicts. A
+ * prediction is a second model of something this already knows first-hand, and
+ * the two drift; the artifact is the only witness.
+ */
+type RootShape = "host" | "component" | "fragment" | "none";
+
+function rootShapeOf(output: ReactNode): RootShape {
+  if (!isValidElement(output)) return "none";
+  if (output.type === Fragment) return "fragment";
+  // A string type is a host element. Anything else React accepts here is a
+  // component, which may or may not render a host element of its own — which
+  // is exactly why the two policies below answer differently about it.
+  return typeof output.type === "string" ? "host" : "component";
 }
 
 /**
@@ -446,11 +478,19 @@ function noHostRootReason(output: ReactNode): string | null {
  * at all are named: no element, or a fragment.
  */
 function brokenRootReason(output: ReactNode): string | null {
-  if (!isValidElement(output)) return "returned no element";
-  if (output.type === Fragment) {
-    return "returned a fragment rather than an element";
+  switch (rootShapeOf(output)) {
+    // A COMPONENT is not broken: one that renders a host element and forwards
+    // `className` gets its compiled styles applied. The placeholder still
+    // refuses to attach root fields to it, not being able to know that — which
+    // is the one place these two policies part company.
+    case "host":
+    case "component":
+      return null;
+    case "none":
+      return "returned no element";
+    case "fragment":
+      return "returned a fragment rather than an element";
   }
-  return null;
 }
 
 /**

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -3,7 +3,12 @@ import { Suspense, cloneElement, isValidElement, type ReactNode } from "react";
 
 import type { BlockHostPolicy, PageContext } from "./context";
 import { BlockPlaceholder } from "./placeholder";
-import { describeThrown, isThenable, normalizeRenderable } from "./renderable";
+import {
+  createsNoHostElement,
+  describeThrown,
+  isThenable,
+  normalizeRenderable,
+} from "./renderable";
 import type { BlockResolver } from "./resolver";
 import { isUnconditional } from "./visibility";
 
@@ -450,26 +455,21 @@ function rootShapeOf(output: ReactNode): RootShape {
   // A string type is a host element, and the only shape that HAS a root.
   if (typeof output.type === "string") return "host";
   /*
-   * A SYMBOL type is one of React's own wrappers — `Fragment`, `Suspense`,
-   * `StrictMode`, `Profiler` — and none of them renders an element of its own,
-   * so the generated class has nowhere to go in any of them.
+   * React's own wrappers — a fragment, a suspense boundary, a context provider
+   * or consumer — create no element of their own, so the generated class has
+   * nowhere to go in any of them.
    *
-   * Asked as "is it a symbol" rather than as a list of the wrappers that exist
-   * today, for the reason a list is the wrong instrument: React adds these, and
-   * a list falls behind silently in the direction of saying nothing. Nothing
-   * with a symbol type can be a host element, so widening this way adds no
-   * false positive.
+   * ASKED rather than restated. `renderable.ts` already separates those from
+   * `memo`, `forwardRef` and `lazy`, which wrap a component that may well
+   * render a host element and forward the class to it; a second reading of the
+   * same tags here is where the two would come to disagree.
    */
-  if (typeof output.type === "symbol") return "builtin";
+  if (createsNoHostElement(output.type)) return "builtin";
   /*
-   * Everything else is a COMPONENT, and that is deliberately under-reporting.
-   * A function component may render a host element and forward `className`, so
-   * it cannot be called broken. React also spells several non-function
-   * constructs as objects — a context provider has no root, while `memo` and
-   * `forwardRef` wrap something that may well have one — and telling those
-   * apart means reading `$$typeof` against React's internal symbols. This check
-   * errs toward silence there rather than risking a warning on a working
-   * `memo`, because a diagnostic that is sometimes false is one people learn to
+   * Everything else is a COMPONENT, which cannot be called broken: it may
+   * render a host element and forward `className`, and only calling it would
+   * say. That is deliberate under-reporting, and the cheaper error for a
+   * diagnostic — a warning that is sometimes false is one people learn to
    * scroll past.
    */
   return "component";

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -466,8 +466,9 @@ function rootShapeOf(output: ReactNode): RootShape {
   if (typeof output.type === "string") return "host";
   /*
    * React's own wrappers — a fragment, a suspense boundary, a context provider
-   * or consumer — create no element of their own, so the generated class has
-   * nowhere to go in any of them.
+   * or consumer — create no element of their own, so none of them is a root the
+   * generated class can be attached to. Whether the block forwarded that class
+   * to a child is a separate question, and not one this classification answers.
    *
    * ASKED rather than restated. `renderable.ts` already separates those from
    * `memo`, `forwardRef` and `lazy`, which wrap a component that may well

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -5700,6 +5700,115 @@ describe("a block that does not render a single element", () => {
   });
 });
 
+describe("an element type that answers differently on a later read", () => {
+  /*
+   * The root shape is a reading of author-controlled data: `output.type`, and
+   * the tag on the type object. Nothing makes that reading stable — a getter
+   * can count, a proxy can flip — so every place that reads it is a place the
+   * author can raise from.
+   *
+   * It used to be read twice per block root: once by the contract warning,
+   * which had a floor under it, and again by the placeholder policy, which had
+   * none. A type whose accessor threw on that second read left this package
+   * entirely: the stream never settled, so not even an error page.
+   *
+   * Now it is read ONCE, under one floor, and both policies are handed the
+   * result. This asserts the property that follows and not the arithmetic
+   * behind it: WHICHEVER read the accessor picks to throw on, containment
+   * holds. Pinning the index instead would pass forever after any change to how
+   * many times the value happens to be read.
+   */
+  const trickyBlock = (onRead: () => void): AnyBlockDefinition =>
+    defineBlock({
+      name: "test/stateful-type-tag",
+      version: 1,
+      description: "Roots at a type whose tag accessor is stateful.",
+      example: { props: {} },
+      defaultProps: {},
+      render: () =>
+        createElement(
+          {
+            get $$typeof() {
+              onRead();
+              // A context object, which React 19 renders as a provider — a
+              // wrapper root, so the shape question is genuinely asked of it.
+              return Symbol.for("react.context");
+            },
+            _currentValue: "held",
+          } as never,
+          null,
+          "shown"
+        ),
+    }) as AnyBlockDefinition;
+
+  const renderTricky = async (
+    onRead: () => void,
+    extra: Partial<BlockNode> = {}
+  ): Promise<string> => {
+    const definition = trickyBlock(onRead);
+    return renderToHtml(
+      <PageRenderer
+        document={doc(node("a", definition.name, extra))}
+        blocks={createBlockResolver([definition])}
+      />
+    );
+  };
+
+  it("renders the fixture when its tag accessor behaves", async () => {
+    /*
+     * The control, and the thing that stops every assertion below passing
+     * because the fixture is broken in some other way: with the accessor
+     * answering consistently, React renders it and its children reach the page.
+     */
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const html = await renderTricky(() => {});
+      expect(html).toContain("shown");
+      expect(html).not.toMatch(PLACEHOLDER);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("placeholders instead of escaping, whichever read throws", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      /*
+       * `cssId` is set so BOTH policies run: the warning classifies, and the
+       * placeholder policy — the one that had no floor — classifies too. Ten
+       * covers every read this path makes today with room over it.
+       */
+      for (let throwOn = 1; throwOn <= 10; throwOn += 1) {
+        let reads = 0;
+        const html = await renderTricky(
+          () => {
+            reads += 1;
+            if (reads === throwOn) throw new Error("tag read");
+          },
+          { cssId: "anchor" }
+        );
+        /*
+         * Contained: the render RESOLVED, and what came back is this block's
+         * placeholder rather than its output.
+         *
+         * Which placeholder depends on where the throw lands, and both are
+         * containment: React validates a type inside `createElement`, so the
+         * earliest read happens while the block's own `render` is running and
+         * the render guard answers it. The later reads are this renderer's, and
+         * they answer `invalid-output`. What matters is that neither escapes,
+         * so the assertion names both rather than pinning an index.
+         */
+        expect(placeholderReasons(html)).toEqual([
+          expect.stringMatching(/^(render-error|invalid-output)$/),
+        ]);
+        expect(html).not.toContain("shown");
+      }
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
 describe("which runtimes the contract warning is willing to speak in", () => {
   const wrapped2 = defineBlock({
     name: "test/wrapped-env",

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -5356,11 +5356,17 @@ describe("a block that does not render a single element", () => {
    * "The generated class the block MUST place on its own root element. Blocks
    * render a single element and never wrap it, so styles target that element."
    *
-   * A block returning a Fragment has nowhere to put that class, so its compiled
-   * styles never apply — it is already broken. Until now the only signal came
-   * from the placeholder, which fires when a DOCUMENT asks for `cssId` or an
+   * A block returning a Fragment has no root element of its own for that class,
+   * so it is already outside the contract. Until now the only signal came from
+   * the placeholder, which fires when a DOCUMENT asks for `cssId` or an
    * attribute: the page author who set an anchor watched the block vanish,
    * while the block author never heard about it.
+   *
+   * NOT "its compiled styles never apply", which is the stronger claim and is
+   * false for a shape tested directly below: `test/fragment-forwards` places
+   * the supplied class on a child, and the assertions there read it back out of
+   * the served HTML. What such a block certainly loses is the node's ROOT
+   * FIELDS, which the renderer attaches to a root element it does not have.
    */
   const wrapped = defineBlock<{ value: string }>({
     name: "test/wrapped",

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -5589,3 +5589,68 @@ describe("a block that does not render a single element", () => {
     }
   });
 });
+
+describe("which runtimes the contract warning is willing to speak in", () => {
+  const wrapped2 = defineBlock({
+    name: "test/wrapped-env",
+    version: 1,
+    description: "Wraps its output in a fragment, against the contract.",
+    example: { props: {} },
+    defaultProps: {},
+    render: () => <>{"held"}</>,
+  });
+
+  const renderIt = async (): Promise<string> =>
+    renderToHtml(
+      <PageRenderer
+        document={doc(node("a", "test/wrapped-env"))}
+        blocks={createBlockResolver([wrapped2 as AnyBlockDefinition])}
+      />
+    );
+
+  const saysNothingWhen = async (env: unknown): Promise<void> => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      vi.stubGlobal("process", { env });
+      await renderIt();
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+      warn.mockRestore();
+    }
+  };
+
+  it("says nothing when NODE_ENV is absent from a real `process`", async () => {
+    /*
+     * A standalone SSR runtime can expose a partial Node shim and never set
+     * `NODE_ENV`. Reading only "is `process` absent" covered ONE way of being
+     * unable to tell, so this one warned — undeduplicated, on every render of
+     * every affected block, in something that may well be production.
+     */
+    await saysNothingWhen({});
+  });
+
+  it("says nothing for an environment name it does not recognise", async () => {
+    // `staging` is neither development nor production, and guessing which it
+    // resembles is exactly the judgement a diagnostic should decline to make.
+    await saysNothingWhen({ NODE_ENV: "staging" });
+  });
+
+  it("DOES speak in development", async () => {
+    /*
+     * The control on all three silences above, and the one that stops this
+     * being satisfied by a warning that never fires at all.
+     */
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      vi.stubGlobal("process", { env: { NODE_ENV: "development" } });
+      const html = await renderIt();
+      expect(html).toContain("held");
+      const said = warn.mock.calls.map(call => String(call[0])).join("\n");
+      expect(said).toContain("test/wrapped-env");
+    } finally {
+      vi.unstubAllGlobals();
+      warn.mockRestore();
+    }
+  });
+});

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -5397,7 +5397,7 @@ describe("a block that does not render a single element", () => {
       expect(html).toContain("<p>");
       const said = warn.mock.calls.map(call => String(call[0])).join("\n");
       expect(said).toContain("test/wrapped");
-      expect(said).toContain("returned a fragment rather than an element");
+      expect(said).toContain("returned a wrapper rather than an element");
     } finally {
       warn.mockRestore();
     }
@@ -5465,6 +5465,108 @@ describe("a block that does not render a single element", () => {
       expect(warn).not.toHaveBeenCalled();
     } finally {
       vi.unstubAllGlobals();
+      warn.mockRestore();
+    }
+  });
+
+  it("warns about a React wrapper that is not a fragment", async () => {
+    /*
+     * `Suspense`, `StrictMode` and `Profiler` have symbol types like `Fragment`
+     * and render no element of their own, so the generated class has nowhere to
+     * go in any of them. Special-casing `Fragment` alone left the diagnostic
+     * silent about the rest — and a list of the wrappers that exist today is
+     * the instrument that falls behind as React adds more.
+     */
+    const suspended = defineBlock({
+      name: "test/suspense-root",
+      version: 1,
+      description: "Wraps its output in Suspense, against the contract.",
+      example: { props: {} },
+      defaultProps: {},
+      render: () => <Suspense fallback={null}>held</Suspense>,
+    });
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const html = await renderWith(suspended as AnyBlockDefinition);
+      // Population first: it rendered, so this is a warning about working
+      // output rather than about a block that failed some other way.
+      expect(html).toContain("held");
+      const said = warn.mock.calls.map(call => String(call[0])).join("\n");
+      expect(said).toContain("test/suspense-root");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("warns about output that is not an element at all", async () => {
+    /*
+     * The `none` branch, which nothing reached: a block returning a string
+     * renders visible output with no element to carry the class. Distinct from
+     * drawing nothing, which is a decision and is exempt below.
+     */
+    const bare = defineBlock({
+      name: "test/bare-string",
+      version: 1,
+      description: "Returns a string, against the contract.",
+      example: { props: {} },
+      defaultProps: {},
+      render: () => "just text" as never,
+    });
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const html = await renderWith(bare as AnyBlockDefinition);
+      expect(html).toContain("just text");
+      const said = warn.mock.calls.map(call => String(call[0])).join("\n");
+      expect(said).toContain("test/bare-string");
+      expect(said).toContain("returned no element");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("says nothing in a production runtime that DOES define `process`", async () => {
+    /*
+     * The ordinary production build, and the branch the absent-runtime test
+     * cannot reach: with `process` undefined the check exits at the first
+     * condition, so `NODE_ENV === "production"` is never evaluated. Both halves
+     * of that expression need a test or half of it is unmeasured.
+     */
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      vi.stubGlobal("process", { env: { NODE_ENV: "production" } });
+      await renderWith(wrapped as AnyBlockDefinition);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+      warn.mockRestore();
+    }
+  });
+
+  it("says nothing about a block that DECLARES it draws nothing", async () => {
+    /*
+     * The declaration exemption on its own. A block that also RETURNS nothing
+     * is exempted by `rendersNothing(output)` whatever the declaration says, so
+     * a fixture doing both cannot tell the two apart — this one declares it
+     * draws nothing while returning a fragment, which only the declaration
+     * excuses.
+     */
+    const declares = defineBlock({
+      name: "test/declares-drawless",
+      version: 1,
+      description: "Says it draws nothing, and returns a fragment.",
+      example: { props: {} },
+      defaultProps: {},
+      rendersNothing: () => true,
+      render: () => <></>,
+    });
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await renderWith(declares as AnyBlockDefinition);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
       warn.mockRestore();
     }
   });

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -5775,18 +5775,44 @@ describe("an element type that answers differently on a later read", () => {
     try {
       /*
        * `cssId` is set so BOTH policies run: the warning classifies, and the
-       * placeholder policy — the one that had no floor — classifies too. Ten
-       * covers every read this path makes today with room over it.
+       * placeholder policy — the one that had no floor — classifies too.
+       *
+       * The bound is MEASURED rather than picked. A sweep past the last read is
+       * a run of iterations whose accessor never throws, and every one of them
+       * passes anyway — this node carries `cssId` on a wrapper root, so it is
+       * replaced by an ordinary `invalid-output` placeholder whether anything
+       * raised or not. Those iterations would report containment without ever
+       * reaching the mechanism, and the count they pad is the only number that
+       * says how much of it was covered.
        */
-      for (let throwOn = 1; throwOn <= 10; throwOn += 1) {
+      let observed = 0;
+      await renderTricky(
+        () => {
+          observed += 1;
+        },
+        { cssId: "anchor" }
+      );
+      // The premise of the whole finding: this path reads the tag more than
+      // once. If that stops being true there is nothing here to contain.
+      expect(observed).toBeGreaterThan(1);
+
+      for (let throwOn = 1; throwOn <= observed; throwOn += 1) {
         let reads = 0;
+        let threw = false;
         const html = await renderTricky(
           () => {
             reads += 1;
-            if (reads === throwOn) throw new Error("tag read");
+            if (reads === throwOn) {
+              threw = true;
+              throw new Error("tag read");
+            }
           },
           { cssId: "anchor" }
         );
+        // Evidence before verdict: this iteration actually reached the read it
+        // names. Without it the assertion below is satisfied by a placeholder
+        // the node was getting anyway.
+        expect(threw).toBe(true);
         /*
          * Contained: the render RESOLVED, and what came back is this block's
          * placeholder rather than its output.
@@ -5853,6 +5879,41 @@ describe("which runtimes the contract warning is willing to speak in", () => {
     // `staging` is neither development nor production, and guessing which it
     // resembles is exactly the judgement a diagnostic should decline to make.
     await saysNothingWhen({ NODE_ENV: "staging" });
+  });
+
+  it("says nothing when reading the environment THROWS", async () => {
+    /*
+     * A standalone SSR host supplies its own `process`, and nothing says its
+     * `env` has to be a plain object — a throwing getter or a proxy is a shape
+     * this renderer will meet. The read used to sit ahead of the diagnostic's
+     * own guard, so it raised before there was anything to catch it.
+     *
+     * Where that lands is the point. `checkedOutput` is called PAST the try
+     * that contains the block's `render` on the synchronous path, so the throw
+     * is not contained into a placeholder: it leaves the package and takes the
+     * page — `renderToHtml` fails the test through its `onError`. An advisory
+     * warning must never be able to do that.
+     */
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      vi.stubGlobal("process", {
+        get env(): never {
+          throw new Error("no env here");
+        },
+      });
+      // Population first: the render COMPLETED and the block's output is on the
+      // page, so this is containment rather than a page that failed some other
+      // way and happened to log nothing.
+      const html = await renderIt();
+      expect(html).toContain("held");
+      expect(html).not.toMatch(PLACEHOLDER);
+      // And unable to tell, it stayed quiet — the same answer every other
+      // unidentifiable environment gets.
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+      warn.mockRestore();
+    }
   });
 
   it("DOES speak in development", async () => {

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -5349,3 +5349,86 @@ describe("PageRenderer", () => {
     });
   });
 });
+
+describe("a block that does not render a single element", () => {
+  /*
+   * `BlockRenderArgs.className` is the contract every block author is handed:
+   * "The generated class the block MUST place on its own root element. Blocks
+   * render a single element and never wrap it, so styles target that element."
+   *
+   * A block returning a Fragment has nowhere to put that class, so its compiled
+   * styles never apply — it is already broken. Until now the only signal came
+   * from the placeholder, which fires when a DOCUMENT asks for `cssId` or an
+   * attribute: the page author who set an anchor watched the block vanish,
+   * while the block author never heard about it.
+   */
+  const wrapped = defineBlock<{ value: string }>({
+    name: "test/wrapped",
+    version: 1,
+    description: "Wraps its output in a fragment, against the contract.",
+    example: { props: { value: "hi" } },
+    defaultProps: { value: "" },
+    render: ({ props }) => (
+      <>
+        <p>{props.value}</p>
+      </>
+    ),
+  });
+
+  const renderWith = async (
+    definition: AnyBlockDefinition,
+    extra: Partial<BlockNode> = {}
+  ): Promise<string> =>
+    renderToHtml(
+      <PageRenderer
+        document={doc(node("a", definition.name, extra))}
+        blocks={createBlockResolver([definition])}
+      />
+    );
+
+  it("warns the BLOCK author on the first render, asked for nothing", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const html = await renderWith(wrapped as AnyBlockDefinition);
+      // The control on the assertions below: the block RENDERED. Its output is
+      // on the page, so this is not a placeholder case and nobody asked for a
+      // root field — the warning is the only thing that fired.
+      expect(html).not.toMatch(PLACEHOLDER);
+      expect(html).toContain("<p>");
+      const said = warn.mock.calls.map(call => String(call[0])).join("\n");
+      expect(said).toContain("test/wrapped");
+      expect(said).toContain("returned a wrapper rather than an element");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("says nothing about a block that renders one element", async () => {
+    // The control that stops this warning firing on every conforming block.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await renderWith(text as AnyBlockDefinition);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("says nothing about a block that draws nothing on purpose", async () => {
+    /*
+     * Rendering nothing is a DECISION, not a violation — `core/image` with no
+     * source returns null deliberately. The same exemption the placeholder
+     * grants, asked the same way, or every conditional block would be scolded
+     * for working correctly.
+     */
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await renderWith(drawless as AnyBlockDefinition, {
+        props: { draw: false },
+      });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -5403,6 +5403,55 @@ describe("a block that does not render a single element", () => {
     }
   });
 
+  it("warns about a wrapper root that DOES forward the class to a child", async () => {
+    /*
+     * The fixture that separates wrapper DETECTION from style LOSS, which the
+     * fragment above cannot: it drops `className` entirely, so a message
+     * claiming its styles were lost and a message claiming its shape is wrong
+     * both pass against it.
+     *
+     * This block wraps, against the contract, and forwards the class to the
+     * child it wraps. Both halves are then measurable at once: the class is on
+     * the page, and the warning still fires — because the shape is what it
+     * reports, not a styling outcome it cannot know.
+     *
+     * The oracle is the RENDER. Asking the renderer a second time whether the
+     * class "would" land compares two derivations of one source and agrees with
+     * whichever is wrong; the served HTML is the only witness that the CSS
+     * matches something.
+     */
+    const forwarding = defineBlock({
+      name: "test/fragment-forwards",
+      version: 1,
+      description: "Wraps a child and forwards the class to it.",
+      example: { props: {} },
+      defaultProps: {},
+      render: ({ className }) => (
+        <>
+          <div className={className}>forwarded</div>
+        </>
+      ),
+    });
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const html = await renderWith(forwarding as AnyBlockDefinition);
+      // The class REACHED the DOM, so this block's compiled styles do apply.
+      expect(html).toContain("forwarded");
+      expect(html).toMatch(bothClasses("test/fragment-forwards"));
+      const said = warn.mock.calls.map(call => String(call[0])).join("\n");
+      // Warned all the same: the shape is outside the contract, and the node's
+      // root fields still have nowhere to go.
+      expect(said).toContain("test/fragment-forwards");
+      expect(said).toContain("returned a wrapper rather than an element");
+      // And it must NOT tell this author their styles are gone. They are on the
+      // page two assertions above.
+      expect(said).not.toMatch(/styles do not apply|nowhere to go/);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("says nothing about a block that renders one element", async () => {
     // The control that stops this warning firing on every conforming block.
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -5544,6 +5544,67 @@ describe("a block that does not render a single element", () => {
     }
   });
 
+  it("warns about a context PROVIDER root", async () => {
+    /*
+     * React 19 tags both `Ctx` and `Ctx.Provider` as `react.context`, and
+     * renders their children itself — so there is no element of its own for the
+     * generated class, exactly as with a fragment. Classifying by "is the type
+     * a symbol" missed it, because a provider's type is a tagged OBJECT.
+     */
+    const Ctx = createContext("none");
+    const provided = defineBlock({
+      name: "test/provider-root",
+      version: 1,
+      description: "Roots at a context provider, against the contract.",
+      example: { props: {} },
+      defaultProps: {},
+      render: () => <Ctx value="held">shown</Ctx>,
+    });
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const html = await renderWith(provided as AnyBlockDefinition);
+      // Population first: it rendered, so this is a warning about working
+      // output rather than about a block that failed some other way.
+      expect(html).toContain("shown");
+      const said = warn.mock.calls.map(call => String(call[0])).join("\n");
+      expect(said).toContain("test/provider-root");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("says nothing about a `memo` root, which may forward the class", async () => {
+    /*
+     * The boundary that stops the provider fix from becoming "every tagged
+     * object is broken". `memo` wraps a component that may render a host
+     * element and forward `className` to it, and only calling it would say —
+     * so warning about it would be false.
+     */
+    const Inner = ({ className }: { className: string }) => (
+      <div className={className}>memoised</div>
+    );
+    const Memo = memo(Inner);
+    const memoised = defineBlock({
+      name: "test/memo-root",
+      version: 1,
+      description: "Roots at a memoised component.",
+      example: { props: {} },
+      defaultProps: {},
+      render: ({ className }) => <Memo className={className} />,
+    });
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const html = await renderWith(memoised as AnyBlockDefinition);
+      expect(html).toContain("memoised");
+      expect(html).toMatch(bothClasses("test/memo-root"));
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("says nothing about a block that DECLARES it draws nothing", async () => {
     /*
      * The declaration exemption on its own. A block that also RETURNS nothing

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -5457,14 +5457,14 @@ describe("a block that does not render a single element", () => {
      * placeholder, which is a visible box rather than a log.
      */
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const original = globalThis.process;
     try {
-      // @ts-expect-error deleting a global for the duration of one assertion.
-      delete globalThis.process;
+      // Modelled the way the placeholder's own absent-runtime test models it,
+      // and without disabling type checking to do so.
+      vi.stubGlobal("process", undefined);
       await renderWith(wrapped as AnyBlockDefinition);
       expect(warn).not.toHaveBeenCalled();
     } finally {
-      globalThis.process = original;
+      vi.unstubAllGlobals();
       warn.mockRestore();
     }
   });

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -5397,7 +5397,7 @@ describe("a block that does not render a single element", () => {
       expect(html).toContain("<p>");
       const said = warn.mock.calls.map(call => String(call[0])).join("\n");
       expect(said).toContain("test/wrapped");
-      expect(said).toContain("returned a wrapper rather than an element");
+      expect(said).toContain("returned a fragment rather than an element");
     } finally {
       warn.mockRestore();
     }
@@ -5410,6 +5410,61 @@ describe("a block that does not render a single element", () => {
       await renderWith(text as AnyBlockDefinition);
       expect(warn).not.toHaveBeenCalled();
     } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("says nothing about a block whose root is a COMPONENT", async () => {
+    /*
+     * The shape this must not scold. A component that renders one host element
+     * and forwards `className` gets its compiled styles applied, so it is not
+     * broken — even though the placeholder path still refuses to attach root
+     * fields to it, because the renderer cannot know the component forwards
+     * those. Two questions, two answers, and only the narrower one belongs in a
+     * diagnostic: a warning that is sometimes false is one people scroll past.
+     */
+    const Root = ({ className }: { className: string }) => (
+      <div className={className}>via a component</div>
+    );
+    const componentRoot = defineBlock({
+      name: "test/component-root",
+      version: 1,
+      description: "Renders its root through a component.",
+      example: { props: {} },
+      defaultProps: {},
+      render: ({ className }) => <Root className={className} />,
+    });
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const html = await renderWith(componentRoot as AnyBlockDefinition);
+      // Population first: the block rendered AND its class landed, which is
+      // what makes "not broken" a measurement rather than an assumption.
+      expect(html).toContain("via a component");
+      expect(html).toMatch(bothClasses("test/component-root"));
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("says nothing in production, including where `process` is absent", async () => {
+    /*
+     * The diagnostic is undeduplicated by design, so a production runtime that
+     * still evaluated it would write a line on every render of every such
+     * block. An Edge or Worker runtime need not define `process` at all, and
+     * unable to tell, this says nothing — the opposite default to the
+     * placeholder, which is a visible box rather than a log.
+     */
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const original = globalThis.process;
+    try {
+      // @ts-expect-error deleting a global for the duration of one assertion.
+      delete globalThis.process;
+      await renderWith(wrapped as AnyBlockDefinition);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      globalThis.process = original;
       warn.mockRestore();
     }
   });

--- a/packages/blocks-react/src/renderable.ts
+++ b/packages/blocks-react/src/renderable.ts
@@ -279,6 +279,28 @@ function reactTag(value: unknown, depth = 0): symbol | null {
 }
 
 /**
+ * Whether an element TYPE creates no host element of its own.
+ *
+ * True for React's own constructs that exist to wrap children — a fragment, a
+ * suspense boundary, a context provider or consumer. There is nowhere in any of
+ * them for a block's generated class to go, which is what a caller asking this
+ * wants to know.
+ *
+ * `memo`, `forwardRef` and `lazy` are deliberately FALSE: each wraps a
+ * component that may well render a host element and forward the class to it,
+ * and the two cannot be told apart without calling it. This is the same
+ * distinction {@link ELEMENT_TYPE_TAGS} already draws between a provider, whose
+ * children React renders itself, and a component wrapper whose children are an
+ * ordinary prop — asked here rather than restated, so a tag added to one set
+ * cannot come to mean two different things.
+ */
+export function createsNoHostElement(type: unknown): boolean {
+  if (isReactBuiltinSymbol(type)) return true;
+  const tag = reactTag(type);
+  return tag !== null && (PROVIDER_TAGS.has(tag) || tag === CONSUMER_TAG);
+}
+
+/**
  * A tag name React's serializer will accept.
  *
  * React creates a perfectly valid element for `"bad tag"`, `"1div"` or `"a/b"`


### PR DESCRIPTION
Closes the second finding carried over from the merged #1164 (thread 3845262554) — but **not** the way that thread proposed, and the research is why.

## What the finding said

Setting an anchor or attribute on a block that returns a Fragment, wrapper or list replaces it with an `invalid-output` placeholder on the live page. The suggestion was to derive a "root-capability verdict" and disable the field.

## Why that fix would have been wrong

`BlockRenderArgs.className`, the contract every block author is handed:

> The generated class the block **MUST** place on its own root element. Blocks render a single element and never wrap it, so styles target that element.

A Fragment-returning block is therefore already **non-conforming**, and not only for anchors — it cannot place `className` either, so **its compiled styles never apply at all**. A `supports.rootless`-style declaration would have given a broken block a supported name for staying broken.

The second thing that changed the reading: the failure is **not silent**. `canvas.tsx` renders through `PageRenderer` with no placeholder bypass, so the author sees the block become a placeholder immediately, with the reason, and can undo.

## The real defect, and the fix

The placeholder **blames the wrong party at the wrong moment**. A page author sets an anchor and watches a block vanish having done nothing wrong; the block author never hears about it.

So the warning fires on the first render, whether or not anyone asked for a root field — telling the block author, in development, that their block does not conform.

## Two constraints it holds to

**Read from what the boundary RECEIVED, never predicted from the definition.** A prediction would be a second model of something the boundary already knows first-hand, and the two drift — the warning and the placeholder would then disagree about one output. The shape question is extracted once and both read it.

**A warning is not an exemption.** That is what makes reading the output safe here where granting one from it would not be: nothing about the render changes, so a reading React need not repeat can at worst produce a wrong message.

Not deduplicated by type, deliberately — a module-scoped set would couple one test's warning to another's or need a reset exported for tests, and this fires only for a block that is already broken. The reasoning is in the docblock so a later change is a decision rather than a discovery.

## Evidence

Three tests, two of them controls: a conforming single-element block warns nothing, and a block that draws nothing **on purpose** is exempt through the same rule the placeholder already uses. The positive test asserts the block actually rendered (`<p>`, no placeholder) before asserting the warning, so it cannot pass by the block having failed some other way.

Break-verified three ways: removing the call, dropping the draws-nothing exemption, and making the shape check reject a conforming element — each fails a different test.

Gates: blocks-react 774, builder 1726, plugin-page-builder 297, `check-types` and lint on both, `lint:design`, comment convention, `fallow` pass with `complexity_introduced: 0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added development-time warnings when blocks return unsupported or unusable root output.
  * Warnings identify the affected block and appear on first render.
  * Intentional empty output and valid element or component roots remain supported.
  * Diagnostics are suppressed in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->