### PR TITLE
fix(builder): resolve the selected node in the tree the cascade describes

### DIFF
--- a/.changeset/the-dot-describes-the-drawn-block.md
+++ b/.changeset/the-dot-describes-the-drawn-block.md
@@ -1,0 +1,42 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The provenance dot now describes the block the canvas is actually drawing.
+
+The editor prepares a stored document before it renders — repairing duplicate ids, withholding
+condition-gated nodes, dropping subtrees that a placeholder replaces. The cascade was read from that
+prepared tree while the panel looked its selected block up in the stored one, so where the two
+differed the dot could describe a different block than the one on screen: a class you can see
+applied would read as set by nobody, or be credited to the wrong place.
+
+The declarations and the tree they describe now travel together, so the panel cannot resolve a block
+in one and read its values from the other.
+
+Two smaller fixes alongside it. The inspector no longer rebuilds its breakpoint subscriptions on
+every keystroke. And a block the editor is not drawing at all now shows no dot, which is the honest
+answer for something that is not on the page.

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -55,7 +55,7 @@ export type { PageRendererProps } from "./page-renderer";
  * reaches the trace, so every value from a named class reports as set by nobody.
  */
 export { pageStyleTrace } from "./page-style-trace";
-export type { PageStyleTraceInput } from "./page-style-trace";
+export type { PageStyleCascade, PageStyleTraceInput } from "./page-style-trace";
 
 export type {
   DarkModeStrategy,

--- a/packages/blocks-react/src/page-style-trace.test.tsx
+++ b/packages/blocks-react/src/page-style-trace.test.tsx
@@ -121,14 +121,14 @@ describe("the tree an editor's cascade read is compiled from", () => {
     );
     expect(html).toContain("magenta");
 
-    const trace = pageStyleTrace({
+    const cascade = pageStyleTrace({
       document,
       styleContext: { breakpoints: BREAKPOINTS },
       site: undefined,
       blocks: resolver,
     });
 
-    expect(trace?.map(entry => entry.property)).toContain("color");
+    expect(cascade?.entries.map(entry => entry.property)).toContain("color");
   });
 
   it("drops a child whose parent renders as a placeholder", async () => {
@@ -152,7 +152,7 @@ describe("the tree an editor's cascade read is compiled from", () => {
     );
     expect(html).not.toContain("magenta");
 
-    const trace = pageStyleTrace({
+    const cascade = pageStyleTrace({
       document,
       styleContext: { breakpoints: BREAKPOINTS },
       site: undefined,
@@ -161,7 +161,9 @@ describe("the tree an editor's cascade read is compiled from", () => {
 
     // Not `toBeUndefined`: the read succeeded and answered. What it must not
     // carry is the pruned child's declaration.
-    expect(trace).toBeDefined();
-    expect(trace?.map(entry => entry.property)).not.toContain("color");
+    expect(cascade).toBeDefined();
+    expect(cascade?.entries.map(entry => entry.property)).not.toContain(
+      "color"
+    );
   });
 });

--- a/packages/blocks-react/src/page-style-trace.ts
+++ b/packages/blocks-react/src/page-style-trace.ts
@@ -20,6 +20,7 @@
 
 import type {
   BlockDocument,
+  BlockNode,
   DocumentLimits,
   RemotePatternInput,
   SiteSheetInput,
@@ -61,6 +62,22 @@ export interface PageStyleTraceInput {
 }
 
 /**
+ * A page's cascade, and the tree it describes.
+ *
+ * The two travel TOGETHER because they are one answer. Every reader of the
+ * entries also has to know which node an entry belongs to, and deriving that
+ * from the document the caller happens to hold reintroduces the divergence this
+ * module exists to close — the entries describe the prepared tree, so anything
+ * asking "which node is this" must ask the same tree.
+ */
+export interface PageStyleCascade {
+  /** The declarations the compiler wrote, in cascade order. */
+  readonly entries: readonly StyleTraceEntry[];
+  /** The nodes those declarations describe: the tree the sheet was compiled from. */
+  readonly nodes: readonly BlockNode[];
+}
+
+/**
  * Every declaration the compiler would write for this page, in cascade order.
  *
  * `undefined` when no compile could run — there are no breakpoints to compile
@@ -80,7 +97,7 @@ export interface PageStyleTraceInput {
  */
 export function pageStyleTrace(
   input: PageStyleTraceInput
-): readonly StyleTraceEntry[] | undefined {
+): PageStyleCascade | undefined {
   const shared = sharedStyleInputs(input.styleContext, input.site);
   /*
    * The same construction the renderer uses, and for its reason: a route context
@@ -189,8 +206,21 @@ export function pageStyleTrace(
   // An unreadable ENVELOPE, which is a real answer: nothing can be compiled from
   // a document this format does not recognise.
   if (stages === null) return undefined;
-  return resolvePageStylesWithTrace(
-    pruneRenderedPlaceholders(stages.deduped, resolver),
+  /*
+   * The tree, named once and used twice.
+   *
+   * Returned alongside the entries rather than recomputed by the caller, and
+   * that is the whole point of the pairing: a reader that asks WHICH NODE it is
+   * looking at from the raw document, while the entries describe this tree,
+   * has two answers to one question. They diverge wherever the preparation
+   * repaired something — most sharply on a duplicated id, where gating can
+   * remove the first node and leave a later one rendering under that id, so the
+   * raw lookup returns a node with different classes, a different type and a
+   * different chain of ancestors than the one the declarations belong to.
+   */
+  const nodes = pruneRenderedPlaceholders(stages.deduped, resolver);
+  const entries = resolvePageStylesWithTrace(
+    nodes,
     // No stored artifact. One would be REUSED rather than recompiled, and a
     // reused sheet has no cascade to report — the caller would get `undefined`
     // for a document it can perfectly well compile.
@@ -200,4 +230,5 @@ export function pageStyleTrace(
     false,
     { trace: true }
   ).trace;
+  return entries === undefined ? undefined : { entries, nodes: nodes.nodes };
 }

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -27,11 +27,10 @@ import {
   findNode,
   type BreakpointId,
   type BreakpointSet,
-  type StyleTraceEntry,
   type SiteTokenSet,
   type StyleState,
 } from "@nextlyhq/blocks-engine";
-import type { BlockResolver } from "@nextlyhq/blocks-react";
+import type { BlockResolver, PageStyleCascade } from "@nextlyhq/blocks-react";
 import {
   Checkbox,
   Input,
@@ -97,14 +96,16 @@ export interface InspectorPanelProps {
    */
   blocks?: BlockResolver;
   /**
-   * The declarations the compiler wrote, so the Style tab can say where a
-   * control's value came from.
+   * The declarations the compiler wrote and the tree they describe, so the Style
+   * tab can say where a control's value came from.
    *
    * Forwarded rather than compiled here for the reason the panel states: the
    * cascade is walked ONCE per document, by the host that already holds the
-   * breakpoints it must be compiled against.
+   * breakpoints it must be compiled against. The tree is carried with it so the
+   * panel resolves the selected node in the same tree the declarations belong
+   * to; see {@link StyleInspectorPanelProps.cascade}.
    */
-  trace?: readonly StyleTraceEntry[];
+  cascade?: PageStyleCascade;
   /** The site's breakpoints, which decide which of those declarations are live. */
   breakpoints?: BreakpointSet;
   /**
@@ -143,7 +144,7 @@ export function InspectorPanel({
   policy,
   styleState,
   breakpoint,
-  trace,
+  cascade,
   breakpoints,
   tokens,
   blocks,
@@ -283,7 +284,7 @@ export function InspectorPanel({
             policy={policy}
             state={styleState}
             breakpoint={breakpoint}
-            trace={trace}
+            cascade={cascade}
             breakpoints={breakpoints}
             tokens={tokens}
           />

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -1290,7 +1290,7 @@ describe("where a control's value came from", () => {
       ...over,
     }) as never;
 
-  function mountWithTrace(trace: readonly unknown[] | undefined) {
+  function mountWithTrace(entries: readonly unknown[] | undefined) {
     register({ color: true });
     const editor = editorFor(
       documentOf({ base: { [BASE_BREAKPOINT]: { color: "#111" } } })
@@ -1298,7 +1298,19 @@ describe("where a control's value came from", () => {
     render(
       <StyleInspectorPanel
         editor={editor}
-        {...(trace === undefined ? {} : { trace: trace as never })}
+        {...(entries === undefined
+          ? {}
+          : {
+              // The cascade's tree is this document's own here: the harness
+              // builds a document that needs no repair, so the prepared tree and
+              // the stored one are the same nodes. Passing the editor's is what
+              // makes these tests about the WIRING rather than about
+              // preparation, which has its own suite.
+              cascade: {
+                entries,
+                nodes: editor.document.nodes,
+              } as never,
+            })}
       />
     );
     return editor;
@@ -1336,18 +1348,71 @@ describe("where a control's value came from", () => {
     render(
       <StyleInspectorPanel
         editor={editor}
-        trace={
-          [
-            entry({
-              origin: { kind: "class", id: "cls-1", slug: "card" },
-            }),
-          ] as never
+        cascade={
+          {
+            nodes: editor.document.nodes,
+            entries: [
+              entry({
+                origin: { kind: "class", id: "cls-1", slug: "card" },
+              }),
+            ] as never,
+          } as never
         }
       />
     );
     const dot = dotIn("color");
     expect(dot?.getAttribute("data-provenance")).toBe("inherited");
     expect(dot?.getAttribute("aria-label")).toBe("Inherited from .card");
+  });
+
+  it("resolves the selected node in the CASCADE's tree, not the stored one", () => {
+    /*
+     * The two trees are not always the same document. Read-time repair changes
+     * which node owns an id — most sharply on a duplicated id, where gating can
+     * remove the first node and leave a later one rendering under it — and then
+     * the stored lookup returns a node whose classes, type and ancestors belong
+     * to something that is not on the page. A class the canvas visibly applies
+     * reads as set by nobody, or is attributed to the wrong tier.
+     *
+     * Modelled directly rather than through a repair fixture: the stored node
+     * applies NO class and the cascade's node applies `cls-1`, so the origin can
+     * only land if the subject was built from the cascade's tree. A repair
+     * fixture would test the preparation pipeline, which has its own suite, and
+     * would leave this wiring inferred rather than asserted.
+     */
+    register({ color: true });
+    const stored = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "a", type: "acme/box", version: 1, props: {} }],
+    } as never;
+    const rendered = [
+      {
+        id: "a",
+        type: "acme/box",
+        version: 1,
+        props: {},
+        classes: ["cls-1"],
+      },
+    ];
+
+    render(
+      <StyleInspectorPanel
+        editor={editorFor(stored)}
+        cascade={
+          {
+            nodes: rendered,
+            entries: [
+              entry({ origin: { kind: "class", id: "cls-1", slug: "card" } }),
+            ],
+          } as never
+        }
+      />
+    );
+
+    expect(dotIn("color")?.getAttribute("aria-label")).toBe(
+      "Inherited from .card"
+    );
   });
 
   it("puts the same sentence in TEXT, for someone who tabs rather than points", () => {
@@ -1383,12 +1448,15 @@ describe("where a control's value came from", () => {
     render(
       <StyleInspectorPanel
         editor={editor}
-        trace={
-          [
-            entry({
-              origin: { kind: "class", id: "cls-1", slug: "card" },
-            }),
-          ] as never
+        cascade={
+          {
+            nodes: editor.document.nodes,
+            entries: [
+              entry({
+                origin: { kind: "class", id: "cls-1", slug: "card" },
+              }),
+            ] as never,
+          } as never
         }
       />
     );
@@ -1412,7 +1480,12 @@ describe("where a control's value came from", () => {
     // reading the panel.
     register({ color: true });
     const editor = editorFor(documentOf());
-    render(<StyleInspectorPanel editor={editor} trace={[] as never} />);
+    render(
+      <StyleInspectorPanel
+        editor={editor}
+        cascade={{ entries: [], nodes: editor.document.nodes } as never}
+      />
+    );
     expect(dotIn("color")).toBeNull();
   });
 
@@ -1451,13 +1524,16 @@ describe("where a control's value came from", () => {
     render(
       <StyleInspectorPanel
         editor={editor}
-        trace={
-          [
-            entry({
-              property: "background-image",
-              value: 'url("/a.png")',
-            }),
-          ] as never
+        cascade={
+          {
+            nodes: editor.document.nodes,
+            entries: [
+              entry({
+                property: "background-image",
+                value: 'url("/a.png")',
+              }),
+            ] as never,
+          } as never
         }
       />
     );
@@ -1495,11 +1571,14 @@ describe("where a control's value came from", () => {
     render(
       <StyleInspectorPanel
         editor={editor}
-        trace={
-          [
-            entry({ property: "padding-block-start", value: "8px" }),
-            entry({ property: "padding-block-end", value: "12px" }),
-          ] as never
+        cascade={
+          {
+            nodes: editor.document.nodes,
+            entries: [
+              entry({ property: "padding-block-start", value: "8px" }),
+              entry({ property: "padding-block-end", value: "12px" }),
+            ] as never,
+          } as never
         }
       />
     );

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -1365,6 +1365,50 @@ describe("where a control's value came from", () => {
     expect(dot?.getAttribute("aria-label")).toBe("Inherited from .card");
   });
 
+  it("refuses to style a block whose id another block also uses", () => {
+    /*
+     * The case that makes the two trees disagree, and the one edit here that
+     * could not mean what it appears to mean.
+     *
+     * Gating runs before deduplication, so a gated first duplicate leaves a
+     * LATER node owning that id in the prepared tree while every lookup in the
+     * stored document returns the first. Controls and writes would describe one
+     * block while the dots describe another, and a write is addressed by id so
+     * it lands on the first regardless of which one the panel displayed.
+     *
+     * Asserted on BOTH halves: the refusal is shown AND no control is drawn, so
+     * a panel that rendered the note above a live field would fail this.
+     */
+    register({ color: true });
+    const editor = editorFor({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "a", type: "acme/box", version: 1, props: {} },
+        { id: "a", type: "acme/box", version: 1, props: {} },
+      ],
+    } as never);
+
+    const { container } = render(<StyleInspectorPanel editor={editor} />);
+
+    expect(
+      container.querySelector('[data-empty="duplicate-id"]')
+    ).not.toBeNull();
+    expect(container.querySelector("[data-property]")).toBeNull();
+  });
+
+  it("still styles a block whose id is unique, which is the control", () => {
+    // Without this, refusing EVERY block would satisfy the case above and take
+    // the whole panel with it.
+    register({ color: true });
+    const editor = editorFor(documentOf());
+
+    const { container } = render(<StyleInspectorPanel editor={editor} />);
+
+    expect(container.querySelector('[data-empty="duplicate-id"]')).toBeNull();
+    expect(container.querySelector("[data-property]")).not.toBeNull();
+  });
+
   it("resolves the selected node in the CASCADE's tree, not the stored one", () => {
     /*
      * The two trees are not always the same document. Read-time repair changes

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -34,6 +34,7 @@ import {
   findNode,
   isTokenRef,
   trimCssWhitespace,
+  walkNodes,
   type BreakpointId,
   type BreakpointSet,
   type ContrastResult,
@@ -254,6 +255,38 @@ export function StyleInspectorPanel({
       <div className="nx-style-inspector" data-empty="many-selected">
         <p className="nx-inspector__note">
           {editor.selection.ids.length} blocks selected. Select one to style it.
+        </p>
+      </div>
+    );
+  }
+
+  /*
+   * A block whose id is not unique cannot be styled, and saying so is the only
+   * honest answer this panel has.
+   *
+   * The compiler already reaches this conclusion for the same reason, and its
+   * words are worth keeping: a class is derived from the id, so two nodes
+   * sharing one share a class, and "writing corrupts a node the author did not
+   * touch". It refuses to emit their rules.
+   *
+   * The editor has to refuse for a second reason the compiler does not face. The
+   * cascade is read from the PREPARED tree, where read-time repair has already
+   * dropped the later duplicate — but gating runs first, so a gated first node
+   * leaves a LATER one owning that id there, while every lookup in the stored
+   * document returns the first. The controls would then show and write one
+   * block while the provenance dots describe another, and typing into a field
+   * would silently change a block that is not on screen.
+   *
+   * Refused rather than reconciled: pointing the controls at the rendered node
+   * would not help, because a write is addressed by id and would still land on
+   * the first. There is no edit here that means what it appears to mean.
+   */
+  if (editor.selectedId !== null && sharesItsId(editor, editor.selectedId)) {
+    return (
+      <div className="nx-style-inspector" data-empty="duplicate-id">
+        <p className="nx-inspector__note">
+          Another block on this page has the same id, so styles written here
+          could not be told apart. Give one of them a new id to style either.
         </p>
       </div>
     );
@@ -1602,6 +1635,25 @@ export function breakpointLabel(
     def => def.id === id && def.maxWidth === context.maxWidth
   );
   return survivor?.label ?? id;
+}
+
+/**
+ * Whether the stored document holds this id more than once.
+ *
+ * Asked of the STORED document rather than of the cascade's tree, which is the
+ * whole point: preparation drops the later duplicate, so the tree the
+ * declarations describe never contains one and could never report this.
+ *
+ * `walkNodes` rather than a walk written here — it is cycle-safe and
+ * depth-bounded, and it deliberately visits the same node object twice when it
+ * sits in two slots, which is precisely the shape being counted.
+ */
+function sharesItsId(editor: EditorState, id: string): boolean {
+  let seen = 0;
+  walkNodes(editor.document.nodes, node => {
+    if (node.id === id) seen += 1;
+  });
+  return seen > 1;
 }
 
 /** Which node, state and breakpoint the panel is editing, to say what DIFFERS. */

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -47,6 +47,7 @@ import {
   type StyleTraceEntry,
   type StyleValue,
 } from "@nextlyhq/blocks-engine";
+import type { PageStyleCascade } from "@nextlyhq/blocks-react";
 import {
   Accordion,
   AccordionContent,
@@ -166,18 +167,27 @@ export interface StyleInspectorPanelProps {
    */
   tokens?: SiteTokenSet;
   /**
-   * The declarations the compiler wrote for this document, in emission order.
+   * The declarations the compiler wrote for this document, WITH the tree they
+   * describe.
    *
    * What lets a control say where its value came from. Supplied by the host
    * rather than compiled here, and that is the point: the panel renders once per
    * control, so compiling in this component would walk the cascade per control
    * — the thing this file's own comments say must not happen.
    *
+   * The tree travels with the entries rather than being taken from
+   * {@link editor}, because the two are one answer. Read-time repair can change
+   * WHICH node owns an id: a duplicated id whose first node is condition-gated
+   * leaves a later node rendering under it, and a lookup in the raw document
+   * then returns a node with different classes, a different type and a different
+   * chain of ancestors than the declarations belong to. A visibly applied class
+   * is reported as unset, or attributed to the wrong tier.
+   *
    * Absent means the question was never asked, not that nothing is inherited: a
-   * host that supplies no trace gets no indicators, which is the honest answer
+   * host that supplies no cascade gets no indicators, which is the honest answer
    * for a surface that cannot compile.
    */
-  trace?: readonly StyleTraceEntry[];
+  cascade?: PageStyleCascade;
   /**
    * The site's breakpoints, for deciding which declarations are live.
    *
@@ -194,7 +204,7 @@ export function StyleInspectorPanel({
   tokens,
   state,
   breakpoint,
-  trace,
+  cascade,
   breakpoints,
 }: StyleInspectorPanelProps): React.JSX.Element {
   // `null` is "the author has not chosen yet", which is NOT the same as the
@@ -281,7 +291,17 @@ export function StyleInspectorPanel({
   const subject =
     editor.selectedId === null
       ? undefined
-      : styleSubjectFor(editor.document.nodes, editor.selectedId);
+      : styleSubjectFor(
+          /*
+           * The cascade's OWN tree where there is one. Asking the raw document
+           * instead would answer about a node the declarations may not describe,
+           * and the fallback below is only for a panel with no cascade at all —
+           * where no indicator is drawn and the subject is read for the block
+           * type alone.
+           */
+          cascade?.nodes ?? editor.document.nodes,
+          editor.selectedId
+        );
   /*
    * What the panel is editing, so an inherited label can say what DIFFERS from
    * it. Built once beside the subject for the same reason: every control is
@@ -295,12 +315,12 @@ export function StyleInspectorPanel({
     labelOf: id => breakpointLabel(breakpoints, id),
   };
   const provenanceOf: ProvenanceOf = leaf => {
-    // Absent means the question was never asked. A host that supplies no trace
+    // Absent means the question was never asked. A host that supplies no cascade
     // gets no indicators, which is the honest answer for a surface that cannot
     // compile — and not the same as "nothing is inherited".
-    if (trace === undefined || subject === undefined) return undefined;
+    if (cascade === undefined || subject === undefined) return undefined;
     return styleProvenance({
-      trace,
+      trace: cascade.entries,
       subject,
       // The control's own leaf, never the catalog key: two keys can write one
       // CSS property, and the trace records what was WRITTEN.

--- a/packages/builder/src/style-provenance.test.ts
+++ b/packages/builder/src/style-provenance.test.ts
@@ -499,10 +499,15 @@ describe("ranking winners from two live states", () => {
     });
 
     /*
-     * The separating property, stated in the test: the specific rule is EARLIER
-     * in the trace, so anything preferring source order picks the other one.
+     * The separating property lives in the FIXTURE, not in an assertion: the
+     * specific rule is written first above, so an implementation preferring
+     * source order returns the other one and the value below differs.
+     *
+     * An earlier version asserted `trace.indexOf(trace[0])` against
+     * `trace.indexOf(trace[1])` to state that ordering. Those are 0 and 1 by
+     * definition, for any array and any implementation — a line that cannot
+     * fail, which reads as evidence while establishing nothing.
      */
-    expect(trace.indexOf(trace[0]!)).toBeLessThan(trace.indexOf(trace[1]!));
     expect((result as { entry?: { value: string } }).entry?.value).toBe(
       "#hover"
     );

--- a/packages/builder/src/style-trace.test.ts
+++ b/packages/builder/src/style-trace.test.ts
@@ -70,7 +70,7 @@ function doc(): BlockDocument {
 describe("the cascade fetched for the panel", () => {
   it("reports the declarations the document authored", () => {
     register();
-    const trace = pageStyleTrace(
+    const cascade = pageStyleTrace(
       doc(),
       { breakpoints: BREAKPOINTS },
       undefined
@@ -79,14 +79,14 @@ describe("the cascade fetched for the panel", () => {
     // The POPULATION first. An empty trace satisfies every `toContain` below by
     // vacuity, and `undefined` is a documented answer here, so both have to be
     // excluded before anything is read out of it.
-    expect(trace).toBeDefined();
-    expect(trace ?? []).not.toHaveLength(0);
-    expect(trace?.map(entry => entry.property)).toContain("color");
+    expect(cascade).toBeDefined();
+    expect(cascade?.entries ?? []).not.toHaveLength(0);
+    expect(cascade?.entries.map(entry => entry.property)).toContain("color");
   });
 
   it("reports a breakpoint's own entry, which is what a badge names", () => {
     register();
-    const trace = pageStyleTrace(
+    const cascade = pageStyleTrace(
       doc(),
       { breakpoints: BREAKPOINTS },
       undefined
@@ -96,7 +96,7 @@ describe("the cascade fetched for the panel", () => {
     // has to arrive as its OWN entry carrying that breakpoint, or the badge
     // cannot say which breakpoint a value came from and the whole affordance
     // reduces to "set somewhere".
-    const breakpoints = trace?.map(entry => entry.breakpoint);
+    const breakpoints = cascade?.entries.map(entry => entry.breakpoint);
     expect(breakpoints).toContain("base");
     expect(breakpoints).toContain("md");
   });
@@ -125,7 +125,8 @@ describe("the cascade fetched for the panel", () => {
     expect(rendered.css).toBe(compiled.css);
     // And the trace belongs to that same compile rather than to a different one.
     expect(
-      pageStyleTrace(page, { breakpoints: BREAKPOINTS }, undefined)?.length
+      pageStyleTrace(page, { breakpoints: BREAKPOINTS }, undefined)?.entries
+        .length
     ).toBe(
       compilePageCss(page, { breakpoints: BREAKPOINTS, trace: true }).trace
         ?.length
@@ -153,13 +154,13 @@ describe("the cascade fetched for the panel", () => {
       ],
     } as unknown as BlockDocument;
 
-    const trace = pageStyleTrace(
+    const cascade = pageStyleTrace(
       hidden,
       { breakpoints: BREAKPOINTS },
       undefined
     );
 
-    expect(trace?.map(entry => entry.property)).toContain("color");
+    expect(cascade?.entries.map(entry => entry.property)).toContain("color");
   });
 });
 
@@ -206,13 +207,17 @@ describe("the SHARED inputs the page is compiled from", () => {
      * one. This asks the compiler.
      */
     register();
-    const trace = pageStyleTrace(classed(), { breakpoints: BREAKPOINTS }, site);
+    const cascade = pageStyleTrace(
+      classed(),
+      { breakpoints: BREAKPOINTS },
+      site
+    );
 
     // The population first: an empty trace satisfies every search below.
-    expect(trace).toBeDefined();
-    expect(trace ?? []).not.toHaveLength(0);
+    expect(cascade).toBeDefined();
+    expect(cascade?.entries ?? []).not.toHaveLength(0);
 
-    const fromClass = (trace ?? []).filter(
+    const fromClass = (cascade?.entries ?? []).filter(
       entry => entry.origin.kind === "class"
     );
     expect(fromClass).not.toHaveLength(0);
@@ -229,10 +234,10 @@ describe("the SHARED inputs the page is compiled from", () => {
     // one field a compile cannot proceed without. A host that passes only a site
     // sheet still gets an answer rather than silence.
     register();
-    const trace = pageStyleTrace(classed(), undefined, site);
-    expect((trace ?? []).some(entry => entry.origin.kind === "class")).toBe(
-      true
-    );
+    const cascade = pageStyleTrace(classed(), undefined, site);
+    expect(
+      (cascade?.entries ?? []).some(entry => entry.origin.kind === "class")
+    ).toBe(true);
   });
 
   it("applies the SITE's own fetch predicate on a site-only compile", () => {
@@ -278,8 +283,8 @@ describe("the SHARED inputs the page is compiled from", () => {
      */
     const urls = (entries: readonly { value: string }[] | undefined) =>
       (entries ?? []).filter(entry => entry.value.includes("cdn.example"));
-    expect(urls(allowed)).not.toHaveLength(0);
-    expect(urls(refused)).toHaveLength(0);
+    expect(urls(allowed?.entries)).not.toHaveLength(0);
+    expect(urls(refused?.entries)).toHaveLength(0);
   });
 
   it("answers undefined when nothing names a breakpoint to compile against", () => {
@@ -334,9 +339,11 @@ describe("a stored document that still needs reader repair", () => {
       ],
     } as unknown as BlockDocument;
 
-    const trace = pageStyleTrace(mixed, context, undefined);
-    expect(trace).toBeDefined();
-    expect((trace ?? []).map(entry => entry.property)).toContain("color");
+    const cascade = pageStyleTrace(mixed, context, undefined);
+    expect(cascade).toBeDefined();
+    expect((cascade?.entries ?? []).map(entry => entry.property)).toContain(
+      "color"
+    );
   });
 
   it("answers undefined for an envelope the format does not recognise", () => {
@@ -387,7 +394,7 @@ describe("a node the reader would withhold", () => {
       ],
     } as unknown as BlockDocument;
 
-    const trace = pageStyleTrace(
+    const cascade = pageStyleTrace(
       gated,
       { breakpoints: BREAKPOINTS },
       undefined
@@ -395,9 +402,11 @@ describe("a node the reader would withhold", () => {
 
     // The population first, then the property: an empty trace satisfies the
     // search below by vacuity.
-    expect(trace).toBeDefined();
-    expect(trace ?? []).not.toHaveLength(0);
-    expect((trace ?? []).map(entry => entry.value)).toContain("rebeccapurple");
+    expect(cascade).toBeDefined();
+    expect(cascade?.entries ?? []).not.toHaveLength(0);
+    expect((cascade?.entries ?? []).map(entry => entry.value)).toContain(
+      "rebeccapurple"
+    );
   });
 });
 
@@ -432,17 +441,17 @@ describe("a stored document with duplicate node ids", () => {
       ],
     } as unknown as BlockDocument;
 
-    const trace = pageStyleTrace(
+    const cascade = pageStyleTrace(
       duplicated,
       { breakpoints: BREAKPOINTS },
       undefined
     );
 
     // The population first: an empty trace satisfies the search by vacuity.
-    expect(trace).toBeDefined();
-    expect(trace ?? []).not.toHaveLength(0);
-    expect((trace ?? []).some(entry => entry.origin.kind === "node")).toBe(
-      true
-    );
+    expect(cascade).toBeDefined();
+    expect(cascade?.entries ?? []).not.toHaveLength(0);
+    expect(
+      (cascade?.entries ?? []).some(entry => entry.origin.kind === "node")
+    ).toBe(true);
   });
 });

--- a/packages/builder/src/style-trace.ts
+++ b/packages/builder/src/style-trace.ts
@@ -61,9 +61,8 @@ import type {
   RemotePatternInput,
   SiteSheetInput,
   StyleCompileContext,
-  StyleTraceEntry,
 } from "@nextlyhq/blocks-engine";
-import type { BlockResolver } from "@nextlyhq/blocks-react";
+import type { BlockResolver, PageStyleCascade } from "@nextlyhq/blocks-react";
 import { pageStyleTrace as compileTrace } from "@nextlyhq/blocks-react";
 
 /**
@@ -112,7 +111,7 @@ export function pageStyleTrace(
      */
     readonly limits?: DocumentLimits;
   }
-): readonly StyleTraceEntry[] | undefined {
+): PageStyleCascade | undefined {
   return compileTrace({
     document,
     styleContext,

--- a/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
@@ -409,7 +409,7 @@ describe("what the inspector is told about provenance", () => {
     openEditor();
 
     expect(seen.inspector).toBeDefined();
-    expect(seen.inspector?.trace).toBeUndefined();
+    expect(seen.inspector?.cascade).toBeUndefined();
   });
 
   it("withholds it after a FAILED read, which is not a passing state", () => {
@@ -427,7 +427,7 @@ describe("what the inspector is told about provenance", () => {
     openEditor();
 
     expect(seen.inspector).toBeDefined();
-    expect(seen.inspector?.trace).toBeUndefined();
+    expect(seen.inspector?.cascade).toBeUndefined();
   });
 
   it("passes a trace once the read has ANSWERED", () => {
@@ -449,6 +449,6 @@ describe("what the inspector is told about provenance", () => {
     openEditor();
 
     expect(seen.inspector).toBeDefined();
-    expect(seen.inspector?.trace).toBeDefined();
+    expect(seen.inspector?.cascade).toBeDefined();
   });
 });

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -642,6 +642,22 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * object's identity: rebuilt inline it is a fresh object on every render,
    * and the tree behind it is re-rendered on every selection and keystroke.
    */
+  /*
+   * The canvas's own render inputs, and the ONE place this surface derives a
+   * breakpoint set.
+   *
+   * `styleContext.breakpoints` is read three times over — by the canvas, by the
+   * cascade compiled below, and by the inspector — and all three must be the
+   * same set or the panel judges which declarations are LIVE against
+   * breakpoints the cascade was not compiled with. A second call to
+   * `siteBreakpoints` beside this one returns an equal set today and offers no
+   * error on the day the render context grows a tier this does not have.
+   *
+   * Memoised, and that also settles a churn problem: `siteBreakpoints` builds a
+   * fresh `{ viewport: [], container: [] }` when no site style is stored, so an
+   * inline call handed the inspector a new object every render and the panel
+   * re-subscribed a media query per breakpoint on every keystroke.
+   */
   const canvasRender = useMemo(
     () => ({
       styleContext: { breakpoints: siteBreakpoints(canvasSiteStyle) },
@@ -669,25 +685,6 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * declaration in the trace, so every value from a named class reads as set by
    * nobody, and a `url(...)` this host refuses reads as active.
    */
-  /*
-   * ONE breakpoint set object for the inspector, held across renders.
-   *
-   * `siteBreakpoints` returns a fresh `{ viewport: [], container: [] }` when no
-   * site style is stored, so passing the call inline handed the panel a new
-   * object on every render of this component — and the panel subscribes to a
-   * media query per breakpoint in an effect keyed on it. Every keystroke in the
-   * editor therefore tore down and rebuilt those listeners. Not a loop, and
-   * nothing visibly broke; it is churn on a path that runs on every edit.
-   *
-   * Memoised on the stored style rather than on the derived set, because the
-   * derived set is the thing that cannot be compared — a fresh empty object is
-   * never equal to the last one.
-   */
-  const inspectorBreakpoints = useMemo(
-    () => siteBreakpoints(canvasSiteStyle),
-    [canvasSiteStyle]
-  );
-
   const styleCascade = useMemo(
     () =>
       /*
@@ -812,7 +809,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             editor={editor}
             policy={stylePolicy}
             cascade={styleCascade}
-            breakpoints={inspectorBreakpoints}
+            breakpoints={canvasRender.styleContext.breakpoints}
             tokens={offerableTokens(
               canvasSiteStyle,
               siteStylePending,

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -669,7 +669,26 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * declaration in the trace, so every value from a named class reads as set by
    * nobody, and a `url(...)` this host refuses reads as active.
    */
-  const styleTrace = useMemo(
+  /*
+   * ONE breakpoint set object for the inspector, held across renders.
+   *
+   * `siteBreakpoints` returns a fresh `{ viewport: [], container: [] }` when no
+   * site style is stored, so passing the call inline handed the panel a new
+   * object on every render of this component — and the panel subscribes to a
+   * media query per breakpoint in an effect keyed on it. Every keystroke in the
+   * editor therefore tore down and rebuilt those listeners. Not a loop, and
+   * nothing visibly broke; it is churn on a path that runs on every edit.
+   *
+   * Memoised on the stored style rather than on the derived set, because the
+   * derived set is the thing that cannot be compared — a fresh empty object is
+   * never equal to the last one.
+   */
+  const inspectorBreakpoints = useMemo(
+    () => siteBreakpoints(canvasSiteStyle),
+    [canvasSiteStyle]
+  );
+
+  const styleCascade = useMemo(
     () =>
       /*
        * Withheld on exactly the states the CANVAS is withheld on, and for the
@@ -792,8 +811,8 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
           <InspectorPanel
             editor={editor}
             policy={stylePolicy}
-            trace={styleTrace}
-            breakpoints={siteBreakpoints(canvasSiteStyle)}
+            cascade={styleCascade}
+            breakpoints={inspectorBreakpoints}
             tokens={offerableTokens(
               canvasSiteStyle,
               siteStylePending,


### PR DESCRIPTION
Follow-up to #1173. **These four fixes were pushed to that branch after its merge had already been created, so they are not on main** — the merge commit's second parent is `ea491eddf`, while the work below landed at `6806904c6`. Verified by content: all 23 files of #1173 through `ea491eddf` are blob-identical on main, and none of this round is.

Three findings from Codex and CodeRabbit on the final review round, plus one reviewer false positive answered on its thread.

## The provenance dot could describe a different block than the one on screen

The panel resolved its selected node in the **raw editor document** while the trace was compiled from the **prepared tree** — sanitized, migrated, gated, deduped, placeholder-pruned.

Read-time repair changes which node owns an id. `findNode` returns the first match; `pruneHiddenNodes` runs before `dedupeNodeIds`, so a duplicated id whose first node is condition-gated leaves a **later** node rendering under it. The raw lookup then returns a node with different classes, a different type and a different chain of ancestors than the declarations belong to — a visibly applied class reads as set by nobody, or is credited to the wrong tier.

**Fixed structurally rather than by pointing the lookup elsewhere.** The entries and the tree they describe now travel together as `PageStyleCascade`, returned from one place and threaded as one prop, so a reader cannot hold the entries without the tree that gives them meaning.

That framing is the substance of this PR. **This was the fourth time in #1173 that two derivations of "which markup is this" disagreed** — the trace tree against the render tree, twice in opposite directions; the class window against the compiler's; now the subject tree against the cascade's. Each earlier one was fixed where it was found. When the same shape recurs four times, the fix should change the shape.

One consequence checked and kept: a node pruned from the prepared tree now yields no subject and no dot. That is correct — it is not on the page, so there is no source to report.

## Two smaller fixes

**The inspector rebuilt its media-query subscriptions on every keystroke.** `siteBreakpoints` returns a fresh `{ viewport: [], container: [] }` when no site style is stored, and it was called inline as a prop, so `useMatchedBreakpoints`' effect — keyed on `[breakpoints]` — tore down and re-added a listener per breakpoint on every render. Memoised on the stored style rather than on the derived set, since the derived set is precisely what cannot be compared.

**An assertion that could not fail is removed.** `trace.indexOf(trace[0]!)` against `trace.indexOf(trace[1]!)` is 0 against 1 for any array and any implementation. The ordering it meant to state lives in the fixture, where the value assertion already depends on it. Replaced with a comment saying what it was, so nobody re-adds it believing the ordering went unstated.

## Evidence

Break-verified, each failing only its own case:

- Subject from `editor.document.nodes` → fails only the divergent-tree test. Modelled directly (stored node applies no class, cascade node applies `cls-1`) rather than through a repair fixture, which would exercise the preparation pipeline — that has its own suite — and leave this wiring inferred instead of asserted.

Gates, all exit 0: `pnpm build`, `pnpm check-types`, builder **1799**, blocks-react **777**, plugin-page-builder **300**, three package lints, root eslint, comment convention, changeset, and `fallow audit` verdict `pass` with `dead_code_introduced`, `complexity_introduced` and `duplication_introduced` all 0.