### PR TITLE
fix(nextly): render a previewed Single as the person who shared it

### DIFF
--- a/.changeset/single-preview-renders-as-the-sharer.md
+++ b/.changeset/single-preview-renders-as-the-sharer.md
@@ -1,0 +1,64 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A preview link for a Single no longer shows its recipient fields the person who shared it cannot
+see. Collections were repaired separately; this is the same defect on the Single path.
+
+A granted draft read is trusted — that is what lets the working draft appear at all, since the
+overlay is gated on edit capability while a preview route resolves anonymously. But one flag
+decided both document trust and FIELD trust, so trusting the document switched field-level read
+rules off along with it. An editor denied a field could read it by sharing a link and opening it
+themselves.
+
+`previewSingleDraftGate` now answers a grant that NAMES the sharer rather than a bare boolean, and
+the route carries that identity into the read as a redaction basis — never as the caller. Every
+hook goes on seeing the anonymous visitor who is actually asking: a hook branching on the caller
+would otherwise produce an editor-only value for whoever holds the link, and a value a hook invents
+need not be a declared field, so redaction could not take it back.
+
+`SingleRouteConfig.draft` accordingly returns `SingleDraftGrant` instead of `boolean`. A literal
+`true` still grants, for a route mounted behind the application's own auth where every visitor is
+already entitled to the draft; it names nobody and so judges by nobody, which is the previous
+behaviour it preserves.
+
+Revocation reaches links already in circulation, and it takes two things rather than one. The
+identity is re-read on every render, so a deleted or deactivated account stops rendering at once.
+But rebuilding an identity re-evaluates field rules and nothing else — the read still bypasses the
+Single's own document rules — so the render also re-asks the question the mint asked: may this
+person still preview this Single. `assertSinglePreviewable` takes `routeAuthorized` per call site
+for that reason: true for the mint, which runs behind the route's access gate, and false for a
+render, which is anonymous and has none.
+
+A link whose sender cannot be identified — an account since deleted or deactivated, or a token
+minted before the record existed — is refused rather than rendered. Rendering it as nobody applies
+no field rules at all, which is the leak itself; the visitor sees the published document or a 404,
+the same as an expired link.
+
+One limit is unchanged and worth repeating: a deployment authenticating through its own provider
+can put arbitrary claims on a token, and those exist only for the duration of a request. A field
+rule reading one sees it absent here, and absence is not the safe direction.

--- a/packages/nextly/src/api/preview-access.ts
+++ b/packages/nextly/src/api/preview-access.ts
@@ -184,7 +184,21 @@ export async function assertEntryPreviewable(
 export async function assertSinglePreviewable(
   single: string,
   locale: string | undefined,
-  user: UserContext
+  user: UserContext,
+  options: {
+    /**
+     * Whether the CALLER has already passed the coarse RBAC / code-defined
+     * access gate for `update` on this Single.
+     *
+     * Required, and per call site rather than defaulted, for the reason
+     * {@link assertEntryPreviewable} states: it is true for the mint, which
+     * runs behind `requireRouteCollectionAccess(req, "update", single)`, and
+     * false for a preview RENDER, which is an anonymous public request with no
+     * route gate at all. Assuming it ran skips the very check that notices a
+     * sharer whose role was withdrawn.
+     */
+    routeAuthorized: boolean;
+  }
 ): Promise<void> {
   const identity = {
     user,
@@ -222,7 +236,7 @@ export async function assertSinglePreviewable(
       ...identity,
       // TRUE here: the mint route ran exactly this gate, so the coarse update
       // check is the redundant one this flag exists to skip.
-      routeAuthorized: true,
+      routeAuthorized: options.routeAuthorized,
     }))
   ) {
     throw NextlyError.forbidden({

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -463,7 +463,12 @@ async function mintForSingle(
   // read below, so a refused caller reaches neither.
   refuseApiKeyMint(auth);
   const { user } = await callerFor(auth);
-  await assertSinglePreviewable(single, locale, user);
+  await assertSinglePreviewable(single, locale, user, {
+    // The route above ran the coarse gate for `update` on this Single, so
+    // repeating it here would ask a question already answered. The preview
+    // RENDER passes `false`: it has no route gate at all.
+    routeAuthorized: true,
+  });
 
   const declaration = await singlePreviewDeclarationFor(single);
 

--- a/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
@@ -1205,6 +1205,10 @@ export class FieldGroupQueryService extends BaseService {
           enforceFieldAccess: access.enforceFieldAccess,
           enforceCollectionAccess: access.enforceCollectionAccess,
           user: access.user,
+          // Beside `user`, never folded into it. Dropping it here rebuilds a
+          // VALID context describing a different caller — one whose related
+          // rows are judged by nobody — which is silent and leaks.
+          fieldAccessUser: access.fieldAccessUser,
           overrideAccess: access.overrideAccess,
           // Narrows that bypass per RELATED collection. Absent means unchanged;
           // dropping it here would silently restore the full bypass.

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -992,6 +992,10 @@ export class SingleQueryService extends BaseService {
       options.depth,
       {
         enforceFieldAccess: enforceRelatedFieldAccess,
+        // Beside the flag, never folded into `user`: a preview judges a related
+        // row's fields as the sharer while every hook goes on seeing the
+        // anonymous visitor who is actually asking.
+        fieldAccessUser: options.fieldAccessUser,
         // Always on, unlike field redaction: the authorization view must not be
         // shown a related row the response is going to withhold, or its rule
         // approves the document and the read's side effects run before the
@@ -1064,6 +1068,10 @@ export class SingleQueryService extends BaseService {
           // caller travels down to reach the related row's own rules.
           access: {
             enforceFieldAccess: enforceRelatedFieldAccess,
+            // Beside the flag, never folded into `user`: a preview judges a related
+            // row's fields as the sharer while every hook goes on seeing the
+            // anonymous visitor who is actually asking.
+            fieldAccessUser: options.fieldAccessUser,
             enforceCollectionAccess: true,
             user: options.user as Record<string, unknown> | undefined,
             overrideAccess: options.overrideAccess,

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -2780,6 +2780,11 @@ export class SingleQueryService extends BaseService {
           enforceFieldAccess: access.enforceFieldAccess,
           enforceCollectionAccess: access.enforceCollectionAccess,
           user: access.user,
+          // Beside `user`, never folded into it. Dropped here, every top-level
+          // relationship — live and working-draft alike — is judged as the
+          // anonymous bearer while the document above it is judged as the
+          // sharer, which is the disclosure the identity exists to close.
+          fieldAccessUser: access.fieldAccessUser,
           overrideAccess: access.overrideAccess,
           // Narrows that bypass per RELATED collection. Absent means unchanged;
           // dropping it here would silently restore the full bypass.

--- a/packages/nextly/src/runtime/preview/__tests__/preview-single-draft-gate.test.ts
+++ b/packages/nextly/src/runtime/preview/__tests__/preview-single-draft-gate.test.ts
@@ -27,8 +27,10 @@ let generation = 1;
 const SHARER = { id: "minter-1", roles: ["editor"], role: "editor" };
 const resolvePreviewIdentity = vi.hoisted(() => vi.fn());
 vi.mock("../preview-identity", () => ({ resolvePreviewIdentity }));
-const assertSinglePreviewable = vi.hoisted(() => vi.fn());
-vi.mock("../../../api/preview-access", () => ({ assertSinglePreviewable }));
+const singleDocumentEditable = vi.hoisted(() => vi.fn());
+vi.mock("../../../domains/singles/services/single-document-access", () => ({
+  singleDocumentEditable,
+}));
 
 vi.mock("../preview-route-defaults", () => ({
   defaultSecret: () => TEST_SECRET,
@@ -61,8 +63,8 @@ beforeEach(() => {
   generation = 1;
   resolvePreviewIdentity.mockClear();
   resolvePreviewIdentity.mockResolvedValue(SHARER);
-  assertSinglePreviewable.mockClear();
-  assertSinglePreviewable.mockResolvedValue(undefined);
+  singleDocumentEditable.mockClear();
+  singleDocumentEditable.mockResolvedValue(true);
 });
 
 describe("previewSingleDraftGate", () => {
@@ -169,7 +171,7 @@ describe("previewSingleDraftGate", () => {
   // Single's own document rules bypassed, so without this the link kept serving
   // the draft until it expired.
   it("refuses once the sharer may no longer preview the Single", async () => {
-    assertSinglePreviewable.mockRejectedValue(new Error("forbidden"));
+    singleDocumentEditable.mockResolvedValue(false);
     await cookieFor({ kind: "single", single: "homepage" });
 
     await expect(previewSingleDraftGate()({ slug: "homepage" })).resolves.toBe(
@@ -178,12 +180,10 @@ describe("previewSingleDraftGate", () => {
     // Asked about the Single the TOKEN names, as the SHARER, and told that
     // nothing gated this request — a render has no route gate, and claiming one
     // ran skips the only check that notices a withdrawn role.
-    expect(assertSinglePreviewable).toHaveBeenCalledWith(
-      "homepage",
-      undefined,
-      SHARER,
-      { routeAuthorized: false }
-    );
+    expect(singleDocumentEditable).toHaveBeenCalledWith("homepage", {
+      user: SHARER,
+      routeAuthorized: false,
+    });
   });
   // A token minted BEFORE the claim existed, built the way one would actually
   // arrive: signed with the same derived key, carrying no `mnt`. The signer

--- a/packages/nextly/src/runtime/preview/__tests__/preview-single-draft-gate.test.ts
+++ b/packages/nextly/src/runtime/preview/__tests__/preview-single-draft-gate.test.ts
@@ -5,6 +5,9 @@
  * entirely correct; a gate that grants too much turns one shared link into a key
  * to every unpublished Single on the site.
  */
+import { hkdfSync } from "node:crypto";
+
+import { SignJWT } from "jose";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { signPreviewToken } from "../../../auth/preview/preview-token";
@@ -14,6 +17,18 @@ const TEST_SECRET = "single-gate-test-secret-at-least-32-chars!!";
 
 let cookieValue: string | undefined;
 let generation = 1;
+
+// The identity lookup and the per-render re-authorization both reach the
+// container and the database. These cases are about CONFINEMENT — which
+// document a token reaches — so the sharer is a fixture here; who the draft
+// renders as is covered in `preview-identity.test.ts`, and what the
+// re-authorization DECIDES is covered where a permission can actually be
+// revoked.
+const SHARER = { id: "minter-1", roles: ["editor"], role: "editor" };
+const resolvePreviewIdentity = vi.hoisted(() => vi.fn());
+vi.mock("../preview-identity", () => ({ resolvePreviewIdentity }));
+const assertSinglePreviewable = vi.hoisted(() => vi.fn());
+vi.mock("../../../api/preview-access", () => ({ assertSinglePreviewable }));
 
 vi.mock("../preview-route-defaults", () => ({
   defaultSecret: () => TEST_SECRET,
@@ -44,15 +59,19 @@ async function cookieFor(
 beforeEach(() => {
   cookieValue = undefined;
   generation = 1;
+  resolvePreviewIdentity.mockClear();
+  resolvePreviewIdentity.mockResolvedValue(SHARER);
+  assertSinglePreviewable.mockClear();
+  assertSinglePreviewable.mockResolvedValue(undefined);
 });
 
 describe("previewSingleDraftGate", () => {
   it("grants the Single its token names", async () => {
     await cookieFor({ kind: "single", single: "homepage" });
 
-    await expect(previewSingleDraftGate()({ slug: "homepage" })).resolves.toBe(
-      true
-    );
+    await expect(
+      previewSingleDraftGate()({ slug: "homepage" })
+    ).resolves.toEqual({ readAs: SHARER });
   });
 
   it("refuses a request with no preview cookie", async () => {
@@ -89,7 +108,7 @@ describe("previewSingleDraftGate", () => {
 
     await expect(
       previewSingleDraftGate()({ slug: "homepage", locale: "en" })
-    ).resolves.toBe(true);
+    ).resolves.toEqual({ readAs: SHARER });
   });
 
   it("refuses a token whose locale is not the one the route reads", async () => {
@@ -107,7 +126,7 @@ describe("previewSingleDraftGate", () => {
 
     await expect(
       previewSingleDraftGate()({ slug: "homepage", locale: "fr" })
-    ).resolves.toBe(true);
+    ).resolves.toEqual({ readAs: SHARER });
   });
 
   it("refuses an expired token", async () => {
@@ -131,5 +150,68 @@ describe("previewSingleDraftGate", () => {
     await expect(previewSingleDraftGate()({ slug: "homepage" })).resolves.toBe(
       false
     );
+  });
+  // A grant with no identity is a grant with no field rules, which is the leak
+  // the identity exists to close — so the draft is refused outright and the
+  // request resolves published-only, indistinguishable from an expired link.
+  it("refuses the draft when the sharer cannot be identified", async () => {
+    resolvePreviewIdentity.mockResolvedValue(null);
+    await cookieFor({ kind: "single", single: "homepage" });
+
+    await expect(previewSingleDraftGate()({ slug: "homepage" })).resolves.toBe(
+      false
+    );
+  });
+
+  // A sharer who is still ACTIVE but no longer authorized — an update role
+  // withdrawn, a custom rule they stopped satisfying. Rebuilding their identity
+  // re-evaluates FIELD rules and nothing else, because the read runs with the
+  // Single's own document rules bypassed, so without this the link kept serving
+  // the draft until it expired.
+  it("refuses once the sharer may no longer preview the Single", async () => {
+    assertSinglePreviewable.mockRejectedValue(new Error("forbidden"));
+    await cookieFor({ kind: "single", single: "homepage" });
+
+    await expect(previewSingleDraftGate()({ slug: "homepage" })).resolves.toBe(
+      false
+    );
+    // Asked about the Single the TOKEN names, as the SHARER, and told that
+    // nothing gated this request — a render has no route gate, and claiming one
+    // ran skips the only check that notices a withdrawn role.
+    expect(assertSinglePreviewable).toHaveBeenCalledWith(
+      "homepage",
+      undefined,
+      SHARER,
+      { routeAuthorized: false }
+    );
+  });
+  // A token minted BEFORE the claim existed, built the way one would actually
+  // arrive: signed with the same derived key, carrying no `mnt`. The signer
+  // refuses to produce one now, so it is hand-built rather than asserted
+  // against a shape this module can no longer make. Honouring it would read the
+  // document with no field rules at all, which is the leak.
+  it("refuses a token minted before it recorded who shared it", async () => {
+    const legacy = await new SignJWT({
+      kind: "single",
+      sng: "homepage",
+      gen: 1,
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setAudience("nextly:preview")
+      .setSubject("single:homepage")
+      .setIssuedAt()
+      .setExpirationTime("10m")
+      .sign(
+        new Uint8Array(
+          hkdfSync("sha256", TEST_SECRET, "", "nextly:preview-token:v1", 32)
+        )
+      );
+    cookieValue = encodeURIComponent(legacy);
+
+    await expect(previewSingleDraftGate()({ slug: "homepage" })).resolves.toBe(
+      false
+    );
+    // And it never reached the identity lookup: there was no id to look up.
+    expect(resolvePreviewIdentity).not.toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/runtime/preview/preview-single-draft-gate.ts
+++ b/packages/nextly/src/runtime/preview/preview-single-draft-gate.ts
@@ -15,10 +15,13 @@
  *
  * @module runtime/preview/preview-single-draft-gate
  */
+import { assertSinglePreviewable } from "../../api/preview-access";
 import { previewTokenCovers } from "../../auth/preview/preview-token";
+import type { UserContext } from "../../direct-api/types/shared";
 import type { SingleDraftRequest } from "../routing/single-route";
 
-import { readPreviewScope } from "./preview-route";
+import { resolvePreviewIdentity } from "./preview-identity";
+import { readPreviewSession } from "./preview-route";
 import type { PreviewScopeReaderConfig } from "./preview-route";
 
 /** Options for {@link previewSingleDraftGate}. */
@@ -33,13 +36,14 @@ export type PreviewSingleDraftGateConfig = PreviewScopeReaderConfig;
  */
 export function previewSingleDraftGate(
   config: PreviewSingleDraftGateConfig = {}
-): (request: SingleDraftRequest) => Promise<boolean> {
+): (request: SingleDraftRequest) => Promise<{ readAs: UserContext } | false> {
   return async ({ slug, locale }) => {
     // Re-read per request. The configuration is captured once, while whether
     // this visitor is previewing — and whether their token has since expired or
     // been revoked — is a fact about the request in hand.
-    const scope = await readPreviewScope(config);
-    if (scope === null) return false;
+    const verified = await readPreviewSession(config);
+    if (verified === null) return false;
+    const { scope, minter } = verified;
 
     // A collection entry's token cannot open a Single — a Single named `pages`
     // is not the `pages` collection — and that comparison is NOT repeated here.
@@ -52,10 +56,55 @@ export function previewSingleDraftGate(
     // token scoped to `en` must not grant the `fr` document, and taking the
     // locale from this gate's own configuration would make it a second
     // declaration of a value the route already holds.
-    return previewTokenCovers(scope, {
-      kind: "single",
-      single: slug,
-      ...(locale === undefined ? {} : { locale }),
-    });
+    if (
+      !previewTokenCovers(scope, {
+        kind: "single",
+        single: slug,
+        ...(locale === undefined ? {} : { locale }),
+      })
+    ) {
+      return false;
+    }
+
+    // The document is read TRUSTED so the working draft appears at all, and
+    // trust switched field-level read rules off with it. So the fields are
+    // judged separately, as the person who shared the link — otherwise the
+    // recipient sees fields the sharer cannot, which turns the link into a way
+    // to read past your own permissions by sending yourself one.
+    //
+    // **No identity, no draft.** A token minted before the claim existed, and a
+    // sharer whose account has been deleted or deactivated, both arrive here
+    // without one. Granting anyway would read the document with no field rules
+    // at all, which IS the defect — so the grant is refused and the request
+    // resolves published-only, indistinguishable from an expired link.
+    if (minter === undefined) return false;
+    const readAs = await resolvePreviewIdentity(minter);
+    if (readAs === null) return false;
+
+    // Asked again, on every render, and that is what makes revocation real.
+    // Rebuilding the sharer's identity re-evaluates FIELD rules and nothing
+    // else: the read below runs with `overrideAccess: true`, so the Single's
+    // own document rules are bypassed. A sharer who loses their update role, or
+    // stops satisfying a custom rule, would otherwise keep serving the draft to
+    // whoever holds the link until it expired — an account that is still
+    // ACTIVE, so the deactivation check does not reach it either.
+    //
+    // The SAME function the mint uses, rather than a second implementation of
+    // "may this person preview this Single". `routeAuthorized: false` because a
+    // render is an anonymous public request: nothing ran the coarse access gate
+    // for it, and claiming otherwise skips the only part that notices a
+    // withdrawn role.
+    try {
+      await assertSinglePreviewable(slug, locale, readAs, {
+        routeAuthorized: false,
+      });
+    } catch {
+      // Refused rather than propagated. A revoked link is an ordinary request
+      // outcome — the visitor sees the published document or a 404, the same as
+      // an expired one — not a 500 on a page that was working yesterday.
+      return false;
+    }
+
+    return { readAs };
   };
 }

--- a/packages/nextly/src/runtime/preview/preview-single-draft-gate.ts
+++ b/packages/nextly/src/runtime/preview/preview-single-draft-gate.ts
@@ -15,9 +15,9 @@
  *
  * @module runtime/preview/preview-single-draft-gate
  */
-import { assertSinglePreviewable } from "../../api/preview-access";
 import { previewTokenCovers } from "../../auth/preview/preview-token";
 import type { UserContext } from "../../direct-api/types/shared";
+import { singleDocumentEditable } from "../../domains/singles/services/single-document-access";
 import type { SingleDraftRequest } from "../routing/single-route";
 
 import { resolvePreviewIdentity } from "./preview-identity";
@@ -89,19 +89,34 @@ export function previewSingleDraftGate(
     // whoever holds the link until it expired — an account that is still
     // ACTIVE, so the deactivation check does not reach it either.
     //
-    // The SAME function the mint uses, rather than a second implementation of
-    // "may this person preview this Single". `routeAuthorized: false` because a
-    // render is an anonymous public request: nothing ran the coarse access gate
-    // for it, and claiming otherwise skips the only part that notices a
-    // withdrawn role.
-    try {
-      await assertSinglePreviewable(slug, locale, readAs, {
+    // **The EDITABLE half alone, and the exclusion is the point.** The mint
+    // asks both halves through `assertSinglePreviewable`, and the readable one
+    // cannot run here: it goes through `SingleQueryService.get`, which
+    // AUTO-CREATES a missing Single — row, localized defaults and a first
+    // version — and runs the Single's read hooks. A render is an anonymous
+    // public request, so that would let whoever holds a link persist a document
+    // and fire hook side effects, attributed to the sharer, on a page view.
+    // Reads do not write.
+    //
+    // What the editable half answers is also the question this gate needs. The
+    // working-draft overlay is gated on being able to EDIT the document, so
+    // edit capability is what decides whether a draft may be handed out at all;
+    // and it is non-mutating by construction, loading the row through the
+    // adapter and evaluating the stored rules against it.
+    //
+    // What it does NOT catch, stated rather than left to be found: a sharer who
+    // keeps update access and loses READ access through a custom rule. Closing
+    // that needs a readable probe that neither materializes nor runs hooks,
+    // which the Single read path does not currently offer.
+    if (
+      !(await singleDocumentEditable(slug, {
+        user: readAs,
+        // FALSE: a render is an anonymous public request. Nothing ran the
+        // coarse access gate for it, and claiming otherwise skips the only part
+        // that notices a withdrawn role.
         routeAuthorized: false,
-      });
-    } catch {
-      // Refused rather than propagated. A revoked link is an ordinary request
-      // outcome — the visitor sees the published document or a 404, the same as
-      // an expired one — not a 500 on a page that was working yesterday.
+      }))
+    ) {
       return false;
     }
 

--- a/packages/nextly/src/runtime/routing/__tests__/single-draft-grant.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/single-draft-grant.test.ts
@@ -31,18 +31,27 @@ describe("normalizeSingleDraftGrant", () => {
     expect(normalizeSingleDraftGrant({ readAs })).toEqual({ readAs });
   });
 
-  // `typeof null === "object"`, so the obvious check is the wrong one. A null
-  // reaching the read as an identity is the case this exists to prevent.
-  it("grants without an identity when readAs is null", () => {
-    expect(normalizeSingleDraftGrant({ readAs: null })).toEqual({});
+  // An OBJECT grant is a hook trying to name someone. One that failed to name
+  // anyone must REFUSE, not fall back to the empty grant: an empty grant means
+  // "trusted read, judged by nobody", which hands back the working draft with
+  // every field — the disclosure this path exists to close. The empty grant is
+  // reserved for a literal `true`, where the application has said so.
+  //
+  // `typeof null === "object"`, so the obvious check is the wrong one.
+  it("refuses an object grant whose readAs is null", () => {
+    expect(normalizeSingleDraftGrant({ readAs: null })).toBeNull();
   });
 
-  it("grants without an identity when readAs is not an object", () => {
+  it("refuses an object grant naming nobody", () => {
+    expect(normalizeSingleDraftGrant({})).toBeNull();
+  });
+
+  it("refuses an object grant whose readAs is not an object", () => {
     // A hook returning the sharer's ID rather than their context. Forwarded, a
     // string would be judged as a user object whose every property is absent —
     // and absence can ALLOW, not merely strip.
-    expect(normalizeSingleDraftGrant({ readAs: "user-1" })).toEqual({});
-    expect(normalizeSingleDraftGrant({ readAs: 42 })).toEqual({});
+    expect(normalizeSingleDraftGrant({ readAs: "user-1" })).toBeNull();
+    expect(normalizeSingleDraftGrant({ readAs: 42 })).toBeNull();
   });
 
   it("refuses a non-object, non-boolean answer outright", () => {

--- a/packages/nextly/src/runtime/routing/__tests__/single-draft-grant.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/single-draft-grant.test.ts
@@ -31,6 +31,20 @@ describe("normalizeSingleDraftGrant", () => {
     expect(normalizeSingleDraftGrant({ readAs })).toEqual({ readAs });
   });
 
+  // A non-null object can still name NOBODY, and an identity with no `id` is
+  // judged as an anonymous-like user whose every property is absent — where a
+  // rule such as `user?.role !== "restricted"` PERMITS rather than denies.
+  it("refuses an identity that names nobody", () => {
+    expect(normalizeSingleDraftGrant({ readAs: {} })).toBeNull();
+    expect(
+      normalizeSingleDraftGrant({ readAs: { roles: ["editor"] } })
+    ).toBeNull();
+    expect(normalizeSingleDraftGrant({ readAs: { id: "" } })).toBeNull();
+    expect(normalizeSingleDraftGrant({ readAs: { id: "   " } })).toBeNull();
+    // Arrays are objects too.
+    expect(normalizeSingleDraftGrant({ readAs: [] })).toBeNull();
+  });
+
   // An OBJECT grant is a hook trying to name someone. One that failed to name
   // anyone must REFUSE, not fall back to the empty grant: an empty grant means
   // "trusted read, judged by nobody", which hands back the working draft with

--- a/packages/nextly/src/runtime/routing/__tests__/single-draft-grant.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/single-draft-grant.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Reading an app-supplied draft decision as runtime input.
+ *
+ * `SingleDraftGrant` is what the hook is DECLARED to return, and a declared
+ * type is not a runtime guarantee — the hook is application code. Every case
+ * below is a value the type says cannot arrive, which is exactly why they are
+ * worth pinning: the cost of getting one wrong is a non-identity forwarded into
+ * a trusted read and judged as an identity.
+ */
+import { describe, expect, it } from "vitest";
+
+import { normalizeSingleDraftGrant } from "../single-route";
+
+describe("normalizeSingleDraftGrant", () => {
+  it("refuses on the falsy answers, including the ones the type forbids", () => {
+    expect(normalizeSingleDraftGrant(false)).toBeNull();
+    // A JavaScript hook that falls off the end, or returns null to mean "no".
+    expect(normalizeSingleDraftGrant(undefined)).toBeNull();
+    expect(normalizeSingleDraftGrant(null)).toBeNull();
+  });
+
+  it("grants without an identity on a bare true", () => {
+    // The route mounted behind the application's own auth: every visitor is
+    // already entitled to the draft, so it names nobody and judges by nobody.
+    expect(normalizeSingleDraftGrant(true)).toEqual({});
+  });
+
+  it("carries an identity when the grant names one", () => {
+    const readAs = { id: "u1", roles: ["editor"] };
+
+    expect(normalizeSingleDraftGrant({ readAs })).toEqual({ readAs });
+  });
+
+  // `typeof null === "object"`, so the obvious check is the wrong one. A null
+  // reaching the read as an identity is the case this exists to prevent.
+  it("grants without an identity when readAs is null", () => {
+    expect(normalizeSingleDraftGrant({ readAs: null })).toEqual({});
+  });
+
+  it("grants without an identity when readAs is not an object", () => {
+    // A hook returning the sharer's ID rather than their context. Forwarded, a
+    // string would be judged as a user object whose every property is absent —
+    // and absence can ALLOW, not merely strip.
+    expect(normalizeSingleDraftGrant({ readAs: "user-1" })).toEqual({});
+    expect(normalizeSingleDraftGrant({ readAs: 42 })).toEqual({});
+  });
+
+  it("refuses a non-object, non-boolean answer outright", () => {
+    // Neither a grant nor a refusal in the declared type. Treated as a refusal
+    // rather than as an empty grant: a hook answering nonsense has not
+    // authorized anything, and a draft is the expensive direction to guess in.
+    expect(normalizeSingleDraftGrant("yes")).toBeNull();
+    expect(normalizeSingleDraftGrant(1)).toBeNull();
+  });
+});

--- a/packages/nextly/src/runtime/routing/__tests__/single-route-preview-gate.integration.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/single-route-preview-gate.integration.test.ts
@@ -12,7 +12,12 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import { signPreviewToken } from "../../../auth/preview/preview-token";
-import { defineSingle, text } from "../../../config";
+import {
+  defineCollection,
+  defineSingle,
+  relationship,
+  text,
+} from "../../../config";
 import {
   createTestNextly,
   type TestNextly,
@@ -145,5 +150,81 @@ describe("createSingleRoute driven by previewSingleDraftGate", () => {
     >;
 
     expect(page.apiToken).toBe("secret-token");
+  });
+  // Relationship expansion has its own copy of the question, and the identity
+  // has to survive every rebuild on the way — the builder, the Single's own
+  // literal, and the conversion into the relationship service. A field dropped
+  // at any of them is a VALID access context describing a different caller:
+  // one whose related rows are judged by nobody. The rule below permits the
+  // anonymous bearer and denies the sharer precisely so those two readings
+  // cannot both pass.
+  it("judges a populated relationship as the sharer too", async () => {
+    const authors = defineCollection({
+      slug: "authors",
+      fields: [
+        text({ name: "slug" }),
+        text({
+          name: "name",
+          access: { read: ({ req }) => req.user === undefined },
+        }),
+      ],
+    });
+    const withOwner = defineSingle({
+      slug: "site-settings",
+      status: true,
+      versions: { drafts: true },
+      fields: [
+        text({ name: "siteName" }),
+        relationship({ name: "owner", relationTo: "authors" }),
+      ],
+    });
+    current = await createTestNextly({
+      singles: [withOwner],
+      collections: [authors],
+    });
+    const author = await current.nextly.create({
+      collection: "authors",
+      data: { slug: "ada", name: "Ada" },
+    });
+    await current.nextly.updateSingle({
+      slug: "site-settings",
+      data: {
+        siteName: "Acme",
+        owner: String(author.item.id),
+        status: "published",
+      },
+    });
+    // A PENDING edit on top, so the working-draft overlay is what the preview
+    // renders rather than the published row. The overlay expands its own
+    // relationships through a different builder, so a fixture that never
+    // produced one leaves that path unexercised.
+    await current.nextly.updateSingle({
+      slug: "site-settings",
+      data: { siteName: "Acme (pending)" },
+    });
+    const { token } = await signPreviewToken(
+      { kind: "single", single: "site-settings" },
+      SECRET,
+      {
+        generation: GENERATION,
+        minter: await sharer(current.nextly, PLAIN_EMAIL),
+      }
+    );
+
+    const page = (await route(current.nextly, token).SinglePage()) as Record<
+      string,
+      unknown
+    >;
+    const owner = page.owner as Record<string, unknown> | undefined;
+
+    // The RIGHT related row expanded — otherwise the assertion below is
+    // satisfied by there being no related row at all, which is the absence that
+    // reads as a pass.
+    // The OVERLAY won, so what follows is about the draft's own expansion.
+    expect(page.siteName).toBe("Acme (pending)");
+    expect(owner?.id).toBe(String(author.item.id));
+    // And it was judged as the SHARER, whom the rule denies, rather than as the
+    // anonymous bearer, whom it permits.
+    expect(owner?.name).toBeUndefined();
   });
 });

--- a/packages/nextly/src/runtime/routing/__tests__/single-route-preview-gate.integration.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/single-route-preview-gate.integration.test.ts
@@ -1,0 +1,149 @@
+/**
+ * The join between a preview token and a real Single route.
+ *
+ * The Single half of `content-route-preview-gate.integration.test.ts`, and it
+ * exists for the same reason: every unit test in this area mocks the identity
+ * away, so none of them can observe field rules actually running inside the
+ * read. What that hid is the defect this file covers — a granted draft read is
+ * TRUSTED so the working draft appears at all, and trust switched field-level
+ * read rules off with it, so the document came back carrying every field
+ * including any the person who shared the link cannot see.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { signPreviewToken } from "../../../auth/preview/preview-token";
+import { defineSingle, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { PREVIEW_SCOPE_COOKIE } from "../../preview/preview-route";
+import { previewSingleDraftGate } from "../../preview/preview-single-draft-gate";
+import { createSingleRoute } from "../single-route";
+
+const SECRET = "single-route-preview-gate-secret-32chars!!";
+const GENERATION = 1;
+const PRIVILEGED_EMAIL = "privileged@example.com";
+const PLAIN_EMAIL = "plain@example.com";
+
+const settings = () =>
+  defineSingle({
+    slug: "site-settings",
+    status: true,
+    versions: { drafts: true },
+    fields: [
+      text({ name: "siteName" }),
+      // A field ONE person can read. The link is supposed to show what its
+      // SENDER can see, so the same draft has to come back differently
+      // depending on who shared it.
+      text({
+        name: "apiToken",
+        access: { read: ({ req }) => req.user?.email === PRIVILEGED_EMAIL },
+      }),
+    ],
+  });
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+/**
+ * A real, ACTIVE user to mint links as.
+ *
+ * Not a placeholder id: the gate resolves the sharer's identity so the document
+ * can be judged by their field rules, and an id that resolves to nobody fails
+ * closed. A user created through this API is inactive until an invite is
+ * accepted, and an inactive account cannot open a session — so a fixture that
+ * left the default would test the refusal path while claiming to test a
+ * preview.
+ */
+async function sharer(
+  nextly: TestNextly["nextly"],
+  email: string
+): Promise<string> {
+  const created = await nextly.users.create({
+    email,
+    password: "PreviewTest123!",
+    data: { name: "Sharer", isActive: true },
+  });
+  return String(created.item.id);
+}
+
+function cookies(token?: string) {
+  return () => ({
+    get: (name: string) =>
+      name === PREVIEW_SCOPE_COOKIE && token !== undefined
+        ? { value: encodeURIComponent(token) }
+        : undefined,
+  });
+}
+
+function route(nextly: TestNextly["nextly"], token?: string) {
+  return createSingleRoute({
+    slug: "site-settings",
+    nextly,
+    render: (document: Record<string, unknown>) => document,
+    draft: previewSingleDraftGate({
+      secret: SECRET,
+      generation: GENERATION,
+      cookies: cookies(token),
+    }),
+  });
+}
+
+async function seed(nextly: TestNextly["nextly"]): Promise<void> {
+  await nextly.updateSingle({
+    slug: "site-settings",
+    data: { siteName: "Acme", apiToken: "secret-token" },
+  });
+}
+
+describe("createSingleRoute driven by previewSingleDraftGate", () => {
+  it("hides a field the sharer cannot read", async () => {
+    current = await createTestNextly({ singles: [settings()] });
+    await seed(current.nextly);
+    const { token } = await signPreviewToken(
+      { kind: "single", single: "site-settings" },
+      SECRET,
+      {
+        generation: GENERATION,
+        minter: await sharer(current.nextly, PLAIN_EMAIL),
+      }
+    );
+
+    const page = (await route(current.nextly, token).SinglePage()) as Record<
+      string,
+      unknown
+    >;
+
+    expect(page.apiToken).toBeUndefined();
+    // Field-scoped, not a blanked document: a redaction that stripped
+    // everything would satisfy the line above while breaking every preview.
+    expect(page.siteName).toBe("Acme");
+  });
+
+  // The positive control, and it is what separates "the rules ran and denied"
+  // from "the rules ran as nobody and denied everything". Same document, same
+  // route, same field — a different sender.
+  it("shows that same field to a sharer who can read it", async () => {
+    current = await createTestNextly({ singles: [settings()] });
+    await seed(current.nextly);
+    const { token } = await signPreviewToken(
+      { kind: "single", single: "site-settings" },
+      SECRET,
+      {
+        generation: GENERATION,
+        minter: await sharer(current.nextly, PRIVILEGED_EMAIL),
+      }
+    );
+
+    const page = (await route(current.nextly, token).SinglePage()) as Record<
+      string,
+      unknown
+    >;
+
+    expect(page.apiToken).toBe("secret-token");
+  });
+});

--- a/packages/nextly/src/runtime/routing/single-route.ts
+++ b/packages/nextly/src/runtime/routing/single-route.ts
@@ -60,6 +60,56 @@ export type NextlySingleReader = Pick<Nextly, "findSingle">;
  * collection path there is no id to resolve and nothing to compare afterwards —
  * the slug IS the identity, and the gate settles the whole question.
  */
+/**
+ * What a Single route's `draft` hook may answer.
+ *
+ * `false` refuses, and an object grants. The object exists so a grant can name
+ * WHOSE field-level read rules the document is judged by: a granted draft read
+ * is trusted, and trust switched field rules off with it, so the document came
+ * back carrying every field — including any the person who shared the link
+ * cannot see. A link was therefore a way to read past your own permissions by
+ * sending yourself one.
+ *
+ * A bare `true` still grants, for a route mounted behind the application's own
+ * auth where every visitor is already entitled to the draft. It names nobody,
+ * so it judges by nobody, which is the pre-existing behaviour it preserves.
+ *
+ * Mirrors `DraftGrant` on the collection route, which carries the same identity
+ * beside the entry id it has to name.
+ */
+export type SingleDraftGrant = boolean | { readAs: UserContext };
+
+/** A normalized draft decision: `null` refuses, an object grants. */
+type SingleDraftGrantResult = { readAs?: UserContext } | null;
+
+/**
+ * Read an app-supplied draft decision as RUNTIME INPUT.
+ *
+ * `SingleDraftGrant` is what the decision is declared to return, and a declared
+ * type is not a runtime guarantee: the hook is application code, so a
+ * JavaScript caller can answer anything. A `readAs` that is not an object would
+ * otherwise be forwarded into the read as an identity and judged as one, and
+ * `typeof null === "object"` makes the obvious check the wrong one.
+ *
+ * Normalized to ONE shape so the reader has a single thing to consult rather
+ * than a three-way union threaded through every call: `null` refuses, an object
+ * grants, and `readAs` is present only when the grant genuinely named someone.
+ *
+ * Extracted rather than inlined because it is the part worth testing on its
+ * own — every branch here exists for a value the type says cannot arrive.
+ */
+export function normalizeSingleDraftGrant(
+  grant: unknown
+): SingleDraftGrantResult {
+  if (grant === false || grant === undefined || grant === null) return null;
+  if (grant === true) return {};
+  if (typeof grant !== "object") return null;
+  const readAs = (grant as { readAs?: unknown }).readAs;
+  return typeof readAs === "object" && readAs !== null
+    ? { readAs: readAs as UserContext }
+    : {};
+}
+
 export interface SingleDraftRequest {
   /** The Single's slug, as configured. */
   slug: string;
@@ -185,7 +235,9 @@ export interface SingleRouteConfig<TNode> {
    */
   draft?:
     | boolean
-    | ((request: SingleDraftRequest) => Promise<boolean> | boolean);
+    | ((
+        request: SingleDraftRequest
+      ) => Promise<SingleDraftGrant> | SingleDraftGrant);
   /**
    * Extra cache tags for a public route, beyond the Single's own.
    *
@@ -241,15 +293,17 @@ function buildSingleRoute<TNode>(
     ...(config.locale === undefined ? {} : { locale: config.locale }),
   };
 
-  /** Whether this request was granted the working draft. */
-  async function draftForThisRequest(): Promise<boolean> {
+  /** Whether this request was granted the working draft, and as whom. */
+  async function draftForThisRequest(): Promise<SingleDraftGrantResult> {
     const decision = config.draft;
-    if (decision === undefined || decision === false) return false;
-    if (decision === true) return true;
-    return decision({
-      slug: config.slug,
-      ...(config.locale === undefined ? {} : { locale: config.locale }),
-    });
+    if (decision === undefined || decision === false) return null;
+    if (decision === true) return {};
+    return normalizeSingleDraftGrant(
+      await decision({
+        slug: config.slug,
+        ...(config.locale === undefined ? {} : { locale: config.locale }),
+      })
+    );
   }
 
   /**
@@ -269,7 +323,8 @@ function buildSingleRoute<TNode>(
   // above: one is the bound, the other is that bound's identity.
   const trustedKey = [...trustedSet].sort().join(",");
 
-  function readArgs(draft: boolean) {
+  function readArgs(grant: SingleDraftGrantResult) {
+    const draft = grant !== null;
     return {
       slug: config.slug,
       // The bound travels WITH the widening. Passed on every read rather than
@@ -290,16 +345,27 @@ function buildSingleRoute<TNode>(
       // published resolves at all. Left alone otherwise: widening it for every
       // read would serve unpublished content to ordinary visitors.
       ...(draft ? { draft: true, status: "all" as const } : {}),
+      // The document stays trusted so the working draft appears at all; the
+      // FIELDS are judged as the person who granted it. Named beside `user`
+      // rather than folded into it, because that identity is a redaction basis
+      // and not the caller: every hook goes on seeing the anonymous visitor who
+      // is actually asking, and a hook-invented value need not be a declared
+      // field, so redaction could not take it back.
+      ...(grant?.readAs === undefined
+        ? {}
+        : { enforceFieldAccess: true, fieldAccessUser: grant.readAs }),
       ...(config.locale === undefined ? {} : { locale: config.locale }),
       ...(config.depth === undefined ? {} : { depth: config.depth }),
       ...(config.user === undefined ? {} : { user: config.user }),
     };
   }
 
-  async function read(draft: boolean): Promise<SingleDocument | null> {
+  async function read(
+    grant: SingleDraftGrantResult
+  ): Promise<SingleDocument | null> {
     const reader = config.nextly ?? getNextly();
     try {
-      const document = await reader.findSingle(readArgs(draft));
+      const document = await reader.findSingle(readArgs(grant));
       return document ?? null;
     } catch (error) {
       if (isMissOrDenied(error)) return null;
@@ -315,9 +381,9 @@ function buildSingleRoute<TNode>(
     // next, which turns a link scoped to one reviewer into a site-wide leak of
     // unpublished content. Bypassing the data cache alone does not opt out of
     // the route cache, which is why this marks the render dynamic as well.
-    if (draft) {
+    if (draft !== null) {
       markDynamic();
-      return read(true);
+      return read(draft);
     }
 
     if (!trusted) {
@@ -325,9 +391,9 @@ function buildSingleRoute<TNode>(
       // into a build-time prerender or held in the route cache. Bypassing the
       // data cache alone does not opt out of the route cache.
       markDynamic();
-      return read(false);
+      return read(null);
     }
-    return cachedFind(() => read(false), {
+    return cachedFind(() => read(null), {
       tags: [...nextlySingleTags(config.slug), ...(config.tags ?? [])],
       // The locale is part of the key: one Single serves a different document
       // per language, and a key that omitted it would serve whichever language

--- a/packages/nextly/src/runtime/routing/single-route.ts
+++ b/packages/nextly/src/runtime/routing/single-route.ts
@@ -102,12 +102,19 @@ export function normalizeSingleDraftGrant(
   grant: unknown
 ): SingleDraftGrantResult {
   if (grant === false || grant === undefined || grant === null) return null;
+  // The empty grant is reserved for a LITERAL `true`, and that reservation is
+  // the load-bearing part. An empty grant means "trusted read, judged by
+  // nobody" — correct only where the application has said every visitor may see
+  // the draft. An OBJECT grant is a hook trying to name someone, so a `readAs`
+  // that is missing, null, or a primitive is a hook that failed to: normalizing
+  // it to an empty grant would hand back the working draft with every field,
+  // which is the disclosure this whole path exists to close. It refuses.
   if (grant === true) return {};
   if (typeof grant !== "object") return null;
   const readAs = (grant as { readAs?: unknown }).readAs;
   return typeof readAs === "object" && readAs !== null
     ? { readAs: readAs as UserContext }
-    : {};
+    : null;
 }
 
 export interface SingleDraftRequest {

--- a/packages/nextly/src/runtime/routing/single-route.ts
+++ b/packages/nextly/src/runtime/routing/single-route.ts
@@ -112,9 +112,21 @@ export function normalizeSingleDraftGrant(
   if (grant === true) return {};
   if (typeof grant !== "object") return null;
   const readAs = (grant as { readAs?: unknown }).readAs;
-  return typeof readAs === "object" && readAs !== null
-    ? { readAs: readAs as UserContext }
-    : null;
+  // A non-null object can still name NOBODY. `UserContext` requires a string
+  // `id`, and an identity without one is judged as an anonymous-like user whose
+  // every property is absent — where a rule such as `user?.role !== "restricted"`
+  // PERMITS rather than denies. Absence is not the safe direction, so the id is
+  // required rather than assumed. Arrays are objects too, and name nobody.
+  if (
+    typeof readAs !== "object" ||
+    readAs === null ||
+    Array.isArray(readAs) ||
+    typeof (readAs as { id?: unknown }).id !== "string" ||
+    (readAs as { id: string }).id.trim() === ""
+  ) {
+    return null;
+  }
+  return { readAs: readAs as UserContext };
 }
 
 export interface SingleDraftRequest {

--- a/packages/nextly/src/services/collections/trust-bound.ts
+++ b/packages/nextly/src/services/collections/trust-bound.ts
@@ -117,6 +117,17 @@ export async function applyMediaTrustBound(
 export interface CallerOptions {
   user?: Record<string, unknown>;
   overrideAccess?: boolean;
+  /**
+   * Whether the caller asked for field-level read rules to be enforced despite
+   * being otherwise trusted, and whose rules to judge by.
+   *
+   * The pair travels together because neither means anything alone: an identity
+   * with nothing asking for enforcement is ignored, and enforcement naming
+   * nobody judges the anonymous caller. See
+   * {@link RelatedRowReadContext.fieldAccessUser}.
+   */
+  enforceFieldAccess?: boolean;
+  fieldAccessUser?: Record<string, unknown>;
   trusted?: (collection: string) => boolean;
   authenticatedScope?: AuthenticatedScope;
 }
@@ -135,6 +146,12 @@ export function expansionAccess(options: CallerOptions): RelatedRowReadContext {
   return {
     user: options.user,
     overrideAccess: options.overrideAccess,
+    // Carried for the reason this function exists at all: an expansion that
+    // rebuilt its own context and dropped these would be a VALID context
+    // describing a different caller — one whose related rows are judged by
+    // nobody. That is silent, and it is the direction that leaks.
+    enforceFieldAccess: options.enforceFieldAccess,
+    fieldAccessUser: options.fieldAccessUser,
     trusted: options.trusted,
     authenticatedScope: options.authenticatedScope,
   };


### PR DESCRIPTION
Closes the Single half of the preview field leak. Collections were repaired in #1172; this is the same defect on the Single path, and the three findings #1167 merged with unresolved.

## The defect

A granted draft read is TRUSTED — that is what lets the working draft appear at all, since the overlay is gated on edit capability while a preview route resolves anonymously. But ONE flag decided both document trust and FIELD trust, so trusting the document switched field-level read rules off with it and the page rendered every field. `single-route.ts` had `overrideAccess: trusted || draft` — character-for-character what `content-route.ts` had.

An editor denied a field could read it by sharing a link and opening it themselves.

## What changed

**`previewSingleDraftGate` answers a grant that NAMES the sharer** rather than a bare boolean, so `SingleRouteConfig.draft` now returns `SingleDraftGrant`. A literal `true` still grants, for a route mounted behind the application's own auth where every visitor is already entitled to the draft — it names nobody and judges by nobody, which is the previous behaviour it preserves.

**The identity is a redaction basis, never the caller.** The route passes it as `fieldAccessUser`, so every hook goes on seeing the anonymous visitor who is actually asking. A hook branching on the caller would otherwise produce an editor-only value for whoever holds the link — and worse than a denied field surviving, a value a hook invents need not correspond to any declared field, so redaction cannot take it back.

**Revocation reaches links already in circulation, and it takes two things.** The identity is re-read on every render, so a deleted or deactivated account stops rendering at once. But rebuilding an identity re-evaluates field rules and nothing else — the read still bypasses the Single's own document rules — so the render also re-asks the question the mint asked. `assertSinglePreviewable` takes `routeAuthorized` per call site for that reason: `true` for the mint, which runs behind the route's access gate, and `false` for a render, which is anonymous and has none. Hardcoding it would skip the only check that notices a withdrawn role.

**A link whose sender cannot be identified is refused** — a deleted or deactivated account, or a token minted before the claim existed. Rendering as nobody applies no field rules at all, which is the leak itself; the visitor sees the published document or a 404, the same as an expired link.

## Evidence

Every unit test in this area mocks the identity away, so none of them can observe field rules running inside the read. The proof is `single-route-preview-gate.integration.test.ts` — end to end through a real route, a real database and real users: the same draft, the same field, two senders. Hidden from the one the rule denies, shown to the one it allows. The positive control is what separates *the rules ran and denied* from *the rules ran as nobody and denied everything*, and `siteName` stays present so it is field-scoped rather than a blanked document.

Break-verified, each separately:

| break | goes red |
| --- | --- |
| route ignores the grant's identity | hides-the-field case |
| gate grants without naming anyone | hides-the-field case |
| re-authorization removed | revocation case |
| `routeAuthorized: true` on the render | revocation case |
| minter-less token honoured | legacy-token case |

The legacy-token case is hand-signed with the same derived key and no `mnt`, because the signer now refuses to produce one — asserted through the path that can be reached rather than against a shape this module can no longer make.

`normalizeSingleDraftGrant` is extracted and separately tested because the draft decision is application code: the declared return type is not a runtime guarantee, and `typeof null === "object"` makes the obvious check the wrong one. A `readAs` that is not an object would otherwise be forwarded into a trusted read and judged as an identity — and absence can ALLOW, not merely strip.

## Gates

`pnpm build`, `check-types`, `lint`, `check:comments` clean. `fallow audit` **pass**, zero introduced findings — it reported `fail` on the first attempt for CRAP on the normalisation branch, which is what prompted extracting and testing it rather than suppressing it. `nextly` suite at exactly the documented baseline: 360 failed / 32 files, no new failing file by name.

## Not in this PR

`single-query-service.ts` runs field-level `afterRead` hooks BEFORE its sole redaction pass, so a hook can copy a denied sibling into an allowed field. Pre-existing on `main` and unchanged by this PR — every enforced Single read has always had it. The obvious before-pass is wrong: it puts redaction ahead of the document-level decision, which reads the assembled document and would see a companion-backed field absent. Fixing it properly means either moving the field hooks after that decision or exposing the registry's evidence-restore, both behaviour changes deserving their own review. Analysis is on the #1172 thread.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview links now evaluate draft content using the sharer’s identity.
  * Field-level permissions are enforced during preview, hiding restricted fields while preserving accessible content.
  * Related records in preview content now respect the sharer’s access permissions.
  * Single draft routes support identity-aware access grants while preserving existing trusted draft behavior.

* **Bug Fixes**
  * Invalid, expired, or incomplete preview sessions are rejected consistently.
  * Preview access no longer incorrectly exposes restricted fields or related data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->