### PR TITLE
feat(builder): mount the breakpoint manager and persist the set

### DIFF
--- a/.changeset/set-your-sites-breakpoints.md
+++ b/.changeset/set-your-sites-breakpoints.md
@@ -1,0 +1,41 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+You can now set your site's breakpoints from the editor.
+
+A Breakpoints button in the top bar opens the manager, showing how many the site defines. Add the
+widths your styles should respond to, on the browser window or on a block's own container, and save
+— the canvas compiles against them immediately and every page follows.
+
+An id is fixed once saved, because it is the key your stored styles are filed under; renaming one
+would quietly detach every style on every page that uses it. Removing a breakpoint is not
+destructive either: styles filed under it simply stop applying, and come back if you add it again
+with the same id.
+
+The button stays unavailable until your saved styles have finished loading, so the dialog can never
+open on the defaults and save them over the breakpoints you already had.

--- a/packages/builder/src/breakpoint-dialog.test.tsx
+++ b/packages/builder/src/breakpoint-dialog.test.tsx
@@ -143,6 +143,85 @@ describe("saving", () => {
     await waitFor(() => expect(saveButton().disabled).toBe(false));
   });
 
+  it("refuses dismissal while a save is in flight", async () => {
+    /*
+     * Freezing the fields left three ways out untouched — Cancel, the content's
+     * X, and Escape — all of which arrive through `onOpenChange`. Taken during a
+     * pending write, the dialog unmounts with the draft: a refusal landing
+     * afterwards has nowhere to be shown, and reopening seeds from a read that
+     * has not caught up.
+     *
+     * Escape is exercised as well as the button, because they are different
+     * paths to the same callback and guarding only the one with a `disabled`
+     * attribute would leave the keyboard route open.
+     */
+    let settle: (value: undefined) => void = () => {};
+    const onSave = vi.fn(
+      () =>
+        new Promise<undefined>(resolve => {
+          settle = resolve;
+        })
+    );
+    const onOpenChange = vi.fn();
+    open(stored(), onSave, onOpenChange);
+
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    fireEvent.keyDown(document.body, { key: "Escape", code: "Escape" });
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    settle(undefined);
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it("awaits a THENABLE that is not the global Promise", async () => {
+    /*
+     * `instanceof Promise` answers about one realm. A promise from another
+     * window or iframe, or a conforming implementation that is not the global
+     * constructor, fails it — and the dialog then closes as though the write
+     * were synchronous, so a refusal arriving afterwards is neither shown nor
+     * handled.
+     *
+     * The fixture is a bare thenable rather than a subclass, because a subclass
+     * still passes `instanceof` and would leave this green against the defect.
+     */
+    const notYet = (): void => {};
+    let settle: (value: string | undefined) => void = notYet;
+    const thenable = {
+      then(resolve: (value: string | undefined) => void) {
+        settle = resolve;
+      },
+    };
+    const onOpenChange = vi.fn();
+    open(
+      stored(),
+      vi.fn(() => thenable as never),
+      onOpenChange
+    );
+
+    fireEvent.click(saveButton());
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(saveButton().disabled).toBe(true);
+
+    /*
+     * The POPULATION before the property. Assimilating a thenable calls its
+     * `then` on a MICROTASK, so settling synchronously here would invoke the
+     * placeholder above and assert nothing — the refusal would never be
+     * delivered and the failure would read as the dialog ignoring it.
+     */
+    await waitFor(() => expect(settle).not.toBe(notYet));
+    settle("The server refused this.");
+
+    await waitFor(() =>
+      expect(screen.getByText("The server refused this.")).toBeDefined()
+    );
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
   it("keeps the draft on screen when the save is REFUSED", async () => {
     /*
      * The case the whole change exists for. A refused write used to close the

--- a/packages/builder/src/breakpoint-dialog.test.tsx
+++ b/packages/builder/src/breakpoint-dialog.test.tsx
@@ -10,7 +10,13 @@
  * definition — the same silent loss the validation exists to prevent, arriving
  * through the screen that was supposed to prevent it.
  */
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { BreakpointDialog } from "./breakpoint-dialog";
@@ -23,11 +29,11 @@ function stored(): BreakpointSet {
   };
 }
 
-function open(value: BreakpointSet, onSave = vi.fn()) {
+function open(value: BreakpointSet, onSave = vi.fn(), onOpenChange = vi.fn()) {
   render(
     <BreakpointDialog
       open
-      onOpenChange={vi.fn()}
+      onOpenChange={onOpenChange}
       value={value}
       onSave={onSave}
     />
@@ -40,9 +46,19 @@ function open(value: BreakpointSet, onSave = vi.fn()) {
 // on the property under test.
 afterEach(cleanup);
 
+/*
+ * Matched on either label, because the button reports its own progress.
+ *
+ * Its accessible name becomes "Saving…" while a write is in flight, and that is
+ * deliberate rather than incidental: a disabled button whose text never changed
+ * tells a sighted author nothing is happening, and an `aria-label` pinned to the
+ * idle wording while the visible text moved on is the label-in-name mismatch
+ * WCAG 2.5.3 exists to prevent. The name changes because the button means
+ * something different.
+ */
 const saveButton = (): HTMLButtonElement =>
   screen.getByRole("button", {
-    name: "Save breakpoints",
+    name: /save breakpoints|saving/i,
   }) as HTMLButtonElement;
 
 describe("saving", () => {
@@ -60,6 +76,92 @@ describe("saving", () => {
     // Not `toEqual("768")`: a string passes a loose comparison and is exactly
     // the value the compiler discards.
     expect(typeof saved.viewport[0]?.maxWidth).toBe("number");
+  });
+
+  it("stays open until an async save settles, then closes", async () => {
+    /*
+     * The close is the destructive half. Until the write lands there is nothing
+     * anywhere else holding this draft, so closing on the click means a refusal
+     * arrives with the set already gone.
+     *
+     * Both moments are asserted, and the ORDER is the property: still open
+     * while the promise is pending, closed only once it resolves. Asserting the
+     * end state alone would pass against a dialog that closed immediately.
+     */
+    let settle: (value: undefined) => void = () => {};
+    const onSave = vi.fn(
+      () =>
+        new Promise<undefined>(resolve => {
+          settle = resolve;
+        })
+    );
+    const onOpenChange = vi.fn();
+    open(stored(), onSave, onOpenChange);
+
+    fireEvent.click(saveButton());
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).not.toHaveBeenCalled();
+    // And it says so, rather than looking idle while a write is in flight.
+    expect(saveButton().disabled).toBe(true);
+
+    settle(undefined);
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it("keeps the draft on screen when the save is REFUSED", async () => {
+    /*
+     * The case the whole change exists for. A refused write used to close the
+     * dialog anyway, discarding a set the author had just built by hand with
+     * nothing left to recover it from.
+     *
+     * Asserted on three things, because any one alone is satisfiable by a
+     * dialog that is simply broken: the reason is shown, the dialog did NOT
+     * close, and the edited value is still in its field.
+     */
+    const onSave = vi.fn(() => Promise.resolve("The server refused this."));
+    const onOpenChange = vi.fn();
+    open(stored(), onSave, onOpenChange);
+
+    fireEvent.change(screen.getByDisplayValue("991"), {
+      target: { value: "768" },
+    });
+    fireEvent.click(saveButton());
+
+    await waitFor(() =>
+      expect(screen.getByText("The server refused this.")).toBeDefined()
+    );
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.getByDisplayValue("768")).toBeDefined();
+  });
+
+  it("treats a REJECTION as a refusal, not as a save", async () => {
+    /*
+     * A host that throws is not following the contract, and the author's draft
+     * is not the place to make that point. An unhandled rejection would also
+     * leave the button disabled forever, so the settled state is asserted too.
+     */
+    const onSave = vi.fn(() => Promise.reject(new Error("Network down")));
+    const onOpenChange = vi.fn();
+    open(stored(), onSave, onOpenChange);
+
+    fireEvent.click(saveButton());
+
+    await waitFor(() => expect(screen.getByText("Network down")).toBeDefined());
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(saveButton().disabled).toBe(false);
+  });
+
+  it("closes at once for a host that saves synchronously", () => {
+    // The contract that already existed must not have grown a microtask: a host
+    // returning nothing is finished when the call returns.
+    const onOpenChange = vi.fn();
+    open(stored(), vi.fn(), onOpenChange);
+
+    fireEvent.click(saveButton());
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   it("is refused while a definition would be dropped", () => {

--- a/packages/builder/src/breakpoint-dialog.test.tsx
+++ b/packages/builder/src/breakpoint-dialog.test.tsx
@@ -110,6 +110,39 @@ describe("saving", () => {
     await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
   });
 
+  it("freezes the form while a save is in flight", async () => {
+    /*
+     * The request carries the draft as it was at the click. Left editable, an
+     * edit made before the promise settles is not in that request AND is
+     * discarded by the close that follows it — the author watches their own
+     * change vanish into a save that reported success.
+     *
+     * Asserted on an attempted EDIT, not only on a disabled attribute: a field
+     * can be visibly disabled and still accept a programmatic change, and the
+     * property that matters is that the value does not move.
+     */
+    let settle: (value: undefined) => void = () => {};
+    const onSave = vi.fn(
+      () =>
+        new Promise<undefined>(resolve => {
+          settle = resolve;
+        })
+    );
+    open(stored(), onSave);
+
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    const width = screen.getByDisplayValue("991");
+    fireEvent.change(width, { target: { value: "640" } });
+
+    expect(screen.getByDisplayValue("991")).toBeDefined();
+    expect(screen.queryByDisplayValue("640")).toBeNull();
+
+    settle(undefined);
+    await waitFor(() => expect(saveButton().disabled).toBe(false));
+  });
+
   it("keeps the draft on screen when the save is REFUSED", async () => {
     /*
      * The case the whole change exists for. A refused write used to close the

--- a/packages/builder/src/breakpoint-dialog.tsx
+++ b/packages/builder/src/breakpoint-dialog.tsx
@@ -225,11 +225,22 @@ export function BreakpointDialog({
     [draft]
   );
 
+  /*
+   * Every edit is refused while a save is in flight, and the fields say so.
+   *
+   * The request carries the draft as it was at the click. Left editable, a
+   * change made in the window before the promise settles is not in that
+   * request AND is discarded by the close that follows it — the author watches
+   * their own edit vanish into a save that reported success. Freezing the form
+   * is what makes "the set that was submitted" and "the set on screen" the same
+   * thing at every moment the dialog is open.
+   */
   const updateRow = (
     axis: BreakpointAxis,
     key: string,
     patch: Partial<DraftRow>
   ): void => {
+    if (saving) return;
     setDraft(current => ({
       ...current,
       [axis]: current[axis].map(row =>
@@ -239,6 +250,7 @@ export function BreakpointDialog({
   };
 
   const addRow = (axis: BreakpointAxis): void => {
+    if (saving) return;
     setDraft(current => ({
       ...current,
       [axis]: [
@@ -255,6 +267,7 @@ export function BreakpointDialog({
   };
 
   const removeRow = (axis: BreakpointAxis, key: string): void => {
+    if (saving) return;
     setDraft(current => ({
       ...current,
       [axis]: current[axis].filter(row => row.key !== key),
@@ -348,6 +361,7 @@ export function BreakpointDialog({
                       >
                         <Field
                           id={`${fieldId}-${row.key}-label`}
+                          readOnly={saving}
                           label="Name"
                           hideLabel={index > 0}
                           value={row.label}
@@ -371,7 +385,7 @@ export function BreakpointDialog({
                           // every style on every page that uses it, silently.
                           // Removing the breakpoint and adding a new one is
                           // the same operation with the loss made visible.
-                          readOnly={!row.isNew}
+                          readOnly={!row.isNew || saving}
                           hint={
                             row.isNew
                               ? undefined
@@ -381,6 +395,7 @@ export function BreakpointDialog({
                         />
                         <Field
                           id={`${fieldId}-${row.key}-width`}
+                          readOnly={saving}
                           label="Up to"
                           hideLabel={index > 0}
                           value={row.width}
@@ -401,6 +416,7 @@ export function BreakpointDialog({
                             index === 0 && "sm:mt-6"
                           )}
                           aria-label={`Remove ${row.label.trim() || "breakpoint"}`}
+                          disabled={saving}
                           onClick={() => removeRow(axis, row.key)}
                         >
                           <Trash2 className="size-4" />
@@ -415,7 +431,7 @@ export function BreakpointDialog({
                     type="button"
                     variant="outline"
                     size="sm"
-                    disabled={atLimit}
+                    disabled={atLimit || saving}
                     onClick={() => addRow(axis)}
                   >
                     <Plus className="size-4" />

--- a/packages/builder/src/breakpoint-dialog.tsx
+++ b/packages/builder/src/breakpoint-dialog.tsx
@@ -53,8 +53,19 @@ export interface BreakpointDialogProps {
    *
    * Only ever called with a set that produces no issues, so a host does not
    * have to re-validate before storing it.
+   *
+   * **A promise is awaited, and the dialog stays open until it settles.** A host
+   * that persists over the network resolves with a message when the write was
+   * refused, and the draft is still on screen to retry or copy from. Closing on
+   * the click instead — which this did — threw away a set the author had just
+   * built by hand the moment a save failed, with nothing left to recover it
+   * from: the dialog was gone, the draft with it, and the site's breakpoints
+   * unchanged.
+   *
+   * Resolving with `undefined`, or returning nothing at all, means saved. A
+   * synchronous host needs no change.
    */
-  onSave: (next: BreakpointSet) => void;
+  onSave: (next: BreakpointSet) => void | Promise<string | undefined>;
 }
 
 /** A draft row. Width is held as TEXT while editing. */
@@ -178,6 +189,17 @@ export function BreakpointDialog({
   // the module has been rendered.
   const addedRows = React.useRef(0);
   const wasOpen = React.useRef(open);
+  /*
+   * Whether a save is in flight, and why the last one was refused.
+   *
+   * Derived here rather than taken as props. A `saving` prop can disagree with
+   * the promise this component is actually awaiting — a host that forgets to
+   * clear it leaves the dialog permanently disabled with no way to close the
+   * loop — and the only thing that knows when THIS save settled is the promise
+   * returned to THIS click.
+   */
+  const [saving, setSaving] = React.useState(false);
+  const [refusal, setRefusal] = React.useState<string | undefined>(undefined);
 
   // Re-seeded on the CLOSED-to-OPEN transition only. Depending on `value`
   // itself would reseed on any parent render that rebuilt it — a background
@@ -188,6 +210,10 @@ export function BreakpointDialog({
     wasOpen.current = open;
     if (!opening) return;
     addedRows.current = 0;
+    // Cleared with the draft it belonged to. A refusal left standing would
+    // describe a set the author is no longer looking at, and reopening after a
+    // failed save would show a stale reason for a draft that has been reseeded.
+    setRefusal(undefined);
     setDraft({
       viewport: toDraft("viewport", value.viewport),
       container: toDraft("container", value.container),
@@ -236,9 +262,40 @@ export function BreakpointDialog({
   };
 
   const save = (): void => {
-    if (issues.length > 0) return;
-    onSave(toSet(draft));
-    onOpenChange(false);
+    if (issues.length > 0 || saving) return;
+    setRefusal(undefined);
+    const outcome = onSave(toSet(draft));
+    // A synchronous host is finished here, and awaiting its `undefined` would
+    // still cost a microtask — long enough to paint a disabled button that has
+    // nothing to wait for.
+    if (!(outcome instanceof Promise)) {
+      onOpenChange(false);
+      return;
+    }
+    setSaving(true);
+    void outcome
+      .then(message => {
+        if (message === undefined) {
+          onOpenChange(false);
+          return;
+        }
+        setRefusal(message);
+      })
+      .catch((reason: unknown) => {
+        /*
+         * A rejection is a refusal too, and the dialog must not close on one.
+         * A host that throws rather than resolving is not following the
+         * contract, but the author's draft is not the place to make that point.
+         */
+        setRefusal(
+          reason instanceof Error
+            ? reason.message
+            : "These breakpoints could not be saved."
+        );
+      })
+      .finally(() => {
+        setSaving(false);
+      });
   };
 
   return (
@@ -381,15 +438,26 @@ export function BreakpointDialog({
           <p
             className={cn(
               "text-xs",
-              issues.length > 0 ? "text-destructive" : "text-muted-foreground"
+              issues.length > 0 || refusal !== undefined
+                ? "text-destructive"
+                : "text-muted-foreground"
             )}
             // Announced rather than only coloured, so the reason Save is
             // unavailable reaches a screen reader too.
             role="status"
           >
-            {issues.length === 0
-              ? "Every breakpoint is usable."
-              : `${issues.length} ${issues.length === 1 ? "problem" : "problems"} to fix before saving.`}
+            {/*
+             * A REFUSAL outranks the issue count, because they answer different
+             * questions and only one of them is news. The count says what the
+             * author must fix before saving; a refusal says the save they just
+             * made did not happen. Showing "Every breakpoint is usable." beside
+             * a failed write — which is what the count says at that moment,
+             * truthfully — would read as confirmation.
+             */}
+            {refusal ??
+              (issues.length === 0
+                ? "Every breakpoint is usable."
+                : `${issues.length} ${issues.length === 1 ? "problem" : "problems"} to fix before saving.`)}
           </p>
           <div className="flex gap-2">
             <Button
@@ -399,8 +467,12 @@ export function BreakpointDialog({
             >
               Cancel
             </Button>
-            <Button type="button" disabled={issues.length > 0} onClick={save}>
-              Save breakpoints
+            <Button
+              type="button"
+              disabled={issues.length > 0 || saving}
+              onClick={save}
+            >
+              {saving ? "Saving…" : "Save breakpoints"}
             </Button>
           </div>
         </DialogFooter>

--- a/packages/builder/src/breakpoint-dialog.tsx
+++ b/packages/builder/src/breakpoint-dialog.tsx
@@ -68,6 +68,20 @@ export interface BreakpointDialogProps {
   onSave: (next: BreakpointSet) => void | Promise<string | undefined>;
 }
 
+/**
+ * Whether a value can be awaited, without asking which realm made it.
+ *
+ * `instanceof Promise` is a check about one global constructor, and the values
+ * this has to recognise may not come from it.
+ */
+function isThenable(value: unknown): value is PromiseLike<string | undefined> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === "function"
+  );
+}
+
 /** A draft row. Width is held as TEXT while editing. */
 interface DraftRow {
   /**
@@ -278,15 +292,26 @@ export function BreakpointDialog({
     if (issues.length > 0 || saving) return;
     setRefusal(undefined);
     const outcome = onSave(toSet(draft));
-    // A synchronous host is finished here, and awaiting its `undefined` would
-    // still cost a microtask — long enough to paint a disabled button that has
-    // nothing to wait for.
-    if (!(outcome instanceof Promise)) {
+    /*
+     * A THENABLE, not an `instanceof Promise`.
+     *
+     * The contract accepts a promise, and `instanceof` answers about one realm:
+     * a promise from another window or iframe, or a conforming implementation
+     * that is not the global constructor, fails the test. The dialog would then
+     * close as though the write were synchronous, and a refusal or rejection
+     * arriving afterwards would be neither shown nor handled — the exact loss
+     * the await exists to prevent, restored by the check meant to detect it.
+     *
+     * A synchronous host is still finished here, and awaiting its `undefined`
+     * would cost a microtask — long enough to paint a disabled button with
+     * nothing to wait for.
+     */
+    if (!isThenable(outcome)) {
       onOpenChange(false);
       return;
     }
     setSaving(true);
-    void outcome
+    void Promise.resolve(outcome)
       .then(message => {
         if (message === undefined) {
           onOpenChange(false);
@@ -311,8 +336,23 @@ export function BreakpointDialog({
       });
   };
 
+  /*
+   * Dismissal is refused while a save is in flight, for the reason the frozen
+   * fields are.
+   *
+   * Freezing the inputs left three ways out untouched — Cancel, the shared
+   * content's X, and Escape, all of which arrive here. Taken during a pending
+   * write, the dialog unmounts with the draft: a refusal that lands afterwards
+   * has nowhere to be shown, and reopening seeds from a read that has not
+   * caught up, so submitting that draft overwrites the write still in flight.
+   */
+  const requestOpenChange = (next: boolean): void => {
+    if (saving && !next) return;
+    onOpenChange(next);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={requestOpenChange}>
       <DialogContent className="max-w-3xl">
         <DialogHeader>
           <DialogTitle>Breakpoints</DialogTitle>
@@ -479,7 +519,8 @@ export function BreakpointDialog({
             <Button
               type="button"
               variant="outline"
-              onClick={() => onOpenChange(false)}
+              disabled={saving}
+              onClick={() => requestOpenChange(false)}
             >
               Cancel
             </Button>

--- a/packages/builder/src/breakpoint-manager.test.tsx
+++ b/packages/builder/src/breakpoint-manager.test.tsx
@@ -50,7 +50,7 @@ describe("the breakpoint trigger", () => {
      * button can be disabled and still have had its dialog mounted beside it.
      */
     render(
-      <BreakpointManager value={empty()} onSave={vi.fn()} ready={false} />
+      <BreakpointManager value={empty()} onSave={vi.fn()} status="loading" />
     );
 
     expect(trigger().disabled).toBe(true);
@@ -58,10 +58,76 @@ describe("the breakpoint trigger", () => {
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 
+  it("says UNAVAILABLE after a failed read, not still loading", () => {
+    /*
+     * Both non-ready states withhold the dialog for the same reason — the value
+     * in hand is the host's config defaults — but they are not the same thing to
+     * say. Told "still loading" after a permission denial or a dropped request,
+     * an author waits for something that already finished, and the only signal
+     * they have says to keep waiting.
+     *
+     * Asserted against the loading wording as well as for its own, so a state
+     * that merely fell through to the same string would fail.
+     */
+    render(
+      <BreakpointManager
+        value={empty()}
+        onSave={vi.fn()}
+        status="unavailable"
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Breakpoints: unavailable" })
+    ).toBeDefined();
+    expect(
+      screen.queryByRole("button", { name: "Breakpoints: still loading" })
+    ).toBeNull();
+    // And it is still withheld, which is the property the wording qualifies.
+    expect(trigger().disabled).toBe(true);
+  });
+
+  it("does not release the hold when the host rebuilds an EQUAL value", async () => {
+    /*
+     * The counterpart to the resurrection case, and the reason the release is
+     * asked of content rather than identity: the prop contract does not promise
+     * a stable reference, so a parent render that rebuilds an equal object is
+     * within its rights. Released on that, the hold lifts before the read has
+     * moved at all, and reopening seeds the dialog from the old set.
+     *
+     * The rebuilt value is a fresh object with the SAME contents, which is
+     * exactly what identity comparison cannot tell from a real change.
+     */
+    const onSave = vi.fn((_next: BreakpointSet) => Promise.resolve(undefined));
+    const { rerender } = render(
+      <BreakpointManager value={defined()} onSave={onSave} status="ready" />
+    );
+
+    fireEvent.click(trigger());
+    fireEvent.click(screen.getByRole("button", { name: "Remove Mobile" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /save breakpoints|saving/i })
+    );
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+
+    // A fresh object, equal in content — the read has NOT caught up.
+    rerender(
+      <BreakpointManager value={defined()} onSave={onSave} status="ready" />
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Breakpoints: 1 defined" })
+      ).toBeDefined()
+    );
+  });
+
   it("opens once it HAS been read, which is the control", () => {
     // Without this, a manager that never opened would satisfy the case above
     // and the feature would be unreachable rather than merely gated.
-    render(<BreakpointManager value={defined()} onSave={vi.fn()} ready />);
+    render(
+      <BreakpointManager value={defined()} onSave={vi.fn()} status="ready" />
+    );
 
     expect(trigger().disabled).toBe(false);
     fireEvent.click(trigger());
@@ -74,7 +140,9 @@ describe("the breakpoint trigger", () => {
      * otherwise reaches a button called "Breakpoints" that gives no hint whether
      * the site has any, which is the one thing the label is worth showing.
      */
-    render(<BreakpointManager value={defined()} onSave={vi.fn()} ready />);
+    render(
+      <BreakpointManager value={defined()} onSave={vi.fn()} status="ready" />
+    );
 
     expect(
       screen.getByRole("button", { name: "Breakpoints: 2 defined" })
@@ -84,7 +152,9 @@ describe("the breakpoint trigger", () => {
   it("reports ZERO for a site that has defined none", () => {
     // The state the count exists to distinguish, and the one an off-by-one
     // counting the base context would report as "1 breakpoint".
-    render(<BreakpointManager value={empty()} onSave={vi.fn()} ready />);
+    render(
+      <BreakpointManager value={empty()} onSave={vi.fn()} status="ready" />
+    );
 
     expect(
       screen.getByRole("button", { name: "Breakpoints: 0 defined" })
@@ -108,7 +178,9 @@ describe("the breakpoint trigger", () => {
       container: [],
     } as unknown as BreakpointSet;
 
-    render(<BreakpointManager value={withReserved} onSave={vi.fn()} ready />);
+    render(
+      <BreakpointManager value={withReserved} onSave={vi.fn()} status="ready" />
+    );
 
     expect(
       screen.getByRole("button", { name: "Breakpoints: 0 defined" })
@@ -140,7 +212,9 @@ describe("the breakpoint trigger", () => {
       container: [],
     } as unknown as BreakpointSet;
 
-    render(<BreakpointManager value={documented} onSave={vi.fn()} ready />);
+    render(
+      <BreakpointManager value={documented} onSave={vi.fn()} status="ready" />
+    );
 
     // The count follows the same rule, so the two cannot disagree. Asserted
     // BEFORE opening: the dialog takes the page out of the accessibility tree
@@ -181,7 +255,9 @@ describe("the breakpoint trigger", () => {
     // records `[]`, and reading index 0 off it is a type error rather than the
     // assertion this test is making.
     const onSave = vi.fn((_next: BreakpointSet) => Promise.resolve(undefined));
-    render(<BreakpointManager value={defined()} onSave={onSave} ready />);
+    render(
+      <BreakpointManager value={defined()} onSave={onSave} status="ready" />
+    );
 
     expect(
       screen.getByRole("button", { name: "Breakpoints: 2 defined" })
@@ -228,7 +304,7 @@ describe("the breakpoint trigger", () => {
     const onSave = vi.fn((_next: BreakpointSet) => Promise.resolve(undefined));
 
     const { rerender } = render(
-      <BreakpointManager value={configObject} onSave={onSave} ready />
+      <BreakpointManager value={configObject} onSave={onSave} status="ready" />
     );
 
     fireEvent.click(trigger());
@@ -239,9 +315,13 @@ describe("the breakpoint trigger", () => {
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
 
     // The read moves — the hold must be released here, permanently.
-    rerender(<BreakpointManager value={other} onSave={onSave} ready />);
+    rerender(
+      <BreakpointManager value={other} onSave={onSave} status="ready" />
+    );
     // And then returns to the very object it was at the save.
-    rerender(<BreakpointManager value={configObject} onSave={onSave} ready />);
+    rerender(
+      <BreakpointManager value={configObject} onSave={onSave} status="ready" />
+    );
 
     await waitFor(() =>
       expect(
@@ -259,10 +339,12 @@ describe("the breakpoint trigger", () => {
      * boot.
      */
     const { rerender } = render(
-      <BreakpointManager value={empty()} onSave={vi.fn()} ready />
+      <BreakpointManager value={empty()} onSave={vi.fn()} status="ready" />
     );
 
-    rerender(<BreakpointManager value={defined()} onSave={vi.fn()} ready />);
+    rerender(
+      <BreakpointManager value={defined()} onSave={vi.fn()} status="ready" />
+    );
     fireEvent.click(trigger());
 
     expect(screen.getByDisplayValue("991")).toBeDefined();

--- a/packages/builder/src/breakpoint-manager.test.tsx
+++ b/packages/builder/src/breakpoint-manager.test.tsx
@@ -208,6 +208,48 @@ describe("the breakpoint trigger", () => {
     );
   });
 
+  it("does not resurrect an old write when the read returns to its old value", async () => {
+    /*
+     * The optimistic hold has to be CLEARED, not merely stopped being consulted.
+     *
+     * `resolveSiteStyle` hands back the host's config OBJECT when nothing is
+     * stored, and that reference is memoised — so a site that saves a set and
+     * later has the stored section cleared through the API or an import sees
+     * `value` return to the very object it was at the save. Left in state, the
+     * hold would match a second time and an old write would become authoritative
+     * over the truth the server and canvas had both moved back to.
+     *
+     * The same object is passed back deliberately: a fresh but equal one would
+     * not reproduce the defect, and the test would pass against the version that
+     * never clears.
+     */
+    const configObject = defined();
+    const other = empty();
+    const onSave = vi.fn((_next: BreakpointSet) => Promise.resolve(undefined));
+
+    const { rerender } = render(
+      <BreakpointManager value={configObject} onSave={onSave} ready />
+    );
+
+    fireEvent.click(trigger());
+    fireEvent.click(screen.getByRole("button", { name: "Remove Mobile" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /save breakpoints|saving/i })
+    );
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+
+    // The read moves — the hold must be released here, permanently.
+    rerender(<BreakpointManager value={other} onSave={onSave} ready />);
+    // And then returns to the very object it was at the save.
+    rerender(<BreakpointManager value={configObject} onSave={onSave} ready />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Breakpoints: 2 defined" })
+      ).toBeDefined()
+    );
+  });
+
   it("seeds the dialog from the set it is given WHEN OPENED", () => {
     /*
      * Mounting the dialog only while open is what makes this true. Kept

--- a/packages/builder/src/breakpoint-manager.test.tsx
+++ b/packages/builder/src/breakpoint-manager.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+/**
+ * What the trigger is responsible for, which is narrower than it looks.
+ *
+ * The dialog has its own suite and the validation has another; what is only
+ * true here is the GATE — that a manager whose saved set has not been read yet
+ * cannot be opened — and the count the trigger reports. Both are the kind of
+ * thing that looks obviously right and is satisfied by a component that does
+ * nothing at all, so each is asserted against its own opposite.
+ *
+ * @module breakpoint-manager.test
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BreakpointManager } from "./breakpoint-manager";
+import type { BreakpointSet } from "./breakpoints";
+
+afterEach(cleanup);
+
+const defined = (): BreakpointSet => ({
+  viewport: [
+    { id: "tablet", label: "Tablet", maxWidth: 991 },
+    { id: "mobile", label: "Mobile", maxWidth: 575 },
+  ],
+  container: [],
+});
+
+const empty = (): BreakpointSet => ({ viewport: [], container: [] });
+
+const trigger = (): HTMLButtonElement =>
+  screen.getByRole("button", { name: /breakpoints/i }) as HTMLButtonElement;
+
+describe("the breakpoint trigger", () => {
+  it("cannot be opened before the saved set has been read", () => {
+    /*
+     * The gate that matters, and the reason it is not cosmetic: until the
+     * stored style answers, the value passed here is the host's CONFIG
+     * DEFAULTS. Opening on it would show a set the site never chose, and saving
+     * from that draft would overwrite the site's real breakpoints with defaults
+     * the author never saw.
+     *
+     * Asserted on the dialog's absence as well as the disabled attribute — a
+     * button can be disabled and still have had its dialog mounted beside it.
+     */
+    render(
+      <BreakpointManager value={empty()} onSave={vi.fn()} ready={false} />
+    );
+
+    expect(trigger().disabled).toBe(true);
+    fireEvent.click(trigger());
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("opens once it HAS been read, which is the control", () => {
+    // Without this, a manager that never opened would satisfy the case above
+    // and the feature would be unreachable rather than merely gated.
+    render(<BreakpointManager value={defined()} onSave={vi.fn()} ready />);
+
+    expect(trigger().disabled).toBe(false);
+    fireEvent.click(trigger());
+    expect(screen.getByRole("dialog")).toBeDefined();
+  });
+
+  it("says how many the site defines, in the accessible name", () => {
+    /*
+     * In the NAME rather than only in the glyph beside it: a screen-reader user
+     * otherwise reaches a button called "Breakpoints" that gives no hint whether
+     * the site has any, which is the one thing the label is worth showing.
+     */
+    render(<BreakpointManager value={defined()} onSave={vi.fn()} ready />);
+
+    expect(
+      screen.getByRole("button", { name: "Breakpoints: 2 defined" })
+    ).toBeDefined();
+  });
+
+  it("reports ZERO for a site that has defined none", () => {
+    // The state the count exists to distinguish, and the one an off-by-one
+    // counting the base context would report as "1 breakpoint".
+    render(<BreakpointManager value={empty()} onSave={vi.fn()} ready />);
+
+    expect(
+      screen.getByRole("button", { name: "Breakpoints: 0 defined" })
+    ).toBeDefined();
+  });
+
+  it("does not count a stored definition using the reserved base id", () => {
+    /*
+     * Not reachable through the dialog, and reachable through the record.
+     * `validateBreakpoints` refuses to SAVE a definition whose id is `base`, so
+     * the editor cannot produce one — but the site style is an ordinary stored
+     * single that the API, an import or a migration can write directly, and the
+     * value here is read from that record rather than from the dialog.
+     *
+     * Counted, the reserved id inflates the total by one, and it does so for a
+     * site that has defined no breakpoints at all — reporting "1" for the exact
+     * state the label exists to distinguish from having some.
+     */
+    const withReserved = {
+      viewport: [{ id: "base", label: "Base", maxWidth: undefined }],
+      container: [],
+    } as unknown as BreakpointSet;
+
+    render(<BreakpointManager value={withReserved} onSave={vi.fn()} ready />);
+
+    expect(
+      screen.getByRole("button", { name: "Breakpoints: 0 defined" })
+    ).toBeDefined();
+  });
+
+  it("seeds the dialog from the set it is given WHEN OPENED", () => {
+    /*
+     * Mounting the dialog only while open is what makes this true. Kept
+     * mounted, a set that arrived in the background — the stored read landing a
+     * moment after the editor booted is exactly that — would sit behind a
+     * closed dialog, and the author would open it onto whatever was current at
+     * boot.
+     */
+    const { rerender } = render(
+      <BreakpointManager value={empty()} onSave={vi.fn()} ready />
+    );
+
+    rerender(<BreakpointManager value={defined()} onSave={vi.fn()} ready />);
+    fireEvent.click(trigger());
+
+    expect(screen.getByDisplayValue("991")).toBeDefined();
+  });
+});

--- a/packages/builder/src/breakpoint-manager.test.tsx
+++ b/packages/builder/src/breakpoint-manager.test.tsx
@@ -10,7 +10,13 @@
  *
  * @module breakpoint-manager.test
  */
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { BreakpointManager } from "./breakpoint-manager";
@@ -107,6 +113,99 @@ describe("the breakpoint trigger", () => {
     expect(
       screen.getByRole("button", { name: "Breakpoints: 0 defined" })
     ).toBeDefined();
+  });
+
+  it("hides a stored base row, which would otherwise deadlock Save", () => {
+    /*
+     * The plugin's own README documents a host config carrying
+     * `{ id: "base", label: "Base" }`, and a stored set can carry one too —
+     * while `validateBreakpoints` reports that id as RESERVED, because the
+     * compiler claims it before reading any stored definition.
+     *
+     * Passed through, the dialog renders it as an ordinary read-only row and
+     * Save stays disabled for as long as it is there: an author on the
+     * documented configuration cannot save breakpoints at all until they delete
+     * a row the interface presents as built in.
+     *
+     * Asserted on Save being ENABLED rather than only on the row's absence. The
+     * absence is the mechanism; being able to save is the property, and a
+     * future change that hid the row while still validating it would pass an
+     * absence check and leave the deadlock exactly where it was.
+     */
+    const documented = {
+      viewport: [
+        { id: "base", label: "Base" },
+        { id: "tablet", label: "Tablet", maxWidth: 1024 },
+      ],
+      container: [],
+    } as unknown as BreakpointSet;
+
+    render(<BreakpointManager value={documented} onSave={vi.fn()} ready />);
+
+    // The count follows the same rule, so the two cannot disagree. Asserted
+    // BEFORE opening: the dialog takes the page out of the accessibility tree
+    // behind it, so the trigger is unreachable while it is up.
+    expect(
+      screen.getByRole("button", { name: "Breakpoints: 1 defined" })
+    ).toBeDefined();
+
+    fireEvent.click(trigger());
+
+    expect(screen.queryAllByDisplayValue("base")).toHaveLength(0);
+    expect(
+      (
+        screen.getByRole("button", {
+          name: /save breakpoints|saving/i,
+        }) as HTMLButtonElement
+      ).disabled
+    ).toBe(false);
+  });
+
+  it("answers from the set it just wrote, not the stale read", async () => {
+    /*
+     * A successful write resolves before the query it invalidates has
+     * refetched, and the read reports `isPending` rather than background
+     * fetching — so for a moment `value` is still the PREVIOUS set while the
+     * trigger is ready and the dialog will reopen.
+     *
+     * Seeded from `value` there, an author who saves and immediately reopens
+     * sees the old set, and saving that draft overwrites the write that had
+     * just succeeded.
+     *
+     * Driven by REMOVING a row rather than adding one, because removal needs a
+     * single unambiguous control and leaves a set that is still valid — an
+     * added row is three empty fields, and a draft that never became savable
+     * would leave this passing on a save that never happened.
+     */
+    // Typed so the recorded call has a readable argument: an untyped `vi.fn`
+    // records `[]`, and reading index 0 off it is a type error rather than the
+    // assertion this test is making.
+    const onSave = vi.fn((_next: BreakpointSet) => Promise.resolve(undefined));
+    render(<BreakpointManager value={defined()} onSave={onSave} ready />);
+
+    expect(
+      screen.getByRole("button", { name: "Breakpoints: 2 defined" })
+    ).toBeDefined();
+
+    fireEvent.click(trigger());
+    fireEvent.click(screen.getByRole("button", { name: "Remove Mobile" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /save breakpoints|saving/i })
+    );
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(onSave.mock.calls[0]?.[0].viewport).toHaveLength(1);
+
+    /*
+     * `value` has NOT changed — the refetch has not landed — so the trigger
+     * must answer from what was written. Reading 2 here is the defect: it means
+     * the surface is still describing the set the write replaced.
+     */
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Breakpoints: 1 defined" })
+      ).toBeDefined()
+    );
   });
 
   it("seeds the dialog from the set it is given WHEN OPENED", () => {

--- a/packages/builder/src/breakpoint-manager.tsx
+++ b/packages/builder/src/breakpoint-manager.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+/**
+ * The editor's way in to the site's breakpoints.
+ *
+ * A TRIGGER plus the dialog, rather than the dialog alone, because open state
+ * is the only thing a host would have to invent to use it and every host would
+ * invent it the same way. What a host does have to supply is the pair this
+ * cannot know: the site's saved set, and how to write one.
+ *
+ * **In the top bar rather than in a left panel.** Breakpoints are site-wide and
+ * set rarely — an author defines them once and then works within them for
+ * months — so they do not earn a permanent region beside Insert and Layers,
+ * which are used on every edit. Every builder researched puts breakpoint
+ * management in the viewport chrome rather than in a content panel, and putting
+ * it there also means the manager sits where a breakpoint SWITCHER will go, so
+ * the two read as one control instead of two unrelated ones.
+ *
+ * @module breakpoint-manager
+ */
+
+import { Button } from "@nextlyhq/ui";
+import { MonitorSmartphone } from "lucide-react";
+import * as React from "react";
+
+import { BreakpointDialog } from "./breakpoint-dialog";
+import { BASE_BREAKPOINT, type BreakpointSet } from "./breakpoints";
+
+/**
+ * Props for BreakpointManager.
+ * @experimental
+ */
+export interface BreakpointManagerProps {
+  /** The site's saved breakpoints, as the canvas is compiled against them. */
+  value: BreakpointSet;
+  /**
+   * Persist the edited set. See {@link BreakpointDialogProps.onSave} — a promise
+   * is awaited and a resolved string is shown as a refusal.
+   */
+  onSave: (next: BreakpointSet) => void | Promise<string | undefined>;
+  /**
+   * Whether the SAVED set has actually been read yet.
+   *
+   * False while the stored site style is loading or could not be read, and the
+   * consequence is why this is a required input rather than an optional nicety.
+   * Until the read answers, `value` is the host's CONFIG DEFAULTS — so a dialog
+   * opened on it would show a set the site never chose, and saving from that
+   * draft would overwrite the site's real breakpoints with defaults the author
+   * never saw. The same gate the canvas and the provenance trace already apply,
+   * one surface over.
+   *
+   * Disabled rather than hidden: a control that vanishes while a request is in
+   * flight moves the buttons beside it under the pointer, and an author who
+   * knows the manager exists is left wondering whether the feature was removed.
+   */
+  ready: boolean;
+}
+
+/**
+ * How many breakpoints the site defines, for the trigger's own label.
+ *
+ * The base is not counted. It is not a definition an author added and cannot be
+ * removed, so including it would report "1 breakpoint" for a site that has
+ * defined none — the exact state the label exists to distinguish.
+ */
+function definedCount(value: BreakpointSet): number {
+  const axes = [value.viewport, value.container];
+  let count = 0;
+  for (const axis of axes) {
+    for (const def of axis ?? []) {
+      if (def?.id !== BASE_BREAKPOINT) count += 1;
+    }
+  }
+  return count;
+}
+
+/**
+ * The button that opens the breakpoint dialog, and the dialog.
+ * @experimental
+ */
+export function BreakpointManager({
+  value,
+  onSave,
+  ready,
+}: BreakpointManagerProps): React.JSX.Element {
+  const [open, setOpen] = React.useState(false);
+  const count = definedCount(value);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        disabled={!ready}
+        onClick={() => setOpen(true)}
+        /*
+         * The count is in the ACCESSIBLE name, not only in the glyph beside it.
+         * A screen-reader user otherwise reaches a button called "Breakpoints"
+         * that gives no hint whether the site has any — which is the single
+         * thing this label is worth showing.
+         */
+        aria-label={
+          ready ? `Breakpoints: ${count} defined` : "Breakpoints: still loading"
+        }
+        title={
+          ready
+            ? undefined
+            : "Available once the site's saved styles have loaded."
+        }
+      >
+        <MonitorSmartphone className="size-4" />
+        <span>Breakpoints</span>
+        {ready && count > 0 ? (
+          <span
+            className="text-muted-foreground tabular-nums"
+            // Already in the button's accessible name above, so announcing it
+            // again would read the number twice.
+            aria-hidden="true"
+          >
+            {count}
+          </span>
+        ) : null}
+      </Button>
+      {/*
+       * Mounted only while open, so the draft is seeded from `value` at the
+       * moment the author opens it. Kept mounted, a set that arrived or changed
+       * in the background would sit behind a closed dialog and the author would
+       * open it onto whatever was current when the editor booted.
+       */}
+      {open ? (
+        <BreakpointDialog
+          open
+          onOpenChange={setOpen}
+          value={value}
+          onSave={onSave}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/packages/builder/src/breakpoint-manager.tsx
+++ b/packages/builder/src/breakpoint-manager.tsx
@@ -24,7 +24,11 @@ import { MonitorSmartphone } from "lucide-react";
 import * as React from "react";
 
 import { BreakpointDialog } from "./breakpoint-dialog";
-import { authoredBreakpoints, type BreakpointSet } from "./breakpoints";
+import {
+  authoredBreakpoints,
+  sameBreakpoints,
+  type BreakpointSet,
+} from "./breakpoints";
 
 /**
  * Props for BreakpointManager.
@@ -39,21 +43,23 @@ export interface BreakpointManagerProps {
    */
   onSave: (next: BreakpointSet) => void | Promise<string | undefined>;
   /**
-   * Whether the SAVED set has actually been read yet.
+   * What the SAVED set's read has actually done — not merely whether it is done.
    *
-   * False while the stored site style is loading or could not be read, and the
-   * consequence is why this is a required input rather than an optional nicety.
-   * Until the read answers, `value` is the host's CONFIG DEFAULTS — so a dialog
-   * opened on it would show a set the site never chose, and saving from that
-   * draft would overwrite the site's real breakpoints with defaults the author
-   * never saw. The same gate the canvas and the provenance trace already apply,
-   * one surface over.
+   * Three states, because the two that are not `ready` need different words and
+   * a boolean cannot carry them. Until the read answers, `value` is the host's
+   * CONFIG DEFAULTS, so a dialog opened on it would show a set the site never
+   * chose and saving that draft would overwrite the site's real breakpoints with
+   * defaults the author never saw. That is true of a FAILED read as much as a
+   * pending one — which is why a `pending`-only gate is wrong — but the two are
+   * not the same thing to say. Told "still loading" after a permission denial,
+   * an author waits for a request that already finished.
    *
-   * Disabled rather than hidden: a control that vanishes while a request is in
-   * flight moves the buttons beside it under the pointer, and an author who
-   * knows the manager exists is left wondering whether the feature was removed.
+   * Disabled rather than hidden in both cases: a control that vanishes while a
+   * request is in flight moves the buttons beside it under the pointer, and an
+   * author who knows the manager exists is left wondering whether the feature
+   * was removed.
    */
-  ready: boolean;
+  status: "loading" | "unavailable" | "ready";
 }
 
 /**
@@ -63,8 +69,9 @@ export interface BreakpointManagerProps {
 export function BreakpointManager({
   value,
   onSave,
-  ready,
+  status,
 }: BreakpointManagerProps): React.JSX.Element {
+  const ready = status === "ready";
   const [open, setOpen] = React.useState(false);
   /*
    * The set this surface last wrote, held until the read catches up.
@@ -87,8 +94,27 @@ export function BreakpointManager({
     | { readonly wrote: BreakpointSet; readonly sawAtSave: BreakpointSet }
     | undefined
   >(undefined);
-  const stillStale =
-    pendingWrite !== undefined && pendingWrite.sawAtSave === value;
+  /*
+   * The hold survives exactly while the read has demonstrably not moved.
+   *
+   * Two earlier versions each failed in one direction, which is the tell that a
+   * third heuristic is the wrong answer. Waiting for the incoming set to MATCH
+   * what was written never ends if the server stored something else. Comparing
+   * object IDENTITY releases on any parent render that rebuilds an equal
+   * object, because the prop contract does not promise a stable reference.
+   *
+   * Both are answered by asking about CONTENT and accepting either outcome as
+   * an arrival: the read has caught up when it now equals what was written, and
+   * it has also caught up when it differs from what was there at the save. What
+   * is left — equal to the pre-save set and not to the written one — is the only
+   * state in which nothing has come back yet, so the hold cannot stick and
+   * cannot lift early.
+   */
+  const readArrived =
+    pendingWrite !== undefined &&
+    (sameBreakpoints(value, pendingWrite.wrote) ||
+      !sameBreakpoints(value, pendingWrite.sawAtSave));
+  const stillStale = pendingWrite !== undefined && !readArrived;
   /*
    * CLEARED once the read moves, not merely stopped being consulted.
    *
@@ -101,10 +127,8 @@ export function BreakpointManager({
    * the server and canvas have both moved back to.
    */
   React.useEffect(() => {
-    setPendingWrite(current =>
-      current !== undefined && current.sawAtSave !== value ? undefined : current
-    );
-  }, [value]);
+    if (readArrived) setPendingWrite(undefined);
+  }, [readArrived]);
   const authored = authoredBreakpoints(stillStale ? pendingWrite.wrote : value);
   const count = authored.viewport.length + authored.container.length;
 
@@ -136,12 +160,18 @@ export function BreakpointManager({
          * thing this label is worth showing.
          */
         aria-label={
-          ready ? `Breakpoints: ${count} defined` : "Breakpoints: still loading"
+          ready
+            ? `Breakpoints: ${count} defined`
+            : status === "loading"
+              ? "Breakpoints: still loading"
+              : "Breakpoints: unavailable"
         }
         title={
           ready
             ? undefined
-            : "Available once the site's saved styles have loaded."
+            : status === "loading"
+              ? "Available once the site's saved styles have loaded."
+              : "Your site's saved styles could not be read, so editing them here could overwrite them."
         }
       >
         <MonitorSmartphone className="size-4" />

--- a/packages/builder/src/breakpoint-manager.tsx
+++ b/packages/builder/src/breakpoint-manager.tsx
@@ -24,7 +24,11 @@ import { MonitorSmartphone } from "lucide-react";
 import * as React from "react";
 
 import { BreakpointDialog } from "./breakpoint-dialog";
-import { BASE_BREAKPOINT, type BreakpointSet } from "./breakpoints";
+import {
+  BASE_BREAKPOINT,
+  type BreakpointDef,
+  type BreakpointSet,
+} from "./breakpoints";
 
 /**
  * Props for BreakpointManager.
@@ -57,21 +61,32 @@ export interface BreakpointManagerProps {
 }
 
 /**
- * How many breakpoints the site defines, for the trigger's own label.
+ * The set with the built-in base removed from both axes.
  *
- * The base is not counted. It is not a definition an author added and cannot be
- * removed, so including it would report "1 breakpoint" for a site that has
- * defined none — the exact state the label exists to distinguish.
+ * A stored set CAN carry a `base` row, and the plugin's own README documents a
+ * host config that does — while `validateBreakpoints` reports the same id as
+ * reserved, because the compiler claims it before reading any stored
+ * definition. Passed through, the dialog renders it as an ordinary read-only
+ * row and Save is disabled for as long as it is there: an author on the
+ * documented configuration cannot save breakpoints at all until they delete a
+ * row the interface presents as built in.
+ *
+ * Dropped here rather than made savable, because the two conventions are not
+ * both right. `breakpointContexts` prepends the base context whether or not one
+ * is stored, so a stored base row is redundant at best and shadowed at worst,
+ * and the dialog is the one surface that must not offer to edit it.
+ *
+ * Applied to the DRAFT as well as the count. An earlier version excluded the
+ * base from the count alone, which fixed the label and left the deadlock — the
+ * same fact used in one of the two places that needed it.
  */
-function definedCount(value: BreakpointSet): number {
-  const axes = [value.viewport, value.container];
-  let count = 0;
-  for (const axis of axes) {
-    for (const def of axis ?? []) {
-      if (def?.id !== BASE_BREAKPOINT) count += 1;
-    }
-  }
-  return count;
+function withoutBase(value: BreakpointSet): BreakpointSet {
+  const authored = (axis: readonly BreakpointDef[] | undefined) =>
+    (axis ?? []).filter(def => def?.id !== BASE_BREAKPOINT);
+  return {
+    viewport: authored(value.viewport),
+    container: authored(value.container),
+  };
 }
 
 /**
@@ -84,7 +99,44 @@ export function BreakpointManager({
   ready,
 }: BreakpointManagerProps): React.JSX.Element {
   const [open, setOpen] = React.useState(false);
-  const count = definedCount(value);
+  /*
+   * The set this surface last wrote, held until the read catches up.
+   *
+   * A successful write resolves before the query it invalidates has refetched,
+   * and `useSiteStyle` reports `isPending` rather than background fetching — so
+   * for a moment after saving, `value` is still the PREVIOUS set while the
+   * trigger is ready and the dialog will reopen. An author who saves and
+   * immediately reopens would be seeded from the old set, and saving that draft
+   * would overwrite the write that had just succeeded.
+   *
+   * Released by ANY change to `value`, not by `value` matching what was
+   * written. Waiting for a match cannot end if the server stored something
+   * different from what was sent — the surface would then show the submitted
+   * set forever and never the truth. Recording the value that was current at
+   * the save and yielding the moment it changes bounds this to exactly the
+   * window it exists for.
+   */
+  const [pendingWrite, setPendingWrite] = React.useState<
+    | { readonly wrote: BreakpointSet; readonly sawAtSave: BreakpointSet }
+    | undefined
+  >(undefined);
+  const stillStale =
+    pendingWrite !== undefined && pendingWrite.sawAtSave === value;
+  const authored = withoutBase(stillStale ? pendingWrite.wrote : value);
+  const count = authored.viewport.length + authored.container.length;
+
+  const persist = async (next: BreakpointSet): Promise<string | undefined> => {
+    // Narrowed rather than passed through: `onSave` may return nothing at all,
+    // and `void` is not `undefined` to the checker even though it is at runtime.
+    const answered = await onSave(next);
+    const outcome = typeof answered === "string" ? answered : undefined;
+    // Held only on success. A refused write changed nothing, so there is no
+    // newer set for the read to catch up to.
+    if (outcome === undefined) {
+      setPendingWrite({ wrote: next, sawAtSave: value });
+    }
+    return outcome;
+  };
 
   return (
     <>
@@ -132,8 +184,8 @@ export function BreakpointManager({
         <BreakpointDialog
           open
           onOpenChange={setOpen}
-          value={value}
-          onSave={onSave}
+          value={authored}
+          onSave={persist}
         />
       ) : null}
     </>

--- a/packages/builder/src/breakpoint-manager.tsx
+++ b/packages/builder/src/breakpoint-manager.tsx
@@ -24,11 +24,7 @@ import { MonitorSmartphone } from "lucide-react";
 import * as React from "react";
 
 import { BreakpointDialog } from "./breakpoint-dialog";
-import {
-  BASE_BREAKPOINT,
-  type BreakpointDef,
-  type BreakpointSet,
-} from "./breakpoints";
+import { authoredBreakpoints, type BreakpointSet } from "./breakpoints";
 
 /**
  * Props for BreakpointManager.
@@ -58,35 +54,6 @@ export interface BreakpointManagerProps {
    * knows the manager exists is left wondering whether the feature was removed.
    */
   ready: boolean;
-}
-
-/**
- * The set with the built-in base removed from both axes.
- *
- * A stored set CAN carry a `base` row, and the plugin's own README documents a
- * host config that does — while `validateBreakpoints` reports the same id as
- * reserved, because the compiler claims it before reading any stored
- * definition. Passed through, the dialog renders it as an ordinary read-only
- * row and Save is disabled for as long as it is there: an author on the
- * documented configuration cannot save breakpoints at all until they delete a
- * row the interface presents as built in.
- *
- * Dropped here rather than made savable, because the two conventions are not
- * both right. `breakpointContexts` prepends the base context whether or not one
- * is stored, so a stored base row is redundant at best and shadowed at worst,
- * and the dialog is the one surface that must not offer to edit it.
- *
- * Applied to the DRAFT as well as the count. An earlier version excluded the
- * base from the count alone, which fixed the label and left the deadlock — the
- * same fact used in one of the two places that needed it.
- */
-function withoutBase(value: BreakpointSet): BreakpointSet {
-  const authored = (axis: readonly BreakpointDef[] | undefined) =>
-    (axis ?? []).filter(def => def?.id !== BASE_BREAKPOINT);
-  return {
-    viewport: authored(value.viewport),
-    container: authored(value.container),
-  };
 }
 
 /**
@@ -122,7 +89,23 @@ export function BreakpointManager({
   >(undefined);
   const stillStale =
     pendingWrite !== undefined && pendingWrite.sawAtSave === value;
-  const authored = withoutBase(stillStale ? pendingWrite.wrote : value);
+  /*
+   * CLEARED once the read moves, not merely stopped being consulted.
+   *
+   * Leaving it in state makes the release temporary rather than permanent:
+   * `resolveSiteStyle` hands back the host's config OBJECT when nothing is
+   * stored, and that reference is memoised — so a site that saves a set and
+   * later has the stored section cleared through the API or an import sees
+   * `value` return to the very object it was at the save, `sawAtSave === value`
+   * become true a second time, and an optimistic write resurrect over the truth
+   * the server and canvas have both moved back to.
+   */
+  React.useEffect(() => {
+    setPendingWrite(current =>
+      current !== undefined && current.sawAtSave !== value ? undefined : current
+    );
+  }, [value]);
+  const authored = authoredBreakpoints(stillStale ? pendingWrite.wrote : value);
   const count = authored.viewport.length + authored.container.length;
 
   const persist = async (next: BreakpointSet): Promise<string | undefined> => {

--- a/packages/builder/src/breakpoints.test.ts
+++ b/packages/builder/src/breakpoints.test.ts
@@ -9,7 +9,10 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { MAX_BREAKPOINT_ID_LENGTH } from "@nextlyhq/blocks-engine";
+
 import {
+  authoredBreakpoints,
   BASE_BREAKPOINT,
   MAX_BREAKPOINTS_PER_AXIS,
   storedLimitFor,
@@ -39,6 +42,70 @@ function rows(prefix: string, count: number) {
     maxWidth: 1000 - i * 50,
   }));
 }
+
+describe("the authored set", () => {
+  it("strips a stored base row from both axes", () => {
+    /*
+     * A stored set CAN carry a `base` row and the plugin's README documents a
+     * host config that does, while the compiler claims that id before reading
+     * any stored definition. Three surfaces ask "what has this site defined" —
+     * the dialog's draft, the trigger's count, and the host deciding whether
+     * config defaults exist — and each one that answered differently produced
+     * its own defect.
+     */
+    const stripped = authoredBreakpoints({
+      viewport: [
+        { id: "base", label: "Base" },
+        { id: "tablet", label: "Tablet", maxWidth: 991 },
+      ],
+      container: [{ id: "base", label: "Base" }],
+    } as unknown as BreakpointSet);
+
+    expect(stripped.viewport.map(def => def.id)).toEqual(["tablet"]);
+    expect(stripped.container).toEqual([]);
+  });
+
+  it("answers for an absent set rather than throwing", () => {
+    // The host's config states no breakpoints at all far more often than it
+    // states some, and that caller reads the field optionally.
+    expect(authoredBreakpoints(undefined)).toEqual({
+      viewport: [],
+      container: [],
+    });
+  });
+});
+
+describe("an id the compiler would drop", () => {
+  it("is reported, rather than saved into nothing", () => {
+    /*
+     * The COMPILER's limit, not one chosen here. `namedDefinition` keeps a
+     * definition only while `def.id.length <= MAX_BREAKPOINT_ID_LENGTH`, so an
+     * id this screen accepted would save, report success, and then exist
+     * nowhere — with every style filed under it silently unapplied.
+     *
+     * Asserted at the boundary in both directions, because an off-by-one here
+     * is the whole defect: one character over must be reported, and exactly at
+     * the limit must not.
+     */
+    const idOf = (length: number) => "b".repeat(length);
+    const setWith = (id: string) =>
+      ({
+        viewport: [{ id, label: "Wide", maxWidth: 900 }],
+        container: [],
+      }) as unknown as BreakpointSet;
+
+    expect(
+      validateBreakpoints(setWith(idOf(MAX_BREAKPOINT_ID_LENGTH + 1))).map(
+        issue => issue.code
+      )
+    ).toContain("id-too-long");
+    expect(
+      validateBreakpoints(setWith(idOf(MAX_BREAKPOINT_ID_LENGTH))).map(
+        issue => issue.code
+      )
+    ).not.toContain("id-too-long");
+  });
+});
 
 describe("breakpoint definitions the compiler would keep", () => {
   it("reports nothing for an ordinary desktop-first set", () => {

--- a/packages/builder/src/breakpoints.ts
+++ b/packages/builder/src/breakpoints.ts
@@ -139,6 +139,34 @@ export function authoredBreakpoints(
 }
 
 /**
+ * Whether two sets describe the same breakpoints.
+ *
+ * By CONTENT, never by object identity. The prop contract does not promise a
+ * stable reference — a host that rebuilds an equal object on any parent render
+ * is within its rights — so identity answers "has the read changed" wrongly in
+ * both directions, and a surface that asks it gets a different wrong answer
+ * depending on which way the host happens to render.
+ *
+ * Compares the AUTHORED sets, so a stored base row on one side and none on the
+ * other is not a difference: the compiler prepends that context either way, and
+ * treating it as a change would report a set that renders identically as new.
+ *
+ * @experimental
+ */
+export function sameBreakpoints(
+  a: BreakpointSet | undefined,
+  b: BreakpointSet | undefined
+): boolean {
+  const shape = (set: BreakpointSet | undefined) => {
+    const authored = authoredBreakpoints(set);
+    const axis = (defs: readonly BreakpointDef[]) =>
+      defs.map(def => `${def.id}\u0000${def.label}\u0000${def.maxWidth ?? ""}`);
+    return [axis(authored.viewport), axis(authored.container)];
+  };
+  return JSON.stringify(shape(a)) === JSON.stringify(shape(b));
+}
+
+/**
  * Whether a bound is one the compiler will keep.
  *
  * @experimental

--- a/packages/builder/src/breakpoints.ts
+++ b/packages/builder/src/breakpoints.ts
@@ -32,6 +32,7 @@
 import {
   BASE_BREAKPOINT,
   BREAKPOINT_AXES,
+  MAX_BREAKPOINT_ID_LENGTH,
   MAX_BREAKPOINTS_PER_AXIS,
   type BreakpointAxis,
   type BreakpointDef,
@@ -67,6 +68,7 @@ export type { BreakpointAxis, BreakpointDef, BreakpointSet };
  * @experimental
  */
 export type BreakpointIssueCode =
+  | "id-too-long"
   | "id-required"
   | "id-reserved"
   | "id-duplicate"
@@ -105,6 +107,35 @@ export function storedLimitFor(axis: BreakpointAxis): number {
   return axis === "viewport"
     ? MAX_BREAKPOINTS_PER_AXIS - 1
     : MAX_BREAKPOINTS_PER_AXIS;
+}
+
+/**
+ * The set with the built-in base removed from both axes.
+ *
+ * The base is not a definition an author added: `breakpointContexts` prepends
+ * its context whether or not one is stored, and `validateBreakpoints` reports
+ * the id as reserved. But a stored set CAN carry a `base` row and the plugin's
+ * README documents a host config that does, so every surface that asks "what
+ * has this site actually defined" has to strip it — and each one that forgets
+ * gets a different wrong answer from the same set.
+ *
+ * Published rather than repeated, because it has three askers already: the
+ * dialog's draft, the trigger's count, and the host deciding whether config
+ * defaults exist. The first two disagreeing is what made Save unreachable on
+ * the documented configuration; the third disagreeing made a site with only a
+ * base row unable to return to it.
+ *
+ * @experimental
+ */
+export function authoredBreakpoints(
+  set: BreakpointSet | undefined
+): BreakpointSet {
+  const authored = (axis: readonly BreakpointDef[] | undefined) =>
+    (axis ?? []).filter(def => def?.id !== BASE_BREAKPOINT);
+  return {
+    viewport: authored(set?.viewport),
+    container: authored(set?.container),
+  };
 }
 
 /**
@@ -170,6 +201,19 @@ export function validateBreakpoints(set: BreakpointSet): BreakpointIssue[] {
       const id = def.id;
       if (id.length === 0) {
         at("id", "id-required", "Give this breakpoint an id.");
+      } else if (id.length > MAX_BREAKPOINT_ID_LENGTH) {
+        /*
+         * The COMPILER's limit, not one chosen here. `namedDefinition` drops a
+         * definition whose id exceeds it, so an id this screen accepted would
+         * save, report success, and then exist nowhere — with every style filed
+         * under it silently unapplied. Two gates disagreeing about what is
+         * storable is worse than either being strict.
+         */
+        at(
+          "id",
+          "id-too-long",
+          `An id can be at most ${MAX_BREAKPOINT_ID_LENGTH} characters.`
+        );
       } else if (id === BASE_BREAKPOINT) {
         at(
           "id",

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -125,6 +125,7 @@ export type { InsertPanelProps } from "./insert-panel";
  * would offer two ways to mount one feature that must agree about when the
  * saved set has actually been read.
  */
+export { authoredBreakpoints } from "./breakpoints";
 export { BreakpointManager } from "./breakpoint-manager";
 export type { BreakpointManagerProps } from "./breakpoint-manager";
 

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -117,6 +117,18 @@ export { InsertPanel } from "./insert-panel";
 export type { InsertPanelProps } from "./insert-panel";
 
 /**
+ * The site's breakpoints, as a trigger and the dialog behind it.
+ *
+ * The MANAGER is published and the dialog is not. A host needs the pair —
+ * something to click and something to edit in — and publishing the dialog alone
+ * would leave every host inventing the same open state, while publishing both
+ * would offer two ways to mount one feature that must agree about when the
+ * saved set has actually been read.
+ */
+export { BreakpointManager } from "./breakpoint-manager";
+export type { BreakpointManagerProps } from "./breakpoint-manager";
+
+/**
  * The editor's keyboard actions — moving, deleting, undoing — behind the same
  * client banner.
  *

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -125,7 +125,7 @@ export type { InsertPanelProps } from "./insert-panel";
  * would offer two ways to mount one feature that must agree about when the
  * saved set has actually been read.
  */
-export { authoredBreakpoints } from "./breakpoints";
+export { authoredBreakpoints, sameBreakpoints } from "./breakpoints";
 export { BreakpointManager } from "./breakpoint-manager";
 export type { BreakpointManagerProps } from "./breakpoint-manager";
 

--- a/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
@@ -491,6 +491,35 @@ describe("what the breakpoint manager is told", () => {
     expect(refusal).toContain("configuration");
   });
 
+  it("does not count a config base row as a configured breakpoint", async () => {
+    /*
+     * A config carrying only the built-in `{ id: "base" }` row states no
+     * authored breakpoint. Counted, it refuses the one save that returns such a
+     * site to its base-only state — and tells the author to remove a config row
+     * the manager deliberately hides as built in, so the instruction cannot be
+     * followed from any screen they can reach.
+     */
+    clientConfig = {
+      siteStyle: {
+        breakpoints: {
+          viewport: [{ id: "base", label: "Base" }],
+          container: [],
+        },
+      },
+    };
+
+    openEditor();
+
+    const onSave = seen.breakpoints?.onSave as (
+      next: unknown
+    ) => Promise<string | undefined>;
+    expect(onSave).toBeDefined();
+
+    await expect(
+      onSave({ viewport: [], container: [] })
+    ).resolves.toBeUndefined();
+  });
+
   it("saves a NON-empty set, which is the control", async () => {
     // Without this, a callback that refused everything would satisfy the case
     // above and no breakpoint could ever be written.

--- a/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
@@ -425,7 +425,7 @@ describe("what the breakpoint manager is told", () => {
     openEditor();
 
     expect(seen.breakpoints).toBeDefined();
-    expect(seen.breakpoints?.ready).toBe(false);
+    expect(seen.breakpoints?.status).toBe("loading");
   });
 
   it("is NOT ready after a FAILED read, which is not a passing state", () => {
@@ -442,7 +442,9 @@ describe("what the breakpoint manager is told", () => {
 
     openEditor();
 
-    expect(seen.breakpoints?.ready).toBe(false);
+    // Named as the FAILURE it is, not as loading: told "still loading" after a
+    // permission denial, an author waits for a request that already finished.
+    expect(seen.breakpoints?.status).toBe("unavailable");
   });
 
   it("IS ready once the read has answered, which is the control", () => {
@@ -454,7 +456,7 @@ describe("what the breakpoint manager is told", () => {
      */
     openEditor();
 
-    expect(seen.breakpoints?.ready).toBe(true);
+    expect(seen.breakpoints?.status).toBe("ready");
   });
 
   it("refuses an empty set while the host config states breakpoints", async () => {

--- a/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
@@ -26,7 +26,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const seen: {
   inspector: Record<string, unknown> | undefined;
   canvas: Record<string, unknown> | undefined;
-} = { inspector: undefined, canvas: undefined };
+  breakpoints: Record<string, unknown> | undefined;
+} = { inspector: undefined, canvas: undefined, breakpoints: undefined };
 
 /** What `usePluginClientConfig` answers with for the test in hand. */
 let clientConfig: Record<string, unknown> | undefined;
@@ -69,16 +70,25 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
     // would leave the canvas unrendered and its assertion passing on absence.
     BuilderShell: ({
       inspector,
+      topBar,
       children,
     }: {
       inspector: React.ReactNode;
+      topBar?: React.ReactNode;
       children?: React.ReactNode;
     }): React.JSX.Element => (
       <div>
+        {/*
+         * The top bar is rendered for the same reason the children are: the
+         * breakpoint manager lives there, and a stub that dropped the slot
+         * would leave its assertions passing on absence.
+         */}
+        {topBar}
         {inspector}
         {children}
       </div>
     ),
+    BreakpointManager: record("breakpoints"),
     InspectorPanel: record("inspector"),
     Canvas: record("canvas"),
     BlockKeyboardActions: passthrough,
@@ -119,6 +129,10 @@ vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
   useEntryFieldsPanel: () => null,
   useReportUnsavedWork: () => {},
   useSuppressAdminChrome: () => {},
+  // `null` is a real answer the pill handles — "no status has been persisted",
+  // which is what a create form and a preview both look like — so this mounts
+  // the top bar without putting a second subject in the assertions below.
+  useDocumentStatus: () => null,
   // The stored style tier. Answered as "nothing stored yet" here, because what
   // this file asserts is which props reach the two enforcing surfaces — the
   // merge of stored over defaults is `site-style-client`'s own question and has
@@ -151,6 +165,7 @@ function openEditor(): void {
 beforeEach(() => {
   seen.inspector = undefined;
   seen.canvas = undefined;
+  seen.breakpoints = undefined;
   clientConfig = undefined;
   siteStyleRead = { data: undefined, isPending: false, error: null };
 });
@@ -392,6 +407,68 @@ describe("the shell mock", () => {
 
     expect(seen.inspector).toBeDefined();
     expect(seen.canvas).toBeDefined();
+  });
+});
+
+describe("what the breakpoint manager is told", () => {
+  it("is NOT ready while the stored style is still arriving", () => {
+    /*
+     * The same gate the canvas and the cascade are held behind, and the one
+     * whose failure is a write rather than a wrong pixel. Until the read
+     * answers, the value handed to the manager is the host's CONFIG DEFAULTS —
+     * so an author who opened the dialog then would edit a set the site never
+     * chose, and saving it would overwrite the site's real breakpoints with
+     * defaults they never saw.
+     */
+    siteStyleRead = { data: undefined, isPending: true, error: null };
+
+    openEditor();
+
+    expect(seen.breakpoints).toBeDefined();
+    expect(seen.breakpoints?.ready).toBe(false);
+  });
+
+  it("is NOT ready after a FAILED read, which is not a passing state", () => {
+    /*
+     * The half a `pending` check alone gets wrong: on failure `pending` goes
+     * false while the value falls back to defaults, so gating on pending alone
+     * would arm the manager over a tier nobody has read.
+     */
+    siteStyleRead = {
+      data: undefined,
+      isPending: false,
+      error: new Error("nope"),
+    };
+
+    openEditor();
+
+    expect(seen.breakpoints?.ready).toBe(false);
+  });
+
+  it("IS ready once the read has answered, which is the control", () => {
+    /*
+     * Without this, a manager that was never ready would satisfy both cases
+     * above and the feature would be permanently unreachable rather than
+     * gated — which is exactly what shipped once before on this surface, when
+     * an `!== undefined` test against an `Error | null` was true on success too.
+     */
+    openEditor();
+
+    expect(seen.breakpoints?.ready).toBe(true);
+  });
+
+  it("is given the SAME breakpoints the canvas renders against", () => {
+    /*
+     * One derivation, not two. The manager edits the set the cascade was
+     * compiled with, so a second call to `siteBreakpoints` beside the canvas's
+     * would let the dialog show and save a set the page was never drawn with.
+     */
+    openEditor();
+
+    expect(seen.breakpoints?.value).toBe(
+      (seen.canvas?.render as { styleContext?: { breakpoints?: unknown } })
+        ?.styleContext?.breakpoints
+    );
   });
 });
 

--- a/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
@@ -457,6 +457,66 @@ describe("what the breakpoint manager is told", () => {
     expect(seen.breakpoints?.ready).toBe(true);
   });
 
+  it("refuses an empty set while the host config states breakpoints", async () => {
+    /*
+     * `resolveSiteStyle` decides "was anything stored" with `hasBreakpoints`,
+     * which is `viewport.length > 0 || container.length > 0`. So writing an
+     * empty set succeeds, reads back as NOTHING STORED, and the config defaults
+     * return — the author removes every row, is told it saved, and watches them
+     * reappear.
+     *
+     * Refused with a reason rather than reported as saved. Representing
+     * "explicitly none" would take a stored-format change, which is not a
+     * decision this callback makes silently.
+     */
+    clientConfig = {
+      siteStyle: {
+        breakpoints: {
+          viewport: [{ id: "tablet", label: "Tablet", maxWidth: 991 }],
+          container: [],
+        },
+      },
+    };
+
+    openEditor();
+
+    const onSave = seen.breakpoints?.onSave as (
+      next: unknown
+    ) => Promise<string | undefined>;
+    expect(onSave).toBeDefined();
+
+    const refusal = await onSave({ viewport: [], container: [] });
+
+    expect(refusal).toBeDefined();
+    expect(refusal).toContain("configuration");
+  });
+
+  it("saves a NON-empty set, which is the control", async () => {
+    // Without this, a callback that refused everything would satisfy the case
+    // above and no breakpoint could ever be written.
+    clientConfig = {
+      siteStyle: {
+        breakpoints: {
+          viewport: [{ id: "tablet", label: "Tablet", maxWidth: 991 }],
+          container: [],
+        },
+      },
+    };
+
+    openEditor();
+
+    const onSave = seen.breakpoints?.onSave as (
+      next: unknown
+    ) => Promise<string | undefined>;
+
+    await expect(
+      onSave({
+        viewport: [{ id: "mobile", label: "Mobile", maxWidth: 575 }],
+        container: [],
+      })
+    ).resolves.toBeUndefined();
+  });
+
   it("is given the SAME breakpoints the canvas renders against", () => {
     /*
      * One derivation, not two. The manager edits the set the cascade was

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -552,6 +552,27 @@ function useBreakpointWriter(
   );
 }
 
+/**
+ * What the stored site style's read has DONE, in the manager's three words.
+ *
+ * Named rather than written inline for the reason the writer moved out of the
+ * editor component: every decision folded into that function is another path
+ * through the whole of it, and `fallow` reports the growth as introduced
+ * complexity.
+ *
+ * `error === null`, not `!== undefined`. `useSiteStyle` types the field as
+ * `Error | null` and normalises a successful read to `null`, so an `undefined`
+ * comparison is true on success as well as on failure — the mistake that once
+ * withheld the provenance trace unconditionally.
+ */
+function siteStyleStatus(
+  pending: boolean,
+  error: Error | null
+): "loading" | "unavailable" | "ready" {
+  if (pending) return "loading";
+  return error === null ? "ready" : "unavailable";
+}
+
 function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   initialValue,
   onCommit,
@@ -893,7 +914,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             <BreakpointManager
               value={canvasRender.styleContext.breakpoints}
               onSave={saveBreakpoints}
-              ready={!siteStylePending && siteStyleError === null}
+              status={siteStyleStatus(siteStylePending, siteStyleError)}
             />
           </>
         }

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -482,6 +482,68 @@ function TokensStudio({
   );
 }
 
+/**
+ * Writing the site's breakpoints, for the manager in the top bar.
+ *
+ * A hook rather than a callback inside the editor, because that component is
+ * already the largest branch point on this surface and every decision folded
+ * into it is one more path through the whole thing. What it needs from here is
+ * one stable function.
+ *
+ * Section-scoped, so this sends the breakpoints and nothing else — the other
+ * three fields of the record are owned by other studios and are not read here in
+ * order to write this one.
+ */
+function useBreakpointWriter(
+  configSiteStyle: SiteStyleData | undefined
+): (next: BreakpointSet) => Promise<string | undefined> {
+  const { save: saveSiteStyle } = useSaveSiteStyle();
+  /*
+   * Whether the HOST states breakpoints in its config, which is what makes an
+   * empty stored set unrepresentable. Read from the config tier rather than from
+   * the merged value, because the merged one cannot tell a stored set from a
+   * defaulted one — which is the ambiguity being guarded.
+   */
+  const configured =
+    (configSiteStyle?.breakpoints?.viewport?.length ?? 0) > 0 ||
+    (configSiteStyle?.breakpoints?.container?.length ?? 0) > 0;
+
+  return useCallback(
+    async (next: BreakpointSet): Promise<string | undefined> => {
+      /*
+       * An empty set is not storable as an intention while the host states
+       * defaults, so it is refused rather than reported as saved.
+       *
+       * `resolveSiteStyle` layers the stored record over the host's config and
+       * decides "was anything stored" with `hasBreakpoints`, which is
+       * `viewport.length > 0 || container.length > 0`. So writing
+       * `{ viewport: [], container: [] }` succeeds, reads back as NOTHING
+       * STORED, and the config defaults return — the author removes every row,
+       * is told it saved, and watches them reappear.
+       *
+       * Refusing says what happened and where the remaining breakpoints come
+       * from, which is the one thing the author cannot see from this screen.
+       * Representing "explicitly none" would take a stored-format change, and
+       * that is not a decision this callback should make silently.
+       */
+      const emptied = next.viewport.length === 0 && next.container.length === 0;
+      if (emptied && configured) {
+        return "Your site's configuration defines these breakpoints, so removing them all here would restore them. Remove them from the config instead.";
+      }
+      const result = await saveSiteStyle("breakpoints", next);
+      if (result.saved) return undefined;
+      const reasons = Object.values(result.issues);
+      // `issues` can be empty on a refusal the transport could not describe.
+      // Answering `undefined` there would report a save that did not happen,
+      // which is the one outcome that must never be silent.
+      return reasons.length > 0
+        ? reasons.join(" ")
+        : "These breakpoints could not be saved.";
+    },
+    [saveSiteStyle, configured]
+  );
+}
+
 function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   initialValue,
   onCommit,
@@ -657,21 +719,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * would silently drop the others — an author told about one refused field
    * while a second is also refused fixes one and is refused again.
    */
-  const { save: saveSiteStyle } = useSaveSiteStyle();
-  const saveBreakpoints = useCallback(
-    async (next: BreakpointSet): Promise<string | undefined> => {
-      const result = await saveSiteStyle("breakpoints", next);
-      if (result.saved) return undefined;
-      const reasons = Object.values(result.issues);
-      // `issues` can be empty on a refusal the transport could not describe.
-      // Answering `undefined` there would report a save that did not happen,
-      // which is the one outcome that must never be silent.
-      return reasons.length > 0
-        ? reasons.join(" ")
-        : "These breakpoints could not be saved.";
-    },
-    [saveSiteStyle]
-  );
+  const saveBreakpoints = useBreakpointWriter(configSiteStyle);
 
   /*
    * The canvas's own render inputs, and the ONE place this surface derives a

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -39,6 +39,7 @@ import {
   registerBlocks,
   registryNestingSource,
   type BlockDocument,
+  type BreakpointSet,
   type SiteTokenSet,
 } from "@nextlyhq/blocks-engine";
 import { CORE_CATEGORIES, coreBlocks } from "@nextlyhq/blocks-react/blocks";
@@ -46,6 +47,7 @@ import { registrySlotSource } from "@nextlyhq/builder";
 import {
   BlockKeyboardActions,
   BlockToolbar,
+  BreakpointManager,
   EditorCommandPalette,
   BuilderShell,
   Canvas,
@@ -643,6 +645,35 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * and the tree behind it is re-rendered on every selection and keystroke.
    */
   /*
+   * Writing the site's breakpoints, for the manager in the top bar.
+   *
+   * Section-scoped, so this sends the breakpoints and nothing else — the other
+   * three fields of the record are owned by other studios and are not read here
+   * in order to write this one.
+   *
+   * The result is narrowed to the shape the dialog understands: `undefined` for
+   * a save that landed, and the reason otherwise. The reasons are joined rather
+   * than picked from, because `issues` is keyed by path and taking the first
+   * would silently drop the others — an author told about one refused field
+   * while a second is also refused fixes one and is refused again.
+   */
+  const { save: saveSiteStyle } = useSaveSiteStyle();
+  const saveBreakpoints = useCallback(
+    async (next: BreakpointSet): Promise<string | undefined> => {
+      const result = await saveSiteStyle("breakpoints", next);
+      if (result.saved) return undefined;
+      const reasons = Object.values(result.issues);
+      // `issues` can be empty on a refusal the transport could not describe.
+      // Answering `undefined` there would report a save that did not happen,
+      // which is the one outcome that must never be silent.
+      return reasons.length > 0
+        ? reasons.join(" ")
+        : "These breakpoints could not be saved.";
+    },
+    [saveSiteStyle]
+  );
+
+  /*
    * The canvas's own render inputs, and the ONE place this surface derives a
    * breakpoint set.
    *
@@ -788,7 +819,28 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
         // shown had this editor not asked for it to be hidden. `undoDepth` is
         // the editor's OWN dirty signal: the form's is false for as long as the
         // editor is open, because the document is committed on the way out.
-        topBar={<DocumentStatusPill isDirty={editor.undoDepth > 0} />}
+        topBar={
+          <>
+            <DocumentStatusPill isDirty={editor.undoDepth > 0} />
+            {/*
+             * Gated on the SAME read the canvas and the cascade are gated on.
+             * Until the stored style has answered, `canvasSiteStyle` is the
+             * host's config defaults — so the dialog would open on a set the
+             * site never chose, and saving from that draft would overwrite the
+             * site's real breakpoints with defaults the author never saw.
+             *
+             * `!== null`, not `!== undefined`: `useSiteStyle` types `error` as
+             * `Error | null` and normalises success to `null`, so the
+             * `undefined` comparison is true on success too — the same mistake
+             * that once withheld the provenance trace unconditionally.
+             */}
+            <BreakpointManager
+              value={canvasRender.styleContext.breakpoints}
+              onSave={saveBreakpoints}
+              ready={!siteStylePending && siteStyleError === null}
+            />
+          </>
+        }
         // The shell owns the region; this fills it. Rendered unconditionally
         // rather than only when something is selected, because the panel states
         // "select a block to edit it" — a region that appears and disappears

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -46,6 +46,7 @@ import { CORE_CATEGORIES, coreBlocks } from "@nextlyhq/blocks-react/blocks";
 import { registrySlotSource } from "@nextlyhq/builder";
 import {
   BlockKeyboardActions,
+  authoredBreakpoints,
   BlockToolbar,
   BreakpointManager,
   EditorCommandPalette,
@@ -503,10 +504,17 @@ function useBreakpointWriter(
    * empty stored set unrepresentable. Read from the config tier rather than from
    * the merged value, because the merged one cannot tell a stored set from a
    * defaulted one — which is the ambiguity being guarded.
+   *
+   * Through the SAME base filter the manager uses. A config carrying only the
+   * built-in `{ id: "base" }` row states no authored breakpoint, so counting it
+   * refuses the one save that returns such a site to its base-only state — and
+   * tells the author to remove a config row the manager deliberately hides as
+   * built in. Three surfaces now ask this question and all three ask it once.
    */
+  const configuredAuthored = authoredBreakpoints(configSiteStyle?.breakpoints);
   const configured =
-    (configSiteStyle?.breakpoints?.viewport?.length ?? 0) > 0 ||
-    (configSiteStyle?.breakpoints?.container?.length ?? 0) > 0;
+    configuredAuthored.viewport.length > 0 ||
+    configuredAuthored.container.length > 0;
 
   return useCallback(
     async (next: BreakpointSet): Promise<string | undefined> => {


### PR DESCRIPTION
C-12. The breakpoint dialog and its validation were built in #728 and **mounted nowhere** — zero references outside their own file — so a site could not define breakpoints at all and `siteBreakpoints()` always answered empty. This gives the dialog a way in and a place to write to.

## The save contract could not survive a network write

The dialog called `onSave` and closed on the same tick. Persisting is asynchronous and can be refused, so a failed save discarded a set the author had just built by hand with nothing left to recover it from: the dialog gone, the draft with it, and the site's breakpoints unchanged.

It now awaits a promise, stays open on a refusal **and** on a rejection, and shows the reason in the footer where the author is already reading the issue count. A refusal outranks that count deliberately — "Every breakpoint is usable." is true at that moment and would read as confirmation of a write that did not happen.

A host that returns nothing still closes on the click, so the synchronous contract is unchanged.

## Two hazards closed at the host

**The trigger is gated on the same read the canvas and the cascade are gated on.** Until the stored style answers, the set in hand is the host's *config defaults* — so an ungated dialog would open on a set the site never chose, and saving it would overwrite the real breakpoints with defaults the author never saw. `!== null`, not `!== undefined`: `useSiteStyle` types `error` as `Error | null`, and the `undefined` comparison is the mistake that once withheld the provenance trace unconditionally.

**The set comes from `canvasRender.styleContext.breakpoints`**, not a second `siteBreakpoints()` call, so the manager edits what the canvas is compiled with rather than something equal to it today. That is the finding from #1182 applied before it could recur.

## Placement

Top bar, not a left panel. Breakpoints are site-wide and set rarely, so they do not earn a region beside Insert and Layers, which are used on every edit; and the top bar is where a breakpoint *switcher* will sit, so the two read as one control. Every builder surveyed puts breakpoint management in the viewport chrome rather than a content panel.

## What the research settled, and what it did not

`research:pb-site-style-studios-save-ux` governs the save semantics: explicit save, commit means live, `versions: true` on the single is the undo path. Its safe-delete recommendation — show a blast-radius count — turns out **not to apply here**, and that is measured rather than assumed. Deleting a breakpoint is not destructive: styles keyed to an unknown id are *warned about, never removed* (`compile-page.ts`, `unknown-breakpoint`: "not defined for this site, so these values were not written"), and re-adding the id restores them. Rename is already prevented — an id is fixed once saved, with the reasoning in the dialog. So the honest thing to tell an author is that removal is reversible, which needs no count.

## Evidence

Break-verified, each failing only its own case:

- Restoring the close-on-click → fails the three async tests, and the synchronous-close test still passes.
- Removing the `ready` gate → fails both withholding tests, not the control.
- A second `siteBreakpoints()` call for the manager → fails only the same-derivation test.
- Counting the reserved base id → fails only its own test.

**One break came back green and is recorded rather than waved through.** Counting the base id failed nothing, because no fixture stored one. `validateBreakpoints` refuses to *save* a `base` definition, but the site style is an ordinary single the API can write directly — so the guard is unreachable through the dialog and reachable through the record. Kept, and now covered by a test that reaches it.

**The policy-test mock was dropping `topBar` entirely**, so nothing in the top bar had ever been covered. Rendering it surfaced a missing `useDocumentStatus` in the SDK mock, added here.

Gates, all exit 0: `pnpm build`, `pnpm check-types`, builder **1823**, blocks-react **777**, plugin-page-builder **304**, four package lints, root eslint, comment convention, changeset, and `fallow audit` verdict `pass` with `dead_code_introduced`, `complexity_introduced` and `duplication_introduced` all 0.

## What this unblocks

The C-6 badge half needs a breakpoint *selector*, which needs a site that can define breakpoints. Nothing sets an edited breakpoint yet and no device switcher exists; both are follow-ups, and the manager is placed where the switcher will join it.