### PR TITLE
feat(plugin-form-builder): give the form's identity fields a surface

### DIFF
--- a/.changeset/form-builder-metadata-card.md
+++ b/.changeset/form-builder-metadata-card.md
@@ -1,0 +1,38 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Give the form builder's identity fields a surface.
+
+Form Name, Slug and Status sat on the bare page with nothing holding them
+together, and their controls were transparent, so they read as outlines rather
+than as inputs. They are now one card.
+
+The builder canvas below stays unframed: it draws its own dashed drop zone, and
+a card around it is a box inside a box. The tab rail sits on the page between
+them, because it switches what is below it rather than belonging to the fields
+above it.

--- a/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
+++ b/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
@@ -14,6 +14,7 @@
 
 import {
   Button,
+  Card,
   FieldShell,
   FormActions,
   Input,
@@ -369,8 +370,12 @@ function FormBuilderViewInner({
         </p>
       </div>
 
-      {/* ── Metadata & tab navigation ── */}
-      <div className="border-b border-border space-y-4 pb-4 mb-6">
+      {/* ── Form metadata ──
+          A card, so the fields that identify the form read as one group and
+          have a surface to sit on. The builder canvas below is deliberately
+          NOT carded: it draws its own drop zone, and a frame around a frame
+          reads as a nested box rather than as structure. */}
+      <Card className="mb-6 px-6 py-5">
         <div className="flex flex-wrap gap-4">
           <FieldShell
             label="Form Name"
@@ -382,7 +387,6 @@ function FormBuilderViewInner({
               value={formData.name || ""}
               onChange={e => handleNameChange(e.target.value)}
               placeholder="e.g., Contact Form"
-              className="bg-transparent"
             />
           </FieldShell>
 
@@ -396,7 +400,7 @@ function FormBuilderViewInner({
               value={formData.slug || ""}
               onChange={e => updateFormData({ slug: e.target.value })}
               placeholder="e.g., contact-form"
-              className="bg-transparent placeholder:text-muted-foreground"
+              className="placeholder:text-muted-foreground"
             />
           </FieldShell>
 
@@ -424,7 +428,6 @@ function FormBuilderViewInner({
                     id={id}
                     aria-describedby={describedBy}
                     aria-invalid={invalid}
-                    className="bg-transparent"
                   >
                     <SelectValue placeholder="Status" />
                   </SelectTrigger>
@@ -438,8 +441,13 @@ function FormBuilderViewInner({
             </FieldShell>
           </div>
         </div>
+      </Card>
 
-        {/* ── Main tab navigation ── */}
+      {/* ── Main tab navigation ──
+          On the page rather than inside the card above: the rail switches what
+          is BELOW it, so grouping it with the metadata would attach it to the
+          wrong thing. */}
+      <div className="border-b border-border mb-6">
         <Tabs
           value={activeTab}
           onValueChange={v => setActiveTab(v as typeof activeTab)}


### PR DESCRIPTION
Closes the last of R-13's five symptoms — the forms page had no surface.

## What changed on screen

Form Name, Slug and Status sat on the bare page with nothing grouping them, and their controls carried `bg-transparent`, so they read as outlines rather than as inputs. They are now one card.

The founder chose this shape after seeing both options screenshotted side by side. The builder canvas below stays **unframed**, deliberately: it draws its own dashed drop zone, so a card around it is a box inside a box — visible in the variant that carded both. The tab rail sits on the page between them, because it switches what is *below* it and grouping it with the fields above would attach it to the wrong thing.

## The three `bg-*` overrides are deleted, not changed

`Input` and `SelectTrigger` already default to the surface these fields now want. My first pass changed `bg-transparent` to `bg-background`; that is a second copy of the component's own default sitting next to it, which is the pattern this task has spent six review rounds removing. Every other carded form in the admin — `WebhookForm`, `ImageSizeForm` — passes no background at all, and this now matches them.

## Verification

- Browser, 1440x1200: breadcrumb and heading share x=436, content column 896px, exactly one `[data-slot=page-shell]` in the tree, console clean.
- `pnpm turbo check-types --continue` — 22/22.
- `packages/plugin-form-builder` 89 passed · `packages/ui` 1135 passed.
- `packages/admin` — 15 failed / 2675 passed, 4 files: the known shared baseline on `main`, untouched by this. CI does not run that suite.
- `fallow audit --base origin/main` — **pass**, zero introduced in all four categories.

No test added. The change is a wrapper element and three deleted attributes; the property worth guarding — that a form body does not set its own measure — is already covered by `form-measure-contract.test.ts`, which has this file in its derived population.

Changeset derived from `.changeset/config.json` — 25 packages, patch.

@codex please review
