### PR TITLE
test(nextly): assert which refusal the preview tests are seeing

### DIFF
--- a/packages/nextly/src/runtime/preview/__tests__/preview-single-draft-gate.test.ts
+++ b/packages/nextly/src/runtime/preview/__tests__/preview-single-draft-gate.test.ts
@@ -190,12 +190,14 @@ describe("previewSingleDraftGate", () => {
   // refuses to produce one now, so it is hand-built rather than asserted
   // against a shape this module can no longer make. Honouring it would read the
   // document with no field rules at all, which is the leak.
-  it("refuses a token minted before it recorded who shared it", async () => {
-    const legacy = await new SignJWT({
-      kind: "single",
-      sng: "homepage",
-      gen: 1,
-    })
+  //
+  // Hand-built in a HELPER shared with the control below, because the refusal
+  // this asserts is only attributable to the missing `mnt` if the token is
+  // valid in every other respect. A drifted claim name, audience or key
+  // derivation would refuse it too, and this test would go on passing while
+  // proving nothing about the claim it names.
+  const legacyToken = async (extra: Record<string, unknown> = {}) =>
+    new SignJWT({ kind: "single", sng: "homepage", gen: 1, ...extra })
       .setProtectedHeader({ alg: "HS256" })
       .setAudience("nextly:preview")
       .setSubject("single:homepage")
@@ -206,12 +208,27 @@ describe("previewSingleDraftGate", () => {
           hkdfSync("sha256", TEST_SECRET, "", "nextly:preview-token:v1", 32)
         )
       );
-    cookieValue = encodeURIComponent(legacy);
+
+  it("refuses a token minted before it recorded who shared it", async () => {
+    cookieValue = encodeURIComponent(await legacyToken());
 
     await expect(previewSingleDraftGate()({ slug: "homepage" })).resolves.toBe(
       false
     );
     // And it never reached the identity lookup: there was no id to look up.
     expect(resolvePreviewIdentity).not.toHaveBeenCalled();
+  });
+
+  // The positive control for the case above, and the whole reason the token is
+  // built by a shared helper: the SAME hand-built token, differing only by the
+  // claim under test, must be GRANTED. Without it the refusal above is
+  // satisfied by any defect in the hand-signing, and would survive the signer
+  // changing its key derivation, audience or claim names underneath it.
+  it("grants that same hand-built token once it records a minter", async () => {
+    cookieValue = encodeURIComponent(await legacyToken({ mnt: "minter-1" }));
+
+    await expect(
+      previewSingleDraftGate()({ slug: "homepage" })
+    ).resolves.toEqual({ readAs: SHARER });
   });
 });


### PR DESCRIPTION
Relands a commit stranded by #1184's merge.

## Why this is a separate PR

#1184 merged at the head GitHub had snapshotted, and the commit I pushed moments earlier was not in it. `scripts/verify-merge.mjs 1184` named it as a candidate; I settled it BY CONTENT against the merge commit rather than trusting the screen:

| marker | merge `f379fdf02` | branch head `4e316a607` |
| --- | --- | --- |
| `const legacyToken = async (extra: ...)` | absent | present |
| `grants that same hand-built token once it records a minter` | absent | present |

Two independent markers, each with its control at the branch head proving the search resolves — an absent marker means nothing until you have shown the search CAN find it. Everything else landed clean: all 11 files the merge touched are blob-identical to the head it snapshotted, and nothing that head changed is missing.

## What the commit does

`preview-single-draft-gate.test.ts` has a case asserting that a token minted before the `mnt` claim existed is REFUSED. The token is hand-signed, because the signer now refuses to produce one — but a refusal is attributable to the missing claim only if the token is valid in every other respect. A drifted audience, claim name, subject or key derivation would refuse it too, and the test would go on passing while proving nothing about the claim it names.

CodeRabbit raised this on #1184. The token is now built by a helper the control shares, so the two cases differ by that one claim and nothing else, and the control asserts the gate GRANTS.

Verified the control actually detects drift rather than assuming it would:

| drift introduced into the shared signer | refusal case | control |
| --- | --- | --- |
| audience → `nextly:preview-DRIFTED` | still green | **RED** |
| scope claim `sng` → `sng_DRIFTED` | still green | **RED** |

Without the control, both of those futures are silent.

## Gates

`pnpm build`, `check-types`, `lint`, `check:comments` clean. `fallow audit` **pass**, zero introduced findings. `nextly` suite at exactly the documented baseline — 360 failed / 32 files, no new failing file by name.

Test-only, so no changeset.