### PR TITLE
test(nextly): assert which refusal the preview route answered

### DIFF
--- a/packages/nextly/src/runtime/routing/__tests__/content-route-preview-gate.integration.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-preview-gate.integration.test.ts
@@ -114,6 +114,28 @@ function route(nextly: TestNextly["nextly"], token?: string) {
   });
 }
 
+/**
+ * The route answered NOT FOUND, rather than merely throwing.
+ *
+ * `.rejects.toThrow()` cannot tell the intended 404 from any other failure on
+ * the way — a query guard refusing the lookup, a fixture that never booted, a
+ * misspelled collection. Every refusal in this file is a NEGATIVE assertion,
+ * and a negative assertion satisfied by the wrong error reads as coverage while
+ * seeing nothing.
+ *
+ * Measured rather than argued: this collection declares a read rule on its slug
+ * field, and for a period every one of these cases passed because a filter
+ * guard was rejecting the slug lookup outright — the enforced route answered no
+ * page at all, and the assertions could not tell that from the entry being
+ * correctly absent.
+ *
+ * Next signals the not-found boundary by throwing a string-tagged error rather
+ * than a typed one, so the tag is what there is to match.
+ */
+async function expectNotFound(page: Promise<unknown>): Promise<void> {
+  await expect(page).rejects.toThrow(/NEXT_HTTP_ERROR_FALLBACK;404/);
+}
+
 describe("createContentRoute driven by previewDraftGate", () => {
   it("serves a never-published entry to the visitor whose token names it", async () => {
     current = await createTestNextly({ collections: [pages()] });
@@ -145,9 +167,9 @@ describe("createContentRoute driven by previewDraftGate", () => {
       data: { slug: "unreleased", title: "Unreleased", status: "draft" },
     });
 
-    await expect(
+    await expectNotFound(
       route(current.nextly).ContentPage({ params: { slug: ["unreleased"] } })
-    ).rejects.toThrow();
+    );
   });
 
   // One link is a key to ONE document. A token minted for entry A must not open
@@ -170,11 +192,11 @@ describe("createContentRoute driven by previewDraftGate", () => {
       { generation: GENERATION, minter: await sharer(current.nextly) }
     );
 
-    await expect(
+    await expectNotFound(
       route(current.nextly, token).ContentPage({
         params: { slug: ["entry-b"] },
       })
-    ).rejects.toThrow();
+    );
   });
 
   // The leak this whole change exists to close. A draft read is TRUSTED so the
@@ -267,11 +289,11 @@ describe("createContentRoute driven by previewDraftGate", () => {
       { generation: GENERATION, minter: "user-that-never-existed" }
     );
 
-    await expect(
+    await expectNotFound(
       route(current.nextly, token).ContentPage({
         params: { slug: ["unreleased"] },
       })
-    ).rejects.toThrow();
+    );
   });
   // A path decided from a REDACTED value is decided from an absence. Once the
   // draft is judged by the sharer, a read rule on the slug field removes it


### PR DESCRIPTION
Relands a commit stranded by #1187's merge — the **second** stranding of this same commit, and the fourth on this task. Details at the bottom, because the pattern is worth more than the fix.

## What it does

`content-route-preview-gate.integration.test.ts` had three cases asserting `.rejects.toThrow()`. That cannot tell the intended 404 from any other failure on the same path, and it was not hypothetical: this collection declares a read rule on its **slug** field, and between #1177 and #1183 all three passed because a filter guard was rejecting the slug lookup outright. The enforced route answered no page at all, and the assertions could not tell that from the entry being correctly absent.

Measured on `main` at the time:

```
expected to throw /NEXT_HTTP_ERROR_FALLBACK;404/  but got 'Validation failed.'
```

They match the not-found tag now. Verified the matcher discriminates rather than passing loosely: given a tag it cannot match, all three go red.

**This also serves as an independent check on #1183.** The assertions live in a file that is not that PR's and was not written for its guard, so three greens on `main` at `fe6b1acce` is evidence its `frameworkFilter` exemption reached `resolveContent`'s lookups rather than only the paths its own tests exercise. Confirmed green.

**The general form**, since it has now bitten twice in one day: when a test asserts a refusal, assert WHICH refusal. `.rejects.toThrow()` is a check whose population is *all failures*, and the paths where refusals cluster — auth, routing, validation — are exactly the ones that acquire new refusals over time. A green there can stop meaning what it meant with nothing moving and nothing reported.

## On the stranding

`verify-merge.mjs 1187` named five candidates. Four were legitimate — three of #1183's commits that reached `main` by its own merge, plus my own merge commit, all correctly absent from a squash. The fifth was this one.

Settled by content, with the control that makes an absence meaningful:

| | merge `fe94216cf` | branch head `dd1f7633a` |
| --- | --- | --- |
| `async function expectNotFound(...)` | absent | present |
| `expectNotFound(` call sites | absent | present |
| `.rejects.toThrow()` still on `main` | 3 | — |

The last row is the decisive one: `main` still carries the loose assertions, so the commit demonstrably did not land.

Test-only, so no changeset.