### PR TITLE
fix(blocks-engine): keep `__proto__`-named slots, and stop refusing damaged documents

### DIFF
--- a/.changeset/engine-proto-safety-and-tolerance.md
+++ b/.changeset/engine-proto-safety-and-tolerance.md
@@ -1,5 +1,29 @@
 ---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
 "@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
 ---
 
 Keep a slot whose stored name is `__proto__`, and stop refusing to edit a document that cannot be serialized.

--- a/.changeset/engine-proto-safety-and-tolerance.md
+++ b/.changeset/engine-proto-safety-and-tolerance.md
@@ -1,0 +1,9 @@
+---
+"@nextlyhq/blocks-engine": patch
+---
+
+Keep a slot whose stored name is `__proto__`, and stop refusing to edit a document that cannot be serialized.
+
+Rebuilding a record under keys that came from stored data lost any entry named `__proto__`: plain assignment invokes the legacy prototype setter rather than creating a property, so the slot vanished from `Object.keys` and from the stored JSON, and the record's prototype was silently replaced. `removeNode` and `migrateDocument` both hit this, which means deleting one node — or migrating an unrelated one — could delete stored content elsewhere in the same document. `insertNode` had it in both directions, since reading `slots["__proto__"]` returns `Object.prototype` rather than `undefined`.
+
+Separately, the tree primitives now agree on what to do with a document that `JSON.stringify` refuses. They transform what they can reach and never refuse work because the document they were given was already damaged; whether the result can be saved is decided once, at the write, by the check that already answers it. Previously `duplicateNode` alone refused outright when any part of the forest was cyclic, so a corrupt block anywhere on a page stopped an author copying a healthy one.

--- a/packages/blocks-engine/src/migration.test.ts
+++ b/packages/blocks-engine/src/migration.test.ts
@@ -560,3 +560,64 @@ describe("resolving a reported pointer", () => {
     expect(nodeAtPointer(doc, "")).toBeUndefined();
   });
 });
+
+describe("a slot named by a stored `__proto__`", () => {
+  // Parsed rather than written as a literal: `{ __proto__: [...] }` in source
+  // sets the prototype instead of creating a key, so a literal fixture would
+  // never carry the own property this is about.
+  function docWithProtoSlot(): BlockDocument {
+    return JSON.parse(
+      JSON.stringify({
+        nodes: [
+          {
+            id: "host",
+            type: "core/box",
+            version: 1,
+            props: {},
+            slots: {
+              PLACEHOLDER: [
+                { id: "kept", type: "core/text", version: 1, props: {} },
+              ],
+              main: [{ id: "stale", type: "core/text", version: 1, props: {} }],
+            },
+          },
+        ],
+      }).replace('"PLACEHOLDER"', '"__proto__"')
+    ) as BlockDocument;
+  }
+
+  it("is a shape the fixture actually produces", () => {
+    // Positive control. Without it every assertion below would also pass on a
+    // fixture that never had the key, which is the same green a working
+    // rebuild produces.
+    const slots = docWithProtoSlot().nodes[0]!.slots!;
+
+    expect(Object.prototype.hasOwnProperty.call(slots, "__proto__")).toBe(true);
+  });
+
+  it("survives a migration that rewrites a DIFFERENT slot's node", () => {
+    const doc = docWithProtoSlot();
+
+    const result = migrateDocument(
+      doc,
+      source({
+        "core/box": { version: 1 },
+        "core/text": {
+          version: 2,
+          migrate: { 1: (p: Record<string, unknown>) => ({ ...p, v2: true }) },
+        },
+      })
+    );
+
+    const slots = result.doc.nodes[0]!.slots!;
+    // The migration was asked to touch `core/text` nodes. Both slots hold one,
+    // so a rebuild that lost the `__proto__` key would be deleting a node it
+    // had just migrated.
+    expect(Object.keys(slots)).toContain("__proto__");
+    expect(JSON.stringify(slots)).toContain("__proto__");
+    expect(Object.getPrototypeOf(slots)).toBe(Object.prototype);
+    // And the migration itself still happened, so this is not passing because
+    // nothing ran.
+    expect(result.doc.nodes[0]!.slots!.main[0]!.props).toEqual({ v2: true });
+  });
+});

--- a/packages/blocks-engine/src/migration.ts
+++ b/packages/blocks-engine/src/migration.ts
@@ -15,6 +15,7 @@
  */
 import type { BlockDocument, BlockNode } from "./document";
 import { isPlainRecord } from "./plain-record";
+import { defineEntry } from "./safe-record";
 
 /** Upgrade a node's props from one schema version to the next. Must be pure. */
 export type MigrateFn = (
@@ -366,14 +367,18 @@ export function migrateDocument(
     const slots: Record<string, BlockNode[]> = {};
     for (const [slot, children] of Object.entries(next.slots)) {
       if (!Array.isArray(children)) {
-        slots[slot] = children;
+        // Defined rather than assigned throughout: slot names come from stored
+        // data, and a `__proto__` slot is dropped by assignment. See
+        // `safe-record`. A migration silently deleting a slot would be
+        // especially hard to trace, because the document it rewrote is gone.
+        defineEntry(slots, slot, children);
         continue;
       }
       const slotPath = pointer(pointer(path, "slots"), slot);
       const migratedChildren = children.map((child, index) =>
         migrateNode(child, pointer(slotPath, index))
       );
-      slots[slot] = migratedChildren;
+      defineEntry(slots, slot, migratedChildren);
       if (migratedChildren.some((c, i) => c !== children[i]))
         slotsChanged = true;
     }

--- a/packages/blocks-engine/src/safe-record.ts
+++ b/packages/blocks-engine/src/safe-record.ts
@@ -1,0 +1,116 @@
+/**
+ * Building a record whose KEYS come from stored data.
+ *
+ * Slot names, node ids and token path segments all reach this package as
+ * strings a user's document supplied, and a record keyed by them is not a
+ * neutral container: two of its keys are answered by `Object.prototype` rather
+ * than by the object, and they fail in opposite directions.
+ *
+ * ## The asymmetry
+ *
+ * `constructor` defeats the READ. `built["constructor"]` resolves
+ * `Object.prototype.constructor` on a record that never had the key, so a
+ * lookup meant to ask "did I rebuild this entry?" answers with a function.
+ *
+ * `__proto__` defeats the WRITE. `target["__proto__"] = value` invokes the
+ * legacy prototype setter instead of creating a property: no own key exists
+ * afterwards, `JSON.stringify` emits the record without it, and the object's
+ * prototype has silently become whatever was assigned. Measured:
+ *
+ * ```js
+ * const src = JSON.parse('{"__proto__":["a"],"content":["b"]}');
+ * Object.keys(src);                       // ['__proto__', 'content']  — an OWN key
+ * const out = {};
+ * for (const [k, v] of Object.entries(src)) out[k] = v;
+ * Object.keys(out);                       // ['content']  — the entry is gone
+ * Object.getPrototypeOf(out) === Object.prototype;  // false
+ * ```
+ *
+ * They are different keys reached by different mechanisms, which is why a guard
+ * built for one leaves the other standing: reading through a `Map` closes
+ * `constructor` and does nothing for `__proto__`, and this closes `__proto__`
+ * and does nothing for `constructor`. A rebuild that reads and writes needs
+ * both.
+ *
+ * ## Why it matters here rather than as a general precaution
+ *
+ * The loss is caused by an edit that named a DIFFERENT node. A document with a
+ * `__proto__` slot is malformed, but this package's contract is that malformed
+ * stored content is preserved rather than normalised — an unrelated edit must
+ * not be the thing that destroys it. Dropping the entry during a rebuild
+ * silently converts "we kept what we could not interpret" into "we deleted it",
+ * and nothing downstream can tell that happened.
+ *
+ * @module safe-record
+ */
+
+/**
+ * Write one entry into a record under a key that came from stored data.
+ *
+ * `Object.defineProperty` rather than assignment, because assignment is not a
+ * plain write for every string: see the module note. Descriptor matches what
+ * assignment to a fresh object would have produced, so a record built this way
+ * is indistinguishable from a normally-built one for every key except the one
+ * that would have been lost.
+ */
+export function defineEntry<T>(
+  target: Record<string, T>,
+  key: string,
+  value: T
+): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  });
+}
+
+/**
+ * Read one entry from a record under a key that came from stored data.
+ *
+ * The read half of the same asymmetry, and it is needed at any site that looks
+ * an entry up before writing it. `record["__proto__"]` returns
+ * `Object.prototype` on a record that has no such key, and `record["toString"]`
+ * returns a function — so `record[key] ?? fallback` does not reach its fallback
+ * for either, and the caller proceeds with an inherited value.
+ *
+ * Measured: `[...(({})["__proto__"] ?? [])]` throws
+ * `TypeError: ... is not iterable` rather than yielding an empty array, because
+ * the nullish coalescing never fires.
+ */
+export function ownEntry<T>(
+  record: Record<string, T>,
+  key: string
+): T | undefined {
+  // `Object.prototype.hasOwnProperty.call` rather than `record.hasOwnProperty`:
+  // the record's own keys are stored data, so it may carry a `hasOwnProperty`
+  // of its own and answer the question with it.
+  return Object.prototype.hasOwnProperty.call(record, key)
+    ? record[key]
+    : undefined;
+}
+
+/**
+ * ## What is already safe, so nobody "fixes" it
+ *
+ * Only ASSIGNMENT is affected. These define rather than assign, and each
+ * preserves a stored `__proto__` as an own key — measured, not assumed:
+ *
+ * - `{ ...stored }`
+ * - `Object.fromEntries(...)`
+ * - `Object.assign({}, stored)`
+ * - `structuredClone(stored)`
+ *
+ * And plain assignment is safe when the TARGET has no prototype to inherit
+ * from. `Object.create(null)` carries no `__proto__` accessor, so
+ * `target[key] = value` there creates an own property like any other key —
+ * `compilePageCss` builds its gated map that way and needs nothing from this
+ * module. A search for the assignment SHAPE alone finds those sites and
+ * misreads them; what decides it is how the target was constructed.
+ *
+ * So a whole-record rebuild needs no helper here; reach for `defineEntry` when
+ * writing ONE key whose name came from stored data, and for `ownEntry` when
+ * reading one. A `recordFromEntries` wrapper lived here briefly and was removed
+ * as a second spelling of `Object.fromEntries`.
+ */

--- a/packages/blocks-engine/src/safe-record.ts
+++ b/packages/blocks-engine/src/safe-record.ts
@@ -99,8 +99,22 @@ export function ownEntry<T>(
  *
  * - `{ ...stored }`
  * - `Object.fromEntries(...)`
- * - `Object.assign({}, stored)`
  * - `structuredClone(stored)`
+ *
+ * **`Object.assign({}, stored)` is NOT among them.** It copies through the
+ * target's ordinary `[[Set]]` path, so it behaves exactly like the plain
+ * assignment this module exists to replace: the own key is dropped and the
+ * target's prototype is replaced. It sits beside three functions that look
+ * interchangeable with it and is the one that fails, which is the reason this
+ * list names it rather than leaving it off:
+ *
+ * ```js
+ * const src = JSON.parse('{"__proto__":["a"],"content":["b"]}');
+ * Object.keys({ ...src });                 // ['__proto__', 'content']
+ * Object.keys(Object.fromEntries(Object.entries(src)));  // ['__proto__', 'content']
+ * Object.keys(structuredClone(src));       // ['__proto__', 'content']
+ * Object.keys(Object.assign({}, src));     // ['content']       ← drops it
+ * ```
  *
  * And plain assignment is safe when the TARGET has no prototype to inherit
  * from. `Object.create(null)` carries no `__proto__` accessor, so

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { BlockNode } from "./document";
 import { countNodes, treeDepth } from "./limits";
+import { measureBytes } from "./measure-bytes";
 import {
   duplicateNode,
   findNode,
@@ -322,36 +323,101 @@ describe("a forest whose slots form a cycle", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it("REFUSES to duplicate a cyclic subtree rather than adding an unusable clone", () => {
-    // The clone is rebuilt without the edge that closes the cycle, but the
-    // ORIGINAL stays in the forest and stays cyclic — so the result carries a
-    // structure `JSON.stringify` refuses and the page cannot be stored at all.
-    // "Did not throw" cannot see that, which is why the previous version of
-    // this test passed while the returned forest was still unusable.
+  it("duplicates inside a cyclic forest, and the CLONE is acyclic", () => {
+    // These primitives do not decline work because the document they were given
+    // is already unstorable; storability is decided once, at the write. So the
+    // duplicate happens, and what has to be true is about the CLONE: it is a
+    // real second copy, and `reidSubtree` rebuilt it without the edge that
+    // closed the cycle.
     //
-    // Refused rather than repaired: silently rebuilding the source would edit a
-    // node the caller never named, on an operation they asked to be additive.
+    // Asserted as reachability from the clone rather than as "did not throw".
+    // The absence of a throw is satisfied by a `duplicateNode` that returns its
+    // argument, which is precisely the implementation this must separate from.
     const nodes = cyclic();
+    const originalId = nodes[0]!.id;
 
-    expect(duplicateNode(nodes, nodes[0]!.id)).toBe(nodes);
+    const next = duplicateNode(nodes, originalId);
+
+    const topIds = next.map(node => node.id);
+    expect(topIds).toHaveLength(2);
+    expect(topIds[0]).toBe(originalId);
+    expect(topIds[1]).not.toBe(originalId);
+
+    // The clone's own subtree terminates without the walk reporting a cycle.
+    // `walkNodes` is cycle-tolerant, so a cyclic clone would still finish here —
+    // what distinguishes them is `onCycle` firing, not the walk completing.
+    let cloneCycles = 0;
+    walkNodes([next[1]!], () => undefined, {
+      onCycle: () => {
+        cloneCycles += 1;
+      },
+    });
+    expect(cloneCycles).toBe(0);
   });
 
-  it("refuses a duplicate when a SIBLING branch carries the cycle", () => {
-    // The selected node is perfectly fine; the cycle is somewhere else in the
-    // forest. The result is equally unstorable, because `JSON.stringify`
-    // refuses the FOREST rather than the node — so a guard that inspected only
-    // the subtree being copied reported success and handed back something that
-    // cannot be persisted.
+  it("duplicates a healthy node when a SIBLING branch carries the cycle", () => {
+    // The selected node is fine; the damage is elsewhere in the forest. Under
+    // the old whole-forest refusal this returned the forest untouched, so an
+    // author could not copy a healthy block because some other block was
+    // corrupt.
     //
-    // The previous test cannot separate these implementations: it selects the
-    // cyclic node itself, so checking the subtree and checking the forest give
-    // the same answer.
-    const cyclic = makeNode("core/box", 1, {}, { main: [] });
-    cyclic.slots!.main.push(cyclic);
+    // This case is kept because it separates implementations the previous test
+    // cannot: that one selects the cyclic node itself, so inspecting the
+    // subtree and inspecting the forest give the same answer.
+    const looped = makeNode("core/box", 1, {}, { main: [] });
+    looped.slots!.main.push(looped);
     const target = makeNode("core/text", 1);
-    const forest = [cyclic, target];
+    const forest = [looped, target];
 
-    expect(duplicateNode(forest, target.id)).toBe(forest);
+    const next = duplicateNode(forest, target.id);
+
+    expect(next).not.toBe(forest);
+    expect(next).toHaveLength(3);
+    // The copy sits immediately after its original and carries a fresh id.
+    expect(next[1]!.id).toBe(target.id);
+    expect(next[2]!.id).not.toBe(target.id);
+    expect(next[2]!.type).toBe("core/text");
+  });
+
+  it("leaves the cycle in place rather than repairing what the caller did not name", () => {
+    // The other half of tolerating: the operation does not quietly rewrite the
+    // damaged part of the document. An author asked to copy one node, and a
+    // primitive that "helpfully" dropped the back edge would be editing content
+    // nobody selected — and would report success for a repair no one can audit.
+    const nodes = cyclic();
+
+    const next = duplicateNode(nodes, nodes[0]!.id);
+
+    // The duplicate has to have HAPPENED for the rest to mean anything —
+    // returning the forest untouched leaves the cycle in place too, and would
+    // satisfy the assertion below while doing no work at all.
+    expect(next).toHaveLength(2);
+    let cycles = 0;
+    walkNodes(next, () => undefined, {
+      onCycle: () => {
+        cycles += 1;
+      },
+    });
+    expect(cycles).toBeGreaterThan(0);
+  });
+
+  it("hands the unstorable verdict to the writer, which still refuses", () => {
+    // The refusal MOVED; it did not disappear. This is the assertion that would
+    // catch someone reading the tolerance rule as "cycles are fine now" — the
+    // document still cannot be saved, and the check that says so is the one the
+    // write path already calls.
+    const source = cyclic();
+    const nodes = duplicateNode(source, source[0]!.id);
+
+    // Same reason as above: an implementation that refused would hand back an
+    // unstorable forest as well, so the verdict alone does not separate them.
+    expect(nodes).toHaveLength(2);
+    const verdict = measureBytes({ nodes }, 1_000_000);
+
+    // Matched as a whole rather than field by field: `reason` exists only on
+    // the refusing arm of `ByteMeasurement`, so reading it after a separate
+    // `exceeded` assertion does not narrow and does not compile.
+    expect(verdict).toMatchObject({ exceeded: true, reason: "unwritable" });
   });
 
   it("still duplicates an ACYCLIC subtree, so the refusal is not blanket", () => {
@@ -870,5 +936,79 @@ describe("counting helpers", () => {
     expect(treeDepth(nodes)).toBe(2);
     expect(countNodes([])).toBe(0);
     expect(treeDepth([])).toBe(0);
+  });
+});
+
+describe("a record keyed by a stored `__proto__`", () => {
+  // `JSON.parse` creates `__proto__` as an OWN property, which is what makes
+  // this reachable at all: the key survives into `Object.entries`, so a rebuild
+  // sees it and then loses it on the way out. A document literal written here
+  // would NOT reproduce it — `{ __proto__: [...] }` in source sets the
+  // prototype instead of creating a key — so these fixtures are parsed.
+  function parsedSlots(): Record<string, BlockNode[]> {
+    return JSON.parse(
+      JSON.stringify({ main: [], other: [] }).replace('"main"', '"__proto__"')
+    ) as Record<string, BlockNode[]>;
+  }
+
+  it("is a shape the fixture actually produces", () => {
+    // The positive control. Without it, every assertion below could be passing
+    // because the fixture never had a `__proto__` key in the first place, and a
+    // rebuild that dropped it would look identical to one that kept it.
+    const slots = parsedSlots();
+
+    expect(Object.keys(slots)).toContain("__proto__");
+    expect(Object.prototype.hasOwnProperty.call(slots, "__proto__")).toBe(true);
+  });
+
+  it("survives removeNode, which rebuilds every slot of every node", () => {
+    const doomed = makeNode("core/text", 1);
+    const slots = parsedSlots();
+    slots.other = [doomed];
+    const parent = makeNode("core/box", 1, {}, slots);
+
+    const next = removeNode([parent], doomed.id);
+
+    // The slot the caller never mentioned is still there, and still a slot —
+    // not swallowed into the prototype, where `Object.keys` and
+    // `JSON.stringify` would both report it gone.
+    expect(Object.keys(next[0]!.slots!)).toContain("__proto__");
+    expect(JSON.stringify(next[0]!.slots)).toContain("__proto__");
+    expect(Object.getPrototypeOf(next[0]!.slots!)).toBe(Object.prototype);
+    // And the edit that was actually requested happened.
+    expect(next[0]!.slots!.other).toHaveLength(0);
+  });
+
+  it("survives insertNode targeting a different slot", () => {
+    const slots = parsedSlots();
+    const parent = makeNode("core/box", 1, {}, slots);
+    const added = makeNode("core/text", 1);
+
+    const next = insertNode([parent], added, {
+      parentId: parent.id,
+      slot: "other",
+      index: 0,
+    });
+
+    expect(Object.keys(next[0]!.slots!)).toContain("__proto__");
+    expect(next[0]!.slots!.other).toHaveLength(1);
+  });
+
+  it("can be the slot being written to, without becoming the prototype", () => {
+    // The direction the spread does not cover: the destination record has no
+    // own `__proto__` to shadow the inherited setter, so plain assignment here
+    // creates no key at all and silently retargets the object's prototype.
+    const parent = makeNode("core/box", 1, {}, { other: [] });
+    const added = makeNode("core/text", 1);
+
+    const next = insertNode([parent], added, {
+      parentId: parent.id,
+      slot: "__proto__",
+      index: 0,
+    });
+
+    expect(Object.keys(next[0]!.slots!)).toContain("__proto__");
+    expect(Object.getPrototypeOf(next[0]!.slots!)).toBe(Object.prototype);
+    expect(next[0]!.slots!.__proto__).toHaveLength(1);
   });
 });

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -379,39 +379,126 @@ describe("a forest whose slots form a cycle", () => {
     expect(next[2]!.type).toBe("core/text");
   });
 
-  it("leaves the cycle in place rather than repairing what the caller did not name", () => {
-    // The other half of tolerating: the operation does not quietly rewrite the
-    // damaged part of the document. An author asked to copy one node, and a
-    // primitive that "helpfully" dropped the back edge would be editing content
-    // nobody selected — and would report success for a repair no one can audit.
-    const nodes = cyclic();
+  it("answers the same way whether the target is TOP-LEVEL or NESTED", () => {
+    // One primitive must not give two answers decided by where the caller
+    // pointed it. The nested path rebuilds through `mapForest`, which drops a
+    // cycle-closing entry; the top-level path copied the array instead, so the
+    // same duplicate removed an unrelated cycle or left it standing depending
+    // on the target's depth.
+    //
+    // Both fixtures share a shape so DEPTH is the only difference between them.
+    function siblingCycle(nested: boolean): {
+      forest: BlockNode[];
+      targetId: string;
+    } {
+      const looped = makeNode("core/box", 1, {}, { main: [] });
+      looped.slots!.main.push(looped);
+      const target = makeNode("core/text", 1);
+      if (!nested) return { forest: [looped, target], targetId: target.id };
+      const host = makeNode("core/box", 1, {}, { main: [target] });
+      return { forest: [looped, host], targetId: target.id };
+    }
 
-    const next = duplicateNode(nodes, nodes[0]!.id);
+    const results = [false, true].map(nested => {
+      const { forest, targetId } = siblingCycle(nested);
+      const next = duplicateNode(forest, targetId);
+      let cycles = 0;
+      walkNodes(next, () => undefined, {
+        onCycle: () => {
+          cycles += 1;
+        },
+      });
+      return { duplicated: next !== forest, cycles };
+    });
 
-    // The duplicate has to have HAPPENED for the rest to mean anything —
-    // returning the forest untouched leaves the cycle in place too, and would
-    // satisfy the assertion below while doing no work at all.
-    expect(next).toHaveLength(2);
+    // Both duplicated rather than refusing, and both say the same thing about
+    // the unrelated cycle. The equality is the property; the absolute value is
+    // asserted too, so two equally broken implementations cannot satisfy it.
+    expect(results[0]!.duplicated).toBe(true);
+    expect(results[1]!.duplicated).toBe(true);
+    expect(results[0]!.cycles).toBe(results[1]!.cycles);
+    expect(results[0]!.cycles).toBe(0);
+  });
+
+  it("keeps a malformed slot VALUE while dropping the cycle edge", () => {
+    // The distinction the whole rule turns on, asserted as a PAIR because
+    // either half alone reads as a policy about damage in general. A cycle edge
+    // cannot round-trip through storage, so dropping it loses nothing a caller
+    // could have saved. A malformed value writes and reads back unchanged, so
+    // dropping that would destroy content the edit never named.
+    const looped = makeNode("core/box", 1, {}, { main: [] });
+    looped.slots!.main.push(looped);
+    const odd = makeNode("core/box", 1, {}, {});
+    // Not an array — the shape unvalidated stored documents actually arrive in.
+    odd.slots = { broken: "kept" as unknown as BlockNode[] };
+    const target = makeNode("core/text", 1);
+
+    const next = duplicateNode([looped, odd, target], target.id);
+
     let cycles = 0;
     walkNodes(next, () => undefined, {
       onCycle: () => {
         cycles += 1;
       },
     });
-    expect(cycles).toBeGreaterThan(0);
+    expect(cycles).toBe(0);
+    expect(next[1]!.slots).toEqual({ broken: "kept" });
   });
 
-  it("hands the unstorable verdict to the writer, which still refuses", () => {
-    // The refusal MOVED; it did not disappear. This is the assertion that would
-    // catch someone reading the tolerance rule as "cycles are fine now" — the
-    // document still cannot be saved, and the check that says so is the one the
-    // write path already calls.
-    const source = cyclic();
-    const nodes = duplicateNode(source, source[0]!.id);
+  it("relocates a node whose own subtree is already cyclic", () => {
+    // The insertion guard refuses a cyclic ARGUMENT so a caller cannot add a
+    // cycle to a healthy forest. A move is not that: the subtree came out of
+    // the document, and refusing it meant a damaged block could never be moved
+    // — the one thing an author might reasonably do to get it out of the way.
+    //
+    // `moveNode` is atomic, so a refused re-insert returns the ORIGINAL forest.
+    // That is why this asserts the node arrived at its destination rather than
+    // merely that something changed: an implementation that still refuses
+    // returns a forest identical to the input, and "no throw" cannot see it.
+    const selfLoop = makeNode("core/box", 1, {}, { main: [] });
+    selfLoop.slots!.main.push(selfLoop);
+    const dest = makeNode("core/box", 1, {}, { main: [] });
 
-    // Same reason as above: an implementation that refused would hand back an
-    // unstorable forest as well, so the verdict alone does not separate them.
-    expect(nodes).toHaveLength(2);
+    const next = moveNode([selfLoop, dest], selfLoop.id, {
+      parentId: dest.id,
+      slot: "main",
+      index: 0,
+    });
+
+    expect(next).toHaveLength(1);
+    expect(next[0]!.id).toBe(dest.id);
+    expect(next[0]!.slots!.main).toHaveLength(1);
+    expect(next[0]!.slots!.main[0]!.id).toBe(selfLoop.id);
+    // Relocated, and the edge that could never have been stored is gone with
+    // it, so the document the author is left with can actually be saved.
+    let cycles = 0;
+    walkNodes(next, () => undefined, {
+      onCycle: () => {
+        cycles += 1;
+      },
+    });
+    expect(cycles).toBe(0);
+  });
+
+  it("hands an unstorable document to the writer, which still refuses", () => {
+    // The refusal MOVED to the write; it did not disappear. The fixture is a
+    // malformed slot VALUE holding a back-reference to its owner — the case a
+    // cycle check cannot see, because the loop runs through a value that is not
+    // a slot array, and the case that must therefore still be preserved.
+    //
+    // A plain cycle would NOT serve here: the rebuild drops that edge, so the
+    // result is storable and the assertion would be about the wrong thing.
+    const holder = makeNode("core/box", 1, {}, {});
+    const value: Record<string, unknown> = {};
+    value.back = holder;
+    holder.slots = { bad: value as unknown as BlockNode[] };
+    const target = makeNode("core/text", 1);
+
+    const nodes = duplicateNode([holder, target], target.id);
+
+    // The operation did its work rather than declining, which is what separates
+    // this from an implementation that refuses and hands back the same forest.
+    expect(nodes).toHaveLength(3);
     const verdict = measureBytes({ nodes }, 1_000_000);
 
     // Matched as a whole rather than field by field: `reason` exists only on

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -20,9 +20,35 @@
  *   `makeNode`/`reidSubtree`, which mint fresh ids, so within a session ids are
  *   unique by construction; a hand-injected duplicate is caught by validation
  *   with a machine-readable path, not silently corrected here.
+ *
+ * ## Storability is not decided here
+ *
+ * A stored document can arrive in a state `JSON.stringify` refuses — a value
+ * that points back at its owner. Nothing in this module creates one; they come
+ * from an import, a restore, or a direct database write.
+ *
+ * **These primitives never refuse work because the DOCUMENT they were given is
+ * already unstorable.** They transform what they can reach and make no claim
+ * about whether the result can be saved. One place decides that, once, at the
+ * point of writing — `measureBytes` already answers it as
+ * `{ exceeded: true, reason: "unwritable" }`, and it answers for the whole
+ * class, including values a cycle check cannot see at all: `BigInt`, a
+ * function, a getter that throws.
+ *
+ * The rule earns its keep by being derivable rather than remembered. Three
+ * operations previously answered three different ways — rebuild, refuse,
+ * preserve — each reasoned correctly from its own case, and the fourth case had
+ * nothing to derive an answer from.
+ *
+ * What they DO refuse is an ARGUMENT that would break id-addressing: a subtree
+ * carrying a duplicate id, or an id already in the destination. That is a
+ * different question. It is about an invariant these primitives depend on to
+ * work at all, and it concerns caller-supplied input rather than the state the
+ * document was already in.
  */
 import type { BlockNode } from "./document";
 import { walkForest } from "./forest-walk";
+import { defineEntry, ownEntry } from "./safe-record";
 
 /** Stable unique node id. `crypto.randomUUID` exists in Node ≥ 20 and browsers. */
 export function newId(): string {
@@ -372,21 +398,10 @@ function assembleSlots(
     // Keeping the stored value is the point: an unrelated edit must not be the
     // thing that destroys it.
     const value = built.get(name) ?? original;
-    // DEFINED rather than assigned. Slot names come from unvalidated stored
-    // data, and plain assignment is not a plain write for all of them: an own
-    // `__proto__` slot invokes the legacy prototype setter instead of creating
-    // a property, so the stored value becomes the object's prototype and
-    // serialization emits `{}` — the slot silently emptied by an edit that
-    // named a different node.
-    //
-    // This is the write-side twin of reading through a `Map`. Fixing only the
-    // read left the one slot name that defeats the write.
-    Object.defineProperty(slots, name, {
-      value,
-      enumerable: true,
-      writable: true,
-      configurable: true,
-    });
+    // DEFINED rather than assigned — the write-side twin of reading through a
+    // `Map` above. `safe-record` carries why; it is shared because fixing this
+    // one site left three others in the package with the plain-assignment form.
+    defineEntry(slots, name, value);
   }
   return { ...mapped, slots };
 }
@@ -414,10 +429,10 @@ function clampIndex(index: number, length: number): number {
  * walk reports is therefore the only account of it, and a second traversal
  * written here to look again would be a second definition of the same thing.
  *
- * Refusing matters more for the writer than tolerating does for the reader: a
- * top-level insert would return a forest that is itself cyclic, and an insert
- * into a parent reaches the recursive `mapForest`, which has no such tolerance
- * and exits with `RangeError: Maximum call stack size exceeded`.
+ * This refuses an incoming ARGUMENT, which is why it survives the rule that
+ * these primitives do not refuse an already-unstorable document: a cyclic
+ * subtree handed in by a caller ADDS a cycle to a forest that may not have had
+ * one, rather than declining to work on damage that was already there.
  */
 function insertionIsUnsafe(nodes: BlockNode[], node: BlockNode): boolean {
   const incoming = new Set<string>();
@@ -470,9 +485,15 @@ export function insertNode(
   return mapForest(nodes, current => {
     if (current.id !== parentId) return current;
     const slots = { ...(current.slots ?? {}) };
-    const children = [...(slots[slot] ?? [])];
+    // Read and written through `safe-record`, because `slot` is a name from
+    // outside this module and both halves fail on it independently. Reading
+    // `slots["__proto__"]` on a record without that key yields
+    // `Object.prototype` rather than `undefined`, so `?? []` does not fire and
+    // the spread throws; writing it invokes the prototype setter and stores
+    // nothing. Fixing either one alone leaves the other.
+    const children = [...(ownEntry(slots, slot) ?? [])];
     children.splice(clampIndex(index, children.length), 0, node);
-    slots[slot] = children;
+    defineEntry(slots, slot, children);
     return { ...current, slots };
   });
 }
@@ -487,10 +508,17 @@ export function removeNode(nodes: BlockNode[], id: string): BlockNode[] {
   const withoutTop = nodes.filter(node => node.id !== id);
   return mapForest(withoutTop, node => {
     if (!node.slots) return node;
-    const slots: Record<string, BlockNode[]> = {};
-    for (const [name, children] of Object.entries(node.slots)) {
-      slots[name] = children.filter(child => child.id !== id);
-    }
+    // `Object.fromEntries` rather than a loop assigning into a fresh object.
+    // Slot names come from stored data, and the loop form drops a `__proto__`
+    // slot — an edit that named a DIFFERENT node silently deleting stored
+    // content. `fromEntries` defines each key, so it keeps one. See
+    // `safe-record` for the two spellings that do not.
+    const slots = Object.fromEntries(
+      Object.entries(node.slots).map(([name, children]) => [
+        name,
+        children.filter(child => child.id !== id),
+      ])
+    );
     return { ...node, slots };
   });
 }
@@ -561,46 +589,18 @@ function reidOne(node: BlockNode): BlockNode {
   return copy;
 }
 
-/**
- * Whether a forest contains a node reached through itself.
- *
- * Asked of the walk rather than looked for here. `walkNodes` is cycle-TOLERANT
- * by design — a reader counting classes or measuring a document must answer
- * rather than fail — so a cycle is invisible in what it visits, and what the
- * walk REPORTS is the only account of it. A second traversal written here would
- * be a second definition of the same thing.
- */
-function isCyclic(nodes: BlockNode[]): boolean {
-  let cyclic = false;
-  walkNodes(nodes, () => undefined, {
-    onCycle: () => {
-      cyclic = true;
-    },
-  });
-  return cyclic;
-}
-
 /** Insert a re-id'd copy of a node immediately after the original. */
 export function duplicateNode(nodes: BlockNode[], id: string): BlockNode[] {
   const found = findNode(nodes, id);
   if (!found) return nodes;
-  // A cyclic subtree cannot be duplicated into a usable forest. The clone is
-  // rebuilt without the edge that closes the cycle, but the ORIGINAL is still
-  // in the forest and still cyclic — so the result carries a structure
-  // `JSON.stringify` refuses, and the page cannot be stored at all.
+  // No check that the forest can be serialized. This once refused outright when
+  // any part of the forest was cyclic, which made it the only primitive that
+  // declined work because of a defect elsewhere in the document — see the
+  // storability note on this module.
   //
-  // Refused rather than repaired, and the no-op contract these primitives share
-  // is what makes that safe to say: silently rebuilding the source would edit a
-  // node the caller never named, on an operation they asked to be additive.
-  // `insertNode` refuses a cyclic subtree for the same reason.
-  // The WHOLE forest, not just the subtree being copied. A cycle in a sibling
-  // branch leaves the result equally unstorable — `JSON.stringify` refuses the
-  // forest, not the node — so an operation reporting success while handing back
-  // something that cannot be persisted is the thing worth refusing.
-  //
-  // The forest was already in that state before the call, so this declines to
-  // ADD to a document that cannot be saved rather than claiming to repair one.
-  if (isCyclic(nodes)) return nodes;
+  // The clone is safe on its own terms regardless: `reidSubtree` rebuilds it
+  // without the edge that closes a cycle, so what gets inserted is acyclic even
+  // when its source was not.
   const location = locateNode(nodes, id);
   if (!location) return nodes;
   return insertNode(nodes, reidSubtree(found), {

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -45,6 +45,25 @@
  * different question. It is about an invariant these primitives depend on to
  * work at all, and it concerns caller-supplied input rather than the state the
  * document was already in.
+ *
+ * ## What a rebuild keeps, and the one thing it drops
+ *
+ * Rebuilding preserves everything it cannot interpret — a malformed entry, a
+ * slot whose value is not an array, a slot named `__proto__`. An unrelated edit
+ * must not be what destroys stored content.
+ *
+ * A cycle-closing entry is the single exception, and the reason generalises:
+ * **it is the one thing in a stored document that cannot round-trip through
+ * storage.** `JSON.stringify` refuses it, so it was never readable back and
+ * dropping it loses nothing a caller could have saved — while KEEPING it during
+ * a rebuild emits the same id twice and makes every lookup ambiguous. A
+ * malformed value is the opposite on both counts: it writes, it reads back, and
+ * it breaks nothing.
+ *
+ * So the test is not "did the caller name it" but "could this have been
+ * stored". That distinction is why `withoutCycleEdges` is applied to a forest a
+ * primitive was ALREADY going to rebuild, and never as a repair pass of its
+ * own.
  */
 import type { BlockNode } from "./document";
 import { walkForest } from "./forest-walk";
@@ -434,7 +453,10 @@ function clampIndex(index: number, length: number): number {
  * subtree handed in by a caller ADDS a cycle to a forest that may not have had
  * one, rather than declining to work on damage that was already there.
  */
-function insertionIsUnsafe(nodes: BlockNode[], node: BlockNode): boolean {
+function checkInsertion(
+  nodes: BlockNode[],
+  node: BlockNode
+): { unsafe: boolean; destinationCyclic: boolean } {
   const incoming = new Set<string>();
   let internalDuplicate = false;
   let cyclic = false;
@@ -450,12 +472,47 @@ function insertionIsUnsafe(nodes: BlockNode[], node: BlockNode): boolean {
       },
     }
   );
-  if (cyclic || internalDuplicate) return true;
+  if (cyclic || internalDuplicate) {
+    return { unsafe: true, destinationCyclic: false };
+  }
   let overlapsForest = false;
-  walkNodes(nodes, n => {
-    if (incoming.has(n.id)) overlapsForest = true;
-  });
-  return overlapsForest;
+  let destinationCyclic = false;
+  // Taken from the walk this already performs. The destination's own state is
+  // needed to keep the two insertion paths in agreement, and asking for it
+  // separately would be a second traversal answering a question this one has
+  // already passed through.
+  walkNodes(
+    nodes,
+    n => {
+      if (incoming.has(n.id)) overlapsForest = true;
+    },
+    {
+      onCycle: () => {
+        destinationCyclic = true;
+      },
+    }
+  );
+  return { unsafe: overlapsForest, destinationCyclic };
+}
+
+/** A node, unchanged. The rebuild is the point; `mapForest` does the rest. */
+function identity(node: BlockNode): BlockNode {
+  return node;
+}
+
+/**
+ * Rebuild a forest, dropping any entry that closes a cycle.
+ *
+ * Named because two callers need it for the same reason and neither is
+ * transforming anything: a cycle-closing entry is the one thing in a stored
+ * document that CANNOT round-trip through storage — `JSON.stringify` refuses
+ * it — so a rebuild that omits it destroys nothing a caller could ever have
+ * saved. That is what separates it from a malformed slot value, which is
+ * preserved exactly: a strange value still writes and reads back, so dropping
+ * one would lose real content.
+ */
+function withoutCycleEdges(nodes: BlockNode[]): BlockNode[] {
+  return mapForest(nodes, identity);
 }
 
 /**
@@ -473,9 +530,17 @@ export function insertNode(
   node: BlockNode,
   at: TreePosition
 ): BlockNode[] {
-  if (insertionIsUnsafe(nodes, node)) return nodes;
+  const check = checkInsertion(nodes, node);
+  if (check.unsafe) return nodes;
   if (at.parentId === undefined) {
-    const next = [...nodes];
+    // Rebuilt rather than copied when the destination carries a cycle, so both
+    // insertion paths answer the same way. The path below reaches `mapForest`,
+    // which drops a cycle-closing entry as it rebuilds; a plain array copy here
+    // does not, so the same operation left the cycle in place for a top-level
+    // target and removed it for a nested one — one primitive with two answers,
+    // decided by where the caller happened to point it.
+    const base = check.destinationCyclic ? withoutCycleEdges(nodes) : nodes;
+    const next = [...base];
     next.splice(clampIndex(at.index, next.length), 0, node);
     return next;
   }
@@ -544,7 +609,14 @@ export function moveNode(
     if (!findNode(nodes, to.parentId)) return nodes;
   }
   const without = removeNode(nodes, id);
-  const next = insertNode(without, moving, to);
+  // Rebuilt before it is re-inserted, because the subtree came out of the
+  // DOCUMENT rather than from the caller. `checkInsertion` refuses a cyclic
+  // argument to stop a caller adding a cycle to a healthy forest, and a node
+  // extracted from a document that was already cyclic is not that — refusing it
+  // meant a damaged block could never be moved, which is the one thing an
+  // author might do to get it out of the way.
+  const [relocated] = withoutCycleEdges([moving]);
+  const next = insertNode(without, relocated ?? moving, to);
   // The move must be atomic. If the re-insert refused — which happens only when
   // the moving subtree is itself already malformed (an internal duplicate id) —
   // `insertNode` returns the `without` forest unchanged; committing that would


### PR DESCRIPTION
Two engine correctness changes in one package. Both came out of the same habit — after fixing one instance, asking what else is in its class — and the second is a founder ruling.

## 1. A record keyed by stored data loses its `__proto__` entry

Plain assignment is not a plain write for every string. `target["__proto__"] = value` invokes the legacy prototype setter: no own property is created, the entry disappears from `Object.keys` and from the serialized document, and the record's prototype is silently replaced.

`JSON.parse` creates `__proto__` as an **own** property, so the key survives into `Object.entries` and a rebuild sees it — then loses it on the way out. Measured in isolation:

```
stored own keys        [ '__proto__', 'content' ]
rebuilt own keys       [ 'content' ]
rebuilt proto changed  true
```

Three sites, all keyed by stored data:

| site | keyed by | consequence |
|---|---|---|
| `removeNode` | `Object.entries(node.slots)` | deleting one node destroys an unrelated stored slot |
| `migrateDocument` | `Object.entries(next.slots)` | a migration deletes a slot, and the document it rewrote is gone |
| `insertNode` | caller-supplied slot name | **both directions** — see below |

`insertNode` had the read side too: `slots["__proto__"]` returns `Object.prototype` rather than `undefined`, so `?? []` never fires and the spread throws `TypeError: ... is not iterable`. That one was found by the test written for the write side.

**The asymmetry worth carrying:** `constructor` defeats the READ (inherited lookup); `__proto__` defeats the WRITE (legacy setter). Different keys, different mechanisms — which is why the `Map` guard added for the read left the write standing, and why fixing one write site left two.

`safe-record.ts` holds the two guarded operations and, deliberately, **records what is already safe**: spread, `Object.fromEntries`, `Object.assign`, `structuredClone`, and any target built with `Object.create(null)`. That list is there because a search for the assignment *shape* finds sites that never needed guarding — `compilePageCss` builds its gated map on a null-prototype object and is fine. I guarded it before checking, then reverted.

## 2. The primitives no longer refuse a document that was already damaged

Per founder ruling. Three operations previously answered three different ways on a forest `JSON.stringify` refuses — rebuild, refuse, preserve — each reasoned correctly from its own case, which is why the fourth case had nothing to derive an answer from.

The rule now, stated once in the module header:

> These primitives never refuse work because the DOCUMENT they were given is already unstorable. They transform what they can reach and make no claim about whether the result can be saved.

Storability is decided once, at the write, by `measureBytes` — which already returns `{ exceeded: true, reason: "unwritable" }` and already covers the whole class, including values a cycle check cannot see at all (`BigInt`, a function, a getter that throws).

What they still refuse is an **argument** that would break id-addressing — a duplicate id within an incoming subtree, or an id already in the destination. That is a different question: an invariant the primitives depend on, about caller input rather than about damage already present.

The visible effect: `duplicateNode` no longer refuses outright when any part of the forest is cyclic. One corrupt block on a page stopped an author copying a healthy one.

Also removed a stale claim in `insertionIsUnsafe` that justified itself with `mapForest` exiting via `RangeError` — `mapForest` became iterative in #1179, so the comment described a repair that no longer existed.

## Evidence

Every test break-verified with the anchor asserted applied. Four assertions initially passed under the break — a stub returning its argument satisfied them — and were strengthened until they discriminate.

One break **passed** and that was the finding: `Object.fromEntries` turns out to define rather than assign, so it was never a break. Re-run with genuine plain assignment, it fails correctly. That is also why `recordFromEntries` is not in this diff — it existed briefly and was removed as a second spelling of a built-in.

Gates, each read separately: build; vitest across blocks-engine (1424), blocks-react (777), builder (1813), plugin-page-builder (300); check-types; package lint; root eslint; comment convention; `fallow audit` `verdict: pass` with every `*_introduced` at 0.

## Note on review coverage

The repo has a runner backlog — 28 queued workflow runs, the oldest from 2026-08-19 — and `main`'s own checks for `3adf7164e` have been queued for over a day. Queued is not green, in either direction.