### PR TITLE
feat(nextly): make a trusted read declare which collections it reaches

### DIFF
--- a/.changeset/trusted-reads-name-their-reach.md
+++ b/.changeset/trusted-reads-name-their-reach.md
@@ -1,0 +1,36 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A read that skips access checks reaches the collections its relationships point at as well,
+and those were never named by the caller — they were reached through a field. Saying which ones
+it may reach was optional, so a read that had weighed the question and one whose author never saw
+it looked identical: both said nothing, and nothing meant all of them. That omission has shipped
+twice and was caught by review both times.
+
+Declaring the reach is now required wherever an expansion runs, and a read that trusts everything
+says so by name. No read changes what it returns.

--- a/packages/nextly/src/direct-api/namespaces/helpers.ts
+++ b/packages/nextly/src/direct-api/namespaces/helpers.ts
@@ -13,6 +13,7 @@ import type { AuthenticatedScope } from "../../auth/authenticated-scope";
 import type { RequestActor } from "../../auth/request-actor";
 import { errorFromServiceEnvelope } from "../../errors/from-service-envelope";
 import { NextlyError } from "../../errors/nextly-error";
+import type { TrustBound } from "../../services/collections/trust-grant";
 import type { RequestContext } from "../../shared/types/index";
 import type {
   DirectAPIConfig,
@@ -81,7 +82,7 @@ export interface AccessOptions {
   overrideAccess?: boolean;
   enforceFieldAccess?: boolean;
   fieldAccessUser?: UserContext;
-  trusted?: (collection: string) => boolean;
+  trusted?: TrustBound;
   authenticatedScope?: AuthenticatedScope;
 }
 

--- a/packages/nextly/src/direct-api/types/shared.ts
+++ b/packages/nextly/src/direct-api/types/shared.ts
@@ -11,6 +11,7 @@ import type { PaginationMeta } from "../../api/response-shapes";
 import type { AuthenticatedScope } from "../../auth/authenticated-scope";
 import type { HookWarning } from "../../hooks/side-effect-warnings";
 import type { RichTextOutputFormat } from "../../lib/rich-text-html";
+import type { TrustBound } from "../../services/collections/trust-grant";
 
 import type { FormsConfig } from "./forms";
 
@@ -435,7 +436,7 @@ export interface DirectAPIConfig {
    *
    * @default undefined — every populated target inherits the caller's trust
    */
-  trusted?: (collection: string) => boolean;
+  trusted?: TrustBound;
 
   /**
    * Enforce FIELD-level read rules even though `overrideAccess` is on.

--- a/packages/nextly/src/domains/collections/__tests__/trust-bound-equivalence.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/trust-bound-equivalence.integration.test.ts
@@ -1,0 +1,143 @@
+/**
+ * `TRUSTS_EVERY_COLLECTION` must be indistinguishable from omitting the bound.
+ *
+ * The constant names what an absent bound already meant, so the one property it
+ * must never have is a behaviour of its own. The way it acquires one is a call
+ * site deriving "this caller narrowed its bypass" from `trusted !== undefined`,
+ * which is true for the constant. `expansionStatusScope` withholds a widened
+ * lifecycle from a narrowed caller, so under that derivation stating the
+ * constant stops drafts propagating into an expansion while omitting it does
+ * not — the same caller, the same intent, different rows.
+ *
+ * Asserted end to end rather than on the predicate, deliberately. A unit test on
+ * `narrows()` would pass while a call site went on asking `!== undefined`, which
+ * is exactly the shape the defect had. The property belongs to the READ, so the
+ * read is what is measured.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, relationship, text } from "../../../config";
+import { clearServices, type getService } from "../../../di/register";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { TRUSTS_EVERY_COLLECTION } from "../../../services/collections/trust-grant";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+  clearServices();
+});
+
+/** A published post pointing at an UNPUBLISHED author. */
+async function boot(): Promise<{
+  handler: ReturnType<typeof getService<"collectionsHandler">>;
+  postId: string;
+}> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: "authors",
+        status: true,
+        fields: [text({ name: "name" })],
+      }),
+      defineCollection({
+        slug: "posts",
+        fields: [
+          text({ name: "title" }),
+          relationship({ name: "author", relationTo: "authors" }),
+        ],
+      }),
+    ],
+  });
+
+  const handler = current.getService("collectionsHandler");
+  const author = await handler.createEntry(
+    { collectionName: "authors", overrideAccess: true },
+    { name: "Unpublished Author", status: "draft" }
+  );
+  const authorId = (author.data as { id: string }).id;
+
+  // The fixture is the thing most likely to be wrong here, and a wrong fixture
+  // makes every assertion below pass for the wrong reason: if the author were
+  // PUBLISHED, all three reads would populate it and the file would read as
+  // proof of equivalence while testing nothing about lifecycle at all.
+  expect((author.data as { status?: string }).status).toBe("draft");
+
+  const post = await handler.createEntry(
+    { collectionName: "posts", overrideAccess: true },
+    { title: "A post", author: authorId }
+  );
+  return { handler, postId: (post.data as { id: string }).id };
+}
+
+/** Whether the expansion actually pulled the unpublished author in. */
+function populated(data: unknown): boolean {
+  return JSON.stringify(data ?? null).includes("Unpublished Author");
+}
+
+describe("TRUSTS_EVERY_COLLECTION is the absent bound (integration)", () => {
+  it("propagates status:all into expansion exactly as an omitted bound does", async () => {
+    const { handler, postId } = await boot();
+
+    // `overrideAccess: false` is LOAD-BEARING and was measured, not chosen.
+    //
+    // On a trusted read the defect is invisible: `widensLifecycle` widens the
+    // lifecycle on its own for an unbounded trusted caller, and it reads the
+    // bound's VALUE rather than its presence, so it already treats the constant
+    // correctly. It therefore masks the wrong answer coming from
+    // `expansionStatusScope` and the read populates either way.
+    //
+    // A trusted read cannot show the divergence at all, so asserting one here
+    // would be a green that proves nothing. The difference is only observable
+    // where the caller's own explicit `status: "all"` is the SOLE thing
+    // carrying drafts into the expansion.
+    const omitted = await handler.getEntry({
+      collectionName: "posts",
+      entryId: postId,
+      depth: 1,
+      overrideAccess: false,
+      status: "all",
+    });
+
+    const stated = await handler.getEntry({
+      collectionName: "posts",
+      entryId: postId,
+      depth: 1,
+      overrideAccess: false,
+      status: "all",
+      trusted: TRUSTS_EVERY_COLLECTION,
+    });
+
+    // The population control. Without it, `toBe(populated(...))` is satisfied by
+    // both reads returning NOTHING — two empty results are equal, and that is
+    // how a previous proof in this repo passed against unfixed code.
+    expect(populated(omitted.data)).toBe(true);
+    expect(populated(stated.data)).toBe(true);
+  });
+
+  it("still withholds them from a caller that genuinely narrowed", async () => {
+    const { handler, postId } = await boot();
+
+    // A predicate that admits the target is STILL a narrowing bound: it declares
+    // one fixed audience, and `expansionStatusScope` refuses to widen a
+    // lifecycle for such a caller whatever the predicate answers.
+    //
+    // This is the discriminator. Without it, the assertions above would pass
+    // just as well if `bounded` were hardcoded `false` everywhere — which would
+    // hand every bounded public route the drafts of collections it refused.
+    const narrowed = await handler.getEntry({
+      collectionName: "posts",
+      entryId: postId,
+      depth: 1,
+      overrideAccess: true,
+      status: "all",
+      trusted: () => true,
+    });
+
+    expect(populated(narrowed.data)).toBe(false);
+  });
+});

--- a/packages/nextly/src/domains/collections/services/__tests__/relationship-redaction.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/relationship-redaction.test.ts
@@ -21,6 +21,7 @@ import {
   registerFieldFunctions,
 } from "../../../../shared/lib/field-level-registry";
 import { CollectionRelationshipService } from "../collection-relationship-service";
+import { TRUSTS_EVERY_COLLECTION } from "../../../../services/collections/trust-grant";
 
 // getSystemEntityTable() resolves the users table via env.DB_DIALECT (not the
 // adapter); sqlite needs no DATABASE_URL, so it validates cleanly in a unit
@@ -354,7 +355,7 @@ describe("relationship expansion secret redaction", () => {
         "members",
         "m1",
         {
-          trusted: undefined,
+          trusted: TRUSTS_EVERY_COLLECTION,
           enforceFieldAccess: true,
           user: { id: "u1", roles: ["editor"] },
         }
@@ -369,7 +370,7 @@ describe("relationship expansion secret redaction", () => {
         "members",
         "m1",
         {
-          trusted: undefined,
+          trusted: TRUSTS_EVERY_COLLECTION,
           enforceFieldAccess: true,
           user: { id: "u2", roles: ["finance"] },
         }
@@ -384,7 +385,7 @@ describe("relationship expansion secret redaction", () => {
       const related = await serviceWithTarget().fetchRelatedEntry(
         "members",
         "m1",
-        { trusted: undefined, enforceFieldAccess: true }
+        { trusted: TRUSTS_EVERY_COLLECTION, enforceFieldAccess: true }
       );
 
       expect(related).not.toHaveProperty("salary");
@@ -394,7 +395,11 @@ describe("relationship expansion secret redaction", () => {
       const related = await serviceWithTarget().fetchRelatedEntry(
         "members",
         "m1",
-        { trusted: undefined, enforceFieldAccess: true, overrideAccess: true }
+        {
+          trusted: TRUSTS_EVERY_COLLECTION,
+          enforceFieldAccess: true,
+          overrideAccess: true,
+        }
       );
 
       expect(related).toMatchObject({ salary: 120000 });
@@ -453,7 +458,7 @@ describe("relationship expansion secret redaction", () => {
       );
 
       const related = await service.fetchRelatedEntry("members", "m1", {
-        trusted: undefined,
+        trusted: TRUSTS_EVERY_COLLECTION,
         enforceFieldAccess: true,
         overrideAccess: true,
       });
@@ -505,7 +510,7 @@ describe("relationship expansion secret redaction", () => {
       );
 
       const related = await service.fetchRelatedEntry("members", "m1", {
-        trusted: undefined,
+        trusted: TRUSTS_EVERY_COLLECTION,
         enforceFieldAccess: true,
         user: { id: "u1" },
       });
@@ -557,7 +562,11 @@ describe("relationship expansion secret redaction", () => {
           type: "relationship",
           options: { targetLabelField: "codename" },
         } as never,
-        { trusted: undefined, enforceFieldAccess: true, user: { id: "u1" } }
+        {
+          trusted: TRUSTS_EVERY_COLLECTION,
+          enforceFieldAccess: true,
+          user: { id: "u1" },
+        }
       );
 
       const related = map.get("m1");
@@ -575,7 +584,7 @@ describe("relationship expansion secret redaction", () => {
         "members",
         "m1",
         {
-          trusted: undefined,
+          trusted: TRUSTS_EVERY_COLLECTION,
           enforceFieldAccess: true,
           user: { id: "u1", roles: ["editor"] },
         }
@@ -685,7 +694,7 @@ describe("related-row re-derivation keeps per-field presentation", () => {
     const access = {
       enforceFieldAccess: true,
       user: { id: "u1" },
-      trusted: undefined,
+      trusted: TRUSTS_EVERY_COLLECTION,
     };
     const state = service.createNestedHookState();
 

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -24,6 +24,7 @@ import { NextlyError } from "../../../errors/nextly-error";
 import type { RevalidationIntent } from "../../../revalidation/types";
 import type { WhereFilter } from "../../../services/collections/query-operators";
 import type { TrustBound } from "../../../services/collections/trust-grant";
+import { narrows } from "../../../services/collections/trust-grant";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
 import { PAGINATION_DEFAULTS } from "../../../types/pagination";
@@ -252,9 +253,7 @@ export class CollectionBulkService extends BaseService {
       // it into every rejected target — whose drafts would then be COPIED into
       // the new row, outliving the refusal as data.
       const sourceStatus =
-        params.overrideAccess && params.trusted === undefined
-          ? "all"
-          : undefined;
+        params.overrideAccess && !narrows(params.trusted) ? "all" : undefined;
       const sourceResult = await this.queryService.getEntry({
         collectionName: params.collectionName,
         entryId: params.entryId,

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -23,6 +23,7 @@ import { errorFromServiceEnvelope } from "../../../errors/from-service-envelope"
 import { NextlyError } from "../../../errors/nextly-error";
 import type { RevalidationIntent } from "../../../revalidation/types";
 import type { WhereFilter } from "../../../services/collections/query-operators";
+import type { TrustBound } from "../../../services/collections/trust-grant";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
 import { PAGINATION_DEFAULTS } from "../../../types/pagination";
@@ -221,7 +222,7 @@ export class CollectionBulkService extends BaseService {
      * Absent means every populated target inherits the caller's trust. Only ever
      * narrows. See {@link RelatedRowReadContext.trusted}.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     /** Route auth already ran the create RBAC gate; skip only that re-check. */
     routeAuthorized?: boolean;
     /** Arbitrary data passed to hooks via context */

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -61,6 +61,7 @@ import type {
   RelationshipDbExecutor,
 } from "../../../services/collections/collection-relationship-service";
 import type { TrustBound } from "../../../services/collections/trust-grant";
+import { narrows } from "../../../services/collections/trust-grant";
 import type { FieldGroupDataService } from "../../../services/field-groups/field-group-data-service";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
@@ -3612,7 +3613,7 @@ export class CollectionMutationService extends BaseService {
               // lifecycle; an untrusted one gets the published default, the
               // same answer its own GET would give.
               status:
-                params.overrideAccess === true && params.trusted === undefined
+                params.overrideAccess === true && !narrows(params.trusted)
                   ? "all"
                   : undefined,
             }
@@ -7052,7 +7053,7 @@ export class CollectionMutationService extends BaseService {
               // lifecycle; an untrusted one gets the published default, the
               // same answer its own GET would give.
               status:
-                params.overrideAccess === true && params.trusted === undefined
+                params.overrideAccess === true && !narrows(params.trusted)
                   ? "all"
                   : undefined,
             }

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -60,6 +60,7 @@ import type {
   CollectionRelationshipService,
   RelationshipDbExecutor,
 } from "../../../services/collections/collection-relationship-service";
+import type { TrustBound } from "../../../services/collections/trust-grant";
 import type { FieldGroupDataService } from "../../../services/field-groups/field-group-data-service";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
@@ -2745,7 +2746,7 @@ export class CollectionMutationService extends BaseService {
        * Absent means every populated target inherits the caller's trust. Only ever
        * narrows. See {@link RelatedRowReadContext.trusted}.
        */
-      trusted?: (collection: string) => boolean;
+      trusted?: TrustBound;
       /** Write locale (i18n M5): translatable values are stored for this language. */
       locale?: string;
       // Set by the REST dispatcher: route-level authorization already ran, so
@@ -5020,7 +5021,7 @@ export class CollectionMutationService extends BaseService {
        * Absent means every populated target inherits the caller's trust. Only ever
        * narrows. See {@link RelatedRowReadContext.trusted}.
        */
-      trusted?: (collection: string) => boolean;
+      trusted?: TrustBound;
       /** Write locale (i18n M5): translatable values are updated for this language only. */
       locale?: string;
       // Set by the REST dispatcher: route-level authorization already ran, so

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -61,7 +61,10 @@ import type {
   ComponentFieldFilter,
 } from "../../../services/collections/query-operators";
 import type { TrustBound } from "../../../services/collections/trust-grant";
-import { assumedBound } from "../../../services/collections/trust-grant";
+import {
+  assumedBound,
+  narrows,
+} from "../../../services/collections/trust-grant";
 import type { FieldGroupDataService } from "../../../services/field-groups/field-group-data-service";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
@@ -1629,7 +1632,7 @@ export class CollectionQueryService extends BaseService {
             status: expansionStatusScope({
               status: params.status,
               overrideAccess: params.overrideAccess,
-              bounded: params.trusted !== undefined,
+              bounded: narrows(params.trusted),
             }),
           }
         );
@@ -1679,7 +1682,7 @@ export class CollectionQueryService extends BaseService {
               status: expansionStatusScope({
                 status: params.status,
                 overrideAccess: params.overrideAccess,
-                bounded: params.trusted !== undefined,
+                bounded: narrows(params.trusted),
               }),
             },
           });
@@ -2869,7 +2872,7 @@ export class CollectionQueryService extends BaseService {
           status: expansionStatusScope({
             status: params.status,
             overrideAccess: params.overrideAccess,
-            bounded: params.trusted !== undefined,
+            bounded: narrows(params.trusted),
           }),
         }
       );
@@ -2911,7 +2914,7 @@ export class CollectionQueryService extends BaseService {
             status: expansionStatusScope({
               status: params.status,
               overrideAccess: params.overrideAccess,
-              bounded: params.trusted !== undefined,
+              bounded: narrows(params.trusted),
             }),
           },
         });
@@ -3109,7 +3112,7 @@ export class CollectionQueryService extends BaseService {
               status: expansionStatusScope({
                 status: params.status,
                 overrideAccess: params.overrideAccess,
-                bounded: params.trusted !== undefined,
+                bounded: narrows(params.trusted),
               }),
             };
             draftEntry = await this.relationshipService.expandRelationships(

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -60,6 +60,8 @@ import type {
   WhereFilter,
   ComponentFieldFilter,
 } from "../../../services/collections/query-operators";
+import type { TrustBound } from "../../../services/collections/trust-grant";
+import { assumedBound } from "../../../services/collections/trust-grant";
 import type { FieldGroupDataService } from "../../../services/field-groups/field-group-data-service";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
@@ -979,7 +981,7 @@ export class CollectionQueryService extends BaseService {
      * the caller's trust. Evaluated as `overrideAccess && trusted(target)`, so it
      * can only ever narrow. See {@link RelatedRowReadContext.trusted}.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     /**
      * The route middleware already ran the RBAC gate for the authorizing
      * operation, so skip only that redundant re-check while still evaluating
@@ -1661,7 +1663,7 @@ export class CollectionQueryService extends BaseService {
               overrideAccess: params.overrideAccess,
               // Narrows that bypass per RELATED collection. Absent means unchanged;
               // dropping it here would silently restore the full bypass.
-              trusted: params.trusted,
+              trusted: assumedBound(params.trusted),
               authenticatedScope: params.authenticatedScope,
               // Shared across every component row this listing expands, so
               // rows pointing at the same target resolve its policy once.
@@ -1779,7 +1781,7 @@ export class CollectionQueryService extends BaseService {
         overrideAccess: params.overrideAccess,
         // Narrows that bypass per RELATED collection. Absent means unchanged;
         // dropping it here would silently restore the full bypass.
-        trusted: params.trusted,
+        trusted: assumedBound(params.trusted),
         authenticatedScope: params.authenticatedScope,
       };
       for (const entry of expandedEntries) {
@@ -2073,7 +2075,7 @@ export class CollectionQueryService extends BaseService {
      * the caller's trust. Evaluated as `overrideAccess && trusted(target)`, so it
      * can only ever narrow. See {@link RelatedRowReadContext.trusted}.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     /**
      * The route middleware already ran the RBAC gate for the authorizing
      * operation; skip only that redundant re-check while stored read rules
@@ -2589,7 +2591,7 @@ export class CollectionQueryService extends BaseService {
      * the caller's trust. Evaluated as `overrideAccess && trusted(target)`, so it
      * can only ever narrow. See {@link RelatedRowReadContext.trusted}.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     /**
      * Draft/Published filter override (only effective when collection.status === true).
      * Public callers default to 'published'; trusted callers see all.
@@ -2897,7 +2899,7 @@ export class CollectionQueryService extends BaseService {
             overrideAccess: params.overrideAccess,
             // Narrows that bypass per RELATED collection. Absent means
             // unchanged; dropping it restores the full bypass silently.
-            trusted: params.trusted,
+            trusted: assumedBound(params.trusted),
             authenticatedScope: params.authenticatedScope,
             // As on the list path: a component's relationship reaches a
             // collection that may scope reads by a localized field.
@@ -3202,7 +3204,7 @@ export class CollectionQueryService extends BaseService {
         overrideAccess: params.overrideAccess,
         // Narrows that bypass per RELATED collection. Absent means unchanged;
         // dropping it here would silently restore the full bypass.
-        trusted: params.trusted,
+        trusted: assumedBound(params.trusted),
         authenticatedScope: params.authenticatedScope,
       };
       await this.relationshipService.applyNestedFieldHooks(

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -44,6 +44,12 @@ import {
   boundRefuses,
   callerId,
 } from "../../../services/collections/trust-bound";
+import type { TrustBound } from "../../../services/collections/trust-grant";
+import {
+  assumedBound,
+  boundReaches,
+  TRUSTS_EVERY_COLLECTION,
+} from "../../../services/collections/trust-grant";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
 import { detachData } from "../../../shared/lib/detach";
@@ -313,7 +319,7 @@ type RelatedRowAccess = RelatedRowReadContext;
  */
 function widensLifecycle(access: RelatedRowAccess): boolean {
   if (access.overrideAccess !== true) return false;
-  return access.trusted === undefined;
+  return access.trusted === TRUSTS_EVERY_COLLECTION;
 }
 
 /**
@@ -334,7 +340,7 @@ function trustsTarget(
   targetCollection: string
 ): boolean {
   if (access.overrideAccess !== true) return false;
-  return access.trusted === undefined || access.trusted(targetCollection);
+  return boundReaches(access.trusted, targetCollection);
 }
 
 /**
@@ -380,7 +386,7 @@ export interface RelationshipExpansionOptions {
    * Narrows `overrideAccess` to the collections a caller names, judged per
    * expansion TARGET. See {@link RelatedRowAccess.trusted}.
    */
-  trusted?: (collection: string) => boolean;
+  trusted?: TrustBound;
 
   /**
    * Opt in to evaluating the target collection's field read rules. Set by the
@@ -2099,7 +2105,7 @@ export class CollectionRelationshipService extends BaseService {
       // reading for the whole expansion, which is the direction that leaks.
       fieldAccessUser: options.fieldAccessUser,
       overrideAccess: options.overrideAccess,
-      trusted: options.trusted,
+      trusted: assumedBound(options.trusted),
       authenticatedScope: options.authenticatedScope,
       locale: options.locale,
       status: options.status,
@@ -2478,7 +2484,7 @@ export class CollectionRelationshipService extends BaseService {
     targetCollection: string,
     relatedIds: string[],
     field: FieldDefinition,
-    access: RelatedRowAccess = { trusted: undefined }
+    access: RelatedRowAccess = { trusted: TRUSTS_EVERY_COLLECTION }
   ): Promise<Map<string, Record<string, unknown>>> {
     const resultMap = new Map<string, Record<string, unknown>>();
 
@@ -2556,7 +2562,7 @@ export class CollectionRelationshipService extends BaseService {
     sourceCollectionName: string,
     sourceEntryIds: string[],
     field: FieldDefinition,
-    access: RelatedRowAccess = { trusted: undefined }
+    access: RelatedRowAccess = { trusted: TRUSTS_EVERY_COLLECTION }
   ): Promise<Map<string, Record<string, unknown>[]>> {
     const resultMap = new Map<string, Record<string, unknown>[]>();
 
@@ -2700,7 +2706,7 @@ export class CollectionRelationshipService extends BaseService {
       // reading for the whole expansion, which is the direction that leaks.
       fieldAccessUser: options.fieldAccessUser,
       overrideAccess: options.overrideAccess,
-      trusted: options.trusted,
+      trusted: assumedBound(options.trusted),
       authenticatedScope: options.authenticatedScope,
       locale: options.locale,
       status: options.status,
@@ -3167,7 +3173,7 @@ export class CollectionRelationshipService extends BaseService {
   private async redactRelatedRows(
     targetCollection: string,
     rows: Record<string, unknown>[],
-    access: RelatedRowAccess = { trusted: undefined }
+    access: RelatedRowAccess = { trusted: TRUSTS_EVERY_COLLECTION }
   ): Promise<void> {
     if (rows.length === 0) return;
     // The system owner column must never ride along a populated relationship:
@@ -4063,7 +4069,7 @@ export class CollectionRelationshipService extends BaseService {
   async fetchRelatedEntry(
     collectionName: string,
     entryId: string,
-    access: RelatedRowAccess = { trusted: undefined }
+    access: RelatedRowAccess = { trusted: TRUSTS_EVERY_COLLECTION }
   ): Promise<Record<string, unknown> | null> {
     try {
       const [readable] = await this.readTargetRows(
@@ -4147,7 +4153,7 @@ export class CollectionRelationshipService extends BaseService {
     // written in it. The target-entry fetch stays on the pool: related rows live
     // in another (already-committed) collection, so they need no tx visibility.
     executor?: RelationshipDbExecutor,
-    access: RelatedRowAccess = { trusted: undefined }
+    access: RelatedRowAccess = { trusted: TRUSTS_EVERY_COLLECTION }
   ): Promise<Record<string, unknown>[]> {
     // Same dual-aware target lookup as fetchManyToManyRelationsBatch above.
     // See that comment for the code-first vs UI-built shape rationale.

--- a/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
@@ -6,6 +6,7 @@ import type { DynamicFieldGroupRecord } from "../../../schemas/dynamic-field-gro
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import type { CollectionRelationshipService } from "../../../services/collections/collection-relationship-service";
 import type { RelatedRowReadContext } from "../../../services/collections/related-row-read-context";
+import { TRUSTS_EVERY_COLLECTION } from "../../../services/collections/trust-grant";
 import type { FieldGroupRegistryService } from "../../../services/field-groups/field-group-registry-service";
 import { BaseService } from "../../../shared/base-service";
 import { stripPasswordFieldValues } from "../../../shared/lib/password-fields";
@@ -452,7 +453,7 @@ export class FieldGroupQueryService extends BaseService {
       fallbackLocale,
       executor,
       strict = false,
-      access = { trusted: undefined },
+      access = { trusted: TRUSTS_EVERY_COLLECTION },
     } = params;
     const entryId = entry.id as string;
     if (!entryId) return entry;
@@ -543,7 +544,7 @@ export class FieldGroupQueryService extends BaseService {
       select,
       locale,
       fallbackLocale,
-      access = { trusted: undefined },
+      access = { trusted: TRUSTS_EVERY_COLLECTION },
     } = params;
     if (entries.length === 0) return entries;
 
@@ -647,7 +648,7 @@ export class FieldGroupQueryService extends BaseService {
     fallbackLocale?: string | false,
     executor?: unknown,
     strict = false,
-    access: ComponentReadAccess = { trusted: undefined }
+    access: ComponentReadAccess = { trusted: TRUSTS_EVERY_COLLECTION }
   ): Promise<Record<string, unknown> | null> {
     const meta = await this.registryService.getComponent(
       componentSlug,
@@ -697,7 +698,7 @@ export class FieldGroupQueryService extends BaseService {
     fallbackLocale?: string | false,
     executor?: unknown,
     strict = false,
-    access: ComponentReadAccess = { trusted: undefined }
+    access: ComponentReadAccess = { trusted: TRUSTS_EVERY_COLLECTION }
   ): Promise<Record<string, unknown>[]> {
     const meta = await this.registryService.getComponent(
       componentSlug,
@@ -749,7 +750,7 @@ export class FieldGroupQueryService extends BaseService {
     fallbackLocale?: string | false,
     executor?: unknown,
     strict = false,
-    access: ComponentReadAccess = { trusted: undefined }
+    access: ComponentReadAccess = { trusted: TRUSTS_EVERY_COLLECTION }
   ): Promise<Record<string, unknown>[]> {
     const allowedSlugs = field.components ?? [];
     const allRows: {
@@ -826,7 +827,7 @@ export class FieldGroupQueryService extends BaseService {
     currentDepth: number,
     locale?: string,
     fallbackLocale?: string | false,
-    access: ComponentReadAccess = { trusted: undefined }
+    access: ComponentReadAccess = { trusted: TRUSTS_EVERY_COLLECTION }
   ): Promise<Map<string, unknown>> {
     const meta = await this.registryService.getComponent(componentSlug);
     const componentFields = meta.fields;
@@ -883,7 +884,7 @@ export class FieldGroupQueryService extends BaseService {
     currentDepth: number,
     locale?: string,
     fallbackLocale?: string | false,
-    access: ComponentReadAccess = { trusted: undefined }
+    access: ComponentReadAccess = { trusted: TRUSTS_EVERY_COLLECTION }
   ): Promise<Map<string, unknown>> {
     const meta = await this.registryService.getComponent(componentSlug);
     const componentFields = meta.fields;
@@ -937,7 +938,7 @@ export class FieldGroupQueryService extends BaseService {
     currentDepth: number,
     locale?: string,
     fallbackLocale?: string | false,
-    access: ComponentReadAccess = { trusted: undefined }
+    access: ComponentReadAccess = { trusted: TRUSTS_EVERY_COLLECTION }
   ): Promise<Map<string, unknown>> {
     const allowedSlugs = field.components ?? [];
 
@@ -1176,7 +1177,7 @@ export class FieldGroupQueryService extends BaseService {
     componentFields: FieldConfig[],
     depth: number,
     currentDepth: number,
-    access: ComponentReadAccess = { trusted: undefined }
+    access: ComponentReadAccess = { trusted: TRUSTS_EVERY_COLLECTION }
   ): Promise<Record<string, unknown>> {
     if (!this.relationshipService) {
       return componentData;
@@ -1238,7 +1239,7 @@ export class FieldGroupQueryService extends BaseService {
     componentFields: FieldConfig[],
     depth: number,
     currentDepth: number,
-    access: ComponentReadAccess = { trusted: undefined }
+    access: ComponentReadAccess = { trusted: TRUSTS_EVERY_COLLECTION }
   ): Promise<Record<string, unknown>[]> {
     if (!this.relationshipService || depth === 0 || currentDepth >= depth) {
       return componentDataArray;

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.media-expansion.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.media-expansion.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it, vi } from "vitest";
 import { getDialectTables } from "../../../database";
 import type { FieldConfig } from "../../../collections/fields/types";
 import { SingleQueryService } from "../services/single-query-service";
+import { TRUSTS_EVERY_COLLECTION } from "../../../services/collections/trust-grant";
 
 /**
  * These cover media expansion itself, not the trust bound, so they read as a
@@ -21,7 +22,7 @@ import { SingleQueryService } from "../services/single-query-service";
  * required precisely because "no bound" and "forgot the caller" want opposite
  * outcomes and look identical when omitted.
  */
-const UNBOUNDED = { trusted: undefined } as const;
+const UNBOUNDED = { trusted: TRUSTS_EVERY_COLLECTION } as const;
 
 // absolutizeMediaUrls resolves the app base URL through the validated env,
 // which unit tests don't populate; pin it like media-variant.test.ts does.

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.read-access.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.read-access.test.ts
@@ -23,6 +23,7 @@ import {
   siteSettingsMeta,
   textField,
 } from "./single-test-helpers";
+import { TRUSTS_EVERY_COLLECTION } from "../../../services/collections/trust-grant";
 
 type Ctor = ConstructorParameters<typeof SingleQueryService>;
 
@@ -460,7 +461,7 @@ describe("SingleQueryService.expandRelationshipFields — enforcement is opt-in"
         { id: "doc1", author: "a1" } as never,
         RELATION_FIELDS as never,
         1,
-        { trusted: undefined },
+        { trusted: TRUSTS_EVERY_COLLECTION },
         true
       )
     ).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
@@ -590,7 +591,11 @@ describe("SingleQueryService.expandRelationshipFields — enforcement is opt-in"
       { id: "doc1" } as never,
       RELATION_FIELDS as never,
       undefined,
-      { trusted: undefined, enforceFieldAccess: true, user: editor }
+      {
+        trusted: TRUSTS_EVERY_COLLECTION,
+        enforceFieldAccess: true,
+        user: editor,
+      }
     );
 
     const options = expandRelationships.mock.calls[0][3];

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -45,6 +45,7 @@ import {
   isSuperAdminContext,
 } from "../../../services/access";
 import { expansionAccess } from "../../../services/collections/trust-bound";
+import { assumedBound } from "../../../services/collections/trust-grant";
 import type { FieldGroupDataService } from "../../../services/field-groups/field-group-data-service";
 import { BaseService } from "../../../shared/base-service";
 import {
@@ -2355,7 +2356,7 @@ export class SingleMutationService extends BaseService {
           overrideAccess: options.overrideAccess,
           // Narrows that bypass per RELATED collection. Absent means unchanged;
           // dropping it here would silently restore the full bypass.
-          trusted: options.trusted,
+          trusted: assumedBound(options.trusted),
           authenticatedScope: options.authenticatedScope,
           // The language just written: a target collection's read rule may
           // scope reads by one of its own localized fields, and that filter

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -45,7 +45,10 @@ import {
   isSuperAdminContext,
 } from "../../../services/access";
 import { expansionAccess } from "../../../services/collections/trust-bound";
-import { assumedBound } from "../../../services/collections/trust-grant";
+import {
+  assumedBound,
+  narrows,
+} from "../../../services/collections/trust-grant";
 import type { FieldGroupDataService } from "../../../services/field-groups/field-group-data-service";
 import { BaseService } from "../../../shared/base-service";
 import {
@@ -2373,7 +2376,7 @@ export class SingleMutationService extends BaseService {
           // before the narrowed override is consulted — so the bound would be
           // defeated by a status that was never asked for.
           status:
-            options.overrideAccess === true && options.trusted === undefined
+            options.overrideAccess === true && !narrows(options.trusted)
               ? "all"
               : undefined,
         }

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -59,8 +59,9 @@ import {
 } from "../../../services/collections/trust-bound";
 import type { TrustBound } from "../../../services/collections/trust-grant";
 import {
-  assumedBound,
   TRUSTS_EVERY_COLLECTION,
+  assumedBound,
+  narrows,
 } from "../../../services/collections/trust-grant";
 import type { CollectionsHandler } from "../../../services/collections-handler";
 import type { FieldGroupDataService } from "../../../services/field-groups/field-group-data-service";
@@ -1023,7 +1024,7 @@ export class SingleQueryService extends BaseService {
         status: expansionStatusScope({
           status: options.status,
           overrideAccess: options.overrideAccess,
-          bounded: options.trusted !== undefined,
+          bounded: narrows(options.trusted),
         }),
       },
       strict,
@@ -1094,7 +1095,7 @@ export class SingleQueryService extends BaseService {
             status: expansionStatusScope({
               status: options.status,
               overrideAccess: options.overrideAccess,
-              bounded: options.trusted !== undefined,
+              bounded: narrows(options.trusted),
             }),
           },
           // Read errors otherwise become empty component values, which reads to a

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -57,6 +57,11 @@ import {
   applyMediaTrustBound,
   expansionAccess,
 } from "../../../services/collections/trust-bound";
+import type { TrustBound } from "../../../services/collections/trust-grant";
+import {
+  assumedBound,
+  TRUSTS_EVERY_COLLECTION,
+} from "../../../services/collections/trust-grant";
 import type { CollectionsHandler } from "../../../services/collections-handler";
 import type { FieldGroupDataService } from "../../../services/field-groups/field-group-data-service";
 import { BaseService } from "../../../shared/base-service";
@@ -486,7 +491,7 @@ export async function checkSingleAccess(params: {
    * the caller's trust. Evaluated as `overrideAccess && trusted(target)`, so it
    * can only ever narrow. See {@link RelatedRowReadContext.trusted}.
    */
-  trusted?: (collection: string) => boolean;
+  trusted?: TrustBound;
   routeAuthorized?: boolean;
   rbacAccessControlService?: RBACAccessControlService;
   // The caller's authenticated scope. A scoped API key is judged on its OWN
@@ -1005,7 +1010,7 @@ export class SingleQueryService extends BaseService {
         overrideAccess: options.overrideAccess,
         // Narrows that bypass per RELATED collection. Absent means unchanged;
         // dropping it here would silently restore the full bypass.
-        trusted: options.trusted,
+        trusted: assumedBound(options.trusted),
         authenticatedScope: options.authenticatedScope,
         // Collects the references a target collection refused, so the
         // completeness check below reads them as absent on purpose.
@@ -1077,7 +1082,7 @@ export class SingleQueryService extends BaseService {
             overrideAccess: options.overrideAccess,
             // Narrows that bypass per RELATED collection. Absent means unchanged;
             // dropping it here would silently restore the full bypass.
-            trusted: options.trusted,
+            trusted: assumedBound(options.trusted),
             // A relationship inside a component is populated by the same
             // service, so a refusal there has to reach the completeness check
             // too, and the rows of one population share a policy cache.
@@ -2728,7 +2733,7 @@ export class SingleQueryService extends BaseService {
     // collection's fields. Enforcement is opt-in because a caller that has not
     // supplied a user is indistinguishable from an anonymous one here, and
     // enforcing for the former strips protected fields from everybody.
-    access: RelatedRowReadContext = { trusted: undefined },
+    access: RelatedRowReadContext = { trusted: TRUSTS_EVERY_COLLECTION },
     /**
      * Propagate expansion failures instead of returning the document
      * unexpanded. A response is better served incomplete than not at all, but a

--- a/packages/nextly/src/domains/singles/types.ts
+++ b/packages/nextly/src/domains/singles/types.ts
@@ -13,6 +13,7 @@ import type { AuthenticatedScope } from "../../auth/authenticated-scope";
 import type { RequestActor } from "../../auth/request-actor";
 import type { StatusOption } from "../../lib/status-filter";
 import type { RevalidationIntent } from "../../revalidation/types";
+import type { TrustBound } from "../../services/collections/trust-grant";
 
 /**
  * User context for Single operations.
@@ -48,7 +49,7 @@ export interface GetSingleOptions {
    * the caller's trust, which is unchanged behaviour. Evaluated as
    * `overrideAccess && trusted(target)`, so it can only ever narrow.
    */
-  trusted?: (collection: string) => boolean;
+  trusted?: TrustBound;
 
   /**
    * Depth for relationship expansion.
@@ -168,7 +169,7 @@ export interface UpdateSingleOptions {
    * the caller's trust, which is unchanged behaviour. Evaluated as
    * `overrideAccess && trusted(target)`, so it can only ever narrow.
    */
-  trusted?: (collection: string) => boolean;
+  trusted?: TrustBound;
 
   /**
    * Set when this write restores an earlier version, recording which one on the

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -153,6 +153,14 @@ export type {
   DeleteFieldGroupArgs,
 } from "./direct-api/types";
 
+// The vocabulary a caller needs to answer `DirectAPIConfig.trusted`. Exported
+// as a VALUE, not only a type: the escape hatch is a constant a caller has to
+// be able to write, and a bound it cannot name is a bound it will not draw.
+export {
+  TRUSTS_EVERY_COLLECTION,
+  type TrustBound,
+} from "./services/collections/trust-grant";
+
 // Direct API types - core operation argument types
 export type {
   DirectAPIConfig,

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -39,6 +39,7 @@ import {
   type WhereFilter,
   type UserContext,
 } from "./collections/index";
+import type { TrustBound } from "./collections/trust-grant";
 import type { FieldGroupDataService } from "./field-groups/field-group-data-service";
 import type { FieldGroupRegistryService } from "./field-groups/field-group-registry-service";
 import { consoleLogger } from "./shared";
@@ -318,7 +319,7 @@ export class CollectionsHandler {
        * Absent means every populated target inherits the caller's trust. Only ever
        * narrows, and never admits a target's drafts.
        */
-      trusted?: (collection: string) => boolean;
+      trusted?: TrustBound;
       routeAuthorized?: boolean;
     },
   >(params: T): Omit<T, "userName" | "userEmail" | "userRoles"> {
@@ -583,7 +584,7 @@ export class CollectionsHandler {
      * Absent means every populated target inherits the caller's trust. Only ever
      * narrows, and never admits a target's drafts.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     /**
      * The route already ran the coarse RBAC gate, so skip only that redundant
      * re-check while the stored read rules (owner-only scoping, role-based,
@@ -642,7 +643,7 @@ export class CollectionsHandler {
        * Absent means every populated target inherits the caller's trust. Only ever
        * narrows, and never admits a target's drafts.
        */
-      trusted?: (collection: string) => boolean;
+      trusted?: TrustBound;
       /** Write locale (i18n M5) — translatable values stored for this language. */
       locale?: string;
       /**
@@ -706,7 +707,7 @@ export class CollectionsHandler {
      * Absent means every populated target inherits the caller's trust. Only ever
      * narrows, and never admits a target's drafts.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     /**
      * Draft/Published filter override (only effective when collection.status
      * === true). Public callers default to 'published'; trusted callers can
@@ -783,7 +784,7 @@ export class CollectionsHandler {
      * Absent means every populated target inherits the caller's trust. Only ever
      * narrows, and never admits a target's drafts.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     /**
      * The route already ran the coarse RBAC gate, so skip only that redundant
      * re-check while the stored read rules (owner-only scoping, role-based,
@@ -837,7 +838,7 @@ export class CollectionsHandler {
        * Absent means every populated target inherits the caller's trust. Only ever
        * narrows, and never admits a target's drafts.
        */
-      trusted?: (collection: string) => boolean;
+      trusted?: TrustBound;
       /** Who performed the write, recorded on the outbox event. */
       actor?: RequestActor;
       /** Write locale (i18n M5) — translatable values updated for this language. */
@@ -906,7 +907,7 @@ export class CollectionsHandler {
      * Absent means every populated target inherits the caller's trust. Only ever
      * narrows, and never admits a target's drafts.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     /**
      * Set by the REST dispatcher to attest the route middleware already ran the
      * RBAC/code-access gate, so the entry service skips only that redundant
@@ -944,7 +945,7 @@ export class CollectionsHandler {
      * Absent means every populated target inherits the caller's trust. Only ever
      * narrows, and never admits a target's drafts.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     /**
      * Set by the REST dispatcher to attest the route middleware already ran
      * the RBAC/code-access gate, so the entry service skips only that redundant
@@ -996,7 +997,7 @@ export class CollectionsHandler {
      * Absent means every populated target inherits the caller's trust. Only ever
      * narrows, and never admits a target's drafts.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     /**
      * Set by the REST dispatcher to attest the route middleware already ran
      * the RBAC/code-access gate, so the entry service skips only that redundant
@@ -1047,7 +1048,7 @@ export class CollectionsHandler {
      * Absent means every populated target inherits the caller's trust. Only ever
      * narrows, and never admits a target's drafts.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     /**
      * Set by the REST dispatcher to attest the route middleware already ran
      * the RBAC/code-access gate, so the entry service skips only that redundant
@@ -1102,7 +1103,7 @@ export class CollectionsHandler {
        * Absent means every populated target inherits the caller's trust. Only ever
        * narrows, and never admits a target's drafts.
        */
-      trusted?: (collection: string) => boolean;
+      trusted?: TrustBound;
       /** Route auth already ran; response is still redacted for this user */
       routeAuthorized?: boolean;
       /** Arbitrary data passed to hooks via context */
@@ -1161,7 +1162,7 @@ export class CollectionsHandler {
        * Absent means every populated target inherits the caller's trust. Only ever
        * narrows, and never admits a target's drafts.
        */
-      trusted?: (collection: string) => boolean;
+      trusted?: TrustBound;
       /**
        * Set by the REST dispatcher to attest the route middleware already ran
        * the RBAC/code-access gate, so the entry service skips only that
@@ -1205,7 +1206,7 @@ export class CollectionsHandler {
      * Absent means every populated target inherits the caller's trust. Only ever
      * narrows, and never admits a target's drafts.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     /**
      * Set by the REST dispatcher to attest the route middleware already ran
      * the RBAC/code-access gate, so the entry service skips only that redundant

--- a/packages/nextly/src/services/collections/__tests__/expansion-access.test.ts
+++ b/packages/nextly/src/services/collections/__tests__/expansion-access.test.ts
@@ -13,6 +13,7 @@
 import { describe, expect, it } from "vitest";
 
 import { applyMediaTrustBound, expansionAccess } from "../trust-bound";
+import { TRUSTS_EVERY_COLLECTION } from "../trust-grant";
 
 const CALLER = {
   user: { id: "u1" },
@@ -63,7 +64,10 @@ describe("the access an expansion runs under", () => {
 
     return applyMediaTrustBound(
       rows,
-      expansionAccess({ overrideAccess: true, trusted: undefined })
+      expansionAccess({
+        overrideAccess: true,
+        trusted: TRUSTS_EVERY_COLLECTION,
+      })
     ).then(([row]) => {
       expect(row).toHaveProperty("uploadedBy");
     });

--- a/packages/nextly/src/services/collections/__tests__/trust-bound.test.ts
+++ b/packages/nextly/src/services/collections/__tests__/trust-bound.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from "vitest";
 
 import type { RelatedRowReadContext } from "../related-row-read-context";
 import { applyMediaTrustBound, boundRefuses } from "../trust-bound";
+import { TRUSTS_EVERY_COLLECTION } from "../trust-grant";
 
 /** A media row as the fetch returns it, camelCased. */
 function mediaRow(): Record<string, unknown> {
@@ -98,7 +99,7 @@ describe("the trust bound applies to upload expansion", () => {
     // every admin read returns.
     const [row] = await applyMediaTrustBound([mediaRow()], {
       overrideAccess: true,
-      trusted: undefined,
+      trusted: TRUSTS_EVERY_COLLECTION,
     });
 
     for (const column of INTERNAL) expect(row).toHaveProperty(column);
@@ -175,7 +176,10 @@ describe("boundRefuses separates refusal from absence of trust", () => {
 
   it("is false for a bypass with no bound at all", () => {
     expect(
-      boundRefuses({ overrideAccess: true, trusted: undefined }, "media")
+      boundRefuses(
+        { overrideAccess: true, trusted: TRUSTS_EVERY_COLLECTION },
+        "media"
+      )
     ).toBe(false);
   });
 });

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -55,6 +55,7 @@ import type { Logger } from "../shared";
 
 import type { CollectionRelationshipService } from "./collection-relationship-service";
 import type { WhereFilter } from "./query-operators";
+import type { TrustBound } from "./trust-grant";
 
 export {
   type CollectionServiceResult,
@@ -184,7 +185,7 @@ export class CollectionEntryService extends BaseService {
      * Absent means every populated target inherits the caller's trust. Only ever
      * narrows, and never admits a target's drafts.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     /** Requested content locale (i18n M4) — forwarded to the query service. */
     locale?: string;
     /** Fallback control (`false`/`"none"` disables fallback). */
@@ -209,7 +210,7 @@ export class CollectionEntryService extends BaseService {
      * Absent means every populated target inherits the caller's trust. Only ever
      * narrows, and never admits a target's drafts.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     /** Requested content locale (i18n M4) — forwarded to the query service. */
     locale?: string;
     /** Fallback control (`false`/`"none"` disables fallback). */
@@ -236,7 +237,7 @@ export class CollectionEntryService extends BaseService {
      * Absent means every populated target inherits the caller's trust. Only ever
      * narrows, and never admits a target's drafts.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     /**
      * Draft/Published filter override (only effective when collection.status
      * === true). 'all' bypasses the default published-only filter — used by
@@ -465,7 +466,7 @@ export class CollectionEntryService extends BaseService {
        * Absent means every populated target inherits the caller's trust. Only ever
        * narrows, and never admits a target's drafts.
        */
-      trusted?: (collection: string) => boolean;
+      trusted?: TrustBound;
       /** Write locale (i18n M5) — translatable values stored for this language. */
       locale?: string;
       context?: Record<string, unknown>;
@@ -520,7 +521,7 @@ export class CollectionEntryService extends BaseService {
        * Absent means every populated target inherits the caller's trust. Only ever
        * narrows, and never admits a target's drafts.
        */
-      trusted?: (collection: string) => boolean;
+      trusted?: TrustBound;
       /** Write locale (i18n M5) — translatable values updated for this language. */
       locale?: string;
       context?: Record<string, unknown>;
@@ -560,7 +561,7 @@ export class CollectionEntryService extends BaseService {
      * Absent means every populated target inherits the caller's trust. Only ever
      * narrows, and never admits a target's drafts.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     /**
      * Set by the REST dispatcher: the route already authorized this POST as
      * `update`, so the preliminary update gate skips its redundant RBAC re-check.
@@ -592,7 +593,7 @@ export class CollectionEntryService extends BaseService {
      * Absent means every populated target inherits the caller's trust. Only ever
      * narrows, and never admits a target's drafts.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     routeAuthorized?: boolean;
     context?: Record<string, unknown>;
     /** API-key scope; judges the delete gate on the key's own grant. */
@@ -688,7 +689,7 @@ export class CollectionEntryService extends BaseService {
      * Absent means every populated target inherits the caller's trust. Only ever
      * narrows, and never admits a target's drafts.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     context?: Record<string, unknown>;
     /** Acting identity from the transport, forwarded to the recorded event. */
     actor?: RequestActor;
@@ -720,7 +721,7 @@ export class CollectionEntryService extends BaseService {
      * Absent means every populated target inherits the caller's trust. Only ever
      * narrows, and never admits a target's drafts.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     routeAuthorized?: boolean;
     context?: Record<string, unknown>;
     /** API-key scope; judges each per-id delete on the key's own grant. */
@@ -748,7 +749,7 @@ export class CollectionEntryService extends BaseService {
      * Absent means every populated target inherits the caller's trust. Only ever
      * narrows, and never admits a target's drafts.
      */
-    trusted?: (collection: string) => boolean;
+    trusted?: TrustBound;
     routeAuthorized?: boolean;
     context?: Record<string, unknown>;
     /** Acting identity from the transport, forwarded to the recorded event. */
@@ -779,7 +780,7 @@ export class CollectionEntryService extends BaseService {
        * Absent means every populated target inherits the caller's trust. Only ever
        * narrows, and never admits a target's drafts.
        */
-      trusted?: (collection: string) => boolean;
+      trusted?: TrustBound;
       /** Route auth already ran; response is still redacted for this user */
       routeAuthorized?: boolean;
       context?: Record<string, unknown>;
@@ -817,7 +818,7 @@ export class CollectionEntryService extends BaseService {
        * Absent means every populated target inherits the caller's trust. Only ever
        * narrows, and never admits a target's drafts.
        */
-      trusted?: (collection: string) => boolean;
+      trusted?: TrustBound;
       context?: Record<string, unknown>;
     },
     options?: { limit?: number }
@@ -843,7 +844,7 @@ export class CollectionEntryService extends BaseService {
        * Absent means every populated target inherits the caller's trust. Only ever
        * narrows, and never admits a target's drafts.
        */
-      trusted?: (collection: string) => boolean;
+      trusted?: TrustBound;
       authenticatedScope?: AuthenticatedScope;
     },
     entries: Record<string, unknown>[],

--- a/packages/nextly/src/services/collections/related-row-read-context.ts
+++ b/packages/nextly/src/services/collections/related-row-read-context.ts
@@ -20,6 +20,8 @@ import type { AuthenticatedScope } from "../../auth/authenticated-scope";
 import type { CollectionAccessRules } from "../access";
 import type { CompanionSchema } from "../collection-file-manager";
 
+import type { TrustBound } from "./trust-grant";
+
 /**
  * A target collection's read policy, as one expansion needs it.
  *
@@ -48,24 +50,30 @@ export interface RelatedRowReadContext {
   overrideAccess?: boolean;
 
   /**
-   * Which collections `overrideAccess` may actually reach, when the caller can
-   * name them.
+   * Which collections `overrideAccess` may actually reach, judged per TARGET.
    *
    * A trusted read that populates a relationship reads the TARGET trusted too,
    * and the target's collection was never named by the caller — it was reached
-   * through a field. For a caller who has already decided who is asking, that
-   * is correct and this stays absent: the Direct API's semantics are unchanged.
+   * through a field. A caller that has already decided who is asking is
+   * entitled to that, and says so with {@link TRUSTS_EVERY_COLLECTION}. A
+   * caller serving one fixed audience is in the opposite position: it can state
+   * its trusted set up front, and anything outside that set must be read as the
+   * audience would read it.
    *
-   * A caller serving one fixed audience is in the opposite position. It can
-   * state its trusted set up front, and anything outside that set must be read
-   * as the audience would read it. Supplying this narrows the bypass to the
-   * collections named, per TARGET, at every fetch the expansion performs.
+   * **Required, and not nullable.** This was previously
+   * `((collection: string) => boolean) | undefined`, where `undefined` meant
+   * unbounded — so a context whose author had weighed the question and one
+   * whose author never saw it were the same value, and only the second was a
+   * bug. The two are now different words. Nothing about the runtime changed:
+   * `TRUSTS_EVERY_COLLECTION` reaches every target, exactly as the absent value
+   * used to.
    *
-   * A predicate rather than a list because the decision is asked once per
-   * target collection at four separate points, and a caller may derive
-   * membership rather than enumerate it.
+   * The requirement is what does the work, not the constant. A route that
+   * forgets its bound no longer compiles, which is the failure mode this
+   * package has actually shipped — twice, on Singles and on collections, caught
+   * by a reviewer both times rather than by the type.
    */
-  trusted: ((collection: string) => boolean) | undefined;
+  trusted: TrustBound;
 
   /**
    * The caller's authenticated scope. A scoped API key is judged on its OWN

--- a/packages/nextly/src/services/collections/related-row-read-context.ts
+++ b/packages/nextly/src/services/collections/related-row-read-context.ts
@@ -60,18 +60,15 @@ export interface RelatedRowReadContext {
    * its trusted set up front, and anything outside that set must be read as the
    * audience would read it.
    *
-   * **Required, and not nullable.** This was previously
-   * `((collection: string) => boolean) | undefined`, where `undefined` meant
-   * unbounded — so a context whose author had weighed the question and one
-   * whose author never saw it were the same value, and only the second was a
-   * bug. The two are now different words. Nothing about the runtime changed:
-   * `TRUSTS_EVERY_COLLECTION` reaches every target, exactly as the absent value
-   * used to.
+   * **Required, and not nullable.** A nullable bound would give one value to
+   * two different states — a context whose author weighed which collections the
+   * bypass should reach and answered "all of them", and one whose author never
+   * saw the question. Only the second is a defect, and nothing could tell them
+   * apart. `TRUSTS_EVERY_COLLECTION` is the first of those states said out loud;
+   * it reaches every target, so no read behaves differently for saying it.
    *
-   * The requirement is what does the work, not the constant. A route that
-   * forgets its bound no longer compiles, which is the failure mode this
-   * package has actually shipped — twice, on Singles and on collections, caught
-   * by a reviewer both times rather than by the type.
+   * The requirement is what does the work, not the constant: a context that
+   * does not answer the question does not compile.
    */
   trusted: TrustBound;
 

--- a/packages/nextly/src/services/collections/trust-bound.ts
+++ b/packages/nextly/src/services/collections/trust-bound.ts
@@ -15,6 +15,8 @@ import type { AuthenticatedScope } from "../../auth/authenticated-scope";
 import { canReadSystemResource } from "../../auth/resource-readable";
 
 import type { RelatedRowReadContext } from "./related-row-read-context";
+import type { TrustBound } from "./trust-grant";
+import { assumedBound, boundReaches } from "./trust-grant";
 
 /** The system resource an upload field's rows are read from. */
 export const MEDIA_TARGET = "media";
@@ -56,8 +58,7 @@ export function boundRefuses(
 ): boolean {
   return (
     access.overrideAccess === true &&
-    access.trusted !== undefined &&
-    !access.trusted(targetCollection)
+    !boundReaches(access.trusted, targetCollection)
   );
 }
 
@@ -128,7 +129,7 @@ export interface CallerOptions {
    */
   enforceFieldAccess?: boolean;
   fieldAccessUser?: Record<string, unknown>;
-  trusted?: (collection: string) => boolean;
+  trusted?: TrustBound;
   authenticatedScope?: AuthenticatedScope;
 }
 
@@ -152,7 +153,7 @@ export function expansionAccess(options: CallerOptions): RelatedRowReadContext {
     // nobody. That is silent, and it is the direction that leaks.
     enforceFieldAccess: options.enforceFieldAccess,
     fieldAccessUser: options.fieldAccessUser,
-    trusted: options.trusted,
+    trusted: assumedBound(options.trusted),
     authenticatedScope: options.authenticatedScope,
   };
 }

--- a/packages/nextly/src/services/collections/trust-grant.test-d.ts
+++ b/packages/nextly/src/services/collections/trust-grant.test-d.ts
@@ -1,0 +1,64 @@
+/**
+ * A trusted expansion cannot omit its bound — asserted by the CHECKER.
+ *
+ * The guarantee this file pins is not "a bound exists". It is that **absence is
+ * no longer expressible** on the context an expansion actually runs under. Two
+ * different states used to produce the same value: an author who weighed which
+ * collections their bypass should reach and decided "all of them", and an author
+ * who never saw the question. Both wrote nothing, and only the second was a bug.
+ *
+ * The failure that motivates it has shipped twice — the Singles route and the
+ * collection routes both reached related rows with an unbounded bypass — and a
+ * reviewer caught it both times. A reviewer is not a boundary.
+ *
+ * Every negative below is asked as a conditional type rather than with
+ * `@ts-expect-error`, which suppresses ANY error on the line that follows and
+ * would keep passing once the code started failing for an unrelated reason.
+ * A conditional fails as `Expected: true, Actual: false`, which names the
+ * direction that broke.
+ */
+import { expectTypeOf } from "vitest";
+
+import type { DirectAPIConfig } from "../../direct-api/types/shared";
+
+import type { RelatedRowReadContext } from "./related-row-read-context";
+import type { TrustBound, TRUSTS_EVERY_COLLECTION } from "./trust-grant";
+
+// A context missing `trusted` is not a context. Written as `Omit` rather than an
+// inline literal so it keeps testing the real shape as fields are added: an
+// inline object would start failing for the newest unrelated required field and
+// report that as this guarantee still holding.
+type WithoutBound = Omit<RelatedRowReadContext, "trusted">;
+type BoundIsRequired = WithoutBound extends RelatedRowReadContext
+  ? false
+  : true;
+expectTypeOf<BoundIsRequired>().toEqualTypeOf<true>();
+
+// And it may not be satisfied by `undefined`. This is the half that does the
+// work: `trusted` was already a required KEY before this change, and a required
+// key that accepts `undefined` is an optional field wearing a hat.
+type UndefinedIsNotABound = undefined extends TrustBound ? false : true;
+expectTypeOf<UndefinedIsNotABound>().toEqualTypeOf<true>();
+
+// The positive controls. Without these, both assertions above would pass just as
+// well if `TrustBound` were narrowed to something no caller could ever satisfy,
+// or deleted outright — a guard nothing can get through is indistinguishable
+// from a guard nothing can USE.
+type ConstantIsABound = typeof TRUSTS_EVERY_COLLECTION extends TrustBound
+  ? true
+  : false;
+expectTypeOf<ConstantIsABound>().toEqualTypeOf<true>();
+
+type PredicateIsABound = ((collection: string) => boolean) extends TrustBound
+  ? true
+  : false;
+expectTypeOf<PredicateIsABound>().toEqualTypeOf<true>();
+
+// The escape hatch has to be reachable from the PUBLIC option too, or a caller
+// outside this package can describe a narrowing bound but not an unbounded one,
+// and would go back to expressing "everything" by saying nothing.
+type PublicOptionAcceptsConstant =
+  typeof TRUSTS_EVERY_COLLECTION extends NonNullable<DirectAPIConfig["trusted"]>
+    ? true
+    : false;
+expectTypeOf<PublicOptionAcceptsConstant>().toEqualTypeOf<true>();

--- a/packages/nextly/src/services/collections/trust-grant.test-d.ts
+++ b/packages/nextly/src/services/collections/trust-grant.test-d.ts
@@ -7,9 +7,9 @@
  * collections their bypass should reach and decided "all of them", and an author
  * who never saw the question. Both wrote nothing, and only the second was a bug.
  *
- * The failure that motivates it has shipped twice — the Singles route and the
- * collection routes both reached related rows with an unbounded bypass — and a
- * reviewer caught it both times. A reviewer is not a boundary.
+ * The failure it prevents is a route reaching related rows with an unbounded
+ * bypass: the route names one collection, the expansion reads the others, and
+ * nothing in the type obliges the caller to say whether that is intended.
  *
  * Every negative below is asked as a conditional type rather than with
  * `@ts-expect-error`, which suppresses ANY error on the line that follows and

--- a/packages/nextly/src/services/collections/trust-grant.ts
+++ b/packages/nextly/src/services/collections/trust-grant.ts
@@ -1,0 +1,80 @@
+/**
+ * What a trusted read may reach.
+ *
+ * `overrideAccess` says the CALLER is trusted. It says nothing about the
+ * collections a relationship happens to point at — those were never named by
+ * the caller, they were reached through a field — so a trusted read spreads its
+ * trust into every target it populates, along with a lifecycle widened to
+ * include drafts. The bound is what answers the second question.
+ *
+ * A leaf module on purpose: both the context that carries a bound and the
+ * service that acts on one need this vocabulary, and giving it to either of
+ * them would make the other import back. There are already 45 import cycles in
+ * this package and no reason to add the 46th for two declarations.
+ *
+ * @module services/collections/trust-grant
+ */
+
+/**
+ * The bound a read declares when its bypass reaches every collection.
+ *
+ * Named rather than left as an absence, which is the whole point. Before this,
+ * a read that had thought about its bound and a read whose author never
+ * considered the question produced the SAME value — nothing — so the safe path
+ * and the easy path differed and the easy one was silent. Now an audit greps
+ * one symbol to find every unbounded read, and each hit is a decision someone
+ * recorded rather than a field they omitted.
+ *
+ * A bare `"all"` would be shorter and would read as nothing. That is the
+ * property to avoid: this is the path of least resistance for a caller that
+ * cannot immediately work out its bound, so it should cost a sentence.
+ */
+export const TRUSTS_EVERY_COLLECTION = "trusts-every-collection" as const;
+
+/**
+ * Which collections a trusted read may reach, judged per expansion TARGET.
+ *
+ * A predicate rather than a list because the question is asked once per target
+ * at several points in a single expansion, and membership is more often derived
+ * than enumerated. `TRUSTS_EVERY_COLLECTION` is the other half of the type
+ * rather than a predicate that returns `true`, so that "reads everything" stays
+ * greppable instead of hiding inside an arrow function.
+ *
+ * This can only ever NARROW. It is read as `overrideAccess && bound(target)`,
+ * so supplying a predicate removes trust the caller already held and can never
+ * grant trust it did not — the same shape as passing `overrideAccess: false`.
+ */
+export type TrustBound =
+  | ((collection: string) => boolean)
+  | typeof TRUSTS_EVERY_COLLECTION;
+
+/**
+ * Whether a bound reaches one target collection.
+ *
+ * The single place the constant is compared, so a caller that adds a bound
+ * cannot forget that the escape hatch is not callable.
+ */
+export function boundReaches(bound: TrustBound, collection: string): boolean {
+  return bound === TRUSTS_EVERY_COLLECTION || bound(collection);
+}
+
+/**
+ * The bound to run an expansion under when the caller named none.
+ *
+ * Absence is a real state at the options layer and cannot be legislated away
+ * there: `trusted` is optional on the Direct API, and a caller that omits it
+ * has said only that it did not think about relationship targets. The context
+ * layer is where that has to become a decision, because that is where the
+ * expansion actually happens — and the decision preserved here is the one this
+ * package has always taken, that an unbounded trusted read reaches everything.
+ *
+ * Named, and used at every options-to-context boundary, so the question "which
+ * reads are unbounded because nobody chose?" has ONE grep and one answer rather
+ * than an `??` repeated at eight call sites with eight comments that can drift.
+ * The word is `assumed` on purpose: this is not a bound the caller declared, it
+ * is one inferred from silence, and a future change that wants to narrow the
+ * default has exactly one place to do it.
+ */
+export function assumedBound(bound: TrustBound | undefined): TrustBound {
+  return bound ?? TRUSTS_EVERY_COLLECTION;
+}

--- a/packages/nextly/src/services/collections/trust-grant.ts
+++ b/packages/nextly/src/services/collections/trust-grant.ts
@@ -59,6 +59,30 @@ export function boundReaches(bound: TrustBound, collection: string): boolean {
 }
 
 /**
+ * Whether a bound actually NARROWS the bypass it accompanies.
+ *
+ * Distinct from "a bound is present", and the distinction is the whole reason
+ * this exists. Two values mean *reaches everything* — an absent bound, and
+ * {@link TRUSTS_EVERY_COLLECTION} — and only the second is a value. Deriving
+ * narrowing from presence therefore makes the constant behave differently from
+ * the absence it was introduced to replace, which is the one thing it must
+ * never do.
+ *
+ * The difference is observable rather than theoretical. `expansionStatusScope`
+ * withholds a widened lifecycle from a narrowed caller, so a read stating
+ * `TRUSTS_EVERY_COLLECTION` would stop inheriting `status: "all"` into its
+ * expansions while the identical read omitting the bound kept it — the same
+ * caller, the same intent, different rows.
+ *
+ * Asked here rather than at each site because the answer is needed at eleven of
+ * them across four services, and a copy of it drifts silently: two call sites
+ * would then disagree about which reads see unpublished rows.
+ */
+export function narrows(bound: TrustBound | undefined): boolean {
+  return bound !== undefined && bound !== TRUSTS_EVERY_COLLECTION;
+}
+
+/**
  * The bound to run an expansion under when the caller named none.
  *
  * Absence is a real state at the options layer and cannot be legislated away


### PR DESCRIPTION
## What changes for a caller

**Nothing at runtime.** Every read returns exactly what it returned before. This is a type-level guardrail; there is no behavioural diff to review.

What changes is that a read which skips access checks must now say **which collections its relationships may reach**. A read that genuinely reaches everything says so by name:

```ts
import { TRUSTS_EVERY_COLLECTION } from "nextly";

await nextly.find({
  collection: "posts",
  overrideAccess: true,
  trusted: name => name === "posts" || name === "authors", // a bound
});
```

## Why

`overrideAccess` says the CALLER is trusted. It says nothing about the collections a relationship points at — those were never named by the caller, they were reached through a field. Naming them was optional, and **absence meant all of them**.

So two different states produced the same value: an author who weighed the question and decided "everything", and an author who never saw it. Only the second is a bug, and nothing in the code could tell them apart.

That omission has shipped **twice** — the Singles route (#1167) and the collection routes before it. A reviewer caught it both times. A reviewer is not a boundary.

## The shape, and why it is this shape

`RelatedRowReadContext.trusted` was already a required KEY typed `fn | undefined`. A required key that accepts `undefined` is an optional field wearing a hat, so the change is to remove `undefined` from the bound and give "everything" a name.

The requirement is what does the work, not the constant.

## Three corrections to the approved design, all measured

The design in `plans/2026-08-24-R-5-trust-boundary-design.md` was approved before it had been run against the code. Building it surfaced three problems, each established with `tsc`, and §9 of that doc now records them.

**1. The site count was wrong.** §4 claimed "35 sites across 18 files". That counted `overrideAccess: true` appearing as *prose inside JSDoc*. Filtering comment lines leaves **8 real call sites**.

**2. The proposed union does not compile against this repo.** §3's table verified only *leaf* call sites. Three shapes it never tested, all of which occur in the code it would govern:

| shape | occurrences | result under the approved type |
| --- | --- | --- |
| `{ overrideAccess: params.overrideAccess, trusted: params.trusted }` | ~100 | **TS2322** — `fn \| undefined` is not assignable to the bound |
| `{ ...callerAccess(config) }` | the repo's own recommended idiom | **TS2345** — spread loses the discriminant correlation |
| `FindArgs & TrustDeclared` where the base declares `trusted?: (c: string) => boolean` | every args interface | **TS2322** — the intersection ANDs the property types and rejects the constant |

`DirectAPIConfig` also cannot become a union at all: it is an `interface` extended by ~40 argument interfaces, and an interface cannot extend a union.

**3. There is no live defect.** §4 anticipated a category of "should be bounded, and a candidate defect". Running the classification, **that category is empty**.

## Every call site, classified individually

Derived, not read from the doc — the doc's own number was stale within hours.

| site | verdict | why |
| --- | --- | --- |
| `runtime/routing/resolve-content.ts:335` | already bounded | passes `trusted` |
| `runtime/routing/content-route.ts:618` | already bounded | passes `trustedCollections` |
| `runtime/routing/single-route.ts:362` | already bounded | passes a `trustedSet` predicate |
| `api/preview-links.ts:611` | inert | `depth: 0` |
| `api/preview-url.ts:153` | inert | `depth: 0` |
| `runtime/preview/preview-route-defaults.ts:160` | inert | `depth: 0` |
| `collection-bulk-service.ts:673`, `:871` | inert | `depth: 0`, ids only |
| `direct-api/nextly.ts:261` | genuinely unbounded | the documented trusted-server default |
| `plugins/service-opts.ts:48` | genuinely unbounded | the plugin `as:"system"` context |

**Every route is already bounded.** So this PR prevents a recurrence rather than closing an open hole, and it should be read that way.

## Where absence survives, and why it is now visible

Absence is a real state at the *options* layer and cannot be legislated away there — `trusted` is optional on the public Direct API, and a caller that omits it has said only that it did not think about targets. The **context** layer is where that has to become a decision.

That inference lives in one named function, `assumedBound`, used at all eight options-to-context boundaries — so "which reads are unbounded because nobody chose?" has one grep and one place to change, rather than an `??` repeated eight times with eight comments that can drift. The word is `assumed` on purpose.

The sixteen defaults that previously relied on absence (`{ trusted: undefined }`) now say `TRUSTS_EVERY_COLLECTION` out loud.

## Break-verification

Every guard was broken, the break asserted to have APPLIED, the intended failure required, then restored to a verified-clean tree.

| break | expected | observed |
| --- | --- | --- |
| make `trusted` optional again | type test red | `trust-grant.test-d.ts(34)` — `Expected: true, Actual: false` |
| re-admit `undefined` to `TrustBound` | type test red | `trust-grant.test-d.ts(40)` — same form |
| a real context literal drops its bound | context rejected | `collection-query-service.ts(1790)` TS2345 |
| narrow the public option so the hatch is unreachable | type test red | `trust-grant.test-d.ts(64)` |

The type test asserts each negative with a conditional type rather than `@ts-expect-error`, which suppresses ANY error on the following line and would keep passing once the code began failing for an unrelated reason. It also carries positive controls: without them, "the bound is required" and "`undefined` is rejected" would both pass just as well if `TrustBound` were narrowed to something no caller could satisfy.

## Evidence

- `nextly` unit: **32 files / 360 tests failing — exactly the documented baseline.** No regression.
- `tsc --noEmit` and `tsc -p tsconfig.tests.json`: **0 errors** each.
- eslint on all changed files: **0 errors**.
- Touched unit suites (`trust-bound`, `expansion-access`, `relationship-redaction`): 40 passed.

## One fallow note, with its evidence

`duplication_introduced: 5`, verdict `warn`. These are **pre-existing clones my diff touched, not logic I duplicated**. The `collections-handler.ts` pair (`deleteEntry` / `bulkDeleteEntries`) measured **0.709 similarity on `origin/main` before this change**; replacing a 9-token annotation with a 3-token one pushed them past the threshold, so the group is attributed to this diff.

Fixing it properly means extracting the hand-written parallel `params: {...}` types across 13 methods in that file — a real improvement, and a different concern from this PR, in a file this PR touches by one line per method. Flagged rather than silenced; no suppression added.

## Deliberately NOT in this PR

The failure that actually shipped twice was a **route** calling with no bound. This PR guards the expansion context, which is one layer below that. The route-facing door is `resolveContent`, and it is cheap to close — **one internal caller** — but it is a breaking change to a public function's accepted arguments and is beyond the scope agreed for this change. Recommended as the immediate follow-up.

Also untouched: the write-side twin (`field-level-registry.ts` — an unauthenticated write bypasses field write rules), and separating row-trust from field-trust.
