### PR TITLE
fix(release): close the frontmatter on the changeset blocking every publish

### DIFF
--- a/.changeset/empty-css-id-removal.md
+++ b/.changeset/empty-css-id-removal.md
@@ -1,5 +1,4 @@
 ---
-
 "nextly": patch
 "create-nextly-app": patch
 "@nextlyhq/admin": patch
@@ -25,6 +24,7 @@
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/builder": patch
 "@nextlyhq/module-specifiers": patch
+---
 
 Lets an author remove a CSS id that is present but empty.
 


### PR DESCRIPTION
## What is wrong

`.changeset/empty-css-id-removal.md` opens its frontmatter and never closes it, with a stray blank line after the opening delimiter. `@changesets/parse` rejects it.

```
$ pnpm exec changeset status
🦋  error Error: could not parse changeset - missing or invalid frontmatter.
$ echo $?
1
```

**The blast radius is every package, not this one.** `getReleasePlan` reads `.changeset/` as a set, so one unparseable member fails the whole call and none of the several hundred pending changesets can be read. Release planning is stopped on `main` right now.

With the delimiter restored, `changeset status` exits `0` and plans the lockstep patch. `pnpm test:scripts` — 602 tests — passes.

## The part worth reading

**The gate for this already exists, it is correct, and it fired.**

`scripts/changesets-parse.test.mjs` parses every changeset with the release tooling's own parser, asserts the population before the verdict, and its docblock names both of these exact spellings as having reached `main` before. It runs in CI as `Script tests`.

On the pull request that introduced this file, `Lint / Typecheck / Test / Build` concluded **`failure`**, and the failing steps were precisely:

```
FAILED STEP: Script tests
FAILED STEP: Changeset covers the lockstep group
```

The pull request merged with that job red. Its three dependents — `Browser tests`, `Scaffold smoke`, `Dev script` — were `skipped` as a consequence and never evaluated.

**So this PR adds no new check.** A second reader of the same question is the duplication that gate's own docblock argues against, and it would not have helped: the check did not fail to fire, it failed to block.

## The thing that actually needs a decision

`main`'s branch protection lists exactly one required status check:

```
$ gh api repos/nextlyhq/nextly/branches/main/protection --jq '.required_status_checks.contexts'
["Decide what this commit can affect"]
```

`Lint / Typecheck / Test / Build`, the three `Integration` legs, `gitleaks`, `Whole repository` and `Comment convention` are **not required**, so GitHub permits a merge while any of them is red. That is what allowed this, and it is not specific to this file or this author.

Changing branch protection is a repository-admin decision with consequences for every contributor, so it is deliberately **not** part of this PR. Raising it here so it is decided rather than rediscovered.

## Verification

- `pnpm exec changeset status` → exit `0`, plans the lockstep patch group
- `pnpm test:scripts` → 24 files, 602 tests, exit `0`
- Removing the closing delimiter again reproduces the original error and exit `1`, so it is that line and not the blank one above it

No changeset accompanies this PR: it edits an existing changeset's syntax and ships no package change.