### PR TITLE
feat(plugin-form-builder): edit a form's notifications on the page

### DIFF
--- a/.changeset/forms-notifications-inline.md
+++ b/.changeset/forms-notifications-inline.md
@@ -1,0 +1,39 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Edit a form's notifications on the page, not in a panel over it.
+
+The editor was a 560px sheet that slid over the form and carried its own
+"Save changes" beside the page's own commit, with nothing saying which one
+persisted. It also dimmed the page it slid over, so the one thing a panel is
+for — keeping the page in view — was not delivered.
+
+Each notification is now a row that expands in place. Edits reach the form as
+they are typed, so the page's action bar is the only commit, and address
+validation moved from a save press to leaving the field. One row opens at a
+time, so the list keeps the overview its summaries exist to give.

--- a/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
+++ b/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
@@ -45,6 +45,7 @@ import {
   FormSettingsTab,
   type SpamDefaults,
 } from "./components/builder/FormSettingsTab";
+import { badAddressMessage } from "./components/builder/notification-addresses";
 import {
   FormBuilderProvider,
   useFormBuilder,
@@ -237,6 +238,17 @@ function FormBuilderViewInner({
     // Check if there are fields
     if (fields.length === 0) {
       toast.error("Please add at least one field to the form");
+      return;
+    }
+
+    // A notification's address fields are validated as they are left, but the
+    // rule is written to the form as it is typed — so leaving a malformed one
+    // and pressing Save here would persist it, and the delivery path would
+    // hand it to the mail provider. The same function the field uses answers
+    // for every rule, so the two cannot disagree about what is valid.
+    const badAddress = badAddressMessage(notifications);
+    if (badAddress) {
+      toast.error(badAddress);
       return;
     }
 

--- a/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
+++ b/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
@@ -45,7 +45,7 @@ import {
   FormSettingsTab,
   type SpamDefaults,
 } from "./components/builder/FormSettingsTab";
-import { badAddressMessage } from "./components/builder/notification-addresses";
+import { notificationsBlockingSave } from "./components/builder/notification-addresses";
 import {
   FormBuilderProvider,
   useFormBuilder,
@@ -241,14 +241,14 @@ function FormBuilderViewInner({
       return;
     }
 
-    // A notification's address fields are validated as they are left, but the
-    // rule is written to the form as it is typed — so leaving a malformed one
-    // and pressing Save here would persist it, and the delivery path would
-    // hand it to the mail provider. The same function the field uses answers
-    // for every rule, so the two cannot disagree about what is valid.
-    const badAddress = badAddressMessage(notifications);
-    if (badAddress) {
-      toast.error(badAddress);
+    // A notification is written to the form as it is typed, so nothing between
+    // the editor and here refuses one. The sheet this replaced disabled its own
+    // commit for a blank name, and the field rejects a malformed address on
+    // blur — both preconditions move to this save, which is now the only
+    // commit, and both are answered by the module the editor itself asks.
+    const blocked = notificationsBlockingSave(notifications);
+    if (blocked) {
+      toast.error(blocked);
       return;
     }
 

--- a/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.test.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.test.tsx
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+
+/**
+ * The notification editor is inline, and these pin the two properties that
+ * choice rests on.
+ *
+ * It replaced a slide-out panel that carried its own save button beside the
+ * page's, so the first property is that editing writes THROUGH to the form as
+ * it happens — there is no second commit, and a rule the page saves is the rule
+ * the author last typed. The second is that one row is open at a time, because
+ * several open at once turns the list into a wall of fields and loses the
+ * overview the summaries exist to give.
+ *
+ * jsdom is requested per file rather than in the shared vitest config: the
+ * integration suites in this package boot a real Nextly instance and have no
+ * use for a DOM.
+ */
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { FormNotification } from "../../../types";
+
+// Radix calls both when a Select opens and jsdom implements neither, so
+// without them a test dies on a missing method rather than failing an
+// assertion.
+beforeAll(() => {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => undefined;
+  Element.prototype.releasePointerCapture = () => undefined;
+  Element.prototype.scrollIntoView = () => undefined;
+});
+
+const updateNotification = vi.fn();
+const addNotification = vi.fn();
+const deleteNotification = vi.fn();
+const duplicateNotification = vi.fn();
+
+let notifications: FormNotification[] = [];
+
+vi.mock("../../context/FormBuilderContext", () => ({
+  useFormBuilder: () => ({
+    notifications,
+    fields: [{ name: "email", label: "Email", type: "email" }],
+    addNotification,
+    duplicateNotification,
+    updateNotification,
+    deleteNotification,
+  }),
+}));
+
+// Imported after the mock, so the component resolves the mocked context.
+const { FormNotificationsTab } = await import("./FormNotificationsTab");
+
+function aNotification(over: Partial<FormNotification> = {}): FormNotification {
+  return {
+    id: "n1",
+    name: "Admin notification",
+    enabled: true,
+    recipientType: "static",
+    to: "admin@example.com",
+    cc: [],
+    bcc: [],
+    ...over,
+  } as FormNotification;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  notifications = [];
+});
+
+describe("the notification list", () => {
+  it("shows a summary with the editor closed", () => {
+    notifications = [aNotification()];
+    render(<FormNotificationsTab defaults={null} />);
+
+    const toggle = screen.getByRole("button", {
+      name: /edit notification admin notification/i,
+    });
+    // The contract the row advertises to assistive tech, not just its looks.
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    // No editor field is reachable while the row is closed.
+    expect(screen.queryByLabelText("Name")).toBeNull();
+  });
+
+  it("opens the editor in place, under the row", async () => {
+    notifications = [aNotification()];
+    const user = userEvent.setup();
+    render(<FormNotificationsTab defaults={null} />);
+
+    const toggle = screen.getByRole("button", {
+      name: /edit notification admin notification/i,
+    });
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    // In place: the region the toggle names is the one that appeared.
+    const region = document.getElementById(
+      toggle.getAttribute("aria-controls") as string
+    );
+    expect(region).not.toBeNull();
+    expect(region).toContainElement(screen.getByDisplayValue("Admin notification"));
+    // And no dialog: an inline editor that still portals is the old panel
+    // wearing a different class.
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("writes an edit through as it is typed, with no save press", async () => {
+    notifications = [aNotification()];
+    const user = userEvent.setup();
+    render(<FormNotificationsTab defaults={null} />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /edit notification admin notification/i,
+      })
+    );
+
+    await user.type(screen.getByDisplayValue("Admin notification"), "!");
+
+    // The page's action bar is the only commit, so an edit that waited for a
+    // button here would be lost by the save the author actually presses.
+    expect(updateNotification).toHaveBeenCalled();
+    const [id, patch] = updateNotification.mock.calls.at(-1) as [
+      string,
+      FormNotification,
+    ];
+    expect(id).toBe("n1");
+    expect(patch.name).toBe("Admin notification!");
+  });
+
+  it("offers no save or cancel of its own", async () => {
+    notifications = [aNotification()];
+    const user = userEvent.setup();
+    render(<FormNotificationsTab defaults={null} />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /edit notification admin notification/i,
+      })
+    );
+
+    // The defect this replaced: two commit buttons on one page, with nothing
+    // saying which one persists.
+    expect(screen.queryByRole("button", { name: /save changes/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^cancel$/i })).toBeNull();
+  });
+
+  it("closes a row when its own toggle is pressed again", async () => {
+    // The separating case for a TOGGLE. Replacing the open row on every press
+    // also satisfies "opening another closes the first", so without this an
+    // implementation that can never be closed passes.
+    notifications = [aNotification()];
+    const user = userEvent.setup();
+    render(<FormNotificationsTab defaults={null} />);
+
+    const toggle = screen.getByRole("button", {
+      name: /notification admin notification/i,
+    });
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByDisplayValue("Admin notification")).toBeNull();
+  });
+
+  it("keeps one row open at a time", async () => {
+    notifications = [
+      aNotification(),
+      aNotification({ id: "n2", name: "Second" }),
+    ];
+    const user = userEvent.setup();
+    render(<FormNotificationsTab defaults={null} />);
+
+    const first = screen.getByRole("button", {
+      name: /notification admin notification/i,
+    });
+    const second = screen.getByRole("button", { name: /notification second/i });
+
+    await user.click(first);
+    expect(first).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(second);
+    expect(second).toHaveAttribute("aria-expanded", "true");
+    // The part that matters: accumulating open rows would satisfy the line
+    // above and turn the list into a wall of fields.
+    expect(first).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.test.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.test.tsx
@@ -102,7 +102,9 @@ describe("the notification list", () => {
       toggle.getAttribute("aria-controls") as string
     );
     expect(region).not.toBeNull();
-    expect(region).toContainElement(screen.getByDisplayValue("Admin notification"));
+    expect(region).toContainElement(
+      screen.getByDisplayValue("Admin notification")
+    );
     // And no dialog: an inline editor that still portals is the old panel
     // wearing a different class.
     expect(screen.queryByRole("dialog")).toBeNull();
@@ -190,5 +192,59 @@ describe("the notification list", () => {
     // The part that matters: accumulating open rows would satisfy the line
     // above and turn the list into a wall of fields.
     expect(first).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("does not re-enable a rule that the summary switch turned off", async () => {
+    // The editor reads the rule from the form on every render rather than
+    // holding a copy. A copy goes stale the moment the summary switch writes to
+    // the form, and the next keystroke sends the whole stale rule back —
+    // silently re-enabling a notification the author turned off, which then
+    // sends mail they stopped.
+    notifications = [aNotification()];
+    const user = userEvent.setup();
+    const { rerender } = render(<FormNotificationsTab defaults={null} />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /notification admin notification/i,
+      })
+    );
+
+    // The summary switch writes straight to the form, which re-renders the
+    // list with the rule disabled while this row stays open.
+    notifications = [aNotification({ enabled: false })];
+    rerender(<FormNotificationsTab defaults={null} />);
+    updateNotification.mockClear();
+
+    await user.type(screen.getByDisplayValue("Admin notification"), "!");
+
+    const [, patch] = updateNotification.mock.calls.at(-1) as [
+      string,
+      FormNotification,
+    ];
+    expect(patch.name).toBe("Admin notification!");
+    expect(patch.enabled).toBe(false);
+  });
+
+  it("dims the summary of a disabled rule, not the editor inside it", async () => {
+    // An expanded editor inside a faded card fades every label, input and
+    // validation message the author is reading in order to fix it.
+    notifications = [aNotification({ enabled: false })];
+    const user = userEvent.setup();
+    render(<FormNotificationsTab defaults={null} />);
+
+    const toggle = screen.getByRole("button", {
+      name: /notification admin notification/i,
+    });
+    await user.click(toggle);
+
+    const summary = toggle.parentElement;
+    expect(summary?.className).toContain("opacity-60");
+
+    const editor = document.getElementById(
+      toggle.getAttribute("aria-controls") as string
+    );
+    expect(editor?.className ?? "").not.toContain("opacity");
+    expect(editor?.closest(".opacity-60")).toBeNull();
   });
 });

--- a/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.tsx
@@ -52,6 +52,15 @@ import {
   type FormNotification,
 } from "../../context/FormBuilderContext";
 
+import {
+  addressError,
+  addressErrorsIn,
+  isValidEmail,
+  parseFieldRef,
+  type AddressErrors,
+  type AddressField,
+} from "./notification-addresses";
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -123,17 +132,8 @@ async function fetchTemplates(): Promise<TemplateOption[]> {
 // Field-reference helpers
 // ============================================================================
 
-/** The `{{fieldName}}` shape the send path resolves against submissions. */
-const FIELD_REF_PATTERN = /^\{\{(\w+)\}\}$/;
-
 function toFieldRef(fieldName: string): string {
   return `{{${fieldName}}}`;
-}
-
-function parseFieldRef(value: string | undefined): string | null {
-  if (!value) return null;
-  const match = value.match(FIELD_REF_PATTERN);
-  return match ? match[1] : null;
 }
 
 /**
@@ -151,16 +151,6 @@ function buildEmailFieldOptions(
     if (current) return [...emailFields, current];
   }
   return emailFields;
-}
-
-/**
- * Deliberately loose email shape check (something@something.tld): the goal
- * is catching typos before they fail at delivery, not RFC 5322 conformance.
- */
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-function isValidEmail(value: string): boolean {
-  return EMAIL_PATTERN.test(value.trim());
 }
 
 // ============================================================================
@@ -266,10 +256,15 @@ function NotificationCard({
   }
 
   return (
-    <div
-      className={`border border-border bg-background ${notification.enabled ? "" : "opacity-60"}`}
-    >
-      <div className="flex items-center gap-2 px-3 py-2.5">
+    <div className="border border-border bg-background">
+      {/* The dimming is the SUMMARY's, not the card's. A disabled rule reads as
+          inactive at a glance, but an expanded editor inside a faded card fades
+          every label, input and validation message the author is reading while
+          they fix it — and takes the already-muted help text below its intended
+          contrast. */}
+      <div
+        className={`flex items-center gap-2 px-3 py-2.5 ${notification.enabled ? "" : "opacity-60"}`}
+      >
         <span className="flex h-7 w-7 shrink-0 items-center justify-center bg-primary/5 text-primary">
           <Mail className="h-3.5 w-3.5" aria-hidden="true" />
         </span>
@@ -497,11 +492,8 @@ interface RecipientFieldsProps {
    * because the editor owns the write-through to the form.
    */
   onRecipientTypeChange: (kind: "static" | "field") => void;
-  addressErrors: Partial<Record<"senderEmail" | "to" | "replyTo", string>>;
-  validateAddress: (
-    key: "senderEmail" | "to" | "replyTo",
-    value: string | undefined
-  ) => void;
+  addressErrors: AddressErrors;
+  validateAddress: (key: AddressField, value: string | undefined) => void;
   replyToMode: ReplyToMode;
   setReplyToMode: (mode: ReplyToMode) => void;
 }
@@ -536,146 +528,45 @@ function RecipientFields({
 
   return (
     <>
-        <div className="space-y-4 pt-4 border-t border-border">
-          <Grid cols={2} responsive>
-            <FieldShell label="Send to" htmlFor="notification-recipient-type">
-              {({ id, describedBy, invalid }) => (
-                <Select
-                  value={form.recipientType}
-                  onValueChange={value => {
-                    // Switching target kinds invalidates the previous `to`
-                    // value shape, so it resets rather than leaking a
-                    // {{ref}} into the static input (or vice versa).
-                    onRecipientTypeChange(value as "static" | "field");
-                  }}
-                >
-                  <SelectTrigger
-                    id={id}
-                    aria-describedby={describedBy}
-                    aria-invalid={invalid}
-                    className="w-full bg-transparent border-input dark:bg-muted/50"
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="static">A specific address</SelectItem>
-                    <SelectItem value="field">
-                      The visitor (email field)
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-              )}
-            </FieldShell>
-
-            {form.recipientType === "field" ? (
-              <div className="space-y-1.5">
-                <FieldShell
-                  label="Visitor email field"
-                  htmlFor="notification-to"
-                >
-                  {({ id, describedBy, invalid }) => (
-                    <Select
-                      value={toRef ?? "__none"}
-                      onValueChange={value =>
-                        update(
-                          "to",
-                          value === "__none" ? "" : toFieldRef(value)
-                        )
-                      }
-                    >
-                      <SelectTrigger
-                        id={id}
-                        aria-describedby={describedBy}
-                        aria-invalid={invalid}
-                        className="w-full bg-transparent border-input dark:bg-muted/50"
-                      >
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="__none">Select a field</SelectItem>
-                        {toFieldOptions.map(f => (
-                          <SelectItem key={f.name} value={f.name}>
-                            {f.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  )}
-                </FieldShell>
-                {toFieldOptions.length === 0 && (
-                  <p className="text-xs text-muted-foreground">
-                    Add an email field to the form first.
-                  </p>
-                )}
-              </div>
-            ) : (
-              <FieldShell
-                label="Recipient address"
-                htmlFor="notification-to"
-                width="half"
-                error={addressErrors.to}
+      <div className="space-y-4 pt-4 border-t border-border">
+        <Grid cols={2} responsive>
+          <FieldShell label="Send to" htmlFor="notification-recipient-type">
+            {({ id, describedBy, invalid }) => (
+              <Select
+                value={form.recipientType}
+                onValueChange={value => {
+                  // Switching target kinds invalidates the previous `to`
+                  // value shape, so it resets rather than leaking a
+                  // {{ref}} into the static input (or vice versa).
+                  onRecipientTypeChange(value as "static" | "field");
+                }}
               >
-                <Input
-                  type="email"
-                  value={form.to}
-                  onChange={e => update("to", e.target.value)}
-                  onBlur={e => validateAddress("to", e.target.value)}
-                  placeholder={
-                    defaults?.defaultToEmail || "admin@example.com"
-                  }
-                />
-              </FieldShell>
+                <SelectTrigger
+                  id={id}
+                  aria-describedby={describedBy}
+                  aria-invalid={invalid}
+                  className="w-full bg-transparent border-input dark:bg-muted/50"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="static">A specific address</SelectItem>
+                  <SelectItem value="field">
+                    The visitor (email field)
+                  </SelectItem>
+                </SelectContent>
+              </Select>
             )}
-          </Grid>
+          </FieldShell>
 
-          {/* Reply-To */}
-          <Grid cols={2} responsive>
-            <FieldShell label="Reply-To" htmlFor="notification-replyto-mode">
-              {({ id, describedBy, invalid }) => (
-                <Select
-                  value={replyToMode}
-                  onValueChange={value => {
-                    const mode = value as ReplyToMode;
-                    setReplyToMode(mode);
-                    // A mode change always clears the stored value (the old
-                    // shape can't be represented in the new mode); it stays
-                    // absent — not an empty string — until the user picks a
-                    // field or types an address.
-                    update("replyTo", undefined);
-                  }}
-                >
-                  <SelectTrigger
-                    id={id}
-                    aria-describedby={describedBy}
-                    aria-invalid={invalid}
-                    className="w-full bg-transparent border-input dark:bg-muted/50"
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    <SelectItem value="field">
-                      The visitor (email field)
-                    </SelectItem>
-                    <SelectItem value="custom">A custom address</SelectItem>
-                  </SelectContent>
-                </Select>
-              )}
-            </FieldShell>
-
-            {replyToMode === "field" && (
-              <FieldShell
-                label="Visitor email field"
-                htmlFor="notification-replyto"
-              >
+          {form.recipientType === "field" ? (
+            <div className="space-y-1.5">
+              <FieldShell label="Visitor email field" htmlFor="notification-to">
                 {({ id, describedBy, invalid }) => (
                   <Select
-                    value={replyToRef ?? "__none"}
+                    value={toRef ?? "__none"}
                     onValueChange={value =>
-                      update(
-                        "replyTo",
-                        value === "__none" ? undefined : toFieldRef(value)
-                      )
+                      update("to", value === "__none" ? "" : toFieldRef(value))
                     }
                   >
                     <SelectTrigger
@@ -688,7 +579,7 @@ function RecipientFields({
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="__none">Select a field</SelectItem>
-                      {replyToFieldOptions.map(f => (
+                      {toFieldOptions.map(f => (
                         <SelectItem key={f.name} value={f.name}>
                           {f.label}
                         </SelectItem>
@@ -697,48 +588,138 @@ function RecipientFields({
                   </Select>
                 )}
               </FieldShell>
-            )}
-            {replyToMode === "custom" && (
-              <FieldShell
-                label="Reply-To address"
-                htmlFor="notification-replyto"
-                width="half"
-                error={addressErrors.replyTo}
-              >
-                <Input
-                  type="email"
-                  value={form.replyTo ?? ""}
-                  onBlur={e => validateAddress("replyTo", e.target.value)}
-                  onChange={e =>
-                    update("replyTo", e.target.value || undefined)
-                  }
-                  placeholder="replies@example.com"
-                />
-              </FieldShell>
-            )}
-          </Grid>
-          {replyToMode === "field" && (
-            <p className="text-xs text-muted-foreground -mt-2">
-              Replying to this email answers the person who submitted the
-              form.
-            </p>
+              {toFieldOptions.length === 0 && (
+                <p className="text-xs text-muted-foreground">
+                  Add an email field to the form first.
+                </p>
+              )}
+            </div>
+          ) : (
+            <FieldShell
+              label="Recipient address"
+              htmlFor="notification-to"
+              width="half"
+              error={addressErrors.to}
+            >
+              <Input
+                type="email"
+                value={form.to}
+                onChange={e => update("to", e.target.value)}
+                onBlur={e => validateAddress("to", e.target.value)}
+                placeholder={defaults?.defaultToEmail || "admin@example.com"}
+              />
+            </FieldShell>
           )}
+        </Grid>
 
-          <AddressChipList
-            id="notification-cc"
-            label="CC (optional)"
-            addresses={form.cc}
-            placeholder="cc@example.com"
-            onChange={cc => update("cc", cc)}
-          />
-          <AddressChipList
-            id="notification-bcc"
-            label="BCC (optional)"
-            addresses={form.bcc}
-            placeholder="bcc@example.com"
-            onChange={bcc => update("bcc", bcc)}
-          />
-        </div>
+        {/* Reply-To */}
+        <Grid cols={2} responsive>
+          <FieldShell label="Reply-To" htmlFor="notification-replyto-mode">
+            {({ id, describedBy, invalid }) => (
+              <Select
+                value={replyToMode}
+                onValueChange={value => {
+                  const mode = value as ReplyToMode;
+                  setReplyToMode(mode);
+                  // A mode change always clears the stored value (the old
+                  // shape can't be represented in the new mode); it stays
+                  // absent — not an empty string — until the user picks a
+                  // field or types an address.
+                  update("replyTo", undefined);
+                }}
+              >
+                <SelectTrigger
+                  id={id}
+                  aria-describedby={describedBy}
+                  aria-invalid={invalid}
+                  className="w-full bg-transparent border-input dark:bg-muted/50"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">None</SelectItem>
+                  <SelectItem value="field">
+                    The visitor (email field)
+                  </SelectItem>
+                  <SelectItem value="custom">A custom address</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          </FieldShell>
+
+          {replyToMode === "field" && (
+            <FieldShell
+              label="Visitor email field"
+              htmlFor="notification-replyto"
+            >
+              {({ id, describedBy, invalid }) => (
+                <Select
+                  value={replyToRef ?? "__none"}
+                  onValueChange={value =>
+                    update(
+                      "replyTo",
+                      value === "__none" ? undefined : toFieldRef(value)
+                    )
+                  }
+                >
+                  <SelectTrigger
+                    id={id}
+                    aria-describedby={describedBy}
+                    aria-invalid={invalid}
+                    className="w-full bg-transparent border-input dark:bg-muted/50"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none">Select a field</SelectItem>
+                    {replyToFieldOptions.map(f => (
+                      <SelectItem key={f.name} value={f.name}>
+                        {f.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </FieldShell>
+          )}
+          {replyToMode === "custom" && (
+            <FieldShell
+              label="Reply-To address"
+              htmlFor="notification-replyto"
+              width="half"
+              error={addressErrors.replyTo}
+            >
+              <Input
+                type="email"
+                value={form.replyTo ?? ""}
+                onBlur={e => validateAddress("replyTo", e.target.value)}
+                onChange={e => update("replyTo", e.target.value || undefined)}
+                placeholder="replies@example.com"
+              />
+            </FieldShell>
+          )}
+        </Grid>
+        {replyToMode === "field" && (
+          <p className="text-xs text-muted-foreground -mt-2">
+            Replying to this email answers the person who submitted the form.
+          </p>
+        )}
+
+        <AddressChipList
+          id="notification-cc"
+          label="CC (optional)"
+          addresses={form.cc}
+          placeholder="cc@example.com"
+          onChange={cc => update("cc", cc)}
+        />
+        <AddressChipList
+          id="notification-bcc"
+          label="BCC (optional)"
+          addresses={form.bcc}
+          placeholder="bcc@example.com"
+          onChange={bcc => update("bcc", bcc)}
+        />
+      </div>
     </>
   );
 }
@@ -766,147 +747,145 @@ function SendConditionField({
 }: SendConditionFieldProps) {
   return (
     <>
-        <div className="space-y-3 pt-4 border-t border-border">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium text-foreground">
-                Send condition
-              </p>
-              <p className="text-xs text-muted-foreground">
-                Only send this notification when a submitted value matches.
-              </p>
-            </div>
-            {!condition && (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() =>
-                  update("condition", {
-                    field: fields[0]?.name ?? "",
-                    comparison: "equals",
-                    value: "",
-                  })
-                }
-                disabled={fields.length === 0}
-              >
-                <Plus className="h-3.5 w-3.5" aria-hidden="true" />
-                Add condition
-              </Button>
-            )}
+      <div className="space-y-3 pt-4 border-t border-border">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-foreground">
+              Send condition
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Only send this notification when a submitted value matches.
+            </p>
           </div>
-
-          {condition && (
-            <div className="flex flex-wrap items-end gap-2 border border-border bg-muted/40 p-3">
-              <FieldShell
-                label="Field"
-                htmlFor="notification-condition-field"
-                className="min-w-36 flex-1"
-              >
-                {({ id, describedBy, invalid }) => (
-                  <Select
-                    value={condition.field || "__none"}
-                    onValueChange={value =>
-                      update("condition", {
-                        ...condition,
-                        field: value === "__none" ? "" : value,
-                      })
-                    }
-                  >
-                    <SelectTrigger
-                      id={id}
-                      aria-describedby={describedBy}
-                      aria-invalid={invalid}
-                      className="w-full bg-transparent border-input dark:bg-muted/50"
-                    >
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none">Select a field</SelectItem>
-                      {fields.map(f => (
-                        <SelectItem key={f.name} value={f.name}>
-                          {f.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-              </FieldShell>
-
-              <FieldShell
-                label="Comparison"
-                htmlFor="notification-condition-comparison"
-                className="min-w-36 flex-1"
-              >
-                {({ id, describedBy, invalid }) => (
-                  <Select
-                    value={condition.comparison}
-                    onValueChange={value =>
-                      update("condition", {
-                        ...condition,
-                        comparison:
-                          value as ConditionalLogicCondition["comparison"],
-                      })
-                    }
-                  >
-                    <SelectTrigger
-                      id={id}
-                      aria-describedby={describedBy}
-                      aria-invalid={invalid}
-                      className="w-full bg-transparent border-input dark:bg-muted/50"
-                    >
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {Object.entries(COMPARISON_LABELS).map(
-                        ([value, label]) => (
-                          <SelectItem key={value} value={value}>
-                            {label}
-                          </SelectItem>
-                        )
-                      )}
-                    </SelectContent>
-                  </Select>
-                )}
-              </FieldShell>
-
-              {!VALUELESS_COMPARISONS.has(condition.comparison) && (
-                <FieldShell
-                  label="Value"
-                  htmlFor="notification-condition-value"
-                  className="min-w-36 flex-1"
-                >
-                  <Input
-                    type="text"
-                    value={
-                      typeof condition.value === "string" ||
-                      typeof condition.value === "number"
-                        ? String(condition.value)
-                        : ""
-                    }
-                    onChange={e =>
-                      update("condition", {
-                        ...condition,
-                        value: e.target.value,
-                      })
-                    }
-                  />
-                </FieldShell>
-              )}
-
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="h-9 w-9 rounded-none text-muted-foreground hover:text-destructive"
-                onClick={() => update("condition", undefined)}
-                aria-label="Remove send condition"
-              >
-                <Trash2 className="h-4 w-4" aria-hidden="true" />
-              </Button>
-            </div>
+          {!condition && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                update("condition", {
+                  field: fields[0]?.name ?? "",
+                  comparison: "equals",
+                  value: "",
+                })
+              }
+              disabled={fields.length === 0}
+            >
+              <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+              Add condition
+            </Button>
           )}
         </div>
+
+        {condition && (
+          <div className="flex flex-wrap items-end gap-2 border border-border bg-muted/40 p-3">
+            <FieldShell
+              label="Field"
+              htmlFor="notification-condition-field"
+              className="min-w-36 flex-1"
+            >
+              {({ id, describedBy, invalid }) => (
+                <Select
+                  value={condition.field || "__none"}
+                  onValueChange={value =>
+                    update("condition", {
+                      ...condition,
+                      field: value === "__none" ? "" : value,
+                    })
+                  }
+                >
+                  <SelectTrigger
+                    id={id}
+                    aria-describedby={describedBy}
+                    aria-invalid={invalid}
+                    className="w-full bg-transparent border-input dark:bg-muted/50"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none">Select a field</SelectItem>
+                    {fields.map(f => (
+                      <SelectItem key={f.name} value={f.name}>
+                        {f.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </FieldShell>
+
+            <FieldShell
+              label="Comparison"
+              htmlFor="notification-condition-comparison"
+              className="min-w-36 flex-1"
+            >
+              {({ id, describedBy, invalid }) => (
+                <Select
+                  value={condition.comparison}
+                  onValueChange={value =>
+                    update("condition", {
+                      ...condition,
+                      comparison:
+                        value as ConditionalLogicCondition["comparison"],
+                    })
+                  }
+                >
+                  <SelectTrigger
+                    id={id}
+                    aria-describedby={describedBy}
+                    aria-invalid={invalid}
+                    className="w-full bg-transparent border-input dark:bg-muted/50"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {Object.entries(COMPARISON_LABELS).map(([value, label]) => (
+                      <SelectItem key={value} value={value}>
+                        {label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </FieldShell>
+
+            {!VALUELESS_COMPARISONS.has(condition.comparison) && (
+              <FieldShell
+                label="Value"
+                htmlFor="notification-condition-value"
+                className="min-w-36 flex-1"
+              >
+                <Input
+                  type="text"
+                  value={
+                    typeof condition.value === "string" ||
+                    typeof condition.value === "number"
+                      ? String(condition.value)
+                      : ""
+                  }
+                  onChange={e =>
+                    update("condition", {
+                      ...condition,
+                      value: e.target.value,
+                    })
+                  }
+                />
+              </FieldShell>
+            )}
+
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-9 w-9 rounded-none text-muted-foreground hover:text-destructive"
+              onClick={() => update("condition", undefined)}
+              aria-label="Remove send condition"
+            >
+              <Trash2 className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </div>
+        )}
+      </div>
     </>
   );
 }
@@ -920,11 +899,8 @@ interface NotificationIdentityFieldsProps {
     key: K,
     value: FormNotification[K]
   ) => void;
-  addressErrors: Partial<Record<"senderEmail" | "to" | "replyTo", string>>;
-  validateAddress: (
-    key: "senderEmail" | "to" | "replyTo",
-    value: string | undefined
-  ) => void;
+  addressErrors: AddressErrors;
+  validateAddress: (key: AddressField, value: string | undefined) => void;
 }
 
 /**
@@ -957,35 +933,64 @@ function NotificationIdentityFields({
 
   return (
     <>
-        {/* Name */}
-        <FieldShell label="Name" htmlFor="notification-name" width="half">
-          <Input
-            type="text"
-            value={form.name}
-            onChange={e => update("name", e.target.value)}
-            placeholder="e.g. Admin notification"
-          />
-        </FieldShell>
+      {/* Name */}
+      <FieldShell label="Name" htmlFor="notification-name" width="half">
+        <Input
+          type="text"
+          value={form.name}
+          onChange={e => update("name", e.target.value)}
+          placeholder="e.g. Admin notification"
+        />
+      </FieldShell>
 
-        {/* Provider & Template. A container-query grid rather than the
+      {/* Provider & Template. A container-query grid rather than the
             viewport's `sm:` breakpoint: the admin content region is
             narrower than the window whenever both sidebars are open, so a
             viewport breakpoint promises columns this sheet does not have. */}
-        <Grid cols={2} responsive>
-          {/* Both `Select`-driven: FieldShell's render-function `children`
+      <Grid cols={2} responsive>
+        {/* Both `Select`-driven: FieldShell's render-function `children`
               applies the computed id/aria-describedby/aria-invalid to
               SelectTrigger, the actual focusable element, rather than to
               `Select`'s root (which accepts a fixed prop list and forwards
               none of the rest). */}
-          <FieldShell label="Email provider" htmlFor="notification-provider">
+        <FieldShell label="Email provider" htmlFor="notification-provider">
+          {({ id, describedBy, invalid }) => (
+            <Select
+              value={form.providerId ?? "__default"}
+              onValueChange={value =>
+                update("providerId", value === "__default" ? undefined : value)
+              }
+            >
+              <SelectTrigger
+                id={id}
+                aria-describedby={describedBy}
+                aria-invalid={invalid}
+                className="w-full bg-transparent border-input dark:bg-muted/50"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__default">
+                  {defaultProviderLabel}
+                </SelectItem>
+                {providers.map(p => (
+                  <SelectItem key={p.id} value={p.id}>
+                    {p.name}
+                    {p.isDefault ? " (Default)" : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </FieldShell>
+
+        <div className="space-y-1.5">
+          <FieldShell label="Email template" htmlFor="notification-template">
             {({ id, describedBy, invalid }) => (
               <Select
-                value={form.providerId ?? "__default"}
+                value={form.templateSlug ?? "__none"}
                 onValueChange={value =>
-                  update(
-                    "providerId",
-                    value === "__default" ? undefined : value
-                  )
+                  update("templateSlug", value === "__none" ? undefined : value)
                 }
               >
                 <SelectTrigger
@@ -997,81 +1002,43 @@ function NotificationIdentityFields({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="__default">
-                    {defaultProviderLabel}
-                  </SelectItem>
-                  {providers.map(p => (
-                    <SelectItem key={p.id} value={p.id}>
-                      {p.name}
-                      {p.isDefault ? " (Default)" : ""}
-                    </SelectItem>
-                  ))}
+                  <SelectItem value="__none">Select a template</SelectItem>
+                  {templates
+                    .filter(t => t.isActive && t.kind !== "layout")
+                    .map(t => (
+                      <SelectItem key={t.id} value={t.slug}>
+                        {t.name}
+                      </SelectItem>
+                    ))}
                 </SelectContent>
               </Select>
             )}
           </FieldShell>
+          {!form.templateSlug && (
+            <p className="flex items-center gap-1 text-xs text-destructive">
+              <TriangleAlert className="h-3 w-3" aria-hidden="true" />
+              Required — a notification without a template is never sent.
+            </p>
+          )}
+        </div>
+      </Grid>
 
-          <div className="space-y-1.5">
-            <FieldShell
-              label="Email template"
-              htmlFor="notification-template"
-            >
-              {({ id, describedBy, invalid }) => (
-                <Select
-                  value={form.templateSlug ?? "__none"}
-                  onValueChange={value =>
-                    update(
-                      "templateSlug",
-                      value === "__none" ? undefined : value
-                    )
-                  }
-                >
-                  <SelectTrigger
-                    id={id}
-                    aria-describedby={describedBy}
-                    aria-invalid={invalid}
-                    className="w-full bg-transparent border-input dark:bg-muted/50"
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="__none">Select a template</SelectItem>
-                    {templates
-                      .filter(t => t.isActive && t.kind !== "layout")
-                      .map(t => (
-                        <SelectItem key={t.id} value={t.slug}>
-                          {t.name}
-                        </SelectItem>
-                      ))}
-                  </SelectContent>
-                </Select>
-              )}
-            </FieldShell>
-            {!form.templateSlug && (
-              <p className="flex items-center gap-1 text-xs text-destructive">
-                <TriangleAlert className="h-3 w-3" aria-hidden="true" />
-                Required — a notification without a template is never sent.
-              </p>
-            )}
-          </div>
-        </Grid>
-
-        {/* Sender */}
-        <FieldShell
-          label="Sender email"
-          htmlFor="notification-sender"
-          width="half"
-          description={addressErrors.senderEmail ? undefined : senderHelp}
-          error={addressErrors.senderEmail}
-        >
-          <Input
-            type="email"
-            value={form.senderEmail ?? ""}
-            onChange={e => update("senderEmail", e.target.value || undefined)}
-            onBlur={e => validateAddress("senderEmail", e.target.value)}
-            placeholder={senderPlaceholder}
-          />
-        </FieldShell>
+      {/* Sender */}
+      <FieldShell
+        label="Sender email"
+        htmlFor="notification-sender"
+        width="half"
+        description={addressErrors.senderEmail ? undefined : senderHelp}
+        error={addressErrors.senderEmail}
+      >
+        <Input
+          type="email"
+          value={form.senderEmail ?? ""}
+          onChange={e => update("senderEmail", e.target.value || undefined)}
+          onBlur={e => validateAddress("senderEmail", e.target.value)}
+          placeholder={senderPlaceholder}
+        />
+      </FieldShell>
     </>
   );
 }
@@ -1083,7 +1050,14 @@ function NotificationIdentityFields({
 type ReplyToMode = "none" | "field" | "custom";
 
 interface NotificationEditorProps {
-  initial: FormNotification;
+  /**
+   * The rule as the form holds it. Read on every render rather than copied
+   * into local state: the summary row edits the same rule (its Enabled switch
+   * writes straight to the form), and a second copy here would go stale the
+   * moment it did — the next edit would then send the whole stale rule back
+   * and undo it.
+   */
+  notification: FormNotification;
   /** Ties the row's toggle to this region for assistive tech. */
   editorId: string;
   providers: ProviderOption[];
@@ -1104,7 +1078,7 @@ function initialReplyToMode(replyTo: string | undefined): ReplyToMode {
 }
 
 function NotificationEditor({
-  initial,
+  notification,
   editorId,
   providers,
   templates,
@@ -1112,40 +1086,34 @@ function NotificationEditor({
   defaults,
   onChange,
 }: NotificationEditorProps) {
-  const [form, setForm] = useState<FormNotification>(initial);
+  const form = notification;
   const [replyToMode, setReplyToMode] = useState<ReplyToMode>(
-    initialReplyToMode(initial.replyTo)
+    initialReplyToMode(notification.replyTo)
   );
   // Save-time address errors, keyed by field. Nothing here goes through
   // form submission (every control is a type="button" callback), so
   // constraint validation never runs — this is its replacement.
-  const [addressErrors, setAddressErrors] = useState<
-    Partial<Record<"senderEmail" | "to" | "replyTo", string>>
-  >({});
+  // Seeded from the rule as it stands, so a row opened onto an address saved
+  // earlier shows the problem straight away rather than waiting to be touched.
+  const [addressErrors, setAddressErrors] = useState<AddressErrors>(() =>
+    addressErrorsIn(notification)
+  );
 
   const update = useCallback(
     <K extends keyof FormNotification>(key: K, value: FormNotification[K]) => {
-      setForm(prev => {
-        const next = { ...prev, [key]: value };
-        onChange(next);
-        return next;
-      });
+      onChange({ ...notification, [key]: value });
       setAddressErrors(prev =>
         key in prev ? { ...prev, [key]: undefined } : prev
       );
     },
-    [onChange]
+    [notification, onChange]
   );
 
   const changeRecipientType = useCallback(
     (kind: "static" | "field") => {
-      setForm(prev => {
-        const next = { ...prev, recipientType: kind, to: "" };
-        onChange(next);
-        return next;
-      });
+      onChange({ ...notification, recipientType: kind, to: "" });
     },
-    [onChange]
+    [notification, onChange]
   );
 
   /**
@@ -1158,16 +1126,8 @@ function NotificationEditor({
    * for most of the time it is being typed.
    */
   const validateAddress = useCallback(
-    (key: "senderEmail" | "to" | "replyTo", value: string | undefined) => {
-      // A `{{field}}` reference resolves against each submission at send time,
-      // so it is not an address and is not checked as one.
-      const literal = key === "replyTo" && parseFieldRef(value) !== null;
-      const invalid =
-        !literal && Boolean(value?.trim()) && !isValidEmail(value as string);
-      setAddressErrors(prev => ({
-        ...prev,
-        [key]: invalid ? "Enter a valid email address." : undefined,
-      }));
+    (key: AddressField, value: string | undefined) => {
+      setAddressErrors(prev => ({ ...prev, [key]: addressError(key, value) }));
     },
     []
   );
@@ -1175,52 +1135,49 @@ function NotificationEditor({
   const condition = form.condition;
 
   return (
-    <div
-      id={editorId}
-      className="border-t border-border bg-muted/20 px-4 py-5"
-    >
+    <div id={editorId} className="border-t border-border bg-muted/20 px-4 py-5">
       <div className="space-y-6">
-          <NotificationIdentityFields
-            form={form}
-            providers={providers}
-            defaults={defaults}
-            templates={templates}
-            update={update}
-            addressErrors={addressErrors}
-            validateAddress={validateAddress}
-          />
-          {/* Recipients */}
-          <RecipientFields
-            form={form}
-            fields={fields}
-            defaults={defaults}
-            update={update}
-            onRecipientTypeChange={changeRecipientType}
-            addressErrors={addressErrors}
-            validateAddress={validateAddress}
-            replyToMode={replyToMode}
-            setReplyToMode={setReplyToMode}
-          />
-          {/* Send condition */}
-          <SendConditionField
-            condition={condition}
-            fields={fields}
-            update={update}
-          />
-          {/* Enabled */}
-          <div className="flex items-center justify-between pt-4 border-t border-border">
-            <div>
-              <Label htmlFor="notification-enabled">Enabled</Label>
-              <p className="text-xs text-muted-foreground">
-                Turn off to keep the rule without sending.
-              </p>
-            </div>
-            <Switch
-              id="notification-enabled"
-              checked={form.enabled}
-              onCheckedChange={checked => update("enabled", checked)}
-            />
+        <NotificationIdentityFields
+          form={form}
+          providers={providers}
+          defaults={defaults}
+          templates={templates}
+          update={update}
+          addressErrors={addressErrors}
+          validateAddress={validateAddress}
+        />
+        {/* Recipients */}
+        <RecipientFields
+          form={form}
+          fields={fields}
+          defaults={defaults}
+          update={update}
+          onRecipientTypeChange={changeRecipientType}
+          addressErrors={addressErrors}
+          validateAddress={validateAddress}
+          replyToMode={replyToMode}
+          setReplyToMode={setReplyToMode}
+        />
+        {/* Send condition */}
+        <SendConditionField
+          condition={condition}
+          fields={fields}
+          update={update}
+        />
+        {/* Enabled */}
+        <div className="flex items-center justify-between pt-4 border-t border-border">
+          <div>
+            <Label htmlFor="notification-enabled">Enabled</Label>
+            <p className="text-xs text-muted-foreground">
+              Turn off to keep the rule without sending.
+            </p>
           </div>
+          <Switch
+            id="notification-enabled"
+            checked={form.enabled}
+            onCheckedChange={checked => update("enabled", checked)}
+          />
+        </div>
       </div>
     </div>
   );
@@ -1346,7 +1303,7 @@ export function FormNotificationsTab({ defaults }: FormNotificationsTabProps) {
               }
             >
               <NotificationEditor
-                initial={notification}
+                notification={notification}
                 editorId={`notification-editor-${notification.id}`}
                 providers={providers}
                 templates={templates}
@@ -1358,7 +1315,6 @@ export function FormNotificationsTab({ defaults }: FormNotificationsTabProps) {
           ))}
         </div>
       )}
-
     </div>
   );
 }

--- a/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.tsx
@@ -30,11 +30,6 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
   Switch,
 } from "@nextlyhq/ui";
 import {
@@ -197,10 +192,16 @@ interface NotificationCardProps {
   notification: FormNotification;
   providerName: string;
   fields: readonly FieldOption[];
-  onEdit: () => void;
+  /** Whether this row's editor is showing. */
+  expanded: boolean;
+  /** The editor region's id, so the summary can point at what it opens. */
+  editorId: string;
+  onToggle: () => void;
   onDuplicate: () => void;
   onDelete: () => void;
   onToggleEnabled: (enabled: boolean) => void;
+  /** The editor, rendered under the summary while `expanded`. */
+  children: React.ReactNode;
 }
 
 function describeRecipient(
@@ -234,10 +235,13 @@ function NotificationCard({
   notification,
   providerName,
   fields,
-  onEdit,
+  expanded,
+  editorId,
+  onToggle,
   onDuplicate,
   onDelete,
   onToggleEnabled,
+  children,
 }: NotificationCardProps) {
   const recipient = describeRecipient(notification, fields);
   const ccCount =
@@ -272,9 +276,11 @@ function NotificationCard({
 
         <button
           type="button"
-          onClick={onEdit}
+          onClick={onToggle}
+          aria-expanded={expanded}
+          aria-controls={editorId}
           className="flex min-w-0 flex-1 items-center gap-3 rounded-none py-1 text-left cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-          aria-label={`Edit notification ${notification.name}`}
+          aria-label={`${expanded ? "Collapse" : "Edit"} notification ${notification.name}`}
         >
           <span className="min-w-0 flex-1">
             <span className="flex items-center gap-2">
@@ -342,9 +348,12 @@ function NotificationCard({
             align="end"
             className="w-56 shadow-none border-border"
           >
-            <DropdownMenuItem onClick={onEdit} className="gap-2 cursor-pointer">
+            <DropdownMenuItem
+              onClick={onToggle}
+              className="gap-2 cursor-pointer"
+            >
               <Pencil className="h-4 w-4 text-muted-foreground" />
-              Edit
+              {expanded ? "Collapse" : "Edit"}
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={onDuplicate}
@@ -364,6 +373,12 @@ function NotificationCard({
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
+
+      {/* Unmounted while collapsed rather than hidden. The editor holds a
+          draft of the rule in its own state, seeded from the row; keeping a
+          closed one mounted would keep a stale draft alive behind a summary
+          that has moved on. */}
+      {expanded && children}
     </div>
   );
 }
@@ -468,152 +483,71 @@ function AddressChipList({
   );
 }
 
-// ============================================================================
-// Notification Sheet
-// ============================================================================
-
-type ReplyToMode = "none" | "field" | "custom";
-
-interface NotificationSheetProps {
-  initial: FormNotification;
-  isEditing: boolean;
-  providers: ProviderOption[];
-  templates: TemplateOption[];
+interface RecipientFieldsProps {
+  form: FormNotification;
   fields: readonly FieldOption[];
   defaults: NotificationDefaults | null;
-  onSave: (notification: FormNotification) => void;
-  onClose: () => void;
+  update: <K extends keyof FormNotification>(
+    key: K,
+    value: FormNotification[K]
+  ) => void;
+  /**
+   * Switching target kinds invalidates the previous `to` value shape, so both
+   * keys move together. It goes back to the editor rather than being done here
+   * because the editor owns the write-through to the form.
+   */
+  onRecipientTypeChange: (kind: "static" | "field") => void;
+  addressErrors: Partial<Record<"senderEmail" | "to" | "replyTo", string>>;
+  validateAddress: (
+    key: "senderEmail" | "to" | "replyTo",
+    value: string | undefined
+  ) => void;
+  replyToMode: ReplyToMode;
+  setReplyToMode: (mode: ReplyToMode) => void;
 }
 
-function initialReplyToMode(replyTo: string | undefined): ReplyToMode {
-  if (!replyTo) return "none";
-  return parseFieldRef(replyTo) ? "field" : "custom";
-}
-
-function NotificationSheet({
-  initial,
-  isEditing,
-  providers,
-  templates,
+/**
+ * Who the notification goes to: the recipient itself, the reply-to, and the
+ * optional cc/bcc lists.
+ *
+ * Extracted from the editor because it is the one part of a notification that
+ * is entirely about addresses — the editor around it is about identity,
+ * sending and conditions — and because leaving it inline made a single
+ * component long enough that no reader could hold it at once.
+ */
+function RecipientFields({
+  form,
   fields,
   defaults,
-  onSave,
-  onClose,
-}: NotificationSheetProps) {
-  const [form, setForm] = useState<FormNotification>(initial);
-  const [replyToMode, setReplyToMode] = useState<ReplyToMode>(
-    initialReplyToMode(initial.replyTo)
-  );
-  // Save-time address errors, keyed by field. Nothing here goes through
-  // form submission (every control is a type="button" callback), so
-  // constraint validation never runs — this is its replacement.
-  const [addressErrors, setAddressErrors] = useState<
-    Partial<Record<"senderEmail" | "to" | "replyTo", string>>
-  >({});
-
-  const update = useCallback(
-    <K extends keyof FormNotification>(key: K, value: FormNotification[K]) => {
-      setForm(prev => ({ ...prev, [key]: value }));
-      setAddressErrors(prev =>
-        key in prev ? { ...prev, [key]: undefined } : prev
-      );
-    },
-    []
-  );
-
-  const handleSave = useCallback(() => {
-    const errors: typeof addressErrors = {};
-    const invalid = (value: string | undefined) =>
-      Boolean(value?.trim()) && !isValidEmail(value as string);
-    if (invalid(form.senderEmail)) {
-      errors.senderEmail = "Enter a valid email address.";
-    }
-    if (form.recipientType === "static" && invalid(form.to)) {
-      errors.to = "Enter a valid email address.";
-    }
-    // Only literal reply-to addresses are validated; {{field}} references
-    // resolve against each submission at send time.
-    if (!parseFieldRef(form.replyTo) && invalid(form.replyTo)) {
-      errors.replyTo = "Enter a valid email address.";
-    }
-    if (Object.values(errors).some(Boolean)) {
-      setAddressErrors(errors);
-      return;
-    }
-    onSave(form);
-  }, [form, onSave]);
-
-  const defaultProvider = providers.find(p => p.isDefault);
-  const defaultProviderLabel = defaultProvider
-    ? `System default (${defaultProvider.name})`
-    : "System default";
-
+  update,
+  onRecipientTypeChange,
+  addressErrors,
+  validateAddress,
+  replyToMode,
+  setReplyToMode,
+}: RecipientFieldsProps) {
+  // Derived here rather than passed in: each of these is a function of `form`
+  // and `fields`, which this component already has, and computing them in the
+  // caller would be the same answer worked out somewhere else.
   const toRef = parseFieldRef(form.to);
-  const toFieldOptions = buildEmailFieldOptions(
-    fields,
-    form.recipientType === "field" ? toRef : null
-  );
+  const toFieldOptions = buildEmailFieldOptions(fields, toRef);
   const replyToRef = parseFieldRef(form.replyTo);
   const replyToFieldOptions = buildEmailFieldOptions(fields, replyToRef);
 
-  const senderPlaceholder = defaults?.defaultFrom || "Provider default";
-  const senderHelp = defaults?.defaultFrom
-    ? `Leave blank to send from ${defaults.defaultFrom} (the configured default).`
-    : "Leave blank to use the template or provider default address.";
-
-  const condition = form.condition;
-
   return (
-    <Sheet
-      open
-      onOpenChange={open => {
-        if (!open) onClose();
-      }}
-    >
-      <SheetContent
-        side="right"
-        className="w-[560px] sm:max-w-[560px] p-0 flex flex-col"
-      >
-        <SheetHeader className="p-4 border-b border-border">
-          <SheetTitle>
-            {isEditing ? "Edit notification" : "New notification"}
-          </SheetTitle>
-          <SheetDescription>
-            Sent when someone submits this form.
-          </SheetDescription>
-        </SheetHeader>
-
-        <div className="flex-1 overflow-y-auto p-4 space-y-6">
-          {/* Name */}
-          <FieldShell label="Name" htmlFor="notification-name" width="half">
-            <Input
-              type="text"
-              value={form.name}
-              onChange={e => update("name", e.target.value)}
-              placeholder="e.g. Admin notification"
-            />
-          </FieldShell>
-
-          {/* Provider & Template. A container-query grid rather than the
-              viewport's `sm:` breakpoint: the admin content region is
-              narrower than the window whenever both sidebars are open, so a
-              viewport breakpoint promises columns this sheet does not have. */}
+    <>
+        <div className="space-y-4 pt-4 border-t border-border">
           <Grid cols={2} responsive>
-            {/* Both `Select`-driven: FieldShell's render-function `children`
-                applies the computed id/aria-describedby/aria-invalid to
-                SelectTrigger, the actual focusable element, rather than to
-                `Select`'s root (which accepts a fixed prop list and forwards
-                none of the rest). */}
-            <FieldShell label="Email provider" htmlFor="notification-provider">
+            <FieldShell label="Send to" htmlFor="notification-recipient-type">
               {({ id, describedBy, invalid }) => (
                 <Select
-                  value={form.providerId ?? "__default"}
-                  onValueChange={value =>
-                    update(
-                      "providerId",
-                      value === "__default" ? undefined : value
-                    )
-                  }
+                  value={form.recipientType}
+                  onValueChange={value => {
+                    // Switching target kinds invalidates the previous `to`
+                    // value shape, so it resets rather than leaking a
+                    // {{ref}} into the static input (or vice versa).
+                    onRecipientTypeChange(value as "static" | "field");
+                  }}
                 >
                   <SelectTrigger
                     id={id}
@@ -624,224 +558,28 @@ function NotificationSheet({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="__default">
-                      {defaultProviderLabel}
+                    <SelectItem value="static">A specific address</SelectItem>
+                    <SelectItem value="field">
+                      The visitor (email field)
                     </SelectItem>
-                    {providers.map(p => (
-                      <SelectItem key={p.id} value={p.id}>
-                        {p.name}
-                        {p.isDefault ? " (Default)" : ""}
-                      </SelectItem>
-                    ))}
                   </SelectContent>
                 </Select>
               )}
             </FieldShell>
 
-            <div className="space-y-1.5">
-              <FieldShell
-                label="Email template"
-                htmlFor="notification-template"
-              >
-                {({ id, describedBy, invalid }) => (
-                  <Select
-                    value={form.templateSlug ?? "__none"}
-                    onValueChange={value =>
-                      update(
-                        "templateSlug",
-                        value === "__none" ? undefined : value
-                      )
-                    }
-                  >
-                    <SelectTrigger
-                      id={id}
-                      aria-describedby={describedBy}
-                      aria-invalid={invalid}
-                      className="w-full bg-transparent border-input dark:bg-muted/50"
-                    >
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none">Select a template</SelectItem>
-                      {templates
-                        .filter(t => t.isActive && t.kind !== "layout")
-                        .map(t => (
-                          <SelectItem key={t.id} value={t.slug}>
-                            {t.name}
-                          </SelectItem>
-                        ))}
-                    </SelectContent>
-                  </Select>
-                )}
-              </FieldShell>
-              {!form.templateSlug && (
-                <p className="flex items-center gap-1 text-xs text-destructive">
-                  <TriangleAlert className="h-3 w-3" aria-hidden="true" />
-                  Required — a notification without a template is never sent.
-                </p>
-              )}
-            </div>
-          </Grid>
-
-          {/* Sender */}
-          <FieldShell
-            label="Sender email"
-            htmlFor="notification-sender"
-            width="half"
-            description={addressErrors.senderEmail ? undefined : senderHelp}
-            error={addressErrors.senderEmail}
-          >
-            <Input
-              type="email"
-              value={form.senderEmail ?? ""}
-              onChange={e => update("senderEmail", e.target.value || undefined)}
-              placeholder={senderPlaceholder}
-            />
-          </FieldShell>
-
-          {/* Recipients */}
-          <div className="space-y-4 pt-4 border-t border-border">
-            <Grid cols={2} responsive>
-              <FieldShell label="Send to" htmlFor="notification-recipient-type">
-                {({ id, describedBy, invalid }) => (
-                  <Select
-                    value={form.recipientType}
-                    onValueChange={value => {
-                      // Switching target kinds invalidates the previous `to`
-                      // value shape, so it resets rather than leaking a
-                      // {{ref}} into the static input (or vice versa).
-                      setForm(prev => ({
-                        ...prev,
-                        recipientType: value as "static" | "field",
-                        to: "",
-                      }));
-                    }}
-                  >
-                    <SelectTrigger
-                      id={id}
-                      aria-describedby={describedBy}
-                      aria-invalid={invalid}
-                      className="w-full bg-transparent border-input dark:bg-muted/50"
-                    >
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="static">A specific address</SelectItem>
-                      <SelectItem value="field">
-                        The visitor (email field)
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                )}
-              </FieldShell>
-
-              {form.recipientType === "field" ? (
-                <div className="space-y-1.5">
-                  <FieldShell
-                    label="Visitor email field"
-                    htmlFor="notification-to"
-                  >
-                    {({ id, describedBy, invalid }) => (
-                      <Select
-                        value={toRef ?? "__none"}
-                        onValueChange={value =>
-                          update(
-                            "to",
-                            value === "__none" ? "" : toFieldRef(value)
-                          )
-                        }
-                      >
-                        <SelectTrigger
-                          id={id}
-                          aria-describedby={describedBy}
-                          aria-invalid={invalid}
-                          className="w-full bg-transparent border-input dark:bg-muted/50"
-                        >
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="__none">Select a field</SelectItem>
-                          {toFieldOptions.map(f => (
-                            <SelectItem key={f.name} value={f.name}>
-                              {f.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    )}
-                  </FieldShell>
-                  {toFieldOptions.length === 0 && (
-                    <p className="text-xs text-muted-foreground">
-                      Add an email field to the form first.
-                    </p>
-                  )}
-                </div>
-              ) : (
-                <FieldShell
-                  label="Recipient address"
-                  htmlFor="notification-to"
-                  width="half"
-                  error={addressErrors.to}
-                >
-                  <Input
-                    type="email"
-                    value={form.to}
-                    onChange={e => update("to", e.target.value)}
-                    placeholder={
-                      defaults?.defaultToEmail || "admin@example.com"
-                    }
-                  />
-                </FieldShell>
-              )}
-            </Grid>
-
-            {/* Reply-To */}
-            <Grid cols={2} responsive>
-              <FieldShell label="Reply-To" htmlFor="notification-replyto-mode">
-                {({ id, describedBy, invalid }) => (
-                  <Select
-                    value={replyToMode}
-                    onValueChange={value => {
-                      const mode = value as ReplyToMode;
-                      setReplyToMode(mode);
-                      // A mode change always clears the stored value (the old
-                      // shape can't be represented in the new mode); it stays
-                      // absent — not an empty string — until the user picks a
-                      // field or types an address.
-                      update("replyTo", undefined);
-                    }}
-                  >
-                    <SelectTrigger
-                      id={id}
-                      aria-describedby={describedBy}
-                      aria-invalid={invalid}
-                      className="w-full bg-transparent border-input dark:bg-muted/50"
-                    >
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="none">None</SelectItem>
-                      <SelectItem value="field">
-                        The visitor (email field)
-                      </SelectItem>
-                      <SelectItem value="custom">A custom address</SelectItem>
-                    </SelectContent>
-                  </Select>
-                )}
-              </FieldShell>
-
-              {replyToMode === "field" && (
+            {form.recipientType === "field" ? (
+              <div className="space-y-1.5">
                 <FieldShell
                   label="Visitor email field"
-                  htmlFor="notification-replyto"
+                  htmlFor="notification-to"
                 >
                   {({ id, describedBy, invalid }) => (
                     <Select
-                      value={replyToRef ?? "__none"}
+                      value={toRef ?? "__none"}
                       onValueChange={value =>
                         update(
-                          "replyTo",
-                          value === "__none" ? undefined : toFieldRef(value)
+                          "to",
+                          value === "__none" ? "" : toFieldRef(value)
                         )
                       }
                     >
@@ -855,7 +593,7 @@ function NotificationSheet({
                       </SelectTrigger>
                       <SelectContent>
                         <SelectItem value="__none">Select a field</SelectItem>
-                        {replyToFieldOptions.map(f => (
+                        {toFieldOptions.map(f => (
                           <SelectItem key={f.name} value={f.name}>
                             {f.label}
                           </SelectItem>
@@ -864,191 +602,611 @@ function NotificationSheet({
                     </Select>
                   )}
                 </FieldShell>
+                {toFieldOptions.length === 0 && (
+                  <p className="text-xs text-muted-foreground">
+                    Add an email field to the form first.
+                  </p>
+                )}
+              </div>
+            ) : (
+              <FieldShell
+                label="Recipient address"
+                htmlFor="notification-to"
+                width="half"
+                error={addressErrors.to}
+              >
+                <Input
+                  type="email"
+                  value={form.to}
+                  onChange={e => update("to", e.target.value)}
+                  onBlur={e => validateAddress("to", e.target.value)}
+                  placeholder={
+                    defaults?.defaultToEmail || "admin@example.com"
+                  }
+                />
+              </FieldShell>
+            )}
+          </Grid>
+
+          {/* Reply-To */}
+          <Grid cols={2} responsive>
+            <FieldShell label="Reply-To" htmlFor="notification-replyto-mode">
+              {({ id, describedBy, invalid }) => (
+                <Select
+                  value={replyToMode}
+                  onValueChange={value => {
+                    const mode = value as ReplyToMode;
+                    setReplyToMode(mode);
+                    // A mode change always clears the stored value (the old
+                    // shape can't be represented in the new mode); it stays
+                    // absent — not an empty string — until the user picks a
+                    // field or types an address.
+                    update("replyTo", undefined);
+                  }}
+                >
+                  <SelectTrigger
+                    id={id}
+                    aria-describedby={describedBy}
+                    aria-invalid={invalid}
+                    className="w-full bg-transparent border-input dark:bg-muted/50"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">None</SelectItem>
+                    <SelectItem value="field">
+                      The visitor (email field)
+                    </SelectItem>
+                    <SelectItem value="custom">A custom address</SelectItem>
+                  </SelectContent>
+                </Select>
               )}
-              {replyToMode === "custom" && (
+            </FieldShell>
+
+            {replyToMode === "field" && (
+              <FieldShell
+                label="Visitor email field"
+                htmlFor="notification-replyto"
+              >
+                {({ id, describedBy, invalid }) => (
+                  <Select
+                    value={replyToRef ?? "__none"}
+                    onValueChange={value =>
+                      update(
+                        "replyTo",
+                        value === "__none" ? undefined : toFieldRef(value)
+                      )
+                    }
+                  >
+                    <SelectTrigger
+                      id={id}
+                      aria-describedby={describedBy}
+                      aria-invalid={invalid}
+                      className="w-full bg-transparent border-input dark:bg-muted/50"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__none">Select a field</SelectItem>
+                      {replyToFieldOptions.map(f => (
+                        <SelectItem key={f.name} value={f.name}>
+                          {f.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              </FieldShell>
+            )}
+            {replyToMode === "custom" && (
+              <FieldShell
+                label="Reply-To address"
+                htmlFor="notification-replyto"
+                width="half"
+                error={addressErrors.replyTo}
+              >
+                <Input
+                  type="email"
+                  value={form.replyTo ?? ""}
+                  onBlur={e => validateAddress("replyTo", e.target.value)}
+                  onChange={e =>
+                    update("replyTo", e.target.value || undefined)
+                  }
+                  placeholder="replies@example.com"
+                />
+              </FieldShell>
+            )}
+          </Grid>
+          {replyToMode === "field" && (
+            <p className="text-xs text-muted-foreground -mt-2">
+              Replying to this email answers the person who submitted the
+              form.
+            </p>
+          )}
+
+          <AddressChipList
+            id="notification-cc"
+            label="CC (optional)"
+            addresses={form.cc}
+            placeholder="cc@example.com"
+            onChange={cc => update("cc", cc)}
+          />
+          <AddressChipList
+            id="notification-bcc"
+            label="BCC (optional)"
+            addresses={form.bcc}
+            placeholder="bcc@example.com"
+            onChange={bcc => update("bcc", bcc)}
+          />
+        </div>
+    </>
+  );
+}
+
+interface SendConditionFieldProps {
+  condition: ConditionalLogicCondition | undefined;
+  fields: readonly FieldOption[];
+  update: <K extends keyof FormNotification>(
+    key: K,
+    value: FormNotification[K]
+  ) => void;
+}
+
+/**
+ * The optional rule that decides whether a notification sends at all.
+ *
+ * Its own component because it is the one part of the editor with a shape of
+ * its own — absent, or a field/comparison/value triple — and inline it made
+ * the editor read as two unrelated forms sharing a scope.
+ */
+function SendConditionField({
+  condition,
+  fields,
+  update,
+}: SendConditionFieldProps) {
+  return (
+    <>
+        <div className="space-y-3 pt-4 border-t border-border">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-foreground">
+                Send condition
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Only send this notification when a submitted value matches.
+              </p>
+            </div>
+            {!condition && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  update("condition", {
+                    field: fields[0]?.name ?? "",
+                    comparison: "equals",
+                    value: "",
+                  })
+                }
+                disabled={fields.length === 0}
+              >
+                <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+                Add condition
+              </Button>
+            )}
+          </div>
+
+          {condition && (
+            <div className="flex flex-wrap items-end gap-2 border border-border bg-muted/40 p-3">
+              <FieldShell
+                label="Field"
+                htmlFor="notification-condition-field"
+                className="min-w-36 flex-1"
+              >
+                {({ id, describedBy, invalid }) => (
+                  <Select
+                    value={condition.field || "__none"}
+                    onValueChange={value =>
+                      update("condition", {
+                        ...condition,
+                        field: value === "__none" ? "" : value,
+                      })
+                    }
+                  >
+                    <SelectTrigger
+                      id={id}
+                      aria-describedby={describedBy}
+                      aria-invalid={invalid}
+                      className="w-full bg-transparent border-input dark:bg-muted/50"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__none">Select a field</SelectItem>
+                      {fields.map(f => (
+                        <SelectItem key={f.name} value={f.name}>
+                          {f.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              </FieldShell>
+
+              <FieldShell
+                label="Comparison"
+                htmlFor="notification-condition-comparison"
+                className="min-w-36 flex-1"
+              >
+                {({ id, describedBy, invalid }) => (
+                  <Select
+                    value={condition.comparison}
+                    onValueChange={value =>
+                      update("condition", {
+                        ...condition,
+                        comparison:
+                          value as ConditionalLogicCondition["comparison"],
+                      })
+                    }
+                  >
+                    <SelectTrigger
+                      id={id}
+                      aria-describedby={describedBy}
+                      aria-invalid={invalid}
+                      className="w-full bg-transparent border-input dark:bg-muted/50"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Object.entries(COMPARISON_LABELS).map(
+                        ([value, label]) => (
+                          <SelectItem key={value} value={value}>
+                            {label}
+                          </SelectItem>
+                        )
+                      )}
+                    </SelectContent>
+                  </Select>
+                )}
+              </FieldShell>
+
+              {!VALUELESS_COMPARISONS.has(condition.comparison) && (
                 <FieldShell
-                  label="Reply-To address"
-                  htmlFor="notification-replyto"
-                  width="half"
-                  error={addressErrors.replyTo}
+                  label="Value"
+                  htmlFor="notification-condition-value"
+                  className="min-w-36 flex-1"
                 >
                   <Input
-                    type="email"
-                    value={form.replyTo ?? ""}
-                    onChange={e =>
-                      update("replyTo", e.target.value || undefined)
+                    type="text"
+                    value={
+                      typeof condition.value === "string" ||
+                      typeof condition.value === "number"
+                        ? String(condition.value)
+                        : ""
                     }
-                    placeholder="replies@example.com"
+                    onChange={e =>
+                      update("condition", {
+                        ...condition,
+                        value: e.target.value,
+                      })
+                    }
                   />
                 </FieldShell>
               )}
-            </Grid>
-            {replyToMode === "field" && (
-              <p className="text-xs text-muted-foreground -mt-2">
-                Replying to this email answers the person who submitted the
-                form.
+
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-9 w-9 rounded-none text-muted-foreground hover:text-destructive"
+                onClick={() => update("condition", undefined)}
+                aria-label="Remove send condition"
+              >
+                <Trash2 className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            </div>
+          )}
+        </div>
+    </>
+  );
+}
+
+interface NotificationIdentityFieldsProps {
+  form: FormNotification;
+  providers: ProviderOption[];
+  defaults: NotificationDefaults | null;
+  templates: TemplateOption[];
+  update: <K extends keyof FormNotification>(
+    key: K,
+    value: FormNotification[K]
+  ) => void;
+  addressErrors: Partial<Record<"senderEmail" | "to" | "replyTo", string>>;
+  validateAddress: (
+    key: "senderEmail" | "to" | "replyTo",
+    value: string | undefined
+  ) => void;
+}
+
+/**
+ * What the notification IS: its name, which provider and template carry it,
+ * and who it comes from.
+ *
+ * Separated from the recipients and the condition because those answer
+ * different questions — where it goes, and whether it goes at all — and one
+ * component answering all three was long enough that no reader could hold it.
+ */
+function NotificationIdentityFields({
+  form,
+  providers,
+  defaults,
+  templates,
+  update,
+  addressErrors,
+  validateAddress,
+}: NotificationIdentityFieldsProps) {
+  // Derived here, from props this component already holds. Passing them in
+  // would be the same answer worked out in the caller.
+  const defaultProvider = providers.find(p => p.isDefault);
+  const defaultProviderLabel = defaultProvider
+    ? `System default (${defaultProvider.name})`
+    : "System default";
+  const senderPlaceholder = defaults?.defaultFrom || "Provider default";
+  const senderHelp = defaults?.defaultFrom
+    ? `Leave blank to send from ${defaults.defaultFrom} (the configured default).`
+    : "Leave blank to use the template or provider default address.";
+
+  return (
+    <>
+        {/* Name */}
+        <FieldShell label="Name" htmlFor="notification-name" width="half">
+          <Input
+            type="text"
+            value={form.name}
+            onChange={e => update("name", e.target.value)}
+            placeholder="e.g. Admin notification"
+          />
+        </FieldShell>
+
+        {/* Provider & Template. A container-query grid rather than the
+            viewport's `sm:` breakpoint: the admin content region is
+            narrower than the window whenever both sidebars are open, so a
+            viewport breakpoint promises columns this sheet does not have. */}
+        <Grid cols={2} responsive>
+          {/* Both `Select`-driven: FieldShell's render-function `children`
+              applies the computed id/aria-describedby/aria-invalid to
+              SelectTrigger, the actual focusable element, rather than to
+              `Select`'s root (which accepts a fixed prop list and forwards
+              none of the rest). */}
+          <FieldShell label="Email provider" htmlFor="notification-provider">
+            {({ id, describedBy, invalid }) => (
+              <Select
+                value={form.providerId ?? "__default"}
+                onValueChange={value =>
+                  update(
+                    "providerId",
+                    value === "__default" ? undefined : value
+                  )
+                }
+              >
+                <SelectTrigger
+                  id={id}
+                  aria-describedby={describedBy}
+                  aria-invalid={invalid}
+                  className="w-full bg-transparent border-input dark:bg-muted/50"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__default">
+                    {defaultProviderLabel}
+                  </SelectItem>
+                  {providers.map(p => (
+                    <SelectItem key={p.id} value={p.id}>
+                      {p.name}
+                      {p.isDefault ? " (Default)" : ""}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </FieldShell>
+
+          <div className="space-y-1.5">
+            <FieldShell
+              label="Email template"
+              htmlFor="notification-template"
+            >
+              {({ id, describedBy, invalid }) => (
+                <Select
+                  value={form.templateSlug ?? "__none"}
+                  onValueChange={value =>
+                    update(
+                      "templateSlug",
+                      value === "__none" ? undefined : value
+                    )
+                  }
+                >
+                  <SelectTrigger
+                    id={id}
+                    aria-describedby={describedBy}
+                    aria-invalid={invalid}
+                    className="w-full bg-transparent border-input dark:bg-muted/50"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none">Select a template</SelectItem>
+                    {templates
+                      .filter(t => t.isActive && t.kind !== "layout")
+                      .map(t => (
+                        <SelectItem key={t.id} value={t.slug}>
+                          {t.name}
+                        </SelectItem>
+                      ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </FieldShell>
+            {!form.templateSlug && (
+              <p className="flex items-center gap-1 text-xs text-destructive">
+                <TriangleAlert className="h-3 w-3" aria-hidden="true" />
+                Required — a notification without a template is never sent.
               </p>
             )}
-
-            <AddressChipList
-              id="notification-cc"
-              label="CC (optional)"
-              addresses={form.cc}
-              placeholder="cc@example.com"
-              onChange={cc => update("cc", cc)}
-            />
-            <AddressChipList
-              id="notification-bcc"
-              label="BCC (optional)"
-              addresses={form.bcc}
-              placeholder="bcc@example.com"
-              onChange={bcc => update("bcc", bcc)}
-            />
           </div>
+        </Grid>
 
+        {/* Sender */}
+        <FieldShell
+          label="Sender email"
+          htmlFor="notification-sender"
+          width="half"
+          description={addressErrors.senderEmail ? undefined : senderHelp}
+          error={addressErrors.senderEmail}
+        >
+          <Input
+            type="email"
+            value={form.senderEmail ?? ""}
+            onChange={e => update("senderEmail", e.target.value || undefined)}
+            onBlur={e => validateAddress("senderEmail", e.target.value)}
+            placeholder={senderPlaceholder}
+          />
+        </FieldShell>
+    </>
+  );
+}
+
+// ============================================================================
+// Notification editor
+// ============================================================================
+
+type ReplyToMode = "none" | "field" | "custom";
+
+interface NotificationEditorProps {
+  initial: FormNotification;
+  /** Ties the row's toggle to this region for assistive tech. */
+  editorId: string;
+  providers: ProviderOption[];
+  templates: TemplateOption[];
+  fields: readonly FieldOption[];
+  defaults: NotificationDefaults | null;
+  /**
+   * Every edit, as it happens. There is no save button here on purpose: the
+   * page's own action bar commits the form, and a second one beside it could
+   * only mean the same thing said twice or two different things unlabelled.
+   */
+  onChange: (notification: FormNotification) => void;
+}
+
+function initialReplyToMode(replyTo: string | undefined): ReplyToMode {
+  if (!replyTo) return "none";
+  return parseFieldRef(replyTo) ? "field" : "custom";
+}
+
+function NotificationEditor({
+  initial,
+  editorId,
+  providers,
+  templates,
+  fields,
+  defaults,
+  onChange,
+}: NotificationEditorProps) {
+  const [form, setForm] = useState<FormNotification>(initial);
+  const [replyToMode, setReplyToMode] = useState<ReplyToMode>(
+    initialReplyToMode(initial.replyTo)
+  );
+  // Save-time address errors, keyed by field. Nothing here goes through
+  // form submission (every control is a type="button" callback), so
+  // constraint validation never runs — this is its replacement.
+  const [addressErrors, setAddressErrors] = useState<
+    Partial<Record<"senderEmail" | "to" | "replyTo", string>>
+  >({});
+
+  const update = useCallback(
+    <K extends keyof FormNotification>(key: K, value: FormNotification[K]) => {
+      setForm(prev => {
+        const next = { ...prev, [key]: value };
+        onChange(next);
+        return next;
+      });
+      setAddressErrors(prev =>
+        key in prev ? { ...prev, [key]: undefined } : prev
+      );
+    },
+    [onChange]
+  );
+
+  const changeRecipientType = useCallback(
+    (kind: "static" | "field") => {
+      setForm(prev => {
+        const next = { ...prev, recipientType: kind, to: "" };
+        onChange(next);
+        return next;
+      });
+    },
+    [onChange]
+  );
+
+  /**
+   * Address validity, checked when the field is LEFT rather than on a save
+   * press.
+   *
+   * Nothing here goes through form submission — every control is a
+   * `type="button"` callback — so constraint validation never runs and this is
+   * its replacement. Blur rather than change, because an address is invalid
+   * for most of the time it is being typed.
+   */
+  const validateAddress = useCallback(
+    (key: "senderEmail" | "to" | "replyTo", value: string | undefined) => {
+      // A `{{field}}` reference resolves against each submission at send time,
+      // so it is not an address and is not checked as one.
+      const literal = key === "replyTo" && parseFieldRef(value) !== null;
+      const invalid =
+        !literal && Boolean(value?.trim()) && !isValidEmail(value as string);
+      setAddressErrors(prev => ({
+        ...prev,
+        [key]: invalid ? "Enter a valid email address." : undefined,
+      }));
+    },
+    []
+  );
+
+  const condition = form.condition;
+
+  return (
+    <div
+      id={editorId}
+      className="border-t border-border bg-muted/20 px-4 py-5"
+    >
+      <div className="space-y-6">
+          <NotificationIdentityFields
+            form={form}
+            providers={providers}
+            defaults={defaults}
+            templates={templates}
+            update={update}
+            addressErrors={addressErrors}
+            validateAddress={validateAddress}
+          />
+          {/* Recipients */}
+          <RecipientFields
+            form={form}
+            fields={fields}
+            defaults={defaults}
+            update={update}
+            onRecipientTypeChange={changeRecipientType}
+            addressErrors={addressErrors}
+            validateAddress={validateAddress}
+            replyToMode={replyToMode}
+            setReplyToMode={setReplyToMode}
+          />
           {/* Send condition */}
-          <div className="space-y-3 pt-4 border-t border-border">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm font-medium text-foreground">
-                  Send condition
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  Only send this notification when a submitted value matches.
-                </p>
-              </div>
-              {!condition && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() =>
-                    update("condition", {
-                      field: fields[0]?.name ?? "",
-                      comparison: "equals",
-                      value: "",
-                    })
-                  }
-                  disabled={fields.length === 0}
-                >
-                  <Plus className="h-3.5 w-3.5" aria-hidden="true" />
-                  Add condition
-                </Button>
-              )}
-            </div>
-
-            {condition && (
-              <div className="flex flex-wrap items-end gap-2 border border-border bg-muted/40 p-3">
-                <FieldShell
-                  label="Field"
-                  htmlFor="notification-condition-field"
-                  className="min-w-36 flex-1"
-                >
-                  {({ id, describedBy, invalid }) => (
-                    <Select
-                      value={condition.field || "__none"}
-                      onValueChange={value =>
-                        update("condition", {
-                          ...condition,
-                          field: value === "__none" ? "" : value,
-                        })
-                      }
-                    >
-                      <SelectTrigger
-                        id={id}
-                        aria-describedby={describedBy}
-                        aria-invalid={invalid}
-                        className="w-full bg-transparent border-input dark:bg-muted/50"
-                      >
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="__none">Select a field</SelectItem>
-                        {fields.map(f => (
-                          <SelectItem key={f.name} value={f.name}>
-                            {f.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  )}
-                </FieldShell>
-
-                <FieldShell
-                  label="Comparison"
-                  htmlFor="notification-condition-comparison"
-                  className="min-w-36 flex-1"
-                >
-                  {({ id, describedBy, invalid }) => (
-                    <Select
-                      value={condition.comparison}
-                      onValueChange={value =>
-                        update("condition", {
-                          ...condition,
-                          comparison:
-                            value as ConditionalLogicCondition["comparison"],
-                        })
-                      }
-                    >
-                      <SelectTrigger
-                        id={id}
-                        aria-describedby={describedBy}
-                        aria-invalid={invalid}
-                        className="w-full bg-transparent border-input dark:bg-muted/50"
-                      >
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {Object.entries(COMPARISON_LABELS).map(
-                          ([value, label]) => (
-                            <SelectItem key={value} value={value}>
-                              {label}
-                            </SelectItem>
-                          )
-                        )}
-                      </SelectContent>
-                    </Select>
-                  )}
-                </FieldShell>
-
-                {!VALUELESS_COMPARISONS.has(condition.comparison) && (
-                  <FieldShell
-                    label="Value"
-                    htmlFor="notification-condition-value"
-                    className="min-w-36 flex-1"
-                  >
-                    <Input
-                      type="text"
-                      value={
-                        typeof condition.value === "string" ||
-                        typeof condition.value === "number"
-                          ? String(condition.value)
-                          : ""
-                      }
-                      onChange={e =>
-                        update("condition", {
-                          ...condition,
-                          value: e.target.value,
-                        })
-                      }
-                    />
-                  </FieldShell>
-                )}
-
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="h-9 w-9 rounded-none text-muted-foreground hover:text-destructive"
-                  onClick={() => update("condition", undefined)}
-                  aria-label="Remove send condition"
-                >
-                  <Trash2 className="h-4 w-4" aria-hidden="true" />
-                </Button>
-              </div>
-            )}
-          </div>
-
+          <SendConditionField
+            condition={condition}
+            fields={fields}
+            update={update}
+          />
           {/* Enabled */}
           <div className="flex items-center justify-between pt-4 border-t border-border">
             <div>
@@ -1063,22 +1221,8 @@ function NotificationSheet({
               onCheckedChange={checked => update("enabled", checked)}
             />
           </div>
-        </div>
-
-        <div className="flex items-center justify-end gap-3 border-t border-border bg-muted p-4">
-          <Button type="button" variant="outline" onClick={onClose}>
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            onClick={handleSave}
-            disabled={!form.name.trim()}
-          >
-            {isEditing ? "Save changes" : "Add notification"}
-          </Button>
-        </div>
-      </SheetContent>
-    </Sheet>
+      </div>
+    </div>
   );
 }
 
@@ -1104,10 +1248,9 @@ export function FormNotificationsTab({ defaults }: FormNotificationsTabProps) {
 
   const [providers, setProviders] = useState<ProviderOption[]>([]);
   const [templates, setTemplates] = useState<TemplateOption[]>([]);
-  const [sheetState, setSheetState] = useState<{
-    open: boolean;
-    editing: FormNotification | null;
-  }>({ open: false, editing: null });
+  // Which row is open. One at a time: several open at once turns the list
+  // into a wall of fields and loses the overview the summaries exist to give.
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   useEffect(() => {
     void fetchProviders().then(setProviders);
@@ -1119,29 +1262,25 @@ export function FormNotificationsTab({ defaults }: FormNotificationsTabProps) {
     [fields]
   );
 
-  const openAddSheet = useCallback(() => {
-    setSheetState({ open: true, editing: null });
-  }, []);
+  /**
+   * A new rule is added immediately and opened, rather than composed in a
+   * draft and committed on a button.
+   *
+   * That is the trade the inline editor makes: there is no save press to
+   * attach a creation to, so the row exists from the moment it is asked for.
+   * An unwanted one is removed the same way any other is, and an incomplete
+   * one is inert — a notification without a template never sends, which the
+   * row says on its face.
+   */
+  const addAndOpen = useCallback(() => {
+    const created = createNotification();
+    addNotification(created);
+    setExpandedId(created.id);
+  }, [addNotification]);
 
-  const openEditSheet = useCallback((notification: FormNotification) => {
-    setSheetState({ open: true, editing: notification });
+  const toggleExpanded = useCallback((id: string) => {
+    setExpandedId(current => (current === id ? null : id));
   }, []);
-
-  const closeSheet = useCallback(() => {
-    setSheetState({ open: false, editing: null });
-  }, []);
-
-  const handleSave = useCallback(
-    (notification: FormNotification) => {
-      if (sheetState.editing) {
-        updateNotification(notification.id, notification);
-      } else {
-        addNotification(notification);
-      }
-      closeSheet();
-    },
-    [sheetState.editing, addNotification, updateNotification, closeSheet]
-  );
 
   const getProviderName = useCallback(
     (providerId?: string) => {
@@ -1153,8 +1292,6 @@ export function FormNotificationsTab({ defaults }: FormNotificationsTabProps) {
     },
     [providers]
   );
-
-  const initialNotification = sheetState.editing ?? createNotification();
 
   return (
     // The measure belongs to the page's shell, not to this tab.
@@ -1168,7 +1305,7 @@ export function FormNotificationsTab({ defaults }: FormNotificationsTabProps) {
             Emails sent when someone submits this form.
           </p>
         </div>
-        <Button type="button" onClick={openAddSheet}>
+        <Button type="button" onClick={addAndOpen}>
           <Plus className="h-4 w-4" aria-hidden="true" />
           Add notification
         </Button>
@@ -1186,7 +1323,7 @@ export function FormNotificationsTab({ defaults }: FormNotificationsTabProps) {
           <p className="text-sm text-muted-foreground mb-6 text-center max-w-sm">
             Add a notification to email someone when this form is submitted.
           </p>
-          <Button type="button" onClick={openAddSheet}>
+          <Button type="button" onClick={addAndOpen}>
             <Plus className="h-4 w-4" aria-hidden="true" />
             Add notification
           </Button>
@@ -1199,30 +1336,29 @@ export function FormNotificationsTab({ defaults }: FormNotificationsTabProps) {
               notification={notification}
               providerName={getProviderName(notification.providerId)}
               fields={fieldList}
-              onEdit={() => openEditSheet(notification)}
+              expanded={expandedId === notification.id}
+              editorId={`notification-editor-${notification.id}`}
+              onToggle={() => toggleExpanded(notification.id)}
               onDuplicate={() => duplicateNotification(notification.id)}
               onDelete={() => deleteNotification(notification.id)}
               onToggleEnabled={enabled =>
                 updateNotification(notification.id, { enabled })
               }
-            />
+            >
+              <NotificationEditor
+                initial={notification}
+                editorId={`notification-editor-${notification.id}`}
+                providers={providers}
+                templates={templates}
+                fields={fieldList}
+                defaults={defaults}
+                onChange={next => updateNotification(notification.id, next)}
+              />
+            </NotificationCard>
           ))}
         </div>
       )}
 
-      {/* Editor sheet */}
-      {sheetState.open && (
-        <NotificationSheet
-          initial={initialNotification}
-          isEditing={!!sheetState.editing}
-          providers={providers}
-          templates={templates}
-          fields={fieldList}
-          defaults={defaults}
-          onSave={handleSave}
-          onClose={closeSheet}
-        />
-      )}
     </div>
   );
 }

--- a/packages/plugin-form-builder/src/admin/components/builder/notification-addresses.test.ts
+++ b/packages/plugin-form-builder/src/admin/components/builder/notification-addresses.test.ts
@@ -15,6 +15,7 @@ import {
   addressError,
   addressErrorsIn,
   badAddressMessage,
+  notificationsBlockingSave,
   notificationsWithBadAddresses,
 } from "./notification-addresses";
 
@@ -49,6 +50,15 @@ describe("one address", () => {
     expect(addressError("replyTo", "{{email}}")).toBeUndefined();
     // And the same spelling IS an error where a reference is not accepted.
     expect(addressError("to", "{{email}}")).toBeDefined();
+  });
+
+  it("recognises only the spelling the send path resolves", () => {
+    // `resolveFieldRef` matches `{{name}}` exactly. A value this exempted but
+    // delivery did not resolve would reach the mail provider with its braces
+    // intact, so the two read one parser and this pins the agreement.
+    expect(addressError("replyTo", "{{ email }}")).toBeDefined();
+    expect(addressError("replyTo", "{{my-field}}")).toBeDefined();
+    expect(addressError("replyTo", "{{my_field}}")).toBeUndefined();
   });
 });
 
@@ -113,5 +123,29 @@ describe("what a save must refuse", () => {
         aNotification({ id: "n2", name: "Receipt", senderEmail: "bad" }),
       ])
     ).toBe("2 notifications have invalid email addresses");
+  });
+
+  it("refuses a nameless rule, and says so before the address", () => {
+    // The sheet disabled its own commit while the name was blank; there is no
+    // commit there any more, so the precondition lives here. Naming comes
+    // first because an address complaint about "Untitled notification" names
+    // nothing the author can go and fix.
+    expect(
+      notificationsBlockingSave([aNotification({ name: "  ", to: "nope" })])
+    ).toBe("A notification needs a name");
+
+    expect(
+      notificationsBlockingSave([
+        aNotification({ name: "" }),
+        aNotification({ id: "n2", name: "" }),
+      ])
+    ).toBe("2 notifications need a name");
+  });
+
+  it("falls through to the address once every rule is named", () => {
+    expect(notificationsBlockingSave([aNotification({ to: "nope" })])).toBe(
+      "Admin notification has an invalid email address"
+    );
+    expect(notificationsBlockingSave([aNotification()])).toBeNull();
   });
 });

--- a/packages/plugin-form-builder/src/admin/components/builder/notification-addresses.test.ts
+++ b/packages/plugin-form-builder/src/admin/components/builder/notification-addresses.test.ts
@@ -1,0 +1,117 @@
+/**
+ * One rule for whether a notification's addresses are usable, asked by two
+ * callers: the field as it is left, and the page before it saves.
+ *
+ * They have to be the same rule. The editor writes to the form as the author
+ * types, so a field that rejects an address and a save that accepts it means
+ * the malformed one persists and the delivery path hands it to the provider —
+ * which is what happened while the editor held the only copy of the answer.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { FormNotification } from "../../../types";
+
+import {
+  addressError,
+  addressErrorsIn,
+  badAddressMessage,
+  notificationsWithBadAddresses,
+} from "./notification-addresses";
+
+function aNotification(over: Partial<FormNotification> = {}): FormNotification {
+  return {
+    id: "n1",
+    name: "Admin notification",
+    enabled: true,
+    recipientType: "static",
+    to: "admin@example.com",
+    cc: [],
+    bcc: [],
+    ...over,
+  } as FormNotification;
+}
+
+describe("one address", () => {
+  it("rejects a malformed one", () => {
+    expect(addressError("to", "not-an-address")).toBeDefined();
+  });
+
+  it("accepts a blank one", () => {
+    // Every address here is optional or has an inherited default, so blank is
+    // a choice rather than a mistake.
+    expect(addressError("senderEmail", "")).toBeUndefined();
+    expect(addressError("senderEmail", undefined)).toBeUndefined();
+  });
+
+  it("leaves a field reference alone in reply-to", () => {
+    // `{{email}}` resolves against each submission at send time, so there is
+    // no address here to check yet.
+    expect(addressError("replyTo", "{{email}}")).toBeUndefined();
+    // And the same spelling IS an error where a reference is not accepted.
+    expect(addressError("to", "{{email}}")).toBeDefined();
+  });
+});
+
+describe("a whole notification", () => {
+  it("reports each bad address by field", () => {
+    const errors = addressErrorsIn(
+      aNotification({ senderEmail: "bad", to: "worse", replyTo: "worst" })
+    );
+    expect(Object.keys(errors).sort()).toEqual([
+      "replyTo",
+      "senderEmail",
+      "to",
+    ]);
+  });
+
+  it("does not check the recipient when it names a field", () => {
+    // A `field` recipient holds a form field's name, which is not an address.
+    const errors = addressErrorsIn(
+      aNotification({ recipientType: "field", to: "email" })
+    );
+    expect(errors.to).toBeUndefined();
+  });
+
+  it("passes a well-formed one", () => {
+    expect(addressErrorsIn(aNotification())).toEqual({});
+  });
+});
+
+describe("what a save must refuse", () => {
+  it("names the offending rules", () => {
+    const names = notificationsWithBadAddresses([
+      aNotification(),
+      aNotification({ id: "n2", name: "Customer receipt", to: "nope" }),
+    ]);
+    expect(names).toEqual(["Customer receipt"]);
+  });
+
+  it("still names an unnamed rule", () => {
+    // "" would make the message read "has an invalid email address" with
+    // nothing in front of it.
+    const names = notificationsWithBadAddresses([
+      aNotification({ name: "  ", to: "nope" }),
+    ]);
+    expect(names).toEqual(["Untitled notification"]);
+  });
+
+  it("passes a list with nothing wrong in it", () => {
+    expect(notificationsWithBadAddresses([aNotification()])).toEqual([]);
+  });
+
+  it("says nothing when there is nothing to say", () => {
+    expect(badAddressMessage([aNotification()])).toBeNull();
+  });
+
+  it("names the single offender, and counts several", () => {
+    expect(badAddressMessage([aNotification({ to: "nope" })])).toBe(
+      "Admin notification has an invalid email address"
+    );
+    expect(
+      badAddressMessage([
+        aNotification({ to: "nope" }),
+        aNotification({ id: "n2", name: "Receipt", senderEmail: "bad" }),
+      ])
+    ).toBe("2 notifications have invalid email addresses");
+  });
+});

--- a/packages/plugin-form-builder/src/admin/components/builder/notification-addresses.ts
+++ b/packages/plugin-form-builder/src/admin/components/builder/notification-addresses.ts
@@ -1,4 +1,5 @@
 import type { FormNotification } from "../../../types";
+import { parseFieldRef } from "../../../utils/field-references";
 
 /**
  * Deliberately loose email shape check (something@something.tld): the goal is
@@ -6,18 +7,14 @@ import type { FormNotification } from "../../../types";
  */
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-/** A `{{field}}` reference, which resolves per submission at send time. */
-const FIELD_REF_PATTERN = /^\{\{\s*([a-zA-Z0-9_-]+)\s*\}\}$/;
-
 export function isValidEmail(value: string): boolean {
   return EMAIL_PATTERN.test(value.trim());
 }
 
-export function parseFieldRef(value: string | undefined): string | null {
-  if (!value) return null;
-  const match = value.match(FIELD_REF_PATTERN);
-  return match ? match[1] : null;
-}
+// Re-exported rather than re-implemented. Whether a value is a field reference
+// is the SEND path's question — a value the editor treats as one and delivery
+// does not goes out with its braces intact — so both read the same parser.
+export { parseFieldRef };
 
 /** The address fields a notification can get wrong. */
 export type AddressField = "senderEmail" | "to" | "replyTo";
@@ -95,4 +92,38 @@ export function badAddressMessage(
   return names.length === 1
     ? `${names[0]} has an invalid email address`
     : `${names.length} notifications have invalid email addresses`;
+}
+
+/**
+ * The one reason a save must refuse the notifications, or `null`.
+ *
+ * A single question so the save has a single branch. Naming comes first: an
+ * address complaint that says "Untitled notification" twice cannot be acted on,
+ * whereas a named rule can then be pointed at.
+ */
+export function notificationsBlockingSave(
+  notifications: readonly FormNotification[]
+): string | null {
+  const unnamed = unnamedNotificationCount(notifications);
+  if (unnamed > 0) {
+    return unnamed === 1
+      ? "A notification needs a name"
+      : `${unnamed} notifications need a name`;
+  }
+  return badAddressMessage(notifications);
+}
+
+/**
+ * Rules a save must refuse for having no name.
+ *
+ * The sheet this editor replaced disabled its own commit while the name was
+ * blank. There is no commit here any more — the page's action bar is the only
+ * one — so the precondition moves to it rather than disappearing with the
+ * button that used to carry it. A nameless rule leaves its summary and its
+ * menu labelled with nothing.
+ */
+export function unnamedNotificationCount(
+  notifications: readonly FormNotification[]
+): number {
+  return notifications.filter(n => !n.name.trim()).length;
 }

--- a/packages/plugin-form-builder/src/admin/components/builder/notification-addresses.ts
+++ b/packages/plugin-form-builder/src/admin/components/builder/notification-addresses.ts
@@ -1,0 +1,98 @@
+import type { FormNotification } from "../../../types";
+
+/**
+ * Deliberately loose email shape check (something@something.tld): the goal is
+ * catching typos before they fail at delivery, not RFC 5322 conformance.
+ */
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** A `{{field}}` reference, which resolves per submission at send time. */
+const FIELD_REF_PATTERN = /^\{\{\s*([a-zA-Z0-9_-]+)\s*\}\}$/;
+
+export function isValidEmail(value: string): boolean {
+  return EMAIL_PATTERN.test(value.trim());
+}
+
+export function parseFieldRef(value: string | undefined): string | null {
+  if (!value) return null;
+  const match = value.match(FIELD_REF_PATTERN);
+  return match ? match[1] : null;
+}
+
+/** The address fields a notification can get wrong. */
+export type AddressField = "senderEmail" | "to" | "replyTo";
+
+export type AddressErrors = Partial<Record<AddressField, string>>;
+
+const MESSAGE = "Enter a valid email address.";
+
+/**
+ * Whether ONE address is unusable, by the single rule the whole feature uses.
+ *
+ * A blank address is not an error — every one of these is optional or has an
+ * inherited default — and a `{{field}}` reference is not an address at all: it
+ * resolves against each submission at send time, so it cannot be checked now.
+ */
+export function addressError(
+  field: AddressField,
+  value: string | undefined
+): string | undefined {
+  if (field === "replyTo" && parseFieldRef(value) !== null) return undefined;
+  if (!value?.trim()) return undefined;
+  return isValidEmail(value) ? undefined : MESSAGE;
+}
+
+/**
+ * Every unusable address in a notification.
+ *
+ * The editor asks this about one field as it is left; the page asks it about
+ * every rule before it saves. The same function answers both, because the
+ * alternative is a field that rejects an address and a save that accepts it —
+ * which is what happened while the editor held the only copy of the answer.
+ *
+ * `to` is checked only when the recipient is a literal address: a `field`
+ * recipient names a form field, which is not an address to validate.
+ */
+export function addressErrorsIn(notification: FormNotification): AddressErrors {
+  const errors: AddressErrors = {};
+
+  const sender = addressError("senderEmail", notification.senderEmail);
+  if (sender) errors.senderEmail = sender;
+
+  if (notification.recipientType === "static") {
+    const to = addressError("to", notification.to);
+    if (to) errors.to = to;
+  }
+
+  const replyTo = addressError("replyTo", notification.replyTo);
+  if (replyTo) errors.replyTo = replyTo;
+
+  return errors;
+}
+
+/** The rules a save must refuse, named so the message can say which. */
+export function notificationsWithBadAddresses(
+  notifications: readonly FormNotification[]
+): string[] {
+  return notifications
+    .filter(n => Object.keys(addressErrorsIn(n)).length > 0)
+    .map(n => n.name.trim() || "Untitled notification");
+}
+
+/**
+ * What to tell an author who pressed Save with a malformed address, or `null`
+ * when there is nothing to tell them.
+ *
+ * The wording lives beside the rule that produces it so the caller has one
+ * question to ask and one branch to write — a save path that composed this
+ * itself would be a second place deciding what counts as wrong.
+ */
+export function badAddressMessage(
+  notifications: readonly FormNotification[]
+): string | null {
+  const names = notificationsWithBadAddresses(notifications);
+  if (names.length === 0) return null;
+  return names.length === 1
+    ? `${names[0]} has an invalid email address`
+    : `${names.length} notifications have invalid email addresses`;
+}

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -30,6 +30,7 @@ import type {
 } from "./types";
 import { evaluateSingleCondition } from "./utils/evaluate-conditions";
 import { exportToCSV, generateExportFilename } from "./utils/export-formats";
+import { parseFieldRef } from "./utils/field-references";
 
 export type NextlyPlugin = PluginDefinition;
 
@@ -517,9 +518,12 @@ export function getFormBuilderConfig(
  * Plain strings (e.g. email addresses) are returned as-is.
  */
 function resolveFieldRef(ref: string, data: Record<string, unknown>): string {
-  const match = ref.match(/^\{\{(\w+)\}\}$/);
-  if (!match) return ref;
-  const value = data[match[1]];
+  // The pattern is shared with the admin, which decides whether a value is a
+  // reference at all. Written twice, a value the editor accepted and this did
+  // not would be delivered with its braces intact.
+  const name = parseFieldRef(ref);
+  if (name === null) return ref;
+  const value = data[name];
   return typeof value === "string" ? value : "";
 }
 

--- a/packages/plugin-form-builder/src/utils/field-references.ts
+++ b/packages/plugin-form-builder/src/utils/field-references.ts
@@ -6,6 +6,24 @@
 
 import type { AnyFormField, FormNotification } from "../types";
 
+/**
+ * The one spelling of a field reference this plugin recognises: `{{fieldName}}`
+ * with no spaces, and `\w` names.
+ *
+ * Exact, because the SEND path is exact — a value the admin accepts as a
+ * reference and the send path does not is delivered with its braces intact,
+ * straight to the mail provider. Both sides read this constant so the question
+ * has one answer.
+ */
+export const FIELD_REF_PATTERN = /^\{\{(\w+)\}\}$/;
+
+/** The field named by a reference, or `null` when the value is not one. */
+export function parseFieldRef(value: string | undefined): string | null {
+  if (!value) return null;
+  const match = value.match(FIELD_REF_PATTERN);
+  return match ? match[1] : null;
+}
+
 export interface FieldReference {
   /** What kind of thing holds the reference. */
   kind: "condition" | "notification";


### PR DESCRIPTION
R-14, first half. The founder chose this shape after seeing the current panel and the alternatives.

## What changed on screen

The notification editor was a 560px sheet that slid over the form. Each notification is now a row that **expands in place**.

Three things were wrong with the panel, and the first is the one that decided it:

1. **Two save buttons, different scopes, no way to tell them apart.** The panel said "Save changes"; the page underneath said "Create". Nothing indicated which one persisted.
2. **The panel's whole justification is keeping the page in view, and it did not.** Measured: a 560px panel over a dimmed backdrop. You could not read the form you were configuring notifications for.
3. **It is not what this feature looks like elsewhere.** I read Payload's `plugin-form-builder` source rather than its docs: `emails` is a plain `array` field with **no** `admin.components.Field` override on the array or any sub-field, so it renders as inline rows. Seven sub-fields to our fourteen.

Now: edits reach the form as they are typed, so the page's action bar is the only commit. Address validation moved from a save press to leaving the field, because there is no longer a press to hang it on. One row opens at a time — several open at once turns the list into a wall of fields and loses the overview the summaries give.

## The editor is split three ways

One component answering "what is this notification", "where does it go" and "does it go at all" ran to **570 lines and 23 branches**. It is now `NotificationIdentityFields`, `RecipientFields` and `SendConditionField`, and the editor that composes them is 10 branches.

Each part derives what it needs from props it already holds rather than being handed the same answer computed in the caller — `toFieldOptions`, `senderHelp` and the provider label were all being worked out upstairs and passed down.

## Tests, where there were none

**Nothing in the suite rendered this component.** 89 tests passed before this change and 89 would have passed after it, because they cover email building and field references and never mount the tab. That green said nothing.

Six tests now do, and each is break-verified against the alternative implementation it exists to rule out:

| test | the break it catches |
| --- | --- |
| writes an edit through as it is typed | local state without `onChange` |
| shows a summary with the editor closed | rendering the editor unconditionally |
| closes a row when its own toggle is pressed again | replace-on-click, which can never close |
| keeps one row open at a time | accumulating open rows |

The third and fourth are worth naming together: **my first version of "keeps one row open at a time" passed against replace-on-click**, because opening a second row closes the first under either implementation. The toggle case is what separates them, and without it a row that could never be closed would have shipped green.

## Verification

- Browser, 1440x1200: the row reports `aria-expanded="true"`, the editor is the region its toggle names, **zero `[role=dialog]`**, nine fields, console clean.
- `pnpm turbo check-types --continue` — 22/22.
- `packages/plugin-form-builder` — 95 passed, 21 files.
- `fallow audit --base origin/main` — **pass**, zero introduced in all four categories. The first pass of this change did introduce a complexity finding; the three-way split is what removed it, not a suppression.

## Not in this PR

R-14's second half — the Settings tab cannot set the "redirect to a linked page" mode, only warn that touching the radio destroys it. The founder approved fixing it. It needs the `builder-config` route to surface `redirectRelationships` (that route is the only channel the admin client has to plugin options) plus a document picker, so it is its own change rather than an addendum to this one.

Changeset derived from `.changeset/config.json` — 25 packages, patch.

@codex please review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Notification settings now edit inline, with expandable rows and immediate updates.
  - Added validation for notification names and email addresses.
  - Save actions now clearly identify and block invalid notifications.
  - Added support for consistent field references in notification settings.

- **Bug Fixes**
  - Prevented malformed notification details from being saved.
  - Improved handling and display of existing address validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->