### PR TITLE
feat(nextly): make a content route declare how far its trust reaches

### DIFF
--- a/.changeset/a-route-states-how-far-its-trust-reaches.md
+++ b/.changeset/a-route-states-how-far-its-trust-reaches.md
@@ -1,0 +1,40 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A route names one collection, and the page it renders reaches others through
+relationships that were never named. A route that skipped access checks could
+stay silent about how far that skipping travelled, and silence meant every
+collection it happened to reach.
+
+On a pre-rendered route that is written into a static file: another
+collection restricted or unpublished rows, served to everyone, still there
+after the row is taken down.
+
+A route that skips access checks must now say which collections that reaches.
+One that genuinely serves everything says so by name. Routes that already
+declared their reach are unaffected, and no page changes what it renders.

--- a/packages/nextly/src/runtime/routing/__tests__/resolve-content-draft-cache.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/resolve-content-draft-cache.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { ListResult } from "../../../direct-api/types/shared";
 import { resolveContent, type NextlyContentReader } from "../resolve-content";
+import { TRUSTS_EVERY_COLLECTION } from "../../../services/collections/trust-grant";
 
 const { cachedFindSpy } = vi.hoisted(() => ({ cachedFindSpy: vi.fn() }));
 
@@ -54,6 +55,7 @@ describe("caching a draft read", () => {
     await resolveContent("posts", "a", {
       nextly: reader(),
       overrideAccess: true,
+      trustedCollections: TRUSTS_EVERY_COLLECTION,
     });
 
     expect(cachedFindSpy).toHaveBeenCalledOnce();
@@ -65,6 +67,7 @@ describe("caching a draft read", () => {
     const result = await resolveContent("posts", "a", {
       nextly: reader(),
       overrideAccess: true,
+      trustedCollections: TRUSTS_EVERY_COLLECTION,
       draft: true,
     });
 

--- a/packages/nextly/src/runtime/routing/__tests__/resolve-content.integration.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/resolve-content.integration.test.ts
@@ -10,6 +10,7 @@ import {
   type TestNextly,
 } from "../../../plugins/test-nextly";
 import { resolveContent } from "../resolve-content";
+import { TRUSTS_EVERY_COLLECTION } from "../../../services/collections/trust-grant";
 
 const pages = () =>
   defineCollection({
@@ -170,6 +171,7 @@ describe("resolveContent (integration)", () => {
       nextly: current.nextly,
       draft: true,
       overrideAccess: true,
+      trustedCollections: TRUSTS_EVERY_COLLECTION,
       draftFieldAccessAs: { id: "u1", email: "nobody@x.test", roles: [] },
     })) as { title?: string; secret?: string } | null;
 
@@ -218,6 +220,7 @@ describe("resolveContent (integration)", () => {
       nextly: current.nextly,
       draft: true,
       overrideAccess: true,
+      trustedCollections: TRUSTS_EVERY_COLLECTION,
       draftFieldAccessAs: { id: "u1", email: "boss@x.test", roles: [] },
     })) as { title?: string; secret?: string } | null;
 

--- a/packages/nextly/src/runtime/routing/__tests__/resolve-content.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/resolve-content.test.ts
@@ -12,6 +12,7 @@ import type {
 import type { ListResult } from "../../../direct-api/types/shared";
 import { NextlyError } from "../../../errors/nextly-error";
 import { resolveContent, type NextlyContentReader } from "../resolve-content";
+import { TRUSTS_EVERY_COLLECTION } from "../../../services/collections/trust-grant";
 
 function stubReader(behavior: {
   items?: Record<string, unknown>[];
@@ -76,6 +77,7 @@ describe("resolveContent (unit)", () => {
     await resolveContent("posts", "a", {
       nextly: reader,
       overrideAccess: true,
+      trustedCollections: TRUSTS_EVERY_COLLECTION,
       user: { id: "u1", role: "editor" },
       status: "all",
     });
@@ -125,6 +127,7 @@ describe("resolveContent (working-draft layer)", () => {
       nextly: reader,
       draft: true,
       overrideAccess: true,
+      trustedCollections: TRUSTS_EVERY_COLLECTION,
     });
 
     expect(result).toEqual({
@@ -150,6 +153,7 @@ describe("resolveContent (working-draft layer)", () => {
       nextly: reader,
       draft: true,
       overrideAccess: true,
+      trustedCollections: TRUSTS_EVERY_COLLECTION,
     });
     expect(calls[0].status).toBe("all");
   });
@@ -205,6 +209,7 @@ describe("resolveContent (working-draft layer)", () => {
       nextly: reader,
       draft: true,
       overrideAccess: true,
+      trustedCollections: TRUSTS_EVERY_COLLECTION,
     });
 
     expect(byIdCalls).toHaveLength(1);
@@ -235,6 +240,7 @@ describe("resolveContent (working-draft layer)", () => {
         nextly: gone.reader,
         draft: true,
         overrideAccess: true,
+        trustedCollections: TRUSTS_EVERY_COLLECTION,
       })
     ).toEqual({ id: "1", title: "live", status: "published" });
 
@@ -248,6 +254,7 @@ describe("resolveContent (working-draft layer)", () => {
         nextly: blip.reader,
         draft: true,
         overrideAccess: true,
+        trustedCollections: TRUSTS_EVERY_COLLECTION,
       })
     ).rejects.toBe(broken);
   });
@@ -264,6 +271,7 @@ describe("resolveContent (working-draft layer)", () => {
         nextly: reader,
         draft: true,
         overrideAccess: true,
+        trustedCollections: TRUSTS_EVERY_COLLECTION,
       })
     ).rejects.toBe(notFound);
   });
@@ -278,6 +286,7 @@ describe("resolveContent (working-draft layer)", () => {
       draft: true,
       status: "published",
       overrideAccess: true,
+      trustedCollections: TRUSTS_EVERY_COLLECTION,
     });
     expect(calls[0].status).toBe("published");
   });
@@ -295,6 +304,7 @@ describe("resolveContent (working-draft layer)", () => {
       locale: "fr",
       richTextFormat: "html",
       overrideAccess: true,
+      trustedCollections: TRUSTS_EVERY_COLLECTION,
       user: { id: "u1", role: "editor" },
     });
 
@@ -317,6 +327,7 @@ describe("resolveContent (working-draft layer)", () => {
         nextly: reader,
         draft: true,
         overrideAccess: true,
+        trustedCollections: TRUSTS_EVERY_COLLECTION,
       })
     ).toEqual({ id: "1", title: "live", status: "published" });
   });
@@ -332,6 +343,7 @@ describe("resolveContent (working-draft layer)", () => {
       nextly: reader,
       draft: true,
       overrideAccess: true,
+      trustedCollections: TRUSTS_EVERY_COLLECTION,
     });
 
     expect(result).toEqual({

--- a/packages/nextly/src/runtime/routing/__tests__/trusted-reaches-every-read.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/trusted-reaches-every-read.test.ts
@@ -40,10 +40,18 @@ function reads(file: string): { issued: number; bounded: number } {
   const text = source(file);
   return {
     issued: [...text.matchAll(/\.(find|findByID)\(\{/g)].length,
-    // The pass-through form only. A `trusted?:` in a doc block or an
-    // interface is a declaration, not a read carrying the bound.
-    bounded: [...text.matchAll(/^\s*(trusted|trustedCollections)[,:][^?]*$/gm)]
-      .length,
+    // The pass-through form only: a property being SET inside an object
+    // literal, which is what carrying the bound into a read looks like.
+    //
+    // Keyed on the trailing comma rather than on the absence of `?`. Optionality
+    // stopped separating the two the moment a declaration became REQUIRED — a
+    // union arm that obliges a trusted caller to state its bound reads as
+    // `trustedCollections: ...;` with no `?` anywhere, and the older form
+    // counted it as a read. A literal's property ends in `,`; a type member ends
+    // in `;`, and that distinction does not depend on how the type is written.
+    bounded: [
+      ...text.matchAll(/^\s*(trusted|trustedCollections)(?::[^?;]*)?,\s*$/gm),
+    ].length,
   };
 }
 

--- a/packages/nextly/src/runtime/routing/resolve-content-trust.test-d.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content-trust.test-d.ts
@@ -1,0 +1,59 @@
+/**
+ * A route cannot hold the access bypass without saying how far it travels —
+ * asserted by the CHECKER.
+ *
+ * `resolveContent` is the surface a custom route calls, and a route names ONE
+ * collection while the page it renders reaches others through relationships.
+ * Those targets were never named, so an unbounded bypass spreads into all of
+ * them; on a pre-rendered route their restricted or unpublished rows are then
+ * written into a static artifact that outlives the row.
+ *
+ * Two properties are pinned, and the second is the one that matters. The first
+ * is that a bypass without a bound is rejected. The second is that this holds
+ * for a COMPUTED flag — `overrideAccess: granted || draft` is the spelling that
+ * actually shipped unbounded, and a union that only caught a literal `true`
+ * would miss every real instance while looking like a guard.
+ *
+ * Written as conditional types rather than `@ts-expect-error`, which suppresses
+ * ANY error on the line beneath it and would keep passing once these calls
+ * started failing for an unrelated reason.
+ */
+import { expectTypeOf } from "vitest";
+
+import type { TRUSTS_EVERY_COLLECTION } from "../../services/collections/trust-grant";
+
+import type { ResolveContentOptions } from "./resolve-content";
+
+type Accepts<T> = T extends ResolveContentOptions ? true : false;
+
+// A read that holds no bypass trusts nothing and is not asked to say so.
+expectTypeOf<Accepts<Record<string, never>>>().toEqualTypeOf<true>();
+expectTypeOf<Accepts<{ overrideAccess: false }>>().toEqualTypeOf<true>();
+
+// A bypass with no bound does not compile.
+expectTypeOf<Accepts<{ overrideAccess: true }>>().toEqualTypeOf<false>();
+
+// And neither does the computed form, which is the one that shipped.
+expectTypeOf<Accepts<{ overrideAccess: boolean }>>().toEqualTypeOf<false>();
+
+// The positive controls. Without these, both rejections above would hold just
+// as firmly if the trusted arm were unsatisfiable — a door nobody can open is
+// indistinguishable from a door that is locked, and only one of them is a
+// working route.
+expectTypeOf<
+  Accepts<{ overrideAccess: true; trustedCollections: readonly string[] }>
+>().toEqualTypeOf<true>();
+
+expectTypeOf<
+  Accepts<{
+    overrideAccess: true;
+    trustedCollections: typeof TRUSTS_EVERY_COLLECTION;
+  }>
+>().toEqualTypeOf<true>();
+
+// The escape hatch must be reachable as the CONSTANT, not merely as some
+// string: if the arm accepted `string`, a caller could satisfy it with a typo
+// and get an unbounded read that reads as a decision.
+expectTypeOf<
+  Accepts<{ overrideAccess: true; trustedCollections: "all" }>
+>().toEqualTypeOf<false>();

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -14,6 +14,7 @@ import { getNextly } from "../../direct-api/nextly";
 import type { Nextly } from "../../direct-api/nextly";
 import type { UserContext } from "../../direct-api/types/shared";
 import { NextlyError } from "../../errors/nextly-error";
+import { TRUSTS_EVERY_COLLECTION } from "../../services/collections/trust-grant";
 import { cachedFind } from "../cache/cached-find";
 import { nextlyTags } from "../cache/nextly-tags";
 
@@ -32,7 +33,7 @@ export type ContentEntry = Record<string, unknown>;
 export type NextlyContentReader = Pick<Nextly, "find" | "findByID">;
 
 /** Options for {@link resolveContent}. */
-export interface ResolveContentOptions {
+interface ResolveContentOptionsBase {
   /**
    * A booted Nextly instance. Defaults to the runtime singleton (`getNextly()`),
    * which requires services to be registered — pass one explicitly (e.g. the
@@ -162,7 +163,7 @@ export interface ResolveContentOptions {
    * predicate plus a separate key would be two options a caller can get out of
    * step.
    */
-  trustedCollections?: readonly string[];
+  trustedCollections?: readonly string[] | typeof TRUSTS_EVERY_COLLECTION;
   /**
    * What the CALLER authorized, before a draft decision widened it.
    *
@@ -201,6 +202,36 @@ export interface ResolveContentOptions {
    */
   draftFieldAccessAs?: UserContext;
 }
+
+/**
+ * A content read, with its trust answered rather than assumed.
+ *
+ * A route names ONE collection. The page it renders reaches others through
+ * relationships, and those were never named here. Saying nothing meant every
+ * populated target inherited the route's bypass — which is how a public route
+ * ends up writing another collection's restricted rows into a static artifact,
+ * where they outlive the row being unpublished.
+ *
+ * Expressed as a union so the question is put only to the reads that can answer
+ * it wrongly. An enforced read trusts nothing and is not asked; a read holding
+ * the bypass does not compile until it says how far that bypass travels. A
+ * route that genuinely serves everything says {@link TRUSTS_EVERY_COLLECTION}
+ * and performs exactly the read it performed before — the value records that
+ * someone decided, which absence could not.
+ *
+ * The union narrows on a COMPUTED flag too, which is the case that matters:
+ * a route writing `overrideAccess: granted || draft` is the shape that shipped
+ * unbounded, and TypeScript checks each constituent of `boolean` separately, so
+ * that spelling is caught as surely as a literal `true`.
+ */
+export type ResolveContentOptions = ResolveContentOptionsBase &
+  (
+    | { overrideAccess?: false }
+    | {
+        overrideAccess: true;
+        trustedCollections: readonly string[] | typeof TRUSTS_EVERY_COLLECTION;
+      }
+  );
 
 /**
  * Resolve a published entry by slug in `collection`, F1-cached and tagged so a
@@ -532,10 +563,18 @@ export async function resolveContent(
   // handed to a request that never asked for one.
   // Sorted and de-duplicated so the same set written two ways is one cache
   // identity, and so the predicate and the key are built from one value.
-  const trustedNames =
-    options.trustedCollections === undefined
+  // Both spellings of "reaches everything" collapse here, and must: an absent
+  // bound and `TRUSTS_EVERY_COLLECTION` describe the same read, so they have to
+  // produce the same predicate AND the same cache identity. Giving the constant
+  // a key of its own would split one read across two entries that can then
+  // diverge under revalidation while claiming to be the same page.
+  const named =
+    options.trustedCollections === undefined ||
+    options.trustedCollections === TRUSTS_EVERY_COLLECTION
       ? undefined
-      : [...new Set(options.trustedCollections)].sort();
+      : options.trustedCollections;
+  const trustedNames =
+    named === undefined ? undefined : [...new Set(named)].sort();
   const trusted =
     trustedNames === undefined
       ? undefined


### PR DESCRIPTION
> **#1191 has merged**, so this now targets `main` directly and its diff is one commit. It uses `TRUSTS_EVERY_COLLECTION`, which #1191 introduced.

## What changes for a caller

A route that skips access checks must now say **which collections that skipping reaches**. A route that genuinely serves everything says so by name:

```ts
await resolveContent("posts", slug, {
  overrideAccess: true,
  trustedCollections: ["posts", "authors"],   // or TRUSTS_EVERY_COLLECTION
});
```

**No page changes what it renders.** Routes that already declared their reach are untouched — the repo's own `content-route.ts` already did, so it needed no edit at all.

## Why this door and not another

#1191 required the bound on the expansion **context**. That is one layer below where the failure actually occurs. The failure that has shipped twice — Singles in #1167, collections before it — was a **route** holding the bypass and never stating its reach. `resolveContent` is that route-facing surface, and it is where a custom route enters.

A route names ONE collection. The page it renders reaches others through relationships that were never named here. On a pre-rendered route the consequence is durable rather than transient: what it read is written into a static artifact, served to everyone, and outlives the row being unpublished.

## The union catches the spelling that actually ships

```ts
export type ResolveContentOptions = ResolveContentOptionsBase &
  (
    | { overrideAccess?: false }
    | {
        overrideAccess: true;
        trustedCollections: readonly string[] | typeof TRUSTS_EVERY_COLLECTION;
      }
  );
```

A read holding no bypass trusts nothing and is not asked to say so. A read holding one does not compile until it declares its reach.

**The load-bearing property is that this holds for a COMPUTED flag.** `overrideAccess: granted || draft` is the shape that shipped unbounded; a guard catching only a literal `true` would miss every real instance while looking like a guard. TypeScript checks each constituent of `boolean` separately, so it is caught. Pinned in `resolve-content-trust.test-d.ts`.

## Break-verified

| break | expected | observed |
| --- | --- | --- |
| the existing caller drops `trustedCollections` | rejected | `content-route.ts(599)` TS2345 |
| a NEW route with `overrideAccess: granted \|\| draft` and no bound | rejected | TS2345 — *the exact historical shape* |
| a read inside `resolveContent` stops forwarding the bound | scan goes red | `expected 4 to be 5` |

Each break was asserted to have applied before the result was read, and each restored to a verified-clean tree.

## One existing test needed repair, and the reason is worth reading

`trusted-reaches-every-read.test.ts` counts reads and bound-carrying pass-throughs in the source. It separated a **pass-through** from a **declaration** by the absence of `?`:

```ts
/^\s*(trusted|trustedCollections)[,:][^?]*$/gm
```

That discriminator stops working the moment a declaration becomes **required** — the new union arm reads `trustedCollections: ...;` with no `?` anywhere, so a type member counted as a read and the test failed at 6-vs-5.

It now keys on the **trailing comma**: an object property ends in `,`, a type member ends in `;`, and that holds however the type is written. Break-verified — removing a real pass-through still fails it at 4-vs-5, so the repair did not make it permissive.

## The escape hatch stays honest

Both spellings of "reaches everything" collapse to one value inside `resolveContent`, so an absent bound and `TRUSTS_EVERY_COLLECTION` produce the same predicate **and the same cache identity**. Splitting one page across two cache entries would let them diverge under revalidation while claiming to be the same page.

The type test also asserts `trustedCollections: "all"` is **rejected** — if the arm accepted `string`, a caller could satisfy it with a typo and get an unbounded read that reads as a decision.

## Test call sites

15 existing `resolveContent` calls in tests were unbounded trusted reads and now fail to compile — that is the guard working. Each was given `TRUSTS_EVERY_COLLECTION`, which is exactly what they did before; none had its behaviour changed.

## Evidence

- `nextly` routing unit: 15 files / 107 tests passed. Routing integration: 5 files / 33 tests passed.
- Full `nextly` **integration on the pushed tree `9aad0b018`**: `224 passed | 38 skipped (262)` files, `1323 passed | 213 skipped` tests, **0 failures**, exit 0.
- `tsc --noEmit` and `-p tsconfig.tests.json`: 0 errors each. eslint on all changed files: 0 errors.
- `fallow`: `dead_code_introduced: 0`, `complexity_introduced: 0`. One clone group attributable to this commit — the type test's assertion lines matching `plugins/codegen/block-document.test-d.ts`, which already contains **six** instances of the same `expectTypeOf` idiom. Repeated assertion shape is what a type test is; no logic is duplicated and no suppression was added.
