### PR TITLE
fix(plugin-form-builder): still the notification toggle's name, and follow the editor out of the sheet

### DIFF
--- a/.changeset/notification-toggle-stable-name.md
+++ b/.changeset/notification-toggle-stable-name.md
@@ -1,0 +1,34 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Keep a notification row's name still while it expands.
+
+The row's accessible name changed with its state — "Edit notification X" when
+closed, "Collapse notification X" when open — while `aria-expanded` already said
+which it was. A name that moves with state is one a screen-reader user cannot
+refer to twice, and one no caller can hold a handle on across a click.

--- a/e2e/tests/form-builder.spec.ts
+++ b/e2e/tests/form-builder.spec.ts
@@ -77,7 +77,7 @@ test("builds a form with catalog fields, keyboard reorder, and a guarded delete"
   await expect(page.getByRole("menuitem", { name: "Delete" })).toBeDisabled();
 });
 
-test("seeds a default notification, edits it in the sheet, and guards referenced fields", async ({
+test("seeds a default notification, edits it in place, and guards referenced fields", async ({
   page,
 }) => {
   await gotoAdmin(page, "/collections/forms/create");
@@ -98,27 +98,36 @@ test("seeds a default notification, edits it in the sheet, and guards referenced
   await expect(page.getByText("Admin notification")).toBeVisible();
   await expect(page.getByText("No template — will not send")).toBeVisible();
 
-  // Edit in the sheet: recipient, visitor reply-to, and a send condition.
-  await page
-    .getByRole("button", { name: "Edit notification Admin notification" })
-    .click();
-  const sheet = page.getByRole("dialog");
-  await sheet
+  // Edit in place: the row expands into an editor on the page, not a panel
+  // over it. Scoped to that region rather than to the page so a control with
+  // the same name elsewhere cannot satisfy these steps.
+  const toggle = page.getByRole("button", {
+    name: "Edit notification Admin notification",
+  });
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+  // There is no overlay. A `getByRole("dialog")` here would have found the
+  // sheet this replaced, which is how this test failed when it moved.
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+
+  const editor = page.locator('[id^="notification-editor-"]');
+  await editor
     .getByRole("textbox", { name: "Recipient address" })
     .fill("team@example.com");
 
-  await sheet.getByLabel("Reply-To").click();
+  await editor.getByLabel("Reply-To").click();
   await page.getByRole("option", { name: "The visitor (email field)" }).click();
-  await sheet.getByLabel("Visitor email field").click();
+  await editor.getByLabel("Visitor email field").click();
   await page.getByRole("option", { name: "Email" }).click();
 
-  await sheet.getByRole("button", { name: "Add condition" }).click();
-  await sheet.getByLabel("Comparison").click();
+  await editor.getByRole("button", { name: "Add condition" }).click();
+  await editor.getByLabel("Comparison").click();
   await page.getByRole("option", { name: "Is not empty" }).click();
 
-  await sheet.getByRole("button", { name: "Save changes" }).click();
-
-  // The card now shows the condition badge and the recipient summary.
+  // No save press: the editor writes through to the form as it is typed, and
+  // the page's own action bar is the only commit. The summary above proves it
+  // — it is driven by the same state the editor is writing.
   await expect(page.getByText("Conditional")).toBeVisible();
   await expect(page.getByText("To team@example.com")).toBeVisible();
 

--- a/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.test.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.test.tsx
@@ -247,4 +247,23 @@ describe("the notification list", () => {
     expect(editor?.className ?? "").not.toContain("opacity");
     expect(editor?.closest(".opacity-60")).toBeNull();
   });
+
+  it("keeps the toggle's accessible name still while it expands", async () => {
+    // `aria-expanded` carries the state, so the NAME must not. A name that
+    // moves with state cannot be referred to twice — a screen-reader user
+    // loses the control they were on, and any caller holding a handle to it
+    // loses it the moment they use it. That is precisely how the browser test
+    // for this broke.
+    notifications = [aNotification()];
+    const user = userEvent.setup();
+    render(<FormNotificationsTab defaults={null} />);
+
+    const toggle = screen.getByRole("button", {
+      name: "Edit notification Admin notification",
+    });
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(toggle).toHaveAccessibleName("Edit notification Admin notification");
+  });
 });

--- a/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.tsx
@@ -275,7 +275,11 @@ function NotificationCard({
           aria-expanded={expanded}
           aria-controls={editorId}
           className="flex min-w-0 flex-1 items-center gap-3 rounded-none py-1 text-left cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-          aria-label={`${expanded ? "Collapse" : "Edit"} notification ${notification.name}`}
+          // The NAME stays put while the state changes. `aria-expanded` above
+          // already says open or closed, and a control whose name moves with
+          // its state is one a screen-reader user cannot refer to twice — and
+          // one no test can hold a handle on across a click.
+          aria-label={`Edit notification ${notification.name}`}
         >
           <span className="min-w-0 flex-1">
             <span className="flex items-center gap-2">


### PR DESCRIPTION
`main` is red on `Browser tests`, and it is mine. Reported by the preview lane, confirmed here.

## What broke

#1193 moved the notification editor out of its slide-out panel and onto the page. `e2e/tests/form-builder.spec.ts` still drove the panel — it scoped its steps to `getByRole("dialog")` and pressed a `Save changes` that no longer exists. There is no dialog on that tab now, so it timed out.

**I never ran this suite.** The PR body quoted 111 passing unit tests in `plugin-form-builder` and said nothing about e2e, which is exactly the gap: a change that deletes a dialog is the shape of change a browser test exists to catch, and I checked everything except the thing that checks that.

## The fix, and one thing it turned up

The steps scope to the editor region instead, and the save press is gone because the editor writes through as it is typed. Two assertions are added rather than only repaired: that no dialog is present, and that the toggle reports `aria-expanded`.

Repairing it surfaced a real accessibility problem I had shipped. The toggle's accessible name changed with its state — `Edit notification X` closed, `Collapse notification X` open — while `aria-expanded` already said which it was. So the test failed a *second* time even after the dialog was gone: the handle it was holding stopped matching the moment it clicked.

That is a bug for a person, not just for a locator. A control whose name moves cannot be referred to twice — a screen-reader user who tabs back finds a different control where they left one. The name is now still and `aria-expanded` carries the state alone, which is what it is for. Pinned by a unit test, break-verified against the shipped behaviour.

## Verification

- `pnpm test:e2e` — **199 passed, 1 failed**, and the failure is not mine: `tests/canvas/spacing-overlay.spec.ts` "draws nothing for a scroll container reserving a scrollbar gutter". I reproduced it on **pristine `main` with my changes reverted**, so it is pre-existing and belongs to the page-builder lane. Flagged to them separately.
- `tests/form-builder.spec.ts` alone — 3 passed.
- `pnpm turbo check-types --continue` — 22/22.
- `packages/plugin-form-builder` — 112 passed.
- `fallow audit --base origin/main` — pass, zero introduced.

Changeset derived from `.changeset/config.json` — 25 packages, patch.

@codex please review
