### PR TITLE
test(builder): force a classic scrollbar so the gutter refusal is testable on macOS

### DIFF
--- a/e2e/tests/canvas/spacing-overlay.spec.ts
+++ b/e2e/tests/canvas/spacing-overlay.spec.ts
@@ -431,12 +431,24 @@ test.describe("spacing values on the canvas", () => {
           }
           if (key === "a scroll container reserving a scrollbar gutter") {
             /*
-             * `scrollbar-gutter: stable` reserves the space deterministically.
-             * Left to the platform this is a coin toss — macOS uses overlay
-             * scrollbars that reserve nothing, so the defect only appears on
-             * Windows and Linux, and a test that depended on that would pass
-             * locally while covering nothing.
+             * The gutter is forced with a CLASSIC scrollbar, not with
+             * `scrollbar-gutter: stable` alone.
+             *
+             * `stable` reserves space only for a scrollbar that occupies
+             * layout, and on macOS Chromium the scrollbar is an OVERLAY with no
+             * width — measured, `offsetWidth - clientWidth` is 0 there with
+             * `stable` set, in headless and headed alike. The refusal under
+             * test reads exactly that difference, so on macOS it correctly
+             * finds no gutter and the assertion below fails, while the same
+             * test passes on the Linux runner where the scrollbar is classic.
+             *
+             * Sizing `::-webkit-scrollbar` opts the element out of the overlay
+             * treatment, so the gutter is real on every platform: measured at
+             * 15px on macOS, where `stable` alone gives 0.
              */
+            const style = el.ownerDocument.createElement("style");
+            style.textContent = `[data-nx-node="${el.dataset.nxNode ?? ""}"]::-webkit-scrollbar { width: 15px; height: 15px; } [data-nx-node="${el.dataset.nxNode ?? ""}"]::-webkit-scrollbar-thumb { background: #888; }`;
+            el.ownerDocument.head.appendChild(style);
             el.style.overflow = "scroll";
             el.style.scrollbarGutter = "stable";
           }


### PR DESCRIPTION
`spacing-overlay.spec.ts` › *"draws nothing for a scroll container reserving a scrollbar gutter"* fails on `main` for every macOS developer, and passes on the ubuntu runner.

Reported by the admin-shell lane, who found it while fixing an unrelated failure and reproduced it against pristine `origin/main` (`git checkout origin/main -- packages e2e`). I reproduced it independently here before changing anything.

## Mechanism

The test relied on `scrollbar-gutter: stable` to reserve a gutter on every platform. **It does not.** `stable` reserves space only for a scrollbar that occupies layout, and macOS Chromium draws an **overlay** scrollbar with no width. Measured, with `overflow: scroll; scrollbar-gutter: stable` set:

```
headless (playwright default)  {"gutterX":0,"gutterY":0}
headed                         {"gutterX":0,"gutterY":0}
```

`hasScrollbarGutter` reads exactly that quantity — `offsetWidth - clientWidth - borders.x` — so on macOS it correctly finds no gutter, the refusal never fires, the bands are drawn, and `toHaveCount(0)` fails.

So the failure is the test's premise, not the overlay code. The refusal is behaving correctly on both platforms; only the fixture differs.

Worth noting the test's own comment claimed to have removed this platform dependence:

> `scrollbar-gutter: stable` reserves the space deterministically. Left to the platform this is a coin toss — macOS uses overlay scrollbars that reserve nothing…

The reasoning was right about the hazard and wrong about the remedy.

## Fix

Sizing `::-webkit-scrollbar` opts the element out of overlay treatment, so the gutter occupies layout everywhere:

```
stable only                      {"gutterX":0,"gutterY":0}
stable + classic webkit          {"gutterX":15,"gutterY":0}
scrollbar-width auto + stable    {"gutterX":0,"gutterY":0}
```

`scrollbar-width: auto` was tried and does not work — recorded because it is the obvious next guess.

## Evidence

- **Fails before**, on this machine, at `spacing-overlay.spec.ts:452`.
- **Passes after** — `1 passed (23.9s)`.
- **Break-verified after the fix**, so it is not now passing for a new reason: raising the gutter threshold past any real value fails the test.

That break-verification took two attempts, and the first is worth recording. Making `hasScrollbarGutter` return early produced unreachable code, the **dev server failed to build**, and the run exited non-zero — a red result that had nothing to do with the assertion. A break must still compile, or it proves the harness can fail rather than that the test covers anything.

## Scope

Test-only, so no changeset (per AGENTS.md). No production code changes: `packages/builder` is untouched.

`e2e` lint clean, comment convention clean, `fallow audit` `verdict: pass`.