### PR TITLE
fix(admin): measure the loaded editor, not its loading skeleton

### DIFF
--- a/.changeset/page-error-fallback-marker.md
+++ b/.changeset/page-error-fallback-marker.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The shared page error fallback carries a stable marker, so a caller can tell an error page apart from the page it replaced.

--- a/e2e/tests/shell/page-measure.spec.ts
+++ b/e2e/tests/shell/page-measure.spec.ts
@@ -72,22 +72,29 @@ const aControl = (page: Page) =>
     .first();
 
 /**
- * The error branch, which every one of these routes renders INSIDE the shell.
+ * The page failed instead of rendering, in either shape the admin uses.
  *
- * `Alert` defaults to `role="alert"`, so this is asked of the role rather than
- * of the copy each route happens to use.
+ * Two, because measurement showed one is not enough. `Alert` defaults to
+ * `role="alert"` and the entry and single routes use it; `/settings/api-keys`
+ * hands its query failure to `PageErrorFallback`, which renders an error PAGE
+ * and so carries no alert role at all. Measured in that state: zero skeletons,
+ * zero alerts, three controls still mounted — indistinguishable from a loaded
+ * page by everything this file checked before.
+ *
+ * `page-error` is page-scoped rather than shell-scoped because the fallback
+ * replaces the page's content, including the shell it was rendered in.
  */
-const errors = (page: Page) => shellOf(page).getByRole("alert");
+const errors = (page: Page) =>
+  page.locator('[data-slot="page-error"]').or(shellOf(page).getByRole("alert"));
 
 /**
- * The page is in its LOADED state — asserted as all three of the states these
- * routes settle into, not as one of them.
+ * The page is in its LOADED state — asserted as all the states these routes
+ * settle into, not as one of them.
  *
  * Each clause is here because a check without it passed on a page that was not
- * the editor: the skeleton renders the same shell, the error branch removes
- * the skeleton and keeps a Back button, and a page that rendered nothing at
- * all satisfies both absences perfectly. So absence is never the whole test —
- * a real control has to be present as well.
+ * the editor: the skeleton renders the same shell, the error branches keep a
+ * control mounted, and a page that rendered nothing satisfies every absence
+ * perfectly — so a real control must be present as well.
  *
  * `timeout` is a parameter so the tests below can ask this to fail fast while
  * the sweep still waits properly for a cold route.
@@ -282,30 +289,47 @@ test.describe("a measured page keeps its children inside the page", () => {
 
   // Readiness is the part of this file that has been wrong most often, and
   // always the same way: satisfied by a page that was not the editor. These
-  // two force the states it must refuse. Without them the sweep's green is
-  // equally consistent with a readiness check that accepts anything.
-  test("readiness refuses a page that is still loading", async ({ page }) => {
-    await page.route("**/api/collections/schema/**", async route => {
+  // force the states it must refuse.
+  //
+  // Both use `/settings/api-keys` deliberately. It is the route whose loading
+  // AND error branches keep a control mounted — its Create API Key button
+  // lives in the layout, outside the part that varies — so each test can only
+  // pass by way of the clause it is named for. On the entry route the skeleton
+  // renders no control at all, so `aControl` alone would reject it and the
+  // skeleton clause would go unexercised.
+  const holdApiKeys = (page: Page, respond: "delay" | "fail") =>
+    page.route("**/admin/api/**", async route => {
+      const url = route.request().url();
+      if (/me\/permissions|dev-reload|\/me$|auth/.test(url))
+        return route.continue();
+      if (respond === "fail") {
+        return route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: { message: "forced" } }),
+        });
+      }
       await new Promise(resolve => setTimeout(resolve, 10_000));
       await route.continue();
     });
-    await gotoAdmin(page, "/collections/posts/create");
+
+  test("readiness refuses a page that is still loading", async ({ page }) => {
+    await holdApiKeys(page, "delay");
+    await gotoAdmin(page, "/settings/api-keys");
+    // The control this route keeps mounted while loading, so the rejection
+    // below cannot come from `aControl`.
+    await expect(aControl(page)).toBeVisible();
 
     await expect(awaitLoaded(page, 2_000)).rejects.toThrow();
   });
 
   test("readiness refuses a page that failed to load", async ({ page }) => {
-    // The state the skeleton check cannot see: placeholders are gone, a Back
-    // button is mounted, and the editor never rendered.
-    await page.route("**/api/collections/schema/**", route =>
-      route.fulfill({
-        status: 500,
-        contentType: "application/json",
-        body: JSON.stringify({ error: { message: "forced" } }),
-      })
-    );
-    await gotoAdmin(page, "/collections/posts/create");
-    await expect(errors(page).first()).toBeVisible();
+    await holdApiKeys(page, "fail");
+    await gotoAdmin(page, "/settings/api-keys");
+    // `PageErrorFallback`, which carries no alert role — the shape that got
+    // past the previous version of this check.
+    await expect(page.locator('[data-slot="page-error"]')).toBeVisible();
+    await expect(skeletons(page)).toHaveCount(0);
 
     await expect(awaitLoaded(page, 2_000)).rejects.toThrow();
   });

--- a/e2e/tests/shell/page-measure.spec.ts
+++ b/e2e/tests/shell/page-measure.spec.ts
@@ -18,7 +18,7 @@
  * of the geometry the browser computed. That makes the check complete for any
  * spelling rather than for the spellings someone thought to enumerate.
  */
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 import { gotoAdmin } from "../support/admin";
 
@@ -26,11 +26,12 @@ import { gotoAdmin } from "../support/admin";
  * Routes rendering the measured frame, reachable with no fixture beyond the
  * seeded dev user.
  *
- * The two form routes are the point rather than extra coverage: they are what
- * this frame was built for, and a sweep of settings pages alone would report
- * green while an editor bled out of its column. `/singles/site-settings` also
- * carries the only STICKY descendant in a measured page, which is a position
- * the containment walk has to measure rather than skip.
+ * `awaitLoaded` is not a convenience here. Every one of these routes renders
+ * `.nx-page-shell` in its LOADING state too, so waiting for the shell says
+ * nothing about whether the editor is on screen — and the editors are what
+ * this frame exists for. Measured without it, the sweep read the skeletons on
+ * both form routes and would have stayed green while `EntryForm` itself bled
+ * out of its column.
  */
 const MEASURED_ROUTES = [
   "/settings",
@@ -38,6 +39,37 @@ const MEASURED_ROUTES = [
   "/collections/posts/create",
   "/singles/site-settings",
 ];
+
+const shellOf = (page: Page) => page.locator(".nx-page-shell");
+
+/** The announcement every one of these routes renders while it is loading. */
+const loadingStatus = (page: Page) =>
+  page.locator('[role="status"]').filter({ hasText: /Loading/ });
+
+/**
+ * A real interactive control inside the shell, of either kind the admin uses.
+ *
+ * This is the POPULATION half of readiness. The loading skeletons render only
+ * `Skeleton` divs, so a control being present separates the loaded page from
+ * them — and it separates both from a page that rendered nothing, which
+ * satisfies "the announcement is gone" perfectly.
+ */
+const aControl = (page: Page) =>
+  shellOf(page)
+    .getByRole("textbox")
+    .or(shellOf(page).getByRole("button"))
+    .first();
+
+/**
+ * Both halves of "the page is ready": the loading announcement gone, and a
+ * real control present. Absence alone is satisfied by a page that rendered
+ * nothing at all, which is the same output as a page that finished.
+ */
+async function awaitLoaded(page: Page) {
+  await expect(shellOf(page)).toBeVisible();
+  await expect(loadingStatus(page)).toHaveCount(0);
+  await expect(aControl(page)).toBeVisible();
+}
 
 /**
  * Viewport widths chosen to cross both container-query steps. The gutter keys
@@ -84,7 +116,7 @@ interface Measurement {
  * examined. "No box escaped" is satisfied perfectly by a page that rendered no
  * boxes, and those are the same output.
  */
-async function measure(page: import("@playwright/test").Page) {
+async function measure(page: Page) {
   return page.evaluate((): Measurement => {
     const empty = { gutter: "", inFlow: 0, escapes: [], tracks: [] };
     const shell = document.querySelector(".nx-page-shell");
@@ -187,7 +219,7 @@ test.describe("a measured page keeps its children inside the page", () => {
       for (const width of SWEEP) {
         await page.setViewportSize({ width, height: 900 });
         await gotoAdmin(page, route);
-        await expect(page.locator(".nx-page-shell")).toBeVisible();
+        await awaitLoaded(page);
 
         const m = await measure(page);
 
@@ -210,6 +242,36 @@ test.describe("a measured page keeps its children inside the page", () => {
       expect([...gutters].sort()).toEqual(["1.5rem", "1rem", "2rem"]);
     });
   }
+
+  test("the loading skeleton keeps its children inside the page", async ({
+    page,
+  }) => {
+    // The skeleton is its own layout, not a blurred copy of the editor, and it
+    // is the state that regressed: its main pane was `flex-1` with no
+    // `min-w-0`, so it would not shrink and pushed the fixed-width rail 4px out
+    // of the column. Measured at 1180px because that is the panel width where
+    // the column is narrow enough for the rail to overflow it.
+    await page.setViewportSize({ width: 1180, height: 900 });
+
+    // Held open deliberately. On a warm dev server the skeleton lasts a few
+    // frames, so a test that merely navigated would race it and read the
+    // editor instead — passing while measuring the wrong state.
+    await page.route("**/api/collections/schema/**", async route => {
+      await new Promise(resolve => setTimeout(resolve, 5_000));
+      await route.continue();
+    });
+
+    await gotoAdmin(page, "/collections/posts/create");
+    await expect(shellOf(page)).toBeVisible();
+    // The skeleton IS what is on screen — asserted, not assumed, so this
+    // cannot quietly become a second measurement of the loaded editor.
+    await expect(loadingStatus(page)).toBeVisible();
+
+    const m = await measure(page);
+    expect(m.tracks).toHaveLength(3);
+    expect(m.inFlow).toBeGreaterThan(10);
+    expect(m.escapes, "at 1180px, loading").toEqual([]);
+  });
 
   test("the measurement reports children that do escape", async ({ page }) => {
     await page.setViewportSize({ width: 1600, height: 900 });

--- a/e2e/tests/shell/page-measure.spec.ts
+++ b/e2e/tests/shell/page-measure.spec.ts
@@ -42,17 +42,28 @@ const MEASURED_ROUTES = [
 
 const shellOf = (page: Page) => page.locator(".nx-page-shell");
 
-/** The announcement every one of these routes renders while it is loading. */
-const loadingStatus = (page: Page) =>
-  page.locator('[role="status"]').filter({ hasText: /Loading/ });
+/**
+ * Placeholder boxes inside the shell, from the shared `Skeleton` and from the
+ * hand-rolled pulses several loading branches use instead of it.
+ *
+ * This is the discriminator rather than a status announcement, because the
+ * announcement does not separate the two states. Measured across these four
+ * routes: `/settings` and `/settings/api-keys` render NO `role="status"` while
+ * loading, and `/collections/posts/create` renders one while LOADED — so a
+ * check for its absence passes on a skeleton AND fails on a finished page,
+ * which is wrong in both directions.
+ *
+ * A placeholder is what "still loading" looks like on screen, and it is what
+ * the measurement must not be reading.
+ */
+const skeletons = (page: Page) =>
+  shellOf(page).locator('[data-slot="skeleton"], .animate-pulse');
 
 /**
  * A real interactive control inside the shell, of either kind the admin uses.
  *
- * This is the POPULATION half of readiness. The loading skeletons render only
- * `Skeleton` divs, so a control being present separates the loaded page from
- * them — and it separates both from a page that rendered nothing, which
- * satisfies "the announcement is gone" perfectly.
+ * The POPULATION half. "No placeholders" is satisfied perfectly by a page that
+ * rendered nothing at all, and those are the same output.
  */
 const aControl = (page: Page) =>
   shellOf(page)
@@ -61,13 +72,12 @@ const aControl = (page: Page) =>
     .first();
 
 /**
- * Both halves of "the page is ready": the loading announcement gone, and a
- * real control present. Absence alone is satisfied by a page that rendered
- * nothing at all, which is the same output as a page that finished.
+ * Both halves of "the page is ready": every placeholder gone, and a real
+ * control present.
  */
 async function awaitLoaded(page: Page) {
   await expect(shellOf(page)).toBeVisible();
-  await expect(loadingStatus(page)).toHaveCount(0);
+  await expect(skeletons(page)).toHaveCount(0, { timeout: 20_000 });
   await expect(aControl(page)).toBeVisible();
 }
 
@@ -145,6 +155,15 @@ async function measure(page: Page) {
     // design — a wide table in its own scroller — and the scroller is what has
     // to stay in the column. Asked of the ancestors rather than of a class
     // name, so any spelling that produces the clip is recognised.
+    //
+    // The exemption is sound because the clip is REAL: the overflow is not
+    // painted outside the ancestor, so nothing reaches the page edge however
+    // far the rect extends. It is worth knowing when verifying this test,
+    // though, since it is not obvious from a failure. Every card in the admin
+    // is `rounded-*` with `overflow-hidden`, so a negative margin planted
+    // inside one is correctly NOT reported — measured here at 7px past the
+    // column and clipped — and a break placed there looks like the check
+    // missing it. Plant the break outside the cards, or on a grid item.
     const clipped = (el: Element) => {
       for (let p = el.parentElement; p && p !== shell; p = p.parentElement) {
         if (getComputedStyle(p).overflowX !== "visible") return true;
@@ -265,7 +284,7 @@ test.describe("a measured page keeps its children inside the page", () => {
     await expect(shellOf(page)).toBeVisible();
     // The skeleton IS what is on screen — asserted, not assumed, so this
     // cannot quietly become a second measurement of the loaded editor.
-    await expect(loadingStatus(page)).toBeVisible();
+    await expect(skeletons(page).first()).toBeVisible();
 
     const m = await measure(page);
     expect(m.tracks).toHaveLength(3);

--- a/e2e/tests/shell/page-measure.spec.ts
+++ b/e2e/tests/shell/page-measure.spec.ts
@@ -72,13 +72,31 @@ const aControl = (page: Page) =>
     .first();
 
 /**
- * Both halves of "the page is ready": every placeholder gone, and a real
- * control present.
+ * The error branch, which every one of these routes renders INSIDE the shell.
+ *
+ * `Alert` defaults to `role="alert"`, so this is asked of the role rather than
+ * of the copy each route happens to use.
  */
-async function awaitLoaded(page: Page) {
-  await expect(shellOf(page)).toBeVisible();
-  await expect(skeletons(page)).toHaveCount(0, { timeout: 20_000 });
-  await expect(aControl(page)).toBeVisible();
+const errors = (page: Page) => shellOf(page).getByRole("alert");
+
+/**
+ * The page is in its LOADED state — asserted as all three of the states these
+ * routes settle into, not as one of them.
+ *
+ * Each clause is here because a check without it passed on a page that was not
+ * the editor: the skeleton renders the same shell, the error branch removes
+ * the skeleton and keeps a Back button, and a page that rendered nothing at
+ * all satisfies both absences perfectly. So absence is never the whole test —
+ * a real control has to be present as well.
+ *
+ * `timeout` is a parameter so the tests below can ask this to fail fast while
+ * the sweep still waits properly for a cold route.
+ */
+async function awaitLoaded(page: Page, timeout = 20_000) {
+  await expect(shellOf(page)).toBeVisible({ timeout });
+  await expect(skeletons(page)).toHaveCount(0, { timeout });
+  await expect(errors(page)).toHaveCount(0, { timeout });
+  await expect(aControl(page)).toBeVisible({ timeout });
 }
 
 /**
@@ -261,6 +279,36 @@ test.describe("a measured page keeps its children inside the page", () => {
       expect([...gutters].sort()).toEqual(["1.5rem", "1rem", "2rem"]);
     });
   }
+
+  // Readiness is the part of this file that has been wrong most often, and
+  // always the same way: satisfied by a page that was not the editor. These
+  // two force the states it must refuse. Without them the sweep's green is
+  // equally consistent with a readiness check that accepts anything.
+  test("readiness refuses a page that is still loading", async ({ page }) => {
+    await page.route("**/api/collections/schema/**", async route => {
+      await new Promise(resolve => setTimeout(resolve, 10_000));
+      await route.continue();
+    });
+    await gotoAdmin(page, "/collections/posts/create");
+
+    await expect(awaitLoaded(page, 2_000)).rejects.toThrow();
+  });
+
+  test("readiness refuses a page that failed to load", async ({ page }) => {
+    // The state the skeleton check cannot see: placeholders are gone, a Back
+    // button is mounted, and the editor never rendered.
+    await page.route("**/api/collections/schema/**", route =>
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { message: "forced" } }),
+      })
+    );
+    await gotoAdmin(page, "/collections/posts/create");
+    await expect(errors(page).first()).toBeVisible();
+
+    await expect(awaitLoaded(page, 2_000)).rejects.toThrow();
+  });
 
   test("the loading skeleton keeps its children inside the page", async ({
     page,

--- a/packages/admin/src/components/features/entries/__tests__/measured-pages-cancel-one-axis.test.ts
+++ b/packages/admin/src/components/features/entries/__tests__/measured-pages-cancel-one-axis.test.ts
@@ -163,7 +163,7 @@ const HORIZONTAL_ONLY = `-mx${"-8"}`;
  * `e2e/tests/shell/page-measure.spec.ts`, which asks the rendered geometry —
  * where the column, the gutter and the resolved distance all exist.
  */
-const HORIZONTAL_CANCEL = /(?:^|[\s:"'`{(,])-mx?-8\b/;
+const HORIZONTAL_CANCEL = /(?:^|[\s:"'`{(,!])-mx?-8\b/;
 
 describe("a measured entry page", () => {
   it("reads every tree the build reads", () => {
@@ -230,6 +230,22 @@ describe("a measured entry page", () => {
     );
     expect(HORIZONTAL_CANCEL.test('<div className="-my-8 flex">')).toBe(false);
     expect(HORIZONTAL_CANCEL.test('<div className="-mx-4">')).toBe(false);
+
+    // Both important spellings. Tailwind 4 puts the modifier at the END, and
+    // still accepts the leading form; compiled here, `!${HORIZONTAL_ONLY}` and
+    // `${HORIZONTAL_ONLY}!` each emit the same declaration with `!important`,
+    // so a rule that wins hardest must not be the one that reads as clean. The
+    // trailing form was already caught by the quote before it — the leading
+    // one was not, because `!` sat outside the boundary class.
+    expect(
+      HORIZONTAL_CANCEL.test(`<div className="!${HORIZONTAL_ONLY}">`)
+    ).toBe(true);
+    expect(
+      HORIZONTAL_CANCEL.test(`<div className="${HORIZONTAL_ONLY}!">`)
+    ).toBe(true);
+    expect(
+      HORIZONTAL_CANCEL.test(`<div className="@4xl/content:!${TWO_AXIS}">`)
+    ).toBe(true);
 
     expect(HORIZONTAL_CANCEL.test(`// cancels ${TWO_AXIS} horizontally`)).toBe(
       true

--- a/packages/admin/src/components/shared/error-fallbacks/PageErrorFallback.tsx
+++ b/packages/admin/src/components/shared/error-fallbacks/PageErrorFallback.tsx
@@ -109,7 +109,14 @@ export function PageErrorFallback({
 
   return (
     <PageContainer>
-      <div className="flex min-h-[60vh] items-center justify-center p-4">
+      {/* Named so a caller can tell this apart from the page it replaced.
+          It renders no `role="alert"` deliberately — an error PAGE is the
+          document, not an interruption announced over one — which leaves
+          nothing else that separates it from a page that simply rendered. */}
+      <div
+        data-slot="page-error"
+        className="flex min-h-[60vh] items-center justify-center p-4"
+      >
         <div className="w-full max-w-xl bg-background  border border-border rounded-lg p-8 md:p-12 flex flex-col items-center text-center animate-in fade-in zoom-in duration-500">
           <div className="h-16 w-16 bg-primary/5 rounded-md flex items-center justify-center mb-8">
             <AlertCircle className="h-8 w-8 text-foreground" />


### PR DESCRIPTION
Recovers the last commit of #1188, which merged from head `045c6f261` while the branch tip was `cee8d0a69`. Verified absent by content: `awaitLoaded` and the skeleton test are in the branch tip and in neither the merge commit nor `main`.

Test-only, so no changeset.

## What was stranded

**The page-measure boundary was reading loading skeletons, not editors.** Every measured route renders `.nx-page-shell` in its loading state, so waiting for the shell said nothing about whether the editor was on screen. As `main` stands, an escape introduced in `EntryForm` or `SingleForm` leaves that spec green.

Readiness now requires both halves — the loading announcement gone AND a real control present inside the shell — because absence alone is satisfied by a page that rendered nothing, which is the same output as one that finished.

The skeleton keeps its own test rather than losing the coverage that found the `min-w-0` defect, with the schema response held open so that state is what is on screen when the measurement runs; on a warm dev server it lasts a few frames and the test would otherwise race into the editor. Each test asserts which state it is looking at, so neither can quietly become a second copy of the other.

**The source tripwire missed the leading important prefix.** Compiled against this repository Tailwind 4.3.2, both `!-mx-8` and `-mx-8!` emit `margin-inline: calc(var(--spacing) * -8) !important`. The trailing form was already matched — the quote before it is in the boundary class — but `!` itself was not, so the leading form passed. Controls added for both spellings.

## Verification

Run against `main` after the cherry-pick, not against the old branch:

- e2e `page-measure.spec.ts` **6/6**
- tripwire unit test **4/4**
- `fallow` **pass**, zero introduced
- break-verified: a `-2rem` inline margin on the LOADED `EntryForm` fails `/collections/posts/create` with `overLeft: 32, overRight: 32`, while the skeleton test stays green. That break is invisible on `main` today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of important utility styles, including leading and variant-prefixed forms, for more accurate layout behavior.
  - Improved page readiness detection by recognizing loading placeholders and rejecting alert or page-level error states before completing measurements.

- **Tests**
  - Added coverage for important-style variations to prevent regressions.
  - Expanded end-to-end coverage for delayed loading, failed API-key loading, and visible loading skeletons.
  - Improved page measurement reliability by waiting for content to fully load before recording results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->