### PR TITLE
feat(blocks-engine): emit a page's breakpoints for a preview surface

### DIFF
--- a/.changeset/preview-a-page-at-a-breakpoint.md
+++ b/.changeset/preview-a-page-at-a-breakpoint.md
@@ -1,0 +1,43 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The editor can compile a page for a preview surface that is not the browser window.
+
+A responsive breakpoint says "apply below this width" and asks the browser window. An editor that
+shows the page inside a resizable box shares that window, so narrowing the box changes nothing about
+which rules apply — the block gets narrower and keeps its widest styling. This adds an option that
+emits those breakpoints against the box instead, so a preview shows what the page will actually look
+like at that width.
+
+Published pages are untouched. The option is off unless a caller asks for it, so a page's compiled
+stylesheet and its cached identity are byte-for-byte what they were.
+
+Breakpoints that respond to a block's own container are deliberately not previewable this way, and
+are emitted so that they match nothing rather than matching the preview box — a container breakpoint
+depends on where the block sits, and showing it against the surrounding editor would be wrong in a
+way that looks right.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -511,6 +511,7 @@ export {
   MAX_PREVIEW_CONTAINER_LENGTH,
   PREVIEW_VIEWPORT_CONTAINER,
   UNPREVIEWABLE_CONTAINER,
+  previewContainerFor,
   previewContainerName,
   type BreakpointContextOptions,
 } from "./style/compile-page";

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -506,9 +506,6 @@ export {
 
 /**
  * Emitting a page's breakpoints for a surface that is not the published page.
- *
- * Appended rather than folded into the `compile-page` export above, so that
- * three lanes editing this file at once collide on nothing.
  */
 export {
   PREVIEW_VIEWPORT_CONTAINER,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -503,3 +503,15 @@ export {
   type RichTextNode,
   type RichTextValue,
 } from "./rich-text";
+
+/**
+ * Emitting a page's breakpoints for a surface that is not the published page.
+ *
+ * Appended rather than folded into the `compile-page` export above, so that
+ * three lanes editing this file at once collide on nothing.
+ */
+export {
+  PREVIEW_VIEWPORT_CONTAINER,
+  UNPREVIEWABLE_CONTAINER,
+  type BreakpointContextOptions,
+} from "./style/compile-page";

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -508,7 +508,9 @@ export {
  * Emitting a page's breakpoints for a surface that is not the published page.
  */
 export {
+  MAX_PREVIEW_CONTAINER_LENGTH,
   PREVIEW_VIEWPORT_CONTAINER,
   UNPREVIEWABLE_CONTAINER,
+  previewContainerName,
   type BreakpointContextOptions,
 } from "./style/compile-page";

--- a/packages/blocks-engine/src/style/breakpoint-preview.test.ts
+++ b/packages/blocks-engine/src/style/breakpoint-preview.test.ts
@@ -1,0 +1,165 @@
+/**
+ * What an editor-only preview compile may and may not change.
+ *
+ * The option exists because `@media` asks the browser WINDOW. A surface that
+ * shows the page inside a resizable box shares that window, so narrowing the
+ * box changes nothing about which rules apply — the block gets narrower and
+ * keeps its widest styling. A container query asked of the box answers about
+ * the box.
+ *
+ * Two properties pull in opposite directions and both are asserted here,
+ * because satisfying either alone is worse than not having the option:
+ *
+ * - OFF must be byte-identical to what it was before the option existed, or
+ *   every stored artifact on the site invalidates for CSS that did not change.
+ * - ON must be unmistakable, or a preview sheet and a published sheet can be
+ *   confused for one another — and a visitor's page has no preview container,
+ *   so its viewport rules would match nothing and every responsive style would
+ *   silently vanish from the live site.
+ *
+ * @module breakpoint-preview.test
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BreakpointSet } from "../document";
+import {
+  PREVIEW_VIEWPORT_CONTAINER,
+  UNPREVIEWABLE_CONTAINER,
+  breakpointContexts,
+} from "./compile-page";
+
+/** Both axes populated, so neither can pass by being empty. */
+const set = (): BreakpointSet =>
+  ({
+    viewport: [
+      { id: "tablet", label: "Tablet", maxWidth: 991 },
+      { id: "mobile", label: "Mobile", maxWidth: 575 },
+    ],
+    container: [
+      { id: "card-wide", label: "Card wide" },
+      { id: "card-narrow", label: "Card narrow", maxWidth: 400 },
+    ],
+  }) as unknown as BreakpointSet;
+
+const ruleFor = (
+  contexts: readonly { id: string; atRule?: string }[],
+  id: string
+): string | undefined => contexts.find(context => context.id === id)?.atRule;
+
+describe("a published compile", () => {
+  it("is untouched by the option existing", () => {
+    /*
+     * The artifact identity a caller derives from these contexts is the whole
+     * of the stamp's breakpoint half, so anything that moved here would
+     * invalidate every artifact on the site for CSS that did not change by a
+     * byte — the exact failure the stamp's own comment says it was written to
+     * prevent.
+     *
+     * Asserted as a DEEP EQUALITY between the defaulted call and the explicitly
+     * empty one, and separately on the at-rule text, so neither an added field
+     * nor a changed string can pass.
+     */
+    const contexts = breakpointContexts(set());
+
+    expect(contexts).toEqual(breakpointContexts(set(), {}));
+    expect(ruleFor(contexts, "tablet")).toBe("@media (max-width: 991px)");
+    expect(ruleFor(contexts, "card-narrow")).toBe(
+      "@container (max-width: 400px)"
+    );
+    expect(ruleFor(contexts, "card-wide")).toBe("@container (min-width: 0)");
+  });
+
+  it("carries no preview name anywhere, on either axis", () => {
+    // The separating property for the stamp: a published context that mentioned
+    // a preview container would be indistinguishable from a preview one, and the
+    // cache keyed on these could then serve either for the other.
+    const text = JSON.stringify(breakpointContexts(set()));
+
+    expect(text).not.toContain(PREVIEW_VIEWPORT_CONTAINER);
+    expect(text).not.toContain(UNPREVIEWABLE_CONTAINER);
+  });
+});
+
+describe("a preview compile", () => {
+  it("asks the previewing BOX about viewport breakpoints, not the window", () => {
+    /*
+     * The whole point. `@media` resolves against the window the surface shares,
+     * so a box narrowed to 991px inside a 1600px window applies nothing.
+     */
+    const contexts = breakpointContexts(set(), {
+      previewContainer: PREVIEW_VIEWPORT_CONTAINER,
+    });
+
+    expect(ruleFor(contexts, "tablet")).toBe(
+      `@container ${PREVIEW_VIEWPORT_CONTAINER} (max-width: 991px)`
+    );
+    expect(ruleFor(contexts, "mobile")).toBe(
+      `@container ${PREVIEW_VIEWPORT_CONTAINER} (max-width: 575px)`
+    );
+    // And no viewport rule is left asking the window.
+    expect(JSON.stringify(contexts)).not.toContain("@media");
+  });
+
+  it("NAMES the container axis to something nothing carries", () => {
+    /*
+     * The hazard that is invisible until it is looked for. An UNNAMED container
+     * query resolves against the nearest ancestor with `container-type` set —
+     * named or not — so once the previewing surface makes its box a query
+     * container, the container-axis rules would start matching against that box
+     * for every node with no authored container ancestor. The editor would then
+     * show container styles the published page does not: the same lying preview,
+     * pointing the other way.
+     *
+     * Asserted on BOTH forms, because the unbounded one is emitted through a
+     * different branch and `min-width: 0` is precisely the query written to
+     * match inside any container.
+     */
+    const contexts = breakpointContexts(set(), {
+      previewContainer: PREVIEW_VIEWPORT_CONTAINER,
+    });
+
+    expect(ruleFor(contexts, "card-narrow")).toBe(
+      `@container ${UNPREVIEWABLE_CONTAINER} (max-width: 400px)`
+    );
+    expect(ruleFor(contexts, "card-wide")).toBe(
+      `@container ${UNPREVIEWABLE_CONTAINER} (min-width: 0)`
+    );
+    expect(UNPREVIEWABLE_CONTAINER).not.toBe(PREVIEW_VIEWPORT_CONTAINER);
+  });
+
+  it("keeps every context id, so no stored style becomes unknown", () => {
+    /*
+     * Named rather than omitted. Dropping the container contexts would be the
+     * simpler way to stop them matching, and it would turn every style stored
+     * at a container breakpoint into an `unknown-breakpoint` warning on every
+     * render — a document that was correct yesterday reporting itself broken.
+     *
+     * Compared against the published call rather than a literal list, so the
+     * property survives any future change to what a site's contexts are.
+     */
+    const published = breakpointContexts(set()).map(context => context.id);
+    const previewed = breakpointContexts(set(), {
+      previewContainer: PREVIEW_VIEWPORT_CONTAINER,
+    }).map(context => context.id);
+
+    // The POPULATION first: two empty lists are equal and would prove nothing.
+    expect(published.length).toBeGreaterThan(1);
+    expect(previewed).toEqual(published);
+  });
+
+  it("cannot be mistaken for a published compile", () => {
+    /*
+     * The consequence the stamp exists to prevent, stated as its own assertion
+     * rather than left to follow from the at-rule tests. A visitor's page has no
+     * preview container, so a preview sheet served to one matches nothing and
+     * every responsive style vanishes from the live page.
+     */
+    expect(
+      JSON.stringify(
+        breakpointContexts(set(), {
+          previewContainer: PREVIEW_VIEWPORT_CONTAINER,
+        })
+      )
+    ).not.toBe(JSON.stringify(breakpointContexts(set())));
+  });
+});

--- a/packages/blocks-engine/src/style/breakpoint-preview.test.ts
+++ b/packages/blocks-engine/src/style/breakpoint-preview.test.ts
@@ -30,6 +30,7 @@ import {
   compilePageCss,
   previewContainerName,
 } from "./compile-page";
+import { EMITTABLE_STRING_BOUNDS } from "./emittable-string-bounds";
 import { compileSiteSheet } from "./site-sheet";
 
 /** Both axes populated, so neither can pass by being empty. */
@@ -274,6 +275,19 @@ describe("the preview container name", () => {
       UNPREVIEWABLE_CONTAINER,
       "has space",
       "1leading-digit",
+      // CSS-wide keywords and `none` match the identifier shape and are
+      // excluded from a `<custom-ident>` anyway. Emitted, they produce an
+      // at-rule the browser drops AND a `container-name` the surface cannot
+      // declare — so the preview loses its rules rather than degrading to the
+      // published compile the way every other refusal here does.
+      "none",
+      "NONE",
+      "initial",
+      "inherit",
+      "unset",
+      "revert",
+      "revert-layer",
+      "default",
       "){color:red}",
       "a".repeat(MAX_PREVIEW_CONTAINER_LENGTH + 1),
       undefined,
@@ -362,5 +376,30 @@ describe("the shared site tier", () => {
 
     expect(published.css).toContain("@media (max-width: 991px)");
     expect(published.css).not.toContain(PREVIEW_VIEWPORT_CONTAINER);
+  });
+});
+
+describe("the bound on a preview container name", () => {
+  it("is registered in the catalog that promises to list every one", () => {
+    /*
+     * `EMITTABLE_STRING_BOUNDS` exists so a consumer choosing a digest
+     * truncation can verify it against the producer's own set rather than a
+     * prose description of it. A caller-controlled string the compiler writes
+     * into CSS and does not register is exactly the member such a consumer
+     * silently stops covering.
+     *
+     * The larger style-value entry happens to mask this one today, so the
+     * omission costs nothing until that unrelated bound changes — which is what
+     * makes it worth pinning rather than leaving to be noticed.
+     *
+     * Asserted by MATCHING the constant rather than a literal, so the entry
+     * cannot drift from the cap it describes.
+     */
+    const entry = EMITTABLE_STRING_BOUNDS.find(bound =>
+      bound.what.includes("preview container")
+    );
+
+    expect(entry).toBeDefined();
+    expect(entry?.max).toBe(MAX_PREVIEW_CONTAINER_LENGTH);
   });
 });

--- a/packages/blocks-engine/src/style/breakpoint-preview.test.ts
+++ b/packages/blocks-engine/src/style/breakpoint-preview.test.ts
@@ -123,12 +123,20 @@ describe("a preview compile", () => {
       previewContainer: PREVIEW_VIEWPORT_CONTAINER,
     });
 
-    expect(ruleFor(contexts, "card-narrow")).toBe(
-      `@container ${UNPREVIEWABLE_CONTAINER} (max-width: 400px)`
-    );
-    expect(ruleFor(contexts, "card-wide")).toBe(
-      `@container ${UNPREVIEWABLE_CONTAINER} (min-width: 0)`
-    );
+    /*
+     * An UNSATISFIABLE condition, not merely an unused name. A CSS identifier
+     * cannot be reserved globally — blocks render host-defined markup and
+     * stylesheets, so anything may declare `container-name: nx-not-previewable`,
+     * and a rule kept inert only by nobody using that name becomes live the
+     * moment somebody does. A width is never negative, so `(width < 0px)` is
+     * false against every container whatever names are in scope.
+     */
+    expect(ruleFor(contexts, "card-narrow")).toContain("(width < 0px)");
+    expect(ruleFor(contexts, "card-wide")).toContain("(width < 0px)");
+    // And the bound they would otherwise have matched on is gone entirely, so
+    // no browser can evaluate them against a real container width.
+    expect(ruleFor(contexts, "card-narrow")).not.toContain("400px");
+    expect(ruleFor(contexts, "card-wide")).not.toContain("min-width: 0");
     expect(UNPREVIEWABLE_CONTAINER).not.toBe(PREVIEW_VIEWPORT_CONTAINER);
   });
 
@@ -401,5 +409,32 @@ describe("the bound on a preview container name", () => {
 
     expect(entry).toBeDefined();
     expect(entry?.max).toBe(MAX_PREVIEW_CONTAINER_LENGTH);
+  });
+});
+
+describe("refusing an oversized name", () => {
+  it("does not scan the whole string to reach a refusal", () => {
+    /*
+     * The raw length is checked before `trim` or any other linear pass. This
+     * name is caller-controlled and is normalised again while deriving artifact
+     * identities, so the scan would recur on render paths rather than once.
+     *
+     * Asserted on the ANSWER as well as on the size, since a correct refusal is
+     * the property and the early exit is how it is reached: a megabyte of
+     * whitespace still refuses, and refuses for the length rather than for
+     * being blank after trimming.
+     */
+    const huge = " ".repeat(1_000_000) + "nx-box";
+
+    expect(previewContainerName(huge)).toBeUndefined();
+    // And a value that only fits AFTER trimming is refused too, because
+    // trimming cannot make an over-cap string legal.
+    expect(
+      previewContainerName(` ${"a".repeat(MAX_PREVIEW_CONTAINER_LENGTH)} `)
+    ).toBeUndefined();
+    // The control: at the cap with no padding, still accepted.
+    expect(previewContainerName("a".repeat(MAX_PREVIEW_CONTAINER_LENGTH))).toBe(
+      "a".repeat(MAX_PREVIEW_CONTAINER_LENGTH)
+    );
   });
 });

--- a/packages/blocks-engine/src/style/breakpoint-preview.test.ts
+++ b/packages/blocks-engine/src/style/breakpoint-preview.test.ts
@@ -21,11 +21,12 @@
  */
 import { describe, expect, it } from "vitest";
 
-import type { BreakpointSet } from "../document";
+import type { BlockDocument, BreakpointSet } from "../document";
 import {
   PREVIEW_VIEWPORT_CONTAINER,
   UNPREVIEWABLE_CONTAINER,
   breakpointContexts,
+  compilePageCss,
 } from "./compile-page";
 
 /** Both axes populated, so neither can pass by being empty. */
@@ -161,5 +162,84 @@ describe("a preview compile", () => {
         })
       )
     ).not.toBe(JSON.stringify(breakpointContexts(set())));
+  });
+});
+
+/** One node styled at a breakpoint, and hidden at one while shown at another. */
+function page(): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      {
+        id: "a",
+        type: "acme/text",
+        version: 1,
+        props: {},
+        styles: { base: { tablet: { color: "magenta" } } },
+        visibility: { devices: { tablet: false, mobile: true } },
+      },
+    ],
+  } as unknown as BlockDocument;
+}
+
+describe("the compiler entry point", () => {
+  it("emits a preview sheet, not only preview CONTEXTS", () => {
+    /*
+     * The option is worth nothing if it stops at the normalisation helper. An
+     * editor compiles through `compilePageCss`, so a sheet that still carried
+     * `@media` would leave the whole feature unreachable from the only entry
+     * point a caller has — the shape where a change is complete, tested, and
+     * never runs.
+     *
+     * Asserted on the EMITTED CSS rather than on the contexts, because that is
+     * the artifact the browser reads.
+     */
+    const previewed = compilePageCss(page(), {
+      breakpoints: set(),
+      previewContainer: PREVIEW_VIEWPORT_CONTAINER,
+    });
+
+    // The population first: an empty sheet contains no `@media` either.
+    expect(previewed.css).toContain("magenta");
+    expect(previewed.css).toContain(
+      `@container ${PREVIEW_VIEWPORT_CONTAINER} (max-width: 991px)`
+    );
+    expect(previewed.css).not.toContain("@media");
+  });
+
+  it("leaves a published compile emitting @media, which is the control", () => {
+    // Without this, a compiler that emitted container queries unconditionally
+    // would satisfy the case above while breaking every published page.
+    const published = compilePageCss(page(), { breakpoints: set() });
+
+    expect(published.css).toContain("@media (max-width: 991px)");
+    expect(published.css).not.toContain(PREVIEW_VIEWPORT_CONTAINER);
+  });
+
+  it("keeps a VISIBILITY band under the same query as the styles", () => {
+    /*
+     * A band is emitted through a different path — `boundedAtRule` builds a
+     * lower-bounded query rather than reusing the context's own at-rule — and
+     * while that path derived its keyword from the axis alone, a previewed page
+     * kept `@media` for visibility while its styles had moved to a container
+     * query. A node could then be styled for a width it was simultaneously
+     * hidden at, and the two would disagree only under preview.
+     *
+     * The fixture hides at `tablet` and shows again at `mobile`, which is what
+     * makes the band bounded rather than a plain `max-width` rule.
+     */
+    const previewed = compilePageCss(page(), {
+      breakpoints: set(),
+      previewContainer: PREVIEW_VIEWPORT_CONTAINER,
+    });
+
+    expect(previewed.css).toContain("width >");
+    // Every bounded band is asked of the preview box, none of the window.
+    for (const rule of previewed.css.split("}")) {
+      if (rule.includes("width >")) {
+        expect(rule).toContain(`@container ${PREVIEW_VIEWPORT_CONTAINER}`);
+      }
+    }
   });
 });

--- a/packages/blocks-engine/src/style/breakpoint-preview.test.ts
+++ b/packages/blocks-engine/src/style/breakpoint-preview.test.ts
@@ -19,7 +19,7 @@
  *
  * @module breakpoint-preview.test
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { BlockDocument, BreakpointSet } from "../document";
 import {
@@ -420,20 +420,53 @@ describe("refusing an oversized name", () => {
      * name is caller-controlled and is normalised again while deriving artifact
      * identities, so the scan would recur on render paths rather than once.
      *
-     * Asserted on the ANSWER as well as on the size, since a correct refusal is
-     * the property and the early exit is how it is reached: a megabyte of
-     * whitespace still refuses, and refuses for the length rather than for
-     * being blank after trimming.
+     * Asserted by OBSERVING the linear pass, not by the answer.
+     *
+     * The answer cannot separate the two implementations: check-then-trim and
+     * trim-then-check both return `undefined` for an over-cap string, so a test
+     * reading only the result stays green against the version this exists to
+     * forbid. What distinguishes them is whether `trim` runs at all, so the spy
+     * is the assertion rather than an aid to it.
      */
-    const huge = " ".repeat(1_000_000) + "nx-box";
+    const trim = vi.spyOn(String.prototype, "trim");
+    try {
+      const huge = " ".repeat(1_000_000) + "nx-box";
 
-    expect(previewContainerName(huge)).toBeUndefined();
-    // And a value that only fits AFTER trimming is refused too, because
-    // trimming cannot make an over-cap string legal.
+      expect(previewContainerName(huge)).toBeUndefined();
+      expect(trim).not.toHaveBeenCalled();
+
+      /*
+       * The control, and it is what makes the silence above mean anything: a
+       * `previewContainerName` that had stopped trimming entirely — or one the
+       * spy simply never reached — would satisfy the assertion above perfectly.
+       * An accepted name must still take the trimming path.
+       */
+      const accepted = `  nx-box  `;
+      expect(previewContainerName(accepted)).toBe("nx-box");
+      expect(trim).toHaveBeenCalled();
+    } finally {
+      // Restored in `finally` so a failed expectation above does not leave
+      // every later test in this file running against a spied prototype.
+      trim.mockRestore();
+    }
+  });
+
+  it("refuses a name that would only FIT after trimming", () => {
+    /*
+     * A consequence of the bound being on the raw input, and a deliberate one
+     * rather than an accident of ordering: a name of exactly the cap's length
+     * wrapped in spaces is legal once trimmed and is refused anyway.
+     *
+     * That is the intended reading of the published bound — it describes the
+     * string a caller hands over, so a consumer digesting these inputs can
+     * check the value it holds rather than a trimmed form it would have to
+     * derive first.
+     */
     expect(
       previewContainerName(` ${"a".repeat(MAX_PREVIEW_CONTAINER_LENGTH)} `)
     ).toBeUndefined();
-    // The control: at the cap with no padding, still accepted.
+    // At the cap with no padding, still accepted — so the refusal above is
+    // about the padding rather than about the length being unusable.
     expect(previewContainerName("a".repeat(MAX_PREVIEW_CONTAINER_LENGTH))).toBe(
       "a".repeat(MAX_PREVIEW_CONTAINER_LENGTH)
     );
@@ -515,11 +548,59 @@ describe("a per-surface preview container", () => {
 
   it("reduces an opaque seed rather than refusing it", () => {
     // A caller passing an id from elsewhere should not have to know this
-    // function's rules; a seed that cannot be made safe falls back rather than
-    // yielding a name the compiler would refuse.
+    // function's rules; whatever it hands over yields a name the compiler
+    // accepts.
     expect(previewContainerName(previewContainerFor(":r1:"))).toBeDefined();
-    expect(previewContainerName(previewContainerFor("x".repeat(500)))).toBe(
-      PREVIEW_VIEWPORT_CONTAINER
-    );
+  });
+
+  it("DIGESTS a seed too long to carry, rather than sharing the default", () => {
+    /*
+     * The case the fallback got wrong, and it failed toward the hazard.
+     *
+     * Prefixed, a seed over about fifty characters exceeds the emitted-name
+     * bound. Returning `PREVIEW_VIEWPORT_CONTAINER` there handed exactly the
+     * surfaces most likely to carry long ids — document paths, composite keys,
+     * opaque route ids — the one globally predictable name this function exists
+     * to avoid, so third-party markup declaring that name could capture their
+     * viewport queries again.
+     *
+     * Asserted as "accepted AND not the default", because either alone passes on
+     * a broken implementation: the old fallback returned an accepted name, and
+     * a function returning some other refused string is not the default either.
+     */
+    const long = previewContainerFor("x".repeat(500));
+
+    expect(previewContainerName(long)).toBe(long);
+    expect(long).not.toBe(PREVIEW_VIEWPORT_CONTAINER);
+  });
+
+  it("gives two long seeds DIFFERENT names, which is the whole point", () => {
+    /*
+     * The control. A digest that ignored its input, or a function returning one
+     * constant, satisfies "accepted and not the default" above perfectly — the
+     * assertion there is about one name's shape, and this is about the property
+     * the name is for.
+     *
+     * The two seeds differ only in a character the identifier reduction
+     * collapses, which is why the digest reads the ORIGINAL seed: reduced first,
+     * `a/b` and `a:b` are one string and the names would legitimately collide.
+     */
+    const a = previewContainerFor(`${"x".repeat(500)}a/b`);
+    const b = previewContainerFor(`${"x".repeat(500)}a:b`);
+
+    expect(a).not.toBe(b);
+  });
+
+  it("gives one seed the SAME name every time, so a render can hydrate", () => {
+    /*
+     * Stability across the server/client boundary is why the seed is the
+     * caller's rather than generated here. A name that differed between the two
+     * renders would leave the preview matching nothing on exactly the first
+     * paint — and React would not complain, because the container name lives in
+     * a style the sheet queries rather than in the markup it compares.
+     */
+    const seed = "y".repeat(500);
+
+    expect(previewContainerFor(seed)).toBe(previewContainerFor(seed));
   });
 });

--- a/packages/blocks-engine/src/style/breakpoint-preview.test.ts
+++ b/packages/blocks-engine/src/style/breakpoint-preview.test.ts
@@ -23,11 +23,14 @@ import { describe, expect, it } from "vitest";
 
 import type { BlockDocument, BreakpointSet } from "../document";
 import {
+  MAX_PREVIEW_CONTAINER_LENGTH,
   PREVIEW_VIEWPORT_CONTAINER,
   UNPREVIEWABLE_CONTAINER,
   breakpointContexts,
   compilePageCss,
+  previewContainerName,
 } from "./compile-page";
+import { compileSiteSheet } from "./site-sheet";
 
 /** Both axes populated, so neither can pass by being empty. */
 const set = (): BreakpointSet =>
@@ -241,5 +244,123 @@ describe("the compiler entry point", () => {
         expect(rule).toContain(`@container ${PREVIEW_VIEWPORT_CONTAINER}`);
       }
     }
+  });
+});
+
+describe("the preview container name", () => {
+  it("refuses every name it could not emit safely", () => {
+    /*
+     * Refused rather than escaped, because a name needing transformation would
+     * no longer match the `container-name` the previewing surface declared —
+     * so escaping produces a sheet that parses and matches nothing, which is
+     * strictly worse than a sheet that is merely not previewable.
+     *
+     * Each rejection is a different failure, so each is named:
+     *
+     * - empty or blank emits `@container (max-width: N)` with NO name, which
+     *   binds to the nearest ancestor query container — an author's own
+     *   included. That is the capture the container axis is named to avoid.
+     * - the reserved unpreviewable name aims the viewport axis at the same
+     *   container as the container axis, making the deliberately inert rules
+     *   live against the preview box.
+     * - punctuation can close the at-rule and open something else.
+     * - over the bound, because the name is copied into every preview at-rule
+     *   and a caller digesting these inputs truncates at what this package
+     *   promises.
+     */
+    for (const refused of [
+      "",
+      "   ",
+      UNPREVIEWABLE_CONTAINER,
+      "has space",
+      "1leading-digit",
+      "){color:red}",
+      "a".repeat(MAX_PREVIEW_CONTAINER_LENGTH + 1),
+      undefined,
+      42,
+    ]) {
+      expect(previewContainerName(refused)).toBeUndefined();
+    }
+  });
+
+  it("accepts an ordinary identifier, which is the control", () => {
+    // Without this, a validator refusing everything would satisfy the case
+    // above and no preview could ever be compiled.
+    expect(previewContainerName(PREVIEW_VIEWPORT_CONTAINER)).toBe(
+      PREVIEW_VIEWPORT_CONTAINER
+    );
+    expect(previewContainerName("  nx-box  ")).toBe("nx-box");
+    expect(previewContainerName("a".repeat(MAX_PREVIEW_CONTAINER_LENGTH))).toBe(
+      "a".repeat(MAX_PREVIEW_CONTAINER_LENGTH)
+    );
+  });
+
+  it("degrades a refused name to a PUBLISHED compile, not a broken one", () => {
+    /*
+     * The consequence of refusing, asserted at the compiler rather than at the
+     * validator. A refused name must leave the sheet exactly as a published one
+     * — not emit an unnamed container query, which is the capture being
+     * prevented.
+     */
+    const refused = compilePageCss(page(), {
+      breakpoints: set(),
+      previewContainer: UNPREVIEWABLE_CONTAINER,
+    });
+
+    expect(refused.css).toContain("@media (max-width: 991px)");
+    expect(refused.css).not.toContain(
+      `@container ${UNPREVIEWABLE_CONTAINER} (max-width: 991px)`
+    );
+    expect(refused.css).toBe(
+      compilePageCss(page(), { breakpoints: set() }).css
+    );
+  });
+});
+
+describe("the shared site tier", () => {
+  /** A named class carrying a value at a viewport breakpoint. */
+  const classes = () =>
+    [
+      {
+        id: "cls-1",
+        slug: "card",
+        orderIndex: 0,
+        styles: { base: { tablet: { color: "teal" } } },
+      },
+    ] as never;
+
+  it("answers the breakpoint question the same way the page tier does", () => {
+    /*
+     * A separate compile, and it was answering separately. The shared classes
+     * and block defaults are emitted into the same document as the node-local
+     * declarations, so a site sheet compiled for the published page beneath
+     * node styles compiled for a preview surface puts two answers to one
+     * breakpoint in one stylesheet — and a container-axis rule from this tier
+     * could still match a real authored container while the node's own rule at
+     * that breakpoint is aimed at a name nothing carries.
+     */
+    const previewed = compileSiteSheet({
+      breakpoints: set(),
+      classes: classes(),
+      previewContainer: PREVIEW_VIEWPORT_CONTAINER,
+    } as never);
+
+    // The population first: a sheet that emitted no class rule at all would
+    // contain no `@media` either and satisfy the negative half by vacuity.
+    expect(previewed.css).toContain("teal");
+    expect(previewed.css).toContain(
+      `@container ${PREVIEW_VIEWPORT_CONTAINER} (max-width: 991px)`
+    );
+    expect(previewed.css).not.toContain("@media");
+  });
+
+  it("still emits @media without the option, which is the control", () => {
+    const published = compileSiteSheet({
+      breakpoints: set(),
+      classes: classes(),
+    } as never);
+
+    expect(published.css).toContain("@media (max-width: 991px)");
+    expect(published.css).not.toContain(PREVIEW_VIEWPORT_CONTAINER);
   });
 });

--- a/packages/blocks-engine/src/style/breakpoint-preview.test.ts
+++ b/packages/blocks-engine/src/style/breakpoint-preview.test.ts
@@ -451,6 +451,39 @@ describe("refusing an oversized name", () => {
     }
   });
 
+  it("refuses the container-query QUERY keywords, which the grammar excludes", () => {
+    /*
+     * `@container <name>? <condition>` puts the name and the condition adjacent
+     * with nothing between them, so these are not merely unusual names — they
+     * change what the at-rule MEANS.
+     *
+     * `and` and `or` produce `@container and (max-width: 991px)`, which is a
+     * malformed condition rather than a container named `and`, and a browser
+     * drops the rule. `not` is the worse one because it PARSES: it reads as the
+     * negation of the condition that follows, so the rule applies at exactly
+     * the widths the author meant to exclude.
+     *
+     * Case-insensitively, because CSS keywords are, and a caller passing `AND`
+     * would otherwise establish a container whose rules are dropped just the
+     * same.
+     */
+    for (const keyword of ["and", "or", "not", "AND", "Not", "OR"]) {
+      expect(previewContainerName(keyword)).toBeUndefined();
+    }
+  });
+
+  it("still ACCEPTS a name merely CONTAINING one, which is the control", () => {
+    /*
+     * Without this, refusing every name with those letters anywhere in it would
+     * satisfy the case above while rejecting ordinary identifiers — `nx-android`
+     * and `nx-notes` are legal container names and a surface seeded from a
+     * document slug will produce them.
+     */
+    expect(previewContainerName("nx-android")).toBe("nx-android");
+    expect(previewContainerName("nx-notes")).toBe("nx-notes");
+    expect(previewContainerName("brand-or-theme")).toBe("brand-or-theme");
+  });
+
   it("refuses a name that would only FIT after trimming", () => {
     /*
      * A consequence of the bound being on the raw input, and a deliberate one

--- a/packages/blocks-engine/src/style/breakpoint-preview.test.ts
+++ b/packages/blocks-engine/src/style/breakpoint-preview.test.ts
@@ -28,6 +28,7 @@ import {
   UNPREVIEWABLE_CONTAINER,
   breakpointContexts,
   compilePageCss,
+  previewContainerFor,
   previewContainerName,
 } from "./compile-page";
 import { EMITTABLE_STRING_BOUNDS } from "./emittable-string-bounds";
@@ -435,6 +436,90 @@ describe("refusing an oversized name", () => {
     // The control: at the cap with no padding, still accepted.
     expect(previewContainerName("a".repeat(MAX_PREVIEW_CONTAINER_LENGTH))).toBe(
       "a".repeat(MAX_PREVIEW_CONTAINER_LENGTH)
+    );
+  });
+});
+
+describe("a bounded visibility band on the container axis", () => {
+  it("keeps the impossible condition rather than rebuilding a named query", () => {
+    /*
+     * A band is emitted through a different path from the context it belongs
+     * to, and rebuilding its wrapper from the prefix alone dropped the
+     * impossible condition — leaving a merely NAMED query an authored ancestor
+     * could satisfy. The node's styles would stay impossible while its
+     * visibility band went live, so preview visibility disagreed with preview
+     * styling in the one direction nobody would look.
+     */
+    const page = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "a",
+          type: "acme/text",
+          version: 1,
+          props: {},
+          styles: { base: { "card-narrow": { color: "magenta" } } },
+          visibility: {
+            devices: { "card-wide": false, "card-narrow": true },
+          },
+        },
+      ],
+    } as unknown as BlockDocument;
+
+    /*
+     * The POPULATION comes from the PUBLISHED compile, because that is where a
+     * bounded band takes its recognisable form. Under preview the band is the
+     * impossible condition itself, so looking for `width >` there would find
+     * nothing whether the fix worked or not — an assertion satisfied by absence.
+     */
+    const published = compilePageCss(page, { breakpoints: set() }).css;
+    expect(published).toContain("width >");
+
+    const previewed = compilePageCss(page, {
+      breakpoints: set(),
+      previewContainer: PREVIEW_VIEWPORT_CONTAINER,
+    }).css;
+
+    // No band survives with a real bound to be satisfied against.
+    expect(previewed).not.toContain("width >");
+    // And every container-axis rule still carries the impossibility.
+    for (const rule of previewed.split("}")) {
+      if (rule.includes(UNPREVIEWABLE_CONTAINER)) {
+        expect(rule).toContain("(width < 0px)");
+      }
+    }
+  });
+});
+
+describe("a per-surface preview container", () => {
+  it("differs per seed, so an authored name cannot shadow every surface", () => {
+    /*
+     * The default is a globally predictable identifier, and a nearer ancestor
+     * declaring `container: nx-preview-viewport / inline-size` satisfies the
+     * named query first — so viewport tiers would follow that inner element
+     * rather than the preview box. The container axis is protected by an
+     * impossible condition; the viewport axis cannot be, because it has to
+     * match something.
+     */
+    expect(previewContainerFor("a1")).not.toBe(previewContainerFor("b2"));
+    // Derived from the seed rather than generated, so a server render and a
+    // client hydration produce the SAME string — a random one would differ
+    // across that boundary and match nothing on first paint.
+    expect(previewContainerFor("a1")).toBe(previewContainerFor("a1"));
+    // And whatever it produces is a name the compiler will actually emit.
+    expect(previewContainerName(previewContainerFor("a1"))).toBe(
+      previewContainerFor("a1")
+    );
+  });
+
+  it("reduces an opaque seed rather than refusing it", () => {
+    // A caller passing an id from elsewhere should not have to know this
+    // function's rules; a seed that cannot be made safe falls back rather than
+    // yielding a name the compiler would refuse.
+    expect(previewContainerName(previewContainerFor(":r1:"))).toBeDefined();
+    expect(previewContainerName(previewContainerFor("x".repeat(500)))).toBe(
+      PREVIEW_VIEWPORT_CONTAINER
     );
   });
 });

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -229,6 +229,24 @@ export interface CompiledPageCss {
    */
   scope?: string;
   /**
+   * The container these breakpoints were aimed at, when the compile was a
+   * PREVIEW one, and absent when it was published.
+   *
+   * Returned rather than assumed to equal the requested name, for the reason
+   * {@link CompiledPageCss.scope} gives about scopes: `previewContainerName`
+   * refuses an empty, reserved, malformed or oversized value and the compile
+   * falls back to published `@media`, so a caller recording what it ASKED for
+   * would stamp a published sheet as a preview one — and, worse, the reverse
+   * never happens, so the mistake is silent in exactly one direction.
+   *
+   * It is on the output because a preview sheet is not publishable: its
+   * viewport tiers are `@container` rules naming a box only the previewing
+   * surface declares, so served on a published page they match nothing and the
+   * page silently loses every breakpoint above the base one. A reader handed a
+   * stored artifact has no other way to tell the two apart.
+   */
+  previewContainer?: string;
+  /**
    * What was not written, and why. Every entry names a value that is in the
    * document and absent from the stylesheet, so "my style did nothing" always
    * has an answer.
@@ -1873,6 +1891,9 @@ export function compilePageCss(
 
   return {
     ...(effectiveScope === undefined ? {} : { scope: effectiveScope }),
+    // The NORMALISED name, so a refused one leaves this absent and the artifact
+    // reads as the published sheet it actually is.
+    ...(preview === undefined ? {} : { previewContainer: preview }),
     css: serializeRules(rules),
     warnings,
     classes: attributeClasses,

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -356,6 +356,49 @@ function emittableBound(maxWidth: unknown): boolean {
  * `@media` for its visibility while its styles had moved to a container query —
  * so a node could be styled for a width it was simultaneously hidden at.
  */
+/** The longest preview container name this compiler will emit. */
+export const MAX_PREVIEW_CONTAINER_LENGTH = 64;
+
+/**
+ * A preview container name this compiler is willing to write into an at-rule,
+ * or `undefined` for anything it is not.
+ *
+ * Refusing rather than escaping, because a name that needs escaping is not a
+ * name a caller meant: the value is a CSS custom identifier the previewing
+ * surface also has to put in its own `container-name`, so anything that would
+ * have to be transformed on the way out would no longer match what the caller
+ * declared. Refusing degrades to a published compile, which is a sheet that is
+ * merely not previewable — writing an unescaped one degrades to a stylesheet
+ * that does not parse.
+ *
+ * Four rejections, and each is a different failure:
+ *
+ * - EMPTY or blank produces `@container (max-width: N)` with no name at all,
+ *   which binds to the nearest ancestor query container — including an author's
+ *   own. That is the exact capture the container axis is named to avoid.
+ * - The RESERVED unpreviewable name aims the viewport axis at the same
+ *   container as the container axis, so the rules kept deliberately inert
+ *   become live against the preview box.
+ * - Anything outside a CSS identifier can close the at-rule and open something
+ *   else. `emittable-string-bounds.ts` requires every string this compiler
+ *   emits to be bounded, and an identifier's shape is the other half of that.
+ * - Over the bound, because the name is copied into every preview at-rule and a
+ *   caller digesting these inputs truncates at what this package promises.
+ */
+export function previewContainerName(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const name = value.trim();
+  if (name.length === 0 || name.length > MAX_PREVIEW_CONTAINER_LENGTH) {
+    return undefined;
+  }
+  if (name === UNPREVIEWABLE_CONTAINER) return undefined;
+  // A CSS custom identifier, conservatively: letters, digits, hyphen and
+  // underscore, not starting with a digit. Narrower than the grammar allows,
+  // because the escapes the full grammar permits are exactly what this refuses
+  // to emit.
+  return /^[A-Za-z_][A-Za-z0-9_-]*$/.test(name) ? name : undefined;
+}
+
 function queryPrefix(
   axis: BreakpointAxis,
   preview: string | undefined
@@ -441,7 +484,7 @@ export function breakpointContexts(
   set: BreakpointSet | undefined,
   options?: BreakpointContextOptions
 ): BreakpointContext[] {
-  const preview = options?.previewContainer;
+  const preview = previewContainerName(options?.previewContainer);
   // The base context carries no upper bound and no at-rule, but it still needs
   // to be bounded from below when a narrower breakpoint shows a node again:
   // without that, hiding at base emits an unconditional rule that a later
@@ -1204,10 +1247,15 @@ export function compilePageCss(
   // stale ids — or a document full of malformed token names — costs its own
   // diagnostics and not the page's stylesheet.
   const warningAllowance = newWarningAllowance();
+  /*
+   * Normalised ONCE for the whole compile, so the contexts and the visibility
+   * bands cannot disagree about it. Two readers of one raw field is how a
+   * refused name would have reached one path and not the other, and the sheet
+   * would then mix previewed styles with published bands.
+   */
+  const preview = previewContainerName(ctx.previewContainer);
   const contexts = breakpointContexts(ctx.breakpoints, {
-    ...(ctx.previewContainer === undefined
-      ? {}
-      : { previewContainer: ctx.previewContainer }),
+    ...(preview === undefined ? {} : { previewContainer: preview }),
   });
   const tokenPrefix = ctx.tokenPrefix ?? DEFAULT_TOKEN_PREFIX;
   const mayFetchUrl = ctx.mayFetchUrl;
@@ -1512,7 +1560,7 @@ export function compilePageCss(
         path,
         warnings,
         warningAllowance,
-        ctx.previewContainer
+        preview
       ),
     ];
     // Held out of the sheet when the node can be pruned at read time. Serialized on its own, so

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -392,6 +392,24 @@ const RESERVED_CONTAINER_NAMES: ReadonlySet<string> = new Set([
   "revert",
   "revert-layer",
   "default",
+  /*
+   * The container-query QUERY keywords, which the grammar excludes from a
+   * container name for a different reason than the CSS-wide keywords above.
+   *
+   * `@container <name>? <condition>` puts the name and the condition adjacent
+   * with nothing between them, so a name spelled `and` or `or` produces
+   * `@container and (max-width: 991px)` — not a container named `and`, but a
+   * malformed condition, which a browser drops entirely. `not` is worse than
+   * malformed: it PARSES, as the negation of the following condition, so the
+   * rule silently applies at every width the author meant to exclude.
+   *
+   * The consequence is the one this whole helper exists to prevent: the box
+   * establishes a perfectly valid named container while its responsive rules
+   * are dropped or evaluated inverted, with nothing on screen to say why.
+   */
+  "and",
+  "or",
+  "not",
 ]);
 
 /**
@@ -498,6 +516,16 @@ export const PREVIEW_VIEWPORT_CONTAINER = "nx-preview-viewport";
  * a string is the same in both. `Math.imul` and `>>> 0` keep every step inside
  * 32 bits, which plain `*` would not.
  */
+/**
+ * What every minted preview name starts with.
+ *
+ * Named because the length check above and the two constructions below must
+ * agree on it: a prefix counted as one length and written as another either
+ * sanitises a seed it did not need to, or lets an over-bound name reach
+ * `previewContainerName` and take the digest path for the wrong reason.
+ */
+const PREVIEW_SEED_PREFIX = "nx-preview-";
+
 function digest(seed: string): string {
   let a = 0x811c9dc5;
   let b = 0x01000193;
@@ -535,8 +563,24 @@ function digest(seed: string): string {
  * fallback was every long-seeded surface sharing one with THIRD-PARTY markup.
  */
 export function previewContainerFor(seed: string): string {
-  const safe = seed.replace(/[^A-Za-z0-9_-]/g, "-");
-  const literal = previewContainerName(`nx-preview-${safe}`);
+  /*
+   * The length is decided BEFORE any linear pass, the same way
+   * `previewContainerName` decides it before trimming.
+   *
+   * A seed that cannot fit under the bound once prefixed is going to be
+   * digested whatever it contains, so sanitising it first walks the whole
+   * string, allocates a full copy, builds a second oversized string in the
+   * template, and has it refused — then the digest walks the original anyway.
+   * Three passes and two allocations to reach a conclusion the length alone
+   * settles. Surfaces call this during render and again on hydration, so the
+   * work recurs rather than happening once.
+   */
+  const literal =
+    PREVIEW_SEED_PREFIX.length + seed.length > MAX_PREVIEW_CONTAINER_LENGTH
+      ? undefined
+      : previewContainerName(
+          `${PREVIEW_SEED_PREFIX}${seed.replace(/[^A-Za-z0-9_-]/g, "-")}`
+        );
   if (literal !== undefined) return literal;
   /*
    * Digested from the ORIGINAL seed rather than the reduced form, so two seeds
@@ -544,7 +588,7 @@ export function previewContainerFor(seed: string): string {
    * become `a-b` — still produce different names.
    */
   return (
-    previewContainerName(`nx-preview-${digest(seed)}`) ??
+    previewContainerName(`${PREVIEW_SEED_PREFIX}${digest(seed)}`) ??
     PREVIEW_VIEWPORT_CONTAINER
   );
 }

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -360,6 +360,23 @@ function emittableBound(maxWidth: unknown): boolean {
 export const MAX_PREVIEW_CONTAINER_LENGTH = 64;
 
 /**
+ * Names a `<custom-ident>` may not take, whatever its shape.
+ *
+ * `none` is excluded from `container-name` by its own grammar, and the CSS-wide
+ * keywords are excluded from every custom identifier. Matching the identifier
+ * pattern is therefore necessary and not sufficient.
+ */
+const RESERVED_CONTAINER_NAMES: ReadonlySet<string> = new Set([
+  "none",
+  "initial",
+  "inherit",
+  "unset",
+  "revert",
+  "revert-layer",
+  "default",
+]);
+
+/**
  * A preview container name this compiler is willing to write into an at-rule,
  * or `undefined` for anything it is not.
  *
@@ -392,6 +409,12 @@ export function previewContainerName(value: unknown): string | undefined {
     return undefined;
   }
   if (name === UNPREVIEWABLE_CONTAINER) return undefined;
+  // The CSS-wide keywords and `none`, which the grammar excludes from a
+  // `<custom-ident>` however well they match its shape. Emitted, they make an
+  // at-rule the browser drops AND a `container-name` the surface cannot declare,
+  // so the preview loses its rules rather than degrading to the published
+  // compile the way every other refusal here does.
+  if (RESERVED_CONTAINER_NAMES.has(name.toLowerCase())) return undefined;
   // A CSS custom identifier, conservatively: letters, digits, hyphen and
   // underscore, not starting with a digit. Narrower than the grammar allows,
   // because the escapes the full grammar permits are exactly what this refuses

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -78,6 +78,17 @@ import type { WarningAllowance } from "./warning-allowance";
 export interface StyleCompileContext {
   breakpoints: BreakpointSet;
   /**
+   * Emit VIEWPORT breakpoints as container queries against this container name,
+   * for a surface that shows the page inside a resizable box rather than at the
+   * browser's own width.
+   *
+   * Absent for every published render, and absent is the default: the contexts a
+   * caller derives an artifact identity from are then byte-identical to what
+   * they were before this existed, so no stored sheet invalidates for CSS that
+   * did not change. See {@link BreakpointContextOptions.previewContainer}.
+   */
+  previewContainer?: string;
+  /**
    * Which hosts this site will fetch from.
    *
    * A stylesheet is a fetching surface: `background-image: url(...)` makes the
@@ -336,6 +347,28 @@ function emittableBound(maxWidth: unknown): boolean {
 }
 
 /**
+ * The at-rule keyword a context's queries are asked under, and the container
+ * they name when they are not asked of the window.
+ *
+ * ONE derivation, because two places need it and they answered differently: the
+ * contexts built below, and the bounded query a visibility band emits. While
+ * the band rebuilt the keyword from the axis alone, a previewed page kept
+ * `@media` for its visibility while its styles had moved to a container query —
+ * so a node could be styled for a width it was simultaneously hidden at.
+ */
+function queryPrefix(
+  axis: BreakpointAxis,
+  preview: string | undefined
+): string {
+  if (preview === undefined) {
+    return axis === "container" ? "@container" : "@media";
+  }
+  return axis === "container"
+    ? `@container ${UNPREVIEWABLE_CONTAINER}`
+    : `@container ${preview}`;
+}
+
+/**
  * The container name a preview sheet aims its VIEWPORT breakpoints at.
  *
  * Reserved and never emitted by an author's own styles, so a query naming it
@@ -538,10 +571,7 @@ export function breakpointContexts(
               ...(def.maxWidth === undefined
                 ? {}
                 : {
-                    atRule:
-                      preview === undefined
-                        ? `@media (max-width: ${def.maxWidth}px)`
-                        : `@container ${preview} (max-width: ${def.maxWidth}px)`,
+                    atRule: `${queryPrefix("viewport", preview)} (max-width: ${def.maxWidth}px)`,
                   }),
             }
           : {
@@ -564,13 +594,9 @@ export function breakpointContexts(
               // container breakpoint stays a known breakpoint rather than
               // becoming an unknown one.
               atRule:
-                preview === undefined
-                  ? def.maxWidth === undefined
-                    ? `@container (min-width: 0)`
-                    : `@container (max-width: ${def.maxWidth}px)`
-                  : def.maxWidth === undefined
-                    ? `@container ${UNPREVIEWABLE_CONTAINER} (min-width: 0)`
-                    : `@container ${UNPREVIEWABLE_CONTAINER} (max-width: ${def.maxWidth}px)`,
+                def.maxWidth === undefined
+                  ? `${queryPrefix("container", preview)} (min-width: 0)`
+                  : `${queryPrefix("container", preview)} (max-width: ${def.maxWidth}px)`,
             }
       );
     }
@@ -909,7 +935,8 @@ function visibilityRules(
   contexts: readonly BreakpointContext[],
   basePath: string,
   warnings: ValidationIssue[],
-  warningAllowance: WarningAllowance
+  warningAllowance: WarningAllowance,
+  preview: string | undefined
 ): CssRule[] {
   // The containing structures get the same account as the values inside them.
   // A `visibility` or `devices` that is an array, a string or null applies none
@@ -960,7 +987,7 @@ function visibilityRules(
     let hidingFrom: BreakpointContext | undefined;
     const flush = (lowerBound: number | undefined): void => {
       if (hidingFrom === undefined) return;
-      const atRule = boundedAtRule(hidingFrom, lowerBound);
+      const atRule = boundedAtRule(hidingFrom, lowerBound, preview);
       rules.push({
         ...(atRule === undefined ? {} : { atRule }),
         // Hiding has to beat the node's own `display`, including one stored on
@@ -1022,10 +1049,11 @@ function visibilityRules(
  */
 function boundedAtRule(
   context: BreakpointContext,
-  lowerBound: number | undefined
+  lowerBound: number | undefined,
+  preview: string | undefined
 ): string | undefined {
   if (lowerBound === undefined) return context.atRule;
-  const feature = context.axis === "container" ? "@container" : "@media";
+  const feature = queryPrefix(context.axis ?? "viewport", preview);
   const upper =
     context.maxWidth === undefined
       ? ""
@@ -1176,7 +1204,11 @@ export function compilePageCss(
   // stale ids — or a document full of malformed token names — costs its own
   // diagnostics and not the page's stylesheet.
   const warningAllowance = newWarningAllowance();
-  const contexts = breakpointContexts(ctx.breakpoints);
+  const contexts = breakpointContexts(ctx.breakpoints, {
+    ...(ctx.previewContainer === undefined
+      ? {}
+      : { previewContainer: ctx.previewContainer }),
+  });
   const tokenPrefix = ctx.tokenPrefix ?? DEFAULT_TOKEN_PREFIX;
   const mayFetchUrl = ctx.mayFetchUrl;
   const scope = scopeSelector(ctx.scope, warnings);
@@ -1479,7 +1511,8 @@ export function compilePageCss(
         contexts,
         path,
         warnings,
-        warningAllowance
+        warningAllowance,
+        ctx.previewContainer
       ),
     ];
     // Held out of the sheet when the node can be pruned at read time. Serialized on its own, so

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -404,10 +404,22 @@ const RESERVED_CONTAINER_NAMES: ReadonlySet<string> = new Set([
  */
 export function previewContainerName(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
+  /*
+   * The RAW length first, before `trim` or any other linear pass.
+   *
+   * Trimming a megabyte of whitespace to reach a refusal that was certain from
+   * the length alone is work done on every compile, and this name is
+   * caller-controlled and is normalised again while deriving artifact
+   * identities — so the scan recurs on render paths rather than once.
+   *
+   * Whitespace cannot make an over-cap string legal: trimming only shortens,
+   * and a value longer than the cap by more than its own surrounding
+   * whitespace is refused either way. Comparing raw is therefore the same
+   * answer, sooner.
+   */
+  if (value.length > MAX_PREVIEW_CONTAINER_LENGTH) return undefined;
   const name = value.trim();
-  if (name.length === 0 || name.length > MAX_PREVIEW_CONTAINER_LENGTH) {
-    return undefined;
-  }
+  if (name.length === 0) return undefined;
   if (name === UNPREVIEWABLE_CONTAINER) return undefined;
   // The CSS-wide keywords and `none`, which the grammar excludes from a
   // `<custom-ident>` however well they match its shape. Emitted, they make an
@@ -458,6 +470,20 @@ export const PREVIEW_VIEWPORT_CONTAINER = "nx-preview-viewport";
  * one and collecting a warning on every render.
  */
 export const UNPREVIEWABLE_CONTAINER = "nx-not-previewable";
+
+/**
+ * A container condition no container can satisfy.
+ *
+ * The NAME is a label and this is the guarantee. A CSS identifier cannot be
+ * reserved globally — blocks render host-defined markup and stylesheets, so
+ * anything may declare `container-name: nx-not-previewable`, and a rule kept
+ * inert only by nobody using that name becomes live the moment somebody does.
+ *
+ * A width is never negative, so `(width < 0px)` is false against every
+ * container, in every browser, whatever names are in scope. Valid syntax that
+ * evaluates false is a boundary; an unused name is a convention.
+ */
+const UNSATISFIABLE_CONDITION = "(width < 0px)";
 
 /**
  * How to emit the contexts, when the caller is not the published page.
@@ -660,9 +686,11 @@ export function breakpointContexts(
               // container breakpoint stays a known breakpoint rather than
               // becoming an unknown one.
               atRule:
-                def.maxWidth === undefined
-                  ? `${queryPrefix("container", preview)} (min-width: 0)`
-                  : `${queryPrefix("container", preview)} (max-width: ${def.maxWidth}px)`,
+                preview !== undefined
+                  ? `@container ${UNPREVIEWABLE_CONTAINER} ${UNSATISFIABLE_CONDITION}`
+                  : def.maxWidth === undefined
+                    ? `@container (min-width: 0)`
+                    : `@container (max-width: ${def.maxWidth}px)`,
             }
       );
     }

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -447,12 +447,42 @@ function queryPrefix(
 }
 
 /**
- * The container name a preview sheet aims its VIEWPORT breakpoints at.
+ * The default container name a preview sheet aims its VIEWPORT breakpoints at.
  *
- * Reserved and never emitted by an author's own styles, so a query naming it
- * resolves against the previewing surface's box and nothing else.
+ * A DEFAULT, not a guarantee. A CSS identifier cannot be reserved globally and
+ * blocks render host-defined markup and stylesheets, so a nearer ancestor
+ * declaring `container: nx-preview-viewport / inline-size` would satisfy the
+ * named query first — and viewport tiers would then follow that inner element
+ * instead of the preview box, so resizing the canvas shows the wrong
+ * breakpoint. The container axis is protected by an impossible condition
+ * instead; the viewport axis cannot be, because it has to match something.
+ *
+ * A surface that renders untrusted or third-party blocks should mint its own
+ * name with {@link previewContainerFor} and pass the SAME value to the compile
+ * and to its box. This constant remains for the ordinary case, where the
+ * previewing surface controls the markup inside it.
  */
 export const PREVIEW_VIEWPORT_CONTAINER = "nx-preview-viewport";
+
+/**
+ * A preview container name unlikely to collide with an authored one.
+ *
+ * Derived from a seed the CALLER owns — a React `useId`, a surface id, anything
+ * stable for the lifetime of that box — rather than generated randomly here, so
+ * the name a server renders and the name a client hydrates are the same string.
+ * A random one would differ across that boundary and the preview would match
+ * nothing on exactly the first paint.
+ *
+ * The seed is reduced to identifier-safe characters rather than rejected, so a
+ * caller passing an opaque id from elsewhere does not have to know this
+ * function's rules to use it.
+ */
+export function previewContainerFor(seed: string): string {
+  const safe = seed.replace(/[^A-Za-z0-9_-]/g, "-");
+  return (
+    previewContainerName(`nx-preview-${safe}`) ?? PREVIEW_VIEWPORT_CONTAINER
+  );
+}
 
 /**
  * The container name a preview sheet aims its CONTAINER breakpoints at, which
@@ -1147,6 +1177,21 @@ function boundedAtRule(
   preview: string | undefined
 ): string | undefined {
   if (lowerBound === undefined) return context.atRule;
+  /*
+   * A band on a context that can never match cannot match either.
+   *
+   * The container axis under preview carries an impossible condition rather
+   * than a bound, and rebuilding the wrapper from the prefix alone dropped it —
+   * leaving a merely NAMED query that an authored ancestor could satisfy. The
+   * node's styles would stay impossible while its visibility band went live, so
+   * preview visibility disagreed with preview styling.
+   *
+   * Returned whole rather than reconstructed, because the context already
+   * states the condition and a second construction of it is what diverged.
+   */
+  if (context.atRule?.includes(UNSATISFIABLE_CONDITION) === true) {
+    return context.atRule;
+  }
   const feature = queryPrefix(context.axis ?? "viewport", preview);
   const upper =
     context.maxWidth === undefined

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -412,10 +412,13 @@ export function previewContainerName(value: unknown): string | undefined {
    * caller-controlled and is normalised again while deriving artifact
    * identities — so the scan recurs on render paths rather than once.
    *
-   * Whitespace cannot make an over-cap string legal: trimming only shortens,
-   * and a value longer than the cap by more than its own surrounding
-   * whitespace is refused either way. Comparing raw is therefore the same
-   * answer, sooner.
+   * The cap is therefore on the RAW input, and that is a deliberate rule rather
+   * than an optimisation that happens to agree. It does not agree: a name of
+   * exactly the cap's length wrapped in spaces would be legal after trimming
+   * and is refused here. That is the intended reading — the bound this package
+   * publishes is on the string a caller hands over, so a caller digesting these
+   * inputs can check the value it holds rather than a trimmed form it would
+   * have to derive first.
    */
   if (value.length > MAX_PREVIEW_CONTAINER_LENGTH) return undefined;
   const name = value.trim();
@@ -465,6 +468,30 @@ function queryPrefix(
 export const PREVIEW_VIEWPORT_CONTAINER = "nx-preview-viewport";
 
 /**
+ * A stable 64-bit digest of a seed, as two base-36 halves.
+ *
+ * FNV-1a, computed in two independently seeded 32-bit passes rather than one,
+ * because a single 32-bit digest collides at roughly one pair in 65k surfaces
+ * by the birthday bound — near enough to be reachable on a large site, and a
+ * collision here silently gives two boxes one container name.
+ *
+ * Written out rather than taken from a hashing library because it has to agree
+ * across the server render and the client hydration, and pure integer maths on
+ * a string is the same in both. `Math.imul` and `>>> 0` keep every step inside
+ * 32 bits, which plain `*` would not.
+ */
+function digest(seed: string): string {
+  let a = 0x811c9dc5;
+  let b = 0x01000193;
+  for (let index = 0; index < seed.length; index += 1) {
+    const code = seed.charCodeAt(index);
+    a = Math.imul(a ^ code, 0x01000193) >>> 0;
+    b = Math.imul(b ^ code, 0x85ebca6b) >>> 0;
+  }
+  return `${a.toString(36)}${b.toString(36)}`;
+}
+
+/**
  * A preview container name unlikely to collide with an authored one.
  *
  * Derived from a seed the CALLER owns — a React `useId`, a surface id, anything
@@ -476,11 +503,31 @@ export const PREVIEW_VIEWPORT_CONTAINER = "nx-preview-viewport";
  * The seed is reduced to identifier-safe characters rather than rejected, so a
  * caller passing an opaque id from elsewhere does not have to know this
  * function's rules to use it.
+ *
+ * **A seed too long to carry literally is DIGESTED, never dropped.** Prefixed,
+ * a seed over about fifty characters exceeds the emitted-name bound, and
+ * returning the shared default there would hand exactly the surfaces most
+ * likely to use long ids — document paths, composite keys, opaque route ids —
+ * the one globally predictable name this function exists to avoid. The digest
+ * keeps the name per-surface and inside the bound.
+ *
+ * Two distinct seeds can still digest alike; the guarantee is a low collision
+ * probability, not uniqueness. That is the right trade here because the cost of
+ * a collision is two boxes sharing a container name, while the cost of the
+ * fallback was every long-seeded surface sharing one with THIRD-PARTY markup.
  */
 export function previewContainerFor(seed: string): string {
   const safe = seed.replace(/[^A-Za-z0-9_-]/g, "-");
+  const literal = previewContainerName(`nx-preview-${safe}`);
+  if (literal !== undefined) return literal;
+  /*
+   * Digested from the ORIGINAL seed rather than the reduced form, so two seeds
+   * differing only in characters the reduction collapses — `a/b` and `a:b` both
+   * become `a-b` — still produce different names.
+   */
   return (
-    previewContainerName(`nx-preview-${safe}`) ?? PREVIEW_VIEWPORT_CONTAINER
+    previewContainerName(`nx-preview-${digest(seed)}`) ??
+    PREVIEW_VIEWPORT_CONTAINER
   );
 }
 

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -336,6 +336,52 @@ function emittableBound(maxWidth: unknown): boolean {
 }
 
 /**
+ * The container name a preview sheet aims its VIEWPORT breakpoints at.
+ *
+ * Reserved and never emitted by an author's own styles, so a query naming it
+ * resolves against the previewing surface's box and nothing else.
+ */
+export const PREVIEW_VIEWPORT_CONTAINER = "nx-preview-viewport";
+
+/**
+ * The container name a preview sheet aims its CONTAINER breakpoints at, which
+ * is deliberately one nothing carries.
+ *
+ * A container breakpoint responds to the width of the element's OWN container,
+ * so it cannot be previewed by resizing a canvas — the answer depends on where
+ * the block sits, not on the surface around it. Left unnamed, those queries
+ * would resolve against the preview container instead, and the editor would
+ * show container styles the published page does not.
+ *
+ * Named to something no element declares rather than omitted, so the contexts
+ * keep their ids: a style stored at a container breakpoint stays a KNOWN
+ * breakpoint that simply does not apply here, instead of becoming an unknown
+ * one and collecting a warning on every render.
+ */
+export const UNPREVIEWABLE_CONTAINER = "nx-not-previewable";
+
+/**
+ * How to emit the contexts, when the caller is not the published page.
+ */
+export interface BreakpointContextOptions {
+  /**
+   * Emit VIEWPORT breakpoints as container queries against this container name.
+   *
+   * For a surface that shows the page inside a resizable box rather than at the
+   * browser's own width. `@media` asks the WINDOW, so a box narrowed to a
+   * breakpoint's width changes nothing about which rules apply — the block gets
+   * narrower and keeps its widest styling, which is a preview that lies. A
+   * container query asked of the box answers about the box.
+   *
+   * Absent for every published render, and absent is the default so that the
+   * artifact identity a caller derives from these contexts is byte-identical to
+   * what it was before this option existed. A stamp that moved would invalidate
+   * every artifact on the site for CSS that did not change.
+   */
+  readonly previewContainer?: string;
+}
+
+/**
  * The breakpoints to emit, in cascade order.
  *
  * The base breakpoint first and unconditional, then viewport widths descending,
@@ -359,8 +405,10 @@ export function breakpointContexts(
   // readers hold the stored settings record rather than a validated context.
   // The body already treats the argument as untrusted, so an absent set answers
   // with the base context alone rather than being a case to guard at each call.
-  set: BreakpointSet | undefined
+  set: BreakpointSet | undefined,
+  options?: BreakpointContextOptions
 ): BreakpointContext[] {
+  const preview = options?.previewContainer;
   // The base context carries no upper bound and no at-rule, but it still needs
   // to be bounded from below when a narrower breakpoint shows a node again:
   // without that, hiding at base emits an unconditional rule that a later
@@ -489,7 +537,12 @@ export function breakpointContexts(
               maxWidth: def.maxWidth,
               ...(def.maxWidth === undefined
                 ? {}
-                : { atRule: `@media (max-width: ${def.maxWidth}px)` }),
+                : {
+                    atRule:
+                      preview === undefined
+                        ? `@media (max-width: ${def.maxWidth}px)`
+                        : `@container ${preview} (max-width: ${def.maxWidth}px)`,
+                  }),
             }
           : {
               id: def.id,
@@ -500,10 +553,24 @@ export function breakpointContexts(
               // apply to a node with no query-container ancestor at all, and would
               // outrank every viewport rule while doing it. `min-width: 0` matches
               // inside any container and nowhere else, which is exactly the scope.
+              //
+              // NAMED under preview, to a name nothing carries. An unnamed
+              // container query resolves against the nearest ancestor that has
+              // `container-type` set — named or not — so a preview surface that
+              // makes its canvas a query container would capture these for every
+              // node with no authored container ancestor, and show container
+              // styles the published page does not. Naming them rather than
+              // omitting them keeps their ids present, so a style stored at a
+              // container breakpoint stays a known breakpoint rather than
+              // becoming an unknown one.
               atRule:
-                def.maxWidth === undefined
-                  ? `@container (min-width: 0)`
-                  : `@container (max-width: ${def.maxWidth}px)`,
+                preview === undefined
+                  ? def.maxWidth === undefined
+                    ? `@container (min-width: 0)`
+                    : `@container (max-width: ${def.maxWidth}px)`
+                  : def.maxWidth === undefined
+                    ? `@container ${UNPREVIEWABLE_CONTAINER} (min-width: 0)`
+                    : `@container ${UNPREVIEWABLE_CONTAINER} (max-width: ${def.maxWidth}px)`,
             }
       );
     }

--- a/packages/blocks-engine/src/style/emittable-string-bounds.ts
+++ b/packages/blocks-engine/src/style/emittable-string-bounds.ts
@@ -70,6 +70,13 @@ export const EMITTABLE_STRING_BOUNDS: readonly EmittableStringBound[] =
       max: MAX_NAMED_CLASS_NAME_LENGTH,
     }),
     Object.freeze({ what: "a breakpoint id", max: MAX_BREAKPOINT_ID_LENGTH }),
+    /*
+     * Emitted into the at-rule of every preview query, so it is a compiled
+     * string like any other here — and it is the only one in this list that is
+     * caller-supplied per render rather than read from a stored document, which
+     * is why a consumer truncating or digesting these inputs has to keep this
+     * bound rather than assume storage already applied one.
+     */
     Object.freeze({
       what: "a preview container name",
       max: MAX_PREVIEW_CONTAINER_LENGTH,

--- a/packages/blocks-engine/src/style/emittable-string-bounds.ts
+++ b/packages/blocks-engine/src/style/emittable-string-bounds.ts
@@ -31,7 +31,7 @@
  */
 import { MAX_BLOCK_TYPE_LENGTH, MAX_BREAKPOINT_ID_LENGTH } from "../document";
 
-import { MAX_SCOPE_LENGTH } from "./compile-page";
+import { MAX_PREVIEW_CONTAINER_LENGTH, MAX_SCOPE_LENGTH } from "./compile-page";
 import { MAX_VALUE_LENGTH } from "./css-value";
 import { MAX_TOKEN_NAME_LENGTH, MAX_TOKEN_PREFIX_LENGTH } from "./declarations";
 import { MAX_NAMED_CLASS_NAME_LENGTH } from "./named-class";
@@ -70,6 +70,10 @@ export const EMITTABLE_STRING_BOUNDS: readonly EmittableStringBound[] =
       max: MAX_NAMED_CLASS_NAME_LENGTH,
     }),
     Object.freeze({ what: "a breakpoint id", max: MAX_BREAKPOINT_ID_LENGTH }),
+    Object.freeze({
+      what: "a preview container name",
+      max: MAX_PREVIEW_CONTAINER_LENGTH,
+    }),
     Object.freeze({ what: "a design token name", max: MAX_TOKEN_NAME_LENGTH }),
     Object.freeze({ what: "a block type", max: MAX_BLOCK_TYPE_LENGTH }),
     Object.freeze({

--- a/packages/blocks-engine/src/style/site-sheet.ts
+++ b/packages/blocks-engine/src/style/site-sheet.ts
@@ -59,6 +59,14 @@ export interface SiteSheetInput {
    * and cannot be mistaken for the old sheet.
    */
   mayFetchUrl?: MayFetchUrl;
+  /**
+   * Emit viewport breakpoints as container queries against this container, for
+   * a surface previewing the page in a resizable box.
+   *
+   * Carried so this tier answers the breakpoint question the same way the page
+   * tier does. See {@link BreakpointContextOptions.previewContainer}.
+   */
+  previewContainer?: string;
 }
 
 /** The shared sheet and the name it is addressed by. */
@@ -160,6 +168,15 @@ export function compileSiteSheet(input: SiteSheetInput): SiteSheetArtifact {
     ...(input.mayFetchUrl === undefined
       ? {}
       : { mayFetchUrl: input.mayFetchUrl }),
+    // The SAME breakpoint emission the page tier uses. Compiled without it, the
+    // shared classes and block defaults answer the published question while the
+    // node-local declarations beside them answer the preview one — so a
+    // container-axis rule from this sheet can match a real authored container
+    // while the node's own rule at that breakpoint is aimed at a name nothing
+    // carries. One document, two answers to one breakpoint.
+    ...(input.previewContainer === undefined
+      ? {}
+      : { previewContainer: input.previewContainer }),
   });
   warnings.push(...tiers.warnings);
   if (tiers.css !== "") blocks.push(tiers.css);

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -334,6 +334,7 @@ describe("the root entry", () => {
       "pageStyleTrace",
       "prepareDocumentForRead",
       "preparePageForRead",
+      "previewContainerStyle",
       "pruneHiddenNodes",
       "registeredBlocks",
       "rendersOwnMarkup",

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -28,6 +28,7 @@ import * as richTextModule from "./rich-text";
 import * as pageRendererModule from "./page-renderer";
 import * as pageStyleTraceModule from "./page-style-trace";
 import * as placeholderModule from "./placeholder";
+import * as previewContainerModule from "./preview-container";
 import * as prepareModule from "./prepare-document";
 import * as readPageModule from "./read-page";
 import * as resolverModule from "./resolver";
@@ -221,6 +222,11 @@ const SOURCE_MODULES: ReadonlyArray<{
   },
   { name: "placeholder", module: placeholderModule, internal: [] },
   {
+    name: "preview-container",
+    module: previewContainerModule,
+    internal: [],
+  },
+  {
     name: "page-renderer",
     module: pageRendererModule,
     // Crosses a module boundary inside this package and is not a consumer
@@ -307,6 +313,10 @@ describe("the root entry", () => {
       // because the surface doing the previewing must put the same identifier
       // in its own `container-name`, and a name spelled twice can be spelled
       // differently.
+      // The style a previewing surface puts on its own box: the container name
+      // AND the `container-type` that makes it a size-query container, in one
+      // value so neither can be applied without the other.
+      "PREVIEW_CONTAINER_STYLE",
       "PREVIEW_VIEWPORT_CONTAINER",
       "PROP_ATTRIBUTE",
       "PageRenderer",

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -334,6 +334,7 @@ describe("the root entry", () => {
       "pageStyleTrace",
       "prepareDocumentForRead",
       "preparePageForRead",
+      "previewContainerFor",
       "previewContainerStyle",
       "pruneHiddenNodes",
       "registeredBlocks",

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -303,9 +303,15 @@ describe("the root entry", () => {
       // renderer would drop rather than keeping a list beside it.
       "EDITOR_NAMESPACE",
       "NODE_ID_ATTRIBUTE",
+      // The container names a preview compile aims its breakpoints at. Public
+      // because the surface doing the previewing must put the same identifier
+      // in its own `container-name`, and a name spelled twice can be spelled
+      // differently.
+      "PREVIEW_VIEWPORT_CONTAINER",
       "PROP_ATTRIBUTE",
       "PageRenderer",
       "RichText",
+      "UNPREVIEWABLE_CONTAINER",
       "createBlockResolver",
       "createStandaloneContext",
       "defineBlock",

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -232,6 +232,7 @@ export type {
   RemotePatternInput,
   SlotLock,
   SlotSpec,
+  BreakpointContextOptions,
   StyleCompileContext,
   StyleOrigin,
   StyleState,

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -256,3 +256,4 @@ export {
   PREVIEW_VIEWPORT_CONTAINER,
   UNPREVIEWABLE_CONTAINER,
 } from "@nextlyhq/blocks-engine";
+export { PREVIEW_CONTAINER_STYLE } from "./preview-container";

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -255,6 +255,19 @@ export type {
 export {
   PREVIEW_VIEWPORT_CONTAINER,
   UNPREVIEWABLE_CONTAINER,
+  /*
+   * The FACTORY as well as the constants, because it is the only supplied way
+   * off the predictable default.
+   *
+   * `PREVIEW_VIEWPORT_CONTAINER` is a default rather than a reservation — an
+   * ancestor declaring the same name captures the viewport queries — so a
+   * surface rendering third-party blocks is meant to mint its own. Under pnpm
+   * an application declaring only this package cannot reliably import a
+   * transitive dependency, so omitting this left the collision-safe path
+   * reachable only by adding `@nextlyhq/blocks-engine` to its manifest or by
+   * reimplementing the name validation, and the second is the one people do.
+   */
+  previewContainerFor,
 } from "@nextlyhq/blocks-engine";
 export {
   PREVIEW_CONTAINER_STYLE,

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -242,3 +242,17 @@ export type {
   TokenRef,
   ValidationIssue,
 } from "@nextlyhq/blocks-engine";
+
+/**
+ * The container names a preview compile emits its breakpoints against.
+ *
+ * Re-exported beside {@link BreakpointContextOptions} because a consumer of this
+ * package does not depend on the engine directly: without them, the previewing
+ * surface would have to hard-code the same reserved identifiers in its own
+ * `container-name`, and a name spelled twice is a name that can be spelled
+ * differently.
+ */
+export {
+  PREVIEW_VIEWPORT_CONTAINER,
+  UNPREVIEWABLE_CONTAINER,
+} from "@nextlyhq/blocks-engine";

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -256,4 +256,7 @@ export {
   PREVIEW_VIEWPORT_CONTAINER,
   UNPREVIEWABLE_CONTAINER,
 } from "@nextlyhq/blocks-engine";
-export { PREVIEW_CONTAINER_STYLE } from "./preview-container";
+export {
+  PREVIEW_CONTAINER_STYLE,
+  previewContainerStyle,
+} from "./preview-container";

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -199,6 +199,7 @@ interface SiteInputRoles {
   classes: "reconciled-here";
   blockBases: "reconciled-here";
   tokenPrefix: "reconciled-here";
+  previewContainer: "reconciled-here";
   mayFetchUrl: "reconciled-elsewhere";
   fonts: "sheet-only";
   tokens: "sheet-only";
@@ -283,6 +284,10 @@ export function sharedStyleInputs(
       stored.tokens?.prefix,
       route.tokenPrefix
     ),
+    // Carried so the SITE sheet and the artifact identity see it too. A page
+    // compiled for a preview surface whose shared tier was compiled for the
+    // published one puts two answers to the same breakpoint in one document.
+    previewContainer: route.previewContainer,
   });
 }
 
@@ -665,6 +670,13 @@ export function PageRenderer({
           ...(mayFetchUrl === undefined || siteInput?.mayFetchUrl !== undefined
             ? {}
             : { mayFetchUrl }),
+          // The RESOLVED preview option, from the same reconciliation the page
+          // context above was given. A shared tier compiled for the published
+          // page beneath node styles compiled for a preview surface puts two
+          // answers to one breakpoint in one document.
+          ...(shared.previewContainer === undefined
+            ? {}
+            : { previewContainer: shared.previewContainer }),
         });
 
   return (

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -284,10 +284,17 @@ export function sharedStyleInputs(
       stored.tokens?.prefix,
       route.tokenPrefix
     ),
-    // Carried so the SITE sheet and the artifact identity see it too. A page
-    // compiled for a preview surface whose shared tier was compiled for the
-    // published one puts two answers to the same breakpoint in one document.
-    previewContainer: route.previewContainer,
+    // Reconciled from BOTH tiers, like every other shared field. Read from the
+    // route alone, a caller stating it on `siteStyles` would have it reach the
+    // site sheet through `...siteInput` while the page context compiled node
+    // rules published — one render carrying two answers to one breakpoint.
+    //
+    // The route wins where both state it: which surface is doing the previewing
+    // is a fact about this render, while the stored tier describes the site.
+    previewContainer: firstStated(
+      route.previewContainer,
+      stored.previewContainer
+    ),
   });
 }
 

--- a/packages/blocks-react/src/preview-container.test.ts
+++ b/packages/blocks-react/src/preview-container.test.ts
@@ -1,5 +1,6 @@
 /**
- * That the two properties a preview box needs cannot be separated.
+ * That the two properties a preview box needs cannot be separated, and that
+ * both bind to the name the compile was actually given.
  *
  * @module preview-container.test
  */
@@ -7,7 +8,10 @@ import { describe, expect, it } from "vitest";
 
 import { PREVIEW_VIEWPORT_CONTAINER } from "@nextlyhq/blocks-engine";
 
-import { PREVIEW_CONTAINER_STYLE } from "./preview-container";
+import {
+  PREVIEW_CONTAINER_STYLE,
+  previewContainerStyle,
+} from "./preview-container";
 
 describe("the preview box style", () => {
   it("carries the container TYPE as well as the name", () => {
@@ -28,17 +32,43 @@ describe("the preview box style", () => {
     });
   });
 
-  it("names the SAME container the compiler emits against", () => {
-    // One source for the name. Spelled separately, the box and the sheet could
-    // disagree, and the preview would match nothing with no error anywhere.
-    expect(PREVIEW_CONTAINER_STYLE.containerName).toBe(
-      PREVIEW_VIEWPORT_CONTAINER
-    );
-  });
-
   it("contains the INLINE axis only, not both", () => {
     // A preview box is sized by its content in the block direction; containing
     // that too would collapse the page's height to nothing.
     expect(PREVIEW_CONTAINER_STYLE.containerType).toBe("inline-size");
+  });
+
+  it("binds to the name the COMPILE was given, not the default", () => {
+    /*
+     * The compile option accepts any usable identifier. Pinned to the constant,
+     * a surface previewing under its own name would declare one container while
+     * the sheet queried another — both valid, and every responsive rule inactive
+     * with nothing on screen to indicate why.
+     */
+    expect(previewContainerStyle("canvas-a")).toEqual({
+      containerName: "canvas-a",
+      containerType: "inline-size",
+    });
+  });
+
+  it("falls back to the default for a name the compiler would refuse", () => {
+    /*
+     * Normalised through the compiler's own rule, so a refusal here matches a
+     * refusal there: the sheet compiles published, and a box declaring the
+     * default container for queries nobody emitted is at worst inert. Declaring
+     * the refused name instead would be a container nothing can ever query.
+     *
+     * The reserved keywords are included because they match an identifier's
+     * SHAPE and are still excluded from a custom identifier — a validator
+     * checking only the pattern would let them through here.
+     */
+    for (const refused of ["", "   ", "has space", "none", "initial"]) {
+      expect(previewContainerStyle(refused).containerName).toBe(
+        PREVIEW_VIEWPORT_CONTAINER
+      );
+    }
+    expect(previewContainerStyle().containerName).toBe(
+      PREVIEW_VIEWPORT_CONTAINER
+    );
   });
 });

--- a/packages/blocks-react/src/preview-container.test.ts
+++ b/packages/blocks-react/src/preview-container.test.ts
@@ -51,24 +51,37 @@ describe("the preview box style", () => {
     });
   });
 
-  it("falls back to the default for a name the compiler would refuse", () => {
+  it("establishes NO container when the compiler refused the name", () => {
     /*
-     * Normalised through the compiler's own rule, so a refusal here matches a
-     * refusal there: the sheet compiles published, and a box declaring the
-     * default container for queries nobody emitted is at worst inert. Declaring
-     * the refused name instead would be a container nothing can ever query.
+     * The symmetry is the property, not a nicety. A refused name makes the
+     * compile PUBLISHED — viewport tiers emit `@media` and container tiers emit
+     * unnamed `@container` rules. A box that established a query container
+     * anyway would let those unnamed rules resolve against IT, so viewport tiers
+     * would follow the window while container tiers followed the canvas: a
+     * hybrid neither mode intends, and exactly the capture a valid preview is
+     * named to prevent.
      *
-     * The reserved keywords are included because they match an identifier's
-     * SHAPE and are still excluded from a custom identifier — a validator
-     * checking only the pattern would let them through here.
+     * Asserted as an empty object, so a caller spreading it onto a style adds
+     * nothing at all.
      */
     for (const refused of ["", "   ", "has space", "none", "initial"]) {
-      expect(previewContainerStyle(refused).containerName).toBe(
-        PREVIEW_VIEWPORT_CONTAINER
-      );
+      expect(previewContainerStyle(refused)).toEqual({});
     }
-    expect(previewContainerStyle().containerName).toBe(
-      PREVIEW_VIEWPORT_CONTAINER
-    );
+  });
+
+  it("establishes one for a name the compiler ACCEPTS, which is the control", () => {
+    /*
+     * The control. Without it, a helper returning `{}` for every input would
+     * satisfy the refusal case above while making previewing impossible — the
+     * assertion there is satisfied by absence, so its meaning depends on this.
+     */
+    expect(previewContainerStyle(PREVIEW_VIEWPORT_CONTAINER)).toEqual({
+      containerName: PREVIEW_VIEWPORT_CONTAINER,
+      containerType: "inline-size",
+    });
+    expect(PREVIEW_CONTAINER_STYLE).toEqual({
+      containerName: PREVIEW_VIEWPORT_CONTAINER,
+      containerType: "inline-size",
+    });
   });
 });

--- a/packages/blocks-react/src/preview-container.test.ts
+++ b/packages/blocks-react/src/preview-container.test.ts
@@ -1,0 +1,44 @@
+/**
+ * That the two properties a preview box needs cannot be separated.
+ *
+ * @module preview-container.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { PREVIEW_VIEWPORT_CONTAINER } from "@nextlyhq/blocks-engine";
+
+import { PREVIEW_CONTAINER_STYLE } from "./preview-container";
+
+describe("the preview box style", () => {
+  it("carries the container TYPE as well as the name", () => {
+    /*
+     * Either alone does nothing, and the failure is silent. A named container
+     * left at the default `container-type: normal` is not a size-query
+     * container, so every `(max-width: ...)` rule the preview compile emitted
+     * stays inactive: the sheet is valid, the name matches, and resizing the box
+     * changes nothing.
+     *
+     * Asserted as the whole object rather than field by field, so a property
+     * removed later fails here rather than going unnoticed until a preview
+     * silently stops responding.
+     */
+    expect(PREVIEW_CONTAINER_STYLE).toEqual({
+      containerName: PREVIEW_VIEWPORT_CONTAINER,
+      containerType: "inline-size",
+    });
+  });
+
+  it("names the SAME container the compiler emits against", () => {
+    // One source for the name. Spelled separately, the box and the sheet could
+    // disagree, and the preview would match nothing with no error anywhere.
+    expect(PREVIEW_CONTAINER_STYLE.containerName).toBe(
+      PREVIEW_VIEWPORT_CONTAINER
+    );
+  });
+
+  it("contains the INLINE axis only, not both", () => {
+    // A preview box is sized by its content in the block direction; containing
+    // that too would collapse the page's height to nothing.
+    expect(PREVIEW_CONTAINER_STYLE.containerType).toBe("inline-size");
+  });
+});

--- a/packages/blocks-react/src/preview-container.ts
+++ b/packages/blocks-react/src/preview-container.ts
@@ -4,7 +4,10 @@
  * @module preview-container
  */
 
-import { PREVIEW_VIEWPORT_CONTAINER } from "@nextlyhq/blocks-engine";
+import {
+  PREVIEW_VIEWPORT_CONTAINER,
+  previewContainerName,
+} from "@nextlyhq/blocks-engine";
 
 /**
  * The style a previewing surface applies to its own box.
@@ -16,12 +19,34 @@ import { PREVIEW_VIEWPORT_CONTAINER } from "@nextlyhq/blocks-engine";
  * nothing at all. That failure is silent: the sheet is valid, the name matches,
  * and the page simply never responds.
  *
- * Published as one object rather than as the name alone, so the second property
- * cannot be the thing a consumer did not know to look for. `inline-size` rather
- * than `size`, because a preview box is sized by its content in the block
- * direction and containing that too would collapse the page's height.
+ * Derived from the name the COMPILE was given rather than fixed to the default,
+ * because the compile option accepts any usable identifier. Pinned to the
+ * constant, a surface previewing under its own name would declare one container
+ * while the sheet queried another — both valid, and every responsive rule
+ * inactive with nothing to indicate why.
+ *
+ * Normalised through the compiler's own rule, so a name it would refuse
+ * produces the same refusal here: the sheet then compiles published, and a box
+ * declaring a container for queries nobody emitted is at worst inert.
+ *
+ * `inline-size` rather than `size`, because a preview box is sized by its
+ * content in the block direction and containing that too would collapse the
+ * page's height.
  */
-export const PREVIEW_CONTAINER_STYLE = Object.freeze({
-  containerName: PREVIEW_VIEWPORT_CONTAINER,
-  containerType: "inline-size",
-} as const);
+export function previewContainerStyle(name?: string): {
+  readonly containerName: string;
+  readonly containerType: "inline-size";
+} {
+  return Object.freeze({
+    containerName: previewContainerName(name) ?? PREVIEW_VIEWPORT_CONTAINER,
+    containerType: "inline-size",
+  } as const);
+}
+
+/**
+ * The style for a surface previewing under the default container name.
+ *
+ * The common case as a value, so a caller naming nothing does not have to call
+ * a function to get the pair.
+ */
+export const PREVIEW_CONTAINER_STYLE = previewContainerStyle();

--- a/packages/blocks-react/src/preview-container.ts
+++ b/packages/blocks-react/src/preview-container.ts
@@ -33,12 +33,30 @@ import {
  * content in the block direction and containing that too would collapse the
  * page's height.
  */
-export function previewContainerStyle(name?: string): {
-  readonly containerName: string;
-  readonly containerType: "inline-size";
-} {
+export function previewContainerStyle(
+  name?: string
+):
+  | { readonly containerName: string; readonly containerType: "inline-size" }
+  | Record<string, never> {
+  const resolved = previewContainerName(name);
+  /*
+   * NO container when the compiler refused the name, and that symmetry is the
+   * whole point rather than a nicety.
+   *
+   * A refused name makes the compile PUBLISHED: viewport tiers emit `@media`
+   * and container tiers emit unnamed `@container` rules. A box that established
+   * a query container anyway would let those unnamed rules resolve against IT,
+   * so viewport tiers would follow the window while container tiers followed
+   * the canvas — a hybrid neither mode intends, and precisely the capture a
+   * valid preview is named to prevent.
+   *
+   * An empty object rather than a thrown error or a null: a caller spreads this
+   * onto a style, and the honest answer for "this is not previewing" is that
+   * the box carries nothing.
+   */
+  if (resolved === undefined) return {};
   return Object.freeze({
-    containerName: previewContainerName(name) ?? PREVIEW_VIEWPORT_CONTAINER,
+    containerName: resolved,
     containerType: "inline-size",
   } as const);
 }
@@ -46,7 +64,9 @@ export function previewContainerStyle(name?: string): {
 /**
  * The style for a surface previewing under the default container name.
  *
- * The common case as a value, so a caller naming nothing does not have to call
- * a function to get the pair.
+ * For a caller that compiled with {@link PREVIEW_VIEWPORT_CONTAINER} and has no
+ * name of its own to pass.
  */
-export const PREVIEW_CONTAINER_STYLE = previewContainerStyle();
+export const PREVIEW_CONTAINER_STYLE = previewContainerStyle(
+  PREVIEW_VIEWPORT_CONTAINER
+);

--- a/packages/blocks-react/src/preview-container.ts
+++ b/packages/blocks-react/src/preview-container.ts
@@ -1,0 +1,27 @@
+/**
+ * What a surface must put on the box it previews a page inside.
+ *
+ * @module preview-container
+ */
+
+import { PREVIEW_VIEWPORT_CONTAINER } from "@nextlyhq/blocks-engine";
+
+/**
+ * The style a previewing surface applies to its own box.
+ *
+ * BOTH properties, in one value, because either alone does nothing. Naming a
+ * container without `container-type` leaves the element at the default
+ * `normal`, which is not a size-query container — so every `(max-width: ...)`
+ * rule the preview compile emitted stays inactive and resizing the box changes
+ * nothing at all. That failure is silent: the sheet is valid, the name matches,
+ * and the page simply never responds.
+ *
+ * Published as one object rather than as the name alone, so the second property
+ * cannot be the thing a consumer did not know to look for. `inline-size` rather
+ * than `size`, because a preview box is sized by its content in the block
+ * direction and containing that too would collapse the page's height.
+ */
+export const PREVIEW_CONTAINER_STYLE = Object.freeze({
+  containerName: PREVIEW_VIEWPORT_CONTAINER,
+  containerType: "inline-size",
+} as const);

--- a/packages/blocks-react/src/preview-reconcile.test.ts
+++ b/packages/blocks-react/src/preview-reconcile.test.ts
@@ -1,0 +1,72 @@
+/**
+ * That a preview surface's container is reconciled from BOTH tiers.
+ *
+ * The site sheet keeps this field through its own input spread, so a caller
+ * stating it on the stored tier and not on the route would have the shared
+ * sheet compiled for a preview while the page context compiled published rules
+ * — one render carrying two answers to one breakpoint, which is the divergence
+ * every other shared field is reconciled here to prevent.
+ *
+ * @module preview-reconcile.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { PREVIEW_VIEWPORT_CONTAINER } from "@nextlyhq/blocks-engine";
+
+import { sharedStyleInputs } from "./page-renderer";
+
+const breakpoints = { viewport: [], container: [] } as never;
+
+describe("the preview container a render resolves", () => {
+  it("is taken from the STORED tier when the route states none", () => {
+    // The case that was dropped: read from the route alone, this answered
+    // `undefined` while the site sheet kept the value and compiled a preview.
+    const shared = sharedStyleInputs(
+      { breakpoints } as never,
+      {
+        breakpoints,
+        previewContainer: PREVIEW_VIEWPORT_CONTAINER,
+      } as never
+    );
+
+    expect(shared.previewContainer).toBe(PREVIEW_VIEWPORT_CONTAINER);
+  });
+
+  it("is taken from the ROUTE when it states one", () => {
+    const shared = sharedStyleInputs(
+      { breakpoints, previewContainer: PREVIEW_VIEWPORT_CONTAINER } as never,
+      { breakpoints } as never
+    );
+
+    expect(shared.previewContainer).toBe(PREVIEW_VIEWPORT_CONTAINER);
+  });
+
+  it("prefers the ROUTE where both state one", () => {
+    // Which surface is previewing is a fact about THIS render; the stored tier
+    // describes the site. A separating fixture, so a resolver picking either
+    // side cannot pass both this and the case above.
+    const shared = sharedStyleInputs(
+      { breakpoints, previewContainer: "nx-route-box" } as never,
+      { breakpoints, previewContainer: "nx-stored-box" } as never
+    );
+
+    expect(shared.previewContainer).toBe("nx-route-box");
+  });
+
+  it("omits the key entirely when neither states one", () => {
+    /*
+     * Omitted rather than present-and-undefined, which is the property the
+     * whole resolver is built around: a context carrying the key would tell a
+     * reader the question was asked and answered as "no preview", and the
+     * artifact identity would then differ from one where it was never asked.
+     */
+    const shared = sharedStyleInputs(
+      { breakpoints } as never,
+      {
+        breakpoints,
+      } as never
+    );
+
+    expect("previewContainer" in shared).toBe(false);
+  });
+});

--- a/packages/blocks-react/src/shared-style-inputs.test.ts
+++ b/packages/blocks-react/src/shared-style-inputs.test.ts
@@ -18,6 +18,7 @@ import {
   MAX_NAMED_CLASS_NAME_LENGTH,
   MAX_SCANNED_KEYS,
   MAX_VALUE_LENGTH,
+  PREVIEW_VIEWPORT_CONTAINER,
 } from "@nextlyhq/blocks-engine";
 
 import {
@@ -78,6 +79,33 @@ describe("the stamp", () => {
     // Nothing else here means anything if this does not hold: a stamp that
     // varied run to run would recompile every page on every render.
     expect(sharedStyleInputsId(inputs())).toBe(sharedStyleInputsId(inputs()));
+  });
+
+  it("separates a PREVIEW compile from a published one", () => {
+    /*
+     * The artifact identity is what decides whether a stored sheet is reused
+     * instead of recompiled, and `resolvePageStyles` is exported and returns a
+     * storable `PageStyles`. So a preview compile stamped as published can be
+     * persisted and then served to a live page — which has no preview
+     * container, so every one of its responsive rules stops matching and the
+     * page silently loses its breakpoints.
+     *
+     * Both halves are asserted. Equal stamps would be the defect; a published
+     * stamp that MOVED would be a different one, invalidating every artifact on
+     * the site for CSS that did not change by a byte.
+     */
+    const published = sharedStyleInputsId(inputs());
+    const previewed = sharedStyleInputsId({
+      ...inputs(),
+      previewContainer: PREVIEW_VIEWPORT_CONTAINER,
+    });
+
+    // The population first: two `undefined`s compare equal and prove nothing.
+    expect(published).toBeDefined();
+    expect(previewed).toBeDefined();
+    expect(previewed).not.toBe(published);
+    // And the published side is untouched by the option existing.
+    expect(published).toBe(sharedStyleInputsId({ ...inputs() }));
   });
 
   it("is absent when the caller states no shared inputs", () => {

--- a/packages/blocks-react/src/shared-style-inputs.ts
+++ b/packages/blocks-react/src/shared-style-inputs.ts
@@ -78,7 +78,11 @@ import type { StyleCompileContext } from "@nextlyhq/blocks-engine";
  */
 export type SharedStyleInputs = Pick<
   StyleCompileContext,
-  "breakpoints" | "namedClasses" | "tokenPrefix" | "blockBases"
+  | "breakpoints"
+  | "namedClasses"
+  | "tokenPrefix"
+  | "blockBases"
+  | "previewContainer"
 >;
 
 /**
@@ -536,7 +540,24 @@ function labelFor(inputs: SharedStyleInputs, reading: Reading): string {
     // `breakpointContexts` slices the stored axis before it sorts, so this call
     // costs what compilation costs. Reading it and calling that bounded would
     // otherwise be a claim about a function this file does not own.
-    breakpointContexts(inputs.breakpoints),
+    // Emitted UNDER THE PREVIEW OPTION, so a preview compile and a published one
+    // can never carry the same identity.
+    //
+    // Folded into this element rather than appended as another, which is what
+    // keeps a published stamp byte-identical: the option is absent there, the
+    // contexts are what they always were, and nothing about this array's shape
+    // moved. Appending a slot would have invalidated every artifact on the site
+    // to record a field that is unset on all of them.
+    //
+    // Without it, `resolvePageStyles` — which is exported, and returns a
+    // storable `PageStyles` — hands back preview CSS stamped as published. Reuse
+    // then serves `@container` rules to a live page that has no such container,
+    // and every responsive rule stops matching.
+    breakpointContexts(inputs.breakpoints, {
+      ...(inputs.previewContainer === undefined
+        ? {}
+        : { previewContainer: inputs.previewContainer }),
+    }),
     // The prefix tokens are actually WRITTEN under, not the one that was stored.
     // `safeTokenPrefix` maps unset, malformed and reserved prefixes alike to the
     // engine's default, so all of them emit identical `var(--site-*)` references

--- a/packages/blocks-react/src/styles.test.ts
+++ b/packages/blocks-react/src/styles.test.ts
@@ -15,8 +15,10 @@ import { describe, expect, it } from "vitest";
 
 import type { BlockDocument, BlockNode } from "@nextlyhq/blocks-engine";
 import { compilePageCss } from "@nextlyhq/blocks-engine";
+import type { StyleCompileContext } from "@nextlyhq/blocks-engine";
 
 import { createBlockResolver } from "./resolver";
+import { sharedStyleInputsId } from "./shared-style-inputs";
 import {
   resolvePageStyles,
   resolvePageStylesWithTrace,
@@ -478,5 +480,85 @@ describe("a stored artifact that was compiled for a PREVIEW", () => {
     );
 
     expect(styles.css).not.toBe("");
+  });
+});
+
+describe("a preview artifact read back UNDER a context", () => {
+  /*
+   * The context-free refusal above must not become a blanket one. A preview
+   * render supplies the same context it compiled under, and the stamp already
+   * proves the inputs match — so recompiling there buys nothing and costs a
+   * full compile of the document on every render of the editor's canvas.
+   */
+  const breakpoints = {
+    viewport: [{ id: "tablet", label: "Tablet", maxWidth: 991 }],
+    container: [],
+  } as never;
+
+  const styled: BlockNode = {
+    id: "a",
+    type: "test/text",
+    version: 1,
+    props: {},
+    styles: { base: { base: { color: "teal" }, tablet: { color: "salmon" } } },
+  } as never;
+
+  const context = (previewContainer?: string): StyleCompileContext =>
+    ({
+      breakpoints,
+      ...(previewContainer === undefined ? {} : { previewContainer }),
+    }) as never;
+
+  /*
+   * A stored artifact whose CSS is recognisable, which is what separates the
+   * two outcomes.
+   *
+   * Reuse and recompilation both return a sheet, and for an unmodified artifact
+   * they return equal ones — so asserting on the CSS alone cannot tell them
+   * apart. Marking the stored copy makes reuse observable: the marker survives
+   * only if the stored bytes were served rather than regenerated.
+   */
+  const marked = (previewContainer?: string): PageStyles => {
+    const compiled = toPageStyles(
+      compilePageCss(doc(styled), context(previewContainer) as never),
+      undefined,
+      undefined,
+      sharedStyleInputsId(context(previewContainer))
+    );
+    return { ...compiled, css: `${compiled.css}\n/* stored-copy */` };
+  };
+
+  it("is REUSED when the context it is read under matches", () => {
+    const styles = resolvePageStyles(
+      doc(styled),
+      marked("nx-preview-viewport"),
+      context("nx-preview-viewport"),
+      blocks
+    );
+
+    expect(styles.css).toContain("stored-copy");
+  });
+
+  it("is REFUSED when read under a published context, which is the control", () => {
+    /*
+     * Without this the reuse above is satisfied by a resolver that trusts every
+     * artifact it is handed — which is the defect the context-free refusal
+     * exists to stop, reintroduced one layer up.
+     *
+     * The stamp is what discriminates: `sharedStyleInputsId` folds the preview
+     * container into its breakpoint contexts, so the preview artifact's stamp
+     * cannot match a published context's.
+     */
+    const styles = resolvePageStyles(
+      doc(styled),
+      marked("nx-preview-viewport"),
+      context(),
+      blocks
+    );
+
+    expect(styles.css).not.toContain("stored-copy");
+    // Recompiled rather than withheld: a context was available, so the right
+    // answer is a correct sheet rather than an empty one.
+    expect(styles.css).toContain("@media (max-width: 991px)");
   });
 });

--- a/packages/blocks-react/src/styles.test.ts
+++ b/packages/blocks-react/src/styles.test.ts
@@ -367,3 +367,116 @@ describe("the cascade the compiler produced, alongside the sheet", () => {
     );
   });
 });
+
+describe("a stored artifact that was compiled for a PREVIEW", () => {
+  /*
+   * `resolvePageStyles` is exported, so this path is reachable rather than
+   * theoretical: a caller can compile with a preview container, persist what
+   * comes back, and hand it to a published render later with no context.
+   */
+  const breakpoints = {
+    viewport: [{ id: "tablet", label: "Tablet", maxWidth: 991 }],
+    container: [],
+  } as never;
+
+  /*
+   * A node carrying a real declaration at a real breakpoint.
+   *
+   * `node()` above has no styles, so compiling it produces an EMPTY sheet — and
+   * a refusal assertion of `css === ""` against that passes without the refusal
+   * ever running. The control below is what exposed that, which is the reason
+   * it is here rather than as a courtesy.
+   */
+  const styled: BlockNode = {
+    id: "a",
+    type: "test/text",
+    version: 1,
+    props: {},
+    styles: { base: { base: { color: "teal" }, tablet: { color: "salmon" } } },
+  } as never;
+
+  const compiled = (previewContainer?: string): PageStyles =>
+    toPageStyles(
+      compilePageCss(doc(styled), {
+        breakpoints,
+        ...(previewContainer === undefined ? {} : { previewContainer }),
+      })
+    );
+
+  it("records the container the compiler AIMED AT, not the one requested", () => {
+    // The population for everything below: without the stamp there is nothing
+    // for a context-free read to judge, so the refusal could not be reached.
+    // The population first: the fixture must really compile a breakpoint rule,
+    // or every assertion below is about an empty sheet.
+    expect(compiled().css).toContain("@media (max-width: 991px)");
+    expect(compiled("nx-preview-viewport").css).toContain(
+      "@container nx-preview-viewport (max-width: 991px)"
+    );
+    expect(compiled("nx-preview-viewport").previewContainer).toBe(
+      "nx-preview-viewport"
+    );
+    // A REFUSED name compiles published, so the artifact must not claim to be a
+    // preview — stamped on request rather than on outcome, every surface that
+    // passed a bad name would have its perfectly publishable sheet withheld.
+    expect(compiled("none").previewContainer).toBeUndefined();
+    expect(compiled().previewContainer).toBeUndefined();
+  });
+
+  it("is REFUSED on a context-free read, which no other staleness rule is", () => {
+    /*
+     * Every other check in `resolvePageStyles` compares the artifact against an
+     * input the compile context supplies, so with no context there is nothing
+     * to compare and the sheet is trusted. This one is a property of the
+     * artifact alone and has to survive that.
+     *
+     * Served instead, the page renders its base tier and silently loses every
+     * breakpoint above it: the `@container` rules name a box only a previewing
+     * surface declares, so they match nothing. It looks deliberately styled at
+     * one width and stops responding at every other, which is the failure mode
+     * worth refusing a sheet over.
+     */
+    const styles = resolvePageStyles(
+      doc(styled),
+      compiled("nx-preview-viewport"),
+      undefined,
+      blocks
+    );
+
+    expect(styles.css).toBe("");
+    // The classes survive the refusal, so a host stylesheet still has something
+    // to select: refusing the CSS is not refusing the artifact.
+    expect(styles.classes).toHaveProperty("a");
+  });
+
+  it("SERVES a published artifact on the same path, which is the control", () => {
+    /*
+     * Without this the refusal above is satisfied by absence — a resolver that
+     * returned an empty sheet for every context-free read would pass it while
+     * making stored styles useless.
+     *
+     * Same document, same call, same absent context; only the stamp differs.
+     */
+    const styles = resolvePageStyles(
+      doc(styled),
+      compiled(),
+      undefined,
+      blocks
+    );
+
+    expect(styles.css).not.toBe("");
+  });
+
+  it("SERVES an artifact whose preview name the compiler refused", () => {
+    // The other direction of the stamp-on-outcome rule: a refused name means a
+    // published sheet, and withholding it would break previewing surfaces that
+    // passed a bad name rather than protecting anyone.
+    const styles = resolvePageStyles(
+      doc(styled),
+      compiled("none"),
+      undefined,
+      blocks
+    );
+
+    expect(styles.css).not.toBe("");
+  });
+});

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -1040,14 +1040,27 @@ export function resolvePageStylesWithTrace(
     (styles.sharedInputsId !== sharedInputsId ||
       styles.sharedInputsId === UNIDENTIFIED_SHARED_INPUTS);
   /*
-   * A PREVIEW artifact, refused WITHOUT a context — the one staleness rule here
-   * that must not be gated on having one.
+   * A PREVIEW artifact on a CONTEXT-FREE read, which is the only place this
+   * question is still open.
    *
-   * Every other check above compares the artifact against an input the context
-   * supplies, so with no context there is nothing to compare and asking would
-   * be meaningless. This one is a property of the artifact ALONE: its viewport
-   * tiers are `@container` rules naming a box that only the previewing surface
-   * declares, so on a published page they match nothing.
+   * Gated the opposite way to every other rule here, and for the same reason
+   * they are gated at all. They compare the artifact against an input the
+   * context supplies, so they can only be asked WITH one. This one is a
+   * property of the artifact alone and can only be asked WITHOUT one — because
+   * when a context exists, `compiledAgainstOtherInputs` has already settled it:
+   * `sharedStyleInputsId` folds the preview container into its breakpoint
+   * contexts, so a preview artifact read under a published context has a
+   * different stamp and is refused there, and one read under the SAME preview
+   * context has a matching stamp and is correctly reused.
+   *
+   * Asking it unconditionally therefore did not add safety, it removed reuse:
+   * every preview render recompiled the whole document even when the stamp
+   * proved the inputs identical, which on a large editor document is the
+   * editor's own hot path.
+   *
+   * What remains is the case no stamp can reach. Its viewport tiers are
+   * `@container` rules naming a box that only the previewing surface declares,
+   * so on a published page they match nothing.
    *
    * That is why the reasoning above — that withholding a sheet is worse than
    * serving a stale one — inverts here. A stale sheet is a page styled with
@@ -1062,7 +1075,9 @@ export function resolvePageStylesWithTrace(
    * back later with `styles` and no `styleContext`.
    */
   const compiledForPreview =
-    styles !== undefined && styles.previewContainer !== undefined;
+    styles !== undefined &&
+    compileContext === undefined &&
+    styles.previewContainer !== undefined;
 
   /*
    * ONE answer to "may this stored sheet be served as it stands", used by both

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -81,6 +81,23 @@ export interface PageStyles {
    * is the one that serves a stale sheet forever.
    */
   sharedInputsId?: string;
+  /**
+   * The container this sheet's breakpoints were aimed at, when it is a PREVIEW
+   * artifact — and absent for every publishable one.
+   *
+   * A preview sheet is not publishable and the difference is invisible in the
+   * CSS: its viewport tiers are `@container` rules naming a box only the
+   * previewing surface declares, so on a published page they match nothing and
+   * every breakpoint above the base one silently disappears. The page still
+   * renders, still looks styled at desktop width, and stops being responsive.
+   *
+   * Recorded on the ARTIFACT because `resolvePageStyles` is exported and
+   * returns this shape, so a preview result can be persisted and later handed
+   * back with no compile context — and a context-free read has nothing else to
+   * judge it by. Every other staleness field here is compared against inputs a
+   * context supplies; this one has to be refusable without one.
+   */
+  previewContainer?: string;
   /** Node id to generated class name. */
   classes: Record<string, string>;
   /**
@@ -141,9 +158,17 @@ export function toPageStyles(
   //
   // The parameter is no longer read for this: a caller cannot know whether the
   // compiler accepted its scope, and only the compiler does.
-  return compiled.scope === undefined
-    ? withGated
-    : { ...withGated, scope: compiled.scope };
+  const withScope =
+    compiled.scope === undefined
+      ? withGated
+      : { ...withGated, scope: compiled.scope };
+  // The container the compiler actually AIMED AT, for the same reason the scope
+  // above is the written one rather than the requested one: a refused name
+  // compiles published, and stamping that artifact as a preview would withhold
+  // a perfectly publishable sheet on every later context-free read.
+  return compiled.previewContainer === undefined
+    ? withScope
+    : { ...withScope, previewContainer: compiled.previewContainer };
 }
 
 /**
@@ -1014,14 +1039,49 @@ export function resolvePageStylesWithTrace(
     compileContext !== undefined &&
     (styles.sharedInputsId !== sharedInputsId ||
       styles.sharedInputsId === UNIDENTIFIED_SHARED_INPUTS);
+  /*
+   * A PREVIEW artifact, refused WITHOUT a context — the one staleness rule here
+   * that must not be gated on having one.
+   *
+   * Every other check above compares the artifact against an input the context
+   * supplies, so with no context there is nothing to compare and asking would
+   * be meaningless. This one is a property of the artifact ALONE: its viewport
+   * tiers are `@container` rules naming a box that only the previewing surface
+   * declares, so on a published page they match nothing.
+   *
+   * That is why the reasoning above — that withholding a sheet is worse than
+   * serving a stale one — inverts here. A stale sheet is a page styled with
+   * yesterday's values, which is wrong and recognisable. A preview sheet served
+   * published renders the base tier and silently drops every breakpoint above
+   * it, so the page looks deliberately styled at one width and stops responding
+   * at every other. Refusing produces a page that is visibly unstyled, which
+   * someone notices.
+   *
+   * `resolvePageStyles` is exported and returns this shape, so this is reachable
+   * rather than theoretical: a caller can persist a preview result and hand it
+   * back later with `styles` and no `styleContext`.
+   */
+  const compiledForPreview =
+    styles !== undefined && styles.previewContainer !== undefined;
 
-  if (
-    styles &&
-    !repairedDocument &&
-    !compiledFromAnotherTree &&
-    !compiledUnderAnotherPolicy &&
-    !compiledAgainstOtherInputs
-  ) {
+  /*
+   * ONE answer to "may this stored sheet be served as it stands", used by both
+   * the trust branch and the context-free refusal below.
+   *
+   * They were the same list written twice, once negated and once positive, so a
+   * reason added to one and missed in the other would trust an artifact on one
+   * path and withhold it on the other — for the same document, decided by
+   * whether a context happened to be supplied. Naming it once makes the two
+   * unable to disagree.
+   */
+  const untrusted =
+    repairedDocument ||
+    compiledFromAnotherTree ||
+    compiledUnderAnotherPolicy ||
+    compiledAgainstOtherInputs ||
+    compiledForPreview;
+
+  if (styles && !untrusted) {
     const normalized = normalizeStoredStyles(styles, document);
     // A refused artifact had its classes rebuilt, so the gated rules — written
     // against the classes it USED to carry — would select nothing. Nothing is
@@ -1032,14 +1092,7 @@ export function resolvePageStylesWithTrace(
         : withGatedRules(normalized.styles, document, drawsNothing),
     };
   }
-  if (
-    styles &&
-    (repairedDocument ||
-      compiledFromAnotherTree ||
-      compiledUnderAnotherPolicy ||
-      compiledAgainstOtherInputs) &&
-    styleContext === undefined
-  ) {
+  if (styles && untrusted && styleContext === undefined) {
     return {
       styles: { ...normalizeStoredStyles(styles, document).styles, css: "" },
     };

--- a/packages/builder/src/breakpoints.test.ts
+++ b/packages/builder/src/breakpoints.test.ts
@@ -9,7 +9,10 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { MAX_BREAKPOINT_ID_LENGTH } from "@nextlyhq/blocks-engine";
+import {
+  MAX_BREAKPOINT_ID_LENGTH,
+  PREVIEW_VIEWPORT_CONTAINER,
+} from "@nextlyhq/blocks-engine";
 
 import {
   authoredBreakpoints,
@@ -42,6 +45,60 @@ function rows(prefix: string, count: number) {
     maxWidth: 1000 - i * 50,
   }));
 }
+
+describe("which breakpoints a window can answer for", () => {
+  it("answers only the BASE context under a container preview", () => {
+    /*
+     * Asked without the preview option, this compares the window against
+     * `@media` rules a preview compile never wrote — and the answer is not
+     * merely stale, it is confidently wrong in a direction that looks
+     * plausible. Measured: with every media query matching, the unaware call
+     * reports tablet and mobile live, which is exactly what a NARROW admin
+     * window reports while a WIDE canvas box is showing desktop.
+     *
+     * Under the option the viewport contexts are container queries, which a
+     * `matchMedia` caller cannot answer, so the honest result is the base
+     * context alone — silence rather than a wrong claim.
+     *
+     * `() => true` is deliberate: it makes the unaware call report everything,
+     * so this cannot pass by the window happening to match nothing.
+     */
+    const always = () => true;
+
+    expect(matchedBreakpoints(BREAKPOINTS_FOR_PREVIEW, always)).toEqual([
+      "base",
+      "tablet",
+      "mobile",
+    ]);
+    expect(
+      matchedBreakpoints(BREAKPOINTS_FOR_PREVIEW, always, {
+        previewContainer: PREVIEW_VIEWPORT_CONTAINER,
+      })
+    ).toEqual(["base"]);
+  });
+
+  it("emits no answerable query under a preview, so nothing is subscribed", () => {
+    // `breakpointQueries` feeds the subscription. Left unaware, the panel would
+    // subscribe to media queries the sheet does not use and re-measure on every
+    // window resize for answers it must not report.
+    expect(breakpointQueries(BREAKPOINTS_FOR_PREVIEW).length).toBeGreaterThan(
+      0
+    );
+    expect(
+      breakpointQueries(BREAKPOINTS_FOR_PREVIEW, {
+        previewContainer: PREVIEW_VIEWPORT_CONTAINER,
+      })
+    ).toEqual([]);
+  });
+});
+
+const BREAKPOINTS_FOR_PREVIEW = {
+  viewport: [
+    { id: "tablet", label: "Tablet", maxWidth: 991 },
+    { id: "mobile", label: "Mobile", maxWidth: 575 },
+  ],
+  container: [],
+} as unknown as BreakpointSet;
 
 describe("the authored set", () => {
   it("strips a stored base row from both axes", () => {

--- a/packages/builder/src/breakpoints.ts
+++ b/packages/builder/src/breakpoints.ts
@@ -37,6 +37,7 @@ import {
   type BreakpointAxis,
   type BreakpointDef,
   breakpointContexts,
+  type BreakpointContextOptions,
   type BreakpointId,
   type BreakpointSet,
 } from "@nextlyhq/blocks-engine";
@@ -445,10 +446,25 @@ export function liveBreakpointsFor(
  */
 export function matchedBreakpoints(
   set: BreakpointSet | undefined,
-  matches: (query: string) => boolean
+  matches: (query: string) => boolean,
+  options?: BreakpointContextOptions
 ): BreakpointId[] {
   const live: BreakpointId[] = [];
-  for (const context of breakpointContexts(set)) {
+  /*
+   * The queries the sheet was actually EMITTED under, preview option included.
+   *
+   * Asked without it, this compares the window against `@media` rules a preview
+   * compile never wrote — and the answer is not merely stale, it is confidently
+   * wrong in a direction that looks plausible: a narrow admin window reports
+   * tablet and mobile live while a wide canvas box is showing desktop.
+   *
+   * Passing the option makes the viewport contexts container queries, which the
+   * `@media` test below then declines to answer, so the result is the base
+   * context alone. That is silence rather than a wrong claim, and it is what a
+   * `matchMedia` caller can honestly say: a container query is a question about
+   * an element, and this function is only given a way to ask the window.
+   */
+  for (const context of breakpointContexts(set, options)) {
     if (context.atRule === undefined) {
       // The unconditional VIEWPORT context: no query to ask, and always
       // applying. A container's widest context is not this case — it still
@@ -480,9 +496,12 @@ export function matchedBreakpoints(
  *
  * @experimental
  */
-export function breakpointQueries(set: BreakpointSet | undefined): string[] {
+export function breakpointQueries(
+  set: BreakpointSet | undefined,
+  options?: BreakpointContextOptions
+): string[] {
   const queries: string[] = [];
-  for (const context of breakpointContexts(set)) {
+  for (const context of breakpointContexts(set, options)) {
     if (context.atRule === undefined) continue;
     const condition = context.atRule.replace(/^@media\s*/, "");
     // The same single test {@link matchedBreakpoints} applies, deliberately.

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -119,6 +119,12 @@ export interface InspectorPanelProps {
    */
   previewContainer?: string;
   /**
+   * Which breakpoints the canvas is ACTUALLY applying, forwarded to the Style
+   * tab. Needed only while previewing, where the queries are about the preview
+   * box and only its owner can observe them.
+   */
+  liveBreakpoints?: readonly BreakpointId[];
+  /**
    * The site's design tokens, forwarded to the Style tab's colour controls.
    *
    * Carried rather than defaulted, as `policy` is: omitting it means the
@@ -157,6 +163,7 @@ export function InspectorPanel({
   cascade,
   breakpoints,
   previewContainer,
+  liveBreakpoints,
   tokens,
   blocks,
 }: InspectorPanelProps): React.JSX.Element {
@@ -298,6 +305,7 @@ export function InspectorPanel({
             cascade={cascade}
             breakpoints={breakpoints}
             previewContainer={previewContainer}
+            liveBreakpoints={liveBreakpoints}
             tokens={tokens}
           />
         </TabsContent>

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -109,6 +109,16 @@ export interface InspectorPanelProps {
   /** The site's breakpoints, which decide which of those declarations are live. */
   breakpoints?: BreakpointSet;
   /**
+   * The container the canvas compiled its breakpoints against, when it is
+   * previewing rather than rendering at the browser's own width.
+   *
+   * Forwarded for the reason the Style tab states: which declarations are LIVE
+   * is a question about the queries the sheet was emitted under, and a panel
+   * given only the set compares the window against rules a preview compile
+   * never wrote.
+   */
+  previewContainer?: string;
+  /**
    * The site's design tokens, forwarded to the Style tab's colour controls.
    *
    * Carried rather than defaulted, as `policy` is: omitting it means the
@@ -146,6 +156,7 @@ export function InspectorPanel({
   breakpoint,
   cascade,
   breakpoints,
+  previewContainer,
   tokens,
   blocks,
 }: InspectorPanelProps): React.JSX.Element {
@@ -286,6 +297,7 @@ export function InspectorPanel({
             breakpoint={breakpoint}
             cascade={cascade}
             breakpoints={breakpoints}
+            previewContainer={previewContainer}
             tokens={tokens}
           />
         </TabsContent>

--- a/packages/builder/src/preview-live-breakpoints.test.tsx
+++ b/packages/builder/src/preview-live-breakpoints.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+/**
+ * That the inspector asks the queries the sheet was actually emitted under.
+ *
+ * The panel decides which declarations are LIVE, and that is a question about
+ * the at-rules the compile wrote. Given only the breakpoint set, it compares the
+ * WINDOW against `@media` rules a preview compile never wrote — which is not a
+ * stale answer but a confident wrong one, and in a plausible direction: a narrow
+ * admin window reports the small breakpoints live while a wide canvas box is
+ * showing the large ones.
+ *
+ * Asserted through the panel rather than the helper, because the helper already
+ * accepted the option while the panel could not supply it — a fix that reached
+ * the lower level and stopped there.
+ *
+ * @module preview-live-breakpoints.test
+ */
+import { PREVIEW_VIEWPORT_CONTAINER } from "@nextlyhq/blocks-engine";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { StyleInspectorPanel } from "./style-inspector-panel";
+import type { BreakpointSet } from "./breakpoints";
+import type { EditorState } from "./editor-state";
+
+const BREAKPOINTS = {
+  viewport: [
+    { id: "tablet", label: "Tablet", maxWidth: 991 },
+    { id: "mobile", label: "Mobile", maxWidth: 575 },
+  ],
+  container: [],
+} as unknown as BreakpointSet;
+
+/** Every query asked of the window, in the order the panel asked. */
+let asked: string[] = [];
+
+/*
+ * Only the WIDTH queries. The panel also asks `prefers-color-scheme` for its
+ * colour controls, which has nothing to do with breakpoints — counting it would
+ * make the preview case fail for a reason unrelated to the property under test.
+ */
+const widthQueries = (): string[] =>
+  asked.filter(query => query.includes("width"));
+
+beforeEach(() => {
+  asked = [];
+  // A NARROW admin window: every max-width query matches. That is the state in
+  // which an unaware panel reports the small breakpoints live while a wide
+  // canvas box is showing the large ones.
+  vi.stubGlobal("matchMedia", (query: string) => {
+    asked.push(query);
+    return {
+      matches: true,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    };
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+});
+
+const editor = {
+  document: { formatVersion: 1, kind: "page", nodes: [] },
+  selection: { ids: [] },
+  selectedId: null,
+  apply: () => null,
+  undoDepth: 0,
+} as unknown as EditorState;
+
+describe("what the inspector asks the window", () => {
+  it("asks nothing at all while the canvas is previewing", () => {
+    /*
+     * Under a preview compile the viewport tiers are container queries, which a
+     * `matchMedia` caller cannot answer — so the honest behaviour is to ask
+     * nothing and report only the unconditional context.
+     *
+     * The population is the published case below: if the panel asked no queries
+     * in EITHER mode, this assertion would pass while proving nothing.
+     */
+    render(
+      <StyleInspectorPanel
+        editor={editor}
+        breakpoints={BREAKPOINTS}
+        previewContainer={PREVIEW_VIEWPORT_CONTAINER}
+      />
+    );
+
+    expect(widthQueries()).toEqual([]);
+  });
+
+  it("asks the window's own queries when it is NOT previewing", () => {
+    // The control, and the population for the case above.
+    render(<StyleInspectorPanel editor={editor} breakpoints={BREAKPOINTS} />);
+
+    expect(widthQueries().length).toBeGreaterThan(0);
+    expect(widthQueries().join(" ")).toContain("max-width: 991px");
+  });
+});

--- a/packages/builder/src/preview-live-breakpoints.test.tsx
+++ b/packages/builder/src/preview-live-breakpoints.test.tsx
@@ -9,9 +9,12 @@
  * admin window reports the small breakpoints live while a wide canvas box is
  * showing the large ones.
  *
- * Asserted through the panel rather than the helper, because the helper already
- * accepted the option while the panel could not supply it — a fix that reached
- * the lower level and stopped there.
+ * Asserted through the PANEL rather than through `matchedBreakpoints` directly,
+ * because the contract under test is the forwarding: the helper takes the
+ * preview option as a parameter and cannot know whether its caller supplies
+ * one, so a helper-level test passes on a panel that never passes it along.
+ * Only a test that renders the panel and reads the queries it actually
+ * subscribes to can tell those apart.
  *
  * @module preview-live-breakpoints.test
  */

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -1638,6 +1638,82 @@ describe("where a control's value came from", () => {
     }
   });
 
+  it("IGNORES a host's live set when the compiler refused the container name", () => {
+    /*
+     * The two halves of one question, which were briefly two answers.
+     *
+     * A refused name makes the compile PUBLISHED — viewport tiers emit ordinary
+     * `@media`, which the window decides. A host that forwards both canvas
+     * props unconditionally then supplies a box-derived set for a sheet the box
+     * is not deciding, and provenance gets judged against a tier the browser is
+     * not displaying.
+     *
+     * `liveBreakpoints` is deliberately a set that would change the verdict if
+     * it were consulted: the entry writes at `mobile`, so believing the host
+     * would report the control as set, while the window here matches nothing
+     * beyond the base context and the honest answer is that it is not.
+     */
+    register({ color: true });
+    const editor = editorFor(documentOf());
+
+    render(
+      <StyleInspectorPanel
+        editor={editor}
+        breakpoints={
+          {
+            viewport: [{ id: "mobile", label: "Mobile", maxWidth: 575 }],
+            container: [],
+          } as never
+        }
+        previewContainer="none"
+        liveBreakpoints={["base", "mobile"]}
+        cascade={
+          {
+            nodes: editor.document.nodes,
+            entries: [entry({ breakpoint: "mobile" })],
+          } as never
+        }
+      />
+    );
+
+    expect(dotIn("color")).toBeNull();
+  });
+
+  it("USES the host's live set when the name was accepted, which is the control", () => {
+    /*
+     * Without this, a panel that ignored `liveBreakpoints` under every
+     * circumstance would satisfy the case above — the assertion there is
+     * satisfied by absence, so its meaning depends on this one.
+     *
+     * Same entry, same host set; only the container name differs, and it is the
+     * difference between a compile the window decides and one the box does.
+     */
+    register({ color: true });
+    const editor = editorFor(documentOf());
+
+    render(
+      <StyleInspectorPanel
+        editor={editor}
+        breakpoints={
+          {
+            viewport: [{ id: "mobile", label: "Mobile", maxWidth: 575 }],
+            container: [],
+          } as never
+        }
+        previewContainer="nx-preview-viewport"
+        liveBreakpoints={["base", "mobile"]}
+        cascade={
+          {
+            nodes: editor.document.nodes,
+            entries: [entry({ breakpoint: "mobile" })],
+          } as never
+        }
+      />
+    );
+
+    expect(dotIn("color")).not.toBeNull();
+  });
+
   it("draws NOTHING for a property no tier set", () => {
     // Eight empty dots per section is the shape that trains an author to stop
     // reading the panel.

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -1519,6 +1519,76 @@ describe("where a control's value came from", () => {
     expect(text?.getAttribute("aria-hidden")).toBe("true");
   });
 
+  it("draws NOTHING while previewing and nobody has said which tier is live", () => {
+    /*
+     * Silence in this API is a CLAIM, which is what makes the obvious fix wrong.
+     *
+     * Under a preview compile the viewport tiers are container queries and a
+     * `matchMedia` caller cannot evaluate them, so the window-derived answer is
+     * the base context alone. Passed on, `liveBreakpoints: ["base"]` asserts
+     * that base is what the browser is applying — and a narrow preview box
+     * showing the mobile tier would have every mobile declaration excluded and
+     * the base value reported as the visible winner.
+     *
+     * No dot means "not asked", which is true until a caller observes the box.
+     */
+    register({ color: true });
+    const editor = editorFor(documentOf());
+
+    render(
+      <StyleInspectorPanel
+        editor={editor}
+        breakpoints={
+          {
+            viewport: [{ id: "mobile", label: "Mobile", maxWidth: 575 }],
+            container: [],
+          } as never
+        }
+        previewContainer="nx-preview-viewport"
+        cascade={
+          {
+            nodes: editor.document.nodes,
+            entries: [entry()],
+          } as never
+        }
+      />
+    );
+
+    expect(dotIn("color")).toBeNull();
+  });
+
+  it("draws one once the host SAYS which tier is live, which is the control", () => {
+    /*
+     * Without this, a panel that never drew a dot while previewing would satisfy
+     * the case above and the affordance would simply be gone rather than
+     * withheld — an absence proving nothing about the gate.
+     */
+    register({ color: true });
+    const editor = editorFor(documentOf());
+
+    render(
+      <StyleInspectorPanel
+        editor={editor}
+        breakpoints={
+          {
+            viewport: [{ id: "mobile", label: "Mobile", maxWidth: 575 }],
+            container: [],
+          } as never
+        }
+        previewContainer="nx-preview-viewport"
+        liveBreakpoints={["base"]}
+        cascade={
+          {
+            nodes: editor.document.nodes,
+            entries: [entry()],
+          } as never
+        }
+      />
+    );
+
+    expect(dotIn("color")).not.toBeNull();
+  });
+
   it("draws NOTHING for a property no tier set", () => {
     // Eight empty dots per section is the shape that trains an author to stop
     // reading the panel.

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -1589,6 +1589,55 @@ describe("where a control's value came from", () => {
     expect(dotIn("color")).not.toBeNull();
   });
 
+  it("still draws one when the compiler REFUSED the stated container name", () => {
+    /*
+     * A stated name is not an active preview, and the two must not be conflated
+     * because the compile does not conflate them either.
+     *
+     * `previewContainerName` refuses an empty, reserved, malformed or oversized
+     * string, and a refused name makes the compile PUBLISHED — viewport tiers
+     * emit ordinary `@media`, which `matchMedia` can evaluate. So the window's
+     * answer is authoritative here, and withholding the indicator would remove
+     * a correct affordance from every surface that passed a name the compiler
+     * threw away.
+     *
+     * Driven through the refusals the compiler actually enumerates rather than
+     * one representative, because each reaches a different branch of it: a
+     * length bound read before trimming, a reserved CSS-wide keyword, and a
+     * character the identifier grammar excludes.
+     */
+    // Registered ONCE: the block registry outlives `cleanup`, which unmounts
+    // the tree and leaves registrations in place, so a second call inside the
+    // loop is a redefinition and the registry refuses it.
+    register({ color: true });
+
+    for (const refused of ["", "   ", "none", "has space"]) {
+      cleanup();
+      const editor = editorFor(documentOf());
+
+      render(
+        <StyleInspectorPanel
+          editor={editor}
+          breakpoints={
+            {
+              viewport: [{ id: "mobile", label: "Mobile", maxWidth: 575 }],
+              container: [],
+            } as never
+          }
+          previewContainer={refused}
+          cascade={
+            {
+              nodes: editor.document.nodes,
+              entries: [entry()],
+            } as never
+          }
+        />
+      );
+
+      expect(dotIn("color")).not.toBeNull();
+    }
+  });
+
   it("draws NOTHING for a property no tier set", () => {
     // Eight empty dots per section is the shape that trains an author to stop
     // reading the panel.

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -47,6 +47,7 @@ import {
   type StyleState,
   type StyleTraceEntry,
   type StyleValue,
+  previewContainerName,
 } from "@nextlyhq/blocks-engine";
 import type { PageStyleCascade } from "@nextlyhq/blocks-react";
 import {
@@ -247,7 +248,19 @@ export function StyleInspectorPanel({
     {}
   );
   const prefersDark = usePrefersDark();
-  const matched = useMatchedBreakpoints(breakpoints, previewContainer);
+  /*
+   * NORMALISED once here, and every question below asks this value rather than
+   * the raw prop — the compiler does exactly the same at its own entry.
+   *
+   * A stated name is not the same as an ACTIVE preview. `previewContainerName`
+   * refuses an empty, reserved, malformed or oversized string, and a refused
+   * name makes the compile published: viewport tiers emit ordinary `@media`,
+   * which `matchMedia` can evaluate. Reading the raw prop as "previewing"
+   * suppressed every indicator for a surface whose sheet the window can answer
+   * for perfectly well.
+   */
+  const preview = previewContainerName(previewContainer);
+  const matched = useMatchedBreakpoints(breakpoints, preview);
 
   // Recomputed each render rather than memoised, as the content tab is: an
   // inspection is only valid against the document it was read from, and an edit
@@ -391,7 +404,7 @@ export function StyleInspectorPanel({
      *
      * No dot says "not asked", which is true until a caller observes the box.
      */
-    if (previewContainer !== undefined && liveBreakpoints === undefined) {
+    if (preview !== undefined && liveBreakpoints === undefined) {
       return undefined;
     }
     return styleProvenance({

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -249,18 +249,21 @@ export function StyleInspectorPanel({
   );
   const prefersDark = usePrefersDark();
   /*
-   * NORMALISED once here, and every question below asks this value rather than
-   * the raw prop — the compiler does exactly the same at its own entry.
+   * What the browser is applying, or `undefined` when nobody can say.
    *
-   * A stated name is not the same as an ACTIVE preview. `previewContainerName`
-   * refuses an empty, reserved, malformed or oversized string, and a refused
-   * name makes the compile published: viewport tiers emit ordinary `@media`,
-   * which `matchMedia` can evaluate. Reading the raw prop as "previewing"
-   * suppressed every indicator for a surface whose sheet the window can answer
-   * for perfectly well.
+   * ONE call, because the component must not hold the two inputs separately.
+   * It did, and they disagreed: the decision to draw an indicator asked whether
+   * a preview name was STATED while the set being judged asked whether the host
+   * had supplied one, so a refused name arriving beside a live set had the
+   * box-derived tiers used against a published compile. Fixing either half
+   * alone left the other standing, which is the tell that the two questions
+   * were one question with two answers.
    */
-  const preview = previewContainerName(previewContainer);
-  const matched = useMatchedBreakpoints(breakpoints, preview);
+  const live = useLiveBreakpoints(
+    breakpoints,
+    previewContainer,
+    liveBreakpoints
+  );
 
   // Recomputed each render rather than memoised, as the content tab is: an
   // inspection is only valid against the document it was read from, and an edit
@@ -404,9 +407,7 @@ export function StyleInspectorPanel({
      *
      * No dot says "not asked", which is true until a caller observes the box.
      */
-    if (preview !== undefined && liveBreakpoints === undefined) {
-      return undefined;
-    }
+    if (live === undefined) return undefined;
     return styleProvenance({
       trace: cascade.entries,
       subject,
@@ -431,7 +432,7 @@ export function StyleInspectorPanel({
        * match reports its controls as unset. That is the honest answer, because
        * the dot describes what is DISPLAYED rather than what is stored.
        */
-      liveBreakpoints: liveBreakpoints ?? matched,
+      liveBreakpoints: live,
     });
   };
 
@@ -531,10 +532,21 @@ function usePrefersDark(): boolean {
  * one frame reporting fewer origins than apply; the alternative is a hydration
  * mismatch.
  */
-function useMatchedBreakpoints(
+function useLiveBreakpoints(
   breakpoints: BreakpointSet | undefined,
-  previewContainer: string | undefined
-): readonly BreakpointId[] {
+  previewContainer: string | undefined,
+  stated: readonly BreakpointId[] | undefined
+): readonly BreakpointId[] | undefined {
+  /*
+   * NORMALISED here, so no caller decides for itself whether a name counts.
+   *
+   * A stated name is not an active preview: `previewContainerName` refuses an
+   * empty, reserved, malformed or oversized string, and a refused name makes
+   * the compile published — viewport tiers emit ordinary `@media`, which the
+   * window can answer for. Read raw, every indicator was withheld from surfaces
+   * that were not previewing at all.
+   */
+  const preview = previewContainerName(previewContainer);
   /*
    * The emission the sheet was compiled under, carried so this asks the SAME
    * queries. Without it the window is compared against `@media` rules a preview
@@ -543,8 +555,8 @@ function useMatchedBreakpoints(
    * box is showing the large ones.
    */
   const options = React.useMemo(
-    () => (previewContainer === undefined ? undefined : { previewContainer }),
-    [previewContainer]
+    () => (preview === undefined ? undefined : { previewContainer: preview }),
+    [preview]
   );
   const never = React.useCallback(() => false, []);
   const [matches, setMatches] = React.useState<readonly BreakpointId[]>(() =>
@@ -577,7 +589,20 @@ function useMatchedBreakpoints(
       for (const list of lists) list.removeEventListener("change", read);
     };
   }, [breakpoints, options]);
-  return matches;
+  /*
+   * Previewing, the window is not the authority and the host is.
+   *
+   * A `matchMedia` caller cannot evaluate a container query, so under a preview
+   * compile `matches` reduces to the base context alone — which is not silence
+   * but the claim that base is what the browser applies. Whoever owns the box
+   * is the only one that can observe it, so `undefined` there means nobody has
+   * looked yet and the caller must say nothing rather than guess.
+   *
+   * Published, the window IS the authority, and a set the host offers describes
+   * a box that is not deciding anything — so it is ignored rather than
+   * preferred.
+   */
+  return preview === undefined ? matches : stated;
 }
 
 /** One catalog group, as a section that opens onto its properties. */

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -196,6 +196,18 @@ export interface StyleInspectorPanelProps {
    * which of them counts as authored here.
    */
   breakpoints?: BreakpointSet;
+  /**
+   * The container the page's breakpoints were compiled against, when the canvas
+   * is previewing rather than rendering at the browser's own width.
+   *
+   * Carried because this panel decides which declarations are LIVE, and that is
+   * a question about the queries the sheet was EMITTED under. Given only the
+   * breakpoint set, it compares the window against `@media` rules a preview
+   * compile never wrote — a confident wrong answer rather than a stale one,
+   * since a narrow admin window then reports the small breakpoints live while a
+   * wide canvas box is showing the large ones.
+   */
+  previewContainer?: string;
 }
 
 export function StyleInspectorPanel({
@@ -206,6 +218,7 @@ export function StyleInspectorPanel({
   breakpoint,
   cascade,
   breakpoints,
+  previewContainer,
 }: StyleInspectorPanelProps): React.JSX.Element {
   // `null` is "the author has not chosen yet", which is NOT the same as the
   // empty string the accordion sends when they collapse the open section. The
@@ -220,7 +233,7 @@ export function StyleInspectorPanel({
     {}
   );
   const prefersDark = usePrefersDark();
-  const matched = useMatchedBreakpoints(breakpoints);
+  const matched = useMatchedBreakpoints(breakpoints, previewContainer);
 
   // Recomputed each render rather than memoised, as the content tab is: an
   // inspection is only valid against the document it was read from, and an edit
@@ -476,11 +489,23 @@ function usePrefersDark(): boolean {
  * mismatch.
  */
 function useMatchedBreakpoints(
-  breakpoints: BreakpointSet | undefined
+  breakpoints: BreakpointSet | undefined,
+  previewContainer: string | undefined
 ): readonly BreakpointId[] {
+  /*
+   * The emission the sheet was compiled under, carried so this asks the SAME
+   * queries. Without it the window is compared against `@media` rules a preview
+   * compile never wrote, which is not a stale answer but a confident wrong one:
+   * a narrow admin window reports the small breakpoints live while a wide canvas
+   * box is showing the large ones.
+   */
+  const options = React.useMemo(
+    () => (previewContainer === undefined ? undefined : { previewContainer }),
+    [previewContainer]
+  );
   const never = React.useCallback(() => false, []);
   const [matches, setMatches] = React.useState<readonly BreakpointId[]>(() =>
-    matchedBreakpoints(breakpoints, never)
+    matchedBreakpoints(breakpoints, never, options)
   );
   React.useEffect(() => {
     // Detected by CALLABILITY rather than presence, the lesson `usePrefersDark`
@@ -493,21 +518,22 @@ function useMatchedBreakpoints(
       return;
     }
     const ask = (query: string): boolean => window.matchMedia(query).matches;
-    const read = (): void => setMatches(matchedBreakpoints(breakpoints, ask));
+    const read = (): void =>
+      setMatches(matchedBreakpoints(breakpoints, ask, options));
     read();
     /*
      * Subscribed to every emitted query, not to a resize. A resize fires
      * continuously and would re-measure on each frame of a drag, while a media
      * query change event fires exactly when an answer here would differ.
      */
-    const lists = breakpointQueries(breakpoints).map(query =>
+    const lists = breakpointQueries(breakpoints, options).map(query =>
       window.matchMedia(query)
     );
     for (const list of lists) list.addEventListener("change", read);
     return () => {
       for (const list of lists) list.removeEventListener("change", read);
     };
-  }, [breakpoints]);
+  }, [breakpoints, options]);
   return matches;
 }
 

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -208,6 +208,19 @@ export interface StyleInspectorPanelProps {
    * wide canvas box is showing the large ones.
    */
   previewContainer?: string;
+  /**
+   * Which breakpoints the canvas is ACTUALLY applying, when the host can say.
+   *
+   * Needed in preview and unnecessary otherwise. Rendering at the browser's own
+   * width, this panel asks `matchMedia` and answers for itself; previewing
+   * inside a box, the queries are about that box and only whoever owns it can
+   * observe them.
+   *
+   * Absent while previewing, no indicator is drawn at all. Reporting the
+   * window's answer there would name the wrong tier as the visible winner,
+   * which is worse than naming none.
+   */
+  liveBreakpoints?: readonly BreakpointId[];
 }
 
 export function StyleInspectorPanel({
@@ -219,6 +232,7 @@ export function StyleInspectorPanel({
   cascade,
   breakpoints,
   previewContainer,
+  liveBreakpoints,
 }: StyleInspectorPanelProps): React.JSX.Element {
   // `null` is "the author has not chosen yet", which is NOT the same as the
   // empty string the accordion sends when they collapse the open section. The
@@ -364,6 +378,22 @@ export function StyleInspectorPanel({
     // gets no indicators, which is the honest answer for a surface that cannot
     // compile — and not the same as "nothing is inherited".
     if (cascade === undefined || subject === undefined) return undefined;
+    /*
+     * The same answer while the canvas is previewing and nobody has said which
+     * tier the preview BOX is showing.
+     *
+     * Under a preview compile the viewport tiers are container queries, and a
+     * `matchMedia` caller cannot evaluate them — so the window-derived set is
+     * the base context alone. Passed on, that is not silence: `["base"]` is the
+     * CLAIM that base is what the browser is applying, and a narrow box showing
+     * the mobile tier would have every mobile declaration excluded and the base
+     * value reported as the visible winner.
+     *
+     * No dot says "not asked", which is true until a caller observes the box.
+     */
+    if (previewContainer !== undefined && liveBreakpoints === undefined) {
+      return undefined;
+    }
     return styleProvenance({
       trace: cascade.entries,
       subject,
@@ -388,7 +418,7 @@ export function StyleInspectorPanel({
        * match reports its controls as unset. That is the honest answer, because
        * the dot describes what is DISPLAYED rather than what is stored.
        */
-      liveBreakpoints: matched,
+      liveBreakpoints: liveBreakpoints ?? matched,
     });
   };
 

--- a/packages/builder/src/style-scrub.test.ts
+++ b/packages/builder/src/style-scrub.test.ts
@@ -3,6 +3,7 @@ import {
   escapeIdentifier,
   nodeClassName,
   PAGE_ROOT_SELECTOR,
+  PREVIEW_VIEWPORT_CONTAINER,
   STYLE_STATES,
   type BlockDocument,
   type StyleState,
@@ -639,5 +640,71 @@ describe("committing at a breakpoint the site no longer defines", () => {
     const live: ScrubTarget = { ...TARGET, breakpoints: BREAKPOINTS };
     expect(scrubPreviewCss(live, "32px").ok).toBe(true);
     expect(scrubCommitOp(live, undefined, "32px").ok).toBe(true);
+  });
+});
+
+describe("a scrub override under a preview compile", () => {
+  const breakpoints = {
+    viewport: [
+      { id: "base", label: "Desktop" },
+      { id: "tablet", label: "Tablet", maxWidth: 991 },
+    ],
+    container: [],
+  } as never;
+
+  const wrapperFor = (previewContainer?: string): string => {
+    const preview = scrubPreviewCss(
+      {
+        nodeId: "n1",
+        nodeClass: nodeClassName("n1"),
+        breakpoints,
+        ...(previewContainer === undefined ? {} : { previewContainer }),
+        address: {
+          state: "base",
+          breakpoint: "tablet",
+          property: "margin",
+          path: ["blockEnd"],
+        },
+      },
+      "32px"
+    );
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) throw new Error("expected a preview");
+    return preview.css.split("{")[0].trim();
+  };
+
+  it("is wrapped in the SAME at-rule the page rule was compiled under", () => {
+    /*
+     * The override has to outrank a rule that lives inside the breakpoint's own
+     * query. Wrapped in `@media` while the page rule sits in a container query,
+     * it matches nothing in a narrow canvas inside a wide window — so the drag
+     * appears frozen and the value jumps into place on commit.
+     *
+     * The published half is asserted first, and it is the population: a preview
+     * wrapper containing no at-rule at all would satisfy the negative below.
+     */
+    expect(wrapperFor()).toContain("@media (max-width: 991px)");
+
+    const previewed = wrapperFor(PREVIEW_VIEWPORT_CONTAINER);
+
+    expect(previewed).toContain(
+      `@container ${PREVIEW_VIEWPORT_CONTAINER} (max-width: 991px)`
+    );
+    expect(previewed).not.toContain("@media");
+  });
+
+  it("does not serve one mode's wrapper from the other's cache", () => {
+    /*
+     * The derived at-rule is cached per breakpoint set, and the preview name
+     * changes it for the same set. Left out of the identity, whichever mode
+     * asked first would answer for both — and the second caller would get a
+     * wrapper that looks right and matches nothing.
+     *
+     * Asked in this order deliberately: published first, so a cache keyed only
+     * on the set would already hold the `@media` answer when the preview asks.
+     */
+    expect(wrapperFor()).toContain("@media");
+    expect(wrapperFor(PREVIEW_VIEWPORT_CONTAINER)).toContain("@container");
+    expect(wrapperFor()).toContain("@media");
   });
 });

--- a/packages/builder/src/style-scrub.test.ts
+++ b/packages/builder/src/style-scrub.test.ts
@@ -693,6 +693,37 @@ describe("a scrub override under a preview compile", () => {
     expect(previewed).not.toContain("@media");
   });
 
+  it("treats a name the compiler REFUSES exactly as no name at all", () => {
+    /*
+     * A refused name — empty, reserved, malformed or over the emitted-string
+     * bound — makes the compile published, so the override must be wrapped in
+     * the same `@media` an unpreviewed scrub gets. Wrapped in a container query
+     * naming a box nothing declares, it would match nothing and the drag would
+     * appear frozen.
+     *
+     * Driven through the distinct refusal branches rather than one
+     * representative: a reserved CSS-wide keyword, a character the identifier
+     * grammar excludes, and a value over the raw-length cap.
+     *
+     * WHAT THIS TEST DOES NOT COVER, stated rather than implied. The reason the
+     * normalisation moved AHEAD of the cache identity is that `scrubPreviewCss`
+     * recomputes that identity on every pointer update, so a refused name of
+     * any size was serialised per frame. That is a property of the module's
+     * private cache and produces identical output either way, so it is not
+     * observable from here and this test would pass against the version without
+     * it. The equivalence below is a regression guard; the placement is
+     * reasoned, not asserted.
+     */
+    const published = wrapperFor();
+
+    for (const refused of ["none", "has space", "x".repeat(5_000)]) {
+      expect(wrapperFor(refused)).toBe(published);
+    }
+    // The population, so the equivalence is not satisfied by every wrapper
+    // being empty: the published form really does carry the query.
+    expect(published).toContain("@media (max-width: 991px)");
+  });
+
   it("does not serve one mode's wrapper from the other's cache", () => {
     /*
      * The derived at-rule is cached per breakpoint set, and the preview name

--- a/packages/builder/src/style-scrub.ts
+++ b/packages/builder/src/style-scrub.ts
@@ -73,6 +73,17 @@ export interface ScrubTarget {
    */
   readonly nodeClass: string;
   /**
+   * The container a preview surface compiled this page's breakpoints against.
+   *
+   * Carried because the override must be wrapped in the SAME at-rule the rule
+   * it outranks was emitted under. Compiled without it while the page was
+   * compiled with it, a non-base override sits in `@media` while its target sits
+   * in a container query — so in a narrow canvas inside a wide window the
+   * override matches nothing, the drag looks frozen, and the value jumps into
+   * place on commit.
+   */
+  readonly previewContainer?: string;
+  /**
    * The document's compile scope, when it has one.
    *
    * `compilePageCss` anchors every rule to `${PAGE_ROOT_SELECTOR}.${scope}`, so
@@ -225,9 +236,13 @@ const AT_RULES = new WeakMap<BreakpointSet, AtRuleCache>();
  */
 function breakpointAtRule(
   breakpoints: BreakpointSet,
+  preview: string | undefined,
   id: string
 ): string | null {
-  const content = JSON.stringify(breakpoints);
+  // The preview name joins the cache identity, because it changes the derived
+  // at-rule for the same breakpoint set — cached without it, the first caller's
+  // mode would be served to the other.
+  const content = JSON.stringify([breakpoints, preview]);
   let entry = AT_RULES.get(breakpoints);
   if (entry === undefined || entry.content !== content) {
     entry = { content, perId: new Map() };
@@ -248,7 +263,14 @@ function breakpointAtRule(
       },
     ],
   };
-  const css = compilePageCss(document, { breakpoints }).css.trim();
+  const css = compilePageCss(document, {
+    breakpoints,
+    // The SAME emission the page rule was compiled under. A scrub override
+    // wrapped in `@media` while the rule it must outrank sits in a container
+    // query matches nothing in a narrow canvas, so the drag looks frozen and
+    // then jumps on commit.
+    ...(preview === undefined ? {} : { previewContainer: preview }),
+  }).css.trim();
   const wrapper = /^@[a-z-]+[^{]*/.exec(css);
   const derived = css === "" ? null : wrapper === null ? "" : wrapper[0].trim();
   entry.perId.set(id, derived);
@@ -267,7 +289,11 @@ function breakpointAtRule(
  */
 function atRuleFor(target: ScrubTarget): string | null {
   if (target.breakpoints !== undefined) {
-    return breakpointAtRule(target.breakpoints, target.address.breakpoint);
+    return breakpointAtRule(
+      target.breakpoints,
+      target.previewContainer,
+      target.address.breakpoint
+    );
   }
   return target.address.breakpoint === BASE_BREAKPOINT ? "" : null;
 }

--- a/packages/builder/src/style-scrub.ts
+++ b/packages/builder/src/style-scrub.ts
@@ -47,6 +47,7 @@ import {
   escapeIdentifier,
   nodeClassName,
   PAGE_ROOT_SELECTOR,
+  previewContainerName,
   STYLE_STATES,
   type BlockDocument,
   type BreakpointSet,
@@ -239,10 +240,26 @@ function breakpointAtRule(
   preview: string | undefined,
   id: string
 ): string | null {
+  /*
+   * NORMALISED before it reaches the cache identity, not merely before the
+   * compile.
+   *
+   * The compiler refuses an empty, reserved, malformed or oversized name and
+   * emits published rules instead, so the raw string is not what decides the
+   * at-rule — the normalised one is, and serialising the raw form keys the
+   * cache on a distinction the output does not have.
+   *
+   * The cost is paid on a hot path rather than once. `scrubPreviewCss`
+   * recomputes this identity on every pointer update during a drag, so a
+   * refused name that is megabytes long is stringified per frame even though
+   * the at-rule it maps to was cached on the first move — the editor stalls
+   * while dragging, with nothing about the drag to explain it.
+   */
+  const effective = previewContainerName(preview);
   // The preview name joins the cache identity, because it changes the derived
   // at-rule for the same breakpoint set — cached without it, the first caller's
   // mode would be served to the other.
-  const content = JSON.stringify([breakpoints, preview]);
+  const content = JSON.stringify([breakpoints, effective]);
   let entry = AT_RULES.get(breakpoints);
   if (entry === undefined || entry.content !== content) {
     entry = { content, perId: new Map() };
@@ -269,7 +286,7 @@ function breakpointAtRule(
     // wrapped in `@media` while the rule it must outrank sits in a container
     // query matches nothing in a narrow canvas, so the drag looks frozen and
     // then jumps on commit.
-    ...(preview === undefined ? {} : { previewContainer: preview }),
+    ...(effective === undefined ? {} : { previewContainer: effective }),
   }).css.trim();
   const wrapper = /^@[a-z-]+[^{]*/.exec(css);
   const derived = css === "" ? null : wrapper === null ? "" : wrapper[0].trim();


### PR DESCRIPTION
## Summary

A viewport breakpoint compiles to `@media (max-width: N)`, which asks the browser **window**. The editor canvas is not an iframe — `grep iframe canvas.tsx` is empty and `PageRenderer` puts its `<style>` into the admin document — so it shares that window. Narrowing the canvas to 991px inside a 1600px window changes nothing about which rules apply: the block gets narrower and keeps its desktop styling. That is a preview that lies.

This adds an option to compile those breakpoints as **named container queries against the previewing box**, so a box asked about its own width answers about its own width. Off by default; published output is byte-identical.

First of three steps toward a responsive editing loop. Today a site can define "Tablet" (#1185) and no author can view or style anything at Tablet — nothing in the repository sets an edited breakpoint and the canvas has no width preview.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / chore (no user-facing change)

## Related issues

Refs `finding:pb-editor-has-no-responsive-editing-loop`, implements `decision:pb-editor-previews-viewport-as-container-queries` (founder ruling: container queries rather than moving the canvas into an iframe, which would put every editing behaviour — drag, click-to-select, keyboard, spacing overlay, selection outlines — across a document boundary).

## Changeset

- [x] I added a changeset — `.changeset/preview-a-page-at-a-breakpoint.md`
- [x] I selected the correct semver bump — patch, covering the full lockstep group

## Test plan

- [x] `pnpm lint` — blocks-engine, blocks-react, builder, plugin-page-builder, plus root eslint on changed files
- [x] `pnpm check-types`
- [x] `pnpm build`
- [x] Manually verified the change — via the compiler entry point rather than the helper; see below

Suites: blocks-engine **1435**, blocks-react **795**, builder **1871**, plugin-page-builder **307**, scripts **602**. Plus comment convention, changeset check, and `fallow audit` verdict `pass` with `dead_code_introduced`, `complexity_introduced` and `duplication_introduced` all 0.

Break-verified, each failing only its own case:

- Container axis left unnamed under preview → fails only the naming test.
- Preview on by default → fails the published-untouched, no-preview-name and cannot-be-mistaken tests.
- Visibility band rebuilding its keyword from the axis → fails the band test and the preview-sheet test.
- The option never reaching `compilePageCss` → fails the preview-sheet test.

## Checklist

- [x] I read CONTRIBUTING
- [x] My commits follow Conventional Commits
- [x] I targeted the `main` branch
- [ ] I updated relevant documentation — no user-facing docs change; the option is internal until the canvas half lands

## Notes for reviewers

**Off by default is the load-bearing half.** `shared-style-inputs.ts` stamps `breakpointContexts`' output into the compiled artifact's cache identity. The published call site passes one argument, so it gets the default by construction and the stamp is unchanged — a stamp that moved would invalidate every artifact on the site for CSS that did not change. The test pins it with a deep equality plus the at-rule text rather than relying on that construction.

**A hazard that is invisible until looked for.** An *unnamed* container query resolves against the nearest ancestor with `container-type` set — named or not. So once a previewing surface makes its box a query container, the container-axis rules (`@container (min-width: 0)`, documented as matching "inside any container and nowhere else") would begin matching against that box for every node with no authored container ancestor. The editor would show container styles the published page does not: the same lie, pointing the other way. Both axes are therefore named under preview, the container one to a reserved name nothing carries — and **named rather than omitted**, so a style stored at a container breakpoint stays a known breakpoint that does not apply here instead of becoming an `unknown-breakpoint` warning on every render.

**Measured, not assumed:** the reverse hazard — a preview sheet reaching a real visitor — is not currently reachable. `toPageStyles`, the only producer of an artifact, is called nowhere outside `blocks-react`; neither `builder` nor `plugin-page-builder` calls it, and the canvas passes no stored artifact so it always compiles fresh. The assertion stays because unreachability is a property of the current call graph, not of the code.

**Territory:** `packages/blocks-engine/src/style/compile-page.ts` plus appended exports. Agreed with the two other lanes in this package — #1190 holds `tree.ts`/`migration.ts`/`safe-record.ts` and nothing in `src/style/`.

**What follows:** the canvas container and the breakpoint switcher, then C-6's badge half, whose reset routes through the batch write path #1194 landed rather than adding a second single-node path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added container-based breakpoint previews with validated custom container names.
  - Preview styles now use container queries while published styles retain viewport behavior.
  - Added consistent preview container styling across page and site previews.
  - Breakpoint matching and style inspection now reflect preview-specific states.
  - Color controls preserve pending edits and support stored token references.

- **Bug Fixes**
  - Invalid preview container names safely fall back to published behavior.
  - Improved breakpoint visibility, style resolution, and preview artifact handling across modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->