### PR TITLE
feat(plugin-form-builder): redirect a form to a page an author picks

### DIFF
--- a/.changeset/form-redirect-to-linked-page.md
+++ b/.changeset/form-redirect-to-linked-page.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A form can redirect to a page an author picks, and the page is resolved to a real URL at submit time.

--- a/apps/playground/nextly.config.ts
+++ b/apps/playground/nextly.config.ts
@@ -23,7 +23,7 @@
  * runtime ignores this field. See packages/nextly/src/auth/handlers/session.ts.
  */
 
-import { formBuilderPlugin } from "@nextlyhq/plugin-form-builder";
+import { formBuilder } from "@nextlyhq/plugin-form-builder";
 import { pageBuilder } from "@nextlyhq/plugin-page-builder";
 import { defineConfig } from "nextly/config";
 
@@ -114,7 +114,14 @@ export default defineConfig({
       siteStyle: SITE_STYLE_DEFAULTS,
       pagePreviewPath: "/{slug}",
     }),
-    formBuilderPlugin,
+    // `redirectRelationships` states where each collection's documents are
+    // served, for the same reason `pagePreviewPath` above does and in the same
+    // syntax: the plugin cannot discover that this app mounts
+    // `(frontend)/[...slug]` at the site root. Without it a form can still
+    // show a message or redirect to a typed URL, but "redirect to a page" is
+    // not offered, because choosing it could only produce a form with nowhere
+    // to send anyone.
+    formBuilder({ redirectRelationships: { pages: "/{slug}" } }).plugin,
     ...(process.env.NEXTLY_E2E_STYLE_FIXTURE === "1"
       ? [styleFixturePlugin]
       : []),

--- a/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
@@ -296,6 +296,39 @@ describe("saving a form that redirects to a page", () => {
     );
   });
 
+  it("refuses a page that has been deleted", async () => {
+    // `findByID` throws NOT_FOUND rather than returning null, so this refusal
+    // is only reachable if a not-found error is told apart from an unreadable
+    // one. Catching everything loses it, and the form saves pointing at a
+    // page that is gone.
+    const { plugin } = formBuilder({
+      redirectRelationships: { pages: "/{slug}" },
+    });
+    current = await createTestNextly({
+      plugins: [plugin],
+      collections: [pagesCollection],
+    });
+
+    const pageId = await seedPage(current);
+    await current.nextly.delete({ collection: "pages", id: pageId });
+
+    await expectRedirectRefusal(
+      current.nextly.create({
+        collection: "forms",
+        data: {
+          name: "Contact",
+          slug: "contact",
+          status: "published",
+          fields: [{ type: "text", name: "message", label: "Message" }],
+          settings: {
+            confirmationType: "relationship",
+            redirectPage: { relationTo: "pages", value: pageId },
+          },
+        },
+      })
+    );
+  });
+
   it("refuses a page that cannot fill the URL pattern", async () => {
     // Shape and membership are not enough: `/{slug}` over a page whose slug is
     // blank produces no URL, so the form would save cleanly and redirect

--- a/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
@@ -147,14 +147,15 @@ describe("a form that redirects to a picked page", () => {
     expect(result.redirect).toBeUndefined();
   });
 
-  it("has no destination when the collection carries no pattern", async () => {
-    const result = await submitPointingAt(
-      (id: string) => ({ relationTo: "pages", value: id }),
-      { redirectRelationships: { posts: "/blog/{slug}" } }
-    );
-
-    expect(result.success).toBe(true);
-    expect(result.redirect).toBeUndefined();
+  it("refuses to save a target in a collection with no pattern", async () => {
+    // Previously this saved and then produced no destination on every
+    // submission. The write path now refuses it, because a reference into a
+    // collection the plugin cannot build a URL for is not a destination.
+    await expect(
+      submitPointingAt((id: string) => ({ relationTo: "pages", value: id }), {
+        redirectRelationships: { posts: "/blog/{slug}" },
+      })
+    ).rejects.toThrow();
   });
 });
 
@@ -216,5 +217,57 @@ describe("saving a form that redirects to a page", () => {
     // The rule is about one option; a message form has no page to name.
     const saved = await create({ confirmationType: "message" });
     expect(saved).toMatchObject({ item: { id: expect.any(String) } });
+  });
+});
+
+describe("a host that overrides the forms collection's hooks", () => {
+  it("keeps the plugin's validation and runs its own hook too", async () => {
+    // `formOverrides.hooks` is a supported option, and a trailing spread would
+    // replace this collection's hooks outright — removing the slug
+    // generation, the at-least-one-field rule and the redirect check, none of
+    // which are the host's to remove. An override extends the collection; it
+    // does not disarm it.
+    const hostRan: string[] = [];
+
+    const { plugin } = formBuilder({
+      redirectRelationships: { pages: "/{slug}" },
+      formOverrides: {
+        hooks: {
+          beforeValidate: [
+            (context: { data?: Record<string, unknown> }) => {
+              hostRan.push("beforeValidate");
+              return context.data;
+            },
+          ],
+        },
+      },
+    } as Parameters<typeof formBuilder>[0]);
+
+    current = await createTestNextly({
+      plugins: [plugin],
+      collections: [pagesCollection],
+    });
+
+    const save = (settings: Record<string, unknown>) =>
+      current!.nextly.create({
+        collection: "forms",
+        data: {
+          name: "Contact",
+          slug: "contact",
+          status: "published",
+          fields: [{ type: "text", name: "message", label: "Message" }],
+          settings,
+        },
+      });
+
+    // The plugin's rule still refuses...
+    await expect(save({ confirmationType: "relationship" })).rejects.toThrow();
+
+    // ...and the host's hook is genuinely wired, not merely tolerated.
+    await save({
+      confirmationType: "relationship",
+      redirectPage: { relationTo: "pages", value: "pg1" },
+    });
+    expect(hostRan).toContain("beforeValidate");
   });
 });

--- a/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
@@ -271,3 +271,74 @@ describe("a host that overrides the forms collection's hooks", () => {
     expect(hostRan).toContain("beforeValidate");
   });
 });
+
+describe("a host hook that rewrites the payload after validation", () => {
+  /** A host `beforeValidate` that turns a valid form into an invalid one. */
+  async function saveThrough(
+    hostHook: (data: Record<string, unknown>) => void
+  ) {
+    const { plugin } = formBuilder({
+      redirectRelationships: { pages: "/{slug}" },
+      formOverrides: {
+        hooks: {
+          beforeValidate: [
+            (context: { data?: Record<string, unknown> }) => {
+              if (context.data) hostHook(context.data);
+              return context.data;
+            },
+          ],
+        },
+      },
+    } as Parameters<typeof formBuilder>[0]);
+
+    current = await createTestNextly({
+      plugins: [plugin],
+      collections: [pagesCollection],
+    });
+
+    return current.nextly.create({
+      collection: "forms",
+      data: {
+        name: "Contact",
+        slug: "contact",
+        status: "published",
+        fields: [{ type: "text", name: "message", label: "Message" }],
+        settings: { confirmationType: "message" },
+      },
+    });
+  }
+
+  it("still refuses a target the host cleared after the first check", async () => {
+    // The plugin's `beforeValidate` runs FIRST so a rejection precedes host
+    // mutation — which means a host that mutates AFTERWARDS was judged on a
+    // payload it then replaced. The trailing `beforeChange` call is what makes
+    // this an invariant rather than a check.
+    await expect(
+      saveThrough(data => {
+        data.settings = { confirmationType: "relationship" };
+      })
+    ).rejects.toThrow();
+  });
+
+  it("still refuses a reference the host rewrote into an unusable one", async () => {
+    await expect(
+      saveThrough(data => {
+        data.settings = {
+          confirmationType: "relationship",
+          redirectPage: { relationTo: "unconfigured", value: "x1" },
+        };
+      })
+    ).rejects.toThrow();
+  });
+
+  it("accepts what the host rewrites into something usable", async () => {
+    // The guarantee must not become "reject anything a host touched".
+    const saved = await saveThrough(data => {
+      data.settings = {
+        confirmationType: "relationship",
+        redirectPage: { relationTo: "pages", value: "pg1" },
+      };
+    });
+    expect(saved).toMatchObject({ item: { id: expect.any(String) } });
+  });
+});

--- a/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
@@ -562,3 +562,52 @@ describe("updating a form that already redirects to a page", () => {
     );
   });
 });
+
+describe("a target collection with the publish lifecycle", () => {
+  /**
+   * The picker offers drafts deliberately (`status=all`), so the save
+   * invariant must accept one. Pinned because the two reads are different code
+   * paths and could drift: if a by-id read ever became published-only, this
+   * would refuse a page the picker had just offered, telling the author it
+   * "no longer exists" while it is on screen.
+   */
+  const draftingPages = defineCollection({
+    slug: "pages",
+    status: true,
+    versions: { drafts: true },
+    fields: [text({ name: "title" }), text({ name: "slug" })],
+  } as never);
+
+  it("accepts a draft page as a redirect target", async () => {
+    const { plugin } = formBuilder({
+      redirectRelationships: { pages: "/{slug}" },
+    });
+    current = await createTestNextly({
+      plugins: [plugin],
+      collections: [draftingPages],
+    });
+
+    const made = await current.nextly.create({
+      collection: "pages",
+      data: { title: "Draft page", slug: "draft-page", status: "draft" },
+    });
+    const draft = made as { item: { id: string; status?: string } };
+    // The fixture is only meaningful if it really is a draft.
+    expect(draft.item.status).toBe("draft");
+
+    const saved = await current.nextly.create({
+      collection: "forms",
+      data: {
+        name: "Contact",
+        slug: "contact",
+        status: "published",
+        fields: [{ type: "text", name: "message", label: "Message" }],
+        settings: {
+          confirmationType: "relationship",
+          redirectPage: { relationTo: "pages", value: draft.item.id },
+        },
+      },
+    });
+    expect(saved).toMatchObject({ item: { id: expect.any(String) } });
+  });
+});

--- a/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
@@ -363,6 +363,41 @@ describe("saving a form that redirects to a page", () => {
     );
   });
 
+  it("stores the collection name trimmed, not merely accepts it", async () => {
+    // Trimming only the parsed copy leaves the padded name in the row, so the
+    // plugin accepts the write while the framework's own relationship
+    // validator still sees a name that matches no collection.
+    const { plugin } = formBuilder({
+      redirectRelationships: { pages: "/{slug}" },
+    });
+    current = await createTestNextly({
+      plugins: [plugin],
+      collections: [pagesCollection],
+    });
+    const pageId = await seedPage(current);
+
+    const saved = (await current.nextly.create({
+      collection: "forms",
+      data: {
+        name: "Contact",
+        slug: "contact",
+        status: "published",
+        fields: [{ type: "text", name: "message", label: "Message" }],
+        settings: {
+          confirmationType: "relationship",
+          redirectPage: { relationTo: "  pages  ", value: pageId },
+        },
+      },
+    })) as { item: { id: string } };
+
+    const row = (await current.nextly.findByID({
+      collection: "forms",
+      id: saved.item.id,
+    })) as { settings?: { redirectPage?: { relationTo?: string } } };
+
+    expect(row.settings?.redirectPage?.relationTo).toBe("pages");
+  });
+
   it("accepts one that names a page", async () => {
     const saved = await create({
       confirmationType: "relationship",

--- a/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
@@ -1,0 +1,138 @@
+/**
+ * A form whose author picked a PAGE as its destination, through the real
+ * submission handler.
+ *
+ * The unit tests beside the resolver cover its decisions; this covers the
+ * wiring, which is where the behaviour was missing. Every part existed — the
+ * `redirectPage` relationship field, a `"relationship"` confirmation type the
+ * admin offers as "Redirect to Page", a settings normaliser that preserved the
+ * value — and a submission still returned no destination, because nothing
+ * joined them up. Only a test that submits can see that.
+ */
+import {
+  createTestNextly,
+  type TestNextly,
+} from "@nextlyhq/plugin-sdk/testing";
+import { createPluginContext } from "nextly";
+import { defineCollection, text } from "nextly/config";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { submitForm } from "../handlers/submit-form";
+import { formBuilder } from "../plugin";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const pagesCollection = defineCollection({
+  slug: "pages",
+  fields: [text({ name: "title" }), text({ name: "slug" })],
+});
+
+/** A form pointed at `pageId`, submitted; returns what the handler answered. */
+async function submitPointingAt(
+  redirectPage: unknown,
+  options: Parameters<typeof formBuilder>[0]
+) {
+  const { plugin, config } = formBuilder(options);
+
+  current = await createTestNextly({
+    plugins: [plugin],
+    collections: [pagesCollection],
+  });
+
+  const page = await current.nextly.create({
+    collection: "pages",
+    data: { title: "Thank you", slug: "thank-you" },
+  });
+  const pageId = (page as { item: { id: string } }).item.id;
+
+  await current.nextly.create({
+    collection: "forms",
+    data: {
+      name: "Contact",
+      slug: "contact",
+      status: "published",
+      fields: [{ type: "text", name: "message", label: "Message" }],
+      settings: {
+        confirmationType: "relationship",
+        redirectPage:
+          typeof redirectPage === "function"
+            ? (redirectPage as (id: string) => unknown)(pageId)
+            : redirectPage,
+      },
+    },
+  });
+
+  // `db` is the raw-database escape hatch, resolved eagerly when the context
+  // is built and not registered by the harness. The submission path never
+  // touches it — it goes through the collections service — so a stub keeps the
+  // rest of the context real rather than mocking the part under test.
+  const getService = ((name: string) =>
+    name === "db" ? {} : current?.getService(name as never)) as never;
+
+  const pluginContext = createPluginContext(getService, current.hooks as never);
+
+  return submitForm(
+    { formSlug: "contact", data: { message: "hello" } },
+    { pluginContext, pluginConfig: config }
+  );
+}
+
+describe("a form that redirects to a picked page", () => {
+  it("answers with the page's real URL", async () => {
+    const result = await submitPointingAt(
+      (id: string) => ({ relationTo: "pages", value: id }),
+      { redirectRelationships: { pages: "/{slug}" } }
+    );
+
+    expect(result.success).toBe(true);
+    // The destination, built from the page that was picked — not a protocol
+    // for somebody else to resolve, and not nothing.
+    expect(result.redirect).toBe("/thank-you");
+  });
+
+  it("uses the collection's own pattern", async () => {
+    const result = await submitPointingAt(
+      (id: string) => ({ relationTo: "pages", value: id }),
+      { redirectRelationships: { pages: "/help/{slug}" } }
+    );
+
+    expect(result.redirect).toBe("/help/thank-you");
+  });
+
+  it("takes /{slug} for the array shorthand", async () => {
+    const result = await submitPointingAt(
+      (id: string) => ({ relationTo: "pages", value: id }),
+      { redirectRelationships: ["pages"] }
+    );
+
+    expect(result.redirect).toBe("/thank-you");
+  });
+
+  it("still submits, with no destination, when the target was deleted", async () => {
+    // The submission is the thing that must not fail: the visitor's data is
+    // already saved by the time a destination is looked up.
+    const result = await submitPointingAt(
+      { relationTo: "pages", value: "pg_missing" },
+      { redirectRelationships: { pages: "/{slug}" } }
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.submission).toBeDefined();
+    expect(result.redirect).toBeUndefined();
+  });
+
+  it("has no destination when the collection carries no pattern", async () => {
+    const result = await submitPointingAt(
+      (id: string) => ({ relationTo: "pages", value: id }),
+      { redirectRelationships: { posts: "/blog/{slug}" } }
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.redirect).toBeUndefined();
+  });
+});

--- a/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
@@ -59,6 +59,36 @@ const pagesCollection = defineCollection({
   fields: [text({ name: "title" }), text({ name: "slug" })],
 });
 
+/**
+ * Stands in for the page id a caller cannot know yet.
+ *
+ * The harness — and therefore the page — is created INSIDE the helpers below,
+ * so a test naming its target has nothing real to name at the point it writes
+ * the settings. It names this instead and the helper substitutes.
+ */
+const SEEDED_PAGE = "__seeded_page__";
+
+/** Settings with the sentinel replaced by the page that now exists. */
+function withSeededPage(
+  settings: Record<string, unknown>,
+  pageId: string
+): Record<string, unknown> {
+  const target = settings.redirectPage as
+    | { relationTo?: string; value?: unknown }
+    | undefined;
+  if (!target || target.value !== SEEDED_PAGE) return settings;
+  return { ...settings, redirectPage: { ...target, value: pageId } };
+}
+
+/** A real page in the harness, so a reference points at something. */
+async function seedPage(harness: TestNextly, slug = "thank-you") {
+  const page = await harness.nextly.create({
+    collection: "pages",
+    data: { title: "Thank you", slug },
+  });
+  return (page as { item: { id: string } }).item.id;
+}
+
 /** A form pointed at `pageId`, submitted; returns what the handler answered. */
 async function submitPointingAt(
   redirectPage: unknown,
@@ -141,11 +171,46 @@ describe("a form that redirects to a picked page", () => {
   });
 
   it("still submits, with no destination, when the target was deleted", async () => {
-    // The submission is the thing that must not fail: the visitor's data is
-    // already saved by the time a destination is looked up.
-    const result = await submitPointingAt(
-      { relationTo: "pages", value: "pg_missing" },
-      { redirectRelationships: { pages: "/{slug}" } }
+    // Reached the way it happens in practice: the form is saved against a real
+    // page and the page is deleted afterwards. A fabricated id cannot get here
+    // any more — the save reads the target and refuses one that is not there —
+    // and that difference is the point. The submission is what must not fail:
+    // the visitor's data is already saved by the time a destination is looked
+    // up.
+    const { plugin, config } = formBuilder({
+      redirectRelationships: { pages: "/{slug}" },
+    });
+    current = await createTestNextly({
+      plugins: [plugin],
+      collections: [pagesCollection],
+    });
+
+    const pageId = await seedPage(current);
+    await current.nextly.create({
+      collection: "forms",
+      data: {
+        name: "Contact",
+        slug: "contact",
+        status: "published",
+        fields: [{ type: "text", name: "message", label: "Message" }],
+        settings: {
+          confirmationType: "relationship",
+          redirectPage: { relationTo: "pages", value: pageId },
+        },
+      },
+    });
+
+    await current.nextly.delete({ collection: "pages", id: pageId });
+
+    const pluginContext = createPluginContext(
+      ((name: string) =>
+        name === "db" ? {} : current?.getService(name as never)) as never,
+      current.hooks as never
+    );
+
+    const result = await submitForm(
+      { formSlug: "contact", data: { message: "hello" } },
+      { pluginContext, pluginConfig: config }
     );
 
     expect(result.success).toBe(true);
@@ -197,6 +262,7 @@ describe("saving a form that redirects to a page", () => {
       collections: [pagesCollection],
     });
 
+    const pageId = await seedPage(current);
     return current.nextly.create({
       collection: "forms",
       data: {
@@ -204,7 +270,7 @@ describe("saving a form that redirects to a page", () => {
         slug: "contact",
         status: "published",
         fields: [{ type: "text", name: "message", label: "Message" }],
-        settings,
+        settings: withSeededPage(settings, pageId),
       },
     });
   }
@@ -230,10 +296,44 @@ describe("saving a form that redirects to a page", () => {
     );
   });
 
+  it("refuses a page that cannot fill the URL pattern", async () => {
+    // Shape and membership are not enough: `/{slug}` over a page whose slug is
+    // blank produces no URL, so the form would save cleanly and redirect
+    // nobody. Caught while the author still has the page in front of them.
+    // The pattern names a field these pages do not carry, which is the same
+    // condition as a blank slug and does not depend on how the store treats an
+    // empty string.
+    const { plugin } = formBuilder({
+      redirectRelationships: { pages: "/{section}/{slug}" },
+    });
+    current = await createTestNextly({
+      plugins: [plugin],
+      collections: [pagesCollection],
+    });
+
+    const blankId = await seedPage(current);
+
+    await expectRedirectRefusal(
+      current.nextly.create({
+        collection: "forms",
+        data: {
+          name: "Contact",
+          slug: "contact",
+          status: "published",
+          fields: [{ type: "text", name: "message", label: "Message" }],
+          settings: {
+            confirmationType: "relationship",
+            redirectPage: { relationTo: "pages", value: blankId },
+          },
+        },
+      })
+    );
+  });
+
   it("accepts one that names a page", async () => {
     const saved = await create({
       confirmationType: "relationship",
-      redirectPage: { relationTo: "pages", value: "pg1" },
+      redirectPage: { relationTo: "pages", value: SEEDED_PAGE },
     });
     expect(saved).toMatchObject({ item: { id: expect.any(String) } });
   });
@@ -289,18 +389,21 @@ describe("a host that overrides the forms collection's hooks", () => {
     await expectRedirectRefusal(save({ confirmationType: "relationship" }));
 
     // ...and the host's hook is genuinely wired, not merely tolerated.
+    const pageId = await seedPage(current);
     await save({
       confirmationType: "relationship",
-      redirectPage: { relationTo: "pages", value: "pg1" },
+      redirectPage: { relationTo: "pages", value: pageId },
     });
     expect(hostRan).toContain("beforeValidate");
   });
 });
 
 describe("a host hook that rewrites the payload after validation", () => {
+  let seededPageId = "";
+
   /** A host `beforeValidate` that turns a valid form into an invalid one. */
   async function saveThrough(
-    hostHook: (data: Record<string, unknown>) => void
+    hostHook: (data: Record<string, unknown>, pageId: string) => void
   ) {
     const { plugin } = formBuilder({
       redirectRelationships: { pages: "/{slug}" },
@@ -308,7 +411,7 @@ describe("a host hook that rewrites the payload after validation", () => {
         hooks: {
           beforeValidate: [
             (context: { data?: Record<string, unknown> }) => {
-              if (context.data) hostHook(context.data);
+              if (context.data) hostHook(context.data, seededPageId);
               return context.data;
             },
           ],
@@ -321,6 +424,9 @@ describe("a host hook that rewrites the payload after validation", () => {
       collections: [pagesCollection],
     });
 
+    // Seeded BEFORE the write, so the host hook has a real page to name when
+    // it rewrites the payload mid-flight.
+    seededPageId = await seedPage(current);
     return current.nextly.create({
       collection: "forms",
       data: {
@@ -358,10 +464,10 @@ describe("a host hook that rewrites the payload after validation", () => {
 
   it("accepts what the host rewrites into something usable", async () => {
     // The guarantee must not become "reject anything a host touched".
-    const saved = await saveThrough(data => {
+    const saved = await saveThrough((data, pageId) => {
       data.settings = {
         confirmationType: "relationship",
-        redirectPage: { relationTo: "pages", value: "pg1" },
+        redirectPage: { relationTo: "pages", value: pageId },
       };
     });
     expect(saved).toMatchObject({ item: { id: expect.any(String) } });
@@ -379,6 +485,7 @@ describe("updating a form that already redirects to a page", () => {
       collections: [pagesCollection],
     });
 
+    const pageId = await seedPage(current);
     const created = await current.nextly.create({
       collection: "forms",
       data: {
@@ -388,7 +495,7 @@ describe("updating a form that already redirects to a page", () => {
         fields: [{ type: "text", name: "message", label: "Message" }],
         settings: {
           confirmationType: "relationship",
-          redirectPage: { relationTo: "pages", value: "pg1" },
+          redirectPage: { relationTo: "pages", value: pageId },
         },
       },
     });

--- a/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
@@ -126,6 +126,27 @@ describe("a form that redirects to a picked page", () => {
     expect(result.redirect).toBeUndefined();
   });
 
+  it("still submits when a pattern function throws", async () => {
+    // A pattern may be host code. Letting it throw would reach submitForm's
+    // outer catch AFTER the submission row exists, telling the caller the
+    // submission failed — and a caller that retries creates a duplicate of a
+    // submission that was already saved.
+    const result = await submitPointingAt(
+      (id: string) => ({ relationTo: "pages", value: id }),
+      {
+        redirectRelationships: {
+          pages: () => {
+            throw new Error("pattern exploded");
+          },
+        },
+      }
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.submission).toBeDefined();
+    expect(result.redirect).toBeUndefined();
+  });
+
   it("has no destination when the collection carries no pattern", async () => {
     const result = await submitPointingAt(
       (id: string) => ({ relationTo: "pages", value: id }),
@@ -134,5 +155,66 @@ describe("a form that redirects to a picked page", () => {
 
     expect(result.success).toBe(true);
     expect(result.redirect).toBeUndefined();
+  });
+});
+
+describe("saving a form that redirects to a page", () => {
+  /** Create through the collection, which is what the browser posts to. */
+  async function create(settings: Record<string, unknown>) {
+    const { plugin } = formBuilder({
+      redirectRelationships: { pages: "/{slug}" },
+    });
+    current = await createTestNextly({
+      plugins: [plugin],
+      collections: [pagesCollection],
+    });
+
+    return current.nextly.create({
+      collection: "forms",
+      data: {
+        name: "Contact",
+        slug: "contact",
+        status: "published",
+        fields: [{ type: "text", name: "message", label: "Message" }],
+        settings,
+      },
+    });
+  }
+
+  it("refuses one that names no page", async () => {
+    // Through the write path the admin actually uses. `validateFormConfig` is
+    // a library entry point that no save goes through, so a rule living only
+    // there would let this save and fail at submit time instead.
+    await expect(
+      create({ confirmationType: "relationship" })
+    ).rejects.toThrow();
+  });
+
+  it("refuses a reference that names nothing", async () => {
+    // Truthy and unreadable: a presence check admits exactly the values that
+    // resolve to no destination.
+    await expect(
+      create({ confirmationType: "relationship", redirectPage: {} })
+    ).rejects.toThrow();
+    await expect(
+      create({
+        confirmationType: "relationship",
+        redirectPage: { relationTo: "pages" },
+      })
+    ).rejects.toThrow();
+  });
+
+  it("accepts one that names a page", async () => {
+    const saved = await create({
+      confirmationType: "relationship",
+      redirectPage: { relationTo: "pages", value: "pg1" },
+    });
+    expect(saved).toMatchObject({ item: { id: expect.any(String) } });
+  });
+
+  it("leaves the other confirmations alone", async () => {
+    // The rule is about one option; a message form has no page to name.
+    const saved = await create({ confirmationType: "message" });
+    expect(saved).toMatchObject({ item: { id: expect.any(String) } });
   });
 });

--- a/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
@@ -20,6 +20,33 @@ import { afterEach, describe, expect, it } from "vitest";
 import { submitForm } from "../handlers/submit-form";
 import { formBuilder } from "../plugin";
 
+/**
+ * Asserts the write was refused BY THE REDIRECT RULE.
+ *
+ * A bare `rejects.toThrow()` passes on any failure — an unregistered
+ * collection, a schema error, a boot problem — so it cannot tell "the rule
+ * refused this" from "the fixture was wrong". Matching the message does not
+ * help either: `NextlyError.validation` carries the generic
+ * `"Validation failed."` and puts the detail in `publicData.errors`, so every
+ * validation rule in the collection produces the same string.
+ *
+ * The field path is the thing that identifies WHICH rule fired.
+ */
+async function expectRedirectRefusal(write: Promise<unknown>) {
+  let refusal: unknown;
+  try {
+    await write;
+  } catch (error) {
+    refusal = error;
+  }
+
+  expect(refusal, "expected the write to be refused").toBeDefined();
+  const errors =
+    (refusal as { publicData?: { errors?: { path?: string }[] } })?.publicData
+      ?.errors ?? [];
+  expect(errors.map(entry => entry.path)).toContain("settings.redirectPage");
+}
+
 let current: TestNextly | undefined;
 
 afterEach(async () => {
@@ -151,11 +178,11 @@ describe("a form that redirects to a picked page", () => {
     // Previously this saved and then produced no destination on every
     // submission. The write path now refuses it, because a reference into a
     // collection the plugin cannot build a URL for is not a destination.
-    await expect(
+    await expectRedirectRefusal(
       submitPointingAt((id: string) => ({ relationTo: "pages", value: id }), {
         redirectRelationships: { posts: "/blog/{slug}" },
       })
-    ).rejects.toThrow();
+    );
   });
 });
 
@@ -186,23 +213,21 @@ describe("saving a form that redirects to a page", () => {
     // Through the write path the admin actually uses. `validateFormConfig` is
     // a library entry point that no save goes through, so a rule living only
     // there would let this save and fail at submit time instead.
-    await expect(
-      create({ confirmationType: "relationship" })
-    ).rejects.toThrow();
+    await expectRedirectRefusal(create({ confirmationType: "relationship" }));
   });
 
   it("refuses a reference that names nothing", async () => {
     // Truthy and unreadable: a presence check admits exactly the values that
     // resolve to no destination.
-    await expect(
+    await expectRedirectRefusal(
       create({ confirmationType: "relationship", redirectPage: {} })
-    ).rejects.toThrow();
-    await expect(
+    );
+    await expectRedirectRefusal(
       create({
         confirmationType: "relationship",
         redirectPage: { relationTo: "pages" },
       })
-    ).rejects.toThrow();
+    );
   });
 
   it("accepts one that names a page", async () => {
@@ -261,7 +286,7 @@ describe("a host that overrides the forms collection's hooks", () => {
       });
 
     // The plugin's rule still refuses...
-    await expect(save({ confirmationType: "relationship" })).rejects.toThrow();
+    await expectRedirectRefusal(save({ confirmationType: "relationship" }));
 
     // ...and the host's hook is genuinely wired, not merely tolerated.
     await save({
@@ -313,22 +338,22 @@ describe("a host hook that rewrites the payload after validation", () => {
     // mutation — which means a host that mutates AFTERWARDS was judged on a
     // payload it then replaced. The trailing `beforeChange` call is what makes
     // this an invariant rather than a check.
-    await expect(
+    await expectRedirectRefusal(
       saveThrough(data => {
         data.settings = { confirmationType: "relationship" };
       })
-    ).rejects.toThrow();
+    );
   });
 
   it("still refuses a reference the host rewrote into an unusable one", async () => {
-    await expect(
+    await expectRedirectRefusal(
       saveThrough(data => {
         data.settings = {
           confirmationType: "relationship",
           redirectPage: { relationTo: "unconfigured", value: "x1" },
         };
       })
-    ).rejects.toThrow();
+    );
   });
 
   it("accepts what the host rewrites into something usable", async () => {
@@ -340,5 +365,60 @@ describe("a host hook that rewrites the payload after validation", () => {
       };
     });
     expect(saved).toMatchObject({ item: { id: expect.any(String) } });
+  });
+});
+
+describe("updating a form that already redirects to a page", () => {
+  /** A saved, valid form; returns its id and the harness it lives in. */
+  async function savedForm() {
+    const { plugin } = formBuilder({
+      redirectRelationships: { pages: "/{slug}" },
+    });
+    current = await createTestNextly({
+      plugins: [plugin],
+      collections: [pagesCollection],
+    });
+
+    const created = await current.nextly.create({
+      collection: "forms",
+      data: {
+        name: "Contact",
+        slug: "contact",
+        status: "published",
+        fields: [{ type: "text", name: "message", label: "Message" }],
+        settings: {
+          confirmationType: "relationship",
+          redirectPage: { relationTo: "pages", value: "pg1" },
+        },
+      },
+    });
+    return (created as { item: { id: string } }).item.id;
+  }
+
+  it("does not reject an update that leaves the settings alone", async () => {
+    // The partial-update trap the fields rule beside it already documents: an
+    // update carries the patch, so treating an absent `settings` as empty
+    // would refuse a rename for a setting it never touched.
+    const id = await savedForm();
+    const renamed = await current!.nextly.update({
+      collection: "forms",
+      id,
+      data: { name: "Renamed" },
+    });
+    expect(renamed).toMatchObject({ item: { id } });
+  });
+
+  it("rejects an update that clears the page", async () => {
+    // The other half: an update that DOES set settings is judged on what it
+    // sets, so removing the target is refused rather than silently leaving a
+    // form that submits to nowhere.
+    const id = await savedForm();
+    await expectRedirectRefusal(
+      current!.nextly.update({
+        collection: "forms",
+        id,
+        data: { settings: { confirmationType: "relationship" } },
+      })
+    );
   });
 });

--- a/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
+++ b/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
@@ -166,6 +166,13 @@ function FormBuilderViewInner({
     string[] | null
   >(null);
 
+  // Whether the configuration request FAILED, kept apart from what it
+  // returned. A 403 or a 500 mapped to an empty list is indistinguishable from
+  // "this site configures no redirect targets" — so the Settings tab would
+  // state that as fact, hide the option, and offer no way to tell the
+  // difference or try again.
+  const [redirectConfigFailed, setRedirectConfigFailed] = useState(false);
+
   useEffect(() => {
     let cancelled = false;
     const allTypes = FORM_FIELD_TYPE_CATALOG.map(entry => entry.type);
@@ -198,6 +205,8 @@ function FormBuilderViewInner({
           );
           setNotificationDefaults(config?.notifications ?? {});
           setSpamDefaults(config?.spamProtection ?? {});
+          // `config === null` is the failure branch: the response was not ok.
+          setRedirectConfigFailed(config === null);
           setRedirectCollections(config?.redirectCollections ?? []);
         }
       )
@@ -206,6 +215,7 @@ function FormBuilderViewInner({
         setEnabledTypes(allTypes);
         setNotificationDefaults({});
         setSpamDefaults({});
+        setRedirectConfigFailed(true);
         setRedirectCollections([]);
       });
     return () => {
@@ -535,6 +545,7 @@ function FormBuilderViewInner({
         <FormSettingsTab
           spamDefaults={spamDefaults}
           redirectCollections={redirectCollections}
+          redirectConfigFailed={redirectConfigFailed}
         />
       )}
 

--- a/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
+++ b/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
@@ -288,11 +288,11 @@ function FormBuilderViewInner({
         body: JSON.stringify(saveData),
       });
       if (!response.ok) {
-        const err = (await response.json().catch(() => ({}))) as {
-          error?: { message?: string };
-        };
         throw new Error(
-          err.error?.message ?? `Failed to save form: ${response.statusText}`
+          saveErrorMessage(
+            await response.json().catch(() => ({})),
+            response.statusText
+          )
         );
       }
 
@@ -610,6 +610,35 @@ function FormBuilderViewInner({
 // ============================================================================
 // Main Component (provides context)
 // ============================================================================
+
+/**
+ * What to tell an author when a save is refused.
+ *
+ * A validation refusal carries the generic `"Validation failed."` at the top
+ * level and puts the actionable part in `data.errors`. Reporting only the top
+ * level tells an author their form was rejected and nothing about what to
+ * change — every rule in the collection produces that same sentence.
+ */
+export function saveErrorMessage(body: unknown, statusText: string): string {
+  const error = (
+    body as {
+      error?: {
+        message?: string;
+        data?: { errors?: { message?: string }[] };
+      };
+    }
+  )?.error;
+
+  const fieldIssues = (error?.data?.errors ?? [])
+    .map(issue => issue.message)
+    .filter((message): message is string => Boolean(message));
+
+  return (
+    fieldIssues.join(" ") ||
+    error?.message ||
+    `Failed to save form: ${statusText}`
+  );
+}
 
 export function FormBuilderView({
   id,

--- a/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
+++ b/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
@@ -159,6 +159,13 @@ function FormBuilderViewInner({
   // "inherit" resolves to. `null` while the config request settles.
   const [spamDefaults, setSpamDefaults] = useState<SpamDefaults | null>(null);
 
+  // Collections a form may redirect to. `null` while the config request
+  // settles, so the Settings tab can tell "not configured" from "not known
+  // yet" and not flash the option away.
+  const [redirectCollections, setRedirectCollections] = useState<
+    string[] | null
+  >(null);
+
   useEffect(() => {
     let cancelled = false;
     const allTypes = FORM_FIELD_TYPE_CATALOG.map(entry => entry.type);
@@ -173,6 +180,7 @@ function FormBuilderViewInner({
             fields?: Record<string, boolean>;
             notifications?: NotificationDefaults;
             spamProtection?: SpamDefaults;
+            redirectCollections?: string[];
           } | null
         ) => {
           if (cancelled) return;
@@ -190,6 +198,7 @@ function FormBuilderViewInner({
           );
           setNotificationDefaults(config?.notifications ?? {});
           setSpamDefaults(config?.spamProtection ?? {});
+          setRedirectCollections(config?.redirectCollections ?? []);
         }
       )
       .catch(() => {
@@ -197,6 +206,7 @@ function FormBuilderViewInner({
         setEnabledTypes(allTypes);
         setNotificationDefaults({});
         setSpamDefaults({});
+        setRedirectCollections([]);
       });
     return () => {
       cancelled = true;
@@ -522,7 +532,10 @@ function FormBuilderViewInner({
 
       {/* Settings tab */}
       {activeTab === "settings" && (
-        <FormSettingsTab spamDefaults={spamDefaults} />
+        <FormSettingsTab
+          spamDefaults={spamDefaults}
+          redirectCollections={redirectCollections}
+        />
       )}
 
       {/* Notifications tab */}

--- a/packages/plugin-form-builder/src/admin/components/builder/FormPreview.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormPreview.tsx
@@ -212,6 +212,54 @@ export interface FormPreviewProps {
   };
 }
 
+/**
+ * What the visitor is told after a successful submission.
+ *
+ * Its own component because the fall-through belongs to the MESSAGE branch: a
+ * confirmation this does not name is previewed as a thank-you note, which is
+ * how the page redirect came to be previewed as something it is not. Each
+ * confirmation that is not a message has to be named here.
+ */
+function Confirmation({
+  settings,
+}: {
+  settings: {
+    confirmationType?: string;
+    redirectUrl?: string;
+    successMessage?: string;
+  };
+}) {
+  const panel = "border border-border bg-muted/40 p-4 text-sm text-foreground";
+
+  if (settings.confirmationType === "redirect") {
+    return (
+      <p className={panel}>
+        The visitor would now be redirected to{" "}
+        <span className="font-mono">
+          {settings.redirectUrl || "(no redirect URL set)"}
+        </span>
+        .
+      </p>
+    );
+  }
+
+  if (settings.confirmationType === "relationship") {
+    return (
+      <p className={panel}>
+        The visitor would now be redirected to the linked page. Its URL is built
+        when the form is submitted, from the pattern the site configured for
+        that collection.
+      </p>
+    );
+  }
+
+  return (
+    <p className={panel}>
+      {settings.successMessage || "Thank you for your submission!"}
+    </p>
+  );
+}
+
 export function FormPreview({ fields, formData }: FormPreviewProps) {
   const { settings } = useFormBuilder();
   const [values, setValues] = useState<Record<string, unknown>>({});
@@ -326,29 +374,7 @@ export function FormPreview({ fields, formData }: FormPreviewProps) {
 
           {confirmed ? (
             <div className="space-y-4">
-              {/* Every confirmation the settings offer, because the fall-through
-                  belongs to the MESSAGE branch: a redirect that this did not
-                  recognise was previewed as a thank-you note while the saved
-                  form would navigate away. */}
-              {settings.confirmationType === "redirect" ? (
-                <p className="border border-border bg-muted/40 p-4 text-sm text-foreground">
-                  The visitor would now be redirected to{" "}
-                  <span className="font-mono">
-                    {settings.redirectUrl || "(no redirect URL set)"}
-                  </span>
-                  .
-                </p>
-              ) : settings.confirmationType === "relationship" ? (
-                <p className="border border-border bg-muted/40 p-4 text-sm text-foreground">
-                  The visitor would now be redirected to the linked page. Its
-                  URL is built when the form is submitted, from the pattern the
-                  site configured for that collection.
-                </p>
-              ) : (
-                <p className="border border-border bg-muted/40 p-4 text-sm text-foreground">
-                  {settings.successMessage || "Thank you for your submission!"}
-                </p>
-              )}
+              <Confirmation settings={settings} />
               <Button type="button" variant="outline" onClick={reset}>
                 Fill again
               </Button>

--- a/packages/plugin-form-builder/src/admin/components/builder/FormPreview.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormPreview.tsx
@@ -326,6 +326,10 @@ export function FormPreview({ fields, formData }: FormPreviewProps) {
 
           {confirmed ? (
             <div className="space-y-4">
+              {/* Every confirmation the settings offer, because the fall-through
+                  belongs to the MESSAGE branch: a redirect that this did not
+                  recognise was previewed as a thank-you note while the saved
+                  form would navigate away. */}
               {settings.confirmationType === "redirect" ? (
                 <p className="border border-border bg-muted/40 p-4 text-sm text-foreground">
                   The visitor would now be redirected to{" "}
@@ -333,6 +337,12 @@ export function FormPreview({ fields, formData }: FormPreviewProps) {
                     {settings.redirectUrl || "(no redirect URL set)"}
                   </span>
                   .
+                </p>
+              ) : settings.confirmationType === "relationship" ? (
+                <p className="border border-border bg-muted/40 p-4 text-sm text-foreground">
+                  The visitor would now be redirected to the linked page. Its
+                  URL is built when the form is submitted, from the pattern the
+                  site configured for that collection.
                 </p>
               ) : (
                 <p className="border border-border bg-muted/40 p-4 text-sm text-foreground">

--- a/packages/plugin-form-builder/src/admin/components/builder/FormPreview.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormPreview.tsx
@@ -39,6 +39,8 @@ import { isKnownFormField } from "../../../types";
 import { evaluateConditions } from "../../../utils/evaluate-conditions";
 import { useFormBuilder } from "../../context/FormBuilderContext";
 
+import { hasStoredRedirectPage } from "./FormSettingsTab";
+
 // ---------------------------------------------------------------------------
 // Field rendering
 // ---------------------------------------------------------------------------
@@ -227,6 +229,7 @@ function Confirmation({
     confirmationType?: string;
     redirectUrl?: string;
     successMessage?: string;
+    redirectPage?: unknown;
   };
 }) {
   const panel = "border border-border bg-muted/40 p-4 text-sm text-foreground";
@@ -244,11 +247,16 @@ function Confirmation({
   }
 
   if (settings.confirmationType === "relationship") {
+    // Whether a page is actually named, not merely that this confirmation is
+    // chosen. Claiming a redirect with no page saved describes something that
+    // cannot happen: the save is refused, and a form that reached this state
+    // another way resolves to no redirect at all.
+    const named = hasStoredRedirectPage(settings);
     return (
       <p className={panel}>
-        The visitor would now be redirected to the linked page. Its URL is built
-        when the form is submitted, from the pattern the site configured for
-        that collection.
+        {named
+          ? "The visitor would now be redirected to the linked page. Its URL is built when the form is submitted, from the pattern the site configured for that collection."
+          : "No page is selected yet, so this form has no destination. Choose one under Settings, or pick a different confirmation."}
       </p>
     );
   }

--- a/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
@@ -29,6 +29,8 @@ import type React from "react";
 
 import { useFormBuilder } from "../../context/FormBuilderContext";
 
+import { RedirectPagePicker } from "./RedirectPagePicker";
+
 // ---------------------------------------------------------------------------
 // Layout helpers
 // ---------------------------------------------------------------------------
@@ -129,9 +131,18 @@ export interface SpamDefaults {
 interface FormSettingsTabProps {
   /** Plugin-level spam defaults (from builder-config); null while loading. */
   spamDefaults: SpamDefaults | null;
+  /**
+   * Collections a form may redirect to (from builder-config); null while
+   * loading. Empty means the site configured none, and the option is not
+   * offered — choosing it could only ever produce a form with no destination.
+   */
+  redirectCollections: string[] | null;
 }
 
-export function FormSettingsTab({ spamDefaults }: FormSettingsTabProps) {
+export function FormSettingsTab({
+  spamDefaults,
+  redirectCollections,
+}: FormSettingsTabProps) {
   const { settings, updateSettings } = useFormBuilder();
 
   return (
@@ -177,17 +188,14 @@ export function FormSettingsTab({ spamDefaults }: FormSettingsTabProps) {
       <section>
         <SectionHeading>After submission</SectionHeading>
         <div className="flex flex-col gap-4 pt-4">
-          {settings.confirmationType === "relationship" && (
-            <p className="border border-border bg-muted/40 p-3 text-sm text-muted-foreground">
-              This form redirects to a linked page (configured via the API).
-              Picking an option below replaces that behavior.
-            </p>
-          )}
           <RadioGroup
             value={settings.confirmationType ?? "message"}
             onValueChange={value =>
               updateSettings({
-                confirmationType: value as "message" | "redirect",
+                confirmationType: value as
+                  | "message"
+                  | "redirect"
+                  | "relationship",
               })
             }
             className="flex flex-col gap-3"
@@ -238,6 +246,27 @@ export function FormSettingsTab({ spamDefaults }: FormSettingsTabProps) {
                 )}
               </div>
             </div>
+            {redirectCollections !== null && redirectCollections.length > 0 && (
+              <div className="flex items-start gap-3">
+                <RadioGroupItem
+                  value="relationship"
+                  id="settings-confirm-page"
+                  className="mt-0.5"
+                />
+                <div className="w-full space-y-2">
+                  <Label htmlFor="settings-confirm-page">
+                    Redirect to a page
+                  </Label>
+                  {settings.confirmationType === "relationship" && (
+                    <RedirectPagePicker
+                      collections={redirectCollections}
+                      value={settings.redirectPage}
+                      onChange={next => updateSettings({ redirectPage: next })}
+                    />
+                  )}
+                </div>
+              </div>
+            )}
           </RadioGroup>
         </div>
       </section>

--- a/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
@@ -176,14 +176,19 @@ interface FormSettingsTabProps {
  * stored: a picker with no collections to offer, and a save that could only be
  * refused. Selecting a confirmation is not a destination.
  *
- * An empty collection list is passed deliberately — a reference carrying its
- * own `relationTo` is readable without configuration, and configuration is
- * exactly what may be missing here.
+ * A BARE id counts. `parseRedirectReference` resolves one only when exactly
+ * one collection is configured, which is the right rule for "which document is
+ * this" — but the question here is "is anything stored at all", and the answer
+ * must not depend on configuration that may have failed to load or been
+ * removed. Those are precisely the states where an author needs to be shown
+ * what is already saved.
  */
 export function hasStoredRedirectPage(settings: {
   redirectPage?: unknown;
 }): boolean {
-  return parseRedirectReference(settings.redirectPage, []) !== null;
+  const value = settings.redirectPage;
+  if (typeof value === "string") return value.trim().length > 0;
+  return parseRedirectReference(value, []) !== null;
 }
 
 export type RedirectOptionState =

--- a/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
@@ -235,14 +235,16 @@ function PageRedirectOption({
 
   return (
     <div className="flex items-start gap-3">
-      {/* Not selectable while the configuration is unknown. Choosing it there
-          leads only to a save that must be refused, since there is nothing to
-          pick and the rule requires a page. */}
+      {/* Selectable only when there are collections to pick from. In every
+          other state choosing it leads to a save the server must refuse: the
+          rule requires a page, and a page can only come from a configured
+          collection. `stored-only` shows what is already saved; it is not an
+          invitation to switch a different form into that state. */}
       <RadioGroupItem
         value="relationship"
         id="settings-confirm-page"
         className="mt-0.5"
-        disabled={state === "unknown"}
+        disabled={state !== "ready"}
       />
       <div className="w-full space-y-2">
         <Label htmlFor="settings-confirm-page">Redirect to a page</Label>

--- a/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
@@ -139,6 +139,61 @@ interface FormSettingsTabProps {
   redirectCollections: string[] | null;
 }
 
+/**
+ * The "Redirect to a page" choice and its picker.
+ *
+ * Shown when the site configures a redirect collection, AND whenever this form
+ * ALREADY redirects to a page. Hiding a stored confirmation leaves the radio
+ * group holding a value none of its items carry, so nothing appears selected —
+ * while that stored value is still posted on the next save. The author would
+ * be looking at a form that says one thing and saves another.
+ *
+ * Configuration can be removed after a form was saved, and the builder-config
+ * request can fail; both arrive here as an empty list, which is why the stored
+ * value rather than the configuration decides whether this renders.
+ */
+function PageRedirectOption({
+  redirectCollections,
+  settings,
+  updateSettings,
+}: {
+  redirectCollections: string[] | null;
+  settings: { confirmationType?: string; redirectPage?: unknown };
+  updateSettings: (patch: { redirectPage?: unknown }) => void;
+}) {
+  const stored = settings.confirmationType === "relationship";
+  const configured =
+    redirectCollections !== null && redirectCollections.length > 0;
+  if (!stored && !configured) return null;
+
+  return (
+    <div className="flex items-start gap-3">
+      <RadioGroupItem
+        value="relationship"
+        id="settings-confirm-page"
+        className="mt-0.5"
+      />
+      <div className="w-full space-y-2">
+        <Label htmlFor="settings-confirm-page">Redirect to a page</Label>
+        {stored && !configured && (
+          <p className="text-[12px] text-muted-foreground">
+            This form redirects to a page, but no collection is configured as a
+            redirect target right now. The stored page is kept until you choose
+            a different confirmation.
+          </p>
+        )}
+        {stored && configured && (
+          <RedirectPagePicker
+            collections={redirectCollections}
+            value={settings.redirectPage}
+            onChange={next => updateSettings({ redirectPage: next })}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function FormSettingsTab({
   spamDefaults,
   redirectCollections,
@@ -246,27 +301,11 @@ export function FormSettingsTab({
                 )}
               </div>
             </div>
-            {redirectCollections !== null && redirectCollections.length > 0 && (
-              <div className="flex items-start gap-3">
-                <RadioGroupItem
-                  value="relationship"
-                  id="settings-confirm-page"
-                  className="mt-0.5"
-                />
-                <div className="w-full space-y-2">
-                  <Label htmlFor="settings-confirm-page">
-                    Redirect to a page
-                  </Label>
-                  {settings.confirmationType === "relationship" && (
-                    <RedirectPagePicker
-                      collections={redirectCollections}
-                      value={settings.redirectPage}
-                      onChange={next => updateSettings({ redirectPage: next })}
-                    />
-                  )}
-                </div>
-              </div>
-            )}
+            <PageRedirectOption
+              redirectCollections={redirectCollections}
+              settings={settings}
+              updateSettings={updateSettings}
+            />
           </RadioGroup>
         </div>
       </section>

--- a/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
@@ -137,6 +137,12 @@ interface FormSettingsTabProps {
    * offered — choosing it could only ever produce a form with no destination.
    */
   redirectCollections: string[] | null;
+  /**
+   * The configuration request failed, as distinct from returning nothing. An
+   * empty list is a valid answer; a failure is not an answer at all, and
+   * saying "no collection is configured" on a 403 states something false.
+   */
+  redirectConfigFailed: boolean;
 }
 
 /**
@@ -152,19 +158,52 @@ interface FormSettingsTabProps {
  * request can fail; both arrive here as an empty list, which is why the stored
  * value rather than the configuration decides whether this renders.
  */
+/**
+ * What the "Redirect to a page" option should show.
+ *
+ * Four outcomes, named because they were four nested conditions and the
+ * difference between two of them is not visual — an empty configuration is an
+ * ANSWER, a failed configuration read is not, and stating the first when the
+ * second happened tells an author something false about their site.
+ */
+export type RedirectOptionState =
+  /** Not offered: nothing stored, nothing configured, nothing unknown. */
+  | "hidden"
+  /** Offered, but the choices could not be loaded. */
+  | "unknown"
+  /** Offered because a page is stored, though none can be chosen now. */
+  | "stored-only"
+  /** Offered with choices. */
+  | "ready";
+
+export function redirectOptionState(input: {
+  stored: boolean;
+  collections: string[] | null;
+  configFailed: boolean;
+}): RedirectOptionState {
+  const configured = input.collections !== null && input.collections.length > 0;
+  if (configured) return "ready";
+  if (input.stored) return "stored-only";
+  return input.configFailed ? "unknown" : "hidden";
+}
+
 function PageRedirectOption({
   redirectCollections,
+  configFailed,
   settings,
   updateSettings,
 }: {
   redirectCollections: string[] | null;
+  configFailed: boolean;
   settings: { confirmationType?: string; redirectPage?: unknown };
   updateSettings: (patch: { redirectPage?: unknown }) => void;
 }) {
-  const stored = settings.confirmationType === "relationship";
-  const configured =
-    redirectCollections !== null && redirectCollections.length > 0;
-  if (!stored && !configured) return null;
+  const state = redirectOptionState({
+    stored: settings.confirmationType === "relationship",
+    collections: redirectCollections,
+    configFailed,
+  });
+  if (state === "hidden") return null;
 
   return (
     <div className="flex items-start gap-3">
@@ -175,27 +214,27 @@ function PageRedirectOption({
       />
       <div className="w-full space-y-2">
         <Label htmlFor="settings-confirm-page">Redirect to a page</Label>
-        {stored && (
-          <>
-            {!configured && (
-              <p className="text-[12px] text-muted-foreground">
-                No collection is configured as a redirect target right now. The
-                page below is still saved, and stays until you choose a
-                different confirmation.
-              </p>
-            )}
-            {/* Mounted whenever a page is stored, including with NO configured
-                collections. The picker is what recovers the stored target by
-                id and labels it, so leaving it out in exactly that case tells
-                an author a page is saved without telling them which — and the
-                only way out of the state is to see it. */}
+
+        {state !== "ready" && (
+          <p className="text-[12px] text-muted-foreground">
+            {configFailed
+              ? "The redirect configuration could not be loaded, so the pages you can choose from are not listed. Reload to try again."
+              : "No collection is configured as a redirect target right now. The page below is still saved, and stays until you choose a different confirmation."}
+          </p>
+        )}
+
+        {/* Mounted whenever a page is stored, including with NO configured
+            collections: the picker is what recovers the stored target by id
+            and labels it, so leaving it out there tells an author a page is
+            saved without telling them which. */}
+        {state !== "unknown" &&
+          settings.confirmationType === "relationship" && (
             <RedirectPagePicker
               collections={redirectCollections ?? []}
               value={settings.redirectPage}
               onChange={next => updateSettings({ redirectPage: next })}
             />
-          </>
-        )}
+          )}
       </div>
     </div>
   );
@@ -204,6 +243,7 @@ function PageRedirectOption({
 export function FormSettingsTab({
   spamDefaults,
   redirectCollections,
+  redirectConfigFailed,
 }: FormSettingsTabProps) {
   const { settings, updateSettings } = useFormBuilder();
 
@@ -310,6 +350,7 @@ export function FormSettingsTab({
             </div>
             <PageRedirectOption
               redirectCollections={redirectCollections}
+              configFailed={redirectConfigFailed}
               settings={settings}
               updateSettings={updateSettings}
             />

--- a/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
@@ -175,19 +175,26 @@ function PageRedirectOption({
       />
       <div className="w-full space-y-2">
         <Label htmlFor="settings-confirm-page">Redirect to a page</Label>
-        {stored && !configured && (
-          <p className="text-[12px] text-muted-foreground">
-            This form redirects to a page, but no collection is configured as a
-            redirect target right now. The stored page is kept until you choose
-            a different confirmation.
-          </p>
-        )}
-        {stored && configured && (
-          <RedirectPagePicker
-            collections={redirectCollections}
-            value={settings.redirectPage}
-            onChange={next => updateSettings({ redirectPage: next })}
-          />
+        {stored && (
+          <>
+            {!configured && (
+              <p className="text-[12px] text-muted-foreground">
+                No collection is configured as a redirect target right now. The
+                page below is still saved, and stays until you choose a
+                different confirmation.
+              </p>
+            )}
+            {/* Mounted whenever a page is stored, including with NO configured
+                collections. The picker is what recovers the stored target by
+                id and labels it, so leaving it out in exactly that case tells
+                an author a page is saved without telling them which — and the
+                only way out of the state is to see it. */}
+            <RedirectPagePicker
+              collections={redirectCollections ?? []}
+              value={settings.redirectPage}
+              onChange={next => updateSettings({ redirectPage: next })}
+            />
+          </>
         )}
       </div>
     </div>

--- a/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
@@ -27,6 +27,7 @@ import {
 } from "@nextlyhq/ui";
 import type React from "react";
 
+import { parseRedirectReference } from "../../../utils/redirect-reference";
 import { useFormBuilder } from "../../context/FormBuilderContext";
 
 import { RedirectPagePicker } from "./RedirectPagePicker";
@@ -166,24 +167,46 @@ interface FormSettingsTabProps {
  * ANSWER, a failed configuration read is not, and stating the first when the
  * second happened tells an author something false about their site.
  */
+/**
+ * Whether these settings actually NAME a page — not whether the page-redirect
+ * option happens to be selected.
+ *
+ * Conflating the two let an author choose the option while the configuration
+ * was unknown, which classified the state as "a page is stored" with nothing
+ * stored: a picker with no collections to offer, and a save that could only be
+ * refused. Selecting a confirmation is not a destination.
+ *
+ * An empty collection list is passed deliberately — a reference carrying its
+ * own `relationTo` is readable without configuration, and configuration is
+ * exactly what may be missing here.
+ */
+export function hasStoredRedirectPage(settings: {
+  redirectPage?: unknown;
+}): boolean {
+  return parseRedirectReference(settings.redirectPage, []) !== null;
+}
+
 export type RedirectOptionState =
   /** Not offered: nothing stored, nothing configured, nothing unknown. */
   | "hidden"
-  /** Offered, but the choices could not be loaded. */
+  /** Offered but not selectable: the choices could not be loaded. */
   | "unknown"
-  /** Offered because a page is stored, though none can be chosen now. */
+  /** Offered because a page IS stored, though none can be chosen now. */
   | "stored-only"
   /** Offered with choices. */
   | "ready";
 
 export function redirectOptionState(input: {
-  stored: boolean;
+  /** A page is actually stored — not merely that this option is selected. */
+  hasStoredPage: boolean;
   collections: string[] | null;
   configFailed: boolean;
 }): RedirectOptionState {
   const configured = input.collections !== null && input.collections.length > 0;
   if (configured) return "ready";
-  if (input.stored) return "stored-only";
+  // A STORED page outranks a failed request: it is a fact about this form,
+  // and the author needs to see it to change it.
+  if (input.hasStoredPage) return "stored-only";
   return input.configFailed ? "unknown" : "hidden";
 }
 
@@ -199,7 +222,7 @@ function PageRedirectOption({
   updateSettings: (patch: { redirectPage?: unknown }) => void;
 }) {
   const state = redirectOptionState({
-    stored: settings.confirmationType === "relationship",
+    hasStoredPage: hasStoredRedirectPage(settings),
     collections: redirectCollections,
     configFailed,
   });
@@ -207,10 +230,14 @@ function PageRedirectOption({
 
   return (
     <div className="flex items-start gap-3">
+      {/* Not selectable while the configuration is unknown. Choosing it there
+          leads only to a save that must be refused, since there is nothing to
+          pick and the rule requires a page. */}
       <RadioGroupItem
         value="relationship"
         id="settings-confirm-page"
         className="mt-0.5"
+        disabled={state === "unknown"}
       />
       <div className="w-full space-y-2">
         <Label htmlFor="settings-confirm-page">Redirect to a page</Label>
@@ -227,14 +254,15 @@ function PageRedirectOption({
             collections: the picker is what recovers the stored target by id
             and labels it, so leaving it out there tells an author a page is
             saved without telling them which. */}
-        {state !== "unknown" &&
-          settings.confirmationType === "relationship" && (
-            <RedirectPagePicker
-              collections={redirectCollections ?? []}
-              value={settings.redirectPage}
-              onChange={next => updateSettings({ redirectPage: next })}
-            />
-          )}
+        {state === "stored-only" || state === "ready"
+          ? settings.confirmationType === "relationship" && (
+              <RedirectPagePicker
+                collections={redirectCollections ?? []}
+                value={settings.redirectPage}
+                onChange={next => updateSettings({ redirectPage: next })}
+              />
+            )
+          : null}
       </div>
     </div>
   );

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.test.ts
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.test.ts
@@ -87,6 +87,18 @@ describe("groupChoices", () => {
     expect(groups[1].label).toContain("no longer configured");
   });
 
+  it("keeps the stored target when NO collection is configured", () => {
+    // The zero-config case specifically. The previous test kept another
+    // configured collection, so it exercised the grouping but never this — and
+    // this is the state where the picker is the only thing that can tell an
+    // author which page is still saved.
+    const groups = groupChoices([choice("retired", "r1")], []);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].collection).toBe("retired");
+    expect(groups[0].removed).toBe(true);
+    expect(groups[0].choices).toHaveLength(1);
+  });
+
   it("does not invent a group for a configured collection with no choices", () => {
     expect(
       groupChoices([choice("pages", "g1")], ["pages", "posts"]).map(

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.test.ts
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { documentLabel, selectionKey } from "./RedirectPagePicker";
+
+describe("selectionKey", () => {
+  const many = ["pages", "posts"];
+
+  it("reads the shape the picker itself writes", () => {
+    expect(selectionKey({ relationTo: "posts", value: "p1" }, many)).toBe(
+      "posts:p1"
+    );
+  });
+
+  it("reads a value populated by a read at depth", () => {
+    // A form saved and reloaded serves the row under `value`; showing the
+    // control blank there would invite an author to re-pick what is already
+    // set, and saving blank is a different document than the one stored.
+    expect(
+      selectionKey({ relationTo: "pages", value: { id: "pg1" } }, many)
+    ).toBe("pages:pg1");
+  });
+
+  it("reads a bare id only when one collection is configured", () => {
+    expect(selectionKey("pg1", ["pages"])).toBe("pages:pg1");
+    expect(selectionKey("pg1", many)).toBeUndefined();
+  });
+
+  it("shows nothing for an unset or unreadable value", () => {
+    for (const empty of [null, undefined, "", [], { relationTo: "pages" }]) {
+      expect(selectionKey(empty, many)).toBeUndefined();
+    }
+  });
+});
+
+describe("documentLabel", () => {
+  it("prefers the field an author would recognise", () => {
+    expect(documentLabel({ id: "1", title: "About", slug: "about" })).toBe(
+      "About"
+    );
+    expect(documentLabel({ id: "1", name: "Contact" })).toBe("Contact");
+    expect(documentLabel({ id: "1", slug: "pricing" })).toBe("pricing");
+  });
+
+  it("skips a blank field rather than showing an empty row", () => {
+    expect(documentLabel({ id: "1", title: "   ", slug: "about" })).toBe(
+      "about"
+    );
+  });
+
+  it("falls back to the id, then to a placeholder", () => {
+    expect(documentLabel({ id: "pg1" })).toBe("pg1");
+    expect(documentLabel({})).toBe("Untitled");
+  });
+});

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.test.ts
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { documentLabel, selectionKey } from "./RedirectPagePicker";
+import {
+  documentLabel,
+  selectionKey,
+  groupChoices,
+} from "./RedirectPagePicker";
 
 describe("selectionKey", () => {
   const many = ["pages", "posts"];
@@ -50,5 +54,54 @@ describe("documentLabel", () => {
   it("falls back to the id, then to a placeholder", () => {
     expect(documentLabel({ id: "pg1" })).toBe("pg1");
     expect(documentLabel({})).toBe("Untitled");
+  });
+});
+
+describe("groupChoices", () => {
+  const choice = (collection: string, id: string) => ({
+    collection,
+    id,
+    label: id,
+  });
+
+  it("orders groups by configuration", () => {
+    const groups = groupChoices(
+      [choice("posts", "p1"), choice("pages", "g1")],
+      ["pages", "posts"]
+    );
+    expect(groups.map(g => g.collection)).toEqual(["pages", "posts"]);
+    expect(groups.every(g => !g.removed)).toBe(true);
+  });
+
+  it("keeps a collection that is no longer configured, marked and last", () => {
+    // The case that made the control blank: a stored target is recovered by
+    // id, and filtering the render by configuration dropped it — over a value
+    // that is still saved, with the unreadable warning cleared because the
+    // recovery had succeeded.
+    const groups = groupChoices(
+      [choice("pages", "g1"), choice("retired", "r1")],
+      ["pages", "posts"]
+    );
+    expect(groups.map(g => g.collection)).toEqual(["pages", "retired"]);
+    expect(groups[1].removed).toBe(true);
+    expect(groups[1].label).toContain("no longer configured");
+  });
+
+  it("does not invent a group for a configured collection with no choices", () => {
+    expect(
+      groupChoices([choice("pages", "g1")], ["pages", "posts"]).map(
+        g => g.collection
+      )
+    ).toEqual(["pages"]);
+  });
+
+  it("puts every choice in exactly one group", () => {
+    const choices = [
+      choice("pages", "a"),
+      choice("pages", "b"),
+      choice("x", "c"),
+    ];
+    const groups = groupChoices(choices, ["pages"]);
+    expect(groups.flatMap(g => g.choices)).toHaveLength(choices.length);
   });
 });

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
@@ -409,6 +409,65 @@ function Empty({
   );
 }
 
+/**
+ * The things this control has to say that its options cannot.
+ *
+ * Three separate states, kept apart deliberately. A collection that could not
+ * be read, a saved page that cannot be IDENTIFIED because no collection is
+ * configured to look it up in, and a saved page whose lookup FAILED are three
+ * different situations, and each one previously appeared as an empty control —
+ * which reads as "nothing is set" and invites an author to overwrite a
+ * destination they were never shown.
+ */
+function PickerNotices({
+  failed,
+  loading,
+  onRetry,
+  unidentifiable,
+  unreadableSelection,
+}: {
+  failed: readonly string[];
+  loading: boolean;
+  onRetry: () => void;
+  unidentifiable: boolean;
+  unreadableSelection: boolean;
+}) {
+  return (
+    <>
+      {failed.length > 0 && (
+        <p className="text-[12px] text-destructive">
+          Could not read {failed.join(" or ")}. You may not have permission to
+          list {failed.length > 1 ? "them" : "it"}, or the request failed.{" "}
+          <button
+            type="button"
+            onClick={onRetry}
+            disabled={loading}
+            className="underline underline-offset-2 disabled:no-underline"
+          >
+            Try again
+          </button>
+        </p>
+      )}
+
+      {unidentifiable && (
+        <p className="text-[12px] text-muted-foreground">
+          A page is saved on this form, but it cannot be identified without a
+          configured redirect collection. Choosing a different confirmation
+          replaces it.
+        </p>
+      )}
+
+      {unreadableSelection && (
+        <p className="text-[12px] text-destructive">
+          This form has a page selected that could not be read. Leave it as it
+          is unless you mean to change it — saving a new choice replaces the
+          stored one.
+        </p>
+      )}
+    </>
+  );
+}
+
 export function RedirectPagePicker({
   collections,
   value,
@@ -435,6 +494,11 @@ export function RedirectPagePicker({
     retryFailed,
   } = useChoices(collections.join(","), applied);
   const selected = selectionKey(value, collections);
+  // A value is stored and this control cannot say WHICH document it is: a bare
+  // id names no collection, and with none configured there is nowhere to look
+  // it up. Distinct from an unreadable selection, which is a failed request
+  // rather than missing information.
+  const unidentifiable = value != null && selected === undefined;
   const selectionUnreadable = useSelectedChoice(selected, choices, setChoices);
 
   if (choices === null) {
@@ -460,31 +524,13 @@ export function RedirectPagePicker({
       {/* Reported BESIDE the choices rather than instead of them: a collection
           the author cannot read is a different problem from one that is empty,
           and the collections that did load are still choosable. */}
-      {failed.length > 0 && (
-        <p className="text-[12px] text-destructive">
-          Could not read {failed.join(" or ")}. You may not have permission to
-          list {failed.length > 1 ? "them" : "it"}, or the request failed.{" "}
-          <button
-            type="button"
-            onClick={retryFailed}
-            disabled={loading}
-            className="underline underline-offset-2 disabled:no-underline"
-          >
-            Try again
-          </button>
-        </p>
-      )}
-
-      {/* Said plainly, because the control cannot show it: a stored value with
-          no matching option renders blank, which reads as "nothing chosen" and
-          invites an author to replace a destination that is still set. */}
-      {selectionUnreadable && (
-        <p className="text-[12px] text-destructive">
-          This form has a page selected that could not be read. Leave it as it
-          is unless you mean to change it — saving a new choice replaces the
-          stored one.
-        </p>
-      )}
+      <PickerNotices
+        failed={failed}
+        loading={loading}
+        onRetry={retryFailed}
+        unidentifiable={unidentifiable}
+        unreadableSelection={selectionUnreadable}
+      />
 
       {choices.length === 0 ? (
         failed.length < collections.length && (

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
@@ -133,6 +133,7 @@ function useChoices(key: string, applied: string) {
   const [failed, setFailed] = useState<readonly string[]>([]);
   const [hasMore, setHasMore] = useState(false);
   const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
 
   // A new query is a new list, not more of the old one.
   useEffect(() => setPage(1), [key, applied]);
@@ -140,11 +141,13 @@ function useChoices(key: string, applied: string) {
   useEffect(() => {
     let cancelled = false;
     const wanted = key ? key.split(",") : [];
+    setLoading(true);
 
     void Promise.all(
       wanted.map(collection => fetchChoices(collection, applied, page))
     ).then(results => {
       if (cancelled) return;
+      setLoading(false);
       // WHICH collections failed, not merely whether any did: one unreadable
       // collection beside a readable-but-empty one otherwise reports "nothing
       // here" about a collection nobody could see.
@@ -170,7 +173,13 @@ function useChoices(key: string, applied: string) {
     setChoices,
     failed,
     hasMore,
-    loadMore: () => setPage(current => current + 1),
+    loading,
+    // Guarded rather than debounced: two clicks before page 2 resolves either
+    // batch into page 3 or cancel page 2's effect, and page 2's documents are
+    // then absent from a list that says it has loaded them.
+    loadMore: () => {
+      if (!loading) setPage(current => current + 1);
+    },
   };
 }
 
@@ -300,10 +309,8 @@ export function RedirectPagePicker({
 
   // `collections` is an array prop, so a new identity every render would
   // refetch forever; the join is the value that actually decides the request.
-  const { choices, setChoices, failed, hasMore, loadMore } = useChoices(
-    collections.join(","),
-    applied
-  );
+  const { choices, setChoices, failed, hasMore, loading, loadMore } =
+    useChoices(collections.join(","), applied);
   const selected = selectionKey(value, collections);
   useSelectedChoice(selected, choices, setChoices);
 
@@ -365,9 +372,10 @@ export function RedirectPagePicker({
         <button
           type="button"
           onClick={loadMore}
-          className="text-[12px] text-muted-foreground underline underline-offset-2 hover:text-foreground"
+          disabled={loading}
+          className="text-[12px] text-muted-foreground underline underline-offset-2 hover:text-foreground disabled:no-underline disabled:opacity-60"
         >
-          Load more
+          {loading ? "Loading…" : "Load more"}
         </button>
       )}
     </div>

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
@@ -159,7 +159,16 @@ function useChoices(key: string, applied: string) {
   const [pages, setPages] = useState<Record<string, number>>({});
 
   // A new query is a new list, not more of the old one.
-  useEffect(() => setPages({}), [key, applied]);
+  //
+  // The SAME reference is returned when there is nothing to clear. Writing a
+  // fresh `{}` every time is a state change even when the map is already
+  // empty, and the fetch effect below depends on `pages` — so each query
+  // change ran the fetch once with the old map, cancelled it, and ran it
+  // again. Every collection was requested twice per search and the first
+  // answer discarded.
+  useEffect(() => {
+    setPages(current => (Object.keys(current).length === 0 ? current : {}));
+  }, [key, applied]);
 
   useEffect(() => {
     let cancelled = false;

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
@@ -80,26 +80,33 @@ export function documentLabel(row: Record<string, unknown>): string {
  */
 async function fetchChoices(
   collection: string,
-  query: string
-): Promise<Choice[] | null> {
+  query: string,
+  page: number
+): Promise<{ rows: Choice[]; hasMore: boolean } | null> {
   const search = query ? `&search=${encodeURIComponent(query)}` : "";
   try {
     const response = await fetch(
       `/admin/api/collections/${collection}/entries` +
-        `?limit=${PAGE_SIZE}&status=all&depth=0${search}`,
+        `?limit=${PAGE_SIZE}&page=${page}&status=all&depth=0${search}`,
       { credentials: "include" }
     );
     if (!response.ok) return null;
     const body = (await response.json()) as {
       items?: Record<string, unknown>[];
+      meta?: { totalPages?: number };
     };
-    return (body.items ?? [])
-      .filter(row => typeof row.id === "string")
-      .map(row => ({
-        collection,
-        id: row.id as string,
-        label: documentLabel(row),
-      }));
+    return {
+      rows: (body.items ?? [])
+        .filter(row => typeof row.id === "string")
+        .map(row => ({
+          collection,
+          id: row.id as string,
+          label: documentLabel(row),
+        })),
+      // Reported rather than assumed, so the control can offer the rest
+      // instead of truncating where the author cannot see it.
+      hasMore: page < (body.meta?.totalPages ?? 1),
+    };
   } catch {
     return null;
   }
@@ -124,30 +131,47 @@ function renderChoice(choice: Choice) {
 function useChoices(key: string, applied: string) {
   const [choices, setChoices] = useState<Choice[] | null>(null);
   const [failed, setFailed] = useState<readonly string[]>([]);
+  const [hasMore, setHasMore] = useState(false);
+  const [page, setPage] = useState(1);
+
+  // A new query is a new list, not more of the old one.
+  useEffect(() => setPage(1), [key, applied]);
 
   useEffect(() => {
     let cancelled = false;
     const wanted = key ? key.split(",") : [];
 
     void Promise.all(
-      wanted.map(collection => fetchChoices(collection, applied))
+      wanted.map(collection => fetchChoices(collection, applied, page))
     ).then(results => {
       if (cancelled) return;
       // WHICH collections failed, not merely whether any did: one unreadable
       // collection beside a readable-but-empty one otherwise reports "nothing
       // here" about a collection nobody could see.
       setFailed(wanted.filter((_, index) => results[index] === null));
-      setChoices(
-        results.filter((rows): rows is Choice[] => rows !== null).flat()
+      const loaded = results.filter(
+        (result): result is { rows: Choice[]; hasMore: boolean } =>
+          result !== null
+      );
+      setHasMore(loaded.some(result => result.hasMore));
+      const rows = loaded.flatMap(result => result.rows);
+      setChoices(current =>
+        page === 1 ? rows : [...(current ?? []), ...rows]
       );
     });
 
     return () => {
       cancelled = true;
     };
-  }, [key, applied]);
+  }, [key, applied, page]);
 
-  return { choices, setChoices, failed };
+  return {
+    choices,
+    setChoices,
+    failed,
+    hasMore,
+    loadMore: () => setPage(current => current + 1),
+  };
 }
 
 /**
@@ -172,7 +196,18 @@ function useSelectedChoice(
     const separator = selected.indexOf(":");
     const collection = selected.slice(0, separator);
     const id = selected.slice(separator + 1);
-    if (!id || choices.some(choice => choice.id === id)) return;
+    // Collection AND id: two configured collections can hold the same id, and
+    // matching on id alone skips the fetch while the option that is actually
+    // selected is absent — leaving the author looking at a blank control over
+    // a stored value.
+    if (
+      !id ||
+      choices.some(
+        choice => choice.id === id && choice.collection === collection
+      )
+    ) {
+      return;
+    }
 
     let cancelled = false;
     void (async () => {
@@ -185,10 +220,10 @@ function useSelectedChoice(
           { credentials: "include" }
         );
         if (!response.ok) return;
-        const body = (await response.json()) as {
-          item?: Record<string, unknown>;
-        };
-        const row = body.item;
+        // A by-id read answers with the document ITSELF. Only mutations carry
+        // the `{ message, item }` envelope, and reaching for `item` here made
+        // this recovery a no-op that no listing-sized fixture could reveal.
+        const row = (await response.json()) as Record<string, unknown>;
         if (cancelled || !row || typeof row.id !== "string") return;
         setChoices(current => [
           { collection, id: row.id as string, label: documentLabel(row) },
@@ -265,7 +300,7 @@ export function RedirectPagePicker({
 
   // `collections` is an array prop, so a new identity every render would
   // refetch forever; the join is the value that actually decides the request.
-  const { choices, setChoices, failed } = useChoices(
+  const { choices, setChoices, failed, hasMore, loadMore } = useChoices(
     collections.join(","),
     applied
   );
@@ -321,6 +356,19 @@ export function RedirectPagePicker({
             <Options choices={choices} collections={collections} />
           </SelectContent>
         </Select>
+      )}
+
+      {/* The rest of the matches, reachable rather than silently absent. A cap
+          with no way past it makes a document beyond it unselectable however
+          high the cap is set. */}
+      {hasMore && (
+        <button
+          type="button"
+          onClick={loadMore}
+          className="text-[12px] text-muted-foreground underline underline-offset-2 hover:text-foreground"
+        >
+          Load more
+        </button>
       )}
     </div>
   );

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
@@ -313,7 +313,60 @@ function useSelectedChoice(
   return unreadable;
 }
 
-/** The options, grouped by collection only when there is more than one. */
+/**
+ * The options, grouped by the collection each one came from.
+ *
+ * The groups are derived from the CHOICES, not from the configured list. A
+ * stored target whose collection was removed since the form was saved is
+ * recovered by id and belongs in the list — filtering by configuration
+ * dropped it, leaving the control blank over a value that is still stored,
+ * with the unreadable warning cleared because the recovery had succeeded.
+ *
+ * That divergence was visible in the code before it was visible on screen: the
+ * single-collection branch rendered every choice and the grouped branch
+ * filtered them, so the same state produced different pickers depending on how
+ * many collections a site happened to configure. One path now.
+ */
+export interface ChoiceGroup {
+  collection: string;
+  label: string;
+  /** True when this collection is no longer a configured redirect target. */
+  removed: boolean;
+  choices: Choice[];
+}
+
+/**
+ * The choices arranged into groups, in configuration order, with collections
+ * that are no longer configured last and marked.
+ *
+ * Derived from the CHOICES rather than from the configured list, which is the
+ * whole point: a stored target whose collection was removed is recovered by id
+ * and belongs in the list.
+ */
+export function groupChoices(
+  choices: readonly Choice[],
+  collections: readonly string[]
+): ChoiceGroup[] {
+  const present = [...new Set(choices.map(choice => choice.collection))];
+  const order = [
+    ...collections.filter(name => present.includes(name)),
+    ...present.filter(name => !collections.includes(name)),
+  ];
+
+  return order.map(collection => {
+    const removed = !collections.includes(collection);
+    return {
+      collection,
+      // Named as unavailable rather than hidden: the value is still stored and
+      // the server refuses a save into a collection with no pattern, so an
+      // author needs to see what is set in order to change it.
+      label: removed ? `${collection} — no longer configured` : collection,
+      removed,
+      choices: choices.filter(choice => choice.collection === collection),
+    };
+  });
+}
+
 function Options({
   choices,
   collections,
@@ -321,21 +374,18 @@ function Options({
   choices: Choice[];
   collections: readonly string[];
 }) {
-  if (collections.length <= 1) return <>{choices.map(renderChoice)}</>;
+  const groups = groupChoices(choices, collections);
+  if (groups.length <= 1 && !groups[0]?.removed) {
+    return <>{choices.map(renderChoice)}</>;
+  }
   return (
     <>
-      {collections.map(collection => {
-        const inCollection = choices.filter(
-          choice => choice.collection === collection
-        );
-        if (inCollection.length === 0) return null;
-        return (
-          <SelectGroup key={collection}>
-            <SelectLabel>{collection}</SelectLabel>
-            {inCollection.map(renderChoice)}
-          </SelectGroup>
-        );
-      })}
+      {groups.map(group => (
+        <SelectGroup key={group.collection}>
+          <SelectLabel>{group.label}</SelectLabel>
+          {group.choices.map(renderChoice)}
+        </SelectGroup>
+      ))}
     </>
   );
 }

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
@@ -132,11 +132,15 @@ function useChoices(key: string, applied: string) {
   const [choices, setChoices] = useState<Choice[] | null>(null);
   const [failed, setFailed] = useState<readonly string[]>([]);
   const [hasMore, setHasMore] = useState(false);
-  const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(false);
+  // Per collection, not shared. A shared counter advances every collection
+  // when any one of them has more, so a collection whose page N failed is
+  // never asked for page N again — and if its N+1 succeeds the warning clears
+  // too, leaving those documents absent with nothing on screen saying so.
+  const [pages, setPages] = useState<Record<string, number>>({});
 
   // A new query is a new list, not more of the old one.
-  useEffect(() => setPage(1), [key, applied]);
+  useEffect(() => setPages({}), [key, applied]);
 
   useEffect(() => {
     let cancelled = false;
@@ -144,29 +148,33 @@ function useChoices(key: string, applied: string) {
     setLoading(true);
 
     void Promise.all(
-      wanted.map(collection => fetchChoices(collection, applied, page))
+      wanted.map(collection =>
+        fetchChoices(collection, applied, pages[collection] ?? 1)
+      )
     ).then(results => {
       if (cancelled) return;
       setLoading(false);
+
       // WHICH collections failed, not merely whether any did: one unreadable
       // collection beside a readable-but-empty one otherwise reports "nothing
       // here" about a collection nobody could see.
       setFailed(wanted.filter((_, index) => results[index] === null));
+
       const loaded = results.filter(
         (result): result is { rows: Choice[]; hasMore: boolean } =>
           result !== null
       );
       setHasMore(loaded.some(result => result.hasMore));
+
       const rows = loaded.flatMap(result => result.rows);
-      setChoices(current =>
-        page === 1 ? rows : [...(current ?? []), ...rows]
-      );
+      const first = wanted.every(collection => (pages[collection] ?? 1) === 1);
+      setChoices(current => (first ? rows : [...(current ?? []), ...rows]));
     });
 
     return () => {
       cancelled = true;
     };
-  }, [key, applied, page]);
+  }, [key, applied, pages]);
 
   return {
     choices,
@@ -174,11 +182,30 @@ function useChoices(key: string, applied: string) {
     failed,
     hasMore,
     loading,
-    // Guarded rather than debounced: two clicks before page 2 resolves either
-    // batch into page 3 or cancel page 2's effect, and page 2's documents are
-    // then absent from a list that says it has loaded them.
+    /**
+     * Advances only the collections that have more to give, and RETRIES the
+     * ones whose last page failed rather than stepping over it.
+     *
+     * Guarded on the in-flight flag: two clicks before the first resolves
+     * either batch into a double increment or cancel the pending effect, and a
+     * skipped page is then absent from a list that reports having loaded it.
+     */
     loadMore: () => {
-      if (!loading) setPage(current => current + 1);
+      if (loading) return;
+      setPages(current => {
+        const next: Record<string, number> = { ...current };
+        for (const collection of key ? key.split(",") : []) {
+          // A failed collection stays on its page so the retry asks for the
+          // page it never got.
+          if (failed.includes(collection)) continue;
+          next[collection] = (current[collection] ?? 1) + 1;
+        }
+        return next;
+      });
+    },
+    /** Ask the failed collections again, without advancing anyone. */
+    retryFailed: () => {
+      if (!loading) setPages(current => ({ ...current }));
     },
   };
 }
@@ -200,6 +227,12 @@ function useSelectedChoice(
   choices: Choice[] | null,
   setChoices: (update: (current: Choice[] | null) => Choice[]) => void
 ) {
+  // Whether the stored selection could not be read. A controlled `Select`
+  // holding a value with no matching option renders BLANK, which looks
+  // identical to "nothing chosen" — so an author with a perfectly good
+  // destination is invited to pick over it. Reported rather than swallowed.
+  const [unreadable, setUnreadable] = useState(false);
+
   useEffect(() => {
     if (!selected || choices === null) return;
     const separator = selected.indexOf(":");
@@ -207,14 +240,14 @@ function useSelectedChoice(
     const id = selected.slice(separator + 1);
     // Collection AND id: two configured collections can hold the same id, and
     // matching on id alone skips the fetch while the option that is actually
-    // selected is absent — leaving the author looking at a blank control over
-    // a stored value.
+    // selected is absent.
     if (
       !id ||
       choices.some(
         choice => choice.id === id && choice.collection === collection
       )
     ) {
+      setUnreadable(false);
       return;
     }
 
@@ -222,24 +255,30 @@ function useSelectedChoice(
     void (async () => {
       try {
         // `status=all` for the same reason the listing carries it: a stored
-        // target may be a draft, and a published-only read answers 404 — so
-        // the control would drop a selection the listing would have shown.
+        // target may be a draft, and a published-only read answers 404.
         const response = await fetch(
           `/admin/api/collections/${collection}/entries/${id}?depth=0&status=all`,
           { credentials: "include" }
         );
-        if (!response.ok) return;
+        if (!response.ok) {
+          if (!cancelled) setUnreadable(true);
+          return;
+        }
         // A by-id read answers with the document ITSELF. Only mutations carry
-        // the `{ message, item }` envelope, and reaching for `item` here made
-        // this recovery a no-op that no listing-sized fixture could reveal.
+        // the `{ message, item }` envelope.
         const row = (await response.json()) as Record<string, unknown>;
-        if (cancelled || !row || typeof row.id !== "string") return;
+        if (cancelled) return;
+        if (!row || typeof row.id !== "string") {
+          setUnreadable(true);
+          return;
+        }
+        setUnreadable(false);
         setChoices(current => [
           { collection, id: row.id as string, label: documentLabel(row) },
           ...(current ?? []),
         ]);
       } catch {
-        // The list still renders; the selection simply cannot be named.
+        if (!cancelled) setUnreadable(true);
       }
     })();
 
@@ -247,6 +286,8 @@ function useSelectedChoice(
       cancelled = true;
     };
   }, [selected, choices, setChoices]);
+
+  return unreadable;
 }
 
 /** The options, grouped by collection only when there is more than one. */
@@ -309,10 +350,17 @@ export function RedirectPagePicker({
 
   // `collections` is an array prop, so a new identity every render would
   // refetch forever; the join is the value that actually decides the request.
-  const { choices, setChoices, failed, hasMore, loading, loadMore } =
-    useChoices(collections.join(","), applied);
+  const {
+    choices,
+    setChoices,
+    failed,
+    hasMore,
+    loading,
+    loadMore,
+    retryFailed,
+  } = useChoices(collections.join(","), applied);
   const selected = selectionKey(value, collections);
-  useSelectedChoice(selected, choices, setChoices);
+  const selectionUnreadable = useSelectedChoice(selected, choices, setChoices);
 
   if (choices === null) {
     return <p className="text-[12px] text-muted-foreground">Loading pages…</p>;
@@ -336,7 +384,26 @@ export function RedirectPagePicker({
       {failed.length > 0 && (
         <p className="text-[12px] text-destructive">
           Could not read {failed.join(" or ")}. You may not have permission to
-          list {failed.length > 1 ? "them" : "it"}, or the request failed.
+          list {failed.length > 1 ? "them" : "it"}, or the request failed.{" "}
+          <button
+            type="button"
+            onClick={retryFailed}
+            disabled={loading}
+            className="underline underline-offset-2 disabled:no-underline"
+          >
+            Try again
+          </button>
+        </p>
+      )}
+
+      {/* Said plainly, because the control cannot show it: a stored value with
+          no matching option renders blank, which reads as "nothing chosen" and
+          invites an author to replace a destination that is still set. */}
+      {selectionUnreadable && (
+        <p className="text-[12px] text-destructive">
+          This form has a page selected that could not be read. Leave it as it
+          is unless you mean to change it — saving a new choice replaces the
+          stored one.
         </p>
       )}
 

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
@@ -28,6 +28,14 @@ import { parseRedirectReference } from "../../../utils/redirect-reference";
 /** Rows per request. Search, not paging, is how the rest are reached. */
 const PAGE_SIZE = 50;
 
+/**
+ * The only fields this control reads, in the order `documentLabel` prefers.
+ *
+ * One declaration, used to build the request AND to choose the label, so a
+ * field added to one cannot go missing from the other.
+ */
+const LABEL_FIELDS = ["id", "title", "name", "label", "slug"] as const;
+
 /** One selectable document, reduced to what the control shows and stores. */
 interface Choice {
   collection: string;
@@ -61,7 +69,7 @@ export function selectionKey(
 
 /** What to call a document, preferring the field an author would recognise. */
 export function documentLabel(row: Record<string, unknown>): string {
-  for (const field of ["title", "name", "label", "slug"]) {
+  for (const field of LABEL_FIELDS.filter(name => name !== "id")) {
     const candidate = row[field];
     if (typeof candidate === "string" && candidate.trim()) return candidate;
   }
@@ -85,9 +93,14 @@ async function fetchChoices(
 ): Promise<{ rows: Choice[]; hasMore: boolean } | null> {
   const search = query ? `&search=${encodeURIComponent(query)}` : "";
   try {
+    // `select` as well as `depth=0`. Without it every scalar and JSON field of
+    // up to fifty documents is downloaded per collection — for page-builder
+    // documents that is the whole block tree — to fill a dropdown that reads
+    // five fields.
     const response = await fetch(
       `/admin/api/collections/${collection}/entries` +
-        `?limit=${PAGE_SIZE}&page=${page}&status=all&depth=0${search}`,
+        `?limit=${PAGE_SIZE}&page=${page}&status=all&depth=0` +
+        `&select=${LABEL_FIELDS.join(",")}${search}`,
       { credentials: "include" }
     );
     if (!response.ok) return null;
@@ -399,7 +412,13 @@ function Options({
   );
 }
 
-/** What to say when there is nothing to choose, and why. */
+/**
+ * What to say when there is nothing to choose, and why.
+ *
+ * `collections` here is the READABLE ones. Passing the full configured list
+ * asserted that a collection which could not be read is empty — printed
+ * directly beneath the notice saying it could not be read.
+ */
 function Empty({
   applied,
   collections,
@@ -543,7 +562,10 @@ export function RedirectPagePicker({
 
       {choices.length === 0 ? (
         failed.length < collections.length && (
-          <Empty applied={applied} collections={collections} />
+          <Empty
+            applied={applied}
+            collections={collections.filter(name => !failed.includes(name))}
+          />
         )
       ) : (
         <Select

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
@@ -402,7 +402,9 @@ function Empty({
     <p className="text-[12px] text-muted-foreground">
       {applied
         ? `No documents match “${applied}”.`
-        : `No documents to redirect to yet. Create one in ${collections.join(" or ")} first.`}
+        : collections.length === 0
+          ? "No collection is configured as a redirect target."
+          : `No documents to redirect to yet. Create one in ${collections.join(" or ")} first.`}
     </p>
   );
 }
@@ -444,12 +446,16 @@ export function RedirectPagePicker({
       {/* Search rather than paging: a dropdown cannot usefully list a large
           collection, and a ceiling on how many pages to walk would leave the
           documents past it unreachable however high it were set. */}
-      <Input
-        aria-label="Search pages"
-        value={query}
-        onChange={event => setQuery(event.target.value)}
-        placeholder="Search…"
-      />
+      {/* Nothing to search when no collection is listed — the only entry in
+          the control then is the stored target, recovered by id. */}
+      {collections.length > 0 && (
+        <Input
+          aria-label="Search pages"
+          value={query}
+          onChange={event => setQuery(event.target.value)}
+          placeholder="Search…"
+        />
+      )}
 
       {/* Reported BESIDE the choices rather than instead of them: a collection
           the author cannot read is a different problem from one that is empty,

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
@@ -12,6 +12,7 @@
  */
 
 import {
+  Input,
   Select,
   SelectContent,
   SelectGroup,
@@ -24,9 +25,8 @@ import { useEffect, useState } from "react";
 
 import { parseRedirectReference } from "../../../utils/redirect-reference";
 
-/** Rows per request, and the ceiling on how many requests one collection costs. */
-const PAGE_SIZE = 100;
-const MAX_PAGES = 10;
+/** Rows per request. Search, not paging, is how the rest are reached. */
+const PAGE_SIZE = 50;
 
 /** One selectable document, reduced to what the control shows and stores. */
 interface Choice {
@@ -59,7 +59,7 @@ export function selectionKey(
   return reference ? `${reference.collection}:${reference.id}` : undefined;
 }
 
-/** What to call a document in the list, preferring what an author would recognise. */
+/** What to call a document, preferring the field an author would recognise. */
 export function documentLabel(row: Record<string, unknown>): string {
   for (const field of ["title", "name", "label", "slug"]) {
     const candidate = row[field];
@@ -68,104 +68,110 @@ export function documentLabel(row: Record<string, unknown>): string {
   return typeof row.id === "string" ? row.id : "Untitled";
 }
 
-export function RedirectPagePicker({
-  collections,
-  value,
-  onChange,
-}: RedirectPagePickerProps) {
+/**
+ * One collection's matching documents, or null when it could not be read.
+ *
+ * `limit`, not `pageSize` — the other name is accepted and ignored, leaving
+ * the default of 10. `status=all` because a form is usually configured
+ * alongside the page it points at, and filtering to published shows "create
+ * one first" while the page sits in the next tab. `depth=0` because this reads
+ * five fields and would otherwise inherit the collection API's expansion,
+ * pulling every nested relation of every row to fill a dropdown.
+ */
+async function fetchChoices(
+  collection: string,
+  query: string
+): Promise<Choice[] | null> {
+  const search = query ? `&search=${encodeURIComponent(query)}` : "";
+  try {
+    const response = await fetch(
+      `/admin/api/collections/${collection}/entries` +
+        `?limit=${PAGE_SIZE}&status=all&depth=0${search}`,
+      { credentials: "include" }
+    );
+    if (!response.ok) return null;
+    const body = (await response.json()) as {
+      items?: Record<string, unknown>[];
+    };
+    return (body.items ?? [])
+      .filter(row => typeof row.id === "string")
+      .map(row => ({
+        collection,
+        id: row.id as string,
+        label: documentLabel(row),
+      }));
+  } catch {
+    return null;
+  }
+}
+
+/** One option, keyed and valued by the pair the caller stores. */
+function renderChoice(choice: Choice) {
+  return (
+    <SelectItem
+      key={`${choice.collection}:${choice.id}`}
+      value={`${choice.collection}:${choice.id}`}
+    >
+      {choice.label}
+    </SelectItem>
+  );
+}
+
+/**
+ * The matching documents for every configured collection, and which of them
+ * could not be read.
+ */
+function useChoices(key: string, applied: string) {
   const [choices, setChoices] = useState<Choice[] | null>(null);
-
-  // `collections` is an array prop, so a new identity every render would
-  // refetch forever; the join is the value that actually decides the request.
-  const key = collections.join(",");
-
-  const [unreadable, setUnreadable] = useState(false);
+  const [failed, setFailed] = useState<readonly string[]>([]);
 
   useEffect(() => {
     let cancelled = false;
     const wanted = key ? key.split(",") : [];
 
-    /** One collection's documents, or null when it could not be read. */
-    const load = async (collection: string): Promise<Choice[] | null> => {
-      const page = async (offset: number) => {
-        // `limit`, not `pageSize` — the other name is accepted and ignored,
-        // leaving the default of 10. `status=all` because a form is usually
-        // configured alongside the page it points at, and filtering to
-        // published shows "publish one first" while the page sits in the next
-        // tab. `depth=0` because this reads five fields and would otherwise
-        // inherit the collection API's default expansion, pulling every
-        // nested relation of every row to fill a dropdown.
-        const response = await fetch(
-          `/admin/api/collections/${collection}/entries` +
-            `?limit=${PAGE_SIZE}&page=${offset}&status=all&depth=0`,
-          { credentials: "include" }
-        );
-        if (!response.ok) throw new Error(String(response.status));
-        return (await response.json()) as {
-          items?: Record<string, unknown>[];
-          meta?: { totalPages?: number };
-        };
-      };
-
-      try {
-        const first = await page(1);
-        const rows = [...(first.items ?? [])];
-        // Follow the pagination rather than stopping at one page: an author
-        // whose document is number 101 could otherwise never select it, and a
-        // form already pointing there would show blank. Bounded so a large
-        // collection cannot hang the tab — what it cannot show, it says.
-        const totalPages = Math.min(first.meta?.totalPages ?? 1, MAX_PAGES);
-        for (let next = 2; next <= totalPages; next++) {
-          rows.push(...((await page(next)).items ?? []));
-        }
-        return rows
-          .filter(row => typeof row.id === "string")
-          .map(row => ({
-            collection,
-            id: row.id as string,
-            label: documentLabel(row),
-          }));
-      } catch {
-        return null;
-      }
-    };
-
-    void Promise.all(wanted.map(load)).then(perCollection => {
+    void Promise.all(
+      wanted.map(collection => fetchChoices(collection, applied))
+    ).then(results => {
       if (cancelled) return;
-      const readable = perCollection.filter(
-        (rows): rows is Choice[] => rows !== null
+      // WHICH collections failed, not merely whether any did: one unreadable
+      // collection beside a readable-but-empty one otherwise reports "nothing
+      // here" about a collection nobody could see.
+      setFailed(wanted.filter((_, index) => results[index] === null));
+      setChoices(
+        results.filter((rows): rows is Choice[] => rows !== null).flat()
       );
-      // "Nothing to choose" and "could not read anything" are different
-      // answers, and only one of them is the author's to fix. Reported apart,
-      // because an editor without read permission was otherwise told the
-      // collection was empty.
-      setUnreadable(readable.length === 0 && wanted.length > 0);
-      setChoices(readable.flat());
     });
 
     return () => {
       cancelled = true;
     };
-  }, [key]);
+  }, [key, applied]);
 
-  const selected = selectionKey(value, collections);
+  return { choices, setChoices, failed };
+}
 
-  /**
-   * The selected document, when the listing did not reach it.
-   *
-   * Its own effect, keyed on the selection rather than on the collection list,
-   * because the stored value arrives with the form and often AFTER this mounts
-   * — an effect that only watched the collections would capture the moment
-   * when nothing was selected yet and never look again.
-   *
-   * A control that silently drops its own value is worse than one that cannot
-   * list everything: the author sees blank, re-picks, and saves a different
-   * destination than the one that was stored.
-   */
+/**
+ * Adds the selected document when the listing did not reach it.
+ *
+ * Keyed on the selection rather than on the collection list, because the
+ * stored value arrives with the form and often AFTER this mounts — a hook
+ * watching only the collections would capture the moment when nothing was
+ * selected and never look again.
+ *
+ * A control that silently drops its own value is worse than one that cannot
+ * list everything: the author sees blank, re-picks, and saves a different
+ * destination than the one that was stored.
+ */
+function useSelectedChoice(
+  selected: string | undefined,
+  choices: Choice[] | null,
+  setChoices: (update: (current: Choice[] | null) => Choice[]) => void
+) {
   useEffect(() => {
     if (!selected || choices === null) return;
-    const [collection, ...rest] = selected.split(":");
-    const id = rest.join(":");
+    const separator = selected.indexOf(":");
+    const collection = selected.slice(0, separator);
+    const id = selected.slice(separator + 1);
     if (!id || choices.some(choice => choice.id === id)) return;
 
     let cancelled = false;
@@ -193,77 +199,126 @@ export function RedirectPagePicker({
     return () => {
       cancelled = true;
     };
-  }, [selected, choices]);
+  }, [selected, choices, setChoices]);
+}
 
-  const grouped = collections.length > 1;
+/** The options, grouped by collection only when there is more than one. */
+function Options({
+  choices,
+  collections,
+}: {
+  choices: Choice[];
+  collections: readonly string[];
+}) {
+  if (collections.length <= 1) return <>{choices.map(renderChoice)}</>;
+  return (
+    <>
+      {collections.map(collection => {
+        const inCollection = choices.filter(
+          choice => choice.collection === collection
+        );
+        if (inCollection.length === 0) return null;
+        return (
+          <SelectGroup key={collection}>
+            <SelectLabel>{collection}</SelectLabel>
+            {inCollection.map(renderChoice)}
+          </SelectGroup>
+        );
+      })}
+    </>
+  );
+}
+
+/** What to say when there is nothing to choose, and why. */
+function Empty({
+  applied,
+  collections,
+}: {
+  applied: string;
+  collections: readonly string[];
+}) {
+  return (
+    <p className="text-[12px] text-muted-foreground">
+      {applied
+        ? `No documents match “${applied}”.`
+        : `No documents to redirect to yet. Create one in ${collections.join(" or ")} first.`}
+    </p>
+  );
+}
+
+export function RedirectPagePicker({
+  collections,
+  value,
+  onChange,
+}: RedirectPagePickerProps) {
+  const [query, setQuery] = useState("");
+  const [applied, setApplied] = useState("");
+
+  // Typing should not issue a request per keystroke.
+  useEffect(() => {
+    const timer = setTimeout(() => setApplied(query), 250);
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  // `collections` is an array prop, so a new identity every render would
+  // refetch forever; the join is the value that actually decides the request.
+  const { choices, setChoices, failed } = useChoices(
+    collections.join(","),
+    applied
+  );
+  const selected = selectionKey(value, collections);
+  useSelectedChoice(selected, choices, setChoices);
 
   if (choices === null) {
     return <p className="text-[12px] text-muted-foreground">Loading pages…</p>;
   }
 
-  if (unreadable) {
-    return (
-      <p className="text-[12px] text-destructive">
-        Could not read {collections.join(" or ")}. You may not have permission
-        to list them, or the request failed.
-      </p>
-    );
-  }
-
-  if (choices.length === 0) {
-    return (
-      <p className="text-[12px] text-muted-foreground">
-        No documents to redirect to yet. Create one in{" "}
-        {collections.join(" or ")} first.
-      </p>
-    );
-  }
-
   return (
-    <Select
-      value={selected ?? ""}
-      onValueChange={next => {
-        const separator = next.indexOf(":");
-        if (separator < 0) return onChange(undefined);
-        onChange({
-          relationTo: next.slice(0, separator),
-          value: next.slice(separator + 1),
-        });
-      }}
-    >
-      <SelectTrigger aria-label="Redirect page" className="w-full">
-        <SelectValue placeholder="Choose a page" />
-      </SelectTrigger>
-      <SelectContent>
-        {grouped
-          ? collections.map(collection => {
-              const inCollection = choices.filter(
-                choice => choice.collection === collection
-              );
-              if (inCollection.length === 0) return null;
-              return (
-                <SelectGroup key={collection}>
-                  <SelectLabel>{collection}</SelectLabel>
-                  {inCollection.map(choice => (
-                    <SelectItem
-                      key={`${choice.collection}:${choice.id}`}
-                      value={`${choice.collection}:${choice.id}`}
-                    >
-                      {choice.label}
-                    </SelectItem>
-                  ))}
-                </SelectGroup>
-              );
-            })
-          : choices.map(choice => (
-              <SelectItem
-                key={`${choice.collection}:${choice.id}`}
-                value={`${choice.collection}:${choice.id}`}
-              >
-                {choice.label}
-              </SelectItem>
-            ))}
-      </SelectContent>
-    </Select>
+    <div className="space-y-2">
+      {/* Search rather than paging: a dropdown cannot usefully list a large
+          collection, and a ceiling on how many pages to walk would leave the
+          documents past it unreachable however high it were set. */}
+      <Input
+        aria-label="Search pages"
+        value={query}
+        onChange={event => setQuery(event.target.value)}
+        placeholder="Search…"
+      />
+
+      {/* Reported BESIDE the choices rather than instead of them: a collection
+          the author cannot read is a different problem from one that is empty,
+          and the collections that did load are still choosable. */}
+      {failed.length > 0 && (
+        <p className="text-[12px] text-destructive">
+          Could not read {failed.join(" or ")}. You may not have permission to
+          list {failed.length > 1 ? "them" : "it"}, or the request failed.
+        </p>
+      )}
+
+      {choices.length === 0 ? (
+        failed.length < collections.length && (
+          <Empty applied={applied} collections={collections} />
+        )
+      ) : (
+        <Select
+          value={selected ?? ""}
+          onValueChange={next => {
+            const separator = next.indexOf(":");
+            if (separator < 0) return onChange(undefined);
+            onChange({
+              relationTo: next.slice(0, separator),
+              value: next.slice(separator + 1),
+            });
+          }}
+        >
+          <SelectTrigger aria-label="Redirect page" className="w-full">
+            <SelectValue placeholder="Choose a page" />
+          </SelectTrigger>
+          <SelectContent>
+            <Options choices={choices} collections={collections} />
+          </SelectContent>
+        </Select>
+      )}
+    </div>
   );
 }

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
@@ -112,6 +112,25 @@ async function fetchChoices(
   }
 }
 
+/**
+ * Existing choices plus new ones, de-duplicated on the pair that identifies a
+ * document. Order is preserved so a list does not reshuffle under the author.
+ */
+function mergeChoices(
+  existing: readonly Choice[],
+  incoming: readonly Choice[]
+): Choice[] {
+  const seen = new Set(existing.map(c => `${c.collection}:${c.id}`));
+  const merged = [...existing];
+  for (const choice of incoming) {
+    const key = `${choice.collection}:${choice.id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(choice);
+  }
+  return merged;
+}
+
 /** One option, keyed and valued by the pair the caller stores. */
 function renderChoice(choice: Choice) {
   return (
@@ -168,7 +187,11 @@ function useChoices(key: string, applied: string) {
 
       const rows = loaded.flatMap(result => result.rows);
       const first = wanted.every(collection => (pages[collection] ?? 1) === 1);
-      setChoices(current => (first ? rows : [...(current ?? []), ...rows]));
+      // Merged by identity rather than appended. A retry re-requests a page
+      // that already succeeded for its siblings, and appending would list
+      // those documents twice — duplicate options, and duplicate React keys.
+      // Keyed, a repeated page is a no-op whatever caused the repeat.
+      setChoices(current => mergeChoices(first ? [] : (current ?? []), rows));
     });
 
     return () => {

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
@@ -24,6 +24,10 @@ import { useEffect, useState } from "react";
 
 import { parseRedirectReference } from "../../../utils/redirect-reference";
 
+/** Rows per request, and the ceiling on how many requests one collection costs. */
+const PAGE_SIZE = 100;
+const MAX_PAGES = 10;
+
 /** One selectable document, reduced to what the control shows and stores. */
 interface Choice {
   collection: string;
@@ -75,49 +79,69 @@ export function RedirectPagePicker({
   // refetch forever; the join is the value that actually decides the request.
   const key = collections.join(",");
 
+  const [unreadable, setUnreadable] = useState(false);
+
   useEffect(() => {
     let cancelled = false;
     const wanted = key ? key.split(",") : [];
 
-    Promise.all(
-      wanted.map(async (collection): Promise<Choice[]> => {
-        try {
-          // `limit`, not `pageSize` — the other name is accepted and ignored,
-          // leaving the default of 10. `status=all` because a form is usually
-          // configured alongside the page it points at: filtering to published
-          // only shows "publish one first" while the page sits in the next tab,
-          // which reads as the control being broken.
-          const response = await fetch(
-            `/admin/api/collections/${collection}/entries?limit=100&status=all`,
-            { credentials: "include" }
-          );
-          if (!response.ok) return [];
-          const body = (await response.json()) as {
-            items?: Record<string, unknown>[];
-          };
-          return (body.items ?? [])
-            .filter(row => typeof row.id === "string")
-            .map(row => ({
-              collection,
-              id: row.id as string,
-              label: documentLabel(row),
-            }));
-        } catch {
-          // One unreadable collection must not blank the whole control; the
-          // others are still choosable and the empty state explains the rest.
-          return [];
+    /** One collection's documents, or null when it could not be read. */
+    const load = async (collection: string): Promise<Choice[] | null> => {
+      const page = async (offset: number) => {
+        // `limit`, not `pageSize` — the other name is accepted and ignored,
+        // leaving the default of 10. `status=all` because a form is usually
+        // configured alongside the page it points at, and filtering to
+        // published shows "publish one first" while the page sits in the next
+        // tab. `depth=0` because this reads five fields and would otherwise
+        // inherit the collection API's default expansion, pulling every
+        // nested relation of every row to fill a dropdown.
+        const response = await fetch(
+          `/admin/api/collections/${collection}/entries` +
+            `?limit=${PAGE_SIZE}&page=${offset}&status=all&depth=0`,
+          { credentials: "include" }
+        );
+        if (!response.ok) throw new Error(String(response.status));
+        return (await response.json()) as {
+          items?: Record<string, unknown>[];
+          meta?: { totalPages?: number };
+        };
+      };
+
+      try {
+        const first = await page(1);
+        const rows = [...(first.items ?? [])];
+        // Follow the pagination rather than stopping at one page: an author
+        // whose document is number 101 could otherwise never select it, and a
+        // form already pointing there would show blank. Bounded so a large
+        // collection cannot hang the tab — what it cannot show, it says.
+        const totalPages = Math.min(first.meta?.totalPages ?? 1, MAX_PAGES);
+        for (let next = 2; next <= totalPages; next++) {
+          rows.push(...((await page(next)).items ?? []));
         }
-      })
-    )
-      .then(perCollection => {
-        if (!cancelled) setChoices(perCollection.flat());
-      })
-      // Each request already degrades to an empty list, so this is only
-      // reachable if the state update itself throws; an empty list is the
-      // honest result either way.
-      .catch(() => {
-        if (!cancelled) setChoices([]);
-      });
+        return rows
+          .filter(row => typeof row.id === "string")
+          .map(row => ({
+            collection,
+            id: row.id as string,
+            label: documentLabel(row),
+          }));
+      } catch {
+        return null;
+      }
+    };
+
+    void Promise.all(wanted.map(load)).then(perCollection => {
+      if (cancelled) return;
+      const readable = perCollection.filter(
+        (rows): rows is Choice[] => rows !== null
+      );
+      // "Nothing to choose" and "could not read anything" are different
+      // answers, and only one of them is the author's to fix. Reported apart,
+      // because an editor without read permission was otherwise told the
+      // collection was empty.
+      setUnreadable(readable.length === 0 && wanted.length > 0);
+      setChoices(readable.flat());
+    });
 
     return () => {
       cancelled = true;
@@ -125,16 +149,71 @@ export function RedirectPagePicker({
   }, [key]);
 
   const selected = selectionKey(value, collections);
+
+  /**
+   * The selected document, when the listing did not reach it.
+   *
+   * Its own effect, keyed on the selection rather than on the collection list,
+   * because the stored value arrives with the form and often AFTER this mounts
+   * — an effect that only watched the collections would capture the moment
+   * when nothing was selected yet and never look again.
+   *
+   * A control that silently drops its own value is worse than one that cannot
+   * list everything: the author sees blank, re-picks, and saves a different
+   * destination than the one that was stored.
+   */
+  useEffect(() => {
+    if (!selected || choices === null) return;
+    const [collection, ...rest] = selected.split(":");
+    const id = rest.join(":");
+    if (!id || choices.some(choice => choice.id === id)) return;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetch(
+          `/admin/api/collections/${collection}/entries/${id}?depth=0`,
+          { credentials: "include" }
+        );
+        if (!response.ok) return;
+        const body = (await response.json()) as {
+          item?: Record<string, unknown>;
+        };
+        const row = body.item;
+        if (cancelled || !row || typeof row.id !== "string") return;
+        setChoices(current => [
+          { collection, id: row.id as string, label: documentLabel(row) },
+          ...(current ?? []),
+        ]);
+      } catch {
+        // The list still renders; the selection simply cannot be named.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selected, choices]);
+
   const grouped = collections.length > 1;
 
   if (choices === null) {
     return <p className="text-[12px] text-muted-foreground">Loading pages…</p>;
   }
 
+  if (unreadable) {
+    return (
+      <p className="text-[12px] text-destructive">
+        Could not read {collections.join(" or ")}. You may not have permission
+        to list them, or the request failed.
+      </p>
+    );
+  }
+
   if (choices.length === 0) {
     return (
       <p className="text-[12px] text-muted-foreground">
-        No documents to redirect to yet. Publish one in{" "}
+        No documents to redirect to yet. Create one in{" "}
         {collections.join(" or ")} first.
       </p>
     );

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+/**
+ * Picks the document a form redirects to after submission.
+ *
+ * The plugin cannot reach the admin's own relationship input: `@nextlyhq/admin`
+ * is not on the plugin import boundary, and `plugin-sdk/admin` does not
+ * re-export it. This is the narrow version of that control — one value, chosen
+ * from the collections the site configured as redirect targets.
+ *
+ * @module admin/components/builder/RedirectPagePicker
+ */
+
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@nextlyhq/ui";
+import { useEffect, useState } from "react";
+
+import { parseRedirectReference } from "../../../utils/redirect-reference";
+
+/** One selectable document, reduced to what the control shows and stores. */
+interface Choice {
+  collection: string;
+  id: string;
+  label: string;
+}
+
+interface RedirectPagePickerProps {
+  /** Collections configured as redirect targets, in configuration order. */
+  collections: readonly string[];
+  /** The stored relationship value, in whatever shape it was saved. */
+  value: unknown;
+  onChange: (next: { relationTo: string; value: string } | undefined) => void;
+}
+
+/**
+ * The document a stored value points at, as `collection:id`.
+ *
+ * The reading is `parseRedirectReference`, not a second copy of it: the picker
+ * and the submit handler have to agree about which document a stored value
+ * names, and two readers that agree today would drift — silently, because a
+ * control showing the wrong page still shows a page.
+ */
+export function selectionKey(
+  value: unknown,
+  collections: readonly string[]
+): string | undefined {
+  const reference = parseRedirectReference(value, collections);
+  return reference ? `${reference.collection}:${reference.id}` : undefined;
+}
+
+/** What to call a document in the list, preferring what an author would recognise. */
+export function documentLabel(row: Record<string, unknown>): string {
+  for (const field of ["title", "name", "label", "slug"]) {
+    const candidate = row[field];
+    if (typeof candidate === "string" && candidate.trim()) return candidate;
+  }
+  return typeof row.id === "string" ? row.id : "Untitled";
+}
+
+export function RedirectPagePicker({
+  collections,
+  value,
+  onChange,
+}: RedirectPagePickerProps) {
+  const [choices, setChoices] = useState<Choice[] | null>(null);
+
+  // `collections` is an array prop, so a new identity every render would
+  // refetch forever; the join is the value that actually decides the request.
+  const key = collections.join(",");
+
+  useEffect(() => {
+    let cancelled = false;
+    const wanted = key ? key.split(",") : [];
+
+    Promise.all(
+      wanted.map(async (collection): Promise<Choice[]> => {
+        try {
+          // `limit`, not `pageSize` — the other name is accepted and ignored,
+          // leaving the default of 10. `status=all` because a form is usually
+          // configured alongside the page it points at: filtering to published
+          // only shows "publish one first" while the page sits in the next tab,
+          // which reads as the control being broken.
+          const response = await fetch(
+            `/admin/api/collections/${collection}/entries?limit=100&status=all`,
+            { credentials: "include" }
+          );
+          if (!response.ok) return [];
+          const body = (await response.json()) as {
+            items?: Record<string, unknown>[];
+          };
+          return (body.items ?? [])
+            .filter(row => typeof row.id === "string")
+            .map(row => ({
+              collection,
+              id: row.id as string,
+              label: documentLabel(row),
+            }));
+        } catch {
+          // One unreadable collection must not blank the whole control; the
+          // others are still choosable and the empty state explains the rest.
+          return [];
+        }
+      })
+    )
+      .then(perCollection => {
+        if (!cancelled) setChoices(perCollection.flat());
+      })
+      // Each request already degrades to an empty list, so this is only
+      // reachable if the state update itself throws; an empty list is the
+      // honest result either way.
+      .catch(() => {
+        if (!cancelled) setChoices([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [key]);
+
+  const selected = selectionKey(value, collections);
+  const grouped = collections.length > 1;
+
+  if (choices === null) {
+    return <p className="text-[12px] text-muted-foreground">Loading pages…</p>;
+  }
+
+  if (choices.length === 0) {
+    return (
+      <p className="text-[12px] text-muted-foreground">
+        No documents to redirect to yet. Publish one in{" "}
+        {collections.join(" or ")} first.
+      </p>
+    );
+  }
+
+  return (
+    <Select
+      value={selected ?? ""}
+      onValueChange={next => {
+        const separator = next.indexOf(":");
+        if (separator < 0) return onChange(undefined);
+        onChange({
+          relationTo: next.slice(0, separator),
+          value: next.slice(separator + 1),
+        });
+      }}
+    >
+      <SelectTrigger aria-label="Redirect page" className="w-full">
+        <SelectValue placeholder="Choose a page" />
+      </SelectTrigger>
+      <SelectContent>
+        {grouped
+          ? collections.map(collection => {
+              const inCollection = choices.filter(
+                choice => choice.collection === collection
+              );
+              if (inCollection.length === 0) return null;
+              return (
+                <SelectGroup key={collection}>
+                  <SelectLabel>{collection}</SelectLabel>
+                  {inCollection.map(choice => (
+                    <SelectItem
+                      key={`${choice.collection}:${choice.id}`}
+                      value={`${choice.collection}:${choice.id}`}
+                    >
+                      {choice.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              );
+            })
+          : choices.map(choice => (
+              <SelectItem
+                key={`${choice.collection}:${choice.id}`}
+                value={`${choice.collection}:${choice.id}`}
+              >
+                {choice.label}
+              </SelectItem>
+            ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
@@ -177,8 +177,11 @@ function useSelectedChoice(
     let cancelled = false;
     void (async () => {
       try {
+        // `status=all` for the same reason the listing carries it: a stored
+        // target may be a draft, and a published-only read answers 404 — so
+        // the control would drop a selection the listing would have shown.
         const response = await fetch(
-          `/admin/api/collections/${collection}/entries/${id}?depth=0`,
+          `/admin/api/collections/${collection}/entries/${id}?depth=0&status=all`,
           { credentials: "include" }
         );
         if (!response.ok) return;

--- a/packages/plugin-form-builder/src/admin/components/builder/redirect-option-state.test.ts
+++ b/packages/plugin-form-builder/src/admin/components/builder/redirect-option-state.test.ts
@@ -83,6 +83,18 @@ describe("hasStoredRedirectPage", () => {
     ).toBe(true);
   });
 
+  it("counts a bare id, which is a valid stored shape", () => {
+    // Valid when exactly one collection is configured. Asking
+    // `parseRedirectReference` with no collections cannot resolve WHICH
+    // document it is — but the question here is whether anything is stored,
+    // and answering "no" hides the destination in exactly the states where the
+    // author needs to see it: configuration failed, or the collection went
+    // away.
+    expect(hasStoredRedirectPage({ redirectPage: "pg1" })).toBe(true);
+    expect(hasStoredRedirectPage({ redirectPage: "" })).toBe(false);
+    expect(hasStoredRedirectPage({ redirectPage: "   " })).toBe(false);
+  });
+
   it("reads a reference without needing the configuration", () => {
     // Configuration is exactly what may be missing when this is asked.
     expect(

--- a/packages/plugin-form-builder/src/admin/components/builder/redirect-option-state.test.ts
+++ b/packages/plugin-form-builder/src/admin/components/builder/redirect-option-state.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { redirectOptionState } from "./FormSettingsTab";
+
+/**
+ * Which of four things the "Redirect to a page" option shows.
+ *
+ * Worth pinning because two of the four are indistinguishable on screen unless
+ * this decision keeps them apart: a site that configures no redirect targets
+ * and a configuration request that FAILED both arrive as an empty list, and
+ * only one of them justifies telling an author "no collection is configured".
+ */
+describe("redirectOptionState", () => {
+  const state = (
+    stored: boolean,
+    collections: string[] | null,
+    configFailed = false
+  ) => redirectOptionState({ stored, collections, configFailed });
+
+  it("offers the option with choices when collections are configured", () => {
+    expect(state(false, ["pages"])).toBe("ready");
+    expect(state(true, ["pages"])).toBe("ready");
+  });
+
+  it("hides it when nothing is stored, configured, or unknown", () => {
+    expect(state(false, [])).toBe("hidden");
+    expect(state(false, null)).toBe("hidden");
+  });
+
+  it("keeps it for a form that already redirects to a page", () => {
+    // The stored value is still posted on save, so hiding it lets an author
+    // overwrite a destination they were never shown.
+    expect(state(true, [])).toBe("stored-only");
+    expect(state(true, null)).toBe("stored-only");
+  });
+
+  it("offers it as unknown when the configuration could not be read", () => {
+    // An empty list is an answer; a failed read is not. Reporting the first
+    // when the second happened states something false about the site.
+    expect(state(false, [], true)).toBe("unknown");
+  });
+
+  it("prefers the stored value over the unknown state", () => {
+    // A stored page is a fact about THIS form; the failed read is a fact about
+    // the request. The form's own state is the more useful thing to show.
+    expect(state(true, [], true)).toBe("stored-only");
+  });
+
+  it("prefers real choices over both", () => {
+    expect(state(true, ["pages"], true)).toBe("ready");
+  });
+});

--- a/packages/plugin-form-builder/src/admin/components/builder/redirect-option-state.test.ts
+++ b/packages/plugin-form-builder/src/admin/components/builder/redirect-option-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { redirectOptionState } from "./FormSettingsTab";
+import { hasStoredRedirectPage, redirectOptionState } from "./FormSettingsTab";
 
 /**
  * Which of four things the "Redirect to a page" option shows.
@@ -12,10 +12,10 @@ import { redirectOptionState } from "./FormSettingsTab";
  */
 describe("redirectOptionState", () => {
   const state = (
-    stored: boolean,
+    hasStoredPage: boolean,
     collections: string[] | null,
     configFailed = false
-  ) => redirectOptionState({ stored, collections, configFailed });
+  ) => redirectOptionState({ hasStoredPage, collections, configFailed });
 
   it("offers the option with choices when collections are configured", () => {
     expect(state(false, ["pages"])).toBe("ready");
@@ -48,5 +48,47 @@ describe("redirectOptionState", () => {
 
   it("prefers real choices over both", () => {
     expect(state(true, ["pages"], true)).toBe("ready");
+  });
+
+  it("asks whether a page is STORED, not whether the option is selected", () => {
+    // Conflating the two let an author choose this option while the
+    // configuration was unknown: the state flipped to `stored-only` with
+    // nothing stored, so the picker had no collections to offer and the save
+    // could only be refused. Selecting the option is not a stored page.
+    expect(state(false, [], true)).toBe("unknown");
+    expect(state(false, null, true)).toBe("unknown");
+  });
+});
+
+describe("hasStoredRedirectPage", () => {
+  /**
+   * The call-site half of the same decision, and the half a break-verification
+   * on `redirectOptionState` cannot reach: the pure function stayed correct
+   * while the value handed to it was wrong.
+   */
+  it("is false when the option is selected but no page is named", () => {
+    expect(hasStoredRedirectPage({})).toBe(false);
+    expect(hasStoredRedirectPage({ redirectPage: undefined })).toBe(false);
+    expect(hasStoredRedirectPage({ redirectPage: {} })).toBe(false);
+    expect(
+      hasStoredRedirectPage({ redirectPage: { relationTo: "pages" } })
+    ).toBe(false);
+  });
+
+  it("is true only when a page is actually named", () => {
+    expect(
+      hasStoredRedirectPage({
+        redirectPage: { relationTo: "pages", value: "p1" },
+      })
+    ).toBe(true);
+  });
+
+  it("reads a reference without needing the configuration", () => {
+    // Configuration is exactly what may be missing when this is asked.
+    expect(
+      hasStoredRedirectPage({
+        redirectPage: { relationTo: "retired", value: "r1" },
+      })
+    ).toBe(true);
   });
 });

--- a/packages/plugin-form-builder/src/admin/save-error-message.test.ts
+++ b/packages/plugin-form-builder/src/admin/save-error-message.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { saveErrorMessage } from "./FormBuilderView";
+
+/**
+ * What a refused save tells the author.
+ *
+ * Worth pinning because the failure mode is silent: every validation rule in
+ * the forms collection throws the same `"Validation failed."` at the top
+ * level, so a regression here does not break a save — it leaves an author
+ * staring at a form that will not save and no statement of what to change.
+ */
+describe("saveErrorMessage", () => {
+  const envelope = (error: unknown) => ({ error });
+
+  it("prefers the field issue over the generic message", () => {
+    expect(
+      saveErrorMessage(
+        envelope({
+          message: "Validation failed.",
+          data: {
+            errors: [
+              {
+                path: "settings.redirectPage",
+                message: "Choose a page to redirect to.",
+              },
+            ],
+          },
+        }),
+        "Bad Request"
+      )
+    ).toBe("Choose a page to redirect to.");
+  });
+
+  it("joins several field issues", () => {
+    expect(
+      saveErrorMessage(
+        envelope({
+          message: "Validation failed.",
+          data: {
+            errors: [{ message: "First problem." }, { message: "Second." }],
+          },
+        }),
+        "Bad Request"
+      )
+    ).toBe("First problem. Second.");
+  });
+
+  it("falls back to the top-level message when there are no field issues", () => {
+    expect(
+      saveErrorMessage(envelope({ message: "Not permitted." }), "Forbidden")
+    ).toBe("Not permitted.");
+  });
+
+  it("ignores field entries carrying no message", () => {
+    // An entry with a path and no message says nothing an author can act on,
+    // so it must not win over the top-level sentence or produce a blank one.
+    expect(
+      saveErrorMessage(
+        envelope({
+          message: "Validation failed.",
+          data: { errors: [{ path: "settings.redirectPage" }] },
+        }),
+        "Bad Request"
+      )
+    ).toBe("Validation failed.");
+  });
+
+  it("falls back to the status when the body is not an envelope", () => {
+    for (const body of [undefined, null, {}, "nonsense", []]) {
+      expect(saveErrorMessage(body, "Bad Gateway")).toBe(
+        "Failed to save form: Bad Gateway"
+      );
+    }
+  });
+});

--- a/packages/plugin-form-builder/src/collections/__tests__/forms-hooks.test.ts
+++ b/packages/plugin-form-builder/src/collections/__tests__/forms-hooks.test.ts
@@ -19,7 +19,7 @@ import { describe, expect, it } from "vitest";
 
 import { NextlyError } from "nextly";
 
-import { formsCollection } from "../forms";
+import { formsCollection, isMissingTarget } from "../forms";
 import type { ResolvedFormBuilderConfig } from "../../types";
 
 /** The hook under test, as the collection factory produces it. */
@@ -100,5 +100,33 @@ describe("forms beforeValidate", () => {
 
   it("accepts an update that replaces the fields", () => {
     expect(() => run({ fields: [{ name: "email" }] }, "update")).not.toThrow();
+  });
+});
+
+describe("isMissingTarget", () => {
+  /**
+   * The two outcomes a failed lookup can carry, and why the difference is
+   * load-bearing: a missing page is the author's to fix and must refuse the
+   * save, while an unreadable one must not — refusing there blocks a save a
+   * retry would complete and tells the author to change a correct setting.
+   *
+   * This has been wrong in BOTH directions, so both are pinned.
+   */
+  it("treats NOT_FOUND as a missing document", () => {
+    expect(isMissingTarget({ code: "NOT_FOUND" })).toBe(true);
+  });
+
+  it("treats every other failure as unreadable, not missing", () => {
+    for (const error of [
+      { code: "DATABASE_ERROR" },
+      { code: "FORBIDDEN" },
+      new Error("connection reset"),
+      { message: "Not found." },
+      undefined,
+      null,
+      "NOT_FOUND",
+    ]) {
+      expect(isMissingTarget(error)).toBe(false);
+    }
   });
 });

--- a/packages/plugin-form-builder/src/collections/access-defaults.test.ts
+++ b/packages/plugin-form-builder/src/collections/access-defaults.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { accessWithDefaults } from "./access-defaults";
+
+/**
+ * The access policy both contributed collections fall back to.
+ *
+ * Pinned directly because this is the one kind of duplication whose drift is
+ * silent AND costly: two copies agree, one is tightened later, and the other
+ * keeps the old rule while looking deliberate.
+ */
+describe("accessWithDefaults", () => {
+  const call = (rule: unknown, args: unknown) =>
+    typeof rule === "function" ? (rule as (a: unknown) => boolean)(args) : rule;
+
+  it("requires a signed-in user for update by default", () => {
+    const access = accessWithDefaults(undefined);
+    expect(call(access.update, { user: { id: "u1" } })).toBe(true);
+    expect(call(access.update, { user: undefined })).toBe(false);
+  });
+
+  it("requires an administrative role to delete", () => {
+    const access = accessWithDefaults(undefined);
+    expect(call(access.delete, { roles: ["admin"] })).toBe(true);
+    expect(call(access.delete, { roles: ["super-admin"] })).toBe(true);
+    expect(call(access.delete, { roles: ["editor"] })).toBe(false);
+    expect(call(access.delete, { roles: [] })).toBe(false);
+  });
+
+  it("takes the per-collection read and create defaults", () => {
+    // Forms are publicly readable; submissions are publicly creatable. Those
+    // are the only two axes the collections differ on.
+    expect(accessWithDefaults(undefined, { read: true }).read).toBe(true);
+    expect(accessWithDefaults(undefined, { create: true }).create).toBe(true);
+  });
+
+  it("defaults the axis a caller does not name to authenticated", () => {
+    const access = accessWithDefaults(undefined, { create: true });
+    expect(call(access.read, { user: { id: "u1" } })).toBe(true);
+    expect(call(access.read, { user: undefined })).toBe(false);
+  });
+
+  it("lets a host CLOSE an operation, not just widen it", () => {
+    // `??` rather than `||`: a host passing `false` means "nobody", and `||`
+    // would have replaced it with the plugin default — quietly reopening an
+    // operation the host had shut.
+    const access = accessWithDefaults(
+      { read: false, create: false, update: false, delete: false },
+      { read: true }
+    );
+    expect(access.read).toBe(false);
+    expect(access.create).toBe(false);
+    expect(access.update).toBe(false);
+    expect(access.delete).toBe(false);
+  });
+
+  it("lets a host replace a rule with its own function", () => {
+    const mine = () => true;
+    expect(accessWithDefaults({ delete: mine }).delete).toBe(mine);
+  });
+});

--- a/packages/plugin-form-builder/src/collections/access-defaults.ts
+++ b/packages/plugin-form-builder/src/collections/access-defaults.ts
@@ -1,0 +1,54 @@
+/**
+ * The access rules both collections this plugin contributes fall back to.
+ *
+ * Written out per collection they were byte-identical apart from `read`, and
+ * two copies of an access policy is the copy that matters most: they agree
+ * today, one gets tightened later, and the other silently keeps the old rule
+ * while looking deliberate.
+ *
+ * `read` and `create` are the axes they genuinely differ on, so both are
+ * parameters: a form is publicly READABLE because a site renders it, and a
+ * submission is publicly CREATABLE because a visitor makes it. Update and
+ * delete are the same policy in both collections.
+ *
+ * @module collections/access-defaults
+ */
+
+import type { CollectionAccessControl } from "nextly";
+
+/** A single rule, in either form the collection config accepts. */
+type AccessRule = NonNullable<CollectionAccessControl["read"]>;
+
+/** The subset of a collection's access declaration these defaults supply. */
+export type AccessOverrides = Pick<
+  CollectionAccessControl,
+  "read" | "create" | "update" | "delete"
+>;
+
+/** Signed in. */
+const authenticated: AccessRule = ({ user }) => !!user;
+
+/** Signed in AND holding an administrative role. */
+const administrative: AccessRule = ({ roles }) =>
+  roles.includes("admin") || roles.includes("super-admin");
+
+/**
+ * Host overrides applied over this plugin's defaults, per operation.
+ *
+ * Each override is taken with `??`, so a host may pass `false` to close an
+ * operation it would otherwise be given — which `||` would have silently
+ * replaced with the default.
+ */
+export function accessWithDefaults(
+  overrides: AccessOverrides | undefined,
+  defaults: { read?: AccessRule; create?: AccessRule } = {}
+): AccessOverrides {
+  return {
+    read: overrides?.read ?? defaults.read ?? authenticated,
+    create: overrides?.create ?? defaults.create ?? authenticated,
+    update: overrides?.update ?? authenticated,
+    // Deleting is administrative in both collections; the DB permission layer
+    // remains the backstop underneath it.
+    delete: overrides?.delete ?? administrative,
+  };
+}

--- a/packages/plugin-form-builder/src/collections/forms.ts
+++ b/packages/plugin-form-builder/src/collections/forms.ts
@@ -94,6 +94,11 @@ export function formsCollection(
     ...overrides
   } = pluginConfig.formOverrides;
 
+  // Derived from the map rather than carried beside it: the collections a form
+  // may redirect to are exactly the ones with a URL pattern configured, so
+  // there is no second list to fall out of step with the first.
+  const redirectCollections = Object.keys(pluginConfig.redirectRelationships);
+
   // Build settings group fields based on plugin configuration
   const settingsFields: FieldConfig[] = [
     text({
@@ -112,7 +117,7 @@ export function formsCollection(
       options: [
         { label: "Show Message", value: "message" },
         { label: "Redirect to URL", value: "redirect" },
-        ...(pluginConfig.redirectRelationships.length > 0
+        ...(redirectCollections.length > 0
           ? [{ label: "Redirect to Page", value: "relationship" }]
           : []),
       ],
@@ -148,12 +153,12 @@ export function formsCollection(
   ];
 
   // Add redirect relationship field if configured
-  if (pluginConfig.redirectRelationships.length > 0) {
+  if (redirectCollections.length > 0) {
     settingsFields.push(
       relationship({
         name: "redirectPage",
         label: "Redirect Page",
-        relationTo: pluginConfig.redirectRelationships,
+        relationTo: redirectCollections,
         admin: {
           description: "Select a page to redirect to after submission",
           condition: {

--- a/packages/plugin-form-builder/src/collections/forms.ts
+++ b/packages/plugin-form-builder/src/collections/forms.ts
@@ -84,6 +84,52 @@ interface ExtendedCollectionConfig extends Omit<CollectionConfig, "admin"> {
  * // Returns a collection with slug "forms" (or custom slug from config)
  * ```
  */
+/**
+ * Whether a stored value names a page this plugin is configured to reach.
+ *
+ * `parseRedirectReference` answers which document a value names; it trusts an
+ * explicit `relationTo` on purpose, because a form validated without plugin
+ * config cannot judge one. Here the configuration IS known, so membership is
+ * checked too: a reference into a collection with no URL pattern is a value
+ * the resolver cannot use, and accepting it saves a form whose every
+ * submission ends nowhere.
+ */
+function namesAConfiguredPage(
+  value: unknown,
+  collections: readonly string[]
+): boolean {
+  const reference = parseRedirectReference(value, collections);
+  return reference !== null && collections.includes(reference.collection);
+}
+
+/**
+ * The plugin's hooks, with a host's own appended per phase.
+ *
+ * A host may pass `formOverrides.hooks`, and the trailing `...overrides` spread
+ * would otherwise replace this object outright — taking with it the slug
+ * generation, the at-least-one-field rule and the redirect check, none of
+ * which are the host's to remove. Those are invariants of the collection this
+ * plugin ships; an override extends it rather than disarming it.
+ *
+ * The plugin's handlers run FIRST, so a rejection happens before host logic
+ * has mutated anything on the way past.
+ */
+function withHostHooks<T>(pluginHooks: T, hostHooks: T | undefined): T {
+  if (!hostHooks) return pluginHooks;
+  const host = hostHooks as Record<string, unknown>;
+
+  const asList = (value: unknown) =>
+    Array.isArray(value) ? value : value === undefined ? [] : [value];
+
+  const merged: Record<string, unknown> = { ...host };
+  for (const [phase, handlers] of Object.entries(
+    pluginHooks as Record<string, unknown>
+  )) {
+    merged[phase] = [...asList(handlers), ...asList(host[phase])];
+  }
+  return merged as T;
+}
+
 export function formsCollection(
   pluginConfig: ResolvedFormBuilderConfig
 ): ExtendedCollectionConfig {
@@ -92,6 +138,8 @@ export function formsCollection(
     labels,
     fields: additionalFields,
     access: accessOverrides,
+    hooks: hookOverrides,
+    admin: adminOverrides,
     ...overrides
   } = pluginConfig.formOverrides;
 
@@ -354,7 +402,7 @@ export function formsCollection(
         },
       },
 
-      ...overrides.admin,
+      ...adminOverrides,
     },
 
     // Access control with sensible defaults
@@ -371,87 +419,87 @@ export function formsCollection(
           roles.includes("admin") || roles.includes("super-admin")),
     },
 
-    hooks: {
-      // Auto-generate slug from name if not provided
-      beforeValidate: [
-        (context: HookContext) => {
-          const { data, operation } = context;
+    hooks: withHostHooks(
+      {
+        // Auto-generate slug from name if not provided
+        beforeValidate: [
+          (context: HookContext) => {
+            const { data, operation } = context;
 
-          // Auto-generate slug from name if not provided (only on create)
-          if (operation === "create" && data && !data.slug && data.name) {
-            data.slug = String(data.name)
-              .toLowerCase()
-              .replace(/[^a-z0-9]+/g, "-")
-              .replace(/^-+|-+$/g, "");
-          }
+            // Auto-generate slug from name if not provided (only on create)
+            if (operation === "create" && data && !data.slug && data.name) {
+              data.slug = String(data.name)
+                .toLowerCase()
+                .replace(/[^a-z0-9]+/g, "-")
+                .replace(/^-+|-+$/g, "");
+            }
 
-          // A form must have at least one field, checked against what the
-          // write actually sets. An update carries the patch rather than the
-          // merged document, so treating an absent `fields` as empty rejects
-          // every partial update -- renaming a form, or changing a setting --
-          // even though its fields are untouched and still there.
-          const setsFields =
-            operation === "create" || data?.fields !== undefined;
-          if (
-            data &&
-            setsFields &&
-            (data.fields === undefined ||
-              (Array.isArray(data.fields) && data.fields.length === 0))
-          ) {
-            // Typed, so the rejection survives as a validation failure with
-            // its field issue rather than being read as a crash and replaced
-            // with a generic server-fault message.
-            throw NextlyError.validation({
-              errors: [
-                {
-                  path: "fields",
-                  code: "REQUIRED",
-                  message: "Form must have at least one field.",
-                },
-              ],
-            });
-          }
+            // A form must have at least one field, checked against what the
+            // write actually sets. An update carries the patch rather than the
+            // merged document, so treating an absent `fields` as empty rejects
+            // every partial update -- renaming a form, or changing a setting --
+            // even though its fields are untouched and still there.
+            const setsFields =
+              operation === "create" || data?.fields !== undefined;
+            if (
+              data &&
+              setsFields &&
+              (data.fields === undefined ||
+                (Array.isArray(data.fields) && data.fields.length === 0))
+            ) {
+              // Typed, so the rejection survives as a validation failure with
+              // its field issue rather than being read as a crash and replaced
+              // with a generic server-fault message.
+              throw NextlyError.validation({
+                errors: [
+                  {
+                    path: "fields",
+                    code: "REQUIRED",
+                    message: "Form must have at least one field.",
+                  },
+                ],
+              });
+            }
 
-          // A form set to redirect to a page must name a page the resolver can
-          // read. Enforced HERE rather than only in `validateFormConfig`,
-          // which is a library entry point that no write goes through: the
-          // browser posts `settings` straight to this collection, so a rule
-          // that lives only there protects nobody.
-          //
-          // The shape is checked, not merely presence. `{}` and
-          // `{ relationTo: "pages" }` are truthy and name no document, so a
-          // presence test admits exactly the values that resolve to no
-          // destination at submit time — which is the failure being prevented.
-          const setsSettings =
-            operation === "create" || data?.settings !== undefined;
-          const settings = data?.settings as
-            | Record<string, unknown>
-            | undefined;
-          if (
-            data &&
-            setsSettings &&
-            settings?.confirmationType === "relationship" &&
-            parseRedirectReference(
-              settings.redirectPage,
-              redirectCollections
-            ) === null
-          ) {
-            throw NextlyError.validation({
-              errors: [
-                {
-                  path: "settings.redirectPage",
-                  code: "REQUIRED",
-                  message:
-                    "Choose a page to redirect to, or pick a different confirmation.",
-                },
-              ],
-            });
-          }
+            // A form set to redirect to a page must name a page the resolver can
+            // read. Enforced HERE rather than only in `validateFormConfig`,
+            // which is a library entry point that no write goes through: the
+            // browser posts `settings` straight to this collection, so a rule
+            // that lives only there protects nobody.
+            //
+            // The shape is checked, not merely presence. `{}` and
+            // `{ relationTo: "pages" }` are truthy and name no document, so a
+            // presence test admits exactly the values that resolve to no
+            // destination at submit time — which is the failure being prevented.
+            const setsSettings =
+              operation === "create" || data?.settings !== undefined;
+            const settings = data?.settings as
+              | Record<string, unknown>
+              | undefined;
+            if (
+              data &&
+              setsSettings &&
+              settings?.confirmationType === "relationship" &&
+              !namesAConfiguredPage(settings.redirectPage, redirectCollections)
+            ) {
+              throw NextlyError.validation({
+                errors: [
+                  {
+                    path: "settings.redirectPage",
+                    code: "REQUIRED",
+                    message:
+                      "Choose a page to redirect to, or pick a different confirmation.",
+                  },
+                ],
+              });
+            }
 
-          return data;
-        },
-      ],
-    },
+            return data;
+          },
+        ],
+      },
+      hookOverrides
+    ),
 
     // Spread any additional overrides (excluding already used properties)
     ...overrides,

--- a/packages/plugin-form-builder/src/collections/forms.ts
+++ b/packages/plugin-form-builder/src/collections/forms.ts
@@ -223,26 +223,15 @@ async function assertRedirectTargetUsable(
   // already was.
   if (context.executor) return;
 
-  // "The page is not there" and "I could not ask" are different answers and
-  // only the first is the author's to fix. Collapsing them blocks a save on a
-  // transient adapter failure while telling the author to pick another page —
-  // a confident, wrong remedy. A failed read skips the check, as the
-  // submit-time resolver does.
-  let target: RedirectTargetDocument | null;
-  try {
-    target = (await nextly.findByID({
-      collection: reference.collection,
-      id: reference.id,
-    })) as RedirectTargetDocument | null;
-  } catch {
-    return;
-  }
-
-  if (!target) {
+  const found = await readRedirectTarget(nextly, reference);
+  if (found.status === "unreadable") return;
+  if (found.status === "missing") {
     throw redirectRefusal(
       `That page no longer exists in "${reference.collection}". Pick another.`
     );
   }
+  const target = found.document;
+
   // A pattern may be a FUNCTION, which is host code and can throw. Authoring
   // must not be blocked by that: the submission path contains the same throw
   // and degrades to no redirect with a log line, so a broken pattern costs a
@@ -259,6 +248,55 @@ async function assertRedirectTargetUsable(
       "That page has no URL yet — give it a slug, or pick another page."
     );
   }
+}
+
+/**
+ * The target document, as one of three outcomes.
+ *
+ * Three rather than a nullable document, because "the page is not there" and
+ * "I could not ask" are different answers and only the first is the author's
+ * to fix. Collapsing them has been wrong in both directions on this rule:
+ * refusing on any failure blocks a save a retry would complete, and skipping
+ * on any failure loses the deleted-page refusal entirely.
+ */
+async function readRedirectTarget(
+  nextly: NonNullable<NonNullable<HookContext["req"]>["nextly"]>,
+  reference: { collection: string; id: string }
+): Promise<
+  | { status: "ok"; document: RedirectTargetDocument }
+  | { status: "missing" }
+  | { status: "unreadable" }
+> {
+  try {
+    const row = (await nextly.findByID({
+      collection: reference.collection,
+      id: reference.id,
+    })) as RedirectTargetDocument | null;
+    return row ? { status: "ok", document: row } : { status: "missing" };
+  } catch (error) {
+    return isMissingTarget(error)
+      ? { status: "missing" }
+      : { status: "unreadable" };
+  }
+}
+
+/**
+ * Whether a failed read means the document is GONE, or that it could not be
+ * asked for.
+ *
+ * Both arrive as exceptions — `findByID` throws `NOT_FOUND` for a missing
+ * entry rather than returning null, despite a signature that says `| null` —
+ * so the two are separated by the error's own code. Not by its message, which
+ * is prose, and not by catching everything, which has now been wrong in both
+ * directions: refusing on any failure blocks a save a retry would complete,
+ * and skipping on any failure loses the deleted-page refusal.
+ */
+export function isMissingTarget(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: unknown }).code === "NOT_FOUND"
+  );
 }
 
 /** One shape for every refusal this rule makes, so callers see one field. */

--- a/packages/plugin-form-builder/src/collections/forms.ts
+++ b/packages/plugin-form-builder/src/collections/forms.ts
@@ -22,6 +22,13 @@ import {
 
 import type { ResolvedFormBuilderConfig } from "../types";
 import { parseRedirectReference } from "../utils/redirect-reference";
+import {
+  applyRedirectPattern,
+  type RedirectRelationships,
+  type RedirectTargetDocument,
+} from "../utils/redirect-target";
+
+import { accessWithDefaults } from "./access-defaults";
 
 // ============================================================
 // Type Augmentation for Custom Admin Components
@@ -85,24 +92,6 @@ interface ExtendedCollectionConfig extends Omit<CollectionConfig, "admin"> {
  * ```
  */
 /**
- * Whether a stored value names a page this plugin is configured to reach.
- *
- * `parseRedirectReference` answers which document a value names; it trusts an
- * explicit `relationTo` on purpose, because a form validated without plugin
- * config cannot judge one. Here the configuration IS known, so membership is
- * checked too: a reference into a collection with no URL pattern is a value
- * the resolver cannot use, and accepting it saves a form whose every
- * submission ends nowhere.
- */
-function namesAConfiguredPage(
-  value: unknown,
-  collections: readonly string[]
-): boolean {
-  const reference = parseRedirectReference(value, collections);
-  return reference !== null && collections.includes(reference.collection);
-}
-
-/**
  * The plugin's hooks, with a host's own appended per phase.
  *
  * A host may pass `formOverrides.hooks`, and the trailing `...overrides` spread
@@ -156,31 +145,101 @@ function withHostHooks<T>(
  * would reject every partial update — renaming a form — for a setting it never
  * touched.
  */
-function assertRedirectTargetUsable(
+/**
+ * The settings a write is SETTING to a page redirect, or null for every other
+ * write.
+ *
+ * `setsSettings` mirrors the fields rule above. An update carries the patch
+ * rather than the merged document, so treating an absent `settings` as empty
+ * would refuse a rename for a setting it never touched.
+ */
+function pageRedirectSettings(
+  data: Record<string, unknown> | undefined,
+  operation: string
+): Record<string, unknown> | null {
+  if (!data) return null;
+  if (operation !== "create" && data.settings === undefined) return null;
+  const settings = data.settings as Record<string, unknown> | undefined;
+  return settings?.confirmationType === "relationship" ? settings : null;
+}
+
+function assertRedirectTargetNamed(
   data: Record<string, unknown> | undefined,
   operation: string,
-  redirectCollections: readonly string[]
+  patterns: RedirectRelationships
+): { collection: string; id: string } | null {
+  const settings = pageRedirectSettings(data, operation);
+  if (!settings) return null;
+
+  const collections = Object.keys(patterns);
+  const reference = parseRedirectReference(settings.redirectPage, collections);
+  if (!reference || !collections.includes(reference.collection)) {
+    throw redirectRefusal(
+      "Choose a page to redirect to, or pick a different confirmation."
+    );
+  }
+  return reference;
+}
+
+/**
+ * The same rule, plus the one question that needs a read: can this document
+ * actually fill its collection's pattern?
+ *
+ * Split from the shape check so the cheap half stays synchronous — the early
+ * `beforeValidate` call wants an error, not a database round trip, and making
+ * that hook async changes what a caller has to do to observe its rejection.
+ *
+ * Best effort by design: `req.nextly` is optional, and a slug can be emptied
+ * AFTER this form is saved. The submit path keeps its own check and its log
+ * line. What this buys is telling the author NOW, while the page they picked
+ * is in front of them, rather than leaving a form that saves cleanly and
+ * redirects nobody.
+ */
+async function assertRedirectTargetUsable(
+  context: HookContext,
+  patterns: RedirectRelationships
 ) {
-  const setsSettings = operation === "create" || data?.settings !== undefined;
-  const settings = data?.settings as Record<string, unknown> | undefined;
-  if (
-    !data ||
-    !setsSettings ||
-    settings?.confirmationType !== "relationship" ||
-    namesAConfiguredPage(settings.redirectPage, redirectCollections)
-  ) {
+  const reference = assertRedirectTargetNamed(
+    context.data,
+    context.operation,
+    patterns
+  );
+  if (!reference) return;
+
+  const nextly = context.req?.nextly;
+  if (!nextly) return;
+
+  const target = (await nextly
+    .findByID({ collection: reference.collection, id: reference.id })
+    .catch(() => null)) as RedirectTargetDocument | null;
+
+  if (!target) {
+    throw redirectRefusal(
+      `That page no longer exists in "${reference.collection}". Pick another.`
+    );
+  }
+  // A pattern may be a FUNCTION, which is host code and can throw. Authoring
+  // must not be blocked by that: the submission path contains the same throw
+  // and degrades to no redirect with a log line, so a broken pattern costs a
+  // destination rather than the ability to edit forms.
+  let url: string | undefined;
+  try {
+    url = applyRedirectPattern(patterns[reference.collection], target);
+  } catch {
     return;
   }
 
-  throw NextlyError.validation({
-    errors: [
-      {
-        path: "settings.redirectPage",
-        code: "REQUIRED",
-        message:
-          "Choose a page to redirect to, or pick a different confirmation.",
-      },
-    ],
+  if (!url) {
+    throw redirectRefusal(
+      "That page has no URL yet — give it a slug, or pick another page."
+    );
+  }
+}
+
+/** One shape for every refusal this rule makes, so callers see one field. */
+function redirectRefusal(message: string) {
+  return NextlyError.validation({
+    errors: [{ path: "settings.redirectPage", code: "REQUIRED", message }],
   });
 }
 
@@ -460,18 +519,9 @@ export function formsCollection(
     },
 
     // Access control with sensible defaults
-    access: {
-      // Anyone can read forms (needed for frontend rendering)
-      read: accessOverrides?.read ?? true,
-      // Only authenticated users can create/update forms
-      create: accessOverrides?.create ?? (({ user }) => !!user),
-      update: accessOverrides?.update ?? (({ user }) => !!user),
-      // Only admins can delete forms (falls back to DB permissions)
-      delete:
-        accessOverrides?.delete ??
-        (({ roles }) =>
-          roles.includes("admin") || roles.includes("super-admin")),
-    },
+    // `read: true` — a form is public because a site renders it. The rest are
+    // the shared defaults.
+    access: accessWithDefaults(accessOverrides, { read: true }),
 
     hooks: withHostHooks(
       {
@@ -518,7 +568,11 @@ export function formsCollection(
             // Reported here so an author sees it beside the form's other
             // errors. The GUARANTEE is the trailing `beforeChange` call below,
             // which a host hook cannot run after.
-            assertRedirectTargetUsable(data, operation, redirectCollections);
+            assertRedirectTargetNamed(
+              data,
+              operation,
+              pluginConfig.redirectRelationships
+            );
 
             return data;
           },
@@ -526,13 +580,24 @@ export function formsCollection(
       },
       hookOverrides,
       {
-        // The authoritative call. A host `beforeValidate` may rewrite the
-        // payload after the check above passed, and `beforeChange` is the last
-        // phase before the write — so this is where the guarantee lives.
+        // The last COLLECTION-level phase, after every host handler in it. A
+        // host `beforeValidate` may rewrite the payload once the earlier call
+        // has passed, so the check has to run again here.
+        //
+        // It is not the last mutating point in the write, and saying so would
+        // be false: `collection-mutation-service` runs FIELD-level
+        // `beforeChange` hooks after this one, and a host may contribute a
+        // field through `formOverrides.fields`. Nothing collection-level can
+        // sit after that — the next steps are hashing and the insert. What
+        // bounds the consequence is the submit path, which resolves an
+        // unusable target to NO redirect and logs it, never to a wrong one.
         beforeChange: [
-          ({ data, operation }: HookContext) => {
-            assertRedirectTargetUsable(data, operation, redirectCollections);
-            return data;
+          async (context: HookContext) => {
+            await assertRedirectTargetUsable(
+              context,
+              pluginConfig.redirectRelationships
+            );
+            return context.data;
           },
         ],
       }

--- a/packages/plugin-form-builder/src/collections/forms.ts
+++ b/packages/plugin-form-builder/src/collections/forms.ts
@@ -209,6 +209,20 @@ async function assertRedirectTargetUsable(
   const nextly = context.req?.nextly;
   if (!nextly) return;
 
+  // Not inside a caller-owned transaction. `context.executor` is present only
+  // there, and the contract on it is explicit: a hook that reads the database
+  // must use that executor, because a second pooled connection can stall
+  // against a small pool while the caller's transaction holds the only one —
+  // and a pooled read cannot see the transaction's own uncommitted rows, so a
+  // page created in the same transaction would read as missing and this would
+  // refuse a correct write.
+  //
+  // `findByID` takes no executor, and reaching for Drizzle directly here would
+  // be raw database access inside a plugin. So the transactional path keeps
+  // the shape check and skips the read; the submit path is the backstop it
+  // already was.
+  if (context.executor) return;
+
   const target = (await nextly
     .findByID({ collection: reference.collection, id: reference.id })
     .catch(() => null)) as RedirectTargetDocument | null;

--- a/packages/plugin-form-builder/src/collections/forms.ts
+++ b/packages/plugin-form-builder/src/collections/forms.ts
@@ -122,7 +122,10 @@ function withHostHooks<T>(
   hostHooks: T | undefined,
   trailing: Partial<Record<string, unknown[]>> = {}
 ): T {
-  const host = hostHooks ?? {};
+  // Annotated rather than asserted. `hostHooks ?? {}` widens to `T | {}`
+  // under the generic and cannot be indexed by phase name; a cast says the
+  // same thing but reads as removable, and `--fix` removes it.
+  const host: Record<string, unknown> = { ...hostHooks };
 
   const asList = (value: unknown) =>
     Array.isArray(value) ? value : value === undefined ? [] : [value];

--- a/packages/plugin-form-builder/src/collections/forms.ts
+++ b/packages/plugin-form-builder/src/collections/forms.ts
@@ -223,9 +223,20 @@ async function assertRedirectTargetUsable(
   // already was.
   if (context.executor) return;
 
-  const target = (await nextly
-    .findByID({ collection: reference.collection, id: reference.id })
-    .catch(() => null)) as RedirectTargetDocument | null;
+  // "The page is not there" and "I could not ask" are different answers and
+  // only the first is the author's to fix. Collapsing them blocks a save on a
+  // transient adapter failure while telling the author to pick another page —
+  // a confident, wrong remedy. A failed read skips the check, as the
+  // submit-time resolver does.
+  let target: RedirectTargetDocument | null;
+  try {
+    target = (await nextly.findByID({
+      collection: reference.collection,
+      id: reference.id,
+    })) as RedirectTargetDocument | null;
+  } catch {
+    return;
+  }
 
   if (!target) {
     throw redirectRefusal(

--- a/packages/plugin-form-builder/src/collections/forms.ts
+++ b/packages/plugin-form-builder/src/collections/forms.ts
@@ -21,6 +21,7 @@ import {
 } from "nextly";
 
 import type { ResolvedFormBuilderConfig } from "../types";
+import { parseRedirectReference } from "../utils/redirect-reference";
 
 // ============================================================
 // Type Augmentation for Custom Admin Components
@@ -406,6 +407,42 @@ export function formsCollection(
                   path: "fields",
                   code: "REQUIRED",
                   message: "Form must have at least one field.",
+                },
+              ],
+            });
+          }
+
+          // A form set to redirect to a page must name a page the resolver can
+          // read. Enforced HERE rather than only in `validateFormConfig`,
+          // which is a library entry point that no write goes through: the
+          // browser posts `settings` straight to this collection, so a rule
+          // that lives only there protects nobody.
+          //
+          // The shape is checked, not merely presence. `{}` and
+          // `{ relationTo: "pages" }` are truthy and name no document, so a
+          // presence test admits exactly the values that resolve to no
+          // destination at submit time — which is the failure being prevented.
+          const setsSettings =
+            operation === "create" || data?.settings !== undefined;
+          const settings = data?.settings as
+            | Record<string, unknown>
+            | undefined;
+          if (
+            data &&
+            setsSettings &&
+            settings?.confirmationType === "relationship" &&
+            parseRedirectReference(
+              settings.redirectPage,
+              redirectCollections
+            ) === null
+          ) {
+            throw NextlyError.validation({
+              errors: [
+                {
+                  path: "settings.redirectPage",
+                  code: "REQUIRED",
+                  message:
+                    "Choose a page to redirect to, or pick a different confirmation.",
                 },
               ],
             });

--- a/packages/plugin-form-builder/src/collections/forms.ts
+++ b/packages/plugin-form-builder/src/collections/forms.ts
@@ -111,12 +111,18 @@ function namesAConfiguredPage(
  * which are the host's to remove. Those are invariants of the collection this
  * plugin ships; an override extends it rather than disarming it.
  *
- * The plugin's handlers run FIRST, so a rejection happens before host logic
- * has mutated anything on the way past.
+ * Handlers in `pluginHooks` run FIRST — they are transformations a host may
+ * want to build on, like the generated slug. Handlers in `trailing` run LAST,
+ * after every host handler in that phase, which is where an INVARIANT has to
+ * sit: one placed first is checked against a payload the host can still
+ * rewrite afterwards.
  */
-function withHostHooks<T>(pluginHooks: T, hostHooks: T | undefined): T {
-  if (!hostHooks) return pluginHooks;
-  const host = hostHooks as Record<string, unknown>;
+function withHostHooks<T>(
+  pluginHooks: T,
+  hostHooks: T | undefined,
+  trailing: Partial<Record<string, unknown[]>> = {}
+): T {
+  const host = hostHooks ?? {};
 
   const asList = (value: unknown) =>
     Array.isArray(value) ? value : value === undefined ? [] : [value];
@@ -127,7 +133,52 @@ function withHostHooks<T>(pluginHooks: T, hostHooks: T | undefined): T {
   )) {
     merged[phase] = [...asList(handlers), ...asList(host[phase])];
   }
+  for (const [phase, handlers] of Object.entries(trailing)) {
+    merged[phase] = [...asList(merged[phase]), ...asList(handlers)];
+  }
   return merged as T;
+}
+
+/**
+ * Refuses a write whose redirect target the resolver could not use.
+ *
+ * One function, called from two phases. `beforeValidate` so an author gets the
+ * error where the rest of the form's errors appear, and LAST in `beforeChange`
+ * so the guarantee survives a host hook: a check placed before host handlers
+ * judges a payload they can still rewrite, and one that can be rewritten past
+ * is not an invariant.
+ *
+ * `setsSettings` mirrors the fields rule above. An update carries the patch
+ * rather than the merged document, so treating an absent `settings` as empty
+ * would reject every partial update — renaming a form — for a setting it never
+ * touched.
+ */
+function assertRedirectTargetUsable(
+  data: Record<string, unknown> | undefined,
+  operation: string,
+  redirectCollections: readonly string[]
+) {
+  const setsSettings = operation === "create" || data?.settings !== undefined;
+  const settings = data?.settings as Record<string, unknown> | undefined;
+  if (
+    !data ||
+    !setsSettings ||
+    settings?.confirmationType !== "relationship" ||
+    namesAConfiguredPage(settings.redirectPage, redirectCollections)
+  ) {
+    return;
+  }
+
+  throw NextlyError.validation({
+    errors: [
+      {
+        path: "settings.redirectPage",
+        code: "REQUIRED",
+        message:
+          "Choose a page to redirect to, or pick a different confirmation.",
+      },
+    ],
+  });
 }
 
 export function formsCollection(
@@ -461,44 +512,27 @@ export function formsCollection(
               });
             }
 
-            // A form set to redirect to a page must name a page the resolver can
-            // read. Enforced HERE rather than only in `validateFormConfig`,
-            // which is a library entry point that no write goes through: the
-            // browser posts `settings` straight to this collection, so a rule
-            // that lives only there protects nobody.
-            //
-            // The shape is checked, not merely presence. `{}` and
-            // `{ relationTo: "pages" }` are truthy and name no document, so a
-            // presence test admits exactly the values that resolve to no
-            // destination at submit time — which is the failure being prevented.
-            const setsSettings =
-              operation === "create" || data?.settings !== undefined;
-            const settings = data?.settings as
-              | Record<string, unknown>
-              | undefined;
-            if (
-              data &&
-              setsSettings &&
-              settings?.confirmationType === "relationship" &&
-              !namesAConfiguredPage(settings.redirectPage, redirectCollections)
-            ) {
-              throw NextlyError.validation({
-                errors: [
-                  {
-                    path: "settings.redirectPage",
-                    code: "REQUIRED",
-                    message:
-                      "Choose a page to redirect to, or pick a different confirmation.",
-                  },
-                ],
-              });
-            }
+            // Reported here so an author sees it beside the form's other
+            // errors. The GUARANTEE is the trailing `beforeChange` call below,
+            // which a host hook cannot run after.
+            assertRedirectTargetUsable(data, operation, redirectCollections);
 
             return data;
           },
         ],
       },
-      hookOverrides
+      hookOverrides,
+      {
+        // The authoritative call. A host `beforeValidate` may rewrite the
+        // payload after the check above passed, and `beforeChange` is the last
+        // phase before the write — so this is where the guarantee lives.
+        beforeChange: [
+          ({ data, operation }: HookContext) => {
+            assertRedirectTargetUsable(data, operation, redirectCollections);
+            return data;
+          },
+        ],
+      }
     ),
 
     // Spread any additional overrides (excluding already used properties)

--- a/packages/plugin-form-builder/src/collections/forms.ts
+++ b/packages/plugin-form-builder/src/collections/forms.ts
@@ -163,6 +163,34 @@ function pageRedirectSettings(
   return settings?.confirmationType === "relationship" ? settings : null;
 }
 
+/**
+ * Writes the parser's normalised names back into the row being saved.
+ *
+ * Not merely read: trimming only the parsed copy leaves the padded name in
+ * `data`, so this rule accepts the write and the framework's own relationship
+ * validator downstream still sees `" pages "`. The plugin and the framework
+ * then disagree about a value this parser has already decided.
+ */
+function normalizeStoredReference(
+  settings: Record<string, unknown>,
+  reference: { collection: string; id: string }
+) {
+  const stored = settings.redirectPage;
+
+  if (typeof stored === "string") {
+    if (stored !== reference.id) settings.redirectPage = reference.id;
+    return;
+  }
+  if (typeof stored !== "object" || stored === null || Array.isArray(stored)) {
+    return;
+  }
+
+  const record = stored as Record<string, unknown>;
+  if (record.relationTo !== reference.collection) {
+    settings.redirectPage = { ...record, relationTo: reference.collection };
+  }
+}
+
 function assertRedirectTargetNamed(
   data: Record<string, unknown> | undefined,
   operation: string,
@@ -178,6 +206,9 @@ function assertRedirectTargetNamed(
       "Choose a page to redirect to, or pick a different confirmation."
     );
   }
+
+  normalizeStoredReference(settings, reference);
+
   return reference;
 }
 
@@ -244,8 +275,14 @@ async function assertRedirectTargetUsable(
   }
 
   if (!url) {
+    // Pattern-agnostic. The configured pattern may depend on any field, or be
+    // a function that declines for its own reasons, so naming a slug states a
+    // remedy that often cannot fix the actual failure — and the save is
+    // correctly blocked either way, leaving the author following wrong advice.
     throw redirectRefusal(
-      "That page has no URL yet — give it a slug, or pick another page."
+      `No URL could be built for that page from the pattern configured for ` +
+        `"${reference.collection}". Choose another page, or ask a developer ` +
+        `to check that collection's redirect pattern.`
     );
   }
 }

--- a/packages/plugin-form-builder/src/collections/submissions.ts
+++ b/packages/plugin-form-builder/src/collections/submissions.ts
@@ -13,6 +13,8 @@ import { text, textarea, select, json, date, relationship } from "nextly";
 
 import type { ResolvedFormBuilderConfig } from "../types";
 
+import { accessWithDefaults } from "./access-defaults";
+
 /**
  * Extended CollectionConfig with isPlugin support.
  * This extends the base CollectionConfig to include the isPlugin property.
@@ -239,19 +241,9 @@ export function submissionsCollection(
 
     // Access control with sensible defaults
     // Public can create (submit forms), but only authenticated users can read/update/delete
-    access: {
-      // Anyone can submit forms (public access)
-      create: accessOverrides?.create ?? true,
-      // Only authenticated users can view submissions
-      read: accessOverrides?.read ?? (({ user }) => !!user),
-      // Only authenticated users can update submissions (e.g., change status, add notes)
-      update: accessOverrides?.update ?? (({ user }) => !!user),
-      // Only admins can delete submissions (falls back to DB permissions)
-      delete:
-        accessOverrides?.delete ??
-        (({ roles }) =>
-          roles.includes("admin") || roles.includes("super-admin")),
-    },
+    // `create: true` — a visitor submits without an account. Reading, updating
+    // and deleting are the shared defaults.
+    access: accessWithDefaults(accessOverrides, { create: true }),
 
     hooks: {
       // Auto-set submittedAt timestamp on creation. (The edit stamp for

--- a/packages/plugin-form-builder/src/config/validate-form.test.ts
+++ b/packages/plugin-form-builder/src/config/validate-form.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Settings validation, through the public entry point.
+ *
+ * The redirect rules are the reason this file exists: a form set to send
+ * visitors somewhere, with nowhere recorded, saves cleanly and then fails at
+ * submit time — where there is no author to tell. Validation is the only point
+ * at which that is still a correctable mistake.
+ */
+import { describe, expect, it } from "vitest";
+
+import { validateFormConfig } from "./validate-form";
+import type { FormConfig } from "../types";
+
+/** A form that is valid but for whatever `settings` the case supplies. */
+function formWith(settings: Record<string, unknown>): FormConfig {
+  return {
+    name: "Contact",
+    slug: "contact",
+    fields: [{ type: "text", name: "message", label: "Message" }],
+    settings,
+  } as unknown as FormConfig;
+}
+
+const codes = (settings: Record<string, unknown>) =>
+  validateFormConfig(formWith(settings)).errors.map(error => error.code);
+
+describe("redirect settings", () => {
+  it("accepts a form that shows a message", () => {
+    expect(codes({ confirmationType: "message" })).toEqual([]);
+  });
+
+  it("requires a destination for a URL redirect", () => {
+    expect(codes({ confirmationType: "redirect" })).toContain(
+      "REDIRECT_URL_REQUIRED"
+    );
+    expect(
+      codes({ confirmationType: "redirect", redirectUrl: "/thanks" })
+    ).toEqual([]);
+  });
+
+  it("accepts a URL redirect that names a document instead", () => {
+    expect(
+      codes({
+        confirmationType: "redirect",
+        redirectRelation: { relationTo: "pages", value: "pg1" },
+      })
+    ).toEqual([]);
+  });
+
+  it("requires a page when the form redirects to one", () => {
+    // The case that motivated the rule: this saved happily and then sent
+    // nobody anywhere.
+    expect(codes({ confirmationType: "relationship" })).toContain(
+      "REDIRECT_PAGE_REQUIRED"
+    );
+  });
+
+  it("accepts a page redirect that names its page", () => {
+    expect(
+      codes({
+        confirmationType: "relationship",
+        redirectPage: { relationTo: "pages", value: "pg1" },
+      })
+    ).toEqual([]);
+  });
+
+  it("does not ask a page redirect for a URL", () => {
+    // The two options have separate requirements; reporting the URL rule here
+    // would send an author to a field the option does not use.
+    expect(codes({ confirmationType: "relationship" })).not.toContain(
+      "REDIRECT_URL_REQUIRED"
+    );
+  });
+
+  it("reports a valid form as valid", () => {
+    const result = validateFormConfig(
+      formWith({
+        confirmationType: "relationship",
+        redirectPage: { relationTo: "pages", value: "pg1" },
+      })
+    );
+    expect(result.valid).toBe(true);
+  });
+});

--- a/packages/plugin-form-builder/src/config/validate-form.ts
+++ b/packages/plugin-form-builder/src/config/validate-form.ts
@@ -66,6 +66,7 @@ export type FormValidationErrorCode =
   // Settings errors
   | "SETTINGS_INVALID_TYPE"
   | "REDIRECT_URL_REQUIRED"
+  | "REDIRECT_PAGE_REQUIRED"
   // Access errors
   | "ACCESS_INVALID_TYPE"
   | "ACCESS_FUNCTION_INVALID";
@@ -604,6 +605,18 @@ function validateSettings(
         code: "REDIRECT_URL_REQUIRED",
       });
     }
+  }
+
+  // A form set to redirect to a page needs the page. Without this the form
+  // saves, the admin shows it as redirecting, and every submission finishes
+  // with nowhere to go — the destination is missing at submit time, when
+  // there is no one to tell.
+  if (s.confirmationType === "relationship" && !s.redirectPage) {
+    errors.push({
+      path: "settings.redirectPage",
+      message: "A page is required when confirmation type is 'relationship'",
+      code: "REDIRECT_PAGE_REQUIRED",
+    });
   }
 }
 

--- a/packages/plugin-form-builder/src/config/validate-form.ts
+++ b/packages/plugin-form-builder/src/config/validate-form.ts
@@ -26,6 +26,7 @@ import { isPluginFieldTypeOnSurface } from "nextly";
 
 import { BUILT_IN_FORM_FIELD_TYPES } from "../types";
 import type { FormConfig, FormField, FormFieldType } from "../types";
+import { parseRedirectReference } from "../utils/redirect-reference";
 
 // ============================================================
 // Validation Error Types
@@ -611,13 +612,38 @@ function validateSettings(
   // saves, the admin shows it as redirecting, and every submission finishes
   // with nowhere to go — the destination is missing at submit time, when
   // there is no one to tell.
-  if (s.confirmationType === "relationship" && !s.redirectPage) {
+  //
+  // The SHAPE, not truthiness. `{}` and `{ relationTo: "pages" }` are truthy
+  // and name no document, so a presence test admits precisely the values that
+  // resolve to nothing. `null` for the collection list because this entry
+  // point does not have the plugin config: a reference carrying its own
+  // `relationTo` is checkable without it, and a bare id is not — which is the
+  // honest limit of validating a form in isolation.
+  if (
+    s.confirmationType === "relationship" &&
+    !namesADocument(s.redirectPage)
+  ) {
     errors.push({
       path: "settings.redirectPage",
       message: "A page is required when confirmation type is 'relationship'",
       code: "REDIRECT_PAGE_REQUIRED",
     });
   }
+}
+
+/**
+ * Whether a stored redirect value names a document at all.
+ *
+ * Derived from the shared reader rather than restating its rules, with an
+ * empty collection list: that accepts every shape carrying its own
+ * `relationTo` and rejects the ones naming nothing. A bare id is the case this
+ * cannot judge here, since which collection it belongs to is plugin
+ * configuration this entry point never sees — so it is accepted rather than
+ * reported, because refusing a valid form is the worse error.
+ */
+function namesADocument(value: unknown): boolean {
+  if (typeof value === "string") return value.length > 0;
+  return parseRedirectReference(value, []) !== null;
 }
 
 /**

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -27,6 +27,7 @@ import {
   applyRedirectPattern,
   parseRedirectReference,
   type RedirectTargetDocument,
+  type RedirectUrlPattern,
 } from "../utils/redirect-target";
 
 import { checkSpam } from "./spam-detection";
@@ -484,14 +485,42 @@ async function urlForPickedDocument(
   const target = await readTarget(reference, form, pluginContext);
   if (!target) return undefined;
 
-  const url = applyRedirectPattern(pattern, target);
-  if (!url) {
-    logger.warn?.(
-      "Form redirect pattern could not be filled from the target document",
-      { form: form.slug, collection: reference.collection }
-    );
+  return buildUrl(pattern, target, reference.collection, form, pluginContext);
+}
+
+/**
+ * The pattern applied, or undefined with the reason logged.
+ *
+ * Separate because a configured pattern may be a FUNCTION — host code, which
+ * can throw. Letting that escape would reach `submitForm`'s outer catch AFTER
+ * the submission row exists, reporting a failure the caller may retry into a
+ * duplicate of a submission that was already saved.
+ */
+function buildUrl(
+  pattern: RedirectUrlPattern,
+  target: RedirectTargetDocument,
+  collection: string,
+  form: FormDocument,
+  pluginContext: PluginContext
+): string | undefined {
+  const { logger } = pluginContext;
+  try {
+    const url = applyRedirectPattern(pattern, target);
+    if (!url) {
+      logger.warn?.(
+        "Form redirect pattern could not be filled from the target document",
+        { form: form.slug, collection }
+      );
+    }
+    return url;
+  } catch (error) {
+    logger.warn?.("Form redirect pattern threw while building a URL", {
+      form: form.slug,
+      collection,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
   }
-  return url;
 }
 
 /** The target row, or undefined — a deleted target and a failed read differ. */

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -23,6 +23,11 @@ import {
   transformFormData,
   getValidationErrors,
 } from "../utils/generate-schema";
+import {
+  applyRedirectPattern,
+  parseRedirectReference,
+  type RedirectTargetDocument,
+} from "../utils/redirect-target";
 
 import { checkSpam } from "./spam-detection";
 
@@ -329,7 +334,11 @@ export async function submitForm(
 
     // 6. Determine redirect URL. Spam gets the same success shape as a real
     // submission (minus the stored row reference) so bots can't diff the two.
-    const redirect = determineRedirectUrl(form);
+    const redirect = await resolveRedirectUrl(
+      form,
+      pluginConfig,
+      pluginContext
+    );
 
     if (isContentSpam) {
       return { success: true, redirect };
@@ -394,38 +403,133 @@ export async function fetchFormBySlug(
 }
 
 /**
- * Determine the redirect URL based on form settings.
+ * Where a successful submission sends the visitor, or undefined for nowhere.
  *
- * @param form - Form document
- * @returns Redirect URL or undefined
+ * A destination is either TYPED as a URL or PICKED as a document, and the two
+ * are answered differently: a typed URL is returned verbatim, since it may
+ * legitimately point off-site, while a picked document has to be read and put
+ * through its collection's configured URL pattern.
+ *
+ * Two settings hold a picked document — `redirectPage` under the
+ * "Redirect to Page" option, and `redirectRelation` under the URL option —
+ * and both resolve through the same path, because they ask the same question.
+ *
+ * Every way of failing to produce a URL is logged. A form whose destination
+ * cannot be built behaves exactly like one configured to stay put, so without
+ * a line in the log the two are indistinguishable from the outside.
  */
-function determineRedirectUrl(form: FormDocument): string | undefined {
-  if (!form.settings) {
+async function resolveRedirectUrl(
+  form: FormDocument,
+  pluginConfig: ResolvedFormBuilderConfig,
+  pluginContext: PluginContext
+): Promise<string | undefined> {
+  const settings = form.settings;
+  if (!settings) return undefined;
+
+  const { confirmationType } = settings;
+  if (confirmationType !== "redirect" && confirmationType !== "relationship") {
     return undefined;
   }
 
-  // Check confirmation type
-  if (form.settings.confirmationType !== "redirect") {
+  // A typed URL is returned verbatim: it is the whole point of that option,
+  // and it may legitimately point off-site.
+  if (confirmationType === "redirect" && settings.redirectUrl) {
+    return settings.redirectUrl;
+  }
+
+  return urlForPickedDocument(
+    confirmationType === "relationship"
+      ? settings.redirectPage
+      : settings.redirectRelation,
+    form,
+    pluginConfig,
+    pluginContext
+  );
+}
+
+/**
+ * The URL for a picked document, or undefined with a reason in the log.
+ *
+ * Every branch reports. A form whose destination cannot be built behaves
+ * exactly like one configured to stay put, so without a line here the two are
+ * indistinguishable from outside — which is how a redirect that never fired
+ * went unnoticed.
+ */
+async function urlForPickedDocument(
+  stored: unknown,
+  form: FormDocument,
+  pluginConfig: ResolvedFormBuilderConfig,
+  pluginContext: PluginContext
+): Promise<string | undefined> {
+  const { logger } = pluginContext;
+  const patterns = pluginConfig.redirectRelationships;
+  const reference = parseRedirectReference(stored, Object.keys(patterns));
+
+  if (!reference) {
+    logger.warn?.("Form redirects to a page, but names no readable document", {
+      form: form.slug,
+    });
     return undefined;
   }
 
-  // Direct URL redirect
-  if (form.settings.redirectUrl) {
-    return form.settings.redirectUrl;
+  const pattern = patterns[reference.collection];
+  if (!pattern) {
+    logger.warn?.(
+      "Form redirects to a collection that is not in redirectRelationships",
+      { form: form.slug, collection: reference.collection }
+    );
+    return undefined;
   }
 
-  // Relationship-based redirect (requires additional lookup)
-  // Note: For relationship redirects, the admin UI should resolve
-  // the URL before saving to redirectUrl, or the frontend should
-  // handle the relationship lookup.
-  if (form.settings.redirectRelation) {
-    // Return a placeholder that the frontend can resolve
-    // Format: relationship://{collection}/{id}
-    const { relationTo, value } = form.settings.redirectRelation;
-    return `relationship://${relationTo}/${value}`;
+  const target = await readTarget(reference, form, pluginContext);
+  if (!target) return undefined;
+
+  const url = applyRedirectPattern(pattern, target);
+  if (!url) {
+    logger.warn?.(
+      "Form redirect pattern could not be filled from the target document",
+      { form: form.slug, collection: reference.collection }
+    );
+  }
+  return url;
+}
+
+/** The target row, or undefined — a deleted target and a failed read differ. */
+async function readTarget(
+  reference: { collection: string; id: string },
+  form: FormDocument,
+  pluginContext: PluginContext
+): Promise<RedirectTargetDocument | undefined> {
+  const { logger } = pluginContext;
+  const context = {
+    form: form.slug,
+    collection: reference.collection,
+    id: reference.id,
+  };
+
+  let row: unknown;
+  try {
+    row = await pluginContext.services.collections.findEntryById(
+      reference.collection,
+      reference.id,
+      { as: "system" }
+    );
+  } catch (error) {
+    // The submission already succeeded, so this degrades to "no redirect"
+    // rather than failing the request — reported, because a broken read and a
+    // deleted target are different problems with the same symptom.
+    logger.warn?.("Form redirect target could not be read", {
+      ...context,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
   }
 
-  return undefined;
+  if (!row || typeof row !== "object") {
+    logger.warn?.("Form redirect target no longer exists", context);
+    return undefined;
+  }
+  return row as RedirectTargetDocument;
 }
 
 // ============================================================

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -31,6 +31,7 @@ import type {
 import { evaluateSingleCondition } from "./utils/evaluate-conditions";
 import { exportToCSV, generateExportFilename } from "./utils/export-formats";
 import { parseFieldRef } from "./utils/field-references";
+import { normalizeRedirectRelationships } from "./utils/redirect-target";
 
 export type NextlyPlugin = PluginDefinition;
 
@@ -96,7 +97,9 @@ function resolveConfig(
       hidden: options.fields?.hidden ?? true,
     },
 
-    redirectRelationships: options.redirectRelationships || [],
+    redirectRelationships: normalizeRedirectRelationships(
+      options.redirectRelationships
+    ),
     beforeEmail: options.beforeEmail,
 
     notifications: {
@@ -356,6 +359,12 @@ export function formBuilder(
                 // Runtime-resolved collection slugs (through ctx.self, so a
                 // framework .rename() is honored too) — admin components
                 // never hardcode "forms"/"form-submissions".
+                // Names only. A pattern may be a function, which does not
+                // survive JSON and which the browser has no use for — the
+                // admin picks a document, the server builds the URL.
+                redirectCollections: Object.keys(
+                  resolvedConfig.redirectRelationships
+                ),
                 slugs: {
                   forms:
                     ctx.self.collections[resolvedConfig.formOverrides.slug] ??

--- a/packages/plugin-form-builder/src/types.ts
+++ b/packages/plugin-form-builder/src/types.ts
@@ -175,6 +175,46 @@ export interface SubmissionDocument {
 /**
  * Configuration options for the form builder plugin.
  */
+/**
+ * Which field types the builder offers, and how each one is customised.
+ *
+ * Declared ONCE and viewed twice: the options surface takes
+ * `Partial<FormFieldToggles>` and the resolved config takes it whole, because
+ * "resolved" means exactly "every toggle now has a value". Written out twice
+ * the two lists agree until someone adds a field type to one of them.
+ */
+export interface FormFieldToggles {
+  text: boolean | Partial<FieldBlockConfig>;
+  email: boolean | Partial<FieldBlockConfig>;
+  number: boolean | Partial<FieldBlockConfig>;
+  phone: boolean | Partial<FieldBlockConfig>;
+  url: boolean | Partial<FieldBlockConfig>;
+  textarea: boolean | Partial<FieldBlockConfig>;
+  select: boolean | Partial<FieldBlockConfig>;
+  checkbox: boolean | Partial<FieldBlockConfig>;
+  radio: boolean | Partial<FieldBlockConfig>;
+  file: boolean | Partial<FieldBlockConfig>;
+  date: boolean | Partial<FieldBlockConfig>;
+  time: boolean | Partial<FieldBlockConfig>;
+  hidden: boolean | Partial<FieldBlockConfig>;
+}
+
+/** What a host may override on a collection this plugin contributes. */
+export type CollectionOverrides = Partial<CollectionConfig> & {
+  slug?: string;
+  labels?: { singular?: string; plural?: string };
+  /** Fields can be an array or a function receiving defaultFields */
+  fields?:
+    | FieldDefinition[]
+    | ((args: { defaultFields: FieldDefinition[] }) => FieldDefinition[]);
+};
+
+/** The same, once the plugin's defaults have filled in what a host omitted. */
+export type ResolvedCollectionOverrides = {
+  slug: string;
+  labels: { singular: string; plural: string };
+} & Partial<CollectionConfig>;
+
 export interface FormBuilderPluginOptions {
   /**
    * Override the default Forms collection configuration.
@@ -217,17 +257,7 @@ export interface FormBuilderPluginOptions {
    * }
    * ```
    */
-  formOverrides?: Partial<CollectionConfig> & {
-    slug?: string;
-    labels?: {
-      singular?: string;
-      plural?: string;
-    };
-    /** Fields can be an array or a function receiving defaultFields */
-    fields?:
-      | FieldDefinition[]
-      | ((args: { defaultFields: FieldDefinition[] }) => FieldDefinition[]);
-  };
+  formOverrides?: CollectionOverrides;
 
   /**
    * Override the default Form Submissions collection configuration.
@@ -274,17 +304,7 @@ export interface FormBuilderPluginOptions {
    * }
    * ```
    */
-  formSubmissionOverrides?: Partial<CollectionConfig> & {
-    slug?: string;
-    labels?: {
-      singular?: string;
-      plural?: string;
-    };
-    /** Fields can be an array or a function receiving defaultFields */
-    fields?:
-      | FieldDefinition[]
-      | ((args: { defaultFields: FieldDefinition[] }) => FieldDefinition[]);
-  };
+  formSubmissionOverrides?: CollectionOverrides;
 
   /**
    * Configure which field types are available in the form builder.
@@ -308,21 +328,7 @@ export interface FormBuilderPluginOptions {
    * }
    * ```
    */
-  fields?: {
-    text?: boolean | Partial<FieldBlockConfig>;
-    email?: boolean | Partial<FieldBlockConfig>;
-    number?: boolean | Partial<FieldBlockConfig>;
-    phone?: boolean | Partial<FieldBlockConfig>;
-    url?: boolean | Partial<FieldBlockConfig>;
-    textarea?: boolean | Partial<FieldBlockConfig>;
-    select?: boolean | Partial<FieldBlockConfig>;
-    checkbox?: boolean | Partial<FieldBlockConfig>;
-    radio?: boolean | Partial<FieldBlockConfig>;
-    file?: boolean | Partial<FieldBlockConfig>;
-    date?: boolean | Partial<FieldBlockConfig>;
-    time?: boolean | Partial<FieldBlockConfig>;
-    hidden?: boolean | Partial<FieldBlockConfig>;
-  };
+  fields?: Partial<FormFieldToggles>;
 
   /**
    * Collections whose documents a form may redirect to after submission, and
@@ -1172,37 +1178,11 @@ export interface FormSubmission {
  * Used internally by the plugin.
  */
 export interface ResolvedFormBuilderConfig {
-  formOverrides: {
-    slug: string;
-    labels: {
-      singular: string;
-      plural: string;
-    };
-  } & Partial<CollectionConfig>;
+  formOverrides: ResolvedCollectionOverrides;
 
-  formSubmissionOverrides: {
-    slug: string;
-    labels: {
-      singular: string;
-      plural: string;
-    };
-  } & Partial<CollectionConfig>;
+  formSubmissionOverrides: ResolvedCollectionOverrides;
 
-  fields: {
-    text: boolean | Partial<FieldBlockConfig>;
-    email: boolean | Partial<FieldBlockConfig>;
-    number: boolean | Partial<FieldBlockConfig>;
-    phone: boolean | Partial<FieldBlockConfig>;
-    url: boolean | Partial<FieldBlockConfig>;
-    textarea: boolean | Partial<FieldBlockConfig>;
-    select: boolean | Partial<FieldBlockConfig>;
-    checkbox: boolean | Partial<FieldBlockConfig>;
-    radio: boolean | Partial<FieldBlockConfig>;
-    file: boolean | Partial<FieldBlockConfig>;
-    date: boolean | Partial<FieldBlockConfig>;
-    time: boolean | Partial<FieldBlockConfig>;
-    hidden: boolean | Partial<FieldBlockConfig>;
-  };
+  fields: FormFieldToggles;
 
   /**
    * The collection-to-URL map, with the array shorthand already expanded.

--- a/packages/plugin-form-builder/src/types.ts
+++ b/packages/plugin-form-builder/src/types.ts
@@ -9,6 +9,8 @@
 import type { CollectionConfig, FieldDefinition, RequestContext } from "nextly";
 import type { ComponentType } from "react";
 
+import type { RedirectRelationships } from "./utils/redirect-target";
+
 // ============================================================
 // Supporting Types
 // ============================================================
@@ -323,17 +325,28 @@ export interface FormBuilderPluginOptions {
   };
 
   /**
-   * Collections that can be used as redirect targets after form submission.
+   * Collections whose documents a form may redirect to after submission, and
+   * how each one's documents become URLs.
    *
-   * When specified, the form builder will allow selecting documents from
-   * these collections as redirect destinations.
+   * The mapping is configuration because it cannot be derived: a site's URL
+   * structure belongs to the site. `{field}` placeholders are filled from the
+   * document; a function covers a path this package cannot express.
+   *
+   * The array shorthand names the collections and takes `/{slug}` for all of
+   * them, which is the routing the page builder ships.
    *
    * @example
    * ```typescript
-   * redirectRelationships: ['pages', 'posts', 'landing-pages']
+   * redirectRelationships: ['pages']
+   *
+   * redirectRelationships: {
+   *   pages: '/{slug}',
+   *   posts: '/blog/{slug}',
+   *   docs: page => `/docs/${String(page.section)}/${String(page.slug)}`,
+   * }
    * ```
    */
-  redirectRelationships?: string[];
+  redirectRelationships?: string[] | RedirectRelationships;
 
   /**
    * Hook called before sending email notifications.
@@ -1191,7 +1204,14 @@ export interface ResolvedFormBuilderConfig {
     hidden: boolean | Partial<FieldBlockConfig>;
   };
 
-  redirectRelationships: string[];
+  /**
+   * The collection-to-URL map, with the array shorthand already expanded.
+   *
+   * ONE shape, so nothing downstream branches on which spelling was written.
+   * The list of redirect collections is `Object.keys` of this rather than a
+   * second field beside it, which would agree with it today and drift later.
+   */
+  redirectRelationships: RedirectRelationships;
 
   beforeEmail?: FormBuilderPluginOptions["beforeEmail"];
 

--- a/packages/plugin-form-builder/src/utils/redirect-reference.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-reference.ts
@@ -36,11 +36,13 @@ export function parseRedirectReference(
   if (value == null) return null;
 
   if (typeof value === "string") {
-    // Emptiness checked here as `referenceId` already does below. Without it a
-    // CLEARED `redirectPage` reads as a reference to id "", which validation
-    // then accepts as a usable target and the submit path resolves to nothing.
-    return value && collections.length === 1
-      ? { collection: collections[0], id: value }
+    // Trimmed, as the object branch trims its collection name. A cleared or
+    // whitespace-only `redirectPage` reads as a reference otherwise, which
+    // validation accepts as a usable target while the collection hook refuses
+    // it as missing and the submit path resolves to nothing.
+    const id = value.trim();
+    return id && collections.length === 1
+      ? { collection: collections[0], id }
       : null;
   }
 
@@ -68,7 +70,7 @@ export function parseRedirectReference(
 }
 
 function referenceId(value: unknown): string | null {
-  if (typeof value === "string") return value || null;
+  if (typeof value === "string") return value.trim() || null;
   if (value !== null && typeof value === "object" && !Array.isArray(value)) {
     const { id } = value as Record<string, unknown>;
     if (typeof id === "string" && id) return id;

--- a/packages/plugin-form-builder/src/utils/redirect-reference.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-reference.ts
@@ -51,12 +51,13 @@ export function parseRedirectReference(
   const inner = record.value;
 
   if (typeof relationTo === "string" && relationTo.trim()) {
-    // Trimmed, because a blank or whitespace collection name is not a
-    // collection: it passes a truthiness test, reads as a valid reference to
-    // the public validator, and then fails the membership check on save while
-    // resolving to no URL at submit time.
+    // Trimmed for the TEST and in the VALUE returned. A blank or whitespace
+    // name is not a collection, and a padded one is not the same string as the
+    // configured key — accepting `" pages "` while returning it unchanged
+    // makes this read valid to the public validator and unusable to every
+    // consumer that looks the name up.
     const id = referenceId(inner);
-    return id ? { collection: relationTo, id } : null;
+    return id ? { collection: relationTo.trim(), id } : null;
   }
 
   // A populated row with no `relationTo` beside it: same ambiguity as a bare

--- a/packages/plugin-form-builder/src/utils/redirect-reference.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-reference.ts
@@ -50,7 +50,11 @@ export function parseRedirectReference(
   const relationTo = record.relationTo;
   const inner = record.value;
 
-  if (typeof relationTo === "string") {
+  if (typeof relationTo === "string" && relationTo.trim()) {
+    // Trimmed, because a blank or whitespace collection name is not a
+    // collection: it passes a truthiness test, reads as a valid reference to
+    // the public validator, and then fails the membership check on save while
+    // resolving to no URL at submit time.
     const id = referenceId(inner);
     return id ? { collection: relationTo, id } : null;
   }

--- a/packages/plugin-form-builder/src/utils/redirect-reference.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-reference.ts
@@ -1,0 +1,69 @@
+/**
+ * Reading the document a form's redirect setting points at.
+ *
+ * Separate from `redirect-target` because this half has no dependencies and
+ * the other half imports `nextly/config`: the admin picker needs to read a
+ * stored reference to show what is selected, and pulling the config surface
+ * into the browser bundle to do it would be a real cost for no gain.
+ */
+
+/** A document being turned into a URL. `id` is always present; the rest is the row. */
+export interface RedirectTargetDocument {
+  id: string;
+  [field: string]: unknown;
+}
+
+/** A stored relationship value reduced to the collection and id it names. */
+export interface RedirectReference {
+  collection: string;
+  id: string;
+}
+
+/**
+ * The reference a `redirectPage` value holds, in any shape a read produces.
+ *
+ * Three arrive in practice and they are not interchangeable: a polymorphic
+ * field stores `{ relationTo, value }`; a read at depth replaces `value` with
+ * the populated row; and a single-target field stores the bare id. The last
+ * names no collection, so it resolves only when exactly one is configured —
+ * guessing which of several a bare id belongs to would send visitors to a
+ * URL built from the wrong collection's pattern.
+ */
+export function parseRedirectReference(
+  value: unknown,
+  collections: readonly string[]
+): RedirectReference | null {
+  if (value == null) return null;
+
+  if (typeof value === "string") {
+    return collections.length === 1
+      ? { collection: collections[0], id: value }
+      : null;
+  }
+
+  if (typeof value !== "object" || Array.isArray(value)) return null;
+
+  const record = value as Record<string, unknown>;
+  const relationTo = record.relationTo;
+  const inner = record.value;
+
+  if (typeof relationTo === "string") {
+    const id = referenceId(inner);
+    return id ? { collection: relationTo, id } : null;
+  }
+
+  // A populated row with no `relationTo` beside it: same ambiguity as a bare
+  // id, and the same answer.
+  const id = referenceId(record);
+  if (!id) return null;
+  return collections.length === 1 ? { collection: collections[0], id } : null;
+}
+
+function referenceId(value: unknown): string | null {
+  if (typeof value === "string") return value || null;
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    const { id } = value as Record<string, unknown>;
+    if (typeof id === "string" && id) return id;
+  }
+  return null;
+}

--- a/packages/plugin-form-builder/src/utils/redirect-reference.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-reference.ts
@@ -36,7 +36,10 @@ export function parseRedirectReference(
   if (value == null) return null;
 
   if (typeof value === "string") {
-    return collections.length === 1
+    // Emptiness checked here as `referenceId` already does below. Without it a
+    // CLEARED `redirectPage` reads as a reference to id "", which validation
+    // then accepts as a usable target and the submit path resolves to nothing.
+    return value && collections.length === 1
       ? { collection: collections[0], id: value }
       : null;
   }

--- a/packages/plugin-form-builder/src/utils/redirect-target.test.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-target.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyRedirectPattern,
+  DEFAULT_REDIRECT_PATTERN,
+  normalizeRedirectRelationships,
+  parseRedirectReference,
+} from "./redirect-target";
+
+describe("normalizeRedirectRelationships", () => {
+  it("gives the array shorthand the default pattern", () => {
+    expect(normalizeRedirectRelationships(["pages", "posts"])).toEqual({
+      pages: DEFAULT_REDIRECT_PATTERN,
+      posts: DEFAULT_REDIRECT_PATTERN,
+    });
+  });
+
+  it("keeps a per-collection pattern", () => {
+    expect(
+      normalizeRedirectRelationships({
+        pages: "/{slug}",
+        posts: "/blog/{slug}",
+      })
+    ).toEqual({ pages: "/{slug}", posts: "/blog/{slug}" });
+  });
+
+  it("treats an unset option as no redirect collections", () => {
+    expect(normalizeRedirectRelationships(undefined)).toEqual({});
+    expect(normalizeRedirectRelationships([])).toEqual({});
+  });
+
+  it("copies rather than aliasing the caller's object", () => {
+    // The resolved config outlives the options object, and a plugin that
+    // mutates its own options afterwards must not change what was resolved.
+    const option = { pages: "/{slug}" };
+    const resolved = normalizeRedirectRelationships(option);
+    option.pages = "/changed";
+    expect(resolved.pages).toBe("/{slug}");
+  });
+});
+
+describe("parseRedirectReference", () => {
+  const many = ["pages", "posts"];
+
+  it("reads the polymorphic shape", () => {
+    expect(
+      parseRedirectReference({ relationTo: "posts", value: "p1" }, many)
+    ).toEqual({ collection: "posts", id: "p1" });
+  });
+
+  it("reads the polymorphic shape when the row is populated", () => {
+    // A read at depth replaces the id with the row it points at.
+    expect(
+      parseRedirectReference(
+        { relationTo: "pages", value: { id: "pg1", slug: "about" } },
+        many
+      )
+    ).toEqual({ collection: "pages", id: "pg1" });
+  });
+
+  it("reads a bare id when exactly one collection is configured", () => {
+    expect(parseRedirectReference("pg1", ["pages"])).toEqual({
+      collection: "pages",
+      id: "pg1",
+    });
+  });
+
+  it("refuses a bare id when several collections are configured", () => {
+    // The id names no collection, and picking one would build the URL from
+    // another collection's pattern — a wrong destination, not a missing one.
+    expect(parseRedirectReference("pg1", many)).toBeNull();
+  });
+
+  it("refuses a populated row that names no collection, when several exist", () => {
+    expect(
+      parseRedirectReference({ id: "pg1", slug: "about" }, many)
+    ).toBeNull();
+  });
+
+  it("reads a populated row with no relationTo when only one collection exists", () => {
+    expect(
+      parseRedirectReference({ id: "pg1", slug: "about" }, ["pages"])
+    ).toEqual({ collection: "pages", id: "pg1" });
+  });
+
+  it("has nothing to read from an unset or empty value", () => {
+    for (const empty of [null, undefined, "", [], { relationTo: "pages" }]) {
+      expect(parseRedirectReference(empty, many)).toBeNull();
+    }
+  });
+});
+
+describe("applyRedirectPattern", () => {
+  const page = { id: "pg1", slug: "thank-you" };
+
+  it("fills a placeholder from the document", () => {
+    expect(applyRedirectPattern("/{slug}", page)).toBe("/thank-you");
+    expect(applyRedirectPattern("/blog/{slug}", page)).toBe("/blog/thank-you");
+  });
+
+  it("fills several placeholders, including repeats", () => {
+    expect(applyRedirectPattern("/{slug}/{id}/{slug}", page)).toBe(
+      "/thank-you/pg1/thank-you"
+    );
+  });
+
+  it("returns nothing when a placeholder has no value", () => {
+    // `/undefined` and `/` are both real URLs that go somewhere wrong, so a
+    // form that cannot build its destination must report having none.
+    expect(applyRedirectPattern("/{slug}", { id: "pg1" })).toBeUndefined();
+    expect(
+      applyRedirectPattern("/{slug}", { id: "pg1", slug: "" })
+    ).toBeUndefined();
+  });
+
+  it("accepts a numeric field", () => {
+    expect(applyRedirectPattern("/p/{year}", { id: "x", year: 2026 })).toBe(
+      "/p/2026"
+    );
+  });
+
+  it("encodes what it substitutes", () => {
+    // A slug is author-entered text, not a URL segment. Left raw, a space or
+    // a `#` produces a link that goes somewhere other than the page picked.
+    expect(
+      applyRedirectPattern("/{slug}", { id: "1", slug: "thank you" })
+    ).toBe("/thank%20you");
+    expect(applyRedirectPattern("/{slug}", { id: "1", slug: "a#b" })).toBe(
+      "/a%23b"
+    );
+  });
+
+  it("substitutes a falsey value that is still a real segment", () => {
+    // `0` and `false` are values; only null, undefined and empty string mean
+    // the field has nothing to give.
+    expect(applyRedirectPattern("/p/{page}", { id: "1", page: 0 })).toBe(
+      "/p/0"
+    );
+    expect(applyRedirectPattern("/p/{flag}", { id: "1", flag: false })).toBe(
+      "/p/false"
+    );
+  });
+
+  it("passes a pattern with no placeholders through", () => {
+    expect(applyRedirectPattern("/thanks", page)).toBe("/thanks");
+  });
+
+  it("calls the function form with the document", () => {
+    expect(applyRedirectPattern(doc => `/x/${String(doc.slug)}`, page)).toBe(
+      "/x/thank-you"
+    );
+  });
+
+  it("returns nothing when the function declines", () => {
+    expect(applyRedirectPattern(() => undefined, page)).toBeUndefined();
+    expect(applyRedirectPattern(() => "", page)).toBeUndefined();
+  });
+});

--- a/packages/plugin-form-builder/src/utils/redirect-target.test.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-target.test.ts
@@ -24,6 +24,21 @@ describe("normalizeRedirectRelationships", () => {
     ).toEqual({ pages: "/{slug}", posts: "/blog/{slug}" });
   });
 
+  it("drops a collection whose pattern cannot produce a URL", () => {
+    // Kept, it would be offered in the picker and accepted by validation while
+    // resolving to nothing at submit time.
+    expect(
+      normalizeRedirectRelationships({ pages: "", posts: "/blog/{slug}" })
+    ).toEqual({ posts: "/blog/{slug}" });
+  });
+
+  it("keeps a function pattern, which has no empty form", () => {
+    const pattern = () => "/x";
+    expect(normalizeRedirectRelationships({ pages: pattern })).toEqual({
+      pages: pattern,
+    });
+  });
+
   it("treats an unset option as no redirect collections", () => {
     expect(normalizeRedirectRelationships(undefined)).toEqual({});
     expect(normalizeRedirectRelationships([])).toEqual({});

--- a/packages/plugin-form-builder/src/utils/redirect-target.test.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-target.test.ts
@@ -65,6 +65,12 @@ describe("parseRedirectReference", () => {
     });
   });
 
+  it("refuses an empty bare id", () => {
+    // A cleared field is not a reference to the empty document. Accepting it
+    // lets validation pass a form whose every submission ends nowhere.
+    expect(parseRedirectReference("", ["pages"])).toBeNull();
+  });
+
   it("refuses a bare id when several collections are configured", () => {
     // The id names no collection, and picking one would build the URL from
     // another collection's pattern — a wrong destination, not a missing one.

--- a/packages/plugin-form-builder/src/utils/redirect-target.test.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-target.test.ts
@@ -104,6 +104,18 @@ describe("parseRedirectReference", () => {
     ).toEqual({ collection: "pages", id: "pg1" });
   });
 
+  it("refuses a blank collection name", () => {
+    // Truthy, and not a collection. The public validator would call the form
+    // valid while the collection save refuses it and submit-time resolution
+    // produces no URL.
+    expect(
+      parseRedirectReference({ relationTo: "", value: "p1" }, many)
+    ).toBeNull();
+    expect(
+      parseRedirectReference({ relationTo: "   ", value: "p1" }, many)
+    ).toBeNull();
+  });
+
   it("has nothing to read from an unset or empty value", () => {
     for (const empty of [null, undefined, "", [], { relationTo: "pages" }]) {
       expect(parseRedirectReference(empty, many)).toBeNull();

--- a/packages/plugin-form-builder/src/utils/redirect-target.test.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-target.test.ts
@@ -24,6 +24,15 @@ describe("normalizeRedirectRelationships", () => {
     ).toEqual({ pages: "/{slug}", posts: "/blog/{slug}" });
   });
 
+  it("drops a whitespace-only pattern, which produces a blank URL", () => {
+    // `previewUrlFromTemplate` returns whitespace unchanged and it is truthy,
+    // so a kept collection would be offered, validated, and then hand a
+    // successful submission "   " as its destination.
+    expect(
+      normalizeRedirectRelationships({ pages: "   ", posts: "/blog/{slug}" })
+    ).toEqual({ posts: "/blog/{slug}" });
+  });
+
   it("drops a collection whose pattern cannot produce a URL", () => {
     // Kept, it would be offered in the picker and accepted by validation while
     // resolving to nothing at submit time.
@@ -78,6 +87,16 @@ describe("parseRedirectReference", () => {
       collection: "pages",
       id: "pg1",
     });
+  });
+
+  it("refuses a whitespace-only bare id", () => {
+    expect(parseRedirectReference("   ", ["pages"])).toBeNull();
+  });
+
+  it("refuses a whitespace-only id inside a reference", () => {
+    expect(
+      parseRedirectReference({ relationTo: "pages", value: "  " }, ["pages"])
+    ).toBeNull();
   });
 
   it("refuses an empty bare id", () => {

--- a/packages/plugin-form-builder/src/utils/redirect-target.test.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-target.test.ts
@@ -104,6 +104,15 @@ describe("parseRedirectReference", () => {
     ).toEqual({ collection: "pages", id: "pg1" });
   });
 
+  it("returns the collection name trimmed, not merely accepts it", () => {
+    // Accepting a padded name while returning it padded is worse than
+    // rejecting it: the validator calls the form valid and every consumer that
+    // looks the name up against configuration then fails to find it.
+    expect(
+      parseRedirectReference({ relationTo: " pages ", value: "p1" }, many)
+    ).toEqual({ collection: "pages", id: "p1" });
+  });
+
   it("refuses a blank collection name", () => {
     // Truthy, and not a collection. The public validator would call the form
     // valid while the collection save refuses it and submit-time resolution

--- a/packages/plugin-form-builder/src/utils/redirect-target.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-target.ts
@@ -62,9 +62,17 @@ export function normalizeRedirectRelationships(
   option: string[] | RedirectRelationships | undefined
 ): RedirectRelationships {
   if (!option) return {};
-  if (!Array.isArray(option)) return { ...option };
+  const entries = Array.isArray(option)
+    ? option.map(collection => [collection, DEFAULT_REDIRECT_PATTERN] as const)
+    : Object.entries(option);
+
+  // An empty pattern is dropped rather than kept, so that being OFFERED as a
+  // redirect target and being able to PRODUCE a URL are one decision. Kept,
+  // the collection appears in the picker, validation accepts a reference into
+  // it, and every submission then resolves to nothing — a form that passes
+  // every check and sends nobody anywhere.
   return Object.fromEntries(
-    option.map(collection => [collection, DEFAULT_REDIRECT_PATTERN])
+    entries.filter(([, pattern]) => typeof pattern !== "string" || pattern)
   );
 }
 

--- a/packages/plugin-form-builder/src/utils/redirect-target.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-target.ts
@@ -1,0 +1,88 @@
+/**
+ * Where a form sends the visitor after a successful submission, when the
+ * author picked a PAGE rather than typing a URL.
+ *
+ * The plugin cannot derive this. A site's URL structure belongs to the site:
+ * the playground serves the `pages` collection at `/{slug}` from its own
+ * catch-all route, and another app may serve the same collection under
+ * `/blog/{slug}` or behind a locale segment. Nothing inside a CMS package can
+ * read that decision off the collection, so the mapping is configuration.
+ *
+ * A pattern covers the common case and a function covers the rest — a path
+ * that depends on a parent document, a locale, or anything else the site
+ * knows and this package does not.
+ *
+ * The pattern syntax is not invented here. `previewUrlFromTemplate` already
+ * turns a `{field}` path into a URL for preview links, for the same reason and
+ * with the same constraint, so this uses it rather than substituting
+ * alongside it: two rules that agree today would drift, and a wrong URL still
+ * looks like a URL. Encoding and the treatment of `0` and `false` come with
+ * it.
+ */
+import { previewUrlFromTemplate } from "nextly/config";
+
+import type { RedirectTargetDocument } from "./redirect-reference";
+
+export type { RedirectTargetDocument } from "./redirect-reference";
+export {
+  parseRedirectReference,
+  type RedirectReference,
+} from "./redirect-reference";
+
+/**
+ * How documents in one collection become URLs.
+ *
+ * A string is a path with `{field}` placeholders filled from the document.
+ * A function receives the document and returns the path itself.
+ */
+export type RedirectUrlPattern =
+  | string
+  | ((document: RedirectTargetDocument) => string | undefined);
+
+/** The collection-to-pattern map, after the array shorthand is normalised. */
+export type RedirectRelationships = Record<string, RedirectUrlPattern>;
+
+/**
+ * The pattern assumed for the `string[]` shorthand.
+ *
+ * `redirectRelationships: ["pages"]` means "pages are redirect targets" and
+ * says nothing about their URLs, so it needs a default. This one matches the
+ * routing the page builder ships and the scaffold templates generate.
+ */
+export const DEFAULT_REDIRECT_PATTERN = "/{slug}";
+
+/**
+ * Both accepted spellings of the option reduced to the map.
+ *
+ * Normalised at the edge so everything downstream reads ONE shape — including
+ * the list of collections, which is `Object.keys` of this rather than a second
+ * field that agrees with it today.
+ */
+export function normalizeRedirectRelationships(
+  option: string[] | RedirectRelationships | undefined
+): RedirectRelationships {
+  if (!option) return {};
+  if (!Array.isArray(option)) return { ...option };
+  return Object.fromEntries(
+    option.map(collection => [collection, DEFAULT_REDIRECT_PATTERN])
+  );
+}
+
+/**
+ * The pattern applied to a document, or undefined when it cannot be.
+ *
+ * Undefined rather than a partial string: a placeholder whose field is empty
+ * would otherwise produce `/undefined` or `/`, and a form that sends every
+ * visitor to a broken URL is worse than one that sends them nowhere. The
+ * caller reports the difference.
+ */
+export function applyRedirectPattern(
+  pattern: RedirectUrlPattern,
+  document: RedirectTargetDocument
+): string | undefined {
+  if (typeof pattern === "function") {
+    const produced = pattern(document);
+    return produced ? produced : undefined;
+  }
+  return previewUrlFromTemplate(pattern)(document) ?? undefined;
+}

--- a/packages/plugin-form-builder/src/utils/redirect-target.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-target.ts
@@ -72,7 +72,9 @@ export function normalizeRedirectRelationships(
   // it, and every submission then resolves to nothing — a form that passes
   // every check and sends nobody anywhere.
   return Object.fromEntries(
-    entries.filter(([, pattern]) => typeof pattern !== "string" || pattern)
+    entries.filter(
+      ([, pattern]) => typeof pattern !== "string" || pattern.trim()
+    )
   );
 }
 


### PR DESCRIPTION
Closes the R-14 settings gap. The audit found the option was not merely missing a control — it was non-functional in three overlapping ways.

## What was broken

`confirmationType: "relationship"` is what the admin offers as **"Redirect to Page"**. The forms collection declares a `redirectPage` relationship field for it, conditioned on that very value, and `normalizeFormSettings` preserves it. A submission still ended with no destination, because `determineRedirectUrl` returned early unless the type was the literal `"redirect"`. Nothing read `redirectPage` anywhere in the repository.

The builder meanwhile rendered a note reading *"This form redirects to a linked page (configured via the API)"* — telling an author it worked.

A second setting, `redirectRelation`, did reach the handler and returned `relationship://<collection>/<id>`. Nothing resolves that protocol; a browser handed it navigates nowhere.

## The decision this needed

Where a document lives is not derivable. The playground serves `pages` at `/{slug}` from its own catch-all route; another app may serve the same collection under `/blog/{slug}`.

**This repo had already reached that conclusion.** `pageBuilder({ pagePreviewPath: "/{slug}" })` exists for preview links, and its rationale is the same sentence: *"the plugin can neither install this app preview route nor discover that `(frontend)/[...slug]` is mounted at the site root."*

So `redirectRelationships` takes a collection-to-pattern map (or the array shorthand, meaning `/{slug}`), in the same syntax an author already met.

## One implementation, not a parallel one

The substitution is `previewUrlFromTemplate` from `nextly/config` — the function preview links use. I had written my own and replaced it on finding this: the canonical one **URL-encodes** what it substitutes (mine did not, so a slug with a space produced a broken link) and treats `0`/`false` as real segments. Its own comment warns that two substitution rules "would drift, and the drift is silent because a wrong preview URL still looks like a URL."

Likewise `selectionKey` in the picker now calls `parseRedirectReference` rather than re-deriving which document a stored value names — the picker and the submit handler must agree, and the same tests pass against the derived version, which is what showed they were duplicates.

The list of redirect collections is `Object.keys` of the map rather than a field beside it.

## Failure is reported

Every way of failing to produce a URL is logged, and validation refuses a page redirect with no page. A form that cannot build its destination is indistinguishable from one configured to stay put, which is exactly how the original gap shipped unnoticed.

## Verification

- **151 tests, 26 files** in the package. Break-verified: restoring the original `!== "redirect"` guard fails 3 of the 5 integration cases while the 2 negative cases correctly still pass; disabling the new validation rule fails 1.
- **In a browser**, on the playground: the third option appears, the picker lists a real page, selecting it saves, and reopening the form shows it still selected. Two defects were found this way and were invisible to the passing tests — the query used `pageSize` where the API takes `limit` (silently capping at 10), and the default filter hid the only page because it was a draft, so the control said "publish one first" while a page existed.
- `check-types` 22/22. `fallow` **warn**, zero introduced dead code or complexity.

## Noted, not fixed

`fallow` reports one introduced duplication: the options type and the resolved-config type in `types.ts` mirror each other. It is pre-existing and attributed here because this change edits both halves; converging them would retype every option in the plugin.

The playground now passes `redirectRelationships: { pages: "/{slug}" }`, which is what makes the option reachable there and is how the browser verification above was possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added page-based redirects after form submission.
  - Authors can select redirect pages from configured collections.
  - Supports customizable URL patterns, including document fields and dynamic rules.
  - Redirect URLs are resolved automatically when submissions are processed.
  - Added paginated page selection with loading, retry, and unavailable-item notices.

- **Bug Fixes**
  - Invalid, missing, deleted, or unresolved redirect targets now fail safely without redirecting.
  - Added validation and clearer handling for incomplete redirect settings.
  - Improved save-error messages and handling when redirect configuration cannot be loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->