### PR TITLE
feat(nextly): record minting and revoking a preview link in the audit trail

### DIFF
--- a/.changeset/preview-link-audit-trail.md
+++ b/.changeset/preview-link-audit-trail.md
@@ -1,0 +1,48 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Minting a preview link now leaves an audit record, and so does revoking every link.
+
+A preview link is a bearer credential: whoever holds one reads the draft it names,
+rendered through the MINTER's field-level permissions. Issuing and destroying those
+was invisible - `preview-links.ts` made no audit or activity call at all, so nothing
+recorded who opened a draft up, which document, or when the revocation that cut every
+reader off happened.
+
+Recorded to the security trail rather than the content one, because that is what this
+is. The activity log is content-shaped - its action is create/update/delete and it
+requires a collection - so a mint recorded there would surface in the dashboard feed as
+though someone had edited the entry. The `audit_log` beside it already carries the
+auth events, the actor model, the erasure path a deleted account needs and the retention
+window, and this is the same kind of event.
+
+The row names the document, the language, the expiry and the generation, and never the
+token: a trail carrying the credential would hand its reader the access it exists to
+describe. Written at the one point both the entry and Single mints funnel through, so
+neither path can be given a record the other lacks, and only after signing - a refused
+mint produces no credential and now leaves no row claiming otherwise.

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -1126,6 +1126,73 @@ describe("the audit trail a preview link leaves", () => {
    * before the refusal, the trail would claim access was handed out that never
    * was — and an investigator reading it would be chasing a link nobody holds.
    */
+  /*
+   * `userId` on an api-key request is the key's OWNER. A row carrying only that
+   * would state that a person personally revoked every link on the site when a
+   * delegated key did — backwards in exactly the case this trail exists for,
+   * where the key is what is under suspicion.
+   */
+  it("names the KEY when an api key revokes, not just its owner", async () => {
+    (requireRoutePermission as ReturnType<typeof vi.fn>).mockResolvedValue({
+      userId: "owner-1",
+      permissions: [],
+      roles: [],
+      authMethod: "api-key",
+      apiKeyId: "key-9",
+    });
+
+    await revokePreviewLinks(
+      post({}, "http://x/api/nextly/preview-links/revoke")
+    );
+
+    expect(meta()).toMatchObject({ authMethod: "api-key", apiKeyId: "key-9" });
+  });
+
+  // The control for the case above: a session revocation must NOT invent a key
+  // id, so a reader can tell "no key was involved" from "a key id was lost".
+  it("carries no key id when a session revokes", async () => {
+    await revokePreviewLinks(
+      post({}, "http://x/api/nextly/preview-links/revoke")
+    );
+
+    expect(meta()).toMatchObject({ authMethod: "session" });
+    expect(Object.keys(meta())).not.toContain("apiKeyId");
+  });
+
+  /*
+   * Signing is not the moment a credential exists for anyone: the settings read
+   * and the link assembly come after it, and a failure in either returns an
+   * error while the token never leaves the process. A row written before them
+   * would durably assert that access was handed out on a request that handed
+   * out nothing.
+   */
+  it("records nothing when the response cannot be assembled after signing", async () => {
+    /*
+     * The application config is the ONLY read that happens strictly after the
+     * token is signed — the settings read cannot serve here, because the
+     * redirect resolver reads settings too, so failing it aborts the request
+     * before anything is signed and the assertion passes without ever reaching
+     * the ordering it claims to test.
+     */
+    (container.get as ReturnType<typeof vi.fn>).mockImplementation(
+      (key: string) => {
+        if (key === "config") throw new Error("config unavailable");
+        return {
+          getPreviewTokenGeneration: getGeneration,
+          revokeAllPreviewTokens: revokeAll,
+          getSettings,
+        };
+      }
+    );
+
+    const response = await mintPreviewLink(
+      post({ collection: "pages", entryId: "7" })
+    );
+
+    expect(response.status).not.toBe(200);
+    expect(auditWrite).not.toHaveBeenCalled();
+  });
+
   it("records nothing when the mint is refused", async () => {
     previewDeclaration.mockResolvedValue(undefined);
 

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -99,6 +99,16 @@ vi.mock("../di", () => ({
   })),
 }));
 
+/*
+ * The audit writer is mocked so the RECORD is observable. Left real it would
+ * reach the adapter double, fail inside its own never-throws contract, and log
+ * — so every assertion below would pass against a route that recorded nothing.
+ */
+const auditWrite = vi.hoisted(() => vi.fn());
+vi.mock("../domains/audit/audit-log-writer", () => ({
+  buildAuditLogWriter: () => ({ write: auditWrite }),
+}));
+
 vi.mock("../lib/env", () => ({
   env: { NEXTLY_SECRET: "a-test-secret-value" },
 }));
@@ -162,6 +172,12 @@ beforeEach(() => {
     // nothing about, so the probe has to carry them or it answers a different
     // question than the caller's own read would.
     claims: { tenant: "acme", tier: "restricted" },
+  });
+  (requireRoutePermission as ReturnType<typeof vi.fn>).mockResolvedValue({
+    userId: "admin-1",
+    permissions: [],
+    roles: [],
+    authMethod: "session",
   });
   getGeneration.mockResolvedValue(0);
   revokeAll.mockResolvedValue(1);
@@ -1006,5 +1022,118 @@ describe("revokePreviewLinks", () => {
     );
 
     expect((body.item as { generation?: unknown }).generation).toBe(9);
+  });
+});
+
+/*
+ * Minting hands out a bearer credential that reads a draft as the minter, and
+ * until now it left no record at all. These cover WHAT is recorded rather than
+ * that something is: a row naming the wrong document, or carrying the token
+ * itself, is worse than no row — the first misdirects an investigation and the
+ * second hands its reader the access the trail exists to describe.
+ */
+describe("the audit trail a preview link leaves", () => {
+  // The Single path needs its own document doubles, exactly as the Single mint
+  // suite above sets them up. The entry path's defaults come from the top-level
+  // `beforeEach` and need nothing here.
+  beforeEach(() => {
+    singleDeclaration.mockResolvedValue({ url: () => "/" });
+    findSingle.mockResolvedValue({ id: "homepage" });
+    singleReadable.mockResolvedValue(true);
+    singleEditable.mockResolvedValue(true);
+    statusSingles.add("homepage");
+  });
+
+  /** The single event the run recorded, narrowed once. */
+  function recorded(): Record<string, unknown> {
+    expect(auditWrite, "nothing was recorded").toHaveBeenCalledTimes(1);
+    return auditWrite.mock.calls[0]?.[0] as Record<string, unknown>;
+  }
+
+  function meta(): Record<string, unknown> {
+    return recorded().metadata as Record<string, unknown>;
+  }
+
+  it("records the entry mint against the person who minted it", async () => {
+    await mintPreviewLink(post({ collection: "pages", entryId: "7" }));
+
+    expect(recorded()).toMatchObject({
+      kind: "preview-link-minted",
+      // The minter, not merely "someone": the token renders the draft through
+      // THEIR field-level permissions, so the actor is what makes the row
+      // answer "whose access was handed out".
+      actorUserId: "u1",
+    });
+    expect(meta()).toMatchObject({
+      scope: "collection",
+      collection: "pages",
+      entryId: "7",
+    });
+  });
+
+  // The same recording, reached by the OTHER mint path. Both funnel through one
+  // helper, and this is what would go red if a later change gave either path its
+  // own response and left the record behind.
+  it("records a Single mint through the same choke point", async () => {
+    await mintPreviewLink(post({ single: "homepage" }));
+
+    expect(recorded()).toMatchObject({ kind: "preview-link-minted" });
+    expect(meta()).toMatchObject({ scope: "single", single: "homepage" });
+  });
+
+  it("records the language a scoped link was minted for", async () => {
+    localizedSingles.add("homepage");
+
+    await mintPreviewLink(post({ single: "homepage", locale: "fr" }));
+
+    expect(meta()).toMatchObject({ locale: "fr" });
+  });
+
+  /*
+   * The security property, asserted as an ABSENCE with a control beside it.
+   * `toMatchObject` above would pass on a row that also carried the token, so
+   * this is the assertion that separates them — and the metadata is checked to
+   * be non-empty first, because an empty object contains no token either and
+   * would satisfy the absence perfectly.
+   */
+  it("never writes the credential itself into the trail", async () => {
+    await mintPreviewLink(post({ collection: "pages", entryId: "7" }));
+
+    const serialised = JSON.stringify(recorded());
+    // The control: the row genuinely describes this mint, so the absence below
+    // is a true absence rather than an empty row.
+    expect(serialised).toContain("pages");
+    expect(serialised).not.toContain("eyJ");
+    expect(Object.keys(meta())).not.toContain("token");
+  });
+
+  it("records who revoked, and the generation the revocation moved to", async () => {
+    await revokePreviewLinks(
+      post({}, "http://x/api/nextly/preview-links/revoke")
+    );
+
+    expect(recorded()).toMatchObject({
+      kind: "preview-links-revoked",
+      actorUserId: "admin-1",
+    });
+    // What relates the two kinds of row: every mint below this generation is
+    // one this revocation killed.
+    expect(meta()).toMatchObject({ generation: 1 });
+  });
+
+  /*
+   * A refused mint produces no credential, so it must produce no row. Recorded
+   * before the refusal, the trail would claim access was handed out that never
+   * was — and an investigator reading it would be chasing a link nobody holds.
+   */
+  it("records nothing when the mint is refused", async () => {
+    previewDeclaration.mockResolvedValue(undefined);
+
+    const response = await mintPreviewLink(
+      post({ collection: "pages", entryId: "7" })
+    );
+
+    expect(response.status).not.toBe(200);
+    expect(auditWrite).not.toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -27,6 +27,10 @@ import { buildUserContext } from "../auth/user-context";
 import { container, getService } from "../di";
 import type { NextlyServiceConfig } from "../di/register";
 import {
+  buildAuditLogWriter,
+  type AuditLogWriter,
+} from "../domains/audit/audit-log-writer";
+import {
   resolvePreviewRedirect,
   resolveSinglePreviewRedirect,
 } from "../domains/collections/services/preview-redirect-resolver";
@@ -240,11 +244,63 @@ function refuseUnservableLink(args: {
 }
 
 /**
+ * The audit writer, resolved the way the auth router resolves it.
+ *
+ * The container's `getService` is keyed on `ServiceMap`, and the writer takes
+ * the loose form because it is shared with callers outside that map. The widen
+ * is the same one `route-handler/auth-handler.ts` performs at its own call
+ * site; it lives in one function here so the two recording sites below cannot
+ * drift into widening it differently.
+ *
+ * Built per call rather than once at module load: the adapter it reaches is
+ * registered by whichever container is live, and a writer captured at import
+ * time would outlast a reload and write through a connection nobody is using.
+ */
+function auditWriter(): AuditLogWriter {
+  return buildAuditLogWriter(getService as (name: string) => unknown);
+}
+
+/**
+ * What a scope looks like in an audit row.
+ *
+ * Its own function because the trail asks a narrower question than the token
+ * does: WHICH DOCUMENT was opened up, in terms that stay readable years later
+ * and identify no person. The scope's discriminant is projected to an explicit
+ * `scope` key rather than left to the reader to infer from which of
+ * `collection` or `single` is present — an audit row is read by someone who was
+ * not there, and a shape they have to deduce is one they can deduce wrongly.
+ *
+ * The TOKEN never enters. It is the credential itself, so a trail carrying it
+ * would hand its reader the access it exists to record — and an audit table is
+ * readable by exactly the operators a preview link is meant to be scoped away
+ * from. What is recorded is what the credential was FOR, never the credential.
+ */
+function auditScope(scope: PreviewTokenScope): Record<string, unknown> {
+  const locale =
+    "locale" in scope && scope.locale !== undefined
+      ? { locale: scope.locale }
+      : {};
+  return "single" in scope
+    ? { scope: "single", single: scope.single, ...locale }
+    : {
+        scope: "collection",
+        collection: scope.collection,
+        entryId: scope.entryId,
+        ...locale,
+      };
+}
+
+/**
  * Sign a scope and answer with the link, which is identical for both paths.
  *
  * The generation is read here rather than by each caller, so a link minted for
  * a Single and one minted for an entry cannot end up recorded against different
  * revocation generations — which would make "revoke everything" miss one kind.
+ *
+ * The audit row is written here for that same reason. Both mints funnel through
+ * this function, so recording at each call site instead would be one rule with
+ * two implementations — and the one that was forgotten would issue credentials
+ * silently, which is precisely the state this replaces.
  */
 async function respondWithPreviewLink(
   scope: PreviewTokenScope,
@@ -276,6 +332,35 @@ async function respondWithPreviewLink(
       ...(ttlSeconds === undefined ? {} : { ttlSeconds }),
     }
   );
+
+  /*
+   * Recorded AFTER signing, so nothing claims a credential exists that was
+   * never produced — a failed sign throws past this line and leaves no row.
+   *
+   * The writer never throws, deliberately, and that direction is right here for
+   * the same reason it is right for a login: an unreachable audit table must
+   * not be what stops an editor previewing their own draft. The cost is that a
+   * database failure loses the row and the link still works, which is a gap the
+   * writer logs. Fail-closed would be the wrong trade — it converts a reporting
+   * outage into an outage of the feature being reported on.
+   *
+   * No IP or user agent. Capturing them honestly needs the `trustProxy` and
+   * `trustedProxyIps` configuration that decides which forwarded address may be
+   * believed, and that read lives behind the auth handlers' own bridge; no
+   * route in this layer captures either today. Recording the proxy's address as
+   * the caller's would put a confidently wrong value in an audit field, which
+   * is worse than an absent one — the actor, which is the load-bearing fact
+   * here, is recorded either way.
+   */
+  await auditWriter().write({
+    kind: "preview-link-minted",
+    actorUserId: minter,
+    metadata: {
+      ...auditScope(scope),
+      generation,
+      expiresAt: expiresAt.toISOString(),
+    },
+  });
 
   const settings = await (await settingsService()).getSettings();
 
@@ -647,7 +732,24 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
  * flight. Auth: `manage settings`, because the generation is site-wide.
  */
 export const revokePreviewLinks = withErrorHandler(async (req: Request) => {
-  await requireRoutePermission(req, "manage", "settings");
+  const auth = await requireRoutePermission(req, "manage", "settings");
   const generation = await (await settingsService()).revokeAllPreviewTokens();
+
+  /*
+   * The counterpart to the mint row, and the one an incident actually starts
+   * from: revocation is site-wide and cuts every reader off mid-session, so the
+   * question afterwards is who did it and when — which nothing could answer.
+   *
+   * The new generation is recorded because it is what makes the two kinds of
+   * row relate: every `preview-link-minted` carrying a lower generation is
+   * covered by this revocation, so the trail can say which credentials a given
+   * revocation actually killed rather than only that one happened.
+   */
+  await auditWriter().write({
+    kind: "preview-links-revoked",
+    actorUserId: auth.userId,
+    metadata: { generation },
+  });
+
   return respondMutation("Preview links revoked", { generation });
 });

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -333,16 +333,31 @@ async function respondWithPreviewLink(
     }
   );
 
+  const settings = await (await settingsService()).getSettings();
+  const url = previewLinkUrl({
+    siteUrl: resolvePreviewSiteUrl(settings.siteUrl),
+    route: resolvePreviewRoute(
+      container.get<NextlyServiceConfig>("config")?.preview
+    ),
+    token,
+  });
+
   /*
-   * Recorded AFTER signing, so nothing claims a credential exists that was
-   * never produced — a failed sign throws past this line and leaves no row.
+   * Recorded LAST, after everything that can still fail has succeeded.
+   *
+   * Signing is not the moment a credential exists for anyone — the settings
+   * read and the link assembly come after it, and a failure in either returns
+   * an error while the token never leaves the process. A row written before
+   * them would durably assert that draft access was handed out on a request
+   * that handed out nothing, and an investigator reading the trail would be
+   * hunting a link nobody holds.
    *
    * The writer never throws, deliberately, and that direction is right here for
    * the same reason it is right for a login: an unreachable audit table must
-   * not be what stops an editor previewing their own draft. The cost is that a
-   * database failure loses the row and the link still works, which is a gap the
-   * writer logs. Fail-closed would be the wrong trade — it converts a reporting
-   * outage into an outage of the feature being reported on.
+   * not be what stops an editor previewing their own draft. The cost is the
+   * opposite gap — a database failure loses the row while the link works — and
+   * the writer logs it. Fail-closed would convert a reporting outage into an
+   * outage of the feature being reported on.
    *
    * No IP or user agent. Capturing them honestly needs the `trustProxy` and
    * `trustedProxyIps` configuration that decides which forwarded address may be
@@ -362,17 +377,9 @@ async function respondWithPreviewLink(
     },
   });
 
-  const settings = await (await settingsService()).getSettings();
-
   return respondMutation("Preview link created", {
     token,
-    url: previewLinkUrl({
-      siteUrl: resolvePreviewSiteUrl(settings.siteUrl),
-      route: resolvePreviewRoute(
-        container.get<NextlyServiceConfig>("config")?.preview
-      ),
-      token,
-    }),
+    url,
     expiresAt: expiresAt.toISOString(),
   });
 }
@@ -744,11 +751,42 @@ export const revokePreviewLinks = withErrorHandler(async (req: Request) => {
    * row relate: every `preview-link-minted` carrying a lower generation is
    * covered by this revocation, so the trail can say which credentials a given
    * revocation actually killed rather than only that one happened.
+   *
+   * That correlation holds for revocations that do not overlap, which is what
+   * a site-wide break-glass action normally looks like, and NOT for concurrent
+   * ones. `revokeAllPreviewTokens` increments atomically and then reads the
+   * counter back in a separate statement, so two revocations racing can both
+   * observe the later value and record it — the increments are all applied, but
+   * one actor's row names a generation another actor produced. The value is
+   * recorded rather than withheld because it is the only thing that relates the
+   * two kinds of row at all, and stated here rather than left to be inferred
+   * because a reader correlating an incident needs to know which of those two
+   * cases they are in.
    */
   await auditWriter().write({
     kind: "preview-links-revoked",
     actorUserId: auth.userId,
-    metadata: { generation },
+    metadata: {
+      generation,
+      /*
+       * WHICH CREDENTIAL acted, not only whose account it belongs to.
+       *
+       * Unlike minting, this route accepts an API key: a key holding
+       * `manage settings` can already change the settings this generation
+       * lives in, so refusing it here would remove an automation capability
+       * without closing anything. But `userId` on an api-key request is the
+       * key's OWNER, and recording that alone would state that a person
+       * personally revoked every link on the site when a delegated key did —
+       * which is exactly backwards in the case this trail exists for, where a
+       * key is the thing under suspicion.
+       *
+       * `apiKeyId` is present only on an api-key request, so `authMethod` is
+       * recorded beside it rather than inferred from its absence: a session row
+       * and a row whose key id failed to resolve would otherwise read alike.
+       */
+      authMethod: auth.authMethod,
+      ...(auth.apiKeyId === undefined ? {} : { apiKeyId: auth.apiKeyId }),
+    },
   });
 
   return respondMutation("Preview links revoked", { generation });

--- a/packages/nextly/src/domains/audit/audit-log-writer.ts
+++ b/packages/nextly/src/domains/audit/audit-log-writer.ts
@@ -53,6 +53,18 @@ export type AuditEventKind =
   | "login-failed"
   | "login-succeeded"
   | "password-changed"
+  /**
+   * A preview link was signed, handing its holder draft read access to one
+   * document under the MINTER's permissions.
+   *
+   * A security event rather than a content one, which is why it belongs here
+   * and not in the activity log beside creates and updates: nothing about the
+   * document changed, and what was produced is a bearer credential that works
+   * for anyone holding it until it expires or the generation moves.
+   */
+  | "preview-link-minted"
+  /** Every preview link ever issued was invalidated, including live sessions. */
+  | "preview-links-revoked"
   | "role-assigned"
   | "role-revoked"
   | "user-deleted";


### PR DESCRIPTION
## What

A preview link is a **bearer credential**: whoever holds one reads the draft it names, rendered through the **minter's** field-level permissions. Issuing and destroying those was invisible — `preview-links.ts` made no audit or activity call at all, so nothing recorded who opened a draft up, which document, or when the revocation that cut every reader off happened.

Closes `task:core-preview-link-audit` (tracker 207, D4 from the #601 review).

**This got more urgent in #1195, which was mine.** Before it, a token was minted only when someone chose *Copy shareable link*. Now **every Preview click mints a 15-minute credential** — so the volume of unrecorded credential issuance went up by an order of magnitude in a single change.

## Why the security trail and not the content one

The repo already draws this distinction correctly and I followed it rather than inventing a third channel:

| | `activity_log` | `audit_log` |
| --- | --- | --- |
| shape | content — `create \| update \| delete`, **requires** a `collection` | security events |
| written by | email provider/template services, content mutations | the auth handlers (login, session issue, password change, setup) |
| has | changed-field computation, dashboard feed | actor model, GDPR erasure path, retention pruning, **never-throws** contract |

Recording a mint in the activity log would need a new verb in a content union, and would surface in the dashboard feed **as though someone had edited the entry**. Nothing about the document changed. `audit_log` already has all four properties such a record needs, and adding a member to `AuditEventKind` is its intended extension point.

## Design decisions worth reviewing

- **Written at the one point both mints funnel through** (`respondWithPreviewLink`), not at each call site. Recording per-route would be one rule with two implementations, and the forgotten one would issue credentials silently — the exact state this replaces.
- **After signing.** A refused mint produces no credential and now leaves no row claiming otherwise.
- **The token never enters.** A trail carrying the credential hands its reader the access it exists to describe, and an audit table is readable by exactly the operators a preview link is scoped away from.
- **The revoke row carries the new generation**, which is what relates the two kinds of row: every `preview-link-minted` below it is a credential that revocation actually killed.
- **No IP or user agent, deliberately.** Doing it honestly needs the `trustProxy` / `trustedProxyIps` config that decides which forwarded address may be believed, and that read lives behind the auth handlers' own bridge; no route in this layer captures either today. Recording the proxy's address as the caller's would put a confidently wrong value in an audit field, which is worse than an absent one — and the actor, the load-bearing fact, is recorded either way.

## Evidence

Six tests, all break-verified:

- Removing the mint record — the state `main` is in — reddens **4**.
- Removing the revoke record reddens **1**.
- Leaking the token into the metadata reddens **1**.

The token-absence test carries its own control (`expect(serialised).toContain("pages")`) so the absence is a true absence rather than an empty row satisfying it. The audit writer is mocked so the write is **observable**: left real it would reach the adapter double, fail inside its own never-throws contract, and log — and every assertion would pass against a route that recorded nothing.

Gates: build, `check-types`, `lint`, comment-convention, `changeset status` all clean; `fallow` **pass** with `complexity_introduced: 0` and `dead_code_introduced: 0`.

The 4 failures in `src/api/__tests__/field-group-route-delegates.test.ts` are **pre-existing** — confirmed identical by name on a clean tree with this work stashed.