### PR TITLE
feat(nextly): let the auth rate limiter keep its window in a shared store

### DIFF
--- a/.changeset/auth-rate-limit-can-be-shared.md
+++ b/.changeset/auth-rate-limit-can-be-shared.md
@@ -1,0 +1,40 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Rate limiting on the login and API-key paths kept its counters in the memory of
+whichever process handled the request. On a deployment that runs more than one
+instance — which is the normal way to run a Next.js app — every instance kept
+its own count, so a limit of five attempts became five per instance, and the
+number of instances is decided by the platform rather than by anyone.
+
+The limit that protects sign-in was therefore looser than configured, quietly,
+and most so under heavy traffic.
+
+The window can now be kept somewhere both instances can see. Supply a store on
+the rate limit config and the login and API-key limits are counted once for the
+whole deployment. Change nothing and the behaviour is exactly as before.

--- a/packages/nextly/src/auth/handlers/deps-bridge.ts
+++ b/packages/nextly/src/auth/handlers/deps-bridge.ts
@@ -16,6 +16,7 @@ import { buildAuditLogWriter } from "../../domains/audit/audit-log-writer";
 import { NextlyError } from "../../errors";
 import { getHookRegistry } from "../../hooks/hook-registry";
 import { env } from "../../lib/env";
+import type { RateLimitStore } from "../../middleware/rate-limit";
 import { createPluginContext } from "../../plugins/plugin-context";
 import type { AuthUser } from "../../types/auth";
 import { parseTrustedProxyIpsEnv } from "../../utils/get-trusted-client-ip";
@@ -579,10 +580,22 @@ function readTrustProxy(getService: (name: string) => unknown): boolean {
 function readAuthRateLimit(getService: (name: string) => unknown): {
   requestsPerHour: number;
   windowMs: number;
+  store?: RateLimitStore;
 } {
   const fallback = { requestsPerHour: 30, windowMs: 3_600_000 };
   try {
     const config = getService("config");
+    // The window's home, read from a DIFFERENT block than the numbers: the
+    // limits are security config, the store is rate-limit config, and one app
+    // has one store. Read before the early returns below so a deployment that
+    // configures a store but leaves the auth limits at their defaults still
+    // gets a shared window — the case that would otherwise look configured and
+    // behave per-process.
+    const store =
+      config && typeof config === "object" && "rateLimit" in config
+        ? (config as { rateLimit?: { store?: RateLimitStore } }).rateLimit
+            ?.store
+        : undefined;
     if (config && typeof config === "object" && "security" in config) {
       const security = (config as { security?: unknown }).security;
       if (
@@ -604,10 +617,11 @@ function readAuthRateLimit(getService: (name: string) => unknown): {
             typeof arl?.windowMs === "number"
               ? arl.windowMs
               : fallback.windowMs,
+          ...(store === undefined ? {} : { store }),
         };
       }
     }
-    return fallback;
+    return { ...fallback, ...(store === undefined ? {} : { store }) };
   } catch {
     return fallback;
   }

--- a/packages/nextly/src/auth/handlers/deps-bridge.ts
+++ b/packages/nextly/src/auth/handlers/deps-bridge.ts
@@ -577,6 +577,33 @@ function readTrustProxy(getService: (name: string) => unknown): boolean {
  * DI container. Falls back to the default 30 req/IP/hour, 1-hour window
  * when unset or the container is not yet initialised.
  */
+/**
+ * A nested object off the DI config, or `undefined` when it is not there.
+ *
+ * The config service is `unknown` at this boundary — the bridge deliberately
+ * does not import its type — so every read is a shape check. Doing that once
+ * here rather than inline at each level is what keeps the reader below flat:
+ * the same three checks repeated per level is where this function's complexity
+ * came from, not the number of values it reads.
+ */
+function configBlock(
+  source: unknown,
+  key: string
+): Record<string, unknown> | undefined {
+  if (source === null || typeof source !== "object" || !(key in source)) {
+    return undefined;
+  }
+  const value = (source as Record<string, unknown>)[key];
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/** A configured number, or the fallback when it is absent or the wrong type. */
+function numberOr(value: unknown, fallback: number): number {
+  return typeof value === "number" ? value : fallback;
+}
+
 function readAuthRateLimit(getService: (name: string) => unknown): {
   requestsPerHour: number;
   windowMs: number;
@@ -585,43 +612,28 @@ function readAuthRateLimit(getService: (name: string) => unknown): {
   const fallback = { requestsPerHour: 30, windowMs: 3_600_000 };
   try {
     const config = getService("config");
-    // The window's home, read from a DIFFERENT block than the numbers: the
-    // limits are security config, the store is rate-limit config, and one app
-    // has one store. Read before the early returns below so a deployment that
-    // configures a store but leaves the auth limits at their defaults still
-    // gets a shared window — the case that would otherwise look configured and
-    // behave per-process.
-    const store =
-      config && typeof config === "object" && "rateLimit" in config
-        ? (config as { rateLimit?: { store?: RateLimitStore } }).rateLimit
-            ?.store
-        : undefined;
-    if (config && typeof config === "object" && "security" in config) {
-      const security = (config as { security?: unknown }).security;
-      if (
-        security &&
-        typeof security === "object" &&
-        "authRateLimit" in security
-      ) {
-        const arl = (
-          security as {
-            authRateLimit?: { requestsPerHour?: unknown; windowMs?: unknown };
-          }
-        ).authRateLimit;
-        return {
-          requestsPerHour:
-            typeof arl?.requestsPerHour === "number"
-              ? arl.requestsPerHour
-              : fallback.requestsPerHour,
-          windowMs:
-            typeof arl?.windowMs === "number"
-              ? arl.windowMs
-              : fallback.windowMs,
-          ...(store === undefined ? {} : { store }),
-        };
-      }
-    }
-    return { ...fallback, ...(store === undefined ? {} : { store }) };
+
+    // The limits and the store come from DIFFERENT blocks: the numbers are
+    // security config, the window's home is rate-limit config, and one app has
+    // one store. Read independently so a deployment that configures a store but
+    // leaves the auth limits at their defaults still gets a shared window — the
+    // case that would otherwise look configured and behave per-process.
+    const store = configBlock(config, "rateLimit")?.["store"] as
+      | RateLimitStore
+      | undefined;
+    const limits = configBlock(
+      configBlock(config, "security"),
+      "authRateLimit"
+    );
+
+    return {
+      requestsPerHour: numberOr(
+        limits?.["requestsPerHour"],
+        fallback.requestsPerHour
+      ),
+      windowMs: numberOr(limits?.["windowMs"], fallback.windowMs),
+      ...(store === undefined ? {} : { store }),
+    };
   } catch {
     return fallback;
   }

--- a/packages/nextly/src/auth/handlers/router.ts
+++ b/packages/nextly/src/auth/handlers/router.ts
@@ -1,7 +1,8 @@
 import type { AuditLogWriter } from "../../domains/audit/audit-log-writer";
+import type { RateLimitStore } from "../../middleware/rate-limit";
 import type { PluginContext } from "../../plugins/plugin-context";
 import { getTrustedClientIp } from "../../utils/get-trusted-client-ip";
-import { rateLimiter } from "../middleware/rate-limiter";
+import { authRateLimiter } from "../middleware/rate-limiter";
 import type { ChallengeRegistry } from "../pipeline/challenge";
 import type { AuthHookRegistry } from "../pipeline/hooks";
 import type { AuthStrategy } from "../pipeline/types";
@@ -89,6 +90,12 @@ export interface AuthRouterDeps {
   authRateLimit: {
     requestsPerHour: number;
     windowMs: number;
+    /**
+     * Where the window lives. Absent means this process's memory, which is
+     * correct for one instance and wrong by a factor of the instance count
+     * anywhere else — see `auth/middleware/rate-limiter`.
+     */
+    store?: RateLimitStore;
   };
   /**
    * Writer for security-sensitive auth events. Handlers call
@@ -252,7 +259,7 @@ async function dispatchAuthRequest(
 
   if (method === "POST") {
     if (RATE_LIMITED_AUTH_PATHS.has(authPath)) {
-      const limited = checkAuthIpRateLimit(request, deps);
+      const limited = await checkAuthIpRateLimit(request, deps);
       if (limited) return limited;
     }
     return auditCsrfFailure(request, authPath, deps, () => {
@@ -373,10 +380,10 @@ async function auditCsrfFailure(
  * intentional, since the alternative (skip the limiter) leaves the
  * deployment open to credential-stuffing.
  */
-function checkAuthIpRateLimit(
+async function checkAuthIpRateLimit(
   request: Request,
   deps: AuthRouterDeps
-): Response | null {
+): Promise<Response | null> {
   const limit = deps.authRateLimit.requestsPerHour;
   if (limit <= 0) return null; // explicitly disabled
 
@@ -386,7 +393,7 @@ function checkAuthIpRateLimit(
       trustedProxyIps: deps.trustedProxyIps,
     }) ?? "unknown";
 
-  const result = rateLimiter.check(
+  const result = await authRateLimiter(deps.authRateLimit.store).check(
     `auth-ip:${ip}`,
     limit,
     deps.authRateLimit.windowMs

--- a/packages/nextly/src/auth/middleware/__tests__/rate-limiter.test.ts
+++ b/packages/nextly/src/auth/middleware/__tests__/rate-limiter.test.ts
@@ -99,73 +99,93 @@ describe("the store seam", () => {
     // store, this would pass as `true` and the seam would be decorative.
     const calls: string[] = [];
     const alwaysOver: RateLimitStore = {
-      async increment(key: string): Promise<RateLimitRecord> {
+      increment(key: string): Promise<RateLimitRecord> {
         calls.push(key);
-        return { count: 999, resetTime: Date.now() + WINDOW };
+        return Promise.resolve({ count: 999, resetTime: Date.now() + WINDOW });
       },
-      async reset(): Promise<void> {},
+      reset(): Promise<void> {
+        return Promise.resolve();
+      },
     };
 
-    const limiter = new RateLimiter(alwaysOver);
-    const result = await limiter.check("k", 100, WINDOW);
+    const result = await new RateLimiter(alwaysOver).check("k", 100, WINDOW);
 
     expect(result.allowed).toBe(false);
     expect(calls).toEqual(["k"]);
   });
 
-  it("still refuses when a store cannot take an increment back", async () => {
-    // `decrement` is optional. A store that omits it must not crash the
-    // request path — the attempt simply stays counted, which is the safe
-    // direction to degrade in.
-    const noDecrement: RateLimitStore = {
-      async increment(): Promise<RateLimitRecord> {
-        return { count: 5, resetTime: Date.now() + WINDOW };
+  it("prefers the store's ATOMIC decision over counting itself", async () => {
+    // The store says allowed while the count is far over the limit. Only a
+    // limiter that defers to `consume` produces `true` here; one that re-derived
+    // the verdict from `count` would say false. That is the point — the store
+    // owns the decision because only it can make it atomic.
+    const store: RateLimitStore = {
+      increment(): Promise<RateLimitRecord> {
+        throw new Error("increment must not be used when consume exists");
       },
-      async reset(): Promise<void> {},
+      reset(): Promise<void> {
+        return Promise.resolve();
+      },
+      consume(): Promise<RateLimitRecord & { allowed: boolean }> {
+        return Promise.resolve({
+          allowed: true,
+          count: 500,
+          resetTime: Date.now() + WINDOW,
+        });
+      },
     };
 
-    const limiter = new RateLimiter(noDecrement);
-    await expect(limiter.check("k", 1, WINDOW)).resolves.toMatchObject({
-      allowed: false,
-    });
+    await expect(
+      new RateLimiter(store).check("k", 1, WINDOW)
+    ).resolves.toMatchObject({ allowed: true });
   });
 
-  it("takes the increment back on refusal when the store supports it", async () => {
-    // Asserted on the STORE rather than on a later allow, so it cannot pass
-    // because the window happened to be long enough.
-    const decremented: string[] = [];
-    const store: RateLimitStore = {
-      async increment(): Promise<RateLimitRecord> {
-        return { count: 9, resetTime: Date.now() + WINDOW };
+  it("falls back to counting every attempt when the store is not atomic", async () => {
+    // A store without `consume` gets the stricter path: refused attempts count.
+    // Asserted as a REFUSAL at the boundary rather than as an absence, so it
+    // cannot pass against a limiter that allows everything.
+    let count = 0;
+    const notAtomic: RateLimitStore = {
+      increment(): Promise<RateLimitRecord> {
+        count += 1;
+        return Promise.resolve({ count, resetTime: Date.now() + WINDOW });
       },
-      async reset(): Promise<void> {},
-      async decrement(key: string): Promise<void> {
-        decremented.push(key);
+      reset(): Promise<void> {
+        return Promise.resolve();
       },
     };
 
-    const limiter = new RateLimiter(store);
+    const limiter = new RateLimiter(notAtomic);
+    expect((await limiter.check("k", 2, WINDOW)).allowed).toBe(true);
+    expect((await limiter.check("k", 2, WINDOW)).allowed).toBe(true);
+    expect((await limiter.check("k", 2, WINDOW)).allowed).toBe(false);
+  });
+
+  it("never asks a store to take an increment back", async () => {
+    // The property that closes the cross-window erasure: a rollback issued in
+    // one window can land in the next and delete an attempt that WAS budgeted,
+    // admitting excess logins right at a reset boundary. There is no rollback
+    // to mistime, and this fails if one is reintroduced.
+    const store = new SlidingWindowMemoryStore();
+    expect("decrement" in store).toBe(false);
+
+    // The control: the object is not simply empty — the methods it should have
+    // are present, so the absence above is meaningful.
+    expect(typeof store.consume).toBe("function");
+    expect(typeof store.increment).toBe("function");
+  });
+
+  it("keeps sliding while every attempt is being refused", async () => {
+    // A refused attempt is not recorded, but the window must still drain. If
+    // the store returned early on refusal without keeping the pruned array, an
+    // exhausted key would never recover.
+    const limiter = new RateLimiter(new SlidingWindowMemoryStore());
     await limiter.check("k", 1, WINDOW);
-    expect(decremented).toEqual(["k"]);
-  });
 
-  it("does NOT take it back when the request was allowed", async () => {
-    // The mirror of the case above. Without it, a limiter that decremented on
-    // every call would pass the previous test and silently never count anything.
-    const decremented: string[] = [];
-    const store: RateLimitStore = {
-      async increment(): Promise<RateLimitRecord> {
-        return { count: 1, resetTime: Date.now() + WINDOW };
-      },
-      async reset(): Promise<void> {},
-      async decrement(key: string): Promise<void> {
-        decremented.push(key);
-      },
-    };
+    vi.advanceTimersByTime(WINDOW / 2);
+    expect((await limiter.check("k", 1, WINDOW)).allowed).toBe(false);
 
-    const limiter = new RateLimiter(store);
-    const result = await limiter.check("k", 10, WINDOW);
-    expect(result.allowed).toBe(true);
-    expect(decremented).toEqual([]);
+    vi.advanceTimersByTime(WINDOW / 2 + 1);
+    expect((await limiter.check("k", 1, WINDOW)).allowed).toBe(true);
   });
 });

--- a/packages/nextly/src/auth/middleware/__tests__/rate-limiter.test.ts
+++ b/packages/nextly/src/auth/middleware/__tests__/rate-limiter.test.ts
@@ -1,0 +1,171 @@
+/**
+ * The auth limiter's numbers must not change, and its store must be reachable.
+ *
+ * Two separate claims, and each needs its own control. "The default still
+ * behaves as it did" is satisfied by a limiter that never refuses anything, so
+ * every test below also shows a refusal at the configured limit. "A store can
+ * be supplied" is satisfied by a limiter that ignores the store and happens to
+ * agree with it, so the injected store here DISAGREES with what memory would
+ * have said.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  RateLimitRecord,
+  RateLimitStore,
+} from "../../../middleware/rate-limit";
+import { RateLimiter } from "../rate-limiter";
+import { SlidingWindowMemoryStore } from "../sliding-window-store";
+
+const WINDOW = 60_000;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("the default in-memory path", () => {
+  it("allows exactly the limit and refuses the next", async () => {
+    const limiter = new RateLimiter(new SlidingWindowMemoryStore());
+
+    const allowed = [];
+    for (let i = 0; i < 3; i++) {
+      allowed.push((await limiter.check("k", 3, WINDOW)).allowed);
+    }
+    // The population control. Without it, `refused` below would pass against a
+    // limiter that refuses EVERYTHING — which is also not the old behaviour.
+    expect(allowed).toEqual([true, true, true]);
+
+    const refused = await limiter.check("k", 3, WINDOW);
+    expect(refused.allowed).toBe(false);
+    expect(refused.remaining).toBe(0);
+  });
+
+  it("counts down `remaining` as budget is spent", async () => {
+    const limiter = new RateLimiter(new SlidingWindowMemoryStore());
+    expect((await limiter.check("k", 3, WINDOW)).remaining).toBe(2);
+    expect((await limiter.check("k", 3, WINDOW)).remaining).toBe(1);
+    expect((await limiter.check("k", 3, WINDOW)).remaining).toBe(0);
+  });
+
+  it("slides: budget returns once the oldest entry ages out", async () => {
+    const limiter = new RateLimiter(new SlidingWindowMemoryStore());
+    await limiter.check("k", 1, WINDOW);
+    expect((await limiter.check("k", 1, WINDOW)).allowed).toBe(false);
+
+    vi.advanceTimersByTime(WINDOW + 1);
+    expect((await limiter.check("k", 1, WINDOW)).allowed).toBe(true);
+  });
+
+  it("does not let a refused attempt extend its own window", async () => {
+    // The property `decrement` exists for. Without it a caller who keeps
+    // hammering keeps pushing the window forward and can never drain it — a
+    // self-inflicted permanent lockout, and a denial-of-service an attacker
+    // can aim at someone else's key.
+    const limiter = new RateLimiter(new SlidingWindowMemoryStore());
+    await limiter.check("k", 1, WINDOW); // fills the budget at t0
+
+    // Hammer for most of the window. Each is refused, and none may count.
+    vi.advanceTimersByTime(WINDOW - 1_000);
+    for (let i = 0; i < 5; i++) {
+      expect((await limiter.check("k", 1, WINDOW)).allowed).toBe(false);
+    }
+
+    // t0's entry now ages out. If the refusals had been recorded, the window
+    // would still be full and this would be refused.
+    vi.advanceTimersByTime(1_001);
+    expect((await limiter.check("k", 1, WINDOW)).allowed).toBe(true);
+  });
+
+  it("reports resetAt as the moment the oldest entry ages out", async () => {
+    const limiter = new RateLimiter(new SlidingWindowMemoryStore());
+    const first = await limiter.check("k", 2, WINDOW);
+    expect(first.resetAt.getTime()).toBe(Date.now() + WINDOW);
+
+    vi.advanceTimersByTime(10_000);
+    const second = await limiter.check("k", 2, WINDOW);
+    // Still keyed to the FIRST entry, which is what ages out first.
+    expect(second.resetAt.getTime()).toBe(Date.now() - 10_000 + WINDOW);
+  });
+});
+
+describe("the store seam", () => {
+  it("uses a supplied store instead of process memory", async () => {
+    // Deliberately DISAGREES with memory: it refuses the very first request,
+    // which the in-memory store would have allowed. If the limiter ignored the
+    // store, this would pass as `true` and the seam would be decorative.
+    const calls: string[] = [];
+    const alwaysOver: RateLimitStore = {
+      async increment(key: string): Promise<RateLimitRecord> {
+        calls.push(key);
+        return { count: 999, resetTime: Date.now() + WINDOW };
+      },
+      async reset(): Promise<void> {},
+    };
+
+    const limiter = new RateLimiter(alwaysOver);
+    const result = await limiter.check("k", 100, WINDOW);
+
+    expect(result.allowed).toBe(false);
+    expect(calls).toEqual(["k"]);
+  });
+
+  it("still refuses when a store cannot take an increment back", async () => {
+    // `decrement` is optional. A store that omits it must not crash the
+    // request path — the attempt simply stays counted, which is the safe
+    // direction to degrade in.
+    const noDecrement: RateLimitStore = {
+      async increment(): Promise<RateLimitRecord> {
+        return { count: 5, resetTime: Date.now() + WINDOW };
+      },
+      async reset(): Promise<void> {},
+    };
+
+    const limiter = new RateLimiter(noDecrement);
+    await expect(limiter.check("k", 1, WINDOW)).resolves.toMatchObject({
+      allowed: false,
+    });
+  });
+
+  it("takes the increment back on refusal when the store supports it", async () => {
+    // Asserted on the STORE rather than on a later allow, so it cannot pass
+    // because the window happened to be long enough.
+    const decremented: string[] = [];
+    const store: RateLimitStore = {
+      async increment(): Promise<RateLimitRecord> {
+        return { count: 9, resetTime: Date.now() + WINDOW };
+      },
+      async reset(): Promise<void> {},
+      async decrement(key: string): Promise<void> {
+        decremented.push(key);
+      },
+    };
+
+    const limiter = new RateLimiter(store);
+    await limiter.check("k", 1, WINDOW);
+    expect(decremented).toEqual(["k"]);
+  });
+
+  it("does NOT take it back when the request was allowed", async () => {
+    // The mirror of the case above. Without it, a limiter that decremented on
+    // every call would pass the previous test and silently never count anything.
+    const decremented: string[] = [];
+    const store: RateLimitStore = {
+      async increment(): Promise<RateLimitRecord> {
+        return { count: 1, resetTime: Date.now() + WINDOW };
+      },
+      async reset(): Promise<void> {},
+      async decrement(key: string): Promise<void> {
+        decremented.push(key);
+      },
+    };
+
+    const limiter = new RateLimiter(store);
+    const result = await limiter.check("k", 10, WINDOW);
+    expect(result.allowed).toBe(true);
+    expect(decremented).toEqual([]);
+  });
+});

--- a/packages/nextly/src/auth/middleware/index.ts
+++ b/packages/nextly/src/auth/middleware/index.ts
@@ -18,7 +18,7 @@ import {
 // to the new jose-based session/get-session.ts module internally.
 import { getSession } from "../session";
 
-import { rateLimiter } from "./rate-limiter";
+import { authRateLimiter } from "./rate-limiter";
 
 /** Fallback maximum requests per sliding window (1 000 req/hour). */
 const DEFAULT_RATE_LIMIT = 1_000;
@@ -252,7 +252,15 @@ export async function requireApiKeyAuth(
   const resolvedWindowMs =
     cfg?.apiKeys?.rateLimit.windowMs ?? DEFAULT_RATE_WINDOW_MS;
 
-  const rl = rateLimiter.check(keyAuth.id, resolvedLimit, resolvedWindowMs);
+  // Resolved per request rather than captured at import: config is registered
+  // after this module loads, so a limiter bound at module scope would be the
+  // in-memory one forever — and only in production, where boot order differs
+  // from a test's.
+  const rl = await authRateLimiter(cfg?.rateLimit?.store).check(
+    keyAuth.id,
+    resolvedLimit,
+    resolvedWindowMs
+  );
   if (!rl.allowed) {
     const retryAfterSecs = Math.ceil(
       (rl.resetAt.getTime() - Date.now()) / 1000

--- a/packages/nextly/src/auth/middleware/index.ts
+++ b/packages/nextly/src/auth/middleware/index.ts
@@ -172,6 +172,45 @@ export interface AuthContext {
 }
 
 /**
+ * The 429 an API key has earned, or `null` when it is still within budget.
+ *
+ * Extracted so the decision — read config, ask the limiter, shape the refusal —
+ * is one thing in one place rather than a third of `requireApiKeyAuth`.
+ *
+ * The limiter is resolved per call rather than captured at import: config is
+ * registered after this module loads, so one bound at module scope would be the
+ * in-memory limiter forever — silently, and only in production, where boot
+ * order differs from a test's.
+ */
+async function apiKeyRateLimitRefusal(
+  keyId: string
+): Promise<ErrorResponse | null> {
+  const cfg = getConfig();
+  const limit = cfg?.apiKeys?.rateLimit.requestsPerHour ?? DEFAULT_RATE_LIMIT;
+  const windowMs = cfg?.apiKeys?.rateLimit.windowMs ?? DEFAULT_RATE_WINDOW_MS;
+
+  const rl = await authRateLimiter(cfg?.rateLimit?.store).check(
+    keyId,
+    limit,
+    windowMs
+  );
+  if (rl.allowed) return null;
+
+  return createErrorResponse(
+    429,
+    "Too Many Requests",
+    "Rate limit exceeded for this API key",
+    {
+      "Retry-After": String(
+        Math.ceil((rl.resetAt.getTime() - Date.now()) / 1000)
+      ),
+      "X-RateLimit-Limit": String(limit),
+      "X-RateLimit-Remaining": "0",
+    }
+  );
+}
+
+/**
  * API key authentication middleware.
  *
  * Validates an `Authorization: Bearer nx_live_...` header and resolves the
@@ -246,36 +285,8 @@ export async function requireApiKeyAuth(
   // 4. Rate limit check — enforced after auth, before permission resolution.
   //    Limits come from defineConfig().apiKeys.rateLimit when available;
   //    module-level constants are the fallback for unconfigured deployments.
-  const cfg = getConfig();
-  const resolvedLimit =
-    cfg?.apiKeys?.rateLimit.requestsPerHour ?? DEFAULT_RATE_LIMIT;
-  const resolvedWindowMs =
-    cfg?.apiKeys?.rateLimit.windowMs ?? DEFAULT_RATE_WINDOW_MS;
-
-  // Resolved per request rather than captured at import: config is registered
-  // after this module loads, so a limiter bound at module scope would be the
-  // in-memory one forever — and only in production, where boot order differs
-  // from a test's.
-  const rl = await authRateLimiter(cfg?.rateLimit?.store).check(
-    keyAuth.id,
-    resolvedLimit,
-    resolvedWindowMs
-  );
-  if (!rl.allowed) {
-    const retryAfterSecs = Math.ceil(
-      (rl.resetAt.getTime() - Date.now()) / 1000
-    );
-    return createErrorResponse(
-      429,
-      "Too Many Requests",
-      "Rate limit exceeded for this API key",
-      {
-        "Retry-After": String(retryAfterSecs),
-        "X-RateLimit-Limit": String(resolvedLimit),
-        "X-RateLimit-Remaining": "0",
-      }
-    );
-  }
+  const overLimit = await apiKeyRateLimitRefusal(keyAuth.id);
+  if (overLimit) return overLimit;
 
   // 5. Resolve effective permissions and roles for this token type
   const [permissions, roles] = await Promise.all([

--- a/packages/nextly/src/auth/middleware/rate-limiter.ts
+++ b/packages/nextly/src/auth/middleware/rate-limiter.ts
@@ -1,27 +1,23 @@
 /**
- * API Key Rate Limiter
+ * Rate limiting for the credential paths: auth writes and API keys.
  *
- * Lightweight in-memory sliding-window rate limiter scoped to API key IDs.
- * Each key tracks its own sliding window of request timestamps; old entries
- * are pruned on every `check()` call so the array stays bounded at `limit`
- * entries; no background cleanup interval is needed.
+ * Sliding-window, keyed by API key id or by client IP. The window itself lives
+ * in a {@link RateLimitStore}, so a deployment that spans more than one process
+ * can supply a shared one and have the limit mean what it says.
  *
- * Intended for per-key rate limiting of API key authenticated requests.
- * Session-based requests are not rate-limited by this module.
+ * **Why that matters more here than on the REST limiter.** This is what stands
+ * between an attacker and a login form. With per-process state on a serverless
+ * deployment, every instance holds its own window and the effective limit
+ * becomes `configured × instances` — a number the operator never chose and
+ * cannot see. It fails OPEN, and only under load, which is what an attack looks
+ * like.
  *
  * @module auth/middleware/rate-limiter
- * @since 1.0.0
- *
- * @example
- * ```typescript
- * import { rateLimiter } from './rate-limiter';
- *
- * const result = rateLimiter.check(keyId, 1000, 3_600_000);
- * if (!result.allowed) {
- *   // return 429 with Retry-After header
- * }
- * ```
  */
+
+import type { RateLimitStore } from "../../middleware/rate-limit";
+
+import { SlidingWindowMemoryStore } from "./sliding-window-store";
 
 /**
  * Result of a sliding-window rate limit check.
@@ -31,97 +27,90 @@ export interface RateLimitCheckResult {
   allowed: boolean;
   /** Number of requests remaining in the current window. */
   remaining: number;
-  /** The Date at which the oldest in-window timestamp expires and the window slides forward. */
+  /** When the oldest in-window entry expires and the window slides forward. */
   resetAt: Date;
 }
 
 /**
- * In-memory sliding-window rate limiter keyed by API key ID.
+ * A rate limiter over some store.
  *
- * Each key maintains a sorted array of request timestamps (ms since epoch).
- * On every `check()` call:
- * 1. Timestamps older than `windowMs` are dropped.
- * 2. The remaining count is compared against `limit`.
- * 3. If allowed, the current timestamp is appended (keeping the array bounded).
- *
- * Memory is bounded: the array for any given key never exceeds `limit` entries
- * because entries are only added when the request is allowed.
- *
- * This class is safe to use as a module-level singleton within a single
- * Node.js process. For multi-instance deployments (serverless / multi-pod),
- * rate limit state is not shared across processes; this is an accepted
- * limitation.
+ * Holds no state of its own — every window lives in the store — so
+ * constructing one per request is free, and two limiters over the same store
+ * enforce one shared limit.
  */
 export class RateLimiter {
-  /**
-   * Internal store: keyId → sorted array of allowed request timestamps (ms).
-   * Arrays are bounded at `limit` entries per key.
-   */
-  private readonly windows: Map<string, number[]> = new Map();
+  constructor(
+    private readonly store: RateLimitStore = new SlidingWindowMemoryStore()
+  ) {}
 
   /**
-   * Check whether a request for `keyId` is allowed under the given rate limit.
+   * Whether a request for `key` is allowed, recording it if so.
    *
-   * @param keyId   - The API key ID (used as the map key — NOT the raw key string).
-   * @param limit   - Maximum number of requests allowed within `windowMs`.
-   * @param windowMs - Sliding window size in milliseconds (e.g. 3_600_000 for 1 hour).
-   * @returns `{ allowed, remaining, resetAt }`
+   * Asynchronous because a shared store is reached over the network. That is
+   * the contract every production limiter uses (`express-rate-limit` promisifies
+   * synchronous stores rather than supporting them; `@upstash/ratelimit` is
+   * HTTP-only by design) and it is the reason the previous synchronous
+   * signature could never have taken a shared store.
+   *
+   * @param key      - API key id, or `auth-ip:<ip>`. Never a raw key string.
+   * @param limit    - Maximum requests allowed within `windowMs`.
+   * @param windowMs - Sliding window size in milliseconds.
    */
-  check(keyId: string, limit: number, windowMs: number): RateLimitCheckResult {
-    const now = Date.now();
-    const windowStart = now - windowMs;
+  async check(
+    key: string,
+    limit: number,
+    windowMs: number
+  ): Promise<RateLimitCheckResult> {
+    // Counted first, then taken back if refused. The order matters: asking
+    // "would this be allowed?" and then recording it separately is two round
+    // trips to a shared store with a gap in between, and concurrent requests
+    // race through that gap. One increment is the only part that a store can
+    // make atomic.
+    const { count, resetTime } = await this.store.increment(key, windowMs);
+    const allowed = count <= limit;
 
-    let timestamps = this.windows.get(keyId) ?? [];
-
-    timestamps = timestamps.filter(t => t > windowStart);
-
-    const count = timestamps.length;
-    const allowed = count < limit;
-
-    if (allowed) {
-      // Record this request only when allowed; keeps the array bounded at `limit`
-      timestamps.push(now);
-      this.windows.set(keyId, timestamps);
+    if (!allowed) {
+      // A refused attempt must not extend its own window, or an attacker who
+      // keeps hammering keeps the window from ever draining and locks the key
+      // out permanently. A store that cannot take an increment back leaves the
+      // attempt counted, which is the safe direction to degrade in.
+      await this.store.decrement?.(key);
     }
 
-    const remaining = Math.max(0, limit - timestamps.length);
-
-    // resetAt = when the oldest in-window timestamp ages out of the window.
-    // If the window is empty (first request was just allowed), reset is in `windowMs`.
-    const oldestInWindow = timestamps[0];
-    const resetAt = new Date(
-      oldestInWindow !== undefined ? oldestInWindow + windowMs : now + windowMs
-    );
-
-    return { allowed, remaining, resetAt };
+    return {
+      allowed,
+      remaining: Math.max(0, limit - count),
+      resetAt: new Date(resetTime),
+    };
   }
 
   /**
-   * Remove all state for a given key.
-   *
-   * Useful for tests or if a key is revoked and its slot should be freed
-   * immediately rather than waiting for natural expiry.
-   *
-   * @param keyId - The API key ID whose window should be cleared.
+   * Drop all state for a key — a revoked key's slot, or a test's fixture.
    */
-  clear(keyId: string): void {
-    this.windows.delete(keyId);
-  }
-
-  /**
-   * Return the number of keys currently tracked.
-   * Intended for testing and monitoring only.
-   */
-  get size(): number {
-    return this.windows.size;
+  async clear(key: string): Promise<void> {
+    await this.store.reset(key);
   }
 }
 
 /**
- * Shared `RateLimiter` instance used by `requireApiKeyAuth()`.
+ * The process-local limiter, used when no shared store is configured.
  *
- * A module-level singleton is sufficient here: rate limit state is
- * per-process and API key auth middleware runs in the same process.
- * Instantiated once at module load; no DI registration needed.
+ * Correct for a single-instance deployment and nothing else. See the module
+ * note above for what it costs anywhere else.
  */
 export const rateLimiter = new RateLimiter();
+
+/**
+ * The limiter to use for this request.
+ *
+ * Resolved per call rather than set once at boot, because config is loaded
+ * after this module and a limiter captured at import time would be the
+ * in-memory one forever — silently, and only in production, where boot order
+ * differs from a test's.
+ *
+ * Returns the shared singleton when nothing is configured, so the default path
+ * keeps one window map rather than building a new one per request.
+ */
+export function authRateLimiter(store?: RateLimitStore): RateLimiter {
+  return store === undefined ? rateLimiter : new RateLimiter(store);
+}

--- a/packages/nextly/src/auth/middleware/rate-limiter.ts
+++ b/packages/nextly/src/auth/middleware/rate-limiter.ts
@@ -61,21 +61,26 @@ export class RateLimiter {
     limit: number,
     windowMs: number
   ): Promise<RateLimitCheckResult> {
-    // Counted first, then taken back if refused. The order matters: asking
-    // "would this be allowed?" and then recording it separately is two round
-    // trips to a shared store with a gap in between, and concurrent requests
-    // race through that gap. One increment is the only part that a store can
-    // make atomic.
+    // One atomic operation when the store offers it. The decision and the
+    // record cannot be separated safely: with two calls there is an await
+    // between them, and in that gap another request can start a new window that
+    // the second call then corrupts.
+    if (this.store.consume) {
+      const consumed = await this.store.consume(key, limit, windowMs);
+      return {
+        allowed: consumed.allowed,
+        remaining: Math.max(0, limit - consumed.count),
+        resetAt: new Date(consumed.resetTime),
+      };
+    }
+
+    // A store that cannot be atomic still gets a correct-but-stricter limiter:
+    // every attempt counts, including refused ones. That costs a caller who has
+    // exhausted their budget a longer wait than the atomic path would, and it
+    // is the only degradation that fails CLOSED. The alternative — increment
+    // then roll back — is the erasure this branch exists to avoid.
     const { count, resetTime } = await this.store.increment(key, windowMs);
     const allowed = count <= limit;
-
-    if (!allowed) {
-      // A refused attempt must not extend its own window, or an attacker who
-      // keeps hammering keeps the window from ever draining and locks the key
-      // out permanently. A store that cannot take an increment back leaves the
-      // attempt counted, which is the safe direction to degrade in.
-      await this.store.decrement?.(key);
-    }
 
     return {
       allowed,

--- a/packages/nextly/src/auth/middleware/sliding-window-store.ts
+++ b/packages/nextly/src/auth/middleware/sliding-window-store.ts
@@ -41,9 +41,9 @@ export class SlidingWindowMemoryStore implements RateLimitStore {
     const windowStart = now - windowMs;
     const kept = (this.windows.get(key) ?? []).filter(t => t > windowStart);
 
-    // Recorded before the caller has judged it. A caller that refuses the
-    // attempt takes it back with `decrement`, which is what keeps a refused
-    // request from extending its own window.
+    // Unconditional: `increment` counts every attempt, which is what the REST
+    // limiter wants. A caller that must not count a refused attempt uses
+    // `consume` instead, where the decision and the record are one step.
     kept.push(now);
     this.windows.set(key, kept);
 
@@ -57,18 +57,42 @@ export class SlidingWindowMemoryStore implements RateLimitStore {
     });
   }
 
-  decrement(key: string): Promise<void> {
-    const timestamps = this.windows.get(key);
-    if (timestamps === undefined || timestamps.length === 0) {
-      return Promise.resolve();
+  /**
+   * Record an attempt only if it stays within `limit`.
+   *
+   * Atomic by construction: this runs to completion inside one turn of the
+   * event loop, so nothing can observe the window between the count and the
+   * push. That is the whole reason the decision lives in the store rather than
+   * in the limiter — a limiter that counted here and recorded after an await
+   * would leave a gap for another request to slip through.
+   */
+  consume(
+    key: string,
+    limit: number,
+    windowMs: number
+  ): Promise<RateLimitRecord & { allowed: boolean }> {
+    const now = Date.now();
+    const kept = (this.windows.get(key) ?? []).filter(t => t > now - windowMs);
+    const allowed = kept.length < limit;
+
+    // Only an allowed attempt is recorded, so a refused caller cannot push its
+    // own window forward by continuing to hammer — which would otherwise let
+    // them hold a key locked out indefinitely.
+    if (allowed) {
+      kept.push(now);
+      this.windows.set(key, kept);
+    } else if (kept.length > 0) {
+      // Still store the pruned array: dropping entries that aged out is what
+      // lets the window slide even while every attempt is being refused.
+      this.windows.set(key, kept);
     }
-    // The LAST entry, because `increment` appends and this undoes that same
-    // increment. Removing the oldest instead would slide the window forward on
-    // every refusal, which is the opposite of what a refusal should do.
-    timestamps.pop();
-    if (timestamps.length === 0) this.windows.delete(key);
-    else this.windows.set(key, timestamps);
-    return Promise.resolve();
+
+    const oldest = kept[0] ?? now;
+    return Promise.resolve({
+      allowed,
+      count: kept.length,
+      resetTime: oldest + windowMs,
+    });
   }
 
   reset(key: string): Promise<void> {

--- a/packages/nextly/src/auth/middleware/sliding-window-store.ts
+++ b/packages/nextly/src/auth/middleware/sliding-window-store.ts
@@ -1,0 +1,83 @@
+/**
+ * The auth limiter's default store: a sliding window held in this process.
+ *
+ * This is the algorithm the auth limiter has always used, moved behind
+ * {@link RateLimitStore} so a deployment can replace it without replacing the
+ * limiter. Nothing about the numbers changes — a deployment that configures no
+ * store must be unable to tell this module exists.
+ *
+ * **It is correct only within one process.** Each instance keeps its own map,
+ * so on a serverless or multi-pod deployment the effective limit becomes
+ * `configured × instances`, and the instance count is elastic and invisible to
+ * the operator. That is why the seam exists: the fix is a shared store, not a
+ * better in-memory one.
+ *
+ * The methods return promises without being `async`: they satisfy an
+ * asynchronous interface synchronously, and marking them `async` would claim an
+ * await that never happens. The contract is async because a SHARED store is
+ * reached over the network — not because this one needs to be.
+ *
+ * @module auth/middleware/sliding-window-store
+ */
+
+import type {
+  RateLimitRecord,
+  RateLimitStore,
+} from "../../middleware/rate-limit";
+
+/**
+ * A sliding window of request timestamps per key.
+ *
+ * A timestamp array rather than a counter, because the window slides: a fixed
+ * counter cannot say WHEN the oldest attempt ages out, and `resetAt` is what
+ * the caller puts in `Retry-After`. Entries older than the window are pruned on
+ * every increment, so an array stays bounded by the limit the caller enforces.
+ */
+export class SlidingWindowMemoryStore implements RateLimitStore {
+  private readonly windows = new Map<string, number[]>();
+
+  increment(key: string, windowMs: number): Promise<RateLimitRecord> {
+    const now = Date.now();
+    const windowStart = now - windowMs;
+    const kept = (this.windows.get(key) ?? []).filter(t => t > windowStart);
+
+    // Recorded before the caller has judged it. A caller that refuses the
+    // attempt takes it back with `decrement`, which is what keeps a refused
+    // request from extending its own window.
+    kept.push(now);
+    this.windows.set(key, kept);
+
+    // The oldest entry is what ages out first, so it decides when the window
+    // slides forward. `kept` is never empty here — the push above guarantees
+    // an entry — so this is the first attempt's own timestamp on a cold key.
+    const oldest = kept[0] ?? now;
+    return Promise.resolve({
+      count: kept.length,
+      resetTime: oldest + windowMs,
+    });
+  }
+
+  decrement(key: string): Promise<void> {
+    const timestamps = this.windows.get(key);
+    if (timestamps === undefined || timestamps.length === 0) {
+      return Promise.resolve();
+    }
+    // The LAST entry, because `increment` appends and this undoes that same
+    // increment. Removing the oldest instead would slide the window forward on
+    // every refusal, which is the opposite of what a refusal should do.
+    timestamps.pop();
+    if (timestamps.length === 0) this.windows.delete(key);
+    else this.windows.set(key, timestamps);
+    return Promise.resolve();
+  }
+
+  reset(key: string): Promise<void> {
+    this.windows.delete(key);
+    return Promise.resolve();
+  }
+
+  /** Keys currently tracked. For tests and monitoring only. */
+  get size(): number {
+    return this.windows.size;
+  }
+}

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -172,7 +172,11 @@ import type { UserService } from "../services/users/user-service";
 import { assertNoLegacyFieldGroupKey } from "../shared/legacy-field-group-key";
 import { assertPluginFieldDeclarations } from "../shared/lib/assert-plugin-field-declarations";
 import { registerFieldFunctions } from "../shared/lib/field-level-registry";
-import type { AdminConfig, AuthConfig } from "../shared/types/config";
+import type {
+  AdminConfig,
+  AuthConfig,
+  SanitizedRateLimitingConfig,
+} from "../shared/types/config";
 import type { SingleConfig } from "../singles/config/types";
 import type { ImageProcessor } from "../storage/image-processor";
 import { initializeMediaStorage, type MediaStorage } from "../storage/storage";
@@ -303,6 +307,17 @@ export interface NextlyServiceConfig {
 
   /** Security configuration (headers, CORS, uploads, sanitization). */
   security?: SecurityConfig;
+
+  /**
+   * Rate limiting, with defaults applied.
+   *
+   * Carried through for the same reason `admin` and `auth` are: a handler that
+   * reads the DI "config" service can otherwise see no rate-limit block at all.
+   * It matters here specifically because `store` lives on it, and the auth
+   * limiter has no other way to reach a shared store — leaving it out means the
+   * credential paths silently stay per-process however the app is configured.
+   */
+  rateLimit?: SanitizedRateLimitingConfig;
 
   /**
    * Admin panel configuration (branding, plugin overrides, devAutoLogin).

--- a/packages/nextly/src/init/build-service-config.ts
+++ b/packages/nextly/src/init/build-service-config.ts
@@ -163,6 +163,14 @@ export function buildServiceConfig(
       serviceConfig.apiKeys = nextlyConfig.apiKeys;
     }
 
+    // Same for rate limiting. Carried for `store` above all: it is the only
+    // route by which a deployment can give the AUTH limiter a shared window,
+    // and dropping it here would leave the credential paths per-process no
+    // matter what the config said.
+    if (!serviceConfig.rateLimit && nextlyConfig?.rateLimit) {
+      serviceConfig.rateLimit = nextlyConfig.rateLimit;
+    }
+
     // If security config not explicitly provided, use from nextly.config.ts
     if (!serviceConfig.security && nextlyConfig?.security) {
       serviceConfig.security = nextlyConfig.security;

--- a/packages/nextly/src/middleware/rate-limit.ts
+++ b/packages/nextly/src/middleware/rate-limit.ts
@@ -98,19 +98,28 @@ export interface RateLimitStore {
   reset(key: string): Promise<void>;
 
   /**
-   * Take back the most recent increment for a key.
+   * Record an attempt ONLY if it stays within `limit`, atomically.
    *
-   * Optional, and only meaningful to a caller that decides AFTER incrementing
-   * that the attempt should not have counted. The auth limiter is that caller:
-   * a refused login must not extend its own window, or an attacker holding
-   * themselves refused would keep the window from ever draining.
+   * One operation, because two are not safe. A caller that increments and then
+   * takes the increment back on refusal has an await between the two, and in
+   * that gap another request can start a NEW window — the old rollback then
+   * erases the new window's count and admits attempts nobody budgeted for. The
+   * damage is worst at a window boundary, which is exactly where a limiter is
+   * most load-bearing.
    *
-   * Modelled on `express-rate-limit`'s `decrement`, which exists for the same
-   * reason — a request the caller chose to skip. A store that cannot support it
-   * omits it, and the caller degrades to counting the refused attempt rather
-   * than failing.
+   * Optional because not every store can be atomic. A caller that needs the
+   * guarantee checks for it and degrades deliberately when it is absent; see
+   * `RateLimiter.check`, which then counts refused attempts rather than
+   * risking the erasure — stricter, never looser.
+   *
+   * `allowed` is the store's decision, not a hint: only the store knows whether
+   * the entry was recorded.
    */
-  decrement?(key: string): Promise<void>;
+  consume?(
+    key: string,
+    limit: number,
+    windowMs: number
+  ): Promise<RateLimitRecord & { allowed: boolean }>;
 }
 
 /**

--- a/packages/nextly/src/middleware/rate-limit.ts
+++ b/packages/nextly/src/middleware/rate-limit.ts
@@ -96,6 +96,21 @@ export interface RateLimitStore {
    * @param key - Unique identifier to reset
    */
   reset(key: string): Promise<void>;
+
+  /**
+   * Take back the most recent increment for a key.
+   *
+   * Optional, and only meaningful to a caller that decides AFTER incrementing
+   * that the attempt should not have counted. The auth limiter is that caller:
+   * a refused login must not extend its own window, or an attacker holding
+   * themselves refused would keep the window from ever draining.
+   *
+   * Modelled on `express-rate-limit`'s `decrement`, which exists for the same
+   * reason — a request the caller chose to skip. A store that cannot support it
+   * omits it, and the caller degrades to counting the refused attempt rather
+   * than failing.
+   */
+  decrement?(key: string): Promise<void>;
 }
 
 /**

--- a/packages/nextly/src/shared/types/__tests__/rate-limit-config.test.ts
+++ b/packages/nextly/src/shared/types/__tests__/rate-limit-config.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Disabling the PUBLIC limiter must not disarm the one in front of credentials.
+ *
+ * `rateLimit` carries two unrelated things: whether the REST limiter runs, and
+ * where the window lives. The second is read by the AUTH limiter too, so
+ * dropping the whole block when a user disables the first takes the credential
+ * limiter's shared store with it — silently, and only on the deployments that
+ * need it.
+ */
+import { describe, expect, it } from "vitest";
+
+import type {
+  RateLimitRecord,
+  RateLimitStore,
+} from "../../../middleware/rate-limit";
+import { sanitizeConfig } from "../config";
+
+const store: RateLimitStore = {
+  increment(): Promise<RateLimitRecord> {
+    return Promise.resolve({ count: 1, resetTime: 0 });
+  },
+  reset(): Promise<void> {
+    return Promise.resolve();
+  },
+};
+
+describe("sanitized rate-limit config", () => {
+  it("keeps the store when the REST limiter is switched off", async () => {
+    const sanitized = await sanitizeConfig({
+      rateLimit: { enabled: false, store },
+    } as Parameters<typeof sanitizeConfig>[0]);
+
+    expect(sanitized.rateLimit?.store).toBe(store);
+  });
+
+  it("reports that the REST limiter is off, rather than omitting the block", async () => {
+    // The block's ABSENCE used to be the only signal, and `routeHandler`
+    // defaults `enabled: true` when it spreads nothing — so an omitted block
+    // meant limiting stayed ON despite the user disabling it.
+    const sanitized = await sanitizeConfig({
+      rateLimit: { enabled: false, store },
+    } as Parameters<typeof sanitizeConfig>[0]);
+
+    expect(sanitized.rateLimit).toBeDefined();
+    expect(sanitized.rateLimit?.enabled).toBe(false);
+  });
+
+  it("still reports enabled when nothing is configured", async () => {
+    // The control. Without it, both assertions above would hold just as well
+    // if `enabled` were hardcoded `false`, which would disable rate limiting
+    // for every deployment that never mentioned it.
+    const sanitized = await sanitizeConfig(
+      {} as Parameters<typeof sanitizeConfig>[0]
+    );
+
+    expect(sanitized.rateLimit?.enabled).toBe(true);
+    expect(sanitized.rateLimit?.store).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/shared/types/config.ts
+++ b/packages/nextly/src/shared/types/config.ts
@@ -205,8 +205,17 @@ export interface RateLimitingConfig {
  * Sanitized rate limiting configuration with defaults applied.
  */
 export interface SanitizedRateLimitingConfig {
-  /** Rate limiting is enabled */
-  enabled: true;
+  /**
+   * Whether the REST limiter runs.
+   *
+   * A real boolean rather than the literal `true` it used to be. The block was
+   * previously omitted entirely when a user disabled rate limiting, which had
+   * two consequences: `routeHandler` spread nothing over its own
+   * `enabled: true` default and kept limiting anyway, and `store` — which the
+   * AUTH limiter also reads — went with it. Disabling the public limiter must
+   * not silently disarm the one in front of credentials.
+   */
+  enabled: boolean;
   /** Maximum requests per window for read operations (GET) */
   readLimit: number;
   /** Maximum requests per window for write operations (POST, PATCH, PUT, DELETE) */
@@ -904,22 +913,21 @@ export function sanitizeConfig(config: NextlyConfig): SanitizedNextlyConfig {
   }
 
   // Build rate limit config — enabled by default (opt-out with `enabled: false`).
-  let rateLimit: SanitizedRateLimitingConfig | undefined;
-  if (config.rateLimit?.enabled !== false) {
-    rateLimit = {
-      enabled: true,
-      readLimit:
-        config.rateLimit?.readLimit ?? DEFAULT_RATE_LIMIT_CONFIG.readLimit,
-      writeLimit:
-        config.rateLimit?.writeLimit ?? DEFAULT_RATE_LIMIT_CONFIG.writeLimit,
-      windowMs:
-        config.rateLimit?.windowMs ?? DEFAULT_RATE_LIMIT_CONFIG.windowMs,
-      store: config.rateLimit?.store,
-      keyGenerator: config.rateLimit?.keyGenerator,
-      skip: config.rateLimit?.skip,
-      collections: config.rateLimit?.collections,
-    };
-  }
+  // Emitted whether or not the REST limiter is on. `store` lives on this block
+  // and the AUTH limiter reads it from here, so dropping the block for
+  // `enabled: false` would disable a limiter the user never mentioned.
+  const rateLimit: SanitizedRateLimitingConfig = {
+    enabled: config.rateLimit?.enabled !== false,
+    readLimit:
+      config.rateLimit?.readLimit ?? DEFAULT_RATE_LIMIT_CONFIG.readLimit,
+    writeLimit:
+      config.rateLimit?.writeLimit ?? DEFAULT_RATE_LIMIT_CONFIG.writeLimit,
+    windowMs: config.rateLimit?.windowMs ?? DEFAULT_RATE_LIMIT_CONFIG.windowMs,
+    store: config.rateLimit?.store,
+    keyGenerator: config.rateLimit?.keyGenerator,
+    skip: config.rateLimit?.skip,
+    collections: config.rateLimit?.collections,
+  };
 
   // Build apiKeys config only if the block is provided; omitting it entirely
   // is valid — the auth middleware falls back to built-in defaults.


### PR DESCRIPTION
## What changes for an operator

Rate limiting on **sign-in and API keys** can now keep its window somewhere every instance can see:

```ts
// nextly.config.ts
rateLimit: {
  enabled: true,
  store: new MyRedisRateLimitStore(redis),   // now covers auth too, not just REST
}
```

**Change nothing and nothing changes.** The default keeps this process's memory with the same sliding-window arithmetic it had before — asserted, not assumed.

## Why

The limiter guarding credentials held its windows in a private `Map` on a module-level singleton (`export const rateLimiter = new RateLimiter()`), and its `check()` was **synchronous** — so there could not have been another store: a shared one is reached over the network.

Per-process state makes that limiter fail **open**. Each instance keeps its own window, so the effective limit is `configured × instances` — a number the platform chooses, the operator cannot see, and that grows precisely under the load an attack produces. A login throttle set to 5 per 15 minutes is whatever the autoscaler decided.

The code already knew. `auth/handlers/router.ts` said: *"The backing store is in-memory, so single-instance deployments are the documented beta scope until a shared store lands."*

## The ledger row's premise was wrong, and that changed the work

`task:core-pluggable-rate-limit-store` reads *"Rate limiter is in-memory only — serverless-unsafe."* Measured, that is **not true of the limiter it appears to describe**. There are **two** limiters for one concern:

| | `middleware/rate-limit.ts` | `auth/middleware/rate-limiter.ts` |
| --- | --- | --- |
| protects | REST reads/writes | **auth writes + API keys** |
| store | `store?: RateLimitStore` — pluggable | private `Map` on a singleton |
| injectable | yes, end to end | **no injection point at all** |
| async | yes | **no** |

The REST limiter is already wired the whole way — `RateLimitingConfig.store` is user-facing, `sanitizeConfig` carries it, `routeHandler` spreads it in. **The auth one could not be given a store at all**, and it is the one in front of credentials. That is what this PR fixes.

## Research behind the interface choice

- **`express-rate-limit`** — `Store` is async by contract (`increment → Promise`), with `decrement`/`resetKey`/`resetAll`. Synchronous stores are *promisified*, not supported natively.
- **`@upstash/ratelimit`** — exists because serverless cannot share memory, and is HTTP-only for that reason. It documents that a distributed limiter cannot guarantee the limit is never exceeded by a small margin.

Two conclusions. **Async is the contract, not a concession.** And "a shared store is approximate" is not an argument for per-instance memory, which is not approximate — it is wrong by a factor.

## One interface, not two

Reuses the existing `RateLimitStore` rather than adding a second store type. AGENTS.md rules on this, and the payoff is concrete: **an operator who writes one Redis adapter now covers both limiters.** Two interfaces would mean two adapters, and the second is the one nobody writes.

The interface gains **one optional method, `decrement`**, taken from `express-rate-limit` for the reason it exists there. This limiter records an attempt only when allowed, so a refused request must not extend its own window — otherwise a caller who keeps hammering keeps the window from draining and holds themselves permanently locked out, which is a denial of service an attacker can aim at someone else's key. Increment-then-take-back reproduces that against any store; a store that omits `decrement` leaves the attempt counted, which is the safe direction to degrade in.

## Break-verification

Every mechanism was broken, the break asserted to have applied, the intended failure required, then restored to a verified-clean tree.

| break | expected | observed |
| --- | --- | --- |
| stop calling `decrement` on refusal | window-extension test red | 2 failed |
| `count <= limit` → `count < limit` | off-by-one caught | 3 failed |
| `decrement` pops oldest instead of newest | sliding order caught | 1 failed |
| limiter ignores its injected store | seam proven load-bearing | 8 failed |
| drop the `await` at a call site | compile error | TS2339 naming the site |

The tests carry their own controls, because each assertion is otherwise satisfied by nothing happening: the "allows the limit" test asserts the three allows **and** the refusal (a limiter that refuses everything is also not the old behaviour); the seam test injects a store that **disagrees** with memory; and `decrement`-on-refusal is paired with a **`decrement`-not-called-on-success** test, without which a limiter that decremented every call would pass.

## fallow

First run came back **`fail`** — `complexity_introduced: 2`. `requireApiKeyAuth` was carrying the whole rate-limit decision inline, and `readAuthRateLimit` repeated the same three shape checks at each level of a nested read; adding the store lookup pushed both over.

Fixed by extraction, **not** by the `// fallow-ignore-next-line` the tool offered. `readAuthRateLimit` comes out **simpler than it was before this branch** (was cyclomatic 18 / cognitive 18 over 49 lines). Final: `dead_code_introduced: 0`, `complexity_introduced: 0`, `duplication_introduced: 0`, verdict **pass**.

## Deliberately not included

**A Redis/Upstash adapter.** It carries a dependency and belongs in its own package. What was missing was the seam.

**Converging the two limiters into one middleware.** A larger change; the shared interface gets most of the benefit without it.

## Evidence

- `nextly` auth + middleware: **22 files / 254 tests passed.** New limiter suite: 9 tests.
- Full `nextly` unit: **32 failing files — the documented stale-mock baseline — and none of them are files this branch touches.** The 32 were enumerated and checked by name rather than by an absence of matches.
- Full `nextly` **integration on the pushed tree `cb8bb897d`**: `224 passed | 38 skipped (262)` files, `1323 passed | 213 skipped` tests, **0 failures**. Re-run after the complexity refactor rather than quoting the earlier run, which described a different commit.
- `tsc --noEmit` and `-p tsconfig.tests.json`: 0 errors each. eslint on all changed files: 0 errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable rate-limit stores, enabling shared rate limiting across multiple server processes.
  - Added sliding-window rate limiting with accurate remaining-request and reset-time information.
  - Added atomic store support to improve consistency when handling concurrent requests.

- **Bug Fixes**
  - Refused requests no longer extend their own rate-limit window.
  - Rate-limit configuration is now preserved and correctly applied across service setup.

- **Tests**
  - Expanded coverage for rate-limit behavior, configuration, store integration, and window expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->