### PR TITLE
ci: let the whole-repo hygiene job post its sticky PR comment

### DIFF
--- a/.github/workflows/code-hygiene.yml
+++ b/.github/workflows/code-hygiene.yml
@@ -350,6 +350,10 @@ jobs:
     permissions:
       contents: read
       issues: write
+      # Commenting on a pull request needs the pull-requests scope even though
+      # it goes through the issue-comments API, so issues:write alone made the
+      # post step 403 and the report never left the step summary.
+      pull-requests: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
The whole-repository job granted its token `issues: write` and nothing else, so every attempt to write the hygiene report onto the pull request came back `Resource not accessible by integration`. Commenting on a pull request is reached through the issue-comments API, but the scope that authorizes it is `pull-requests`, not `issues` — the endpoint dispatches on what the number refers to, and for a pull request the issues scope alone is not enough.

The failure was invisible. The posting step wraps both the list and the create call in a try/catch that logs and continues, so a token without the scope produced a green job and no comment: the full dead-code, duplication, and complexity report reached the step summary and stopped there, while the sticky comment the workflow header describes never appeared on any PR.

The sibling `gate` job in this same file already holds `pull-requests: write` and posts its review threads to the same pull requests without error, which is what identifies the scope rather than the surrounding setup as the cause: same token, same repository, same PR, one scope apart. Job-level elevation is therefore permitted here, so granting it is sufficient.

`issues: write` is left in place; it is unused for a pull-request target but harmless, and dropping it is a separate decision from fixing the
403. Verified by parsing the workflow: the job's permissions now read contents/read, issues/write, pull-requests/write, and the file's two jobs and eight whole-repo steps are unchanged otherwise.

## Summary

<!-- What does this PR do and why? Keep it short. -->

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / chore (no user-facing change)

## Related issues

<!-- e.g. Closes #123, Refs #456 -->

## Changeset

This repo uses [Changesets](https://github.com/changesets/changesets). If your PR changes any publishable package under `packages/*`, you **must** include a changeset:

```bash
pnpm changeset
```

Then commit the generated `.changeset/*.md` file.

- [ ] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [ ] I selected the correct semver bump (patch / minor / major)

> The `changeset-check` CI job will fail if a publishable package is modified without a changeset.

## Test plan

<!-- How did you verify this works? Commands run, scenarios tested, screenshots, etc. -->

- [ ] `pnpm lint`
- [ ] `pnpm check-types`
- [ ] `pnpm build`
- [ ] Manually verified the change

## Checklist

- [ ] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [ ] I targeted the `main` branch
- [ ] I updated relevant documentation

## Screenshots / recordings

<!-- Optional. Drag images or videos here for UI changes. -->

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to? Migration risks, perf concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated repository checks to post and update comments on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->