### PR TITLE
feat(admin): edit an entry beside the page it becomes

### DIFF
--- a/.changeset/preview-split-view.md
+++ b/.changeset/preview-split-view.md
@@ -52,3 +52,13 @@ this is a pane beside the editor, not a surface that took the window.
 The credential is minted when the pane opens and re-minted only as it approaches
 expiry. An ordinary refresh remounts the frame, so watching a page through a long edit
 does not issue a bearer credential per save.
+
+Two situations leave the pane empty with a sentence rather than a frame, because in
+both the browser would quietly serve the PUBLISHED page into something captioned as a
+draft. A site served from a different address than the admin cannot receive the preview
+cookie in a frame at all — the Preview button still opens it in a tab, which works
+everywhere. And because a site keeps one preview session per browser, opening previews
+for two different entries takes the session from the first; that pane now says so and
+takes it back when refreshed, instead of showing published content under a draft label.
+The default scaffold, where the admin is mounted inside the site's own app, is affected
+by neither.

--- a/.changeset/preview-split-view.md
+++ b/.changeset/preview-split-view.md
@@ -1,0 +1,54 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+An entry can now be edited beside the page it becomes. A new control in the editor
+opens a preview pane: the editor keeps the left of the screen, the site renders in a
+frame on the right, and the divider between them moves.
+
+The frame is an IFRAME rather than the page redrawn inside the admin, and that is the
+decision the rest follows from. A frame is a real browsing context with a real
+viewport, so the site's own responsive rules resolve exactly as they do for a visitor,
+and its document is the site's — nothing the admin styles reaches in and nothing the
+site styles reaches out.
+
+It shows the last SAVED draft, and says so on the toolbar rather than leaving an
+author to infer it. Saving refreshes it. Autosave does not, and cannot: autosave
+records a private per-author recovery point while the preview reads the working draft,
+so the two are different rows and moving one changes nothing the other can show.
+Making them the same thing would let anyone holding a preview link read half-typed
+content, which is a decision about who sees unfinished work rather than a refresh
+strategy.
+
+Opening the pane releases the editor's 56rem measure by ASKING for it, the way the
+page builder asks, rather than by the page declaring a second width — so a reader who
+never opens the preview gets exactly the page they had. The admin's navigation stays:
+this is a pane beside the editor, not a surface that took the window.
+
+The credential is minted when the pane opens and re-minted only as it approaches
+expiry. An ordinary refresh remounts the frame, so watching a page through a long edit
+does not issue a bearer credential per save.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -54,6 +54,7 @@ import { collectionSourceFetcher } from "../entry-locale-source";
 import { EntryLocaleProvider } from "../EntryLocaleContext";
 import { LanguagePanel } from "../LanguagePanel";
 import { PreviewPanes } from "../PreviewMode/PreviewPanes";
+import { previewRevisionOf } from "../PreviewMode/previewRevision";
 import { TranslationPanes } from "../TranslationMode/TranslationPanes";
 import { useTranslationSource } from "../TranslationMode/useTranslationSource";
 import { useEntryLocaleContext } from "../useEntryLocaleContext";
@@ -262,7 +263,6 @@ export function EntryForm({
    * have to be threaded back down through props that exist for nothing else.
    */
   const [previewOpen, setPreviewOpen] = useState(false);
-  const [savedAt, setSavedAt] = useState(0);
 
   const {
     form,
@@ -279,15 +279,6 @@ export function EntryForm({
     locale,
     readDraft,
     onSuccess: data => {
-      /*
-       * The save token the preview pane watches. Bumped HERE rather than in the
-       * pane, because this is the only place that knows a write completed — the
-       * pane cannot observe the form's mutation, and autosave is a different
-       * row entirely: it records a private recovery point, not the working
-       * draft the site renders, so it moves without changing anything a preview
-       * could show.
-       */
-      setSavedAt(Date.now());
       onSuccess?.(data);
     },
     onError,
@@ -639,6 +630,8 @@ export function EntryForm({
    * grant over every translation, while a preview opened without one silently
    * shows the wrong one.
    */
+  const previewRevision = previewRevisionOf(entry);
+
   const canPreview =
     entryPreview.isPreviewAvailable &&
     savedEntryId !== "" &&
@@ -749,7 +742,7 @@ export function EntryForm({
                 ? { locale: linkLocale.locale }
                 : {})}
               label={entryPreview.label}
-              savedAt={savedAt}
+              revision={previewRevision}
             >
               <TranslationPanes
                 source={translationMode.source}

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -53,6 +53,7 @@ import { cn } from "@admin/lib/utils";
 import { collectionSourceFetcher } from "../entry-locale-source";
 import { EntryLocaleProvider } from "../EntryLocaleContext";
 import { LanguagePanel } from "../LanguagePanel";
+import { PreviewPanes } from "../PreviewMode/PreviewPanes";
 import { TranslationPanes } from "../TranslationMode/TranslationPanes";
 import { useTranslationSource } from "../TranslationMode/useTranslationSource";
 import { useEntryLocaleContext } from "../useEntryLocaleContext";
@@ -253,6 +254,16 @@ export function EntryForm({
   embedded = false,
   className,
 }: EntryFormProps) {
+  /*
+   * Whether the preview pane is open, and when the document last saved.
+   *
+   * Held by the form rather than the page: the pane wraps the editor, and the
+   * save that refreshes it is this component's own. A page-level flag would
+   * have to be threaded back down through props that exist for nothing else.
+   */
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [savedAt, setSavedAt] = useState(0);
+
   const {
     form,
     handleSubmit,
@@ -268,6 +279,15 @@ export function EntryForm({
     locale,
     readDraft,
     onSuccess: data => {
+      /*
+       * The save token the preview pane watches. Bumped HERE rather than in the
+       * pane, because this is the only place that knows a write completed — the
+       * pane cannot observe the form's mutation, and autosave is a different
+       * row entirely: it records a private recovery point, not the working
+       * draft the site renders, so it moves without changing anything a preview
+       * could show.
+       */
+      setSavedAt(Date.now());
       onSuccess?.(data);
     },
     onError,
@@ -713,287 +733,324 @@ export function EntryForm({
         <EntryLocaleProvider value={localeCtx}>
           <DocumentHistoryContext.Provider value={documentHistory}>
             {/* Renders its child alone when there is no source — see the module. */}
-            <TranslationPanes
-              source={translationMode.source}
-              onExit={translationMode.onExit}
-              control={form.control}
+            <PreviewPanes
+              /*
+               * Withheld while translation mode is on. That mode already splits
+               * the editor and takes the window, and a third pane inside it is
+               * a different layout question than this one answers — offering it
+               * would produce two nested resizable groups and two chrome
+               * requests disagreeing about how much of the admin is left.
+               */
+              open={previewOpen && translationMode.source === undefined}
+              onClose={() => setPreviewOpen(false)}
+              collection={collection.name}
+              entryId={savedEntryId}
+              {...(linkLocale.kind === "scoped"
+                ? { locale: linkLocale.locale }
+                : {})}
+              label={entryPreview.label}
+              savedAt={savedAt}
             >
-              <EntryFormContextProvider
-                entryId={entry?.id}
-                collectionSlug={collection.name}
-                isCreateMode={mode === "create"}
-                // Only where a takeover can happen. The embedded branch renders
-                // the whole body in a modal and hides nothing, so a panel there
-                // would offer a second copy of fields already on screen.
-                renderEntryFields={renderEntryFields}
+              <TranslationPanes
+                source={translationMode.source}
+                onExit={translationMode.onExit}
+                control={form.control}
               >
-                <div className={cn("space-y-0", className)}>
-                  <EntryFormProvider form={form} onSubmit={handleSubmit}>
-                    <FormErrorSummary
-                      errors={errors}
-                      submitCount={submitCount}
-                      className="mx-6 mt-3"
-                    />
+                <EntryFormContextProvider
+                  entryId={entry?.id}
+                  collectionSlug={collection.name}
+                  isCreateMode={mode === "create"}
+                  // Only where a takeover can happen. The embedded branch renders
+                  // the whole body in a modal and hides nothing, so a panel there
+                  // would offer a second copy of fields already on screen.
+                  renderEntryFields={renderEntryFields}
+                >
+                  <div className={cn("space-y-0", className)}>
+                    <EntryFormProvider form={form} onSubmit={handleSubmit}>
+                      <FormErrorSummary
+                        errors={errors}
+                        submitCount={submitCount}
+                        className="mx-6 mt-3"
+                      />
 
-                    {/* Vertical only, not both axes. The vertical half still cancels
-                        `PageContainer`'s `py-8` so the editor's two columns
-                        reach the top and bottom of the panel. The horizontal
-                        half cancelled its `px-8`, and there is none left to
-                        cancel: a page that asks for a measure spends its inset
-                        as GRID COLUMNS, so the same negative margin now pulls
-                        the editor 32px past the content column on each side
-                        rather than back to the panel edge. Measured at a
-                        1600px viewport: 960px of editor in an 896px column.
-                        The two modal callers never had that padding either. */}
-                    <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-my-8">
-                      {/* Main column */}
-                      <div className="flex-1 min-w-0 flex flex-col">
-                        {/* No horizontal negative inset here. These bands fill the Main column,
-                  which is already as wide as the content column allows;
-                  pulling them wider pushed both ~32px past the page edges
-                  and clipped the title's first character on the left and
-                  the rail toggle on the right. */}
-                        <EntrySystemHeader
-                          mode={mode}
-                          titleField={titleField}
-                          hasStatus={hasStatus}
-                          draftsEnabled={collection.draftsEnabled === true}
-                          isSubmitting={isSubmitting}
-                          isDirty={isDirty}
-                          autosaveEnabled={autosaveScope !== null}
-                          autosaveStatus={autosave.status}
-                          autosaveLastSavedAt={autosave.lastSavedAt}
-                          entry={entry}
-                          collectionSlug={collection.name}
-                          historyFields={getCollectionFields(collection)}
-                          historyEnabled={historyEnabledFrom(collection)}
-                          locale={locale}
-                          onLocaleChange={onLocaleChange}
-                          localized={collection.localized === true}
-                          isPreviewAvailable={canPreview}
-                          previewLabel={entryPreview.label}
-                          {...(canPreview
-                            ? { onPreview: entryPreview.openPreview }
-                            : {})}
-                          // Withheld while the language is unknown as well as while
-                          // the entry is unsaved: a link minted without a resolvable
-                          // locale is either refused by the mint route or, if the claim
-                          // were dropped to avoid that, a grant over every translation.
-                          isLinkAvailable={
-                            savedEntryId !== "" &&
-                            linkLocale.kind !== "unresolved"
-                          }
-                          {...(savedEntryId === ""
-                            ? {}
-                            : {
-                                onCopyLink: () => {
-                                  previewLink.mutate();
-                                },
-                              })}
-                          isCopyingLink={previewLink.isPending}
-                          toolbarSlot={
-                            <EntryFormToolbarSlots
-                              context="collection"
-                              controllerField={controllerNames[0]}
-                            />
-                          }
-                          onSaveDraft={() => {
-                            void handleSubmit(undefined, "save-draft");
-                          }}
-                          onPublish={() => {
-                            void handleSubmit(undefined, "publish");
-                          }}
-                          onSaveChanges={() => {
-                            void handleSubmit(undefined, "save-changes");
-                          }}
-                          onSaveWorkingDraft={() => {
-                            void handleSubmit(undefined, "save-working-draft");
-                          }}
-                          onUnpublish={() => {
-                            void handleSubmit(undefined, "unpublish");
-                          }}
-                          onCancel={handleCancel}
-                          onDelete={handleDelete}
-                          onDiscardWorkingDraft={handleDiscardWorkingDraft}
-                          isRailCollapsed={railCollapsed}
-                          onToggleRail={
-                            mode === "edit" ? toggleRail : undefined
-                          }
-                        />
-                        {/* Above the fields and below the header: the reader sees
-                    the document it refers to without the offer covering it. */}
-                        {recovery.offer ? (
-                          <AutosaveRecoveryBanner
-                            savedAt={recovery.offer.savedAt}
-                            onRestore={restoreRecovery}
-                            onDismiss={recovery.dismiss}
-                          />
-                        ) : null}
-                        {viewingVersion ? (
-                          <HistoricalDocumentBanner
-                            versionNo={viewingVersion.versionNo}
-                            locale={viewingVersion.locale}
-                            // Routed through the panel when one is mounted, so its
-                            // selection clears with the shared state. The direct
-                            // fallback keeps the banner working without a panel.
-                            onReturnToCurrent={
-                              restoreAffordance?.returnToCurrent ??
-                              (() => setViewingVersion(null))
+                      {/* Vertical only, not both axes. The vertical half still cancels
+                          `PageContainer`'s `py-8` so the editor's two columns
+                          reach the top and bottom of the panel. The horizontal
+                          half cancelled its `px-8`, and there is none left to
+                          cancel: a page that asks for a measure spends its inset
+                          as GRID COLUMNS, so the same negative margin now pulls
+                          the editor 32px past the content column on each side
+                          rather than back to the panel edge. Measured at a
+                          1600px viewport: 960px of editor in an 896px column.
+                          The two modal callers never had that padding either. */}
+                      <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-my-8">
+                        {/* Main column */}
+                        <div className="flex-1 min-w-0 flex flex-col">
+                          {/* No horizontal negative inset here. These bands fill the Main column,
+                    which is already as wide as the content column allows;
+                    pulling them wider pushed both ~32px past the page edges
+                    and clipped the title's first character on the left and
+                    the rail toggle on the right. */}
+                          <EntrySystemHeader
+                            mode={mode}
+                            titleField={titleField}
+                            hasStatus={hasStatus}
+                            draftsEnabled={collection.draftsEnabled === true}
+                            isSubmitting={isSubmitting}
+                            isDirty={isDirty}
+                            autosaveEnabled={autosaveScope !== null}
+                            autosaveStatus={autosave.status}
+                            autosaveLastSavedAt={autosave.lastSavedAt}
+                            entry={entry}
+                            collectionSlug={collection.name}
+                            historyFields={getCollectionFields(collection)}
+                            historyEnabled={historyEnabledFrom(collection)}
+                            locale={locale}
+                            onLocaleChange={onLocaleChange}
+                            localized={collection.localized === true}
+                            isPreviewAvailable={canPreview}
+                            previewLabel={entryPreview.label}
+                            {...(canPreview &&
+                            translationMode.source === undefined
+                              ? {
+                                  onTogglePreviewPane: () =>
+                                    setPreviewOpen(open => !open),
+                                  previewPaneOpen: previewOpen,
+                                }
+                              : {})}
+                            {...(canPreview
+                              ? { onPreview: entryPreview.openPreview }
+                              : {})}
+                            // Withheld while the language is unknown as well as while
+                            // the entry is unsaved: a link minted without a resolvable
+                            // locale is either refused by the mint route or, if the claim
+                            // were dropped to avoid that, a grant over every translation.
+                            isLinkAvailable={
+                              savedEntryId !== "" &&
+                              linkLocale.kind !== "unresolved"
                             }
-                            // Offered only when the panel says this caller may write.
-                            onRestore={
-                              restoreAffordance?.canRestore
-                                ? restoreAffordance.request
-                                : undefined
-                            }
-                            // And only once the version is actually on screen:
-                            // restoring from a skeleton, or from a failed read, is a
-                            // decision made without having seen what is being chosen.
-                            restoreDisabled={!versionOnScreen}
-                          />
-                        ) : null}
-                        <EntryMetaStrip
-                          slugField={slugField}
-                          hasStatus={hasStatus}
-                          // The pill reports the language being edited, matching the header's submit
-                          // affordances. Reading the main row instead would show "Published" beside a
-                          // Publish button whenever a translation lags its default language.
-                          status={
-                            effectiveEntryStatus(
-                              entry,
-                              locale,
-                              defaultLocale
-                            ) ?? "draft"
-                          }
-                          hasWorkingDraft={hasPendingWorkingDraft(entry)}
-                          isRailCollapsed={railCollapsed}
-                          hasPublicAddress={hasPublicAddress}
-                        />
-
-                        {/* The language panel, inline. Its rail mount is
-                      `hidden @4xl/content:flex`, so this is the exact
-                      complement: shown only where the rail is not. When the
-                      rail cannot carry it at all — create mode, or the author
-                      collapsed it — the panel renders unconditionally instead,
-                      because "the actions live in the rail" is precisely the
-                      failure this stage removes. */}
-                        {localizationEnabled && (
-                          <div
-                            className={cn(
-                              "px-6 pt-4",
-                              mode === "edit" &&
-                                !railCollapsed &&
-                                "@4xl/content:hidden"
-                            )}
-                          >
-                            <LanguagePanel
-                              {...(entry?._translations === undefined
-                                ? {}
-                                : {
-                                    translations: entry._translations as Record<
-                                      string,
-                                      { translated: boolean; status?: string }
-                                    >,
-                                  })}
-                              {...(locale === undefined
-                                ? {}
-                                : { activeLocale: locale })}
-                              {...(onLocaleChange === undefined
-                                ? {}
-                                : { onSelect: onLocaleChange })}
-                              hasStatus={hasStatus}
-                              actionsDisabled={viewingVersion !== null}
-                            />
-                          </div>
-                        )}
-
-                        {/* Reading a past version replaces the document rather than
-                    opening beside it: the question an editor is asking is how
-                    this page read then, and that is answered by the page. The
-                    live form stays mounted underneath — the historical values
-                    are rendered against a form of their own, so nothing typed
-                    here is disturbed and nothing historical can reach a save. */}
-                        {viewingVersion ? (
-                          <div className="@4xl/content:p-8 pt-6">
-                            {viewingVersion.error ? (
-                              // A failed read must not render as an empty document:
-                              // that is a different and wrong claim about the version.
-                              <Alert variant="destructive">
-                                <AlertDescription>
-                                  This version could not be loaded.
-                                </AlertDescription>
-                              </Alert>
-                            ) : !versionOnScreen ? (
-                              <div
-                                className="flex flex-col gap-4"
-                                aria-busy="true"
-                              >
-                                <span className="sr-only" role="status">
-                                  Loading version {viewingVersion.versionNo}
-                                </span>
-                                {[0, 1, 2, 3].map(i => (
-                                  <div key={i} className="flex flex-col gap-1">
-                                    <Skeleton className="h-3 w-24" />
-                                    <Skeleton className="h-9 w-full" />
-                                  </div>
-                                ))}
-                              </div>
-                            ) : (
-                              <VersionSnapshotForm
-                                fields={historicalFields ?? mainFields}
-                                snapshot={viewingVersion.snapshot}
+                            {...(savedEntryId === ""
+                              ? {}
+                              : {
+                                  onCopyLink: () => {
+                                    previewLink.mutate();
+                                  },
+                                })}
+                            isCopyingLink={previewLink.isPending}
+                            toolbarSlot={
+                              <EntryFormToolbarSlots
+                                context="collection"
+                                controllerField={controllerNames[0]}
                               />
-                            )}
-                          </div>
-                        ) : (
-                          mainFields.length > 0 && (
-                            <div className="@4xl/content:p-8 pt-6">
-                              {/* Forward the form mode: in edit mode a blank password
-                      field means "keep the current password" rather than a
-                      required-field violation (see note on the layout form
-                      above). */}
-                              <EntryFormContent
-                                fields={mainFields}
-                                disabled={isSubmitting}
-                                withCard
-                                mode={mode}
+                            }
+                            onSaveDraft={() => {
+                              void handleSubmit(undefined, "save-draft");
+                            }}
+                            onPublish={() => {
+                              void handleSubmit(undefined, "publish");
+                            }}
+                            onSaveChanges={() => {
+                              void handleSubmit(undefined, "save-changes");
+                            }}
+                            onSaveWorkingDraft={() => {
+                              void handleSubmit(
+                                undefined,
+                                "save-working-draft"
+                              );
+                            }}
+                            onUnpublish={() => {
+                              void handleSubmit(undefined, "unpublish");
+                            }}
+                            onCancel={handleCancel}
+                            onDelete={handleDelete}
+                            onDiscardWorkingDraft={handleDiscardWorkingDraft}
+                            isRailCollapsed={railCollapsed}
+                            onToggleRail={
+                              mode === "edit" ? toggleRail : undefined
+                            }
+                          />
+                          {/* Above the fields and below the header: the reader sees
+                      the document it refers to without the offer covering it. */}
+                          {recovery.offer ? (
+                            <AutosaveRecoveryBanner
+                              savedAt={recovery.offer.savedAt}
+                              onRestore={restoreRecovery}
+                              onDismiss={recovery.dismiss}
+                            />
+                          ) : null}
+                          {viewingVersion ? (
+                            <HistoricalDocumentBanner
+                              versionNo={viewingVersion.versionNo}
+                              locale={viewingVersion.locale}
+                              // Routed through the panel when one is mounted, so its
+                              // selection clears with the shared state. The direct
+                              // fallback keeps the banner working without a panel.
+                              onReturnToCurrent={
+                                restoreAffordance?.returnToCurrent ??
+                                (() => setViewingVersion(null))
+                              }
+                              // Offered only when the panel says this caller may write.
+                              onRestore={
+                                restoreAffordance?.canRestore
+                                  ? restoreAffordance.request
+                                  : undefined
+                              }
+                              // And only once the version is actually on screen:
+                              // restoring from a skeleton, or from a failed read, is a
+                              // decision made without having seen what is being chosen.
+                              restoreDisabled={!versionOnScreen}
+                            />
+                          ) : null}
+                          <EntryMetaStrip
+                            slugField={slugField}
+                            hasStatus={hasStatus}
+                            // The pill reports the language being edited, matching the header's submit
+                            // affordances. Reading the main row instead would show "Published" beside a
+                            // Publish button whenever a translation lags its default language.
+                            status={
+                              effectiveEntryStatus(
+                                entry,
+                                locale,
+                                defaultLocale
+                              ) ?? "draft"
+                            }
+                            hasWorkingDraft={hasPendingWorkingDraft(entry)}
+                            isRailCollapsed={railCollapsed}
+                            hasPublicAddress={hasPublicAddress}
+                          />
+
+                          {/* The language panel, inline. Its rail mount is
+                        `hidden @4xl/content:flex`, so this is the exact
+                        complement: shown only where the rail is not. When the
+                        rail cannot carry it at all — create mode, or the author
+                        collapsed it — the panel renders unconditionally instead,
+                        because "the actions live in the rail" is precisely the
+                        failure this stage removes. */}
+                          {localizationEnabled && (
+                            <div
+                              className={cn(
+                                "px-6 pt-4",
+                                mode === "edit" &&
+                                  !railCollapsed &&
+                                  "@4xl/content:hidden"
+                              )}
+                            >
+                              <LanguagePanel
+                                {...(entry?._translations === undefined
+                                  ? {}
+                                  : {
+                                      translations:
+                                        entry._translations as Record<
+                                          string,
+                                          {
+                                            translated: boolean;
+                                            status?: string;
+                                          }
+                                        >,
+                                    })}
+                                {...(locale === undefined
+                                  ? {}
+                                  : { activeLocale: locale })}
+                                {...(onLocaleChange === undefined
+                                  ? {}
+                                  : { onSelect: onLocaleChange })}
+                                hasStatus={hasStatus}
+                                actionsDisabled={viewingVersion !== null}
                               />
                             </div>
-                          )
+                          )}
+
+                          {/* Reading a past version replaces the document rather than
+                      opening beside it: the question an editor is asking is how
+                      this page read then, and that is answered by the page. The
+                      live form stays mounted underneath — the historical values
+                      are rendered against a form of their own, so nothing typed
+                      here is disturbed and nothing historical can reach a save. */}
+                          {viewingVersion ? (
+                            <div className="@4xl/content:p-8 pt-6">
+                              {viewingVersion.error ? (
+                                // A failed read must not render as an empty document:
+                                // that is a different and wrong claim about the version.
+                                <Alert variant="destructive">
+                                  <AlertDescription>
+                                    This version could not be loaded.
+                                  </AlertDescription>
+                                </Alert>
+                              ) : !versionOnScreen ? (
+                                <div
+                                  className="flex flex-col gap-4"
+                                  aria-busy="true"
+                                >
+                                  <span className="sr-only" role="status">
+                                    Loading version {viewingVersion.versionNo}
+                                  </span>
+                                  {[0, 1, 2, 3].map(i => (
+                                    <div
+                                      key={i}
+                                      className="flex flex-col gap-1"
+                                    >
+                                      <Skeleton className="h-3 w-24" />
+                                      <Skeleton className="h-9 w-full" />
+                                    </div>
+                                  ))}
+                                </div>
+                              ) : (
+                                <VersionSnapshotForm
+                                  fields={historicalFields ?? mainFields}
+                                  snapshot={viewingVersion.snapshot}
+                                />
+                              )}
+                            </div>
+                          ) : (
+                            mainFields.length > 0 && (
+                              <div className="@4xl/content:p-8 pt-6">
+                                {/* Forward the form mode: in edit mode a blank password
+                        field means "keep the current password" rather than a
+                        required-field violation (see note on the layout form
+                        above). */}
+                                <EntryFormContent
+                                  fields={mainFields}
+                                  disabled={isSubmitting}
+                                  withCard
+                                  mode={mode}
+                                />
+                              </div>
+                            )
+                          )}
+                        </div>
+
+                        {/* Rail (collapsible). Width 320px. Hidden until the content panel
+                  is wide enough (@4xl) to fit it beside the main column, until a
+                  future mobile sheet ships.
+
+                  The mode === "edit" gate: in create mode the entry does not
+                  exist yet, so DocumentPanel returns null and the rail has
+                  nothing to show. Rendering it anyway left an empty 320px
+                  strip down the right side of the page, which reads as a
+                  failed load rather than as an absence. */}
+                        {mode === "edit" && !railCollapsed && (
+                          <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
+                            <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
+                              <EntryFormSidebar
+                                mode={mode}
+                                entry={entry}
+                                hasStatus={hasStatus}
+                                {...(locale === undefined ? {} : { locale })}
+                                {...(onLocaleChange === undefined
+                                  ? {}
+                                  : { onLocaleChange })}
+                                actionsDisabled={viewingVersion !== null}
+                                isDirty={isDirty}
+                              />
+                            </div>
+                          </div>
                         )}
                       </div>
-
-                      {/* Rail (collapsible). Width 320px. Hidden until the content panel
-                is wide enough (@4xl) to fit it beside the main column, until a
-                future mobile sheet ships.
-
-                The mode === "edit" gate: in create mode the entry does not
-                exist yet, so DocumentPanel returns null and the rail has
-                nothing to show. Rendering it anyway left an empty 320px
-                strip down the right side of the page, which reads as a
-                failed load rather than as an absence. */}
-                      {mode === "edit" && !railCollapsed && (
-                        <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
-                          <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
-                            <EntryFormSidebar
-                              mode={mode}
-                              entry={entry}
-                              hasStatus={hasStatus}
-                              {...(locale === undefined ? {} : { locale })}
-                              {...(onLocaleChange === undefined
-                                ? {}
-                                : { onLocaleChange })}
-                              actionsDisabled={viewingVersion !== null}
-                              isDirty={isDirty}
-                            />
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  </EntryFormProvider>
-                </div>
-              </EntryFormContextProvider>
-            </TranslationPanes>
+                    </EntryFormProvider>
+                  </div>
+                </EntryFormContextProvider>
+              </TranslationPanes>
+            </PreviewPanes>
           </DocumentHistoryContext.Provider>
         </EntryLocaleProvider>
       </UnsavedWorkProvider>

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -264,6 +264,21 @@ export function EntryForm({
    */
   const [previewOpen, setPreviewOpen] = useState(false);
 
+  /*
+   * How many times THIS form has saved, which the preview revision folds in.
+   *
+   * Needed because the derived half of that revision goes blind for the most
+   * ordinary edit there is. A status-less save of a published entry writes the
+   * working-draft sidecar and leaves the live row untouched, so from the second
+   * such save onward the document's `updatedAt` and its working-draft flag both
+   * stand still while its content changes underneath them. Counting saves is
+   * the only signal to that write available on this side of the wire.
+   *
+   * A count rather than a timestamp: two saves inside the same millisecond are
+   * indistinguishable by clock, and nothing here needs to know WHEN.
+   */
+  const [savedCount, setSavedCount] = useState(0);
+
   const {
     form,
     handleSubmit,
@@ -279,6 +294,10 @@ export function EntryForm({
     locale,
     readDraft,
     onSuccess: data => {
+      // Before the caller's handler, which may navigate away: this is the only
+      // point that knows a write landed, and a revision that misses one leaves
+      // the pane showing the previous draft.
+      setSavedCount(n => n + 1);
       onSuccess?.(data);
     },
     onError,
@@ -630,7 +649,7 @@ export function EntryForm({
    * grant over every translation, while a preview opened without one silently
    * shows the wrong one.
    */
-  const previewRevision = previewRevisionOf(entry);
+  const previewRevision = previewRevisionOf(entry, savedCount);
 
   const canPreview =
     entryPreview.isPreviewAvailable &&

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -116,6 +116,22 @@ export interface EntrySystemHeaderProps {
   /** Label for the preview action. Defaults to "Preview". */
   previewLabel?: string;
   /**
+   * Opens and closes the preview PANE, which is a different action from opening
+   * the preview in a tab.
+   *
+   * Two controls rather than one with a mode, because they answer different
+   * questions: a tab is for looking at the page on its own — on a phone, on a
+   * second monitor, to send to someone standing beside you — and the pane is
+   * for watching it while you edit. A single control would have to guess which,
+   * and the wrong guess costs a page load and the editor's place on screen.
+   *
+   * Absent means the surface offers no pane at all, which is what an embedded
+   * editor in a modal does.
+   */
+  onTogglePreviewPane?: () => void;
+  /** Whether that pane is currently open, for the control's pressed state. */
+  previewPaneOpen?: boolean;
+  /**
    * Whether there is a saved document for a link to name.
    *
    * Deliberately NOT ANDed with `update-{slug}` here. The mint endpoint
@@ -256,6 +272,8 @@ export function EntrySystemHeader({
   isPreviewAvailable = false,
   onPreview,
   previewLabel,
+  onTogglePreviewPane,
+  previewPaneOpen = false,
   isLinkAvailable = false,
   onCopyLink,
   isCopyingLink = false,
@@ -491,6 +509,30 @@ export function EntrySystemHeader({
             isCopyingLink={isCopyingLink}
             disabled={isSubmitting}
           />
+          {/* The pane toggle, beside the preview actions rather than inside
+              them: `PreviewActions` decides its own shape from which of OPEN
+              and COPY are available, and a third action would make that a
+              three-way decision for a control whose whole design is that it
+              collapses to one button when only one thing can be done.
+
+              Offered only where a pane exists to open — an embedded editor in
+              a modal passes no handler and gets no control. */}
+          {onTogglePreviewPane !== undefined && (
+            <Button
+              type="button"
+              variant={previewPaneOpen ? "secondary" : "ghost"}
+              size="sm"
+              onClick={onTogglePreviewPane}
+              disabled={isSubmitting}
+              aria-pressed={previewPaneOpen}
+              title={previewPaneOpen ? "Hide the preview" : "Show the preview"}
+            >
+              <PanelRight className="h-4 w-4" aria-hidden="true" />
+              <ToolbarLabel priority="secondary">
+                {previewPaneOpen ? "Hide preview" : "Show preview"}
+              </ToolbarLabel>
+            </Button>
+          )}
           {/* Sits with the actions rather than beside the title: it reports on
             the same work the save buttons act on, and reads as status for that
             cluster.

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+/**
+ * The site, rendered inside the admin, showing the draft as last saved.
+ *
+ * An IFRAME rather than a rendered-in-place copy, and that is the load-bearing
+ * decision rather than a convenience. The frame is a real browsing context with
+ * a real viewport, so the page's own `@media` rules resolve exactly as they do
+ * for a visitor — and its document is the SITE's, so nothing the admin styles
+ * leaks in and nothing the site styles leaks out. Rendering the page inside the
+ * admin document would answer a different question than the one an author is
+ * asking, which is "what will this look like".
+ *
+ * `sandbox` is deliberately NOT set. The site is first-party content the editor
+ * is authorised to read, and a sandbox without `allow-same-origin` would break
+ * the site's own cookies — including the preview cookie the token was exchanged
+ * for, which is what makes the draft visible at all.
+ *
+ * @module components/features/entries/PreviewMode/PreviewFrame
+ */
+
+import { Button } from "@nextlyhq/ui";
+
+import { ExternalLink, Loader2, RefreshCw, X } from "@admin/components/icons";
+import { PREVIEW_MESSAGES } from "@admin/hooks/useEntryPreview";
+
+import type { UsePreviewFrameResult } from "./usePreviewFrame";
+
+export interface PreviewFrameProps extends UsePreviewFrameResult {
+  /** Close the pane and return the editor to its ordinary measure. */
+  onClose: () => void;
+  /** The label the collection chose for its preview, for the frame's title. */
+  label: string;
+}
+
+export function PreviewFrame({
+  url,
+  reloadKey,
+  isLoading,
+  reason,
+  refresh,
+  onClose,
+  label,
+}: PreviewFrameProps) {
+  return (
+    <div className="flex h-full min-h-0 flex-col border-l border-border bg-muted/40">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border bg-background px-3 py-2">
+        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {label}
+        </span>
+        {/* States what the frame IS showing rather than what an author might
+            hope it shows. The pane cannot reflect unsaved edits — the site
+            renders the saved draft on its own server — and an author who is not
+            told that reads a stale-looking page as the preview being broken. */}
+        <span className="truncate text-xs text-muted-foreground">
+          · last saved draft
+        </span>
+
+        <div className="ml-auto flex items-center gap-1">
+          {isLoading && (
+            <Loader2
+              className="h-3.5 w-3.5 animate-spin text-muted-foreground"
+              aria-hidden="true"
+            />
+          )}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={refresh}
+            disabled={url === null}
+            title="Refresh the preview"
+          >
+            <RefreshCw className="h-4 w-4" aria-hidden="true" />
+            <span className="sr-only">Refresh the preview</span>
+          </Button>
+          {url !== null && (
+            <Button asChild variant="ghost" size="sm" title="Open in a new tab">
+              {/* `rel` carries noopener as well as noreferrer: a preview URL is
+                  a bearer credential, and a referrer header would hand it to
+                  whatever the opened page links to next. */}
+              <a href={url} target="_blank" rel="noopener noreferrer">
+                <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                <span className="sr-only">Open the preview in a new tab</span>
+              </a>
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+            title="Close the preview"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+            <span className="sr-only">Close the preview</span>
+          </Button>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1">
+        {reason !== null ? (
+          /* The reason, not a generic failure. Each of these names something
+             the reader can act on, and the pane is the only place they will
+             see it — unlike the Preview button, which can raise a toast. */
+          <p className="p-6 text-sm text-muted-foreground">
+            {PREVIEW_MESSAGES[reason]}
+          </p>
+        ) : url === null ? (
+          <p className="p-6 text-sm text-muted-foreground">
+            Preparing the preview…
+          </p>
+        ) : (
+          <iframe
+            // Remounted rather than navigated: see `usePreviewFrame` on why a
+            // key beats appending a cache-buster the SITE would have to read.
+            key={reloadKey}
+            src={url}
+            title={`${label} preview`}
+            className="h-full w-full border-0 bg-background"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
@@ -16,6 +16,12 @@
  * the site's own cookies — including the preview cookie the token was exchanged
  * for, which is what makes the draft visible at all.
  *
+ * When the pane cannot carry a preview session it renders the reason and NO
+ * iframe. That is the whole point of the state: both blocking conditions end in
+ * the site serving the published page, which looks like a working preview of
+ * unsaved-looking content. An empty pane with a sentence beats a frame that is
+ * confidently wrong, and the tab remains one click away in every such state.
+ *
  * @module components/features/entries/PreviewMode/PreviewFrame
  */
 
@@ -24,7 +30,10 @@ import { Button } from "@nextlyhq/ui";
 import { ExternalLink, Loader2, RefreshCw, X } from "@admin/components/icons";
 import { PREVIEW_MESSAGES } from "@admin/hooks/useEntryPreview";
 
-import type { UsePreviewFrameResult } from "./usePreviewFrame";
+import {
+  PREVIEW_PANE_BLOCK_MESSAGES,
+  type UsePreviewFrameResult,
+} from "./usePreviewFrame";
 
 export interface PreviewFrameProps extends UsePreviewFrameResult {
   /** Close the pane and return the editor to its ordinary measure. */
@@ -38,6 +47,7 @@ export function PreviewFrame({
   reloadKey,
   isLoading,
   reason,
+  block,
   refresh,
   onClose,
   label,
@@ -51,10 +61,13 @@ export function PreviewFrame({
         {/* States what the frame IS showing rather than what an author might
             hope it shows. The pane cannot reflect unsaved edits — the site
             renders the saved draft on its own server — and an author who is not
-            told that reads a stale-looking page as the preview being broken. */}
-        <span className="truncate text-xs text-muted-foreground">
-          · last saved draft
-        </span>
+            told that reads a stale-looking page as the preview being broken.
+            Withdrawn while blocked, where no draft is on screen to describe. */}
+        {block === null && (
+          <span className="truncate text-xs text-muted-foreground">
+            · last saved draft
+          </span>
+        )}
 
         <div className="ml-auto flex items-center gap-1">
           {isLoading && (
@@ -74,7 +87,8 @@ export function PreviewFrame({
              * reason, and the message beside it asks the editor to try again —
              * so keying the control on `url` disabled the one affordance that
              * message points at, and the only way to retry was to close the
-             * pane and reopen it.
+             * pane and reopen it. A superseded pane needs it for the same
+             * reason: refreshing is how the session comes back.
              */
             disabled={isLoading}
             title="Refresh the preview"
@@ -113,6 +127,14 @@ export function PreviewFrame({
              see it — unlike the Preview button, which can raise a toast. */
           <p className="p-6 text-sm text-muted-foreground">
             {PREVIEW_MESSAGES[reason]}
+          </p>
+        ) : block !== null ? (
+          /* Ahead of the `url === null` branch on purpose: a blocked pane HAS a
+             url — that is what makes the tab button beside this message the
+             remedy — so testing for a missing url first would render "Preparing
+             the preview…" forever over a pane that is not preparing anything. */
+          <p className="p-6 text-sm text-muted-foreground">
+            {PREVIEW_PANE_BLOCK_MESSAGES[block]}
           </p>
         ) : url === null ? (
           <p className="p-6 text-sm text-muted-foreground">

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
@@ -68,7 +68,15 @@ export function PreviewFrame({
             variant="ghost"
             size="sm"
             onClick={refresh}
-            disabled={url === null}
+            /*
+             * Disabled only while a mint is IN FLIGHT, never because there is
+             * nothing to show. A failed mint leaves `url` null and sets a
+             * reason, and the message beside it asks the editor to try again —
+             * so keying the control on `url` disabled the one affordance that
+             * message points at, and the only way to retry was to close the
+             * pane and reopen it.
+             */
+            disabled={isLoading}
             title="Refresh the preview"
           >
             <RefreshCw className="h-4 w-4" aria-hidden="true" />

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
@@ -56,14 +56,17 @@ export interface PreviewPanesProps {
   /** The collection's own word for its preview. */
   label: string;
   /**
-   * Changes whenever the document is saved.
+   * What the preview would render, as a value that changes when it does.
    *
-   * A TOKEN rather than a callback the form invokes, because the pane may not
-   * be open when a save happens and a callback would need the form to know
-   * whether anyone is listening. A value that changes is a fact about the
-   * document; whether it causes a reload is this component's business.
+   * DERIVED from the document rather than notified by whoever wrote it, because
+   * a form submission is not the only write: discarding a working draft and
+   * restoring a version both persist through their own mutations, and a token
+   * bumped by the submit handler leaves the frame showing content that was just
+   * discarded. Deriving means a write nobody remembered to announce still moves
+   * it — which is the difference between covering the writes we listed and
+   * covering the writes there are.
    */
-  savedAt: number;
+  revision: string;
   children: ReactNode;
 }
 
@@ -84,7 +87,7 @@ function ActivePreviewPanes({
   entryId,
   locale,
   label,
-  savedAt,
+  revision,
   children,
 }: Omit<PreviewPanesProps, "open">) {
   /*
@@ -129,7 +132,7 @@ function ActivePreviewPanes({
       <ResizablePanel id="entry-preview" minSize="25%">
         <PreviewFrameOnSave
           frame={frame}
-          savedAt={savedAt}
+          revision={revision}
           onClose={onClose}
           label={label}
         />
@@ -139,9 +142,9 @@ function ActivePreviewPanes({
 }
 
 /**
- * Turns "the document was saved" into "show it again".
+ * Turns "what the preview would render has changed" into "show it again".
  *
- * Its own component so the effect that watches `savedAt` sits beside the frame
+ * Its own component so the effect that watches the revision sits beside the frame
  * it refreshes rather than in the layout above.
  *
  * The first value is REMEMBERED rather than acted on. The frame has just minted
@@ -151,23 +154,23 @@ function ActivePreviewPanes({
  */
 function PreviewFrameOnSave({
   frame,
-  savedAt,
+  revision,
   onClose,
   label,
 }: {
   frame: UsePreviewFrameResult;
-  savedAt: number;
+  revision: string;
   onClose: () => void;
   label: string;
 }) {
   const { refresh } = frame;
-  const lastSeen = useRef(savedAt);
+  const lastSeen = useRef(revision);
 
   useEffect(() => {
-    if (lastSeen.current === savedAt) return;
-    lastSeen.current = savedAt;
+    if (lastSeen.current === revision) return;
+    lastSeen.current = revision;
     refresh();
-  }, [savedAt, refresh]);
+  }, [revision, refresh]);
 
   return <PreviewFrame {...frame} onClose={onClose} label={label} />;
 }

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
@@ -58,13 +58,18 @@ export interface PreviewPanesProps {
   /**
    * What the preview would render, as a value that changes when it does.
    *
-   * DERIVED from the document rather than notified by whoever wrote it, because
-   * a form submission is not the only write: discarding a working draft and
-   * restoring a version both persist through their own mutations, and a token
-   * bumped by the submit handler leaves the frame showing content that was just
-   * discarded. Deriving means a write nobody remembered to announce still moves
-   * it — which is the difference between covering the writes we listed and
-   * covering the writes there are.
+   * Both DERIVED from the document and COUNTED from the form's own saves,
+   * because each kind of evidence is blind where the other sees. Deriving
+   * catches writes nobody announced — discarding a working draft and restoring
+   * a version each persist through their own mutation, so a token bumped only
+   * by the submit handler leaves the frame showing content that was just
+   * discarded. Counting catches the opposite: a status-less save of a published
+   * entry writes the draft sidecar and moves nothing the document exposes, so
+   * every save after the first is invisible to derivation alone.
+   *
+   * {@link previewRevisionOf} builds it. Passed in rather than computed here so
+   * the pane stays a layout: the facts it is made of belong to the form that
+   * holds the document.
    */
   revision: string;
   children: ReactNode;

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+/**
+ * The entry being edited, beside the page it becomes.
+ *
+ * A WRAPPER rather than a second editor, for the reason `TranslationPanes` is
+ * one: the document keeps the form it already had — same context, same unsaved
+ * guard, same autosave, same save intent — and this puts a frame beside it. A
+ * route of its own would duplicate all four and give the guard a second address
+ * to learn.
+ *
+ * Inactive it renders `children` and nothing else: no wrapper element, no
+ * suppression request, no credential minted. An editor who never opens the
+ * preview gets the ordinary page, and that has to be true STRUCTURALLY rather
+ * than by the styles happening to agree.
+ *
+ * ## Why this asks for the page frame and nothing else
+ *
+ * The editor's measure is a 56rem column, declared by `MeasuredPageFrame`, and
+ * two panes cannot share it. The frame is released the way the page builder
+ * releases it — by asking, from inside — rather than by the page passing a
+ * different width: `MeasuredPageFrame` states that framed and immersive are the
+ * whole vocabulary, and a third value would be a second way to answer a
+ * question it already answers.
+ *
+ * The admin's NAVIGATION stays. This is an auxiliary pane rather than a
+ * takeover: an author opening a preview has not left the admin, and taking the
+ * rail would make the editor behave like the page builder for a control that is
+ * closed again a moment later.
+ *
+ * @module components/features/entries/PreviewMode/PreviewPanes
+ */
+
+import { useEffect, useRef, type ReactNode } from "react";
+
+import { useSuppressAdminChrome } from "@admin/components/layout/ChromeSuppression";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@admin/components/ui";
+
+import { PreviewFrame } from "./PreviewFrame";
+import { usePreviewFrame, type UsePreviewFrameResult } from "./usePreviewFrame";
+
+export interface PreviewPanesProps {
+  /** Whether the pane is open. Closed renders `children` untouched. */
+  open: boolean;
+  /** Close the pane. Rendered by this component, so it cannot be forgotten. */
+  onClose: () => void;
+  collection: string;
+  /** The SAVED entry id. */
+  entryId: string;
+  /** The language to scope the preview credential to, when there is one. */
+  locale?: string | undefined;
+  /** The collection's own word for its preview. */
+  label: string;
+  /**
+   * Changes whenever the document is saved.
+   *
+   * A TOKEN rather than a callback the form invokes, because the pane may not
+   * be open when a save happens and a callback would need the form to know
+   * whether anyone is listening. A value that changes is a fact about the
+   * document; whether it causes a reload is this component's business.
+   */
+  savedAt: number;
+  children: ReactNode;
+}
+
+export function PreviewPanes({ open, children, ...rest }: PreviewPanesProps) {
+  if (!open) return <>{children}</>;
+  return <ActivePreviewPanes {...rest}>{children}</ActivePreviewPanes>;
+}
+
+/**
+ * A separate component so the chrome request and the mint run only while the
+ * pane is open — the same split `TranslationPanes` and `BlocksField` both make.
+ * Calling either from the wrapper would release the page frame for every entry
+ * whether or not anyone asked, and mint a credential for a pane nobody opened.
+ */
+function ActivePreviewPanes({
+  onClose,
+  collection,
+  entryId,
+  locale,
+  label,
+  savedAt,
+  children,
+}: Omit<PreviewPanesProps, "open">) {
+  /*
+   * `pageFrame` alone. The rail, the sidebars and the header stay: this is a
+   * pane beside the editor, not a surface that took the window, and an author
+   * who can still see the navigation has not been stranded by it.
+   *
+   * `canExit` is nonetheless true and honest — the frame renders its own close
+   * control — so the claim stays correct if this ever asks for the rail too.
+   */
+  useSuppressAdminChrome({ layers: ["pageFrame"], canExit: true });
+
+  const frame = usePreviewFrame({ collection, entryId, locale, active: true });
+
+  return (
+    <ResizablePanelGroup
+      orientation="horizontal"
+      className="min-h-0 flex-1"
+      // Percentage STRINGS: this library reads a bare number as pixels, so
+      // `defaultSize={55}` would be a 55-pixel pane rather than 55 percent.
+    >
+      <ResizablePanel id="entry-editor" minSize="35%" defaultSize="55%">
+        {/*
+         * `@container/content` is declared HERE, and it is what stops the
+         * editor laying itself out against the page while rendering into half
+         * of it. The dashboard's `<main>` carries that container and stays
+         * full-page width, so without this every `@4xl/content:` query inside
+         * the form measures the window: the document rail is placed beside a
+         * column that no longer has room for it and overflows the pane.
+         */}
+        <div className="@container/content h-full overflow-y-auto">
+          {/* The pane stands in for `PageContainer`, so it owes the same
+              horizontal inset — and stops owing it where the editor's own
+              columns go edge-to-edge. On an INNER element because a container
+              cannot query itself. */}
+          <div className="px-4 @sm/content:px-6 @2xl/content:px-8 @4xl/content:px-0">
+            {children}
+          </div>
+        </div>
+      </ResizablePanel>
+      <ResizableHandle withGrip />
+      <ResizablePanel id="entry-preview" minSize="25%">
+        <PreviewFrameOnSave
+          frame={frame}
+          savedAt={savedAt}
+          onClose={onClose}
+          label={label}
+        />
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  );
+}
+
+/**
+ * Turns "the document was saved" into "show it again".
+ *
+ * Its own component so the effect that watches `savedAt` sits beside the frame
+ * it refreshes rather than in the layout above.
+ *
+ * The first value is REMEMBERED rather than acted on. The frame has just minted
+ * and loaded when the pane opens, and treating the token's initial value as a
+ * save would load the same page a second time on every open — visible as a
+ * flash, and a wasted render of the site.
+ */
+function PreviewFrameOnSave({
+  frame,
+  savedAt,
+  onClose,
+  label,
+}: {
+  frame: UsePreviewFrameResult;
+  savedAt: number;
+  onClose: () => void;
+  label: string;
+}) {
+  const { refresh } = frame;
+  const lastSeen = useRef(savedAt);
+
+  useEffect(() => {
+    if (lastSeen.current === savedAt) return;
+    lastSeen.current = savedAt;
+    refresh();
+  }, [savedAt, refresh]);
+
+  return <PreviewFrame {...frame} onClose={onClose} label={label} />;
+}
+
+export { PreviewFrame };

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewPanes.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewPanes.test.tsx
@@ -11,6 +11,11 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const suppress = vi.hoisted(() => vi.fn());
+/*
+ * Typed WIDER than its initial value on purpose: two cases below drive the
+ * frame's failure and loading states, and an inferred `url: string` /
+ * `reason: null` would reject exactly the states worth testing.
+ */
 const frameState = vi.hoisted(() => ({
   current: {
     url: "https://site.example/api/preview?token=t",
@@ -18,6 +23,12 @@ const frameState = vi.hoisted(() => ({
     isLoading: false,
     reason: null,
     refresh: vi.fn(),
+  } as {
+    url: string | null;
+    reloadKey: number;
+    isLoading: boolean;
+    reason: string | null;
+    refresh: ReturnType<typeof vi.fn>;
   },
 }));
 
@@ -36,12 +47,21 @@ const props = {
   collection: "pages",
   entryId: "7",
   label: "Preview",
-  savedAt: 0,
+  revision: "r1",
 };
 
 beforeEach(() => {
   vi.clearAllMocks();
-  frameState.current.refresh = vi.fn();
+  // Rebuilt each time: two cases below replace the whole object to drive the
+  // frame's failure and loading states, and leaving that in place would carry
+  // into the next test.
+  frameState.current = {
+    url: "https://site.example/api/preview?token=t",
+    reloadKey: 0,
+    isLoading: false,
+    reason: null,
+    refresh: vi.fn(),
+  };
 });
 
 describe("PreviewPanes when the pane is closed", () => {
@@ -100,12 +120,58 @@ describe("PreviewPanes when the pane is open", () => {
   });
 });
 
-describe("the save that refreshes the frame", () => {
+describe("retrying after a mint that failed", () => {
+  it("leaves the refresh control usable", async () => {
+    // The message beside it asks the editor to try again, and `refresh` mints
+    // again — so a control disabled here points at an affordance that is not
+    // there, and the only retry was to close the pane and reopen it.
+    frameState.current = {
+      ...frameState.current,
+      url: null,
+      reason: "failed",
+      isLoading: false,
+    };
+
+    render(
+      <PreviewPanes {...props} open>
+        <p>editor</p>
+      </PreviewPanes>
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Refresh the preview" })
+    ).toBeEnabled();
+  });
+
+  it("disables it only while a mint is in flight", () => {
+    // The control for the case above: there IS a state that disables it, so
+    // the assertion above is about the failure case rather than about a
+    // control that can never be disabled at all.
+    frameState.current = {
+      ...frameState.current,
+      url: null,
+      reason: null,
+      isLoading: true,
+    };
+
+    render(
+      <PreviewPanes {...props} open>
+        <p>editor</p>
+      </PreviewPanes>
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Refresh the preview" })
+    ).toBeDisabled();
+  });
+});
+
+describe("the document change that refreshes the frame", () => {
   it("does not reload on the first render", () => {
     // The frame has just minted and loaded. Treating the token's initial value
     // as a save would render the site twice on every open.
     render(
-      <PreviewPanes {...props} open savedAt={0}>
+      <PreviewPanes {...props} open revision="r1">
         <p>editor</p>
       </PreviewPanes>
     );
@@ -113,9 +179,9 @@ describe("the save that refreshes the frame", () => {
     expect(frameState.current.refresh).not.toHaveBeenCalled();
   });
 
-  it("reloads when the document is saved", () => {
+  it("reloads when the document revision changes", () => {
     const { rerender } = render(
-      <PreviewPanes {...props} open savedAt={0}>
+      <PreviewPanes {...props} open revision="r1">
         <p>editor</p>
       </PreviewPanes>
     );
@@ -125,7 +191,7 @@ describe("the save that refreshes the frame", () => {
     expect(frameState.current.refresh).not.toHaveBeenCalled();
 
     rerender(
-      <PreviewPanes {...props} open savedAt={1730000000000}>
+      <PreviewPanes {...props} open revision="r2">
         <p>editor</p>
       </PreviewPanes>
     );
@@ -135,19 +201,19 @@ describe("the save that refreshes the frame", () => {
 
   it("does not reload again when something else rerenders it", () => {
     const { rerender } = render(
-      <PreviewPanes {...props} open savedAt={5}>
+      <PreviewPanes {...props} open revision="r1">
         <p>editor</p>
       </PreviewPanes>
     );
     rerender(
-      <PreviewPanes {...props} open savedAt={9}>
+      <PreviewPanes {...props} open revision="r2">
         <p>editor</p>
       </PreviewPanes>
     );
     expect(frameState.current.refresh).toHaveBeenCalledTimes(1);
 
     rerender(
-      <PreviewPanes {...props} open savedAt={9} label="Preview">
+      <PreviewPanes {...props} open revision="r2" label="Preview">
         <p>editor</p>
       </PreviewPanes>
     );

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewPanes.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewPanes.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * What the preview pane costs when nobody opens it, and what it asks for when
+ * somebody does.
+ *
+ * The claims worth pinning are the ones the component's own docblock makes:
+ * inactive it is structurally absent rather than merely invisible, and active
+ * it releases the page MEASURE without taking the admin's navigation. Both are
+ * assertions about what did NOT happen, so each carries a control.
+ */
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const suppress = vi.hoisted(() => vi.fn());
+const frameState = vi.hoisted(() => ({
+  current: {
+    url: "https://site.example/api/preview?token=t",
+    reloadKey: 0,
+    isLoading: false,
+    reason: null,
+    refresh: vi.fn(),
+  },
+}));
+
+vi.mock("@admin/components/layout/ChromeSuppression", () => ({
+  useSuppressAdminChrome: (o: unknown) => suppress(o),
+}));
+
+vi.mock("../usePreviewFrame", () => ({
+  usePreviewFrame: () => frameState.current,
+}));
+
+import { PreviewPanes } from "../PreviewPanes";
+
+const props = {
+  onClose: vi.fn(),
+  collection: "pages",
+  entryId: "7",
+  label: "Preview",
+  savedAt: 0,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  frameState.current.refresh = vi.fn();
+});
+
+describe("PreviewPanes when the pane is closed", () => {
+  it("renders the editor with no wrapper of its own", () => {
+    const { container } = render(
+      <PreviewPanes {...props} open={false}>
+        <p data-testid="editor">editor</p>
+      </PreviewPanes>
+    );
+
+    // The child is the ROOT, so nothing was wrapped around it. A wrapper that
+    // merely had no styles would still show up here as a parent element.
+    expect(container.firstElementChild).toBe(screen.getByTestId("editor"));
+  });
+
+  it("asks for no chrome, so a closed pane costs the page nothing", () => {
+    render(
+      <PreviewPanes {...props} open={false}>
+        <p>editor</p>
+      </PreviewPanes>
+    );
+
+    expect(suppress).not.toHaveBeenCalled();
+  });
+});
+
+describe("PreviewPanes when the pane is open", () => {
+  it("releases the page measure and keeps the admin's navigation", () => {
+    render(
+      <PreviewPanes {...props} open>
+        <p>editor</p>
+      </PreviewPanes>
+    );
+
+    // The POSITIVE half: it does ask, so the negative above is a true absence
+    // rather than a hook that never runs.
+    expect(suppress).toHaveBeenCalledWith({
+      layers: ["pageFrame"],
+      canExit: true,
+    });
+  });
+
+  it("declares its own content container around the editor", () => {
+    // Without this the editor's `@4xl/content:` queries measure the dashboard's
+    // full-width `<main>` while rendering into half of it, and the document
+    // rail is laid out beside a column with no room for it.
+    const { container } = render(
+      <PreviewPanes {...props} open>
+        <p data-testid="editor">editor</p>
+      </PreviewPanes>
+    );
+
+    const editor = screen.getByTestId("editor");
+    expect(container.querySelector(".\\@container\\/content")).not.toBeNull();
+    expect(editor.closest(".\\@container\\/content")).not.toBeNull();
+  });
+});
+
+describe("the save that refreshes the frame", () => {
+  it("does not reload on the first render", () => {
+    // The frame has just minted and loaded. Treating the token's initial value
+    // as a save would render the site twice on every open.
+    render(
+      <PreviewPanes {...props} open savedAt={0}>
+        <p>editor</p>
+      </PreviewPanes>
+    );
+
+    expect(frameState.current.refresh).not.toHaveBeenCalled();
+  });
+
+  it("reloads when the document is saved", () => {
+    const { rerender } = render(
+      <PreviewPanes {...props} open savedAt={0}>
+        <p>editor</p>
+      </PreviewPanes>
+    );
+    // The control for the assertion above: same component, same props but for
+    // the token, and now it DOES refresh — so the silence above is about the
+    // first render rather than about a wire that was never connected.
+    expect(frameState.current.refresh).not.toHaveBeenCalled();
+
+    rerender(
+      <PreviewPanes {...props} open savedAt={1730000000000}>
+        <p>editor</p>
+      </PreviewPanes>
+    );
+
+    expect(frameState.current.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload again when something else rerenders it", () => {
+    const { rerender } = render(
+      <PreviewPanes {...props} open savedAt={5}>
+        <p>editor</p>
+      </PreviewPanes>
+    );
+    rerender(
+      <PreviewPanes {...props} open savedAt={9}>
+        <p>editor</p>
+      </PreviewPanes>
+    );
+    expect(frameState.current.refresh).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <PreviewPanes {...props} open savedAt={9} label="Preview">
+        <p>editor</p>
+      </PreviewPanes>
+    );
+
+    expect(frameState.current.refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewPanes.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewPanes.test.tsx
@@ -22,12 +22,14 @@ const frameState = vi.hoisted(() => ({
     reloadKey: 0,
     isLoading: false,
     reason: null,
+    block: null,
     refresh: vi.fn(),
   } as {
     url: string | null;
     reloadKey: number;
     isLoading: boolean;
     reason: string | null;
+    block: string | null;
     refresh: ReturnType<typeof vi.fn>;
   },
 }));
@@ -36,7 +38,13 @@ vi.mock("@admin/components/layout/ChromeSuppression", () => ({
   useSuppressAdminChrome: (o: unknown) => suppress(o),
 }));
 
-vi.mock("../usePreviewFrame", () => ({
+/*
+ * Only the HOOK is replaced. The block messages come from the real module, so
+ * the cases below render the copy an author would actually read rather than a
+ * fixture that would keep passing after the real text was emptied.
+ */
+vi.mock("../usePreviewFrame", async importOriginal => ({
+  ...(await importOriginal<typeof import("../usePreviewFrame")>()),
   usePreviewFrame: () => frameState.current,
 }));
 
@@ -60,6 +68,7 @@ beforeEach(() => {
     reloadKey: 0,
     isLoading: false,
     reason: null,
+    block: null,
     refresh: vi.fn(),
   };
 });
@@ -163,6 +172,81 @@ describe("retrying after a mint that failed", () => {
     expect(
       screen.getByRole("button", { name: "Refresh the preview" })
     ).toBeDisabled();
+  });
+});
+
+describe("a pane that holds a url it must not frame", () => {
+  /*
+   * Both blocking states end the same way if the frame is rendered anyway: the
+   * site receives a request with no preview session and answers with the
+   * PUBLISHED page, inside a pane captioned as a draft. So the assertion that
+   * matters is the absence of the iframe, and it carries its control below.
+   */
+  it("renders no iframe when the site is on another origin", () => {
+    frameState.current = { ...frameState.current, block: "crossOrigin" };
+
+    const { container } = render(
+      <PreviewPanes {...props} open>
+        <p>editor</p>
+      </PreviewPanes>
+    );
+
+    expect(container.querySelector("iframe")).toBeNull();
+  });
+
+  it("renders no iframe when another pane took the session", () => {
+    frameState.current = { ...frameState.current, block: "superseded" };
+
+    const { container } = render(
+      <PreviewPanes {...props} open>
+        <p>editor</p>
+      </PreviewPanes>
+    );
+
+    expect(container.querySelector("iframe")).toBeNull();
+  });
+
+  it("DOES render one when nothing blocks it", () => {
+    // The control for both absences above: the pane is capable of rendering a
+    // frame, so those are refusals rather than a component that never does.
+    const { container } = render(
+      <PreviewPanes {...props} open>
+        <p>editor</p>
+      </PreviewPanes>
+    );
+
+    expect(container.querySelector("iframe")).not.toBeNull();
+  });
+
+  it("keeps the new-tab link, which is what the message points at", () => {
+    // A cross-origin site previews perfectly well in a TAB — only the frame
+    // cannot carry the cookie — so removing the link with the frame would take
+    // away the remedy along with the problem.
+    frameState.current = { ...frameState.current, block: "crossOrigin" };
+
+    render(
+      <PreviewPanes {...props} open>
+        <p>editor</p>
+      </PreviewPanes>
+    );
+
+    expect(
+      screen.getByRole("link", { name: "Open the preview in a new tab" })
+    ).toHaveAttribute("href", "https://site.example/api/preview?token=t");
+  });
+
+  it("leaves refresh enabled, since refreshing is how the session comes back", () => {
+    frameState.current = { ...frameState.current, block: "superseded" };
+
+    render(
+      <PreviewPanes {...props} open>
+        <p>editor</p>
+      </PreviewPanes>
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Refresh the preview" })
+    ).toBeEnabled();
   });
 });
 

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/previewRevision.test.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/previewRevision.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Whether the revision actually MOVES for each write that changes the preview.
+ *
+ * The pane test proves that a changed revision reloads the frame. It does that
+ * by handing the component `"r1"` and then `"r2"`, which says nothing about
+ * whether this function would ever have produced the second value — so the
+ * writes themselves are exercised here, on documents shaped the way the server
+ * really returns them.
+ *
+ * Every case needs TWO saves. One save cannot distinguish an implementation
+ * that tracks the write from one that never updates at all, because both agree
+ * on the first value.
+ */
+import { describe, expect, it } from "vitest";
+
+import { previewRevisionOf } from "../previewRevision";
+
+/** A published entry, as read before anyone edits it. */
+const published = {
+  id: "7",
+  updatedAt: "2026-08-25T10:00:00.000Z",
+};
+
+/**
+ * The same entry after a status-less save.
+ *
+ * `updatedAt` is UNCHANGED on purpose, and that is the whole point of these
+ * cases rather than a shortcut in the fixture: the save writes the working-draft
+ * sidecar and leaves the live row alone, and `shapeDraftForResponse` then copies
+ * the live parent's timestamps onto the response. The document a client sees
+ * after such a save carries the published row's `updatedAt`, every time.
+ */
+const draftSave = {
+  ...published,
+  _isWorkingDraft: true,
+};
+
+describe("previewRevisionOf across working-draft saves", () => {
+  it("moves on the FIRST draft save of a published entry", () => {
+    // Derivation alone is enough here: `_isWorkingDraft` flips false to true.
+    expect(previewRevisionOf(published, 0)).not.toBe(
+      previewRevisionOf(draftSave, 1)
+    );
+  });
+
+  it("moves on the SECOND draft save, where both derived facts stand still", () => {
+    /*
+     * The regression this exists for. After the first save `_isWorkingDraft` is
+     * already `true` and `updatedAt` is frozen at the published row's value, so
+     * every later draft save changes the content and moves neither fact. A
+     * revision built from the document alone is constant from here on and the
+     * pane silently stops matching what the author is editing.
+     */
+    expect(previewRevisionOf(draftSave, 1)).not.toBe(
+      previewRevisionOf(draftSave, 2)
+    );
+  });
+
+  it("keeps moving across a run of draft saves", () => {
+    const seen = [1, 2, 3, 4, 5].map(n => previewRevisionOf(draftSave, n));
+    expect(new Set(seen).size).toBe(seen.length);
+  });
+});
+
+describe("previewRevisionOf on writes the form never announced", () => {
+  it("moves when a working draft is discarded, with no save of its own", () => {
+    /*
+     * The other half of the union, and why the save count is not the whole
+     * answer. Discarding persists through its own mutation: the count does not
+     * move, `updatedAt` does not move — the draft is a separate row from the
+     * published one — and only the flag going false says the frame is now
+     * showing content that no longer exists.
+     */
+    expect(previewRevisionOf(draftSave, 3)).not.toBe(
+      previewRevisionOf(published, 3)
+    );
+  });
+
+  it("moves when a restore rewrites the live row under an unchanged count", () => {
+    const restored = { ...published, updatedAt: "2026-08-25T11:30:00.000Z" };
+    expect(previewRevisionOf(published, 3)).not.toBe(
+      previewRevisionOf(restored, 3)
+    );
+  });
+});
+
+describe("previewRevisionOf reading the timestamp", () => {
+  it("accepts the snake_case spelling the other read path returns", () => {
+    // A reader that knew only one spelling returned "" for the other, which
+    // compares equal to itself forever — the revision would stop moving rather
+    // than fail loudly.
+    const a = { updated_at: "2026-08-25T10:00:00.000Z" };
+    const b = { updated_at: "2026-08-25T10:00:01.000Z" };
+    expect(previewRevisionOf(a, 0)).not.toBe(previewRevisionOf(b, 0));
+  });
+
+  it("keeps sub-second precision, so two saves in one second differ", () => {
+    // `String(new Date())` drops milliseconds, and these two would compare
+    // equal under it.
+    const a = { updatedAt: new Date("2026-08-25T10:00:00.100Z") };
+    const b = { updatedAt: new Date("2026-08-25T10:00:00.900Z") };
+    expect(previewRevisionOf(a, 0)).not.toBe(previewRevisionOf(b, 0));
+  });
+
+  it("survives a document that is missing entirely", () => {
+    expect(() => previewRevisionOf(null, 0)).not.toThrow();
+    expect(() => previewRevisionOf(undefined, 0)).not.toThrow();
+  });
+});

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/sameOriginPreview.test.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/sameOriginPreview.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Which minted URLs the pane will frame, and which it hands to a tab instead.
+ *
+ * The consequence of getting this wrong is not an error: a cross-origin frame
+ * loads, the preview cookie never reaches it, and the site answers with the
+ * PUBLISHED page. So the interesting assertions here are the refusals, and each
+ * one is paired with the accept that proves the predicate is not simply
+ * refusing everything.
+ */
+import { describe, expect, it } from "vitest";
+
+import { isSameOriginPreview } from "../sameOriginPreview";
+
+const ADMIN = "https://admin.example.com";
+
+describe("isSameOriginPreview", () => {
+  it("accepts the same scheme, host and port", () => {
+    expect(
+      isSameOriginPreview("https://admin.example.com/blog/post", ADMIN)
+    ).toBe(true);
+  });
+
+  it("accepts a default port written out, because origins normalise it", () => {
+    // `https://h:443` and `https://h` are the same origin, and a deployment
+    // that spells the port would otherwise lose the pane for no reason.
+    expect(
+      isSameOriginPreview("https://admin.example.com:443/blog/post", ADMIN)
+    ).toBe(true);
+  });
+
+  it("refuses a different host on the same site", () => {
+    // The over-refusal this is KNOWN to make: the cookie would in fact have
+    // worked here, because same-site is broader than same-origin. Deciding
+    // same-site needs the public suffix list, which no browser API exposes, and
+    // this direction of wrongness costs the pane rather than showing published
+    // content in it.
+    expect(isSameOriginPreview("https://example.com/blog/post", ADMIN)).toBe(
+      false
+    );
+  });
+
+  it("refuses a different port", () => {
+    // The scaffold's own failure mode: admin on 3000, site on 3001.
+    expect(
+      isSameOriginPreview("https://admin.example.com:8443/blog/post", ADMIN)
+    ).toBe(false);
+  });
+
+  it("refuses a different scheme", () => {
+    expect(
+      isSameOriginPreview("http://admin.example.com/blog/post", ADMIN)
+    ).toBe(false);
+  });
+
+  it("refuses a URL it cannot parse", () => {
+    // Reaching this means the mint stopped returning an absolute URL. Guessing
+    // "probably fine" is how the silent failure gets in.
+    expect(isSameOriginPreview("/blog/post", ADMIN)).toBe(false);
+    expect(isSameOriginPreview("", ADMIN)).toBe(false);
+  });
+
+  it("refuses opaque origins rather than letting two of them match", () => {
+    // `blob:`, `data:` and `file:` all serialise their origin as the STRING
+    // "null", so a plain equality would call two unrelated opaque origins the
+    // same one.
+    expect(isSameOriginPreview("data:text/html,hi", "null")).toBe(false);
+  });
+});

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/usePreviewFrame.test.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/usePreviewFrame.test.ts
@@ -82,6 +82,50 @@ describe("usePreviewFrame", () => {
     await waitFor(() => expect(mint).toHaveBeenCalledTimes(2));
   });
 
+  it("renews on a timer, without anyone asking", async () => {
+    /*
+     * The case a refresh-time check cannot cover: nobody calls `refresh` while
+     * an author reads, so the token lapses in place and the next navigation
+     * inside the frame is answered with the published page.
+     */
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mint.mockResolvedValue(expiringIn(90_000));
+
+    const { result } = renderHook(() => usePreviewFrame(args));
+    await waitFor(() => expect(result.current.url).not.toBeNull());
+    expect(mint).toHaveBeenCalledTimes(1);
+
+    // Past the margin, without touching `refresh`.
+    await act(async () => {
+      vi.advanceTimersByTime(31_000);
+    });
+
+    await waitFor(() => expect(mint).toHaveBeenCalledTimes(2));
+    vi.useRealTimers();
+  });
+
+  it("schedules NOTHING for a token that is already inside the margin", async () => {
+    /*
+     * Such a token means the TTL is shorter than the margin. Renewing at once
+     * returns another token inside the margin and schedules the next
+     * immediately — an unbounded mint loop, each turn issuing a credential and
+     * an audit row. The count staying put is the whole assertion, and the test
+     * above is its control: the timer DOES fire when there is time to wait.
+     */
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mint.mockResolvedValue(expiringIn(10_000));
+
+    const { result } = renderHook(() => usePreviewFrame(args));
+    await waitFor(() => expect(result.current.url).not.toBeNull());
+
+    await act(async () => {
+      vi.advanceTimersByTime(120_000);
+    });
+
+    expect(mint).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
   it("reports the reason a mint refused, and shows no frame", async () => {
     mint.mockResolvedValue({ kind: "report", reason: "noSiteUrl" });
 

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/usePreviewFrame.test.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/usePreviewFrame.test.ts
@@ -1,0 +1,93 @@
+/**
+ * When a refresh RELOADS and when it mints a new credential.
+ *
+ * The distinction is the whole of this hook's reason to exist: reloading is
+ * free and re-minting issues a bearer credential and an audit row, so doing
+ * the second every time would be wasteful, and doing the first when the token
+ * has lapsed shows the PUBLISHED page while looking like a working preview.
+ */
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mint = vi.hoisted(() => vi.fn());
+vi.mock("@admin/hooks/useEntryPreview", () => ({
+  mintSelfPreview: mint,
+  PREVIEW_MESSAGES: {},
+}));
+
+import { usePreviewFrame } from "../usePreviewFrame";
+
+/** A mint that expires the given number of milliseconds from now. */
+function expiringIn(ms: number) {
+  return {
+    kind: "open" as const,
+    url: "https://site.example/api/preview?token=t",
+    expiresAt: new Date(Date.now() + ms).toISOString(),
+  };
+}
+
+const args = { collection: "pages", entryId: "7", active: true };
+
+/*
+ * REAL timers, deliberately. `waitFor` polls on real ones, so faking them
+ * starves every assertion here into its timeout — and nothing in this hook
+ * needs the clock moved: each fixture states its expiry RELATIVE to now, which
+ * is what the margin comparison reads.
+ */
+beforeEach(() => {
+  mint.mockReset();
+});
+
+describe("usePreviewFrame", () => {
+  it("mints once when the pane opens", async () => {
+    mint.mockResolvedValue(expiringIn(15 * 60_000));
+
+    const { result } = renderHook(() => usePreviewFrame(args));
+    await waitFor(() => expect(result.current.url).not.toBeNull());
+
+    expect(mint).toHaveBeenCalledTimes(1);
+  });
+
+  it("mints NOTHING while the pane is closed", async () => {
+    renderHook(() => usePreviewFrame({ ...args, active: false }));
+    await act(async () => {});
+
+    expect(mint).not.toHaveBeenCalled();
+  });
+
+  it("reloads without re-minting while the token is comfortably valid", async () => {
+    mint.mockResolvedValue(expiringIn(15 * 60_000));
+
+    const { result } = renderHook(() => usePreviewFrame(args));
+    await waitFor(() => expect(result.current.url).not.toBeNull());
+    const before = result.current.reloadKey;
+
+    act(() => result.current.refresh());
+
+    // The key moved, so the frame remounts — and no second credential exists.
+    expect(result.current.reloadKey).toBe(before + 1);
+    expect(mint).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-mints when the token is close enough to expiry to lapse mid-load", async () => {
+    // Inside the margin: a reload that begins now can arrive after the token
+    // dies, and the site answers that with the published page rather than an
+    // error — a preview that silently stops being one.
+    mint.mockResolvedValue(expiringIn(30_000));
+
+    const { result } = renderHook(() => usePreviewFrame(args));
+    await waitFor(() => expect(result.current.url).not.toBeNull());
+
+    act(() => result.current.refresh());
+    await waitFor(() => expect(mint).toHaveBeenCalledTimes(2));
+  });
+
+  it("reports the reason a mint refused, and shows no frame", async () => {
+    mint.mockResolvedValue({ kind: "report", reason: "noSiteUrl" });
+
+    const { result } = renderHook(() => usePreviewFrame(args));
+    await waitFor(() => expect(result.current.reason).toBe("noSiteUrl"));
+
+    expect(result.current.url).toBeNull();
+  });
+});

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/usePreviewFrame.test.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/usePreviewFrame.test.ts
@@ -1,13 +1,21 @@
 /**
- * When a refresh RELOADS and when it mints a new credential.
+ * When a refresh RELOADS and when it mints a new credential, and when the pane
+ * refuses to frame a URL it nonetheless holds.
  *
- * The distinction is the whole of this hook's reason to exist: reloading is
- * free and re-minting issues a bearer credential and an audit row, so doing
- * the second every time would be wasteful, and doing the first when the token
- * has lapsed shows the PUBLISHED page while looking like a working preview.
+ * The reload/re-mint distinction is the hook's original reason to exist:
+ * reloading is free and re-minting issues a bearer credential and an audit row,
+ * so doing the second every time would be wasteful, and doing the first when the
+ * token has lapsed shows the PUBLISHED page while looking like a working
+ * preview.
+ *
+ * The refusals are the same failure by two other routes. A cross-origin frame
+ * never receives the preview cookie, and a second pane overwrites the one cookie
+ * the site keeps — both end in the published page rendering inside something
+ * captioned as a draft. None of the three is visible from inside the frame, so
+ * each is asserted here on the state the pane renders from.
  */
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mint = vi.hoisted(() => vi.fn());
 vi.mock("@admin/hooks/useEntryPreview", () => ({
@@ -17,16 +25,34 @@ vi.mock("@admin/hooks/useEntryPreview", () => ({
 
 import { usePreviewFrame } from "../usePreviewFrame";
 
+/*
+ * Same-origin by construction. jsdom serves the test document from some origin
+ * and the pane only frames a URL matching it, so hardcoding a host here would
+ * make every case below exercise the cross-origin refusal instead of the
+ * behaviour it names.
+ */
+const ORIGIN = window.location.origin;
+
 /** A mint that expires the given number of milliseconds from now. */
-function expiringIn(ms: number) {
+function expiringIn(ms: number, url = `${ORIGIN}/blog/post?preview=1`) {
   return {
     kind: "open" as const,
-    url: "https://site.example/api/preview?token=t",
+    url,
     expiresAt: new Date(Date.now() + ms).toISOString(),
   };
 }
 
 const args = { collection: "pages", entryId: "7", active: true };
+
+/** The channel the panes announce on. Must match `previewSessionLock`. */
+const CHANNEL = "nextly.preview.session";
+
+/** Another pane, on another entry, taking the browser's one preview session. */
+function anotherPaneClaims(scopeKey = "pages 9 ") {
+  const other = new BroadcastChannel(CHANNEL);
+  other.postMessage({ scopeKey });
+  other.close();
+}
 
 /*
  * REAL timers, deliberately. `waitFor` polls on real ones, so faking them
@@ -36,6 +62,10 @@ const args = { collection: "pages", entryId: "7", active: true };
  */
 beforeEach(() => {
   mint.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("usePreviewFrame", () => {
@@ -101,7 +131,6 @@ describe("usePreviewFrame", () => {
     });
 
     await waitFor(() => expect(mint).toHaveBeenCalledTimes(2));
-    vi.useRealTimers();
   });
 
   it("schedules NOTHING for a token that is already inside the margin", async () => {
@@ -123,7 +152,6 @@ describe("usePreviewFrame", () => {
     });
 
     expect(mint).toHaveBeenCalledTimes(1);
-    vi.useRealTimers();
   });
 
   it("reports the reason a mint refused, and shows no frame", async () => {
@@ -133,5 +161,129 @@ describe("usePreviewFrame", () => {
     await waitFor(() => expect(result.current.reason).toBe("noSiteUrl"));
 
     expect(result.current.url).toBeNull();
+  });
+});
+
+describe("a site served from another origin", () => {
+  it("blocks the frame but KEEPS the url, because the tab still works", async () => {
+    /*
+     * The browser will not carry the preview cookie into a cross-origin frame,
+     * and the site answers a frame without one by serving the published page.
+     * Nothing about that is observable from the admin — the frame's document
+     * belongs to the site — so the pane declines rather than rendering
+     * something it cannot check.
+     */
+    mint.mockResolvedValue(expiringIn(15 * 60_000, "https://elsewhere.test/p"));
+
+    const { result } = renderHook(() => usePreviewFrame(args));
+    await waitFor(() => expect(result.current.block).toBe("crossOrigin"));
+
+    // Kept, so the toolbar's "open in a new tab" — which is the remedy this
+    // state points the author at — has somewhere to go.
+    expect(result.current.url).toBe("https://elsewhere.test/p");
+    expect(result.current.reason).toBeNull();
+  });
+
+  it("does NOT block a same-origin site", async () => {
+    // The control: the refusal above is about the origin rather than about a
+    // gate that blocks everything.
+    mint.mockResolvedValue(expiringIn(15 * 60_000));
+
+    const { result } = renderHook(() => usePreviewFrame(args));
+    await waitFor(() => expect(result.current.url).not.toBeNull());
+
+    expect(result.current.block).toBeNull();
+  });
+
+  it("schedules no renewal for a blocked pane", async () => {
+    // Nothing is framed, so nothing needs a live credential — and renewing
+    // would claim the shared cookie away from a pane that is using it.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mint.mockResolvedValue(expiringIn(90_000, "https://elsewhere.test/p"));
+
+    const { result } = renderHook(() => usePreviewFrame(args));
+    await waitFor(() => expect(result.current.block).toBe("crossOrigin"));
+
+    await act(async () => {
+      vi.advanceTimersByTime(31_000);
+    });
+
+    expect(mint).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("another pane taking the browser's one preview session", () => {
+  it("marks this pane superseded when another scope claims", async () => {
+    /*
+     * The site keeps ONE preview cookie, so the last mint wins and the loser is
+     * not told. Its next in-frame navigation carries the winner's scope, the
+     * draft gate refuses it, and the published page is served into a pane
+     * captioned "last saved draft".
+     */
+    mint.mockResolvedValue(expiringIn(15 * 60_000));
+
+    const { result } = renderHook(() => usePreviewFrame(args));
+    await waitFor(() => expect(result.current.url).not.toBeNull());
+
+    act(() => anotherPaneClaims());
+
+    await waitFor(() => expect(result.current.block).toBe("superseded"));
+    // The url survives so refreshing can take the session back.
+    expect(result.current.url).not.toBeNull();
+  });
+
+  it("ignores a claim on the SAME scope, which shares one valid cookie", async () => {
+    // The control, and a real case: the same entry open in two tabs is not a
+    // conflict, because both are covered by the one cookie.
+    mint.mockResolvedValue(expiringIn(15 * 60_000));
+
+    const { result } = renderHook(() => usePreviewFrame(args));
+    await waitFor(() => expect(result.current.url).not.toBeNull());
+
+    act(() => anotherPaneClaims("pages 7 "));
+    await act(async () => {});
+
+    expect(result.current.block).toBeNull();
+  });
+
+  it("takes the session back on refresh, by minting rather than reloading", async () => {
+    /*
+     * A superseded pane holds no session, so remounting the frame would replay
+     * the same refusal. Only a mint rewrites the cookie.
+     */
+    mint.mockResolvedValue(expiringIn(15 * 60_000));
+
+    const { result } = renderHook(() => usePreviewFrame(args));
+    await waitFor(() => expect(result.current.url).not.toBeNull());
+    act(() => anotherPaneClaims());
+    await waitFor(() => expect(result.current.block).toBe("superseded"));
+
+    act(() => result.current.refresh());
+
+    // A second credential, even though the first has 15 minutes left — which is
+    // exactly what the reload/re-mint rule would otherwise have declined.
+    await waitFor(() => expect(mint).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(result.current.block).toBeNull());
+  });
+
+  it("schedules no renewal while superseded, so two panes cannot fight", async () => {
+    /*
+     * Renewal re-claims. Two idle panes both renewing on a timer would take the
+     * session from each other forever with nobody touching anything, trading a
+     * silent failure for a perpetual one.
+     */
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mint.mockResolvedValue(expiringIn(90_000));
+
+    const { result } = renderHook(() => usePreviewFrame(args));
+    await waitFor(() => expect(result.current.url).not.toBeNull());
+    act(() => anotherPaneClaims());
+    await waitFor(() => expect(result.current.block).toBe("superseded"));
+
+    await act(async () => {
+      vi.advanceTimersByTime(31_000);
+    });
+
+    expect(mint).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/admin/src/components/features/entries/PreviewMode/previewRevision.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/previewRevision.ts
@@ -1,0 +1,56 @@
+/**
+ * What the preview would render, as a value that changes when it does.
+ *
+ * One function rather than an expression at the call site, because it answers a
+ * question with more than one part and getting either part wrong is silent: the
+ * frame simply keeps showing content that is no longer there.
+ *
+ * @module components/features/entries/PreviewMode/previewRevision
+ */
+
+import { hasPendingWorkingDraft } from "../EntryForm/EntryFormContext";
+
+/**
+ * The document's own modification time, as a comparable string.
+ *
+ * Both spellings are accepted for the reason `DocumentPanel` accepts both: the
+ * shape depends on how the row was read, and a reader that knows only one
+ * returns the empty string for the other — which compares equal to itself
+ * forever and would make the revision stop moving rather than fail loudly.
+ *
+ * A `Date` is normalised rather than stringified by default, because
+ * `String(new Date())` drops sub-second precision and two saves inside the same
+ * second would compare equal.
+ */
+function modifiedAt(document: unknown): string {
+  const row = document as
+    | { updatedAt?: unknown; updated_at?: unknown }
+    | null
+    | undefined;
+  const raw = row?.updatedAt ?? row?.updated_at;
+  if (typeof raw === "string") return raw;
+  if (raw instanceof Date) return raw.toISOString();
+  if (typeof raw === "number") return String(raw);
+  return "";
+}
+
+/**
+ * DERIVED from the document rather than notified by whoever wrote it.
+ *
+ * A form submission is not the only write. Discarding a working draft and
+ * restoring a version each persist through their own mutation, so a token
+ * bumped by the submit handler leaves the frame showing content that was just
+ * discarded. Deriving means a write nobody remembered to announce still moves
+ * the value — the difference between covering the writes that were listed and
+ * covering the writes there are.
+ *
+ * TWO facts, because the preview route reads both. `updatedAt` moves on a save
+ * and on a version restore, which resubmits through the ordinary update path.
+ * It does NOT move when a working draft is discarded — the draft is a separate
+ * row from the published one — and that discard changes what the preview
+ * renders, because the route reads the draft overlay. Either fact alone misses
+ * a write the frame would then keep showing.
+ */
+export function previewRevisionOf(document: unknown): string {
+  return `${modifiedAt(document)}|${hasPendingWorkingDraft(document)}`;
+}

--- a/packages/admin/src/components/features/entries/PreviewMode/previewRevision.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/previewRevision.ts
@@ -2,7 +2,7 @@
  * What the preview would render, as a value that changes when it does.
  *
  * One function rather than an expression at the call site, because it answers a
- * question with more than one part and getting either part wrong is silent: the
+ * question with more than one part and getting any part wrong is silent: the
  * frame simply keeps showing content that is no longer there.
  *
  * @module components/features/entries/PreviewMode/previewRevision
@@ -35,22 +35,42 @@ function modifiedAt(document: unknown): string {
 }
 
 /**
- * DERIVED from the document rather than notified by whoever wrote it.
+ * THREE facts, because no two of them cover the writes the third does.
  *
- * A form submission is not the only write. Discarding a working draft and
- * restoring a version each persist through their own mutation, so a token
- * bumped by the submit handler leaves the frame showing content that was just
- * discarded. Deriving means a write nobody remembered to announce still moves
- * the value — the difference between covering the writes that were listed and
- * covering the writes there are.
+ * Derived from the document, and counted from this form's own saves, because
+ * each half is blind to writes the other sees.
  *
- * TWO facts, because the preview route reads both. `updatedAt` moves on a save
- * and on a version restore, which resubmits through the ordinary update path.
- * It does NOT move when a working draft is discarded — the draft is a separate
- * row from the published one — and that discard changes what the preview
- * renders, because the route reads the draft overlay. Either fact alone misses
- * a write the frame would then keep showing.
+ * `updatedAt` moves on a save and on a version restore, which resubmits through
+ * the ordinary update path. It does NOT move when a working draft is discarded
+ * — the draft is a separate row from the published one — and that discard
+ * changes what the preview renders, because the route reads the draft overlay.
+ * So `hasPendingWorkingDraft` is read too.
+ *
+ * And BOTH derived facts stand still for the case that turns out to be the
+ * ordinary one: editing a published entry. A status-less save of a published,
+ * drafts-enabled document writes the working-draft sidecar and leaves the live
+ * row alone, and `shapeDraftForResponse` then copies the LIVE parent's
+ * timestamps onto the response — so after the first such save `_isWorkingDraft`
+ * is already `true` and `updatedAt` is frozen at the published row's value.
+ * Every later draft save changes the content and moves neither fact. The
+ * sidecar does carry its own advancing `updatedAt`, but it never leaves the
+ * server, so no amount of care with the document can recover it.
+ *
+ * `savedCount` closes exactly that gap and nothing else. It is a NOTIFICATION,
+ * which is the weaker kind of evidence and why it is not the whole answer: it
+ * knows only about writes this form performed, so a discard, a restore, or
+ * another author's change would move nothing if it were used alone. The derived
+ * facts cover those. Used together each covers the other's blind spot — writes
+ * nobody announced, and announced writes that move nothing observable.
+ *
+ * A save the server treated as a no-op still bumps the count, costing one
+ * reload of identical content. That is the safe direction: a reload is a
+ * remount of an existing credential, while a missed change is a preview that
+ * quietly stops matching the document.
  */
-export function previewRevisionOf(document: unknown): string {
-  return `${modifiedAt(document)}|${hasPendingWorkingDraft(document)}`;
+export function previewRevisionOf(
+  document: unknown,
+  savedCount: number
+): string {
+  return `${modifiedAt(document)}|${hasPendingWorkingDraft(document)}|${savedCount}`;
 }

--- a/packages/admin/src/components/features/entries/PreviewMode/previewSessionLock.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/previewSessionLock.ts
@@ -1,0 +1,93 @@
+"use client";
+
+/**
+ * Which pane owns this browser's ONE preview session.
+ *
+ * The site stores the preview credential in a single cookie - one name, one
+ * value, `Path=/` - so a browser profile holds at most one preview scope at a
+ * time no matter how many panes are open. Every mint overwrites it. Two panes
+ * on different entries therefore take the session from each other, and the
+ * loser is not told: its next in-frame navigation carries the WINNER's scope,
+ * the draft gate refuses it, and the site answers with the published page. A
+ * pane showing published content while captioned "last saved draft" is the
+ * failure this exists to prevent.
+ *
+ * The renewal timer is what made silence intolerable. A pane left open re-mints
+ * on its own every few minutes, so two idle panes in two tabs would take the
+ * session from each other indefinitely with nobody touching anything.
+ * Announcing each claim turns that into a state the loser can see and recover
+ * from.
+ *
+ * Panes on the SAME scope do not conflict - they share one valid cookie - so
+ * the key carries the locale as well as the entry. A preview of the same entry
+ * in another language is a different scope and does supersede.
+ *
+ * This does not FIX the singleton; it makes it honest. The durable answer is a
+ * cookie that can hold more than one scope, which is a change to the site's
+ * preview route rather than to the admin.
+ *
+ * @module components/features/entries/PreviewMode/previewSessionLock
+ */
+
+/** Shared by every admin tab on this origin. */
+const CHANNEL = "nextly.preview.session";
+
+/**
+ * What a pane is previewing, as the value two panes compare.
+ *
+ * A string rather than the parts, because it is only ever compared for equality
+ * and a structured payload invites a reader to match on one field.
+ */
+export function previewScopeKey(
+  collection: string,
+  entryId: string,
+  locale: string | undefined
+): string {
+  return `${collection} ${entryId} ${locale ?? ""}`;
+}
+
+export interface PreviewSessionLock {
+  /** Announce that this pane just minted and now owns the cookie. */
+  claim: () => void;
+  /** Stop listening. Safe to call more than once. */
+  release: () => void;
+}
+
+/**
+ * Watch for another pane taking the session, and announce when this one takes it.
+ *
+ * `onSuperseded` fires only for a claim on a DIFFERENT scope.
+ * `BroadcastChannel` does not deliver a message back to the context that posted
+ * it, so a pane cannot supersede itself and no echo guard is needed.
+ *
+ * Returns an inert lock where `BroadcastChannel` is missing rather than
+ * throwing. Losing the warning degrades the pane to today's behaviour; refusing
+ * to mint would remove a preview that otherwise works.
+ */
+export function watchPreviewSession(
+  scopeKey: string,
+  onSuperseded: () => void
+): PreviewSessionLock {
+  if (typeof BroadcastChannel === "undefined") {
+    return { claim: () => {}, release: () => {} };
+  }
+
+  const channel = new BroadcastChannel(CHANNEL);
+  channel.onmessage = (event: MessageEvent) => {
+    const claimed = (event.data as { scopeKey?: unknown } | null)?.scopeKey;
+    if (typeof claimed !== "string") return;
+    if (claimed === scopeKey) return;
+    onSuperseded();
+  };
+
+  return {
+    claim: () => channel.postMessage({ scopeKey }),
+    release: () => {
+      // Drop the handler before closing: a message already queued would
+      // otherwise reach a pane that has unmounted, and the state write that
+      // follows is one React warns about.
+      channel.onmessage = null;
+      channel.close();
+    },
+  };
+}

--- a/packages/admin/src/components/features/entries/PreviewMode/sameOriginPreview.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/sameOriginPreview.ts
@@ -1,0 +1,72 @@
+/**
+ * Whether a minted preview URL can be rendered in a frame at all.
+ *
+ * The site's draft route needs the `__nextly_preview` cookie, and the preview
+ * route both SETS that cookie and then redirects — so a frame pointed at
+ * another site has to store a third-party cookie and send it back. Browsers
+ * refuse in both directions, and they refuse SILENTLY: the frame loads, the
+ * draft gate finds no session, and the reader is served the published page or a
+ * 404. A preview that shows published content while looking like a preview is
+ * worse than no pane at all, so the pane declines rather than lying.
+ *
+ * Same ORIGIN rather than same site, deliberately. Same-site is the property
+ * the cookie is actually keyed on, but deciding it needs the public suffix
+ * list — `example.com` and `example.co.uk` differ by a rule no browser API
+ * exposes to a page. Origin equality is scheme, host and port, it needs no
+ * table, and it is a strict SUBSET of same-site: every URL this accepts would
+ * have worked, and the ones it wrongly refuses (`admin.example.com` against
+ * `example.com`) lose the pane rather than gaining a broken one. That is the
+ * safe direction to be wrong in, and it is the only direction available without
+ * asking the site itself.
+ *
+ * Asking the site is the better answer and it is a different change: the
+ * previewed page reporting back that it holds a preview session would observe
+ * the outcome instead of predicting it, and would recover every deployment this
+ * refuses. Until then this is a prediction, and it is built to err toward the
+ * tab.
+ *
+ * The default deployment is unaffected. `templates/base` mounts the admin at
+ * `/admin` inside the same Next.js app that serves the site, and
+ * `resolvePreviewSiteUrl` falls back to `NEXT_PUBLIC_APP_URL` — the origin the
+ * admin is already being served from.
+ *
+ * @module components/features/entries/PreviewMode/sameOriginPreview
+ */
+
+/**
+ * @param href - the minted preview URL
+ * @param adminOrigin - the origin the admin is served from
+ * @returns true when a frame at `adminOrigin` can carry the preview cookie
+ */
+export function isSameOriginPreview(
+  href: string,
+  adminOrigin: string
+): boolean {
+  let previewOrigin: string;
+  try {
+    previewOrigin = new URL(href).origin;
+  } catch {
+    // Unparseable is not framable. The mint is expected to return an absolute
+    // http(s) URL, so reaching this means something upstream changed shape —
+    // and guessing "probably fine" there is how the silent failure gets in.
+    return false;
+  }
+  // `origin` is opaque for schemes that have none — `blob:`, `data:`, `file:`
+  // all serialise as the string "null", and two of them comparing equal must
+  // not read as same-origin.
+  if (previewOrigin === "null" || adminOrigin === "null") return false;
+  return previewOrigin === adminOrigin;
+}
+
+/**
+ * The origin this admin is served from, or null where there is no document.
+ *
+ * Returns null under SSR rather than a guess. Nothing calls the predicate on
+ * the server today — minting happens in an effect — but a null that a caller
+ * must handle is a better shape than an empty string that quietly fails every
+ * comparison and reports every deployment as cross-origin.
+ */
+export function currentAdminOrigin(): string | null {
+  if (typeof window === "undefined") return null;
+  return window.location.origin;
+}

--- a/packages/admin/src/components/features/entries/PreviewMode/usePreviewFrame.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/usePreviewFrame.ts
@@ -9,7 +9,7 @@
  * button uses, so the pane and the tab cannot disagree about the TTL, the
  * refusal mapping or what a missing site URL means.
  *
- * Two things make this more than "hold a URL":
+ * Three things make this more than "hold a URL":
  *
  * A frame STAYS on screen, unlike a tab that is handed a URL once and forgotten.
  * A fifteen-minute token is ample for a tab and finite for a pane left open
@@ -22,6 +22,14 @@
  * for something the existing one covers. Remounting the frame is the cheap path
  * and is what a save takes.
  *
+ * And a frame is subject to two constraints a tab is not, both of which fail
+ * SILENTLY by showing the published page: the browser will not carry the
+ * preview cookie into a cross-origin frame, and the site holds only one preview
+ * session per browser, so a second pane takes it from the first. Neither is
+ * detectable from inside the frame — its document is the site's and the admin
+ * cannot read it — so both are predicted here and reported as a state the pane
+ * renders instead of the iframe. See {@link PreviewPaneBlock}.
+ *
  * @module components/features/entries/PreviewMode/usePreviewFrame
  */
 
@@ -32,6 +40,13 @@ import {
   type PreviewUnavailableReason,
 } from "@admin/hooks/useEntryPreview";
 
+import {
+  previewScopeKey,
+  watchPreviewSession,
+  type PreviewSessionLock,
+} from "./previewSessionLock";
+import { currentAdminOrigin, isSameOriginPreview } from "./sameOriginPreview";
+
 /**
  * How close to expiry a refresh re-mints rather than reloads.
  *
@@ -41,6 +56,24 @@ import {
  * rather than expressing a preference.
  */
 const REMINT_MARGIN_MS = 60_000;
+
+/**
+ * Why a URL exists but this PANE must not render it.
+ *
+ * Deliberately not folded into {@link PreviewUnavailableReason}, which the
+ * Preview BUTTON shares: both of these are frame-only, a tab is unaffected by
+ * either, and adding them to the shared union would put reasons in the button's
+ * message map that can never apply to it. The url is kept in both states so the
+ * toolbar's "open in a new tab" still works — that path is exactly the remedy.
+ */
+export type PreviewPaneBlock = "crossOrigin" | "superseded";
+
+export const PREVIEW_PANE_BLOCK_MESSAGES: Record<PreviewPaneBlock, string> = {
+  crossOrigin:
+    "The site is served from a different address than this admin, so the browser will not carry the preview session into a frame here. Open the preview in a new tab instead.",
+  superseded:
+    "Another preview took over this browser's preview session — the site allows one at a time. Refresh to bring it back to this pane.",
+};
 
 export interface PreviewFrameState {
   /** The URL to render, or null while there is nothing to show. */
@@ -58,6 +91,8 @@ export interface PreviewFrameState {
   isLoading: boolean;
   /** Why there is nothing to show, when that is the case. */
   reason: PreviewUnavailableReason | null;
+  /** Why the URL that exists cannot be framed here, when that is the case. */
+  block: PreviewPaneBlock | null;
 }
 
 export interface UsePreviewFrameResult extends PreviewFrameState {
@@ -87,6 +122,7 @@ export function usePreviewFrame({
     reloadKey: 0,
     isLoading: false,
     reason: null,
+    block: null,
   });
 
   /*
@@ -103,9 +139,18 @@ export function usePreviewFrame({
    */
   const generation = useRef(0);
 
+  const scopeKey = previewScopeKey(collection, entryId, locale);
+
+  /*
+   * The lock this pane announces through. A ref because `mint` claims through
+   * it and must not be rebuilt — and therefore must not re-run the open effect
+   * — every time the subscription is re-established.
+   */
+  const lock = useRef<PreviewSessionLock | null>(null);
+
   const mint = useCallback(async () => {
     const mine = ++generation.current;
-    setState(prev => ({ ...prev, isLoading: true, reason: null }));
+    setState(prev => ({ ...prev, isLoading: true, reason: null, block: null }));
 
     const outcome = await mintSelfPreview(collection, entryId, locale);
 
@@ -119,18 +164,65 @@ export function usePreviewFrame({
         reloadKey: prev.reloadKey,
         isLoading: false,
         reason: outcome.reason,
+        block: null,
       }));
       return;
     }
 
+    /*
+     * Judged HERE rather than when the pane opened, because this is the first
+     * point the answer is knowable: the site URL sits behind a `settings`
+     * permission that editors do not hold, so the admin learns where an entry
+     * previews only by asking, and only when someone asks for it.
+     *
+     * A null admin origin (no document) counts as cross-origin. Erring toward
+     * the tab is the safe direction: the tab works everywhere the pane does.
+     */
+    const adminOrigin = currentAdminOrigin();
+    const framable =
+      adminOrigin !== null && isSameOriginPreview(outcome.url, adminOrigin);
+
     expiresAt.current = Date.parse(outcome.expiresAt);
+
+    /*
+     * Claimed only for a frame that will actually load. A blocked pane renders
+     * no iframe, so it never exchanges the token and never writes the cookie —
+     * announcing a claim it did not make would evict a pane that holds a live
+     * session.
+     */
+    if (framable) lock.current?.claim();
+
     setState(prev => ({
       url: outcome.url,
       reloadKey: prev.reloadKey + 1,
       isLoading: false,
       reason: null,
+      block: framable ? null : "crossOrigin",
     }));
   }, [collection, entryId, locale]);
+
+  /*
+   * Subscribed for the whole time the pane is open, not per mint: the message
+   * that matters arrives while this pane is idle, which is exactly when it is
+   * not minting.
+   */
+  useEffect(() => {
+    if (!active) return;
+    const opened = watchPreviewSession(scopeKey, () => {
+      setState(prev =>
+        // Only a pane actually showing a frame has a session to lose. One still
+        // minting will claim when its own mint resolves and win on its merits.
+        prev.url === null || prev.block !== null
+          ? prev
+          : { ...prev, block: "superseded" }
+      );
+    });
+    lock.current = opened;
+    return () => {
+      lock.current = null;
+      opened.release();
+    };
+  }, [active, scopeKey]);
 
   // Minting is what OPENING costs, so it happens when the pane becomes active
   // rather than on mount: a closed pane issues no credential and writes no
@@ -146,6 +238,7 @@ export function usePreviewFrame({
         url: null,
         isLoading: false,
         reason: null,
+        block: null,
       }));
       return;
     }
@@ -165,9 +258,15 @@ export function usePreviewFrame({
    * Scheduled against the margin rather than the expiry so the replacement is
    * in hand before the old one dies, and cleared on unmount so a closed pane
    * mints nothing.
+   *
+   * A BLOCKED pane schedules nothing, and that is what keeps two open panes from
+   * fighting. Renewing re-claims the shared cookie, so two idle panes on a timer
+   * would take the session from each other forever with nobody touching
+   * anything — trading a silent failure for a noisy one. A superseded pane stays
+   * dormant until an author asks for it back.
    */
   useEffect(() => {
-    if (!active || state.url === null) return;
+    if (!active || state.url === null || state.block !== null) return;
 
     const renewIn = expiresAt.current - REMINT_MARGIN_MS - Date.now();
     /*
@@ -186,16 +285,25 @@ export function usePreviewFrame({
     // `state.url` rather than the whole state: a reload changes `reloadKey` and
     // must not restart the renewal clock, because the credential it reloads is
     // the same one and its expiry has not moved.
-  }, [active, state.url, mint]);
+  }, [active, state.url, state.block, mint]);
 
   const refresh = useCallback(() => {
     if (!active) return;
+    /*
+     * A blocked pane always re-mints, whatever the clock says. Reloading is
+     * what a valid session takes, and a blocked pane has none: a superseded one
+     * must take the cookie back, which only a mint does.
+     */
+    if (state.block !== null) {
+      void mint();
+      return;
+    }
     if (Date.now() >= expiresAt.current - REMINT_MARGIN_MS) {
       void mint();
       return;
     }
     setState(prev => ({ ...prev, reloadKey: prev.reloadKey + 1 }));
-  }, [active, mint]);
+  }, [active, state.block, mint]);
 
   return { ...state, refresh };
 }

--- a/packages/admin/src/components/features/entries/PreviewMode/usePreviewFrame.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/usePreviewFrame.ts
@@ -152,6 +152,42 @@ export function usePreviewFrame({
     void mint();
   }, [active, mint]);
 
+  /*
+   * Renewal on a TIMER, not only when someone asks.
+   *
+   * A pane left open through a long edit is the case a refresh-time check
+   * cannot cover: nothing calls `refresh` while an author reads, so the token
+   * lapses in place and the next navigation INSIDE the frame — a link, a form,
+   * anything the site itself does — arrives without a preview session and is
+   * answered with the published page. Nothing announces that; the frame simply
+   * stops being a preview.
+   *
+   * Scheduled against the margin rather than the expiry so the replacement is
+   * in hand before the old one dies, and cleared on unmount so a closed pane
+   * mints nothing.
+   */
+  useEffect(() => {
+    if (!active || state.url === null) return;
+
+    const renewIn = expiresAt.current - REMINT_MARGIN_MS - Date.now();
+    /*
+     * Nothing is scheduled for a token that arrives ALREADY inside the margin,
+     * and that guard is not defensive — it is the difference between renewing
+     * and spinning. Such a token means the configured TTL is shorter than the
+     * margin, so a renewal fires at once, returns another token inside the
+     * margin, and schedules the next one immediately: an unbounded mint loop,
+     * each iteration issuing a credential and an audit row. A refresh still
+     * re-mints on demand, which is the correct behaviour for a TTL that short.
+     */
+    if (renewIn <= 0) return;
+
+    const timer = setTimeout(() => void mint(), renewIn);
+    return () => clearTimeout(timer);
+    // `state.url` rather than the whole state: a reload changes `reloadKey` and
+    // must not restart the renewal clock, because the credential it reloads is
+    // the same one and its expiry has not moved.
+  }, [active, state.url, mint]);
+
   const refresh = useCallback(() => {
     if (!active) return;
     if (Date.now() >= expiresAt.current - REMINT_MARGIN_MS) {

--- a/packages/admin/src/components/features/entries/PreviewMode/usePreviewFrame.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/usePreviewFrame.ts
@@ -1,0 +1,165 @@
+"use client";
+
+/**
+ * The credentialed URL an in-admin preview frame renders, and when to re-ask.
+ *
+ * The frame shows the site's own draft route, which needs a signed token to
+ * render a draft at all — the admin's session does not reach the site's origin.
+ * That token is minted by {@link mintSelfPreview}, the same call the Preview
+ * button uses, so the pane and the tab cannot disagree about the TTL, the
+ * refusal mapping or what a missing site URL means.
+ *
+ * Two things make this more than "hold a URL":
+ *
+ * A frame STAYS on screen, unlike a tab that is handed a URL once and forgotten.
+ * A fifteen-minute token is ample for a tab and finite for a pane left open
+ * through a long edit, so the expiry is tracked and a fresh credential minted
+ * before the current one lapses rather than after the frame has already failed
+ * to load.
+ *
+ * And a reload is not a re-mint. Most refreshes happen while the token is still
+ * good, and re-minting each time would issue a credential — and an audit row —
+ * for something the existing one covers. Remounting the frame is the cheap path
+ * and is what a save takes.
+ *
+ * @module components/features/entries/PreviewMode/usePreviewFrame
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  mintSelfPreview,
+  type PreviewUnavailableReason,
+} from "@admin/hooks/useEntryPreview";
+
+/**
+ * How close to expiry a refresh re-mints rather than reloads.
+ *
+ * A reload that begins before the token lapses can still arrive after it, and
+ * the site answers that with the published page rather than an error — a
+ * preview that silently stops being a preview. The margin buys the round trip
+ * rather than expressing a preference.
+ */
+const REMINT_MARGIN_MS = 60_000;
+
+export interface PreviewFrameState {
+  /** The URL to render, or null while there is nothing to show. */
+  url: string | null;
+  /**
+   * Changes on every reload, and is the frame's React key.
+   *
+   * A key rather than a query parameter appended to the URL: the site sees the
+   * address the token names, unchanged, and the browser performs an ordinary
+   * navigation. Adding a cache-buster would put an admin-invented parameter on
+   * a request the SITE has to interpret, which is a contract nobody agreed.
+   */
+  reloadKey: number;
+  /** True while a credential is being minted. */
+  isLoading: boolean;
+  /** Why there is nothing to show, when that is the case. */
+  reason: PreviewUnavailableReason | null;
+}
+
+export interface UsePreviewFrameResult extends PreviewFrameState {
+  /** Show the draft as it now stands. Re-mints only if the token is near expiry. */
+  refresh: () => void;
+}
+
+/**
+ * @param collection - the collection slug the entry belongs to
+ * @param entryId - the SAVED entry id; the frame shows nothing without one
+ * @param locale - the language to scope the token to, on a localized collection
+ * @param active - whether the pane is open; nothing is minted while it is not
+ */
+export function usePreviewFrame({
+  collection,
+  entryId,
+  locale,
+  active,
+}: {
+  collection: string;
+  entryId: string;
+  locale?: string | undefined;
+  active: boolean;
+}): UsePreviewFrameResult {
+  const [state, setState] = useState<PreviewFrameState>({
+    url: null,
+    reloadKey: 0,
+    isLoading: false,
+    reason: null,
+  });
+
+  /*
+   * Held in a ref rather than in state because nothing renders from it: it
+   * decides whether a refresh re-mints, and putting it in state would rerender
+   * the frame on every mint for a value the frame never reads.
+   */
+  const expiresAt = useRef<number>(0);
+
+  /*
+   * Guards against a resolved mint writing over a newer one, and against
+   * writing to a pane that has since closed. Two mints can be in flight when a
+   * save lands while the pane is opening, and the older one must not win.
+   */
+  const generation = useRef(0);
+
+  const mint = useCallback(async () => {
+    const mine = ++generation.current;
+    setState(prev => ({ ...prev, isLoading: true, reason: null }));
+
+    const outcome = await mintSelfPreview(collection, entryId, locale);
+
+    // A newer mint started, or the pane closed, while this one was in flight.
+    if (mine !== generation.current) return;
+
+    if (outcome.kind === "report") {
+      expiresAt.current = 0;
+      setState(prev => ({
+        url: null,
+        reloadKey: prev.reloadKey,
+        isLoading: false,
+        reason: outcome.reason,
+      }));
+      return;
+    }
+
+    expiresAt.current = Date.parse(outcome.expiresAt);
+    setState(prev => ({
+      url: outcome.url,
+      reloadKey: prev.reloadKey + 1,
+      isLoading: false,
+      reason: null,
+    }));
+  }, [collection, entryId, locale]);
+
+  // Minting is what OPENING costs, so it happens when the pane becomes active
+  // rather than on mount: a closed pane issues no credential and writes no
+  // audit row.
+  useEffect(() => {
+    if (!active) {
+      // Invalidates any mint still in flight, so a pane closed mid-request does
+      // not populate itself a moment after the editor dismissed it.
+      generation.current += 1;
+      expiresAt.current = 0;
+      setState(prev => ({
+        ...prev,
+        url: null,
+        isLoading: false,
+        reason: null,
+      }));
+      return;
+    }
+    void mint();
+  }, [active, mint]);
+
+  const refresh = useCallback(() => {
+    if (!active) return;
+    if (Date.now() >= expiresAt.current - REMINT_MARGIN_MS) {
+      void mint();
+      return;
+    }
+    setState(prev => ({ ...prev, reloadKey: prev.reloadKey + 1 }));
+  }, [active, mint]);
+
+  return { ...state, refresh };
+}

--- a/packages/admin/src/hooks/useEntryPreview.ts
+++ b/packages/admin/src/hooks/useEntryPreview.ts
@@ -166,8 +166,21 @@ export const PREVIEW_MESSAGES: Record<PreviewUnavailableReason, string> = {
  * opener and closing it again are all forced by how browsers treat a click,
  * while this is a mapping that can be read on its own.
  */
-type PreviewOutcome =
-  | { kind: "open"; url: string }
+export type PreviewOutcome =
+  | {
+      kind: "open";
+      url: string;
+      /**
+       * When the credential in that URL stops working.
+       *
+       * Carried even though opening a tab has no use for it, because the
+       * SURFACE decides what it needs and the mint is the only thing that
+       * knows. A pane that keeps the frame on screen has to re-mint before the
+       * token lapses; dropping the value here would make it ask again for
+       * something this call already learned.
+       */
+      expiresAt: string;
+    }
   | { kind: "report"; reason: PreviewUnavailableReason };
 
 /**
@@ -233,7 +246,13 @@ function reasonForRefusal(error: unknown): PreviewUnavailableReason {
 }
 
 /**
- * Mints the credential this preview opens with.
+ * Mints the credential a preview surface opens with.
+ *
+ * Exported because there is more than one surface — a tab and an in-admin
+ * pane — and "a self-preview credential for this document" is ONE question. A
+ * pane that minted its own would be a second implementation of the TTL, the
+ * refusal mapping and the null-url case, and the two would agree until one of
+ * them was edited.
  *
  * The mint is the ONLY question asked, and that is deliberate. It already
  * resolves the destination through the same function the preview route will
@@ -246,7 +265,7 @@ function reasonForRefusal(error: unknown): PreviewUnavailableReason {
  * locale travels with it: on a localized collection an unscoped token opens the
  * default language whichever one was being edited.
  */
-async function authorizedOutcome(
+export async function mintSelfPreview(
   collection: string,
   entryId: string,
   locale: string | undefined
@@ -264,7 +283,7 @@ async function authorizedOutcome(
     // missing, which is a thing an administrator can fix, so it is reported as
     // itself rather than as an opaque failure.
     if (link.url === null) return { kind: "report", reason: "noSiteUrl" };
-    return { kind: "open", url: link.url };
+    return { kind: "open", url: link.url, expiresAt: link.expiresAt };
   } catch (error) {
     return { kind: "report", reason: reasonForRefusal(error) };
   }
@@ -368,7 +387,7 @@ export function useEntryPreview({
 
     settle(
       claimed.target,
-      await authorizedOutcome(collection.name, target.entryId, locale),
+      await mintSelfPreview(collection.name, target.entryId, locale),
       onUnavailable
     );
   }, [collection.name, entry, locale, onUnavailable, previewConfig]);


### PR DESCRIPTION
R-17, PR 2 of 2. PR 1 (#1195) made the Preview action reachable and gave it a real draft credential; this puts that preview beside the editor.

## What it does

A control in the entry editor opens a preview pane. Editor left, site right, resizable divider. Saving refreshes the frame.

## The finding that shaped it

**R-17's own title says the preview should update "as the editor types". It cannot, and this is worth stating plainly rather than shipping something that half-does it.**

`useDocumentAutosave` writes to `/autosave` — its own docblock calls it *"this author's recovery point"*, a private per-author rolling row. The preview route reads the **working draft** (`includeWorkingDraft: true`, `preview-route-defaults.ts:169`). Two endpoints, two rows. Autosave firing changes nothing a preview can see.

So the pane refreshes on **Save Draft / Publish**, and its toolbar says *"last saved draft"* rather than leaving an author to infer why a stale-looking page is not a bug.

Founder ruled: ship this, and treat "make autosave write the working draft" as its own decision — because it converts a private recovery row into something **any preview-link holder can read**. Half-typed content becoming visible would arrive disguised as a responsiveness improvement.

## Design, and where each piece comes from

**An iframe, not the page redrawn in the admin.** A frame is a real browsing context with a real viewport, so the site's `@media` rules resolve as they do for a visitor, and its document is the site's — no style leaks either way. This is also why R-17 and `#1201` legitimately differ: the editor canvas is *not* an iframe, so it needs container queries; a frame does not. Recorded as `decision:preview-truth-is-the-iframe`.

**The measure is released by ASKING.** `MeasuredPageFrame` states that framed and immersive are the whole vocabulary and there is no third case for a width — so the pane asks for `pageFrame` via `useSuppressAdminChrome`, the way `BlocksField` does, rather than the page declaring a second width. **The entry page file is untouched.** A reader who never opens the pane gets exactly the measure the page-shell work established.

**Only `pageFrame`.** Navigation stays: this is a pane beside the editor, not a takeover.

**Shaped after `TranslationPanes`**, which already solves this problem in this directory: a wrapper rather than a second editor, inactive rendering `children` and nothing else, `ResizablePanelGroup` with percentage-string sizes, and `@container/content` declared on the editor pane — without which every `@4xl/content:` query measures the full-width `<main>` while rendering into half of it, and the document rail overflows.

**Withheld during translation mode**, which already splits the editor and takes the window.

## Credential handling

Minted when the pane opens, re-minted only within 60s of expiry; an ordinary refresh remounts the frame. So a long edit does not issue a bearer credential — or an audit row, per #1205 — per save. `mintSelfPreview` is now exported and shared with the tab, so the TTL, the refusal mapping and the null-url case have one implementation.

## Evidence

12 new tests. Five break-verifications, each reddening exactly its own assertion:

| break | result |
|---|---|
| closed pane renders a wrapper | `renders the editor with no wrapper of its own` red |
| suppress `primaryRail` too | `releases the page measure and keeps the admin's navigation` red |
| refresh on first render | 3 red |
| never re-mint near expiry | `re-mints when the token is close enough to expiry` red |
| always re-mint | `reloads without re-minting while the token is comfortably valid` red |

Two mistakes worth recording: my hook tests first timed out because `vi.useFakeTimers()` starves `waitFor`, which polls on real timers — the fakes were unnecessary since each fixture states expiry relative to now. And one break-verify reported "applied" when its `perl` had errored; the guard was a `grep -q ... || echo`, which prints success on a failed search. Redone with an assertion that the anchor exists.

Gates: 827/827 in touched areas, build / `check-types` / `lint` / `lint:design` / comment-convention / `changeset status` clean, `fallow` **pass** with zero introduced.

## Not in scope

**Device presets.** They need `authoredBreakpoints` and `inCascadeOrder`, which are builder-only today and which lane `pb-breakpoint-badges` is moving into `blocks-engine` with its switcher work. Reimplementing the base-row strip and cascade order here would be the second definition we agreed to avoid.

**Singles.** `PreviewUrlRequest` requires a `collection`; a Single needs a server change first.