### PR TITLE
feat(plugin-page-builder): store which documents reference which named classes

### DIFF
--- a/.changeset/class-usage-index-storage.md
+++ b/.changeset/class-usage-index-storage.md
@@ -57,5 +57,20 @@ The table is written by the plugin and closed to everything else. `internal` set
 the access rules are the only thing keeping these rows private, not a second layer behind
 a first.
 
+A document whose references cannot all be read contributes ONE row with an empty class id
+rather than a row per class it managed to read. Skipping the write preserves whatever rows a
+subject already had and preserves nothing when it has none - which is the state an oversized
+document is in the first time anything indexes it - so without the marker that subject looks
+exactly like one referencing nothing, and a class its unread part applies reads as unused. A
+lookup for a real class never matches a marker, since a class id is never empty.
+
+The table records no webhook events. An omitted `webhooks` option RECORDS - the registry
+reads `webhooks?.record !== false`, which `undefined` satisfies - so a site with an endpoint
+subscribed to `entry.*` would otherwise receive every row this table writes, carrying the
+full document, and access rules are not consulted for outbox delivery.
+
 This release adds the table and the logic that decides its contents. Nothing maintains it
-yet; the write path follows.
+yet; the write path follows, and it owes reconciliation one guarantee this cannot give
+itself: the diff must be serialised with the document write it derives from, or re-derived
+from the row that won, because two writes diffing against the same stored rows can otherwise
+let the loser's removals delete rows the winning document still justifies.

--- a/.changeset/class-usage-index-storage.md
+++ b/.changeset/class-usage-index-storage.md
@@ -1,0 +1,53 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The page builder now stores a reverse index of which documents reference which named classes.
+
+The classes UI has to answer "how many places is this used" before an author renames or
+deletes a class, and a class is referenced BY ID from inside each page's stored document.
+Answering that live means opening every page on the site every time the number is shown -
+and a page's blocks live in one JSON-shaped column across three dialects with no shared,
+portable containment query, so there is no cheap version of that scan.
+
+`nx_pb_class_usage` records one row per reference: a document that uses three classes
+contributes three rows. The question the library asks is "which documents use THIS class",
+so a row per pair answers it with an indexed lookup instead of a walk over every document.
+
+A single is addressed by its SLUG, with an empty entity key, because its row may not exist
+until somebody edits it - an unedited single still renders its declared defaults. The key
+is kept non-null so the five columns form a real uniqueness constraint: a nullable member
+compares as unknown on most dialects, which would let duplicate rows through exactly where
+the count needs them not to.
+
+The table is written by the plugin and closed to everything else. `internal` sets
+`admin.hidden` and nothing more - no API route, dispatcher or registry sync reads it - so
+the access rules are the only thing keeping these rows private, not a second layer behind
+a first.
+
+This release adds the table and the logic that decides its contents. Nothing maintains it
+yet; the write path follows.

--- a/.changeset/class-usage-index-storage.md
+++ b/.changeset/class-usage-index-storage.md
@@ -47,10 +47,8 @@ No composite constraint is created over those columns, and that is a limitation 
 a choice: a collection's declared `indexes` do not reach the schema pipeline, which derives
 a table's indexes from its FIELDS. Uniqueness is kept by reconciliation instead - a second
 row for a class already recorded is removed rather than counted - so a race between two
-writes to one document leaves the count reading HIGH until that document is next written.
-That is the safe direction: an over-count warns about a delete that was safe, where an
-under-count permits one that was not. The `classId` lookup is a field-level index, which the
-pipeline does build.
+writes to one document can both insert. The `classId` lookup is a field-level index, which
+the pipeline does build.
 
 The table is written by the plugin and closed to everything else. `internal` sets
 `admin.hidden` and nothing more - no API route, dispatcher or registry sync reads it - so

--- a/.changeset/class-usage-index-storage.md
+++ b/.changeset/class-usage-index-storage.md
@@ -55,12 +55,18 @@ The table is written by the plugin and closed to everything else. `internal` set
 the access rules are the only thing keeping these rows private, not a second layer behind
 a first.
 
-A document whose references cannot all be read contributes ONE row with an empty class id
-rather than a row per class it managed to read. Skipping the write preserves whatever rows a
-subject already had and preserves nothing when it has none - which is the state an oversized
-document is in the first time anything indexes it - so without the marker that subject looks
-exactly like one referencing nothing, and a class its unread part applies reads as unused. A
-lookup for a real class never matches a marker, since a class id is never empty.
+A document whose references cannot all be read contributes ONE marker row rather than a row
+per class it managed to read. Skipping the write preserves whatever rows a subject already
+had and preserves nothing when it has none - which is the state an oversized document is in
+the first time anything indexes it - so without the marker that subject looks exactly like
+one referencing nothing, and a class its unread part applies reads as unused.
+
+The marker's class id is LONGER than the engine's cap on a class id, which is what keeps it
+disjoint from every real reference. Not the empty string: `isUsableNamedClass` constrains an
+id by type and length only - no pattern and no minimum - so the empty string is a usable
+class id and a document can genuinely reference one. Length is the only lever that rule
+leaves, so anything building on this design must use the exported constant rather than
+inventing a sentinel.
 
 The table records no webhook events. An omitted `webhooks` option RECORDS - the registry
 reads `webhooks?.record !== false`, which `undefined` satisfies - so a site with an endpoint

--- a/.changeset/class-usage-index-storage.md
+++ b/.changeset/class-usage-index-storage.md
@@ -39,10 +39,18 @@ contributes three rows. The question the library asks is "which documents use TH
 so a row per pair answers it with an indexed lookup instead of a walk over every document.
 
 A single is addressed by its SLUG, with an empty entity key, because its row may not exist
-until somebody edits it - an unedited single still renders its declared defaults. The key
-is kept non-null so the five columns form a real uniqueness constraint: a nullable member
-compares as unknown on most dialects, which would let duplicate rows through exactly where
-the count needs them not to.
+until somebody edits it - an unedited single still renders its declared defaults. The key is
+kept non-null rather than nullable, because a nullable member of a uniqueness constraint
+compares as unknown on most dialects.
+
+No composite constraint is created over those columns, and that is a limitation rather than
+a choice: a collection's declared `indexes` do not reach the schema pipeline, which derives
+a table's indexes from its FIELDS. Uniqueness is kept by reconciliation instead - a second
+row for a class already recorded is removed rather than counted - so a race between two
+writes to one document leaves the count reading HIGH until that document is next written.
+That is the safe direction: an over-count warns about a delete that was safe, where an
+under-count permits one that was not. The `classId` lookup is a field-level index, which the
+pipeline does build.
 
 The table is written by the plugin and closed to everything else. `internal` sets
 `admin.hidden` and nothing more - no API route, dispatcher or registry sync reads it - so

--- a/packages/plugin-page-builder/src/class-usage-reconcile.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-reconcile.test.ts
@@ -12,9 +12,10 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { DEFAULT_LIMITS } from "@nextlyhq/blocks-engine";
+import { DEFAULT_LIMITS, isUsableNamedClass } from "@nextlyhq/blocks-engine";
 
 import {
+  UNDETERMINED_CLASS_ID,
   deriveClassUsageRows,
   reconcileClassUsage,
   type ClassUsageSubject,
@@ -123,10 +124,35 @@ describe("deriving a document's index rows", () => {
 
     expect(derivation).toEqual({
       complete: false,
-      // Empty class id, not one of the ids it managed to read. A marker naming
+      // The marker id, not one of the ids it managed to read. A marker naming
       // a real class would be counted as a reference by every lookup for it.
-      undetermined: { ...page, classId: "" },
+      undetermined: { ...page, classId: UNDETERMINED_CLASS_ID },
     });
+  });
+
+  it("uses a marker id the engine will not accept as a class", () => {
+    // What makes the marker disjoint from every real reference, and the reason
+    // it is not the empty string: `isUsableNamedClass` constrains an id by TYPE
+    // and LENGTH only — no pattern, no minimum — so the empty string IS a
+    // usable class id and a document can genuinely reference one. Exceeding the
+    // cap is the only lever the rule leaves.
+    //
+    // Asserted against the engine's own predicate rather than by restating the
+    // cap, so this fails if that rule ever changes rather than the marker
+    // silently starting to collide.
+    expect(
+      isUsableNamedClass({
+        id: UNDETERMINED_CLASS_ID,
+        slug: "undetermined",
+        styles: {},
+      })
+    ).toBe(false);
+
+    // The control: the same entry with a short id IS accepted, so the rejection
+    // above is caused by the marker's length and not by the rest of the shape.
+    expect(
+      isUsableNamedClass({ id: "hero", slug: "undetermined", styles: {} })
+    ).toBe(true);
   });
 });
 

--- a/packages/plugin-page-builder/src/class-usage-reconcile.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-reconcile.test.ts
@@ -166,11 +166,11 @@ describe("reconciling derived rows against stored ones", () => {
       { ...page, classId: "card" },
     ];
     const stored = [
-      { id: "r1", classId: "hero" },
-      { id: "r2", classId: "card" },
+      { id: "r1", ...page, classId: "hero" },
+      { id: "r2", ...page, classId: "card" },
     ];
 
-    expect(reconcileClassUsage(derived, stored)).toEqual({
+    expect(reconcileClassUsage(page, derived, stored)).toEqual({
       insert: [],
       remove: [],
     });
@@ -181,12 +181,12 @@ describe("reconciling derived rows against stored ones", () => {
       { ...page, classId: "hero" },
       { ...page, classId: "card" },
     ];
-    const stored = [{ id: "r1", classId: "hero" }];
+    const stored = [{ id: "r1", ...page, classId: "hero" }];
 
     // `hero` is untouched rather than removed and re-added. A reference that
     // survives an edit must never be absent from the table, because a usage
     // count read between the two writes would not see it.
-    expect(reconcileClassUsage(derived, stored)).toEqual({
+    expect(reconcileClassUsage(page, derived, stored)).toEqual({
       insert: [{ ...page, classId: "card" }],
       remove: [],
     });
@@ -195,11 +195,11 @@ describe("reconciling derived rows against stored ones", () => {
   it("removes the row for a reference the document has dropped", () => {
     const derived = [{ ...page, classId: "hero" }];
     const stored = [
-      { id: "r1", classId: "hero" },
-      { id: "r2", classId: "card" },
+      { id: "r1", ...page, classId: "hero" },
+      { id: "r2", ...page, classId: "card" },
     ];
 
-    expect(reconcileClassUsage(derived, stored)).toEqual({
+    expect(reconcileClassUsage(page, derived, stored)).toEqual({
       insert: [],
       remove: ["r2"],
     });
@@ -212,11 +212,11 @@ describe("reconciling derived rows against stored ones", () => {
     // the reference out of the table for the duration of the write.
     const derived = [{ ...page, classId: "hero" }];
     const stored = [
-      { id: "r1", classId: "hero" },
-      { id: "r2", classId: "hero" },
+      { id: "r1", ...page, classId: "hero" },
+      { id: "r2", ...page, classId: "hero" },
     ];
 
-    expect(reconcileClassUsage(derived, stored)).toEqual({
+    expect(reconcileClassUsage(page, derived, stored)).toEqual({
       insert: [],
       remove: ["r2"],
     });
@@ -230,14 +230,42 @@ describe("reconciling derived rows against stored ones", () => {
     // an author a count could not be checked when it now can.
     const derived = [{ ...page, classId: "hero" }];
     const stored = [
-      { id: "m1", classId: "" },
-      { id: "r1", classId: "hero" },
+      { id: "m1", ...page, classId: UNDETERMINED_CLASS_ID },
+      { id: "r1", ...page, classId: "hero" },
     ];
 
-    expect(reconcileClassUsage(derived, stored)).toEqual({
+    expect(reconcileClassUsage(page, derived, stored)).toEqual({
       insert: [],
       remove: ["m1"],
     });
+  });
+
+  it("refuses stored rows belonging to a different document", () => {
+    // The failure this guards is a maintenance query that omits or misbinds one
+    // of the four subject predicates. Those rows are not references the subject
+    // has dropped — they belong to somebody else — and reconciliation would
+    // return their ids to be deleted, taking another document's record with it
+    // and leaving ITS count reading low.
+    const other = { ...page, entityKey: "page-2" };
+    const derived = [{ ...page, classId: "hero" }];
+    const stored = [{ id: "r9", ...other, classId: "hero" }];
+
+    // Refused rather than skipped. Skipping would correct the misbound query's
+    // damage invisibly on every call, so nothing would ever report it.
+    expect(() => reconcileClassUsage(page, derived, stored)).toThrow(
+      /belongs to collection:pages:page-2:content/
+    );
+  });
+
+  it("refuses derived rows that do not describe the subject", () => {
+    // The same guard from the other side. A caller reconciling one subject with
+    // another's derivation would insert rows attributing this document's
+    // classes to that one.
+    const derived = [{ ...page, entity: "posts", classId: "hero" }];
+
+    expect(() => reconcileClassUsage(page, derived, [])).toThrow(
+      /does not describe the subject/
+    );
   });
 
   it("removes every row of a dropped class, naming each id exactly once", () => {
@@ -247,12 +275,12 @@ describe("reconciling derived rows against stored ones", () => {
     // no longer exists by the time the second one runs.
     const derived = [{ ...page, classId: "hero" }];
     const stored = [
-      { id: "r1", classId: "hero" },
-      { id: "r2", classId: "card" },
-      { id: "r3", classId: "card" },
+      { id: "r1", ...page, classId: "hero" },
+      { id: "r2", ...page, classId: "card" },
+      { id: "r3", ...page, classId: "card" },
     ];
 
-    const result = reconcileClassUsage(derived, stored);
+    const result = reconcileClassUsage(page, derived, stored);
 
     expect(result.insert).toEqual([]);
     expect(result.remove).toEqual(["r2", "r3"]);

--- a/packages/plugin-page-builder/src/class-usage-reconcile.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-reconcile.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Whether a document's index rows are derived correctly, and whether
+ * reconciling them against stored rows issues the right writes.
+ *
+ * The cases are chosen around the two directions that hurt. Deriving too FEW
+ * references reports a class as unused and licences deleting it while pages
+ * render it; recording too MANY reports a class as used and blocks a delete
+ * that was safe. The first is the one that breaks a live site, so the
+ * truncation case below is the one this file exists for.
+ *
+ * @module class-usage-reconcile.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_LIMITS } from "@nextlyhq/blocks-engine";
+
+import {
+  deriveClassUsageRows,
+  reconcileClassUsage,
+  type ClassUsageSubject,
+} from "./class-usage-reconcile";
+
+/** A page, addressed the way a collection document is. */
+const page: ClassUsageSubject = {
+  scope: "collection",
+  entity: "pages",
+  entityKey: "page-1",
+  field: "content",
+};
+
+/** A document whose single node applies the given classes. */
+const documentUsing = (...classes: string[]) => ({
+  formatVersion: 1,
+  kind: "page",
+  nodes: [{ id: "n1", type: "core/text", version: 1, props: {}, classes }],
+});
+
+describe("deriving a document's index rows", () => {
+  it("produces one row per referenced class, each carrying the subject", () => {
+    const derivation = deriveClassUsageRows(
+      page,
+      documentUsing("hero", "card")
+    );
+
+    // The subject travels onto every row rather than being stored once beside
+    // them: the table is read by class, so a row has to name its own document
+    // to answer "which documents use this" without a second lookup.
+    expect(derivation).toEqual({
+      complete: true,
+      rows: [
+        { ...page, classId: "card" },
+        { ...page, classId: "hero" },
+      ],
+    });
+  });
+
+  it("carries a single's empty entity key through unchanged", () => {
+    // A single is addressed by its slug because its ROW may not exist, and the
+    // empty string is what keeps the five key columns non-null. A derivation
+    // that helpfully substituted an id here would produce rows the reconciler
+    // could never match against the ones already stored.
+    const single: ClassUsageSubject = {
+      scope: "single",
+      entity: "homepage",
+      entityKey: "",
+      field: "content",
+    };
+
+    const derivation = deriveClassUsageRows(single, documentUsing("hero"));
+
+    expect(derivation).toEqual({
+      complete: true,
+      rows: [{ ...single, classId: "hero" }],
+    });
+  });
+
+  it("yields NO rows when the document could not be read whole", () => {
+    // The failure this whole module is arranged around. A document larger than
+    // the bounds gives a PREFIX of its references, and reconciling against a
+    // prefix removes the rows for everything past the bound — turning "could
+    // not read it all" into "references nothing", which is precisely the answer
+    // that lets a live class be deleted.
+    const many = Array.from({ length: 20 }, (_, i) => ({
+      id: `n${i}`,
+      type: "core/text",
+      version: 1,
+      props: {},
+      classes: [`c${i}`],
+    }));
+
+    const derivation = deriveClassUsageRows(
+      page,
+      { formatVersion: 1, kind: "page", nodes: many },
+      { ...DEFAULT_LIMITS, maxNodes: 5 }
+    );
+
+    expect(derivation.complete).toBe(false);
+    // Asserted as ABSENCE of the member, not as an empty list. An empty list
+    // would still be a list a caller could reconcile against; the point of the
+    // union is that there is nothing there to reach for.
+    expect("rows" in derivation).toBe(false);
+  });
+});
+
+describe("reconciling derived rows against stored ones", () => {
+  it("issues no writes when the document's references are unchanged", () => {
+    // The common case by a wide margin: editing a page's text changes no class
+    // references at all. A reconciler that rewrote the rows anyway would move
+    // every row on every save, for nothing.
+    const derived = [
+      { ...page, classId: "hero" },
+      { ...page, classId: "card" },
+    ];
+    const stored = [
+      { id: "r1", classId: "hero" },
+      { id: "r2", classId: "card" },
+    ];
+
+    expect(reconcileClassUsage(derived, stored)).toEqual({
+      insert: [],
+      remove: [],
+    });
+  });
+
+  it("inserts only the reference the stored rows do not have", () => {
+    const derived = [
+      { ...page, classId: "hero" },
+      { ...page, classId: "card" },
+    ];
+    const stored = [{ id: "r1", classId: "hero" }];
+
+    // `hero` is untouched rather than removed and re-added. A reference that
+    // survives an edit must never be absent from the table, because a usage
+    // count read between the two writes would not see it.
+    expect(reconcileClassUsage(derived, stored)).toEqual({
+      insert: [{ ...page, classId: "card" }],
+      remove: [],
+    });
+  });
+
+  it("removes the row for a reference the document has dropped", () => {
+    const derived = [{ ...page, classId: "hero" }];
+    const stored = [
+      { id: "r1", classId: "hero" },
+      { id: "r2", classId: "card" },
+    ];
+
+    expect(reconcileClassUsage(derived, stored)).toEqual({
+      insert: [],
+      remove: ["r2"],
+    });
+  });
+
+  it("removes a duplicate row without re-inserting the class it duplicates", () => {
+    // Two rows saying the same thing is one reference recorded twice, and the
+    // library would report the class as used in more places than it is. The
+    // keeper has to survive: removing both and inserting a fresh one would take
+    // the reference out of the table for the duration of the write.
+    const derived = [{ ...page, classId: "hero" }];
+    const stored = [
+      { id: "r1", classId: "hero" },
+      { id: "r2", classId: "hero" },
+    ];
+
+    expect(reconcileClassUsage(derived, stored)).toEqual({
+      insert: [],
+      remove: ["r2"],
+    });
+  });
+
+  it("removes every row of a dropped class, naming each id exactly once", () => {
+    // A class that is BOTH duplicated and no longer referenced meets two
+    // reasons to be removed, and an implementation that applies them
+    // independently names the same id twice — which is a delete of a row that
+    // no longer exists by the time the second one runs.
+    const derived = [{ ...page, classId: "hero" }];
+    const stored = [
+      { id: "r1", classId: "hero" },
+      { id: "r2", classId: "card" },
+      { id: "r3", classId: "card" },
+    ];
+
+    const result = reconcileClassUsage(derived, stored);
+
+    expect(result.insert).toEqual([]);
+    expect(result.remove).toEqual(["r2", "r3"]);
+    expect(new Set(result.remove).size).toBe(result.remove.length);
+  });
+});

--- a/packages/plugin-page-builder/src/class-usage-reconcile.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-reconcile.test.ts
@@ -100,6 +100,34 @@ describe("deriving a document's index rows", () => {
     // union is that there is nothing there to reach for.
     expect("rows" in derivation).toBe(false);
   });
+
+  it("carries a marker row for a document it could not read whole", () => {
+    // Skipping the write preserves rows the subject ALREADY has and preserves
+    // nothing when it has none — the state an oversized document is in the
+    // first time anything indexes it. Without the marker that subject looks
+    // exactly like one referencing nothing, and the class its unread suffix
+    // applies reads as unused.
+    const many = Array.from({ length: 20 }, (_, i) => ({
+      id: `n${i}`,
+      type: "core/text",
+      version: 1,
+      props: {},
+      classes: [`c${i}`],
+    }));
+
+    const derivation = deriveClassUsageRows(
+      page,
+      { formatVersion: 1, kind: "page", nodes: many },
+      { ...DEFAULT_LIMITS, maxNodes: 5 }
+    );
+
+    expect(derivation).toEqual({
+      complete: false,
+      // Empty class id, not one of the ids it managed to read. A marker naming
+      // a real class would be counted as a reference by every lookup for it.
+      undetermined: { ...page, classId: "" },
+    });
+  });
 });
 
 describe("reconciling derived rows against stored ones", () => {
@@ -165,6 +193,24 @@ describe("reconciling derived rows against stored ones", () => {
     expect(reconcileClassUsage(derived, stored)).toEqual({
       insert: [],
       remove: ["r2"],
+    });
+  });
+
+  it("clears a stale marker once the document can be read again", () => {
+    // The marker is a row like any other, so a complete derivation that does
+    // not name it removes it by the ordinary rule. Asserted rather than left
+    // implicit: a marker that outlived the condition would report a readable
+    // document as permanently unverifiable, and the library would keep telling
+    // an author a count could not be checked when it now can.
+    const derived = [{ ...page, classId: "hero" }];
+    const stored = [
+      { id: "m1", classId: "" },
+      { id: "r1", classId: "hero" },
+    ];
+
+    expect(reconcileClassUsage(derived, stored)).toEqual({
+      insert: [],
+      remove: ["m1"],
     });
   });
 

--- a/packages/plugin-page-builder/src/class-usage-reconcile.ts
+++ b/packages/plugin-page-builder/src/class-usage-reconcile.ts
@@ -36,6 +36,7 @@
  *
  * @module class-usage-reconcile
  */
+import { MAX_NAMED_CLASS_NAME_LENGTH } from "@nextlyhq/blocks-engine";
 import type { DocumentLimits } from "@nextlyhq/blocks-engine";
 
 import { classUsageOf } from "./class-usage";
@@ -43,6 +44,25 @@ import type {
   ClassUsageRow,
   ClassUsageScope,
 } from "./collections/class-usage-index";
+
+/**
+ * The class id a marker row carries, chosen so no real reference can wear it.
+ *
+ * The engine constrains a class id by TYPE and LENGTH and nothing else —
+ * `isUsableNamedClass` tests `typeof id === "string"` and
+ * `id.length <= MAX_NAMED_CLASS_NAME_LENGTH`, with no pattern and no minimum.
+ * So the empty string is a usable id, and a document really can reference one;
+ * a marker wearing it would be indistinguishable from that reference, and a
+ * lookup could not tell a class in use from a subject nobody could read.
+ *
+ * Exceeding the cap is therefore the ONLY way to be disjoint by construction
+ * rather than by convention, because length is the only lever the rule offers.
+ * A test asserts the engine rejects this value, so the day that rule changes,
+ * this fails rather than silently starting to collide.
+ */
+export const UNDETERMINED_CLASS_ID = `undetermined:${"-".repeat(
+  MAX_NAMED_CLASS_NAME_LENGTH
+)}`;
 
 /**
  * The document being described, minus the classes it references.
@@ -121,7 +141,10 @@ export function deriveClassUsageRows(
     // The prefix it DID read is discarded rather than recorded. A partial list
     // stored as a list is indistinguishable from a complete one, and the whole
     // point of the marker is to be distinguishable.
-    return { complete: false, undetermined: { ...subject, classId: "" } };
+    return {
+      complete: false,
+      undetermined: { ...subject, classId: UNDETERMINED_CLASS_ID },
+    };
   }
   return {
     complete: true,

--- a/packages/plugin-page-builder/src/class-usage-reconcile.ts
+++ b/packages/plugin-page-builder/src/class-usage-reconcile.ts
@@ -67,10 +67,16 @@ export interface ClassUsageSubject {
  * A discriminated union rather than a list plus a flag: the incomplete arm has
  * no `rows` member, so a caller that forgets to check cannot read a truncated
  * list. The narrowing is the control.
+ *
+ * It carries a single marker row instead, which is a different thing from a
+ * shorter list and is written rather than skipped. Skipping preserves whatever
+ * rows the subject already had, and preserves NOTHING when it has none — which
+ * is the state an oversized document is in the first time anything indexes it.
+ * The marker is what stops that reading as "references nothing".
  */
 export type ClassUsageDerivation =
   | { complete: true; rows: ClassUsageRow[] }
-  | { complete: false };
+  | { complete: false; undetermined: ClassUsageRow };
 
 /**
  * Enough of a stored row to reconcile against it.
@@ -111,7 +117,12 @@ export function deriveClassUsageRows(
   limits?: DocumentLimits
 ): ClassUsageDerivation {
   const usage = classUsageOf(document, limits);
-  if (!usage.complete) return { complete: false };
+  if (!usage.complete) {
+    // The prefix it DID read is discarded rather than recorded. A partial list
+    // stored as a list is indistinguishable from a complete one, and the whole
+    // point of the marker is to be distinguishable.
+    return { complete: false, undetermined: { ...subject, classId: "" } };
+  }
   return {
     complete: true,
     rows: usage.ids.map(classId => ({ ...subject, classId })),
@@ -148,11 +159,19 @@ export function reconcileClassUsage(
     //
     // This is the ONLY thing keeping the rows unique. The database holds no
     // composite constraint over the key columns, because a collection's
-    // declared indexes do not reach the schema pipeline, so two writes racing
-    // on one document can both insert. What that leaves is a count reading
-    // HIGH until the next write to that document, which is the safe direction:
-    // an over-count warns about a delete that was safe, where an under-count
-    // permits one that was not.
+    // declared indexes do not reach the schema pipeline, so two concurrent
+    // writes to one document can both insert.
+    //
+    // A duplicate insert is the benign outcome, and it is NOT the only one a
+    // race produces. Both writes diff against the same stored rows, so the
+    // loser's diff describes a document that is no longer the live one: if it
+    // commits second, its removals delete rows the winning document still
+    // justifies, and the count reads LOW — the direction that permits deleting
+    // a class the page renders. Reconciliation is therefore only sound when
+    // the caller serialises it with the document write it derives from, or
+    // re-derives from the row that won. That is a property of the write path,
+    // which cannot be established here, and this comment is where it is
+    // recorded rather than assumed.
     const duplicate = kept.has(row.classId);
     if (duplicate || !wanted.has(row.classId)) {
       remove.push(row.id);

--- a/packages/plugin-page-builder/src/class-usage-reconcile.ts
+++ b/packages/plugin-page-builder/src/class-usage-reconcile.ts
@@ -1,0 +1,161 @@
+/**
+ * Turning one document into the index rows that describe it, and working out
+ * what has to change for the stored rows to say the same thing.
+ *
+ * Split from the write path deliberately: deciding what the rows SHOULD be is a
+ * question about a document, and it is answerable without a database, a
+ * transaction or a hook. Everything here is a pure function over values, so the
+ * hard part is tested against documents rather than against a store.
+ *
+ * ## Reconcile rather than replace
+ *
+ * The obvious maintenance is "delete this document's rows, insert the derived
+ * ones". It is wrong for a table whose rows are read constantly: between the
+ * delete and the insert the document appears to reference NOTHING, so a usage
+ * count read in that window reports zero and a safe-delete check performed in
+ * it is answered with the one value that licences the deletion. Reconciling
+ * writes only the difference, so a reference that survives the edit is never
+ * absent at any instant.
+ *
+ * It is also the cheaper shape by far in the common case: an author editing a
+ * page's text changes no class references at all, and reconciliation of an
+ * unchanged document issues no writes.
+ *
+ * ## An incomplete derivation is not a shorter one
+ *
+ * `classUsageOf` reads a bounded number of nodes, so a document larger than the
+ * bound yields a PREFIX of its references rather than all of them. A prefix
+ * must never be reconciled against, because reconciliation would remove the
+ * rows for every reference past the bound — turning "we could not read it all"
+ * into "it references nothing", which is the under-count direction that gets a
+ * live class deleted.
+ *
+ * That is why {@link ClassUsageDerivation} carries no `rows` at all when it is
+ * incomplete. A caller cannot reach for a list that does not exist, so the rule
+ * is enforced by the type rather than remembered by each caller.
+ *
+ * @module class-usage-reconcile
+ */
+import type { DocumentLimits } from "@nextlyhq/blocks-engine";
+
+import { classUsageOf } from "./class-usage";
+import type {
+  ClassUsageRow,
+  ClassUsageScope,
+} from "./collections/class-usage-index";
+
+/**
+ * The document being described, minus the classes it references.
+ *
+ * These four columns are constant for one document's rows, which is what lets
+ * everything below identify a row by its `classId` alone.
+ */
+export interface ClassUsageSubject {
+  scope: ClassUsageScope;
+  /** The collection's or single's slug. */
+  entity: string;
+  /** The row id for a collection, or the empty string for a single. */
+  entityKey: string;
+  /** The blocks field the document was read from. */
+  field: string;
+}
+
+/**
+ * What a document's rows should be, or the fact that they could not be
+ * determined.
+ *
+ * A discriminated union rather than a list plus a flag: the incomplete arm has
+ * no `rows` member, so a caller that forgets to check cannot read a truncated
+ * list. The narrowing is the control.
+ */
+export type ClassUsageDerivation =
+  | { complete: true; rows: ClassUsageRow[] }
+  | { complete: false };
+
+/**
+ * Enough of a stored row to reconcile against it.
+ *
+ * Narrower than {@link ClassUsageRow} on purpose. The four subject columns are
+ * fixed by the query that fetched these, so repeating them here would invite a
+ * caller to pass rows belonging to some OTHER document — and reconciliation
+ * would then read those as references this document has dropped and remove
+ * them. Asking only for what varies makes that mistake harder to make.
+ */
+export interface StoredClassUsageRow {
+  /** The row's own id, which is what a removal names. */
+  id: string;
+  classId: string;
+}
+
+/** The writes that bring a document's stored rows into agreement with it. */
+export interface ClassUsageReconciliation {
+  /** References the document has that no stored row records yet. */
+  insert: ClassUsageRow[];
+  /**
+   * Ids of stored rows to remove: references the document no longer has, plus
+   * any duplicate recording a reference another row already records.
+   */
+  remove: string[];
+}
+
+/**
+ * The rows describing one document, or the fact that it could not be read whole.
+ *
+ * `classUsageOf` is total — a malformed document yields a list rather than an
+ * error — so the only way this reports incompleteness is a document larger than
+ * the bounds the page is rendered under.
+ */
+export function deriveClassUsageRows(
+  subject: ClassUsageSubject,
+  document: unknown,
+  limits?: DocumentLimits
+): ClassUsageDerivation {
+  const usage = classUsageOf(document, limits);
+  if (!usage.complete) return { complete: false };
+  return {
+    complete: true,
+    rows: usage.ids.map(classId => ({ ...subject, classId })),
+  };
+}
+
+/**
+ * The difference between what a document references and what its stored rows
+ * say it references.
+ *
+ * Duplicates among `stored` are resolved by keeping the first row for each
+ * class; the branch below says why that is the right resolution.
+ *
+ * Takes derived ROWS rather than a derivation, so an incomplete read cannot be
+ * reconciled: there is no value of {@link ClassUsageDerivation} whose
+ * incomplete arm can be passed here.
+ */
+export function reconcileClassUsage(
+  derived: readonly ClassUsageRow[],
+  stored: readonly StoredClassUsageRow[]
+): ClassUsageReconciliation {
+  const wanted = new Set(derived.map(row => row.classId));
+  // Which classes a SURVIVING stored row records. A class reaches this set only
+  // by having a row that is both wanted and the first of its class, which is
+  // what makes it the right thing to subtract the inserts from: a class whose
+  // every row is being removed is absent from it, so its row is re-inserted.
+  const kept = new Set<string>();
+  const remove: string[] = [];
+
+  for (const row of stored) {
+    // A duplicate is not a reference held twice — a document applying one class
+    // to ten nodes references it once — so a second row for a class already
+    // kept is removed rather than counted. Rows predating the uniqueness
+    // constraint are why this is handled rather than assumed away by it.
+    const duplicate = kept.has(row.classId);
+    if (duplicate || !wanted.has(row.classId)) {
+      remove.push(row.id);
+      continue;
+    }
+    kept.add(row.classId);
+  }
+
+  return {
+    insert: derived.filter(row => !kept.has(row.classId)),
+    remove,
+  };
+}

--- a/packages/plugin-page-builder/src/class-usage-reconcile.ts
+++ b/packages/plugin-page-builder/src/class-usage-reconcile.ts
@@ -40,10 +40,7 @@ import { MAX_NAMED_CLASS_NAME_LENGTH } from "@nextlyhq/blocks-engine";
 import type { DocumentLimits } from "@nextlyhq/blocks-engine";
 
 import { classUsageOf } from "./class-usage";
-import type {
-  ClassUsageRow,
-  ClassUsageScope,
-} from "./collections/class-usage-index";
+import type { ClassUsageRow } from "./collections/class-usage-index";
 
 /**
  * The class id a marker row carries, chosen so no real reference can wear it.
@@ -67,17 +64,38 @@ export const UNDETERMINED_CLASS_ID = `undetermined:${"-".repeat(
 /**
  * The document being described, minus the classes it references.
  *
- * These four columns are constant for one document's rows, which is what lets
- * everything below identify a row by its `classId` alone.
+ * DERIVED from {@link ClassUsageRow} rather than restated. The two are the same
+ * four columns, and a second declaration of one shape agrees with the first on
+ * the day it is written: a column added to the row would silently not be part
+ * of a subject, so derivation would go on producing rows missing it.
  */
-export interface ClassUsageSubject {
-  scope: ClassUsageScope;
-  /** The collection's or single's slug. */
-  entity: string;
-  /** The row id for a collection, or the empty string for a single. */
-  entityKey: string;
-  /** The blocks field the document was read from. */
-  field: string;
+export type ClassUsageSubject = Omit<ClassUsageRow, "classId">;
+
+/**
+ * The columns that identify a subject, as values rather than as types.
+ *
+ * Built through a `Record` keyed by the subject's own keys, which is what makes
+ * it exhaustive: a `Record<K, ...>` requires EVERY member of `K`, so adding a
+ * column to {@link ClassUsageRow} fails to compile here until it is listed.
+ * An array annotated `(keyof ClassUsageSubject)[]` type-checks perfectly while
+ * missing a member, which is how a comparison silently stops covering one.
+ */
+const SUBJECT_KEYS = Object.keys({
+  scope: true,
+  entity: true,
+  entityKey: true,
+  field: true,
+} satisfies Record<
+  keyof ClassUsageSubject,
+  true
+>) as (keyof ClassUsageSubject)[];
+
+/** Whether a row describes the subject being reconciled. */
+function describesSubject(
+  row: ClassUsageSubject,
+  subject: ClassUsageSubject
+): boolean {
+  return SUBJECT_KEYS.every(key => row[key] === subject[key]);
 }
 
 /**
@@ -99,18 +117,18 @@ export type ClassUsageDerivation =
   | { complete: false; undetermined: ClassUsageRow };
 
 /**
- * Enough of a stored row to reconcile against it.
+ * A stored row, as reconciliation needs to see it.
  *
- * Narrower than {@link ClassUsageRow} on purpose. The four subject columns are
- * fixed by the query that fetched these, so repeating them here would invite a
- * caller to pass rows belonging to some OTHER document — and reconciliation
- * would then read those as references this document has dropped and remove
- * them. Asking only for what varies makes that mistake harder to make.
+ * Carries its subject columns rather than only what varies. An earlier shape
+ * asked for `{ id, classId }` alone, on the reasoning that a caller cannot
+ * misuse what it is not asked for — which is false: a caller maps its rows to
+ * the narrow shape and a misbound query is exactly as wrong, only now
+ * undetectable. Reconciliation issues REMOVALS, so it has to be able to refuse
+ * rows that are not the subject's rather than trust that they are.
  */
-export interface StoredClassUsageRow {
+export interface StoredClassUsageRow extends ClassUsageRow {
   /** The row's own id, which is what a removal names. */
   id: string;
-  classId: string;
 }
 
 /** The writes that bring a document's stored rows into agreement with it. */
@@ -162,11 +180,43 @@ export function deriveClassUsageRows(
  * Takes derived ROWS rather than a derivation, so an incomplete read cannot be
  * reconciled: there is no value of {@link ClassUsageDerivation} whose
  * incomplete arm can be passed here.
+ *
+ * THROWS when any row belongs to a different subject, rather than skipping it.
+ * The caller supplies `stored` from a query, and a query missing or misbinding
+ * one of the four subject predicates hands over another document's rows — which
+ * this would otherwise report as references the subject has dropped, returning
+ * their ids to be deleted. Refusing is what a guard on a destructive operation
+ * owes: skipping silently would leave the misbound query in place, correcting
+ * its damage invisibly on every call.
+ *
+ * The check is an equality over values already in hand, so it costs nothing on
+ * the path where it never rejects.
  */
 export function reconcileClassUsage(
+  subject: ClassUsageSubject,
   derived: readonly ClassUsageRow[],
   stored: readonly StoredClassUsageRow[]
 ): ClassUsageReconciliation {
+  for (const row of derived) {
+    if (!describesSubject(row, subject)) {
+      throw new Error(
+        `Derived row for ${row.scope}:${row.entity}:${row.entityKey}:${row.field} ` +
+          `does not describe the subject being reconciled ` +
+          `(${subject.scope}:${subject.entity}:${subject.entityKey}:${subject.field}).`
+      );
+    }
+  }
+  for (const row of stored) {
+    if (!describesSubject(row, subject)) {
+      throw new Error(
+        `Stored row ${row.id} belongs to ` +
+          `${row.scope}:${row.entity}:${row.entityKey}:${row.field}, ` +
+          `not to the subject being reconciled ` +
+          `(${subject.scope}:${subject.entity}:${subject.entityKey}:${subject.field}).`
+      );
+    }
+  }
+
   const wanted = new Set(derived.map(row => row.classId));
   // Which classes a SURVIVING stored row records. A class reaches this set only
   // by having a row that is both wanted and the first of its class, which is

--- a/packages/plugin-page-builder/src/class-usage-reconcile.ts
+++ b/packages/plugin-page-builder/src/class-usage-reconcile.ts
@@ -144,8 +144,15 @@ export function reconcileClassUsage(
   for (const row of stored) {
     // A duplicate is not a reference held twice — a document applying one class
     // to ten nodes references it once — so a second row for a class already
-    // kept is removed rather than counted. Rows predating the uniqueness
-    // constraint are why this is handled rather than assumed away by it.
+    // kept is removed rather than counted.
+    //
+    // This is the ONLY thing keeping the rows unique. The database holds no
+    // composite constraint over the key columns, because a collection's
+    // declared indexes do not reach the schema pipeline, so two writes racing
+    // on one document can both insert. What that leaves is a count reading
+    // HIGH until the next write to that document, which is the safe direction:
+    // an over-count warns about a delete that was safe, where an under-count
+    // permits one that was not.
     const duplicate = kept.has(row.classId);
     if (duplicate || !wanted.has(row.classId)) {
       remove.push(row.id);

--- a/packages/plugin-page-builder/src/collections/class-usage-index.test.ts
+++ b/packages/plugin-page-builder/src/collections/class-usage-index.test.ts
@@ -81,11 +81,4 @@ describe("the class-usage index collection", () => {
     // the closed rules above do not cover that path.
     expect(contributed().webhooks).toBe(false);
   });
-
-  it("stores no timestamps", () => {
-    // A row is a fact derived from a document, not an event. A `createdAt` here
-    // answers when the ROW was written, which is not when the reference
-    // appeared, and the two differ by every rebuild.
-    expect(classUsageIndexCollection().timestamps).toBe(false);
-  });
 });

--- a/packages/plugin-page-builder/src/collections/class-usage-index.test.ts
+++ b/packages/plugin-page-builder/src/collections/class-usage-index.test.ts
@@ -15,7 +15,6 @@ import { pageBuilder } from "../plugin";
 
 import {
   CLASS_USAGE_INDEX_SLUG,
-  CLASS_USAGE_KEY_FIELDS,
   classUsageIndexCollection,
 } from "./class-usage-index";
 
@@ -52,40 +51,26 @@ describe("the class-usage index collection", () => {
     }
   });
 
-  it("constrains exactly the five columns that identify a reference", () => {
-    // The empty-string entity key is only sound if these columns really are a
-    // uniqueness constraint — a comment saying they form a total key is not
-    // one. Written out here rather than compared against the constant the
-    // collection builds from: a test that reads the same source the code reads
-    // agrees with it however that source changes, and would not notice a
-    // column leaving the key.
-    const unique = (contributed().indexes ?? []).filter(i => i.unique === true);
-
-    expect(unique).toHaveLength(1);
-    expect(unique[0]?.fields).toEqual([
-      "scope",
-      "entity",
-      "entityKey",
-      "field",
-      "classId",
-    ]);
-    // And the constant the collection is built from says the same, so the two
-    // are checked against each other rather than only one being checked.
-    expect([...CLASS_USAGE_KEY_FIELDS]).toEqual(unique[0]?.fields);
-  });
-
-  it("carries an index leading with the column the library filters on", () => {
+  it("indexes the column the library filters on, in a form the pipeline builds", () => {
     // The read this table exists to serve is "given a class, which documents
-    // reference it". Without an index led by `classId` that question scans
-    // every row — which is the cost the table was chosen to avoid, so its
-    // absence would not fail anything, it would just make the feature slow in
-    // exactly the way the design rejected.
-    const byClass = (contributed().indexes ?? []).filter(
-      i => i.unique !== true
+    // reference it". A collection-level `indexes` entry does not reach the
+    // schema pipeline — `buildDesiredTableFromFields` is given the fields and
+    // derives only system and per-field indexes — so the index has to be
+    // declared on the field or it exists only in the config.
+    const classId = contributed().fields.find(
+      f => "name" in f && f.name === "classId"
     );
 
-    expect(byClass).toHaveLength(1);
-    expect(byClass[0]?.fields[0]).toBe("classId");
+    expect(classId).toBeDefined();
+    expect(classId).toMatchObject({ index: true });
+  });
+
+  it("declares no collection-level index, which would not be built", () => {
+    // Asserted rather than left absent: a declared index reads as a constraint
+    // to anyone who finds it, and this one would never exist in the database.
+    // The empty-string entity key and the reconciler's duplicate removal are
+    // what the design rests on instead.
+    expect(contributed().indexes).toBeUndefined();
   });
 
   it("stores no timestamps", () => {

--- a/packages/plugin-page-builder/src/collections/class-usage-index.test.ts
+++ b/packages/plugin-page-builder/src/collections/class-usage-index.test.ts
@@ -73,6 +73,15 @@ describe("the class-usage index collection", () => {
     expect(contributed().indexes).toBeUndefined();
   });
 
+  it("records no webhook event for its writes", () => {
+    // An OMITTED option records: the registry reads `webhooks?.record !== false`
+    // and `undefined` satisfies it. So a site with an endpoint subscribed to
+    // `entry.*` would receive every row this table writes, carrying the full
+    // document — and access rules are not consulted for outbox delivery, so
+    // the closed rules above do not cover that path.
+    expect(contributed().webhooks).toBe(false);
+  });
+
   it("stores no timestamps", () => {
     // A row is a fact derived from a document, not an event. A `createdAt` here
     // answers when the ROW was written, which is not when the reference

--- a/packages/plugin-page-builder/src/collections/class-usage-index.test.ts
+++ b/packages/plugin-page-builder/src/collections/class-usage-index.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Whether the index collection is a config the host will actually accept, and
+ * whether its constraints describe the columns it declares.
+ *
+ * A collection definition nothing constructs is a set of claims: it type-checks
+ * against the config types and is never validated against the rules the host
+ * applies at boot. These cases construct it through the plugin, which is where
+ * an invalid rule stops being a claim and becomes an error.
+ *
+ * @module collections/class-usage-index.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { pageBuilder } from "../plugin";
+
+import {
+  CLASS_USAGE_INDEX_SLUG,
+  CLASS_USAGE_KEY_FIELDS,
+  classUsageIndexCollection,
+} from "./class-usage-index";
+
+/** The index as the plugin contributes it, built the way a host builds it. */
+const contributed = () => {
+  const collections = pageBuilder().contributes?.collections ?? [];
+  const index = collections.find(c => c.slug === CLASS_USAGE_INDEX_SLUG);
+  if (index === undefined)
+    throw new Error("the plugin contributes no usage index");
+  return index;
+};
+
+describe("the class-usage index collection", () => {
+  it("is contributed by the plugin, and survives config validation", () => {
+    // `defineCollection` validates, so an access rule of the wrong TYPE — the
+    // shape a reader naturally writes for "nobody may do this" — throws here
+    // rather than at a host's boot. Constructing through the plugin is what
+    // makes that reachable: the definition alone is only ever type-checked.
+    expect(contributed().slug).toBe(CLASS_USAGE_INDEX_SLUG);
+  });
+
+  it("refuses all four operations over the wire", () => {
+    // These rules are the ONLY thing keeping the table private. `internal`
+    // sets `admin.hidden` and nothing else, so an internal collection is
+    // routed and dispatched exactly like any other.
+    const access = contributed().access ?? {};
+    for (const rule of ["create", "read", "update", "delete"] as const) {
+      const fn = access[rule];
+      expect(typeof fn).toBe("function");
+      // Called with no argument on purpose: a rule that refuses only for SOME
+      // caller is not a closed door, and one that reads its argument would
+      // throw here rather than quietly answering for the anonymous case.
+      expect((fn as () => unknown)()).toBe(false);
+    }
+  });
+
+  it("constrains exactly the five columns that identify a reference", () => {
+    // The empty-string entity key is only sound if these columns really are a
+    // uniqueness constraint — a comment saying they form a total key is not
+    // one. Written out here rather than compared against the constant the
+    // collection builds from: a test that reads the same source the code reads
+    // agrees with it however that source changes, and would not notice a
+    // column leaving the key.
+    const unique = (contributed().indexes ?? []).filter(i => i.unique === true);
+
+    expect(unique).toHaveLength(1);
+    expect(unique[0]?.fields).toEqual([
+      "scope",
+      "entity",
+      "entityKey",
+      "field",
+      "classId",
+    ]);
+    // And the constant the collection is built from says the same, so the two
+    // are checked against each other rather than only one being checked.
+    expect([...CLASS_USAGE_KEY_FIELDS]).toEqual(unique[0]?.fields);
+  });
+
+  it("carries an index leading with the column the library filters on", () => {
+    // The read this table exists to serve is "given a class, which documents
+    // reference it". Without an index led by `classId` that question scans
+    // every row — which is the cost the table was chosen to avoid, so its
+    // absence would not fail anything, it would just make the feature slow in
+    // exactly the way the design rejected.
+    const byClass = (contributed().indexes ?? []).filter(
+      i => i.unique !== true
+    );
+
+    expect(byClass).toHaveLength(1);
+    expect(byClass[0]?.fields[0]).toBe("classId");
+  });
+
+  it("stores no timestamps", () => {
+    // A row is a fact derived from a document, not an event. A `createdAt` here
+    // answers when the ROW was written, which is not when the reference
+    // appeared, and the two differ by every rebuild.
+    expect(classUsageIndexCollection().timestamps).toBe(false);
+  });
+});

--- a/packages/plugin-page-builder/src/collections/class-usage-index.ts
+++ b/packages/plugin-page-builder/src/collections/class-usage-index.ts
@@ -41,21 +41,6 @@ export const CLASS_USAGE_INDEX_SLUG = "nx_pb_class_usage";
  */
 export type ClassUsageScope = "collection" | "single";
 
-/**
- * The columns that together identify one reference.
- *
- * Named once and used by both the uniqueness constraint and the type, so the
- * key cannot be widened in one and left alone in the other — the failure that
- * leaves a constraint enforcing a key nobody means any more.
- */
-export const CLASS_USAGE_KEY_FIELDS = [
-  "scope",
-  "entity",
-  "entityKey",
-  "field",
-  "classId",
-] as const;
-
 /** One reference: this document, through this field, uses this class. */
 export interface ClassUsageRow {
   scope: ClassUsageScope;
@@ -70,9 +55,12 @@ export interface ClassUsageRow {
    * absent until somebody types.
    *
    * Kept as an empty string rather than null so the five columns form a total
-   * key: a nullable member of a uniqueness constraint compares as unknown on
-   * most dialects, which would let duplicate rows through exactly where the
-   * index needs them not to.
+   * key. Nothing in the database enforces that today — a collection's declared
+   * indexes do not reach the schema pipeline, so the composite constraint this
+   * key describes cannot currently be created — and it is the reconciler that
+   * keeps the rows unique instead. A null here would still be wrong the day
+   * that changes, because a nullable member of a uniqueness constraint compares
+   * as unknown on most dialects.
    */
   entityKey: string;
   /** The blocks field the reference was found in. */
@@ -104,35 +92,12 @@ export function classUsageIndexCollection() {
       text({ name: "entity", label: "Entity" }),
       text({ name: "entityKey", label: "Entity key" }),
       text({ name: "field", label: "Field" }),
-      text({ name: "classId", label: "Class id" }),
-    ],
-    indexes: [
-      {
-        // What makes reconciliation idempotent rather than merely intended. The
-        // maintenance path derives a document's rows and writes the ones that
-        // are missing, so a save applied twice — a retry, a concurrent write,
-        // a rebuild racing an edit — must be unable to leave two rows saying
-        // the same thing. Without this the duplicate is invisible: nothing
-        // reads a row's identity, so the library would just report a class as
-        // used in more places than it is, and the number would drift upward
-        // with every retry the site ever performs.
-        fields: [...CLASS_USAGE_KEY_FIELDS],
-        unique: true,
-        name: "nx_pb_class_usage_reference_unique",
-      },
-      {
-        // The read this table exists to serve: given a class, which documents
-        // reference it. Without an index that question scans every row, which
-        // is the cost the whole design was chosen to avoid — the count is shown
-        // ambiently beside every class in the library, so it is asked once per
-        // class per render rather than once per delete.
-        //
-        // `classId` leads because it is the column the question filters on, and
-        // `scope` follows so a caller narrowing to one kind of content reads
-        // the index rather than the rows behind it.
-        fields: ["classId", "scope"],
-        name: "nx_pb_class_usage_by_class_idx",
-      },
+      // Indexed because this is the column the library filters on: the count
+      // is shown beside every class, so "which documents use this one" is asked
+      // once per class per render rather than once per delete. Declared on the
+      // FIELD rather than as a collection-level index, which is the form the
+      // schema pipeline materialises.
+      text({ name: "classId", label: "Class id", index: true }),
     ],
     access: {
       // Derived from documents on every write, and rebuilt from them on demand.

--- a/packages/plugin-page-builder/src/collections/class-usage-index.ts
+++ b/packages/plugin-page-builder/src/collections/class-usage-index.ts
@@ -1,0 +1,171 @@
+/**
+ * Where the record of "which documents reference which named class" lives.
+ *
+ * One row per reference: a document that uses three classes contributes three
+ * rows. That normalisation is the whole point — the question the class library
+ * asks is "which documents use THIS class", and a row per pair answers it with
+ * a lookup rather than a scan over every stored document.
+ *
+ * ## Why a collection rather than a table
+ *
+ * A plugin cannot own a table. `PluginContributions` offers `collections`,
+ * `singles` and `fieldGroups`, and nothing else, so a collection marked
+ * `internal` is the storage unit available — and it is the one the option was
+ * added for, its own docblock naming "a plugin's internal records".
+ *
+ * Being a collection also means the schema pipeline builds and migrates it on
+ * every dialect for free, which a hand-rolled table would have to reimplement
+ * three times.
+ *
+ * ## `internal` hides it from navigation and NOTHING else
+ *
+ * Measured: `internal: true` sets `admin.hidden` and stops there. No API
+ * routing, no dispatcher and no registry sync reads the flag, so an internal
+ * collection is reachable over the Direct API and the wire API exactly like any
+ * other. The access rules below are therefore the ONLY thing keeping this
+ * private, rather than a second layer behind a first.
+ *
+ * @module collections/class-usage-index
+ */
+import { defineCollection, text } from "nextly/config";
+
+/** The slug this plugin's usage index is stored under. */
+export const CLASS_USAGE_INDEX_SLUG = "nx_pb_class_usage";
+
+/**
+ * Which kind of content a row points at.
+ *
+ * Collections and singles are addressed differently and the difference is not
+ * cosmetic, so the kind is stored rather than inferred from whether `entityKey`
+ * happens to be empty.
+ */
+export type ClassUsageScope = "collection" | "single";
+
+/**
+ * The columns that together identify one reference.
+ *
+ * Named once and used by both the uniqueness constraint and the type, so the
+ * key cannot be widened in one and left alone in the other — the failure that
+ * leaves a constraint enforcing a key nobody means any more.
+ */
+export const CLASS_USAGE_KEY_FIELDS = [
+  "scope",
+  "entity",
+  "entityKey",
+  "field",
+  "classId",
+] as const;
+
+/** One reference: this document, through this field, uses this class. */
+export interface ClassUsageRow {
+  scope: ClassUsageScope;
+  /** The collection's or single's slug. */
+  entity: string;
+  /**
+   * Which document within `entity`, or empty for a single.
+   *
+   * A single has one document, and its ROW MAY NOT EXIST — an unedited single
+   * still renders its declared defaults. So a single is addressed by its slug
+   * alone, in `entity`, and this stays empty rather than holding an id that is
+   * absent until somebody types.
+   *
+   * Kept as an empty string rather than null so the five columns form a total
+   * key: a nullable member of a uniqueness constraint compares as unknown on
+   * most dialects, which would let duplicate rows through exactly where the
+   * index needs them not to.
+   */
+  entityKey: string;
+  /** The blocks field the reference was found in. */
+  field: string;
+  /** The named class's id, as stored in `node.classes`. */
+  classId: string;
+}
+
+/**
+ * The index collection.
+ *
+ * Every column is `text` deliberately. These are identifiers — slugs, ids,
+ * field names — that arrive from stored documents and from a plugin's own
+ * declarations, and none of them is a number, a date or a relationship this
+ * plugin may assume exists. A relationship to `pages` in particular would be
+ * wrong twice over: the index spans every collection that mounts a blocks
+ * field, not one, and a single has no row to relate to.
+ */
+export function classUsageIndexCollection() {
+  return defineCollection({
+    slug: CLASS_USAGE_INDEX_SLUG,
+    labels: { singular: "Class usage", plural: "Class usage" },
+    // Bookkeeping the plugin maintains, never authored. `internal` keeps it out
+    // of the admin's navigation; the access rules below are what keep it out of
+    // everything else.
+    internal: true,
+    fields: [
+      text({ name: "scope", label: "Scope" }),
+      text({ name: "entity", label: "Entity" }),
+      text({ name: "entityKey", label: "Entity key" }),
+      text({ name: "field", label: "Field" }),
+      text({ name: "classId", label: "Class id" }),
+    ],
+    indexes: [
+      {
+        // What makes reconciliation idempotent rather than merely intended. The
+        // maintenance path derives a document's rows and writes the ones that
+        // are missing, so a save applied twice — a retry, a concurrent write,
+        // a rebuild racing an edit — must be unable to leave two rows saying
+        // the same thing. Without this the duplicate is invisible: nothing
+        // reads a row's identity, so the library would just report a class as
+        // used in more places than it is, and the number would drift upward
+        // with every retry the site ever performs.
+        fields: [...CLASS_USAGE_KEY_FIELDS],
+        unique: true,
+        name: "nx_pb_class_usage_reference_unique",
+      },
+      {
+        // The read this table exists to serve: given a class, which documents
+        // reference it. Without an index that question scans every row, which
+        // is the cost the whole design was chosen to avoid — the count is shown
+        // ambiently beside every class in the library, so it is asked once per
+        // class per render rather than once per delete.
+        //
+        // `classId` leads because it is the column the question filters on, and
+        // `scope` follows so a caller narrowing to one kind of content reads
+        // the index rather than the rows behind it.
+        fields: ["classId", "scope"],
+        name: "nx_pb_class_usage_by_class_idx",
+      },
+    ],
+    access: {
+      // Derived from documents on every write, and rebuilt from them on demand.
+      // Nothing outside this plugin has a reason to author a row, and a row
+      // authored by hand would disagree with the document it claims to describe
+      // until the next rebuild silently replaced it.
+      //
+      // Written as functions returning a constant rather than as bare `false`:
+      // access rules are validated as callables, and a boolean is rejected at
+      // config time rather than read as "never".
+      //
+      // A constant rather than a role check: an administrator editing this by hand
+      // is not a privilege to grant, it is a way to make the record wrong. The
+      // plugin's own maintenance runs through the Direct API, which defaults to
+      // `overrideAccess: true`, so these close the wire API without closing the
+      // path that maintains the rows.
+      create: () => false,
+      update: () => false,
+      delete: () => false,
+      // Read is closed for the same reason the rest are, and one more: the rows
+      // enumerate which documents exist and what they reference, which is a map
+      // of the site's content to anyone who can list them. The class library
+      // reads this through the plugin, on the same overriding path.
+      read: () => false,
+    },
+    admin: {
+      description:
+        "Which documents reference which named classes. Maintained automatically; editing it cannot change what any page renders.",
+    },
+    // No timestamps. A row is a fact derived from a document, not an event, and
+    // `createdAt`/`updatedAt` on a derived row invite exactly the question they
+    // cannot answer — when the REFERENCE appeared, which is a property of the
+    // document's history rather than of this row's.
+    timestamps: false,
+  });
+}

--- a/packages/plugin-page-builder/src/collections/class-usage-index.ts
+++ b/packages/plugin-page-builder/src/collections/class-usage-index.ts
@@ -65,7 +65,25 @@ export interface ClassUsageRow {
   entityKey: string;
   /** The blocks field the reference was found in. */
   field: string;
-  /** The named class's id, as stored in `node.classes`. */
+  /**
+   * The named class's id, as stored in `node.classes`, or empty on a marker
+   * row.
+   *
+   * A document whose references could not all be read contributes ONE row with
+   * this empty rather than a row per class it managed to read. Without it, a
+   * document nobody has been able to read looks exactly like one that
+   * references nothing — and "references nothing" is the answer that permits
+   * deleting a class the unread part of the document still applies.
+   *
+   * Empty rather than a separate column, and rather than a flag on every row,
+   * because the state belongs to the SUBJECT and there may be no rows to carry
+   * a flag: an oversized document indexed for the first time has none. It
+   * reads the way the empty `entityKey` does, as "there is no such thing here".
+   *
+   * A lookup for a real class never matches one, since a class id is never
+   * empty; asking for the empty id is how the library counts the documents it
+   * could not check.
+   */
   classId: string;
 }
 
@@ -123,6 +141,17 @@ export function classUsageIndexCollection() {
       // reads this through the plugin, on the same overriding path.
       read: () => false,
     },
+    // No webhook recording. An omitted option RECORDS — the registry reads
+    // `webhooks?.record !== false`, which `undefined` satisfies — so a site
+    // with an endpoint subscribed to `entry.*` receives every row this table
+    // writes, carrying the full document. Access rules are not consulted for
+    // outbox delivery, so the rules above do not cover this path.
+    //
+    // Two reasons, either sufficient. These rows enumerate which documents
+    // exist and what they reference, which is a map of the site's content;
+    // and reconciliation writes on every save, so recording them would put an
+    // event on the outbox for each reference that changed.
+    webhooks: false,
     admin: {
       description:
         "Which documents reference which named classes. Maintained automatically; editing it cannot change what any page renders.",

--- a/packages/plugin-page-builder/src/collections/class-usage-index.ts
+++ b/packages/plugin-page-builder/src/collections/class-usage-index.ts
@@ -166,10 +166,18 @@ export function classUsageIndexCollection() {
       description:
         "Which documents reference which named classes. Maintained automatically; editing it cannot change what any page renders.",
     },
-    // No timestamps. A row is a fact derived from a document, not an event, and
+    // A row is a fact derived from a document, not an event, and
     // `createdAt`/`updatedAt` on a derived row invite exactly the question they
     // cannot answer — when the REFERENCE appeared, which is a property of the
     // document's history rather than of this row's.
+    //
+    // Declared even though nothing honours it today. The schema pipeline is
+    // given `{ builtBy, hasStatus, localized }` and injects both timestamp
+    // columns unconditionally, and the mutation service stamps them on every
+    // create, so this table carries two values per reference that mean nothing.
+    // Kept rather than dropped because it is the correct statement for this
+    // collection and a pipeline that learns to read it should apply it here;
+    // removing it would make that future fix silently skip this table.
     timestamps: false,
   });
 }

--- a/packages/plugin-page-builder/src/collections/class-usage-index.ts
+++ b/packages/plugin-page-builder/src/collections/class-usage-index.ts
@@ -22,8 +22,15 @@
  * Measured: `internal: true` sets `admin.hidden` and stops there. No API
  * routing, no dispatcher and no registry sync reads the flag, so an internal
  * collection is reachable over the Direct API and the wire API exactly like any
- * other. The access rules below are therefore the ONLY thing keeping this
- * private, rather than a second layer behind a first.
+ * other. The access rules below are what close it, rather than a second layer
+ * behind a first.
+ *
+ * They do not close it for everyone. `checkCollectionAccess` returns before
+ * evaluating a collection's own rules when the caller is a super-admin session,
+ * so a super-admin can address this slug directly and write to it. That is a
+ * property of the access service rather than of this collection, and it is why
+ * the rebuild exists: a row authored by hand disagrees with the document it
+ * claims to describe until a rebuild replaces it.
  *
  * @module collections/class-usage-index
  */
@@ -66,23 +73,23 @@ export interface ClassUsageRow {
   /** The blocks field the reference was found in. */
   field: string;
   /**
-   * The named class's id, as stored in `node.classes`, or empty on a marker
-   * row.
+   * The named class's id, as stored in `node.classes`, or the marker id on a
+   * marker row.
    *
-   * A document whose references could not all be read contributes ONE row with
-   * this empty rather than a row per class it managed to read. Without it, a
+   * A document whose references could not all be read contributes ONE row
+   * carrying the marker id, rather than a row per class it managed to read. Without it, a
    * document nobody has been able to read looks exactly like one that
    * references nothing — and "references nothing" is the answer that permits
    * deleting a class the unread part of the document still applies.
    *
-   * Empty rather than a separate column, and rather than a flag on every row,
-   * because the state belongs to the SUBJECT and there may be no rows to carry
-   * a flag: an oversized document indexed for the first time has none. It
-   * reads the way the empty `entityKey` does, as "there is no such thing here".
+   * A marker row rather than a separate column, and rather than a flag on every
+   * row, because the state belongs to the SUBJECT and there may be no rows to
+   * carry a flag: an oversized document indexed for the first time has none.
    *
-   * A lookup for a real class never matches one, since a class id is never
-   * empty; asking for the empty id is how the library counts the documents it
-   * could not check.
+   * The marker id is longer than the engine's cap on a class id, which is what
+   * makes it disjoint from every real reference. NOT the empty string: the
+   * engine constrains an id by type and length only, so the empty string is a
+   * usable class id and a document can genuinely reference one.
    */
   classId: string;
 }
@@ -130,8 +137,11 @@ export function classUsageIndexCollection() {
       // A constant rather than a role check: an administrator editing this by hand
       // is not a privilege to grant, it is a way to make the record wrong. The
       // plugin's own maintenance runs through the Direct API, which defaults to
-      // `overrideAccess: true`, so these close the wire API without closing the
-      // path that maintains the rows.
+      // `overrideAccess: true`, so these close the wire API for an ordinary
+      // caller without closing the path that maintains the rows.
+      //
+      // A super-admin session is not an ordinary caller and bypasses these
+      // entirely; the rebuild is what repairs a table written that way.
       create: () => false,
       update: () => false,
       delete: () => false,

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -18,6 +18,7 @@ import {
   registerCoreBlocks,
   registerDeclaredBlocks,
 } from "./blocks/registration-service";
+import { classUsageIndexCollection } from "./collections/class-usage-index";
 import { pagesCollection } from "./collections/pages";
 import { blocksFieldType } from "./fields/blocksField";
 import { hostFetchPolicy } from "./host-policy";
@@ -219,7 +220,14 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
       services: {
         [BLOCK_SERVICE]: () => createBlockRegistrationService(),
       },
-      collections: [pagesCollection(opts.pagePreviewPath, opts.limits)],
+      // The index is contributed unconditionally, alongside the pages it
+      // describes. Its table existing is what lets the maintenance path write
+      // to it without a first-run branch, exactly as the site style single is
+      // registered whether or not the host stated any defaults.
+      collections: [
+        pagesCollection(opts.pagePreviewPath, opts.limits),
+        classUsageIndexCollection(),
+      ],
       // The Site Style global: one versioned, access-controlled document the
       // stored style tier lives in. Registered whether or not the host stated
       // defaults, because the storage existing is what the style studios and


### PR DESCRIPTION
## What

Adds `nx_pb_class_usage` — a reverse index recording which documents reference which named classes — and the pure logic that decides its contents.

**This PR adds the table and the derivation. Nothing maintains it yet; the write path follows in the next one.** Splitting it that way keeps the logic reviewable without the wiring, since the logic is the part with the sharp edges.

## Why a stored index rather than a live count

The classes UI answers *"how many places is this used"* before an author renames or deletes a class. A class is referenced by id from inside each page's stored document, so answering live means walking every page on every read — and a page's blocks sit in one JSON-shaped column across three dialects with no shared containment query, so there is no cheap version of that walk.

Prior art converges here: Elementor V4 maintains exactly this reverse index in WordPress postmeta, and design-system tooling (Zeroheight, Supernova) pays the same cost on write. Figma skipped it, and its community had to build asynchronous scanning plugins with progress bars specifically to avoid freezing on the live scan.

## The key

`(scope, entity, entityKey, field, classId)`, unique.

A single is addressed by its **slug**, with an **empty** entity key — its row may not exist until somebody edits it, while its declared defaults still render. Empty string rather than null so the five columns form a real constraint: a nullable member compares as unknown on most dialects, which would let duplicates through exactly where the count needs them not to.

There is a second index led by `classId`, because that is the column the library filters on and its absence would not fail anything — it would just make the feature slow in the way the design rejected.

## An incomplete read carries no rows

`classUsageOf` walks a bounded number of nodes, so a document past the bound yields a *prefix* of its references. Reconciling against a prefix removes the rows for everything past it — turning "could not read it all" into "references nothing", which is the one answer that licences deleting a class the site still renders.

So `ClassUsageDerivation`'s incomplete arm has **no `rows` member at all**. A caller cannot reach for a list that does not exist; the narrowing is the control rather than a rule each caller remembers.

## Reconcile, not replace

The obvious maintenance is "delete this document's rows, insert the derived ones". Between the two, the document appears to reference nothing — so a usage count read in that window reports zero, and a safe-delete check performed in it gets the one answer that permits the delete. Reconciling writes only the difference, so a reference that survives an edit is never absent at any instant. It is also free in the common case: editing a page's text changes no class references, and reconciliation then issues no writes.

## Privacy

`internal: true` sets `admin.hidden` and stops there — measured: nothing in `api/`, `direct-api/` or `dispatcher/` reads it. The access rules are therefore the **only** thing keeping these rows private, not a second layer behind a first. All four refuse; the plugin maintains the table through the Direct API, which overrides access by default.

## Verification

All gates run and read separately: package suite 320 passed, `check-types` clean, package lint clean at `--max-warnings 0`, root eslint clean, comment convention reports no new offence, `fallow audit` `verdict: pass` with every `*_introduced` at 0.

Every test was break-verified individually against a mutation of the branch its name claims, and each mutation was confirmed to still compile. Three findings came out of that and are fixed here:

- The draft's access rules were **booleans**, which the validator rejects as `ACCESS_FUNCTION_INVALID`. It type-checked and was wrong; wiring the collection into the plugin is what exposed it.
- The uniqueness-key assertion originally compared the index against the same constant the collection is built from, so a mutation moved both sides and the test agreed with itself. It now asserts a literal, with the constant checked against that.
- A test asserting no index names an undeclared column was removed as redundant — the config validator already rejects that with `INDEX_FIELD_UNKNOWN`, so the test could never be the one to fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an internal index to track CSS class usage across page documents.
  * Added automatic reconciliation to add new references, remove stale references, and eliminate duplicates.
  * Added safeguards and an undetermined status for incomplete document reads.
  * Registered the class-usage index with the page builder plugin.
* **Tests**
  * Added comprehensive coverage for reconciliation, validation, access controls, and indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->