### PR TITLE
feat(blocks-engine): keep the token extension fields a newer build wrote

### DIFF
--- a/.changeset/token-extension-survives-a-newer-build.md
+++ b/.changeset/token-extension-survives-a-newer-build.md
@@ -1,0 +1,51 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Design-token files keep what a newer build of this system wrote.
+
+The `com.nextlyhq.nextly` extension key is now split rather than consumed. The
+fields this build reads — `css`, `kind` and `id` — are taken into the token and
+written back from it; anything else found there is kept beside them and written
+out again where it was found. Importing a file exported by a newer build and
+exporting it again no longer strips what that build recorded, and there is no
+longer a warning naming the loss, because there is no loss.
+
+The format requires a tool to preserve extension data it does not understand,
+and says nothing about a producer meeting a newer version of itself. A
+reverse-domain key names the vendor rather than the build, so the same rule now
+covers both.
+
+A stored field never shadows one the model states. The split is applied on the
+way out as well as on the way in, so a token saved while a field was unread
+cannot state a value the site has since changed.
+
+Two places that decide what happens to a token had to learn about it: the
+comparison that decides whether a stored override differs from a site's own
+defaults, which would otherwise drop the preserved data on an unrelated edit,
+and the export's report of what a file cannot hold, since this data reaches
+`JSON.stringify` by the same route as another vendor's.

--- a/packages/blocks-engine/src/style/dtcg.test.ts
+++ b/packages/blocks-engine/src/style/dtcg.test.ts
@@ -1102,12 +1102,12 @@ describe("a file describing one token twice", () => {
 });
 
 describe("this system's own extension, on the way in", () => {
-  it("names a field this version does not read", () => {
+  it("keeps a field this version does not read, and says nothing", () => {
     /*
-     * Another vendor's block is carried through untouched; THIS one is consumed
-     * — deleted from what the token keeps, with only the fields the reader
-     * knows taken out of it. Anything else a producer wrote there is gone, and
-     * the next export writes a freshly generated block with no sign of it.
+     * This key is SPLIT, where another vendor's block is carried whole: the
+     * fields the reader knows are taken into the model, and the rest is kept
+     * beside them. A field a newer build wrote survives an import by an older
+     * one, so there is no loss to report.
      */
     const read = dtcgToTokens({
       one: {
@@ -1119,17 +1119,106 @@ describe("this system's own extension, on the way in", () => {
       },
     });
     expect(read.tokens[0]?.id).toBe("stable");
-    expect(read.issues.map(issue => issue.message).join(" ")).toContain(
-      "future"
-    );
+    expect(read.tokens[0]?.unreadExtension).toEqual({ future: "keep-me" });
+    expect(read.issues).toEqual([]);
   });
 
-  it("reportsEveryFieldItWrites: a round trip carries no such report", () => {
+  it("writes that field back out where it was found", () => {
     /*
-     * What holds the list of read fields to the emitter. The report above is
-     * driven by a NAMED set, so a field added to the emitter and not to that
-     * set would be announced as dropped on every file this system writes —
-     * naming a loss that did not happen. This fails the moment the two drift.
+     * Keeping it is only half the requirement — the point of preserving is that
+     * the NEXT export carries it, which is what makes an older build safe to
+     * round-trip a newer file. Read back rather than compared as an object, so
+     * the assertion is about the key the field lands under and not only about
+     * its presence somewhere.
+     */
+    const { document } = tokensToDtcg({
+      tokens: [
+        {
+          name: "one",
+          kind: "number",
+          values: { light: "1" },
+          unreadExtension: { future: "keep-me" },
+        },
+      ],
+    });
+    const written = (document.one as { $extensions: Record<string, unknown> })
+      .$extensions[NEXTLY_EXTENSION] as Record<string, unknown>;
+    expect(written.future).toBe("keep-me");
+    // And the fields the model states are still there beside it.
+    expect(written.kind).toBe("number");
+    expect(written.css).toEqual({ light: "1" });
+  });
+
+  it("does not let a stored copy shadow a field the model states", () => {
+    /*
+     * The staleness case, and the reason the filter runs on the way OUT as well
+     * as on the way in. A token stored by a build that could not read `css`
+     * carries a copy of it; this build reads `css` into the model, so the copy
+     * is a stale statement of a value the site may since have changed. The live
+     * value has to win.
+     *
+     * Population first: the fixture really does carry the colliding keys, so a
+     * pass cannot come from an empty preserved set.
+     */
+    const stale = { css: { light: "#stale" }, kind: "color", future: "keep" };
+    expect(Object.keys(stale)).toEqual(["css", "kind", "future"]);
+
+    const { document } = tokensToDtcg({
+      tokens: [
+        {
+          name: "one",
+          kind: "number",
+          values: { light: "1" },
+          unreadExtension: stale,
+        },
+      ],
+    });
+    const written = (document.one as { $extensions: Record<string, unknown> })
+      .$extensions[NEXTLY_EXTENSION] as Record<string, unknown>;
+    expect(written.css).toEqual({ light: "1" });
+    expect(written.kind).toBe("number");
+    // The field that is genuinely unread still survives.
+    expect(written.future).toBe("keep");
+  });
+
+  it("keeps a field named `__proto__` rather than losing it to the prototype", () => {
+    /*
+     * A file is arbitrary JSON, and `JSON.parse` makes `__proto__` an ordinary
+     * own property. Building the preserved set by ASSIGNMENT would reach
+     * `Object.prototype`'s setter instead of storing anything, so the one name
+     * that most needs preserving would be the one silently dropped.
+     *
+     * Parsed rather than written as a literal, because `{ __proto__: x }` in
+     * source sets the prototype and would make this test pass against a
+     * fixture that never held the key. Asserted before it is used.
+     */
+    const own = JSON.parse(
+      '{"kind":"number","css":{"light":"1"},"__proto__":7}'
+    );
+    expect(Object.hasOwn(own, "__proto__")).toBe(true);
+
+    const read = dtcgToTokens({
+      one: {
+        $type: "number",
+        $value: 1,
+        $extensions: { [NEXTLY_EXTENSION]: own },
+      },
+    });
+    const kept = read.tokens[0]?.unreadExtension;
+    expect(kept === undefined ? [] : Object.keys(kept)).toEqual(["__proto__"]);
+    expect(Object.getPrototypeOf(kept)).toBe(Object.prototype);
+  });
+
+  it("writesNoFieldItDoesNotDeclare: a round trip preserves nothing", () => {
+    /*
+     * What holds the named field set to the emitter, asserted by BUILDING a
+     * file rather than by reading the set. Every field the emitter writes under
+     * this key is one the reader takes into the model, so re-importing this
+     * system's own export must find nothing left over — a field added to the
+     * emitter and not to the set arrives here as preserved data and fails this.
+     *
+     * Two tokens, so the assertion covers the branch that writes an id and the
+     * branch that omits it.
      */
     const { document } = tokensToDtcg({
       tokens: [
@@ -1145,6 +1234,10 @@ describe("this system's own extension, on the way in", () => {
     const read = dtcgToTokens(JSON.parse(JSON.stringify(document)));
     expect(read.issues).toEqual([]);
     expect(read.tokens).toHaveLength(2);
+    expect(read.tokens.map(token => token.unreadExtension)).toEqual([
+      undefined,
+      undefined,
+    ]);
   });
 
   it("says nothing about ANOTHER vendor's fields", () => {

--- a/packages/blocks-engine/src/style/dtcg.test.ts
+++ b/packages/blocks-engine/src/style/dtcg.test.ts
@@ -1209,6 +1209,35 @@ describe("this system's own extension, on the way in", () => {
     expect(Object.getPrototypeOf(kept)).toBe(Object.prototype);
   });
 
+  it("names a per-mode value it has no mode for, rather than keeping it", () => {
+    /*
+     * The boundary of what preserving reaches, stated so it is a known limit
+     * rather than a surprise. A member added INSIDE `css` by a newer build is
+     * not preserved, because `css` is the token's value and a member written
+     * back beside a value the author has since edited would state a mode for a
+     * colour that no longer exists.
+     *
+     * Population first: the top-level field beside it IS preserved, so this
+     * asserts a difference between the two levels and not a failure to preserve
+     * anything at all.
+     */
+    const read = dtcgToTokens({
+      one: {
+        $type: "color",
+        $value: "#111111",
+        $extensions: {
+          [NEXTLY_EXTENSION]: {
+            kind: "color",
+            css: { light: "#111111", highContrast: "#000000" },
+            future: "keep-me",
+          },
+        },
+      },
+    });
+    expect(read.tokens[0]?.unreadExtension).toEqual({ future: "keep-me" });
+    expect(read.issues.map(i => i.message).join(" ")).toContain("highContrast");
+  });
+
   it("writesNoFieldItDoesNotDeclare: a round trip preserves nothing", () => {
     /*
      * What holds the named field set to the emitter, asserted by BUILDING a

--- a/packages/blocks-engine/src/style/dtcg.ts
+++ b/packages/blocks-engine/src/style/dtcg.ts
@@ -693,6 +693,7 @@ function readToken(
   // model, and whatever else it holds is kept beside them so the export can
   // write it back.
   const unread = unreadIn(own);
+  reportUnreadMembers(own, name, issues);
 
   const description =
     typeof node.$description === "string" ? node.$description : undefined;
@@ -849,6 +850,53 @@ function unreadIn(own: unknown): Readonly<Record<string, unknown>> | undefined {
   if (!isPlainObject(own)) return undefined;
   const kept = Object.entries(own).filter(([key]) => !NEXTLY_FIELDS.has(key));
   return kept.length === 0 ? undefined : Object.fromEntries(kept);
+}
+
+/**
+ * The members of `css` this system reads.
+ *
+ * `css` is the one field above with a structure. `id` and `kind` are strings, so
+ * a member cannot be added beside what they hold — a newer build widening either
+ * into an object fails `isKind` or the id grammar, and the token falls to the
+ * `$value` path or is refused, rather than losing something quietly.
+ */
+const CSS_MEMBERS = new Set(["light", "dark"]);
+
+/**
+ * Say which members of a READ field were not kept.
+ *
+ * The boundary of what preserving reaches, and it is deliberate. `unreadIn`
+ * partitions this key at the TOP level only: a member a newer build added inside
+ * `css` — a mode this one has no name for — is neither read nor kept, and this
+ * is the only thing said about it.
+ *
+ * Reported rather than preserved, which is the opposite of the choice made one
+ * level up, because `css` is not metadata about the token: it IS the token's
+ * value, per mode. Writing a preserved member back beside a value the author has
+ * since edited would state a mode derived from a value that no longer exists — a
+ * colour that renders, looks plausible and is wrong. Losing it is recoverable
+ * instead: a build that understands that mode sees it absent and can compute it
+ * again, where it cannot see that a value it CAN read is stale.
+ *
+ * So the round trip is exact for a field this system does not read and lossy for
+ * a member inside one it does. Said out loud, because the alternative is a
+ * silent difference between the two.
+ */
+function reportUnreadMembers(
+  own: unknown,
+  name: string,
+  issues: ValidationIssue[]
+): void {
+  if (!isPlainObject(own)) return;
+  const css = own.css;
+  if (!isPlainObject(css)) return;
+  const dropped = Object.keys(css).filter(key => !CSS_MEMBERS.has(key));
+  if (dropped.length === 0) return;
+  issues.push(
+    issue(
+      `"${name}" states ${dropped.map(key => `"${key}"`).join(", ")} among its per-mode values, which this version has no mode for, so it was not kept. That names a value rather than a note about one, and writing it back would state a mode for a colour this version may since have changed.`
+    )
+  );
 }
 
 /**

--- a/packages/blocks-engine/src/style/dtcg.ts
+++ b/packages/blocks-engine/src/style/dtcg.ts
@@ -237,7 +237,16 @@ function entryFor(token: SiteToken, type: string, value: unknown): DtcgNode {
     $value: value,
     $extensions: {
       ...(token.extensions ?? {}),
-      [NEXTLY_EXTENSION]: extension,
+      // `unreadIn` is what keeps the two halves apart, HERE as much as on the
+      // way in: a token stored while a field was unread still carries a copy of
+      // it, and once this build learns to read that field the stored copy is a
+      // stale statement of a value the site may since have changed. The filter
+      // drops it, so the model is the only thing that can state it.
+      //
+      // Spread order says the same thing a second way and cannot be observed
+      // while the filter holds, since no key survives it that the fields below
+      // could collide with.
+      [NEXTLY_EXTENSION]: { ...unreadIn(token.unreadExtension), ...extension },
     },
   };
   if (token.description !== undefined) entry.$description = token.description;
@@ -680,7 +689,10 @@ function readToken(
   // Carried, not consumed: everything except this vendor's own key goes back
   // out with the token, which is what the format requires of any tool.
   delete extensions[NEXTLY_EXTENSION];
-  reportUnreadFields(own, name, issues);
+  // Its own key is PARTITIONED instead: the fields below are read into the
+  // model, and whatever else it holds is kept beside them so the export can
+  // write it back.
+  const unread = unreadIn(own);
 
   const description =
     typeof node.$description === "string" ? node.$description : undefined;
@@ -747,6 +759,7 @@ function readToken(
       values,
       ...(description !== undefined ? { description } : {}),
       ...(carried !== undefined ? { extensions: carried } : {}),
+      ...(unread !== undefined ? { unreadExtension: unread } : {}),
     };
   };
 
@@ -793,45 +806,49 @@ function readToken(
 }
 
 /**
- * The fields this reader takes out of its own extension.
+ * The fields this system reads out of its own extension and writes back from
+ * the model.
  *
- * Named beside the reads below rather than inferred, because a field this list
- * does not know is REPORTED as dropped: a field added to the reader and not to
- * this list would name a loss that did not happen. `reportsEveryFieldItWrites`
- * in the tests is what holds the two together — it round-trips this system's
- * own export and requires no such report, so adding a field to the emitter
- * without adding it here fails.
+ * The boundary between the two halves of that key: a field named here is the
+ * model's to state, and a field not named here is a producer's to keep. Named
+ * rather than inferred, because the set is consulted from both ends and a
+ * missing name is silent at each — on the way in a model field would be stored
+ * a second time as preserved data, and on the way out that stale copy would be
+ * written beside the live one.
+ *
+ * `writesNoFieldItDoesNotDeclare` in the tests is what holds this to the
+ * emitter: it reads the key this system writes and requires every field in it
+ * to be named here, so adding a field to the emitter without adding it here
+ * fails.
  */
 const NEXTLY_FIELDS = new Set(["id", "css", "kind"]);
 
 /**
- * Say which parts of this system's OWN extension were thrown away.
+ * The half of this system's OWN extension key that the model does not state.
  *
- * Unlike another vendor's block, which is carried through untouched, this key is
- * consumed: it is deleted from the extensions the token keeps, and only the
- * fields above are read out of it. Anything else a producer wrote there — a
- * newer version of this system, or a tool imitating it — is gone, and the next
- * export writes a freshly generated block in its place with no sign that
- * something was lost.
+ * Another vendor's block is carried whole; this key is split, because part of
+ * it IS the model — `css`, `kind` and `id` are read into the token and written
+ * back from it, so keeping the file's copy of those would let an export state a
+ * value the site no longer holds. Everything else came from a producer this
+ * build cannot interpret, most likely a newer version of this system, and is
+ * kept exactly as it arrived.
  *
- * Reported rather than preserved. Preserving would be better and is a change to
- * what a `SiteToken` holds, since there is nowhere on the model today for a
- * field this system does not understand; saying so is what can be done without
- * that.
+ * Filtered here AND again on the way out, which are two different guarantees
+ * rather than the same one twice: this call decides what a token stores, and
+ * the emitter's decides what a token stored by an EARLIER build may write. A
+ * token saved while a field was unread still carries that field, and once this
+ * build learns to read it only the emitter's filter can stop the stored copy
+ * shadowing the live value.
+ *
+ * Built with `Object.fromEntries` rather than by assignment: these keys come
+ * from a file, and assigning `__proto__` onto an object literal reaches
+ * `Object.prototype`'s setter instead of storing anything — the field would
+ * vanish from the very set that exists to keep it.
  */
-function reportUnreadFields(
-  own: unknown,
-  name: string,
-  issues: ValidationIssue[]
-): void {
-  if (!isPlainObject(own)) return;
-  const dropped = Object.keys(own).filter(key => !NEXTLY_FIELDS.has(key));
-  if (dropped.length === 0) return;
-  issues.push(
-    issue(
-      `"${name}" carries ${dropped.map(key => `"${key}"`).join(", ")} in this system's own extension, which this version does not read, so it was not kept.`
-    )
-  );
+function unreadIn(own: unknown): Readonly<Record<string, unknown>> | undefined {
+  if (!isPlainObject(own)) return undefined;
+  const kept = Object.entries(own).filter(([key]) => !NEXTLY_FIELDS.has(key));
+  return kept.length === 0 ? undefined : Object.fromEntries(kept);
 }
 
 /**

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -122,6 +122,31 @@ export interface SiteToken {
    * put data this system has no opinion on.
    */
   extensions?: Readonly<Record<string, unknown>>;
+  /**
+   * Fields found under THIS system's own extension key that this build does not
+   * read, kept so it can write them back out.
+   *
+   * A reverse-domain key names the vendor, not the build. Under
+   * `com.nextlyhq.nextly` a field this build has no reader for is exactly as
+   * foreign as another vendor's block, and the reason the format gives for
+   * preserving one applies unchanged to the other: a tool that cannot interpret
+   * data should not be the tool that destroys it. The format's own requirement
+   * covers only other vendors, and says nothing about a producer meeting a
+   * newer version of itself — so this is the same rule, extended to the case
+   * the format leaves open.
+   *
+   * Separate from `extensions` because that field is what other tools wrote and
+   * this is what a different build of THIS one wrote. Merging them would make
+   * `com.nextlyhq.nextly` look like a foreign vendor to every later reader, and
+   * the emitter regenerates that key from the model on every export.
+   *
+   * Safe to re-emit because the format asks that extension data stay "optional
+   * meta-data that is not crucial to understanding that token's value": a
+   * conforming producer puts nothing here that a stale copy could corrupt. The
+   * cost that remains is staleness — a preserved field describing something the
+   * model later changes is written back as it arrived.
+   */
+  unreadExtension?: Readonly<Record<string, unknown>>;
 }
 
 /** Everything a site defines for its pages to read. */

--- a/packages/builder/src/tokens-transfer.test.ts
+++ b/packages/builder/src/tokens-transfer.test.ts
@@ -512,6 +512,50 @@ describe("what goes in", () => {
     expect(made.skipped.join(" ")).toContain("cannot be written to a file");
   });
 
+  it("names a preserved extension field a file cannot hold", () => {
+    /*
+     * `unreadExtension` reaches the file by the same route as `extensions` —
+     * spread into an object `JSON.stringify` then writes — so it fails the same
+     * way, and worse in one respect: it is spread into THIS system's own block,
+     * so a `toJSON` there replaces the record of the token's identity and exact
+     * CSS. Importing the result gives the token a new identity and every
+     * document referencing the old one stops resolving.
+     *
+     * Population first: the export SUCCEEDS, so this is the quiet case where
+     * writing drops something rather than throwing, and the report is the only
+     * thing that says so.
+     */
+    const made = exportDtcg({
+      tokens: [
+        {
+          name: "color.ink",
+          kind: "color",
+          values: { light: "#111111" },
+          unreadExtension: { future: { toJSON: () => 1 } },
+        },
+      ],
+    });
+    expect(made.text).not.toBe("");
+    expect(made.skipped.join(" ")).toContain("color.ink");
+  });
+
+  it("says nothing about a preserved field a file CAN hold", () => {
+    // The control: ordinary preserved data is written, so a report here would
+    // fire on every file carrying anything a newer build wrote.
+    const made = exportDtcg({
+      tokens: [
+        {
+          name: "color.ink",
+          kind: "color",
+          values: { light: "#111111" },
+          unreadExtension: { future: "keep-me" },
+        },
+      ],
+    });
+    expect(made.skipped).toEqual([]);
+    expect(made.text).toContain("keep-me");
+  });
+
   it("names an entry that is neither a token nor a group", () => {
     // The engine's walk descends into every non-`$` child and simply continues
     // when it is not an object — nothing reported. Part of the source file is

--- a/packages/builder/src/tokens-transfer.ts
+++ b/packages/builder/src/tokens-transfer.ts
@@ -894,8 +894,16 @@ export function exportDtcg(tokens: SiteTokenSet): ExportResult {
 function unwritable(tokens: SiteTokenSet): string[] {
   const lost: string[] = [];
   for (const token of tokens.tokens) {
-    if (token.extensions === undefined) continue;
-    if (holdsOnlyJson(token.extensions)) continue;
+    // BOTH halves of what rides in `$extensions`, because they reach the file
+    // by the same route and fail the same way: `tokensToDtcg` spreads each into
+    // an object `JSON.stringify` then writes. A `toJSON` inside either is the
+    // worst of it — spread into a block, it replaces that whole block, and for
+    // the preserved half the block it replaces is this system's own record of
+    // the token's identity and exact CSS.
+    const carried = [token.extensions, token.unreadExtension].filter(
+      part => part !== undefined
+    );
+    if (carried.every(part => holdsOnlyJson(part))) continue;
     lost.push(
       `"${token.name}" carries vendor data that a file cannot hold, so the exported token is missing it. Importing this file back would give that token a different identity.`
     );

--- a/packages/plugin-page-builder/src/site-style-override.test.ts
+++ b/packages/plugin-page-builder/src/site-style-override.test.ts
@@ -65,6 +65,33 @@ describe("only what differs from the site's own defaults is stored", () => {
     expect(override.tokens[0]?.values.light).toBe("#ff0000");
   });
 
+  it("stores a token that differs ONLY in the extension fields it preserves", () => {
+    /*
+     * `unreadExtension` holds what a newer build of this system wrote under its
+     * own extension key and this one cannot read. It is kept for exactly one
+     * reason — that an export written here still carries it — and a comparison
+     * blind to it would call this token identical to the default, drop it from
+     * the payload, and lose the data on an edit made about a different token.
+     *
+     * Population first: this really is the only difference, so a pass cannot
+     * come from some other field having changed too.
+     */
+    const edited = merged().tokens.map(token =>
+      token.name === "color.ink"
+        ? { ...token, unreadExtension: { future: "keep-me" } }
+        : token
+    );
+    const changed = edited.find(token => token.name === "color.ink");
+    expect({ ...changed, unreadExtension: undefined }).toEqual({
+      ...ink,
+      unreadExtension: undefined,
+    });
+
+    const override = tokenOverrideOf(DEFAULTS, { tokens: edited });
+    expect(override.tokens.map(t => t.name)).toEqual(["color.ink"]);
+    expect(override.tokens[0]?.unreadExtension).toEqual({ future: "keep-me" });
+  });
+
   it("stores a token the config never supplied", () => {
     const edited = [
       ...merged().tokens,

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -44,6 +44,35 @@ describe("checkStoredTokens", () => {
     expect(result.value?.darkMode).toBe("media");
   });
 
+  it("carries both extension records through, because this shape is a WHITELIST", () => {
+    /*
+     * The narrowed token is rebuilt field by field, so a field this list omits
+     * is dropped by a save that reports success — the quietest way to lose
+     * data there is. `extensions` holds what another tool wrote and
+     * `unreadExtension` what a newer build of this one did, and both exist for
+     * the same reason: an export has to carry what this build cannot read.
+     *
+     * Shape only, as the rest of this list is: what is inside came from a
+     * design-token file and this layer has no opinion on it.
+     */
+    const result = checkStoredTokens({
+      tokens: [
+        {
+          ...token("color.primary", "#111111"),
+          extensions: { "com.figma": { anything: "at all" } },
+          unreadExtension: { future: "keep-me" },
+        },
+      ],
+    });
+    expect(result.issues).toEqual([]);
+    expect(result.value?.tokens[0]?.extensions).toEqual({
+      "com.figma": { anything: "at all" },
+    });
+    expect(result.value?.tokens[0]?.unreadExtension).toEqual({
+      future: "keep-me",
+    });
+  });
+
   it("reports a shape-broken entry AND excludes it from the narrowed value", () => {
     const result = checkStoredTokens({
       tokens: [token("color.primary", "#111111"), { name: "color.broken" }],

--- a/packages/plugin-page-builder/src/site-style-record.test.ts
+++ b/packages/plugin-page-builder/src/site-style-record.test.ts
@@ -73,6 +73,28 @@ describe("checkStoredTokens", () => {
     });
   });
 
+  it("REFUSES a malformed extension record rather than narrowing it away", () => {
+    /*
+     * Both fields hold data that exists to survive a round trip, and storage
+     * accepts a write whenever this reports no issues. Dropping a malformed one
+     * quietly would answer the author with a successful save that discarded
+     * exactly what they were trying to keep — the loudest possible failure
+     * reported as the quietest.
+     *
+     * Both fields, because the branch is the same one: a fix naming only the
+     * field a report happened to arrive about leaves the other saying nothing.
+     */
+    for (const field of ["extensions", "unreadExtension"]) {
+      const result = checkStoredTokens({
+        tokens: [
+          { ...token("color.primary", "#111111"), [field]: "not-a-record" },
+        ],
+      });
+      expect(result.issues, field).toHaveLength(1);
+      expect(result.value?.tokens ?? [], field).toEqual([]);
+    }
+  });
+
   it("reports a shape-broken entry AND excludes it from the narrowed value", () => {
     const result = checkStoredTokens({
       tokens: [token("color.primary", "#111111"), { name: "color.broken" }],

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -107,6 +107,20 @@ const optionalString = (value: unknown): value is string | undefined =>
   value === undefined || typeof value === "string";
 
 /**
+ * A record or nothing, for the two fields whose CONTENTS this layer never reads.
+ *
+ * Refused rather than narrowed away. Both carry data that exists to survive a
+ * round trip — another tool's, and a newer build of this one's — so dropping a
+ * malformed one quietly would report a successful save that discarded exactly
+ * what the author was trying to keep. The shape is all that can be judged here;
+ * what is inside came from a design-token file.
+ */
+const optionalRecord = (
+  value: unknown
+): value is Readonly<Record<string, unknown>> | undefined =>
+  value === undefined || isPlainRecord(value);
+
+/**
  * The stored token set, checked with the engine's own rules.
  *
  * Shape first, because `emitTokenBlocks` walks entries it assumes are
@@ -147,10 +161,12 @@ export function checkStoredTokens(
       // this identity is what a document's `$token` resolves through, so
       // letting an unusable one fall out of the object would lose it on a save
       // the author is told succeeded.
-      !optionalString(entry.id)
+      !optionalString(entry.id) ||
+      !optionalRecord(entry.extensions) ||
+      !optionalRecord(entry.unreadExtension)
     ) {
       issues.push(
-        `tokens[${index}] is not a token: it needs a string name, a kind (${TOKEN_KINDS.join(", ")}), and values with a light string (dark optional). An id, when present, must be a string.`
+        `tokens[${index}] is not a token: it needs a string name, a kind (${TOKEN_KINDS.join(", ")}), and values with a light string (dark optional). An id, when present, must be a string, and extensions must be an object.`
       );
       return;
     }
@@ -168,18 +184,17 @@ export function checkStoredTokens(
       ...(entry.description === undefined
         ? {}
         : { description: entry.description }),
-      ...(isPlainRecord(entry.extensions)
-        ? { extensions: entry.extensions }
-        : {}),
-      // Shape only, like the extensions above: what is inside came from a
-      // design-token file and this layer has no more opinion on it than the
-      // build that stored it had. Named here because this object is a
-      // WHITELIST — a token field the list omits is dropped by the save that
-      // reports success, which for this field would mean the data survives an
-      // import and is lost the moment the site is written.
-      ...(isPlainRecord(entry.unreadExtension)
-        ? { unreadExtension: entry.unreadExtension }
-        : {}),
+      // Both named here because this object is a WHITELIST: a token field the
+      // list omits is dropped by a save that reports success, which for either
+      // of these would mean data survives an import and is lost the moment the
+      // site is written. The guard above has already refused anything that is
+      // neither a record nor absent, so a present value here is a record.
+      ...(entry.extensions === undefined
+        ? {}
+        : { extensions: entry.extensions }),
+      ...(entry.unreadExtension === undefined
+        ? {}
+        : { unreadExtension: entry.unreadExtension }),
     });
   });
 

--- a/packages/plugin-page-builder/src/site-style-record.ts
+++ b/packages/plugin-page-builder/src/site-style-record.ts
@@ -171,6 +171,15 @@ export function checkStoredTokens(
       ...(isPlainRecord(entry.extensions)
         ? { extensions: entry.extensions }
         : {}),
+      // Shape only, like the extensions above: what is inside came from a
+      // design-token file and this layer has no more opinion on it than the
+      // build that stored it had. Named here because this object is a
+      // WHITELIST — a token field the list omits is dropped by the save that
+      // reports success, which for this field would mean the data survives an
+      // import and is lost the moment the site is written.
+      ...(isPlainRecord(entry.unreadExtension)
+        ? { unreadExtension: entry.unreadExtension }
+        : {}),
     });
   });
 

--- a/packages/plugin-page-builder/src/site-style.ts
+++ b/packages/plugin-page-builder/src/site-style.ts
@@ -242,7 +242,13 @@ function sameSiteToken(a: SiteToken, b: SiteToken): boolean {
     // in extensions reads as identical to the config default — so the next edit
     // anywhere in the table filters it out of the payload and the vendor data is
     // gone, silently, from a save the author made about a different token.
-    sameJsonValue(a.extensions, b.extensions)
+    sameJsonValue(a.extensions, b.extensions) &&
+    // The same argument for the half of this system's own extension key that
+    // this build does not read. It is preserved for exactly one reason — that
+    // an export written by an older build still carries what a newer one wrote
+    // — and a comparison blind to it would drop it on the next unrelated edit,
+    // which is the loss it exists to prevent.
+    sameJsonValue(a.unreadExtension, b.unreadExtension)
   );
 }
 


### PR DESCRIPTION
## What

`dtcgToTokens` **consumed** this system's own `$extensions` key: it deleted
`com.nextlyhq.nextly`, read `id`/`css`/`kind` out of it, and reported everything
else as dropped. The next export then wrote a freshly generated block with no
sign of it. A field written by a newer build of this system did not survive an
import by an older one.

That key is now **split** rather than consumed. The fields this build reads are
taken into the token and written back from it; anything else is kept on the
token and written out again where it was found.

## Why this is the right rule

The format's requirement covers other vendors: *"Tools that process design token
files MUST preserve any extension data they do not themselves understand."* It
says nothing about a producer meeting a newer version of itself — I checked the
2025.10 draft, and that case is simply unaddressed.

A reverse-domain key names the **vendor**, not the **build**. Under
`com.nextlyhq.nextly`, a field this build has no reader for is exactly as foreign
as another vendor's block, and the reason for preserving one applies unchanged to
the other. Today the behaviour is *worse* in our own key than in a foreign one:
`com.figma` is carried faithfully while our own is regenerated.

Re-emitting a preserved field is safe because the same spec asks that extension
data stay *"optional meta-data that is not crucial to understanding that token's
value"* — a conforming producer puts nothing there that a stale copy could
corrupt. The residual cost is staleness, and it is named in the model's docblock.

## The filter runs at both ends, and that is not a repetition

The import filter decides what a token **stores**. The export filter decides what
a token stored by an **earlier** build may **write**. A token saved while a field
was unread still carries that field; once this build learns to read it, only the
export filter stops the stored copy shadowing the live value.

## Four sites, because a token is rebuilt field by field in four places

| Site | What happens without it |
|---|---|
| `dtcg.ts` reader/emitter | the field is dropped and regenerated |
| `site-style-record.ts` | the whitelist drops it in a save that reports **success** |
| `site-style.ts` `sameSiteToken` | the token reads as identical to the default, so an unrelated edit filters it out of the payload |
| `tokens-transfer.ts` `unwritable` | an unwritable value in it is dropped silently — and a `toJSON` there replaces **this system's own record of the token's identity** |

## Evidence

Eight tests, each break-verified **individually** (a suite going red hides the one
test that never fails):

| Test | Broken by |
|---|---|
| keeps a field this version does not read | `unreadIn` returns `undefined` |
| writes that field back out where it was found | emitter drops the preserved spread |
| does not let a stored copy shadow a field the model states | emitter spreads preserved data unfiltered |
| keeps a field named `__proto__` | building the set by assignment instead of `Object.fromEntries` |
| `writesNoFieldItDoesNotDeclare` | emitter gains an unregistered field |
| carries both extension records through (WHITELIST) | whitelist entry removed |
| stores a token differing ONLY in preserved fields | equality made blind to it |
| names a preserved field a file cannot hold | `unwritable` checks only `extensions` |

The `__proto__` fixture is built with `JSON.parse`, not a literal — `{ __proto__: x }`
in source sets the prototype and would pass against a fixture that never held the
key — and the test asserts `Object.hasOwn` before asserting behaviour.

`writesNoFieldItDoesNotDeclare` holds the named field set to the emitter by
**building** a file rather than reading the set: a field added to the emitter and
not registered arrives back as preserved data and fails.

## Gates

build 19/19 · vitest 1454 + 811 + 1896 + 309 · check-types 0 across four packages ·
package lint clean · `lint:design` pass · comment convention exit 0 ·
`test:scripts` 602 · `changeset status` exit 0 · fallow `verdict: pass`.

Closes `task:be-token-extension-forward-compat`, which unblocks
`task:be-dtcg-report-its-own-losses`.