### PR TITLE
fix(blocks-engine): digest a preview seed whose reduction would lose information

### DIFF
--- a/.changeset/digest-a-lossy-preview-seed.md
+++ b/.changeset/digest-a-lossy-preview-seed.md
@@ -1,0 +1,37 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Digest a preview container seed whose reduction to identifier-safe characters
+would lose information, rather than carrying the reduced form.
+
+The reduction is many-to-one, so two short seeds differing only in collapsed
+characters received one container name — the collision the per-surface factory
+exists to prevent, and an authored container spelled with that name would
+capture the responsive queries of every surface colliding there. Only seeds long
+enough to exceed the emitted-name bound were digested, so the guarantee held
+above the length threshold and not below it.

--- a/packages/blocks-engine/src/style/breakpoint-preview.test.ts
+++ b/packages/blocks-engine/src/style/breakpoint-preview.test.ts
@@ -607,6 +607,32 @@ describe("a per-surface preview container", () => {
     expect(long).not.toBe(PREVIEW_VIEWPORT_CONTAINER);
   });
 
+  it("gives two SHORT seeds different names when the reduction collapses them", () => {
+    /*
+     * The reduction to identifier-safe characters is many-to-one, so carrying a
+     * seed literally is only sound when it changed nothing. `a/b` and `a:b` both
+     * reduce to `a-b`, and two surfaces handed one name is exactly the collision
+     * this factory exists to prevent — worse, an authored container spelled
+     * `nx-preview-a-b` would then capture the responsive queries of both.
+     *
+     * SHORT deliberately. The long-seed case below exercises the same property
+     * on inputs that exceed the emitted-name bound and therefore digest anyway,
+     * so it holds whether or not the lossy case is handled — it cannot see this
+     * defect at all.
+     */
+    expect(previewContainerFor("a/b")).not.toBe(previewContainerFor("a:b"));
+  });
+
+  it("carries a LOSSLESS short seed literally, which is the control", () => {
+    /*
+     * Without this, digesting every seed would satisfy the case above while
+     * throwing away the readable names that make a surface identifiable in
+     * devtools — and the assertion there is about two values differing, which
+     * two digests satisfy perfectly.
+     */
+    expect(previewContainerFor("canvas-a")).toBe("nx-preview-canvas-a");
+  });
+
   it("gives two long seeds DIFFERENT names, which is the whole point", () => {
     /*
      * The control. A digest that ignored its input, or a function returning one

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -538,6 +538,27 @@ function digest(seed: string): string {
 }
 
 /**
+ * The seed carried LITERALLY, or `undefined` when carrying it would lose
+ * information.
+ *
+ * The reduction to identifier-safe characters is many-to-one: `a/b` and `a:b`
+ * both become `a-b`. Carrying the reduced form is therefore only sound when the
+ * reduction changed NOTHING — otherwise two distinct surfaces receive one name,
+ * which is precisely the collision the factory exists to prevent, and an
+ * authored container spelled `nx-preview-a-b` would capture the responsive
+ * queries of every surface that collides there.
+ *
+ * Compared against the original rather than tested for "contains an unsafe
+ * character", because those are the same question and only one of them has a
+ * character class to keep up to date.
+ */
+function losslessName(seed: string): string | undefined {
+  const safe = seed.replace(/[^A-Za-z0-9_-]/g, "-");
+  if (safe !== seed) return undefined;
+  return previewContainerName(`${PREVIEW_SEED_PREFIX}${safe}`);
+}
+
+/**
  * A preview container name unlikely to collide with an authored one.
  *
  * Derived from a seed the CALLER owns — a React `useId`, a surface id, anything
@@ -550,12 +571,15 @@ function digest(seed: string): string {
  * caller passing an opaque id from elsewhere does not have to know this
  * function's rules to use it.
  *
- * **A seed too long to carry literally is DIGESTED, never dropped.** Prefixed,
- * a seed over about fifty characters exceeds the emitted-name bound, and
- * returning the shared default there would hand exactly the surfaces most
- * likely to use long ids — document paths, composite keys, opaque route ids —
- * the one globally predictable name this function exists to avoid. The digest
- * keeps the name per-surface and inside the bound.
+ * **A seed that cannot be carried LITERALLY is DIGESTED, never dropped**, and
+ * that is two cases rather than one. A seed over about fifty characters exceeds
+ * the emitted-name bound once prefixed; a seed containing anything outside
+ * `[A-Za-z0-9_-]` cannot be carried either, because the reduction is
+ * many-to-one and two distinct seeds would receive one name. Returning the
+ * shared default in either case would hand exactly the surfaces most likely to
+ * hit them — document paths, composite keys, opaque route ids — the one
+ * globally predictable name this function exists to avoid. The digest keeps the
+ * name per-surface and inside the bound.
  *
  * Two distinct seeds can still digest alike; the guarantee is a low collision
  * probability, not uniqueness. That is the right trade here because the cost of
@@ -578,9 +602,7 @@ export function previewContainerFor(seed: string): string {
   const literal =
     PREVIEW_SEED_PREFIX.length + seed.length > MAX_PREVIEW_CONTAINER_LENGTH
       ? undefined
-      : previewContainerName(
-          `${PREVIEW_SEED_PREFIX}${seed.replace(/[^A-Za-z0-9_-]/g, "-")}`
-        );
+      : losslessName(seed);
   if (literal !== undefined) return literal;
   /*
    * Digested from the ORIGINAL seed rather than the reduced form, so two seeds


### PR DESCRIPTION
## What

Recovers the round-10 fix from #1201, which was **stranded**: it was pushed after GitHub had computed that PR's merge, so it is on the branch and not on `main`.

## The defect, which is live on main right now

`previewContainerFor` mints a per-surface container name so that two previewing surfaces cannot be captured by one authored container. The reduction to identifier-safe characters is **many-to-one** — `a/b` and `a:b` both become `a-b` — so two short seeds differing only in collapsed characters received **one name**. An authored container spelled `nx-preview-a-b` then captures the responsive queries of every surface colliding there, which is exactly what the factory exists to prevent.

Long seeds were unaffected: they exceed the emitted-name bound and take the digest path, which reads the original seed. So the guarantee held **above** the length threshold and not below it.

A seed is now carried literally only when the reduction changed **nothing**:

```ts
function losslessName(seed: string): string | undefined {
  const safe = seed.replace(/[^A-Za-z0-9_-]/g, "-");
  if (safe !== seed) return undefined;
  return previewContainerName(`${PREVIEW_SEED_PREFIX}${safe}`);
}
```

Compared against the original rather than tested for "contains an unsafe character" — the same question, and only one of the two has a character class to keep up to date. The length short-circuit stays ahead of it, so an oversized seed still reaches the digest without being scanned first.

## Why the existing test could not see it

`gives two long seeds DIFFERENT names` asserted the right property using five-hundred-character seeds — inputs that digest whatever the lossy path does. It passed against the defect it was written to guard.

The new case is deliberately SHORT, with `carries a LOSSLESS short seed literally` as its control: without that, digesting everything would satisfy a distinctness assertion perfectly while discarding the readable names that make a surface identifiable in devtools.

## How the strand was found, since the same window will catch others

#1201 merged as `2246c76ed` (two parents: `0022432bc` + head `8b7937aae`) at 16:28:44Z. Commit `21f24ace7` was pushed after that snapshot.

```
git log --oneline 8b7937aae..21f24ace7                        → 21f24ace7  (stranded)
git grep -F losslessName origin/main -- .../compile-page.ts   → absent
git grep -F losslessName 21f24ace7  -- .../compile-page.ts    → 2 hits (control)
```

Ancestry would not have shown it and the PR page reads merged and clean. The control is what makes the absence evidence rather than a failed search.

## Test plan

- `pnpm build`, `pnpm check-types` — pass
- `blocks-engine` 1453, `blocks-react` 811, `builder` 1894 — pass
- `pnpm test:scripts` 602 — pass
- lint, comment convention, changeset validation, `fallow audit` — pass
- Break-verified both directions: removing the lossless guard fails the short-seed test; always digesting fails the control.