### PR TITLE
refactor(blocks-engine): move the breakpoint-set helpers into the engine

### DIFF
--- a/.changeset/breakpoint-helpers-move-to-the-engine.md
+++ b/.changeset/breakpoint-helpers-move-to-the-engine.md
@@ -1,0 +1,40 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Move `authoredBreakpoints` and `inCascadeOrder` from the page-builder editor
+into the blocks engine, beside the `BreakpointDef` and `BreakpointSet` types
+they operate on.
+
+Both answer questions that the stored record does not: which rows an author
+actually defined — a stored set may carry a reserved `base` row that the
+compiler prepends regardless — and the order in which the cascade applies them.
+More than one package now asks, so a second implementation would agree about
+what a breakpoint means while disagreeing about which rows exist and in what
+order they apply.
+
+The editor re-exports both, so every existing import keeps working.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -464,6 +464,16 @@ export type { SiteSheetArtifact, SiteSheetInput } from "./style/site-sheet";
 export { compileSiteSheet } from "./style/site-sheet";
 export { styleOrigin } from "./style/style-origin";
 export { BREAKPOINT_AXES } from "./style/breakpoint-axes";
+/*
+ * What a stored breakpoint set MEANS, which the type does not say.
+ *
+ * Exported because more than one package now asks: the editor reads them to
+ * build its dialog and its switcher, and a preview surface outside the builder
+ * derives device presets from the same set. Reimplemented on either side, the
+ * two would agree about what a breakpoint IS and disagree about which rows an
+ * author defined and in what order they apply.
+ */
+export { authoredBreakpoints, inCascadeOrder } from "./style/breakpoint-set";
 
 // The remote-host policy: which hosts a compiled page may fetch from. Exported
 // so the React renderer applies the SAME matcher the style compiler does.

--- a/packages/blocks-engine/src/style/breakpoint-set.test.ts
+++ b/packages/blocks-engine/src/style/breakpoint-set.test.ts
@@ -1,0 +1,70 @@
+/**
+ * What a stored breakpoint set means, as opposed to what it literally contains.
+ *
+ * Both questions here are answered identically by every surface that reads a
+ * site's breakpoints, and neither is answered by the type. A surface getting one
+ * wrong does not fail — it shows a plausible list that disagrees with the one
+ * beside it, which is why these live in the engine rather than in whichever
+ * package happened to ask first.
+ *
+ * @module breakpoint-set.test
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BreakpointSet } from "../document";
+
+import { authoredBreakpoints, inCascadeOrder } from "./breakpoint-set";
+
+describe("the authored set", () => {
+  it("strips a stored base row from both axes", () => {
+    /*
+     * A stored set CAN carry a `base` row and the plugin's README documents a
+     * host config that does, while the compiler claims that id before reading
+     * any stored definition. Three surfaces ask "what has this site defined" —
+     * the dialog's draft, the trigger's count, and the host deciding whether
+     * config defaults exist — and each one that answered differently produced
+     * its own defect.
+     */
+    const stripped = authoredBreakpoints({
+      viewport: [
+        { id: "base", label: "Base" },
+        { id: "tablet", label: "Tablet", maxWidth: 991 },
+      ],
+      container: [{ id: "base", label: "Base" }],
+    } as unknown as BreakpointSet);
+
+    expect(stripped.viewport.map(def => def.id)).toEqual(["tablet"]);
+    expect(stripped.container).toEqual([]);
+  });
+
+  it("answers for an absent set rather than throwing", () => {
+    // The host's config states no breakpoints at all far more often than it
+    // states some, and that caller reads the field optionally.
+    expect(authoredBreakpoints(undefined)).toEqual({
+      viewport: [],
+      container: [],
+    });
+  });
+});
+
+describe("cascade order", () => {
+  it("puts an unbounded definition first, then widest to narrowest", () => {
+    const ordered = inCascadeOrder([
+      { id: "narrow", label: "Narrow", maxWidth: 400 },
+      { id: "unbounded", label: "Unbounded" },
+      { id: "wide", label: "Wide", maxWidth: 900 },
+    ]);
+
+    expect(ordered.map(d => d.id)).toEqual(["unbounded", "wide", "narrow"]);
+  });
+
+  it("does not mutate the array it was given", () => {
+    const defs = [
+      { id: "a", label: "A", maxWidth: 100 },
+      { id: "b", label: "B", maxWidth: 900 },
+    ];
+    inCascadeOrder(defs);
+
+    expect(defs.map(d => d.id)).toEqual(["a", "b"]);
+  });
+});

--- a/packages/blocks-engine/src/style/breakpoint-set.ts
+++ b/packages/blocks-engine/src/style/breakpoint-set.ts
@@ -1,0 +1,67 @@
+// What a stored breakpoint set MEANS, as opposed to what it literally contains.
+//
+// Two questions that every surface reading a site's breakpoints has to answer the same way, and
+// that neither the type nor the stored record answers on its own: which definitions did an author
+// actually add, and in what order does the cascade apply them. A surface that gets either wrong
+// does not fail — it shows a plausible list that disagrees with the one next to it.
+//
+// Here rather than in the editor because the editor is no longer the only asker. A preview surface
+// outside the builder derives device presets from the same set, and the two must not answer
+// differently; the alternative is each package reimplementing a base-row strip and a sort, which is
+// the drift this repository has a rule about.
+//
+// Beside `breakpoint-axes.ts` for the same reason that file exists: these are facts about the
+// document model, readable without reading the emitter that consumes them.
+
+import type { BreakpointDef, BreakpointSet } from "../document";
+
+import { BASE_BREAKPOINT } from "./compile-page";
+
+/**
+ * The set with the built-in base removed from both axes.
+ *
+ * The base is not a definition an author added: `breakpointContexts` prepends
+ * its context whether or not one is stored, and `validateBreakpoints` reports
+ * the id as reserved. But a stored set CAN carry a `base` row — the page-builder
+ * plugin's README documents a host config that does — so every surface asking
+ * "what has this site actually defined" has to strip it, and each one that
+ * forgets gets a different wrong answer from the same set.
+ *
+ * The failures are not hypothetical. A dialog and a trigger disagreeing about
+ * this made Save unreachable on the documented configuration; a host that did
+ * not strip it could not return a site to its config defaults.
+ *
+ * @experimental
+ */
+export function authoredBreakpoints(
+  set: BreakpointSet | undefined
+): BreakpointSet {
+  const authored = (axis: readonly BreakpointDef[] | undefined) =>
+    (axis ?? []).filter(def => def?.id !== BASE_BREAKPOINT);
+  return {
+    viewport: authored(set?.viewport),
+    container: authored(set?.container),
+  };
+}
+
+/**
+ * The definitions of one axis in the order the compiler applies them: widest
+ * first, an unbounded definition ahead of every bounded one.
+ *
+ * Presenting them in stored order instead would show an author a list whose
+ * cascade runs in a different direction than it reads.
+ *
+ * Copied before sorting, because `Array.prototype.sort` mutates: sorting the
+ * caller's array in place reorders a stored record that other readers still
+ * hold, and the reorder is invisible until one of them reports a different
+ * winner.
+ *
+ * @experimental
+ */
+export function inCascadeOrder(
+  defs: readonly BreakpointDef[]
+): BreakpointDef[] {
+  return [...defs].sort(
+    (a, b) => (b.maxWidth ?? Infinity) - (a.maxWidth ?? Infinity)
+  );
+}

--- a/packages/builder/src/breakpoints.test.ts
+++ b/packages/builder/src/breakpoints.test.ts
@@ -100,38 +100,6 @@ const BREAKPOINTS_FOR_PREVIEW = {
   container: [],
 } as unknown as BreakpointSet;
 
-describe("the authored set", () => {
-  it("strips a stored base row from both axes", () => {
-    /*
-     * A stored set CAN carry a `base` row and the plugin's README documents a
-     * host config that does, while the compiler claims that id before reading
-     * any stored definition. Three surfaces ask "what has this site defined" —
-     * the dialog's draft, the trigger's count, and the host deciding whether
-     * config defaults exist — and each one that answered differently produced
-     * its own defect.
-     */
-    const stripped = authoredBreakpoints({
-      viewport: [
-        { id: "base", label: "Base" },
-        { id: "tablet", label: "Tablet", maxWidth: 991 },
-      ],
-      container: [{ id: "base", label: "Base" }],
-    } as unknown as BreakpointSet);
-
-    expect(stripped.viewport.map(def => def.id)).toEqual(["tablet"]);
-    expect(stripped.container).toEqual([]);
-  });
-
-  it("answers for an absent set rather than throwing", () => {
-    // The host's config states no breakpoints at all far more often than it
-    // states some, and that caller reads the field optionally.
-    expect(authoredBreakpoints(undefined)).toEqual({
-      viewport: [],
-      container: [],
-    });
-  });
-});
-
 describe("an id the compiler would drop", () => {
   it("is reported, rather than saved into nothing", () => {
     /*
@@ -368,28 +336,6 @@ describe("ids are compared as the compiler compares them", () => {
     expect(
       codes(set({ viewport: [{ id: "base", label: "B", maxWidth: 1200 }] }))
     ).toEqual(["id-reserved"]);
-  });
-});
-
-describe("cascade order", () => {
-  it("puts an unbounded definition first, then widest to narrowest", () => {
-    const ordered = inCascadeOrder([
-      { id: "narrow", label: "Narrow", maxWidth: 400 },
-      { id: "unbounded", label: "Unbounded" },
-      { id: "wide", label: "Wide", maxWidth: 900 },
-    ]);
-
-    expect(ordered.map(d => d.id)).toEqual(["unbounded", "wide", "narrow"]);
-  });
-
-  it("does not mutate the array it was given", () => {
-    const defs = [
-      { id: "a", label: "A", maxWidth: 100 },
-      { id: "b", label: "B", maxWidth: 900 },
-    ];
-    inCascadeOrder(defs);
-
-    expect(defs.map(d => d.id)).toEqual(["a", "b"]);
   });
 });
 

--- a/packages/builder/src/breakpoints.ts
+++ b/packages/builder/src/breakpoints.ts
@@ -30,8 +30,10 @@
  * @module breakpoints
  */
 import {
+  authoredBreakpoints,
   BASE_BREAKPOINT,
   BREAKPOINT_AXES,
+  inCascadeOrder,
   MAX_BREAKPOINT_ID_LENGTH,
   MAX_BREAKPOINTS_PER_AXIS,
   type BreakpointAxis,
@@ -60,7 +62,13 @@ import {
  *
  * @experimental
  */
-export { BASE_BREAKPOINT, BREAKPOINT_AXES, MAX_BREAKPOINTS_PER_AXIS };
+export {
+  authoredBreakpoints,
+  BASE_BREAKPOINT,
+  BREAKPOINT_AXES,
+  inCascadeOrder,
+  MAX_BREAKPOINTS_PER_AXIS,
+};
 export type { BreakpointAxis, BreakpointDef, BreakpointSet };
 
 /**
@@ -108,35 +116,6 @@ export function storedLimitFor(axis: BreakpointAxis): number {
   return axis === "viewport"
     ? MAX_BREAKPOINTS_PER_AXIS - 1
     : MAX_BREAKPOINTS_PER_AXIS;
-}
-
-/**
- * The set with the built-in base removed from both axes.
- *
- * The base is not a definition an author added: `breakpointContexts` prepends
- * its context whether or not one is stored, and `validateBreakpoints` reports
- * the id as reserved. But a stored set CAN carry a `base` row and the plugin's
- * README documents a host config that does, so every surface that asks "what
- * has this site actually defined" has to strip it — and each one that forgets
- * gets a different wrong answer from the same set.
- *
- * Published rather than repeated, because it has three askers already: the
- * dialog's draft, the trigger's count, and the host deciding whether config
- * defaults exist. The first two disagreeing is what made Save unreachable on
- * the documented configuration; the third disagreeing made a site with only a
- * base row unable to return to it.
- *
- * @experimental
- */
-export function authoredBreakpoints(
-  set: BreakpointSet | undefined
-): BreakpointSet {
-  const authored = (axis: readonly BreakpointDef[] | undefined) =>
-    (axis ?? []).filter(def => def?.id !== BASE_BREAKPOINT);
-  return {
-    viewport: authored(set?.viewport),
-    container: authored(set?.container),
-  };
 }
 
 /**
@@ -308,21 +287,6 @@ export function validateBreakpoints(set: BreakpointSet): BreakpointIssue[] {
   }
 
   return issues;
-}
-
-/**
- * The definitions of one axis in the order the compiler applies them: widest
- * first, an unbounded definition ahead of every bounded one.
- *
- * Presenting them in stored order instead would show an author a list whose
- * cascade runs in a different direction than it reads.
- *
- * @experimental
- */
-export function inCascadeOrder(defs: BreakpointDef[]): BreakpointDef[] {
-  return [...defs].sort(
-    (a, b) => (b.maxWidth ?? Infinity) - (a.maxWidth ?? Infinity)
-  );
 }
 
 /**


### PR DESCRIPTION
## What

Moves `authoredBreakpoints` and `inCascadeOrder` from `packages/builder/src/breakpoints.ts` into `packages/blocks-engine/src/style/breakpoint-set.ts`, beside the `BreakpointDef` / `BreakpointSet` types they operate on. The editor re-exports both, so every existing import is unchanged.

## Why now

Both answer questions the stored record does not:

- **which rows an author actually defined.** A stored set may carry a reserved `base` row — the page-builder plugin's own README documents a host config that does — while `breakpointContexts` prepends that context regardless and `validateBreakpoints` reports the id as reserved.
- **the order the cascade applies them in**, which is widest-first with an unbounded definition ahead of every bounded one, not stored order.

They lived in the editor because the editor asked first. A preview surface outside the builder now derives device presets from the same record, and a second implementation would agree about what a breakpoint MEANS while disagreeing about which rows exist and in what order — the quieter half of the same defect. A consumer that skips the strip shows an author a "Base" device preset that is not a device.

Both are pure functions over engine-owned types with no builder dependency, so the engine is where they belong regardless of who asked.

## Placement

`packages/blocks-engine/src/style/breakpoint-set.ts`, beside `breakpoint-axes.ts` and for the reason that file exists: facts about the document model, readable without reading the emitter that consumes them.

The editor re-exports rather than keeping copies, which is the convention its own module header already states for every value the compiler decides — `BASE_BREAKPOINT`, `BREAKPOINT_AXES`, `MAX_BREAKPOINTS_PER_AXIS`. This adds two to that list.

## One behavioural note

`inCascadeOrder` now takes `readonly BreakpointDef[]`. It already copied before sorting — `sort` mutates, and sorting a caller's stored record reorders it for every other reader — so this only makes the parameter type say what the body already did. No caller changes.

## Test plan

Their tests move with them, extracted by brace balance and verified balanced on both sides rather than by anchor matching.

- `blocks-engine` 1451 → **1455**, `builder` 1894 → **1890** — the same four, relocated. Reconciled deliberately, since a suite that silently stops being discovered reads as a pass.
- `blocks-react` 811, `ui` 1135, `plugin-page-builder` 307 — unchanged
- `pnpm build`, `pnpm check-types`, `pnpm test:scripts`, package lints, root lint, comment convention, changeset validation, `fallow audit` — all pass

Break-verified in their new home, each failing only its own test:

- stop stripping the base row → `strips a stored base row from both axes`
- sort in place → `does not mutate the array it was given`
- reverse the comparator → `puts an unbounded definition first, then widest to narrowest`

## Reviewer note

`packages/plugin-page-builder/src/admin/BlocksField.tsx` imports `authoredBreakpoints` from `@nextlyhq/builder` and is untouched — worth confirming that re-export path is the one you want kept, rather than pointing the plugin at the engine directly. I left it alone because changing it is a separate decision about which surface the plugin should depend on, not part of the move.